### PR TITLE
Update progress usage display with icons

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -16,6 +16,7 @@ import {
   formatLogEntry,
   getStatusIcon,
   formatDuration,
+  formatTokens,
 } from './logFormatters.js';
 import { STATUS, COMMANDS, SPLIT_SIZES, TOOLBAR_BUTTONS } from './constants.js';
 import { createIconButton } from '@common/templateUtils.js';
@@ -161,7 +162,7 @@ export function updateUsageSummary(usage) {
   if (!totals) {
     totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
     for (const group of getLogGroups().values()) {
-      if (/^Round\s*\d+/i.test(group.name) && group.usage) {
+      if (group.usage) {
         totals.inputTokens += group.usage.inputTokens || 0;
         totals.outputTokens += group.usage.outputTokens || 0;
         totals.cost += group.usage.cost || 0;
@@ -177,7 +178,10 @@ export function updateUsageSummary(usage) {
     return;
   }
 
-  summaryElem.textContent = `in: ${totals.inputTokens}, out: ${totals.outputTokens}, $${totals.cost.toFixed(3)}`;
+  summaryElem.innerHTML =
+    `<i class="codicon codicon-arrow-down"></i> ${formatTokens(totals.inputTokens)}, ` +
+    `<i class="codicon codicon-arrow-up"></i> ${formatTokens(totals.outputTokens)}, ` +
+    `$${totals.cost.toFixed(3)}`;
 }
 
 /**
@@ -211,7 +215,10 @@ export function updateGroupUsage(groupId, usage) {
   }
 
   const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
-  usageElem.textContent = ` • in: ${inputTokens}, out: ${outputTokens}, $${cost.toFixed(3)}`;
+  usageElem.innerHTML =
+    ` • <i class="codicon codicon-arrow-down"></i> ${formatTokens(inputTokens)}, ` +
+    `<i class="codicon codicon-arrow-up"></i> ${formatTokens(outputTokens)}, ` +
+    `$${cost.toFixed(3)}`;
 
   // Persist usage on the group state so the summary can be computed
   const group = getLogGroup(groupId);

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -2,6 +2,15 @@ import { marked } from 'marked';
 import { getLogGroup, setLogGroup } from './stateManager.js';
 import { STATUS } from './constants.js';
 
+/**
+ * Format token counts, displaying values in "k" units when exceeding 4096.
+ * @param {number} tokens - Raw token count
+ * @returns {string} Formatted token count
+ */
+export function formatTokens(tokens) {
+  return tokens > 4096 ? `${Math.round(tokens / 1000)}k` : `${tokens}`;
+}
+
 // Configure marked options
 marked.setOptions({
   gfm: true, // Enable GitHub Flavored Markdown
@@ -160,7 +169,10 @@ export function createGroupHeader(group) {
   let usageDisplay = '';
   if (group.usage) {
     const { inputTokens = 0, outputTokens = 0, cost = 0 } = group.usage;
-    usageDisplay = `<span class="group-usage"> • in: ${inputTokens}, out: ${outputTokens}, $${cost.toFixed(3)}</span>`;
+    usageDisplay =
+      `<span class="group-usage"> • <i class="codicon codicon-arrow-down"></i> ${formatTokens(inputTokens)}, ` +
+      `<i class="codicon codicon-arrow-up"></i> ${formatTokens(outputTokens)}, ` +
+      `$${cost.toFixed(3)}</span>`;
   }
 
   const titleMarkup = isTopLevel


### PR DESCRIPTION
## Summary
- show token icons in progress usage displays
- abbreviate large token counts using k notation
- aggregate costs across all groups for stream summary

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com)*

------
https://chatgpt.com/codex/tasks/task_e_683f74640f4c8324821bfd1f1c274984