### PR TITLE
Fix bullet handling for log group headers

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -19,6 +19,7 @@ import {
   formatTokens,
   formatGroupHeaderElements,
   getGroupHeaderClass,
+  BULLET_MARKUP,
 } from './logFormatters.js';
 import { STATUS, COMMANDS, SPLIT_SIZES, TOOLBAR_BUTTONS } from './constants.js';
 import { createIconButton } from '@common/templateUtils.js';
@@ -247,16 +248,25 @@ function propagateUsageToParents(groupId) {
 function insertUsageElement(groupHeader, usageElem, isTopLevel) {
   const timeContainer = groupHeader.querySelector('.group-time');
 
+  let bulletElem = groupHeader.querySelector('.group-bullet');
+  if (!bulletElem) {
+    const tmpl = document.createElement('template');
+    tmpl.innerHTML = BULLET_MARKUP;
+    bulletElem = tmpl.content.firstElementChild;
+  }
+
   if (timeContainer) {
     if (isTopLevel) {
       // For top-level groups: time comes first, then usage
       timeContainer.parentNode.insertBefore(
-        usageElem,
+        bulletElem,
         timeContainer.nextSibling,
       );
+      timeContainer.parentNode.insertBefore(usageElem, bulletElem.nextSibling);
     } else {
       // For non-top-level groups: usage comes first, then time
       groupHeader.insertBefore(usageElem, timeContainer);
+      groupHeader.insertBefore(bulletElem, timeContainer);
     }
   } else {
     groupHeader.appendChild(usageElem);

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -2,6 +2,9 @@ import { marked } from 'marked';
 import { getLogGroup, setLogGroup } from './stateManager.js';
 import { STATUS } from './constants.js';
 
+export const BULLET_MARKUP =
+  '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
+
 /**
  * Format token counts, displaying values in "k" units when exceeding 4096.
  * @param {number} tokens - Raw token count
@@ -205,7 +208,7 @@ export function createGroupHeader(group) {
         ${durationDisplay}
       </span>`;
 
-  const bulletMarkup = ' <i class="codicon codicon-circle-small-filled"></i> ';
+  const bulletMarkup = BULLET_MARKUP;
 
   const headerContents = formatGroupHeaderElements(
     isTopLevel,

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -63,6 +63,10 @@
   margin-right: var(--spacing-small);
 }
 
+.group-bullet {
+  margin: 0 var(--spacing-tiny);
+}
+
 /* Use the spin animation defined in base.css */
 .spin {
   animation: spin 2s linear infinite;


### PR DESCRIPTION
## Summary
- ensure bullet markup is exported
- insert bullet element whenever usage is added to a group
- style bullet element for consistent spacing
- standardize bullet markup spacing

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: "Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.")*

------
https://chatgpt.com/codex/tasks/task_e_684575d2ac288324a85ef3b699d77914