### PR TITLE
Add file actions and grouping in progress view

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -14,9 +14,16 @@ import {
   bestConnectionMethod,
   getTeXCountStats,
 } from '../latex';
+import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
+import { diff_match_patch } from 'diff-match-patch';
 
 // Local imports - utilities
-import { writeFile, appendFile, fileExists } from '../utils/workspaceFileUtils';
+import {
+  writeFile,
+  appendFile,
+  fileExists,
+  readFile,
+} from '../utils/workspaceFileUtils';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
@@ -542,6 +549,32 @@ export abstract class BaseReflectionAgent {
     return prefill;
   }
 
+  private async computeDiffStats(
+    baseFile: string,
+    outputFile: string,
+  ): Promise<{ added: number; removed: number }> {
+    try {
+      const [baseContent, outContent] = await Promise.all([
+        readFile(baseFile),
+        readFile(outputFile),
+      ]);
+      const dmp = new diff_match_patch();
+      const diffs = dmp.diff_main(baseContent, outContent);
+      let added = 0;
+      let removed = 0;
+      for (const [op, text] of diffs) {
+        if (op === 1) {
+          added += text.split(/\n/).length;
+        } else if (op === -1) {
+          removed += text.split(/\n/).length;
+        }
+      }
+      return { added, removed };
+    } catch {
+      return { added: 0, removed: 0 };
+    }
+  }
+
   /**
    * Processes completion of conversation round.
    */
@@ -577,6 +610,53 @@ export abstract class BaseReflectionAgent {
       this.logger.info(`Completed round ${currRound}`, roundGroupId);
     } catch (error) {
       throw error;
+    }
+
+    const provider = ProgressViewProvider.getInstance();
+    if (provider) {
+      const roundOutputs = this.outputHandler.outputFiles[currRound] || [];
+
+      // Map output files to their original base files
+      const baseMap = this.outputHandler.createFileMapping(
+        this.baseFiles,
+        roundOutputs,
+        'contains',
+      );
+
+      // Map output files to previous round files if available
+      const prevMap =
+        currRound > 0
+          ? this.outputHandler.createFileMapping(
+              this.outputHandler.outputFiles[currRound - 1] || [],
+              roundOutputs,
+              'basename',
+              true,
+            )
+          : new Map<string, string>();
+
+      const fileInfos = [] as any[];
+      for (const file of roundOutputs) {
+        const baseFile =
+          Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
+          null;
+        const prevFile =
+          Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
+          null;
+        let stats = { added: 0, removed: 0 };
+        if (baseFile) {
+          stats = await this.computeDiffStats(baseFile, file);
+        }
+        fileInfos.push({
+          path: file,
+          base: baseFile,
+          prev: prevFile,
+          ...stats,
+        });
+      }
+
+      provider.addOutputFiles(this.logger.channelId, {
+        [currRound]: fileInfos,
+      });
     }
   }
 

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -201,7 +201,7 @@ export class OutputHandler {
    * @returns Map of source files to their best matching target files
    * @private
    */
-  private createFileMapping(
+  public createFileMapping(
     sourceFiles: string[],
     targetFiles: string[],
     matchStrategy: 'basename' | 'contains' = 'basename',

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,6 +27,7 @@ import { registerArXivCommands } from './commands/arXivCommands';
 import { registerCompareCommands } from './commands/compareCommands';
 import { registerProgressViewCommands } from './commands/progressViewCommands';
 import { registerHelpCommands } from './commands/helpCommands';
+import { registerOpenFileCommands } from './commands/openFileCommands';
 
 import * as logger from './logger/logUtils';
 
@@ -64,6 +65,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     arXiv: registerArXivCommands(context),
     compare: registerCompareCommands(context),
     progressView: registerProgressViewCommands(context),
+    openFile: registerOpenFileCommands(context),
     help: registerHelpCommands(context),
   };
 
@@ -106,3 +108,4 @@ export { historyCommands } from './commands/historyCommands';
 export { arXivCommands } from './commands/arXivCommands';
 export { compareCommands } from './commands/compareCommands';
 export { helpCommands } from './commands/helpCommands';
+export { registerOpenFileCommands as openFileCommands } from './commands/openFileCommands';

--- a/src/commands/openFileCommands.ts
+++ b/src/commands/openFileCommands.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+import * as logger from '../logger/logUtils';
+import {
+  fileExists,
+  getFullPathFromWorkspace,
+} from '../utils/workspaceFileUtils';
+
+const CHANNEL = 'OpenFileCommands';
+logger.initialize(CHANNEL);
+
+export function registerOpenFileCommands(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('texra.openFileCompile', handleOpenFile),
+  );
+  return { openFileCompile: handleOpenFile };
+}
+
+async function handleOpenFile(file: string) {
+  try {
+    if (!(await fileExists(file))) {
+      vscode.window.showErrorMessage(`File not found: ${file}`);
+      return;
+    }
+    const fullPath = vscode.Uri.file(getFullPathFromWorkspace(file));
+    const doc = await vscode.workspace.openTextDocument(fullPath);
+    await vscode.window.showTextDocument(doc, { preview: false });
+
+    if (file.endsWith('.tex')) {
+      try {
+        await vscode.commands.executeCommand('latex-workshop.build', fullPath);
+      } catch (err) {
+        logger.warn(CHANNEL, `LaTeX Workshop build failed: ${err}`);
+      }
+    }
+  } catch (err) {
+    logger.error(CHANNEL, `Error opening file: ${err}`);
+  }
+}

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -52,6 +52,52 @@ export class ProgressViewMessageHandler {
       case COMMANDS.RESTORE_STATE:
         await this.handleRestoreState(message.stream);
         break;
+      case COMMANDS.OPEN_FILE:
+        await vscode.commands.executeCommand(
+          'texra.openFileCompile',
+          message.file,
+        );
+        break;
+      case COMMANDS.COMPARE_ORIGINAL:
+        await vscode.commands.executeCommand(
+          'texra.compare',
+          undefined,
+          message.base,
+          message.file,
+        );
+        break;
+      case COMMANDS.COMPARE_PREVIOUS:
+        await vscode.commands.executeCommand(
+          'texra.compare',
+          undefined,
+          message.prev,
+          message.file,
+        );
+        break;
+      case COMMANDS.ACCEPT_FILE:
+        await vscode.commands.executeCommand(
+          'texra.acceptEdited',
+          undefined,
+          message.base,
+          message.file,
+        );
+        break;
+      case COMMANDS.MERGE_FILE:
+        await vscode.commands.executeCommand(
+          'texra.merge',
+          undefined,
+          message.base,
+          message.file,
+        );
+        break;
+      case COMMANDS.LATEXDIFF_FILE:
+        await vscode.commands.executeCommand(
+          'texra.latexdiff',
+          undefined,
+          message.base,
+          message.file,
+        );
+        break;
       default:
         logger.warn(CHANNEL, `Unknown command: ${message.command}`);
     }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -43,15 +43,26 @@ interface LogGroup {
 
 // Channels that should not be persisted in workspace storage
 
+interface OutputFileInfo {
+  path: string;
+  base?: string | null;
+  prev?: string | null;
+  added?: number;
+  removed?: number;
+}
+
 export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private static _instance: ProgressViewProvider | undefined;
   private _view?: vscode.WebviewView;
   private _logStreams: Map<string, ColoredLogMessage[]> = new Map();
   private _logGroups: Map<string, Map<string, LogGroup>> = new Map(); // streamId -> groupId -> LogGroup
+  private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
+    new Map();
   private readonly _contentProvider: ProgressViewContentProvider;
   private readonly _messageHandler: ProgressViewMessageHandler;
   private readonly _storageKey = 'texra.logStreams';
   private readonly _groupsStorageKey = 'texra.logGroups';
+  private readonly _filesStorageKey = 'texra.outputFiles';
   private readonly _taskStateKey = 'texra.taskStates';
   private _disposables: vscode.Disposable[] = [];
   private readonly _extensionUri: vscode.Uri;
@@ -139,6 +150,20 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._logGroups.clear();
     }
 
+    // Load output files
+    const savedFiles = this.context.workspaceState.get<{
+      [key: string]: { [key: number]: OutputFileInfo[] };
+    }>(this._getWorkspaceKey(this._filesStorageKey));
+    if (savedFiles) {
+      this._outputFiles = new Map(
+        Object.entries(savedFiles).filter(([channel]) =>
+          shouldPersistStream(channel),
+        ),
+      );
+    } else {
+      this._outputFiles.clear();
+    }
+
     // Load active stream
     const savedActiveStream = this.context.workspaceState.get<string>(
       this._activeStreamKey,
@@ -195,6 +220,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     // Save taskStates
     const taskStatesObj = Object.fromEntries(this._taskStates.entries());
     this.context.workspaceState.update(this._taskStateKey, taskStatesObj);
+
+    // Save output files
+    const filesObj = Object.fromEntries(this._outputFiles.entries());
+    this.context.workspaceState.update(
+      this._getWorkspaceKey(this._filesStorageKey),
+      filesObj,
+    );
   }
 
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
@@ -286,6 +318,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       currentStream: this._activeStream,
     });
     this.updateLogContent(this._activeStream);
+
+    // Send output files for current stream
+    const files = this._outputFiles.get(this._activeStream) || {};
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_FILES,
+      stream: this._activeStream,
+      files,
+    });
 
     // Update status for current stream
     if (this._activeStream) {
@@ -491,6 +531,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       command: COMMANDS.UPDATE_STATUS,
       status: status,
     });
+
+    // Send output files for this stream
+    const files = this._outputFiles.get(stream) || {};
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_FILES,
+      stream: stream,
+      files,
+    });
   }
 
   public getLogStreams(): Map<string, ColoredLogMessage[]> {
@@ -505,6 +553,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     if (this._logStreams.has(stream)) {
       this._logStreams.get(stream)!.length = 0;
       this._logGroups.delete(stream);
+      this._outputFiles.delete(stream);
       this._saveState();
       this.updateLogContent(stream);
     }
@@ -514,6 +563,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._logStreams.clear();
     this._logGroups.clear();
     this._taskStates.clear();
+    this._outputFiles.clear();
     this._saveState();
     if (this._view) {
       this._view.webview.postMessage({ command: COMMANDS.CLEAR_LOGS });
@@ -534,6 +584,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._logStreams.delete(stream);
       this._logGroups.delete(stream);
       this._taskStates.delete(stream);
+      this._outputFiles.delete(stream);
 
       // If the deleted stream was the active one, switch to another stream if available
       if (stream === this._activeStream) {
@@ -567,6 +618,29 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   public getStreamStatus(stream: string): StreamStatusType | undefined {
     return this._streamStatus.get(stream);
+  }
+
+  public addOutputFiles(
+    stream: string,
+    filesByRound: { [key: number]: OutputFileInfo[] },
+  ): void {
+    const existing = this._outputFiles.get(stream) || {};
+    const merged = { ...existing, ...filesByRound };
+    this._outputFiles.set(stream, merged);
+    this._saveState();
+    if (this._view && stream === this._activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_FILES,
+        stream,
+        files: merged,
+      });
+    }
+  }
+
+  public getOutputFiles(
+    stream: string,
+  ): { [key: number]: OutputFileInfo[] } | undefined {
+    return this._outputFiles.get(stream);
   }
 
   public setActiveStream(stream: string) {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -176,8 +176,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     // Load taskStates
     const savedTaskStates = this.context.workspaceState.get<
-      | { [key: string]: Record<string, any> }
-      | [string, Record<string, any>][]
+      { [key: string]: Record<string, any> } | [string, Record<string, any>][]
     >(this._taskStateKey);
     if (savedTaskStates) {
       if (Array.isArray(savedTaskStates)) {

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -101,6 +101,7 @@
           </div>
         </div>
         <div id="logContent" class="log-container"></div>
+        <div id="generatedFiles" class="files-container"></div>
       </div>
       <div class="tabs split">
         <div id="streamTabs" class="tabs-content">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -34,4 +34,11 @@ export const COMMANDS = {
   ADD_LOG_GROUP: 'addLogGroup',
   UPDATE_LOG_GROUP: 'updateLogGroup',
   UPDATE_STATUS: 'updateStatus',
+  UPDATE_FILES: 'updateFiles',
+  OPEN_FILE: 'openFile',
+  COMPARE_ORIGINAL: 'compareOriginal',
+  COMPARE_PREVIOUS: 'comparePrevious',
+  ACCEPT_FILE: 'acceptFile',
+  MERGE_FILE: 'mergeFile',
+  LATEXDIFF_FILE: 'latexdiffFile',
 };

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -126,6 +126,137 @@ export function updateStatus(status) {
 }
 
 /**
+ * Update the generated files list
+ * @param {Array<string>} files - Array of file paths
+ */
+export function updateFileList(filesByRound) {
+  const container = document.getElementById('generatedFiles');
+  if (!container) return;
+
+  container.innerHTML = '';
+
+  if (!filesByRound || Object.keys(filesByRound).length === 0) {
+    container.textContent = 'No generated files';
+    return;
+  }
+
+  const rounds = Object.keys(filesByRound)
+    .map((r) => parseInt(r, 10))
+    .sort((a, b) => a - b);
+
+  rounds.forEach((round) => {
+    const group = document.createElement('div');
+    group.className = 'round-group';
+
+    const header = document.createElement('div');
+    header.className = 'round-header';
+    header.textContent = `Round ${round}`;
+    group.appendChild(header);
+
+    const files = filesByRound[round] || [];
+    files.forEach((info) => {
+      const item = document.createElement('div');
+      item.className = 'file-item';
+
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'file-name';
+      nameSpan.textContent = info.path;
+
+      if (info.added !== undefined && info.removed !== undefined) {
+        const statsSpan = document.createElement('span');
+        statsSpan.innerHTML = `<span class="added">+${info.added}</span> <span class="removed">-${info.removed}</span>`;
+        nameSpan.appendChild(statsSpan);
+      }
+
+      const actions = document.createElement('span');
+      actions.className = 'file-actions';
+
+      const openBtn = document.createElement('button');
+      openBtn.className = 'vscode-button tiny';
+      openBtn.title = 'Open file';
+      openBtn.innerHTML = '<i class="codicon codicon-go-to-file"></i>';
+      openBtn.addEventListener('click', () => {
+        vscode.postMessage({ command: COMMANDS.OPEN_FILE, file: info.path });
+      });
+
+      const compareBtn = document.createElement('button');
+      compareBtn.className = 'vscode-button tiny';
+      compareBtn.title = 'Compare with base';
+      compareBtn.innerHTML = '<i class="codicon codicon-diff"></i>';
+      compareBtn.addEventListener('click', () => {
+        vscode.postMessage({
+          command: COMMANDS.COMPARE_ORIGINAL,
+          file: info.path,
+          base: info.base,
+        });
+      });
+
+      const prevBtn = document.createElement('button');
+      prevBtn.className = 'vscode-button tiny';
+      prevBtn.title = 'Compare with previous round';
+      prevBtn.innerHTML = '<i class="codicon codicon-diff-all"></i>';
+      prevBtn.addEventListener('click', () => {
+        vscode.postMessage({
+          command: COMMANDS.COMPARE_PREVIOUS,
+          file: info.path,
+          prev: info.prev,
+        });
+      });
+
+      const acceptBtn = document.createElement('button');
+      acceptBtn.className = 'vscode-button tiny';
+      acceptBtn.title = 'Accept edits';
+      acceptBtn.innerHTML = '<i class="codicon codicon-pass"></i>';
+      acceptBtn.addEventListener('click', () => {
+        vscode.postMessage({
+          command: COMMANDS.ACCEPT_FILE,
+          file: info.path,
+          base: info.base,
+        });
+      });
+
+      const mergeBtn = document.createElement('button');
+      mergeBtn.className = 'vscode-button tiny';
+      mergeBtn.title = 'Merge edits';
+      mergeBtn.innerHTML = '<i class="codicon codicon-merge"></i>';
+      mergeBtn.addEventListener('click', () => {
+        vscode.postMessage({
+          command: COMMANDS.MERGE_FILE,
+          file: info.path,
+          base: info.base,
+        });
+      });
+
+      const diffBtn = document.createElement('button');
+      diffBtn.className = 'vscode-button tiny';
+      diffBtn.title = 'Latexdiff again';
+      diffBtn.innerHTML = '<i class="codicon codicon-diff-added"></i>';
+      diffBtn.addEventListener('click', () => {
+        vscode.postMessage({
+          command: COMMANDS.LATEXDIFF_FILE,
+          file: info.path,
+          base: info.base,
+          prev: info.prev,
+        });
+      });
+
+      actions.appendChild(openBtn);
+      actions.appendChild(compareBtn);
+      actions.appendChild(prevBtn);
+      actions.appendChild(acceptBtn);
+      actions.appendChild(mergeBtn);
+      actions.appendChild(diffBtn);
+
+      item.appendChild(nameSpan);
+      item.appendChild(actions);
+      group.appendChild(item);
+    });
+
+    container.appendChild(group);
+  });
+}
+
+/**
  * Adds a log group to the DOM
  * @param {Object} group - Group data
  */

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -160,16 +160,54 @@ export function updateFileList(filesByRound) {
 
       const nameSpan = document.createElement('span');
       nameSpan.className = 'file-name';
-      nameSpan.textContent = info.path;
+
+      // Get basename of the file for cleaner display
+      const basename = info.path.split('/').pop();
+      const dirPath = info.path.substring(
+        0,
+        info.path.length - basename.length,
+      );
+
+      // Create two spans - one for directory and one for filename
+      const dirSpan = document.createElement('span');
+      dirSpan.className = 'file-dir';
+      dirSpan.style.opacity = '0.7';
+      dirSpan.textContent = dirPath;
+
+      const fileSpan = document.createElement('span');
+      fileSpan.className = 'file-basename';
+      fileSpan.textContent = basename;
+
+      nameSpan.appendChild(dirSpan);
+      nameSpan.appendChild(fileSpan);
 
       if (info.added !== undefined && info.removed !== undefined) {
         const statsSpan = document.createElement('span');
-        statsSpan.innerHTML = `<span class="added">+${info.added}</span> <span class="removed">-${info.removed}</span>`;
+        statsSpan.className = 'file-stats';
+        statsSpan.innerHTML = `<span class="added">+${info.added}</span><span class="removed">-${info.removed}</span>`;
         nameSpan.appendChild(statsSpan);
       }
 
       const actions = document.createElement('span');
       actions.className = 'file-actions';
+
+      // Create all buttons
+
+      // Only create the previous round comparison button if there's a previous file
+      // Put this first since this is right aligned to be more symmetric
+      const prevBtn = info.prev ? document.createElement('button') : null;
+      if (prevBtn) {
+        prevBtn.className = 'vscode-button tiny';
+        prevBtn.title = 'Compare with previous round';
+        prevBtn.innerHTML = '<i class="codicon codicon-diff-added"></i>';
+        prevBtn.addEventListener('click', () => {
+          vscode.postMessage({
+            command: COMMANDS.COMPARE_PREVIOUS,
+            file: info.path,
+            prev: info.prev,
+          });
+        });
+      }
 
       const openBtn = document.createElement('button');
       openBtn.className = 'vscode-button tiny';
@@ -191,22 +229,10 @@ export function updateFileList(filesByRound) {
         });
       });
 
-      const prevBtn = document.createElement('button');
-      prevBtn.className = 'vscode-button tiny';
-      prevBtn.title = 'Compare with previous round';
-      prevBtn.innerHTML = '<i class="codicon codicon-diff-all"></i>';
-      prevBtn.addEventListener('click', () => {
-        vscode.postMessage({
-          command: COMMANDS.COMPARE_PREVIOUS,
-          file: info.path,
-          prev: info.prev,
-        });
-      });
-
       const acceptBtn = document.createElement('button');
       acceptBtn.className = 'vscode-button tiny';
       acceptBtn.title = 'Accept edits';
-      acceptBtn.innerHTML = '<i class="codicon codicon-pass"></i>';
+      acceptBtn.innerHTML = '<i class="codicon codicon-check"></i>';
       acceptBtn.addEventListener('click', () => {
         vscode.postMessage({
           command: COMMANDS.ACCEPT_FILE,
@@ -218,7 +244,7 @@ export function updateFileList(filesByRound) {
       const mergeBtn = document.createElement('button');
       mergeBtn.className = 'vscode-button tiny';
       mergeBtn.title = 'Merge edits';
-      mergeBtn.innerHTML = '<i class="codicon codicon-merge"></i>';
+      mergeBtn.innerHTML = '<i class="codicon codicon-git-merge"></i>';
       mergeBtn.addEventListener('click', () => {
         vscode.postMessage({
           command: COMMANDS.MERGE_FILE,
@@ -229,8 +255,8 @@ export function updateFileList(filesByRound) {
 
       const diffBtn = document.createElement('button');
       diffBtn.className = 'vscode-button tiny';
-      diffBtn.title = 'Latexdiff again';
-      diffBtn.innerHTML = '<i class="codicon codicon-diff-added"></i>';
+      diffBtn.title = 'LaTeXdiff';
+      diffBtn.innerHTML = '<i class="codicon codicon-git-compare"></i>';
       diffBtn.addEventListener('click', () => {
         vscode.postMessage({
           command: COMMANDS.LATEXDIFF_FILE,
@@ -240,12 +266,15 @@ export function updateFileList(filesByRound) {
         });
       });
 
+      // Add all buttons to the actions container
       actions.appendChild(openBtn);
       actions.appendChild(compareBtn);
-      actions.appendChild(prevBtn);
       actions.appendChild(acceptBtn);
       actions.appendChild(mergeBtn);
       actions.appendChild(diffBtn);
+      if (prevBtn) {
+        actions.appendChild(prevBtn);
+      }
 
       item.appendChild(nameSpan);
       item.appendChild(actions);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -12,6 +12,7 @@ import {
   addLogGroup,
   updateLogGroupUI,
   appendLogToGroup,
+  updateFileList,
 } from './domHandlers.js';
 import {
   formatLogEntry,
@@ -166,6 +167,23 @@ export function setupMessageHandlers() {
 
       case COMMANDS.UPDATE_STATUS:
         updateStatus(message.status);
+        break;
+
+      case COMMANDS.UPDATE_FILES:
+        if (message.stream === getCurrentStream()) {
+          updateFileList(message.files);
+        }
+        break;
+
+      case COMMANDS.OPEN_FILE:
+        // no-op in webview, handled in extension
+        break;
+      case COMMANDS.COMPARE_ORIGINAL:
+      case COMMANDS.COMPARE_PREVIOUS:
+      case COMMANDS.ACCEPT_FILE:
+      case COMMANDS.MERGE_FILE:
+      case COMMANDS.LATEXDIFF_FILE:
+        // handled by extension
         break;
 
       case COMMANDS.DELETE_STREAM:

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -151,6 +151,8 @@
   border-top: 1px solid var(--vscode-panel-border);
   background-color: var(--vscode-sideBar-background);
   font-size: var(--vscode-editor-font-size);
+  overflow-y: auto;
+  max-height: 300px;
 }
 
 .file-item {
@@ -158,27 +160,84 @@
   justify-content: space-between;
   align-items: center;
   padding: 2px 0;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
 }
 
-.file-actions button {
-  margin-left: 4px;
+.file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 100px;
+  padding-right: 8px;
+}
+
+.file-dir {
+  opacity: 0.7;
+  font-size: 0.9em;
+}
+
+.file-basename {
+  font-weight: 500;
+}
+
+.file-stats {
+  margin-left: 8px;
+  white-space: nowrap;
+}
+
+.file-actions {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 2px;
+}
+
+/* Remove custom button styling to use common.css styles instead */
+.file-actions .vscode-button {
+  /* Keep only essential positioning */
+  margin-right: 0; /* Override the default margin-right from common.css */
+  margin-left: 1px; /* Small gap between buttons */
 }
 
 .round-group {
-  margin-bottom: 6px;
+  margin-bottom: 10px;
 }
 
 .round-header {
   font-weight: bold;
-  margin-top: 4px;
+  margin-top: 6px;
+  margin-bottom: 4px;
+  padding: 2px 4px;
+  background-color: var(--vscode-sideBarSectionHeader-background);
+  border-radius: 2px;
 }
 
 .added {
   color: var(--vscode-charts-green, green);
   margin-left: 4px;
+  font-size: 0.9em;
 }
 
 .removed {
   color: var(--vscode-charts-red, red);
   margin-left: 4px;
+  font-size: 0.9em;
+}
+
+/* Responsive adjustments */
+@media (max-width: 500px) {
+  .file-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .file-name {
+    margin-bottom: 4px;
+    width: 100%;
+  }
+
+  .file-actions {
+    align-self: flex-end;
+  }
 }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -144,3 +144,41 @@
   background-color: var(--vscode-testing-iconSkipped, #cca700);
   box-shadow: 0 0 4px var(--vscode-testing-iconSkipped, #cca700);
 }
+
+/* Generated files list */
+.files-container {
+  padding: 4px;
+  border-top: 1px solid var(--vscode-panel-border);
+  background-color: var(--vscode-sideBar-background);
+  font-size: var(--vscode-editor-font-size);
+}
+
+.file-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+}
+
+.file-actions button {
+  margin-left: 4px;
+}
+
+.round-group {
+  margin-bottom: 6px;
+}
+
+.round-header {
+  font-weight: bold;
+  margin-top: 4px;
+}
+
+.added {
+  color: var(--vscode-charts-green, green);
+  margin-left: 4px;
+}
+
+.removed {
+  color: var(--vscode-charts-red, red);
+  margin-left: 4px;
+}

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -528,7 +528,7 @@
                 class="vscode-button"
                 title="Accept changes from edited file and overwrite base file"
               >
-                <i class="codicon codicon-pass"></i>
+                <i class="codicon codicon-check"></i>
               </button>
               <button
                 id="compareButton"


### PR DESCRIPTION
## Summary
- group output files by round in the progress view
- show per-file actions for opening, comparing, accepting, merging and rerunning latexdiff
- compute basic diff stats for generated files
- persist output file state and open files via new command

## Testing
- `npm run format`
- `npm test`
