### PR TITLE
Introduce watchConfig helper

### DIFF
--- a/src/ViewProvider.ts
+++ b/src/ViewProvider.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { WebviewMessageHandler } from './webview/MessageHandler';
 import { WebviewContentProvider } from './webview/WebviewContentProvider';
 import { anyApiKeyExists } from './utils/secretUtils';
+import { watchConfig } from './utils/configUtils';
 
 export class TeXRAViewProvider implements vscode.WebviewViewProvider {
   private messageHandler: WebviewMessageHandler;
@@ -76,16 +77,10 @@ export class TeXRAViewProvider implements vscode.WebviewViewProvider {
 
   private setupConfigurationWatcher() {
     // Watch for configuration changes
-    this.context.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration((e) => {
-        if (
-          e.affectsConfiguration('texra.agents') ||
-          e.affectsConfiguration('texra.models') ||
-          e.affectsConfiguration('texra.files')
-        ) {
-          this.refreshOptionsAndView();
-        }
-      }),
+    watchConfig(
+      this.context,
+      ['texra.agents', 'texra.models', 'texra.files'],
+      () => this.refreshOptionsAndView(),
     );
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import * as logger from './logger/logUtils';
 import { initializeSecrets } from './utils/secretUtils';
 import { copyDefaultAgents, configureLatexSettings } from './utils/setupUtils';
+import { watchConfig } from './utils/configUtils';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -57,16 +58,15 @@ export async function activate(context: vscode.ExtensionContext) {
       'texra.folderExplorer',
       folderExplorer,
     ),
-    // Add watcher for configuration changes
-    vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration('texra.explorer.agentsDirectory')) {
-        folderExplorer.setupFileSystemWatcher();
-        folderExplorer.refresh();
-      }
-    }),
     // Add disposable for cleanup
     { dispose: () => folderExplorer.dispose() },
   );
+
+  // Watch for agents directory changes
+  watchConfig(context, 'texra.explorer.agentsDirectory', () => {
+    folderExplorer.setupFileSystemWatcher();
+    folderExplorer.refresh();
+  });
 }
 
 export function deactivate() {

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 import * as vscode from 'vscode';
 
 export function getConfig<T>(path: string, defaultValue?: T): T {
@@ -20,4 +21,29 @@ export function getConfig<T>(path: string, defaultValue?: T): T {
 
   // Return default value if still undefined
   return result !== undefined ? result : (defaultValue as T);
+}
+
+/**
+ * Register a listener for configuration changes on the given keys.
+ *
+ * @param context Extension context used to dispose the listener
+ * @param keys Configuration keys to watch
+ * @param callback Callback executed when any watched key changes
+ * @returns Disposable for the registered listener
+ */
+export function watchConfig(
+  context: vscode.ExtensionContext,
+  keys: string | string[],
+  callback: () => void,
+): vscode.Disposable {
+  const keyArray = Array.isArray(keys) ? keys : [keys];
+
+  const disposable = vscode.workspace.onDidChangeConfiguration((e) => {
+    if (keyArray.some((key) => e.affectsConfiguration(key))) {
+      callback();
+    }
+  });
+
+  context.subscriptions.push(disposable);
+  return disposable;
 }


### PR DESCRIPTION
## Summary
- add a watchConfig helper to centralize config watchers
- update extension.ts and ViewProvider.ts to use the helper

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*