### PR TITLE
Fix progress view spacing

### DIFF
--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -178,7 +178,7 @@
   align-items: center;
   padding: var(--spacing-tiny) 0;
   gap: var(--spacing-medium);
-  margin-bottom: var(--spacing-small);
+  margin-bottom: var(--spacing-tiny);
 }
 
 .file-name {


### PR DESCRIPTION
## Summary
- shrink margin between generated files in the progress view

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_683f79c6ab688324a11787341e57c671