### PR TITLE
Replace filler words in docs

### DIFF
--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -260,7 +260,7 @@ Preserve mathematical notation and citations from the original.
 
 ## Next Steps
 
-Now that you understand the default built-in agents, you might want to explore:
+Now that you understand the default built-in agents, you might want to learn more:
 
 - [Agent Architecture & Execution Flow](./agent-architecture.md) - Understand how agents work internally.
 - [Custom Agents](./custom-agents.md) - Learn how to create your own specialized agents.

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -26,7 +26,7 @@ Clearly state what should and shouldn't be changed:
 
 Help the AI understand the purpose and audience:
 
-✅ "Polish this abstract for submission to the Journal of Quantum Physics. The target audience is scientists with expertise in quantum field theory. Focus on highlighting the novelty and significance of the results."
+✅ "Polish this abstract for submission to the Journal of Quantum Physics. The target audience is scientists with expertise in quantum field theory. Focus on highlighting the originality and significance of the results."
 
 ### Use Structured Instructions
 
@@ -259,7 +259,7 @@ IEEE formatting style.
 ```
 Improve the clarity and flow of this paper for submission to Nature Communications.
 The target audience consists of interdisciplinary researchers in computational
-biology. Enhance the introduction to better highlight our novel contributions.
+biology. Enhance the introduction to better highlight our original contributions.
 Make the methodology section more accessible while maintaining technical accuracy.
 Strengthen the conclusion by emphasizing broader impacts. Maintain all citations,
 mathematical notation, and technical terms.
@@ -305,7 +305,7 @@ over text and include bullet points rather than full paragraphs.
 
 ## Next Steps
 
-Now that you're familiar with TeXRA best practices, you might want to explore:
+Now that you're familiar with TeXRA best practices, you may wish to review:
 
 - [Configuration](/guide/configuration) - Learn how to customize TeXRA
 - [Custom Agents](/guide/custom-agents) - Create specialized agents for your workflow

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -180,7 +180,7 @@ Transcribe the provided lecture audio file [lecture.mp3]. Provide the output as 
 
 ## Next Steps
 
-Now that you've met the built-in crew, you might want to dive deeper:
+Now that you've met the built-in crew, you may want to learn more:
 
 - [Agent Architecture & Execution Flow](./agent-architecture.md) - Understand how agents work internally.
 - [Custom Agents](./custom-agents.md) - Learn how to create your own specialized agents.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -327,7 +327,7 @@ Common configuration issues include:
 
 ## Next Steps
 
-Now that you understand how to configure TeXRA, you might want to explore:
+Now that you understand how to configure TeXRA, you may want to learn about:
 
 - [Custom Agents](/guide/custom-agents) - Learn how to create your own specialized agents
 - [Best Practices](/reference/best-practices) - Discover recommended settings for different workflows

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -238,7 +238,7 @@ Replace `/path/to/Dropbox` and `/path/to/local` with your actual Dropbox and loc
 
 ## Next Steps
 
-Now that you understand how to manage files in TeXRA, you might want to explore:
+Now that you understand how to manage files in TeXRA, you might want to learn about:
 
 - [Tool Integration](/guide/tool-integration) - Learn how TeXRA leverages external tools
 - [LaTeX Diff](/guide/latex-diff) - Understand how to compare document versions

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -228,4 +228,4 @@ If you encounter persistent installation issues:
 
 ## Next Steps
 
-With TeXRA and all dependencies installed, you're ready to start using the tool to enhance your academic research. Check out the [Quick Start Guide](/guide/quick-start) to learn the basics, or explore specific features in the other documentation sections.
+With TeXRA and all dependencies installed, you're ready to start using the tool to enhance your academic research. Check out the [Quick Start Guide](/guide/quick-start) to learn the basics, or examine specific features in the other documentation sections.

--- a/docs/guide/latex-diff.md
+++ b/docs/guide/latex-diff.md
@@ -375,7 +375,7 @@ Maintain a clear version strategy:
 
 ## Next Steps
 
-Now that you understand TeXRA's LaTeX diff functionality, you might want to explore:
+Now that you understand TeXRA's LaTeX diff functionality, you may be interested in:
 
 - [Intelligent Merge](/guide/intelligent-merge) - Learn how to combine changes intelligently
 - [File Management](/guide/file-management) - Understand how to organize your files effectively

--- a/docs/guide/multiple-output.md
+++ b/docs/guide/multiple-output.md
@@ -4,7 +4,7 @@ TeXRA excels at managing complex academic projects often split across multiple f
 
 ## Why Use Multiple Files?
 
-Working with multiple files is essential when:
+Working with multiple files is often necessary when:
 
 - Your source document is split (e.g., `chapter1.tex`, `chapter2.tex`, `appendixA.tex`).
 - You need to apply consistent changes (like polishing or correcting) across related documents.

--- a/docs/guide/tikz-figures.md
+++ b/docs/guide/tikz-figures.md
@@ -234,7 +234,7 @@ TikZ compilation can be resource-intensive:
 
 ## Next Steps
 
-Now that you understand how to work with TikZ figures in TeXRA, you might want to explore:
+Now that you understand how to work with TikZ figures in TeXRA, you may want to learn about:
 
 - [LaTeX Diff](/guide/latex-diff) - Learn how to compare document versions including figures
 - [Tool Integration](/guide/tool-integration) - Discover other tools TeXRA integrates with

--- a/docs/public/examples/draft.tex
+++ b/docs/public/examples/draft.tex
@@ -22,7 +22,7 @@
 \maketitle
 
 \section{Introduction}
-In these notes, we explore the spectral properties of random graphs, with particular emphasis on the eighenvalue distribution of their adjacency matrices. The study of random graphs was initiated by Erdős and Renyi \cite{erdos1960evolution}, and has since become a central topic in discrete mathematics and theoretical computer scince.
+In these notes, we study the spectral properties of random graphs, with particular emphasis on the eighenvalue distribution of their adjacency matrices. The study of random graphs was initiated by Erdős and Renyi \cite{erdos1960evolution}, and has since become a central topic in discrete mathematics and theoretical computer scince.
 
 \section{Preliminaries}
 \begin{definition}


### PR DESCRIPTION
## Summary
- remove ChatGPT filler words
- adjust example LaTeX document

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test exits early)*