### PR TITLE
Add shared sleep helper and use it

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -41,6 +41,7 @@ import {
   extractAndLogScratchpad,
   formatAndLogThinking,
 } from '../utils/xmlUtils';
+import { sleep } from '../utils/timeUtils';
 
 // Local imports - agent components
 import { AgentConfig } from './AgentConfig';
@@ -151,7 +152,7 @@ export abstract class BaseReflectionAgent {
   protected async initializeClient(): Promise<void> {
     this.client = await this.modelHandler.getClient();
     // wait for 50 mili seconds
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await sleep(50);
   }
 
   /**

--- a/src/commands/latexCommands.ts
+++ b/src/commands/latexCommands.ts
@@ -6,6 +6,7 @@ import * as logger from '../logger/logUtils';
 
 // Local imports - utilities
 import { getRelativePath } from '../utils/workspaceFileUtils';
+import { sleep } from '../utils/timeUtils';
 import {
   applyReplacements,
   getAllReplacements,
@@ -122,7 +123,7 @@ async function handleIndentCurrentTeX(): Promise<void> {
     if (success) {
       // Instead of trying to modify the document directly,
       // let VS Code handle the file change notification
-      await new Promise((resolve) => setTimeout(resolve, 100)); // Small delay to ensure file is written
+      await sleep(100); // Small delay to ensure file is written
       vscode.window.showInformationMessage('LaTeX file indented successfully');
     } else {
       vscode.window.showErrorMessage('Failed to indent LaTeX file');

--- a/src/commands/linterCommands.ts
+++ b/src/commands/linterCommands.ts
@@ -7,6 +7,7 @@ import * as logger from '../logger/logUtils';
 // Local imports - utils
 import { getLinterMessages } from '../utils/linterUtils';
 import { getRelativePath } from '../utils/workspaceFileUtils';
+import { sleep } from '../utils/timeUtils';
 
 // Local imports - core
 import { TeXLinterFixAgent } from '../AnthropicTool';
@@ -198,8 +199,9 @@ export async function handleFixLinterIssues(): Promise<void> {
           progress.report({ message: 'Could not fix all issues' });
         }
 
-        // Return a Promise that resolves after 1.5 seconds to give user time to see the result
-        return new Promise((resolve) => setTimeout(resolve, 1500));
+        // Short delay to give user time to see the result
+        await sleep(1500);
+        return;
       },
     );
   } catch (err) {

--- a/src/commands/xmlCommands.ts
+++ b/src/commands/xmlCommands.ts
@@ -10,6 +10,7 @@ import { XMLValidatorAgent } from '../AnthropicTool';
 
 // Local imports - utils
 import { getRelativePath } from '../utils/workspaceFileUtils';
+import { sleep } from '../utils/timeUtils';
 
 const CHANNEL = 'XmlCommands';
 logger.initialize(CHANNEL);
@@ -135,8 +136,9 @@ export async function handleValidateAndFixXml(): Promise<void> {
           progress.report({ message: 'Could not fix all issues' });
         }
 
-        // Return a Promise that resolves after 1.5 seconds to give user time to see the result
-        return new Promise((resolve) => setTimeout(resolve, 1500));
+        // Short delay to give user time to see the result
+        await sleep(1500);
+        return;
       },
     );
   } catch (err) {

--- a/src/latex/latexindent.ts
+++ b/src/latex/latexindent.ts
@@ -11,6 +11,7 @@ import * as logger from '../logger/logUtils';
 // Local imports - utilities
 import { deleteFile, getWorkspacePath } from '../utils/workspaceFileUtils';
 import { executeCommand } from '../utils/execUtils';
+import { sleep } from '../utils/timeUtils';
 import { checkToolInstalled } from './texTools';
 
 const CHANNEL = 'LaTeXCommands';
@@ -46,7 +47,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     }
 
     // Wait a moment for the file system to stabilize
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await sleep(100);
 
     // Setup cleanup patterns relative to workspace
     const fileBaseName = path.basename(filePath, '.tex');

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -3,6 +3,7 @@
 
 // Local imports - log
 import * as logger from './logUtils';
+import { sleep } from '../utils/timeUtils';
 
 /**
  * Encapsulates logging functionality for agents with a dedicated channel.
@@ -43,7 +44,7 @@ export class AgentLogger {
     parentGroupId?: string,
   ): Promise<string> {
     // wait for 50 mili seconds
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await sleep(50);
     return logger.startGroup(this.channelId, groupName, id, parentGroupId);
   }
 

--- a/src/utils/linterUtils.ts
+++ b/src/utils/linterUtils.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '../logger/logUtils';
 import { getFullPathFromWorkspace } from './workspaceFileUtils';
+import { sleep } from './timeUtils';
 
 const CHANNEL = 'LinterUtils';
 logger.initialize(CHANNEL);
@@ -72,7 +73,7 @@ export async function triggerLaTeXBuild(filePath: string): Promise<void> {
     await vscode.commands.executeCommand('latex-workshop.build', fileUri);
 
     // Wait for the build and diagnostics to complete
-    await new Promise((resolve) => setTimeout(resolve, 2500));
+    await sleep(2500);
 
     // Try to trigger diagnostics refresh explicitly if the editor is available
     if (editor) {
@@ -82,7 +83,7 @@ export async function triggerLaTeXBuild(filePath: string): Promise<void> {
     }
 
     // Wait a bit more for diagnostics to be updated
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await sleep(500);
   } catch (buildErr) {
     logger.warn(
       CHANNEL,

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -1,0 +1,10 @@
+// Standard library imports
+// (none needed)
+
+/**
+ * Asynchronously wait for the specified number of milliseconds.
+ * @param ms Number of milliseconds to sleep
+ */
+export async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -21,6 +21,7 @@ import {
   getFilesIfNotEmpty,
 } from '../frontend-utils/fileListingUtils';
 import { polishTextWithAI, FileContext } from '../utils/textEnhancementUtils';
+import { sleep } from '../utils/timeUtils';
 
 // Local imports - agent
 import { ToolConfig } from '../agent/ToolConfig';
@@ -735,7 +736,7 @@ export class WebviewMessageHandler {
             progress.report({ message: 'Preparing text and context...' });
 
             // Short delay to show first progress step
-            await new Promise((resolve) => setTimeout(resolve, 300));
+            await sleep(300);
 
             // Update progress
             progress.report({
@@ -750,7 +751,7 @@ export class WebviewMessageHandler {
             progress.report({ message: 'Applying changes...', increment: 60 });
 
             // Short delay to show final progress step
-            await new Promise((resolve) => setTimeout(resolve, 300));
+            await sleep(300);
 
             if (result.success) {
               // Send the polished text back to the webview


### PR DESCRIPTION
## Summary
- add a simple `sleep` function in `timeUtils`
- replace inline `new Promise` timeouts with `await sleep` across the codebase

## Testing
- `npm run lint`