### PR TITLE
Search common tool paths when PATH missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ Optionally, you can also install GraphicsMagick/ImageMagick & Ghostscript for th
 
 See the [Installation Guide](https://texra.ai/guide/installation.html) for setup details if needed.
 
-After installing these dependencies, ensure they are accessible from the command line by adding them to your system's PATH environment variable if necessary.
+After installing these dependencies, ensure they are accessible from the command
+line by adding them to your system's PATH if necessary. When VS Code is started
+from a system menu rather than a terminal, it may not inherit your full shell
+environment. TeXRA searches common locations for tools, but launching VS Code
+from a configured terminal is the safest approach.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ See the [Installation Guide](https://texra.ai/guide/installation.html) for setup
 After installing these dependencies, ensure they are accessible from the command
 line by adding them to your system's PATH if necessary. When VS Code is started
 from a system menu rather than a terminal, it may not inherit your full shell
-environment. TeXRA searches common locations for tools, but launching VS Code
-from a configured terminal is the safest approach.
+environment. TeXRA searches common locations for tools, including Homebrew,
+Linuxbrew, TeX Live and MiKTeX bins. Newer TeX Live installations are
+preferred when multiple versions are found. Launching VS Code from a configured
+terminal is still the most reliable approach.
 
 ## Basic Usage
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -52,10 +52,12 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 
    - Ensure installation directories are in your system PATH
    - Restart your terminal and VS Code after updating PATH
-   - When launching VS Code from the system menu or Finder, it may inherit a
-     minimal PATH. TeXRA automatically searches common locations like
-     Homebrew and TeX&nbsp;Live bins, but opening VS Code from a configured
-     terminal provides the most reliable environment.
+
+- When launching VS Code from the system menu or Finder, it may inherit a
+  minimal PATH. TeXRA automatically searches common locations such as
+  Homebrew, Linuxbrew, TeX&nbsp;Live and MiKTeX bins (newer TeX&nbsp;Live
+  releases are preferred). Opening VS Code from a configured terminal
+  provides the most reliable environment.
 
 3. **Manual installation**:
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -52,6 +52,10 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 
    - Ensure installation directories are in your system PATH
    - Restart your terminal and VS Code after updating PATH
+   - When launching VS Code from the system menu or Finder, it may inherit a
+     minimal PATH. TeXRA automatically searches common locations like
+     Homebrew and TeX&nbsp;Live bins, but opening VS Code from a configured
+     terminal provides the most reliable environment.
 
 3. **Manual installation**:
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -286,7 +286,7 @@ export abstract class ModelHandler {
       '.pdf': await (async () => {
         // Check if ImageMagick is installed
         const isImageMagickInstalled = await checkMultipleToolsInstalled(
-          ['imagemagick', 'gm'],
+          ['magick', 'gm'],
           false,
         );
         const pageCount = await countPdfPages(mediaFile);

--- a/src/utils/execUtils.ts
+++ b/src/utils/execUtils.ts
@@ -1,6 +1,10 @@
 // Standard library imports
+import * as fs from 'fs';
+import * as path from 'path';
+
 // Third-party imports
 import spawn from 'cross-spawn';
+import glob from 'glob';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
@@ -13,6 +17,46 @@ const CHANNEL = 'execUtils';
 logger.initialize(CHANNEL);
 
 const MAX_OUTPUT_LENGTH = 150;
+
+// Additional directories that commonly contain LaTeX tools
+function getExtraDirs(): string[] {
+  const dirs = [
+    '/opt/homebrew/bin', // Homebrew on Apple Silicon
+    '/usr/local/bin',
+    '/Library/TeX/texbin',
+    '/usr/texbin',
+  ];
+  try {
+    dirs.push(...glob.sync('/usr/local/texlive/*/bin/*'));
+  } catch {
+    // ignore glob errors
+  }
+  return dirs;
+}
+
+// Extend PATH with common directories if they are missing
+export function extendEnvPath(
+  basePath: string = process.env.PATH || '',
+): string {
+  const segments = basePath.split(path.delimiter).filter(Boolean);
+  for (const dir of getExtraDirs()) {
+    if (!segments.includes(dir) && fs.existsSync(dir)) {
+      segments.push(dir);
+    }
+  }
+  return segments.join(path.delimiter);
+}
+
+// Locate a tool in the common directories
+export function findToolInCommonPaths(tool: string): string | null {
+  for (const dir of getExtraDirs()) {
+    const candidate = path.join(dir, tool);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
 
 /**
  * Truncate text to maxChars by keeping the end portion.
@@ -53,9 +97,14 @@ export async function executeCommand(
       `Running command: ${finalCommand}`,
     );
 
+    const env = options.env
+      ? { ...process.env, ...options.env }
+      : { ...process.env };
+    env.PATH = extendEnvPath(env.PATH);
+
     const spawnOptions = {
       cwd: workspacePath,
-      env: options.env ? { ...process.env, ...options.env } : process.env,
+      env,
       shell: true,
     };
 

--- a/src/utils/execUtils.ts
+++ b/src/utils/execUtils.ts
@@ -20,18 +20,46 @@ const MAX_OUTPUT_LENGTH = 150;
 
 // Additional directories that commonly contain LaTeX tools
 function getExtraDirs(): string[] {
-  const dirs = [
-    '/opt/homebrew/bin', // Homebrew on Apple Silicon
-    '/usr/local/bin',
-    '/Library/TeX/texbin',
-    '/usr/texbin',
-  ];
-  try {
-    dirs.push(...glob.sync('/usr/local/texlive/*/bin/*'));
-  } catch {
-    // ignore glob errors
+  const dirs: string[] = [];
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    dirs.push(
+      '/opt/homebrew/bin', // Homebrew on Apple Silicon
+      '/usr/local/bin',
+      '/Library/TeX/texbin',
+      '/usr/texbin',
+    );
+  } else if (platform === 'win32') {
+    dirs.push(
+      'C:\\Program Files\\MiKTeX\\miktex\\bin\\x64',
+      'C:\\Program Files\\MiKTeX\\miktex\\bin',
+      'C:\\Program Files (x86)\\MiKTeX\\miktex\\bin',
+    );
+  } else {
+    // Linux and others
+    dirs.push(
+      '/usr/local/bin',
+      '/usr/bin',
+      '/usr/texbin',
+      '/home/linuxbrew/.linuxbrew/bin',
+    );
   }
-  return dirs;
+
+  const texlivePatterns =
+    platform === 'win32'
+      ? ['C:/texlive/*/bin/*']
+      : ['/usr/local/texlive/*/bin/*'];
+  for (const pattern of texlivePatterns) {
+    try {
+      const matches = glob.sync(pattern).sort().reverse();
+      dirs.push(...matches);
+    } catch {
+      // ignore glob errors
+    }
+  }
+
+  return Array.from(new Set(dirs));
 }
 
 // Extend PATH with common directories if they are missing
@@ -49,10 +77,17 @@ export function extendEnvPath(
 
 // Locate a tool in the common directories
 export function findToolInCommonPaths(tool: string): string | null {
+  const candidates = [tool];
+  if (process.platform === 'win32' && !tool.toLowerCase().endsWith('.exe')) {
+    candidates.unshift(`${tool}.exe`);
+  }
+
   for (const dir of getExtraDirs()) {
-    const candidate = path.join(dir, tool);
-    if (fs.existsSync(candidate)) {
-      return candidate;
+    for (const name of candidates) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
     }
   }
   return null;

--- a/src/utils/imgUtils.ts
+++ b/src/utils/imgUtils.ts
@@ -138,7 +138,7 @@ export async function singlePagePdf2Png(
 
     // Check for GraphicsMagick/ImageMagick installation
     const isImageMagickInstalled = await checkMultipleToolsInstalled(
-      ['imagemagick', 'gm'],
+      ['magick', 'gm'],
       false,
     );
     if (!isImageMagickInstalled.some(Boolean)) {

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -149,7 +149,8 @@ export async function checkToolInstalled(
         const toolName = cmd.split(' ')[0];
         const fallback = findToolInCommonPaths(toolName);
         if (fallback) {
-          result = spawn.sync(`${fallback} --version`, spawnOptions);
+          const originalArgs = cmd.substring(cmd.indexOf(' ') + 1);
+          result = spawn.sync(`${fallback} ${originalArgs}`, spawnOptions);
           if (result.status === 0) {
             isInstalled = true;
             break;
@@ -163,7 +164,8 @@ export async function checkToolInstalled(
         const toolName = config.command.split(' ')[0];
         const fallback = findToolInCommonPaths(toolName);
         if (fallback) {
-          result = spawn.sync(`${fallback} --version`, spawnOptions);
+          const originalArgs = config.command.substring(config.command.indexOf(' ') + 1);
+          result = spawn.sync(`${fallback} ${originalArgs}`, spawnOptions);
           isInstalled = result.status === 0;
         }
       }

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode';
 
 // Interface for tool configuration
 export interface ToolConfig {
-  command: string | string[];
+  command?: string | string[]; // Optional - defaults to "${toolName} --version"
   errorMessage: string;
   openDocsCommand?: string; // Optional command to open documentation
 }
@@ -44,8 +44,7 @@ const TEXCOUNT_INSTRUCTIONS =
 // All tool configurations in one place
 const TOOL_CONFIGS: Record<string, ToolConfig> = {
   // ImageMagick tools
-  imagemagick: {
-    command: 'convert -version',
+  magick: {
     errorMessage:
       'ImageMagick is not installed. Please install ImageMagick to use PDF to PNG conversion.\n' +
       'Installation instructions:\n' +
@@ -74,35 +73,30 @@ const TOOL_CONFIGS: Record<string, ToolConfig> = {
 
   // LaTeX tools
   latexdiff: {
-    command: 'latexdiff --version',
     errorMessage:
       'latexdiff is not installed. Please install it to use this feature.\n' +
       LATEXDIFF_INSTRUCTIONS,
     openDocsCommand: 'texra.openDoc,installation',
   },
   'latexdiff-vc': {
-    command: 'latexdiff-vc --version',
     errorMessage:
       'latexdiff-vc is not installed. Please install it to use this feature.\n' +
       LATEXDIFF_INSTRUCTIONS,
     openDocsCommand: 'texra.openDoc,installation',
   },
   latexindent: {
-    command: 'latexindent --version',
     errorMessage:
       'latexindent is not installed. Please install it to use this feature.\n' +
       LATEXINDENT_INSTRUCTIONS,
     openDocsCommand: 'texra.openDoc,installation',
   },
   'tex-fmt': {
-    command: 'tex-fmt --version',
     errorMessage:
       'tex-fmt is not installed. Please install it to use this feature.\n' +
       TEXFMT_INSTRUCTIONS,
     openDocsCommand: 'texra.openDoc,installation',
   },
   texcount: {
-    command: 'texcount --version',
     errorMessage:
       'texcount is not installed. Please install it to use this feature.\n' +
       TEXCOUNT_INSTRUCTIONS,
@@ -122,6 +116,7 @@ export async function checkToolInstalled(
 ): Promise<boolean> {
   try {
     // Get the config object - either passed directly or looked up by string key
+    const toolName = typeof toolOrConfig === 'string' ? toolOrConfig : null;
     const config =
       typeof toolOrConfig === 'string'
         ? TOOL_CONFIGS[toolOrConfig]
@@ -131,6 +126,13 @@ export async function checkToolInstalled(
       throw new Error(`Unknown tool: ${toolOrConfig}`);
     }
 
+    // Generate default command if not specified
+    const command = config.command || (toolName ? `${toolName} --version` : null);
+    
+    if (!command) {
+      throw new Error('No command specified and tool name could not be determined');
+    }
+
     let isInstalled = false;
 
     const spawnOptions = {
@@ -138,9 +140,9 @@ export async function checkToolInstalled(
       shell: true,
     };
 
-    if (Array.isArray(config.command)) {
+    if (Array.isArray(command)) {
       // Try each command in the array until one succeeds
-      for (const cmd of config.command) {
+      for (const cmd of command) {
         let result = spawn.sync(cmd, spawnOptions);
         if (result.status === 0) {
           isInstalled = true;
@@ -149,8 +151,9 @@ export async function checkToolInstalled(
         const toolName = cmd.split(' ')[0];
         const fallback = findToolInCommonPaths(toolName);
         if (fallback) {
-          const originalArgs = cmd.substring(cmd.indexOf(' ') + 1);
-          result = spawn.sync(`${fallback} ${originalArgs}`, spawnOptions);
+          const spaceIndex = cmd.indexOf(' ');
+          const originalArgs = spaceIndex > -1 ? cmd.substring(spaceIndex + 1) : '';
+          result = spawn.sync(originalArgs ? `${fallback} ${originalArgs}` : fallback, spawnOptions);
           if (result.status === 0) {
             isInstalled = true;
             break;
@@ -158,14 +161,15 @@ export async function checkToolInstalled(
         }
       }
     } else {
-      let result = spawn.sync(config.command, spawnOptions);
+      let result = spawn.sync(command, spawnOptions);
       isInstalled = result.status === 0;
       if (!isInstalled) {
-        const toolName = config.command.split(' ')[0];
-        const fallback = findToolInCommonPaths(toolName);
+        const cmdToolName = command.split(' ')[0];
+        const fallback = findToolInCommonPaths(cmdToolName);
         if (fallback) {
-          const originalArgs = config.command.substring(config.command.indexOf(' ') + 1);
-          result = spawn.sync(`${fallback} ${originalArgs}`, spawnOptions);
+          const spaceIndex = command.indexOf(' ');
+          const originalArgs = spaceIndex > -1 ? command.substring(spaceIndex + 1) : '';
+          result = spawn.sync(originalArgs ? `${fallback} ${originalArgs}` : fallback, spawnOptions);
           isInstalled = result.status === 0;
         }
       }

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -1,6 +1,9 @@
 // Standard library imports
 import spawn from 'cross-spawn';
 
+// Local imports
+import { extendEnvPath, findToolInCommonPaths } from './execUtils';
+
 // Third-party imports
 import * as vscode from 'vscode';
 
@@ -130,18 +133,40 @@ export async function checkToolInstalled(
 
     let isInstalled = false;
 
+    const spawnOptions = {
+      env: { ...process.env, PATH: extendEnvPath() },
+      shell: true,
+    };
+
     if (Array.isArray(config.command)) {
       // Try each command in the array until one succeeds
       for (const cmd of config.command) {
-        const result = spawn.sync(cmd, { shell: true });
+        let result = spawn.sync(cmd, spawnOptions);
         if (result.status === 0) {
           isInstalled = true;
           break;
         }
+        const toolName = cmd.split(' ')[0];
+        const fallback = findToolInCommonPaths(toolName);
+        if (fallback) {
+          result = spawn.sync(`${fallback} --version`, spawnOptions);
+          if (result.status === 0) {
+            isInstalled = true;
+            break;
+          }
+        }
       }
     } else {
-      const result = spawn.sync(config.command, { shell: true });
+      let result = spawn.sync(config.command, spawnOptions);
       isInstalled = result.status === 0;
+      if (!isInstalled) {
+        const toolName = config.command.split(' ')[0];
+        const fallback = findToolInCommonPaths(toolName);
+        if (fallback) {
+          result = spawn.sync(`${fallback} --version`, spawnOptions);
+          isInstalled = result.status === 0;
+        }
+      }
     }
 
     if (!isInstalled && showError) {


### PR DESCRIPTION
## Summary
- search common directories for LaTeX tools when PATH is incomplete
- extend PATH with typical install locations when executing commands
- document PATH issues when launching VS Code from GUI

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_684566565fc08324b5c4bda6a95d4602