### PR TITLE
Fix clickable file name underlines

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -168,7 +168,10 @@ export function updateFileList(filesByRound) {
         info.path.length - basename.length,
       );
 
-      // Create two spans - one for directory and one for filename
+      // Create a clickable container for the directory and filename
+      const pathSpan = document.createElement('span');
+      pathSpan.className = 'file-path clickable';
+
       const dirSpan = document.createElement('span');
       dirSpan.className = 'file-dir';
       dirSpan.style.opacity = '0.7';
@@ -178,8 +181,9 @@ export function updateFileList(filesByRound) {
       fileSpan.className = 'file-basename';
       fileSpan.textContent = basename;
 
-      nameSpan.appendChild(dirSpan);
-      nameSpan.appendChild(fileSpan);
+      pathSpan.appendChild(dirSpan);
+      pathSpan.appendChild(fileSpan);
+      nameSpan.appendChild(pathSpan);
 
       if (info.added !== undefined && info.removed !== undefined) {
         const statsSpan = document.createElement('span');
@@ -209,9 +213,8 @@ export function updateFileList(filesByRound) {
         });
       }
 
-      // Make the filename clickable to open the file directly
-      nameSpan.classList.add('clickable');
-      nameSpan.addEventListener('click', () => {
+      // Make the file path clickable to open the file directly
+      pathSpan.addEventListener('click', () => {
         vscode.postMessage({ command: COMMANDS.OPEN_FILE, file: info.path });
       });
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -173,14 +173,20 @@
   padding-right: var(--spacing-medium);
 }
 
-.file-name.clickable {
+.file-path.clickable {
   cursor: pointer;
   color: var(--vscode-textLink-foreground);
 }
 
-.file-name.clickable:hover {
+.file-path.clickable:hover {
   color: var(--vscode-textLink-activeForeground);
   text-decoration: underline;
+}
+
+.file-stats {
+  margin-left: var(--spacing-medium);
+  white-space: nowrap;
+  text-decoration: none;
 }
 
 .file-dir {
@@ -190,11 +196,6 @@
 
 .file-basename {
   font-weight: 500;
-}
-
-.file-stats {
-  margin-left: var(--spacing-medium);
-  white-space: nowrap;
 }
 
 .file-actions {


### PR DESCRIPTION
## Summary
- stop diff counts from being part of the clickable output file name
- adjust CSS so only the path text shows underline on hover

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: VS Code cannot download in this environment)*