### PR TITLE
Add auto PDF compile for input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ TeXRA offers various customization options through VS Code settings:
 
 - Multi-file processing for complex projects
 - Automatic TikZ figure extraction and compilation
+- Automatic compilation of input and output LaTeX files to PDFs
 - LaTeX diff functionality for version comparison
 - Git integration for accessing recent commits
 - Intelligent document merging with conflict resolution

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -13,6 +13,7 @@ import {
   extractFigurePathsFromLatex,
   bestConnectionMethod,
   getTeXCountStats,
+  compileLatex2Pdf,
 } from '../latex';
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 import { diff_match_patch } from 'diff-match-patch';
@@ -784,6 +785,33 @@ export abstract class BaseReflectionAgent {
             }
           }
         }
+
+        if (this.agentConfig.toolConfig.autoCompileInputPdf) {
+          for (const inputFile of inputFiles) {
+            if (!inputFile.toLowerCase().endsWith('.tex')) {
+              continue;
+            }
+            const buildDir = path.join(path.dirname(inputFile), 'build');
+            const compiled = await compileLatex2Pdf(
+              inputFile,
+              undefined,
+              buildDir,
+            );
+            if (compiled) {
+              const pdfFile = path.join(
+                buildDir,
+                path.basename(inputFile).replace(/\.tex$/, '.pdf'),
+              );
+              if (await fileExists(pdfFile)) {
+                this.logger.info(
+                  `Compiled PDF for ${inputFile}: ${pdfFile}`,
+                  round0GroupId,
+                );
+                toolState.addMediaFiles([pdfFile]);
+              }
+            }
+          }
+        }
       }
 
       const messages: any[] = [];
@@ -1116,6 +1144,36 @@ export abstract class BaseReflectionAgent {
           await extractAndCompileTikzPicturesWithLabels(outputFile);
         if (extractedTikzFigures) {
           toolState.addMediaFiles(extractedTikzFigures);
+        }
+      }
+    }
+
+    if (
+      this.modelHandler.capabilities.supportsVision &&
+      this.agentConfig.toolConfig.autoCompileInputPdf
+    ) {
+      for (const outputFile of outputFiles) {
+        if (!outputFile.toLowerCase().endsWith('.tex')) {
+          continue;
+        }
+        const buildDir = path.join(path.dirname(outputFile), 'build');
+        const compiled = await compileLatex2Pdf(
+          outputFile,
+          undefined,
+          buildDir,
+        );
+        if (compiled) {
+          const pdfFile = path.join(
+            buildDir,
+            path.basename(outputFile).replace(/\.tex$/, '.pdf'),
+          );
+          if (await fileExists(pdfFile)) {
+            this.logger.info(
+              `Compiled PDF for ${outputFile}: ${pdfFile}`,
+              this.logger.getActiveGroupId(),
+            );
+            toolState.addMediaFiles([pdfFile]);
+          }
         }
       }
     }

--- a/src/agent/ModelHandler.ts
+++ b/src/agent/ModelHandler.ts
@@ -61,6 +61,7 @@ export abstract class ModelHandler {
         reflect: false,
         attachTeXCount: false,
         printInputPrompt: false,
+        autoCompileInputPdf: false,
       },
     };
     this.capabilities = config.capabilities;

--- a/src/agent/ToolConfig.ts
+++ b/src/agent/ToolConfig.ts
@@ -6,4 +6,5 @@ export interface ToolConfig {
   autoExtractTikzFigure: boolean;
   attachTeXCount: boolean;
   printInputPrompt: boolean;
+  autoCompileInputPdf: boolean;
 }

--- a/src/agent/userVars.ts
+++ b/src/agent/userVars.ts
@@ -253,5 +253,6 @@ function getToolFlags(
     INCLUDE_TEX_COUNT: agentConfig.toolConfig.attachTeXCount,
     USE_PREFILL_FROM_INPUT: agentConfig.toolConfig.usePrefillFromInput,
     PRINT_INPUT_PROMPT: agentConfig.toolConfig.printInputPrompt,
+    AUTO_COMPILE_INPUT_PDF: agentConfig.toolConfig.autoCompileInputPdf,
   };
 }

--- a/src/commands/stateRestoreCommand.ts
+++ b/src/commands/stateRestoreCommand.ts
@@ -46,6 +46,7 @@ async function restoreState(config: any) {
         usePrefillFromInput: taskState.usePrefillFromInput,
         printInputPrompt: taskState.printInputPrompt,
         reflect: taskState.reflect,
+        autoCompileInputPdf: taskState.autoCompileInputPdf,
       },
     };
 

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -14,7 +14,7 @@ import * as logger from '../logger/logUtils';
 // Local imports - utilities
 import { executeCommand } from '../utils/execUtils';
 import { getConfig } from '../utils/configUtils';
-import { getWorkspacePath } from '../utils/workspaceFileUtils';
+import { getWorkspacePath, createDirectory } from '../utils/workspaceFileUtils';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -109,14 +109,17 @@ export async function checkToolInstalled(
  * Compile a LaTeX file to PDF
  * @param latexFile Path to the LaTeX file
  * @param channel Optional channel for logging
+ * @param outputDirectory Directory for compiled PDF (default: alongside file)
  * @returns Promise<boolean> True if compilation succeeded
  */
 export async function compileLatex2Pdf(
   latexFile: string,
   channel: string = CHANNEL,
+  outputDirectory?: string,
 ): Promise<boolean> {
   try {
-    const outputDirectory = path.dirname(latexFile);
+    const outDir = outputDirectory || path.dirname(latexFile);
+    await createDirectory(outDir);
 
     // Get TikZ input directory from configuration
     const tikzInputDirectory = getConfig<string>(
@@ -171,7 +174,7 @@ export async function compileLatex2Pdf(
     const command = [
       'pdflatex',
       '-interaction=nonstopmode',
-      `-output-directory="${outputDirectory}"`,
+      `-output-directory="${outDir}"`,
       `"${latexFile}"`,
     ];
 

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -35,6 +35,7 @@ export interface TaskState {
   attachTeXCount: boolean;
   usePrefillFromInput: boolean;
   printInputPrompt: boolean;
+  autoCompileInputPdf: boolean;
 
   // Output name override visibility
   outputNameOverrideVisible: boolean;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const ACTIVE_FLAGS = FILE_TYPES.map((type) => `${type}FilesActive`);
 export const AUTO_EXTRACT_FIELDS = [
   'autoExtractFigure',
   'autoExtractTikzFigure',
+  'autoCompileInputPdf',
 ] as const;
 export const TOOL_CONFIG_FIELDS = [
   'attachTeXCount',

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -183,6 +183,7 @@ export class WebviewMessageHandler {
         attachTeXCount: message.attachTeXCount,
         usePrefillFromInput: message.usePrefillFromInput,
         printInputPrompt: message.printInputPrompt,
+        autoCompileInputPdf: message.autoCompileInputPdf,
       };
 
       const agentConfig: AgentConfig = {

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -264,6 +264,12 @@
                       ></i
                       >TikZ Figures</label
                     >
+                    <label class="vscode-checkbox"
+                      ><input type="checkbox" id="autoCompileInputPdf" /><i
+                        class="codicon codicon-file-pdf"
+                      ></i
+                      >Compile Input PDF</label
+                    >
                   </div>
                 </div>
               </div>

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -24,6 +24,7 @@ export const MULTIPLE_SELECTIONS = FILE_TYPES.map((type) => `${type}Files`);
 export const CHECK_BOXES_AUTO_EXTRACT = [
   'autoExtractFigure',
   'autoExtractTikzFigure',
+  'autoCompileInputPdf',
 ];
 
 // Tool configuration checkboxes

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -94,6 +94,9 @@ function handleStateRestoration(state) {
     printInputPrompt:
       state.printInputPrompt ||
       (toolConfig ? toolConfig.printInputPrompt : false),
+    autoCompileInputPdf:
+      state.autoCompileInputPdf ||
+      (toolConfig ? toolConfig.autoCompileInputPdf : false),
   };
 
   // Process multiple file selections


### PR DESCRIPTION
## Summary
- compile LaTeX input and output files to PDF in `build/`
- attach compiled PDFs to media list for subsequent rounds
- move `Compile Input PDF` setting next to figure extraction
- support custom output directory for `compileLatex2Pdf`

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(failed: vscode-test requires network)*