### PR TITLE
Convert execute button to VSCode native icon button

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -473,8 +473,8 @@
               </select>
             </div>
           </div>
-          <button id="executeButton" class="vscode-button primary">
-            <i class="codicon codicon-play"></i> Execute
+          <button id="executeButton" class="vscode-button" title="Execute">
+            <i class="codicon codicon-play"></i>
           </button>
         </div>
       </div>


### PR DESCRIPTION
Convert execute button in main webview to use VSCode native icon button pattern.

- Remove "Execute" text label for cleaner icon-only design
- Remove "primary" class to match other icon buttons in interface
- Add "title" attribute for accessibility and tooltip
- Maintain existing codicon-play icon and functionality

Resolves #192

Generated with [Claude Code](https://claude.ai/code)