### PR TITLE
Add module alias support

### DIFF
--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -5,10 +5,10 @@ import * as path from 'path';
 import { XMLParser } from 'fast-xml-parser';
 
 // Local imports - log
-import { AgentLogger } from '../../../logger/AgentLogger';
+import { AgentLogger } from '@/logger/AgentLogger';
 
 // Local imports - utilities
-import { readFile, writeFile } from '../../../utils/files';
+import { readFile, writeFile } from '@/utils/files';
 import {
   addCdataToTags,
   addCdataToTagsMultiple,
@@ -16,29 +16,29 @@ import {
   extractTextFromTag,
   extractContentFromXMLbyTagMultiple,
   extractMultipleTextFromTag,
-} from '../../../utils/text/xmlUtils';
+} from '@/utils/text/xmlUtils';
 import {
   applyReplacements,
   getReplacementsByCategory,
   getAllReplacements,
-} from '../../../replacement/replacementUtils';
+} from '@/replacement/replacementUtils';
 import {
   runLatexdiffForRound,
   runLatexdiffBetweenRounds,
   LaTeXdiffResult,
-} from '../../../latex/latexdiff';
-import { compileLatex2Pdf } from '../../../latex/texTools';
-import { checkToolInstalled } from '../../../utils/system';
-import { runLatexFormatter } from '../../../latex/texFormatter';
+} from '@/latex/latexdiff';
+import { compileLatex2Pdf } from '@/latex/texTools';
+import { checkToolInstalled } from '@/utils/system';
+import { runLatexFormatter } from '@/latex/texFormatter';
 
 // Local imports - agent components
-import { AgentConfig } from '../../core/AgentConfig';
-import { AgentSetting } from '../../core/AgentDataclass';
-import { AgentStateGlobal, AgentStateRound } from '../../core/AgentState';
-import { ProgressViewProvider } from '../../../progressView/ProgressViewProvider';
+import { AgentConfig } from '@/agent/core/AgentConfig';
+import { AgentSetting } from '@/agent/core/AgentDataclass';
+import { AgentStateGlobal, AgentStateRound } from '@/agent/core/AgentState';
+import { ProgressViewProvider } from '@/progressView/ProgressViewProvider';
 
 // Local imports - types
-import { TokenUsageStats } from '../../../types/UsageTypes';
+import { TokenUsageStats } from '@/types/UsageTypes';
 
 /** Generates output filename incorporating model and round information. */
 export function getOutputFileName(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,10 @@
     "lib": ["ES2022", "DOM"],
     "sourceMap": false,
     "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "moduleResolution": "node",
     "strict": true /* enable all strict type-checking options */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,9 @@ const extensionConfig = {
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
     extensions: ['.ts', '.js'],
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
     fallback: {
       fs: false,
       path: require.resolve('path-browserify'),


### PR DESCRIPTION
## Summary
- support `@` path alias in `tsconfig.json`
- configure webpack alias for `@`
- update output handler imports

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find module `@modelcontextprotocol`)*

------
https://chatgpt.com/codex/tasks/task_e_684dc09250008324acfac8b0ade68a17