### PR TITLE
Add numeric timestamps for log groups

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -92,7 +92,7 @@ class VSCodeTransport extends Transport {
 
     // Extract parts of the timestamp for display formatting
     // Full format is: YYYY-MM-DD HH:mm:ss.SSS
-    const timeDisplay = timestamp.split(' ')[1]; // Just show the time part in the UI
+    const timeDisplay = timestamp.split(' ')[1].split('.')[0]; // Drop milliseconds for UI display
 
     // For consolidated channel, include the source channel in the message
     const channelPrefix = this.useConsolidatedChannel
@@ -218,13 +218,12 @@ class VSCodeTransport extends Transport {
   startGroup(groupName: string, id?: string, parentGroupId?: string): string {
     const groupId =
       id || `group-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-    const now = new Date();
-    const timeString = now.toISOString();
+    const now = Date.now();
 
     this.groups.set(groupId, {
       id: groupId,
       name: groupName,
-      startTime: timeString,
+      startTime: now,
       status: 'running',
       parentGroupId,
     });
@@ -242,7 +241,7 @@ class VSCodeTransport extends Transport {
         this.streamName,
         groupId,
         groupName,
-        timeString,
+        now,
         'running',
         undefined, // No end time for a new group
         parentGroupId, // Pass the parent group ID
@@ -259,8 +258,8 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    const now = new Date();
-    group.endTime = now.toISOString();
+    const now = Date.now();
+    group.endTime = now;
     group.status = status;
 
     // Skip progress view updates for consolidated channels

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -157,7 +157,24 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           .filter(([channel]) => shouldPersistStream(channel))
           .map(([streamId, groups]) => [
             streamId,
-            new Map(Object.entries(groups)),
+            new Map(
+              Object.entries(groups).map(([id, g]) => [
+                id,
+                {
+                  ...g,
+                  startTime:
+                    typeof g.startTime === 'string'
+                      ? new Date(g.startTime).getTime()
+                      : g.startTime,
+                  endTime:
+                    g.endTime !== undefined
+                      ? typeof g.endTime === 'string'
+                        ? new Date(g.endTime).getTime()
+                        : g.endTime
+                      : undefined,
+                },
+              ]),
+            ),
           ]),
       );
     } else {
@@ -471,9 +488,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     stream: string,
     groupId: string,
     groupName: string,
-    startTime: string,
+    startTime: number,
     status: StatusType,
-    endTime?: string,
+    endTime?: number,
     parentGroupId?: string,
   ) {
     // Skip if this stream should be excluded from the progress view
@@ -532,7 +549,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     stream: string,
     groupId: string,
     status: StatusType,
-    endTime?: string,
+    endTime?: number,
   ) {
     // Skip if this stream should be excluded from the progress view
     if (shouldExcludeFromProgressView(stream)) {
@@ -843,7 +860,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Set end time for all groups
-    const endTime = new Date().toISOString();
+    const endTime = Date.now();
     const STATUS_CANCELLED = STATUS.ERROR;
 
     // Update each running stream
@@ -888,7 +905,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     );
 
     const STATUS_INTERRUPTED = STATUS.ERROR;
-    const endTime = new Date().toISOString();
+    const endTime = Date.now();
     let updatedStreams = 0;
     let updatedGroups = 0;
 

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -403,7 +403,7 @@ export function addLogGroup(group) {
 
     if (parentContentElement) {
       // Find the correct chronological position to insert the group
-      const startTime = new Date(group.startTime);
+      const startTime = group.startTime;
       let insertPosition = null;
 
       // Get all existing child elements in the parent container
@@ -430,7 +430,7 @@ export function addLogGroup(group) {
               : new Date(`2000-01-01 ${msgTimestamp}`);
           }
 
-          if (startTime < msgTime) {
+          if (startTime < msgTime.getTime()) {
             insertPosition = child;
             break;
           }
@@ -445,7 +445,7 @@ export function addLogGroup(group) {
             const otherGroup = getLogGroup(otherGroupId);
 
             if (otherGroup && otherGroup.startTime) {
-              const otherTime = new Date(otherGroup.startTime);
+              const otherTime = otherGroup.startTime;
 
               if (startTime < otherTime) {
                 insertPosition = child;
@@ -453,7 +453,7 @@ export function addLogGroup(group) {
               }
             } else {
               const timeText = timeElem.textContent.replace('Started: ', '');
-              const otherTime = new Date(`2000-01-01 ${timeText}`);
+              const otherTime = new Date(`2000-01-01 ${timeText}`).getTime();
 
               if (startTime < otherTime) {
                 insertPosition = child;
@@ -513,8 +513,8 @@ export function updateLogGroupUI(groupId, status, endTime) {
     const timeContainer = header.querySelector('.group-time');
 
     if (endTime) {
-      const endDate = new Date(endTime);
-      const startDate = new Date(group.startTime);
+      const endDate = endTime;
+      const startDate = group.startTime;
       const durationMs = endDate - startDate;
 
       // Update or create duration element
@@ -583,10 +583,10 @@ export function appendLogToGroup(logMessage) {
             const groupId = headerEl.id.replace('group-header-', '');
             const group = getLogGroup(groupId);
             if (group && group.startTime) {
-              const childDate = new Date(group.startTime);
+              const childTime = group.startTime;
 
-              if (msgDate && childDate) {
-                if (msgDate < childDate) {
+              if (msgDate && childTime) {
+                if (msgDate.getTime() < childTime) {
                   insertPosition = child;
                   break;
                 }

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -146,8 +146,7 @@ export function createGroupHeader(group) {
 
   let durationDisplay = '';
   if (group.endTime) {
-    const endDate = new Date(group.endTime);
-    const durationMs = endDate - startDate;
+    const durationMs = group.endTime - group.startTime;
     durationDisplay = `<span class="group-duration">${formatDuration(durationMs)}</span>`;
   }
 
@@ -215,9 +214,9 @@ export function formatDuration(durationMs) {
   // Handle edge cases
   if (durationMs < 0) return '0s';
 
-  // For very short durations, show milliseconds
+  // For very short durations, show under a second
   if (durationMs < 1000) {
-    return `${durationMs}ms`;
+    return '<1s';
   }
 
   const seconds = Math.floor(durationMs / 1000) % 60;

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -39,10 +39,10 @@ const handlers = {
         const parentGroups = message.groups.filter((g) => !g.parentGroupId);
         const childGroups = message.groups.filter((g) => g.parentGroupId);
         parentGroups
-          .sort((a, b) => new Date(a.startTime) - new Date(b.startTime))
+          .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => addLogGroup(g));
         childGroups
-          .sort((a, b) => new Date(a.startTime) - new Date(b.startTime))
+          .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => addLogGroup(g));
       }
       const sortedMessages = [...message.messages].sort((a, b) => {

--- a/src/types/LogTypes.ts
+++ b/src/types/LogTypes.ts
@@ -9,10 +9,10 @@ export interface LogGroup {
   id: string;
   /** Display name of the group */
   name: string;
-  /** ISO timestamp when the group started */
-  startTime: string;
-  /** ISO timestamp when the group ended */
-  endTime?: string;
+  /** Unix timestamp (ms) when the group started */
+  startTime: number;
+  /** Unix timestamp (ms) when the group ended */
+  endTime?: number;
   /** Current status of the group */
   status: 'running' | 'error' | 'stopped' | 'ready';
   /** Parent group ID for nested groups */


### PR DESCRIPTION
## Summary
- represent log group times as numbers
- show timestamps without milliseconds in progress view
- calculate group durations with numerical times
- display `<1s` for very short durations

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com)*

------
https://chatgpt.com/codex/tasks/task_e_683f565bf5e483249b315d5417d1e143