### PR TITLE
feat: simplify progress view log format

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -146,10 +146,17 @@ class VSCodeTransport extends Transport {
         : 'default';
 
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
+    const isVerbose = getConfig<boolean>('logger.verboseOutput', false);
     const coloredFormattedMessage =
       `<div class="log-line ${isScratchpad ? 'scratchpad-log' : ''}" ${scratchpadAttr} ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
-      `<span class="timestamp" title="${timestamp}">${emoji} [${timeDisplay}]</span> ` +
-      `<span class="level-${level}">${level.toUpperCase().padEnd(8)}</span> ` +
+      `<span class="timestamp" title="${timestamp}">${emoji}${
+        isVerbose ? ` [${timeDisplay}]` : ''
+      }</span> ` +
+      (isVerbose
+        ? `<span class="level-${level}">${level
+            .toUpperCase()
+            .padEnd(8)}</span> `
+        : '') +
       `<span class="message-${level}">${escapedMessage}</span>` +
       `</div>`;
 


### PR DESCRIPTION
## Summary
- streamline ProgressView logs by hiding timestamp and level unless verbose mode is on

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d1d60cc832489481459e0d4762e