### PR TITLE
Refactor history buttons to use shared styles

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -200,3 +200,10 @@ select:focus {
   align-items: center;
   margin-bottom: var(--spacing-medium);
 }
+
+/* Generic button group container */
+.button-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -33,20 +33,20 @@
         <input
           type="text"
           id="searchInput"
-          class="search-input"
+          class="search-input vscode-input"
           placeholder="Search history items..."
         />
         <div class="search-controls">
           <button
             id="prevMatch"
-            class="button search-nav-btn"
+            class="vscode-button search-nav-btn"
             title="Previous match"
           >
             ↑
           </button>
           <button
             id="nextMatch"
-            class="button search-nav-btn"
+            class="vscode-button search-nav-btn"
             title="Next match"
           >
             ↓

--- a/src/historyView/modules/domHandlers.js
+++ b/src/historyView/modules/domHandlers.js
@@ -25,7 +25,7 @@ export function renderHistoryItems(historyItems) {
 
   // Add clear button
   clearButtonContainer.innerHTML = `
-    <button class="button button-clear" id="clearHistoryBtn">Clear All History</button>
+    <button class="vscode-button button-clear" id="clearHistoryBtn">Clear All History</button>
   `;
 
   // Add event listener for clear button
@@ -68,11 +68,11 @@ function createHistoryItemElement(item) {
   header.className = 'history-item-header';
   header.innerHTML = `
     <div class="history-timestamp">${formattedDate}</div>
-    <div class="history-actions">
-      <button class="button delete-btn" data-id="${item.id}" title="Delete this history item">Delete</button>
-      <button class="button restore-btn" data-id="${item.id}" title="Load configuration to main view">Restore</button>
-      <button class="button rerun-btn" data-id="${item.id}" title="Execute this configuration">Rerun</button>
-    </div>
+      <div class="history-actions button-group">
+        <button class="vscode-button delete-btn" data-id="${item.id}" title="Delete this history item">Delete</button>
+        <button class="vscode-button restore-btn" data-id="${item.id}" title="Load configuration to main view">Restore</button>
+        <button class="vscode-button rerun-btn" data-id="${item.id}" title="Execute this configuration">Rerun</button>
+      </div>
   `;
 
   // Create the basic details section

--- a/src/historyView/style.css
+++ b/src/historyView/style.css
@@ -25,16 +25,8 @@ h2 {
 
 .search-input {
   flex-grow: 1;
-  background-color: var(--vscode-input-background);
-  color: var(--vscode-input-foreground);
-  border: 1px solid var(--vscode-input-border, transparent);
-  border-radius: 2px;
   padding: 6px 8px;
   font-size: 14px;
-}
-
-.search-input:focus {
-  outline: 1px solid var(--vscode-focusBorder);
 }
 
 .search-controls {
@@ -128,24 +120,6 @@ mark.current-match {
   padding: 4px 0;
 }
 
-/* Buttons */
-.button {
-  background-color: var(--vscode-button-background);
-  color: var(--vscode-button-foreground);
-  border: none;
-  padding: 4px 8px;
-  border-radius: 2px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 60px;
-}
-
-.button:hover {
-  background-color: var(--vscode-button-hoverBackground);
-}
-
 .button-clear {
   background-color: var(--vscode-errorForeground);
   margin-bottom: 20px;
@@ -157,7 +131,6 @@ mark.current-match {
 }
 
 .history-actions {
-  display: flex;
   gap: 8px;
 }
 

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -42,7 +42,7 @@
               data-status="Ready"
             ></span>
           </div>
-          <div class="header-actions">
+          <div class="header-actions button-group">
             <button
               class="vscode-button stop-button"
               id="stopStreamBtn"

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -189,7 +189,7 @@ export function updateFileList(filesByRound) {
       }
 
       const actions = document.createElement('span');
-      actions.className = 'file-actions';
+      actions.className = 'file-actions button-group';
 
       // Create all buttons
 

--- a/src/progressView/styles/buttons.css
+++ b/src/progressView/styles/buttons.css
@@ -20,12 +20,6 @@
   color: var(--vscode-testing-runAction, #2ea043);
 }
 
-/* Header actions container */
-.header-actions {
-  display: flex;
-  gap: 4px;
-}
-
 /* Codicon override for trash icon */
 .codicon-trash:before {
   content: '\eb9f';

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -188,7 +188,6 @@
 }
 
 .file-actions {
-  display: flex;
   flex-wrap: nowrap;
   gap: 2px;
 }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -42,7 +42,7 @@
                   Input</label
                 >
               </div>
-              <div class="file-select-actions">
+              <div class="file-select-actions button-group">
                 <button
                   id="currentInputFileButton"
                   class="vscode-button"
@@ -105,7 +105,7 @@
                 ></i>
                 Reference</label
               >
-              <div class="file-select-actions">
+              <div class="file-select-actions button-group">
                 <button
                   id="currentReferenceFileButton"
                   class="vscode-button"
@@ -171,7 +171,7 @@
                 ></i>
                 Auxiliary</label
               >
-              <div class="file-select-actions">
+              <div class="file-select-actions button-group">
                 <button
                   id="currentAuxiliaryFileButton"
                   class="vscode-button"
@@ -269,7 +269,7 @@
                   </div>
                 </div>
               </div>
-              <div class="file-select-actions">
+              <div class="file-select-actions button-group">
                 <button
                   id="emptyMediaFileButton"
                   class="vscode-button"
@@ -320,7 +320,7 @@
                 >
                 <span class="optional-label">Multiple Outputs</span>
               </div>
-              <div class="file-select-actions">
+              <div class="file-select-actions button-group">
                 <button
                   id="emptyOutputFilesButton"
                   class="vscode-button"
@@ -410,7 +410,7 @@
                 </div>
               </div>
             </div>
-            <div class="instruction-header-actions">
+            <div class="instruction-header-actions button-group">
               <button
                 id="settingsButton"
                 class="vscode-button"
@@ -490,7 +490,7 @@
                 ><i class="codicon codicon-file"></i> Base</label
               >
             </div>
-            <div class="file-select-actions">
+            <div class="file-select-actions button-group">
               <button
                 id="currentBaseFileButton"
                 class="vscode-button"
@@ -522,7 +522,7 @@
                 Edited</label
               >
             </div>
-            <div class="file-select-actions">
+            <div class="file-select-actions button-group">
               <button
                 id="acceptButton"
                 class="vscode-button"
@@ -582,7 +582,7 @@
                 Commit</label
               >
             </div>
-            <div class="file-select-actions">
+            <div class="file-select-actions button-group">
               <button
                 id="latexdiffvcButton"
                 class="vscode-button"

--- a/src/webview/styles/file-selection.css
+++ b/src/webview/styles/file-selection.css
@@ -50,9 +50,6 @@
 }
 
 .file-select-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
   flex-wrap: nowrap;
   margin-left: auto;
   position: relative;

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -42,12 +42,6 @@
   gap: var(--spacing-medium);
 }
 
-.instruction-header-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
 .instruction-header label {
   font-size: var(--font-size);
   font-weight: bold;


### PR DESCRIPTION
## Summary
- use `.vscode-button` and `.vscode-input` classes in history view
- remove duplicate button and input styles

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test`