### PR TITLE
Unify state persistence across views

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -35,6 +35,7 @@ resources/.DS_Store
 !src/webview/styles/*.css
 !src/webview/modules/*.js
 !src/common/styles/*.css
+!src/common/webviewState.js
 
 !src/historyView/modules/*.js
 !src/historyView/styles/*.css

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,7 @@ export default tseslint.config(
       'src/historyView/modules/**/*.js',
       'src/progressView/modules/**/*.js',
       'src/webview/modules/**/*.js',
+      'src/common/*.js',
       'src/historyView/script.js',
       'src/progressView/script.js',
       'src/webview/script.js',

--- a/src/common/webviewState.js
+++ b/src/common/webviewState.js
@@ -1,0 +1,23 @@
+const vscode = acquireVsCodeApi();
+
+export function getWebviewState() {
+  try {
+    return vscode.getState() || {};
+  } catch (e) {
+    console.error('Failed to get state:', e);
+    return {};
+  }
+}
+
+export function setWebviewState(state) {
+  try {
+    vscode.setState(state);
+  } catch (e) {
+    console.error('Failed to set state:', e);
+  }
+}
+
+export function updateWebviewState(partial) {
+  const current = getWebviewState();
+  setWebviewState({ ...current, ...partial });
+}

--- a/src/progressView/modules/stateManager.js
+++ b/src/progressView/modules/stateManager.js
@@ -1,4 +1,7 @@
-import { vscode } from './vscodeApi.js';
+import {
+  getWebviewState,
+  updateWebviewState,
+} from '../../common/webviewState.js';
 
 // State variables
 let currentStream = '';
@@ -10,7 +13,7 @@ let groupToggleStates = new Map(); // groupId -> collapsed state
  * Initializes state from previously saved state
  */
 export function initializeState() {
-  const previousState = vscode.getState() || {};
+  const previousState = getWebviewState();
   if (previousState.groupToggleStates) {
     try {
       groupToggleStates = new Map(JSON.parse(previousState.groupToggleStates));
@@ -29,8 +32,7 @@ export function saveState() {
     const serializedGroupStates = JSON.stringify([
       ...groupToggleStates.entries(),
     ]);
-    vscode.setState({
-      ...vscode.getState(),
+    updateWebviewState({
       groupToggleStates: serializedGroupStates,
     });
   } catch (e) {

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -1,5 +1,9 @@
 import { vscode } from './vscodeApi.js';
 import { saveState } from './stateManager.js';
+import {
+  getWebviewState,
+  updateWebviewState,
+} from '../../common/webviewState.js';
 import { MULTIPLE_SELECTIONS } from './constants.js';
 import {
   addEventListenerSafely,
@@ -178,7 +182,7 @@ export function handleCheckboxChange(event) {
  */
 export function initializeOutputFiles() {
   // Get the current state
-  const state = vscode.getState();
+  const state = getWebviewState();
 
   // Get references to the DOM elements
   const inputFileDiv = safeGetElementById('inputFile');
@@ -221,7 +225,7 @@ export function initializeOutputFiles() {
   }
 
   // Add opened files to the output files list
-  const openedFiles = vscode.getState()?.openedFiles ?? [];
+  const openedFiles = getWebviewState()?.openedFiles ?? [];
   openedFiles.forEach((file) => {
     addFileToList('outputFiles', file);
   });
@@ -234,7 +238,7 @@ export function initializeOutputFiles() {
 
   if (outputNameOverrideInput && outputNameOverrideToggle) {
     // Get the current state from the stored state
-    const state = vscode.getState();
+    const state = getWebviewState();
     const isOutputNameOverrideVisible =
       state && state.outputNameOverrideVisible;
 
@@ -270,9 +274,7 @@ export function toggleOutputNameOverride() {
   toggleIcon.textContent = isVisible ? '>' : '<';
 
   // Store the visibility state in the vscode state
-  const state = vscode.getState() || {};
-  state.outputNameOverrideVisible = !isVisible;
-  vscode.setState(state);
+  updateWebviewState({ outputNameOverrideVisible: !isVisible });
 
   saveState();
 }
@@ -307,9 +309,7 @@ export function emptyMultipleFiles(containerId, toggleId) {
       outputNameOverrideToggle.textContent = '>';
 
       // Update the state
-      const state = vscode.getState() || {};
-      state.outputNameOverrideVisible = false;
-      vscode.setState(state);
+      updateWebviewState({ outputNameOverrideVisible: false });
     }
   }
 
@@ -341,7 +341,7 @@ export function initializeOutputContainer() {
   const toggleIcon = safeGetElementById('toggleOutputFiles');
 
   if (container && toggleIcon) {
-    const state = vscode.getState();
+    const state = getWebviewState();
     const shouldShow = state && state.outputFilesActive;
 
     container.style.display = shouldShow ? 'block' : 'none';

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -10,6 +10,11 @@ import { safeSetElementValue, safeGetElementById } from './utils.js';
 import { restoreState, saveState } from './stateManager.js';
 import { FILE_TYPES } from './constants.js';
 import { capitalize, uncapitalize } from './stringUtils.js';
+import {
+  getWebviewState,
+  updateWebviewState,
+  setWebviewState,
+} from '../../common/webviewState.js';
 
 /**
  * Handle state restoration from log view
@@ -164,11 +169,9 @@ function handleStateRestoration(state) {
               });
 
               // Save state to persist changes
-              // saveState();
-              // Use vscode.setState directly instead of calling saveState
-              const currentState = vscode.getState() || {};
-              currentState[`${fileType}Files`] = updatedFiles;
-              vscode.setState(currentState);
+              updateWebviewState({
+                [`${fileType}Files`]: updatedFiles,
+              });
             });
           }
         });
@@ -177,7 +180,7 @@ function handleStateRestoration(state) {
   }
 
   // Save the prepared state
-  vscode.setState(savedState);
+  setWebviewState(savedState);
 
   // Use the stateManager's restoreState to update UI elements from this state
   // This will handle setting all form values and updating indicators
@@ -300,7 +303,7 @@ export function setupMessageHandlers() {
           updateFileSelect('baseFile', message.files);
 
           // Get the stored state
-          const state = vscode.getState();
+          const state = getWebviewState();
           const storedBaseFile = state?.baseFile;
 
           // First try to restore from stored state, then fallback to current if preserveBaseFile

--- a/src/webview/modules/stateManager.js
+++ b/src/webview/modules/stateManager.js
@@ -1,4 +1,9 @@
 import { vscode } from './vscodeApi.js';
+import {
+  getWebviewState,
+  updateWebviewState,
+  setWebviewState,
+} from '../../common/webviewState.js';
 
 import {
   MULTIPLE_SELECTIONS,
@@ -56,7 +61,7 @@ export function setDefaultState() {
 }
 
 export function restoreState() {
-  const previousState = vscode.getState();
+  const previousState = getWebviewState();
   if (previousState) {
     const defaultValues = {
       agent: 'correct',
@@ -179,5 +184,5 @@ export function saveState() {
   // Log the state being saved for debugging
   console.log('Saving state:', state);
 
-  vscode.setState(state);
+  setWebviewState(state);
 }


### PR DESCRIPTION
## Notes
- Added shared `webviewState` module for interacting with `vscode` state
- Updated progress and main webviews to use the new helpers
- Adjusted ESLint config and `.vscodeignore` to include new module

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
