### PR TITLE
Refactor styles to use shared variables

### DIFF
--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -28,7 +28,7 @@
   color: white;
   padding: var(--spacing-tiny) var(--spacing-small);
   border-radius: 0 0 var(--border-radius) var(--border-radius);
-  font-size: 12px;
+  font-size: calc(var(--font-size) * 0.85);
   font-weight: 500;
 }
 
@@ -64,29 +64,29 @@
 }
 
 .scratchpad-content h1 {
-  font-size: 1.3em;
+  font-size: calc(var(--font-size) * 1.3);
   border-bottom: 1px solid var(--vscode-panel-border, #555);
   padding-bottom: 4px;
 }
 
 .scratchpad-content h2 {
-  font-size: 1.2em;
-  padding-left: 8px;
-  margin-top: 12px;
+  font-size: calc(var(--font-size) * 1.2);
+  padding-left: var(--spacing-medium);
+  margin-top: var(--spacing-large);
   margin-bottom: 5px;
   border-left: 3px solid var(--vscode-activityBarBadge-background, #007acc);
   border-bottom: 1px solid rgba(85, 85, 85, 0.3);
-  padding-bottom: 2px;
+  padding-bottom: var(--spacing-tiny);
   border-radius: 3px 0 0 3px;
   color: var(--vscode-textLink-foreground, #3794ff);
 }
 
 .scratchpad-content h3 {
-  font-size: 1.1em;
+  font-size: calc(var(--font-size) * 1.1);
 }
 
 .scratchpad-content h4 {
-  font-size: 1.05em;
+  font-size: calc(var(--font-size) * 1.05);
 }
 
 /* Add styles to control paragraph spacing */
@@ -117,14 +117,15 @@
 
 .scratchpad-content code {
   background-color: var(--vscode-textPreformat-background, #0a0a0a);
-  padding: 1px 4px;
+  padding: var(--spacing-tiny) var(--spacing-small);
   border-radius: 3px;
   font-family: var(--vscode-editor-font-family);
-  font-size: 0.9em;
+  font-size: calc(var(--font-size) * 0.9);
 }
 
 .scratchpad-content pre {
-  padding: 8px 10px;
+  padding: var(--spacing-medium)
+    calc(var(--spacing-medium) + var(--spacing-tiny));
   margin: 0.5em 0;
   border-radius: 3px;
   background-color: var(--vscode-textPreformat-background, #0a0a0a);
@@ -156,8 +157,8 @@
 
 .scratchpad-content blockquote {
   border-left: 3px solid var(--vscode-activityBarBadge-background, #007acc);
-  margin: 8px 0;
-  padding-left: 16px;
+  margin: var(--spacing-medium) 0;
+  padding-left: calc(var(--spacing-medium) * 2);
   color: var(--vscode-descriptionForeground, #cccccc);
   font-style: italic;
 }
@@ -165,13 +166,14 @@
 .scratchpad-content table {
   border-collapse: collapse;
   width: 100%;
-  margin: 16px 0;
+  margin: calc(var(--spacing-medium) * 2) 0;
 }
 
 .scratchpad-content table th,
 .scratchpad-content table td {
   border: 1px solid var(--vscode-panel-border, #555);
-  padding: 6px 10px;
+  padding: calc(var(--spacing-small) + var(--spacing-tiny))
+    calc(var(--spacing-medium) + var(--spacing-tiny));
 }
 
 .scratchpad-content table th {
@@ -208,8 +210,8 @@
 
 /* Special styling for scratchpad log entries */
 .scratchpad-log {
-  margin-top: 8px;
-  margin-bottom: 4px; /* Reduced spacing after log header */
+  margin-top: var(--spacing-medium);
+  margin-bottom: var(--spacing-small); /* Reduced spacing after log header */
   background-color: var(--vscode-editor-background);
   border-radius: 6px 6px 0 0; /* Rounded corners only on top */
   overflow: hidden;
@@ -238,7 +240,7 @@
 /* Special handling for reflection patterns */
 .scratchpad-content p:has(strong:first-child) {
   border-left: 3px solid var(--vscode-notificationsInfoIcon-foreground, #75beff);
-  padding-left: 8px;
+  padding-left: var(--spacing-medium);
 }
 
 /* Paragraph spacing */

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -9,7 +9,7 @@
   width: 120px;
   min-width: 80px;
   max-width: 400px;
-  font-size: 11px;
+  font-size: calc(var(--font-size) * 0.85);
   border-left: 1px solid var(--vscode-panel-border);
   height: 100%;
   overflow: hidden;
@@ -26,20 +26,20 @@
   flex-shrink: 0;
   background-color: var(--vscode-sideBar-background);
   border-top: 1px solid var(--vscode-panel-border);
-  padding: 4px;
+  padding: var(--spacing-small);
 }
 
 .clear-button {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 4px;
+  gap: var(--spacing-small);
+  padding: var(--spacing-small) var(--spacing-small);
   cursor: pointer;
   border: none;
   background: none;
   color: var(--vscode-foreground);
   font-family: var(--vscode-font-family);
-  font-size: 11px;
+  font-size: calc(var(--font-size) * 0.85);
 }
 
 .clear-button:hover {
@@ -67,7 +67,7 @@
 
 .tab {
   flex: 1;
-  padding: 4px 8px;
+  padding: var(--spacing-small) var(--spacing-medium);
   cursor: pointer;
   border: none;
   background: none;
@@ -86,16 +86,16 @@
 
 .tab-delete {
   display: none;
-  padding: 2px;
+  padding: var(--spacing-tiny);
   border: none;
   background: none;
   color: var(--vscode-foreground);
   opacity: 0.7;
   cursor: pointer;
-  margin-right: 4px;
-  font-size: 11px;
-  width: 20px;
-  height: 20px;
+  margin-right: var(--spacing-small);
+  font-size: calc(var(--font-size) * 0.85);
+  width: calc(var(--control-height) - var(--spacing-small));
+  height: calc(var(--control-height) - var(--spacing-small));
   align-items: center;
   justify-content: center;
 }
@@ -111,7 +111,7 @@
 }
 
 .tab-delete .codicon {
-  font-size: 12px;
+  font-size: calc(var(--font-size) * 0.9);
   color: var(--vscode-foreground);
   opacity: 0.7;
   margin-right: 0;

--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -49,7 +49,7 @@ body {
 .select-group select {
   flex-grow: 1;
   padding: var(--spacing-small);
-  height: 28px;
+  height: calc(var(--control-height) + var(--spacing-small));
   border: 1px solid var(--input-border);
   border-radius: var(--border-radius);
   background-color: var(--input-background);
@@ -60,23 +60,25 @@ body {
 /* Input field */
 .vscode-input {
   width: 100%;
-  height: 24px;
-  padding: 4px 8px;
-  border: 1px solid var(--vscode-input-border);
+  height: var(--control-height);
+  padding: var(--spacing-small) var(--spacing-medium);
+  border: 1px solid var(--input-border);
   border-radius: var(--border-radius);
-  background-color: var(--vscode-input-background);
-  color: var(--vscode-input-foreground);
-  font-family: var(--vscode-font-family);
+  background-color: var(--input-background);
+  color: var(--input-foreground);
+  font-family: var(--font-family);
   font-size: var(--font-size);
+  box-sizing: border-box;
 }
 
 .vscode-input:focus {
-  outline: 1px solid var(--vscode-focusBorder);
+  outline: 1px solid var(--focus-border);
   outline-offset: -1px;
 }
 
 .vscode-input::placeholder {
-  color: var(--vscode-input-placeholderForeground);
+  color: var(--text-color);
+  opacity: 0.7;
 }
 
 .section-header {
@@ -84,8 +86,8 @@ body {
   font-weight: bold;
   margin-top: var(--spacing-small);
   margin-bottom: var(--spacing-small);
-  padding-bottom: 4px;
-  border-bottom: 1px solid #ccc;
+  padding-bottom: var(--spacing-small);
+  border-bottom: 1px solid var(--vscode-panel-border);
   display: flex;
   align-items: center;
   line-height: 1.5;

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -27,8 +27,8 @@
 /* Ensure all button sizes are consistent */
 .latexdiffs-section .vscode-button,
 .file-select-actions .vscode-button {
-  width: 24px;
-  height: 24px;
+  width: var(--control-height);
+  height: var(--control-height);
 }
 
 /* Container for multiple files */
@@ -56,7 +56,7 @@
 }
 
 .multiple-files-list div {
-  padding: 2px 4px;
+  padding: var(--spacing-tiny) var(--spacing-small);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -64,10 +64,10 @@
 
 .output-filename-override {
   border-top: 1px solid var(--dropdown-border);
-  padding-top: 8px;
+  padding-top: var(--spacing-medium);
 }
 
 .remove-button {
-  color: #ff4444;
+  color: var(--vscode-errorForeground);
   cursor: pointer;
 }

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -21,7 +21,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-tiny);
-  padding: 2px 6px;
+  padding: var(--spacing-tiny) calc(var(--spacing-small) + var(--spacing-tiny));
   font-size: calc(var(--font-size) * 0.9);
   border-radius: var(--border-radius);
   background: transparent;
@@ -71,14 +71,14 @@
   min-width: 180px;
   display: none;
   font-size: calc(var(--font-size) * 0.8);
-  padding: 4px;
+  padding: var(--spacing-small);
   white-space: nowrap;
   font-weight: normal;
 }
 
 /* Dropdown option labels - special styles not covered by vscode-checkbox */
 .dropdown-options .vscode-checkbox {
-  padding: 4px 8px;
+  padding: var(--spacing-small) var(--spacing-medium);
   border-radius: calc(var(--border-radius) - 1px);
   font-weight: normal;
 }

--- a/src/webview/styles/file-selection.css
+++ b/src/webview/styles/file-selection.css
@@ -4,12 +4,12 @@
  */
 
 .file-select {
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-large);
 }
 
 /* Make optional sections more compact */
 .file-select:has(.optional-label) {
-  margin-bottom: 2px;
+  margin-bottom: var(--spacing-tiny);
 }
 
 .file-select-header {
@@ -31,11 +31,11 @@
 .file-select-label-group {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-small);
   flex-wrap: nowrap;
   flex: 1;
   min-width: 0;
-  min-height: 24px;
+  min-height: var(--control-height);
   position: relative;
 }
 
@@ -57,7 +57,7 @@
 
 .file-select label {
   display: block;
-  margin-bottom: 2px;
+  margin-bottom: var(--spacing-tiny);
   font-size: var(--font-size);
 }
 
@@ -73,7 +73,7 @@
   min-width: 160px;
   display: flex;
   align-items: center;
-  height: 24px;
+  height: var(--control-height);
   opacity: 0.7;
 }
 
@@ -82,12 +82,12 @@
   user-select: none;
   margin: 0;
   position: relative;
-  padding: 0 2px;
+  padding: 0 var(--spacing-tiny);
   color: var(--text-color);
   opacity: 0.8;
   display: flex;
   align-items: center;
-  height: 24px;
+  height: var(--control-height);
 }
 
 /* When toggled (input is visible), make the label more prominent */

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -6,8 +6,8 @@
 /* Model Selection Footer styles */
 .model-selection-footer {
   position: absolute;
-  bottom: 16px;
-  left: 16px;
+  bottom: calc(var(--spacing-medium) * 2);
+  left: calc(var(--spacing-medium) * 2);
   display: flex;
   gap: var(--spacing-small);
   z-index: 10;
@@ -20,9 +20,9 @@
 }
 
 .model-selection-footer .select-group select {
-  height: 24px;
+  height: var(--control-height);
   font-size: var(--font-size);
-  padding: 2px 4px;
+  padding: var(--spacing-tiny) var(--spacing-small);
 }
 
 .model-selection-footer .codicon {


### PR DESCRIPTION
## Summary
- unify fonts and spacing in scratchpad and tabs
- replace hard-coded values in webview styles with common variables
- keep button sizes consistent via `--control-height`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: environment lacks required browser)*