### PR TITLE
Refactor file selection flags

### DIFF
--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -120,7 +120,9 @@ export async function handleClean(config: any) {
     return;
   }
 
-  const outputFiles = config.outputFilesActive ? config.outputFiles || [] : [];
+  const outputFiles = config.activeFiles?.output
+    ? config.outputFiles || []
+    : [];
 
   if (outputFiles.length > 0) {
     logger.info(

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -45,7 +45,9 @@ async function handlePack(config: any) {
   }
 
   // Get output files if multiple files mode is enabled
-  const outputFiles = config.outputFilesActive ? config.outputFiles || [] : [];
+  const outputFiles = config.activeFiles?.output
+    ? config.outputFiles || []
+    : [];
 
   await runPack(
     config.model,

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -1,3 +1,6 @@
+// Local imports - constants
+import type { FileType } from '../utils/constants';
+
 /** Interface for storing task execution state */
 export interface TaskState {
   // Basic task info
@@ -20,11 +23,8 @@ export interface TaskState {
   outputFiles: string[];
 
   // Multiple file selection visibility
-  inputFilesActive: boolean;
-  referenceFilesActive: boolean;
-  auxiliaryFilesActive: boolean;
-  mediaFilesActive: boolean;
-  outputFilesActive: boolean;
+  /** Map of file type to active state */
+  activeFiles: Record<FileType, boolean>;
 
   // Auto extract settings
   autoExtractFigure: boolean;

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -102,7 +102,7 @@ export class ProgressViewMessageHandler {
       inputFile: taskState.inputFile,
       outputNameOverride: taskState.outputNameOverride,
       outputFiles: taskState.outputFiles,
-      outputFilesActive: taskState.outputFilesActive,
+      outputFilesActive: taskState.activeFiles.output,
     });
   }
 
@@ -140,7 +140,7 @@ export class ProgressViewMessageHandler {
       inputFile: taskState.inputFile,
       outputNameOverride: taskState.outputNameOverride,
       outputFiles: taskState.outputFiles,
-      outputFilesActive: taskState.outputFilesActive,
+      outputFilesActive: taskState.activeFiles.output,
     });
   }
 
@@ -181,7 +181,7 @@ export class ProgressViewMessageHandler {
       inputFile: taskState.inputFile,
       outputNameOverride: taskState.outputNameOverride,
       outputFiles: taskState.outputFiles,
-      outputFilesActive: taskState.outputFilesActive,
+      outputFilesActive: taskState.activeFiles.output,
     });
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -803,7 +803,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     const state = this._taskStates.get(streamId);
     if (state) {
       state.outputFiles = [];
-      state.outputFilesActive = false;
+      if (state.activeFiles) {
+        state.activeFiles.output = false;
+      }
       this._taskStates.set(streamId, state);
       this.saveTaskStates();
     }

--- a/src/utils/configConversion.ts
+++ b/src/utils/configConversion.ts
@@ -12,7 +12,8 @@ import { ToolConfig } from '../agent/ToolConfig';
 import {
   SINGLE_FILE_FIELDS,
   MULTIPLE_FILE_FIELDS,
-  ACTIVE_FLAGS,
+  FILE_TYPES,
+  type FileType,
   AUTO_EXTRACT_FIELDS,
   TOOL_CONFIG_FIELDS,
 } from './constants';
@@ -42,23 +43,27 @@ function copyToolFlags(
   });
 }
 
-function setActiveFlagsFromArrays(
-  dest: Record<string, any>,
+function createActiveFilesFromArrays(
   src: Record<string, any>,
-) {
-  ACTIVE_FLAGS.forEach((flag) => {
-    const filesField = flag.replace('Active', '');
-    dest[flag] = Array.isArray(src[filesField]) && src[filesField].length > 0;
+): Record<FileType, boolean> {
+  const active: Record<FileType, boolean> = {} as Record<FileType, boolean>;
+  FILE_TYPES.forEach((type) => {
+    const filesField = `${type}Files`;
+    const flagField = `${filesField}Active`;
+    active[type] =
+      (Array.isArray(src[filesField]) && src[filesField].length > 0) ||
+      !!src[flagField];
   });
+  return active;
 }
 
 function copyActiveFileLists(
   dest: Record<string, any>,
-  src: Record<string, any>,
+  src: { [key: string]: any; activeFiles: Record<FileType, boolean> },
 ) {
   MULTIPLE_FILE_FIELDS.forEach((field) => {
-    const activeFlag = `${field}Active`;
-    dest[field] = src[activeFlag] && src[field] ? src[field] : null;
+    const type = field.replace('Files', '') as FileType;
+    dest[field] = src.activeFiles[type] && src[field] ? src[field] : null;
   });
 }
 
@@ -87,8 +92,8 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
   });
   copyFields(taskState, config, MULTIPLE_FILE_FIELDS, []);
 
-  // Set active flags based on array content
-  setActiveFlagsFromArrays(taskState, config);
+  // Determine active file sets based on array content
+  taskState.activeFiles = createActiveFilesFromArrays(config);
 
   // Add tool config settings
   copyToolFlags(taskState, config, false);
@@ -121,8 +126,8 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   copyFields(taskState, obj, SINGLE_FILE_FIELDS, '', { skipOutputFile: true });
   copyFields(taskState, obj, MULTIPLE_FILE_FIELDS, []);
 
-  // Set active flags
-  copyFields(taskState, obj, ACTIVE_FLAGS, false);
+  // Set active file visibility
+  taskState.activeFiles = createActiveFilesFromArrays(obj);
 
   // Add tool config settings - check both direct property and toolConfig
   copyToolFlags(taskState, obj, false);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,7 +5,9 @@ export const FILE_TYPES = [
   'auxiliary',
   'media',
   'output',
-];
+] as const;
+
+export type FileType = (typeof FILE_TYPES)[number];
 export const SINGLE_FILE_FIELDS = FILE_TYPES.map((type) => `${type}File`);
 export const MULTIPLE_FILE_FIELDS = FILE_TYPES.map((type) => `${type}Files`);
 export const ACTIVE_FLAGS = FILE_TYPES.map((type) => `${type}FilesActive`);


### PR DESCRIPTION
## Summary
- consolidate file selection booleans under an `activeFiles` map
- adapt config conversion helpers for new representation
- update commands and progress view handlers to use the new structure
- expose `FileType` union in constants

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_683f3057b5e08324946992dc3c5431a3