### PR TITLE
Fix task state persistence format

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -609,9 +609,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   private saveTaskStates(): void {
     this.logger.debug('Saving taskStates to workspace state');
-    const taskStatesArray = Array.from(this._taskStates.entries());
-    this.logger.debug(`Saving taskStates: ${JSON.stringify(taskStatesArray)}`);
-    this.context.workspaceState.update(this._taskStateKey, taskStatesArray);
+    const taskStatesObj = Object.fromEntries(this._taskStates.entries());
+    this.logger.debug(`Saving taskStates: ${JSON.stringify(taskStatesObj)}`);
+    this.context.workspaceState.update(this._taskStateKey, taskStatesObj);
   }
 
   /**


### PR DESCRIPTION
## Summary
- save task state map to workspace storage using an object

## Testing
- `npm test` *(fails: cannot find name 'ErrorEvent')*