### PR TITLE
Add compare view terminal close and wrap config

### DIFF
--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -65,6 +65,9 @@ async function handleCompare(
     const title = `Compare: ${editedFileName} ↔ ${baseFileName}`;
     // const title = `Compare: ${baseFileName} ↔ ${editedFileName}`;
 
+    // Close the terminal panel before opening the diff view
+    await vscode.commands.executeCommand('workbench.action.closePanel');
+
     // Open files in diff editor
     await vscode.commands.executeCommand(
       'vscode.diff',


### PR DESCRIPTION
## Summary
- close terminal panel when opening compare/diff view
- revert new compare.wrap config and just check `editor.wordWrap`

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test`
