### PR TITLE
Make output filename clickable in progress view

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -209,11 +209,9 @@ export function updateFileList(filesByRound) {
         });
       }
 
-      const openBtn = document.createElement('button');
-      openBtn.className = 'vscode-button tiny';
-      openBtn.title = 'Open file';
-      openBtn.innerHTML = '<i class="codicon codicon-go-to-file"></i>';
-      openBtn.addEventListener('click', () => {
+      // Make the filename clickable to open the file directly
+      nameSpan.classList.add('clickable');
+      nameSpan.addEventListener('click', () => {
         vscode.postMessage({ command: COMMANDS.OPEN_FILE, file: info.path });
       });
 
@@ -267,7 +265,6 @@ export function updateFileList(filesByRound) {
       });
 
       // Add all buttons to the actions container
-      actions.appendChild(openBtn);
       actions.appendChild(compareBtn);
       actions.appendChild(acceptBtn);
       actions.appendChild(mergeBtn);

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -173,6 +173,16 @@
   padding-right: var(--spacing-medium);
 }
 
+.file-name.clickable {
+  cursor: pointer;
+  color: var(--vscode-textLink-foreground);
+}
+
+.file-name.clickable:hover {
+  color: var(--vscode-textLink-activeForeground);
+  text-decoration: underline;
+}
+
 .file-dir {
   opacity: 0.7;
   font-size: 0.9em;


### PR DESCRIPTION
## Summary
- enable clicking the filename in ProgressView to open the file
- style clickable filenames

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: can't resolve certain modules)*