### PR TITLE
Fix info message condition

### DIFF
--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -166,34 +166,6 @@ async function executeAgentWithLogging<T extends AgentWithConfig>(
       throw new Error(errorMsg);
     }
 
-    // Check if the progress view is visible, if not show a helpful message
-    if (!progressViewProvider.isViewVisible()) {
-      const inputFileName = path.basename(config.inputFile);
-      const outputInfo = config.outputFiles?.length
-        ? `to ${
-            config.outputFiles.length > 1
-              ? config.outputFiles.length + ' files'
-              : path.basename(config.outputFiles[0])
-          }`
-        : '';
-
-      vscode.window
-        .showInformationMessage(
-          `TeXRA Agent Started: "${agentName}" is processing ${inputFileName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
-          {
-            modal: false,
-            detail:
-              'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
-          },
-          'Show ProgressBoard',
-        )
-        .then((selection) => {
-          if (selection === 'Show ProgressBoard') {
-            vscode.commands.executeCommand('texra.showProgressView');
-          }
-        });
-    }
-
     // Create a main task group for the entire execution
     const mainTaskGroupId = await logger.startGroup(
       `Task: ${agentName}@${config.model}`,
@@ -230,6 +202,34 @@ async function executeAgentWithLogging<T extends AgentWithConfig>(
         // Switch to this stream and set its status to running
         progressViewProvider.setActiveStream(fullStreamId);
         progressViewProvider.updateStreamStatus(fullStreamId, 'running');
+
+        // Notify user only if the progress view isn't visible after switching
+        if (!progressViewProvider.isViewVisible()) {
+          const inputFileName = path.basename(config.inputFile);
+          const outputInfo = config.outputFiles?.length
+            ? `to ${
+                config.outputFiles.length > 1
+                  ? config.outputFiles.length + ' files'
+                  : path.basename(config.outputFiles[0])
+              }`
+            : '';
+
+          vscode.window
+            .showInformationMessage(
+              `TeXRA Agent Started: "${agentName}" is processing ${inputFileName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
+              {
+                modal: false,
+                detail:
+                  'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
+              },
+              'Show ProgressBoard',
+            )
+            .then((selection) => {
+              if (selection === 'Show ProgressBoard') {
+                vscode.commands.executeCommand('texra.showProgressView');
+              }
+            });
+        }
 
         // Store taskState
         logger.debug(


### PR DESCRIPTION
## Summary
- show agent started notification only if progress view isn't visible after switching streams

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: ESLint warnings only)*
