### PR TITLE
Update quoting cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texra",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texra",
-      "version": "0.30.6",
+      "version": "0.30.7",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.51.0",

--- a/src/replacement/replacementAdvanced.ts
+++ b/src/replacement/replacementAdvanced.ts
@@ -354,3 +354,23 @@ export function replaceMathUnicode(text: string): string {
 
   return text;
 }
+
+/**
+ * Fix orientation of LaTeX-style quotes and adjust punctuation placement.
+ * Only processes well-formed quoted segments to avoid affecting apostrophes.
+ */
+export function fixLatexQuoteIssues(text: string): string {
+  // ''text'' -> ``text''
+  text = text.replace(/''([^']+?)''/g, "``$1''");
+
+  // 'text' -> `text'
+  text = text.replace(/(?<![\w])'([^']+?)'(?![\w])/g, "`$1'");
+
+  // Move punctuation outside closing double quotes
+  text = text.replace(/(``[^']+?)([.,;:])''/g, "$1''$2");
+
+  // Move punctuation outside closing single quotes
+  text = text.replace(/(`[^']+?)([.,;:])'/g, "$1'$2");
+
+  return text;
+}

--- a/src/replacement/replacementUtils.ts
+++ b/src/replacement/replacementUtils.ts
@@ -15,6 +15,7 @@ import { ReplacementCategory } from './replacementTypes';
 import {
   applyLatexQuotesFormatting,
   replaceMathUnicode,
+  fixLatexQuoteIssues,
 } from './replacementAdvanced';
 
 import {
@@ -259,6 +260,9 @@ export function applyReplacements(
 
   // Apply LaTeX quotes formatting
   text = applyLatexQuotesFormatting(text);
+
+  // Cleanup common quote issues
+  text = fixLatexQuoteIssues(text);
 
   return text;
 }


### PR DESCRIPTION
## Summary
- remove quoting guidelines from docs and YAML templates
- add fixLatexQuoteIssues helper to handle basic LaTeX quote cleanup
- call new helper from applyReplacements

## Testing
- `npm run format`
- `npm test` *(fails: getaddrinfo ENOTFOUND update.code.visualstudio.com)*
