### PR TITLE
Add texrarules support

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -30,6 +30,7 @@ import {
   getFirstKCharsFromDocument,
   writePromptToXml,
 } from '../utils/promptUtils';
+import { loadTexraRules } from '../utils/texraRulesUtils';
 import {
   applyReplacements,
   getAllReplacements,
@@ -250,6 +251,18 @@ export abstract class BaseReflectionAgent {
   }
 
   /**
+   * Combines the base system prompt with additional rules from `.texrarules`.
+   */
+  protected async getSystemPromptWithRules(): Promise<string> {
+    const basePrompt = await renderPrompt(
+      this.agentPrompt.systemPrompt,
+      this.userVars,
+    );
+    const rules = await loadTexraRules();
+    return rules ? `${basePrompt}\n${rules}` : basePrompt;
+  }
+
+  /**
    * Manages single response cycle with model interaction.
    * @param messages Current conversation messages
    * @param stateRound Current round state
@@ -282,10 +295,7 @@ export abstract class BaseReflectionAgent {
 
         const exists = await fileExists(outputFile);
         const startTime = Date.now();
-        const systemPrompt = await renderPrompt(
-          this.agentPrompt.systemPrompt,
-          this.userVars,
-        );
+        const systemPrompt = await this.getSystemPromptWithRules();
 
         // Save message object to file for debugging if enabled in settings
         const shouldSaveMessageObjects = getConfig(
@@ -825,7 +835,7 @@ export abstract class BaseReflectionAgent {
 
       // Set up initial prompts
       const [systemPrompt, userRequest, userPrefix] = await Promise.all([
-        renderPrompt(this.agentPrompt.systemPrompt, this.userVars),
+        this.getSystemPromptWithRules(),
         renderPrompt(this.agentPrompt.userRequest, this.userVars),
         renderPrompt(this.agentPrompt.userPrefix, this.userVars),
       ]);

--- a/src/utils/texraRulesUtils.ts
+++ b/src/utils/texraRulesUtils.ts
@@ -1,0 +1,48 @@
+// Standard library imports
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Local imports - log
+import * as logger from '../logger/logUtils';
+
+// Local imports - utilities
+import { getWorkspacePath, fileExists, readFile } from './workspaceFileUtils';
+import { fileExistsAbsolute } from './absoluteFileUtils';
+
+const CHANNEL = 'texraRulesUtils';
+logger.initialize(CHANNEL);
+
+/**
+ * Load `.texrarules` from the workspace root or the user's home directory.
+ * @returns The rules content trimmed or an empty string if none found.
+ */
+export async function loadTexraRules(): Promise<string> {
+  try {
+    const workspacePath = getWorkspacePath();
+    const rulesFile = '.texrarules';
+
+    if (workspacePath && (await fileExists(rulesFile))) {
+      const content = await readFile(rulesFile);
+      if (content.trim()) {
+        logger.debug(CHANNEL, `Loaded workspace ${rulesFile}`);
+        return content.trim();
+      }
+    }
+
+    const homeFile = path.join(os.homedir(), rulesFile);
+    if (await fileExistsAbsolute(homeFile)) {
+      const content = await fs.promises.readFile(homeFile, 'utf-8');
+      if (content.trim()) {
+        logger.debug(CHANNEL, `Loaded home ${rulesFile}`);
+        return content.trim();
+      }
+    }
+  } catch (err) {
+    logger.warn(
+      CHANNEL,
+      `Failed to load ${'.texrarules'}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return '';
+}


### PR DESCRIPTION
## Summary
- load `.texrarules` from workspace or home directory
- combine `texrarules` with system prompt

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f1fb8d56483248ef4c83b7ef2f27b