### PR TITLE
Add viewer helper and auto-open outputs

### DIFF
--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -23,6 +23,7 @@ import { CoTAgent } from './CoTAgent';
 import { MergeAgent } from './MergeAgent';
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 import { AgentLogger } from '../logger/AgentLogger';
+import { openBuildDisplayIfTex } from '../utils/openBuildUtils';
 
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
@@ -266,6 +267,12 @@ async function executeAgentWithLogging<T extends AgentWithConfig>(
           logger.endGroup(mainTaskGroupId, 'stopped');
           // Update status to stopped on successful completion
           progressViewProvider.updateStreamStatus(fullStreamId, 'stopped');
+
+          if (config.outputFiles && config.outputFiles.length > 0) {
+            for (const out of config.outputFiles) {
+              await openBuildDisplayIfTex(out, { preserveFocus: true });
+            }
+          }
         } catch (err) {
           // Mark the task as failed
           logger.error(

--- a/src/commands/latexdiffCommands.ts
+++ b/src/commands/latexdiffCommands.ts
@@ -10,7 +10,7 @@ import * as logger from '../logger/logUtils';
 // Local imports - utilities
 import { getWorkspacePath } from '../utils/workspaceFileUtils';
 import { fileExists } from '../utils/workspaceFileUtils';
-import { openAndBuildIfTex } from '../utils/openBuildUtils';
+import { openBuildDisplayIfTex } from '../utils/openBuildUtils';
 
 // Local imports - latex utils
 import {
@@ -110,15 +110,7 @@ async function handleLatexdiff(
       return;
     }
 
-    await openAndBuildIfTex(filePathRelative, { preserveFocus: true });
-    await vscode.commands.executeCommand(
-      'workbench.view.extension.latex-workshop-activitybar',
-    );
-
-    // Wait for build to complete before viewing
-    setTimeout(async () => {
-      await vscode.commands.executeCommand('latex-workshop.view');
-    }, 10000);
+    await openBuildDisplayIfTex(filePathRelative, { preserveFocus: true });
   } catch (err) {
     vscode.window.showErrorMessage(
       `Error creating LaTeX diff: ${err instanceof Error ? err.message : String(err)}`,
@@ -167,12 +159,7 @@ async function handleLatexdiffvc(
       return;
     }
 
-    await openAndBuildIfTex(filePathRelative, { preserveFocus: true });
-
-    // Wait for build to complete before viewing
-    setTimeout(async () => {
-      await vscode.commands.executeCommand('latex-workshop.view');
-    }, 5000);
+    await openBuildDisplayIfTex(filePathRelative, { preserveFocus: true });
   } catch (err) {
     vscode.window.showErrorMessage(
       `Error creating LaTeX diff: ${err instanceof Error ? err.message : String(err)}`,
@@ -533,21 +520,9 @@ async function handleRunLatexdiff(config: any) {
               CHANNEL,
               `Successfully generated diff: ${result.diffFile}`,
             );
-            await openAndBuildIfTex(result.diffFile, { preserveFocus: true });
-            await vscode.commands.executeCommand(
-              'workbench.view.extension.latex-workshop-activitybar',
-            );
-
-            setTimeout(async () => {
-              await vscode.commands.executeCommand('latex-workshop.view');
-              setTimeout(
-                () =>
-                  vscode.commands.executeCommand(
-                    'latex-workshop.refresh-viewer',
-                  ),
-                5000,
-              );
-            }, 10000);
+            await openBuildDisplayIfTex(result.diffFile, {
+              preserveFocus: true,
+            });
           } else {
             logger.warn(CHANNEL, `Failed to generate diff: ${result.message}`);
           }

--- a/src/commands/openFileCommands.ts
+++ b/src/commands/openFileCommands.ts
@@ -1,11 +1,14 @@
 import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { openAndBuildIfTex } from '../utils/openBuildUtils';
+import { openBuildDisplayIfTex } from '../utils/openBuildUtils';
 
 export function registerOpenFileCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand('texra.openFileCompile', openAndBuildIfTex),
+    vscode.commands.registerCommand(
+      'texra.openFileCompile',
+      openBuildDisplayIfTex,
+    ),
   );
-  return { openFileCompile: openAndBuildIfTex };
+  return { openFileCompile: openBuildDisplayIfTex };
 }

--- a/src/utils/openBuildUtils.ts
+++ b/src/utils/openBuildUtils.ts
@@ -42,3 +42,31 @@ export async function openAndBuildIfTex(
     logger.error(CHANNEL, `Error opening file: ${err}`);
   }
 }
+
+/**
+ * Open a file, compile if it is TeX, and display the resulting PDF.
+ * The PDF viewer is refreshed if already loaded.
+ *
+ * @param file Relative path to the file within the workspace
+ * @param options Optional settings for showing the document
+ */
+export async function openBuildDisplayIfTex(
+  file: string,
+  options: { preserveFocus?: boolean } = {},
+): Promise<void> {
+  await openAndBuildIfTex(file, options);
+
+  if (file.toLowerCase().endsWith('.tex')) {
+    try {
+      setTimeout(async () => {
+        await vscode.commands.executeCommand('latex-workshop.view');
+        setTimeout(
+          () => vscode.commands.executeCommand('latex-workshop.refresh-viewer'),
+          5000,
+        );
+      }, 5000);
+    } catch (err) {
+      logger.warn(CHANNEL, `Viewer display failed: ${err}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- rename viewer helper to `openBuildDisplayIfTex`
- use this helper for `openFileCompile` and latexdiff commands
- open generated output PDFs automatically after agent tasks
- drop redundant viewer commands in latexdiff

## Testing
- `npm run format`
- `npm run lint` *(warnings only)*
- `npm test` *(fails: warnings only)*
