### PR TITLE
Improve output file grouping in progress view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ releases/
 .cursor
 .cursor/rules
 **/.claude/settings.local.json
+out/

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -14,6 +14,7 @@ import {
   bestConnectionMethod,
   getTeXCountStats,
 } from '../latex';
+import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 // Local imports - utilities
 import { writeFile, appendFile, fileExists } from '../utils/workspaceFileUtils';
@@ -577,6 +578,15 @@ export abstract class BaseReflectionAgent {
       this.logger.info(`Completed round ${currRound}`, roundGroupId);
     } catch (error) {
       throw error;
+    }
+
+    const provider = ProgressViewProvider.getInstance();
+    if (provider) {
+      provider.addOutputFiles(
+        this.logger.channelId,
+        this.outputHandler.outputFiles[currRound],
+        currRound,
+      );
     }
   }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -52,6 +52,12 @@ export class ProgressViewMessageHandler {
       case COMMANDS.RESTORE_STATE:
         await this.handleRestoreState(message.stream);
         break;
+      case COMMANDS.OPEN_FILE:
+        await vscode.commands.executeCommand(
+          'vscode.open',
+          vscode.Uri.file(message.file),
+        );
+        break;
       default:
         logger.warn(CHANNEL, `Unknown command: ${message.command}`);
     }
@@ -67,14 +73,23 @@ export class ProgressViewMessageHandler {
     logger.debug(CHANNEL, `Found taskState for stream: ${stream}`);
     logger.debug(CHANNEL, `Task state: ${JSON.stringify(taskState)}`);
 
-    // Execute pack command with taskState
+    const generated = this.provider.getOutputFiles(stream);
+    let files: string[] = [];
+    if (generated) {
+      for (const arr of Object.values(generated)) {
+        files.push(...arr);
+      }
+    } else if (taskState.outputFilesActive) {
+      files = taskState.outputFiles;
+    }
+
     await vscode.commands.executeCommand('texra.pack', {
       agent: taskState.agent,
       model: taskState.model,
       inputFile: taskState.inputFile,
       outputNameOverride: taskState.outputNameOverride,
-      outputFiles: taskState.outputFiles,
-      outputFilesActive: taskState.outputFilesActive,
+      outputFiles: files,
+      outputFilesActive: files.length > 0,
     });
   }
 
@@ -105,14 +120,23 @@ export class ProgressViewMessageHandler {
     logger.debug(CHANNEL, `Found taskState for stream: ${stream}`);
     logger.debug(CHANNEL, `Task state: ${JSON.stringify(taskState)}`);
 
-    // Execute clean command with taskState
+    const generated = this.provider.getOutputFiles(stream);
+    let files: string[] = [];
+    if (generated) {
+      for (const arr of Object.values(generated)) {
+        files.push(...arr);
+      }
+    } else if (taskState.outputFilesActive) {
+      files = taskState.outputFiles;
+    }
+
     await vscode.commands.executeCommand('texra.clean', {
       agent: taskState.agent,
       model: taskState.model,
       inputFile: taskState.inputFile,
       outputNameOverride: taskState.outputNameOverride,
-      outputFiles: taskState.outputFiles,
-      outputFilesActive: taskState.outputFilesActive,
+      outputFiles: files,
+      outputFilesActive: files.length > 0,
     });
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -48,10 +48,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private _view?: vscode.WebviewView;
   private _logStreams: Map<string, ColoredLogMessage[]> = new Map();
   private _logGroups: Map<string, Map<string, LogGroup>> = new Map(); // streamId -> groupId -> LogGroup
+  private _outputFiles: Map<string, Record<string, string[]>> = new Map();
   private readonly _contentProvider: ProgressViewContentProvider;
   private readonly _messageHandler: ProgressViewMessageHandler;
   private readonly _storageKey = 'texra.logStreams';
   private readonly _groupsStorageKey = 'texra.logGroups';
+  private readonly _filesStorageKey = 'texra.outputFiles';
   private readonly _taskStateKey = 'texra.taskStates';
   private _disposables: vscode.Disposable[] = [];
   private readonly _extensionUri: vscode.Uri;
@@ -139,6 +141,20 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._logGroups.clear();
     }
 
+    // Load output files
+    const savedFiles = this.context.workspaceState.get<{
+      [key: string]: Record<string, string[]>;
+    }>(this._getWorkspaceKey(this._filesStorageKey));
+    if (savedFiles) {
+      this._outputFiles = new Map(
+        Object.entries(savedFiles).filter(([channel]) =>
+          shouldPersistStream(channel),
+        ),
+      );
+    } else {
+      this._outputFiles.clear();
+    }
+
     // Load active stream
     const savedActiveStream = this.context.workspaceState.get<string>(
       this._activeStreamKey,
@@ -195,6 +211,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     // Save taskStates
     const taskStatesObj = Object.fromEntries(this._taskStates.entries());
     this.context.workspaceState.update(this._taskStateKey, taskStatesObj);
+
+    // Save output files
+    const filesObj = Object.fromEntries(this._outputFiles.entries());
+    this.context.workspaceState.update(
+      this._getWorkspaceKey(this._filesStorageKey),
+      filesObj,
+    );
   }
 
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
@@ -286,6 +309,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       currentStream: this._activeStream,
     });
     this.updateLogContent(this._activeStream);
+
+    // Send output files for current stream
+    const files = this._outputFiles.get(this._activeStream) || {};
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_FILES,
+      stream: this._activeStream,
+      files,
+    });
 
     // Update status for current stream
     if (this._activeStream) {
@@ -491,6 +522,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       command: COMMANDS.UPDATE_STATUS,
       status: status,
     });
+
+    // Send output files for this stream
+    const files = this._outputFiles.get(stream) || {};
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_FILES,
+      stream: stream,
+      files,
+    });
   }
 
   public getLogStreams(): Map<string, ColoredLogMessage[]> {
@@ -505,6 +544,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     if (this._logStreams.has(stream)) {
       this._logStreams.get(stream)!.length = 0;
       this._logGroups.delete(stream);
+      this._outputFiles.delete(stream);
       this._saveState();
       this.updateLogContent(stream);
     }
@@ -514,6 +554,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._logStreams.clear();
     this._logGroups.clear();
     this._taskStates.clear();
+    this._outputFiles.clear();
     this._saveState();
     if (this._view) {
       this._view.webview.postMessage({ command: COMMANDS.CLEAR_LOGS });
@@ -534,6 +575,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._logStreams.delete(stream);
       this._logGroups.delete(stream);
       this._taskStates.delete(stream);
+      this._outputFiles.delete(stream);
 
       // If the deleted stream was the active one, switch to another stream if available
       if (stream === this._activeStream) {
@@ -567,6 +609,25 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   public getStreamStatus(stream: string): StreamStatusType | undefined {
     return this._streamStatus.get(stream);
+  }
+
+  public addOutputFiles(stream: string, files: string[], round: number): void {
+    const roundKey = `r${round}`;
+    const existing = this._outputFiles.get(stream) || {};
+    existing[roundKey] = files;
+    this._outputFiles.set(stream, existing);
+    this._saveState();
+    if (this._view && stream === this._activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_FILES,
+        stream,
+        files: existing,
+      });
+    }
+  }
+
+  public getOutputFiles(stream: string): Record<string, string[]> | undefined {
+    return this._outputFiles.get(stream);
   }
 
   public setActiveStream(stream: string) {

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -101,6 +101,7 @@
           </div>
         </div>
         <div id="logContent" class="log-container"></div>
+        <div id="generatedFiles" class="files-container"></div>
       </div>
       <div class="tabs split">
         <div id="streamTabs" class="tabs-content">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -34,4 +34,6 @@ export const COMMANDS = {
   ADD_LOG_GROUP: 'addLogGroup',
   UPDATE_LOG_GROUP: 'updateLogGroup',
   UPDATE_STATUS: 'updateStatus',
+  UPDATE_FILES: 'updateFiles',
+  OPEN_FILE: 'openFile',
 };

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -126,6 +126,54 @@ export function updateStatus(status) {
 }
 
 /**
+ * Update the generated files list
+ * @param {Object} filesByRound - Mapping of round -> Array of file paths
+ */
+export function updateFileList(filesByRound) {
+  const container = document.getElementById('generatedFiles');
+  if (!container) return;
+
+  container.innerHTML = '';
+
+  if (!filesByRound || Object.keys(filesByRound).length === 0) {
+    container.textContent = 'No generated files';
+    return;
+  }
+
+  Object.entries(filesByRound).forEach(([round, files]) => {
+    const roundHeader = document.createElement('div');
+    roundHeader.className = 'round-header';
+    roundHeader.textContent = `Round ${round.replace(/^r/, '')}`;
+    container.appendChild(roundHeader);
+
+    files.forEach((file) => {
+      const item = document.createElement('div');
+      item.className = 'file-item';
+
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'file-name';
+      nameSpan.textContent = file;
+
+      const actions = document.createElement('span');
+      actions.className = 'file-actions';
+
+      const openBtn = document.createElement('button');
+      openBtn.className = 'vscode-button tiny';
+      openBtn.title = 'Open file';
+      openBtn.innerHTML = '<i class="codicon codicon-go-to-file"></i>';
+      openBtn.addEventListener('click', () => {
+        vscode.postMessage({ command: COMMANDS.OPEN_FILE, file });
+      });
+
+      actions.appendChild(openBtn);
+      item.appendChild(nameSpan);
+      item.appendChild(actions);
+      container.appendChild(item);
+    });
+  });
+}
+
+/**
  * Adds a log group to the DOM
  * @param {Object} group - Group data
  */

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -12,6 +12,7 @@ import {
   addLogGroup,
   updateLogGroupUI,
   appendLogToGroup,
+  updateFileList,
 } from './domHandlers.js';
 import {
   formatLogEntry,
@@ -166,6 +167,16 @@ export function setupMessageHandlers() {
 
       case COMMANDS.UPDATE_STATUS:
         updateStatus(message.status);
+        break;
+
+      case COMMANDS.UPDATE_FILES:
+        if (message.stream === getCurrentStream()) {
+          updateFileList(message.files);
+        }
+        break;
+
+      case COMMANDS.OPEN_FILE:
+        // no-op in webview, handled in extension
         break;
 
       case COMMANDS.DELETE_STREAM:

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -144,3 +144,40 @@
   background-color: var(--vscode-testing-iconSkipped, #cca700);
   box-shadow: 0 0 4px var(--vscode-testing-iconSkipped, #cca700);
 }
+
+/* Generated files list */
+.files-container {
+  padding: 4px;
+  border-top: 1px solid var(--vscode-panel-border);
+  background-color: var(--vscode-sideBar-background);
+  font-size: var(--vscode-editor-font-size);
+  overflow-x: auto;
+}
+
+.file-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+}
+
+.round-header {
+  margin-top: 4px;
+  font-weight: bold;
+}
+
+.file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.file-actions {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.file-actions button {
+  margin-left: 4px;
+}


### PR DESCRIPTION
## Summary
- track generated files by round in progress view
- show generated files grouped by round with ellipsised file names
- use generated files for pack/clean operations if available

## Testing
- `npm run format`
- `npm test`
