### PR TITLE
Add OpenAI Responses API support

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -182,3 +182,4 @@ Configure streaming in VS Code Settings:
 
 - [Built-in Agents](./built-in-agents.md): See which agents work well with different models.
 - [Configuration](./configuration.md): Learn about other model-related settings like streaming.
+- [OpenAI Responses API](./openai-responses-api.md): Overview of the new stateful API and how TeXRA uses it.

--- a/docs/guide/openai-responses-api.md
+++ b/docs/guide/openai-responses-api.md
@@ -1,0 +1,34 @@
+# Using the OpenAI Responses API
+
+The Responses API is OpenAI's latest method for interacting with models. It keeps the conversation state on the server, so you can continue a dialogue just by passing the `previous_response_id` of an earlier call.
+
+```python
+response_two = client.responses.create(
+    model="gpt-4o-mini",
+    input="tell me another",
+    previous_response_id=response.id
+)
+```
+
+Inputs use new item types like `input_text` and `input_image` instead of the older `text` or `image_url` fields. Outputs can be accessed via `response.output_text` or from the first item of `response.output`:
+
+```python
+print(response.output[0].content[0].text)
+```
+
+You can also use hosted tools such as web search directly:
+
+```python
+response = client.responses.create(
+    model="gpt-4o",
+    input=[{
+        "role": "user",
+        "content": [
+            {"type": "input_text", "text": "What's new in AI today?"}
+        ]
+    }],
+    tools=[{"type": "web_search"}]
+)
+```
+
+This API is now supported by TeXRA's OpenAI model handler.

--- a/src/agent/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlerOpenAIResponse.ts
@@ -52,7 +52,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
 
     const newMessages = messages.slice(this.sentMessages).map((msg) => ({
       role: msg.role,
-      content: msg.content,
+      content: msg.content.map((part: any) => {
+        if (part.type === 'text') {
+          return { type: 'input_text', text: part.text };
+        }
+        if (part.type === 'image_url') {
+          const url =
+            typeof part.image_url === 'string'
+              ? part.image_url
+              : part.image_url.url;
+          const detail = part.image_url?.detail ?? 'auto';
+          return { type: 'input_image', image_url: url, detail };
+        }
+        return part;
+      }),
     }));
 
     const params: any = {
@@ -108,7 +121,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       input_tokens_details: { cached_tokens: 0 },
       output_tokens_details: { reasoning_tokens: 0 },
     };
-    const newResponse = responseObject.output_text?.trim() || '';
+    let newResponse = responseObject.output_text?.trim() || '';
+    if (!newResponse && Array.isArray(responseObject.output)) {
+      const first = responseObject.output[0];
+      const textPart = first?.content?.[0]?.text;
+      if (typeof textPart === 'string') {
+        newResponse = textPart.trim();
+      }
+    }
     const stopReason =
       responseObject.status === 'completed' ? 'stop' : 'length';
 


### PR DESCRIPTION
## Summary
- update OpenAI Responses handler for `input_text`/`input_image` conversion
- read text output from `response.output` as fallback
- document the new OpenAI Responses API usage

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe9a14a1c8324ba0788dceb2b3f7d