### PR TITLE
Add tooltip for progress view tabs

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -69,7 +69,7 @@ export function updateStreamTabs(streams, activeStream) {
   tabsContainer.innerHTML = streams
     .map(
       (stream) =>
-        `<div class="tab-container ${stream === activeStream ? 'active' : ''}">
+        `<div class="tab-container ${stream === activeStream ? 'active' : ''}" title="${stream}">
           <button class="tab" data-stream="${stream}" title="${stream}">${stream}</button>
           <button class="tab-delete" data-stream="${stream}" title="Delete stream">
             <i class="codicon codicon-close"></i>


### PR DESCRIPTION
## Summary
- show full stream name as tooltip on progress view tabs

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_683f629902fc8324b71b374f13713369