### PR TITLE
Add cumulative usage summary

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -39,6 +39,8 @@ The header provides a summary and actions for the selected stream:
   - **Grey (Stopped)**: The agent finished successfully or was stopped manually before completion.
   - **Red (Error)**: The agent encountered an error during execution.
   - **Yellow (Ready/Initial)**: The view is ready, but no stream is active yet.
+- **Token & Cost Summary**: Displays the combined input and output token counts
+  from all completed rounds (`r0` and `r1`) along with the estimated cost.
 - **Stream Header Actions**:
   - <i class="codicon codicon-debug-stop"></i> **Stop**: Attempts to gracefully stop the currently running task for this stream. For providers supporting `AbortController` (like OpenAI or Anthropic) the active request is aborted immediately; otherwise the current API call will finish before stopping.
   - <i class="codicon codicon-debug-rerun"></i> **Run Again**: Re-runs the task associated with this stream using the _exact same configuration_ (agent, model, files, instruction) that was used when it originally ran. Useful for retrying failed tasks or reproducing results.

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -147,15 +147,37 @@ export function updateStatus(status) {
 }
 
 /**
- * Update token and cost summary in the header (now cleared since we show per-group)
- * @param {Object} usage - Usage data with inputTokens, outputTokens, cost
+ * Update token and cost summary in the header by aggregating usage from
+ * "Round" groups. Falls back to the provided usage if given.
+ * @param {Object} [usage] - Optional pre-computed usage totals
  */
 export function updateUsageSummary(usage) {
   const summaryElem = document.getElementById('runSummary');
   if (!summaryElem) return;
 
-  // Clear global usage display since we now show usage per-group
-  summaryElem.textContent = '';
+  let totals = usage;
+
+  // If usage is not provided, compute it from existing log groups
+  if (!totals) {
+    totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
+    for (const group of getLogGroups().values()) {
+      if (/^Round\s*\d+/i.test(group.name) && group.usage) {
+        totals.inputTokens += group.usage.inputTokens || 0;
+        totals.outputTokens += group.usage.outputTokens || 0;
+        totals.cost += group.usage.cost || 0;
+      }
+    }
+  }
+
+  if (
+    !totals ||
+    (!totals.inputTokens && !totals.outputTokens && !totals.cost)
+  ) {
+    summaryElem.textContent = '';
+    return;
+  }
+
+  summaryElem.textContent = `in: ${totals.inputTokens}, out: ${totals.outputTokens}, $${totals.cost.toFixed(3)}`;
 }
 
 /**
@@ -190,6 +212,16 @@ export function updateGroupUsage(groupId, usage) {
 
   const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
   usageElem.textContent = ` • in: ${inputTokens}, out: ${outputTokens}, $${cost.toFixed(3)}`;
+
+  // Persist usage on the group state so the summary can be computed
+  const group = getLogGroup(groupId);
+  if (group) {
+    group.usage = { inputTokens, outputTokens, cost };
+    setLogGroup(groupId, group);
+  }
+
+  // Refresh the cumulative summary displayed in the header
+  updateUsageSummary();
 }
 
 /**

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -69,6 +69,9 @@ const handlers = {
         }
       });
       logContent.scrollTop = logContent.scrollHeight;
+
+      // Recalculate cumulative usage after loading groups
+      updateUsageSummary();
     }
   },
 


### PR DESCRIPTION
## Summary
- show a combined token/cost summary in ProgressBoard header
- recompute totals when logs load or group usage updates
- document token and cost summary

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683f292d669883248e8c4cb6182159ca