### PR TITLE
Update progress headers

### DIFF
--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -142,7 +142,10 @@ export function getMessageTimestamp(message) {
  */
 export function createGroupHeader(group) {
   const startDate = new Date(group.startTime);
-  const formattedStartTime = formatTime(startDate);
+  const isTopLevel = !group.parentGroupId;
+  const formattedStartTime = isTopLevel
+    ? formatDateTime(startDate)
+    : formatTime(startDate);
 
   let durationDisplay = '';
   if (group.endTime) {
@@ -161,10 +164,15 @@ export function createGroupHeader(group) {
     usageDisplay = `<span class="group-usage"> • in: ${inputTokens}, out: ${outputTokens}, $${cost.toFixed(3)}</span>`;
   }
 
+  const titleMarkup = isTopLevel
+    ? ''
+    : `<span class="group-title">${group.name}</span>`;
+  const topLevelClass = isTopLevel ? 'top-level' : '';
+
   return `
-    <summary id="group-header-${group.id}" class="log-group-header ${group.status}">
+    <summary id="group-header-${group.id}" class="log-group-header ${group.status} ${topLevelClass}">
       <span class="group-status-icon">${statusIcon}</span>
-      <span class="group-title">${group.name}</span>
+      ${titleMarkup}
       <span class="group-time">
         <span class="group-start-time">Started: ${formattedStartTime}</span>
         ${durationDisplay}
@@ -204,6 +212,16 @@ export function formatTime(date) {
     second: '2-digit',
     hour12: false,
   });
+}
+
+/**
+ * Format a date object to a date and time string
+ * @param {Date} date - Date object to format
+ * @returns {string} Formatted date and time string
+ */
+export function formatDateTime(date) {
+  const datePart = date.toLocaleDateString('en-CA');
+  return `${datePart} ${formatTime(date)}`;
 }
 
 /**

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -53,6 +53,11 @@
   margin-left: var(--spacing-medium);
 }
 
+.log-group-header.top-level .group-time {
+  flex-grow: 1;
+  margin-left: 0;
+}
+
 .group-start-time,
 .group-duration {
   margin-right: var(--spacing-medium);


### PR DESCRIPTION
## Summary
- show date in top-level group start time
- left-align time in top-level group header

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(fails: Failed to parse response)*

------
https://chatgpt.com/codex/tasks/task_e_683f56f0940c83248059a352ceaa5f28