### PR TITLE
Implement AbortController-based stream cancelation

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -40,7 +40,7 @@ The header provides a summary and actions for the selected stream:
   - **Red (Error)**: The agent encountered an error during execution.
   - **Yellow (Ready/Initial)**: The view is ready, but no stream is active yet.
 - **Stream Header Actions**:
-  - <i class="codicon codicon-debug-stop"></i> **Stop**: Attempts to gracefully stop the currently running task for this stream. Note that the current API call (if any) will complete first.
+  - <i class="codicon codicon-debug-stop"></i> **Stop**: Attempts to gracefully stop the currently running task for this stream. If the provider supports `AbortController` for streaming requests (such as OpenRouter), any ongoing streaming call is cancelled immediately; otherwise the current API call will finish first.
   - <i class="codicon codicon-debug-rerun"></i> **Run Again**: Re-runs the task associated with this stream using the _exact same configuration_ (agent, model, files, instruction) that was used when it originally ran. Useful for retrying failed tasks or reproducing results.
   - <i class="codicon codicon-reply"></i> **Restore**: Loads the configuration (agent, model, files, instruction) from this stream back into the main TeXRA webview interface. This allows you to easily modify and re-run a previous task.
   - <i class="codicon codicon-diff-multiple"></i> **Diff**: Triggers the `latexdiff` process to compare the original input file(s) with the generated output `.tex` file(s) from this stream. Generates `_diff_rN.tex` and `_diff_rN-rM.tex` files. Requires `latexdiff` to be installed. See [LaTeX Diff](./latex-diff.md).

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -83,6 +83,7 @@ export abstract class BaseReflectionAgent {
   /** Group ID for the main run group, used as parent for subgroups */
   protected runGroupId?: string;
   private isInterrupted: boolean = false;
+  private abortController: AbortController | null = null;
 
   // Static map to track running agents by their stream ID
   private static runningAgents: Map<string, BaseReflectionAgent> = new Map();
@@ -533,13 +534,31 @@ export abstract class BaseReflectionAgent {
           }
         }
 
-        const responseObject = await this.modelHandler.createResponse(
-          this.client,
-          messages,
-          this.agentSetting.temperature || 0.0,
-          systemPrompt,
-          this.agentSetting.endTag,
-        );
+        const useStreaming = this.modelHandler.getStreamingConfig();
+        if (useStreaming) {
+          this.abortController = new AbortController();
+        }
+        let responseObject: any;
+        try {
+          responseObject = await this.modelHandler.createResponse(
+            this.client,
+            messages,
+            this.agentSetting.temperature || 0.0,
+            systemPrompt,
+            this.agentSetting.endTag,
+            useStreaming ? this.abortController?.signal : undefined,
+          );
+        } catch (error: any) {
+          if (error.name === 'AbortError') {
+            this.logger.info('Request aborted by user', responseCycleGroupId);
+            break;
+          }
+          throw error;
+        } finally {
+          if (useStreaming) {
+            this.abortController = null;
+          }
+        }
         const responseTime = (Date.now() - startTime) / 1000;
         stateRound.updateResponseTime(responseTime);
         this.logger.info(
@@ -1375,6 +1394,9 @@ export abstract class BaseReflectionAgent {
    */
   public interrupt(): void {
     this.isInterrupted = true;
+    if (this.abortController) {
+      this.abortController.abort();
+    }
     this.logger.info(
       'Agent execution interrupted by user. Note that already sent response might still return outputs but no more request messages will be sent.',
     );

--- a/src/agent/ModelHandler.ts
+++ b/src/agent/ModelHandler.ts
@@ -540,6 +540,7 @@ export abstract class ModelHandler {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any>;
 
   /**

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -59,6 +59,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -129,7 +130,10 @@ export class ModelHandlerAnthropic extends ModelHandler {
     if (useStreaming) {
       // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
       // we should also make sure partial results can be returned in the presence of errors!
-      const stream = await client.beta.messages.stream(options);
+      const stream = await client.beta.messages.stream(
+        options,
+        signal ? { signal } : undefined,
+      );
       const response = await stream.finalMessage();
       return response;
     } else {

--- a/src/agent/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlerDashScope.ts
@@ -71,7 +71,6 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     return processedMessages;
   }
 
-
   /**
    * Override createResponse to preprocess messages for DashScope models
    */
@@ -81,6 +80,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Preprocess messages for DashScope compatibility
     const processedMessages = this.preprocessMessages(messages);
@@ -107,6 +107,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
       temperature,
       systemPrompt,
       endTag,
+      signal,
     );
   }
 

--- a/src/agent/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlerDeepSeek.ts
@@ -90,7 +90,6 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     return reasoningContent;
   }
 
-
   /**
    * Preprocess messages array to ensure there are no consecutive user or assistant messages
    * and that content is in string format for DeepSeek models
@@ -183,6 +182,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Preprocess messages to merge consecutive messages and convert content to strings
     const processedMessages = this.preprocessMessages(messages);
@@ -209,6 +209,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
       temperature,
       systemPrompt,
       endTag,
+      signal,
     );
   }
 }

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -149,6 +149,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<GenerateContentResponse> {
     if (messages.length === 0) {
       this.logger.error('Cannot create response from empty messages array.');

--- a/src/agent/modelHandlerKimi.ts
+++ b/src/agent/modelHandlerKimi.ts
@@ -126,7 +126,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     return processedMessages;
   }
 
-
   /**
    * Override createResponse to preprocess messages for Kimi models
    */
@@ -136,6 +135,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Preprocess messages for Kimi compatibility
     const processedMessages = this.preprocessMessages(messages);
@@ -195,6 +195,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
       temperature,
       systemPrompt,
       endTag,
+      signal,
     );
   }
 

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -51,6 +51,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -126,7 +127,10 @@ export class ModelHandlerOpenAI extends ModelHandler {
       let response: any;
       kwargs.stream_options = { include_usage: true };
       try {
-        const stream = client.beta.chat.completions.stream(kwargs);
+        const stream = client.beta.chat.completions.stream(
+          kwargs,
+          signal ? { signal } : undefined,
+        );
         response = await stream.finalMessage();
 
         // in the future we can add: stream_options: {"include_usage": true} to get usage statistics

--- a/src/agent/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlerOpenRouter.ts
@@ -30,6 +30,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -64,7 +65,10 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
 
     if (useStreaming) {
       kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
-      const stream = client.beta.chat.completions.stream(kwargs);
+      const stream = client.beta.chat.completions.stream(
+        kwargs,
+        signal ? { signal } : undefined,
+      );
       return await stream.finalMessage();
     } else {
       return await client.chat.completions.create(kwargs);


### PR DESCRIPTION
## Summary
- introduce AbortController handling in BaseReflectionAgent and interrupt()
- add optional `signal` parameter to ModelHandler.createResponse and implementations
- pass AbortController signal to model handlers to enable real-time request abort
- document stop button behaviour with providers supporting AbortController

## Testing
- `npm run format`
- `npm test` *(fails: ErrorEvent types missing)*