### PR TITLE
Fix progress view command constant

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -454,7 +454,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     if (this._view) {
       this._view.webview.postMessage({
-        command: 'appendLog',
+        command: COMMANDS.APPEND_LOG,
         stream: stream,
         logMessage,
       });


### PR DESCRIPTION
## Summary
- centralize progress view message name by using `COMMANDS.APPEND_LOG`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683e262fd9e88324b999cb0e45ac45d5