### PR TITLE
Fix latexdiff errors with missing base files

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -718,11 +718,22 @@ export abstract class BaseReflectionAgent implements IAgent {
       this.outputHandler.outputFiles[currRound] &&
       this.outputHandler.outputFiles[currRound].length > 0
     ) {
-      // Pass the process group ID to maintain proper nesting in the log hierarchy
-      await this.outputHandler.handleLatexdiffofOutput(
-        currRound,
-        processGroupId,
+      const existingBase = await Promise.all(
+        this.baseFiles.map(async (f) => await fileExists(f)),
       );
+
+      if (existingBase.some((e) => e)) {
+        // Pass the process group ID to maintain proper nesting in the log hierarchy
+        await this.outputHandler.handleLatexdiffofOutput(
+          currRound,
+          processGroupId,
+        );
+      } else {
+        this.logger.debug(
+          `Skipping latexdiff for round ${currRound} - base files missing`,
+          processGroupId,
+        );
+      }
     }
 
     return this.outputHandler.outputFiles[currRound] || [];

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -217,7 +217,7 @@ export class OutputHandler {
     }
 
     for (const targetFile of targetFiles) {
-      if (!targetFile) {
+      if (!targetFile || typeof targetFile !== 'string') {
         continue;
       }
 
@@ -228,7 +228,7 @@ export class OutputHandler {
       let bestMatchScore = 0;
 
       for (const sourceFile of sourceFiles) {
-        if (!sourceFile) {
+        if (!sourceFile || typeof sourceFile !== 'string') {
           continue;
         }
 


### PR DESCRIPTION
## Summary
- avoid undefined entries when mapping files
- skip latexdiff when no base files exist

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68434502c2848324a9397916f1c0b68f