### PR TITLE
Refactor small try/catch blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texra",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texra",
-      "version": "0.30.6",
+      "version": "0.30.7",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.51.0",

--- a/src/commands/executeCommand.ts
+++ b/src/commands/executeCommand.ts
@@ -22,14 +22,10 @@ export const executeCommand = {
     config: AgentConfig,
     context: vscode.ExtensionContext,
   ) => {
-    try {
-      // Save the agent configuration to history (silently)
-      await AgentHistoryManager.addToHistory(context, config);
+    // Save the agent configuration to history (silently)
+    await AgentHistoryManager.addToHistory(context, config);
 
-      // Run the agent directly
-      await executeAgent(config, context);
-    } catch (err) {
-      throw err;
-    }
+    // Run the agent directly
+    await executeAgent(config, context);
   },
 };

--- a/src/commands/progressViewCommands.ts
+++ b/src/commands/progressViewCommands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { AgentLogger } from '../logger/AgentLogger';
+import { safeExecuteCommand } from '../utils/commandUtils';
 
 const CHANNEL = 'progressViewCommands';
 const logger = new AgentLogger(CHANNEL);
@@ -8,20 +9,9 @@ const logger = new AgentLogger(CHANNEL);
  * Show the Progress View panel
  */
 async function showProgressView() {
-  try {
-    // Focus the view in the panel
-    await vscode.commands.executeCommand(
-      'workbench.view.extension.texra-panel',
-    );
-
-    // Then specifically focus the progress view
-    await vscode.commands.executeCommand('texra.progressView.focus');
-
-    logger.info('ProgressView panel shown');
-  } catch (error) {
-    logger.error(`Error showing ProgressView: ${error}`);
-    vscode.window.showErrorMessage(`Could not open ProgressView: ${error}`);
-  }
+  await safeExecuteCommand('workbench.view.extension.texra-panel', [], CHANNEL);
+  await safeExecuteCommand('texra.progressView.focus', [], CHANNEL);
+  logger.info('ProgressView panel shown');
 }
 
 /**

--- a/src/commands/stateRestoreCommand.ts
+++ b/src/commands/stateRestoreCommand.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '../logger/logUtils';
 import { objectToTaskState } from '../utils/configConversion';
+import { safeExecuteCommand } from '../utils/commandUtils';
 
 const CHANNEL = 'stateRestoreCommand';
 logger.initialize(CHANNEL);
@@ -32,7 +33,7 @@ async function restoreState(config: any) {
   try {
     // Focus the webview panel first to make sure it's visible
     // Use the specific view ID instead of the extension to avoid sidebar switching issues
-    await vscode.commands.executeCommand('texra.mainView.focus');
+    await safeExecuteCommand('texra.mainView.focus', [], CHANNEL);
 
     // Create a complete state object from the task state using utility function
     const taskState = objectToTaskState(config);
@@ -79,7 +80,7 @@ async function restoreState(config: any) {
 
         // Try to focus the main view to trigger its activation
         // Use the specific view ID to avoid sidebar switching issues
-        await vscode.commands.executeCommand('texra.mainView.focus');
+        await safeExecuteCommand('texra.mainView.focus', [], CHANNEL);
         logger.info(CHANNEL, 'State stored in context for later restoration');
       }
     } catch (error) {
@@ -102,7 +103,7 @@ async function restoreState(config: any) {
 
       // Try to focus the main view to trigger its activation
       // Use the specific view ID to avoid sidebar switching issues
-      await vscode.commands.executeCommand('texra.mainView.focus');
+      await safeExecuteCommand('texra.mainView.focus', [], CHANNEL);
       logger.info(CHANNEL, 'State stored in context for later restoration');
     }
 

--- a/src/utils/commandUtils.ts
+++ b/src/utils/commandUtils.ts
@@ -1,0 +1,29 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - log
+import * as logger from '../logger/logUtils';
+
+const CHANNEL = 'commandUtils';
+logger.initialize(CHANNEL);
+
+/**
+ * Execute a VS Code command and handle any errors.
+ * @param channel Optional channel for logging errors
+ * @param command Command identifier
+ * @param args Arguments to pass to the command
+ */
+export async function safeExecuteCommand<T>(
+  command: string,
+  args: any[] = [],
+  channel: string = CHANNEL,
+): Promise<T | undefined> {
+  try {
+    return await vscode.commands.executeCommand<T>(command, ...args);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(channel, `Error executing command ${command}: ${message}`);
+    vscode.window.showErrorMessage(`Failed to execute command: ${command}`);
+    return undefined;
+  }
+}

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -22,6 +22,7 @@ import {
 } from '../frontend-utils/fileListingUtils';
 import { polishTextWithAI, FileContext } from '../utils/textEnhancementUtils';
 import { sleep } from '../utils/timeUtils';
+import { safeExecuteCommand } from '../utils/commandUtils';
 
 // Local imports - agent
 import { ToolConfig } from '../agent/ToolConfig';
@@ -138,16 +139,11 @@ export class WebviewMessageHandler {
    * Handle opening the extension settings
    */
   private async handleOpenSettings() {
-    try {
-      await vscode.commands.executeCommand(
-        'workbench.action.openSettings',
-        '@ext:texra-ai.texra',
-      );
-    } catch (error) {
-      vscode.window.showErrorMessage(
-        `Failed to open extension settings: ${error}`,
-      );
-    }
+    await safeExecuteCommand(
+      'workbench.action.openSettings',
+      ['@ext:texra-ai.texra'],
+      CHANNEL,
+    );
   }
 
   private async handleInfoMessage(message: any) {
@@ -812,10 +808,6 @@ export class WebviewMessageHandler {
    * Handle showing the agent history view
    */
   private async handleShowAgentHistory() {
-    try {
-      await vscode.commands.executeCommand('texra.showAgentHistory');
-    } catch (error) {
-      vscode.window.showErrorMessage(`Failed to open agent history: ${error}`);
-    }
+    await safeExecuteCommand('texra.showAgentHistory', [], CHANNEL);
   }
 }


### PR DESCRIPTION
## Summary
- add `safeExecuteCommand` helper to unify logging for VS Code commands
- refactor message and view command handlers to use the helper
- clean up redundant try/catch when running `executeAgent`

## Testing
- `npx prettier -w src/utils/commandUtils.ts src/webview/MessageHandler.ts src/commands/progressViewCommands.ts src/commands/stateRestoreCommand.ts src/commands/executeCommand.ts`
- `npx eslint src/utils/commandUtils.ts src/webview/MessageHandler.ts src/commands/progressViewCommands.ts src/commands/stateRestoreCommand.ts src/commands/executeCommand.ts`
- `npm run lint`
- `npm test` *(fails: getaddrinfo ENOTFOUND update.code.visualstudio.com)*

------
https://chatgpt.com/codex/tasks/task_e_682b2fa9a9288324bef591a2bfa99d09