### PR TITLE
Fix async agent copy

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ import { ProgressViewProvider } from './progressView/ProgressViewProvider';
 import { FolderExplorer } from './FolderExplorer';
 import { registerCommands } from './commands';
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   // Initialize secrets storage
   initializeSecrets(context);
 
@@ -33,7 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
   progressViewProvider.cleanupTasksAfterRestart();
 
   // Copy default agents
-  copyDefaultAgents(context);
+  await copyDefaultAgents(context);
 
   // Configure LaTeX settings if LaTeX Workshop is installed
   configureLatexSettings();


### PR DESCRIPTION
## Summary
- copy default agents on activation using `await`

## Testing
- `npm test` *(fails: cannot find name 'ErrorEvent')*