### PR TITLE
Add tool use token tracking

### DIFF
--- a/src/agent/AgentState.ts
+++ b/src/agent/AgentState.ts
@@ -149,7 +149,9 @@ export class AgentStateGlobal implements IAgentStateGlobal {
       }
 
       // Track tokens used for tool calls
-      if (stateRound.APIUsage?.tool_use_tokens != null) {
+      // Note: Only Google models provide tool_use_tokens (as toolUsePromptTokenCount)
+      // OpenAI and Anthropic don't provide this information in their API responses
+      if ('tool_use_tokens' in stateRound.APIUsage && stateRound.APIUsage.tool_use_tokens != null) {
         this.totalToolUseTokens += stateRound.APIUsage.tool_use_tokens;
       }
 

--- a/src/agent/AgentState.ts
+++ b/src/agent/AgentState.ts
@@ -92,6 +92,7 @@ export class AgentStateGlobal implements IAgentStateGlobal {
   public totalCacheReadInputTokens: number = 0;
   public totalCacheCreationInputTokens: number = 0;
   public totalReasoningTokens: number = 0;
+  public totalToolUseTokens: number = 0;
 
   constructor() {
     this.firstInputTokens = 0;
@@ -147,6 +148,11 @@ export class AgentStateGlobal implements IAgentStateGlobal {
         this.totalReasoningTokens += stateRound.APIUsage.reasoning_tokens ?? 0;
       }
 
+      // Track tokens used for tool calls
+      if ('tool_use_tokens' in stateRound.APIUsage) {
+        this.totalToolUseTokens += stateRound.APIUsage.tool_use_tokens ?? 0;
+      }
+
       // Update global totals
       this.totalInputTokens += stateRound.APIUsage.totalInputTokens;
       this.totalOutputTokens += stateRound.APIUsage.totalOutputTokens;
@@ -168,6 +174,7 @@ export class AgentStateGlobal implements IAgentStateGlobal {
       totalCacheReadInputTokens: this.totalCacheReadInputTokens,
       totalCacheCreationInputTokens: this.totalCacheCreationInputTokens,
       totalReasoningTokens: this.totalReasoningTokens,
+      totalToolUseTokens: this.totalToolUseTokens,
     };
   }
 
@@ -188,6 +195,7 @@ export class AgentStateGlobal implements IAgentStateGlobal {
     state.totalCacheCreationInputTokens =
       stateObj.totalCacheCreationInputTokens ?? 0;
     state.totalReasoningTokens = stateObj.totalReasoningTokens ?? 0;
+    state.totalToolUseTokens = stateObj.totalToolUseTokens ?? 0;
     return state;
   }
 }

--- a/src/agent/AgentState.ts
+++ b/src/agent/AgentState.ts
@@ -149,8 +149,8 @@ export class AgentStateGlobal implements IAgentStateGlobal {
       }
 
       // Track tokens used for tool calls
-      if ('tool_use_tokens' in stateRound.APIUsage) {
-        this.totalToolUseTokens += stateRound.APIUsage.tool_use_tokens ?? 0;
+      if (stateRound.APIUsage?.tool_use_tokens != null) {
+        this.totalToolUseTokens += stateRound.APIUsage.tool_use_tokens;
       }
 
       // Update global totals

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -860,7 +860,7 @@ export class OutputHandler {
           responseUsage = {
             prompt_tokens: stateGlobal.totalInputTokens,
             completion_tokens: stateGlobal.totalOutputTokens,
-            tool_use_tokens: stateGlobal.totalToolUseTokens,
+            // Note: OpenAI doesn't provide tool_use_tokens in their API
             prompt_tokens_details: {
               cached_tokens: stateGlobal.totalCacheReadInputTokens,
             },
@@ -872,7 +872,7 @@ export class OutputHandler {
           responseUsage = {
             prompt_tokens: stateGlobal.totalInputTokens,
             completion_tokens: stateGlobal.totalOutputTokens,
-            tool_use_tokens: stateGlobal.totalToolUseTokens,
+            // Note: OpenAI doesn't provide tool_use_tokens in their API
             reasoning_tokens: stateGlobal.totalReasoningTokens,
             cached_tokens: stateGlobal.totalCacheReadInputTokens,
           };
@@ -881,6 +881,7 @@ export class OutputHandler {
         responseUsage = {
           input_tokens: stateGlobal.totalInputTokens,
           output_tokens: stateGlobal.totalOutputTokens,
+          // Note: Anthropic doesn't provide tool_use_tokens in their API
           cache_read_input_tokens: stateGlobal.totalCacheReadInputTokens,
           cache_creation_input_tokens:
             stateGlobal.totalCacheCreationInputTokens,

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -846,6 +846,13 @@ export class OutputHandler {
         );
       }
 
+      if (stateGlobal.totalToolUseTokens > 0) {
+        this.logger.info(
+          `Total tool use tokens: ${stateGlobal.totalToolUseTokens}`,
+          statsGroupId,
+        );
+      }
+
       // Format token usage reporting by model provider
       let responseUsage: any = {};
       if (this.modelHandler.isOpenai) {
@@ -853,6 +860,7 @@ export class OutputHandler {
           responseUsage = {
             prompt_tokens: stateGlobal.totalInputTokens,
             completion_tokens: stateGlobal.totalOutputTokens,
+            tool_use_tokens: stateGlobal.totalToolUseTokens,
             prompt_tokens_details: {
               cached_tokens: stateGlobal.totalCacheReadInputTokens,
             },
@@ -864,6 +872,7 @@ export class OutputHandler {
           responseUsage = {
             prompt_tokens: stateGlobal.totalInputTokens,
             completion_tokens: stateGlobal.totalOutputTokens,
+            tool_use_tokens: stateGlobal.totalToolUseTokens,
             reasoning_tokens: stateGlobal.totalReasoningTokens,
             cached_tokens: stateGlobal.totalCacheReadInputTokens,
           };
@@ -880,6 +889,7 @@ export class OutputHandler {
         responseUsage = {
           promptTokens: stateGlobal.totalInputTokens,
           completionTokens: stateGlobal.totalOutputTokens,
+          toolUseTokenCount: stateGlobal.totalToolUseTokens,
         };
       }
 

--- a/src/agent/ResponseUsage.ts
+++ b/src/agent/ResponseUsage.ts
@@ -54,6 +54,7 @@ export interface AnthropicAPIResponseUsage extends ResponseUsageBase {
   output_tokens: number;
   cache_read_input_tokens: number | null;
   cache_creation_input_tokens: number | null;
+  tool_use_tokens: number;
 }
 
 /** Factory class for creating provider-specific response usage objects. */
@@ -125,6 +126,9 @@ export class ResponseUsageFactory {
     const cacheCreationInputTokens =
       responseUsage.cache_creation_input_tokens ?? null;
 
+    // Extract tool use tokens (if available)
+    const toolUseTokens = (responseUsage as any).tool_use_tokens ?? 0;
+
     // Calculate percentage cached
     const totalCacheTokens =
       (cacheReadInputTokens ?? 0) + (cacheCreationInputTokens ?? 0);
@@ -136,7 +140,7 @@ export class ResponseUsageFactory {
     return {
       // Base fields
       totalInputTokens: responseUsage.input_tokens,
-      totalOutputTokens: responseUsage.output_tokens,
+      totalOutputTokens: responseUsage.output_tokens + toolUseTokens,
       percentageCached,
       cost,
       responseTime,
@@ -145,6 +149,7 @@ export class ResponseUsageFactory {
       output_tokens: responseUsage.output_tokens,
       cache_read_input_tokens: cacheReadInputTokens,
       cache_creation_input_tokens: cacheCreationInputTokens,
+      tool_use_tokens: toolUseTokens,
     };
   }
 }

--- a/src/agent/ResponseUsage.ts
+++ b/src/agent/ResponseUsage.ts
@@ -4,12 +4,12 @@ import type { CompletionUsage } from 'openai/resources/completions';
 import type { Usage as AnthropicUsage } from '@anthropic-ai/sdk/resources/messages';
 import type { UsageMetadata as GenerateContentResponseUsageMetadata } from '@google/genai';
 
-/** 
+/**
  * Extended OpenAI usage type with additional fields used by various providers.
- * 
+ *
  * This interface extends the `CompletionUsage` type from the OpenAI SDK to include
- * additional metrics required by DeepSeek and other providers. 
- * 
+ * additional metrics required by DeepSeek and other providers.
+ *
  * Fields:
  * - `prompt_cache_hit_tokens` (optional): Represents the number of tokens retrieved
  *   from the prompt cache during a completion request. This is specific to DeepSeek's
@@ -18,6 +18,7 @@ import type { UsageMetadata as GenerateContentResponseUsageMetadata } from '@goo
  */
 export interface ExtendedCompletionUsage extends CompletionUsage {
   prompt_cache_hit_tokens?: number;
+  tool_use_tokens?: number;
 }
 
 // Re-export SDK types for use in model handlers
@@ -42,6 +43,7 @@ export interface OpenAIAPIResponseUsage extends ResponseUsageBase {
   completion_tokens: number;
   cached_tokens: number;
   reasoning_tokens: number;
+  tool_use_tokens: number;
   accepted_prediction_tokens: number | null;
   rejected_prediction_tokens: number | null;
 }
@@ -81,6 +83,8 @@ export class ResponseUsageFactory {
       completionDetails?.rejected_prediction_tokens ?? null;
 
     // Calculate percentage cached
+    const toolUseTokens = responseUsage.tool_use_tokens ?? 0;
+
     const percentageCached =
       responseUsage.prompt_tokens > 0
         ? (cachedTokens / responseUsage.prompt_tokens) * 100
@@ -89,13 +93,14 @@ export class ResponseUsageFactory {
     return {
       // Base fields
       totalInputTokens: responseUsage.prompt_tokens,
-      totalOutputTokens: responseUsage.completion_tokens,
+      totalOutputTokens: responseUsage.completion_tokens + toolUseTokens,
       percentageCached,
       cost,
       responseTime,
       // OpenAI specific fields (keeping snake_case)
       prompt_tokens: responseUsage.prompt_tokens,
       completion_tokens: responseUsage.completion_tokens,
+      tool_use_tokens: toolUseTokens,
       cached_tokens: cachedTokens,
       reasoning_tokens: reasoningTokens,
       accepted_prediction_tokens: acceptedPredictionTokens,

--- a/src/agent/ResponseUsage.ts
+++ b/src/agent/ResponseUsage.ts
@@ -18,7 +18,7 @@ import type { UsageMetadata as GenerateContentResponseUsageMetadata } from '@goo
  */
 export interface ExtendedCompletionUsage extends CompletionUsage {
   prompt_cache_hit_tokens?: number;
-  tool_use_tokens?: number;
+  // Note: tool_use_tokens is not provided by OpenAI API
 }
 
 // Re-export SDK types for use in model handlers
@@ -43,9 +43,11 @@ export interface OpenAIAPIResponseUsage extends ResponseUsageBase {
   completion_tokens: number;
   cached_tokens: number;
   reasoning_tokens: number;
-  tool_use_tokens: number;
+  // Note: OpenAI API doesn't provide tool_use_tokens
   accepted_prediction_tokens: number | null;
   rejected_prediction_tokens: number | null;
+  // Only present for Google models when using OpenAI-compatible interface
+  tool_use_tokens?: number;
 }
 
 /** Anthropic-specific response usage metrics with cache statistics. */
@@ -54,7 +56,7 @@ export interface AnthropicAPIResponseUsage extends ResponseUsageBase {
   output_tokens: number;
   cache_read_input_tokens: number | null;
   cache_creation_input_tokens: number | null;
-  tool_use_tokens: number;
+  // Note: Anthropic API doesn't provide tool_use_tokens
 }
 
 /** Factory class for creating provider-specific response usage objects. */
@@ -84,8 +86,6 @@ export class ResponseUsageFactory {
       completionDetails?.rejected_prediction_tokens ?? null;
 
     // Calculate percentage cached
-    const toolUseTokens = responseUsage.tool_use_tokens ?? 0;
-
     const percentageCached =
       responseUsage.prompt_tokens > 0
         ? (cachedTokens / responseUsage.prompt_tokens) * 100
@@ -94,14 +94,13 @@ export class ResponseUsageFactory {
     return {
       // Base fields
       totalInputTokens: responseUsage.prompt_tokens,
-      totalOutputTokens: responseUsage.completion_tokens + toolUseTokens,
+      totalOutputTokens: responseUsage.completion_tokens,
       percentageCached,
       cost,
       responseTime,
       // OpenAI specific fields (keeping snake_case)
       prompt_tokens: responseUsage.prompt_tokens,
       completion_tokens: responseUsage.completion_tokens,
-      tool_use_tokens: toolUseTokens,
       cached_tokens: cachedTokens,
       reasoning_tokens: reasoningTokens,
       accepted_prediction_tokens: acceptedPredictionTokens,
@@ -126,9 +125,6 @@ export class ResponseUsageFactory {
     const cacheCreationInputTokens =
       responseUsage.cache_creation_input_tokens ?? null;
 
-    // Extract tool use tokens (if available)
-    const toolUseTokens = (responseUsage as any).tool_use_tokens ?? 0;
-
     // Calculate percentage cached
     const totalCacheTokens =
       (cacheReadInputTokens ?? 0) + (cacheCreationInputTokens ?? 0);
@@ -140,7 +136,7 @@ export class ResponseUsageFactory {
     return {
       // Base fields
       totalInputTokens: responseUsage.input_tokens,
-      totalOutputTokens: responseUsage.output_tokens + toolUseTokens,
+      totalOutputTokens: responseUsage.output_tokens,
       percentageCached,
       cost,
       responseTime,
@@ -149,7 +145,6 @@ export class ResponseUsageFactory {
       output_tokens: responseUsage.output_tokens,
       cache_read_input_tokens: cacheReadInputTokens,
       cache_creation_input_tokens: cacheCreationInputTokens,
-      tool_use_tokens: toolUseTokens,
     };
   }
 }

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -558,8 +558,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       return 0;
     }
     
-    // Extract tool use tokens if available
-    const toolUseTokens = (responseUsage as any).tool_use_tokens ?? 0;
+    // Note: Anthropic doesn't provide tool_use_tokens in their API response
     
     let basePrice = calculateTokenPrice(
       responseUsage.input_tokens,
@@ -567,11 +566,6 @@ export class ModelHandlerAnthropic extends ModelHandler {
       this.config.inputPrice,
       this.config.outputPrice,
     );
-
-    // Add tool use token costs (typically priced as output tokens)
-    if (toolUseTokens > 0) {
-      basePrice += (toolUseTokens * this.config.outputPrice) / 1e6;
-    }
 
     if (this.capabilities.supportsPromptCaching) {
       if (

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -557,12 +557,21 @@ export class ModelHandlerAnthropic extends ModelHandler {
     if (!responseUsage) {
       return 0;
     }
+    
+    // Extract tool use tokens if available
+    const toolUseTokens = (responseUsage as any).tool_use_tokens ?? 0;
+    
     let basePrice = calculateTokenPrice(
       responseUsage.input_tokens,
       responseUsage.output_tokens,
       this.config.inputPrice,
       this.config.outputPrice,
     );
+
+    // Add tool use token costs (typically priced as output tokens)
+    if (toolUseTokens > 0) {
+      basePrice += (toolUseTokens * this.config.outputPrice) / 1e6;
+    }
 
     if (this.capabilities.supportsPromptCaching) {
       if (

--- a/src/agent/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlerGoogle.ts
@@ -43,6 +43,7 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
       completion_tokens:
         (usage.completionTokens ?? 0) + thoughtTokens + toolTokens,
       total_tokens: usage.totalTokens ?? 0,
+      tool_use_tokens: toolTokens,
       prompt_tokens_details: {
         cached_tokens: usage.cachedContentTokenCount ?? 0,
       },

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -584,7 +584,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     const usageObj: ExtendedCompletionUsage = {
       prompt_tokens: responseUsage?.promptTokenCount ?? 0,
       completion_tokens: responseUsage?.responseTokenCount ?? 0,
-      total_tokens: responseUsage?.totalTokenCount ?? 0,
+      total_tokens: (responseUsage?.totalTokenCount ?? 0) + (responseUsage?.toolUsePromptTokenCount ?? 0),
       tool_use_tokens: responseUsage?.toolUsePromptTokenCount ?? 0,
       prompt_tokens_details: {
         cached_tokens: responseUsage?.cachedContentTokenCount ?? 0,

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -585,6 +585,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       prompt_tokens: responseUsage?.promptTokenCount ?? 0,
       completion_tokens: responseUsage?.responseTokenCount ?? 0,
       total_tokens: responseUsage?.totalTokenCount ?? 0,
+      tool_use_tokens: responseUsage?.toolUsePromptTokenCount ?? 0,
       prompt_tokens_details: {
         cached_tokens: responseUsage?.cachedContentTokenCount ?? 0,
       },

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -564,10 +564,11 @@ export class ModelHandlerOpenAI extends ModelHandler {
     // Get token counts
     const promptTokens = responseUsage.prompt_tokens ?? 0;
     const completionTokens = responseUsage.completion_tokens ?? 0;
+    const toolUseTokens = responseUsage.tool_use_tokens ?? 0;
 
     let basePrice = calculateTokenPrice(
       promptTokens,
-      completionTokens,
+      completionTokens + toolUseTokens,
       this.config.inputPrice,
       this.config.outputPrice,
     );
@@ -605,6 +606,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
         prompt_tokens: 0,
         completion_tokens: 0,
         total_tokens: 0,
+        tool_use_tokens: 0,
         prompt_tokens_details: { cached_tokens: 0 },
         completion_tokens_details: {
           reasoning_tokens: 0,

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -564,11 +564,11 @@ export class ModelHandlerOpenAI extends ModelHandler {
     // Get token counts
     const promptTokens = responseUsage.prompt_tokens ?? 0;
     const completionTokens = responseUsage.completion_tokens ?? 0;
-    const toolUseTokens = responseUsage.tool_use_tokens ?? 0;
+    // Note: OpenAI doesn't provide tool_use_tokens in their API response
 
     let basePrice = calculateTokenPrice(
       promptTokens,
-      completionTokens + toolUseTokens,
+      completionTokens,
       this.config.inputPrice,
       this.config.outputPrice,
     );
@@ -606,7 +606,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
         prompt_tokens: 0,
         completion_tokens: 0,
         total_tokens: 0,
-        tool_use_tokens: 0,
+        // Note: OpenAI doesn't provide tool_use_tokens, so we don't include it
         prompt_tokens_details: { cached_tokens: 0 },
         completion_tokens_details: {
           reasoning_tokens: 0,


### PR DESCRIPTION
## Summary
- extend `ResponseUsage` interfaces with `tool_use_tokens`
- include tool call tokens when creating response usage data
- accumulate tool use tokens across rounds
- show tool token totals in statistics output
- support tool use token pricing for OpenAI and Google models

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Module not found: Error: Can't resolve 'bufferutil')*