### PR TITLE
feat: improve agent directory structure with built-in and custom paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coauthor",
   "displayName": "CoAuthor",
   "description": "CoAuthor: your never complain nor PUA nor on two-month holidays coauthor.",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "publisher": "Sirui-Lu",
   "engines": {
     "vscode": "^1.96.2"
@@ -394,7 +394,7 @@
         "properties": {
           "coauthor.explorer.agentsDirectory": {
             "type": "string",
-            "default": "agents",
+            "default": "",
             "description": "Root path for the CoAuthor file explorer view. Can be absolute or relative to workspace root.",
             "scope": "resource"
           }

--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -6,7 +6,10 @@ import * as vscode from 'vscode';
 import * as logger from './logger/logUtils';
 
 // Local imports
-import { getAgentsDirectory } from './utils/pathUtils';
+import {
+  getBuiltInAgentsDirectory,
+  getCustomAgentsDirectory,
+} from './utils/pathUtils';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);
@@ -24,7 +27,7 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
   readonly onDidChangeTreeData: vscode.Event<
     FileItem | undefined | null | void
   > = this._onDidChangeTreeData.event;
-  private fileSystemWatcher: vscode.FileSystemWatcher | undefined;
+  private fileSystemWatchers: vscode.FileSystemWatcher[] = [];
   private editingItem: FileItem | undefined;
 
   constructor(
@@ -64,7 +67,9 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
     try {
       const parentPath =
         node?.resourceUri.fsPath ||
-        (this.context ? await getAgentsDirectory(this.context) : undefined);
+        (this.context
+          ? await getBuiltInAgentsDirectory(this.context)
+          : undefined);
 
       if (!parentPath) {
         throw new Error('No valid parent path found');
@@ -174,22 +179,39 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
         return;
       }
 
-      const watchPath = await getAgentsDirectory(this.context);
+      // Watch both built-in and custom directories
+      const builtInPath = await getBuiltInAgentsDirectory(this.context);
+      const customPath = await getCustomAgentsDirectory();
 
-      // Dispose of existing watcher if any
-      this.fileSystemWatcher?.dispose();
+      // Dispose of existing watchers
+      this.dispose();
 
-      // Create new watcher for the directory
-      this.fileSystemWatcher = vscode.workspace.createFileSystemWatcher(
-        new vscode.RelativePattern(watchPath, '**/*'),
-      );
+      // Create watchers for both directories
+      this.fileSystemWatchers = [
+        vscode.workspace.createFileSystemWatcher(
+          new vscode.RelativePattern(builtInPath, '**/*'),
+        ),
+      ];
+
+      if (customPath) {
+        this.fileSystemWatchers.push(
+          vscode.workspace.createFileSystemWatcher(
+            new vscode.RelativePattern(customPath, '**/*'),
+          ),
+        );
+      }
 
       // Watch for all file system events
-      this.fileSystemWatcher.onDidCreate(() => this.refresh());
-      this.fileSystemWatcher.onDidDelete(() => this.refresh());
-      this.fileSystemWatcher.onDidChange(() => this.refresh());
+      this.fileSystemWatchers.forEach((watcher) => {
+        watcher.onDidCreate(() => this.refresh());
+        watcher.onDidDelete(() => this.refresh());
+        watcher.onDidChange(() => this.refresh());
+      });
 
-      logger.info(CHANNEL, `File system watcher set up for: ${watchPath}`);
+      logger.info(
+        CHANNEL,
+        `File system watchers set up for: ${[builtInPath, customPath].filter(Boolean).join(', ')}`,
+      );
     } catch (err) {
       logger.error(CHANNEL, `Error setting up file system watcher: ${err}`);
     }
@@ -197,7 +219,8 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
 
   // Add dispose method to clean up resources
   dispose() {
-    this.fileSystemWatcher?.dispose();
+    this.fileSystemWatchers.forEach((watcher) => watcher.dispose());
+    this.fileSystemWatchers = [];
   }
 
   refresh(): void {
@@ -217,28 +240,44 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
   }
 
   async getChildren(element?: FileItem): Promise<FileItem[]> {
-    if (element) {
-      // If element is provided, get its children
-      const dirPath = element.resourceUri.fsPath;
-      return this.getFilesInDirectory(dirPath);
-    } else {
-      // For root level, use getAgentsDirectory
-      if (!this.context) {
-        logger.error(CHANNEL, 'Extension context not available');
-        return Promise.resolve([]);
-      }
+    if (!this.context) {
+      logger.error(CHANNEL, 'Extension context not available');
+      return Promise.resolve([]);
+    }
 
-      try {
-        const absolutePath = await getAgentsDirectory(this.context);
-        logger.debug(CHANNEL, `Reading from: ${absolutePath}`);
-        return this.getFilesInDirectory(absolutePath);
-      } catch (err) {
-        logger.error(
-          CHANNEL,
-          `Error getting agents directory: ${err instanceof Error ? err.message : String(err)}`,
+    try {
+      if (element) {
+        // If element is provided, get its children
+        return this.getFilesInDirectory(element.resourceUri.fsPath);
+      } else {
+        // For root level, create Built-in and Custom root items
+        const items: FileItem[] = [];
+
+        // Add Built-in Agents folder
+        const builtInPath = await getBuiltInAgentsDirectory(this.context);
+        const builtInItem = new FileItem(
+          'Built-in Agents',
+          vscode.Uri.file(builtInPath),
+          vscode.TreeItemCollapsibleState.Collapsed,
         );
-        return Promise.resolve([]);
+        items.push(builtInItem);
+
+        // Add Custom Agents folder if configured
+        const customPath = await getCustomAgentsDirectory();
+        if (customPath) {
+          const customItem = new FileItem(
+            'Custom Agents',
+            vscode.Uri.file(customPath),
+            vscode.TreeItemCollapsibleState.Collapsed,
+          );
+          items.push(customItem);
+        }
+
+        return items;
       }
+    } catch (err) {
+      logger.error(CHANNEL, `Error getting children: ${err}`);
+      return [];
     }
   }
 

--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -7,7 +7,10 @@ import { glob } from 'glob';
 // (none needed)
 
 // Local imports - utilities
-import { getAgentsDirectory } from '../utils/pathUtils';
+import {
+  getBuiltInAgentsDirectory,
+  getCustomAgentsDirectory,
+} from '../utils/pathUtils';
 
 // Local imports - agent components
 import { AgentConfig, createAgentConfig } from './AgentConfig';
@@ -48,24 +51,40 @@ export async function getAgentPath(
   context: vscode.ExtensionContext,
 ): Promise<string> {
   try {
-    const basePath = await getAgentsDirectory(context);
+    // First check custom agents directory
+    const customDir = await getCustomAgentsDirectory();
+    if (customDir) {
+      const customMatches = await glob(`**/${agentName}.yaml`, {
+        cwd: customDir,
+        dot: false,
+        nodir: true,
+        absolute: false,
+      });
 
-    // Use glob to find the yaml file recursively
-    const matches = await glob(`**/${agentName}.yaml`, {
-      cwd: basePath,
+      if (customMatches.length > 0) {
+        return path.join(customDir, path.dirname(customMatches[0]));
+      }
+    }
+
+    // If not found in custom directory, check built-in directory
+    const builtInDir = await getBuiltInAgentsDirectory(context);
+    const builtInMatches = await glob(`**/${agentName}.yaml`, {
+      cwd: builtInDir,
       dot: false,
       nodir: true,
       absolute: false,
     });
 
-    if (matches.length === 0) {
+    if (builtInMatches.length === 0) {
       const errorMsg = `Could not find yaml file for agent: ${agentName}`;
-      vscode.window.showErrorMessage(`${errorMsg} from ${basePath}`);
+      vscode.window.showErrorMessage(
+        `${errorMsg} in either custom or built-in directories`,
+      );
       throw new Error(errorMsg);
     }
 
     // Return the directory containing the yaml file
-    return path.join(basePath, path.dirname(matches[0]));
+    return path.join(builtInDir, path.dirname(builtInMatches[0]));
   } catch (err) {
     const errorMsg = `Error finding agent path: ${err instanceof Error ? err.message : String(err)}`;
     vscode.window.showErrorMessage(errorMsg);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ async function copyDefaultAgents(context: vscode.ExtensionContext) {
         console.log(`Skipping directory: ${file}`);
         continue;
       }
-      
+
       // In the future new versions should update prompt?
 
       // Only copy if target doesn't exist

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -10,37 +10,59 @@ const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
 
 /**
- * Get the absolute path to the agents directory, handling both absolute and relative paths.
+ * Get the absolute path to the built-in agents directory in global storage.
  */
-export async function getAgentsDirectory(
+export async function getBuiltInAgentsDirectory(
   context: vscode.ExtensionContext,
 ): Promise<string> {
-  const rootPath = getConfig<string>('explorer.agentsDirectory', 'agents');
-
-  if (rootPath && path.isAbsolute(rootPath)) {
-    return rootPath;
-  }
-
   if (!context) {
-    throw new Error('Extension context required for relative paths');
+    throw new Error('Extension context required for built-in agents');
   }
 
-  const basePath = path.join(context.globalStorageUri.fsPath, rootPath);
+  const basePath = path.join(context.globalStorageUri.fsPath, 'agents');
 
   // Ensure the directory exists
   await vscode.workspace.fs.createDirectory(vscode.Uri.file(basePath));
-  logger.debug(CHANNEL, `Using agents directory: ${basePath}`);
+  logger.debug(CHANNEL, `Using built-in agents directory: ${basePath}`);
 
   return basePath;
 }
 
 /**
- * Resolve a path relative to the agents directory.
+ * Get the absolute path to the custom agents directory from configuration.
+ * Returns empty string if not configured or invalid.
  */
-export async function resolveAgentPath(
-  relativePath: string,
+export async function getCustomAgentsDirectory(): Promise<string> {
+  const customPath = getConfig<string>('explorer.agentsDirectory', '');
+
+  if (!customPath) {
+    return '';
+  }
+
+  if (!path.isAbsolute(customPath)) {
+    logger.error(
+      CHANNEL,
+      `Custom agents directory must be an absolute path: ${customPath}`,
+    );
+    vscode.window.showErrorMessage(
+      'Custom agents directory must be an absolute path',
+    );
+    return '';
+  }
+
+  return customPath;
+}
+
+/**
+ * Get the absolute path to the agents directory, prioritizing custom over built-in.
+ * This maintains backward compatibility for existing code.
+ */
+export async function getAgentsDirectory(
   context: vscode.ExtensionContext,
 ): Promise<string> {
-  const agentsDir = await getAgentsDirectory(context);
-  return path.join(agentsDir, relativePath);
+  const customDir = await getCustomAgentsDirectory();
+  if (customDir) {
+    return customDir;
+  }
+  return getBuiltInAgentsDirectory(context);
 }


### PR DESCRIPTION
- Add separate management for built-in and custom agent directories
- Display "Built-in Agents" and "Custom Agents" as root folders in explorer
- Change default agents directory to empty string
- Add multiple file system watchers to monitor both directories
- Improve error handling and logging for directory operations