### PR TITLE
Fix o1-pro entry

### DIFF
--- a/src/model/providers/openaiReasoningModels.ts
+++ b/src/model/providers/openaiReasoningModels.ts
@@ -80,6 +80,21 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
+  o1pro: {
+    name: 'o1pro',
+    fullName: 'o1-pro-2025-03-19',
+    openrouterFullName: 'openai/o1-pro-2025-03-19',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 100000,
+    contextWindow: 200000,
+    inputPrice: 150.0,
+    outputPrice: 600.0,
+    capabilities: {
+      ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
+      supportsVision: true,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
   o1preview: {
     name: 'o1preview',
     fullName: 'o1-preview-2024-09-12',


### PR DESCRIPTION
## Summary
- drop docs mention for `o1pro`
- adjust pricing in the registry

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no results due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6840685eb41c83248b8d74792366e5a2