### PR TITLE
Implement dynamic file selectors

### DIFF
--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -37,6 +37,7 @@ export class WebviewContentProvider {
       const messageHandlersPath = getWebviewPath('modules/messageHandlers.js');
       const fileHandlersPath = getWebviewPath('modules/fileHandlers.js');
       const uiHandlersPath = getWebviewPath('modules/uiHandlers.js');
+      const fileTemplatesPath = getWebviewPath('modules/fileTemplates.js');
       const utilsPath = getWebviewPath('modules/utils.js');
       const vscodeApiPath = getWebviewPath('modules/vscodeApi.js');
 
@@ -51,6 +52,7 @@ export class WebviewContentProvider {
       const messageHandlersUri = webview.asWebviewUri(messageHandlersPath);
       const fileHandlersUri = webview.asWebviewUri(fileHandlersPath);
       const uiHandlersUri = webview.asWebviewUri(uiHandlersPath);
+      const fileTemplatesUri = webview.asWebviewUri(fileTemplatesPath);
       const utilsUri = webview.asWebviewUri(utilsPath);
       const vscodeApiUri = webview.asWebviewUri(vscodeApiPath);
 
@@ -89,6 +91,7 @@ export class WebviewContentProvider {
         .replace('${messageHandlersUri}', messageHandlersUri.toString())
         .replace('${fileHandlersUri}', fileHandlersUri.toString())
         .replace('${uiHandlersUri}', uiHandlersUri.toString())
+        .replace('${fileTemplatesUri}', fileTemplatesUri.toString())
         .replace('${vscodeApiUri}', vscodeApiUri.toString())
         .replace('${codiconUri}', codiconUri.toString())
         .replace('${codiconsFontUri}', codiconsFontUri.toString());

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -18,6 +18,7 @@
           "./modules/uiHandlers.js": "${uiHandlersUri}",
           "./modules/messageHandlers.js": "${messageHandlersUri}",
           "./modules/vscodeApi.js": "${vscodeApiUri}",
+          "./modules/fileTemplates.js": "${fileTemplatesUri}",
           "./modules/utils.js": "${utilsUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs"
         }
@@ -30,338 +31,67 @@
   <body>
     <div class="content-wrapper">
       <div class="main-content">
-        <div class="file-selection-group">
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="inputFile"
-                  ><i
-                    class="codicon codicon-file-code clickable"
-                    title="Input (Click to refresh)"
-                  ></i>
-                  Input</label
-                >
-              </div>
-              <div class="file-select-actions button-group">
-                <button
-                  id="currentInputFileButton"
-                  class="vscode-button"
-                  title="Set current file as input"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
-                <button
-                  id="emptyInputFileButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
-                <span id="toggleInputFiles" class="toggle-icon" title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <button
-                  id="addOpenedInputFilesButton"
-                  class="vscode-button"
-                  title="Add opened files as input"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
-                <button
-                  id="emptyInputFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectInputFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
+        <div id="fileSelectionGroup" class="file-selection-group"></div>
+        <div class="file-select">
+          <div class="file-select-header">
+            <div class="file-select-label-group">
+              <span
+                id="toggleOutputFiles"
+                class="toggle-icon"
+                title="Multiple"
+                data-action="toggle-multiple"
+                data-filetype="output"
+                ><i class="codicon codicon-chevron-down"></i
+              ></span>
+              <span class="optional-label">Multiple Outputs</span>
             </div>
-            <select id="inputFile">
-              <option value="">None</option>
-            </select>
-            <div
-              id="inputFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="inputFiles" class="multiple-files-list"></div>
-              </div>
-            </div>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <label for="referenceFile"
-                ><i
-                  class="codicon codicon-book clickable"
-                  title="Reference (Click to refresh)"
-                ></i>
-                Reference</label
+            <div class="file-select-actions button-group">
+              <button
+                id="emptyOutputFilesButton"
+                class="vscode-button"
+                title="Empty"
+                data-action="clear-multiple"
+                data-filetype="output"
               >
-              <div class="file-select-actions button-group">
-                <button
-                  id="currentReferenceFileButton"
-                  class="vscode-button"
-                  title="Set current file as reference"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
-                <button
-                  id="emptyReferenceFileButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
-                <span
-                  id="toggleReferenceFiles"
-                  class="toggle-icon"
-                  title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <button
-                  id="addOpenedReferenceFilesButton"
-                  class="vscode-button"
-                  title="Add opened files as reference"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
-                <button
-                  id="emptyReferenceFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectReferenceFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
-            </div>
-            <select id="referenceFile">
-              <option value="">None</option>
-            </select>
-            <div
-              id="referenceFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="referenceFiles" class="multiple-files-list"></div>
-              </div>
-            </div>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <label for="auxiliaryFile"
-                ><i
-                  class="codicon codicon-file-add clickable"
-                  title="Auxiliary (Click to refresh)"
-                ></i>
-                Auxiliary</label
+                <i class="codicon codicon-trash"></i>
+              </button>
+              <button
+                id="selectOutputFilesButton"
+                class="vscode-button"
+                title="Add"
+                data-action="select-multiple"
+                data-filetype="output"
               >
-              <div class="file-select-actions button-group">
-                <button
-                  id="currentAuxiliaryFileButton"
-                  class="vscode-button"
-                  title="Set current file as auxiliary"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
-                <button
-                  id="emptyAuxiliaryFileButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
-                <span
-                  id="toggleAuxiliaryFiles"
-                  class="toggle-icon"
-                  title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <button
-                  id="addOpenedAuxiliaryFilesButton"
-                  class="vscode-button"
-                  title="Add opened files as auxiliary"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
-                <button
-                  id="emptyAuxiliaryFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectAuxiliaryFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
-            </div>
-            <select id="auxiliaryFile">
-              <option value="">None</option>
-            </select>
-            <div
-              id="auxiliaryFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="auxiliaryFiles" class="multiple-files-list"></div>
-              </div>
+                <i class="codicon codicon-add"></i>
+              </button>
             </div>
           </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="mediaFile"
-                  ><i
-                    class="codicon codicon-file-media clickable"
-                    title="Media (Click to refresh)"
-                  ></i>
-                  Media</label
-                >
-                <div class="dropdown-container dropdown-left">
-                  <span
-                    id="toggleAutoExtract"
-                    class="auto-toggle"
-                    title="Auto-extract options"
-                  >
-                    <i class="codicon codicon-wand"></i
-                    ><i class="codicon codicon-chevron-down"></i>
-                  </span>
-                  <div
-                    id="autoExtractOptions"
-                    class="dropdown-options"
-                    style="display: none"
-                  >
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="autoExtractFigure" /><i
-                        class="codicon codicon-file-media"
-                      ></i
-                      >Figures</label
-                    >
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="autoExtractTikzFigure" /><i
-                        class="codicon codicon-file-code"
-                      ></i
-                      >TikZ Figures</label
-                    >
-                  </div>
-                </div>
-              </div>
-              <div class="file-select-actions button-group">
-                <button
-                  id="emptyMediaFileButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
-                <span id="toggleMediaFiles" class="toggle-icon" title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <button
-                  id="emptyMediaFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectMediaFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
-            </div>
-            <select id="mediaFile">
-              <option value="">None</option>
-            </select>
-            <div
-              id="mediaFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="mediaFiles" class="multiple-files-list"></div>
-              </div>
-            </div>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <span
-                  id="toggleOutputFiles"
-                  class="toggle-icon"
-                  title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <span class="optional-label">Multiple Outputs</span>
-              </div>
-              <div class="file-select-actions button-group">
-                <button
-                  id="emptyOutputFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectOutputFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
-            </div>
-            <div
-              id="outputFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="outputFiles" class="multiple-files-list"></div>
+          <div
+            id="outputFilesContainer"
+            class="multiple-files-container"
+            style="display: none"
+          >
+            <div class="multiple-files-content">
+              <div id="outputFiles" class="multiple-files-list"></div>
+              <div
+                class="output-filename-override"
+                style="margin-top: var(--spacing-medium)"
+              >
                 <div
-                  class="output-filename-override"
-                  style="margin-top: var(--spacing-medium)"
+                  class="file-select-label-group"
+                  title="Optional: Customize the output filename (including extension)"
                 >
-                  <div
-                    class="file-select-label-group"
-                    title="Optional: Customize the output filename (including extension)"
-                  >
-                    <span id="toggleOutputNameOverride" class="toggle-icon"
-                      ><i class="codicon codicon-chevron-right"></i
-                    ></span>
-                    <span class="optional-label">Output Filename</span>
-                    <input
-                      type="text"
-                      id="outputNameOverride"
-                      class="vscode-input"
-                      placeholder="(including extension)"
-                      style="display: none"
-                    />
-                  </div>
+                  <span id="toggleOutputNameOverride" class="toggle-icon"
+                    ><i class="codicon codicon-chevron-right"></i
+                  ></span>
+                  <span class="optional-label">Output Filename</span>
+                  <input
+                    type="text"
+                    id="outputNameOverride"
+                    class="vscode-input"
+                    placeholder="(including extension)"
+                    style="display: none"
+                  />
                 </div>
               </div>
             </div>
@@ -494,6 +224,8 @@
                 id="currentBaseFileButton"
                 class="vscode-button"
                 title="Set current file as base"
+                data-action="current-file"
+                data-filetype="base"
               >
                 <i class="codicon codicon-file-code"></i>
               </button>
@@ -501,6 +233,8 @@
                 id="emptyBaseFileButton"
                 class="vscode-button"
                 title="Empty"
+                data-action="clear-single"
+                data-filetype="base"
               >
                 <i class="codicon codicon-close"></i>
               </button>
@@ -554,6 +288,8 @@
                 id="currentEditedFileButton"
                 class="vscode-button"
                 title="Set current file as edited"
+                data-action="current-file"
+                data-filetype="edited"
               >
                 <i class="codicon codicon-file-code"></i>
               </button>
@@ -561,6 +297,8 @@
                 id="emptyEditedFileButton"
                 class="vscode-button"
                 title="Empty"
+                data-action="clear-single"
+                data-filetype="edited"
               >
                 <i class="codicon codicon-close"></i>
               </button>

--- a/src/webview/modules/fileTemplates.js
+++ b/src/webview/modules/fileTemplates.js
@@ -1,0 +1,88 @@
+// Local imports - utils
+import { FILE_TYPES } from './constants.js';
+import { capitalize } from './stringUtils.js';
+
+const ICONS = {
+  input: 'file-code',
+  reference: 'book',
+  auxiliary: 'file-add',
+  media: 'file-media',
+};
+
+const LABELS = {
+  input: 'Input',
+  reference: 'Reference',
+  auxiliary: 'Auxiliary',
+  media: 'Media',
+};
+
+function createBlock(type) {
+  const icon = ICONS[type] || 'file';
+  const label = LABELS[type] || capitalize(type);
+  const cap = capitalize(type);
+  const hasCurrent = ['input', 'reference', 'auxiliary'].includes(type);
+  const hasAddOpened = hasCurrent;
+  const hasAutoExtract = type === 'media';
+  return `
+  <div class="file-select">
+    <div class="file-select-header">
+      <div class="file-select-label-group">
+        <label for="${type}File"><i class="codicon codicon-${icon} clickable" title="${label} (Click to refresh)"></i> ${label}</label>
+        ${
+          hasAutoExtract
+            ? `<div class="dropdown-container dropdown-left">
+          <span id="toggleAutoExtract" class="auto-toggle" title="Auto-extract options">
+            <i class="codicon codicon-wand"></i><i class="codicon codicon-chevron-down"></i>
+          </span>
+          <div id="autoExtractOptions" class="dropdown-options" style="display: none">
+            <label class="vscode-checkbox"><input type="checkbox" id="autoExtractFigure" /><i class="codicon codicon-file-media"></i>Figures</label>
+            <label class="vscode-checkbox"><input type="checkbox" id="autoExtractTikzFigure" /><i class="codicon codicon-file-code"></i>TikZ Figures</label>
+          </div>
+        </div>`
+            : ''
+        }
+      </div>
+      <div class="file-select-actions button-group">
+        ${
+          hasCurrent
+            ? `<button id="current${cap}FileButton" class="vscode-button" title="Set current file as ${type}" data-action="current-file" data-filetype="${type}">
+          <i class="codicon codicon-file-code"></i>
+        </button>`
+            : ''
+        }
+        <button id="empty${cap}FileButton" class="vscode-button" title="Empty" data-action="clear-single" data-filetype="${type}">
+          <i class="codicon codicon-close"></i>
+        </button>
+        <span id="toggle${cap}Files" class="toggle-icon" title="Multiple" data-action="toggle-multiple" data-filetype="${type}"><i class="codicon codicon-chevron-down"></i></span>
+        ${
+          hasAddOpened
+            ? `<button id="addOpened${cap}FilesButton" class="vscode-button" title="Add opened files as ${type}" data-action="add-opened" data-filetype="${type}">
+          <i class="codicon codicon-folder-opened"></i>
+        </button>`
+            : ''
+        }
+        <button id="empty${cap}FilesButton" class="vscode-button" title="Empty" data-action="clear-multiple" data-filetype="${type}">
+          <i class="codicon codicon-trash"></i>
+        </button>
+        <button id="select${cap}FilesButton" class="vscode-button" title="Add" data-action="select-multiple" data-filetype="${type}">
+          <i class="codicon codicon-add"></i>
+        </button>
+      </div>
+    </div>
+    <select id="${type}File">
+      <option value="">None</option>
+    </select>
+    <div id="${type}FilesContainer" class="multiple-files-container" style="display: none">
+      <div class="multiple-files-content">
+        <div id="${type}Files" class="multiple-files-list"></div>
+      </div>
+    </div>
+  </div>`;
+}
+
+export function insertFileSelectors(containerId = 'fileSelectionGroup') {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  const types = FILE_TYPES.filter((t) => t !== 'output');
+  container.innerHTML = types.map(createBlock).join('');
+}

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -136,24 +136,36 @@ export function setupUIHandlers() {
     });
   });
 
-  // Add event listeners for the empty buttons
-  const fileTypesWithEmptyButtons = [
-    'input',
-    'reference',
-    'auxiliary',
-    'media',
-    'base',
-    'edited',
-  ];
-  fileTypesWithEmptyButtons.forEach((type) => {
-    const capitalizedType = capitalize(type);
-    addEventListenerSafely(`empty${capitalizedType}FileButton`, 'click', () => {
-      const selectElement = safeGetElementById(`${type}File`);
-      if (selectElement) {
-        selectElement.value = '';
-        saveState();
+  // Delegate file action buttons
+  addEventListenerSafely(document, 'click', (event) => {
+    const target = event.target.closest('[data-filetype][data-action]');
+    if (!target) return;
+
+    const { filetype, action } = target.dataset;
+    const cap = capitalize(filetype);
+
+    switch (action) {
+      case 'clear-single': {
+        const selectElement = safeGetElementById(`${filetype}File`);
+        if (selectElement) {
+          selectElement.value = '';
+          saveState();
+        }
+        break;
       }
-    });
+      case 'clear-multiple':
+        emptyMultipleFiles(`${filetype}Files`, `toggle${cap}Files`);
+        break;
+      case 'toggle-multiple':
+        if (filetype === 'output') {
+          toggleOutputFiles();
+        } else {
+          toggleMultipleFiles(`${filetype}Files`, `toggle${cap}Files`);
+        }
+        break;
+      default:
+        break;
+    }
   });
 
   addEventListenerSafely('agent', 'change', function () {
@@ -211,17 +223,6 @@ export function setupUIHandlers() {
         currentFile: currentFile,
       });
     });
-  });
-
-  // Handle empty buttons and toggles for all multiple selections
-  MULTIPLE_SELECTIONS.forEach((id) => {
-    const toggleId = `toggle${capitalize(id)}`;
-    const emptyButtonId = `empty${capitalize(id)}Button`;
-
-    // Empty button handler
-    addEventListenerSafely(emptyButtonId, 'click', () =>
-      emptyMultipleFiles(id, toggleId),
-    );
   });
 
   CHECK_BOXES.forEach((id) => {
@@ -514,17 +515,6 @@ export function setupUIHandlers() {
       baseFile: baseFile,
     });
     updateEditedFileSelect(baseFile);
-  });
-
-  MULTIPLE_SELECTIONS.forEach((id) => {
-    const toggleId = `toggle${capitalize(id)}`;
-    addEventListenerSafely(toggleId, 'click', () => {
-      if (id === 'outputFiles') {
-        toggleOutputFiles();
-      } else {
-        toggleMultipleFiles(id, toggleId);
-      }
-    });
   });
 
   // Add event listener for history button

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -2,6 +2,7 @@ import { vscode } from './modules/vscodeApi.js';
 import { restoreState, saveState } from './modules/stateManager.js';
 import { setupMessageHandlers } from './modules/messageHandlers.js';
 import { setupUIHandlers } from './modules/uiHandlers.js';
+import { insertFileSelectors } from './modules/fileTemplates.js';
 
 import { CHECK_BOXES_TOOL_USE } from './modules/constants.js';
 import { autoResizeTextarea } from './modules/uiHandlers.js';
@@ -51,6 +52,7 @@ window.onload = function () {
 setupMessageHandlers();
 
 document.addEventListener('DOMContentLoaded', function () {
+  insertFileSelectors();
   setupUIHandlers();
 
   // Pack and Clean button handlers


### PR DESCRIPTION
## Notes
- Prettier and ESLint executed with warnings but no errors.
- VS Code tests were executed.

## Summary
- generate file selector blocks via `fileTemplates.js`
- call `insertFileSelectors` on page load
- delegate file actions using data attributes
- add module path resolution for new script

## Testing
- `npm run format`
- `npm run lint`
- `npm test`