### PR TITLE
Fix tikzpicture end replacement

### DIFF
--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -325,8 +325,8 @@ async function processTikzPictureEndings(
   const patterns_scope_tikzpicture = [
     // Some of these might be too aggressive because i am getting an edge cases wihtout any spaces before \} somehow
 
-    // Fix cases where }; appears before \end{tikzpicture}
-    [/\};(\s*)\\end\{tikzpicture\}/g, '\\end{tikzpicture}\\};'],
+    // Fix cases where `};` directly precedes \end{tikzpicture} on the same line
+    [/\};([ \t]*)\\end\{tikzpicture\}/g, '\\end{tikzpicture}\n\\};$1'],
     // Original patterns
     [/\}(\s*)\\end\{tikzpicture\};/g, '};$1\\end{tikzpicture}'],
     [


### PR DESCRIPTION
## Summary
- refine tikzpicture replacement rule so `};` only moves when on the same line as `\end{tikzpicture}`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test requires network)*

------
https://chatgpt.com/codex/tasks/task_e_683eedb289a083248c3a7b7d2b8fcb7e