### PR TITLE
Update OpenAI o3 pricing and introduce o3pro

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -44,6 +44,8 @@ Known for strong reasoning and creative capabilities.
 | `gpt41--` | Long-context vision, cheapest       | $             | Medium         | 1M tokens context, nano |
 | `gpt4o`   | Strong all-rounder, vision          | $$$           | Medium         | Good default choice     |
 | `gpt4ol`  | Latest `gpt4o`, potentially better  | $$$           | Medium         |                         |
+| `o3`      | Coding, tool calling                | $$$           | Medium         |                         |
+| `o3pro`   | Reliable answers, heavy compute     | $$$$          | Slow           | `o3-pro`                |
 | `o3-`     | Fast reasoning                      | $$$           | Fast           | `o3-mini`               |
 | `o1-`     | Fast reasoning (smaller `o1`)       | $$$           | Fast           | `o1-mini`               |
 

--- a/src/model/providers/openaiReasoningModels.ts
+++ b/src/model/providers/openaiReasoningModels.ts
@@ -42,8 +42,8 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     provider: ModelProvider.OPENAI,
     maxOutputTokens: 100000,
     contextWindow: 200000,
-    inputPrice: 10.0,
-    outputPrice: 40.0,
+    inputPrice: 2.0,
+    outputPrice: 8.0,
     capabilities: {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
       cacheDiscountFactor: 0.25,
@@ -64,6 +64,21 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     capabilities: {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
       supportsVision: false,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
+  o3pro: {
+    name: 'o3pro',
+    fullName: 'o3-pro-2025-06-10',
+    openrouterFullName: 'openai/o3-pro-2025-06-10',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 100000,
+    contextWindow: 200000,
+    inputPrice: 20.0,
+    outputPrice: 80.0,
+    capabilities: {
+      ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
+      supportsVision: true,
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },

--- a/src/model/providers/openaiReasoningModels.ts
+++ b/src/model/providers/openaiReasoningModels.ts
@@ -70,7 +70,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
   o3pro: {
     name: 'o3pro',
     fullName: 'o3-pro-2025-06-10',
-    openrouterFullName: 'openai/o3-pro-2025-06-10',
+    openrouterFullName: 'openai/o3-pro',
     provider: ModelProvider.OPENAI,
     maxOutputTokens: 100000,
     contextWindow: 200000,

--- a/src/utils/xmlUtils.ts
+++ b/src/utils/xmlUtils.ts
@@ -304,7 +304,7 @@ export function formatAndLogContent(
     // Clean up excessive whitespace and normalize line breaks
     .replace(/\n{4,}/g, '\n\n') // Replace 4+ newlines with 2
 
-    .replace(/    /gm, '  '); // Replace 4 spaces with 2 spaces
+    .replace(/ {4}/gm, '  '); // Replace 4 spaces with 2 spaces
   // .replace(/ +$/gm, ''); // Remove trailing spaces only
 
   // agentLogger.info(formattedContent, groupId); // for debugging


### PR DESCRIPTION
## Summary
- drop o3 pricing to $2/$8 per 1M tokens
- add new `o3pro` configuration with higher compute
- document `o3` and `o3pro` in the model guide
- fix ESLint warning in `xmlUtils`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68489651c570832498ee64353feaf99d