### PR TITLE
fix: use single OutputHandler subgroup for progress view logging

### DIFF
--- a/src/agent/CoTAgent.ts
+++ b/src/agent/CoTAgent.ts
@@ -50,7 +50,7 @@ export class CoTAgent extends BaseReflectionAgent {
       // Start a main output processing group if none provided
       if (!processGroupId) {
         outputProcessGroupId = await this.logger.startGroup(
-          `OutputProcessing-Round${currRound}`,
+          `OutputHandler`,
           undefined,
           this.logger.getActiveGroupId(),
         );

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -351,7 +351,7 @@ export class OutputHandler {
     currRound: number,
     groupId?: string,
   ): Promise<void> {
-    const diffProcessGroupId = groupId;
+    const diffProcessGroupId = groupId ?? this.logger.getActiveGroupId();
 
     try {
       // Check if latexdiff is installed before proceeding
@@ -773,7 +773,7 @@ export class OutputHandler {
     stateGlobal: AgentStateGlobal,
     groupId?: string,
   ): Promise<void> {
-    const statsGroupId = groupId;
+    const statsGroupId = groupId ?? this.logger.getActiveGroupId();
 
     try {
       this.logger.info('=== Task Statistics ===', statsGroupId);


### PR DESCRIPTION
Fixes the OutputHandler subgroup implementation based on feedback from PR #225.

## Changes:
- Change CoTAgent to create single "OutputHandler" group instead of round-specific groups
- Add fallback handling for undefined groupId in OutputHandler methods
- Consolidates all output processing logs under one subgroup as requested

## Testing:
- Verified structure change from `OutputProcessing-Round${currRound}` to `OutputHandler`
- Added proper undefined groupId fallbacks addressing review comments

Generated with [Claude Code](https://claude.ai/code)