### PR TITLE
fix: convert remaining chevron characters to codicon icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texra",
-  "version": "0.30.8",
+  "version": "0.30.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texra",
-      "version": "0.30.8",
+      "version": "0.30.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -572,13 +572,13 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.2.0.tgz",
-      "integrity": "sha512-8hXezgz7jexGHdo5WN6JBEIPHCSFyyU4vgbxevu4YLVS5vl+sxqAAGyXSzfNDyR6xMNSH5H1x67nsXcYMOHtZA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.4.0.tgz",
+      "integrity": "sha512-bIh/d9X+OQLCAMdhHtps+frvyjvAM4B1YlSJzcEEhl7wXLIqPar3ngn9DrHhkBOrTA/z9J0bUMtctAspe0dxdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.23.0",
+        "@typescript-eslint/utils": "^8.32.1",
         "eslint-visitor-keys": "^4.2.0",
         "espree": "^10.3.0",
         "estraverse": "^5.3.0",
@@ -666,9 +666,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
-      "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.155",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
-      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+      "version": "1.5.157",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
+      "integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3417,9 +3417,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -4201,9 +4201,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.100.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.100.0.tgz",
-      "integrity": "sha512-9soq/wukv3utxcuD7TWFqKdKp0INWdeyhUCvxwrne5KwnxaCp4eHL4GdT/tMFhYolxgNhxFzg5GFwM331Z5CZg==",
+      "version": "4.103.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.103.0.tgz",
+      "integrity": "sha512-eWcz9kdurkGOFDtd5ySS5y251H2uBgq9+1a2lTBnjMMzlexJ40Am5t6Mu76SSE87VvitPa0dkIAp75F+dZVC0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -4231,9 +4231,9 @@
       }
     },
     "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.101",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.101.tgz",
-      "integrity": "sha512-Ykg7fcE3+cOQlLUv2Ds3zil6DVjriGQaSN/kEpl5HQ3DIGM6W0F2n9+GkWV4bRt7KjLymgzNdTnSKCbFUUJ7Kw==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -5595,9 +5595,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.3.tgz",
-      "integrity": "sha512-adBYQLivcg1jbdKEJeqScJJFvgm4qY9+3tXw+jdG6lkVeqRJEtiQmSWjmth8GKmDZuX7sYM4YFxQsf0AzMfGGw==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
+      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -5738,9 +5738,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.0.tgz",
+      "integrity": "sha512-77R0RDmJfj9dyv5p3bM5pOHa+X8/ZkO9c7kpDstigkC4nIDobadsfSGCwB4bKhMVxqAok8tajaoR8rirM7+VFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -6123,9 +6123,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.7.tgz",
-      "integrity": "sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==",
+      "version": "3.25.28",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
+      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -244,7 +244,7 @@ export function initializeOutputFiles() {
     // Restore the output name override toggle state
     if (isOutputNameOverrideVisible) {
       outputNameOverrideInput.style.display = 'inline-block';
-      outputNameOverrideToggle.textContent = '<';
+      outputNameOverrideToggle.innerHTML = '<i class="codicon codicon-chevron-left"></i>';
     }
   }
 

--- a/src/webview/modules/stateManager.js
+++ b/src/webview/modules/stateManager.js
@@ -30,7 +30,7 @@ export function setDefaultState() {
   );
   if (outputNameOverride) outputNameOverride.style.display = 'none';
   if (toggleOutputNameOverrideDiv)
-    toggleOutputNameOverrideDiv.textContent = '>';
+    toggleOutputNameOverrideDiv.innerHTML = '<i class="codicon codicon-chevron-right"></i>';
 
   // Initialize auto-extract toggle with default state
   const autoExtractToggle = safeGetElementById('toggleAutoExtract');
@@ -129,7 +129,7 @@ export function restoreState() {
     if (previousState.outputNameOverrideVisible) {
       if (outputNameOverride) outputNameOverride.style.display = 'inline-block';
       if (toggleOutputNameOverrideDiv)
-        toggleOutputNameOverrideDiv.textContent = '<';
+        toggleOutputNameOverrideDiv.innerHTML = '<i class="codicon codicon-chevron-left"></i>';
       safeSetElementValue(
         'outputNameOverride',
         previousState.outputNameOverride ?? '',
@@ -137,7 +137,7 @@ export function restoreState() {
     } else {
       if (outputNameOverride) outputNameOverride.style.display = 'none';
       if (toggleOutputNameOverrideDiv)
-        toggleOutputNameOverrideDiv.textContent = '>';
+        toggleOutputNameOverrideDiv.innerHTML = '<i class="codicon codicon-chevron-right"></i>';
     }
   } else {
     // If there's no previous state, set to default


### PR DESCRIPTION
## Summary
- Completes the chevron icon conversion that was started in commit a9cc7052
- Converts remaining `<` and `>` characters to proper codicon chevron icons

## Changes
- Updated `src/webview/modules/fileHandlers.js` line 247
- Updated `src/webview/modules/stateManager.js` lines 33, 132, and 140
- Changed from `textContent = '<'` to `innerHTML = '<i class="codicon codicon-chevron-left"></i>'`
- Changed from `textContent = '>'` to `innerHTML = '<i class="codicon codicon-chevron-right"></i>'`

These changes ensure all toggle icons in the Output Filename section use consistent codicon styling.

🤖 Generated with [Claude Code](https://claude.ai/code)