### PR TITLE
Update progress styling

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -297,8 +297,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
             finalResponse.promptFeedback = chunk.promptFeedback;
           }
         }
-        if (finalResponse.candidates?.[0]) {
-        }
 
         if (fullParts.length === 0) {
           throw new Error('Stream yielded no chunks');

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -179,9 +179,7 @@ export function createGroupHeader(group) {
       `$${cost.toFixed(3)}</span>`;
   }
 
-  const titleMarkup = isTopLevel
-    ? ''
-    : `<span class="group-title">${group.name}</span>`;
+  const titleMarkup = `<span class="group-title">${group.name}</span>`;
   const topLevelClass = isTopLevel ? 'top-level' : '';
 
   const timeMarkup = `

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -15,6 +15,27 @@
   border-left: var(--border-medium) solid var(--vscode-panel-border);
 }
 
+/* Minimal styling for top-level task groups */
+.log-group-header.top-level {
+  border-left-width: var(--border-thin);
+  border-right: var(--border-thin) solid var(--vscode-panel-border);
+  justify-content: space-between;
+}
+
+.log-group-header.top-level + .log-group-content {
+  margin-left: 0;
+  padding-left: 0;
+  border-left: none;
+}
+
+.log-group-header.top-level + .log-group-content .log-group-header {
+  margin-left: 0;
+}
+
+.log-group-header.top-level .group-usage {
+  margin-left: var(--spacing-small);
+}
+
 .log-group-header.running {
   border-left-color: var(--vscode-statusBarItem-warningBackground);
 }
@@ -54,8 +75,8 @@
 }
 
 .log-group-header.top-level .group-time {
-  flex-grow: 1;
-  margin-left: 0;
+  flex-grow: 0;
+  margin-left: var(--spacing-small);
 }
 
 .group-start-time,


### PR DESCRIPTION
## Summary
- show task name on top-level log groups
- adjust top-level header layout for name and time usage

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(fails: missing vscode environment)*


------
https://chatgpt.com/codex/tasks/task_e_6842da420a208324977df7d4caa6b5cd