### PR TITLE
Enhance progress view file actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -887,6 +887,11 @@
         "category": "TeXRA"
       },
       {
+        "command": "texra.openFileCompile",
+        "title": "Open and Compile LaTeX File",
+        "category": "TeXRA"
+      },
+      {
         "command": "texra.showAgentHistory",
         "title": "Show Agent Execution History",
         "category": "TeXRA"

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -14,6 +14,7 @@ import {
   bestConnectionMethod,
   getTeXCountStats,
 } from '../latex';
+import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 // Local imports - utilities
 import { writeFile, appendFile, fileExists } from '../utils/workspaceFileUtils';
@@ -577,6 +578,31 @@ export abstract class BaseReflectionAgent {
       this.logger.info(`Completed round ${currRound}`, roundGroupId);
     } catch (error) {
       throw error;
+    }
+
+    const provider = ProgressViewProvider.getInstance();
+    if (provider) {
+      const outputFiles = this.outputHandler.outputFiles[currRound];
+      const baseMap = this.outputHandler.getFileMapping(
+        this.outputHandler.baseFiles,
+        outputFiles,
+        'contains',
+      );
+      const prevFiles =
+        currRound > 0 ? this.outputHandler.outputFiles[currRound - 1] : [];
+      const prevMap = this.outputHandler.getFileMapping(
+        prevFiles,
+        outputFiles,
+        'basename',
+        true,
+      );
+      await provider.addOutputFiles(
+        this.logger.channelId,
+        currRound,
+        outputFiles,
+        baseMap,
+        prevMap,
+      );
     }
   }
 

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -271,6 +271,23 @@ export class OutputHandler {
     return fileMapping;
   }
 
+  /**
+   * Public wrapper around createFileMapping to expose file mapping logic
+   */
+  public getFileMapping(
+    sourceFiles: string[],
+    targetFiles: string[],
+    matchStrategy: 'basename' | 'contains' = 'basename',
+    roundAware: boolean = false,
+  ): Map<string, string> {
+    return this.createFileMapping(
+      sourceFiles,
+      targetFiles,
+      matchStrategy,
+      roundAware,
+    );
+  }
+
   /** Updates \input commands in output files to reference new file paths. */
   public async replaceInputCommands(
     baseFiles: string[],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,6 +27,7 @@ import { registerArXivCommands } from './commands/arXivCommands';
 import { registerCompareCommands } from './commands/compareCommands';
 import { registerProgressViewCommands } from './commands/progressViewCommands';
 import { registerHelpCommands } from './commands/helpCommands';
+import { registerOpenFileCommands } from './commands/openFileCommands';
 
 import * as logger from './logger/logUtils';
 
@@ -65,6 +66,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     compare: registerCompareCommands(context),
     progressView: registerProgressViewCommands(context),
     help: registerHelpCommands(context),
+    openFile: registerOpenFileCommands(context),
   };
 
   // Register webview provider
@@ -106,3 +108,4 @@ export { historyCommands } from './commands/historyCommands';
 export { arXivCommands } from './commands/arXivCommands';
 export { compareCommands } from './commands/compareCommands';
 export { helpCommands } from './commands/helpCommands';
+export { registerOpenFileCommands as openFileCommands } from './commands/openFileCommands';

--- a/src/commands/openFileCommands.ts
+++ b/src/commands/openFileCommands.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+import * as logger from '../logger/logUtils';
+import { getFullPathFromWorkspace } from '../utils/workspaceFileUtils';
+
+const CHANNEL = 'openFileCommands';
+logger.initialize(CHANNEL);
+
+export function registerOpenFileCommands(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('texra.openFileCompile', openFileCompile),
+  );
+  return { openFileCompile };
+}
+
+async function openFileCompile(file: string) {
+  try {
+    const fullPath = getFullPathFromWorkspace(file);
+    const uri = vscode.Uri.file(fullPath);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, { preview: false });
+
+    if (file.toLowerCase().endsWith('.tex')) {
+      await vscode.commands.executeCommand('latex-workshop.build', uri);
+    }
+  } catch (err) {
+    logger.error(
+      CHANNEL,
+      `Failed to open file ${file}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    vscode.window.showErrorMessage(`Could not open ${file}`);
+  }
+}

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -52,6 +52,52 @@ export class ProgressViewMessageHandler {
       case COMMANDS.RESTORE_STATE:
         await this.handleRestoreState(message.stream);
         break;
+      case COMMANDS.OPEN_FILE:
+        await vscode.commands.executeCommand(
+          'texra.openFileCompile',
+          message.file,
+        );
+        break;
+      case COMMANDS.COMPARE_ORIGINAL:
+        await vscode.commands.executeCommand(
+          'texra.compare',
+          undefined,
+          message.base,
+          message.file,
+        );
+        break;
+      case COMMANDS.COMPARE_PREVIOUS:
+        await vscode.commands.executeCommand(
+          'texra.compare',
+          undefined,
+          message.prev,
+          message.file,
+        );
+        break;
+      case COMMANDS.ACCEPT_FILE:
+        await vscode.commands.executeCommand(
+          'texra.acceptEdited',
+          undefined,
+          message.base,
+          message.file,
+        );
+        break;
+      case COMMANDS.MERGE_FILE:
+        await vscode.commands.executeCommand(
+          'texra.merge',
+          undefined,
+          message.base,
+          message.file,
+        );
+        break;
+      case COMMANDS.LATEXDIFF_FILE:
+        await vscode.commands.executeCommand(
+          'texra.latexdiff',
+          undefined,
+          message.base,
+          message.file,
+        );
+        break;
       default:
         logger.warn(CHANNEL, `Unknown command: ${message.command}`);
     }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -12,6 +12,7 @@ import {
   shouldExcludeFromProgressView,
   shouldPersistStream,
 } from '../utils/loggerUtils';
+import { computeDiffStats } from '../utils/diffStats';
 // @ts-ignore - Import JavaScript module
 import { STATUS, COMMANDS } from './modules/constants.js';
 
@@ -32,6 +33,14 @@ interface ColoredLogMessage {
   groupId?: string;
 }
 
+interface FileInfo {
+  file: string;
+  base?: string;
+  prev?: string;
+  added?: number;
+  removed?: number;
+}
+
 interface LogGroup {
   id: string;
   name: string;
@@ -48,10 +57,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private _view?: vscode.WebviewView;
   private _logStreams: Map<string, ColoredLogMessage[]> = new Map();
   private _logGroups: Map<string, Map<string, LogGroup>> = new Map(); // streamId -> groupId -> LogGroup
+  private _outputFiles: Map<string, { [round: string]: FileInfo[] }> =
+    new Map();
   private readonly _contentProvider: ProgressViewContentProvider;
   private readonly _messageHandler: ProgressViewMessageHandler;
   private readonly _storageKey = 'texra.logStreams';
   private readonly _groupsStorageKey = 'texra.logGroups';
+  private readonly _filesStorageKey = 'texra.outputFiles';
   private readonly _taskStateKey = 'texra.taskStates';
   private _disposables: vscode.Disposable[] = [];
   private readonly _extensionUri: vscode.Uri;
@@ -139,6 +151,20 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._logGroups.clear();
     }
 
+    // Load output files
+    const savedFiles = this.context.workspaceState.get<{
+      [key: string]: { [round: string]: FileInfo[] };
+    }>(this._getWorkspaceKey(this._filesStorageKey));
+    if (savedFiles) {
+      this._outputFiles = new Map(
+        Object.entries(savedFiles).filter(([channel]) =>
+          shouldPersistStream(channel),
+        ),
+      );
+    } else {
+      this._outputFiles.clear();
+    }
+
     // Load active stream
     const savedActiveStream = this.context.workspaceState.get<string>(
       this._activeStreamKey,
@@ -195,6 +221,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     // Save taskStates
     const taskStatesObj = Object.fromEntries(this._taskStates.entries());
     this.context.workspaceState.update(this._taskStateKey, taskStatesObj);
+
+    // Save output files
+    const filesObj = Object.fromEntries(this._outputFiles.entries());
+    this.context.workspaceState.update(
+      this._getWorkspaceKey(this._filesStorageKey),
+      filesObj,
+    );
   }
 
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
@@ -286,6 +319,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       currentStream: this._activeStream,
     });
     this.updateLogContent(this._activeStream);
+
+    // Send output files for current stream
+    const files = this._outputFiles.get(this._activeStream) || {};
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_FILES,
+      stream: this._activeStream,
+      files,
+    });
 
     // Update status for current stream
     if (this._activeStream) {
@@ -491,6 +532,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       command: COMMANDS.UPDATE_STATUS,
       status: status,
     });
+
+    // Send output files for this stream
+    const files = this._outputFiles.get(stream) || {};
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_FILES,
+      stream: stream,
+      files,
+    });
   }
 
   public getLogStreams(): Map<string, ColoredLogMessage[]> {
@@ -505,6 +554,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     if (this._logStreams.has(stream)) {
       this._logStreams.get(stream)!.length = 0;
       this._logGroups.delete(stream);
+      this._outputFiles.delete(stream);
       this._saveState();
       this.updateLogContent(stream);
     }
@@ -514,6 +564,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._logStreams.clear();
     this._logGroups.clear();
     this._taskStates.clear();
+    this._outputFiles.clear();
     this._saveState();
     if (this._view) {
       this._view.webview.postMessage({ command: COMMANDS.CLEAR_LOGS });
@@ -534,6 +585,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._logStreams.delete(stream);
       this._logGroups.delete(stream);
       this._taskStates.delete(stream);
+      this._outputFiles.delete(stream);
 
       // If the deleted stream was the active one, switch to another stream if available
       if (stream === this._activeStream) {
@@ -567,6 +619,55 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   public getStreamStatus(stream: string): StreamStatusType | undefined {
     return this._streamStatus.get(stream);
+  }
+
+  public async addOutputFiles(
+    stream: string,
+    round: number,
+    files: string[],
+    baseMap?: Map<string, string>,
+    prevMap?: Map<string, string>,
+  ): Promise<void> {
+    if (!this._outputFiles.has(stream)) {
+      this._outputFiles.set(stream, {});
+    }
+
+    const roundMap = this._outputFiles.get(stream)!;
+    const infos: FileInfo[] = [];
+    for (const file of files) {
+      const info: FileInfo = { file };
+      if (baseMap) {
+        const b = baseMap.get(file);
+        if (b) {
+          info.base = b;
+          const stats = await computeDiffStats(b, file);
+          info.added = stats.added;
+          info.removed = stats.removed;
+        }
+      }
+      if (prevMap) {
+        const p = prevMap.get(file);
+        if (p) {
+          info.prev = p;
+        }
+      }
+      infos.push(info);
+    }
+    roundMap[round.toString()] = infos;
+    this._saveState();
+    if (this._view && stream === this._activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_FILES,
+        stream,
+        files: roundMap,
+      });
+    }
+  }
+
+  public getOutputFiles(
+    stream: string,
+  ): { [round: string]: FileInfo[] } | undefined {
+    return this._outputFiles.get(stream);
   }
 
   public setActiveStream(stream: string) {

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -101,6 +101,7 @@
           </div>
         </div>
         <div id="logContent" class="log-container"></div>
+        <div id="generatedFiles" class="files-container"></div>
       </div>
       <div class="tabs split">
         <div id="streamTabs" class="tabs-content">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -34,4 +34,11 @@ export const COMMANDS = {
   ADD_LOG_GROUP: 'addLogGroup',
   UPDATE_LOG_GROUP: 'updateLogGroup',
   UPDATE_STATUS: 'updateStatus',
+  UPDATE_FILES: 'updateFiles',
+  OPEN_FILE: 'openFile',
+  COMPARE_ORIGINAL: 'compareOriginal',
+  COMPARE_PREVIOUS: 'comparePrevious',
+  ACCEPT_FILE: 'acceptFile',
+  MERGE_FILE: 'mergeFile',
+  LATEXDIFF_FILE: 'latexdiffFile',
 };

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -126,6 +126,136 @@ export function updateStatus(status) {
 }
 
 /**
+ * Update the generated files list
+ * @param {Array<string>} files - Array of file paths
+ */
+export function updateFileList(filesByRound) {
+  const container = document.getElementById('generatedFiles');
+  if (!container) return;
+
+  container.innerHTML = '';
+
+  if (!filesByRound || Object.keys(filesByRound).length === 0) {
+    container.textContent = 'No generated files';
+    return;
+  }
+
+  const rounds = Object.keys(filesByRound).sort(
+    (a, b) => Number(a) - Number(b),
+  );
+
+  rounds.forEach((round) => {
+    const header = document.createElement('div');
+    header.className = 'round-header';
+    header.textContent = `Round ${round}`;
+    container.appendChild(header);
+
+    filesByRound[round].forEach((info) => {
+      const item = document.createElement('div');
+      item.className = 'file-item';
+
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'file-name';
+      nameSpan.textContent = info.file;
+
+      const statsSpan = document.createElement('span');
+      statsSpan.className = 'file-stats';
+      if (info.added !== undefined && info.removed !== undefined) {
+        statsSpan.innerHTML = `<span class="added">+${info.added}</span> <span class="removed">-${info.removed}</span>`;
+      }
+
+      const actions = document.createElement('span');
+      actions.className = 'file-actions';
+
+      const openBtn = document.createElement('button');
+      openBtn.className = 'vscode-button tiny';
+      openBtn.title = 'Open file';
+      openBtn.innerHTML = '<i class="codicon codicon-go-to-file"></i>';
+      openBtn.addEventListener('click', () => {
+        vscode.postMessage({ command: COMMANDS.OPEN_FILE, file: info.file });
+      });
+      actions.appendChild(openBtn);
+
+      if (info.base) {
+        const compareBtn = document.createElement('button');
+        compareBtn.className = 'vscode-button tiny';
+        compareBtn.title = 'Compare with original';
+        compareBtn.innerHTML = '<i class="codicon codicon-diff"></i>';
+        compareBtn.addEventListener('click', () => {
+          vscode.postMessage({
+            command: COMMANDS.COMPARE_ORIGINAL,
+            base: info.base,
+            file: info.file,
+          });
+        });
+        actions.appendChild(compareBtn);
+      }
+
+      if (info.prev) {
+        const prevBtn = document.createElement('button');
+        prevBtn.className = 'vscode-button tiny';
+        prevBtn.title = 'Compare with previous';
+        prevBtn.innerHTML = '<i class="codicon codicon-history"></i>';
+        prevBtn.addEventListener('click', () => {
+          vscode.postMessage({
+            command: COMMANDS.COMPARE_PREVIOUS,
+            prev: info.prev,
+            file: info.file,
+          });
+        });
+        actions.appendChild(prevBtn);
+      }
+
+      if (info.base) {
+        const acceptBtn = document.createElement('button');
+        acceptBtn.className = 'vscode-button tiny';
+        acceptBtn.title = 'Accept edits';
+        acceptBtn.innerHTML = '<i class="codicon codicon-check"></i>';
+        acceptBtn.addEventListener('click', () => {
+          vscode.postMessage({
+            command: COMMANDS.ACCEPT_FILE,
+            base: info.base,
+            file: info.file,
+          });
+        });
+        actions.appendChild(acceptBtn);
+
+        const mergeBtn = document.createElement('button');
+        mergeBtn.className = 'vscode-button tiny';
+        mergeBtn.title = 'Merge using AI';
+        mergeBtn.innerHTML = '<i class="codicon codicon-git-merge"></i>';
+        mergeBtn.addEventListener('click', () => {
+          vscode.postMessage({
+            command: COMMANDS.MERGE_FILE,
+            base: info.base,
+            file: info.file,
+          });
+        });
+        actions.appendChild(mergeBtn);
+
+        const diffAgainBtn = document.createElement('button');
+        diffAgainBtn.className = 'vscode-button tiny';
+        diffAgainBtn.title = 'Run latexdiff again';
+        diffAgainBtn.innerHTML = '<i class="codicon codicon-diff-added"></i>';
+        diffAgainBtn.addEventListener('click', () => {
+          vscode.postMessage({
+            command: COMMANDS.LATEXDIFF_FILE,
+            base: info.base,
+            file: info.file,
+          });
+        });
+        actions.appendChild(diffAgainBtn);
+      }
+
+      item.appendChild(nameSpan);
+      item.appendChild(statsSpan);
+      item.appendChild(actions);
+      container.appendChild(item);
+    });
+  });
+}
+
+/**
  * Adds a log group to the DOM
  * @param {Object} group - Group data
  */

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -12,6 +12,7 @@ import {
   addLogGroup,
   updateLogGroupUI,
   appendLogToGroup,
+  updateFileList,
 } from './domHandlers.js';
 import {
   formatLogEntry,
@@ -166,6 +167,23 @@ export function setupMessageHandlers() {
 
       case COMMANDS.UPDATE_STATUS:
         updateStatus(message.status);
+        break;
+
+      case COMMANDS.UPDATE_FILES:
+        if (message.stream === getCurrentStream()) {
+          updateFileList(message.files);
+        }
+        break;
+
+      case COMMANDS.OPEN_FILE:
+        // no-op in webview, handled in extension
+        break;
+      case COMMANDS.COMPARE_ORIGINAL:
+      case COMMANDS.COMPARE_PREVIOUS:
+      case COMMANDS.ACCEPT_FILE:
+      case COMMANDS.MERGE_FILE:
+      case COMMANDS.LATEXDIFF_FILE:
+        // handled in extension
         break;
 
       case COMMANDS.DELETE_STREAM:

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -144,3 +144,41 @@
   background-color: var(--vscode-testing-iconSkipped, #cca700);
   box-shadow: 0 0 4px var(--vscode-testing-iconSkipped, #cca700);
 }
+
+/* Generated files list */
+.files-container {
+  padding: 4px;
+  border-top: 1px solid var(--vscode-panel-border);
+  background-color: var(--vscode-sideBar-background);
+  font-size: var(--vscode-editor-font-size);
+}
+
+.file-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+}
+
+.file-actions button {
+  margin-left: 4px;
+}
+
+.round-header {
+  margin-top: 4px;
+  font-weight: bold;
+}
+
+.file-stats {
+  margin-left: auto;
+  margin-right: 8px;
+}
+
+.file-stats .added {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #81b88b);
+}
+
+.file-stats .removed {
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #c74e39);
+  margin-left: 4px;
+}

--- a/src/types/diff.d.ts
+++ b/src/types/diff.d.ts
@@ -1,0 +1,3 @@
+declare module 'diff' {
+  export function diffLines(oldStr: string, newStr: string): Array<{ added?: boolean; removed?: boolean; value: string; count?: number }>;
+}

--- a/src/utils/diffStats.ts
+++ b/src/utils/diffStats.ts
@@ -1,0 +1,33 @@
+import { diffLines } from 'diff';
+import { readFile } from './workspaceFileUtils';
+
+export interface DiffStats {
+  added: number;
+  removed: number;
+}
+
+export async function computeDiffStats(
+  baseFile: string,
+  editedFile: string,
+): Promise<DiffStats> {
+  try {
+    const [baseContent, editedContent] = await Promise.all([
+      readFile(baseFile),
+      readFile(editedFile),
+    ]);
+    const diffs = diffLines(baseContent, editedContent);
+    let added = 0;
+    let removed = 0;
+    for (const part of diffs) {
+      const lineCount = part.count ?? part.value.split(/\r?\n/).length - 1;
+      if (part.added) {
+        added += lineCount;
+      } else if (part.removed) {
+        removed += lineCount;
+      }
+    }
+    return { added, removed };
+  } catch {
+    return { added: 0, removed: 0 };
+  }
+}


### PR DESCRIPTION
## Summary
- support per-round output files with diff stats in progress view
- add openFileCompile command
- provide various file actions (compare, merge, accept, etc.)
- compute diff statistics for generated files
- improve generated files list UI

## Testing
- `npm run format`
- `npm test` (with warnings)
