### PR TITLE
Refactor nonce generation

### DIFF
--- a/src/historyView/AgentHistoryViewProvider.ts
+++ b/src/historyView/AgentHistoryViewProvider.ts
@@ -6,6 +6,7 @@ import { AgentHistoryManager } from './AgentHistoryManager';
 import { executeCommand } from '../commands/executeCommand';
 
 import { agentConfigToTaskState } from '../utils/configConversion';
+import { generateNonce } from '../utils/nonceUtils';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
@@ -169,7 +170,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
       );
 
       // Create a nonce for script security
-      const nonce = this.getNonce();
+      const nonce = generateNonce();
 
       // Replace placeholders in HTML with actual content
       return htmlContent
@@ -207,19 +208,6 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
       relativePath,
     );
     return this._view.webview.asWebviewUri(diskPath);
-  }
-
-  /**
-   * Generate a nonce for content security policy
-   */
-  private getNonce(): string {
-    let text = '';
-    const possible =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-      text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
   }
 
   /**

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
+import { generateNonce } from '../utils/nonceUtils';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);
@@ -49,7 +50,7 @@ export class ProgressViewContentProvider {
         '@vscode/codicons/dist/codicon.ttf',
       );
       const htmlContent = fs.readFileSync(htmlPath.fsPath, 'utf-8');
-      const nonce = this.getNonce();
+      const nonce = generateNonce();
       const styleUri = webview.asWebviewUri(cssPath);
       const commonStyleUri = webview.asWebviewUri(commonCssPath);
       const scriptUri = webview.asWebviewUri(scriptPath);
@@ -91,15 +92,5 @@ export class ProgressViewContentProvider {
       );
       return '<html><body>Error loading content</body></html>';
     }
-  }
-
-  private getNonce() {
-    let text = '';
-    const possible =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-      text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
   }
 }

--- a/src/utils/nonceUtils.ts
+++ b/src/utils/nonceUtils.ts
@@ -1,0 +1,10 @@
+// Utility to generate nonce strings for Webview content security policy
+export function generateNonce(length = 32): string {
+  const possible =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let text = '';
+  for (let i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}

--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -9,6 +9,7 @@ import * as logger from '../logger/logUtils';
 
 // Local imports - utilities
 import { getConfig } from '../utils/configUtils';
+import { generateNonce } from '../utils/nonceUtils';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);
@@ -41,7 +42,7 @@ export class WebviewContentProvider {
 
       const htmlContent = fs.readFileSync(htmlPath.fsPath, 'utf-8');
 
-      const nonce = this.getNonce();
+      const nonce = generateNonce();
       const styleUri = webview.asWebviewUri(cssPath);
       const commonStyleUri = webview.asWebviewUri(commonCssPath);
       const scriptUri = webview.asWebviewUri(mainScriptPath);
@@ -100,15 +101,5 @@ export class WebviewContentProvider {
       );
       return '<html><body>Error loading content</body></html>';
     }
-  }
-
-  private getNonce() {
-    let text = '';
-    const possible =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-      text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
   }
 }


### PR DESCRIPTION
## Summary
- move nonce logic into `generateNonce`
- use the new helper in webview providers

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands)*