### PR TITLE
Update progress view after pack or clean

### DIFF
--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -1,5 +1,8 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import * as path from 'path';
+
+import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
@@ -14,6 +17,17 @@ import {
 
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
+
+function getStreamId(
+  agent: string,
+  model: string,
+  inputFile: string,
+  outputFiles?: string[],
+): string {
+  const agentName =
+    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
+  return `${agentName}@${model}: ${path.basename(inputFile)}`;
+}
 
 export function registerCleanCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -47,6 +61,12 @@ async function handleCleanSingle(
     return;
   }
   await runCleanSingle(model, outputNameOverride || inputFile, agent);
+
+  const provider = ProgressViewProvider.getInstance();
+  if (provider) {
+    const streamId = getStreamId(agent, model, inputFile);
+    provider.clearOutputFiles(streamId);
+  }
 }
 
 async function handleCleanMultiple(
@@ -78,6 +98,12 @@ async function handleCleanMultiple(
     : outputFiles;
 
   await runCleanMultiple(model, inputFile, agent, inputFilesWithOverride);
+
+  const provider = ProgressViewProvider.getInstance();
+  if (provider) {
+    const streamId = getStreamId(agent, model, inputFile, outputFiles);
+    provider.clearOutputFiles(streamId);
+  }
 }
 
 export async function handleClean(config: any) {
@@ -108,6 +134,17 @@ export async function handleClean(config: any) {
   } else {
     logger.info(CHANNEL, `Running clean single`);
     await runCleanSingle(config.model, config.inputFile, config.agent);
+  }
+
+  const provider = ProgressViewProvider.getInstance();
+  if (provider) {
+    const streamId = getStreamId(
+      config.agent,
+      config.model,
+      config.inputFile,
+      outputFiles,
+    );
+    provider.clearOutputFiles(streamId);
   }
 }
 

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -1,5 +1,8 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import * as path from 'path';
+
+import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
@@ -9,6 +12,17 @@ import { runPack, runPackSingle, runPackMultiple } from '../housekeeping';
 
 const CHANNEL = 'packCommands';
 logger.initialize(CHANNEL);
+
+function getStreamId(
+  agent: string,
+  model: string,
+  inputFile: string,
+  outputFiles?: string[],
+): string {
+  const agentName =
+    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
+  return `${agentName}@${model}: ${path.basename(inputFile)}`;
+}
 
 export function registerPackCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -40,6 +54,17 @@ async function handlePack(config: any) {
     outputFiles,
     config.outputNameOverride,
   );
+
+  const provider = ProgressViewProvider.getInstance();
+  if (provider) {
+    const streamId = getStreamId(
+      config.agent,
+      config.model,
+      config.inputFile,
+      outputFiles,
+    );
+    provider.clearOutputFiles(streamId);
+  }
 }
 
 async function handlePackSingle(
@@ -66,6 +91,12 @@ async function handlePackSingle(
 
   const fileToPack = outputNameOverride || inputFile;
   await runPackSingle(model, fileToPack, agent);
+
+  const provider = ProgressViewProvider.getInstance();
+  if (provider) {
+    const streamId = getStreamId(agent, model, inputFile);
+    provider.clearOutputFiles(streamId);
+  }
 }
 
 async function handlePackMultiple(
@@ -99,6 +130,12 @@ async function handlePackMultiple(
     outputFiles,
     outputNameOverride,
   );
+
+  const provider = ProgressViewProvider.getInstance();
+  if (provider) {
+    const streamId = getStreamId(agent, model, inputFile, outputFiles);
+    provider.clearOutputFiles(streamId);
+  }
 }
 
 export const packCommands = {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -674,6 +674,20 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     return this._outputFiles.get(stream);
   }
 
+  public clearOutputFiles(stream: string): void {
+    if (this._outputFiles.has(stream)) {
+      this._outputFiles.delete(stream);
+      this._saveState();
+      if (this._view && stream === this._activeStream) {
+        this._view.webview.postMessage({
+          command: COMMANDS.UPDATE_FILES,
+          stream,
+          files: {},
+        });
+      }
+    }
+  }
+
   public setActiveStream(stream: string) {
     if (this._logStreams.has(stream)) {
       this._activeStream = stream;


### PR DESCRIPTION
## Summary
- keep progress board up to date by clearing stored output files when running pack or clean
- add `clearOutputFiles` helper to `ProgressViewProvider`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`