### PR TITLE
Add numeric timestamps for log messages

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -69,7 +69,7 @@ class VSCodeTransport extends Transport {
   private messageBuffer: {
     level: string;
     message: string;
-    timestamp: string;
+    timestamp: number;
     groupId?: string;
   }[] = [];
   private groups: Map<string, LogGroup> = new Map();
@@ -150,19 +150,21 @@ class VSCodeTransport extends Transport {
       `</div>`;
 
     // Write to ProgressView if available (with colors and escaped HTML)
+    const numericTimestamp = new Date(timestamp).getTime();
     if (this.progressViewProvider) {
       this.progressViewProvider.addLogMessage(
         this.streamName,
         coloredFormattedMessage,
         level as 'error' | 'warn' | 'info' | 'debug',
         groupId,
+        numericTimestamp,
       );
     } else {
       // Buffer the message if ProgressViewProvider is not available
       this.messageBuffer.push({
         level,
         message: coloredFormattedMessage,
-        timestamp,
+        timestamp: numericTimestamp,
         groupId,
       });
     }
@@ -198,6 +200,7 @@ class VSCodeTransport extends Transport {
         msg.message,
         msg.level as 'error' | 'warn' | 'info' | 'debug',
         msg.groupId,
+        msg.timestamp,
       );
     }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -137,7 +137,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
                 );
                 const timeString =
                   attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
-                msg.timestamp = new Date(timeString).getTime() || Date.now();
+                const timestamp = new Date(timeString).getTime();
+                msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
               }
               return msg;
             }),

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -29,6 +29,7 @@ type StreamStatusType =
 interface ColoredLogMessage {
   message: string;
   level: 'error' | 'warn' | 'info' | 'debug';
+  timestamp: number;
   groupId?: string;
 }
 
@@ -125,9 +126,22 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     if (savedState) {
       // Only load channels that should be persisted
       this._logStreams = new Map(
-        Object.entries(savedState).filter(([channel]) =>
-          shouldPersistStream(channel),
-        ),
+        Object.entries(savedState)
+          .filter(([channel]) => shouldPersistStream(channel))
+          .map(([stream, messages]) => [
+            stream,
+            messages.map((msg) => {
+              if (msg.timestamp === undefined) {
+                const attrMatch = msg.message.match(
+                  /data-full-timestamp="([^"]+)"/,
+                );
+                const timeString =
+                  attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
+                msg.timestamp = new Date(timeString).getTime() || Date.now();
+              }
+              return msg;
+            }),
+          ]),
       );
     } else {
       this._logStreams.clear();
@@ -360,6 +374,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     message: string,
     level: 'error' | 'warn' | 'info' | 'debug' = 'info',
     groupId?: string,
+    timestamp: number = Date.now(),
   ) {
     // Skip if this stream should be excluded from the progress view
     if (shouldExcludeFromProgressView(stream)) {
@@ -404,6 +419,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     const logMessage: ColoredLogMessage = {
       message,
       level,
+      timestamp,
       groupId,
     };
 

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -492,10 +492,11 @@ export function appendLogToGroup(logMessage) {
       const logLineElement = messageElement.firstElementChild;
 
       // Extract timestamp from the message for chronological ordering
-      const msgTimestamp = getMessageTimestamp(logMessage.message);
-      const msgDate = msgTimestamp.includes('-')
-        ? new Date(msgTimestamp)
+      const msgDate = logMessage.timestamp
+        ? new Date(logMessage.timestamp)
         : null;
+      const msgTimestamp =
+        msgDate?.toISOString() || getMessageTimestamp(logMessage.message);
 
       // Find where to insert this message chronologically
       let insertPosition = null;

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -76,22 +76,11 @@ export function setupMessageHandlers() {
           // Now add messages to their groups - sort them by timestamp first
           // This ensures we process messages in chronological order
           const sortedMessages = [...message.messages].sort((a, b) => {
+            if (a.timestamp !== undefined && b.timestamp !== undefined) {
+              return a.timestamp - b.timestamp;
+            }
             const timestampA = getMessageTimestamp(a.message);
             const timestampB = getMessageTimestamp(b.message);
-
-            // Try to use Date objects for more accurate comparison
-            const dateA = timestampA.includes('-')
-              ? new Date(timestampA)
-              : null;
-            const dateB = timestampB.includes('-')
-              ? new Date(timestampB)
-              : null;
-
-            if (dateA && dateB) {
-              return dateA - dateB;
-            }
-
-            // Fallback to string comparison
             return timestampA.localeCompare(timestampB);
           });
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -79,6 +79,14 @@ export function setupMessageHandlers() {
             if (a.timestamp !== undefined && b.timestamp !== undefined) {
               return a.timestamp - b.timestamp;
             }
+            // Handle cases where only one has a timestamp
+            if (a.timestamp !== undefined) {
+              return -1; // a comes before b
+            }
+            if (b.timestamp !== undefined) {
+              return 1; // b comes before a
+            }
+            // Both undefined, fall back to string comparison
             const timestampA = getMessageTimestamp(a.message);
             const timestampB = getMessageTimestamp(b.message);
             return timestampA.localeCompare(timestampB);


### PR DESCRIPTION
## Summary
- include a `timestamp` field in `ColoredLogMessage`
- store timestamps when logging and replaying
- preserve timestamps when loading existing state
- sort webview logs using the numeric timestamp
- use timestamp when inserting messages into groups

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: environment lacks network access)*