### PR TITLE
Add typed MediaEntry handling

### DIFF
--- a/src/agent/ModelHandler.ts
+++ b/src/agent/ModelHandler.ts
@@ -31,6 +31,7 @@ import {
   ModelCapabilities,
 } from '../model/ModelConfig';
 import { ToolState } from './ToolState';
+import { MediaEntry } from './mediaTypes';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;
@@ -382,7 +383,7 @@ export abstract class ModelHandler {
    * Individual providers can override if needed.
    */
   public async createMediaMessage(mediaFiles: string[]): Promise<any[]> {
-    const mediaMessage: any[] = [];
+    const mediaMessage: MediaEntry[] = [];
     const addedMedia: string[] = [];
 
     for (const mediaFile of mediaFiles) {
@@ -410,12 +411,11 @@ export abstract class ModelHandler {
           this.capabilities.supportsNativePdf &&
           mediaType === 'application/pdf'
         ) {
-          const imageEntry = {
-            type: 'file',
-            file: {
-              file_name: path.basename(mediaFile),
-              file_data: Array.isArray(mediaData) ? mediaData[0] : mediaData,
-            },
+          const imageEntry: MediaEntry = {
+            file_name: path.basename(mediaFile),
+            data: Array.isArray(mediaData) ? mediaData[0] : mediaData,
+            media_type: mediaType,
+            media_category: mediaCategory,
           };
           mediaMessage.push(imageEntry);
           addedMedia.push(mediaFile);
@@ -428,7 +428,7 @@ export abstract class ModelHandler {
             `Adding ${mediaData.length} pages/parts to the media contents`,
           );
           for (let i = 0; i < mediaData.length; i++) {
-            const mediaEntry = {
+            const mediaEntry: MediaEntry = {
               file_name: `${path.basename(mediaFile)}_page_${i + 1}`,
               data: mediaData[i],
               media_type: mediaType,
@@ -441,7 +441,7 @@ export abstract class ModelHandler {
           this.logger.debug(
             `Adding single part to the media contents: ${mediaFile}`,
           );
-          const mediaEntry = {
+          const mediaEntry: MediaEntry = {
             file_name: path.basename(mediaFile),
             data: mediaData,
             media_type: mediaType,
@@ -567,7 +567,7 @@ export abstract class ModelHandler {
    * Formats image content into provider-specific message format.
    * @returns Array of formatted image/document content objects
    */
-  abstract createMediaContent(mediaMessage: any[]): any[];
+  abstract createMediaContent(mediaMessage: MediaEntry[]): any[];
 
   /**
    * Extracts the response text and metadata from the model's response object

--- a/src/agent/mediaTypes.ts
+++ b/src/agent/mediaTypes.ts
@@ -1,5 +1,5 @@
 /**
- * Structured representation of media data used when constructing 
+ * Structured representation of media data used when constructing
  * multi-modal messages before provider-specific formatting.
  */
 export interface MediaEntry {

--- a/src/agent/mediaTypes.ts
+++ b/src/agent/mediaTypes.ts
@@ -1,0 +1,14 @@
+/**
+ * Structured representation of media data used when constructing 
+ * multi-modal messages before provider-specific formatting.
+ */
+export interface MediaEntry {
+  /** File name for reference, typically without directory */
+  file_name: string;
+  /** Base64 encoded media content */
+  data: string;
+  /** MIME type of the media */
+  media_type: string;
+  /** Category of the media, e.g. 'image' or 'audio' */
+  media_category: string;
+}

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -32,6 +32,7 @@ import {
   ResponseUsageFactory,
 } from './ResponseUsage';
 import { ToolState } from './ToolState';
+import { MediaEntry } from './mediaTypes';
 import { AgentStateRound } from './AgentState';
 import { messageToSkeleton } from './messageUtils';
 import { getConfig } from '../utils/configUtils';
@@ -255,7 +256,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
   }
 
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */
-  createMediaContent(mediaMessage: any[]): ContentBlock[] {
+  createMediaContent(mediaMessage: MediaEntry[]): ContentBlock[] {
     if (mediaMessage.length === 0) {
       return [];
     }

--- a/src/agent/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlerDashScope.ts
@@ -7,6 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from './ToolState';
+import { MediaEntry } from './mediaTypes';
 
 // Local imports - utilities
 import { convertContentToString } from '../utils/messageUtils';
@@ -114,7 +115,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
    * Creates media content formatted for DashScope Qwen-VL models
    * Overrides the parent method to handle DashScope-specific formatting
    */
-  createMediaContent(mediaMessage: any[]): any[] {
+  createMediaContent(mediaMessage: MediaEntry[]): any[] {
     return mediaMessage.flatMap((media): any[] => {
       if (media.media_category === 'image') {
         return [

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -19,6 +19,7 @@ import { AgentSetting, hasEndTag } from './AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from './AgentState';
 import { ToolState } from './ToolState';
 import { OpenAIAPIResponseUsage, ResponseUsageFactory } from './ResponseUsage';
+import { MediaEntry } from './mediaTypes';
 
 // Local imports - utilities
 import {
@@ -430,7 +431,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     return messages;
   }
 
-  createMediaContent(mediaMessage: any[]): any[] {
+  createMediaContent(mediaMessage: MediaEntry[]): any[] {
     this.logger.warn(
       'createMediaContent called on ModelHandlerGoogleGenAI - should be obsolete.',
     );

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -314,6 +314,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       `Determining MIME type for extension: '${ext}' from file: ${filePath}`,
     );
 
+    // TODO: this map/function can be put somewhere else to be more DRY and reusable
     const mimeMap: { [key: string]: string } = {
       '.jpg': 'image/jpeg',
       '.jpeg': 'image/jpeg',

--- a/src/agent/modelHandlerKimi.ts
+++ b/src/agent/modelHandlerKimi.ts
@@ -7,6 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from './ToolState';
+import { MediaEntry } from './mediaTypes';
 
 // Local imports - utilities
 import { convertContentToString } from '../utils/messageUtils';
@@ -202,7 +203,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
    * Creates media content formatted for Kimi models
    * Overrides the parent method to handle Kimi-specific formatting
    */
-  createMediaContent(mediaMessage: any[]): any[] {
+  createMediaContent(mediaMessage: MediaEntry[]): any[] {
     return mediaMessage.flatMap((media): any[] => {
       if (media.media_category === 'image') {
         return [

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -29,6 +29,7 @@ import { OpenAIAPIResponseUsage, ResponseUsageFactory } from './ResponseUsage';
 import { ToolState } from './ToolState';
 import { K_SLICE } from '../utils/constants';
 import { calculateTokenPrice } from '../utils/priceUtils';
+import { MediaEntry } from './mediaTypes';
 
 /**
  * OpenAI-specific handlers.
@@ -274,7 +275,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
   }
 
   /** Formats image/audio content for OpenAI/Google's vision/audio API. */
-  createMediaContent(mediaMessage: any[]): ChatCompletionContentPart[] {
+  createMediaContent(mediaMessage: MediaEntry[]): ChatCompletionContentPart[] {
     return mediaMessage.flatMap((media): ChatCompletionContentPart[] => {
       if (media.media_category === 'image') {
         return [
@@ -319,7 +320,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
             type: 'input_audio' as any, // Cast as any to bypass strict OpenAI typing for now
             input_audio: {
               data: media.data,
-              format: audioFormat,
+              format: audioFormat as any,
             },
           },
         ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "sourceMap": false,
     "rootDir": "src",
     "moduleResolution": "node",


### PR DESCRIPTION
## Summary
- add `MediaEntry` interface for media handling
- use `MediaEntry` in OpenAI and Anthropic handlers
- remove unused barrel `index.ts` files

## Testing
- `npm run lint`
- `npm test` *(fails: `vscode-test: not found`)*
- `npm run compile-tests`
