### PR TITLE
Fix incorrect activity bar setting

### DIFF
--- a/src/utils/setupUtils.ts
+++ b/src/utils/setupUtils.ts
@@ -163,21 +163,22 @@ export async function configureLatexSettings() {
         vscode.ConfigurationTarget.Global,
       );
 
-      // Check if the workbench.auxiliaryActivityBar.location setting exists
-      const activityBarSetting = config.inspect(
-        'workbench.auxiliaryActivityBar.location',
-      );
-      if (activityBarSetting) {
-        // Setting exists, update it
-        await config.update(
-          'workbench.auxiliaryActivityBar.location',
-          'default',
-          vscode.ConfigurationTarget.Global,
-        );
-        logger.info(
-          'extension',
-          'Auxiliary activity bar location set to default',
-        );
+      const isWindsurf = vscode.env.appName?.toLowerCase().includes('windsurf');
+
+      if (!isWindsurf) {
+        const activityBarKey = 'workbench.activityBar.location';
+
+        // Check if the activity bar location setting exists
+        const activityBarSetting = config.inspect(activityBarKey);
+        if (activityBarSetting) {
+          // Setting exists, update it
+          await config.update(
+            activityBarKey,
+            'default',
+            vscode.ConfigurationTarget.Global,
+          );
+          logger.info('extension', 'Activity bar location set to default');
+        }
       }
 
       logger.info(


### PR DESCRIPTION
## Summary
- skip updating activity bar location when running on Windsurf

## Testing
- `npm run format`
- `npm run lint` *(warnings only)*
- `npm test` *(fails: vscode-test cannot run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_684551c83c2083248e184abd630d34c4