### PR TITLE
Refactor webview message dispatch

### DIFF
--- a/src/historyView/AgentHistoryViewProvider.ts
+++ b/src/historyView/AgentHistoryViewProvider.ts
@@ -87,27 +87,18 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
   /**
    * Handle messages from the webview
    */
+  private handlers: Record<string, (message: any) => Promise<void> | void> = {
+    getHistoryData: () => this.sendHistoryData(),
+    rerunAgent: (m) => this.rerunAgent(m.historyId),
+    restoreAgent: (m) => this.restoreAgent(m.historyId),
+    deleteAgent: (m) => this.deleteHistoryItem(m.historyId),
+    clearHistory: () => this.clearHistory(),
+  };
+
   private async handleWebviewMessage(message: any) {
-    switch (message.command) {
-      case 'getHistoryData':
-        await this.sendHistoryData();
-        break;
-
-      case 'rerunAgent':
-        await this.rerunAgent(message.historyId);
-        break;
-
-      case 'restoreAgent':
-        await this.restoreAgent(message.historyId);
-        break;
-
-      case 'deleteAgent':
-        await this.deleteHistoryItem(message.historyId);
-        break;
-
-      case 'clearHistory':
-        await this.clearHistory();
-        break;
+    const handler = this.handlers[message.command];
+    if (handler) {
+      await handler(message);
     }
   }
 

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -323,6 +323,8 @@ async function processTikzPictureEndings(
   ];
 
   const patterns_scope_tikzpicture = [
+    // Some of these might be too aggressive because i am getting an edge cases wihtout any spaces before \} somehow
+
     // Fix cases where }; appears before \end{tikzpicture}
     [/\};(\s*)\\end\{tikzpicture\}/g, '\\end{tikzpicture}\\};'],
     // Original patterns
@@ -332,6 +334,7 @@ async function processTikzPictureEndings(
       '$1\\end{tikzpicture}};\\DIFaddendFL',
     ],
     // Handle node closures with tikzpicture
+    
     [/\};(\s*)\\end\{tikzpicture\}(\s*)\};/g, '\\end{tikzpicture}$1\\};$2\\};'],
     // Handle semicolons inside tikzpicture that should be after the environment
     [

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -334,7 +334,7 @@ async function processTikzPictureEndings(
       '$1\\end{tikzpicture}};\\DIFaddendFL',
     ],
     // Handle node closures with tikzpicture
-    
+
     [/\};(\s*)\\end\{tikzpicture\}(\s*)\};/g, '\\end{tikzpicture}$1\\};$2\\};'],
     // Handle semicolons inside tikzpicture that should be after the environment
     [

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -13,7 +13,63 @@ import { COMMANDS } from './modules/constants.js';
 const CHANNEL = 'MessageHandler';
 
 export class ProgressViewMessageHandler {
-  constructor(private readonly provider: ProgressViewProvider) {}
+  private handlers: Record<
+    string,
+    (message: any, webviewView: vscode.WebviewView) => Promise<void> | void
+  >;
+
+  constructor(private readonly provider: ProgressViewProvider) {
+    this.handlers = {
+      [COMMANDS.SWITCH_STREAM]: (m) => this.provider.setActiveStream(m.stream),
+      [COMMANDS.ERASE_STREAM]: (m) => this.provider.eraseStream(m.stream),
+      [COMMANDS.DELETE_STREAM]: (m) => this.provider.deleteStream(m.stream),
+      [COMMANDS.DELETE_ALL]: () => this.provider.deleteAllStreams(),
+      [COMMANDS.STOP_STREAM]: (m) =>
+        vscode.commands.executeCommand('texra.stopAgent', m.stream),
+      [COMMANDS.DIFF_STREAM]: (m) => this.handleDiffStream(m.stream),
+      [COMMANDS.PACK_STREAM]: (m) => this.handlePackStream(m.stream),
+      [COMMANDS.CLEAN_STREAM]: (m) => this.handleCleanStream(m.stream),
+      [COMMANDS.RUN_AGAIN]: (m) => this.handleRunAgain(m.stream),
+      [COMMANDS.RESTORE_STATE]: (m) => this.handleRestoreState(m.stream),
+      [COMMANDS.OPEN_FILE]: (m) =>
+        vscode.commands.executeCommand('texra.openFileCompile', m.file),
+      [COMMANDS.COMPARE_ORIGINAL]: (m) =>
+        vscode.commands.executeCommand(
+          'texra.compare',
+          undefined,
+          m.base,
+          m.file,
+        ),
+      [COMMANDS.COMPARE_PREVIOUS]: (m) =>
+        vscode.commands.executeCommand(
+          'texra.compare',
+          undefined,
+          m.prev,
+          m.file,
+        ),
+      [COMMANDS.ACCEPT_FILE]: (m) =>
+        vscode.commands.executeCommand(
+          'texra.acceptEdited',
+          undefined,
+          m.base,
+          m.file,
+        ),
+      [COMMANDS.MERGE_FILE]: (m) =>
+        vscode.commands.executeCommand(
+          'texra.merge',
+          undefined,
+          m.base,
+          m.file,
+        ),
+      [COMMANDS.LATEXDIFF_FILE]: (m) =>
+        vscode.commands.executeCommand(
+          'texra.latexdiff',
+          undefined,
+          m.base,
+          m.file,
+        ),
+    };
+  }
 
   async handleMessage(
     message: any,
@@ -21,85 +77,11 @@ export class ProgressViewMessageHandler {
   ): Promise<void> {
     logger.debug(CHANNEL, `Received message: ${message.command}`);
 
-    switch (message.command) {
-      case COMMANDS.SWITCH_STREAM:
-        this.provider.setActiveStream(message.stream);
-        break;
-      case COMMANDS.ERASE_STREAM:
-        this.provider.eraseStream(message.stream);
-        break;
-      case COMMANDS.DELETE_STREAM:
-        this.provider.deleteStream(message.stream);
-        break;
-      case COMMANDS.DELETE_ALL:
-        this.provider.deleteAllStreams();
-        break;
-      case COMMANDS.STOP_STREAM:
-        vscode.commands.executeCommand('texra.stopAgent', message.stream);
-        break;
-      case COMMANDS.DIFF_STREAM:
-        await this.handleDiffStream(message.stream);
-        break;
-      case COMMANDS.PACK_STREAM:
-        await this.handlePackStream(message.stream);
-        break;
-      case COMMANDS.CLEAN_STREAM:
-        await this.handleCleanStream(message.stream);
-        break;
-      case COMMANDS.RUN_AGAIN:
-        await this.handleRunAgain(message.stream);
-        break;
-      case COMMANDS.RESTORE_STATE:
-        await this.handleRestoreState(message.stream);
-        break;
-      case COMMANDS.OPEN_FILE:
-        await vscode.commands.executeCommand(
-          'texra.openFileCompile',
-          message.file,
-        );
-        break;
-      case COMMANDS.COMPARE_ORIGINAL:
-        await vscode.commands.executeCommand(
-          'texra.compare',
-          undefined,
-          message.base,
-          message.file,
-        );
-        break;
-      case COMMANDS.COMPARE_PREVIOUS:
-        await vscode.commands.executeCommand(
-          'texra.compare',
-          undefined,
-          message.prev,
-          message.file,
-        );
-        break;
-      case COMMANDS.ACCEPT_FILE:
-        await vscode.commands.executeCommand(
-          'texra.acceptEdited',
-          undefined,
-          message.base,
-          message.file,
-        );
-        break;
-      case COMMANDS.MERGE_FILE:
-        await vscode.commands.executeCommand(
-          'texra.merge',
-          undefined,
-          message.base,
-          message.file,
-        );
-        break;
-      case COMMANDS.LATEXDIFF_FILE:
-        await vscode.commands.executeCommand(
-          'texra.latexdiff',
-          undefined,
-          message.base,
-          message.file,
-        );
-        break;
-      default:
-        logger.warn(CHANNEL, `Unknown command: ${message.command}`);
+    const handler = this.handlers[message.command];
+    if (handler) {
+      await handler(message, webviewView);
+    } else {
+      logger.warn(CHANNEL, `Unknown command: ${message.command}`);
     }
   }
 

--- a/src/replacement/replacementHelpers.ts
+++ b/src/replacement/replacementHelpers.ts
@@ -15,7 +15,7 @@ export const GREEK_UPPERCASE = 'Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Io
 // Common LaTeX environments
 // prettier-ignore
 export const COMMON_ENVIRONMENTS = [
-  'document',
+  // 'document',
   'figure',
   'figure*',
   'tikzpicture',

--- a/src/replacement/replacementRules.ts
+++ b/src/replacement/replacementRules.ts
@@ -478,6 +478,7 @@ export const LATEX_XML_REPLACEMENTS: ReplacementCategory = {
       // 'document', // this also replaced xml tags which is also being used!!
       'figure',
       'figure*',
+      'axis',
       'tikzpicture',
       'scope',
       // 'output', // this might also be a xml tag?
@@ -608,8 +609,8 @@ export const LATEX_DOCUMENT_REPLACEMENTS: ReplacementCategory = {
       '\\end{document}\n</document>\n</latex_documents>',
     '\\end{document}\n\n<document name':
       '\\end{document}\n</document>\n\n<document name',
-    // '\\end{document}\n<document name':
-    //   '\\end{document}\n</document>\n<document name',
+    '\\end{document}\n<document name':
+      '\\end{document}\n</document>\n<document name',
     '\\end{document}\n</rebuttal_package>':
       '\\end{document}\n</document>\n</rebuttal_package>',
     '<latex_document>\n```xml<latex_document>': '<latex_document>\n',

--- a/src/replacement/replacementRules.ts
+++ b/src/replacement/replacementRules.ts
@@ -475,12 +475,12 @@ export const LATEX_XML_REPLACEMENTS: ReplacementCategory = {
 
     // Lists of environment/tag names
     const latexEnvironments = [
-      'document',
+      // 'document', // this also replaced xml tags which is also being used!!
       'figure',
       'figure*',
       'tikzpicture',
       'scope',
-      'output',
+      // 'output', // this might also be a xml tag?
       'response',
       'itemize',
       'enumerate',
@@ -539,6 +539,7 @@ export const LATEX_XML_REPLACEMENTS: ReplacementCategory = {
     latexEnvironments.forEach((env) => {
       patterns[`\\end{${env}>}`] = `\\end{${env}}`;
       patterns[`\\end{${env}>`] = `\\end{${env}}`;
+      patterns[`</end{${env}>`] = `\\end{${env}}`;
     });
 
     // ===== 2. XML BRACE FIXES =====
@@ -592,20 +593,23 @@ export const LATEX_DOCUMENT_REPLACEMENTS: ReplacementCategory = {
     '</latex_document>\n\n</latex_document>': '</latex_document>\n',
 
     // ===== 9. DOCUMENT STRUCTURE FIXES =====
-    '\\end{document}\n\n\\<document name=':
-      '\\end{document}\\n</document>\\n\\<document name=',
-    '\\end{document}\n\\<document name=':
-      '\\end{document}\n</document>\n\\<document name=',
+    // '\\end{document}\n\n\\<document name=':
+    //   '\\end{document}\\n</document>\\n\\<document name=',
+    '\\end{document}\n\\end{document}\n<document name=':
+      '\\end{document}\n</document>\n<document name=',
+    // '\\end{document}\n\\<document name=':
+    //   '\\end{document}\n</document>\n\\<document name=',
     '\\end{latex_document}\n</latex_document>':
       '\\end{document}\n</latex_document>',
+    '\\end{document}\n\\end{document}\n</latex_documents>':
+      '\\end{document}\n</document>\n</latex_documents>',
+    // The following two might be aggressive
     '\\end{document}\n</latex_documents>':
       '\\end{document}\n</document>\n</latex_documents>',
     '\\end{document}\n\n<document name':
       '\\end{document}\n</document>\n\n<document name',
-    '\\end{document}\n\\end{document}\n<document':
-      '\\end{document}\n</document>\n<document',
-    '\\end{document}\n<document name':
-      '\\end{document}\n</document>\n<document name',
+    // '\\end{document}\n<document name':
+    //   '\\end{document}\n</document>\n<document name',
     '\\end{document}\n</rebuttal_package>':
       '\\end{document}\n</document>\n</rebuttal_package>',
     '<latex_document>\n```xml<latex_document>': '<latex_document>\n',
@@ -631,7 +635,6 @@ export const LATEX_DOCUMENT_REPLACEMENTS: ReplacementCategory = {
     '\\end\n': '\\end{document}\n',
 
     // ===== Debtable one-offs =====
-
   },
 };
 

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -30,107 +30,107 @@ import { AgentConfig } from '../agent/AgentConfig';
 const CHANNEL = 'MessageHandler';
 
 export class WebviewMessageHandler {
-  constructor(private readonly context: vscode.ExtensionContext) {}
+  private handlers: Record<
+    string,
+    (message: any, webviewView: vscode.WebviewView) => unknown
+  >;
+
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this.handlers = {
+      showInformationMessage: (message) => this.handleInfoMessage(message),
+      getTheme: (_m, view) => this.handleThemeRequest(view),
+      modelSelected: (message, view) =>
+        this.handleModelSelection(message, view),
+      execute: (message) => this.handleExecute(message),
+      merge: (message) => this.handleMerge(message),
+      compare: (message) => this.handleCompare(message),
+      acceptEdited: (message) => this.handleAcceptEdited(message),
+      // File selection cases
+      selectInputFile: (message, view) =>
+        this.handleFileSelection(message, view),
+      selectReferenceFile: (message, view) =>
+        this.handleFileSelection(message, view),
+      selectAuxiliaryFile: (message, view) =>
+        this.handleFileSelection(message, view),
+      selectMediaFile: (message, view) =>
+        this.handleFileSelection(message, view),
+      selectEditedFile: (_m, view) => this.handleEditedFileSelection(view),
+      // File selected cases
+      inputFileSelected: (message, view) =>
+        this.handleInputFileSelected(message, view),
+      referenceFileSelected: (message) =>
+        this.handleGenericFileSelected(message),
+      auxiliaryFileSelected: (message) =>
+        this.handleGenericFileSelected(message),
+      mediaFileSelected: (message) => this.handleGenericFileSelected(message),
+      editedFileSelected: (message) => this.handleGenericFileSelected(message),
+      // Request file cases
+      requestInputFile: (_m, view) => this.handleRequestInputFile(view),
+      requestReferenceFile: (message, view) =>
+        this.handleRequestFile(message, view),
+      requestAuxiliaryFile: (message, view) =>
+        this.handleRequestFile(message, view),
+      requestMediaFile: (message, view) =>
+        this.handleRequestFile(message, view),
+      requestEditedFile: (message, view) =>
+        this.handleRequestEditedFile(message, view),
+      requestBaseFile: (_m, view) => this.handleRequestBaseFile(view),
+      // Handle file list updates from webview
+      updateInputFiles: (message, view) =>
+        this.handleUpdateFiles(message, view),
+      updateReferenceFiles: (message, view) =>
+        this.handleUpdateFiles(message, view),
+      updateAuxiliaryFiles: (message, view) =>
+        this.handleUpdateFiles(message, view),
+      updateMediaFiles: (message, view) =>
+        this.handleUpdateFiles(message, view),
+      updateOutputFiles: (message, view) =>
+        this.handleUpdateFiles(message, view),
+      // Multiple file selection cases
+      setInputFiles: (message, view) =>
+        this.handleSetMultipleFiles(message, view),
+      setReferenceFiles: (message, view) =>
+        this.handleSetMultipleFiles(message, view),
+      setAuxiliaryFiles: (message, view) =>
+        this.handleSetMultipleFiles(message, view),
+      setMediaFiles: (message, view) =>
+        this.handleSetMultipleFiles(message, view),
+      selectMultipleFiles: (message, view) =>
+        this.handleSelectMultipleFiles(message, view),
+      refreshAllFiles: (_m, view) => this.handleRefreshAllFiles(view),
+      // Housekeeping cases
+      cleanOutput: (message) => this.handleHousekeeping(message),
+      cleanBuild: (message) => this.handleHousekeeping(message),
+      indentTeX: (message) => this.handleHousekeeping(message),
+      packSingle: (message) => this.handleSingleOperation(message),
+      cleanSingle: (message) => this.handleSingleOperation(message),
+      packMultiple: (message) => this.handleMultipleOperation(message),
+      cleanMultiple: (message) => this.handleMultipleOperation(message),
+      // Latex diff cases
+      latexdiff: (message) => this.handleLatexdiff(message),
+      latexdiffvc: (message) => this.handleLatexdiffvc(message),
+      requestRecentCommits: (_m, view) => this.handleRequestRecentCommits(view),
+      refreshCommits: (_m, view) => this.handleRefreshCommits(view),
+      packLatexdiffvc: (message) => this.handleLatexdiffvcOperation(message),
+      cleanLatexdiffvc: (message) => this.handleLatexdiffvcOperation(message),
+      // VS Code logic cases
+      getCurrentFile: (message, view) =>
+        this.handleGetCurrentFile(message, view),
+      addOpenedFiles: (message, view) =>
+        this.handleAddOpenedFiles(message.fileType, view),
+      polishInstructionText: (message, view) =>
+        this.handlePolishInstructionText(message, view),
+      showAgentHistory: () => this.handleShowAgentHistory(),
+      openSettings: () => this.handleOpenSettings(),
+    };
+  }
 
   async handleMessage(message: any, webviewView: vscode.WebviewView) {
     logger.debug(CHANNEL, `Received message: ${message.command}`);
 
-    switch (message.command) {
-      case 'showInformationMessage':
-        return this.handleInfoMessage(message);
-      case 'getTheme':
-        return this.handleThemeRequest(webviewView);
-      // Why no agentSelected?
-      case 'modelSelected':
-        return this.handleModelSelection(message, webviewView);
-      case 'execute':
-        return this.handleExecute(message);
-      case 'merge':
-        return this.handleMerge(message);
-      case 'compare':
-        return this.handleCompare(message);
-      case 'acceptEdited':
-        return this.handleAcceptEdited(message);
-      // File selection cases
-      case 'selectInputFile':
-      case 'selectReferenceFile':
-      case 'selectAuxiliaryFile':
-      case 'selectMediaFile':
-        return this.handleFileSelection(message, webviewView);
-      case 'selectEditedFile':
-        return this.handleEditedFileSelection(webviewView);
-      // File Selected cases
-      case 'inputFileSelected':
-        return this.handleInputFileSelected(message, webviewView);
-      case 'referenceFileSelected':
-      case 'auxiliaryFileSelected':
-      case 'mediaFileSelected':
-      case 'editedFileSelected':
-        return this.handleGenericFileSelected(message);
-      // Request File cases
-      case 'requestInputFile':
-        return this.handleRequestInputFile(webviewView);
-      case 'requestReferenceFile':
-      case 'requestAuxiliaryFile':
-      case 'requestMediaFile':
-        return this.handleRequestFile(message, webviewView);
-      case 'requestEditedFile':
-        return this.handleRequestEditedFile(message, webviewView);
-      case 'requestBaseFile':
-        return this.handleRequestBaseFile(webviewView);
-      // Handle file list updates from webview
-      case 'updateInputFiles':
-      case 'updateReferenceFiles':
-      case 'updateAuxiliaryFiles':
-      case 'updateMediaFiles':
-      case 'updateOutputFiles':
-        return this.handleUpdateFiles(message, webviewView);
-      // Multiple file selection cases
-      case 'setInputFiles':
-      case 'setReferenceFiles':
-      case 'setAuxiliaryFiles':
-      case 'setMediaFiles':
-        return this.handleSetMultipleFiles(message, webviewView);
-      case 'selectMultipleFiles':
-        return this.handleSelectMultipleFiles(message, webviewView);
-      case 'refreshAllFiles':
-        return this.handleRefreshAllFiles(webviewView);
-      // Housekeeping cases
-      case 'cleanOutput':
-      case 'cleanBuild':
-      case 'indentTeX':
-        return this.handleHousekeeping(message);
-      case 'packSingle':
-      case 'cleanSingle':
-        return this.handleSingleOperation(message);
-      case 'packMultiple':
-      case 'cleanMultiple':
-        return this.handleMultipleOperation(message);
-      // Latex Diff cases
-      case 'latexdiff':
-        return this.handleLatexdiff(message);
-      case 'latexdiffvc':
-        return this.handleLatexdiffvc(message);
-      case 'requestRecentCommits':
-        return this.handleRequestRecentCommits(webviewView);
-      case 'refreshCommits':
-        return this.handleRefreshCommits(webviewView);
-      case 'packLatexdiffvc':
-      case 'cleanLatexdiffvc':
-        return this.handleLatexdiffvcOperation(message);
-      // VS Code Logic cases
-      case 'getCurrentFile':
-        return this.handleGetCurrentFile(message, webviewView);
-      case 'addOpenedFiles':
-        return this.handleAddOpenedFiles(message.fileType, webviewView);
-      case 'polishInstructionText':
-        return this.handlePolishInstructionText(message, webviewView);
-      case 'showAgentHistory':
-        this.handleShowAgentHistory();
-        break;
-      case 'openSettings':
-        this.handleOpenSettings();
-        break;
+    const handler = this.handlers[message.command];
+    if (handler) {
+      return handler(message, webviewView);
     }
   }
 

--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -39,6 +39,7 @@ export class WebviewContentProvider {
       const templateUtilsPath = getCommonPath('modules/templateUtils.js');
       const domUtilsPath = getCommonPath('modules/domUtils.js');
       const stringUtilsPath = getCommonPath('modules/stringUtils.js');
+      const messageRouterPath = getCommonPath('modules/messageRouter.js');
       const vscodeApiPath = getCommonPath('modules/vscodeApi.js');
 
       const styleUri = webview.asWebviewUri(cssPath);
@@ -52,6 +53,7 @@ export class WebviewContentProvider {
       const templateUtilsUri = webview.asWebviewUri(templateUtilsPath);
       const domUtilsUri = webview.asWebviewUri(domUtilsPath);
       const stringUtilsUri = webview.asWebviewUri(stringUtilsPath);
+      const messageRouterUri = webview.asWebviewUri(messageRouterPath);
       const vscodeApiUri = webview.asWebviewUri(vscodeApiPath);
 
       const codiconPath = getNodeModulesPath(
@@ -88,6 +90,7 @@ export class WebviewContentProvider {
         fileHandlersUri,
         uiHandlersUri,
         templateUtilsUri,
+        messageRouterUri,
         vscodeApiUri,
         codiconUri,
         codiconsFontUri,

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -22,6 +22,7 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/messageRouter.js": "${messageRouterUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs"
         }
       }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1,5 +1,23 @@
 import { vscode } from '@common/vscodeApi.js';
 import { registerMessageHandlers } from '@common/messageRouter.js';
+import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
+import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import {
+  getWebviewState,
+  updateWebviewState,
+  setWebviewState,
+} from '@common/webviewState.js';
+
+import {
+  updateFileSelect,
+  updateEditedFileSelect,
+  updateMultipleFileSelect,
+  handleRecentCommits,
+  handleSetCurrentFile,
+} from './fileHandlers.js';
+
+import { restoreState, saveState } from './stateManager.js';
+import { FILE_TYPES } from './constants.js';
 
 /**
  * Initialize data requests on window load
@@ -19,22 +37,6 @@ export function initializeDataRequests() {
     vscode.postMessage({ command: request });
   });
 }
-import {
-  updateFileSelect,
-  updateEditedFileSelect,
-  updateMultipleFileSelect,
-  handleRecentCommits,
-  handleSetCurrentFile,
-} from './fileHandlers.js';
-import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
-import { restoreState, saveState } from './stateManager.js';
-import { FILE_TYPES } from './constants.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import {
-  getWebviewState,
-  updateWebviewState,
-  setWebviewState,
-} from '@common/webviewState.js';
 
 /**
  * Handle state restoration from log view

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1,4 +1,5 @@
 import { vscode } from '@common/vscodeApi.js';
+import { registerMessageHandlers } from '@common/messageRouter.js';
 
 /**
  * Initialize data requests on window load
@@ -222,138 +223,166 @@ function handleStateRestoration(state) {
   window._skipNextRestoreState = true;
 }
 
+function postHandle() {
+  if (window._skipNextRestoreState) {
+    window._skipNextRestoreState = false;
+  } else {
+    restoreState();
+  }
+}
+
 export function setupMessageHandlers() {
-  window.addEventListener('message', (event) => {
-    const message = event.data;
-
-    switch (message.command) {
-      case 'setTheme':
-        document.body.className = message.theme;
-        break;
-      case 'modelSelected':
-        safeSetElementValue('model', message.model);
-        break;
-      case 'restoreState':
-        handleStateRestoration(message.state);
-        break;
-      case 'checkRestoredBaseFile':
-        const restoredBaseFileDiv = safeGetElementById('baseFile');
-        if (restoredBaseFileDiv && restoredBaseFileDiv.value) {
-          updateEditedFileSelect(restoredBaseFileDiv.value);
-        }
-        break;
-      case 'instructionTextPolished':
-        const instruction = safeGetElementById('instruction');
-        if (instruction && message.text) {
-          instruction.value = message.text;
-          vscode.postMessage({
-            command: 'showInformationMessage',
-            text: 'Instruction text has been polished!',
-          });
-          saveState();
-        }
-        break;
-      // File selection
-      case 'setInputFile':
-      case 'setReferenceFile':
-      case 'setAuxiliaryFile':
-      case 'setMediaFile':
-      case 'setEditedFile':
-        // console.log(
-        //   `Handling ${message.command} with ${message.files ? message.files.length : 0} files`,
-        // );
-        updateFileSelect(uncapitalize(message.command.slice(3)), message.files);
-        break;
-      case 'inputFileSelected':
-      case 'referenceFileSelected':
-      case 'auxiliaryFileSelected':
-      case 'mediaFileSelected':
-      case 'editedFileSelected':
-        safeSetElementValue(
-          message.command.replace('Selected', ''),
-          message.filePath,
-        );
-        break;
-      // Multiple file selection
-      case 'setInputFiles':
-      case 'setReferenceFiles':
-      case 'setAuxiliaryFiles':
-      case 'setMediaFiles':
-      case 'setOutputFiles':
-        // console.log(
-        //   `Handling ${message.command} with ${message.files ? message.files.length : 0} files`,
-        // );
-        // Always use lowercase container ID to match HTML structure
-        const fileTypeKey = message.command.replace('set', '');
-        const containerID = uncapitalize(fileTypeKey);
-        const toggleID = `toggle${fileTypeKey}`;
-
-        updateMultipleFileSelect(containerID, toggleID, message.files);
-        break;
-      case 'setRecentCommits':
-        handleRecentCommits(message);
-        break;
-      case 'setCurrentFile':
-        handleSetCurrentFile({
-          fileType: message.fileType,
-          filePath: message.filePath,
+  const handlers = {
+    setTheme: (m) => {
+      document.body.className = m.theme;
+      postHandle();
+    },
+    modelSelected: (m) => {
+      safeSetElementValue('model', m.model);
+      postHandle();
+    },
+    restoreState: (m) => {
+      handleStateRestoration(m.state);
+      postHandle();
+    },
+    checkRestoredBaseFile: () => {
+      const restoredBaseFileDiv = safeGetElementById('baseFile');
+      if (restoredBaseFileDiv && restoredBaseFileDiv.value) {
+        updateEditedFileSelect(restoredBaseFileDiv.value);
+      }
+      postHandle();
+    },
+    instructionTextPolished: (m) => {
+      const instruction = safeGetElementById('instruction');
+      if (instruction && m.text) {
+        instruction.value = m.text;
+        vscode.postMessage({
+          command: 'showInformationMessage',
+          text: 'Instruction text has been polished!',
         });
-        break;
-      case 'setOpenedFiles':
-        // Only update the specified file type's multiple selection
-        if (message.fileType) {
-          const fileType = message.fileType.replace('Files', '');
-          const singleFileId = `${uncapitalize(fileType)}File`;
-          const multipleFileId = `${uncapitalize(fileType)}Files`;
-          const toggleId = `toggle${capitalize(fileType)}Files`;
+        saveState();
+      }
+      postHandle();
+    },
+    setInputFile: (m) => {
+      updateFileSelect('inputFile', m.files);
+      postHandle();
+    },
+    setReferenceFile: (m) => {
+      updateFileSelect('referenceFile', m.files);
+      postHandle();
+    },
+    setAuxiliaryFile: (m) => {
+      updateFileSelect('auxiliaryFile', m.files);
+      postHandle();
+    },
+    setMediaFile: (m) => {
+      updateFileSelect('mediaFile', m.files);
+      postHandle();
+    },
+    setEditedFile: (m) => {
+      updateFileSelect('editedFile', m.files);
+      postHandle();
+    },
+    inputFileSelected: (m) => {
+      safeSetElementValue('inputFile', m.filePath);
+      postHandle();
+    },
+    referenceFileSelected: (m) => {
+      safeSetElementValue('referenceFile', m.filePath);
+      postHandle();
+    },
+    auxiliaryFileSelected: (m) => {
+      safeSetElementValue('auxiliaryFile', m.filePath);
+      postHandle();
+    },
+    mediaFileSelected: (m) => {
+      safeSetElementValue('mediaFile', m.filePath);
+      postHandle();
+    },
+    editedFileSelected: (m) => {
+      safeSetElementValue('editedFile', m.filePath);
+      postHandle();
+    },
+    setInputFiles: (m) => {
+      updateMultipleFileSelect('inputFiles', 'toggleInputFiles', m.files);
+      postHandle();
+    },
+    setReferenceFiles: (m) => {
+      updateMultipleFileSelect(
+        'referenceFiles',
+        'toggleReferenceFiles',
+        m.files,
+      );
+      postHandle();
+    },
+    setAuxiliaryFiles: (m) => {
+      updateMultipleFileSelect(
+        'auxiliaryFiles',
+        'toggleAuxiliaryFiles',
+        m.files,
+      );
+      postHandle();
+    },
+    setMediaFiles: (m) => {
+      updateMultipleFileSelect('mediaFiles', 'toggleMediaFiles', m.files);
+      postHandle();
+    },
+    setOutputFiles: (m) => {
+      updateMultipleFileSelect('outputFiles', 'toggleOutputFiles', m.files);
+      postHandle();
+    },
+    setRecentCommits: (m) => {
+      handleRecentCommits(m);
+      postHandle();
+    },
+    setCurrentFile: (m) => {
+      handleSetCurrentFile({ fileType: m.fileType, filePath: m.filePath });
+      postHandle();
+    },
+    setOpenedFiles: (m) => {
+      if (m.fileType) {
+        const fileType = m.fileType.replace('Files', '');
+        const singleFileId = `${uncapitalize(fileType)}File`;
+        const multipleFileId = `${uncapitalize(fileType)}Files`;
+        const toggleId = `toggle${capitalize(fileType)}Files`;
 
-          let filesToAdd = message.files ?? [];
-
-          // If shouldFilter is true, filter out the file that's already selected in the single select
-          if (message.shouldFilter) {
-            const singleFileSelect = safeGetElementById(singleFileId);
-            if (singleFileSelect && singleFileSelect.value) {
-              filesToAdd = filesToAdd.filter(
-                (file) => file !== singleFileSelect.value,
-              );
-            }
+        let filesToAdd = m.files ?? [];
+        if (m.shouldFilter) {
+          const singleFileSelect = safeGetElementById(singleFileId);
+          if (singleFileSelect && singleFileSelect.value) {
+            filesToAdd = filesToAdd.filter((f) => f !== singleFileSelect.value);
           }
-
-          updateMultipleFileSelect(multipleFileId, toggleId, filesToAdd);
         }
-        break;
-      case 'setBaseFile':
-        const currentBaseFileDiv = safeGetElementById('baseFile');
-        if (currentBaseFileDiv) {
-          const currentBaseFile = currentBaseFileDiv.value;
-          updateFileSelect('baseFile', message.files);
 
-          // Get the stored state
-          const state = getWebviewState();
-          const storedBaseFile = state?.baseFile;
+        updateMultipleFileSelect(multipleFileId, toggleId, filesToAdd);
+      }
+      postHandle();
+    },
+    setBaseFile: (m) => {
+      const currentBaseFileDiv = safeGetElementById('baseFile');
+      if (currentBaseFileDiv) {
+        const currentBaseFile = currentBaseFileDiv.value;
+        updateFileSelect('baseFile', m.files);
 
-          // First try to restore from stored state, then fallback to current if preserveBaseFile
-          if (storedBaseFile && message.files.includes(storedBaseFile)) {
-            currentBaseFileDiv.value = storedBaseFile;
-          } else if (
-            message.preserveBaseFile &&
-            currentBaseFile &&
-            message.files.includes(currentBaseFile)
-          ) {
-            currentBaseFileDiv.value = currentBaseFile;
-          }
+        const state = getWebviewState();
+        const storedBaseFile = state?.baseFile;
 
-          // Always update edited files based on final base file value
-          updateEditedFileSelect(currentBaseFileDiv.value);
+        if (storedBaseFile && m.files.includes(storedBaseFile)) {
+          currentBaseFileDiv.value = storedBaseFile;
+        } else if (
+          m.preserveBaseFile &&
+          currentBaseFile &&
+          m.files.includes(currentBaseFile)
+        ) {
+          currentBaseFileDiv.value = currentBaseFile;
         }
-        break;
-    }
 
-    // Only restore state if we didn't just handle a state restoration
-    if (window._skipNextRestoreState) {
-      window._skipNextRestoreState = false;
-    } else {
-      restoreState();
-    }
-  });
+        updateEditedFileSelect(currentBaseFileDiv.value);
+      }
+      postHandle();
+    },
+  };
+
+  registerMessageHandlers(handlers);
 }


### PR DESCRIPTION
## Summary
- map commands to handlers for consistency
- refactor progress view and history view handlers
- replace switch statement in webview script with command map

## Testing
- `npm run lint`
- `npm test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683e261eb09c8324a2f48c0a1b74870a