### PR TITLE
Add default template for new agent files

### DIFF
--- a/docs/guide/agent-explorer.md
+++ b/docs/guide/agent-explorer.md
@@ -28,7 +28,7 @@ You can manage your custom agent files directly within the "Custom Agents" secti
 
 Available actions for **Custom Agents** include:
 
-- **New File** <i class="codicon codicon-new-file"></i>: Creates a new, empty file (e.g., `new-file.yaml`) within the selected folder (or the root custom agents folder). You will be prompted to rename it immediately.
+- **New File** <i class="codicon codicon-new-file"></i>: Creates a new file populated with a starter template (e.g., `new-file.yaml`) within the selected folder (or the root custom agents folder). You will be prompted to rename it immediately.
 - **New Folder** <i class="codicon codicon-new-folder"></i>: Creates a new folder within the selected folder. You will be prompted to rename it.
 - **Rename** <i class="codicon codicon-edit"></i>: Renames the selected custom file or folder.
 - **Delete** <i class="codicon codicon-trash"></i>: Deletes the selected custom file or folder (with confirmation).

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -29,7 +29,7 @@ Custom agents reside in a specific directory.
 
 ### Step 3: Define the Agent
 
-Open the newly created `.yaml` file and define your agent's structure. Start with a basic template and customize it. Here are the key fields:
+Open the newly created `.yaml` file and you'll find a starter template already inserted. Customize it to define your agent's structure. Here are the key fields:
 
 ```yaml
 # --- Agent Inheritance (Optional) ---

--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -16,6 +16,32 @@ import { isValidAgentYaml } from './agent/agentLoad';
 import { fileExistsAbsolute } from './utils/absoluteFileUtils';
 import { getConfig } from './utils/configUtils';
 
+const NEW_AGENT_TEMPLATE = `# --- Agent Inheritance (Optional) ---
+# inherits: base
+
+# --- Agent Settings ---
+settings:
+  agentType: CoT
+  temperature: 0.1
+  isRewrite: true
+  documentTag: document
+  endTag: '</document>'
+  outputExt: tex
+  prefills:
+    - "<document>\n"
+
+# --- Agent Prompts ---
+prompts:
+  systemPrompt: |
+    [Define the AI's role and core instructions]
+
+  userPrefix: |
+    [Provide context using variables like {{ INPUT_CONTENT }}]
+
+  userRequest: |
+    [Define the initial task prompt]
+`;
+
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);
 
@@ -246,6 +272,8 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
     });
 
     // Handle the rename result
+    let createdFile: vscode.Uri | undefined;
+
     if (newName && newName !== item.label) {
       try {
         const oldPath = item.resourceUri.fsPath;
@@ -254,11 +282,15 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
         // For new items, create them
         if (!(await fileExistsAbsolute(oldPath))) {
           if (item.collapsibleState === vscode.TreeItemCollapsibleState.None) {
-            // Create new file
+            // Create new file with starter content if it's YAML
+            const content = newPath.endsWith('.yaml')
+              ? Buffer.from(NEW_AGENT_TEMPLATE)
+              : new Uint8Array();
             await vscode.workspace.fs.writeFile(
               vscode.Uri.file(newPath),
-              new Uint8Array(),
+              content,
             );
+            createdFile = vscode.Uri.file(newPath);
           } else {
             // Create new folder
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(newPath));
@@ -275,6 +307,11 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
         logger.error(CHANNEL, `Error renaming item: ${err}`);
         vscode.window.showErrorMessage('Failed to rename item');
       }
+    }
+
+    if (createdFile) {
+      const doc = await vscode.workspace.openTextDocument(createdFile);
+      await vscode.window.showTextDocument(doc);
     }
 
     // Clear editing state


### PR DESCRIPTION
## Summary
- prepopulate new agent YAML files with a starter template and open them
- document that new files include the template

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails to fully run due to environment restrictions)*