### PR TITLE
Improve progress view styles

### DIFF
--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -15,6 +15,12 @@
   border-left: var(--border-medium) solid var(--vscode-panel-border);
 }
 
+/* Minimal styling for top-level task headers */
+.log-group-header.top-level {
+  border-left: var(--border-thin) solid var(--vscode-panel-border);
+  border-right: var(--border-thin) solid var(--vscode-panel-border);
+}
+
 .log-group-header.running {
   border-left-color: var(--vscode-statusBarItem-warningBackground);
 }
@@ -82,24 +88,22 @@
 /* Child group headers have a different style to show hierarchy */
 .log-group-content .log-group-header {
   border-left-width: var(--border-thin); /* Thinner border for child groups */
-  margin-left: var(--spacing-medium); /* Small indent for child group headers */
+  margin-left: 0; /* Remove indent for child group headers */
 }
 
 /* Indent child group content */
 .log-group-content .log-group-content {
-  margin-left: var(--spacing-large); /* Indent nested content */
+  margin-left: 0; /* Remove indent for nested group content */
 }
 
 /* Log lines within a group */
 .log-group-content > .log-line {
-  margin-left: var(--spacing-small); /* Small indent for log lines */
+  margin-left: 0; /* Remove indent for log lines */
 }
 
 /* Log lines within a nested group */
 .log-group-content .log-group-content .log-line {
-  margin-left: var(
-    --spacing-tiny
-  ); /* Less indent needed since parent container is already indented */
+  margin-left: 0; /* No extra indent for nested log lines */
 }
 
 /* Visual indicator for nested structure */


### PR DESCRIPTION
## Summary
- simplify progress view headers with thin borders
- remove indentation from child groups so content aligns

## Testing
- `npm run lint`
- `npm test` *(fails: vscode-test can't run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6845a3c02e0c8324832565310b25f674