### PR TITLE
Fix progress view empty after reload

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -74,6 +74,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private readonly _activeStreamKey = 'texra.activeLogStream';
   private _taskStates: Map<string, TaskState> = new Map();
   private _usageStats: Map<string, TokenUsageStats> = new Map();
+  private _webviewReady = false;
+  private _pendingUpdate = false;
   private readonly logger: AgentLogger;
 
   constructor(
@@ -120,6 +122,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._viewDisposables.forEach((d) => d.dispose());
     this._viewDisposables = [];
     this._view = undefined;
+    this._webviewReady = false;
+    this._pendingUpdate = false;
   }
 
   private _getWorkspaceKey(key: string = this._storageKey): string {
@@ -369,6 +373,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     // Clean up old view if it exists
     this._cleanupView();
 
+    this._webviewReady = false;
+    this._pendingUpdate = false;
+
     // Instead of automatically marking running tasks as errors, preserve their status
     // We no longer need to reset running stream statuses - they'll be preserved from storage
     // this._resetRunningStreamStatuses();
@@ -419,12 +426,19 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       webviewView.webview,
     );
 
-    // Initialize webview with current state
+    // Initialize webview with current state after webview signals readiness
     this._updateWebview();
 
     // Handle webview messages
     this._viewDisposables.push(
       webviewView.webview.onDidReceiveMessage(async (message) => {
+        if (message.command === COMMANDS.WEBVIEW_READY) {
+          this._webviewReady = true;
+          if (this._pendingUpdate) {
+            this._updateWebview();
+          }
+          return;
+        }
         await this._messageHandler.handleMessage(message, webviewView);
       }),
     );
@@ -439,6 +453,11 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   private _updateWebview() {
     if (!this._view) {
+      return;
+    }
+
+    if (!this._webviewReady) {
+      this._pendingUpdate = true;
       return;
     }
 
@@ -486,6 +505,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         status: STATUS.READY,
       });
     }
+
+    this._pendingUpdate = false;
   }
 
   public addLogMessage(

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -43,6 +43,7 @@ export const COMMANDS = {
   ACCEPT_FILE: 'acceptFile',
   MERGE_FILE: 'mergeFile',
   LATEXDIFF_FILE: 'latexdiffFile',
+  WEBVIEW_READY: 'webviewReady',
 };
 
 export const TOOLBAR_BUTTONS = [

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -5,6 +5,8 @@ import {
   applyGroupToggleStates,
   renderToolbar,
 } from './modules/domHandlers.js';
+import { vscode } from '@common/vscodeApi.js';
+import { COMMANDS } from './modules/constants.js';
 
 // Initialize the state when the window loads
 initializeState();
@@ -20,4 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Apply saved group toggle states to any groups already in the DOM
   applyGroupToggleStates();
+
+  // Notify extension that the webview is ready to receive messages
+  vscode.postMessage({ command: COMMANDS.WEBVIEW_READY });
 });


### PR DESCRIPTION
## Summary
- ensure ProgressView waits for frontend ready signal before updating
- signal readiness from progress view script
- expose `WEBVIEW_READY` constant

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack error due to env)*

------
https://chatgpt.com/codex/tasks/task_e_68453a8c6ba88324a716bf2e629a873e