### PR TITLE
Refactor platform-specific path logic

### DIFF
--- a/src/utils/execUtils.ts
+++ b/src/utils/execUtils.ts
@@ -1,10 +1,5 @@
-// Standard library imports
-import * as fs from 'fs';
-import * as path from 'path';
-
 // Third-party imports
 import spawn from 'cross-spawn';
-import glob from 'glob';
 
 // Local imports - log
 import * as logger from '../logger/logUtils';
@@ -12,86 +7,12 @@ import * as logger from '../logger/logUtils';
 // Local imports - utilities
 import { getWorkspacePath } from './workspaceFileUtils';
 import { ExecResult } from '../types/ResultTypes';
+import { extendEnvPath } from './platformPaths';
 
 const CHANNEL = 'execUtils';
 logger.initialize(CHANNEL);
 
 const MAX_OUTPUT_LENGTH = 150;
-
-// Additional directories that commonly contain LaTeX tools
-function getExtraDirs(): string[] {
-  const dirs: string[] = [];
-  const platform = process.platform;
-
-  if (platform === 'darwin') {
-    dirs.push(
-      '/opt/homebrew/bin', // Homebrew on Apple Silicon
-      '/usr/local/bin',
-      '/Library/TeX/texbin',
-      '/usr/texbin',
-    );
-  } else if (platform === 'win32') {
-    dirs.push(
-      'C:\\Program Files\\MiKTeX\\miktex\\bin\\x64',
-      'C:\\Program Files\\MiKTeX\\miktex\\bin',
-      'C:\\Program Files (x86)\\MiKTeX\\miktex\\bin',
-    );
-  } else {
-    // Linux and others
-    dirs.push(
-      '/usr/local/bin',
-      '/usr/bin',
-      '/usr/texbin',
-      '/home/linuxbrew/.linuxbrew/bin',
-    );
-  }
-
-  const texlivePatterns =
-    platform === 'win32'
-      ? ['C:/texlive/*/bin/*']
-      : ['/usr/local/texlive/*/bin/*'];
-  for (const pattern of texlivePatterns) {
-    try {
-      const matches = glob.sync(pattern).sort().reverse();
-      dirs.push(...matches);
-    } catch {
-      // ignore glob errors
-    }
-  }
-
-  return Array.from(new Set(dirs));
-}
-
-// Extend PATH with common directories if they are missing
-export function extendEnvPath(
-  basePath: string = process.env.PATH || '',
-): string {
-  const segments = basePath.split(path.delimiter).filter(Boolean);
-  for (const dir of getExtraDirs()) {
-    if (!segments.includes(dir) && fs.existsSync(dir)) {
-      segments.push(dir);
-    }
-  }
-  return segments.join(path.delimiter);
-}
-
-// Locate a tool in the common directories
-export function findToolInCommonPaths(tool: string): string | null {
-  const candidates = [tool];
-  if (process.platform === 'win32' && !tool.toLowerCase().endsWith('.exe')) {
-    candidates.unshift(`${tool}.exe`);
-  }
-
-  for (const dir of getExtraDirs()) {
-    for (const name of candidates) {
-      const candidate = path.join(dir, name);
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  return null;
-}
 
 /**
  * Truncate text to maxChars by keeping the end portion.

--- a/src/utils/platformPaths.ts
+++ b/src/utils/platformPaths.ts
@@ -1,0 +1,92 @@
+// Standard library imports
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Third-party imports
+import glob from 'glob';
+
+// Local imports - log
+import * as logger from '../logger/logUtils';
+
+const CHANNEL = 'platformPaths';
+logger.initialize(CHANNEL);
+
+/**
+ * Return common tool directories based on the current platform.
+ */
+export function getExtraDirs(): string[] {
+  const dirs: string[] = [];
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    dirs.push(
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/Library/TeX/texbin',
+      '/usr/texbin',
+    );
+  } else if (platform === 'win32') {
+    dirs.push(
+      'C:\\Program Files\\MiKTeX\\miktex\\bin\\x64',
+      'C:\\Program Files\\MiKTeX\\miktex\\bin',
+      'C:\\Program Files (x86)\\MiKTeX\\miktex\\bin',
+    );
+  } else {
+    dirs.push(
+      '/usr/local/bin',
+      '/usr/bin',
+      '/usr/texbin',
+      '/home/linuxbrew/.linuxbrew/bin',
+    );
+  }
+
+  const texlivePatterns =
+    platform === 'win32'
+      ? ['C:/texlive/*/bin/*']
+      : ['/usr/local/texlive/*/bin/*'];
+  for (const pattern of texlivePatterns) {
+    try {
+      const matches = glob.sync(pattern).sort().reverse();
+      dirs.push(...matches);
+    } catch {
+      // ignore glob errors
+    }
+  }
+
+  return Array.from(new Set(dirs));
+}
+
+/**
+ * Extend PATH with common directories if they are missing.
+ */
+export function extendEnvPath(
+  basePath: string = process.env.PATH || '',
+): string {
+  const segments = basePath.split(path.delimiter).filter(Boolean);
+  for (const dir of getExtraDirs()) {
+    if (!segments.includes(dir) && fs.existsSync(dir)) {
+      segments.push(dir);
+    }
+  }
+  return segments.join(path.delimiter);
+}
+
+/**
+ * Locate a tool in the common directories.
+ */
+export function findToolInCommonPaths(tool: string): string | null {
+  const candidates = [tool];
+  if (process.platform === 'win32' && !tool.toLowerCase().endsWith('.exe')) {
+    candidates.unshift(`${tool}.exe`);
+  }
+
+  for (const dir of getExtraDirs()) {
+    for (const name of candidates) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -2,7 +2,7 @@
 import spawn from 'cross-spawn';
 
 // Local imports
-import { extendEnvPath, findToolInCommonPaths } from './execUtils';
+import { extendEnvPath, findToolInCommonPaths } from './platformPaths';
 
 // Third-party imports
 import * as vscode from 'vscode';


### PR DESCRIPTION
## Summary
- create `platformPaths` utility for cross-platform PATH management
- use the new utility in `executeCommand` and tool checks

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: compiler output only, likely due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_684c94b962e0832488357ce86ec29c7e