### PR TITLE
Implement streaming reasoning updates

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -716,4 +716,36 @@ export abstract class ModelHandler {
   ): void {
     this.logger.endGroup(groupId, status);
   }
+
+  /**
+   * Streams reasoning content chunks and updates the progress view.
+   */
+  protected async streamReasoning<T>(
+    stream: AsyncIterable<T>,
+    extract: (chunk: T) => string | undefined,
+    streamId: string,
+    groupId?: string,
+  ): Promise<{ id?: string; content: string }> {
+    let aggregated = '';
+    let msgId: string | undefined;
+
+    for await (const chunk of stream) {
+      const part = extract(chunk);
+      if (!part) continue;
+      aggregated += part;
+      if (!msgId) {
+        msgId = this.logger.infoWithId(
+          `Thinking content: <span class="message-info">${part}</span>`,
+          groupId,
+        );
+      } else {
+        this.logger.infoWithId(
+          `Thinking content: <span class="message-info">${aggregated}</span>`,
+          groupId,
+          msgId,
+        );
+      }
+    }
+    return { id: msgId, content: aggregated };
+  }
 }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -151,7 +151,28 @@ export class ModelHandlerAnthropic extends ModelHandler {
         // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
         // we should also make sure partial results can be returned in the presence of errors!
         const stream = client.beta.messages.stream(options, { signal });
+        const activeGroup = this.logger.getActiveGroupId();
+        const { id: reasonId } = await this.streamReasoning(
+          stream,
+          (chunk: any) =>
+            chunk?.delta?.type === 'thinking' ? chunk.delta.text : undefined,
+          this.logger.channelId,
+          activeGroup,
+        );
         response = await stream.finalMessage();
+        if (reasonId) {
+          const finalThinking = this.processThinkingBlock(
+            response,
+            activeGroup,
+          );
+          if (finalThinking) {
+            this.logger.infoWithId(
+              `Thinking content: <span class="message-info">${finalThinking}</span>`,
+              activeGroup,
+              reasonId,
+            );
+          }
+        }
       } else {
         response = await client.beta.messages.create(options, { signal });
       }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -297,8 +297,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
             finalResponse.promptFeedback = chunk.promptFeedback;
           }
         }
-        if (finalResponse.candidates?.[0]) {
-        }
+
 
         if (fullParts.length === 0) {
           throw new Error('Stream yielded no chunks');

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -137,15 +137,29 @@ export class ModelHandlerOpenAI extends ModelHandler {
         const stream = client.chat.completions.stream(kwargs, {
           signal,
         });
+        const activeGroup = this.logger.getActiveGroupId();
 
         if (this.config.fullName.includes('deepseek')) {
           // This wait for finalMessage method do not support deepseek models, so we need to aggreatate the results manually like this:
           let reasoning_content = '';
           let content = '';
+          let msgId: string | undefined;
           for await (const chunk of stream) {
             if ((chunk.choices[0].delta as any).reasoning_content) {
               reasoning_content += (chunk.choices[0].delta as any)
                 .reasoning_content;
+              if (!msgId) {
+                msgId = this.logger.infoWithId(
+                  `Thinking content: <span class="message-info">${reasoning_content}</span>`,
+                  activeGroup,
+                );
+              } else {
+                this.logger.infoWithId(
+                  `Thinking content: <span class="message-info">${reasoning_content}</span>`,
+                  activeGroup,
+                  msgId,
+                );
+              }
             } else {
               content += (chunk.choices[0].delta as any).content;
             }
@@ -178,7 +192,27 @@ export class ModelHandlerOpenAI extends ModelHandler {
           return response;
         }
 
+        const { id: reasonId } = await this.streamReasoning(
+          stream,
+          (chunk) => (chunk.choices[0].delta as any).reasoning_content,
+          this.logger.channelId,
+          activeGroup,
+        );
+
         response = await stream.finalMessage();
+
+        if (
+          reasonId &&
+          (response.choices?.[0].message as any)?.reasoning_content
+        ) {
+          this.logger.infoWithId(
+            `Thinking content: <span class="message-info">${
+              (response.choices[0].message as any).reasoning_content
+            }</span>`,
+            activeGroup,
+            reasonId,
+          );
+        }
 
         // in the future we can add: stream_options: {"include_usage": true} to get usage statistics
         // in the future if we pass stream to outside (signal: controller.signal)), calling stream.controller.abort() will abort the stream; which will be very useful for our stop button (controller.abort();)

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -24,6 +24,10 @@ export class AgentLogger {
     logger.info(this.channelId, message, groupId);
   }
 
+  infoWithId(message: string, groupId?: string, id?: string): string {
+    return logger.infoWithId(this.channelId, message, groupId, id);
+  }
+
   warn(message: string, groupId?: string): void {
     logger.warn(this.channelId, message, groupId);
   }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -42,6 +42,12 @@ function escapeHtml(text: string): string {
     .replace(/'/g, '&#039;');
 }
 
+export function generateMessageId(): string {
+  return (
+    'msg-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2)
+  );
+}
+
 // Main TeXRA output channel for non-agent logs
 let mainOutputChannel: vscode.OutputChannel | null = null;
 
@@ -60,6 +66,7 @@ class VSCodeTransport extends Transport {
   private streamName: string;
   private useConsolidatedChannel: boolean;
   private messageBuffer: {
+    id: string;
     level: string;
     message: string;
     timestamp: number;
@@ -85,6 +92,7 @@ class VSCodeTransport extends Transport {
 
   log(info: any, callback: () => void) {
     const { level, message, timestamp } = info;
+    const messageId = info.id || generateMessageId();
     // Use the provided groupId or fall back to the activeGroupId if available
     const groupId = info.groupId || this.activeGroupId;
 
@@ -148,7 +156,7 @@ class VSCodeTransport extends Transport {
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
     const isVerbose = getConfig<boolean>('logger.verboseOutput', false);
     const coloredFormattedMessage =
-      `<div class="log-line ${isScratchpad ? 'scratchpad-log' : ''}" ${scratchpadAttr} ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
+      `<div class="log-line ${isScratchpad ? 'scratchpad-log' : ''}" ${scratchpadAttr} ${groupId ? `data-group-id="${groupId}"` : ''} data-log-id="${messageId}" data-full-timestamp="${timestamp}">` +
       `<span class="timestamp" title="${timestamp}">${emoji}${
         isVerbose ? ` [${timeDisplay}]` : ''
       }</span> ` +
@@ -163,17 +171,28 @@ class VSCodeTransport extends Transport {
     // Write to ProgressView if available (with colors and escaped HTML)
     const numericTimestamp = new Date(timestamp).getTime();
     if (this.progressViewProvider) {
-      this.progressViewProvider.addLogMessage(
-        this.streamName,
-        coloredFormattedMessage,
-        level as 'error' | 'warn' | 'info' | 'debug',
-        groupId,
-        numericTimestamp,
-        messageType,
-      );
+      if (this.progressViewProvider.hasLogMessage(this.streamName, messageId)) {
+        this.progressViewProvider.updateLogMessage(
+          this.streamName,
+          messageId,
+          coloredFormattedMessage,
+          messageType,
+        );
+      } else {
+        this.progressViewProvider.addLogMessage(
+          this.streamName,
+          coloredFormattedMessage,
+          level as 'error' | 'warn' | 'info' | 'debug',
+          groupId,
+          numericTimestamp,
+          messageType,
+          messageId,
+        );
+      }
     } else {
       // Buffer the message if ProgressViewProvider is not available
       this.messageBuffer.push({
+        id: messageId,
         level,
         message: coloredFormattedMessage,
         timestamp: numericTimestamp,
@@ -215,6 +234,7 @@ class VSCodeTransport extends Transport {
         msg.groupId,
         msg.timestamp,
         msg.messageType ?? 'default',
+        msg.id,
       );
     }
 
@@ -436,6 +456,22 @@ function logWithGroup(
   logger[level](message, { groupId: actualGroupId });
 }
 
+function logWithGroupReturnId(
+  channel: string,
+  level: string,
+  message: string,
+  groupId?: string,
+  id?: string,
+): string {
+  const logger = getOrCreateLogger(channel);
+  const transport = channelTransports.get(channel);
+  const actualGroupId = groupId || transport?.getActiveGroupId();
+  const msgId = id || generateMessageId();
+  // @ts-ignore
+  logger[level](message, { groupId: actualGroupId, id: msgId });
+  return msgId;
+}
+
 // Simplified logging methods that use channel as channel name
 export const debug = (
   channel: string,
@@ -451,6 +487,15 @@ export const info = (
   groupId?: string,
 ): void => {
   logWithGroup(channel, 'info', message, groupId);
+};
+
+export const infoWithId = (
+  channel: string,
+  message: string,
+  groupId?: string,
+  id?: string,
+): string => {
+  return logWithGroupReturnId(channel, 'info', message, groupId, id);
 };
 
 export const warn = (

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -29,6 +29,7 @@ type StreamStatusType =
   | typeof STATUS.STOPPED;
 
 interface ColoredLogMessage {
+  id: string;
   message: string;
   level: 'error' | 'warn' | 'info' | 'debug';
   timestamp: number;
@@ -135,6 +136,11 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
                   attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
                 const timestamp = new Date(timeString).getTime();
                 msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
+              }
+              if (!msg.id) {
+                msg.id = `msg-${Date.now()}-${Math.random()
+                  .toString(36)
+                  .slice(2)}`;
               }
               if (!msg.messageType) {
                 msg.messageType = 'default';
@@ -417,6 +423,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     groupId?: string,
     timestamp: number = Date.now(),
     messageType: 'default' | 'scratchpad' | 'thinking' = 'default',
+    id: string = `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   ) {
     // Skip if this stream should be excluded from the progress view
     if (shouldExcludeFromProgressView(stream)) {
@@ -459,6 +466,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     const logMessage: ColoredLogMessage = {
+      id,
       message,
       level,
       timestamp,
@@ -480,6 +488,33 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         command: COMMANDS.APPEND_LOG,
         stream: stream,
         logMessage,
+      });
+    }
+  }
+
+  public hasLogMessage(stream: string, id: string): boolean {
+    const messages = this._logStreams.get(stream);
+    return messages ? messages.some((m) => m.id === id) : false;
+  }
+
+  public updateLogMessage(
+    stream: string,
+    id: string,
+    message: string,
+    messageType: 'default' | 'scratchpad' | 'thinking' = 'default',
+  ) {
+    const messages = this._logStreams.get(stream);
+    if (!messages) return;
+    const msg = messages.find((m) => m.id === id);
+    if (!msg) return;
+    msg.message = message;
+    msg.messageType = messageType;
+    this._saveState();
+    if (this._view && stream === this._activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_LOG,
+        stream,
+        logMessage: msg,
       });
     }
   }

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -31,6 +31,7 @@ export const COMMANDS = {
   UPDATE_LOGS: 'updateLogs',
   CLEAR_LOGS: 'clearLogs',
   APPEND_LOG: 'appendLog',
+  UPDATE_LOG: 'updateLog',
   ADD_LOG_GROUP: 'addLogGroup',
   UPDATE_LOG_GROUP: 'updateLogGroup',
   UPDATE_STATUS: 'updateStatus',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -742,6 +742,21 @@ export function appendLogToGroup(logMessage) {
 }
 
 /**
+ * Updates an existing log message element in the DOM
+ * @param {Object} logMessage - The updated log message object
+ */
+export function updateLogMessage(logMessage) {
+  const existing = document.querySelector(
+    `.log-line[data-log-id="${logMessage.id}"]`,
+  );
+  if (existing) {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = formatLogEntry(logMessage);
+    existing.replaceWith(wrapper.firstElementChild);
+  }
+}
+
+/**
  * Apply saved toggle states to any groups already in the DOM
  */
 export function applyGroupToggleStates() {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -12,6 +12,7 @@ import {
   addLogGroup,
   updateLogGroupUI,
   appendLogToGroup,
+  updateLogMessage,
   updateFileList,
   updateUsageSummary,
   updateGroupUsage,
@@ -97,6 +98,12 @@ const handlers = {
         logContent.appendChild(el.firstElementChild);
       }
       logContent.scrollTop = logContent.scrollHeight;
+    }
+  },
+
+  [COMMANDS.UPDATE_LOG]: (message) => {
+    if (message.stream === getCurrentStream()) {
+      updateLogMessage(message.logMessage);
     }
   },
 


### PR DESCRIPTION
## Summary
- support updating individual log lines
- add streaming reasoning helper and use it in OpenAI/Anthropic handlers
- track message IDs in logger and progress view
- update webview scripts for new `updateLog` command

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68429c6fa6748324bd3ea10197fca02a