### PR TITLE
Fix verbose response logging

### DIFF
--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -37,6 +37,7 @@ import { AgentStateRound } from './AgentState';
 import { messageToSkeleton } from './messageUtils';
 import { getConfig } from '../utils/configUtils';
 import { K_SLICE } from '../utils/constants';
+import { objectToLogString } from '../utils/stringUtils';
 import { calculateTokenPrice } from '../utils/priceUtils';
 
 /**
@@ -342,8 +343,10 @@ export class ModelHandlerAnthropic extends ModelHandler {
       // Anthropic specific empty response check
       const errorMsg = 'No output generated - API returned empty response';
       this.logger.error(errorMsg);
-      this.logger.debug(`responseObject: ${responseObject}`);
-      this.logger.debug(`responseObject.content: ${responseObject.content}`);
+      this.logger.debug(`responseObject: ${objectToLogString(responseObject)}`);
+      this.logger.debug(
+        `responseObject.content: ${objectToLogString(responseObject.content)}`,
+      );
       throw new Error(errorMsg);
     }
 

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -28,6 +28,7 @@ import { ModelHandler } from './ModelHandler';
 import { OpenAIAPIResponseUsage, ResponseUsageFactory } from './ResponseUsage';
 import { ToolState } from './ToolState';
 import { K_SLICE } from '../utils/constants';
+import { objectToLogString } from '../utils/stringUtils';
 import { calculateTokenPrice } from '../utils/priceUtils';
 import { MediaEntry } from './mediaTypes';
 
@@ -339,7 +340,9 @@ export class ModelHandlerOpenAI extends ModelHandler {
   /** Extracts response text and usage statistics from API response. */
   extractResponse(responseObject: any, endTag: string): [string, any, string] {
     if (!responseObject.choices?.length) {
-      this.logger.debug(`Response object: ${JSON.stringify(responseObject)}`);
+      this.logger.debug(
+        `Response object: ${objectToLogString(responseObject)}`,
+      );
 
       // Add fallback for streaming which returns content directly in responseObject
       if (responseObject.role && responseObject.content) {
@@ -380,7 +383,9 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
       const errorMsg = 'Invalid response from API: missing choices';
       this.logger.error(errorMsg);
-      this.logger.error(`Response object: ${JSON.stringify(responseObject)}`);
+      this.logger.error(
+        `Response object: ${objectToLogString(responseObject)}`,
+      );
       throw new Error(errorMsg);
     }
 
@@ -393,7 +398,9 @@ export class ModelHandlerOpenAI extends ModelHandler {
       newResponse = choice.message.content.trim();
     } else {
       newResponse = '';
-      this.logger.error(`Response object: ${JSON.stringify(responseObject)}`);
+      this.logger.error(
+        `Response object: ${objectToLogString(responseObject)}`,
+      );
       this.logger.error('content is empty');
     }
 

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -5,3 +5,14 @@ export function capitalize(str: string): string {
 export function uncapitalize(str: string): string {
   return str.charAt(0).toLowerCase() + str.slice(1);
 }
+
+export function objectToLogString(obj: any, maxLength: number = 1000): string {
+  try {
+    const json = JSON.stringify(obj);
+    return json.length > maxLength
+      ? `${json.substring(0, maxLength)}... (${json.length} chars)`
+      : json;
+  } catch {
+    return String(obj);
+  }
+}


### PR DESCRIPTION
## Summary
- add `objectToLogString` helper for truncated logging
- shorten response logs in OpenAI and Anthropic handlers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`