### PR TITLE
Add font command normalization

### DIFF
--- a/src/replacement/replacementRules.ts
+++ b/src/replacement/replacementRules.ts
@@ -308,6 +308,31 @@ export const CHARACTER_REPLACEMENTS: ReplacementCategory = {
   },
 };
 
+// Deprecated font commands (e.g., {\rm X}) to modern equivalents
+export const FONT_COMMAND_REPLACEMENTS: ReplacementCategory = {
+  name: 'font_commands',
+  description: 'Normalize deprecated font commands to modern equivalents',
+  isRegex: false,
+  patterns: (() => {
+    const patterns: { [key: string]: string } = {};
+    const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('');
+    letters.forEach((letter) => {
+      patterns[`{\\rm ${letter}}`] = `\\mathrm{${letter}}`;
+      patterns[`{\\bf ${letter}}`] = `\\mathbf{${letter}}`;
+      patterns[`{\\it ${letter}}`] = `\\mathit{${letter}}`;
+      patterns[`{\\sf ${letter}}`] = `\\mathsf{${letter}}`;
+      patterns[`{\\tt ${letter}}`] = `\\mathtt{${letter}}`;
+    });
+
+    const uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+    uppercase.forEach((letter) => {
+      patterns[`{\\cal ${letter}}`] = `\\mathcal{${letter}}`;
+    });
+
+    return patterns;
+  })(),
+};
+
 // Unicode character replacements
 export const UNICODE_REPLACEMENTS: ReplacementCategory = {
   name: 'unicode',

--- a/src/replacement/replacementUtils.ts
+++ b/src/replacement/replacementUtils.ts
@@ -21,6 +21,7 @@ import {
   EQUATION_REPLACEMENTS,
   SECTION_REPLACEMENTS,
   CHARACTER_REPLACEMENTS,
+  FONT_COMMAND_REPLACEMENTS,
   UNICODE_REPLACEMENTS,
   LATEX_SPACING_REPLACEMENTS,
   LATEX_XML_REPLACEMENTS,
@@ -54,6 +55,7 @@ function getEnabledReplacements(): string[] {
     'equations',
     'sections',
     'characters',
+    'font_commands',
     'latex_xml',
     'latex_document',
     'unicode',
@@ -69,6 +71,7 @@ const NON_REGEX_CATEGORIES: ReplacementCategory[] = [
   EQUATION_REPLACEMENTS,
   SECTION_REPLACEMENTS,
   CHARACTER_REPLACEMENTS,
+  FONT_COMMAND_REPLACEMENTS,
   UNICODE_REPLACEMENTS,
   LATEX_SPACING_REPLACEMENTS,
   // XML/Structural Formatting


### PR DESCRIPTION
## Summary
- normalize deprecated font commands like `{\rm F}` to modern equivalents
- include new font command replacement category in utils
- add more replacements for `\sf`, `\tt`, and `\cal`

## Testing
- `npm run lint`
- `npm test` *(fails: cannot find name 'ErrorEvent' in @google/genai)*