### PR TITLE
Add keybindings for main and progress views

### DIFF
--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -185,7 +185,7 @@ Customize your VS Code environment for a smoother TeXRA experience:
 
 For easier access, especially on wider screens, consider moving the TeXRA view to the secondary sidebar:
 
-1.  Ensure the secondary sidebar is visible: Open VS Code's Command Palette (Ctrl+Shift+P or Cmd+Shift+P on macOS) and run "View: Toggle Secondary Side Bar Visibility" (or use Alt+Cmd+B on macOS).
+1.  Ensure the secondary sidebar is visible: Open VS Code's Command Palette (Ctrl+Shift+P or Cmd+Shift+P on macOS) and run "View: Toggle Secondary Side Bar Visibility" (or use Option+Cmd+B on macOS).
 2.  Drag the TeXRA icon from the primary sidebar (usually on the left) to the secondary sidebar (usually on the right).
 
 ### Cross-Computer Sync for Outputs

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -7,7 +7,7 @@ The ProgressBoard is TeXRA's central hub for monitoring agent execution, viewing
 The ProgressBoard typically appears in the **Panel area** at the bottom of your VS Code window.
 
 - **Automatic**: It often opens automatically when you execute an agent.
-- **Manual**: If it's closed, you can open it via the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) by searching for `View: Show TeXRA ProgressBoard`.
+- **Manual**: If it's closed, you can open it via the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) by searching for `View: Show TeXRA ProgressBoard`, or press `Ctrl+Alt+P` (`Cmd+Option+P` on macOS).
 
 ![ProgressBoard Layout Placeholder](/images/progress-board-layout.png)
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -39,7 +39,7 @@ Let's go through an example to illustrate the basic workflow.
 ### Step 1: Open a Document
 
 1. Open VS Code
-2. Navigate to the TeXRA panel in the sidebar (click the brain icon)
+2. Navigate to the TeXRA panel in the sidebar (click the brain icon) or press `Ctrl+Alt+M` (`Cmd+Option+M` on macOS)
 3. Open or create a LaTeX document from the workspace you'd like to improve
 
 ::: tip Example

--- a/package.json
+++ b/package.json
@@ -1059,7 +1059,19 @@
           "group": "3_modification"
         }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "command": "texra.mainView.focus",
+        "key": "ctrl+alt+m",
+        "mac": "cmd+option+m"
+      },
+      {
+        "command": "texra.showProgressView",
+        "key": "ctrl+alt+p",
+        "mac": "cmd+option+p"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run package",


### PR DESCRIPTION
## Summary
- add keybindings section with mac-specific options
- document shortcuts in guides using Option on macOS

## Testing
- `npm run format`
- `npm run lint` (with warnings)
- `npm test` *(failed: Failed to parse response from https://update.code.visualstudio.com)*

------
https://chatgpt.com/codex/tasks/task_e_683f2c4cdd708324ae5b0ea8337526af