### PR TITLE
Add AbortController support for agents

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -40,7 +40,7 @@ The header provides a summary and actions for the selected stream:
   - **Red (Error)**: The agent encountered an error during execution.
   - **Yellow (Ready/Initial)**: The view is ready, but no stream is active yet.
 - **Stream Header Actions**:
-  - <i class="codicon codicon-debug-stop"></i> **Stop**: Attempts to gracefully stop the currently running task for this stream. Note that the current API call (if any) will complete first.
+  - <i class="codicon codicon-debug-stop"></i> **Stop**: Attempts to gracefully stop the currently running task for this stream. For providers supporting `AbortController` (like OpenAI or Anthropic) the active request is aborted immediately; otherwise the current API call will finish before stopping.
   - <i class="codicon codicon-debug-rerun"></i> **Run Again**: Re-runs the task associated with this stream using the _exact same configuration_ (agent, model, files, instruction) that was used when it originally ran. Useful for retrying failed tasks or reproducing results.
   - <i class="codicon codicon-reply"></i> **Restore**: Loads the configuration (agent, model, files, instruction) from this stream back into the main TeXRA webview interface. This allows you to easily modify and re-run a previous task.
   - <i class="codicon codicon-diff-multiple"></i> **Diff**: Triggers the `latexdiff` process to compare the original input file(s) with the generated output `.tex` file(s) from this stream. Generates `_diff_rN.tex` and `_diff_rN-rM.tex` files. Requires `latexdiff` to be installed. See [LaTeX Diff](./latex-diff.md).

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -87,6 +87,7 @@ export abstract class BaseReflectionAgent {
   /** Group ID for the main run group, used as parent for subgroups */
   protected runGroupId?: string;
   private isInterrupted: boolean = false;
+  private abortController: AbortController | null = null;
 
   // Static map to track running agents by their stream ID
   private static runningAgents: Map<string, BaseReflectionAgent> = new Map();
@@ -307,13 +308,20 @@ export abstract class BaseReflectionAgent {
           }
         }
 
-        const responseObject = await this.modelHandler.createResponse(
-          this.client,
-          messages,
-          this.agentSetting.temperature || 0.0,
-          systemPrompt,
-          this.agentSetting.endTag,
-        );
+        this.abortController = new AbortController();
+        let responseObject;
+        try {
+          responseObject = await this.modelHandler.createResponse(
+            this.client,
+            messages,
+            this.agentSetting.temperature || 0.0,
+            systemPrompt,
+            this.agentSetting.endTag,
+            this.abortController.signal,
+          );
+        } finally {
+          this.abortController = null;
+        }
         const responseTime = (Date.now() - startTime) / 1000;
         stateRound.updateResponseTime(responseTime);
         this.logger.info(
@@ -1232,6 +1240,9 @@ export abstract class BaseReflectionAgent {
    */
   public interrupt(): void {
     this.isInterrupted = true;
+    if (this.abortController) {
+      this.abortController.abort();
+    }
     this.logger.info(
       'Agent execution interrupted by user. Note that already sent response might still return outputs but no more request messages will be sent.',
     );

--- a/src/agent/ModelHandler.ts
+++ b/src/agent/ModelHandler.ts
@@ -547,6 +547,7 @@ export abstract class ModelHandler {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any>;
 
   /**

--- a/src/agent/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlerAnthropic.ts
@@ -65,6 +65,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -156,10 +157,10 @@ export class ModelHandlerAnthropic extends ModelHandler {
       if (useStreaming) {
         // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
         // we should also make sure partial results can be returned in the presence of errors!
-        const stream = await client.beta.messages.stream(options);
+        const stream = await client.beta.messages.stream(options, { signal });
         response = await stream.finalMessage();
       } else {
-        response = await client.beta.messages.create(options);
+        response = await client.beta.messages.create(options, { signal });
       }
     } catch (err) {
       this.logger.error(formatProviderError('Error creating response', err));

--- a/src/agent/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlerDashScope.ts
@@ -82,6 +82,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Preprocess messages for DashScope compatibility
     const processedMessages = this.preprocessMessages(messages);
@@ -108,6 +109,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
       temperature,
       systemPrompt,
       endTag,
+      signal,
     );
   }
 

--- a/src/agent/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlerDeepSeek.ts
@@ -183,6 +183,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Preprocess messages to merge consecutive messages and convert content to strings
     const processedMessages = this.preprocessMessages(messages);
@@ -209,6 +210,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
       temperature,
       systemPrompt,
       endTag,
+      signal,
     );
   }
 }

--- a/src/agent/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlerGoogleGenAI.ts
@@ -156,6 +156,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<GenerateContentResponse> {
     if (messages.length === 0) {
       this.logger.error('Cannot create response from empty messages array.');
@@ -221,6 +222,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
         const responseTokenCount = await client.models.countTokens({
           model: this.config.fullName,
           contents: countContents,
+          config: { abortSignal: signal },
         });
         const totalTokens = responseTokenCount.totalTokens ?? 0;
         this.logger.debug(`Token count of message: ${totalTokens}`);
@@ -268,7 +270,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       this.logger.debug(
         `Sending message with ${lastMessageParts.length} parts.`,
       );
-      const result = await chat.sendMessage({ message: lastMessageParts });
+      const result = await chat.sendMessage({
+        message: lastMessageParts,
+        config: { abortSignal: signal },
+      });
 
       return result;
     } catch (error: any) {

--- a/src/agent/modelHandlerKimi.ts
+++ b/src/agent/modelHandlerKimi.ts
@@ -137,6 +137,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Preprocess messages for Kimi compatibility
     const processedMessages = this.preprocessMessages(messages);
@@ -179,7 +180,9 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
       }
 
       try {
-        const response = await client.chat.completions.create(kwargs);
+        const response = await client.chat.completions.create(kwargs, {
+          signal,
+        });
         return response;
       } catch (err) {
         this.logger.error(
@@ -196,6 +199,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
       temperature,
       systemPrompt,
       endTag,
+      signal,
     );
   }
 

--- a/src/agent/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlerOpenAI.ts
@@ -57,6 +57,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -132,7 +133,9 @@ export class ModelHandlerOpenAI extends ModelHandler {
       let response: any;
       kwargs.stream_options = { include_usage: true };
       try {
-        const stream = client.beta.chat.completions.stream(kwargs);
+        const stream = client.beta.chat.completions.stream(kwargs, {
+          signal,
+        });
         response = await stream.finalMessage();
 
         // in the future we can add: stream_options: {"include_usage": true} to get usage statistics
@@ -151,7 +154,9 @@ export class ModelHandlerOpenAI extends ModelHandler {
       return response;
     } else {
       try {
-        const response = await client.chat.completions.create(kwargs);
+        const response = await client.chat.completions.create(kwargs, {
+          signal,
+        });
         return response;
       } catch (err) {
         this.logger.error(`Error in createResponse: ${err}`);

--- a/src/agent/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlerOpenAIResponse.ts
@@ -41,6 +41,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     const useStreaming = this.getStreamingConfig();
 
@@ -66,13 +67,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
 
     if (useStreaming) {
       params.stream = true;
-      const stream = (await client.responses.create(params)) as any;
+      const stream = (await client.responses.create(params, {
+        signal,
+      })) as any;
       const response = await stream.finalResponse();
       this.previousResponseId = response.id;
       this.sentMessages = messages.length;
       return response;
     } else {
-      const response = await client.responses.create(params);
+      const response = await client.responses.create(params, {
+        signal,
+      });
       this.previousResponseId = response.id;
       this.sentMessages = messages.length;
       return response;

--- a/src/agent/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlerOpenRouter.ts
@@ -31,6 +31,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -65,10 +66,10 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
 
     if (useStreaming) {
       kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
-      const stream = client.beta.chat.completions.stream(kwargs);
+      const stream = client.beta.chat.completions.stream(kwargs, { signal });
       return await stream.finalMessage();
     } else {
-      return await client.chat.completions.create(kwargs);
+      return await client.chat.completions.create(kwargs, { signal });
     }
   }
 

--- a/src/utils/sdkErrorUtils.ts
+++ b/src/utils/sdkErrorUtils.ts
@@ -36,7 +36,7 @@ export function getSdkErrorMessage(err: unknown): string {
   }
 
   // In normal mode, provide graceful error messages
-  const errorMapping: [Function, string][] = [
+  const errorMapping: [new (...args: any[]) => any, string][] = [
     [OpenAIRateLimitError, 'Rate limit exceeded.'],
     [AnthropicRateLimitError, 'Rate limit exceeded.'],
     [OpenAIConnectionTimeoutError, 'Connection timed out.'],


### PR DESCRIPTION
## Summary
- introduce AbortController usage in BaseReflectionAgent and interrupt logic
- allow ModelHandler implementations to accept optional AbortSignal
- pass signal through createResponse calls for OpenAI, Anthropic, OpenRouter, DashScope, Kimi, DeepSeek and Google GenAI handlers
- update ProgressBoard docs on stop button behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: eqeqeq warnings, `Mark` undefined)*