### PR TITLE
Refactor constants and file cleanup

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -54,7 +54,8 @@ import { messageToSkeleton } from './messageUtils';
 // System imports - common utilities
 import { getConfig } from '../utils/configUtils';
 
-const K_SLICE = 200;
+// Shared constants
+import { K_SLICE } from '../utils/constants';
 
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -19,6 +19,7 @@ import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
+  cleanFileContent,
 } from '../replacement/replacementUtils';
 import { extractAndLogScratchpad } from '../utils/xmlUtils';
 
@@ -34,8 +35,7 @@ import { ToolState } from './ToolState';
 import { AgentStateRound } from './AgentState';
 import { messageToSkeleton } from './messageUtils';
 import { getConfig } from '../utils/configUtils';
-
-const K_SLICE = 200;
+import { K_SLICE } from '../utils/constants';
 
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.
@@ -453,11 +453,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
 
     // Get prefill from existing and non-trivial file
     let fileContent = await readFile(outputFile);
-    fileContent = applyReplacements(fileContent, getAllReplacements()).trim();
-    fileContent = applyReplacements(
-      fileContent,
-      getAllReplacementsRegex(),
-    ).trim();
+    fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
     extractAndLogScratchpad(fileContent, this.logger);

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -32,12 +32,13 @@ import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
+  cleanFileContent,
 } from '../replacement/replacementUtils';
 import { extractAndLogScratchpad } from '../utils/xmlUtils';
 import { getConfig } from '../utils/configUtils';
 
 // Local constant
-const K_SLICE = 200;
+import { K_SLICE } from '../utils/constants';
 
 // Internal type definition
 type InternalMessagePart = {
@@ -674,11 +675,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       `Output file ${outputFile} exists and is non-trivial. Reading content.`,
     );
     let fileContent = await readFile(outputFile);
-    fileContent = applyReplacements(fileContent, getAllReplacements()).trim();
-    fileContent = applyReplacements(
-      fileContent,
-      getAllReplacementsRegex(),
-    ).trim();
+    fileContent = cleanFileContent(fileContent);
 
     extractAndLogScratchpad(fileContent, this.logger);
     await writeFile(outputFile, fileContent);

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -16,11 +16,7 @@ import {
   writeFile,
   fileExistsAndNonTrivial,
 } from '../utils/workspaceFileUtils';
-import {
-  applyReplacements,
-  getAllReplacements,
-  getAllReplacementsRegex,
-} from '../replacement/replacementUtils';
+import { cleanFileContent } from '../replacement/replacementUtils';
 import { getConfig } from '../utils/configUtils';
 import { extractAndLogScratchpad } from '../utils/xmlUtils';
 
@@ -31,8 +27,7 @@ import { AgentStateRound } from './AgentState';
 import { ModelHandler } from './ModelHandler';
 import { OpenAIAPIResponseUsage, ResponseUsageFactory } from './ResponseUsage';
 import { ToolState } from './ToolState';
-
-const K_SLICE = 200;
+import { K_SLICE } from '../utils/constants';
 
 /**
  * OpenAI-specific handlers.
@@ -486,11 +481,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
     // Get prefill from existing and non-trivial file
     let fileContent = await readFile(outputFile);
-    fileContent = applyReplacements(fileContent, getAllReplacements()).trim();
-    fileContent = applyReplacements(
-      fileContent,
-      getAllReplacementsRegex(),
-    ).trim();
+    fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
     extractAndLogScratchpad(fileContent, this.logger);

--- a/src/replacement/replacementAdvanced.ts
+++ b/src/replacement/replacementAdvanced.ts
@@ -334,7 +334,7 @@ export function replaceMathUnicode(text: string): string {
   }
 
   // Also handle inline math with $ ... $
-  let inlineMathPattern = /\$(.*?)\$/g;
+  const inlineMathPattern = /\$(.*?)\$/g;
   text = text.replace(inlineMathPattern, (match, p1) => {
     let content = p1;
 

--- a/src/replacement/replacementUtils.ts
+++ b/src/replacement/replacementUtils.ts
@@ -259,3 +259,12 @@ export function applyReplacements(
 
   return text;
 }
+
+/**
+ * Clean content using all replacement rules.
+ */
+export function cleanFileContent(content: string): string {
+  let cleaned = applyReplacements(content, getAllReplacements()).trim();
+  cleaned = applyReplacements(cleaned, getAllReplacementsRegex()).trim();
+  return cleaned;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,3 +21,6 @@ export const TOOL_CONFIG_FIELDS = [
   'printInputPrompt',
   'reflect',
 ] as const;
+
+// Length for preview slices of tool output and responses
+export const K_SLICE = 200;


### PR DESCRIPTION
## Summary
- centralize `K_SLICE` in `constants.ts`
- add `cleanFileContent` helper in `replacementUtils.ts`
- use the shared constant and cleanup helper in model handlers
- fix lint issue in `replacementAdvanced.ts`

## Testing
- `npm run format`
- `npm run lint` *(fails: Mark is not defined warning)*