### PR TITLE
Refine multi-round guide

### DIFF
--- a/docs/guide/multi-round.md
+++ b/docs/guide/multi-round.md
@@ -1,0 +1,25 @@
+# Towards Multi-round Agents
+
+This document outlines initial considerations for extending `BaseReflectionAgent` to handle more than the current two rounds (process and optional reflection).
+
+## Infrastructure Needs
+
+- **Configuration**
+  - Introduce a `rounds` field in `ToolConfig` so a workflow can define how many sequential steps to perform.
+  - Prompts may need to support an array of `userReflect` templates or reuse a single template for each additional round.
+
+- **State Management**
+  - The agent already tracks `AgentStateRound` and `AgentStateGlobal` which are not tied to a fixed number of rounds. These classes should work for arbitrary counts as long as arrays are sized dynamically.
+  - `OutputHandler` stores processed files per round in `outputFiles[currRound]`; this can naturally extend to more rounds.
+
+- **Agent Core Logic**
+  - Refactor `BaseReflectionAgent` so `run()` iterates over rounds rather than calling `process()` and `reflect()` only once. Each iteration would:
+    1. Render prompts for the current round.
+    2. Invoke `processResponseCycle`.
+    3. Run `handleRoundCompletion`.
+  - The `outputFile` property has been changed to an array to simplify managing an arbitrary number of round outputs.
+
+- **Prompt Rendering**
+  - New helper methods may be needed to retrieve the correct `prefill` and prompt text for each round.
+
+These changes should provide a smoother path to implementing true multi-round workflows in the future.

--- a/docs/next/multi-round.md
+++ b/docs/next/multi-round.md
@@ -22,4 +22,4 @@ This document outlines initial considerations for extending `BaseReflectionAgent
 - **Prompt Rendering**
   - New helper methods may be needed to retrieve the correct `prefill` and prompt text for each round.
 
-These changes should provide a smoother path to implementing true multi-round workflows in the future.
+These changes should provide a smoother path to implementing true multi-round workflows in the future. Nothing is yet decided on this yet.

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -69,7 +69,8 @@ export abstract class BaseReflectionAgent {
   protected agentSetting: AgentSetting;
   protected agentPrompt: AgentPrompt;
   protected agentPath: string;
-  protected outputFile: [string, string];
+  /** File paths for each round's raw model output. */
+  protected outputFile: string[];
   protected outputFiles: { [key: number]: string[] };
   protected baseFiles: string[];
   protected client: any;
@@ -113,7 +114,7 @@ export abstract class BaseReflectionAgent {
     this.modelHandler.setLogger(this.logger);
 
     // Initialize basic attributes
-    this.outputFile = ['', ''];
+    this.outputFile = [];
     this.outputFiles = { 0: [], 1: [] };
     this.baseFiles = this.agentConfig.outputFiles || [
       this.agentConfig.inputFile,
@@ -125,7 +126,7 @@ export abstract class BaseReflectionAgent {
     this.useScratchpad =
       this.agentSetting.prefills?.includes('<scratchpad>') || false;
 
-    // Set output files
+    // Set output files for the existing two rounds
     this.outputFile[0] = this.getOutputFile(0);
     this.outputFile[1] = this.getOutputFile(1);
 


### PR DESCRIPTION
## Summary
- document round counts instead of `maxRounds`
- tweak output file comment for clarity

## Testing
- `npm run lint`
- `npm test` *(fails: ErrorEvent/CloseEvent types not found)*