### PR TITLE
Remove unused CSS selectors

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -49,17 +49,6 @@
   top: 0;
 }
 
-/* Common icon styling */
-.icon-with-text {
-  display: flex;
-  align-items: center;
-}
-
-.icon-with-text .codicon {
-  margin-right: var(--spacing-small);
-  color: var(--icon-color);
-}
-
 /* Unified button styling */
 .vscode-button {
   height: 24px;
@@ -188,14 +177,6 @@
   margin-right: var(--spacing-small);
 }
 
-/* Container styling */
-.container-box {
-  background-color: var(--dropdown-background);
-  border: 1px solid var(--dropdown-border);
-  border-radius: 4px;
-  padding: var(--spacing-medium);
-  margin-bottom: var(--spacing-large);
-}
 
 /* Dropdown/Select styling */
 select {
@@ -225,30 +206,3 @@ select:focus {
   justify-content: space-between;
 }
 
-/* Common layout utilities */
-.flex-row {
-  display: flex;
-  align-items: center;
-}
-
-.flex-column {
-  display: flex;
-  flex-direction: column;
-}
-
-.flex-space-between {
-  justify-content: space-between;
-}
-
-.flex-center {
-  justify-content: center;
-  align-items: center;
-}
-
-.flex-gap-small {
-  gap: var(--spacing-small);
-}
-
-.flex-gap-medium {
-  gap: var(--spacing-medium);
-}

--- a/src/progressView/styles/buttons.css
+++ b/src/progressView/styles/buttons.css
@@ -26,11 +26,6 @@
   gap: 4px;
 }
 
-/* X icon for clear buttons */
-.x-icon {
-  font-family: codicon;
-  font-size: var(--font-size);
-}
 
 /* Codicon override for trash icon */
 .codicon-trash:before {

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -154,11 +154,6 @@
   color: var(--vscode-symbolIcon-keywordForeground, #569cd6);
 }
 
-/* Add custom styling for special latex markup */
-.scratchpad-content .latex-inline {
-  font-style: italic;
-  color: var(--vscode-symbolIcon-functionForeground, #dcdcaa);
-}
 
 .scratchpad-content a {
   color: var(--vscode-textLink-activeForeground, #3794ff);

--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -57,22 +57,6 @@ body {
   cursor: pointer;
 }
 
-/* Basic button group */
-.button-group {
-  margin-bottom: var(--spacing-small);
-}
-
-.button-group label {
-  display: block;
-  font-size: var(--font-size);
-  margin-bottom: var(--spacing-small);
-}
-
-.button-container {
-  display: flex;
-  gap: var(--spacing-small);
-  flex-wrap: wrap; /* Allow wrapping if space is limited */
-}
 
 /* Input field */
 .vscode-input {

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -45,9 +45,6 @@
   padding: 0;
 }
 
-.multiple-files-header {
-  margin-bottom: var(--spacing-small);
-}
 
 .multiple-files-list {
   background-color: var(--dropdown-background);

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -8,10 +8,6 @@
   position: relative;
 }
 
-.dropdown-right .dropdown-options {
-  right: 0;
-  left: auto;
-}
 
 .dropdown-left .dropdown-options {
   left: 0;


### PR DESCRIPTION
## Summary
- drop stale class definitions from CSS files

## Testing
- `npm test` *(fails: Cannot find name 'ErrorEvent' in @google/genai)*