### PR TITLE
feat: compute diff stats for new files

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -17,6 +17,7 @@ import {
 } from '../latex';
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 import { diff_match_patch } from 'diff-match-patch';
+import type { DiffStats } from '../types/DiffTypes';
 
 // Local imports - utilities
 import {
@@ -581,18 +582,25 @@ export abstract class BaseReflectionAgent implements IAgent {
   }
 
   private async computeDiffStats(
-    baseFile: string,
+    baseFile: string | null,
     outputFile: string,
-  ): Promise<{ added: number; removed: number }> {
+  ): Promise<DiffStats> {
     try {
+      if (!baseFile) {
+        const outContent = await readFile(outputFile);
+        return { added: outContent.split(/\n/).length };
+      }
+
       const [baseContent, outContent] = await Promise.all([
         readFile(baseFile),
         readFile(outputFile),
       ]);
+
       const dmp = new diff_match_patch();
       const diffs = dmp.diff_main(baseContent, outContent);
       let added = 0;
       let removed = 0;
+
       for (const [op, text] of diffs) {
         if (op === 1) {
           added += text.split(/\n/).length;
@@ -600,9 +608,10 @@ export abstract class BaseReflectionAgent implements IAgent {
           removed += text.split(/\n/).length;
         }
       }
+
       return { added, removed };
     } catch {
-      return { added: 0, removed: 0 };
+      return {};
     }
   }
 
@@ -673,10 +682,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         const prevFile =
           Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
           null;
-        let stats = { added: 0, removed: 0 };
-        if (baseFile) {
-          stats = await this.computeDiffStats(baseFile, file);
-        }
+        const stats = await this.computeDiffStats(baseFile, file);
         fileInfos.push({
           path: file,
           base: baseFile,

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -588,7 +588,12 @@ export abstract class BaseReflectionAgent implements IAgent {
     try {
       if (!baseFile) {
         const outContent = await readFile(outputFile);
-        return { added: outContent.split(/\n/).length };
+        // For new files, calculate lines correctly:
+        // - Empty file = 0 lines
+        // - Non-empty file = number of lines (handle trailing newlines properly)
+        const added = outContent.length === 0 ? 0 : 
+          outContent.endsWith('\n') ? outContent.split('\n').length - 1 : outContent.split('\n').length;
+        return { added, removed: 0 };
       }
 
       const [baseContent, outContent] = await Promise.all([

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -581,6 +581,13 @@ export abstract class BaseReflectionAgent implements IAgent {
     return prefill;
   }
 
+  // Helper function to consistently count lines in text
+  private countLines(text: string): number {
+    if (text.length === 0) return 0;
+    // Handle trailing newlines consistently: subtract 1 if text ends with newline
+    return text.endsWith('\n') ? text.split('\n').length - 1 : text.split('\n').length;
+  }
+
   private async computeDiffStats(
     baseFile: string | null,
     outputFile: string,
@@ -588,12 +595,9 @@ export abstract class BaseReflectionAgent implements IAgent {
     try {
       if (!baseFile) {
         const outContent = await readFile(outputFile);
-        // For new files, calculate lines correctly:
-        // - Empty file = 0 lines
-        // - Non-empty file = number of lines (handle trailing newlines properly)
-        const added = outContent.length === 0 ? 0 : 
-          outContent.endsWith('\n') ? outContent.split('\n').length - 1 : outContent.split('\n').length;
-        return { added, removed: 0 };
+        const added = this.countLines(outContent);
+        // For new files, only return added count (removed should be undefined for UI)
+        return { added };
       }
 
       const [baseContent, outContent] = await Promise.all([
@@ -608,9 +612,9 @@ export abstract class BaseReflectionAgent implements IAgent {
 
       for (const [op, text] of diffs) {
         if (op === 1) {
-          added += text.split(/\n/).length;
+          added += this.countLines(text);
         } else if (op === -1) {
-          removed += text.split(/\n/).length;
+          removed += this.countLines(text);
         }
       }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -18,6 +18,7 @@ import {
 
 import { TokenUsageStats } from '../types/UsageTypes';
 import { LogGroup } from '../types/LogTypes';
+import type { DiffStats } from '../types/DiffTypes';
 
 // @ts-ignore - Import JavaScript module
 import { STATUS, COMMANDS } from './modules/constants.js';
@@ -43,12 +44,10 @@ interface ColoredLogMessage {
 
 // Channels that should not be persisted in workspace storage
 
-interface OutputFileInfo {
+interface OutputFileInfo extends DiffStats {
   path: string;
   base?: string | null;
   prev?: string | null;
-  added?: number;
-  removed?: number;
 }
 
 export class ProgressViewProvider implements vscode.WebviewViewProvider {

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -394,6 +394,8 @@ export function updateFileList(filesByRound) {
       if (statsSpan) {
         if (info.added !== undefined && info.removed !== undefined) {
           statsSpan.innerHTML = `<span class="added">+${info.added}</span><span class="removed">-${info.removed}</span>`;
+        } else if (info.added !== undefined) {
+          statsSpan.innerHTML = `<span class="added">+${info.added}</span>`;
         } else {
           statsSpan.remove();
         }

--- a/src/types/DiffTypes.ts
+++ b/src/types/DiffTypes.ts
@@ -1,0 +1,10 @@
+/**
+ * Diff statistic interfaces used for file comparisons.
+ */
+
+export interface DiffStats {
+  /** Number of added lines */
+  added?: number;
+  /** Number of removed lines */
+  removed?: number;
+}


### PR DESCRIPTION
## Summary
- add `DiffStats` interface for diff counts
- update `computeDiffStats` to handle new files
- extend `OutputFileInfo` with `DiffStats`

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(fails: VS Code tests require environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_684aa35376748324b887c8f04f83e2f2