### PR TITLE
Simplify ProgressView styling

### DIFF
--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -5,14 +5,14 @@
 
 /* Log Group Styles */
 .log-group-header {
-  padding: 4px 8px;
-  margin: 4px 0;
-  border-radius: 4px;
+  padding: 2px 6px;
+  margin: 2px 0;
+  border-radius: 2px;
   cursor: pointer;
   display: flex;
   align-items: center;
   background-color: var(--vscode-editor-background);
-  border-left: 4px solid var(--vscode-activityBarBadge-background);
+  border-left: 2px solid var(--vscode-panel-border);
 }
 
 .log-group-header.running {
@@ -28,17 +28,17 @@
 }
 
 .log-group-content {
-  margin-left: 20px;
-  padding-left: 12px;
-  border-left: 1px solid var(--vscode-editorGroupHeader-tabsBorder);
+  margin-left: 16px;
+  padding-left: 8px;
+  border-left: 1px dashed var(--vscode-editorGroupHeader-tabsBorder);
 }
 
 .group-toggle {
-  margin-right: 8px;
+  margin-right: 4px;
 }
 
 .group-status-icon {
-  margin-right: 8px;
+  margin-right: 4px;
 }
 
 .group-title {
@@ -49,7 +49,7 @@
 .group-time {
   font-size: 12px;
   opacity: 0.7;
-  margin-left: 12px;
+  margin-left: 8px;
 }
 
 .group-start-time,
@@ -71,23 +71,23 @@
 
 /* Child group headers have a different style to show hierarchy */
 .log-group-content .log-group-header {
-  border-left-width: 2px; /* Thinner border for child groups */
+  border-left-width: 1px; /* Thinner border for child groups */
   margin-left: 8px; /* Small indent for child group headers */
 }
 
 /* Indent child group content */
 .log-group-content .log-group-content {
-  margin-left: 16px; /* Indent nested content */
+  margin-left: 12px; /* Indent nested content */
 }
 
 /* Log lines within a group */
 .log-group-content > .log-line {
-  margin-left: 8px; /* Small indent for log lines */
+  margin-left: 4px; /* Small indent for log lines */
 }
 
 /* Log lines within a nested group */
 .log-group-content .log-group-content .log-line {
-  margin-left: 4px; /* Less indent needed since parent container is already indented */
+  margin-left: 2px; /* Less indent needed since parent container is already indented */
 }
 
 /* Visual indicator for nested structure */

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -6,10 +6,10 @@
 .log-container {
   flex: 1;
   overflow-y: auto;
-  padding: 2px 4px;
+  padding: 2px 6px;
   min-width: 0;
   min-height: 0;
-  background-color: var(--vscode-sideBar-background);
+  background-color: var(--vscode-editor-background);
   font-family: var(--vscode-editor-font-family);
   font-size: var(--vscode-editor-font-size);
 }


### PR DESCRIPTION
## Summary
- use editor background for log container
- reduce margins and borders in log groups for a more minimal look

## Testing
- `npm run lint`
- `npm test` *(fails: environment lacks network access)*