### PR TITLE
Improve button sizing and history view styles

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -115,7 +115,7 @@
   background-color: var(--button-background);
   color: var(--button-foreground);
   padding: 4px 10px;
-  height: 28px;
+  height: 24px;
   min-width: 80px;
 }
 

--- a/src/historyView/style.css
+++ b/src/historyView/style.css
@@ -122,35 +122,8 @@ mark.current-match {
 }
 
 .button-clear {
-  background-color: var(--vscode-errorForeground);
   margin-bottom: var(--spacing-xlarge);
   padding: calc(var(--spacing-small) + var(--spacing-tiny)) var(--spacing-large);
-}
-
-.button-clear:hover {
-  background-color: var(--vscode-testing-iconErrored);
-}
-
-.history-actions {
-  gap: var(--spacing-medium);
-}
-
-.restore-btn {
-  background-color: var(--vscode-button-secondaryBackground);
-  color: var(--vscode-button-secondaryForeground);
-}
-
-.restore-btn:hover {
-  background-color: var(--vscode-button-secondaryHoverBackground);
-}
-
-.delete-btn {
-  background-color: var(--vscode-errorForeground);
-  color: var(--vscode-button-foreground);
-}
-
-.delete-btn:hover {
-  background-color: var(--vscode-testing-iconErrored);
 }
 
 /* Empty state */


### PR DESCRIPTION
## Summary
- use smaller height for primary buttons to match selects
- simplify history webview button styles for a minimalist look

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(fails: environment lacks network)*