### PR TITLE
Avoid messages for empty pack/clean

### DIFF
--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -72,6 +72,17 @@ export async function runCleanSingle(
     }
   }
 
+  const onlyInputFileFound =
+    filesToDelete.length === 1 && filesToDelete[0] === inputFile;
+
+  if (onlyInputFileFound) {
+    logger.warn(CHANNEL, `No matching files found to clean for ${inputFile}`);
+    vscode.window.showInformationMessage(
+      `No files found to clean for ${inputFile}`,
+    );
+    return;
+  }
+
   if (filesToDelete.length === 0) {
     logger.warn(CHANNEL, `No matching files found to clean for ${inputFile}`);
     vscode.window.showInformationMessage(

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -77,6 +77,19 @@ export async function runPackSingle(
     }
   }
 
+  const onlyInputFilePacked =
+    movedFiles.length === 0 &&
+    copiedFiles.length === 1 &&
+    copiedFiles[0] === inputFile;
+
+  if (onlyInputFilePacked) {
+    logger.warn(CHANNEL, `No files found to pack for ${inputFile}`);
+    vscode.window.showInformationMessage(
+      `No files found to pack for ${inputFile}`,
+    );
+    return '';
+  }
+
   if (movedFiles.length > 0 || copiedFiles.length > 0) {
     logger.debug(
       CHANNEL,
@@ -111,9 +124,8 @@ export async function runPackSingle(
         operations.push(`Copying: ${file} -> ${destination}`);
         await copyFile(file, destination);
       }
-      // if only inputFile is packed, don't show message
-      // potential improvement here
-      if (operations.length > 1) {
+      // Display a summary only when actual files were packed
+      if (operations.length > 0 && !onlyInputFilePacked) {
         logger.info(CHANNEL, `Files packed into ${outputFolder}`);
         vscode.window.showInformationMessage(
           `Files packed into ${outputFolder}`,


### PR DESCRIPTION
## Summary
- suppress messages when only the input file is packed or cleaned
- log pack summary only when something besides the input file was processed

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: missing VS Code)*