### PR TITLE
Add log message type for ProgressBoard

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -56,7 +56,7 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 
 - **Structure**: Logs are organized into expandable/collapsible groups (e.g., `Initialization`, `Round 0`, `Model Operation`, `Response Cycle`) allowing you to focus on specific stages. Click the arrow next to a group name to toggle it.
 - **Log Levels**: Messages are prefixed with levels like `INFO`, `DEBUG`, `WARN`, `ERROR` to indicate severity. Verbose debug messages (`DEBUG`) are only shown if `texra.logger.verboseOutput` is enabled in settings.
-- **Agent Thinking**: Look for entries indicating `<scratchpad>` content or `Thinking:` blocks, which show the intermediate reasoning steps of the AI model (especially for CoT agents).
+- **Agent Thinking**: The log highlights model reasoning in purple **Model Thinking** blocks. These sections are flagged internally with a `thinking` type so you can easily spot when the AI is exploring ideas.
 - **Errors**: Errors are highlighted, often providing clues if something went wrong.
 
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -64,6 +64,7 @@ class VSCodeTransport extends Transport {
     message: string;
     timestamp: number;
     groupId?: string;
+    messageType?: 'default' | 'scratchpad' | 'thinking';
   }[] = [];
   private groups: Map<string, LogGroup> = new Map();
   private activeGroupId?: string;
@@ -131,8 +132,18 @@ class VSCodeTransport extends Transport {
     const isScratchpad =
       level === 'info' && message.includes('Scratchpad content:');
 
+    // Check if this is a thinking message
+    const isThinking =
+      level === 'info' && message.includes('Thinking content:');
+
     // Add a data attribute for scratchpad messages to help with styling and processing
     const scratchpadAttr = isScratchpad ? 'data-is-scratchpad="true"' : '';
+
+    const messageType = isScratchpad
+      ? 'scratchpad'
+      : isThinking
+        ? 'thinking'
+        : 'default';
 
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
     const coloredFormattedMessage =
@@ -151,6 +162,7 @@ class VSCodeTransport extends Transport {
         level as 'error' | 'warn' | 'info' | 'debug',
         groupId,
         numericTimestamp,
+        messageType,
       );
     } else {
       // Buffer the message if ProgressViewProvider is not available
@@ -159,6 +171,7 @@ class VSCodeTransport extends Transport {
         message: coloredFormattedMessage,
         timestamp: numericTimestamp,
         groupId,
+        messageType,
       });
     }
 
@@ -194,6 +207,7 @@ class VSCodeTransport extends Transport {
         msg.level as 'error' | 'warn' | 'info' | 'debug',
         msg.groupId,
         msg.timestamp,
+        msg.messageType ?? 'default',
       );
     }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -33,6 +33,7 @@ interface ColoredLogMessage {
   level: 'error' | 'warn' | 'info' | 'debug';
   timestamp: number;
   groupId?: string;
+  messageType?: 'default' | 'scratchpad' | 'thinking';
 }
 
 // Channels that should not be persisted in workspace storage
@@ -134,6 +135,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
                   attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
                 const timestamp = new Date(timeString).getTime();
                 msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
+              }
+              if (!msg.messageType) {
+                msg.messageType = 'default';
               }
               return msg;
             }),
@@ -395,6 +399,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     level: 'error' | 'warn' | 'info' | 'debug' = 'info',
     groupId?: string,
     timestamp: number = Date.now(),
+    messageType: 'default' | 'scratchpad' | 'thinking' = 'default',
   ) {
     // Skip if this stream should be excluded from the progress view
     if (shouldExcludeFromProgressView(stream)) {
@@ -441,6 +446,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       level,
       timestamp,
       groupId,
+      messageType,
     };
 
     const messages = this._logStreams.get(stream)!;
@@ -848,6 +854,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         streamId,
         'Task cancelled due to extension deactivation.',
         'warn',
+        undefined,
+        Date.now(),
+        'default',
       );
 
       // Update all active groups for this stream
@@ -894,6 +903,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           streamId,
           'Task was interrupted due to extension restart.',
           'warn',
+          undefined,
+          Date.now(),
+          'default',
         );
         wasUpdated = true;
         updatedStreams++;
@@ -913,6 +925,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
               streamId,
               `Found inconsistent state: stream status is ${this._streamStatus.get(streamId)} but has running groups.`,
               'warn',
+              undefined,
+              Date.now(),
+              'default',
             );
             updatedStreams++;
           }

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -19,7 +19,10 @@ export function formatLogEntry(logMessage) {
   let message = logMessage.message;
 
   // Show thinking content before scratchpad content
-  if (message.includes('Thinking content:')) {
+  if (
+    logMessage.messageType === 'thinking' ||
+    message.includes('Thinking content:')
+  ) {
     // Extract the actual thinking content
     const thinkingMatch = message.match(
       /<span class="message-info">(Thinking content:.*?)<\/span>/s,
@@ -40,7 +43,10 @@ export function formatLogEntry(logMessage) {
   }
 
   // Check for scratchpad content
-  if (message.includes('data-is-scratchpad="true"')) {
+  if (
+    logMessage.messageType === 'scratchpad' ||
+    message.includes('data-is-scratchpad="true"')
+  ) {
     // Extract the actual scratchpad content
     const scratchpadMatch = message.match(
       /<span class="message-info">(Scratchpad content:.*?)<\/span>/s,


### PR DESCRIPTION
## Summary
- capture a new `messageType` on each log entry
- forward this information to the ProgressBoard
- highlight model thinking based on the flag
- document how thinking sections are shown

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: src/utils/fileVarUtils.ts:36:76 - TS18046)*

------
https://chatgpt.com/codex/tasks/task_e_683f42d1157c8324a1ca5448e11fbc61