### PR TITLE
feat: display token usage summary

### DIFF
--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -37,6 +37,9 @@ import { AgentSetting } from './AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from './AgentState';
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
+// Local imports - types
+import { TokenUsageStats } from '../types/UsageTypes';
+
 /** Generates output filename incorporating model and round information. */
 export function getOutputFileName(
   inputFile: string,

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -35,6 +35,7 @@ import { runLatexIndent } from '../latex/latexindent';
 import { AgentConfig } from './AgentConfig';
 import { AgentSetting } from './AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from './AgentState';
+import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 /** Generates output filename incorporating model and round information. */
 export function getOutputFileName(
@@ -884,6 +885,15 @@ export class OutputHandler {
       }
 
       const cost = this.modelHandler.computePrice(responseUsage);
+
+      const provider = ProgressViewProvider.getInstance();
+      if (provider) {
+        provider.updateStreamUsage(this.channel, {
+          inputTokens: stateGlobal.totalInputTokens,
+          outputTokens: stateGlobal.totalOutputTokens,
+          cost,
+        });
+      }
 
       this.logger.info(
         `Total response time : ${stateGlobal.totalResponseTime.toFixed(1)} seconds`,

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -891,7 +891,8 @@ export class OutputHandler {
 
       const provider = ProgressViewProvider.getInstance();
       if (provider) {
-        provider.updateStreamUsage(this.channel, {
+        // Update group-level usage stats instead of stream-level
+        provider.updateGroupUsage(this.channel, statsGroupId, {
           inputTokens: stateGlobal.totalInputTokens,
           outputTokens: stateGlobal.totalOutputTokens,
           cost,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -64,6 +64,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private readonly _groupsStorageKey = 'texra.logGroups';
   private readonly _filesStorageKey = 'texra.outputFiles';
   private readonly _taskStateKey = 'texra.taskStates';
+  private readonly _usageKey = 'texra.usageStats';
   private _disposables: vscode.Disposable[] = [];
   private readonly _extensionUri: vscode.Uri;
   private readonly _viewTitle: string;
@@ -72,6 +73,10 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private _activeStream: string = '';
   private readonly _activeStreamKey = 'texra.activeLogStream';
   private _taskStates: Map<string, TaskState> = new Map();
+  private _usageStats: Map<
+    string,
+    { inputTokens: number; outputTokens: number; cost: number }
+  > = new Map();
   private readonly logger: AgentLogger;
 
   constructor(
@@ -198,6 +203,20 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     } else {
       this._taskStates.clear();
     }
+
+    // Load usage stats
+    const savedUsage = this.context.workspaceState.get<{
+      [key: string]: {
+        inputTokens: number;
+        outputTokens: number;
+        cost: number;
+      };
+    }>(this._usageKey);
+    if (savedUsage) {
+      this._usageStats = new Map(Object.entries(savedUsage));
+    } else {
+      this._usageStats.clear();
+    }
   }
 
   private _saveState() {
@@ -237,6 +256,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._getWorkspaceKey(this._filesStorageKey),
       filesObj,
     );
+
+    const usageObj = Object.fromEntries(this._usageStats.entries());
+    this.context.workspaceState.update(this._usageKey, usageObj);
   }
 
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
@@ -335,6 +357,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       command: COMMANDS.UPDATE_FILES,
       stream: this._activeStream,
       files,
+    });
+
+    const usage = this._usageStats.get(this._activeStream);
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_USAGE,
+      usage,
     });
 
     // Update status for current stream
@@ -595,6 +623,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._logGroups.clear();
     this._taskStates.clear();
     this._outputFiles.clear();
+    this._usageStats.clear();
     this._saveState();
     if (this._view) {
       this._view.webview.postMessage({ command: COMMANDS.CLEAR_LOGS });
@@ -616,6 +645,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._logGroups.delete(stream);
       this._taskStates.delete(stream);
       this._outputFiles.delete(stream);
+      this._usageStats.delete(stream);
 
       // If the deleted stream was the active one, switch to another stream if available
       if (stream === this._activeStream) {
@@ -686,6 +716,26 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         });
       }
     }
+  }
+
+  public updateStreamUsage(
+    stream: string,
+    usage: { inputTokens: number; outputTokens: number; cost: number },
+  ): void {
+    this._usageStats.set(stream, usage);
+    this._saveState();
+    if (this._view && stream === this._activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_USAGE,
+        usage,
+      });
+    }
+  }
+
+  public getStreamUsage(
+    stream: string,
+  ): { inputTokens: number; outputTokens: number; cost: number } | undefined {
+    return this._usageStats.get(stream);
   }
 
   public setActiveStream(stream: string) {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -12,6 +12,7 @@ import {
   shouldExcludeFromProgressView,
   shouldPersistStream,
 } from '../utils/loggerUtils';
+import { TokenUsageStats } from '../types/UsageTypes';
 // @ts-ignore - Import JavaScript module
 import { STATUS, COMMANDS } from './modules/constants.js';
 
@@ -73,10 +74,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private _activeStream: string = '';
   private readonly _activeStreamKey = 'texra.activeLogStream';
   private _taskStates: Map<string, TaskState> = new Map();
-  private _usageStats: Map<
-    string,
-    { inputTokens: number; outputTokens: number; cost: number }
-  > = new Map();
+  private _usageStats: Map<string, TokenUsageStats> = new Map();
   private readonly logger: AgentLogger;
 
   constructor(
@@ -718,10 +716,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  public updateStreamUsage(
-    stream: string,
-    usage: { inputTokens: number; outputTokens: number; cost: number },
-  ): void {
+  public updateStreamUsage(stream: string, usage: TokenUsageStats): void {
     this._usageStats.set(stream, usage);
     this._saveState();
     if (this._view && stream === this._activeStream) {
@@ -732,9 +727,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  public getStreamUsage(
-    stream: string,
-  ): { inputTokens: number; outputTokens: number; cost: number } | undefined {
+  public getStreamUsage(stream: string): TokenUsageStats | undefined {
     return this._usageStats.get(stream);
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -40,6 +40,7 @@ interface LogGroup {
   endTime?: string;
   status: StatusType;
   parentGroupId?: string;
+  usage?: TokenUsageStats;
 }
 
 // Channels that should not be persisted in workspace storage
@@ -724,6 +725,27 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         command: COMMANDS.UPDATE_USAGE,
         usage,
       });
+    }
+  }
+
+  public updateGroupUsage(stream: string, groupId: string, usage: TokenUsageStats): void {
+    const streamGroups = this._logGroups.get(stream);
+    if (streamGroups) {
+      const group = streamGroups.get(groupId);
+      if (group) {
+        group.usage = usage;
+        this._saveState();
+        
+        // Notify frontend about group usage update
+        if (this._view && stream === this._activeStream) {
+          this._view.webview.postMessage({
+            command: COMMANDS.UPDATE_GROUP_USAGE,
+            stream,
+            groupId,
+            usage,
+          });
+        }
+      }
     }
   }
 

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -41,6 +41,7 @@
               class="status-indicator stopped"
               data-status="Ready"
             ></span>
+            <span id="runSummary" class="run-summary"></span>
           </div>
           <div class="header-actions button-group">
             <button

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -36,6 +36,7 @@ export const COMMANDS = {
   UPDATE_STATUS: 'updateStatus',
   UPDATE_FILES: 'updateFiles',
   UPDATE_USAGE: 'updateUsage',
+  UPDATE_GROUP_USAGE: 'updateGroupUsage',
   OPEN_FILE: 'openFile',
   COMPARE_ORIGINAL: 'compareOriginal',
   COMPARE_PREVIOUS: 'comparePrevious',

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -35,6 +35,7 @@ export const COMMANDS = {
   UPDATE_LOG_GROUP: 'updateLogGroup',
   UPDATE_STATUS: 'updateStatus',
   UPDATE_FILES: 'updateFiles',
+  UPDATE_USAGE: 'updateUsage',
   OPEN_FILE: 'openFile',
   COMPARE_ORIGINAL: 'compareOriginal',
   COMPARE_PREVIOUS: 'comparePrevious',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -126,6 +126,23 @@ export function updateStatus(status) {
 }
 
 /**
+ * Update token and cost summary in the header
+ * @param {Object} usage - Usage data with inputTokens, outputTokens, cost
+ */
+export function updateUsageSummary(usage) {
+  const summaryElem = document.getElementById('runSummary');
+  if (!summaryElem) return;
+
+  if (!usage) {
+    summaryElem.textContent = '';
+    return;
+  }
+
+  const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
+  summaryElem.textContent = `in: ${inputTokens}, out: ${outputTokens}, $${cost.toFixed(3)}`;
+}
+
+/**
  * Update the generated files list
  * @param {Array<string>} files - Array of file paths
  */

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -126,20 +126,49 @@ export function updateStatus(status) {
 }
 
 /**
- * Update token and cost summary in the header
+ * Update token and cost summary in the header (now cleared since we show per-group)
  * @param {Object} usage - Usage data with inputTokens, outputTokens, cost
  */
 export function updateUsageSummary(usage) {
   const summaryElem = document.getElementById('runSummary');
   if (!summaryElem) return;
 
+  // Clear global usage display since we now show usage per-group
+  summaryElem.textContent = '';
+}
+
+/**
+ * Update token and cost usage for a specific group
+ * @param {string} groupId - ID of the group to update
+ * @param {Object} usage - Usage data with inputTokens, outputTokens, cost
+ */
+export function updateGroupUsage(groupId, usage) {
+  const groupHeader = document.getElementById(`group-header-${groupId}`);
+  if (!groupHeader) return;
+
+  // Find or create usage display element in the group header
+  let usageElem = groupHeader.querySelector('.group-usage');
+  if (!usageElem) {
+    usageElem = document.createElement('span');
+    usageElem.className = 'group-usage';
+    
+    // Insert usage display after the group time element
+    const timeContainer = groupHeader.querySelector('.group-time');
+    if (timeContainer) {
+      timeContainer.appendChild(usageElem);
+    } else {
+      // Fallback: append to the header
+      groupHeader.appendChild(usageElem);
+    }
+  }
+
   if (!usage) {
-    summaryElem.textContent = '';
+    usageElem.textContent = '';
     return;
   }
 
   const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
-  summaryElem.textContent = `in: ${inputTokens}, out: ${outputTokens}, $${cost.toFixed(3)}`;
+  usageElem.textContent = ` • in: ${inputTokens}, out: ${outputTokens}, $${cost.toFixed(3)}`;
 }
 
 /**

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -147,6 +147,13 @@ export function createGroupHeader(group) {
 
   // Add indicator based on status
   const statusIcon = getStatusIcon(group.status);
+  
+  // Add usage information if available
+  let usageDisplay = '';
+  if (group.usage) {
+    const { inputTokens = 0, outputTokens = 0, cost = 0 } = group.usage;
+    usageDisplay = `<span class="group-usage"> • in: ${inputTokens}, out: ${outputTokens}, $${cost.toFixed(3)}</span>`;
+  }
 
   return `
     <summary id="group-header-${group.id}" class="log-group-header ${group.status}">
@@ -155,6 +162,7 @@ export function createGroupHeader(group) {
       <span class="group-time">
         <span class="group-start-time">Started: ${formattedStartTime}</span>
         ${durationDisplay}
+        ${usageDisplay}
       </span>
     </summary>
   `;

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -13,6 +13,7 @@ import {
   updateLogGroupUI,
   appendLogToGroup,
   updateFileList,
+  updateUsageSummary,
 } from './domHandlers.js';
 import {
   formatLogEntry,
@@ -167,6 +168,10 @@ export function setupMessageHandlers() {
 
       case COMMANDS.UPDATE_STATUS:
         updateStatus(message.status);
+        break;
+
+      case COMMANDS.UPDATE_USAGE:
+        updateUsageSummary(message.usage);
         break;
 
       case COMMANDS.UPDATE_FILES:

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -14,6 +14,7 @@ import {
   appendLogToGroup,
   updateFileList,
   updateUsageSummary,
+  updateGroupUsage,
 } from './domHandlers.js';
 import {
   formatLogEntry,
@@ -172,6 +173,12 @@ export function setupMessageHandlers() {
 
       case COMMANDS.UPDATE_USAGE:
         updateUsageSummary(message.usage);
+        break;
+
+      case COMMANDS.UPDATE_GROUP_USAGE:
+        if (message.stream === getCurrentStream()) {
+          updateGroupUsage(message.groupId, message.usage);
+        }
         break;
 
       case COMMANDS.UPDATE_FILES:

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -239,6 +239,14 @@
   font-size: var(--font-size-sm);
 }
 
+/* Group usage display styling */
+.group-usage {
+  color: var(--vscode-descriptionForeground);
+  font-size: var(--font-size-sm);
+  opacity: var(--opacity-subtle);
+  font-weight: normal;
+}
+
 /* Responsive adjustments */
 @media (max-width: 500px) {
   .file-item {

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -84,6 +84,10 @@
   gap: var(--spacing-medium);
 }
 
+.run-summary {
+  opacity: var(--opacity-subtle);
+}
+
 /* Status indicator styling */
 .status-indicator {
   width: var(--spacing-medium);

--- a/src/types/UsageTypes.ts
+++ b/src/types/UsageTypes.ts
@@ -1,0 +1,19 @@
+/**
+ * Token usage statistics for tracking model usage and costs.
+ */
+export interface TokenUsageStats {
+  /** Number of input tokens consumed */
+  inputTokens: number;
+  /** Number of output tokens generated */
+  outputTokens: number;
+  /** Total cost in USD for the request */
+  cost: number;
+}
+
+/**
+ * Message interface for updating usage stats in the progress view.
+ */
+export interface StreamUsageMessage {
+  command: 'updateUsage';
+  usage: TokenUsageStats | undefined;
+}


### PR DESCRIPTION
## Summary
- show token usage and cost in progress header
- send token usage stats from OutputHandler
- persist usage stats in ProgressViewProvider
- update webview and DOM handlers to display new summary

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test requires network)*