### PR TITLE
Merge initialization logs into main run group

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -185,9 +185,13 @@ export abstract class BaseReflectionAgent {
    * Initializes user variables that require async operations.
    * Must be called after constructor before using the agent.
    */
-  public async init(): Promise<void> {
+  public async init(parentGroupId?: string): Promise<void> {
     // Create an initialization group for better log organization
-    const initGroupId = await this.logger.startGroup(`Initialization`);
+    const initGroupId = await this.logger.startGroup(
+      `Initialization`,
+      undefined,
+      parentGroupId,
+    );
 
     try {
       // Log configuration details in the initialization group
@@ -1047,6 +1051,9 @@ export abstract class BaseReflectionAgent {
     );
 
     try {
+      // Initialize agent variables within the run group
+      await this.init(this.runGroupId);
+
       // Initialize client before starting
       await this.initializeClient();
 

--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -214,9 +214,6 @@ async function executeAgentWithLogging<T extends AgentWithConfig>(
       logger.info(`Input file: ${config.inputFile}`, taskDetailsGroupId);
 
       try {
-        // Initializes user variables
-        await agent.init();
-
         logger.debug(
           `Creating stream with ID: ${fullStreamId}`,
           taskDetailsGroupId,


### PR DESCRIPTION
## Summary
- nest initialization logs under the main run group
- start initialization from `run()` rather than `executeAgent`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: ws bufferutil/utf-8-validate modules missing)*