### PR TITLE
Update message param typing

### DIFF
--- a/src/AnthropicTool/AnthropicToolAgent.ts
+++ b/src/AnthropicTool/AnthropicToolAgent.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 // Third-party imports
 import Anthropic from '@anthropic-ai/sdk';
+import type { MessageCreateParams } from '@anthropic-ai/sdk/resources/messages';
 
 // Local imports - error utils
 import { getSdkErrorMessage } from '../utils/sdkErrorUtils';
@@ -272,13 +273,14 @@ export abstract class AnthropicToolAgent<
         const systemMessage = createSystemMessage(validationResult);
 
         // Call Claude API
-        const response = await client.messages.create({
+        const params: MessageCreateParams = {
           model: this.model,
           max_tokens: this.maxTokens,
           system: systemMessage,
           messages,
           tools: [this.textEditorTool.toParams() as any], // Type assertion needed for Claude 4 compatibility
-        });
+        };
+        const response = await client.messages.create(params);
 
         logger.debug(
           CHANNEL,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -6,6 +6,7 @@ import { Anthropic } from '@anthropic-ai/sdk';
 import {
   MessageParam,
   ContentBlock,
+  MessageCreateParams,
 } from '@anthropic-ai/sdk/resources/messages';
 
 // Local imports - error utils
@@ -68,7 +69,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     const useStreaming = this.getStreamingConfig();
 
     // Prepare options for the API call
-    const options: any = {
+    const options: MessageCreateParams & { betas?: string[] } = {
       model: this.config.fullName,
       max_tokens: this.config.maxOutputTokens,
       messages,
@@ -144,7 +145,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       // in the future we log this in firstInputTokens of the AgentStateGlobal
     }
 
-    let response;
+    let response: any;
 
     try {
       if (useStreaming) {

--- a/src/utils/textEnhancementUtils.ts
+++ b/src/utils/textEnhancementUtils.ts
@@ -3,6 +3,7 @@
 
 // Third-party imports
 import Anthropic from '@anthropic-ai/sdk';
+import type { MessageCreateParams } from '@anthropic-ai/sdk/resources/messages';
 import * as vscode from 'vscode';
 
 // Local imports - error utils
@@ -166,11 +167,12 @@ ${text}`;
     } else {
       // Use the Anthropic SDK
       const anthropic = new Anthropic({ apiKey: apiKey! });
-      const response = await anthropic.beta.messages.create({
+      const params: MessageCreateParams = {
         model: 'claude-3-7-sonnet-20250219',
         messages: [{ role: 'user', content: prompt }],
         max_tokens: 4096,
-      });
+      };
+      const response = await anthropic.beta.messages.create(params);
 
       if (
         response.content &&

--- a/src/utils/xmlUtils.ts
+++ b/src/utils/xmlUtils.ts
@@ -304,7 +304,7 @@ export function formatAndLogContent(
     // Clean up excessive whitespace and normalize line breaks
     .replace(/\n{4,}/g, '\n\n') // Replace 4+ newlines with 2
 
-    .replace(/    /gm, '  '); // Replace 4 spaces with 2 spaces
+    .replace(/ {4}/gm, '  '); // Replace 4 spaces with 2 spaces
   // .replace(/ +$/gm, ''); // Remove trailing spaces only
 
   // agentLogger.info(formattedContent, groupId); // for debugging


### PR DESCRIPTION
## Summary
- use `MessageCreateParams` from SDK for Anthropic tool and helpers
- type option map in Anthropic model handler
- tweak whitespace cleanup regex

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Compiler complains missing VS Code environment)*

------
https://chatgpt.com/codex/tasks/task_e_68460e6f115483249b842c7751f00ab2