### PR TITLE
Use pandoc for scratchpad conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "gpt-tokenizer": "^3.0.0",
         "identifiers-arxiv": "^0.1.1",
         "marked": "^15.0.12",
+        "node-pandoc": "^0.3.0",
         "openai": "^5.3.0",
         "pdf2pic": "^3.2.0",
         "sortablejs": "^1.15.6",
@@ -4495,6 +4496,12 @@
       "peerDependencies": {
         "webpack": "^5.0.0"
       }
+    },
+    "node_modules/node-pandoc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-pandoc/-/node-pandoc-0.3.0.tgz",
+      "integrity": "sha512-e+kANHQQFBlN7J8wEFf7sNc1sSCLltyPtPqNA/IEapiNsA1LjZ9mtV/B0lU6b2cAdvn7rrAVNBONw+Fo1YsY+A==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -1165,6 +1165,7 @@
     "gpt-tokenizer": "^3.0.0",
     "identifiers-arxiv": "^0.1.1",
     "marked": "^15.0.12",
+    "node-pandoc": "^0.3.0",
     "openai": "^5.3.0",
     "pdf2pic": "^3.2.0",
     "sortablejs": "^1.15.6",

--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -373,7 +373,7 @@ export abstract class BaseReflectionAgent implements IAgent {
 
         // If thinking content was extracted, format and log it first
         if (thinkingContent) {
-          formatAndLogContent(
+          await formatAndLogContent(
             thinkingContent,
             this.logger,
             'Thinking',
@@ -385,7 +385,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         }
 
         // Extract thinking from XML tags in the response text
-        this.extractAndLogScratchpad(
+        await this.extractAndLogScratchpad(
           newResponse,
           'scratchpad',
           responseCycleGroupId,
@@ -1384,7 +1384,12 @@ export abstract class BaseReflectionAgent implements IAgent {
     outputContent: string,
     thinkingTag: string = 'scratchpad',
     groupId?: string,
-  ): void {
-    extractAndLogScratchpad(outputContent, this.logger, thinkingTag, groupId);
+  ): Promise<void> {
+    return extractAndLogScratchpad(
+      outputContent,
+      this.logger,
+      thinkingTag,
+      groupId,
+    );
   }
 }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -511,7 +511,12 @@ export class ModelHandlerAnthropic extends ModelHandler {
     fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
-    extractAndLogScratchpad(fileContent, this.logger, 'scratchpad', groupId);
+    await extractAndLogScratchpad(
+      fileContent,
+      this.logger,
+      'scratchpad',
+      groupId,
+    );
 
     await writeFile(outputFile, fileContent);
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -825,7 +825,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
-    extractAndLogScratchpad(fileContent, this.logger, 'scratchpad', groupId);
+    await extractAndLogScratchpad(
+      fileContent,
+      this.logger,
+      'scratchpad',
+      groupId,
+    );
 
     await writeFile(outputFile, fileContent);
     this.logger.debug(`Cleaned and saved existing content to ${outputFile}.`);

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -545,7 +545,12 @@ export class ModelHandlerOpenAI extends ModelHandler {
     fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
-    extractAndLogScratchpad(fileContent, this.logger, 'scratchpad', groupId);
+    await extractAndLogScratchpad(
+      fileContent,
+      this.logger,
+      'scratchpad',
+      groupId,
+    );
 
     // Write file content to output file
     await writeFile(outputFile, fileContent);

--- a/src/utils/pandocUtils.ts
+++ b/src/utils/pandocUtils.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import fs from 'fs/promises';
+import os from 'os';
+import { executeCommand } from './execUtils';
+import { checkToolInstalled } from './toolUtils';
+
+/**
+ * Convert input text using pandoc.
+ * @param content Text content to convert.
+ * @param from Format to convert from (e.g. 'html', 'latex').
+ * @param to Format to convert to (default 'markdown').
+ * @returns Converted text on success, or original content on failure.
+ */
+export async function pandocConvert(
+  content: string,
+  from: 'html' | 'latex' | 'markdown',
+  to: 'markdown' | 'html' = 'markdown',
+): Promise<string> {
+  const installed = await checkToolInstalled('pandoc', false);
+  if (!installed) {
+    return content;
+  }
+  const tmpFile = path.join(os.tmpdir(), `pandoc_in_${Date.now()}.txt`);
+  await fs.writeFile(tmpFile, content);
+  const cmd = `pandoc -f ${from} -t ${to} ${tmpFile}`;
+  const result = await executeCommand(cmd, { channel: 'pandocUtils' });
+  await fs.unlink(tmpFile).catch(() => {});
+  return result.success && result.stdout ? result.stdout : content;
+}
+
+/**
+ * Guess the format of the given content.
+ * @param content Input content string.
+ * @returns Detected format string.
+ */
+export function detectFormat(content: string): 'html' | 'latex' | 'markdown' {
+  if (/<\/?[a-z][\s\S]*>/i.test(content)) {
+    return 'html';
+  }
+  if (/\\begin\{|\\section\{/.test(content)) {
+    return 'latex';
+  }
+  return 'markdown';
+}

--- a/src/utils/xmlUtils.ts
+++ b/src/utils/xmlUtils.ts
@@ -235,12 +235,14 @@ export function extractContentFromXMLbyTagMultiple(
  * @param contentType The type of content (e.g., 'Scratchpad', 'Thinking')
  * @param groupId Optional group ID for logging
  */
-export function formatAndLogContent(
+import { detectFormat, pandocConvert } from './pandocUtils';
+
+export async function formatAndLogContent(
   content: string,
   agentLogger: AgentLogger,
   contentType: string = 'Scratchpad',
   groupId?: string,
-): void {
+): Promise<void> {
   if (!content) {
     return;
   }
@@ -254,58 +256,72 @@ export function formatAndLogContent(
   // Format the content for improved rendering
   let formattedContent = content.trim();
 
-  // Replace LaTeX notation with markdown-friendly equivalents
-  formattedContent = formattedContent
-    .replace(/\\section\{([^}]+)\}/g, '## $1')
-    .replace(/\\subsection\{([^}]+)\}/g, '### $1')
-    .replace(/\\begin\{itemize\}/g, '')
-    .replace(/\\end\{itemize\}/g, '')
-    // Also handle enumerate environments like itemize
-    .replace(/\\begin\{enumerate\}/g, '')
-    .replace(/\\end\{enumerate\}/g, '')
-    .replace(/\\item\s+/g, '- ')
-    // Standardize bullet lists starting with asterisk while avoiding emphasis markers
-    .replace(/(^|\n)(\s*)\*\s+(?=\S)/g, '$1$2- ')
-    .replace(/\\textbf\{([^}]+)\}/g, '**$1**')
-    .replace(/\\textit\{([^}]+)\}/g, '*$1*')
-    .replace(/\\emph\{([^}]+)\}/g, '*$1*')
-    // Convert common HTML tags to markdown before generic XML handling
-    .replace(/<br\s*\/?>/gi, '\n')
-    // Handle p and div tags more carefully to avoid excessive newlines
-    .replace(/<(?:p|div)\b[^>]*>/gi, '')
-    .replace(/<\/(?:p|div)>/gi, '\n')
-    .replace(/<(strong|b)>(.*?)<\/\1>/gi, '**$2**')
-    .replace(/<(em|i)>(.*?)<\/\1>/gi, '*$2*')
-    .replace(/<code>(.*?)<\/code>/gi, '`$1`')
-    .replace(/<pre>([\s\S]*?)<\/pre>/gi, '```\n$1\n```')
-    .replace(/<h1>(.*?)<\/h1>/gi, '# $1\n')
-    .replace(/<h2>(.*?)<\/h2>/gi, '## $1\n')
-    .replace(/<h3>(.*?)<\/h3>/gi, '### $1\n')
-    .replace(/<h4>(.*?)<\/h4>/gi, '#### $1\n')
-    .replace(/<h5>(.*?)<\/h5>/gi, '##### $1\n')
-    .replace(/<h6>(.*?)<\/h6>/gi, '###### $1\n')
-    // Handle lists - simple approach
-    // For XML tags containing lists (ol/ul), just remove the wrapper tag
-    .replace(/<([\w-]{6,})>\s*(<[ou]l\b[\s\S]*?<\/[ou]l>)\s*<\/\1>/g, '$2')
-    // Convert XML tags to markdown headings - only for semantic tags with 6+ characters that don't contain lists
-    .replace(/<([\w-]{6,})>\s*([^<]*?)\s*<\/\1>/g, '## $1\n$2')
-    // Remove ul and ol tags
-    .replace(/<[ou]l>/gi, '')
-    .replace(/<\/[ou]l>/gi, '')
-    // Replace <li> with bullet point and remove </li> tags
-    .replace(/<li>/gi, '- ')
-    .replace(/<\/li>/gi, '')
-    // Escape LaTeX references but preserve the content
-    .replace(/~\\ref\{/g, ' \\ref{')
-    .replace(/\\ref\{([^}]+)\}/g, '\\\\ref{$1}')
-    // Remove multiple empty lines before list items, preserving indentation
-    .replace(/\n(\s*)\n(\s*)\n(\s*)- /g, '\n$3- ')
-    .replace(/\n(\s*)\n(\s*)- /g, '\n$2- ')
-    // Clean up excessive whitespace and normalize line breaks
-    .replace(/\n{4,}/g, '\n\n') // Replace 4+ newlines with 2
+  const fromFormat = detectFormat(formattedContent);
+  let usedPandoc = false;
+  try {
+    const pandocResult = await pandocConvert(formattedContent, fromFormat);
+    if (pandocResult && pandocResult.trim()) {
+      formattedContent = pandocResult.trim();
+      usedPandoc = true;
+    }
+  } catch {
+    // ignore pandoc errors and fallback to regex rules
+  }
 
-    .replace(/ {4}/gm, '  '); // Replace 4 spaces with 2 spaces
-  // .replace(/ +$/gm, ''); // Remove trailing spaces only
+  if (!usedPandoc) {
+    // Replace LaTeX notation with markdown-friendly equivalents
+    formattedContent = formattedContent
+      .replace(/\\section\{([^}]+)\}/g, '## $1')
+      .replace(/\\subsection\{([^}]+)\}/g, '### $1')
+      .replace(/\\begin\{itemize\}/g, '')
+      .replace(/\\end\{itemize\}/g, '')
+      // Also handle enumerate environments like itemize
+      .replace(/\\begin\{enumerate\}/g, '')
+      .replace(/\\end\{enumerate\}/g, '')
+      .replace(/\\item\s+/g, '- ')
+      // Standardize bullet lists starting with asterisk while avoiding emphasis markers
+      .replace(/(^|\n)(\s*)\*\s+(?=\S)/g, '$1$2- ')
+      .replace(/\\textbf\{([^}]+)\}/g, '**$1**')
+      .replace(/\\textit\{([^}]+)\}/g, '*$1*')
+      .replace(/\\emph\{([^}]+)\}/g, '*$1*')
+      // Convert common HTML tags to markdown before generic XML handling
+      .replace(/<br\s*\/?>/gi, '\n')
+      // Handle p and div tags more carefully to avoid excessive newlines
+      .replace(/<(?:p|div)\b[^>]*>/gi, '')
+      .replace(/<\/(?:p|div)>/gi, '\n')
+      .replace(/<(strong|b)>(.*?)<\/\1>/gi, '**$2**')
+      .replace(/<(em|i)>(.*?)<\/\1>/gi, '*$2*')
+      .replace(/<code>(.*?)<\/code>/gi, '`$1`')
+      .replace(/<pre>([\s\S]*?)<\/pre>/gi, '```\n$1\n```')
+      .replace(/<h1>(.*?)<\/h1>/gi, '# $1\n')
+      .replace(/<h2>(.*?)<\/h2>/gi, '## $1\n')
+      .replace(/<h3>(.*?)<\/h3>/gi, '### $1\n')
+      .replace(/<h4>(.*?)<\/h4>/gi, '#### $1\n')
+      .replace(/<h5>(.*?)<\/h5>/gi, '##### $1\n')
+      .replace(/<h6>(.*?)<\/h6>/gi, '###### $1\n')
+      // Handle lists - simple approach
+      // For XML tags containing lists (ol/ul), just remove the wrapper tag
+      .replace(/<([\w-]{6,})>\s*(<[ou]l\b[\s\S]*?<\/[ou]l>)\s*<\/\1>/g, '$2')
+      // Convert XML tags to markdown headings - only for semantic tags with 6+ characters that don't contain lists
+      .replace(/<([\w-]{6,})>\s*([^<]*?)\s*<\/\1>/g, '## $1\n$2')
+      // Remove ul and ol tags
+      .replace(/<[ou]l>/gi, '')
+      .replace(/<\/[ou]l>/gi, '')
+      // Replace <li> with bullet point and remove </li> tags
+      .replace(/<li>/gi, '- ')
+      .replace(/<\/li>/gi, '')
+      // Escape LaTeX references but preserve the content
+      .replace(/~\\ref\{/g, ' \\ref{')
+      .replace(/\\ref\{([^}]+)\}/g, '\\\\ref{$1}')
+      // Remove multiple empty lines before list items, preserving indentation
+      .replace(/\n(\s*)\n(\s*)\n(\s*)- /g, '\n$3- ')
+      .replace(/\n(\s*)\n(\s*)- /g, '\n$2- ')
+      // Clean up excessive whitespace and normalize line breaks
+      .replace(/\n{4,}/g, '\n\n') // Replace 4+ newlines with 2
+
+      .replace(/ {4}/gm, '  '); // Replace 4 spaces with 2 spaces
+    // .replace(/ +$/gm, ''); // Remove trailing spaces only
+  }
 
   // agentLogger.info(formattedContent, groupId); // for debugging
 
@@ -322,17 +338,22 @@ export function formatAndLogContent(
  * @param thinkingTag The XML tag name used for the scratchpad content
  * @param groupId Optional group ID for logging
  */
-export function extractAndLogScratchpad(
+export async function extractAndLogScratchpad(
   outputContent: string,
   agentLogger: AgentLogger,
   thinkingTag: string = 'scratchpad',
   groupId?: string,
-): void {
+): Promise<void> {
   const extractedContent = extractTextFromTag(outputContent, thinkingTag);
   if (extractedContent) {
     // Always log using the canonical "Scratchpad" label so that the progress
     // view recognises the message. The thinkingTag is still used for
     // extraction so alternative tag names continue to work.
-    formatAndLogContent(extractedContent, agentLogger, 'Scratchpad', groupId);
+    await formatAndLogContent(
+      extractedContent,
+      agentLogger,
+      'Scratchpad',
+      groupId,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add pandoc utilities
- convert scratchpad and thinking logs using pandoc when available
- make scratchpad extraction asynchronous in agents

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d336b91e08324867df150e3609f88