### PR TITLE
Centralize interface definitions

### DIFF
--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -10,6 +10,7 @@ import * as logger from '../logger/logUtils';
 // Local imports - utilities
 import { readFile, writeFile, fileExists } from '../utils/workspaceFileUtils';
 import { executeCommand } from '../utils/execUtils';
+import { ExecResult } from '../types/ResultTypes';
 import { getConfig } from '../utils/configUtils';
 
 // Local imports - latex utils
@@ -126,20 +127,12 @@ function buildLatexdiffVcCommand(
   return baseCommand;
 }
 
-// Type for command execution result
-interface CommandResult {
-  success: boolean;
-  stdout?: string | null;
-  stderr?: string | null;
-  timedOut?: boolean;
-}
-
 // Helper function to execute command with fallback
 async function executeWithFallback(
   commandBuilder: (useFlatten: boolean) => string[],
   commandType: string,
   channel: string,
-): Promise<CommandResult> {
+): Promise<ExecResult> {
   // First attempt with --flatten
   logger.debug(channel, `Attempting ${commandType} with --flatten flag`);
   let result = await executeCommand(commandBuilder(true), {

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -11,6 +11,7 @@ import {
   getColorForLevel,
   isAgentStream,
 } from '../utils/loggerUtils';
+import { LogGroup } from '../types/LogTypes';
 
 const { combine, timestamp } = winston.format;
 
@@ -30,14 +31,6 @@ const emojis = {
 };
 
 // Group State
-interface LogGroup {
-  id: string;
-  name: string;
-  startTime: string;
-  endTime?: string;
-  status: 'running' | 'error' | 'stopped' | 'ready';
-  parentGroupId?: string; // Optional parent group for nested groups
-}
 
 // Helper function to escape HTML tags
 function escapeHtml(text: string): string {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -13,6 +13,7 @@ import {
   shouldPersistStream,
 } from '../utils/loggerUtils';
 import { TokenUsageStats } from '../types/UsageTypes';
+import { LogGroup } from '../types/LogTypes';
 // @ts-ignore - Import JavaScript module
 import { STATUS, COMMANDS } from './modules/constants.js';
 
@@ -32,16 +33,6 @@ interface ColoredLogMessage {
   level: 'error' | 'warn' | 'info' | 'debug';
   timestamp: number;
   groupId?: string;
-}
-
-interface LogGroup {
-  id: string;
-  name: string;
-  startTime: string;
-  endTime?: string;
-  status: StatusType;
-  parentGroupId?: string;
-  usage?: TokenUsageStats;
 }
 
 // Channels that should not be persisted in workspace storage

--- a/src/types/LogTypes.ts
+++ b/src/types/LogTypes.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared logging interfaces used by the logger and progress view.
+ */
+
+import type { TokenUsageStats } from './UsageTypes';
+
+export interface LogGroup {
+  /** Unique identifier for the group */
+  id: string;
+  /** Display name of the group */
+  name: string;
+  /** ISO timestamp when the group started */
+  startTime: string;
+  /** ISO timestamp when the group ended */
+  endTime?: string;
+  /** Current status of the group */
+  status: 'running' | 'error' | 'stopped' | 'ready';
+  /** Parent group ID for nested groups */
+  parentGroupId?: string;
+  /** Optional usage stats attached to the group */
+  usage?: TokenUsageStats;
+}

--- a/src/types/ResultTypes.ts
+++ b/src/types/ResultTypes.ts
@@ -1,0 +1,14 @@
+/**
+ * Common result interfaces used across utilities.
+ */
+
+export interface ExecResult {
+  /** Indicates whether the command succeeded */
+  success: boolean;
+  /** Standard output from the command, if available */
+  stdout: string | null;
+  /** Standard error from the command, if available */
+  stderr: string | null;
+  /** True if the command timed out */
+  timedOut?: boolean;
+}

--- a/src/utils/execUtils.ts
+++ b/src/utils/execUtils.ts
@@ -7,6 +7,7 @@ import * as logger from '../logger/logUtils';
 
 // Local imports - utilities
 import { getWorkspacePath } from './workspaceFileUtils';
+import { ExecResult } from '../types/ResultTypes';
 
 const execAsync = promisify(cp.exec);
 
@@ -26,13 +27,6 @@ function truncateOutput(
     return '...' + text.slice(-maxChars);
   }
   return text;
-}
-
-interface ExecResult {
-  success: boolean;
-  stdout: string | null;
-  stderr: string | null;
-  timedOut?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `ExecResult` and `LogGroup` shared interfaces
- refactor modules to import the shared interfaces

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: 9 warnings)*