### PR TITLE
Fix duration calculation

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -34,7 +34,9 @@ interface LogGroup {
   id: string;
   name: string;
   startTime: string;
+  startTimestamp: number;
   endTime?: string;
+  endTimestamp?: number;
   status: 'running' | 'error' | 'stopped' | 'ready';
   parentGroupId?: string; // Optional parent group for nested groups
 }
@@ -188,8 +190,10 @@ class VSCodeTransport extends Transport {
         group.id,
         group.name,
         group.startTime,
+        group.startTimestamp,
         group.status,
         group.endTime,
+        group.endTimestamp,
       );
     }
 
@@ -211,13 +215,14 @@ class VSCodeTransport extends Transport {
   startGroup(groupName: string, id?: string, parentGroupId?: string): string {
     const groupId =
       id || `group-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-    const now = new Date();
-    const timeString = now.toISOString();
+    const now = Date.now();
+    const timeString = new Date(now).toISOString();
 
     this.groups.set(groupId, {
       id: groupId,
       name: groupName,
       startTime: timeString,
+      startTimestamp: now,
       status: 'running',
       parentGroupId,
     });
@@ -236,8 +241,10 @@ class VSCodeTransport extends Transport {
         groupId,
         groupName,
         timeString,
+        now,
         'running',
         undefined, // No end time for a new group
+        undefined,
         parentGroupId, // Pass the parent group ID
       );
     }
@@ -252,8 +259,9 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    const now = new Date();
-    group.endTime = now.toISOString();
+    const now = Date.now();
+    group.endTime = new Date(now).toISOString();
+    group.endTimestamp = now;
     group.status = status;
 
     // Skip progress view updates for consolidated channels
@@ -267,6 +275,7 @@ class VSCodeTransport extends Transport {
         groupId,
         status,
         group.endTime,
+        now,
       );
     }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -38,7 +38,9 @@ interface LogGroup {
   id: string;
   name: string;
   startTime: string;
+  startTimestamp: number;
   endTime?: string;
+  endTimestamp?: number;
   status: StatusType;
   parentGroupId?: string;
   usage?: TokenUsageStats;
@@ -162,7 +164,17 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           .filter(([channel]) => shouldPersistStream(channel))
           .map(([streamId, groups]) => [
             streamId,
-            new Map(Object.entries(groups)),
+            new Map(
+              Object.entries(groups).map(([id, group]) => {
+                if (group.startTimestamp === undefined) {
+                  group.startTimestamp = new Date(group.startTime).getTime();
+                }
+                if (group.endTime && group.endTimestamp === undefined) {
+                  group.endTimestamp = new Date(group.endTime).getTime();
+                }
+                return [id, group];
+              }),
+            ),
           ]),
       );
     } else {
@@ -474,8 +486,10 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     groupId: string,
     groupName: string,
     startTime: string,
+    startTimestamp: number,
     status: StatusType,
     endTime?: string,
+    endTimestamp?: number,
     parentGroupId?: string,
   ) {
     // Skip if this stream should be excluded from the progress view
@@ -507,7 +521,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       id: groupId,
       name: groupName,
       startTime,
+      startTimestamp,
       endTime,
+      endTimestamp,
       status,
       parentGroupId,
     });
@@ -522,7 +538,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           id: groupId,
           name: groupName,
           startTime,
+          startTimestamp,
           endTime,
+          endTimestamp,
           status,
           parentGroupId,
         },
@@ -535,6 +553,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     groupId: string,
     status: StatusType,
     endTime?: string,
+    endTimestamp?: number,
   ) {
     // Skip if this stream should be excluded from the progress view
     if (shouldExcludeFromProgressView(stream)) {
@@ -555,6 +574,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     if (endTime) {
       group.endTime = endTime;
     }
+    if (endTimestamp !== undefined) {
+      group.endTimestamp = endTimestamp;
+    }
 
     this._saveState();
 
@@ -565,6 +587,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         groupId,
         status,
         endTime,
+        endTimestamp,
       });
     }
   }
@@ -843,7 +866,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Set end time for all groups
-    const endTime = new Date().toISOString();
+    const endTimestamp = Date.now();
+    const endTime = new Date(endTimestamp).toISOString();
     const STATUS_CANCELLED = STATUS.ERROR;
 
     // Update each running stream
@@ -864,7 +888,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         );
 
         for (const [groupId, group] of activeGroups) {
-          this.updateLogGroup(streamId, groupId, STATUS_CANCELLED, endTime);
+          this.updateLogGroup(
+            streamId,
+            groupId,
+            STATUS_CANCELLED,
+            endTime,
+            endTimestamp,
+          );
         }
       }
     }
@@ -885,7 +915,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     );
 
     const STATUS_INTERRUPTED = STATUS.ERROR;
-    const endTime = new Date().toISOString();
+    const endTimestamp = Date.now();
+    const endTime = new Date(endTimestamp).toISOString();
     let updatedStreams = 0;
     let updatedGroups = 0;
 
@@ -925,7 +956,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
           // Mark all active groups as interrupted
           for (const [groupId, group] of activeGroups) {
-            this.updateLogGroup(streamId, groupId, STATUS_INTERRUPTED, endTime);
+            this.updateLogGroup(
+              streamId,
+              groupId,
+              STATUS_INTERRUPTED,
+              endTime,
+              endTimestamp,
+            );
             updatedGroups++;
           }
         }

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -382,7 +382,7 @@ export function addLogGroup(group) {
 
     if (parentContentElement) {
       // Find the correct chronological position to insert the group
-      const startTime = new Date(group.startTime);
+      const startTime = new Date(group.startTimestamp || group.startTime);
       let insertPosition = null;
 
       // Get all existing child elements in the parent container
@@ -423,8 +423,13 @@ export function addLogGroup(group) {
             const otherGroupId = headerEl.id.replace('group-header-', '');
             const otherGroup = getLogGroup(otherGroupId);
 
-            if (otherGroup && otherGroup.startTime) {
-              const otherTime = new Date(otherGroup.startTime);
+            if (
+              otherGroup &&
+              (otherGroup.startTimestamp || otherGroup.startTime)
+            ) {
+              const otherTime = new Date(
+                otherGroup.startTimestamp || otherGroup.startTime,
+              );
 
               if (startTime < otherTime) {
                 insertPosition = child;
@@ -468,13 +473,16 @@ export function addLogGroup(group) {
  * @param {string} status - New status
  * @param {string} endTime - End time (optional)
  */
-export function updateLogGroupUI(groupId, status, endTime) {
+export function updateLogGroupUI(groupId, status, endTime, endTimestamp) {
   const group = getLogGroup(groupId);
   if (!group) return;
 
   group.status = status;
   if (endTime) {
     group.endTime = endTime;
+  }
+  if (endTimestamp !== undefined) {
+    group.endTimestamp = endTimestamp;
   }
 
   // Update the header in the UI if it exists
@@ -493,7 +501,7 @@ export function updateLogGroupUI(groupId, status, endTime) {
 
     if (endTime) {
       const endDate = new Date(endTime);
-      const startDate = new Date(group.startTime);
+      const startDate = new Date(group.startTimestamp || group.startTime);
       const durationMs = endDate - startDate;
 
       // Update or create duration element
@@ -561,8 +569,10 @@ export function appendLogToGroup(logMessage) {
           if (startTimeElem) {
             const groupId = headerEl.id.replace('group-header-', '');
             const group = getLogGroup(groupId);
-            if (group && group.startTime) {
-              const childDate = new Date(group.startTime);
+            if (group && (group.startTimestamp || group.startTime)) {
+              const childDate = new Date(
+                group.startTimestamp || group.startTime,
+              );
 
               if (msgDate && childDate) {
                 if (msgDate < childDate) {

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -135,12 +135,12 @@ export function getMessageTimestamp(message) {
  * @returns {string} HTML for group header
  */
 export function createGroupHeader(group) {
-  const startDate = new Date(group.startTime);
+  const startDate = new Date(group.startTimestamp || group.startTime);
   const formattedStartTime = formatTime(startDate);
 
   let durationDisplay = '';
-  if (group.endTime) {
-    const endDate = new Date(group.endTime);
+  if (group.endTimestamp || group.endTime) {
+    const endDate = new Date(group.endTimestamp ?? group.endTime);
     const durationMs = endDate - startDate;
     durationDisplay = `<span class="group-duration">${formatDuration(durationMs)}</span>`;
   }
@@ -209,9 +209,9 @@ export function formatDuration(durationMs) {
   // Handle edge cases
   if (durationMs < 0) return '0s';
 
-  // For very short durations, show milliseconds
+  // For very short durations, avoid showing milliseconds
   if (durationMs < 1000) {
-    return `${durationMs}ms`;
+    return '<1s';
   }
 
   const seconds = Math.floor(durationMs / 1000) % 60;
@@ -232,13 +232,16 @@ export function formatDuration(durationMs) {
  * @param {string} status - New status
  * @param {string} endTime - End time (optional)
  */
-export function updateLogGroup(groupId, status, endTime) {
+export function updateLogGroup(groupId, status, endTime, endTimestamp) {
   const group = getLogGroup(groupId);
   if (!group) return;
 
   group.status = status;
   if (endTime) {
     group.endTime = endTime;
+  }
+  if (endTimestamp !== undefined) {
+    group.endTimestamp = endTimestamp;
   }
 
   setLogGroup(groupId, group);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -52,8 +52,8 @@ export function setupMessageHandlers() {
 
             // Sort parent groups by timestamp
             parentGroups.sort((a, b) => {
-              const timeA = new Date(a.startTime);
-              const timeB = new Date(b.startTime);
+              const timeA = a.startTimestamp || new Date(a.startTime).getTime();
+              const timeB = b.startTimestamp || new Date(b.startTime).getTime();
               return timeA - timeB;
             });
 
@@ -64,8 +64,8 @@ export function setupMessageHandlers() {
 
             // Sort child groups by timestamp
             childGroups.sort((a, b) => {
-              const timeA = new Date(a.startTime);
-              const timeB = new Date(b.startTime);
+              const timeA = a.startTimestamp || new Date(a.startTime).getTime();
+              const timeB = b.startTimestamp || new Date(b.startTime).getTime();
               return timeA - timeB;
             });
 
@@ -159,8 +159,18 @@ export function setupMessageHandlers() {
 
       case COMMANDS.UPDATE_LOG_GROUP:
         if (message.stream === getCurrentStream()) {
-          updateLogGroup(message.groupId, message.status, message.endTime);
-          updateLogGroupUI(message.groupId, message.status, message.endTime);
+          updateLogGroup(
+            message.groupId,
+            message.status,
+            message.endTime,
+            message.endTimestamp,
+          );
+          updateLogGroupUI(
+            message.groupId,
+            message.status,
+            message.endTime,
+            message.endTimestamp,
+          );
         }
         break;
 

--- a/src/utils/sdkErrorUtils.ts
+++ b/src/utils/sdkErrorUtils.ts
@@ -36,7 +36,7 @@ export function getSdkErrorMessage(err: unknown): string {
   }
 
   // In normal mode, provide graceful error messages
-  const errorMapping: [Function, string][] = [
+  const errorMapping: [new (...args: any[]) => Error, string][] = [
     [OpenAIRateLimitError, 'Rate limit exceeded.'],
     [AnthropicRateLimitError, 'Rate limit exceeded.'],
     [OpenAIConnectionTimeoutError, 'Connection timed out.'],


### PR DESCRIPTION
## Summary
- compute durations using numeric timestamps for groups
- sort groups chronologically with timestamps
- show "<1s" for short durations

## Testing
- `npm run lint`
- `npm test` *(fails: TS compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68345b7876908324907528d6176c05ca