### PR TITLE
Refactor thinking logging

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -28,10 +28,7 @@ import {
   getAllReplacementsRegex,
 } from '../replacement/replacementUtils';
 import { checkForMassiveRepetition } from '../utils/repetitionUtils';
-import {
-  extractAndLogScratchpad,
-  formatAndLogThinking,
-} from '../utils/xmlUtils';
+import { extractAndLogScratchpad, formatAndLogContent } from '../utils/xmlUtils';
 import { sleep } from '../utils/timeUtils';
 
 // Local imports - agent components
@@ -342,9 +339,10 @@ export abstract class BaseReflectionAgent {
 
         // If thinking content was extracted, format and log it
         if (thinkingContent) {
-          formatAndLogThinking(
+          formatAndLogContent(
             thinkingContent,
             this.logger,
+            'Thinking',
             responseCycleGroupId,
           );
 
@@ -740,6 +738,7 @@ export abstract class BaseReflectionAgent {
           toolState,
           this.outputFile[0],
           prefill,
+          round0GroupId,
         );
 
       const stateRound = new AgentStateRound(currRound);
@@ -899,6 +898,7 @@ export abstract class BaseReflectionAgent {
           toolState,
           this.outputFile[1],
           prefill,
+          round1GroupId,
         );
 
       if (!endTurn) {

--- a/src/agent/ModelHandler.ts
+++ b/src/agent/ModelHandler.ts
@@ -615,6 +615,7 @@ export abstract class ModelHandler {
     toolState: ToolState,
     outputFile: string,
     prefill: string,
+    groupId?: string,
   ): Promise<[boolean, any[]]>;
 
   /**

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -411,6 +411,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     toolState: ToolState,
     outputFile: string,
     prefill: string,
+    groupId?: string,
   ): Promise<[boolean, any[]]> {
     let endTurn = false;
 
@@ -458,8 +459,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
-    // This did not export group ID??
-    extractAndLogScratchpad(fileContent, this.logger);
+    extractAndLogScratchpad(fileContent, this.logger, 'scratchpad', groupId);
 
     await writeFile(outputFile, fileContent);
 

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -689,6 +689,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     toolState: ToolState,
     outputFile: string,
     prefill: string,
+    groupId?: string,
   ): Promise<[boolean, any[]]> {
     let endTurn = false;
     this.logger.debug(
@@ -733,8 +734,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     let fileContent = await readFile(outputFile);
     fileContent = cleanFileContent(fileContent);
 
-    // TODO: this did not export groupID of the logger?
-    extractAndLogScratchpad(fileContent, this.logger);
+    // Extract and log any existing scratchpad content
+    extractAndLogScratchpad(fileContent, this.logger, 'scratchpad', groupId);
 
     await writeFile(outputFile, fileContent);
     this.logger.debug(`Cleaned and saved existing content to ${outputFile}.`);

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -457,6 +457,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
     toolState: ToolState,
     outputFile: string,
     prefill: string,
+    groupId?: string,
   ): Promise<[boolean, any[]]> {
     let endTurn = false;
 
@@ -486,8 +487,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
     fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
-    // TODO: this did not export group ID??
-    extractAndLogScratchpad(fileContent, this.logger);
+    extractAndLogScratchpad(fileContent, this.logger, 'scratchpad', groupId);
 
     // Write file content to output file
     await writeFile(outputFile, fileContent);

--- a/src/utils/xmlUtils.ts
+++ b/src/utils/xmlUtils.ts
@@ -298,22 +298,9 @@ export function extractAndLogScratchpad(
 ): void {
   const extractedContent = extractTextFromTag(outputContent, thinkingTag);
   if (extractedContent) {
-    formatAndLogContent(extractedContent, agentLogger, thinkingTag, groupId);
+    // Always log using the canonical "Scratchpad" label so that the progress
+    // view recognises the message. The thinkingTag is still used for
+    // extraction so alternative tag names continue to work.
+    formatAndLogContent(extractedContent, agentLogger, 'Scratchpad', groupId);
   }
-}
-
-/**
- * Formats and logs model thinking content.
- * Uses the same formatting logic as the scratchpad content.
- *
- * @param thinkingContent The thinking content to format and log
- * @param logger The logger instance to use for logging
- * @param groupId Optional group ID for logging
- */
-export function formatAndLogThinking(
-  thinkingContent: string,
-  agentLogger: AgentLogger,
-  groupId?: string,
-): void {
-  formatAndLogContent(thinkingContent, agentLogger, 'Thinking', groupId);
 }


### PR DESCRIPTION
## Summary
- remove unused wrapper `formatAndLogThinking`
- call `formatAndLogContent` directly when logging thinking content

## Testing
- `npm run lint`
- `npm run compile-tests`
- `npm test`
