### PR TITLE
Refactor reflection messaging

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -905,7 +905,7 @@ export abstract class BaseReflectionAgent implements IAgent {
           this.agentSetting,
           messages,
           toolState,
-          this.outputFile[0],
+          this.outputFile[currRound],
           prefill,
           round0GroupId,
         );
@@ -924,7 +924,7 @@ export abstract class BaseReflectionAgent implements IAgent {
           stateRound,
           stateGlobal,
           toolState,
-          this.outputFile[0],
+          this.outputFile[currRound],
           round0GroupId, // Pass the round group ID to processResponseCycle
         );
         finalEndTurn = newEndTurn;
@@ -933,7 +933,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         await this.handleRoundCompletion(
           updatedStateRound,
           updatedStateGlobal,
-          this.outputFile[0],
+          this.outputFile[currRound],
           finalEndTurn,
           currRound,
           round0GroupId, // Pass the round group ID
@@ -960,7 +960,7 @@ export abstract class BaseReflectionAgent implements IAgent {
       await this.handleRoundCompletion(
         stateRound,
         stateGlobal,
-        this.outputFile[0],
+        this.outputFile[currRound],
         finalEndTurn,
         currRound,
         round0GroupId, // Pass the round group ID
@@ -984,7 +984,7 @@ export abstract class BaseReflectionAgent implements IAgent {
   }
 
   /**
-   * Processes reflection/refinement round.
+   * Processes a follow-up conversation round.
    * @returns Tuple of [round state, global state, messages, completion flag]
    */
   protected async reflect(
@@ -995,7 +995,7 @@ export abstract class BaseReflectionAgent implements IAgent {
   ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean]> {
     this.logger.debug(`Processing round ${currRound}`);
 
-    // Create a dedicated group for Round 1 reflection, as a child of the main run group
+    // Create a dedicated group for round 1, as a child of the main run group
     const round1GroupId = await this.logger.startGroup(
       `r${currRound}`,
       undefined,
@@ -1011,8 +1011,8 @@ export abstract class BaseReflectionAgent implements IAgent {
           toolState,
         );
       } else {
-        // Handle single output file
-        const outputFiles = this.outputHandler.outputFiles[0];
+        // Handle single output file from previous round
+        const outputFiles = this.outputHandler.outputFiles[currRound - 1];
         if (outputFiles && outputFiles.length > 0) {
           await this._handleToolStateForOutput(
             [outputFiles[0]],
@@ -1029,10 +1029,10 @@ export abstract class BaseReflectionAgent implements IAgent {
         );
       }
 
-      // Initialize reflection round
+      // Initialize round
       const stateRound = new AgentStateRound(currRound);
 
-      // Prepare reflection message
+      // Prepare round message
       const userRequestReflect = await renderPrompt(
         this.agentPrompt.userReflect,
         this.userVars,
@@ -1048,14 +1048,13 @@ export abstract class BaseReflectionAgent implements IAgent {
         return [stateRound, stateGlobal, messages, true];
       }
 
-      const reflectionMessages =
-        await this.modelHandler.createReflectionMessages(
-          messages,
-          userMessage,
-          toolState.mediaFiles,
-        );
+      const roundMessages = await this.modelHandler.createRoundMessages(
+        messages,
+        userMessage,
+        toolState.mediaFiles,
+      );
 
-      // Handle prefill for reflection round
+      // Handle prefill for round
       const prefill = this.getPrefillForRound(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
@@ -1063,9 +1062,9 @@ export abstract class BaseReflectionAgent implements IAgent {
         await this.modelHandler.initializeOutputAndPrefill(
           this.agentConfig,
           this.agentSetting,
-          reflectionMessages,
+          roundMessages,
           toolState,
-          this.outputFile[1],
+          this.outputFile[currRound],
           prefill,
           round1GroupId,
         );
@@ -1081,7 +1080,7 @@ export abstract class BaseReflectionAgent implements IAgent {
           stateRound,
           stateGlobal,
           toolState,
-          this.outputFile[1],
+          this.outputFile[currRound],
           round1GroupId,
         );
 
@@ -1089,7 +1088,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         await this.handleRoundCompletion(
           updatedStateRound,
           updatedStateGlobal,
-          this.outputFile[1],
+          this.outputFile[currRound],
           newEndTurn,
           currRound,
           round1GroupId,
@@ -1108,7 +1107,7 @@ export abstract class BaseReflectionAgent implements IAgent {
       await this.handleRoundCompletion(
         stateRound,
         stateGlobal,
-        this.outputFile[1],
+        this.outputFile[currRound],
         endTurn,
         currRound,
         round1GroupId,
@@ -1143,7 +1142,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         await this.process();
       this.logger.debug(`Round 0 completed\n`, this.runGroupId);
 
-      // Check for interruption before reflection
+      // Check for interruption before next round
       if (
         !this.isInterrupted &&
         this.agentConfig.toolConfig.reflect &&

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -570,10 +570,10 @@ export abstract class ModelHandler {
   ): Promise<any[]>;
 
   /**
-   * Creates reflection messages for multi-turn conversations with optional images.
-   * @returns Provider-specific message array with reflection content
+   * Creates messages for follow-up conversation rounds with optional images.
+   * @returns Provider-specific message array with new round content
    */
-  abstract createReflectionMessages(
+  abstract createRoundMessages(
     messages: any[],
     userMessage: string,
     mediaFiles?: string[],

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -245,14 +245,14 @@ export class ModelHandlerAnthropic extends ModelHandler {
     }
   }
 
-  /** Creates a reflection message array for Anthropic models, managing cache control and image content. */
-  async createReflectionMessages(
+  /** Creates message array for subsequent rounds, managing cache control and image content. */
+  async createRoundMessages(
     messages: MessageParam[],
     userMessage: string,
     mediaFiles?: string[],
   ): Promise<MessageParam[]> {
-    // Create content list for the reflection message
-    const reflectionContent: ContentBlock[] = [];
+    // Create content list for the new round message
+    const roundContent: ContentBlock[] = [];
 
     // Add media if provided (Anthropic currently only supports images)
     if (
@@ -263,7 +263,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       try {
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
         // Filter out any non-image content
-        reflectionContent.push(
+        roundContent.push(
           ...formattedMediaContent.filter(
             (c) =>
               c.type === 'image' ||
@@ -272,7 +272,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
         );
       } catch (err) {
         this.logger.error(
-          `Error processing media files for reflection: ${err}`,
+          `Error processing media files for follow-up round: ${err}`,
         );
       }
     }
@@ -286,7 +286,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
         ? { cache_control: { type: 'ephemeral' } }
         : {}),
     };
-    reflectionContent.push(messageBlock);
+    roundContent.push(messageBlock);
 
     // We need to ensure we don't exceed Anthropic's limit of 4 cache_control blocks
     // Remove cache_control from ALL previous message contents
@@ -298,7 +298,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       }
     }
 
-    messages.push({ role: 'user', content: reflectionContent });
+    messages.push({ role: 'user', content: roundContent });
     return messages;
   }
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -477,14 +477,14 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     return mimeType || null;
   }
 
-  /** Creates a reflection message array for Google GenAI models, managing image content and message structure. */
-  async createReflectionMessages(
+  /** Creates message array for subsequent rounds, managing image content and message structure. */
+  async createRoundMessages(
     messages: Message[],
     userMessage: string,
     mediaFiles?: string[],
   ): Promise<Message[]> {
     const client = await this.getClient();
-    const reflectionParts: InternalMessagePart[] = [];
+    const roundParts: InternalMessagePart[] = [];
 
     if (
       mediaFiles &&
@@ -493,7 +493,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
         this.config.capabilities.supportsNativeAudio)
     ) {
       this.logger.info(
-        `Uploading ${mediaFiles.length} media files for reflection via native SDK...`,
+        `Uploading ${mediaFiles.length} media files for follow-up round via native SDK...`,
       );
       for (const mediaFile of mediaFiles) {
         try {
@@ -507,7 +507,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
 
           if (!explicitMimeType) {
             this.logger.error(
-              `Cannot determine mime type for reflection file ${mediaFile}. Skipping file.`,
+              `Cannot determine mime type for file ${mediaFile}. Skipping file.`,
             );
             continue;
           }
@@ -518,28 +518,28 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
           };
 
           this.logger.debug(
-            `Attempting reflection upload for ${mediaFile} with params: ${JSON.stringify(uploadParams)}`,
+            `Attempting upload for ${mediaFile} with params: ${JSON.stringify(uploadParams)}`,
           );
           this.logger.debug(`MIME type being used: ${explicitMimeType}`);
 
           const uploadResult: File = await client.files.upload(uploadParams);
 
           this.logger.info(
-            `Uploaded reflection file ${mediaFile}, URI: ${uploadResult.uri}, MimeType: ${uploadResult.mimeType}`,
+            `Uploaded file ${mediaFile}, URI: ${uploadResult.uri}, MimeType: ${uploadResult.mimeType}`,
           );
 
           if (!uploadResult.uri || !uploadResult.mimeType) {
             this.logger.error(
-              `Upload result for reflection file ${mediaFile} missing URI or MimeType. API might have failed inference. Skipping file.`,
+              `Upload result for file ${mediaFile} missing URI or MimeType. API might have failed inference. Skipping file.`,
             );
             continue;
           }
 
-          reflectionParts.push({
+          roundParts.push({
             type: 'text',
-            text: `\nReflecting on file: ${path.basename(mediaFile)}`,
+            text: `\nProcessing file: ${path.basename(mediaFile)}`,
           });
-          reflectionParts.push({
+          roundParts.push({
             type: 'file_uri',
             uri: uploadResult.uri,
             mimeType: uploadResult.mimeType,
@@ -547,7 +547,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
         } catch (error) {
           this.logger.error(
             formatProviderError(
-              `Failed to upload media file ${mediaFile} for reflection`,
+              `Failed to upload media file ${mediaFile} for follow-up round`,
               error,
             ),
           );
@@ -555,9 +555,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       }
     }
 
-    reflectionParts.push({ type: 'text', text: userMessage });
+    roundParts.push({ type: 'text', text: userMessage });
 
-    messages.push({ role: 'user', content: reflectionParts });
+    messages.push({ role: 'user', content: roundParts });
     return messages;
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -289,18 +289,18 @@ export class ModelHandlerOpenAI extends ModelHandler {
     return messages;
   }
 
-  /** Adds user message with reflection content to existing messages. */
-  async createReflectionMessages(
+  /** Adds user message content for subsequent rounds. */
+  async createRoundMessages(
     messages: any[],
     userMessage: string,
     mediaFiles?: string[],
   ): Promise<any[]> {
-    const reflectionContent: ChatCompletionContentPart[] = [];
+    const roundContent: ChatCompletionContentPart[] = [];
 
     // const role = this.config.capabilities.supportsIntermDevMsgs
     // ? 'system'
     // : 'user';
-    // technically we can use system for the reflection messages, but it does not support images...
+    // technically we can use system for the follow-up round messages, but it does not support images...
     // Error in createResponse: Error: 400 Invalid 'messages[4]'. Image URLs are only allowed for messages with role 'user', but this message with role 'system' contains an image URL.
     // system role does not support images/audio
     const role = 'user';
@@ -313,16 +313,16 @@ export class ModelHandlerOpenAI extends ModelHandler {
     ) {
       try {
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
-        reflectionContent.push(...formattedMediaContent);
+        roundContent.push(...formattedMediaContent);
       } catch (err) {
         this.logger.error(
-          `Error processing media files for reflection: ${err}`,
+          `Error processing media files for follow-up round: ${err}`,
         );
       }
     }
-    reflectionContent.push({ type: 'text', text: userMessage });
+    roundContent.push({ type: 'text', text: userMessage });
 
-    messages.push({ role, content: reflectionContent });
+    messages.push({ role, content: roundContent });
     return messages;
   }
 


### PR DESCRIPTION
## Summary
- generalize round handling in BaseReflectionAgent
- rename `createReflectionMessages` to `createRoundMessages`
- update model handlers for new method name and wording

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test output not supported in container)*

------
https://chatgpt.com/codex/tasks/task_e_684c66515be08324bc4230846e6aa526