### PR TITLE
Fix stray \end{document> replacement

### DIFF
--- a/src/replacement/replacementRules.ts
+++ b/src/replacement/replacementRules.ts
@@ -633,6 +633,8 @@ export const LATEX_DOCUMENT_REPLACEMENTS: ReplacementCategory = {
     '</xml:documents>': '</latex_documents>',
     '```xml\n': '',
     '</xml>': '',
+    '\\end{document>': '\\end{document}',
+    '\\end{document>\n': '\\end{document}\n',
     '\\end\n': '\\end{document}\n',
 
     // ===== Debtable one-offs =====


### PR DESCRIPTION
## Summary
- handle accidental `\end{document>` sequences lacking the closing brace

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Failed to parse response from update server)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c521f7c83249022ca4d1b03c822