### PR TITLE
Centralize open-and-build helper

### DIFF
--- a/src/commands/latexdiffCommands.ts
+++ b/src/commands/latexdiffCommands.ts
@@ -10,6 +10,7 @@ import * as logger from '../logger/logUtils';
 // Local imports - utilities
 import { getWorkspacePath } from '../utils/workspaceFileUtils';
 import { fileExists } from '../utils/workspaceFileUtils';
+import { openAndBuildIfTex } from '../utils/openBuildUtils';
 
 // Local imports - latex utils
 import {
@@ -100,15 +101,10 @@ async function handleLatexdiff(
       return;
     }
 
-    const doc = await vscode.window.showTextDocument(fullPath);
-    await vscode.window.showTextDocument(doc.document, {
-      preview: false,
-      preserveFocus: true,
-    });
+    await openAndBuildIfTex(filePathRelative, { preserveFocus: true });
     await vscode.commands.executeCommand(
       'workbench.view.extension.latex-workshop-activitybar',
     );
-    await vscode.commands.executeCommand('latex-workshop.build');
 
     // Wait for build to complete before viewing
     setTimeout(async () => {
@@ -162,12 +158,7 @@ async function handleLatexdiffvc(
       return;
     }
 
-    const doc = await vscode.window.showTextDocument(fullPath);
-    await vscode.window.showTextDocument(doc.document, {
-      preview: false,
-      preserveFocus: true,
-    });
-    await vscode.commands.executeCommand('latex-workshop.build');
+    await openAndBuildIfTex(filePathRelative, { preserveFocus: true });
 
     // Wait for build to complete before viewing
     setTimeout(async () => {

--- a/src/commands/openFileCommands.ts
+++ b/src/commands/openFileCommands.ts
@@ -1,38 +1,11 @@
 import * as vscode from 'vscode';
-import * as logger from '../logger/logUtils';
-import {
-  fileExists,
-  getFullPathFromWorkspace,
-} from '../utils/workspaceFileUtils';
 
-const CHANNEL = 'OpenFileCommands';
-logger.initialize(CHANNEL);
+// Local imports - utilities
+import { openAndBuildIfTex } from '../utils/openBuildUtils';
 
 export function registerOpenFileCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand('texra.openFileCompile', handleOpenFile),
+    vscode.commands.registerCommand('texra.openFileCompile', openAndBuildIfTex),
   );
-  return { openFileCompile: handleOpenFile };
-}
-
-async function handleOpenFile(file: string) {
-  try {
-    if (!(await fileExists(file))) {
-      vscode.window.showErrorMessage(`File not found: ${file}`);
-      return;
-    }
-    const fullPath = vscode.Uri.file(getFullPathFromWorkspace(file));
-    const doc = await vscode.workspace.openTextDocument(fullPath);
-    await vscode.window.showTextDocument(doc, { preview: false });
-
-    if (file.endsWith('.tex')) {
-      try {
-        await vscode.commands.executeCommand('latex-workshop.build', fullPath);
-      } catch (err) {
-        logger.warn(CHANNEL, `LaTeX Workshop build failed: ${err}`);
-      }
-    }
-  } catch (err) {
-    logger.error(CHANNEL, `Error opening file: ${err}`);
-  }
+  return { openFileCompile: openAndBuildIfTex };
 }

--- a/src/utils/openBuildUtils.ts
+++ b/src/utils/openBuildUtils.ts
@@ -1,0 +1,44 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - log
+import * as logger from '../logger/logUtils';
+import { fileExists, getFullPathFromWorkspace } from './workspaceFileUtils';
+
+const CHANNEL = 'OpenBuildUtils';
+logger.initialize(CHANNEL);
+
+/**
+ * Open a file and run a LaTeX build if it is a TeX file.
+ *
+ * @param file Relative path to the file within the workspace
+ * @param options Optional settings for showing the document
+ */
+export async function openAndBuildIfTex(
+  file: string,
+  options: { preserveFocus?: boolean } = {},
+): Promise<void> {
+  try {
+    if (!(await fileExists(file))) {
+      vscode.window.showErrorMessage(`File not found: ${file}`);
+      return;
+    }
+
+    const uri = vscode.Uri.file(getFullPathFromWorkspace(file));
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, {
+      preview: false,
+      preserveFocus: options.preserveFocus ?? false,
+    });
+
+    if (file.toLowerCase().endsWith('.tex')) {
+      try {
+        await vscode.commands.executeCommand('latex-workshop.build', uri);
+      } catch (err) {
+        logger.warn(CHANNEL, `LaTeX Workshop build failed: ${err}`);
+      }
+    }
+  } catch (err) {
+    logger.error(CHANNEL, `Error opening file: ${err}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add `openAndBuildIfTex` utility for opening and compiling TeX files
- use the helper when registering `openFileCompile`
- reuse the helper in LaTeX diff commands

## Testing
- `npm run format`
- `npm run lint`
- `npm test`