### PR TITLE
Handle legacy font commands

### DIFF
--- a/src/replacement/replacementHelpers.ts
+++ b/src/replacement/replacementHelpers.ts
@@ -524,9 +524,6 @@ export function generateLegacyTextCommandNormalization(
   variantsToUse.forEach((v) => {
     terms.forEach((term) => {
       patterns[`{\\${v} ${term}}`] = `\\${targetCommand}{${term}}`;
-      patterns[`{\\${v} ${term}}}`] = `\\${targetCommand}{${term}}}`;
-      patterns[`{\\${v} ${term}}_`] = `\\${targetCommand}{${term}}_`;
-      patterns[`{\\${v} ${term}}^`] = `\\${targetCommand}{${term}}^`;
       // Handle {\rm{X}} style
       patterns[`{\\${v}{${term}}}`] = `\\${targetCommand}{${term}}`;
     });

--- a/src/replacement/replacementHelpers.ts
+++ b/src/replacement/replacementHelpers.ts
@@ -484,7 +484,7 @@ export function generateVectorShortcuts(
  *
  * @param terms List of terms to generate patterns for
  * @param targetCommand Target command to convert to (default: 'text')
- * @param variant Specific variant to convert from: 'mathrm', 'mbox', 'textrm', or 'rm'.
+ * @param variant Specific variant to convert from: 'mathrm', 'mbox', or 'textrm'.
  *                If not provided, handles all variants.
  */
 export function generateTextCommandNormalization(
@@ -495,27 +495,41 @@ export function generateTextCommandNormalization(
   const patterns: { [key: string]: string } = {};
 
   // Define all possible variants if none specified
-  const allVariants = ['mathrm', 'mbox', 'textrm', 'rm'];
+  const allVariants = ['mathrm', 'mbox', 'textrm'];
   const variantsToUse = variant ? [variant] : allVariants;
 
   variantsToUse.forEach((v) => {
-    if (v === 'rm') {
-      // Special handling for \rm which uses {\\rm XYZ} format
-      terms.forEach((term) => {
-        patterns[`{\\${v} ${term}}`] = `\\${targetCommand}{${term}}`;
-        // Also handle common scenarios with brackets
-        patterns[`{\\${v} ${term}}}`] = `\\${targetCommand}{${term}}}`;
-        // Handle with underscore
-        patterns[`{\\${v} ${term}}_`] = `\\${targetCommand}{${term}}_`;
-        // Handle with superscript
-        patterns[`{\\${v} ${term}}^`] = `\\${targetCommand}{${term}}^`;
-      });
-    } else {
-      // Standard handling for \mathrm{}, \mbox{}, \textrm{}
-      terms.forEach((term) => {
-        patterns[`\\${v}{${term}}`] = `\\${targetCommand}{${term}}`;
-      });
-    }
+    terms.forEach((term) => {
+      patterns[`\\${v}{${term}}`] = `\\${targetCommand}{${term}}`;
+    });
+  });
+
+  return patterns;
+}
+
+/**
+ * Generate patterns to normalize legacy font commands like {\rm X}, {\bf X},
+ * or {\cal X}.
+ */
+export function generateLegacyTextCommandNormalization(
+  terms: string[],
+  targetCommand: string,
+  variant?: string,
+): { [key: string]: string } {
+  const patterns: { [key: string]: string } = {};
+
+  const allVariants = ['rm', 'bf', 'cal'];
+  const variantsToUse = variant ? [variant] : allVariants;
+
+  variantsToUse.forEach((v) => {
+    terms.forEach((term) => {
+      patterns[`{\\${v} ${term}}`] = `\\${targetCommand}{${term}}`;
+      patterns[`{\\${v} ${term}}}`] = `\\${targetCommand}{${term}}}`;
+      patterns[`{\\${v} ${term}}_`] = `\\${targetCommand}{${term}}_`;
+      patterns[`{\\${v} ${term}}^`] = `\\${targetCommand}{${term}}^`;
+      // Handle {\rm{X}} style
+      patterns[`{\\${v}{${term}}}`] = `\\${targetCommand}{${term}}`;
+    });
   });
 
   return patterns;

--- a/src/replacement/replacementMax.ts
+++ b/src/replacement/replacementMax.ts
@@ -11,6 +11,8 @@ import {
   generateCommandShortcuts,
   generateArrowRelationShortcuts,
   generateBackslashFixes,
+  generateTextCommandNormalization,
+  generateLegacyTextCommandNormalization,
   GREEK_LETTERS,
 } from './replacementHelpers';
 
@@ -255,6 +257,22 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     Object.assign(
       patterns,
       generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
+    );
+
+    // Normalize legacy font commands {\rm X}, {\bf X} and {\cal X}
+    const alphabetLetters =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('');
+    Object.assign(
+      patterns,
+      generateLegacyTextCommandNormalization(alphabetLetters, 'mathrm', 'rm'),
+    );
+    Object.assign(
+      patterns,
+      generateLegacyTextCommandNormalization(alphabetLetters, 'mathbf', 'bf'),
+    );
+    Object.assign(
+      patterns,
+      generateLegacyTextCommandNormalization(alphabetLetters, 'mathcal', 'cal'),
     );
 
     // Tilde variables - simple letters


### PR DESCRIPTION
## Summary
- split legacy font normalization into a dedicated helper
- normalize `{\rm X}`, `{\bf X}` and `{\cal X}` patterns

## Testing
- `npx prettier -w src/replacement/replacementHelpers.ts src/replacement/replacementMax.ts`
