### PR TITLE
Prioritize thinking logs

### DIFF
--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -11,43 +11,14 @@ marked.setOptions({
 });
 
 /**
- * Format a log entry
+ * Format a log entry with Markdown rendering for special content
  * @param {Object} logMessage - The log message to format
  * @returns {string} Formatted HTML for the log message
  */
 export function formatLogEntry(logMessage) {
-  // Process message for special formats like scratchpad
-  return processScratchpadContent(logMessage.message);
-}
+  let message = logMessage.message;
 
-/**
- * Process scratchpad content with Markdown formatting
- * @param {string} message - The message containing scratchpad content
- * @returns {string} Processed message with formatted scratchpad content
- */
-export function processScratchpadContent(message) {
-  // Check if this message has the scratchpad data attribute
-  if (message.includes('data-is-scratchpad="true"')) {
-    // Extract the actual scratchpad content
-    const scratchpadMatch = message.match(
-      /<span class="message-info">(Scratchpad content:.*?)<\/span>/s,
-    );
-    if (scratchpadMatch && scratchpadMatch[1]) {
-      let content = scratchpadMatch[1];
-
-      // Extract content after the "Scratchpad content:" prefix
-      const contentStartIndex = content.indexOf('Scratchpad content:');
-      if (contentStartIndex !== -1) {
-        content = content.substring(
-          contentStartIndex + 'Scratchpad content:'.length,
-        );
-
-        return formatSpecialContent(message, content, 'Scratchpad content:');
-      }
-    }
-  }
-
-  // Check for thinking content
+  // Show thinking content before scratchpad content
   if (message.includes('Thinking content:')) {
     // Extract the actual thinking content
     const thinkingMatch = message.match(
@@ -64,6 +35,27 @@ export function processScratchpadContent(message) {
         );
 
         return formatSpecialContent(message, content, 'Thinking content:');
+      }
+    }
+  }
+
+  // Check for scratchpad content
+  if (message.includes('data-is-scratchpad="true"')) {
+    // Extract the actual scratchpad content
+    const scratchpadMatch = message.match(
+      /<span class="message-info">(Scratchpad content:.*?)<\/span>/s,
+    );
+    if (scratchpadMatch && scratchpadMatch[1]) {
+      let content = scratchpadMatch[1];
+
+      // Extract content after the "Scratchpad content:" prefix
+      const contentStartIndex = content.indexOf('Scratchpad content:');
+      if (contentStartIndex !== -1) {
+        content = content.substring(
+          contentStartIndex + 'Scratchpad content:'.length,
+        );
+
+        return formatSpecialContent(message, content, 'Scratchpad content:');
       }
     }
   }


### PR DESCRIPTION
## Summary
- inline scratchpad processing into `formatLogEntry`
- keep thinking content above scratchpad messages

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(fails: no network access)*