### PR TITLE
Refactor compare command to use workspace utils

### DIFF
--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -1,6 +1,5 @@
 // Standard library imports
 import * as path from 'path';
-import * as fs from 'fs/promises';
 
 // Third-party imports
 import * as vscode from 'vscode';
@@ -12,6 +11,8 @@ import * as logger from '../logger/logUtils';
 import {
   getFullPathFromWorkspace,
   fileExists,
+  readFile,
+  writeFile,
 } from '../utils/workspaceFileUtils';
 import { registerDiffRefresh } from '../utils/diffViewUtils';
 import { DIFF_REGISTRATION_DELAY_MS } from '../utils/constants';
@@ -141,12 +142,8 @@ async function handleAcceptEdited(
       return;
     }
 
-    // Get full paths
-    const baseFilePath = getFullPathFromWorkspace(fileToUse);
-    const editedFilePath = getFullPathFromWorkspace(editedFile);
-
-    // Read content from edited file
-    const editedContent = await fs.readFile(editedFilePath, 'utf8');
+    // Read content from edited file using workspace utilities
+    const editedContent = await readFile(editedFile);
 
     // Confirm with user
     const baseFileName = path.basename(fileToUse);
@@ -163,8 +160,8 @@ async function handleAcceptEdited(
       return;
     }
 
-    // Write content to base file
-    await fs.writeFile(baseFilePath, editedContent);
+    // Write content to base file using workspace utilities
+    await writeFile(fileToUse, editedContent);
 
     vscode.window.showInformationMessage(
       `Successfully replaced '${baseFileName}' with content from '${editedFileName}'`,

--- a/src/utils/absoluteFileUtils.ts
+++ b/src/utils/absoluteFileUtils.ts
@@ -9,3 +9,9 @@ export async function fileExistsAbsolute(filePath: string): Promise<boolean> {
     return false;
   }
 }
+
+export async function readFileAbsolute(filePath: string): Promise<string> {
+  const uri = vscode.Uri.file(filePath);
+  const content = await vscode.workspace.fs.readFile(uri);
+  return Buffer.from(content).toString('utf-8');
+}

--- a/src/utils/fileVarUtils.ts
+++ b/src/utils/fileVarUtils.ts
@@ -1,6 +1,8 @@
 // Local imports - utilities
-import * as fs from 'fs/promises';
 import { readFile } from './workspaceFileUtils';
+import { readFileAbsolute } from './absoluteFileUtils';
+
+// Local imports - log
 import { AgentLogger } from '../logger/AgentLogger';
 
 /**
@@ -25,7 +27,7 @@ export async function setVarFromFile(
 ): Promise<boolean> {
   try {
     const fileContent = absolute
-      ? await fs.readFile(filePath, 'utf-8')
+      ? await readFileAbsolute(filePath)
       : await readFile(filePath);
     userVars[`${varName}_FILE`] = filePath;
     userVars[`${varName}_CONTENT`] = fileContent;

--- a/src/utils/texraRulesUtils.ts
+++ b/src/utils/texraRulesUtils.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -8,7 +7,7 @@ import * as logger from '../logger/logUtils';
 
 // Local imports - utilities
 import { getWorkspacePath, fileExists, readFile } from './workspaceFileUtils';
-import { fileExistsAbsolute } from './absoluteFileUtils';
+import { fileExistsAbsolute, readFileAbsolute } from './absoluteFileUtils';
 
 const CHANNEL = 'texraRulesUtils';
 logger.initialize(CHANNEL);
@@ -32,7 +31,7 @@ export async function loadTexraRules(): Promise<string> {
 
     const homeFile = path.join(os.homedir(), rulesFile);
     if (await fileExistsAbsolute(homeFile)) {
-      const content = await fs.promises.readFile(homeFile, 'utf-8');
+      const content = await readFileAbsolute(homeFile);
       if (content.trim()) {
         logger.debug(CHANNEL, `Loaded home ${rulesFile}`);
         return content.trim();


### PR DESCRIPTION
## Summary
- use `readFile` and `writeFile` from `workspaceFileUtils`
- drop direct `fs` usage in compare command
- replace `fs` use in texraRulesUtils and fileVarUtils
- add `readFileAbsolute` helper

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test output only)*

------
https://chatgpt.com/codex/tasks/task_e_68454a41416483249786e2694d7707d7