### PR TITLE
Refactor content conversion utility

### DIFF
--- a/src/agent/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlerDashScope.ts
@@ -8,6 +8,9 @@ import OpenAI from 'openai';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from './ToolState';
 
+// Local imports - utilities
+import { convertContentToString } from '../utils/messageUtils';
+
 /**
  * Handler for DashScope Qwen models using OpenAI-compatible API.
  */
@@ -54,7 +57,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
 
       // Convert content to string if it's an array
       if (Array.isArray(processedMessage.content)) {
-        processedMessage.content = this.convertContentToString(
+        processedMessage.content = convertContentToString(
           processedMessage.content,
         );
         this.logger.debug(
@@ -68,25 +71,6 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     return processedMessages;
   }
 
-  /**
-   * Convert content array to a string for DashScope compatibility
-   * @param content The message content (array or string)
-   * @returns String representation of the content
-   */
-  private convertContentToString(content: any): string {
-    if (typeof content === 'string') {
-      return content;
-    }
-
-    if (Array.isArray(content)) {
-      return content
-        .filter((item) => item.type === 'text')
-        .map((item) => item.text)
-        .join('\n');
-    }
-
-    return '';
-  }
 
   /**
    * Override createResponse to preprocess messages for DashScope models

--- a/src/agent/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlerDeepSeek.ts
@@ -8,6 +8,9 @@ import OpenAI from 'openai';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from './ToolState';
 
+// Local imports - utilities
+import { convertContentToString } from '../utils/messageUtils';
+
 /**
  * Handler for DeepSeek models using OpenAI-compatible API.
  */
@@ -87,25 +90,6 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     return reasoningContent;
   }
 
-  /**
-   * Convert content array to a string for DeepSeek compatibility
-   * @param content The message content (array or string)
-   * @returns String representation of the content
-   */
-  private convertContentToString(content: any): string {
-    if (typeof content === 'string') {
-      return content;
-    }
-
-    if (Array.isArray(content)) {
-      return content
-        .filter((item) => item.type === 'text')
-        .map((item) => item.text)
-        .join('\n');
-    }
-
-    return '';
-  }
 
   /**
    * Preprocess messages array to ensure there are no consecutive user or assistant messages
@@ -176,7 +160,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
 
       // Convert content to string if it's an array
       if (Array.isArray(processedMessage.content)) {
-        processedMessage.content = this.convertContentToString(
+        processedMessage.content = convertContentToString(
           processedMessage.content,
         );
         this.logger.debug(

--- a/src/agent/modelHandlerKimi.ts
+++ b/src/agent/modelHandlerKimi.ts
@@ -8,6 +8,9 @@ import OpenAI from 'openai';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from './ToolState';
 
+// Local imports - utilities
+import { convertContentToString } from '../utils/messageUtils';
+
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
  */
@@ -109,7 +112,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
 
       // Convert content to string if it's an array
       if (Array.isArray(processedMessage.content)) {
-        processedMessage.content = this.convertContentToString(
+        processedMessage.content = convertContentToString(
           processedMessage.content,
         );
         this.logger.debug(
@@ -123,25 +126,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     return processedMessages;
   }
 
-  /**
-   * Convert content array to a string for Kimi compatibility
-   * @param content The message content (array or string)
-   * @returns String representation of the content
-   */
-  private convertContentToString(content: any): string {
-    if (typeof content === 'string') {
-      return content;
-    }
-
-    if (Array.isArray(content)) {
-      return content
-        .filter((item) => item.type === 'text')
-        .map((item) => item.text)
-        .join('\n');
-    }
-
-    return '';
-  }
 
   /**
    * Override createResponse to preprocess messages for Kimi models

--- a/src/utils/messageUtils.ts
+++ b/src/utils/messageUtils.ts
@@ -1,0 +1,22 @@
+// Utility functions for chat message handling
+
+/**
+ * Convert content array to a string for provider compatibility.
+ *
+ * @param content The message content (array or string)
+ * @returns String representation of the content
+ */
+export function convertContentToString(content: any): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .filter((item) => item.type === 'text')
+      .map((item) => item.text)
+      .join('\n');
+  }
+
+  return '';
+}


### PR DESCRIPTION
## Summary
- extract a shared `convertContentToString` helper to `src/utils/messageUtils.ts`
- update DashScope, Kimi and DeepSeek handlers to use the new utility

## Testing
- `npm run lint`
- `npm run compile-tests` *(fails: Cannot find name 'ErrorEvent' etc.)*