### PR TITLE
Simplify dropdown frames in webview

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -252,20 +252,18 @@
                     class="dropdown-options"
                     style="display: none"
                   >
-                    <div class="dropdown-options-content">
-                      <label class="vscode-checkbox"
-                        ><input type="checkbox" id="autoExtractFigure" /><i
-                          class="codicon codicon-file-media"
-                        ></i
-                        >Figures</label
-                      >
-                      <label class="vscode-checkbox"
-                        ><input type="checkbox" id="autoExtractTikzFigure" /><i
-                          class="codicon codicon-file-code"
-                        ></i
-                        >TikZ Figures</label
-                      >
-                    </div>
+                    <label class="vscode-checkbox"
+                      ><input type="checkbox" id="autoExtractFigure" /><i
+                        class="codicon codicon-file-media"
+                      ></i
+                      >Figures</label
+                    >
+                    <label class="vscode-checkbox"
+                      ><input type="checkbox" id="autoExtractTikzFigure" /><i
+                        class="codicon codicon-file-code"
+                      ></i
+                      >TikZ Figures</label
+                    >
                   </div>
                 </div>
               </div>
@@ -389,27 +387,25 @@
                   class="dropdown-options"
                   style="display: none"
                 >
-                  <div class="dropdown-options-content">
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="reflect" />
-                      <i class="codicon codicon-refresh"></i> Reflect</label
-                    >
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="attachTeXCount" />
-                      <i class="codicon codicon-symbol-numeric"></i> Attach TeX
-                      Count</label
-                    >
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="usePrefillFromInput" />
-                      <i class="codicon codicon-edit"></i> Use Prefill from
-                      Input</label
-                    >
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="printInputPrompt" />
-                      <i class="codicon codicon-file-code"></i> Print Input
-                      Prompt</label
-                    >
-                  </div>
+                  <label class="vscode-checkbox"
+                    ><input type="checkbox" id="reflect" />
+                    <i class="codicon codicon-refresh"></i> Reflect</label
+                  >
+                  <label class="vscode-checkbox"
+                    ><input type="checkbox" id="attachTeXCount" />
+                    <i class="codicon codicon-symbol-numeric"></i> Attach TeX
+                    Count</label
+                  >
+                  <label class="vscode-checkbox"
+                    ><input type="checkbox" id="usePrefillFromInput" />
+                    <i class="codicon codicon-edit"></i> Use Prefill from
+                    Input</label
+                  >
+                  <label class="vscode-checkbox"
+                    ><input type="checkbox" id="printInputPrompt" />
+                    <i class="codicon codicon-file-code"></i> Print Input
+                    Prompt</label
+                  >
                 </div>
               </div>
             </div>

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -70,18 +70,9 @@
   box-shadow: var(--vscode-widget-shadow);
   min-width: 180px;
   display: none;
-  font-size: calc(var(--font-size) * 0.9);
+  font-size: calc(var(--font-size) * 0.8);
   padding: 4px;
   white-space: nowrap;
-}
-
-/* Dropdown options content */
-.dropdown-options-content {
-  font-size: calc(var(--font-size) * 0.8);
-  background: var(--vscode-menu-background);
-  border: 1px solid var(--vscode-input-border);
-  border-radius: var(--border-radius);
-  box-shadow: inset 0 0 0 1px var(--vscode-menu-border);
   font-weight: normal;
 }
 


### PR DESCRIPTION
## Summary
- simplify auto-extract and tool config dropdowns by removing extra wrapper
- tweak dropdown style to use a single frame

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: "vscode-test" output incomplete)*