### PR TITLE
Fix progress view header styling

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -18,6 +18,7 @@ import {
   formatDuration,
   formatTokens,
   formatGroupHeaderElements,
+  getGroupHeaderClass,
 } from './logFormatters.js';
 import { STATUS, COMMANDS, SPLIT_SIZES, TOOLBAR_BUTTONS } from './constants.js';
 import { createIconButton } from '@common/templateUtils.js';
@@ -582,7 +583,7 @@ export function updateLogGroupUI(groupId, status, endTime) {
   // Update the header in the UI if it exists
   const header = document.getElementById(`group-header-${groupId}`);
   if (header) {
-    header.className = `log-group-header ${status}`;
+    header.className = getGroupHeaderClass(group);
 
     // Update the status icon
     const statusIconElem = header.querySelector('.group-status-icon');

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -149,6 +149,19 @@ export function formatGroupHeaderElements(
 }
 
 /**
+ * Get the CSS class string for a group header
+ * @param {Object} group - Log group data
+ * @returns {string} Computed class string
+ */
+export function getGroupHeaderClass(group) {
+  const classes = ['log-group-header', group.status];
+  if (!group.parentGroupId) {
+    classes.push('top-level');
+  }
+  return classes.join(' ');
+}
+
+/**
  * Create a group header HTML
  * @param {Object} group - Log group data
  * @returns {string} HTML for group header
@@ -182,7 +195,7 @@ export function createGroupHeader(group) {
   const titleMarkup = isTopLevel
     ? ''
     : `<span class="group-title">${group.name}</span>`;
-  const topLevelClass = isTopLevel ? 'top-level' : '';
+  const headerClass = getGroupHeaderClass(group);
 
   const timeMarkup = `
       <span class="group-time">
@@ -202,7 +215,7 @@ export function createGroupHeader(group) {
   );
 
   return `
-    <summary id="group-header-${group.id}" class="log-group-header ${group.status} ${topLevelClass}">
+    <summary id="group-header-${group.id}" class="${headerClass}">
       <span class="group-status-icon">${statusIcon}</span>${titleMarkup}${headerContents}
     </summary>
   `;


### PR DESCRIPTION
## Summary
- preserve `top-level` class when log group headers update
- centralize header class generation

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no output due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68454cd59bc88324a39cc0798a39e09e