### PR TITLE
Refactor to use SDK types

### DIFF
--- a/src/agent/ResponseUsage.ts
+++ b/src/agent/ResponseUsage.ts
@@ -1,4 +1,7 @@
 /** Types and utilities for tracking and analyzing model API response usage metrics. */
+// Third-party imports
+import { CompletionUsage } from 'openai/resources/completions';
+import { Usage as AnthropicUsage } from '@anthropic-ai/sdk/src/resources/messages/messages';
 
 /** Base interface for common response usage metrics across all model providers. */
 export interface ResponseUsageBase {
@@ -37,7 +40,7 @@ export class ResponseUsageFactory {
    * @returns Structured OpenAI usage metrics
    */
   static fromOpenAIResponse(
-    responseUsage: any,
+    responseUsage: CompletionUsage,
     cost: number,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
@@ -84,7 +87,7 @@ export class ResponseUsageFactory {
    * @returns Structured Anthropic usage metrics
    */
   static fromAnthropicResponse(
-    responseUsage: any,
+    responseUsage: AnthropicUsage,
     cost: number,
     responseTime: number,
   ): AnthropicAPIResponseUsage {

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -6,6 +6,7 @@ import { Anthropic } from '@anthropic-ai/sdk';
 import {
   MessageParam,
   ContentBlock,
+  Usage,
 } from '@anthropic-ai/sdk/resources/messages';
 
 // Local imports - utilities
@@ -57,7 +58,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
   /** Creates a chat completion response using Anthropic's API with specified parameters and optional system prompt. */
   async createResponse(
     client: Anthropic,
-    messages: any[],
+    messages: MessageParam[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
@@ -221,7 +222,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
 
   /** Creates a reflection message array for Anthropic models, managing cache control and image content. */
   async createReflectionMessages(
-    messages: any[],
+    messages: MessageParam[],
     userMessage: string,
     mediaFiles?: string[],
   ): Promise<MessageParam[]> {
@@ -387,7 +388,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
 
   /** Manages continuation with prefill support (typically no-op for models with prefill). */
   addContinueMessageWithPrefill(
-    messages: any[],
+    messages: MessageParam[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -399,7 +400,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
 
   /** Manages continuation for models without prefill support by adding a continuation prompt. */
   addContinueMessageWithoutPrefill(
-    messages: any[],
+    messages: MessageParam[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -430,12 +431,12 @@ export class ModelHandlerAnthropic extends ModelHandler {
   async initializeOutputAndPrefill(
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
-    messages: any[],
+    messages: MessageParam[],
     toolState: ToolState,
     outputFile: string,
     prefill: string,
     groupId?: string,
-  ): Promise<[boolean, any[]]> {
+  ): Promise<[boolean, MessageParam[]]> {
     let endTurn = false;
 
     if (!(await fileExistsAndNonTrivial(outputFile))) {
@@ -552,7 +553,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
   }
 
   /** Calculates API usage cost based on input/output tokens and cache usage if supported. */
-  computePrice(responseUsage: any): number {
+  computePrice(responseUsage: Usage): number {
     let basePrice = calculateTokenPrice(
       responseUsage.input_tokens,
       responseUsage.output_tokens,
@@ -582,7 +583,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
 
   /** Computes detailed response usage metrics including tokens, price, and response time. */
   computeResponseUsage(
-    responseUsage: any,
+    responseUsage: Usage,
     responseTime: number,
   ): AnthropicAPIResponseUsage {
     return ResponseUsageFactory.fromAnthropicResponse(
@@ -593,7 +594,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
   }
 
   updateMessageContentWithPrefill(
-    messages: any[],
+    messages: MessageParam[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,
@@ -638,7 +639,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
   }
 
   updateMessageContentWithoutPrefill(
-    messages: any[],
+    messages: MessageParam[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -40,6 +40,11 @@ import { getConfig } from '../utils/configUtils';
 import { K_SLICE } from '../utils/constants';
 import { objectToLogString } from '../utils/stringUtils';
 import { calculateTokenPrice } from '../utils/priceUtils';
+import {
+  appendToLastMessage,
+  getMessageAt,
+  PROVIDERS,
+} from '../utils/messageContentUtils';
 
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.
@@ -205,7 +210,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     return messages;
   }
 
-  public removeCacheControl(content: any[]) {
+  public removeCacheControl(content: any[] | string) {
     // With the updated Anthropic prompt caching, we should ensure we never exceed
     // Anthropic's limit of 4 cache_control blocks across the entire conversation
 
@@ -218,6 +223,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
         }
       }
     }
+    // If content is a string, there's nothing to remove
   }
 
   /** Creates a reflection message array for Anthropic models, managing cache control and image content. */
@@ -467,10 +473,17 @@ export class ModelHandlerAnthropic extends ModelHandler {
         // add prefill as part of the user message like OpenAI handler
 
         const PseudoPrefillMsgContentString = `Start your response with:\n${prefill}`;
-        messages.at(-1).content.push({
-          type: 'text',
-          text: PseudoPrefillMsgContentString,
-        });
+        if (
+          !appendToLastMessage(
+            messages,
+            PseudoPrefillMsgContentString,
+            'anthropic',
+          )
+        ) {
+          this.logger.warn(
+            'Failed to append pseudo prefill message to last message',
+          );
+        }
         this.logger.debug(
           `Added pseudo prefill message to messages:\n${PseudoPrefillMsgContentString}`,
         );
@@ -495,18 +508,23 @@ export class ModelHandlerAnthropic extends ModelHandler {
     if (hasEndTag(agentSetting, fileContent)) {
       this.logger.debug('End tag detected - skipping continuation');
       // this is suspicious, because the two conflicts!!! we should check
-      if (Array.isArray(lastMessage.content)) {
-        lastMessage.content[lastMessage.content.length - 1].text = fileContent;
-      } else {
-        lastMessage.content = [
-          {
-            type: 'text',
-            text: fileContent,
-          },
-        ];
+      if (lastMessage) {
+        if (Array.isArray(lastMessage.content)) {
+          const lastContentItem =
+            lastMessage.content[lastMessage.content.length - 1];
+          if (lastContentItem && 'text' in lastContentItem) {
+            lastContentItem.text = fileContent;
+          }
+        } else {
+          lastMessage.content = [
+            {
+              type: 'text',
+              text: fileContent,
+            },
+          ];
+        }
+        this.removeCacheControl(lastMessage.content);
       }
-
-      this.removeCacheControl(messages.at(-1).content);
 
       endTurn = true;
       return [endTurn, messages];
@@ -519,12 +537,13 @@ export class ModelHandlerAnthropic extends ModelHandler {
     // For thinking-enabled models that don't support assistant prefill,
     // add continuation as part of the user message
 
-    const content = [
+    const content: ContentBlock[] = [
       {
-        type: 'text',
+        type: 'text' as const,
         text: fileContent,
+        citations: null,
         ...(this.capabilities.supportsPromptCaching
-          ? { cache_control: { type: 'ephemeral' } }
+          ? { cache_control: { type: 'ephemeral' as const } }
           : {}),
       },
     ];
@@ -562,14 +581,20 @@ export class ModelHandlerAnthropic extends ModelHandler {
     );
 
     if (this.capabilities.supportsPromptCaching) {
-      if ('cache_creation_input_tokens' in responseUsage) {
+      if (
+        'cache_creation_input_tokens' in responseUsage &&
+        responseUsage.cache_creation_input_tokens !== null
+      ) {
         basePrice +=
           (responseUsage.cache_creation_input_tokens *
             this.config.inputPrice *
             1.25) /
           1e6;
       }
-      if ('cache_read_input_tokens' in responseUsage) {
+      if (
+        'cache_read_input_tokens' in responseUsage &&
+        responseUsage.cache_read_input_tokens !== null
+      ) {
         basePrice +=
           (responseUsage.cache_read_input_tokens *
             this.config.inputPrice *
@@ -599,20 +624,18 @@ export class ModelHandlerAnthropic extends ModelHandler {
     newResponse: string,
     toolState: ToolState,
   ): void {
-    const lastMessage = messages.at(-1);
+    const lastMessage = getMessageAt(messages, -1);
 
-    if (lastMessage.role === 'assistant') {
-      if (Array.isArray(lastMessage.content)) {
-        const newMessage = {
-          type: 'text',
-          text: bestConnector + newResponse,
-        };
-        lastMessage.content.push(newMessage);
-      } else {
+    if (lastMessage && lastMessage.role === 'assistant') {
+      if (
+        !appendToLastMessage(messages, bestConnector + newResponse, 'anthropic')
+      ) {
+        // Fallback to direct assignment if append fails
         lastMessage.content = [
           {
-            type: 'text',
+            type: 'text' as const,
             text: toolState.accumulatedOutput,
+            citations: null,
           },
         ];
       }
@@ -629,9 +652,16 @@ export class ModelHandlerAnthropic extends ModelHandler {
           // Remove all existing cache_control
           this.removeCacheControl(lastMessage.content);
 
-          lastMessage.content.at(-1).cache_control = {
-            type: 'ephemeral',
-          };
+          const lastContentItem = lastMessage.content.at(-1);
+          if (
+            lastContentItem &&
+            typeof lastContentItem === 'object' &&
+            'type' in lastContentItem
+          ) {
+            (lastContentItem as any).cache_control = {
+              type: 'ephemeral',
+            };
+          }
         }
       }
     }
@@ -649,7 +679,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     const lastMessage = messages.at(-1);
     const secondLastMessage = messages.at(-2);
 
-    if (lastMessage.role !== 'user') {
+    if (!lastMessage || lastMessage.role !== 'user') {
       this.logger.error(
         'Last message is not a user message - unexpected format',
       );
@@ -666,16 +696,15 @@ export class ModelHandlerAnthropic extends ModelHandler {
       // The last message is a user message
       // So the second last message must be an assistant message
 
-      if (secondLastMessage.role === 'assistant') {
+      if (secondLastMessage && secondLastMessage.role === 'assistant') {
         // Preserve any thinking blocks that might exist in the content array
-        const thinkingBlocks = secondLastMessage.content.filter(
+        const contentArray = Array.isArray(secondLastMessage.content)
+          ? secondLastMessage.content
+          : [{ type: 'text', text: secondLastMessage.content }];
+
+        const thinkingBlocks = contentArray.filter(
           (item: any) =>
             item.type === 'thinking' || item.type === 'redacted_thinking',
-        );
-
-        // Find text blocks in the content array
-        const textBlocks = secondLastMessage.content.filter(
-          (item: any) => item.type === 'text',
         );
 
         // Anthropic models should include thinking blocks first in the content array
@@ -685,15 +714,33 @@ export class ModelHandlerAnthropic extends ModelHandler {
           this.logger.debug(
             `Using ${thinkingBlocks.length} existing thinking blocks from previous message`,
           );
-          secondLastMessage.content.push({
-            type: 'text',
-            text: bestConnector + newResponse,
-          });
+          // Ensure content is an array before pushing
+          if (Array.isArray(secondLastMessage.content)) {
+            secondLastMessage.content.push({
+              type: 'text',
+              text: bestConnector + newResponse,
+            });
+          } else {
+            // Convert string content to array
+            secondLastMessage.content = [
+              { type: 'text', text: secondLastMessage.content },
+              { type: 'text', text: bestConnector + newResponse },
+            ];
+          }
         } else {
-          secondLastMessage.content.push({
-            type: 'text',
-            text: bestConnector + newResponse,
-          });
+          // Ensure content is an array before pushing
+          if (Array.isArray(secondLastMessage.content)) {
+            secondLastMessage.content.push({
+              type: 'text',
+              text: bestConnector + newResponse,
+            });
+          } else {
+            // Convert string content to array
+            secondLastMessage.content = [
+              { type: 'text', text: secondLastMessage.content },
+              { type: 'text', text: bestConnector + newResponse },
+            ];
+          }
           // Add the updated text content
           // If there are existing text blocks, update with new content
           // Otherwise create a new text block with the new returned thinking block if it is not after cut off
@@ -750,7 +797,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
         'Last message is a request message rather than a ask to continue after cut off',
       );
       // Create a new assistant message with the response
-      const assistantMessage: { role: string; content: any[] } = {
+      const assistantMessage: MessageParam = {
         role: 'assistant',
         content: [],
       };
@@ -760,14 +807,18 @@ export class ModelHandlerAnthropic extends ModelHandler {
         this.logger.debug(
           `Adding ${toolState.thinkingBlocks.length} thinking blocks to new assistant message`,
         );
-        assistantMessage.content.push(...toolState.thinkingBlocks);
+        if (Array.isArray(assistantMessage.content)) {
+          assistantMessage.content.push(...toolState.thinkingBlocks);
+        }
       }
 
       // Add the text content
-      assistantMessage.content.push({
-        type: 'text',
-        text: toolState.accumulatedOutput,
-      });
+      if (Array.isArray(assistantMessage.content)) {
+        assistantMessage.content.push({
+          type: 'text',
+          text: toolState.accumulatedOutput,
+        });
+      }
 
       messages.push(assistantMessage);
       this.logger.debug('Added a new assistant message');

--- a/src/agent/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlerGoogle.ts
@@ -3,6 +3,7 @@
 
 // Third-party imports
 import OpenAI from 'openai';
+import { CompletionUsage } from 'openai/resources/completions';
 import { GenerateContentResponseUsageMetadata } from '@google/genai/dist/node/node';
 
 // Local imports - agent components
@@ -26,40 +27,57 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
     return new OpenAI({ apiKey, baseURL });
   }
 
-  /** Computes cost based on Google's token usage format. */
-  computePrice(responseUsage: GenerateContentResponseUsageMetadata): number {
-    // Google models return completionTokens, promptTokens instead of completion_tokens, prompt_tokens
-    const promptTokens = responseUsage?.promptTokens ?? 0;
-    const completionTokens = responseUsage?.completionTokens ?? 0;
-    const thoughtTokens =
-      responseUsage?.thoughtsTokenCount ?? responseUsage?.thoughtTokens ?? 0;
-    const toolUseTokens = responseUsage?.toolUseTokenCount ?? 0;
+  /** Computes cost based on token usage. Overrides base implementation to handle Google's format. */
+  computePrice(
+    responseUsage: CompletionUsage | GenerateContentResponseUsageMetadata,
+  ): number {
+    // Handle OpenAI CompletionUsage format (from base class)
+    if ('prompt_tokens' in responseUsage) {
+      return super.computePrice(responseUsage as CompletionUsage);
+    }
+
+    // Handle Google's GenerateContentResponseUsageMetadata format
+    const googleUsage = responseUsage as GenerateContentResponseUsageMetadata;
+    const promptTokens = googleUsage?.promptTokenCount ?? 0;
+    const completionTokens = googleUsage?.candidatesTokenCount ?? 0;
+    const thoughtTokens = googleUsage?.thoughtsTokenCount ?? 0;
 
     return calculateTokenPrice(
       promptTokens,
-      completionTokens + thoughtTokens + toolUseTokens,
+      completionTokens + thoughtTokens,
       this.config.inputPrice,
       this.config.outputPrice,
     );
   }
 
-  /** Creates usage statistics from Google's response format. */
+  /** Creates usage statistics from response format. Overrides base implementation to handle Google's format. */
   computeResponseUsage(
-    responseUsage: GenerateContentResponseUsageMetadata,
+    responseUsage: CompletionUsage | GenerateContentResponseUsageMetadata,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
-    // Create a minimal usage object with Google's token counts
-    const usageObj = {
-      prompt_tokens: responseUsage?.candidatesTokenCount ?? 0,
-      completion_tokens: responseUsage?.completionTokens ?? 0,
-      total_tokens: responseUsage?.totalTokenCount ?? 0,
+    // Handle OpenAI CompletionUsage format (from base class)
+    if ('prompt_tokens' in responseUsage) {
+      return super.computeResponseUsage(
+        responseUsage as CompletionUsage,
+        responseTime,
+      );
+    }
+
+    // Handle Google's GenerateContentResponseUsageMetadata format
+    const googleUsage = responseUsage as GenerateContentResponseUsageMetadata;
+
+    // Create a CompletionUsage object compatible with OpenAI's format
+    const usageObj: CompletionUsage = {
+      prompt_tokens: googleUsage?.promptTokenCount ?? 0,
+      completion_tokens: googleUsage?.candidatesTokenCount ?? 0,
+      total_tokens: googleUsage?.totalTokenCount ?? 0,
       prompt_tokens_details: {
-        cached_tokens: responseUsage?.cachedContentTokenCount ?? 0,
+        cached_tokens: googleUsage?.cachedContentTokenCount ?? 0,
       },
       completion_tokens_details: {
-        reasoning_tokens: responseUsage?.thoughtsTokenCount ?? 0,
-        accepted_prediction_tokens: null,
-        rejected_prediction_tokens: null,
+        reasoning_tokens: googleUsage?.thoughtsTokenCount ?? 0,
+        accepted_prediction_tokens: undefined,
+        rejected_prediction_tokens: undefined,
       },
     };
 

--- a/src/agent/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlerGoogle.ts
@@ -3,6 +3,7 @@
 
 // Third-party imports
 import OpenAI from 'openai';
+import { GenerateContentResponseUsageMetadata } from '@google/genai/dist/node/node';
 
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
@@ -26,7 +27,7 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
   }
 
   /** Computes cost based on Google's token usage format. */
-  computePrice(responseUsage: any): number {
+  computePrice(responseUsage: GenerateContentResponseUsageMetadata): number {
     // Google models return completionTokens, promptTokens instead of completion_tokens, prompt_tokens
     const promptTokens = responseUsage?.promptTokens ?? 0;
     const completionTokens = responseUsage?.completionTokens ?? 0;
@@ -44,7 +45,7 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
 
   /** Creates usage statistics from Google's response format. */
   computeResponseUsage(
-    responseUsage: any,
+    responseUsage: GenerateContentResponseUsageMetadata,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
     // Create a minimal usage object with Google's token counts

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -9,7 +9,6 @@ import {
   GenerateContentResponse,
   FinishReason,
   File,
-  createPartFromUri,
 } from '@google/genai';
 import { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import { CompletionUsage } from 'openai/resources/completions';
@@ -19,7 +18,7 @@ import { GenerateContentResponseUsageMetadata } from '@google/genai/dist/node/no
 import { ModelHandler } from './ModelHandler';
 import { AgentConfig } from './AgentConfig';
 import { AgentSetting, hasEndTag } from './AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from './AgentState';
+import { AgentStateRound } from './AgentState';
 import { ToolState } from './ToolState';
 import { OpenAIAPIResponseUsage, ResponseUsageFactory } from './ResponseUsage';
 import { MediaEntry } from './mediaTypes';
@@ -44,37 +43,16 @@ import { calculateTokenPrice } from '../utils/priceUtils';
 
 // Local constant
 import { K_SLICE } from '../utils/constants';
+import {
+  appendToLastMessage,
+  appendContentToLastMessage,
+  updateLastTextPart,
+  getMessageAt,
+} from '../utils/messageContentUtils';
 
-// Internal type definition
-type InternalMessagePart = {
-  type: 'text' | 'file_uri' | string;
-  text?: string;
-  uri?: string;
-  mimeType?: string;
-};
+// No need for custom types - use native Google GenAI Part type directly
 
-// Helper function
-function convertInternalPartsToGoogleParts(
-  internalParts: InternalMessagePart[],
-  logger: any,
-): Part[] {
-  return internalParts
-    .map((part: InternalMessagePart): Part | null => {
-      if (part.type === 'text' && typeof part.text === 'string') {
-        return { text: part.text };
-      } else if (part.type === 'file_uri' && part.uri && part.mimeType) {
-        return createPartFromUri(part.uri, part.mimeType);
-      } else {
-        logger.warn(
-          `Skipping unsupported internal part type for sendMessage: ${JSON.stringify(part)}`,
-        );
-        return null;
-      }
-    })
-    .filter((part: Part | null): part is Part => part != null);
-}
-
-// Helper function
+// Helper function to convert OpenAI messages to Google GenAI Content format
 function convertMessagesToGoogleContentHistory(
   messages: ChatCompletionMessageParam[],
   logger: any,
@@ -91,15 +69,23 @@ function convertMessagesToGoogleContentHistory(
     let parts: Part[] = [];
     if (Array.isArray(msg.content)) {
       parts = msg.content
-        .map((part: InternalMessagePart): Part | null => {
-          if (part.type === 'text' && typeof part.text === 'string') {
+        .map((part: any): Part | null => {
+          // Native Google Part format (from our own messages)
+          if (part.text !== undefined) {
             return { text: part.text };
-          } else if (part.type === 'file_uri' && part.uri && part.mimeType) {
-            return { fileData: { fileUri: part.uri, mimeType: part.mimeType } };
+          } else if (part.fileData) {
+            return { fileData: part.fileData };
+          }
+          // OpenAI text format (from other handlers)
+          else if (part.type === 'text' && typeof part.text === 'string') {
+            return { text: part.text };
+          }
+          // Handle image URLs by skipping (Google needs file URIs)
+          else if (part.type === 'image_url') {
+            logger.warn('Image URLs not supported by Google GenAI - skipping');
+            return null;
           } else {
-            logger.warn(
-              `Skipping unsupported internal part type for history conversion: ${JSON.stringify(part)}`,
-            );
+            logger.warn(`Skipping unsupported part: ${JSON.stringify(part)}`);
             return null;
           }
         })
@@ -173,10 +159,21 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     let lastMessageParts: Part[] = [];
     if (lastMessage?.content) {
       if (Array.isArray(lastMessage.content)) {
-        lastMessageParts = convertInternalPartsToGoogleParts(
-          lastMessage.content,
-          this.logger,
-        );
+        // Convert content array to Google Parts
+        lastMessageParts = lastMessage.content
+          .map((part: any): Part | null => {
+            if (part.text !== undefined) {
+              return { text: part.text };
+            } else if (part.fileData) {
+              return { fileData: part.fileData };
+            } else {
+              this.logger.warn(
+                `Skipping unsupported part in sendMessage: ${JSON.stringify(part)}`,
+              );
+              return null;
+            }
+          })
+          .filter((part): part is Part => part !== null);
       } else if (typeof lastMessage.content === 'string') {
         lastMessageParts = [{ text: lastMessage.content }];
       }
@@ -246,7 +243,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       }
     }
 
-    const useStreaming = false; // Hardcoded to false
     if (getConfig<boolean>('model.useStreaming', false)) {
       this.logger.warn(
         'Streaming is configured but currently disabled in ModelHandlerGoogleGenAI (using Chat API).',
@@ -292,9 +288,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     systemPrompt?: string,
   ): Promise<ChatCompletionMessageParam[]> {
     const client = await this.getClient();
-    const userContentParts: InternalMessagePart[] = [
-      { type: 'text', text: userPrefix },
-    ];
+    const userContentParts: Part[] = [{ text: userPrefix }];
 
     if (
       mediaFiles &&
@@ -338,14 +332,20 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
           );
 
           userContentParts.push({
-            type: 'text',
             text: `\nFile attached: ${path.basename(mediaFile)}`,
           });
-          userContentParts.push({
-            type: 'file_uri',
-            uri: uploadResult.uri,
-            mimeType: uploadResult.mimeType,
-          });
+          if (uploadResult.uri && uploadResult.mimeType) {
+            userContentParts.push({
+              fileData: {
+                fileUri: uploadResult.uri,
+                mimeType: uploadResult.mimeType,
+              },
+            });
+          } else {
+            this.logger.error(
+              `Upload result missing URI or MIME type for ${mediaFile}`,
+            );
+          }
         } catch (error) {
           this.logger.error(
             `Failed to upload media file ${mediaFile} via native SDK: ${error}`,
@@ -354,9 +354,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       }
     }
 
-    userContentParts.push({ type: 'text', text: `\n${userRequest}` });
+    userContentParts.push({ text: `\n${userRequest}` });
 
-    return [{ role: 'user', content: userContentParts }];
+    return [{ role: 'user', content: userContentParts as any }];
   }
 
   private determineMimeType(filePath: string): string | null {
@@ -409,7 +409,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     mediaFiles?: string[],
   ): Promise<ChatCompletionMessageParam[]> {
     const client = await this.getClient();
-    const reflectionParts: InternalMessagePart[] = [];
+    const reflectionParts: Part[] = [];
 
     if (
       mediaFiles &&
@@ -461,14 +461,16 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
           }
 
           reflectionParts.push({
-            type: 'text',
             text: `\nReflecting on file: ${path.basename(mediaFile)}`,
           });
-          reflectionParts.push({
-            type: 'file_uri',
-            uri: uploadResult.uri,
-            mimeType: uploadResult.mimeType,
-          });
+          if (uploadResult.uri && uploadResult.mimeType) {
+            reflectionParts.push({
+              fileData: {
+                fileUri: uploadResult.uri,
+                mimeType: uploadResult.mimeType,
+              },
+            });
+          }
         } catch (error) {
           this.logger.error(
             `Failed to upload media file ${mediaFile} for reflection: ${error}`,
@@ -477,9 +479,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       }
     }
 
-    reflectionParts.push({ type: 'text', text: userMessage });
+    reflectionParts.push({ text: userMessage });
 
-    messages.push({ role: 'user', content: reflectionParts });
+    messages.push({ role: 'user', content: reflectionParts as any });
     return messages;
   }
 
@@ -564,7 +566,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     const promptTokens = responseUsage.promptTokenCount ?? 0;
     const completionTokens = responseUsage.candidatesTokenCount ?? 0;
     const thoughtTokens = responseUsage.thoughtsTokenCount ?? 0;
-    const toolUseTokens = responseUsage.toolUseTokenCount ?? 0;
+    // Keep toolUseTokenCount for future use even if the type doesn't have it yet
+    const toolUseTokens = (responseUsage as any).toolUseTokenCount ?? 0;
     return calculateTokenPrice(
       promptTokens,
       completionTokens + thoughtTokens + toolUseTokens,
@@ -577,7 +580,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     responseUsage: GenerateContentResponseUsageMetadata,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
-    const usageObj = {
+    const usageObj: CompletionUsage = {
       prompt_tokens: responseUsage?.promptTokenCount ?? 0,
       completion_tokens: responseUsage?.candidatesTokenCount ?? 0,
       total_tokens: responseUsage?.totalTokenCount ?? 0,
@@ -586,8 +589,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       },
       completion_tokens_details: {
         reasoning_tokens: responseUsage?.thoughtsTokenCount ?? 0,
-        accepted_prediction_tokens: null,
-        rejected_prediction_tokens: null,
+        accepted_prediction_tokens: undefined,
+        rejected_prediction_tokens: undefined,
       },
     };
     return ResponseUsageFactory.fromOpenAIResponse(
@@ -643,37 +646,24 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       this.logger.debug('Removed user continuation prompt.');
     }
 
-    const modelMessage = messages.at(-1);
+    const modelMessage = getMessageAt(messages, -1);
     if (modelMessage?.role === 'assistant') {
-      if (Array.isArray(modelMessage.content)) {
-        let lastTextPart = null;
-        for (let i = modelMessage.content.length - 1; i >= 0; i--) {
-          if (
-            modelMessage.content[i] &&
-            modelMessage.content[i].type === 'text'
-          ) {
-            lastTextPart = modelMessage.content[i];
-            break;
-          }
-        }
-        if (lastTextPart) {
-          lastTextPart.text =
-            (lastTextPart.text || '') + bestConnector + newResponse;
-        } else {
-          modelMessage.content.push({
-            type: 'text',
-            text: bestConnector + newResponse,
-          });
-          this.logger.warn(
-            'Added new text part to last model message as none existed.',
-          );
-        }
-      } else {
-        modelMessage.content = [
-          { type: 'text', text: toolState.accumulatedOutput },
-        ];
-        this.logger.error(
-          'Last model message content was not an array. Resetting content.',
+      // Use unified function to update last text part
+      const updated = updateLastTextPart(
+        modelMessage,
+        (text) => text + bestConnector + newResponse,
+        'google',
+      );
+
+      if (!updated) {
+        // If no text part found, append new one using unified function
+        appendContentToLastMessage(
+          messages,
+          { text: bestConnector + newResponse },
+          'google',
+        );
+        this.logger.warn(
+          'Added new text part to last model message as none existed.',
         );
       }
     } else {
@@ -718,13 +708,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       }
 
       // Add pseudo-prefill instruction instead of skipping it
-      const lastMessage = messages[messages.length - 1];
       const pseudoPrefillMsg = `Organize your response with XML tags. Start your response with:\n${prefill}`;
 
-      if (Array.isArray(lastMessage.content)) {
-        lastMessage.content.push({ type: 'text', text: pseudoPrefillMsg });
-      } else {
-        lastMessage.content = [{ type: 'text', text: pseudoPrefillMsg }];
+      if (!appendToLastMessage(messages, pseudoPrefillMsg, 'google')) {
+        this.logger.warn('Failed to append pseudo-prefill message');
       }
 
       this.logger.debug(`Added pseudo-prefill message: "${pseudoPrefillMsg}"`);

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -11,6 +11,9 @@ import {
   File,
   createPartFromUri,
 } from '@google/genai';
+import { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import { CompletionUsage } from 'openai/resources/completions';
+import { GenerateContentResponseUsageMetadata } from '@google/genai/dist/node/node';
 
 // Local imports - agent components
 import { ModelHandler } from './ModelHandler';
@@ -73,7 +76,7 @@ function convertInternalPartsToGoogleParts(
 
 // Helper function
 function convertMessagesToGoogleContentHistory(
-  messages: any[],
+  messages: ChatCompletionMessageParam[],
   logger: any,
 ): Content[] {
   const history: Content[] = [];
@@ -146,7 +149,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
   /** Creates a chat completion response using Google's GenAI API with specified parameters and optional system prompt. */
   async createResponse(
     client: GoogleGenAI,
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
@@ -287,7 +290,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     userRequest: string,
     mediaFiles?: string[],
     systemPrompt?: string,
-  ): Promise<any[]> {
+  ): Promise<ChatCompletionMessageParam[]> {
     const client = await this.getClient();
     const userContentParts: InternalMessagePart[] = [
       { type: 'text', text: userPrefix },
@@ -401,10 +404,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
 
   /** Creates a reflection message array for Google GenAI models, managing image content and message structure. */
   async createReflectionMessages(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     userMessage: string,
     mediaFiles?: string[],
-  ): Promise<any[]> {
+  ): Promise<ChatCompletionMessageParam[]> {
     const client = await this.getClient();
     const reflectionParts: InternalMessagePart[] = [];
 
@@ -556,7 +559,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     return [responseText, usage, stopReason];
   }
 
-  computePrice(responseUsage: any): number {
+  computePrice(responseUsage: GenerateContentResponseUsageMetadata): number {
     if (!responseUsage) return 0.0;
     const promptTokens = responseUsage.promptTokenCount ?? 0;
     const completionTokens = responseUsage.candidatesTokenCount ?? 0;
@@ -571,7 +574,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
   }
 
   computeResponseUsage(
-    responseUsage: any,
+    responseUsage: GenerateContentResponseUsageMetadata,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
     const usageObj = {
@@ -601,7 +604,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
   }
 
   addContinueMessageWithoutPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -623,7 +626,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
   }
 
   updateMessageContentWithoutPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,
@@ -685,12 +688,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
   async initializeOutputAndPrefill(
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     toolState: ToolState,
     outputFile: string,
     prefill: string,
     groupId?: string,
-  ): Promise<[boolean, any[]]> {
+  ): Promise<[boolean, ChatCompletionMessageParam[]]> {
     let endTurn = false;
     this.logger.debug(
       `Initializing output and prefill for ${outputFile}. Prefill content: "${prefill.slice(0, 100)}..."`,

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -7,7 +7,11 @@ import OpenAI, {
   NotFoundError,
   PermissionDeniedError,
 } from 'openai';
-import { ChatCompletionContentPart } from 'openai/resources/chat/completions';
+import {
+  ChatCompletionContentPart,
+  ChatCompletionMessageParam,
+} from 'openai/resources/chat/completions';
+import { CompletionUsage } from 'openai/resources/completions';
 import { countTokens } from 'gpt-tokenizer';
 
 // Local imports - utilities
@@ -49,7 +53,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
   /** Creates a chat completion with model-specific parameters. */
   async createResponse(
     client: OpenAI,
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
@@ -162,8 +166,8 @@ export class ModelHandlerOpenAI extends ModelHandler {
     userRequest: string,
     mediaFiles?: string[],
     systemPrompt?: string,
-  ): Promise<any[]> {
-    const messages: any[] = [];
+  ): Promise<ChatCompletionMessageParam[]> {
+    const messages: ChatCompletionMessageParam[] = [];
 
     // Handle system prompt differently for O1 models
     if (systemPrompt) {
@@ -240,10 +244,10 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
   /** Adds user message with reflection content to existing messages. */
   async createReflectionMessages(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     userMessage: string,
     mediaFiles?: string[],
-  ): Promise<any[]> {
+  ): Promise<ChatCompletionMessageParam[]> {
     const reflectionContent: ChatCompletionContentPart[] = [];
 
     // const role = this.config.capabilities.supportsIntermDevMsgs
@@ -415,7 +419,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
   /** Manages continuation with prefill support (typically no-op for models with prefill). */
   addContinueMessageWithPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -427,7 +431,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
   /** Manages continuation for models without prefill support by adding a continuation prompt. */
   addContinueMessageWithoutPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -460,12 +464,12 @@ export class ModelHandlerOpenAI extends ModelHandler {
   async initializeOutputAndPrefill(
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     toolState: ToolState,
     outputFile: string,
     prefill: string,
     groupId?: string,
-  ): Promise<[boolean, any[]]> {
+  ): Promise<[boolean, ChatCompletionMessageParam[]]> {
     let endTurn = false;
 
     if (!(await fileExistsAndNonTrivial(outputFile))) {
@@ -551,7 +555,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
   }
 
   /** Computes cost based on token usage and model pricing. */
-  computePrice(responseUsage: any): number {
+  computePrice(responseUsage: CompletionUsage): number {
     // Handle models that return None for usage
     if (!responseUsage) {
       return 0.0;
@@ -592,7 +596,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
   /** Creates usage statistics from OpenAI's response format. */
   computeResponseUsage(
-    responseUsage: any,
+    responseUsage: CompletionUsage,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
     // For Google models, create a minimal usage object with zeros
@@ -623,7 +627,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
   /** Updates message content for models with prefill support. */
   updateMessageContentWithPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,
@@ -663,7 +667,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
   /** Updates message content for models without prefill support. */
   updateMessageContentWithoutPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,
@@ -763,7 +767,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
    * @throws Error if token calculation fails.
    */
   private _calculateApproximateTokens(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     systemPrompt?: string,
   ): number {
     // Note: This is a simplified token count. A more accurate count would

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -35,6 +35,12 @@ import { K_SLICE } from '../utils/constants';
 import { objectToLogString } from '../utils/stringUtils';
 import { calculateTokenPrice } from '../utils/priceUtils';
 import { MediaEntry } from './mediaTypes';
+import {
+  appendToLastMessage,
+  getMessageAt,
+  createTextPart,
+  PROVIDERS,
+} from '../utils/messageContentUtils';
 
 /**
  * OpenAI-specific handlers.
@@ -203,11 +209,24 @@ export class ModelHandlerOpenAI extends ModelHandler {
     }
 
     // Append the formatted content to the correct message
-    let lastRole = messages.length > 0 ? messages.at(-1).role : null;
+    const lastMessage = getMessageAt(messages, -1);
+    let lastRole = lastMessage?.role || null;
     if (lastRole === 'system' || messages.length === 0) {
       messages.push({ role: 'user', content: userMessageContent });
-    } else if (lastRole === 'user') {
-      messages.at(-1).content.push(...userMessageContent);
+    } else if (lastRole === 'user' && lastMessage) {
+      // Use utility to safely append content
+      if (Array.isArray(lastMessage.content)) {
+        (lastMessage.content as ChatCompletionContentPart[]).push(
+          ...userMessageContent,
+        );
+      } else {
+        // Convert string content to array format
+        const existingContent = lastMessage.content;
+        lastMessage.content = [
+          createTextPart(existingContent || ''),
+          ...userMessageContent,
+        ] as ChatCompletionContentPart[];
+      }
     } else {
       // Fallback: Should not happen with current logic but good to handle
       messages.push({ role: 'user', content: userMessageContent });
@@ -220,18 +239,29 @@ export class ModelHandlerOpenAI extends ModelHandler {
     const requestRole = this.config.capabilities.supportsIntermDevMsgs
       ? 'system'
       : 'user';
-    lastRole = messages.length > 0 ? messages.at(-1).role : null;
+    const lastMsg = messages.length > 0 ? messages.at(-1) : null;
+    lastRole = lastMsg?.role || null;
 
     if (requestRole === 'system') {
       messages.push({
         role: requestRole,
         content: [{ type: 'text', text: userRequest }],
       });
-    } else if (requestRole === 'user' && lastRole === 'user') {
-      messages.at(-1).content.push({
-        type: 'text',
-        text: userRequest,
-      });
+    } else if (requestRole === 'user' && lastRole === 'user' && lastMsg) {
+      // Ensure content is an array before pushing
+      if (Array.isArray(lastMsg.content)) {
+        (lastMsg.content as ChatCompletionContentPart[]).push({
+          type: 'text' as const,
+          text: userRequest,
+        });
+      } else {
+        // Convert string content to array format
+        const existingContent = lastMsg.content;
+        lastMsg.content = [
+          { type: 'text' as const, text: existingContent || '' },
+          { type: 'text' as const, text: userRequest },
+        ] as ChatCompletionContentPart[];
+      }
     } else {
       messages.push({
         role: requestRole,
@@ -483,10 +513,13 @@ export class ModelHandlerOpenAI extends ModelHandler {
       }
 
       const PseudoPrefillMsgContentString = `Organize your response with xml tags. Start your response with:\n${prefill}`;
-      messages.at(-1).content.push({
-        type: 'text',
-        text: PseudoPrefillMsgContentString,
-      });
+      if (
+        !appendToLastMessage(messages, PseudoPrefillMsgContentString, 'openai')
+      ) {
+        this.logger.warn(
+          'Failed to append pseudo prefill message to last message',
+        );
+      }
       this.logger.debug(
         `Added pseudo prefill message to messages:\n${PseudoPrefillMsgContentString}`,
       );
@@ -516,16 +549,22 @@ export class ModelHandlerOpenAI extends ModelHandler {
     const lastMessage = messages.at(-1);
     if (hasEndTag(agentSetting, fileContent)) {
       this.logger.info('End tag detected - skipping continuation');
-      if (Array.isArray(lastMessage.content)) {
-        // this is suspicious, because the two conflicts!!!
-        lastMessage.content[lastMessage.content.length - 1].text = fileContent;
-      } else {
-        lastMessage.content = [
-          {
-            type: 'text',
-            text: fileContent,
-          },
-        ];
+      if (lastMessage) {
+        if (Array.isArray(lastMessage.content)) {
+          // Update the last text content part
+          const lastContentPart =
+            lastMessage.content[lastMessage.content.length - 1];
+          if (lastContentPart && 'text' in lastContentPart) {
+            lastContentPart.text = fileContent;
+          }
+        } else {
+          lastMessage.content = [
+            {
+              type: 'text' as const,
+              text: fileContent,
+            },
+          ];
+        }
       }
       endTurn = true;
       return [endTurn, messages];
@@ -577,7 +616,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
       responseUsage.completion_tokens_details?.reasoning_tokens ?? 0;
     const cachedTokens =
       responseUsage.prompt_tokens_details?.cached_tokens ??
-      responseUsage.prompt_cache_hit_tokens ?? // deepseek
+      (responseUsage as any).prompt_cache_hit_tokens ?? // deepseek - non-standard property
       0;
 
     if (reasoningTokens) {
@@ -601,14 +640,15 @@ export class ModelHandlerOpenAI extends ModelHandler {
   ): OpenAIAPIResponseUsage {
     // For Google models, create a minimal usage object with zeros
     if (!responseUsage) {
-      const emptyUsage = {
+      const emptyUsage: CompletionUsage = {
         prompt_tokens: 0,
         completion_tokens: 0,
+        total_tokens: 0,
         prompt_tokens_details: { cached_tokens: 0 },
         completion_tokens_details: {
           reasoning_tokens: 0,
-          accepted_prediction_tokens: null,
-          rejected_prediction_tokens: null,
+          accepted_prediction_tokens: 0,
+          rejected_prediction_tokens: 0,
         },
       };
       return ResponseUsageFactory.fromOpenAIResponse(
@@ -636,24 +676,19 @@ export class ModelHandlerOpenAI extends ModelHandler {
       'Updating message content for OpenAI models with prefill support',
     );
 
-    const lastMessage = messages.at(-1);
+    const lastMessage = getMessageAt(messages, -1);
 
-    if (lastMessage.role === 'assistant') {
-      if (Array.isArray(lastMessage.content)) {
-        const newMessage = {
-          type: 'text',
-          text: bestConnector + newResponse,
-        };
-        lastMessage.content.push(newMessage);
-      } else {
-        lastMessage.content = [
-          {
-            type: 'text',
-            text: toolState.accumulatedOutput,
-          },
-        ];
+    if (lastMessage && lastMessage.role === 'assistant') {
+      if (
+        !appendToLastMessage(messages, bestConnector + newResponse, 'openai')
+      ) {
+        // Fallback to direct assignment if append fails
+        lastMessage.content = [createTextPart(toolState.accumulatedOutput)];
       }
-    } else if (lastMessage.role === 'user' || lastMessage.role === 'system') {
+    } else if (
+      lastMessage &&
+      (lastMessage.role === 'user' || lastMessage.role === 'system')
+    ) {
       this.logger.debug(
         ' Last message is a user or system message - unexpected format',
       );
@@ -680,7 +715,10 @@ export class ModelHandlerOpenAI extends ModelHandler {
     const lastMessage = messages.at(-1);
     const secondLastMessage = messages.at(-2);
 
-    if (lastMessage.role !== 'user' && lastMessage.role !== 'system') {
+    if (
+      !lastMessage ||
+      (lastMessage.role !== 'user' && lastMessage.role !== 'system')
+    ) {
       this.logger.error(
         'Last message is not a user or system message - unexpected format',
       );
@@ -688,25 +726,25 @@ export class ModelHandlerOpenAI extends ModelHandler {
     }
     this.logger.debug('Last message is a user/system message');
 
-    if (this.containCutOffMessage(lastMessage.content)) {
+    if (lastMessage && this.containCutOffMessage(lastMessage.content)) {
       this.logger.debug(
         'Last message is a user message asking to continue after cut off',
       );
       // Then the last message is a user message
       // So the second last message must be an assistant message
-      if (secondLastMessage.role === 'assistant') {
+      if (secondLastMessage && secondLastMessage.role === 'assistant') {
         // we get gradually get rid if this kind of isArray conditioning since now we are consistently using the content array
         // but why do the following two differ?
         if (Array.isArray(secondLastMessage.content)) {
           secondLastMessage.content.push({
-            type: 'text',
+            type: 'text' as const,
             text: bestConnector + newResponse,
           });
         } else {
           this.logger.error('Second last message content is not a list');
           secondLastMessage.content = [
             {
-              type: 'text',
+              type: 'text' as const,
               text: toolState.accumulatedOutput,
             },
           ];
@@ -727,7 +765,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
       );
       messages.push({
         role: 'assistant',
-        content: [{ type: 'text', text: toolState.accumulatedOutput }],
+        content: [{ type: 'text' as const, text: toolState.accumulatedOutput }],
       });
     }
   }

--- a/src/utils/messageContentUtils.ts
+++ b/src/utils/messageContentUtils.ts
@@ -1,0 +1,228 @@
+// No third-party imports needed - this module is provider-agnostic
+
+/**
+ * Utility functions for manipulating message content in a type-safe way
+ * across different AI provider formats (OpenAI, Anthropic, Google GenAI, etc.)
+ */
+
+// Common types for unified handling
+export type MessageContent = string | any[] | null | undefined;
+export type ContentPart = {
+  type?: string;
+  text?: string;
+  [key: string]: any;
+};
+
+// Type guards
+export function isArrayContent(content: any): content is any[] {
+  return Array.isArray(content);
+}
+
+export function isStringContent(content: any): content is string {
+  return typeof content === 'string';
+}
+
+// Helper for creating text content parts
+export function createTextPart(text: string) {
+  return {
+    type: 'text' as const,
+    text: text,
+  };
+}
+
+// Helper for safely accessing message at index
+export function getMessageAt(messages: any[], index: number): any | null {
+  if (index < 0) {
+    const actualIndex = messages.length + index;
+    return actualIndex >= 0 ? messages[actualIndex] : null;
+  }
+  return index < messages.length ? messages[index] : null;
+}
+
+// ===== UNIFIED PROVIDER-AGNOSTIC FUNCTIONS =====
+
+/**
+ * Provider configuration for content manipulation
+ */
+export interface ProviderConfig {
+  // How to create a text content part
+  createTextPart: (text: string) => any;
+  // How to extract text from a content part
+  extractText?: (part: any) => string | undefined;
+  // Whether to include type field in text parts
+  includeTypeInTextPart?: boolean;
+}
+
+// Provider configurations
+export const PROVIDERS = {
+  openai: {
+    createTextPart: (text: string) => ({ type: 'text' as const, text }),
+    extractText: (part: any) => part.text,
+    includeTypeInTextPart: true,
+  },
+  anthropic: {
+    createTextPart: (text: string) => ({
+      type: 'text' as const,
+      text,
+      citations: null,
+    }),
+    extractText: (part: any) => part.text,
+    includeTypeInTextPart: true,
+  },
+  google: {
+    createTextPart: (text: string) => ({ text }),
+    extractText: (part: any) => part.text,
+    includeTypeInTextPart: false,
+  },
+} as const;
+
+/**
+ * Append text to the last message in a provider-agnostic way
+ */
+export function appendToLastMessage(
+  messages: any[],
+  text: string,
+  provider: keyof typeof PROVIDERS = 'openai',
+): boolean {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage) return false;
+
+  const config = PROVIDERS[provider];
+  const newPart = config.createTextPart(text);
+
+  if (isArrayContent(lastMessage.content)) {
+    lastMessage.content.push(newPart);
+    return true;
+  } else if (isStringContent(lastMessage.content)) {
+    // Convert string to array format
+    const existingPart = config.createTextPart(lastMessage.content);
+    lastMessage.content = [existingPart, newPart];
+    return true;
+  } else if (
+    lastMessage.content === null ||
+    lastMessage.content === undefined
+  ) {
+    lastMessage.content = [newPart];
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Set the content of the last message
+ */
+export function setLastMessageContent(
+  messages: any[],
+  text: string,
+  provider: keyof typeof PROVIDERS = 'openai',
+): boolean {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage) return false;
+
+  const config = PROVIDERS[provider];
+
+  if (isArrayContent(lastMessage.content)) {
+    // Find and update the last text part
+    for (let i = lastMessage.content.length - 1; i >= 0; i--) {
+      const part = lastMessage.content[i];
+      if (part && part.text !== undefined) {
+        part.text = text;
+        return true;
+      }
+    }
+    // If no text part found, add one
+    lastMessage.content.push(config.createTextPart(text));
+    return true;
+  } else {
+    // For string content, just replace it
+    lastMessage.content = text;
+    return true;
+  }
+}
+
+/**
+ * Get the text content of the last message
+ */
+export function getLastMessageText(
+  messages: any[],
+  provider: keyof typeof PROVIDERS = 'openai',
+): string | null {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage) return null;
+
+  const config = PROVIDERS[provider];
+
+  if (isStringContent(lastMessage.content)) {
+    return lastMessage.content;
+  } else if (isArrayContent(lastMessage.content)) {
+    // Find the last text part
+    for (let i = lastMessage.content.length - 1; i >= 0; i--) {
+      const part = lastMessage.content[i];
+      if (part && config.extractText) {
+        const text = config.extractText(part);
+        if (text !== undefined) return text;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Append content part (more flexible than just text)
+ */
+export function appendContentToLastMessage(
+  messages: any[],
+  content: any,
+  provider: keyof typeof PROVIDERS = 'openai',
+): boolean {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage) return false;
+
+  if (isArrayContent(lastMessage.content)) {
+    lastMessage.content.push(content);
+    return true;
+  } else if (isStringContent(lastMessage.content)) {
+    const config = PROVIDERS[provider];
+    const existingPart = config.createTextPart(lastMessage.content);
+    lastMessage.content = [existingPart, content];
+    return true;
+  } else if (
+    lastMessage.content === null ||
+    lastMessage.content === undefined
+  ) {
+    lastMessage.content = [content];
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Find and update the last text part in a message
+ */
+export function updateLastTextPart(
+  message: any,
+  updater: (text: string) => string,
+  provider: keyof typeof PROVIDERS = 'openai',
+): boolean {
+  if (!message) return false;
+
+  const config = PROVIDERS[provider];
+
+  if (isStringContent(message.content)) {
+    message.content = updater(message.content);
+    return true;
+  } else if (isArrayContent(message.content)) {
+    // Find and update the last text part
+    for (let i = message.content.length - 1; i >= 0; i--) {
+      const part = message.content[i];
+      if (part && config.extractText) {
+        const text = config.extractText(part);
+        if (text !== undefined) {
+          part.text = updater(text);
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "ES2022",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": false,
     "rootDir": "src",
     "moduleResolution": "node",


### PR DESCRIPTION
## Summary
- Drop `any` for response usage conversions
- Type message arrays in model handlers using native SDK types
- Compute usage with provider-specific types
- Add unified message content utilities for cross-provider compatibility
- Fix TypeScript errors from native type migration

## Changes
- ✅ Fixed type union handling for content (string | array types)
- ✅ Added proper null/undefined checks
- ✅ Created unified message manipulation utilities in `messageContentUtils.ts`
- ✅ Updated all handlers to use native SDK types properly
- ✅ Simplified Google GenAI handler to use native `Part` type directly
- ✅ Removed legacy provider-specific functions

## Remaining Work
- [ ] Address unused parameters in interface methods (currently prefixed with `_`)
- [ ] Consider further consolidation of message manipulation patterns
- [ ] Add comprehensive tests for edge cases with different content types
- [ ] Validate behavior with multi-modal content (images, audio)

## Testing
- `npm run format` ✅
- `npm run lint` ✅
- `npm run compile` ✅ (warnings only for optional native modules)
- `npm test` ⚠️ (needs investigation)