### PR TITLE
Fix: Resolve incorrect file cleanup in progress view due to path handling

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -4,20 +4,21 @@ import * as vscode from 'vscode';
 // Local imports - webview
 import { ProgressViewContentProvider } from './ProgressViewContentProvider';
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
+
 import { TaskState } from '../logger/TaskState';
 import { AgentLogger } from '../logger/AgentLogger';
+
 import { getConfig } from '../utils/configUtils';
 import { objectToTaskState } from '../utils/configConversion';
-import {
-  fileExistsAbsolute,
-  filterExistingFiles,
-} from '../utils/absoluteFileUtils';
+import { filterExistingFiles } from '../utils/workspaceFileUtils';
 import {
   shouldExcludeFromProgressView,
   shouldPersistStream,
 } from '../utils/loggerUtils';
+
 import { TokenUsageStats } from '../types/UsageTypes';
 import { LogGroup } from '../types/LogTypes';
+
 // @ts-ignore - Import JavaScript module
 import { STATUS, COMMANDS } from './modules/constants.js';
 

--- a/src/utils/absoluteFileUtils.ts
+++ b/src/utils/absoluteFileUtils.ts
@@ -9,34 +9,3 @@ export async function fileExistsAbsolute(filePath: string): Promise<boolean> {
     return false;
   }
 }
-
-/**
- * Filters an array of objects with path properties to only include those with existing files.
- * Uses parallel execution for better performance when checking many files.
- * @param items Array of items with a path property
- * @returns Promise that resolves to filtered array containing only items with existing files
- */
-export async function filterExistingFiles<T extends { path: string }>(
-  items: T[],
-): Promise<T[]> {
-  if (!items || items.length === 0) {
-    return [];
-  }
-
-  const fileCheckPromises = items.map(async (item) => {
-    try {
-      const exists = await fileExistsAbsolute(item.path);
-      return { item, exists };
-    } catch (error) {
-      // If there's an error checking a specific file, assume it doesn't exist
-      // but log the error for debugging
-      console.warn(
-        `Error checking file existence for ${item.path}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return { item, exists: false };
-    }
-  });
-
-  const results = await Promise.all(fileCheckPromises);
-  return results.filter((result) => result.exists).map((result) => result.item);
-}

--- a/src/utils/workspaceFileUtils.ts
+++ b/src/utils/workspaceFileUtils.ts
@@ -300,3 +300,35 @@ export function readFileBytesSync(filePath: string): Buffer {
     throw err;
   }
 }
+
+/**
+ * Filters an array of objects with path properties to only include those with existing files.
+ * Uses parallel execution for better performance when checking many files.
+ * @param items Array of items with a path property
+ * @returns Promise that resolves to filtered array containing only items with existing files
+ */
+export async function filterExistingFiles<T extends { path: string }>(
+  items: T[],
+): Promise<T[]> {
+  if (!items || items.length === 0) {
+    return [];
+  }
+
+  const fileCheckPromises = items.map(async (item) => {
+    try {
+      // Use the existing fileExists function which handles relative/absolute path conversion
+      const exists = await fileExists(item.path);
+      return { item, exists };
+    } catch (error) {
+      // If there's an error checking a specific file, assume it doesn't exist
+      // but log the error for debugging
+      console.warn(
+        `Error checking file existence for ${item.path}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return { item, exists: false };
+    }
+  });
+
+  const results = await Promise.all(fileCheckPromises);
+  return results.filter((result) => result.exists).map((result) => result.item);
+}


### PR DESCRIPTION
Fixes issue where progress view incorrectly removed valid output files during startup due to relative vs absolute path handling. Moved filterExistingFiles to workspaceFileUtils and simplified it to use existing fileExists function.