### PR TITLE
fix: make diff stats visible when file names are long

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -185,11 +185,12 @@ export function updateFileList(filesByRound) {
       pathSpan.appendChild(fileSpan);
       nameSpan.appendChild(pathSpan);
 
+      // Create diff stats outside the file-name container so they're always visible
+      let statsSpan = null;
       if (info.added !== undefined && info.removed !== undefined) {
-        const statsSpan = document.createElement('span');
+        statsSpan = document.createElement('span');
         statsSpan.className = 'file-stats';
         statsSpan.innerHTML = `<span class="added">+${info.added}</span><span class="removed">-${info.removed}</span>`;
-        nameSpan.appendChild(statsSpan);
       }
 
       const actions = document.createElement('span');
@@ -277,6 +278,9 @@ export function updateFileList(filesByRound) {
       }
 
       item.appendChild(nameSpan);
+      if (statsSpan) {
+        item.appendChild(statsSpan);
+      }
       item.appendChild(actions);
       group.appendChild(item);
     });

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -156,10 +156,9 @@
 
 .file-item {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   padding: var(--spacing-tiny) 0;
-  flex-wrap: wrap;
+  gap: var(--spacing-medium);
   margin-bottom: var(--spacing-small);
 }
 
@@ -168,8 +167,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1;
-  min-width: calc(var(--width-button-min) + var(--spacing-xlarge));
-  padding-right: var(--spacing-medium);
+  min-width: 200px;
 }
 
 .file-path.clickable {
@@ -183,9 +181,11 @@
 }
 
 .file-stats {
-  margin-left: var(--spacing-medium);
   white-space: nowrap;
   text-decoration: none;
+  flex-shrink: 0;
+  font-size: var(--font-size-sm);
+  color: var(--vscode-descriptionForeground);
 }
 
 .file-dir {
@@ -199,6 +199,7 @@
 
 .file-actions {
   flex-wrap: nowrap;
+  flex-shrink: 0;
   gap: var(--spacing-tiny);
 }
 
@@ -239,11 +240,15 @@
   .file-item {
     flex-direction: column;
     align-items: flex-start;
+    gap: var(--spacing-small);
   }
 
   .file-name {
-    margin-bottom: var(--spacing-small);
     width: 100%;
+  }
+
+  .file-stats {
+    align-self: flex-start;
   }
 
   .file-actions {


### PR DESCRIPTION
Fixes #201

This PR addresses the issue where diff stats (+4 -107) were not visible when file names were too long in the progress view.

## Changes

- Moved diff stats outside of the file-name container to prevent truncation
- Updated CSS layout to use flexbox with gap for better responsive design
- Added mobile-responsive styles for screens < 500px
- Ensured diff stats are always visible regardless of filename length

## Testing

The generated output files in the progress view now respond well to resize and adapt to different widths as requested.

Generated with [Claude Code](https://claude.ai/code)