### PR TITLE
Add optional suppress button

### DIFF
--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -316,7 +316,6 @@ async function executeAgentWithLogging<T extends IAgent>(
       errorMsg.includes('Missing API key') ||
       errorMsg.includes('API key not found')
     ) {
-      vscode.window.showErrorMessage(errorMsg);
       const setKey = 'Set API Key';
       await showInstructionWithSuppress(
         context,
@@ -362,7 +361,6 @@ export async function executeAgent(
       // Get model configuration
       const modelName = fullConfig.model;
       if (!(modelName in MODEL_CONFIGS)) {
-        vscode.window.showErrorMessage(`Model ${modelName} is not recognized.`);
         const openDocs = 'Model Documentation';
         await showInstructionWithSuppress(
           context,

--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -94,6 +94,7 @@ export async function getAgentPath(
               ),
           },
         ],
+        false,
       );
 
       const errorMsg = `Could not find yaml file for agent: ${agentName}`;
@@ -322,6 +323,7 @@ async function executeAgentWithLogging<T extends IAgent>(
             callback: () => vscode.commands.executeCommand('texra.setApiKey'),
           },
         ],
+        false,
       );
     } else {
       // Show regular error message for other errors
@@ -368,6 +370,7 @@ export async function executeAgent(
                 vscode.commands.executeCommand('texra.openDoc', 'models'),
             },
           ],
+          false,
         );
         throw new Error(`Model ${modelName} not found in MODEL_CONFIGS`);
       }

--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -79,11 +79,6 @@ export async function getAgentPath(
     });
 
     if (builtInMatches.length === 0) {
-      const errorMessage = `Agent "${agentName}" not found`;
-      vscode.window.showErrorMessage(
-        `${errorMessage}. TeXRA couldn't find this agent in either the built-in or custom directories.`,
-      );
-
       const configureButton = 'Open Settings';
       await showInstructionWithSuppress(
         context,

--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -24,6 +24,10 @@ import { MergeAgent } from './MergeAgent';
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 import { AgentLogger } from '../logger/AgentLogger';
 import { openBuildDisplayIfTex } from '../utils/openBuildUtils';
+import {
+  checkExpectedOutputs,
+  showInstructionWithSuppress,
+} from '../utils/instructionUtils';
 import { IAgent } from './IAgent';
 
 const CHANNEL = 'executeAgent';
@@ -75,27 +79,27 @@ export async function getAgentPath(
     });
 
     if (builtInMatches.length === 0) {
-      const configureButton = 'Configure Custom Agents';
       const errorMessage = `Agent "${agentName}" not found`;
+      vscode.window.showErrorMessage(
+        `${errorMessage}. TeXRA couldn't find this agent in either the built-in or custom directories.`,
+      );
 
-      vscode.window
-        .showErrorMessage(
-          `${errorMessage}. TeXRA couldn't find this agent in either the built-in or custom directories.`,
+      const configureButton = 'Open Settings';
+      await showInstructionWithSuppress(
+        context,
+        'agentNotFound',
+        'Agent configuration is missing. Configure your custom agents directory and ensure the YAML file exists.',
+        [
           {
-            modal: true,
-            detail:
-              'You can configure a custom agents directory in the extension settings.',
+            title: configureButton,
+            callback: () =>
+              vscode.commands.executeCommand(
+                'workbench.action.openSettings',
+                '@ext:texra-ai.texra explorer.agentsDirectory',
+              ),
           },
-          configureButton,
-        )
-        .then((selection) => {
-          if (selection === configureButton) {
-            vscode.commands.executeCommand(
-              'workbench.action.openSettings',
-              '@ext:texra-ai.texra explorer.agentsDirectory',
-            );
-          }
-        });
+        ],
+      );
 
       const errorMsg = `Could not find yaml file for agent: ${agentName}`;
       throw new Error(errorMsg);
@@ -260,6 +264,7 @@ async function executeAgentWithLogging<T extends IAgent>(
             mainTaskGroupId,
           );
           await agent.run();
+          await checkExpectedOutputs(config.outputFiles, context, agent);
           // Mark the task as completed successfully
           logger.debug(`Task completed successfully`, mainTaskGroupId);
           logger.endGroup(mainTaskGroupId, 'stopped');
@@ -311,16 +316,19 @@ async function executeAgentWithLogging<T extends IAgent>(
       errorMsg.includes('Missing API key') ||
       errorMsg.includes('API key not found')
     ) {
+      vscode.window.showErrorMessage(errorMsg);
       const setKey = 'Set API Key';
-      const result = await vscode.window.showErrorMessage(
-        errorMsg,
-        { modal: true },
-        setKey,
+      await showInstructionWithSuppress(
+        context,
+        'missingApiKey',
+        'API key not found. Set your API key in the extension settings and run again.',
+        [
+          {
+            title: setKey,
+            callback: () => vscode.commands.executeCommand('texra.setApiKey'),
+          },
+        ],
       );
-
-      if (result === setKey) {
-        vscode.commands.executeCommand('texra.setApiKey');
-      }
     } else {
       // Show regular error message for other errors
       vscode.window.showErrorMessage(errorMsg);
@@ -354,14 +362,20 @@ export async function executeAgent(
       // Get model configuration
       const modelName = fullConfig.model;
       if (!(modelName in MODEL_CONFIGS)) {
+        vscode.window.showErrorMessage(`Model ${modelName} is not recognized.`);
         const openDocs = 'Model Documentation';
-        const choice = await vscode.window.showErrorMessage(
-          `Model ${modelName} is not recognized.`,
-          openDocs,
+        await showInstructionWithSuppress(
+          context,
+          'modelNotRecognized',
+          `Model "${modelName}" is not recognized. Review the documentation for supported models.`,
+          [
+            {
+              title: openDocs,
+              callback: () =>
+                vscode.commands.executeCommand('texra.openDoc', 'models'),
+            },
+          ],
         );
-        if (choice === openDocs) {
-          vscode.commands.executeCommand('texra.openDoc', 'models');
-        }
         throw new Error(`Model ${modelName} not found in MODEL_CONFIGS`);
       }
 

--- a/src/commands/yamlCommands.ts
+++ b/src/commands/yamlCommands.ts
@@ -10,6 +10,7 @@ import { loadYaml, loadAgentSettingAndPrompts } from '../agent/agentLoad';
 import * as logger from '../logger/logUtils';
 import { getAgentPath } from '../agent/executeAgent';
 import { AgentType } from '../agent/AgentDataclass';
+import { showInstructionWithSuppress } from '../utils/instructionUtils';
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);
@@ -196,7 +197,9 @@ export async function handleLoadSpecificAgent(
   }
 }
 
-export async function handleParseYaml(): Promise<void> {
+export async function handleParseYaml(
+  context: vscode.ExtensionContext,
+): Promise<void> {
   try {
     // Get active editor
     const editor = vscode.window.activeTextEditor;
@@ -240,6 +243,13 @@ export async function handleParseYaml(): Promise<void> {
         `Failed to parse YAML: ${err instanceof Error ? err.message : String(err)}`,
       );
       vscode.window.showErrorMessage('Failed to parse YAML content');
+      await showInstructionWithSuppress(
+        context,
+        'yamlParseFail',
+        'The YAML file contains syntax errors. Please correct them and run the command again.',
+        undefined,
+        false,
+      );
     }
   } catch (err) {
     logger.error(
@@ -330,7 +340,9 @@ export function registerYamlCommands(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(yamlCommands.loadSpecificAgent, () =>
       handleLoadSpecificAgent(context),
     ),
-    vscode.commands.registerCommand(yamlCommands.parseYaml, handleParseYaml),
+    vscode.commands.registerCommand(yamlCommands.parseYaml, () =>
+      handleParseYaml(context),
+    ),
     vscode.commands.registerCommand(yamlCommands.testYamlBrackets, () =>
       handleTestYamlBrackets(context),
     ),

--- a/src/utils/instructionUtils.ts
+++ b/src/utils/instructionUtils.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { getFullPathFromWorkspace, fileExists } from './workspaceFileUtils';
+import { fileExistsAbsolute } from './absoluteFileUtils';
+
+/**
+ * Show an instruction message that can be permanently dismissed.
+ *
+ * @param context Extension context for global storage
+ * @param key Unique key for the instruction
+ * @param message Message to display to the user
+ */
+export async function showInstructionWithSuppress(
+  context: vscode.ExtensionContext,
+  key: string,
+  message: string,
+  actions?: { title: string; callback: () => Thenable<void> | void }[],
+  showSuppress = true,
+): Promise<void> {
+  if (showSuppress) {
+    const dismissed = context.globalState.get<boolean>(`instruction.${key}`);
+    if (dismissed) {
+      return;
+    }
+  }
+
+  const never = 'Never remind again';
+  const buttons = actions?.map((a) => a.title) ?? [];
+  const choice = await vscode.window.showInformationMessage(
+    message,
+    ...buttons,
+    ...(showSuppress ? [never] : []),
+  );
+
+  if (showSuppress && choice === never) {
+    await context.globalState.update(`instruction.${key}`, true);
+  } else if (choice) {
+    const action = actions?.find((a) => a.title === choice);
+    await action?.callback();
+  }
+}
+
+/**
+ * Validate that expected output files exist. If any are missing,
+ * show a reminder about checking the XML output.
+ */
+export async function checkExpectedOutputs(
+  expectedFiles: string[] | null | undefined,
+  context: vscode.ExtensionContext,
+  agent?: unknown,
+): Promise<void> {
+  if (!expectedFiles || expectedFiles.length === 0) {
+    return;
+  }
+
+  for (const file of expectedFiles) {
+    const exists = path.isAbsolute(file)
+      ? await fileExistsAbsolute(file)
+      : await fileExists(file);
+    if (!exists) {
+      const openBtn = 'Open XML';
+
+      let xmlPath: string | undefined;
+      const outputs: string[] = [];
+
+      if (agent && typeof agent === 'object') {
+        const anyAgent = agent as any;
+        if (Array.isArray(anyAgent.outputFile)) {
+          outputs.push(...anyAgent.outputFile.filter(Boolean));
+        }
+        if (anyAgent.outputHandler?.outputFiles) {
+          const fileMap = anyAgent.outputHandler.outputFiles as Record<
+            string,
+            string[]
+          >;
+          for (const roundFiles of Object.values(fileMap)) {
+            if (Array.isArray(roundFiles)) {
+              outputs.push(...roundFiles.filter(Boolean));
+            }
+          }
+        }
+      }
+
+      xmlPath = outputs.find((p) => p.endsWith('.xml') || p.endsWith('.tex'));
+      if (!xmlPath) {
+        xmlPath = file.replace(/\.[^.]+$/, '.xml');
+      }
+
+      await showInstructionWithSuppress(
+        context,
+        'xmlOutputMismatch',
+        `Expected output "${path.basename(
+          file,
+        )}" was not generated. Open the XML file to check tag consistency, then run again.`,
+        [
+          {
+            title: openBtn,
+            callback: async () => {
+              if (!xmlPath) {
+                vscode.window.showWarningMessage('XML file path not found');
+                return;
+              }
+
+              const xmlExists = path.isAbsolute(xmlPath)
+                ? await fileExistsAbsolute(xmlPath)
+                : await fileExists(xmlPath);
+              if (!xmlExists) {
+                vscode.window.showWarningMessage(
+                  `XML file not found: ${path.basename(xmlPath)}`,
+                );
+                return;
+              }
+              const uri = path.isAbsolute(xmlPath)
+                ? vscode.Uri.file(xmlPath)
+                : vscode.Uri.file(getFullPathFromWorkspace(xmlPath));
+              const doc = await vscode.workspace.openTextDocument(uri);
+              await vscode.window.showTextDocument(doc, { preview: false });
+            },
+          },
+        ],
+      );
+      break;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `showSuppress` parameter to `showInstructionWithSuppress`
- disable suppression for YAML parse errors

## Testing
- `npm run lint`
- `npm test` *(webpack compile with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68432502dbd48324b5c09224a4af05e3