### PR TITLE
Remove thin latexdiff wrappers

### DIFF
--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -26,9 +26,9 @@ import {
   runLatexdiff,
   runLatexdiffForRound,
   runLatexdiffBetweenRounds,
-  ensureLatexdiffInstalled,
   LaTeXdiffResult,
 } from '../latex/latexdiff';
+import { checkToolInstalled } from '../latex/texTools';
 import { runLatexIndent } from '../latex/latexindent';
 
 // Local imports - agent components
@@ -355,7 +355,7 @@ export class OutputHandler {
 
     try {
       // Check if latexdiff is installed before proceeding
-      if (!(await ensureLatexdiffInstalled())) {
+      if (!(await checkToolInstalled('latexdiff'))) {
         this.logger.warn(
           'Skipping latexdiff operations - latexdiff not installed',
           diffProcessGroupId,

--- a/src/commands/latexdiffCommands.ts
+++ b/src/commands/latexdiffCommands.ts
@@ -15,11 +15,10 @@ import { fileExists } from '../utils/workspaceFileUtils';
 import {
   runLatexdiff,
   runLatexdiffvc,
-  ensureLatexdiffInstalled,
-  ensureLatexdiffVcInstalled,
   runLatexdiffForRound,
   runLatexdiffBetweenRounds,
 } from '../latex/latexdiff';
+import { checkToolInstalled } from '../latex/texTools';
 
 // Local imports - housekeeping
 import {
@@ -67,7 +66,7 @@ async function handleLatexdiff(
   const fileToUse = baseFile || inputFile;
   try {
     // Check if latexdiff is installed
-    if (!(await ensureLatexdiffInstalled())) {
+    if (!(await checkToolInstalled('latexdiff'))) {
       return;
     }
 
@@ -130,7 +129,7 @@ async function handleLatexdiffvc(
   const fileToUse = baseFile || inputFile;
   try {
     // Check if latexdiff-vc is installed
-    if (!(await ensureLatexdiffVcInstalled())) {
+    if (!(await checkToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -189,7 +188,7 @@ async function handlePackLatexdiffvc(
 ) {
   try {
     // Check if latexdiff-vc is installed
-    if (!(await ensureLatexdiffVcInstalled())) {
+    if (!(await checkToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -213,7 +212,7 @@ async function handlePackLatexdiffvcMultiple(
 ) {
   try {
     // Check if latexdiff-vc is installed
-    if (!(await ensureLatexdiffVcInstalled())) {
+    if (!(await checkToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -237,7 +236,7 @@ async function handleCleanLatexdiffvc(
 ) {
   try {
     // Check if latexdiff-vc is installed
-    if (!(await ensureLatexdiffVcInstalled())) {
+    if (!(await checkToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -260,7 +259,7 @@ async function handleCleanLatexdiffvcMultiple(
 ) {
   try {
     // Check if latexdiff-vc is installed
-    if (!(await ensureLatexdiffVcInstalled())) {
+    if (!(await checkToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -286,7 +285,7 @@ async function handleRunLatexdiff(config: any) {
     );
 
     // Check if latexdiff is installed
-    if (!(await ensureLatexdiffInstalled())) {
+    if (!(await checkToolInstalled('latexdiff'))) {
       return;
     }
 

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -42,23 +42,6 @@ export interface LaTeXdiffMultipleResult {
   message?: string;
 }
 
-/**
- * Checks if latexdiff is installed and shows error if not
- */
-export async function ensureLatexdiffInstalled(
-  showError: boolean = true,
-): Promise<boolean> {
-  return checkToolInstalled('latexdiff', showError);
-}
-
-/**
- * Checks if latexdiff-vc is installed and shows error if not
- */
-export async function ensureLatexdiffVcInstalled(
-  showError: boolean = true,
-): Promise<boolean> {
-  return checkToolInstalled('latexdiff-vc', showError);
-}
 
 async function processDiffFile(
   diffFileName: string,

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -98,23 +98,6 @@ export async function checkToolInstalled(
   }
 }
 
-// Specific tool check functions for backward compatibility
-export async function checkLatexdiffInstalled(): Promise<boolean> {
-  return checkToolInstalled('latexdiff', false);
-}
-
-export async function checkLatexdiffVcInstalled(): Promise<boolean> {
-  return checkToolInstalled('latexdiff-vc', false);
-}
-
-export async function checkLatexindentInstalled(): Promise<boolean> {
-  return checkToolInstalled('latexindent', false);
-}
-
-export async function checkTexcountInstalled(): Promise<boolean> {
-  return checkToolInstalled('texcount', false);
-}
-
 /**
  * Compile a LaTeX file to PDF
  * @param latexFile Path to the LaTeX file


### PR DESCRIPTION
## Summary
- delete `ensureLatexdiffInstalled`/`ensureLatexdiffVcInstalled`
- call `checkToolInstalled` directly in latex diff handlers
- drop unused wrappers in `texTools`

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find name 'ErrorEvent')*