### PR TITLE
Avoid message when packing only input file

### DIFF
--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -77,6 +77,19 @@ export async function runPackSingle(
     }
   }
 
+  const onlyInputFilePacked =
+    movedFiles.length === 0 &&
+    copiedFiles.length === 1 &&
+    copiedFiles[0] === inputFile;
+
+  if (onlyInputFilePacked) {
+    logger.warn(CHANNEL, `No files found to pack for ${inputFile}`);
+    vscode.window.showInformationMessage(
+      `No files found to pack for ${inputFile}`,
+    );
+    return '';
+  }
+
   if (movedFiles.length > 0 || copiedFiles.length > 0) {
     logger.debug(
       CHANNEL,

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -29,7 +29,7 @@ export async function runPackSingle(
   inputFile: string,
   agent: string,
   outputFolder?: string,
-): Promise<string> {
+): Promise<string | undefined> {
   logger.info(
     CHANNEL,
     `Starting packing with model=${model}, inputFile=${inputFile}, agent=${agent}, outputFolder=${outputFolder}`,
@@ -84,10 +84,10 @@ export async function runPackSingle(
 
   if (onlyInputFilePacked) {
     logger.warn(CHANNEL, `No files found to pack for ${inputFile}`);
-    vscode.window.showInformationMessage(
+    vscode.window.showWarningMessage(
       `No files found to pack for ${inputFile}`,
     );
-    return '';
+    return undefined;
   }
 
   if (movedFiles.length > 0 || copiedFiles.length > 0) {


### PR DESCRIPTION
## Summary
- suppress "Files packed" info when only the source .tex is found

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: VS Code unavailable)*