### PR TITLE
Centralize constants for previews and delays

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -56,7 +56,11 @@ import { messageToSkeleton } from './messageUtils';
 import { getConfig } from '../utils/configUtils';
 
 // Shared constants
-import { K_SLICE } from '../utils/constants';
+import {
+  K_SLICE,
+  SHORT_SLEEP_MS,
+  REPETITION_DETECTION_THRESHOLD,
+} from '../utils/constants';
 
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.
@@ -151,8 +155,8 @@ export abstract class BaseReflectionAgent {
    */
   protected async initializeClient(): Promise<void> {
     this.client = await this.modelHandler.getClient();
-    // wait for 50 mili seconds
-    await sleep(50);
+    // wait briefly to avoid rate limit issues
+    await sleep(SHORT_SLEEP_MS);
   }
 
   /**
@@ -601,7 +605,7 @@ export abstract class BaseReflectionAgent {
         );
         if (repetitionResult.massiveRepetitionDetected) {
           this.logger.error(
-            `The new response is (first 1000 chars): ${newResponse.substring(0, 1000)}`,
+            `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
             responseCycleGroupId,
           );
           this.logger.error(

--- a/src/agent/messageUtils.ts
+++ b/src/agent/messageUtils.ts
@@ -2,6 +2,8 @@
  * Utility functions for working with message objects in agent conversations.
  */
 
+import { MESSAGE_PREVIEW_LENGTH } from '../utils/constants';
+
 /**
  * Creates a skeleton representation of a message object for debugging.
  * Preserves structure while truncating content to avoid cluttering logs.
@@ -11,7 +13,7 @@
  */
 export function messageToSkeleton(
   message: any,
-  maxContentLength: number = 50,
+  maxContentLength: number = MESSAGE_PREVIEW_LENGTH,
 ): any {
   if (!message) {
     return null;

--- a/src/agent/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlerDashScope.ts
@@ -10,6 +10,7 @@ import { ToolState } from './ToolState';
 
 // Local imports - utilities
 import { convertContentToString } from '../utils/messageUtils';
+import { MESSAGE_PREVIEW_LENGTH } from '../utils/constants';
 
 /**
  * Handler for DashScope Qwen models using OpenAI-compatible API.
@@ -95,7 +96,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     processedMessages.forEach((msg, index) => {
       const contentPreview =
         typeof msg.content === 'string'
-          ? msg.content.substring(0, 50)
+          ? msg.content.substring(0, MESSAGE_PREVIEW_LENGTH)
           : 'non-string content';
       this.logger.debug(`Message ${index} (${msg.role}): ${contentPreview}...`);
     });

--- a/src/agent/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlerDeepSeek.ts
@@ -10,6 +10,7 @@ import { ToolState } from './ToolState';
 
 // Local imports - utilities
 import { convertContentToString } from '../utils/messageUtils';
+import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '../utils/constants';
 
 /**
  * Handler for DeepSeek models using OpenAI-compatible API.
@@ -82,7 +83,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
 
     // Log preview of thinking content (assuming it's a string)
     this.logger.debug(
-      `DeepSeek reasoning content preview: ${reasoningContent.substring(0, 200)}...`,
+      `DeepSeek reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
       groupId,
     );
 
@@ -197,7 +198,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     processedMessages.forEach((msg, index) => {
       const contentPreview =
         typeof msg.content === 'string'
-          ? msg.content.substring(0, 50)
+          ? msg.content.substring(0, MESSAGE_PREVIEW_LENGTH)
           : 'non-string content';
       this.logger.debug(`Message ${index} (${msg.role}): ${contentPreview}...`);
     });

--- a/src/agent/modelHandlerKimi.ts
+++ b/src/agent/modelHandlerKimi.ts
@@ -10,6 +10,7 @@ import { ToolState } from './ToolState';
 
 // Local imports - utilities
 import { convertContentToString } from '../utils/messageUtils';
+import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '../utils/constants';
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
@@ -86,7 +87,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
 
     // Log preview of thinking content
     this.logger.debug(
-      `Kimi thinking content preview: ${reasoningContent.substring(0, 200)}...`,
+      `Kimi thinking content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
       groupId,
     );
 
@@ -150,7 +151,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     processedMessages.forEach((msg, index) => {
       const contentPreview =
         typeof msg.content === 'string'
-          ? msg.content.substring(0, 50)
+          ? msg.content.substring(0, MESSAGE_PREVIEW_LENGTH)
           : 'non-string content';
       this.logger.debug(`Message ${index} (${msg.role}): ${contentPreview}...`);
     });

--- a/src/agent/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlerOpenRouter.ts
@@ -7,6 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from './ToolState';
+import { K_SLICE } from '../utils/constants';
 
 /**
  * Handler for models accessed through OpenRouter.
@@ -94,7 +95,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       // Log preview of reasoning content
       if (typeof reasoning === 'string') {
         this.logger.debug(
-          `Reasoning preview: ${reasoning.substring(0, 200)}...`,
+          `Reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
           groupId,
         );
         return reasoning;
@@ -102,7 +103,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
         // If reasoning is an object, convert to string
         const reasoningStr = JSON.stringify(reasoning);
         this.logger.debug(
-          `Reasoning preview: ${reasoningStr.substring(0, 200)}...`,
+          `Reasoning preview: ${reasoningStr.substring(0, K_SLICE)}...`,
           groupId,
         );
         return reasoningStr;

--- a/src/agent/modelHandlerXAI.ts
+++ b/src/agent/modelHandlerXAI.ts
@@ -7,6 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from './ToolState';
+import { K_SLICE } from '../utils/constants';
 
 /**
  * Handler for xAI models using OpenAI-compatible API.
@@ -76,7 +77,7 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
 
     // Log preview of thinking content
     this.logger.debug(
-      `xAI reasoning content preview: ${reasoningContent.substring(0, 200)}...`,
+      `xAI reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
       groupId,
     );
 

--- a/src/commands/wolframScriptCommands.ts
+++ b/src/commands/wolframScriptCommands.ts
@@ -7,6 +7,7 @@ import {
   executeWolframCode,
   executeWolframScriptFile,
 } from '../WolframTool/wolframScriptUtils';
+import { REPETITION_DETECTION_THRESHOLD } from '../utils/constants';
 
 export const wolframScriptCommands = {
   testWolframScript: 'texra.testWolframScript',
@@ -217,8 +218,8 @@ export function registerWolframScriptCommands(
         // Read a sample of the file content to display in the result
         const fileContent = editor.document.getText();
         const sampleContent =
-          fileContent.length > 1000
-            ? `${fileContent.substring(0, 1000)}...`
+          fileContent.length > REPETITION_DETECTION_THRESHOLD
+            ? `${fileContent.substring(0, REPETITION_DETECTION_THRESHOLD)}...`
             : fileContent;
 
         // Create a webview panel to display the result

--- a/src/commands/wolframScriptCommands.ts
+++ b/src/commands/wolframScriptCommands.ts
@@ -7,7 +7,7 @@ import {
   executeWolframCode,
   executeWolframScriptFile,
 } from '../WolframTool/wolframScriptUtils';
-import { REPETITION_DETECTION_THRESHOLD } from '../utils/constants';
+import { MAX_PREVIEW_LENGTH } from '../utils/constants';
 
 export const wolframScriptCommands = {
   testWolframScript: 'texra.testWolframScript',
@@ -218,8 +218,8 @@ export function registerWolframScriptCommands(
         // Read a sample of the file content to display in the result
         const fileContent = editor.document.getText();
         const sampleContent =
-          fileContent.length > REPETITION_DETECTION_THRESHOLD
-            ? `${fileContent.substring(0, REPETITION_DETECTION_THRESHOLD)}...`
+          fileContent.length > MAX_PREVIEW_LENGTH
+            ? `${fileContent.substring(0, MAX_PREVIEW_LENGTH)}...`
             : fileContent;
 
         // Create a webview panel to display the result

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -4,6 +4,7 @@
 // Local imports - log
 import * as logger from './logUtils';
 import { sleep } from '../utils/timeUtils';
+import { SHORT_SLEEP_MS } from '../utils/constants';
 
 /**
  * Encapsulates logging functionality for agents with a dedicated channel.
@@ -43,8 +44,8 @@ export class AgentLogger {
     id?: string,
     parentGroupId?: string,
   ): Promise<string> {
-    // wait for 50 mili seconds
-    await sleep(50);
+    // brief delay to ensure log order
+    await sleep(SHORT_SLEEP_MS);
     return logger.startGroup(this.channelId, groupName, id, parentGroupId);
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -30,5 +30,8 @@ export const MESSAGE_PREVIEW_LENGTH = 50;
 export const REPETITION_PREVIEW_LENGTH = 400;
 export const REPETITION_DETECTION_THRESHOLD = 1000;
 
+// for file preview
+export const MAX_PREVIEW_LENGTH = 1000;
+
 // Time constants
 export const SHORT_SLEEP_MS = 50;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,3 +24,11 @@ export const TOOL_CONFIG_FIELDS = [
 
 // Length for preview slices of tool output and responses
 export const K_SLICE = 200;
+
+// Generic preview lengths for logging and repetition checks
+export const MESSAGE_PREVIEW_LENGTH = 50;
+export const REPETITION_PREVIEW_LENGTH = 400;
+export const REPETITION_DETECTION_THRESHOLD = 1000;
+
+// Time constants
+export const SHORT_SLEEP_MS = 50;

--- a/src/utils/repetitionUtils.ts
+++ b/src/utils/repetitionUtils.ts
@@ -24,6 +24,8 @@ export interface RepetitionResult {
 /**
  * Checks for massive repetition using diff-match-patch
  */
+
+// TODO: the following functions seem not DRY. Need to refactor into one with the more prominent used one as the default.
 export function checkForMassiveRepetition(
   lastResponse: string,
   newResponse: string,

--- a/src/utils/repetitionUtils.ts
+++ b/src/utils/repetitionUtils.ts
@@ -7,6 +7,10 @@ import * as difflib from 'difflib';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
+import {
+  REPETITION_DETECTION_THRESHOLD,
+  REPETITION_PREVIEW_LENGTH,
+} from './constants';
 
 const CHANNEL = 'repetitionUtils';
 logger.initialize(CHANNEL);
@@ -43,13 +47,14 @@ export function checkForMassiveRepetition(
     );
     const ratio =
       (2.0 * matchLength) / (lastResponse.length + newResponse.length);
-    const massiveRepetitionDetected = longestMatch.length > 1000;
+    const massiveRepetitionDetected =
+      longestMatch.length > REPETITION_DETECTION_THRESHOLD;
 
     if (massiveRepetitionDetected) {
       logger.error(CHANNEL, `Repetition ratio: ${ratio}`);
       logger.error(
         CHANNEL,
-        `Longest matching substring(preview): ${longestMatch.slice(0, 400)}`,
+        `Longest matching substring(preview): ${longestMatch.slice(0, REPETITION_PREVIEW_LENGTH)}`,
       );
       logger.error(CHANNEL, 'Massive repetition detected - stopping process.');
     }
@@ -89,13 +94,14 @@ export function checkRepetitionDifflib(
       newResponse.length,
     );
     const longestMatch = lastResponse.slice(match[0], match[0] + match[2]);
-    const massiveRepetitionDetected = longestMatch.length > 1000;
+    const massiveRepetitionDetected =
+      longestMatch.length > REPETITION_DETECTION_THRESHOLD;
 
     if (massiveRepetitionDetected) {
       logger.debug(CHANNEL, `Repetition ratio: ${ratio}`);
       logger.debug(
         CHANNEL,
-        `Longest matching substring (preview): ${longestMatch.slice(0, 400)}`,
+        `Longest matching substring (preview): ${longestMatch.slice(0, REPETITION_PREVIEW_LENGTH)}`,
       );
       logger.error(CHANNEL, 'Massive repetition detected - stopping process.');
     }

--- a/src/utils/xmlUtils.ts
+++ b/src/utils/xmlUtils.ts
@@ -1,6 +1,7 @@
 // Local imports - log
 import * as logger from '../logger/logUtils';
 import { AgentLogger } from '../logger/AgentLogger';
+import { K_SLICE } from './constants';
 
 const CHANNEL = 'xmlUtils';
 logger.initialize(CHANNEL);
@@ -247,7 +248,7 @@ export function formatAndLogContent(
   // Log original content for debugging
   logger.debug(
     CHANNEL,
-    `Original ${contentType.toLowerCase()} content before formatting: ${content.substring(0, 200)}${content.length > 200 ? '...' : ''}`,
+    `Original ${contentType.toLowerCase()} content before formatting: ${content.substring(0, K_SLICE)}${content.length > K_SLICE ? '...' : ''}`,
   );
 
   // Format the content for improved rendering


### PR DESCRIPTION
## Summary
- add new logging and time constants in `constants.ts`
- apply `MESSAGE_PREVIEW_LENGTH`, `K_SLICE`, and repetition constants across agent handlers and utils
- replace magic numbers in logger and wolfram commands with shared constants

## Testing
- `npm test` *(fails: Cannot find name 'ErrorEvent')*