### PR TITLE
Simplify special content CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.94.0"

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -28,8 +28,8 @@
 }
 
 .log-group-content {
-  margin-left: 16px;
-  padding-left: 8px;
+  margin-left: 12px;
+  padding-left: 4px;
   border-left: 1px dashed var(--vscode-editorGroupHeader-tabsBorder);
 }
 

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -5,14 +5,14 @@
 
 /* Log Group Styles */
 .log-group-header {
-  padding: 4px 8px;
-  margin: 4px 0;
-  border-radius: 4px;
+  padding: 2px 6px;
+  margin: 2px 0;
+  border-radius: 2px;
   cursor: pointer;
   display: flex;
   align-items: center;
   background-color: var(--vscode-editor-background);
-  border-left: 4px solid var(--vscode-activityBarBadge-background);
+  border-left: 2px solid var(--vscode-panel-border);
 }
 
 .log-group-header.running {
@@ -28,17 +28,17 @@
 }
 
 .log-group-content {
-  margin-left: 20px;
-  padding-left: 12px;
-  border-left: 1px solid var(--vscode-editorGroupHeader-tabsBorder);
+  margin-left: 16px;
+  padding-left: 8px;
+  border-left: 1px dashed var(--vscode-editorGroupHeader-tabsBorder);
 }
 
 .group-toggle {
-  margin-right: 8px;
+  margin-right: 4px;
 }
 
 .group-status-icon {
-  margin-right: 8px;
+  margin-right: 4px;
 }
 
 .group-title {
@@ -49,7 +49,7 @@
 .group-time {
   font-size: 12px;
   opacity: 0.7;
-  margin-left: 12px;
+  margin-left: 8px;
 }
 
 .group-start-time,
@@ -71,23 +71,23 @@
 
 /* Child group headers have a different style to show hierarchy */
 .log-group-content .log-group-header {
-  border-left-width: 2px; /* Thinner border for child groups */
+  border-left-width: 1px; /* Thinner border for child groups */
   margin-left: 8px; /* Small indent for child group headers */
 }
 
 /* Indent child group content */
 .log-group-content .log-group-content {
-  margin-left: 16px; /* Indent nested content */
+  margin-left: 12px; /* Indent nested content */
 }
 
 /* Log lines within a group */
 .log-group-content > .log-line {
-  margin-left: 8px; /* Small indent for log lines */
+  margin-left: 4px; /* Small indent for log lines */
 }
 
 /* Log lines within a nested group */
 .log-group-content .log-group-content .log-line {
-  margin-left: 4px; /* Less indent needed since parent container is already indented */
+  margin-left: 2px; /* Less indent needed since parent container is already indented */
 }
 
 /* Visual indicator for nested structure */

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -6,10 +6,10 @@
 .log-container {
   flex: 1;
   overflow-y: auto;
-  padding: 2px 4px;
+  padding: 2px 6px;
   min-width: 0;
   min-height: 0;
-  background-color: var(--vscode-sideBar-background);
+  background-color: var(--vscode-editor-background);
   font-family: var(--vscode-editor-font-family);
   font-size: var(--vscode-editor-font-size);
 }

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -7,50 +7,41 @@
 .special-content,
 .scratchpad-content,
 .thinking-content {
-  border-radius: 6px;
-  padding: 16px 20px;
-  margin: 8px 0;
+  --special-color: var(--vscode-panel-border);
+  --label: '';
+  border-radius: calc(var(--border-radius) * 2);
+  padding: var(--spacing-medium)
+    calc(var(--spacing-medium) + var(--spacing-small));
+  margin: var(--spacing-small) 0;
   overflow: auto;
   max-height: 500px;
   position: relative;
+  border-left: 4px solid var(--special-color);
+}
+
+.special-content::before {
+  content: var(--label);
+  position: absolute;
+  top: 0;
+  right: var(--spacing-small);
+  background-color: var(--special-color);
+  color: white;
+  padding: var(--spacing-tiny) var(--spacing-small);
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  font-size: 12px;
+  font-weight: 500;
 }
 
 /* Scratchpad content */
 .scratchpad-content {
-  border-left: 4px solid #0366d6; /* Blue border for scratchpad */
-}
-
-/* Add a label to the scratchpad content */
-.scratchpad-content:before {
-  content: 'Scratchpad';
-  position: absolute;
-  top: 0;
-  right: 10px;
-  background-color: #0366d6;
-  color: white;
-  padding: 2px 8px;
-  border-radius: 0 0 4px 4px;
-  font-size: 12px;
-  font-weight: 500;
+  --special-color: var(--vscode-activityBarBadge-background, #007acc);
+  --label: 'Scratchpad';
 }
 
 /* Thinking content */
 .thinking-content {
-  border-left: 4px solid #8250df; /* Purple border for thinking content */
-}
-
-/* Add a label to the thinking content */
-.thinking-content:before {
-  content: 'Model Thinking';
-  position: absolute;
-  top: 0;
-  right: 10px;
-  background-color: #8250df;
-  color: white;
-  padding: 2px 8px;
-  border-radius: 0 0 4px 4px;
-  font-size: 12px;
-  font-weight: 500;
+  --special-color: var(--vscode-symbolIcon-snippetForeground, #8250df);
+  --label: 'Model Thinking';
 }
 
 /* Style markdown elements in scratchpad */


### PR DESCRIPTION
## Summary
- unify scratchpad and thinking styles using CSS variables

## Testing
- `npm run lint`
- `npm test` *(fails: environment lacks network access)*