### PR TITLE
Fix diff PDF compile output directory

### DIFF
--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -422,7 +422,8 @@ export class OutputHandler {
               path.dirname(baseFile),
               result.diffFileName,
             );
-            await compileLatex2Pdf(diffPath, this.channel);
+            const buildDir = path.join(path.dirname(diffPath), 'build');
+            await compileLatex2Pdf(diffPath, this.channel, buildDir);
           }
         }
       }
@@ -478,7 +479,8 @@ export class OutputHandler {
               path.dirname(prevOutputFile),
               result.diffFileName,
             );
-            await compileLatex2Pdf(diffPath, this.channel);
+            const buildDir = path.join(path.dirname(diffPath), 'build');
+            await compileLatex2Pdf(diffPath, this.channel, buildDir);
           }
         }
       }


### PR DESCRIPTION
## Summary
- compile auto-generated round and between-round diff files into a `build/` subfolder

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Failed to parse response from update.code.visualstudio.com)*

------
https://chatgpt.com/codex/tasks/task_e_683f83a35c148324ab90cfe8b750e29e