### PR TITLE
Clean up unused styles

### DIFF
--- a/docs/next/multi-round.md
+++ b/docs/next/multi-round.md
@@ -5,14 +5,17 @@ This document outlines initial considerations for extending `BaseReflectionAgent
 ## Infrastructure Needs
 
 - **Configuration**
+
   - Introduce a `rounds` field in `ToolConfig` so a workflow can define how many sequential steps to perform.
   - Prompts may need to support an array of `userReflect` templates or reuse a single template for each additional round.
 
 - **State Management**
+
   - The agent already tracks `AgentStateRound` and `AgentStateGlobal` which are not tied to a fixed number of rounds. These classes should work for arbitrary counts as long as arrays are sized dynamically.
   - `OutputHandler` stores processed files per round in `outputFiles[currRound]`; this can naturally extend to more rounds.
 
 - **Agent Core Logic**
+
   - Refactor `BaseReflectionAgent` so `run()` iterates over rounds rather than calling `process()` and `reflect()` only once. Each iteration would:
     1. Render prompts for the current round.
     2. Invoke `processResponseCycle`.

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -177,7 +177,6 @@
   margin-right: var(--spacing-small);
 }
 
-
 /* Dropdown/Select styling */
 select {
   padding: 4px 8px;
@@ -201,8 +200,3 @@ select:focus {
   align-items: center;
   margin-bottom: var(--spacing-medium);
 }
-
-.section-header-between {
-  justify-content: space-between;
-}
-

--- a/src/progressView/styles/base.css
+++ b/src/progressView/styles/base.css
@@ -39,6 +39,20 @@ body {
   background-color: var(--vscode-focusBorder);
 }
 
+.gutter-horizontal {
+  cursor: col-resize;
+  width: 1px;
+}
+
+.gutter-horizontal::after {
+  content: '';
+  position: absolute;
+  left: -4px;
+  right: -4px;
+  top: 0;
+  bottom: 0;
+}
+
 /* Animations */
 /* Animation for status indicator */
 @keyframes pulse {

--- a/src/progressView/styles/base.css
+++ b/src/progressView/styles/base.css
@@ -39,20 +39,6 @@ body {
   background-color: var(--vscode-focusBorder);
 }
 
-.gutter-horizontal {
-  cursor: col-resize;
-  width: 1px;
-}
-
-.gutter-horizontal::after {
-  content: '';
-  position: absolute;
-  left: -4px;
-  right: -4px;
-  top: 0;
-  bottom: 0;
-}
-
 /* Animations */
 /* Animation for status indicator */
 @keyframes pulse {

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -144,8 +144,3 @@
   background-color: var(--vscode-testing-iconSkipped, #cca700);
   box-shadow: 0 0 4px var(--vscode-testing-iconSkipped, #cca700);
 }
-
-/* Basic status color class */
-.error {
-  color: inherit;
-}

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -145,10 +145,7 @@
   box-shadow: 0 0 4px var(--vscode-testing-iconSkipped, #cca700);
 }
 
-/* Basic status color classes */
-.debug,
-.info,
-.warn,
+/* Basic status color class */
 .error {
   color: inherit;
 }

--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -57,7 +57,6 @@ body {
   cursor: pointer;
 }
 
-
 /* Input field */
 .vscode-input {
   width: 100%;
@@ -78,16 +77,6 @@ body {
 
 .vscode-input::placeholder {
   color: var(--vscode-input-placeholderForeground);
-}
-
-.input-container {
-  width: 100%;
-  margin: var(--spacing-small) 0;
-}
-
-/* Basic section styling */
-.section {
-  margin-bottom: var(--spacing-small);
 }
 
 .section-header {

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -78,20 +78,3 @@
   right: 16px;
   z-index: 10;
 }
-
-/* Checkbox group within instruction box */
-.checkbox-group {
-  display: flex;
-  gap: 1px;
-  flex-direction: column;
-}
-
-.checkbox-group label {
-  display: flex;
-  align-items: center;
-  font-size: var(--font-size);
-}
-
-.checkbox-group input[type='checkbox'] {
-  margin-right: var(--spacing-small);
-}


### PR DESCRIPTION
## Summary
- remove unused `.input-container` and `.section` rules
- drop old checkbox group layout
- remove unused gutter styles and simplify status color classes
- drop `.section-header-between`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find name 'ErrorEvent')*