### PR TITLE
Add streaming thinking content

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -148,6 +148,7 @@ const baseConfig = {
             { text: 'LaTeX Diff', link: '/guide/latex-diff' },
             { text: 'Intelligent Merge', link: '/guide/intelligent-merge' },
             { text: 'Multiple Output', link: '/guide/multiple-output' },
+            { text: 'Streaming Thinking', link: '/guide/streaming-thinking' },
           ],
         },
         {

--- a/docs/guide/streaming-thinking.md
+++ b/docs/guide/streaming-thinking.md
@@ -1,0 +1,45 @@
+# Streaming model thinking
+
+TeXRA highlights reasoning blocks from supported models in the ProgressBoard. Models that stream responses can also stream their `thinking` content so you can watch reasoning evolve in real time.
+
+This note outlines a clean approach for aggregating streaming chunks and updating the UI.
+
+## Aggregating chunks
+
+Every model handler that supports streaming already gathers chunks from the provider. For example OpenAI models use `stream.finalMessage()` while Google GenAI collects chunks manually:
+
+```ts
+const stream = await chat.sendMessageStream({ message, config });
+const fullParts: Part[] = [];
+for await (const chunk of stream) {
+  if (chunk.candidates?.[0]?.content?.parts) {
+    fullParts.push(...chunk.candidates[0].content.parts);
+  }
+}
+```
+
+_(see `modelHandlerGoogleGenAI.ts` lines 276‑302)_
+
+A similar loop exists in `modelHandlerOpenAI.ts` when `finalMessage()` is not available and reasoning content must be concatenated from `chunk.choices[0].delta` fields.
+
+## Proposed helper
+
+Add a `streamThinking()` utility to `ModelHandler` that accepts the streaming iterator and a provider‑specific parser. It would:
+
+1. Maintain `accumulatedContent` and `accumulatedThinking` strings.
+2. After each chunk, update these strings and log the current thinking block via `AgentLogger.info('Thinking content:\n' + accumulatedThinking)` so the ProgressBoard renders it with the `thinking` style.
+3. When `finalMessage()` is supported, call it after the loop and update the last log entry with the complete text.
+
+Each provider handler only supplies the parser that extracts `content` and `reasoning` fields from its chunk structure. This keeps streaming logic DRY while preserving provider specifics.
+
+## Frontend update
+
+The ProgressBoard already handles messages flagged as `thinking`. As chunks arrive the backend sends updated text; the frontend can simply replace the previous `thinking` block. When the final message resolves the block is replaced one last time with the full reasoning.
+
+## Benefits
+
+- Unified streaming logic across providers
+- Minimal changes in individual handlers
+- Real‑time display of model reasoning
+
+This approach leverages existing message types and logging utilities without major refactoring.

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -689,6 +689,41 @@ export abstract class ModelHandler {
   ): string | null;
 
   /**
+   * Aggregate streamed chunks and log incremental thinking content.
+   *
+   * @param stream Async iterator yielding provider-specific chunks
+   * @param parser Function extracting content and thinking from each chunk
+   * @param groupId Optional progress view group ID for logging
+   * @returns Accumulated content and thinking strings
+   */
+  protected async streamThinking<T>(
+    stream: AsyncIterable<T>,
+    parser: (chunk: T) => { content?: string; thinking?: string } | null,
+    groupId?: string,
+  ): Promise<{ content: string; thinking: string }> {
+    let accumulatedContent = '';
+    let accumulatedThinking = '';
+
+    for await (const chunk of stream) {
+      const result = parser(chunk);
+      if (!result) {
+        continue;
+      }
+
+      if (result.content) {
+        accumulatedContent += result.content;
+      }
+
+      if (result.thinking) {
+        accumulatedThinking += result.thinking;
+        this.logger.info(`Thinking content:\n${accumulatedThinking}`, groupId);
+      }
+    }
+
+    return { content: accumulatedContent, thinking: accumulatedThinking };
+  }
+
+  /**
    * Creates a log group for model operations with the given name.
    * @param name Name of the operation group
    * @param parentGroupId Optional parent group ID

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -151,7 +151,40 @@ export class ModelHandlerAnthropic extends ModelHandler {
         // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
         // we should also make sure partial results can be returned in the presence of errors!
         const stream = client.beta.messages.stream(options, { signal });
+
+        const parseChunk = (event: any) => {
+          if (event.type === 'content_block_delta') {
+            if (event.delta.type === 'text_delta') {
+              return { content: event.delta.text };
+            }
+            if (event.delta.type === 'thinking_delta') {
+              return { thinking: event.delta.thinking };
+            }
+          }
+          return null;
+        };
+
+        await this.streamThinking(
+          stream,
+          parseChunk,
+          this.logger.getActiveGroupId(),
+        );
         response = await stream.finalMessage();
+
+        if (Array.isArray(response.content)) {
+          let finalThinking = '';
+          for (const block of response.content) {
+            if (block.type === 'thinking' && block.thinking) {
+              finalThinking += block.thinking;
+            }
+          }
+          if (finalThinking) {
+            this.logger.info(
+              `Thinking content:\n${finalThinking}`,
+              this.logger.getActiveGroupId(),
+            );
+          }
+        }
       } else {
         response = await client.beta.messages.create(options, { signal });
       }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -279,26 +279,39 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
           message: lastMessageParts,
           config: { ...generationConfig, abortSignal: signal },
         });
-
         const fullParts: Part[] = [];
         const finalResponse = new GenerateContentResponse();
-        for await (const chunk of stream) {
-          if (chunk.candidates?.[0]?.content?.parts) {
-            fullParts.push(...chunk.candidates[0].content.parts);
-          }
-          if (chunk.usageMetadata) {
-            finalResponse.usageMetadata = chunk.usageMetadata;
-          }
-          if (chunk.responseId) finalResponse.responseId = chunk.responseId;
-          if (chunk.createTime) finalResponse.createTime = chunk.createTime;
-          if (chunk.modelVersion)
-            finalResponse.modelVersion = chunk.modelVersion;
-          if (!finalResponse.promptFeedback && chunk.promptFeedback) {
-            finalResponse.promptFeedback = chunk.promptFeedback;
-          }
-        }
-        if (finalResponse.candidates?.[0]) {
-        }
+        await this.streamThinking(
+          stream,
+          (chunk) => {
+            if (chunk.candidates?.[0]?.content?.parts) {
+              const parts = chunk.candidates[0].content.parts;
+              fullParts.push(...parts);
+              let text = '';
+              let thinking = '';
+              for (const p of parts) {
+                if ((p as any).thought && typeof p.text === 'string') {
+                  thinking += p.text;
+                } else if (typeof p.text === 'string') {
+                  text += p.text;
+                }
+              }
+              return { content: text, thinking };
+            }
+            if (chunk.usageMetadata) {
+              finalResponse.usageMetadata = chunk.usageMetadata;
+            }
+            if (chunk.responseId) finalResponse.responseId = chunk.responseId;
+            if (chunk.createTime) finalResponse.createTime = chunk.createTime;
+            if (chunk.modelVersion)
+              finalResponse.modelVersion = chunk.modelVersion;
+            if (!finalResponse.promptFeedback && chunk.promptFeedback) {
+              finalResponse.promptFeedback = chunk.promptFeedback;
+            }
+            return null;
+          },
+          this.logger.getActiveGroupId(),
+        );
 
         if (fullParts.length === 0) {
           throw new Error('Stream yielded no chunks');
@@ -307,7 +320,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
         finalResponse.candidates = [
           {
             content: { role: 'model', parts: fullParts },
-            finishReason: FinishReason.STOP, // there is no good choice, could be length, but let us just put this.
+            finishReason: FinishReason.STOP,
           },
         ];
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -138,33 +138,35 @@ export class ModelHandlerOpenAI extends ModelHandler {
           signal,
         });
 
+        const parseChunk = (chunk: any) => {
+          const delta = chunk.choices?.[0]?.delta as any;
+          if (!delta) return null;
+          return {
+            content: delta.content,
+            thinking: delta.reasoning_content,
+          };
+        };
+
         if (this.config.fullName.includes('deepseek')) {
-          // This wait for finalMessage method do not support deepseek models, so we need to aggreatate the results manually like this:
-          let reasoning_content = '';
-          let content = '';
-          for await (const chunk of stream) {
-            if ((chunk.choices[0].delta as any).reasoning_content) {
-              reasoning_content += (chunk.choices[0].delta as any)
-                .reasoning_content;
-            } else {
-              content += (chunk.choices[0].delta as any).content;
-            }
-          }
+          const { content, thinking } = await this.streamThinking(
+            stream,
+            parseChunk,
+            this.logger.getActiveGroupId(),
+          );
           response = {
             role: 'assistant',
-            finish_reason: 'stop', // there is no good choice it seems unless deepseek models support it;
-            // In the future maybe we can count the output tokens to see if it is at the limit approximatelly..
+            finish_reason: 'stop',
             choices: [
               {
                 message: {
                   content: content,
-                  reasoning_content: reasoning_content,
+                  reasoning_content: thinking,
                 },
                 finish_reason: 'stop',
               },
             ],
           };
-          const tokenCount = countTokens(content + reasoning_content);
+          const tokenCount = countTokens(content + thinking);
           this.logger.debug(
             `Token count output of deepseek model: ${tokenCount}`,
           );
@@ -178,7 +180,20 @@ export class ModelHandlerOpenAI extends ModelHandler {
           return response;
         }
 
+        await this.streamThinking(
+          stream,
+          parseChunk,
+          this.logger.getActiveGroupId(),
+        );
         response = await stream.finalMessage();
+
+        const finalMessage = response as any;
+        if (finalMessage?.reasoning_content) {
+          this.logger.info(
+            `Thinking content:\n${finalMessage.reasoning_content}`,
+            this.logger.getActiveGroupId(),
+          );
+        }
 
         // in the future we can add: stream_options: {"include_usage": true} to get usage statistics
         // in the future if we pass stream to outside (signal: controller.signal)), calling stream.controller.abort() will abort the stream; which will be very useful for our stop button (controller.abort();)

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -67,7 +67,32 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     if (useStreaming) {
       kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
       const stream = client.chat.completions.stream(kwargs, { signal });
-      return await stream.finalMessage();
+
+      const parseChunk = (chunk: any) => {
+        const delta = chunk.choices?.[0]?.delta as any;
+        if (!delta) return null;
+        return {
+          content: delta.content,
+          thinking: delta.reasoning_content,
+        };
+      };
+
+      await this.streamThinking(
+        stream,
+        parseChunk,
+        this.logger.getActiveGroupId(),
+      );
+      const response = await stream.finalMessage();
+
+      const finalMessage = response as any;
+      if (finalMessage?.reasoning_content) {
+        this.logger.info(
+          `Thinking content:\n${finalMessage.reasoning_content}`,
+          this.logger.getActiveGroupId(),
+        );
+      }
+
+      return response;
     } else {
       return await client.chat.completions.create(kwargs, { signal });
     }


### PR DESCRIPTION
## Summary
- implement `streamThinking` helper in `ModelHandler`
- stream reasoning chunks for OpenAI, OpenRouter, Google GenAI and Anthropic
- log incremental thinking blocks while streaming

## Testing
- `npm run format`
- `npm run lint` *(warnings only)*
- `npm test` *(fails: webpack compiler starting; no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68429d04eb848324a85e5ef998bcd308