### PR TITLE
Add command to apply LaTeX replacements to current file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.94.0"
@@ -658,6 +658,20 @@
         "enablement": "!virtualWorkspace"
       },
       {
+        "command": "texra.applyReplacements",
+        "title": "Apply LaTeX Replacements to Current File",
+        "category": "TeXRA",
+        "icon": "$(symbol-text)",
+        "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "texra.getTeXCount",
+        "title": "Count Words in Current TeX File",
+        "category": "TeXRA",
+        "icon": "$(symbol-number)",
+        "enablement": "!virtualWorkspace"
+      },
+      {
         "command": "texra.countPdfPages",
         "title": "Count PDF Pages",
         "category": "TeXRA"
@@ -691,13 +705,6 @@
         "command": "texra.compileTikzFigures",
         "title": "Compile TikZ Figures from Current File",
         "category": "TeXRA"
-      },
-      {
-        "command": "texra.getTeXCount",
-        "title": "Count Words in Current TeX File",
-        "category": "TeXRA",
-        "icon": "$(symbol-number)",
-        "enablement": "!virtualWorkspace"
       },
       {
         "command": "texra.testConnection",
@@ -897,6 +904,11 @@
         {
           "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.indentCurrentTeX",
+          "group": "navigation"
+        },
+        {
+          "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "command": "texra.applyReplacements",
           "group": "navigation"
         },
         {

--- a/src/commands/latexCommands.ts
+++ b/src/commands/latexCommands.ts
@@ -6,6 +6,11 @@ import * as logger from '../logger/logUtils';
 
 // Local imports - utilities
 import { getRelativePath } from '../utils/workspaceFileUtils';
+import {
+  applyReplacements,
+  getAllReplacements,
+  getAllReplacementsRegex,
+} from '../utils/replacementUtils';
 
 // Local imports - latex utils
 import { runLatexIndent } from '../latex/latexindent';
@@ -28,7 +33,64 @@ export function registerLatexCommands(context: vscode.ExtensionContext) {
     ),
     vscode.commands.registerCommand('texra.getTeXCount', handleGetTeXCount),
     vscode.commands.registerCommand('texra.indentTeX', runIndentTeX),
+    vscode.commands.registerCommand(
+      'texra.applyReplacements',
+      handleApplyReplacements,
+    ),
   );
+}
+
+async function handleApplyReplacements(): Promise<void> {
+  try {
+    // Get active editor
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showWarningMessage('No active text editor found');
+      return;
+    }
+    if (editor?.document.isDirty) {
+      await editor.document.save();
+    }
+
+    // Get document content
+    const document = editor.document;
+    const text = document.getText();
+
+    // Apply replacements
+    let processedText = text;
+    processedText = applyReplacements(
+      processedText,
+      getAllReplacements(),
+    ).trim();
+    processedText = applyReplacements(
+      processedText,
+      getAllReplacementsRegex(),
+    ).trim();
+    processedText = applyReplacements(
+      processedText,
+      getAllReplacements(),
+    ).trim();
+
+    // Update document content
+    const fullRange = new vscode.Range(
+      document.positionAt(0),
+      document.positionAt(text.length),
+    );
+
+    await editor.edit((editBuilder) => {
+      editBuilder.replace(fullRange, processedText);
+    });
+
+    vscode.window.showInformationMessage(
+      'LaTeX replacements applied successfully',
+    );
+  } catch (err) {
+    logger.error(
+      CHANNEL,
+      `Error applying replacements: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    vscode.window.showErrorMessage('Error applying LaTeX replacements');
+  }
 }
 
 async function handleIndentCurrentTeX(): Promise<void> {
@@ -164,4 +226,5 @@ export const latexCommands = {
   handleIndentCurrentTeX,
   handleGetTeXCount,
   runIndentTeX,
+  handleApplyReplacements,
 };


### PR DESCRIPTION
This PR adds a new command that applies LaTeX replacements to the current file content, using the same replacement logic as in the agent code. The version has also been bumped to 0.30.5.