### PR TITLE
Add codicon icons for history actions

### DIFF
--- a/src/historyView/AgentHistoryViewProvider.ts
+++ b/src/historyView/AgentHistoryViewProvider.ts
@@ -53,6 +53,13 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
             'common',
             'styles',
           ),
+          vscode.Uri.joinPath(
+            this.context.extensionUri,
+            'node_modules',
+            '@vscode',
+            'codicons',
+            'dist',
+          ),
         ],
       },
     );
@@ -144,6 +151,15 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
       const styleUri = this.getWebviewUri('style.css');
       const vscodeApiUri = this.getWebviewUri('modules/vscodeApi.js');
       const domHandlersUri = this.getWebviewUri('modules/domHandlers.js');
+      const codiconPath = vscode.Uri.joinPath(
+        this.context.extensionUri,
+        'node_modules',
+        '@vscode',
+        'codicons',
+        'dist',
+        'codicon.css',
+      );
+      const codiconUri = this._view?.webview.asWebviewUri(codiconPath);
       const commonStyleUri = vscode.Uri.joinPath(
         this.context.extensionUri,
         'src',
@@ -167,6 +183,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
         )
         .replace('${vscodeApiUri}', vscodeApiUri.toString())
         .replace('${domHandlersUri}', domHandlersUri.toString())
+        .replace('${codiconUri}', codiconUri?.toString() ?? '')
         .replace(/\${nonce}/g, nonce)
         .replace(/\${cspSource}/g, this._view?.webview.cspSource ?? '');
     } catch (error) {

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -9,6 +9,7 @@
     />
     <link rel="stylesheet" href="${commonStyleUri}" />
     <link rel="stylesheet" href="${styleUri}" />
+    <link rel="stylesheet" href="${codiconUri}" />
     <title>TeXRA History</title>
     <script
       nonce="${nonce}"

--- a/src/historyView/modules/domHandlers.js
+++ b/src/historyView/modules/domHandlers.js
@@ -69,9 +69,15 @@ function createHistoryItemElement(item) {
   header.innerHTML = `
     <div class="history-timestamp">${formattedDate}</div>
       <div class="history-actions button-group">
-        <button class="vscode-button delete-btn" data-id="${item.id}" title="Delete this history item">Delete</button>
-        <button class="vscode-button restore-btn" data-id="${item.id}" title="Load configuration to main view">Restore</button>
-        <button class="vscode-button rerun-btn" data-id="${item.id}" title="Execute this configuration">Rerun</button>
+        <button class="vscode-button delete-btn" data-id="${item.id}" title="Delete this history item">
+          <i class="codicon codicon-trash"></i>
+        </button>
+        <button class="vscode-button restore-btn" data-id="${item.id}" title="Load configuration to main view">
+          <i class="codicon codicon-reply"></i>
+        </button>
+        <button class="vscode-button rerun-btn" data-id="${item.id}" title="Execute this configuration">
+          <i class="codicon codicon-debug-rerun"></i>
+        </button>
       </div>
   `;
 


### PR DESCRIPTION
## Notes
- Formatted, linted and ran tests per repository guidelines

## Summary
- add icon style link in history view webview
- load codicon resources for history view webview
- display codicon icons for delete, restore and rerun buttons

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode tests cannot run in this environment)*