### PR TITLE
Centralize extension configuration

### DIFF
--- a/src/commands/fileSelectionCommands.ts
+++ b/src/commands/fileSelectionCommands.ts
@@ -11,7 +11,7 @@ import {
 } from '../frontend-utils/commonUtils';
 import { getRelativePath } from '../utils/workspaceFileUtils';
 import { listInputFiles } from '../frontend-utils/fileListingUtils';
-import { getConfig } from '../utils/configUtils';
+import { getIncludedExtensions } from '../utils/fileTypeUtils';
 import { selectFile, selectFiles } from '../utils/fileDialogUtils';
 const CHANNEL = 'fileSelectionCommands';
 logger.initialize(CHANNEL);
@@ -54,8 +54,8 @@ async function selectInputFile(
     currentFile: currentInputFile,
     openLabel: 'Select File',
     filters: {
-      'Text files': getConfig<string[]>('files.included.inputExtensions').map(
-        (ext) => ext.replace('.', ''),
+      'Text files': getIncludedExtensions('input').map((ext) =>
+        ext.replace('.', ''),
       ),
     },
   });
@@ -68,10 +68,11 @@ async function selectInputFile(
 async function selectInputFiles(
   currentInputFile: string,
 ): Promise<string[] | null> {
-  const includedInputExtensions = getConfig<string[]>(
-    'files.included.inputExtensions',
-    ['.txt', '.tex', '.md'],
-  );
+  const includedInputExtensions = getIncludedExtensions('input', [
+    '.txt',
+    '.tex',
+    '.md',
+  ]);
 
   try {
     const relativePaths = await selectFiles({
@@ -104,9 +105,7 @@ async function selectInputFiles(
 async function selectReferenceFiles(
   currentReferenceFile: string,
 ): Promise<string[] | null> {
-  const includedReferenceExtensions = getConfig<string[]>(
-    'files.included.referenceExtensions',
-  );
+  const includedReferenceExtensions = getIncludedExtensions('reference');
   const relativePaths = await selectFiles({
     currentFile: currentReferenceFile,
     allowMany: true,
@@ -132,9 +131,7 @@ async function selectReferenceFiles(
 async function selectAuxiliaryFiles(
   currentAuxiliaryFile: string,
 ): Promise<string[] | null> {
-  const includedAuxiliaryExtensions = getConfig<string[]>(
-    'files.included.auxiliaryExtensions',
-  );
+  const includedAuxiliaryExtensions = getIncludedExtensions('auxiliary');
   const relativePaths = await selectFiles({
     currentFile: currentAuxiliaryFile,
     allowMany: true,
@@ -156,14 +153,8 @@ async function selectAuxiliaryFiles(
 async function selectMediaFiles(
   currentMediaFile: string,
 ): Promise<string[] | null> {
-  const includedFigureExtensions = getConfig<string[]>(
-    'files.included.mediaExtensions',
-    [],
-  );
-  const includedAudioExtensions = getConfig<string[]>(
-    'files.included.audioExtensions',
-    [],
-  );
+  const includedFigureExtensions = getIncludedExtensions('media');
+  const includedAudioExtensions = getIncludedExtensions('audio');
   const relativePaths = await selectFiles({
     currentFile: currentMediaFile,
     allowMany: true,
@@ -187,13 +178,10 @@ async function selectMediaFile(): Promise<string | null> {
   const result = await selectFile({
     openLabel: 'Select Media File',
     filters: {
-      Images: getConfig<string[]>('files.included.mediaExtensions', []).map(
-        (ext) => ext.replace('.', ''),
+      Images: getIncludedExtensions('media').map((ext) => ext.replace('.', '')),
+      'Audio files': getIncludedExtensions('audio').map((ext) =>
+        ext.replace('.', ''),
       ),
-      'Audio files': getConfig<string[]>(
-        'files.included.audioExtensions',
-        [],
-      ).map((ext) => ext.replace('.', '')),
     },
   });
   if (result) {
@@ -261,8 +249,8 @@ async function selectBaseFile(): Promise<string | null> {
   const result = await selectFile({
     openLabel: 'Select Base File',
     filters: {
-      'Text files': getConfig<string[]>('files.included.inputExtensions').map(
-        (ext) => ext.replace('.', ''),
+      'Text files': getIncludedExtensions('input').map((ext) =>
+        ext.replace('.', ''),
       ),
     },
   });

--- a/src/frontend-utils/fileListingUtils.ts
+++ b/src/frontend-utils/fileListingUtils.ts
@@ -10,6 +10,7 @@ import * as logger from '../logger/logUtils';
 // Local imports - utilities
 import { getConfig } from '../utils/configUtils';
 import { getWorkspacePath } from '../utils/workspaceFileUtils';
+import { getIncludedExtensions } from '../utils/fileTypeUtils';
 
 const CHANNEL = 'FrontendUtils';
 logger.initialize(CHANNEL);
@@ -30,9 +31,7 @@ export async function listInputFiles(): Promise<string[]> {
     return [];
   }
 
-  const INCLUDED_INPUT_EXTENSIONS = getConfig<string[]>(
-    'files.included.inputExtensions',
-  );
+  const INCLUDED_INPUT_EXTENSIONS = getIncludedExtensions('input');
 
   return getFilesRecursively(
     workspacePath,
@@ -57,9 +56,7 @@ export async function listAuxiliaryFiles(): Promise<string[]> {
     'files.ignored.auxiliaryKeywords',
   );
 
-  const INCLUDED_AUXILIARY_EXTENSIONS = getConfig<string[]>(
-    'files.included.auxiliaryExtensions',
-  );
+  const INCLUDED_AUXILIARY_EXTENSIONS = getIncludedExtensions('auxiliary');
 
   return getFilesInDirectory(
     workspacePath,
@@ -80,9 +77,7 @@ export async function listMediaFiles(): Promise<string[]> {
     'files.ignored.mediaDirectories',
   );
 
-  const INCLUDED_FIGURE_EXTENSIONS = getConfig<string[]>(
-    'files.included.mediaExtensions',
-  );
+  const INCLUDED_FIGURE_EXTENSIONS = getIncludedExtensions('media');
 
   return getFilesRecursively(
     workspacePath,
@@ -100,9 +95,7 @@ export async function listEditedFiles(baseFileName: string): Promise<string[]> {
     return [];
   }
 
-  const INCLUDED_EDITED_EXTENSIONS = getConfig<string[]>(
-    'files.included.editedExtensions',
-  );
+  const INCLUDED_EDITED_EXTENSIONS = getIncludedExtensions('edited');
 
   const files = await getFilesRecursively(
     workspacePath,

--- a/src/utils/fileTypeUtils.ts
+++ b/src/utils/fileTypeUtils.ts
@@ -1,0 +1,29 @@
+// Local imports
+import { getConfig } from './configUtils';
+
+export type FileType =
+  | 'input'
+  | 'reference'
+  | 'auxiliary'
+  | 'media'
+  | 'audio'
+  | 'edited';
+
+const INCLUDED_EXTENSION_KEYS: Record<FileType, string> = {
+  input: 'files.included.inputExtensions',
+  reference: 'files.included.referenceExtensions',
+  auxiliary: 'files.included.auxiliaryExtensions',
+  media: 'files.included.mediaExtensions',
+  audio: 'files.included.audioExtensions',
+  edited: 'files.included.editedExtensions',
+};
+
+/**
+ * Retrieve included extensions for the given file type.
+ */
+export function getIncludedExtensions(
+  type: FileType,
+  defaultExtensions: string[] = [],
+): string[] {
+  return getConfig<string[]>(INCLUDED_EXTENSION_KEYS[type], defaultExtensions);
+}


### PR DESCRIPTION
## Summary
- add `fileTypeUtils` helper
- use `getIncludedExtensions` in file listing and selection commands

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6838761968988324850b917516c445b6