### PR TITLE
Clean up duplicate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ See [texra.ai](https://texra.ai). For detailed guides and usage instructions, vi
   - Smart merging of included files
 - YAML and XML configuration support
 - Git integration for version control
+- ProgressBoard view for detailed logs and re-running tasks
+- Multiple output support and intelligent merge tools
 
 ## Architecture
 
@@ -32,7 +34,7 @@ TeXRA is built as a TypeScript-based VS Code extension that provides:
 - Automatic figure and TikZ extraction
 - Version control integration (latexdiff functionality)
 - Customizable prompts and settings
-- Direct integration with OpenAI and Anthropic APIs
+- Direct integration with OpenAI, Anthropic, Google, DeepSeek, Moonshot (Kimi), and DashScope (Qwen) APIs with optional OpenRouter routing
 
 ## Installation Guide
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -38,31 +38,12 @@ Control which agents are available in the dropdown menu. Below is the default li
 
 ### Model Configuration
 
-Define which AI models appear in the model selection dropdown. The default list is:
+Define which AI models appear in the model selection dropdown. The current
+default list is maintained in the [Models Guide](./models.md). Override it by
+specifying your own model identifiers:
 
 ```json
-"texra.models": [
-  "sonnet37T",
-  "sonnet37",
-  "sonnet35",
-  "opus",
-  "o4-",
-  "o3",
-  "o3-",
-  "o1",
-  "gpt45",
-  "gpt4o",
-  "gpt4ol",
-  "gemini25p",
-  "gemini25f",
-  "gemini2p",
-  "gemini2f",
-  "gemini2fT",
-  "DSV3",
-  "DSR1",
-  "grok3",
-  "grok3-"
-]
+"texra.models": ["sonnet37T", "gpt4o"]
 ```
 
 ### API Provider Settings
@@ -228,7 +209,7 @@ For project-specific configurations, use workspace settings:
 ```json
 // .vscode/settings.json
 {
-  "texra.files.included.inputExtensions": [".tex", ".md", ".txt"],
+  "texra.files.included.inputExtensions": [".tex", ".md"],
   "texra.latex.tikzInputDirectory": "${workspaceFolder}/styles"
 }
 ```

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -96,21 +96,13 @@ TeXRA intelligently handles file paths to ensure proper document processing:
 
 ### File Path Configuration
 
-You can customize how TeXRA handles files by configuring file extensions and ignored paths in VS Code settings:
+You can customize file extensions and ignored paths in VS Code settings. The
+default values are listed in the [Configuration Guide](./configuration.md). A
+minimal example configuration might look like this:
 
 ```json
-"texra.files.included.inputExtensions": [
-  ".txt",
-  ".tex",
-  ".md"
-],
-"texra.files.ignored.directories": [
-  "build",
-  "node_modules",
-  "__pycache__",
-  "figures",
-  "venv"
-],
+"texra.files.included.inputExtensions": [".tex", ".md"],
+"texra.files.ignored.directories": ["build", "node_modules"]
 ```
 
 ## Output File Naming

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -65,6 +65,26 @@ Strong technical and coding performance, cost-effective.
 | `DSV3`   | Good coding & general tasks | $             | Fast           | DeepSeek V3 Chat |
 | `DSR1`   | Advanced reasoning          | $$            | Medium         | DeepSeek R1      |
 
+### Moonshot Kimi Models
+
+High context models from Moonshot, suitable for complex reasoning and large documents.
+
+| Model ID | Key Strength / Use Case        | Relative Cost | Relative Speed | Notes                 |
+| :------- | :----------------------------- | :------------ | :------------- | :-------------------- |
+| `kimit`  | Detailed reasoning with vision | $$$           | Medium         | Kimi Thinking Preview |
+| `kimi`   | Large context, general tasks   | $$            | Medium         | 128k context          |
+| `kimiv`  | Vision-enabled variant         | $$            | Medium         | 128k context, vision  |
+
+### DashScope Qwen Models
+
+Cost-effective models from Alibaba with strong multilingual capabilities.
+
+| Model ID    | Key Strength / Use Case       | Relative Cost | Relative Speed | Notes      |
+| :---------- | :---------------------------- | :------------ | :------------- | :--------- |
+| `qwenmax`   | Advanced reasoning            | $$            | Medium         | Qwen Max   |
+| `qwenplus`  | Large context general purpose | $$            | Medium         | Qwen Plus  |
+| `qwenturbo` | Fast responses                | $             | Fast           | Qwen Turbo |
+
 ### Grok / xAI Models
 
 Large context models from xAI.
@@ -108,20 +128,21 @@ The specific models available by default and their identifiers (`sonnet37`, `gpt
 "texra.models": [
   "sonnet37T",
   "sonnet37",
+  "o3",
+  "o4-",
   "o3-",
   "o1",
-  "gpt45",
+  "gpt41",
   "gpt4o",
-  "gpt4ol",
   "gemini25p",
   "gemini25f",
-  "gemini2p",
-  "gemini2f",
   "gemini2fT",
   "DSV3",
   "DSR1",
   "grok3",
-  "grok3-"
+  "qwenplus",
+  "kimit",
+  "kimiv"
 ]
 ```
 


### PR DESCRIPTION
## Summary
- remove the full default model list from `configuration.md`
- point file-management guide to configuration doc instead of repeating defaults
- trim example workspace settings

## Testing
- `npm run lint`
