### PR TITLE
Auto-refresh diff view

### DIFF
--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -10,10 +10,10 @@ import * as logger from '../logger/logUtils';
 
 // Local imports - utilities
 import {
-  getWorkspacePath,
   getFullPathFromWorkspace,
   fileExists,
 } from '../utils/workspaceFileUtils';
+import { registerDiffRefresh } from '../utils/diffViewUtils';
 
 const CHANNEL = 'CompareCommands';
 logger.initialize(CHANNEL);
@@ -108,6 +108,7 @@ async function handleCompare(
           `Error handling word wrap: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
+      registerDiffRefresh(editedUri, baseUri, title);
     }, 300);
 
     logger.info(

--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -14,11 +14,7 @@ import {
   fileExists,
 } from '../utils/workspaceFileUtils';
 import { registerDiffRefresh } from '../utils/diffViewUtils';
-import { 
-  DIFF_EDITOR_DELAY_MS, 
-  WORD_WRAP_INIT_DELAY_MS, 
-  DIFF_REGISTRATION_DELAY_MS 
-} from '../utils/constants';
+import { DIFF_REGISTRATION_DELAY_MS } from '../utils/constants';
 
 const CHANNEL = 'CompareCommands';
 logger.initialize(CHANNEL);
@@ -82,27 +78,8 @@ async function handleCompare(
     );
 
     // Wait a short time for the diff editor to fully open, then register listeners
-    setTimeout(async () => {
-      // Register diff refresh listeners which now include word wrap protection
+    setTimeout(() => {
       registerDiffRefresh(editedUri, baseUri, title);
-      
-      // Ensure word wrap is enabled after diff editor is ready
-      setTimeout(async () => {
-        try {
-          // Force word wrap to be enabled for diff editors
-          await vscode.commands.executeCommand('editor.action.toggleWordWrap');
-          // Small delay, then toggle again to ensure it's on (toggle off then on)
-          setTimeout(async () => {
-            await vscode.commands.executeCommand('editor.action.toggleWordWrap');
-            logger.debug(CHANNEL, 'Initialized word wrap for diff editor');
-          }, DIFF_EDITOR_DELAY_MS);
-        } catch (err) {
-          logger.error(
-            CHANNEL,
-            `Error initializing word wrap: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-      }, WORD_WRAP_INIT_DELAY_MS);
     }, DIFF_REGISTRATION_DELAY_MS);
 
     logger.info(

--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -76,42 +76,28 @@ async function handleCompare(
       title,
     );
 
-    // Wait a short time for the diff editor to fully open, then check word wrap setting
+    // Wait a short time for the diff editor to fully open, then register listeners
     setTimeout(async () => {
-      // try {
-      // TODO: this codepath is not working as expected
-      // TODO: this config does not seem to fetcht the correct word wrap status?
-      //   // Get current editor
-      //   const editor = vscode.window.activeTextEditor;
-      //   if (editor) {
-      //     // Check if word wrap is enabled through configuration for this editor
-      //     const editorConfig = vscode.workspace.getConfiguration(
-      //       'editor',
-      //       editor.document.uri,
-      //     );
-      //     const isWordWrapEnabled = editorConfig.get('wordWrap') === 'on';
-
-      //     // Only toggle if word wrap is not already on
-      //     if (!isWordWrapEnabled) {
-      //       await vscode.commands.executeCommand(
-      //         'editor.action.toggleWordWrap',
-      //       );
-      //       logger.debug(CHANNEL, 'Toggled word wrap on for diff editor');
-      //     } else {
-      //       logger.debug(
-      //         CHANNEL,
-      //         'Word wrap already enabled, no change needed',
-      //       );
-      //     }
-      //   }
-      // } catch (err) {
-      //   logger.error(
-      //     CHANNEL,
-      //     `Error handling word wrap: ${err instanceof Error ? err.message : String(err)}`,
-      //   );
-      // }
-      // the 
+      // Register diff refresh listeners which now include word wrap protection
       registerDiffRefresh(editedUri, baseUri, title);
+      
+      // Ensure word wrap is enabled after diff editor is ready
+      setTimeout(async () => {
+        try {
+          // Force word wrap to be enabled for diff editors
+          await vscode.commands.executeCommand('editor.action.toggleWordWrap');
+          // Small delay, then toggle again to ensure it's on (toggle off then on)
+          setTimeout(async () => {
+            await vscode.commands.executeCommand('editor.action.toggleWordWrap');
+            logger.debug(CHANNEL, 'Initialized word wrap for diff editor');
+          }, 100);
+        } catch (err) {
+          logger.error(
+            CHANNEL,
+            `Error initializing word wrap: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }, 200);
     }, 300);
 
     logger.info(

--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -78,36 +78,39 @@ async function handleCompare(
 
     // Wait a short time for the diff editor to fully open, then check word wrap setting
     setTimeout(async () => {
-      try {
-        // Get current editor
-        const editor = vscode.window.activeTextEditor;
-        if (editor) {
-          // Check if word wrap is enabled through configuration for this editor
-          const editorConfig = vscode.workspace.getConfiguration(
-            'editor',
-            editor.document.uri,
-          );
-          const isWordWrapEnabled = editorConfig.get('wordWrap') === 'on';
+      // try {
+      // TODO: this codepath is not working as expected
+      // TODO: this config does not seem to fetcht the correct word wrap status?
+      //   // Get current editor
+      //   const editor = vscode.window.activeTextEditor;
+      //   if (editor) {
+      //     // Check if word wrap is enabled through configuration for this editor
+      //     const editorConfig = vscode.workspace.getConfiguration(
+      //       'editor',
+      //       editor.document.uri,
+      //     );
+      //     const isWordWrapEnabled = editorConfig.get('wordWrap') === 'on';
 
-          // Only toggle if word wrap is not already on
-          if (!isWordWrapEnabled) {
-            await vscode.commands.executeCommand(
-              'editor.action.toggleWordWrap',
-            );
-            logger.debug(CHANNEL, 'Toggled word wrap on for diff editor');
-          } else {
-            logger.debug(
-              CHANNEL,
-              'Word wrap already enabled, no change needed',
-            );
-          }
-        }
-      } catch (err) {
-        logger.error(
-          CHANNEL,
-          `Error handling word wrap: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      //     // Only toggle if word wrap is not already on
+      //     if (!isWordWrapEnabled) {
+      //       await vscode.commands.executeCommand(
+      //         'editor.action.toggleWordWrap',
+      //       );
+      //       logger.debug(CHANNEL, 'Toggled word wrap on for diff editor');
+      //     } else {
+      //       logger.debug(
+      //         CHANNEL,
+      //         'Word wrap already enabled, no change needed',
+      //       );
+      //     }
+      //   }
+      // } catch (err) {
+      //   logger.error(
+      //     CHANNEL,
+      //     `Error handling word wrap: ${err instanceof Error ? err.message : String(err)}`,
+      //   );
+      // }
+      // the 
       registerDiffRefresh(editedUri, baseUri, title);
     }, 300);
 

--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -14,6 +14,11 @@ import {
   fileExists,
 } from '../utils/workspaceFileUtils';
 import { registerDiffRefresh } from '../utils/diffViewUtils';
+import { 
+  DIFF_EDITOR_DELAY_MS, 
+  WORD_WRAP_INIT_DELAY_MS, 
+  DIFF_REGISTRATION_DELAY_MS 
+} from '../utils/constants';
 
 const CHANNEL = 'CompareCommands';
 logger.initialize(CHANNEL);
@@ -90,15 +95,15 @@ async function handleCompare(
           setTimeout(async () => {
             await vscode.commands.executeCommand('editor.action.toggleWordWrap');
             logger.debug(CHANNEL, 'Initialized word wrap for diff editor');
-          }, 100);
+          }, DIFF_EDITOR_DELAY_MS);
         } catch (err) {
           logger.error(
             CHANNEL,
             `Error initializing word wrap: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
-      }, 200);
-    }, 300);
+      }, WORD_WRAP_INIT_DELAY_MS);
+    }, DIFF_REGISTRATION_DELAY_MS);
 
     logger.info(
       CHANNEL,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import * as logger from './logger/logUtils';
 import { initializeSecrets } from './utils/secretUtils';
 import { copyDefaultAgents, configureLatexSettings } from './utils/setupUtils';
 import { watchConfig } from './utils/configUtils';
+import { disposeDiffRefresh } from './utils/diffViewUtils';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -76,4 +77,5 @@ export function deactivate() {
     // Mark all running tasks as cancelled when extension deactivates
     progressViewProvider.markAllRunningTasksAsCancelled();
   }
+  disposeDiffRefresh();
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -37,3 +37,6 @@ export const MAX_PREVIEW_LENGTH = 1000;
 // Time constants
 export const SHORT_SLEEP_MS = 50;
 export const REFRESH_THRESHOLD_MS = 200;
+export const DIFF_EDITOR_DELAY_MS = 100;
+export const WORD_WRAP_INIT_DELAY_MS = 200;
+export const DIFF_REGISTRATION_DELAY_MS = 300;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -36,3 +36,4 @@ export const MAX_PREVIEW_LENGTH = 1000;
 
 // Time constants
 export const SHORT_SLEEP_MS = 50;
+export const REFRESH_THRESHOLD_MS = 200;

--- a/src/utils/diffViewUtils.ts
+++ b/src/utils/diffViewUtils.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
-import { REFRESH_THRESHOLD_MS, DIFF_EDITOR_DELAY_MS } from './constants';
+import { REFRESH_THRESHOLD_MS } from './constants';
 
 const CHANNEL = 'DiffRefresh';
 logger.initialize(CHANNEL);
@@ -46,55 +46,7 @@ function onVisibleRangeChange(e: vscode.TextEditorVisibleRangesChangeEvent) {
 // command doesn't update the configuration that can be read via Configuration API
 
 function onViewColumnChange() {
-  // When view columns change (e.g., switching from split to inline or vice versa),
-  // VS Code may reset word wrap. Apply a small delay then ensure word wrap is enabled.
-  setTimeout(() => {
-    ensureWordWrapEnabled();
-  }, DIFF_EDITOR_DELAY_MS);
-}
-
-function ensureWordWrapEnabled() {
-  const activeEditor = vscode.window.activeTextEditor;
-  if (!activeEditor || !diffInfo) {
-    return;
-  }
-
-  // Check if the active editor is showing one of our diff files
-  const activeUri = activeEditor.document.uri.toString();
-  const leftUri = diffInfo.left.toString();
-  const rightUri = diffInfo.right.toString();
-  
-  if (activeUri === leftUri || activeUri === rightUri) {
-    // Use command-only approach since config API doesn't detect toggleWordWrap changes
-    fallbackWordWrapToggle();
-  }
-}
-
-function fallbackWordWrapToggle() {
-  // This approach uses a smart toggle: turn off then on to ensure consistent state
-  vscode.commands.executeCommand('editor.action.toggleWordWrap').then(() => {
-    setTimeout(() => {
-      vscode.commands.executeCommand('editor.action.toggleWordWrap').then(() => {
-        logger.debug(CHANNEL, 'Applied word wrap toggle for diff editor');
-      });
-    }, DIFF_EDITOR_DELAY_MS);
-  });
-}
-
-function onVisibleEditorsChange() {
-  const info = diffInfo;
-  if (!info) {
-    return;
-  }
-  const left = info.left.toString();
-  const right = info.right.toString();
-  const open = vscode.window.visibleTextEditors.some((editor) => {
-    const uri = editor.document.uri.toString();
-    return uri === left || uri === right;
-  });
-  if (!open) {
-    disposeDiffRefresh();
-  }
+  refreshDiff();
 }
 
 export function registerDiffRefresh(
@@ -108,14 +60,9 @@ export function registerDiffRefresh(
 
   disposables.push(
     vscode.window.onDidChangeTextEditorVisibleRanges(onVisibleRangeChange),
-    vscode.window.onDidChangeVisibleTextEditors(onVisibleEditorsChange),
-    vscode.window.onDidChangeActiveTextEditor(() => {
-      // When active editor changes (including view mode switches), ensure word wrap
-      setTimeout(ensureWordWrapEnabled, DIFF_EDITOR_DELAY_MS);
-    }),
     vscode.window.onDidChangeTextEditorViewColumn(onViewColumnChange),
   );
-  logger.debug(CHANNEL, 'Registered diff refresh listeners with word wrap protection');
+  logger.debug(CHANNEL, 'Registered diff refresh listeners');
 }
 
 export function disposeDiffRefresh() {

--- a/src/utils/diffViewUtils.ts
+++ b/src/utils/diffViewUtils.ts
@@ -48,6 +48,62 @@ function onConfigChange(e: vscode.ConfigurationChangeEvent) {
   }
 }
 
+function onViewColumnChange() {
+  // When view columns change (e.g., switching from split to inline or vice versa),
+  // VS Code may reset word wrap. Apply a small delay then ensure word wrap is enabled.
+  setTimeout(() => {
+    ensureWordWrapEnabled();
+  }, 100);
+}
+
+function ensureWordWrapEnabled() {
+  const activeEditor = vscode.window.activeTextEditor;
+  if (!activeEditor || !diffInfo) {
+    return;
+  }
+
+  // Check if the active editor is showing one of our diff files
+  const activeUri = activeEditor.document.uri.toString();
+  const leftUri = diffInfo.left.toString();
+  const rightUri = diffInfo.right.toString();
+  
+  if (activeUri === leftUri || activeUri === rightUri) {
+    // Try to enable word wrap through configuration first
+    try {
+      const config = vscode.workspace.getConfiguration('editor', activeEditor.document.uri);
+      const currentWordWrap = config.get('wordWrap');
+      
+      if (currentWordWrap !== 'on') {
+        // Try to update the configuration
+        config.update('wordWrap', 'on', vscode.ConfigurationTarget.WorkspaceFolder).then(() => {
+          logger.debug(CHANNEL, 'Updated word wrap configuration for diff editor');
+        }).catch(() => {
+          // If configuration update fails, fall back to command
+          fallbackWordWrapToggle();
+        });
+      } else {
+        // Configuration says it's on, but might not be applied in diff editor
+        // Force a refresh by toggling twice with proper timing
+        fallbackWordWrapToggle();
+      }
+    } catch (error) {
+      // Configuration approach failed, use command approach
+      fallbackWordWrapToggle();
+    }
+  }
+}
+
+function fallbackWordWrapToggle() {
+  // This approach uses a smart toggle: turn off then on to ensure consistent state
+  vscode.commands.executeCommand('editor.action.toggleWordWrap').then(() => {
+    setTimeout(() => {
+      vscode.commands.executeCommand('editor.action.toggleWordWrap').then(() => {
+        logger.debug(CHANNEL, 'Applied word wrap toggle fallback for diff editor');
+      });
+    }, 100);
+  });
+}
+
 function onVisibleEditorsChange() {
   const info = diffInfo;
   if (!info) {
@@ -77,8 +133,13 @@ export function registerDiffRefresh(
     vscode.window.onDidChangeTextEditorVisibleRanges(onVisibleRangeChange),
     vscode.workspace.onDidChangeConfiguration(onConfigChange),
     vscode.window.onDidChangeVisibleTextEditors(onVisibleEditorsChange),
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      // When active editor changes (including view mode switches), ensure word wrap
+      setTimeout(ensureWordWrapEnabled, 100);
+    }),
+    vscode.window.onDidChangeTextEditorViewColumn(onViewColumnChange),
   );
-  logger.debug(CHANNEL, 'Registered diff refresh listeners');
+  logger.debug(CHANNEL, 'Registered diff refresh listeners with word wrap protection');
 }
 
 export function disposeDiffRefresh() {

--- a/src/utils/diffViewUtils.ts
+++ b/src/utils/diffViewUtils.ts
@@ -1,0 +1,88 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - log
+import * as logger from '../logger/logUtils';
+
+const CHANNEL = 'DiffRefresh';
+logger.initialize(CHANNEL);
+
+let disposables: vscode.Disposable[] = [];
+let diffInfo:
+  | { left: vscode.Uri; right: vscode.Uri; title: string }
+  | undefined;
+let lastRefresh = 0;
+
+function refreshDiff() {
+  if (!diffInfo) {
+    return;
+  }
+  const now = Date.now();
+  if (now - lastRefresh < 200) {
+    return;
+  }
+  lastRefresh = now;
+  vscode.commands.executeCommand(
+    'vscode.diff',
+    diffInfo.left,
+    diffInfo.right,
+    diffInfo.title,
+  );
+  logger.debug(CHANNEL, 'Refreshed diff view');
+}
+
+function onVisibleRangeChange(e: vscode.TextEditorVisibleRangesChangeEvent) {
+  if (!diffInfo) {
+    return;
+  }
+  if (!vscode.window.visibleTextEditors.includes(e.textEditor)) {
+    return;
+  }
+  refreshDiff();
+}
+
+function onConfigChange(e: vscode.ConfigurationChangeEvent) {
+  if (e.affectsConfiguration('editor.wordWrap')) {
+    refreshDiff();
+  }
+}
+
+function onVisibleEditorsChange() {
+  const info = diffInfo;
+  if (!info) {
+    return;
+  }
+  const left = info.left.toString();
+  const right = info.right.toString();
+  const open = vscode.window.visibleTextEditors.some((editor) => {
+    const uri = editor.document.uri.toString();
+    return uri === left || uri === right;
+  });
+  if (!open) {
+    disposeDiffRefresh();
+  }
+}
+
+export function registerDiffRefresh(
+  left: vscode.Uri,
+  right: vscode.Uri,
+  title: string,
+) {
+  diffInfo = { left, right, title };
+  disposables.forEach((d) => d.dispose());
+  disposables = [];
+
+  disposables.push(
+    vscode.window.onDidChangeTextEditorVisibleRanges(onVisibleRangeChange),
+    vscode.workspace.onDidChangeConfiguration(onConfigChange),
+    vscode.window.onDidChangeVisibleTextEditors(onVisibleEditorsChange),
+  );
+  logger.debug(CHANNEL, 'Registered diff refresh listeners');
+}
+
+export function disposeDiffRefresh() {
+  disposables.forEach((d) => d.dispose());
+  disposables = [];
+  diffInfo = undefined;
+  logger.debug(CHANNEL, 'Disposed diff refresh listeners');
+}

--- a/src/utils/diffViewUtils.ts
+++ b/src/utils/diffViewUtils.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
-import { REFRESH_THRESHOLD_MS } from './constants';
+import { REFRESH_THRESHOLD_MS, DIFF_EDITOR_DELAY_MS } from './constants';
 
 const CHANNEL = 'DiffRefresh';
 logger.initialize(CHANNEL);
@@ -42,18 +42,15 @@ function onVisibleRangeChange(e: vscode.TextEditorVisibleRangesChangeEvent) {
   refreshDiff();
 }
 
-function onConfigChange(e: vscode.ConfigurationChangeEvent) {
-  if (e.affectsConfiguration('editor.wordWrap')) {
-    refreshDiff();
-  }
-}
+// Note: Configuration change listener removed as editor.action.toggleWordWrap
+// command doesn't update the configuration that can be read via Configuration API
 
 function onViewColumnChange() {
   // When view columns change (e.g., switching from split to inline or vice versa),
   // VS Code may reset word wrap. Apply a small delay then ensure word wrap is enabled.
   setTimeout(() => {
     ensureWordWrapEnabled();
-  }, 100);
+  }, DIFF_EDITOR_DELAY_MS);
 }
 
 function ensureWordWrapEnabled() {
@@ -68,28 +65,8 @@ function ensureWordWrapEnabled() {
   const rightUri = diffInfo.right.toString();
   
   if (activeUri === leftUri || activeUri === rightUri) {
-    // Try to enable word wrap through configuration first
-    try {
-      const config = vscode.workspace.getConfiguration('editor', activeEditor.document.uri);
-      const currentWordWrap = config.get('wordWrap');
-      
-      if (currentWordWrap !== 'on') {
-        // Try to update the configuration
-        config.update('wordWrap', 'on', vscode.ConfigurationTarget.WorkspaceFolder).then(() => {
-          logger.debug(CHANNEL, 'Updated word wrap configuration for diff editor');
-        }).catch(() => {
-          // If configuration update fails, fall back to command
-          fallbackWordWrapToggle();
-        });
-      } else {
-        // Configuration says it's on, but might not be applied in diff editor
-        // Force a refresh by toggling twice with proper timing
-        fallbackWordWrapToggle();
-      }
-    } catch (error) {
-      // Configuration approach failed, use command approach
-      fallbackWordWrapToggle();
-    }
+    // Use command-only approach since config API doesn't detect toggleWordWrap changes
+    fallbackWordWrapToggle();
   }
 }
 
@@ -98,9 +75,9 @@ function fallbackWordWrapToggle() {
   vscode.commands.executeCommand('editor.action.toggleWordWrap').then(() => {
     setTimeout(() => {
       vscode.commands.executeCommand('editor.action.toggleWordWrap').then(() => {
-        logger.debug(CHANNEL, 'Applied word wrap toggle fallback for diff editor');
+        logger.debug(CHANNEL, 'Applied word wrap toggle for diff editor');
       });
-    }, 100);
+    }, DIFF_EDITOR_DELAY_MS);
   });
 }
 
@@ -131,11 +108,10 @@ export function registerDiffRefresh(
 
   disposables.push(
     vscode.window.onDidChangeTextEditorVisibleRanges(onVisibleRangeChange),
-    vscode.workspace.onDidChangeConfiguration(onConfigChange),
     vscode.window.onDidChangeVisibleTextEditors(onVisibleEditorsChange),
     vscode.window.onDidChangeActiveTextEditor(() => {
       // When active editor changes (including view mode switches), ensure word wrap
-      setTimeout(ensureWordWrapEnabled, 100);
+      setTimeout(ensureWordWrapEnabled, DIFF_EDITOR_DELAY_MS);
     }),
     vscode.window.onDidChangeTextEditorViewColumn(onViewColumnChange),
   );

--- a/src/utils/diffViewUtils.ts
+++ b/src/utils/diffViewUtils.ts
@@ -32,16 +32,6 @@ function refreshDiff() {
   logger.debug(CHANNEL, 'Refreshed diff view');
 }
 
-function onVisibleRangeChange(e: vscode.TextEditorVisibleRangesChangeEvent) {
-  if (!diffInfo) {
-    return;
-  }
-  if (!vscode.window.visibleTextEditors.includes(e.textEditor)) {
-    return;
-  }
-  refreshDiff();
-}
-
 // Note: Configuration change listener removed as editor.action.toggleWordWrap
 // command doesn't update the configuration that can be read via Configuration API
 
@@ -59,7 +49,6 @@ export function registerDiffRefresh(
   disposables = [];
 
   disposables.push(
-    vscode.window.onDidChangeTextEditorVisibleRanges(onVisibleRangeChange),
     vscode.window.onDidChangeTextEditorViewColumn(onViewColumnChange),
   );
   logger.debug(CHANNEL, 'Registered diff refresh listeners');

--- a/src/utils/diffViewUtils.ts
+++ b/src/utils/diffViewUtils.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
+import { REFRESH_THRESHOLD_MS } from './constants';
 
 const CHANNEL = 'DiffRefresh';
 logger.initialize(CHANNEL);
@@ -18,7 +19,7 @@ function refreshDiff() {
     return;
   }
   const now = Date.now();
-  if (now - lastRefresh < 200) {
+  if (now - lastRefresh < REFRESH_THRESHOLD_MS) {
     return;
   }
   lastRefresh = now;


### PR DESCRIPTION
## Summary
- refresh diff editors after window size or word wrap changes
- wire refresh listener into compare command
- dispose refresh listeners once diff closes

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683db54020bc8324affa5dcb1c72658b