### PR TITLE
Fix output cleanup after pack/clean

### DIFF
--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -66,6 +66,7 @@ async function handleCleanSingle(
   if (provider) {
     const streamId = getStreamId(agent, model, inputFile);
     provider.clearOutputFiles(streamId);
+    provider.clearTaskOutput(streamId);
   }
 }
 
@@ -103,6 +104,7 @@ async function handleCleanMultiple(
   if (provider) {
     const streamId = getStreamId(agent, model, inputFile, outputFiles);
     provider.clearOutputFiles(streamId);
+    provider.clearTaskOutput(streamId);
   }
 }
 
@@ -145,6 +147,7 @@ export async function handleClean(config: any) {
       outputFiles,
     );
     provider.clearOutputFiles(streamId);
+    provider.clearTaskOutput(streamId);
   }
 }
 

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -64,6 +64,7 @@ async function handlePack(config: any) {
       outputFiles,
     );
     provider.clearOutputFiles(streamId);
+    provider.clearTaskOutput(streamId);
   }
 }
 
@@ -96,6 +97,7 @@ async function handlePackSingle(
   if (provider) {
     const streamId = getStreamId(agent, model, inputFile);
     provider.clearOutputFiles(streamId);
+    provider.clearTaskOutput(streamId);
   }
 }
 
@@ -135,6 +137,7 @@ async function handlePackMultiple(
   if (provider) {
     const streamId = getStreamId(agent, model, inputFile, outputFiles);
     provider.clearOutputFiles(streamId);
+    provider.clearTaskOutput(streamId);
   }
 }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -717,6 +717,20 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     return taskState;
   }
 
+  /**
+   * Clears output file information from the stored task state
+   * @param streamId Stream identifier
+   */
+  public clearTaskOutput(streamId: string): void {
+    const state = this._taskStates.get(streamId);
+    if (state) {
+      state.outputFiles = [];
+      state.outputFilesActive = false;
+      this._taskStates.set(streamId, state);
+      this.saveTaskStates();
+    }
+  }
+
   private saveTaskStates(): void {
     this.logger.debug('Saving taskStates to workspace state');
     const taskStatesObj = Object.fromEntries(this._taskStates.entries());


### PR DESCRIPTION
## Summary
- update ProgressViewProvider to clear task output
- ensure pack and clean commands remove output file metadata

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test unavailable)*