### PR TITLE
Refactor: remove extra factory wrappers

### DIFF
--- a/src/AnthropicTool/AnthropicToolAgent.ts
+++ b/src/AnthropicTool/AnthropicToolAgent.ts
@@ -64,23 +64,12 @@ export abstract class AnthropicToolAgent<
   }
 
   /**
-   * Standard public method to fix issues in a file
-   * Clients should call this method rather than the protected runFixIssues
+   * Fix issues in the specified file.
    *
    * @param filePath Path to the file to fix
    * @returns Whether the fixing was successful
    */
   public async fixIssues(filePath: string): Promise<boolean> {
-    return this.runFixIssues(filePath);
-  }
-
-  /**
-   * Protected method that implements the fixing logic
-   *
-   * @param filePath Path to the file to fix
-   * @returns Whether the fixing was successful
-   */
-  protected async runFixIssues(filePath: string): Promise<boolean> {
     logger.info(CHANNEL, `Starting issue fixing for ${filePath}`);
 
     try {

--- a/src/AnthropicTool/TeXLinterFixAgent.ts
+++ b/src/AnthropicTool/TeXLinterFixAgent.ts
@@ -22,12 +22,6 @@ logger.initialize(CHANNEL);
  * Agent that fixes linter issues in TeX files using Claude
  */
 export class TeXLinterFixAgent extends AnthropicToolAgent<LinterMessage[]> {
-  /**
-   * Static factory method to create a TeXLinterFixAgent instance
-   */
-  public static create(): TeXLinterFixAgent {
-    return new TeXLinterFixAgent();
-  }
 
   /**
    * Validate if the file has any linter issues

--- a/src/AnthropicTool/XMLValidatorAgent.ts
+++ b/src/AnthropicTool/XMLValidatorAgent.ts
@@ -22,12 +22,6 @@ logger.initialize(CHANNEL);
  * Agent that validates XML files and fixes validation errors using Claude
  */
 export class XMLValidatorAgent extends AnthropicToolAgent<XMLValidationError> {
-  /**
-   * Static factory method to create an XMLValidatorAgent instance
-   */
-  public static create(): XMLValidatorAgent {
-    return new XMLValidatorAgent();
-  }
 
   /**
    * Validate XML file

--- a/src/commands/linterCommands.ts
+++ b/src/commands/linterCommands.ts
@@ -178,7 +178,7 @@ export async function handleFixLinterIssues(): Promise<void> {
     );
 
     // Create the agent
-    const linterFixAgent = TeXLinterFixAgent.create();
+    const linterFixAgent = new TeXLinterFixAgent();
 
     // Show progress indicator
     await vscode.window.withProgress(

--- a/src/commands/xmlCommands.ts
+++ b/src/commands/xmlCommands.ts
@@ -106,7 +106,7 @@ export async function handleValidateAndFixXml(): Promise<void> {
     }
 
     // Initialize the validator agent
-    const validator = XMLValidatorAgent.create();
+    const validator = new XMLValidatorAgent();
 
     // Save the file first to make sure we're working with the latest content
     await editor.document.save();


### PR DESCRIPTION
## Summary
- drop unused `create` factories from agents
- instantiate agents directly in command handlers

## Testing
- `npm run lint`
- `npm run compile-tests` *(fails: Cannot find name 'ErrorEvent')*
- `npm test` *(fails during compile-tests step)*