### PR TITLE
refactor: drop unnecessary initializers

### DIFF
--- a/src/agent/AgentState.ts
+++ b/src/agent/AgentState.ts
@@ -41,7 +41,6 @@ export class AgentStateRound implements IAgentStateRound {
     this.APIUsage = null;
   }
 
-
   /** Updates token usage metrics from model API response. */
   updateTokenCounts(
     responseUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage,
@@ -102,7 +101,6 @@ export class AgentStateGlobal implements IAgentStateGlobal {
     this.totalRounds = 0;
     this.APIUsage = null;
   }
-
 
   /** Updates global metrics by incorporating round state data. */
   updateFromCurrRound(stateRound: AgentStateRound): void {

--- a/src/agent/AgentState.ts
+++ b/src/agent/AgentState.ts
@@ -33,7 +33,7 @@ export class AgentStateRound implements IAgentStateRound {
   outputFile: string;
   APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
 
-  private constructor(currRound: number) {
+  constructor(currRound: number) {
     this.currRound = currRound;
     this.continuationCount = 0;
     this.responseTime = 0;
@@ -41,10 +41,6 @@ export class AgentStateRound implements IAgentStateRound {
     this.APIUsage = null;
   }
 
-  /** Creates a new AgentStateRound instance with initial values. */
-  static initialize(currRound: number): AgentStateRound {
-    return new AgentStateRound(currRound);
-  }
 
   /** Updates token usage metrics from model API response. */
   updateTokenCounts(
@@ -98,7 +94,7 @@ export class AgentStateGlobal implements IAgentStateGlobal {
   public totalCacheCreationInputTokens: number = 0;
   public totalReasoningTokens: number = 0;
 
-  private constructor() {
+  constructor() {
     this.firstInputTokens = 0;
     this.totalResponseTime = 0;
     this.totalInputTokens = 0;
@@ -107,10 +103,6 @@ export class AgentStateGlobal implements IAgentStateGlobal {
     this.APIUsage = null;
   }
 
-  /** Creates a new AgentStateGlobal instance with zeroed metrics. */
-  static initialize(): AgentStateGlobal {
-    return new AgentStateGlobal();
-  }
 
   /** Updates global metrics by incorporating round state data. */
   updateFromCurrRound(stateRound: AgentStateRound): void {
@@ -184,7 +176,7 @@ export class AgentStateGlobal implements IAgentStateGlobal {
   /** Creates an AgentStateGlobal instance from a persisted state object. */
   static fromObject(stateObj: Record<string, any> | null): AgentStateGlobal {
     if (!stateObj) {
-      return AgentStateGlobal.initialize();
+      return new AgentStateGlobal();
     }
 
     const state = new AgentStateGlobal();

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -861,11 +861,11 @@ export abstract class BaseReflectionAgent {
       this.agentConfig.inputFile,
       ...(this.agentConfig.inputFiles || []),
     ];
-    const toolState = ToolState.initialize();
+    const toolState = new ToolState();
 
     // Initialize state and messages
     const currRound = 0;
-    const stateGlobal = AgentStateGlobal.initialize();
+    const stateGlobal = new AgentStateGlobal();
 
     this.logger.info(`Processing round ${currRound}`);
 
@@ -975,7 +975,7 @@ export abstract class BaseReflectionAgent {
           prefill,
         );
 
-      const stateRound = AgentStateRound.initialize(currRound);
+      const stateRound = new AgentStateRound(currRound);
       let finalEndTurn = endTurn;
 
       if (!endTurn) {
@@ -1095,7 +1095,7 @@ export abstract class BaseReflectionAgent {
       }
 
       // Initialize reflection round
-      const stateRound = AgentStateRound.initialize(currRound);
+      const stateRound = new AgentStateRound(currRound);
 
       // Prepare reflection message
       const userRequestReflect = await renderPrompt(
@@ -1210,7 +1210,7 @@ export abstract class BaseReflectionAgent {
         this.agentConfig.toolConfig.reflect &&
         endTurn
       ) {
-        const toolStateReflection = ToolState.initialize();
+        const toolStateReflection = new ToolState();
         await this.reflect(stateGlobal, messages, toolStateReflection);
         this.logger.info(`Round 1 completed\n`, this.runGroupId);
       }

--- a/src/agent/ToolState.ts
+++ b/src/agent/ToolState.ts
@@ -44,7 +44,7 @@ export class ToolState implements IToolState {
     return this.thinkingBlocks.length > 0 ? this.thinkingBlocks[0] : null;
   }
 
-  private constructor() {
+  constructor() {
     this.texcountStats = null;
     this.firstKCharsFromInput = null;
     this.lastResponse = '';
@@ -54,10 +54,6 @@ export class ToolState implements IToolState {
     this.thinkingAdded = false;
   }
 
-  /** Creates a new ToolState instance with initialized values. */
-  static initialize(): ToolState {
-    return new ToolState();
-  }
 
   /**
    * Updates the most recent model response.

--- a/src/agent/ToolState.ts
+++ b/src/agent/ToolState.ts
@@ -54,7 +54,6 @@ export class ToolState implements IToolState {
     this.thinkingAdded = false;
   }
 
-
   /**
    * Updates the most recent model response.
    * @param response New response text from the model

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -508,7 +508,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     if (!this.capabilities.supportsAssistantPrefill) {
       // For models that don't support assistant prefill, we need to:
       // add a continuation message in addition
-      const state = AgentStateRound.initialize(0);
+      const state = new AgentStateRound(0);
       this.addContinueMessageWithoutPrefill(
         messages,
         state,

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -703,7 +703,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     );
     toolState.updateAccumulatedOutput(fileContent);
     toolState.lastResponse = fileContent;
-    const state = AgentStateRound.initialize(0);
+    const state = new AgentStateRound(0);
     this.addContinueMessageWithoutPrefill(
       messages,
       state,

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -527,7 +527,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
       toolState.updateAccumulatedOutput(prefill + fileContent);
       await writeFile(outputFile, toolState.accumulatedOutput);
     }
-    const state = AgentStateRound.initialize(0);
+    const state = new AgentStateRound(0);
     toolState.lastResponse = toolState.accumulatedOutput;
     this.addContinueMessageWithoutPrefill(
       messages,


### PR DESCRIPTION
## Summary
- drop static initialize methods from tool and state classes
- construct new instances directly
- update all usages of removed initializers

## Testing
- `npm test` *(fails: cannot find name 'ErrorEvent' in @google/genai typings)*