### PR TITLE
Add multi-round scaffolding

### DIFF
--- a/docs/next/multi-round.md
+++ b/docs/next/multi-round.md
@@ -6,7 +6,8 @@ This document outlines initial considerations for extending `BaseReflectionAgent
 
 - **Configuration**
 
-  - Introduce a `rounds` field in `ToolConfig` so a workflow can define how many sequential steps to perform.
+  - A `rounds` field now exists in `AgentSetting` allowing a workflow to specify how many sequential steps to perform (defaults to `2`).
+  - The value is exposed to prompt templates via the `ROUNDS` user variable.
   - Prompts may need to support an array of `userReflect` templates or reuse a single template for each additional round.
 
 - **State Management**
@@ -20,7 +21,7 @@ This document outlines initial considerations for extending `BaseReflectionAgent
     1. Render prompts for the current round.
     2. Invoke `processResponseCycle`.
     3. Run `handleRoundCompletion`.
-  - The `outputFile` property has been changed to an array to simplify managing an arbitrary number of round outputs.
+  - The `outputFile` property is initialized based on the configured number of rounds rather than assuming two.
 
 - **Prompt Rendering**
   - New helper methods may be needed to retrieve the correct `prefill` and prompt text for each round.

--- a/src/agent/AgentDataclass.ts
+++ b/src/agent/AgentDataclass.ts
@@ -9,6 +9,7 @@ export const DEFAULT_AGENT_SETTINGS: AgentSetting = {
   agentType: AgentType.CoT,
   documentTag: 'document',
   temperature: 0.0,
+  rounds: 2,
   prefills: [],
   outputExt: 'txt',
   endTag: '</latex_document>',
@@ -34,6 +35,9 @@ export interface AgentSetting {
   documentTag: string;
   temperature: number | null;
   isRewrite: boolean;
+
+  /** Number of conversation rounds to run. */
+  rounds?: number;
 
   /** Generation settings */
   prefills: string[];

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -110,8 +110,12 @@ export abstract class BaseReflectionAgent {
     this.modelHandler.setLogger(this.logger);
 
     // Initialize basic attributes
-    this.outputFile = [];
-    this.outputFiles = { 0: [], 1: [] };
+    const numRounds = this.getNumberOfRounds();
+    this.outputFile = new Array(numRounds);
+    this.outputFiles = {};
+    for (let i = 0; i < numRounds; i++) {
+      this.outputFiles[i] = [];
+    }
     this.baseFiles = this.agentConfig.outputFiles || [
       this.agentConfig.inputFile,
     ];
@@ -122,9 +126,10 @@ export abstract class BaseReflectionAgent {
     this.useScratchpad =
       this.agentSetting.prefills?.includes('<scratchpad>') || false;
 
-    // Set output files for the existing two rounds
-    this.outputFile[0] = this.getOutputFile(0);
-    this.outputFile[1] = this.getOutputFile(1);
+    // Set output files for all rounds
+    for (let i = 0; i < numRounds; i++) {
+      this.outputFile[i] = this.getOutputFile(i);
+    }
 
     // Initialize logging
     this.logId = 0;
@@ -222,6 +227,13 @@ export abstract class BaseReflectionAgent {
       this.modelHandler,
       this.logger,
     );
+  }
+
+  /**
+   * Returns the configured number of conversation rounds.
+   */
+  protected getNumberOfRounds(): number {
+    return this.agentSetting.rounds ?? 2;
   }
 
   /**

--- a/src/agent/userVars.ts
+++ b/src/agent/userVars.ts
@@ -32,7 +32,7 @@ export async function buildUserVars(
     await getPatternBasedFileVars(agentConfig, agentSetting, logger),
   );
   Object.assign(userVars, getOutputFilesOrder(agentConfig, agentSetting));
-  Object.assign(userVars, getToolFlags(agentConfig));
+  Object.assign(userVars, getToolFlags(agentConfig, agentSetting));
   return userVars;
 }
 
@@ -242,8 +242,12 @@ function getOutputFilesOrder(
   return userVars;
 }
 
-function getToolFlags(agentConfig: AgentConfig): Record<string, any> {
+function getToolFlags(
+  agentConfig: AgentConfig,
+  agentSetting: AgentSetting,
+): Record<string, any> {
   return {
+    ROUNDS: agentSetting.rounds ?? 2,
     AUTO_EXTRACT_FIGURE: agentConfig.toolConfig.autoExtractFigure,
     AUTO_EXTRACT_TIKZ_FIGURE: agentConfig.toolConfig.autoExtractTikzFigure,
     INCLUDE_TEX_COUNT: agentConfig.toolConfig.attachTeXCount,


### PR DESCRIPTION
## Summary
- extend ToolConfig with rounds field
- default to two rounds in AgentConfig and ModelHandler
- dynamically initialise round output arrays in BaseReflectionAgent
- expose ROUNDS variable to prompts
- document upcoming multi-round support

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND update.code.visualstudio.com)*
- `npm run compile`
