### PR TITLE
Refactor user variable logic

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -224,7 +224,6 @@ export abstract class BaseReflectionAgent {
     );
   }
 
-
   /**
    * Manages single response cycle with model interaction.
    * @param messages Current conversation messages

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -1,6 +1,5 @@
 // Standard library imports
 import * as path from 'path';
-import * as fs from 'fs';
 
 // Third-party imports
 // (none needed)
@@ -17,22 +16,14 @@ import {
 } from '../latex';
 
 // Local imports - utilities
-import {
-  readFile,
-  writeFile,
-  appendFile,
-  fileExists,
-} from '../utils/workspaceFileUtils';
+import { writeFile, appendFile, fileExists } from '../utils/workspaceFileUtils';
 import {
   renderPrompt,
-  getListOfFiles,
   getFirstKCharsFromDocument,
   writePromptToXml,
-  getXmlFormatFromFiles,
 } from '../utils/promptUtils';
 import {
   applyReplacements,
-  getReplacementsByCategory,
   getAllReplacements,
   getAllReplacementsRegex,
 } from '../replacement/replacementUtils';
@@ -51,6 +42,7 @@ import { ToolState } from './ToolState';
 import { ModelHandler } from './ModelHandler';
 import { OutputHandler } from './OutputHandler';
 import { messageToSkeleton } from './messageUtils';
+import { buildUserVars } from './userVars';
 
 // System imports - common utilities
 import { getConfig } from '../utils/configUtils';
@@ -222,261 +214,16 @@ export abstract class BaseReflectionAgent {
    * @returns Combined dictionary of variables for prompt templates
    */
   protected async getUserVars(): Promise<Record<string, any>> {
-    // Build user variables incrementally with clear categories
     this.logger.debug(`Obtaining dynamic variables...`);
-    const userVars: Record<string, any> = {};
-    Object.assign(userVars, this.getBasicVars());
-    Object.assign(userVars, await this.getFileVars());
-    Object.assign(userVars, await this.getRequiredFileVars());
-    Object.assign(userVars, await this.getPatternBasedFileVars());
-    Object.assign(userVars, this.getOutputFilesOrder());
-    Object.assign(userVars, this.getToolFlags());
-    return userVars;
+    return buildUserVars(
+      this.agentConfig,
+      this.agentSetting,
+      this.agentPath,
+      this.modelHandler,
+      this.logger,
+    );
   }
 
-  /**
-   * Collects basic model and instruction variables.
-   * @returns Core variables about model capabilities and instructions
-   */
-  private getBasicVars(): Record<string, any> {
-    return {
-      MODEL: this.agentConfig.model,
-      INSTRUCTION: this.agentConfig.instruction,
-      IS_OPENAI_MODEL: this.modelHandler.isOpenai,
-      IS_ANTHROPIC_MODEL: this.modelHandler.isAnthropic,
-      IS_GOOGLE_MODEL: this.modelHandler.isGoogle,
-    };
-  }
-
-  /**
-   * Processes input, reference, and auxiliary files into variables.
-   * @returns File content and metadata variables for prompts
-   */
-  private async getFileVars(): Promise<Record<string, any>> {
-    const userVars: Record<string, any> = {};
-
-    const allInputFiles = [
-      this.agentConfig.inputFile,
-      ...(this.agentConfig.inputFiles?.filter(Boolean) || []),
-    ];
-    const allReferenceFiles = [
-      this.agentConfig.referenceFile,
-      ...(this.agentConfig.referenceFiles?.filter(Boolean) || []),
-    ];
-    const allAuxiliaryFiles = [
-      this.agentConfig.auxiliaryFile,
-      ...(this.agentConfig.auxiliaryFiles?.filter(Boolean) || []),
-    ];
-
-    // Handle single files
-    const singleFileMappings = {
-      INPUT: this.agentConfig.inputFile,
-      REFERENCE: this.agentConfig.referenceFile,
-      AUXILIARY: this.agentConfig.auxiliaryFile,
-      EDITED: this.agentConfig.editedFile,
-    };
-
-    for (const [prefix, filePath] of Object.entries(singleFileMappings)) {
-      userVars[`${prefix}_FILE`] = filePath;
-      userVars[`${prefix}_CONTENT`] = filePath
-        ? await readFile(filePath)
-        : null;
-    }
-
-    // Handle file collections
-    const collectionMappings = {
-      INPUT: [
-        this.agentConfig.inputFiles?.filter(Boolean),
-        allInputFiles.filter(Boolean),
-      ],
-      REFERENCE: [
-        this.agentConfig.referenceFiles?.filter(Boolean),
-        allReferenceFiles.filter(Boolean),
-      ],
-      AUXILIARY: [
-        this.agentConfig.auxiliaryFiles?.filter(Boolean),
-        allAuxiliaryFiles.filter(Boolean),
-      ],
-    };
-
-    for (const [prefix, [additionalFiles, allFiles]] of Object.entries(
-      collectionMappings,
-    )) {
-      const additionalXml = additionalFiles
-        ? await getXmlFormatFromFiles(additionalFiles as string[])
-        : null;
-      const allXml = allFiles
-        ? await getXmlFormatFromFiles(allFiles as string[])
-        : null;
-
-      userVars[`ADDITIONAL_${prefix}S`] = additionalXml;
-      userVars[`ALL_${prefix}S`] = allXml;
-      userVars[`LIST_OF_ALL_${prefix}S`] = getListOfFiles(allFiles as string[]);
-    }
-
-    return userVars;
-  }
-
-  /**
-   * Processes required files specified in agent settings.
-   * @returns Variables containing required file contents
-   */
-  private async getRequiredFileVars(): Promise<Record<string, any>> {
-    const userVars: Record<string, any> = {};
-
-    // Add variables for required files
-    if (this.agentSetting.requiredFiles) {
-      for (const [varName, filePath] of Object.entries(
-        this.agentSetting.requiredFiles,
-      )) {
-        if (filePath) {
-          try {
-            const fileContent = await readFile(filePath);
-            userVars[`${varName}_FILE`] = filePath;
-            userVars[`${varName}_CONTENT`] = fileContent;
-            this.logger.info(
-              `Found from [requiredFiles] the [VAR '${varName}']: ${filePath}`,
-            );
-          } catch (err) {
-            this.logger.warn(
-              `[Required file] ${filePath} not found from [VAR '${varName}']`,
-            );
-          }
-        }
-      }
-    }
-
-    // Add variables for internal required files (from prompt directory)
-    if (this.agentSetting.requiredFilesInternal) {
-      for (const [varName, filePath] of Object.entries(
-        this.agentSetting.requiredFilesInternal,
-      )) {
-        const fullPath = path.join(this.agentPath, filePath);
-        try {
-          const fileContent = await fs.promises.readFile(fullPath, 'utf-8');
-          userVars[`${varName}_FILE`] = fullPath;
-          userVars[`${varName}_CONTENT`] = fileContent;
-          this.logger.info(
-            `Found from [requiredFilesInternal] the [VAR '${varName}']: ${fullPath}`,
-          );
-        } catch (err) {
-          this.logger.warn(
-            `[Required file internal] ${fullPath} not found from [VAR '${varName}']`,
-          );
-        }
-      }
-    }
-
-    return userVars;
-  }
-
-  /**
-   * Processes files matching patterns in agent settings.
-   * @returns Variables from pattern-matched files
-   */
-  private async getPatternBasedFileVars(): Promise<Record<string, any>> {
-    const userVars: Record<string, any> = {};
-
-    // Handle pattern-based file mappings if defined in settings
-    if (this.agentSetting.filePatternsContain) {
-      for (const patternConfig of this.agentSetting.filePatternsContain) {
-        const pattern = patternConfig.pattern.toLowerCase();
-        const varName = patternConfig.varName;
-        const categories = patternConfig.categories;
-
-        // Search in specified categories
-        for (const category of categories) {
-          // Get the value from AgentConfig using dictionary-style access
-          const categoryValue = (this.agentConfig as any)[category];
-
-          if (category.endsWith('File')) {
-            // Single file categories
-            if (
-              categoryValue &&
-              categoryValue.toLowerCase().includes(pattern)
-            ) {
-              try {
-                const fileContent = await readFile(categoryValue);
-                userVars[`${varName}_FILE`] = categoryValue;
-                userVars[`${varName}_CONTENT`] = fileContent;
-                this.logger.info(
-                  `Found from [Pattern '${pattern}'] the [VAR '${varName}']: ${categoryValue}`,
-                );
-              } catch (err) {
-                this.logger.warn(
-                  `File ${categoryValue} not found from [Pattern '${pattern}']`,
-                );
-              }
-            }
-          } else if (category.endsWith('Files')) {
-            // Multiple file categories
-            if (categoryValue) {
-              for (const file of categoryValue) {
-                if (file.toLowerCase().includes(pattern)) {
-                  try {
-                    const fileContent = await readFile(file);
-                    userVars[`${varName}_FILE`] = file;
-                    userVars[`${varName}_CONTENT`] = fileContent;
-                    this.logger.info(
-                      `Found from [Pattern '${pattern}'] the [VAR '${varName}']: ${file}`,
-                    );
-                    break; // Stop after first match
-                  } catch (err) {
-                    this.logger.warn(
-                      `File ${file} not found from [Pattern '${pattern}']`,
-                    );
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    return userVars;
-  }
-
-  /**
-   * Determines order of output file processing.
-   * @returns Variables controlling output file ordering
-   */
-  private getOutputFilesOrder(): Record<string, any> {
-    const userVars: Record<string, any> = {};
-
-    // Handle output files order - use defaultOutputFiles if no outputFiles specified
-    if (
-      Array.isArray(this.agentConfig.outputFiles) &&
-      this.agentConfig.outputFiles.length > 0
-    ) {
-      userVars.OUTPUT_FILES_ORDER = this.agentConfig.outputFiles.join(', ');
-    } else if (
-      Array.isArray(this.agentSetting.defaultOutputFiles) &&
-      this.agentSetting.defaultOutputFiles.length > 0
-    ) {
-      // If no outputFiles specified but defaultOutputFiles exists in settings
-      this.agentConfig.outputFiles = this.agentSetting.defaultOutputFiles;
-      userVars.OUTPUT_FILES_ORDER =
-        this.agentSetting.defaultOutputFiles.join(', ');
-    }
-
-    return userVars;
-  }
-
-  /**
-   * Collects tool-specific configuration flags.
-   * @returns Variables for tool behavior control
-   */
-  private getToolFlags(): Record<string, any> {
-    return {
-      AUTO_EXTRACT_FIGURE: this.agentConfig.toolConfig.autoExtractFigure,
-      AUTO_EXTRACT_TIKZ_FIGURE:
-        this.agentConfig.toolConfig.autoExtractTikzFigure,
-      INCLUDE_TEX_COUNT: this.agentConfig.toolConfig.attachTeXCount,
-      USE_PREFILL_FROM_INPUT: this.agentConfig.toolConfig.usePrefillFromInput,
-      PRINT_INPUT_PROMPT: this.agentConfig.toolConfig.printInputPrompt,
-    };
-  }
 
   /**
    * Manages single response cycle with model interaction.

--- a/src/agent/userVars.ts
+++ b/src/agent/userVars.ts
@@ -5,10 +5,7 @@ import * as fs from 'fs';
 
 import { AgentLogger } from '../logger/AgentLogger';
 import { readFile } from '../utils/workspaceFileUtils';
-import {
-  getXmlFormatFromFiles,
-  getListOfFiles,
-} from '../utils/promptUtils';
+import { getXmlFormatFromFiles, getListOfFiles } from '../utils/promptUtils';
 import { AgentConfig } from './AgentConfig';
 import { AgentSetting } from './AgentDataclass';
 import { ModelHandler } from './ModelHandler';
@@ -57,19 +54,18 @@ async function getFileVars(
 ): Promise<Record<string, any>> {
   const userVars: Record<string, any> = {};
 
-  const allInputFiles = (
-    [agentConfig.inputFile, ...(agentConfig.inputFiles || [])].filter(Boolean)
-  ) as string[];
-  const allReferenceFiles = (
-    [agentConfig.referenceFile, ...(agentConfig.referenceFiles || [])].filter(
-      Boolean,
-    )
-  ) as string[];
-  const allAuxiliaryFiles = (
-    [agentConfig.auxiliaryFile, ...(agentConfig.auxiliaryFiles || [])].filter(
-      Boolean,
-    )
-  ) as string[];
+  const allInputFiles = [
+    agentConfig.inputFile,
+    ...(agentConfig.inputFiles || []),
+  ].filter(Boolean) as string[];
+  const allReferenceFiles = [
+    agentConfig.referenceFile,
+    ...(agentConfig.referenceFiles || []),
+  ].filter(Boolean) as string[];
+  const allAuxiliaryFiles = [
+    agentConfig.auxiliaryFile,
+    ...(agentConfig.auxiliaryFiles || []),
+  ].filter(Boolean) as string[];
 
   const singleFileMappings = {
     INPUT: agentConfig.inputFile,
@@ -84,9 +80,18 @@ async function getFileVars(
   }
 
   const collectionMappings: Record<string, [string[] | undefined, string[]]> = {
-    INPUT: [agentConfig.inputFiles?.filter(Boolean) as string[] | undefined, allInputFiles],
-    REFERENCE: [agentConfig.referenceFiles?.filter(Boolean) as string[] | undefined, allReferenceFiles],
-    AUXILIARY: [agentConfig.auxiliaryFiles?.filter(Boolean) as string[] | undefined, allAuxiliaryFiles],
+    INPUT: [
+      agentConfig.inputFiles?.filter(Boolean) as string[] | undefined,
+      allInputFiles,
+    ],
+    REFERENCE: [
+      agentConfig.referenceFiles?.filter(Boolean) as string[] | undefined,
+      allReferenceFiles,
+    ],
+    AUXILIARY: [
+      agentConfig.auxiliaryFiles?.filter(Boolean) as string[] | undefined,
+      allAuxiliaryFiles,
+    ],
   };
 
   for (const [prefix, [additionalFiles, allFiles]] of Object.entries(
@@ -95,7 +100,9 @@ async function getFileVars(
     const additionalXml = additionalFiles
       ? await getXmlFormatFromFiles(additionalFiles as string[])
       : null;
-    const allXml = allFiles ? await getXmlFormatFromFiles(allFiles as string[]) : null;
+    const allXml = allFiles
+      ? await getXmlFormatFromFiles(allFiles as string[])
+      : null;
 
     userVars[`ADDITIONAL_${prefix}S`] = additionalXml;
     userVars[`ALL_${prefix}S`] = allXml;
@@ -113,15 +120,21 @@ async function getRequiredFileVars(
   const userVars: Record<string, any> = {};
 
   if (agentSetting.requiredFiles) {
-    for (const [varName, filePath] of Object.entries(agentSetting.requiredFiles)) {
+    for (const [varName, filePath] of Object.entries(
+      agentSetting.requiredFiles,
+    )) {
       if (filePath) {
         try {
           const fileContent = await readFile(filePath);
           userVars[`${varName}_FILE`] = filePath;
           userVars[`${varName}_CONTENT`] = fileContent;
-          logger.info(`Found from [requiredFiles] the [VAR '${varName}']: ${filePath}`);
+          logger.info(
+            `Found from [requiredFiles] the [VAR '${varName}']: ${filePath}`,
+          );
         } catch {
-          logger.warn(`[Required file] ${filePath} not found from [VAR '${varName}']`);
+          logger.warn(
+            `[Required file] ${filePath} not found from [VAR '${varName}']`,
+          );
         }
       }
     }
@@ -140,7 +153,9 @@ async function getRequiredFileVars(
           `Found from [requiredFilesInternal] the [VAR '${varName}']: ${fullPath}`,
         );
       } catch {
-        logger.warn(`[Required file internal] ${fullPath} not found from [VAR '${varName}']`);
+        logger.warn(
+          `[Required file internal] ${fullPath} not found from [VAR '${varName}']`,
+        );
       }
     }
   }
@@ -174,7 +189,9 @@ async function getPatternBasedFileVars(
                 `Found from [Pattern '${pattern}'] the [VAR '${varName}']: ${categoryValue}`,
               );
             } catch {
-              logger.warn(`File ${categoryValue} not found from [Pattern '${pattern}']`);
+              logger.warn(
+                `File ${categoryValue} not found from [Pattern '${pattern}']`,
+              );
             }
           }
         } else if (category.endsWith('Files')) {
@@ -190,7 +207,9 @@ async function getPatternBasedFileVars(
                   );
                   break;
                 } catch {
-                  logger.warn(`File ${file} not found from [Pattern '${pattern}']`);
+                  logger.warn(
+                    `File ${file} not found from [Pattern '${pattern}']`,
+                  );
                 }
               }
             }
@@ -208,7 +227,10 @@ function getOutputFilesOrder(
   agentSetting: AgentSetting,
 ): Record<string, any> {
   const userVars: Record<string, any> = {};
-  if (Array.isArray(agentConfig.outputFiles) && agentConfig.outputFiles.length > 0) {
+  if (
+    Array.isArray(agentConfig.outputFiles) &&
+    agentConfig.outputFiles.length > 0
+  ) {
     userVars.OUTPUT_FILES_ORDER = agentConfig.outputFiles.join(', ');
   } else if (
     Array.isArray(agentSetting.defaultOutputFiles) &&

--- a/src/agent/userVars.ts
+++ b/src/agent/userVars.ts
@@ -1,0 +1,231 @@
+// Utility functions for building user variables for prompts
+
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { AgentLogger } from '../logger/AgentLogger';
+import { readFile } from '../utils/workspaceFileUtils';
+import {
+  getXmlFormatFromFiles,
+  getListOfFiles,
+} from '../utils/promptUtils';
+import { AgentConfig } from './AgentConfig';
+import { AgentSetting } from './AgentDataclass';
+import { ModelHandler } from './ModelHandler';
+
+/**
+ * Build all user variables needed for prompt rendering.
+ */
+export async function buildUserVars(
+  agentConfig: AgentConfig,
+  agentSetting: AgentSetting,
+  agentPath: string,
+  modelHandler: ModelHandler,
+  logger: AgentLogger,
+): Promise<Record<string, any>> {
+  const userVars: Record<string, any> = {};
+  Object.assign(userVars, getBasicVars(agentConfig, modelHandler));
+  Object.assign(userVars, await getFileVars(agentConfig));
+  Object.assign(
+    userVars,
+    await getRequiredFileVars(agentSetting, agentPath, logger),
+  );
+  Object.assign(
+    userVars,
+    await getPatternBasedFileVars(agentConfig, agentSetting, logger),
+  );
+  Object.assign(userVars, getOutputFilesOrder(agentConfig, agentSetting));
+  Object.assign(userVars, getToolFlags(agentConfig));
+  return userVars;
+}
+
+function getBasicVars(
+  agentConfig: AgentConfig,
+  modelHandler: ModelHandler,
+): Record<string, any> {
+  return {
+    MODEL: agentConfig.model,
+    INSTRUCTION: agentConfig.instruction,
+    IS_OPENAI_MODEL: modelHandler.isOpenai,
+    IS_ANTHROPIC_MODEL: modelHandler.isAnthropic,
+    IS_GOOGLE_MODEL: modelHandler.isGoogle,
+  };
+}
+
+async function getFileVars(
+  agentConfig: AgentConfig,
+): Promise<Record<string, any>> {
+  const userVars: Record<string, any> = {};
+
+  const allInputFiles = (
+    [agentConfig.inputFile, ...(agentConfig.inputFiles || [])].filter(Boolean)
+  ) as string[];
+  const allReferenceFiles = (
+    [agentConfig.referenceFile, ...(agentConfig.referenceFiles || [])].filter(
+      Boolean,
+    )
+  ) as string[];
+  const allAuxiliaryFiles = (
+    [agentConfig.auxiliaryFile, ...(agentConfig.auxiliaryFiles || [])].filter(
+      Boolean,
+    )
+  ) as string[];
+
+  const singleFileMappings = {
+    INPUT: agentConfig.inputFile,
+    REFERENCE: agentConfig.referenceFile,
+    AUXILIARY: agentConfig.auxiliaryFile,
+    EDITED: agentConfig.editedFile,
+  } as Record<string, string | undefined>;
+
+  for (const [prefix, filePath] of Object.entries(singleFileMappings)) {
+    userVars[`${prefix}_FILE`] = filePath;
+    userVars[`${prefix}_CONTENT`] = filePath ? await readFile(filePath) : null;
+  }
+
+  const collectionMappings: Record<string, [string[] | undefined, string[]]> = {
+    INPUT: [agentConfig.inputFiles?.filter(Boolean) as string[] | undefined, allInputFiles],
+    REFERENCE: [agentConfig.referenceFiles?.filter(Boolean) as string[] | undefined, allReferenceFiles],
+    AUXILIARY: [agentConfig.auxiliaryFiles?.filter(Boolean) as string[] | undefined, allAuxiliaryFiles],
+  };
+
+  for (const [prefix, [additionalFiles, allFiles]] of Object.entries(
+    collectionMappings,
+  )) {
+    const additionalXml = additionalFiles
+      ? await getXmlFormatFromFiles(additionalFiles as string[])
+      : null;
+    const allXml = allFiles ? await getXmlFormatFromFiles(allFiles as string[]) : null;
+
+    userVars[`ADDITIONAL_${prefix}S`] = additionalXml;
+    userVars[`ALL_${prefix}S`] = allXml;
+    userVars[`LIST_OF_ALL_${prefix}S`] = getListOfFiles(allFiles as string[]);
+  }
+
+  return userVars;
+}
+
+async function getRequiredFileVars(
+  agentSetting: AgentSetting,
+  agentPath: string,
+  logger: AgentLogger,
+): Promise<Record<string, any>> {
+  const userVars: Record<string, any> = {};
+
+  if (agentSetting.requiredFiles) {
+    for (const [varName, filePath] of Object.entries(agentSetting.requiredFiles)) {
+      if (filePath) {
+        try {
+          const fileContent = await readFile(filePath);
+          userVars[`${varName}_FILE`] = filePath;
+          userVars[`${varName}_CONTENT`] = fileContent;
+          logger.info(`Found from [requiredFiles] the [VAR '${varName}']: ${filePath}`);
+        } catch {
+          logger.warn(`[Required file] ${filePath} not found from [VAR '${varName}']`);
+        }
+      }
+    }
+  }
+
+  if (agentSetting.requiredFilesInternal) {
+    for (const [varName, filePath] of Object.entries(
+      agentSetting.requiredFilesInternal,
+    )) {
+      const fullPath = path.join(agentPath, filePath);
+      try {
+        const fileContent = await fs.promises.readFile(fullPath, 'utf-8');
+        userVars[`${varName}_FILE`] = fullPath;
+        userVars[`${varName}_CONTENT`] = fileContent;
+        logger.info(
+          `Found from [requiredFilesInternal] the [VAR '${varName}']: ${fullPath}`,
+        );
+      } catch {
+        logger.warn(`[Required file internal] ${fullPath} not found from [VAR '${varName}']`);
+      }
+    }
+  }
+
+  return userVars;
+}
+
+async function getPatternBasedFileVars(
+  agentConfig: AgentConfig,
+  agentSetting: AgentSetting,
+  logger: AgentLogger,
+): Promise<Record<string, any>> {
+  const userVars: Record<string, any> = {};
+
+  if (agentSetting.filePatternsContain) {
+    for (const patternConfig of agentSetting.filePatternsContain) {
+      const pattern = patternConfig.pattern.toLowerCase();
+      const varName = patternConfig.varName;
+      const categories = patternConfig.categories;
+
+      for (const category of categories) {
+        const categoryValue = (agentConfig as any)[category];
+
+        if (category.endsWith('File')) {
+          if (categoryValue && categoryValue.toLowerCase().includes(pattern)) {
+            try {
+              const fileContent = await readFile(categoryValue);
+              userVars[`${varName}_FILE`] = categoryValue;
+              userVars[`${varName}_CONTENT`] = fileContent;
+              logger.info(
+                `Found from [Pattern '${pattern}'] the [VAR '${varName}']: ${categoryValue}`,
+              );
+            } catch {
+              logger.warn(`File ${categoryValue} not found from [Pattern '${pattern}']`);
+            }
+          }
+        } else if (category.endsWith('Files')) {
+          if (categoryValue) {
+            for (const file of categoryValue) {
+              if (file.toLowerCase().includes(pattern)) {
+                try {
+                  const fileContent = await readFile(file);
+                  userVars[`${varName}_FILE`] = file;
+                  userVars[`${varName}_CONTENT`] = fileContent;
+                  logger.info(
+                    `Found from [Pattern '${pattern}'] the [VAR '${varName}']: ${file}`,
+                  );
+                  break;
+                } catch {
+                  logger.warn(`File ${file} not found from [Pattern '${pattern}']`);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return userVars;
+}
+
+function getOutputFilesOrder(
+  agentConfig: AgentConfig,
+  agentSetting: AgentSetting,
+): Record<string, any> {
+  const userVars: Record<string, any> = {};
+  if (Array.isArray(agentConfig.outputFiles) && agentConfig.outputFiles.length > 0) {
+    userVars.OUTPUT_FILES_ORDER = agentConfig.outputFiles.join(', ');
+  } else if (
+    Array.isArray(agentSetting.defaultOutputFiles) &&
+    agentSetting.defaultOutputFiles.length > 0
+  ) {
+    agentConfig.outputFiles = agentSetting.defaultOutputFiles;
+    userVars.OUTPUT_FILES_ORDER = agentSetting.defaultOutputFiles.join(', ');
+  }
+  return userVars;
+}
+
+function getToolFlags(agentConfig: AgentConfig): Record<string, any> {
+  return {
+    AUTO_EXTRACT_FIGURE: agentConfig.toolConfig.autoExtractFigure,
+    AUTO_EXTRACT_TIKZ_FIGURE: agentConfig.toolConfig.autoExtractTikzFigure,
+    INCLUDE_TEX_COUNT: agentConfig.toolConfig.attachTeXCount,
+    USE_PREFILL_FROM_INPUT: agentConfig.toolConfig.usePrefillFromInput,
+    PRINT_INPUT_PROMPT: agentConfig.toolConfig.printInputPrompt,
+  };
+}


### PR DESCRIPTION
## Summary
- move user variable helpers to `userVars.ts`
- simplify `BaseReflectionAgent` by delegating variable creation

## Testing
- `npm run lint`
- `npm test` *(fails to fetch VS Code update but build succeeds)*