### PR TITLE
Add messageType flag for scratchpad and thinking logs

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -54,7 +54,7 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 
 - **Structure**: Logs are organized into expandable/collapsible groups (e.g., `Initialization`, `Round 0`, `Model Operation`, `Response Cycle`) allowing you to focus on specific stages. Click the arrow next to a group name to toggle it.
 - **Log Levels**: Messages are prefixed with levels like `INFO`, `DEBUG`, `WARN`, `ERROR` to indicate severity. Verbose debug messages (`DEBUG`) are only shown if `texra.logger.verboseOutput` is enabled in settings.
-- **Agent Thinking**: Look for entries indicating `<scratchpad>` content or `Thinking:` blocks, which show the intermediate reasoning steps of the AI model (especially for CoT agents).
+- **Agent Thinking**: The extension flags messages that contain `Scratchpad` or `Thinking` content. These sections reveal the model's intermediate reasoning steps and can be hidden or shown independently of regular log lines.
 - **Errors**: Errors are highlighted, often providing clues if something went wrong.
 
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -71,6 +71,7 @@ class VSCodeTransport extends Transport {
     message: string;
     timestamp: number;
     groupId?: string;
+    messageType: 'scratchpad' | 'thinking' | 'normal';
   }[] = [];
   private groups: Map<string, LogGroup> = new Map();
   private activeGroupId?: string;
@@ -134,16 +135,27 @@ class VSCodeTransport extends Transport {
     // Escape HTML tags in message for ProgressView
     const escapedMessage = escapeHtml(message);
 
-    // Check if this is a scratchpad message
+    // Check if this is scratchpad or thinking content
     const isScratchpad =
       level === 'info' && message.includes('Scratchpad content:');
+    const isThinking =
+      level === 'info' && message.includes('Thinking content:');
+
+    let messageType: 'scratchpad' | 'thinking' | 'normal' = 'normal';
+    if (isScratchpad) {
+      messageType = 'scratchpad';
+    } else if (isThinking) {
+      messageType = 'thinking';
+    }
 
     // Add a data attribute for scratchpad messages to help with styling and processing
     const scratchpadAttr = isScratchpad ? 'data-is-scratchpad="true"' : '';
+    const messageTypeAttr =
+      messageType !== 'normal' ? `data-message-type="${messageType}"` : '';
 
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
     const coloredFormattedMessage =
-      `<div class="log-line ${isScratchpad ? 'scratchpad-log' : ''}" ${scratchpadAttr} ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
+      `<div class="log-line ${isScratchpad ? 'scratchpad-log' : ''}" ${scratchpadAttr} ${messageTypeAttr} ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
       `<span class="timestamp" title="${timestamp}">${emoji} [${timeDisplay}]</span> ` +
       `<span class="level-${level}">${level.toUpperCase().padEnd(8)}</span> ` +
       `<span class="message-${level}">${escapedMessage}</span>` +
@@ -158,6 +170,7 @@ class VSCodeTransport extends Transport {
         level as 'error' | 'warn' | 'info' | 'debug',
         groupId,
         numericTimestamp,
+        messageType,
       );
     } else {
       // Buffer the message if ProgressViewProvider is not available
@@ -166,6 +179,7 @@ class VSCodeTransport extends Transport {
         message: coloredFormattedMessage,
         timestamp: numericTimestamp,
         groupId,
+        messageType,
       });
     }
 
@@ -201,6 +215,7 @@ class VSCodeTransport extends Transport {
         msg.level as 'error' | 'warn' | 'info' | 'debug',
         msg.groupId,
         msg.timestamp,
+        msg.messageType,
       );
     }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -32,6 +32,7 @@ interface ColoredLogMessage {
   level: 'error' | 'warn' | 'info' | 'debug';
   timestamp: number;
   groupId?: string;
+  messageType?: 'scratchpad' | 'thinking' | 'normal';
 }
 
 interface LogGroup {
@@ -403,6 +404,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     level: 'error' | 'warn' | 'info' | 'debug' = 'info',
     groupId?: string,
     timestamp: number = Date.now(),
+    messageType: 'scratchpad' | 'thinking' | 'normal' = 'normal',
   ) {
     // Skip if this stream should be excluded from the progress view
     if (shouldExcludeFromProgressView(stream)) {
@@ -449,6 +451,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       level,
       timestamp,
       groupId,
+      messageType,
     };
 
     const messages = this._logStreams.get(stream)!;

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -18,8 +18,10 @@ marked.setOptions({
 export function formatLogEntry(logMessage) {
   let message = logMessage.message;
 
+  const type = logMessage.messageType;
+
   // Show thinking content before scratchpad content
-  if (message.includes('Thinking content:')) {
+  if (type === 'thinking' || message.includes('Thinking content:')) {
     // Extract the actual thinking content
     const thinkingMatch = message.match(
       /<span class="message-info">(Thinking content:.*?)<\/span>/s,
@@ -40,7 +42,7 @@ export function formatLogEntry(logMessage) {
   }
 
   // Check for scratchpad content
-  if (message.includes('data-is-scratchpad="true"')) {
+  if (type === 'scratchpad' || message.includes('data-is-scratchpad="true"')) {
     // Extract the actual scratchpad content
     const scratchpadMatch = message.match(
       /<span class="message-info">(Scratchpad content:.*?)<\/span>/s,

--- a/src/utils/sdkErrorUtils.ts
+++ b/src/utils/sdkErrorUtils.ts
@@ -36,7 +36,7 @@ export function getSdkErrorMessage(err: unknown): string {
   }
 
   // In normal mode, provide graceful error messages
-  const errorMapping: [Function, string][] = [
+  const errorMapping: [new (...args: any[]) => Error, string][] = [
     [OpenAIRateLimitError, 'Rate limit exceeded.'],
     [AnthropicRateLimitError, 'Rate limit exceeded.'],
     [OpenAIConnectionTimeoutError, 'Connection timed out.'],


### PR DESCRIPTION
## Summary
- introduce `messageType` for log messages
- forward the type from logger to ProgressView
- use the new flag in the progress webview
- document how thinking sections are flagged
- fix linter issue in `sdkErrorUtils`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: ExtendedCompletionUsage type errors)*

------
https://chatgpt.com/codex/tasks/task_e_683459ae5968832494f67371cb29f580