### PR TITLE
Fix auto-extract dropdown

### DIFF
--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -5,6 +5,7 @@ import {
   CHECK_BOXES,
   ELEMENTS_TO_SAVE,
   CHECK_BOXES_AUTO_EXTRACT,
+  CHECK_BOXES_TOOL_USE,
   FILE_TYPES,
 } from './constants.js';
 import {
@@ -39,6 +40,38 @@ export function autoResizeTextarea(textarea) {
   // Show/hide scrollbar based on content height
   textarea.style.overflowY =
     textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+}
+
+function updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {
+  const toggle = safeGetElementById(toggleId);
+  const options = safeGetElementById(optionsId);
+  const isVisible = options.style.display === 'block';
+
+  const hasChecked = checkboxIds.some((id) => safeGetElementChecked(id));
+  const direction = isVisible ? 'up' : 'down';
+
+  if (toggle) {
+    toggle.classList.toggle('active', hasChecked);
+    toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="codicon codicon-chevron-${direction}"></i>`;
+  }
+}
+
+export function updateAutoToggleState() {
+  updateDropdownToggleState(
+    'toggleAutoExtract',
+    'autoExtractOptions',
+    CHECK_BOXES_AUTO_EXTRACT,
+    'wand',
+  );
+}
+
+export function updateToolConfigToggleState() {
+  updateDropdownToggleState(
+    'toggleToolConfig',
+    'toolConfigOptions',
+    CHECK_BOXES_TOOL_USE,
+    'tools',
+  );
 }
 
 export function setupUIHandlers() {
@@ -101,25 +134,6 @@ export function setupUIHandlers() {
     return multipleFilesData;
   }
 
-  // Add auto-extract toggle handler
-  function updateAutoToggleState() {
-    const autoExtractToggle = safeGetElementById('toggleAutoExtract');
-    const autoExtractOptions = safeGetElementById('autoExtractOptions');
-    const isVisible = autoExtractOptions.style.display === 'block';
-
-    // Check if any auto-extract checkbox is checked
-    const hasAutoExtractChecked = CHECK_BOXES_AUTO_EXTRACT.some((id) =>
-      safeGetElementChecked(id),
-    );
-
-    const direction = isVisible ? 'up' : 'down';
-
-    if (autoExtractToggle) {
-      autoExtractToggle.classList.toggle('active', hasAutoExtractChecked);
-      autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="codicon codicon-chevron-${direction}"></i>`;
-    }
-  }
-
   addEventListenerSafely('toggleAutoExtract', 'click', function () {
     const autoExtractOptions = safeGetElementById('autoExtractOptions');
     const isVisible = autoExtractOptions.style.display === 'block';
@@ -128,10 +142,25 @@ export function setupUIHandlers() {
     updateAutoToggleState();
   });
 
+  addEventListenerSafely('toggleToolConfig', 'click', function () {
+    const toolConfigOptions = safeGetElementById('toolConfigOptions');
+    const isVisible = toolConfigOptions.style.display === 'block';
+
+    toolConfigOptions.style.display = isVisible ? 'none' : 'block';
+    updateToolConfigToggleState();
+  });
+
   // Add checkbox change listeners for auto-extract options
   CHECK_BOXES_AUTO_EXTRACT.forEach((id) => {
     addEventListenerSafely(id, 'change', function () {
       updateAutoToggleState();
+      handleCheckboxChange.call(this);
+    });
+  });
+
+  CHECK_BOXES_TOOL_USE.forEach((id) => {
+    addEventListenerSafely(id, 'change', function () {
+      updateToolConfigToggleState();
       handleCheckboxChange.call(this);
     });
   });

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -134,7 +134,8 @@ export function setupUIHandlers() {
     return multipleFilesData;
   }
 
-  addEventListenerSafely('toggleAutoExtract', 'click', function () {
+  addEventListenerSafely('toggleAutoExtract', 'click', function (e) {
+    e.stopPropagation();
     const autoExtractOptions = safeGetElementById('autoExtractOptions');
     const isVisible = autoExtractOptions.style.display === 'block';
 
@@ -142,7 +143,8 @@ export function setupUIHandlers() {
     updateAutoToggleState();
   });
 
-  addEventListenerSafely('toggleToolConfig', 'click', function () {
+  addEventListenerSafely('toggleToolConfig', 'click', function (e) {
+    e.stopPropagation();
     const toolConfigOptions = safeGetElementById('toolConfigOptions');
     const isVisible = toolConfigOptions.style.display === 'block';
 

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -119,21 +119,9 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  // Tool Config dropdown toggle
-  const toggleToolConfig = document.getElementById('toggleToolConfig');
-  const toolConfigOptions = document.getElementById('toolConfigOptions');
-
-  if (toggleToolConfig && toolConfigOptions) {
-    // Initial state
-    updateToolConfigToggleState();
-
-    toggleToolConfig.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const isVisible = toolConfigOptions.style.display === 'block';
-      toolConfigOptions.style.display = isVisible ? 'none' : 'block';
-      updateToolConfigToggleState();
-    });
-  }
+  // Update initial toggle states
+  updateToolConfigToggleState();
+  updateAutoToggleState();
 
   // Close dropdowns when clicking outside
   document.addEventListener('click', (e) => {
@@ -146,15 +134,19 @@ document.addEventListener('DOMContentLoaded', function () {
       !toggleToolConfig?.contains(e.target) &&
       !toolConfigOptions?.contains(e.target)
     ) {
-      toolConfigOptions.style.display = 'none';
-      updateToolConfigToggleState();
+      if (toolConfigOptions) {
+        toolConfigOptions.style.display = 'none';
+        updateToolConfigToggleState();
+      }
     }
     if (
       !toggleAutoExtract?.contains(e.target) &&
       !autoExtractOptions?.contains(e.target)
     ) {
-      autoExtractOptions.style.display = 'none';
-      updateAutoToggleState();
+      if (autoExtractOptions) {
+        autoExtractOptions.style.display = 'none';
+        updateAutoToggleState();
+      }
     }
   });
 });

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -1,10 +1,12 @@
 import { vscode } from './modules/vscodeApi.js';
 import { restoreState, saveState } from './modules/stateManager.js';
 import { setupMessageHandlers } from './modules/messageHandlers.js';
-import { setupUIHandlers } from './modules/uiHandlers.js';
-
-import { CHECK_BOXES_TOOL_USE } from './modules/constants.js';
-import { autoResizeTextarea } from './modules/uiHandlers.js';
+import {
+  setupUIHandlers,
+  updateAutoToggleState,
+  updateToolConfigToggleState,
+  autoResizeTextarea,
+} from './modules/uiHandlers.js';
 
 window.onload = function () {
   const dataRequests = [
@@ -127,8 +129,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     toggleToolConfig.addEventListener('click', (e) => {
       e.stopPropagation();
-      toolConfigOptions.style.display =
-        toolConfigOptions.style.display === 'none' ? 'block' : 'none';
+      const isVisible = toolConfigOptions.style.display === 'block';
+      toolConfigOptions.style.display = isVisible ? 'none' : 'block';
+      updateToolConfigToggleState();
     });
   }
 
@@ -144,34 +147,14 @@ document.addEventListener('DOMContentLoaded', function () {
       !toolConfigOptions?.contains(e.target)
     ) {
       toolConfigOptions.style.display = 'none';
+      updateToolConfigToggleState();
     }
     if (
       !toggleAutoExtract?.contains(e.target) &&
       !autoExtractOptions?.contains(e.target)
     ) {
       autoExtractOptions.style.display = 'none';
-    }
-  });
-
-  // Update checkbox states in toggle button
-  function updateToolConfigToggleState() {
-    const toggleToolConfig = document.getElementById('toggleToolConfig');
-
-    const checkedCount = CHECK_BOXES_TOOL_USE.filter(
-      (id) => document.getElementById(id)?.checked,
-    ).length;
-
-    if (toggleToolConfig) {
-      toggleToolConfig.classList.toggle('active', checkedCount > 0);
-      toggleToolConfig.innerHTML = `<i class="codicon codicon-tools"></i><i class="codicon codicon-chevron-down"></i>`;
-    }
-  }
-
-  // Add change listeners to all tool config checkboxes
-  CHECK_BOXES_TOOL_USE.forEach((id) => {
-    const checkbox = document.getElementById(id);
-    if (checkbox) {
-      checkbox.addEventListener('change', updateToolConfigToggleState);
+      updateAutoToggleState();
     }
   });
 });


### PR DESCRIPTION
## Summary
- unify dropdown toggle logic
- update tool config toggle on open/close
- close auto-extract menu cleanly with shared helper

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(fails: missing native modules)*