### PR TITLE
Fix noise from output processing logs

### DIFF
--- a/src/agent/CoTAgent.ts
+++ b/src/agent/CoTAgent.ts
@@ -88,7 +88,7 @@ export class CoTAgent extends BaseReflectionAgent {
           currRound,
           fileProcessGroupId,
         );
-        this.logger.info(
+        this.logger.debug(
           `Output files processed for round ${currRound}`,
           fileProcessGroupId,
         );

--- a/src/agent/DirectAgent.ts
+++ b/src/agent/DirectAgent.ts
@@ -74,7 +74,7 @@ export class DirectAgent extends BaseReflectionAgent {
           currRound,
           fileProcessGroupId,
         );
-        this.logger.info(
+        this.logger.debug(
           `Output files processed for round ${currRound}`,
           fileProcessGroupId,
         );

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -141,7 +141,7 @@ export async function runPackLatexdiffvcMultiple(
     await runPackLatexdiffvc(inputFile, commitHash, clean);
   }
 
-  logger.info(CHANNEL, 'Multiple LaTeX diff files processed');
+  logger.debug(CHANNEL, 'Multiple LaTeX diff files processed');
 }
 
 export async function runCleanLatexdiffvc(


### PR DESCRIPTION
## Summary
- tone down logging after XML/file processing
- tone down direct agent output file logs
- make multi-file latexdiff summary a debug log

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
