### PR TITLE
Refactor webview file selectors and listeners

### DIFF
--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -37,6 +37,9 @@ export class WebviewContentProvider {
       const messageHandlersPath = getWebviewPath('modules/messageHandlers.js');
       const fileHandlersPath = getWebviewPath('modules/fileHandlers.js');
       const uiHandlersPath = getWebviewPath('modules/uiHandlers.js');
+      const fileSelectorTemplatesPath = getWebviewPath(
+        'modules/fileSelectorTemplates.js',
+      );
       const templateUtilsPath = getCommonPath('modules/templateUtils.js');
       const utilsPath = getWebviewPath('modules/utils.js');
       const vscodeApiPath = getCommonPath('modules/vscodeApi.js');
@@ -52,6 +55,9 @@ export class WebviewContentProvider {
       const messageHandlersUri = webview.asWebviewUri(messageHandlersPath);
       const fileHandlersUri = webview.asWebviewUri(fileHandlersPath);
       const uiHandlersUri = webview.asWebviewUri(uiHandlersPath);
+      const fileSelectorTemplatesUri = webview.asWebviewUri(
+        fileSelectorTemplatesPath,
+      );
       const templateUtilsUri = webview.asWebviewUri(templateUtilsPath);
       const utilsUri = webview.asWebviewUri(utilsPath);
       const vscodeApiUri = webview.asWebviewUri(vscodeApiPath);
@@ -91,6 +97,10 @@ export class WebviewContentProvider {
         .replace('${messageHandlersUri}', messageHandlersUri.toString())
         .replace('${fileHandlersUri}', fileHandlersUri.toString())
         .replace('${uiHandlersUri}', uiHandlersUri.toString())
+        .replace(
+          '${fileSelectorTemplatesUri}',
+          fileSelectorTemplatesUri.toString(),
+        )
         .replace('${templateUtilsUri}', templateUtilsUri.toString())
         .replace('${vscodeApiUri}', vscodeApiUri.toString())
         .replace('${codiconUri}', codiconUri.toString())

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -18,6 +18,7 @@
           "./modules/uiHandlers.js": "${uiHandlersUri}",
           "./modules/messageHandlers.js": "${messageHandlersUri}",
           "./modules/utils.js": "${utilsUri}",
+          "./modules/fileSelectorTemplates.js": "${fileSelectorTemplatesUri}",
           "@common/vscodeApi.js": "${vscodeApiUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
@@ -32,289 +33,8 @@
   <body>
     <div class="content-wrapper">
       <div class="main-content">
-        <div class="file-selection-group">
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="inputFile"
-                  ><i
-                    class="codicon codicon-file-code clickable"
-                    title="Input (Click to refresh)"
-                  ></i>
-                  Input</label
-                >
-              </div>
-              <div class="file-select-actions button-group">
-                <button
-                  id="currentInputFileButton"
-                  class="vscode-button"
-                  title="Set current file as input"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
-                <button
-                  id="emptyInputFileButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
-                <span id="toggleInputFiles" class="toggle-icon" title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <button
-                  id="addOpenedInputFilesButton"
-                  class="vscode-button"
-                  title="Add opened files as input"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
-                <button
-                  id="emptyInputFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectInputFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
-            </div>
-            <select id="inputFile">
-              <option value="">None</option>
-            </select>
-            <div
-              id="inputFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="inputFiles" class="multiple-files-list"></div>
-              </div>
-            </div>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <label for="referenceFile"
-                ><i
-                  class="codicon codicon-book clickable"
-                  title="Reference (Click to refresh)"
-                ></i>
-                Reference</label
-              >
-              <div class="file-select-actions button-group">
-                <button
-                  id="currentReferenceFileButton"
-                  class="vscode-button"
-                  title="Set current file as reference"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
-                <button
-                  id="emptyReferenceFileButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
-                <span
-                  id="toggleReferenceFiles"
-                  class="toggle-icon"
-                  title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <button
-                  id="addOpenedReferenceFilesButton"
-                  class="vscode-button"
-                  title="Add opened files as reference"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
-                <button
-                  id="emptyReferenceFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectReferenceFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
-            </div>
-            <select id="referenceFile">
-              <option value="">None</option>
-            </select>
-            <div
-              id="referenceFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="referenceFiles" class="multiple-files-list"></div>
-              </div>
-            </div>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <label for="auxiliaryFile"
-                ><i
-                  class="codicon codicon-file-add clickable"
-                  title="Auxiliary (Click to refresh)"
-                ></i>
-                Auxiliary</label
-              >
-              <div class="file-select-actions button-group">
-                <button
-                  id="currentAuxiliaryFileButton"
-                  class="vscode-button"
-                  title="Set current file as auxiliary"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
-                <button
-                  id="emptyAuxiliaryFileButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
-                <span
-                  id="toggleAuxiliaryFiles"
-                  class="toggle-icon"
-                  title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <button
-                  id="addOpenedAuxiliaryFilesButton"
-                  class="vscode-button"
-                  title="Add opened files as auxiliary"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
-                <button
-                  id="emptyAuxiliaryFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectAuxiliaryFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
-            </div>
-            <select id="auxiliaryFile">
-              <option value="">None</option>
-            </select>
-            <div
-              id="auxiliaryFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="auxiliaryFiles" class="multiple-files-list"></div>
-              </div>
-            </div>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="mediaFile"
-                  ><i
-                    class="codicon codicon-file-media clickable"
-                    title="Media (Click to refresh)"
-                  ></i>
-                  Media</label
-                >
-                <div class="dropdown-container dropdown-left">
-                  <span
-                    id="toggleAutoExtract"
-                    class="auto-toggle"
-                    title="Auto-extract options"
-                  >
-                    <i class="codicon codicon-wand"></i
-                    ><i class="codicon codicon-chevron-down"></i>
-                  </span>
-                  <div
-                    id="autoExtractOptions"
-                    class="dropdown-options"
-                    style="display: none"
-                  >
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="autoExtractFigure" /><i
-                        class="codicon codicon-file-media"
-                      ></i
-                      >Figures</label
-                    >
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="autoExtractTikzFigure" /><i
-                        class="codicon codicon-file-code"
-                      ></i
-                      >TikZ Figures</label
-                    >
-                    <label class="vscode-checkbox"
-                      ><input type="checkbox" id="autoCompileInputPdf" /><i
-                        class="codicon codicon-file-pdf"
-                      ></i
-                      >Compile Input PDF</label
-                    >
-                  </div>
-                </div>
-              </div>
-              <div class="file-select-actions button-group">
-                <button
-                  id="emptyMediaFileButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
-                <span id="toggleMediaFiles" class="toggle-icon" title="Multiple"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <button
-                  id="emptyMediaFilesButton"
-                  class="vscode-button"
-                  title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
-                <button
-                  id="selectMediaFilesButton"
-                  class="vscode-button"
-                  title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
-              </div>
-            </div>
-            <select id="mediaFile">
-              <option value="">None</option>
-            </select>
-            <div
-              id="mediaFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
-            >
-              <div class="multiple-files-content">
-                <div id="mediaFiles" class="multiple-files-list"></div>
-              </div>
-            </div>
-          </div>
+        <div id="fileSelectionGroup" class="file-selection-group">
+          <!-- File selectors inserted dynamically -->
           <div class="file-select">
             <div class="file-select-header">
               <div class="file-select-label-group">
@@ -322,6 +42,8 @@
                   id="toggleOutputFiles"
                   class="toggle-icon"
                   title="Multiple"
+                  data-action="toggle"
+                  data-filetype="output"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
                 <span class="optional-label">Multiple Outputs</span>
@@ -331,6 +53,8 @@
                   id="emptyOutputFilesButton"
                   class="vscode-button"
                   title="Empty"
+                  data-action="empty"
+                  data-filetype="output"
                 >
                   <i class="codicon codicon-trash"></i>
                 </button>
@@ -619,6 +343,146 @@
         </div>
       </div>
     </div>
+    <template id="fileSelectorTemplate">
+      <div class="file-select">
+        <div class="file-select-header">
+          <div class="file-select-label-group">
+            <label>
+              <i class="codicon clickable file-icon"></i>
+              <span class="file-label"></span>
+            </label>
+          </div>
+          <div class="file-select-actions button-group">
+            <button class="vscode-button current-button" title="">
+              <i class="codicon codicon-file-code"></i>
+            </button>
+            <button class="vscode-button single-empty-button" title="Empty">
+              <i class="codicon codicon-close"></i>
+            </button>
+            <span class="toggle-icon multiple-toggle" data-action="toggle">
+              <i class="codicon codicon-chevron-down"></i>
+            </span>
+            <button class="vscode-button add-opened-button" title="">
+              <i class="codicon codicon-folder-opened"></i>
+            </button>
+            <button
+              class="vscode-button multi-empty-button"
+              title="Empty"
+              data-action="empty"
+            >
+              <i class="codicon codicon-trash"></i>
+            </button>
+            <button class="vscode-button select-multiple-button" title="Add">
+              <i class="codicon codicon-add"></i>
+            </button>
+          </div>
+        </div>
+        <select>
+          <option value="">None</option>
+        </select>
+        <div class="multiple-files-container" style="display: none">
+          <div class="multiple-files-content">
+            <div class="multiple-files-list"></div>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <template id="mediaFileSelectorTemplate">
+      <div class="file-select">
+        <div class="file-select-header">
+          <div class="file-select-label-group">
+            <label for="mediaFile"
+              ><i
+                class="codicon codicon-file-media clickable"
+                title="Media (Click to refresh)"
+              ></i>
+              Media</label
+            >
+            <div class="dropdown-container dropdown-left">
+              <span
+                id="toggleAutoExtract"
+                class="auto-toggle"
+                title="Auto-extract options"
+              >
+                <i class="codicon codicon-wand"></i
+                ><i class="codicon codicon-chevron-down"></i>
+              </span>
+              <div
+                id="autoExtractOptions"
+                class="dropdown-options"
+                style="display: none"
+              >
+                <label class="vscode-checkbox"
+                  ><input type="checkbox" id="autoExtractFigure" /><i
+                    class="codicon codicon-file-media"
+                  ></i
+                  >Figures</label
+                >
+                <label class="vscode-checkbox"
+                  ><input type="checkbox" id="autoExtractTikzFigure" /><i
+                    class="codicon codicon-file-code"
+                  ></i
+                  >TikZ Figures</label
+                >
+                <label class="vscode-checkbox"
+                  ><input type="checkbox" id="autoCompileInputPdf" /><i
+                    class="codicon codicon-file-pdf"
+                  ></i
+                  >Compile Input PDF</label
+                >
+              </div>
+            </div>
+          </div>
+          <div class="file-select-actions button-group">
+            <button
+              id="emptyMediaFileButton"
+              class="vscode-button"
+              title="Empty"
+            >
+              <i class="codicon codicon-close"></i>
+            </button>
+            <span
+              id="toggleMediaFiles"
+              class="toggle-icon"
+              title="Multiple"
+              data-action="toggle"
+              data-filetype="media"
+              ><i class="codicon codicon-chevron-down"></i
+            ></span>
+            <button
+              id="emptyMediaFilesButton"
+              class="vscode-button"
+              title="Empty"
+              data-action="empty"
+              data-filetype="media"
+            >
+              <i class="codicon codicon-trash"></i>
+            </button>
+            <button
+              id="selectMediaFilesButton"
+              class="vscode-button"
+              title="Add"
+            >
+              <i class="codicon codicon-add"></i>
+            </button>
+          </div>
+        </div>
+        <select id="mediaFile">
+          <option value="">None</option>
+        </select>
+        <div
+          id="mediaFilesContainer"
+          class="multiple-files-container"
+          style="display: none"
+        >
+          <div class="multiple-files-content">
+            <div id="mediaFiles" class="multiple-files-list"></div>
+          </div>
+        </div>
+      </div>
+    </template>
+
     <template id="iconButtonTemplate">
       <button class="vscode-button">
         <i class="codicon"></i>

--- a/src/webview/modules/fileSelectorTemplates.js
+++ b/src/webview/modules/fileSelectorTemplates.js
@@ -1,0 +1,78 @@
+import { FILE_TYPES } from './constants.js';
+import { capitalize } from './stringUtils.js';
+import { renderTemplate } from './utils.js';
+
+const CONFIG = {
+  input: { label: 'Input', icon: 'file-code' },
+  reference: { label: 'Reference', icon: 'book' },
+  auxiliary: { label: 'Auxiliary', icon: 'file-add' },
+};
+
+function createFileSelector(type) {
+  const cfg = CONFIG[type];
+  const cap = capitalize(type);
+  const element = renderTemplate('fileSelectorTemplate');
+  if (!element) return null;
+
+  const labelEl = element.querySelector('label');
+  if (labelEl) {
+    labelEl.setAttribute('for', `${type}File`);
+    const iconEl = element.querySelector('.file-icon');
+    if (iconEl) {
+      iconEl.classList.add(`codicon-${cfg.icon}`);
+      iconEl.title = `${cfg.label} (Click to refresh)`;
+    }
+    const labelSpan = element.querySelector('.file-label');
+    if (labelSpan) labelSpan.textContent = cfg.label;
+  }
+
+  const idMap = {
+    '.current-button': `current${cap}FileButton`,
+    '.single-empty-button': `empty${cap}FileButton`,
+    '.multiple-toggle': `toggle${cap}Files`,
+    '.add-opened-button': `addOpened${cap}FilesButton`,
+    '.multi-empty-button': `empty${cap}FilesButton`,
+    '.select-multiple-button': `select${cap}FilesButton`,
+    select: `${type}File`,
+    '.multiple-files-container': `${type}FilesContainer`,
+    '.multiple-files-list': `${type}Files`,
+  };
+
+  Object.entries(idMap).forEach(([selector, id]) => {
+    const el = element.querySelector(selector);
+    if (el) el.id = id;
+  });
+
+  const toggle = element.querySelector('.multiple-toggle');
+  if (toggle) toggle.dataset.filetype = type;
+  const multiEmpty = element.querySelector('.multi-empty-button');
+  if (multiEmpty) multiEmpty.dataset.filetype = type;
+  const addOpened = element.querySelector('.add-opened-button');
+  if (addOpened) addOpened.title = `Add opened files as ${type}`;
+  const currentBtn = element.querySelector('.current-button');
+  if (currentBtn) currentBtn.title = `Set current file as ${type}`;
+
+  return element;
+}
+
+export function insertFileSelectors() {
+  const container = document.getElementById('fileSelectionGroup');
+  const mediaTemplate = document.getElementById('mediaFileSelectorTemplate');
+  if (!container) return;
+
+  const frag = document.createDocumentFragment();
+  FILE_TYPES.forEach((type) => {
+    if (type === 'output') return;
+    if (type === 'media') {
+      if (mediaTemplate) {
+        const mediaNode =
+          mediaTemplate.content.firstElementChild.cloneNode(true);
+        frag.appendChild(mediaNode);
+      }
+      return;
+    }
+    const selector = createFileSelector(type);
+    if (selector) frag.appendChild(selector);
+  });
+  container.prepend(frag);
+}

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -276,16 +276,25 @@ export function setupUIHandlers() {
     });
   });
 
-  // Handle empty buttons and toggles for all multiple selections
-  MULTIPLE_SELECTIONS.forEach((id) => {
-    const toggleId = `toggle${capitalize(id)}`;
-    const emptyButtonId = `empty${capitalize(id)}Button`;
-
-    // Empty button handler
-    addEventListenerSafely(emptyButtonId, 'click', () =>
-      emptyMultipleFiles(id, toggleId),
-    );
-  });
+  const fileSelectionGroup = safeGetElementById('fileSelectionGroup');
+  if (fileSelectionGroup) {
+    fileSelectionGroup.addEventListener('click', (e) => {
+      const target = e.target.closest('[data-action][data-filetype]');
+      if (!target) return;
+      const { action, filetype } = target.dataset;
+      const containerId = `${filetype}Files`;
+      const toggleId = `toggle${capitalize(filetype)}Files`;
+      if (action === 'empty') {
+        emptyMultipleFiles(containerId, toggleId);
+      } else if (action === 'toggle') {
+        if (filetype === 'output') {
+          toggleOutputFiles();
+        } else {
+          toggleMultipleFiles(containerId, toggleId);
+        }
+      }
+    });
+  }
 
   CHECK_BOXES.forEach((id) => {
     addEventListenerSafely(id, 'change', handleCheckboxChange);
@@ -577,17 +586,6 @@ export function setupUIHandlers() {
       baseFile: baseFile,
     });
     updateEditedFileSelect(baseFile);
-  });
-
-  MULTIPLE_SELECTIONS.forEach((id) => {
-    const toggleId = `toggle${capitalize(id)}`;
-    addEventListenerSafely(toggleId, 'click', () => {
-      if (id === 'outputFiles') {
-        toggleOutputFiles();
-      } else {
-        toggleMultipleFiles(id, toggleId);
-      }
-    });
   });
 
   // Add event listener for history button

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -10,6 +10,7 @@ import {
   autoResizeTextarea,
   setupDocumentListeners,
 } from './modules/uiHandlers.js';
+import { insertFileSelectors } from './modules/fileSelectorTemplates.js';
 
 // Initialize data requests when window loads
 window.onload = function () {
@@ -47,6 +48,7 @@ setupMessageHandlers();
 
 // Setup UI when DOM is loaded
 document.addEventListener('DOMContentLoaded', function () {
+  insertFileSelectors();
   setupUIHandlers();
 
   // Update initial toggle states


### PR DESCRIPTION
## Summary
- generate file selector HTML with a template module
- insert selectors on DOM load before handlers initialize
- delegate file toggle/empty actions via a single listener
- simplify file selector creation via renderTemplate

## Testing
- `npm run format`
- `npm run lint` (with warnings)
- `npm test` (with warnings)


------
https://chatgpt.com/codex/tasks/task_e_683e144f647c8324b25bc27f2d6de96a