### PR TITLE
Add module alias support

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 // (none needed)
 
 // Local imports - log
-import { AgentLogger } from '@/logger/AgentLogger';
+import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - latex utils
 import {
@@ -14,55 +14,55 @@ import {
   bestConnectionMethod,
   getTeXCountStats,
   compileLatex2Pdf,
-} from '@/latex';
-import { ProgressViewProvider } from '@/progressView/ProgressViewProvider';
+} from '@latex';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { diff_match_patch } from 'diff-match-patch';
 import type { DiffStats } from '@/types/DiffTypes';
 
 // Local imports - utilities
-import { writeFile, appendFile, fileExists, readFile } from '@/utils/files';
+import { writeFile, appendFile, fileExists, readFile } from '@utils/files';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
   writePromptToXml,
-} from '@/utils/promptUtils';
-import { loadTexraRules } from '@/frontend/files/rules';
+} from '@utils/promptUtils';
+import { loadTexraRules } from '@frontend/files/rules';
 import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
-} from '@/replacement/replacementUtils';
-import { checkForMassiveRepetition } from '@/utils/text/repetitionUtils';
+} from '@replacement/replacementUtils';
+import { checkForMassiveRepetition } from '@utils/text/repetitionUtils';
 import {
   extractAndLogScratchpad,
   formatAndLogContent,
-} from '@/utils/text/xmlUtils';
-import { sleep } from '@/utils/helpers';
+} from '@utils/text/xmlUtils';
+import { sleep } from '@utils/helpers';
 
 // Local imports - agent components
-import { AgentConfig } from '@/agent/core/AgentConfig';
+import { AgentConfig } from '@agent/core/AgentConfig';
 import {
   AgentSetting,
   AgentPrompt,
   AgentType,
-} from '@/agent/core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '@/agent/core/AgentState';
-import { ToolState } from '@/agent/core/ToolState';
-import { ModelHandler } from '@/agent/modelHandlers';
-import { OutputHandler } from '@/agent/runtime/OutputHandler';
-import { messageToSkeleton } from '@/agent/utils/messageUtils';
-import { buildUserVars } from '@/agent/utils/userVars';
-import { IAgent } from '@/agent/core/IAgent';
+} from '@agent/core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
+import { ToolState } from '@agent/core/ToolState';
+import { ModelHandler } from '@agent/modelHandlers';
+import { OutputHandler } from '@agent/runtime/OutputHandler';
+import { messageToSkeleton } from '@agent/utils/messageUtils';
+import { buildUserVars } from '@agent/utils/userVars';
+import { IAgent } from '@agent/core/IAgent';
 
 // System imports - common utilities
-import { getConfig } from '@/utils/config';
+import { getConfig } from '@utils/config';
 
 // Shared constants
 import {
   K_SLICE,
   SHORT_SLEEP_MS,
   REPETITION_DETECTION_THRESHOLD,
-} from '@/utils/config';
+} from '@utils/config';
 
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 // (none needed)
 
 // Local imports - log
-import { AgentLogger } from '../../logger/AgentLogger';
+import { AgentLogger } from '@/logger/AgentLogger';
 
 // Local imports - latex utils
 import {
@@ -14,51 +14,55 @@ import {
   bestConnectionMethod,
   getTeXCountStats,
   compileLatex2Pdf,
-} from '../../latex';
-import { ProgressViewProvider } from '../../progressView/ProgressViewProvider';
+} from '@/latex';
+import { ProgressViewProvider } from '@/progressView/ProgressViewProvider';
 import { diff_match_patch } from 'diff-match-patch';
-import type { DiffStats } from '../../types/DiffTypes';
+import type { DiffStats } from '@/types/DiffTypes';
 
 // Local imports - utilities
-import { writeFile, appendFile, fileExists, readFile } from '../../utils/files';
+import { writeFile, appendFile, fileExists, readFile } from '@/utils/files';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
   writePromptToXml,
-} from '../../utils/promptUtils';
-import { loadTexraRules } from '../../frontend/files/rules';
+} from '@/utils/promptUtils';
+import { loadTexraRules } from '@/frontend/files/rules';
 import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
-} from '../../replacement/replacementUtils';
-import { checkForMassiveRepetition } from '../../utils/text/repetitionUtils';
+} from '@/replacement/replacementUtils';
+import { checkForMassiveRepetition } from '@/utils/text/repetitionUtils';
 import {
   extractAndLogScratchpad,
   formatAndLogContent,
-} from '../../utils/text/xmlUtils';
-import { sleep } from '../../utils/helpers';
+} from '@/utils/text/xmlUtils';
+import { sleep } from '@/utils/helpers';
 
 // Local imports - agent components
-import { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, AgentPrompt, AgentType } from '../core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
-import { ToolState } from '../core/ToolState';
-import { ModelHandler } from '../modelHandlers';
-import { OutputHandler } from '../runtime/OutputHandler';
-import { messageToSkeleton } from '../utils/messageUtils';
-import { buildUserVars } from '../utils/userVars';
-import { IAgent } from '../core/IAgent';
+import { AgentConfig } from '@/agent/core/AgentConfig';
+import {
+  AgentSetting,
+  AgentPrompt,
+  AgentType,
+} from '@/agent/core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '@/agent/core/AgentState';
+import { ToolState } from '@/agent/core/ToolState';
+import { ModelHandler } from '@/agent/modelHandlers';
+import { OutputHandler } from '@/agent/runtime/OutputHandler';
+import { messageToSkeleton } from '@/agent/utils/messageUtils';
+import { buildUserVars } from '@/agent/utils/userVars';
+import { IAgent } from '@/agent/core/IAgent';
 
 // System imports - common utilities
-import { getConfig } from '../../utils/config';
+import { getConfig } from '@/utils/config';
 
 // Shared constants
 import {
   K_SLICE,
   SHORT_SLEEP_MS,
   REPETITION_DETECTION_THRESHOLD,
-} from '../../utils/config';
+} from '@/utils/config';
 
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -12,33 +12,33 @@ import {
 import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 
 // Local imports - error utils
-import { formatProviderError } from '@/utils/sdkErrorUtils';
+import { formatProviderError } from '@utils/sdkErrorUtils';
 
 // Local imports - utilities
-import { readFile, writeFile, fileExistsAndNonTrivial } from '@/utils/files';
+import { readFile, writeFile, fileExistsAndNonTrivial } from '@utils/files';
 import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
   cleanFileContent,
-} from '@/replacement/replacementUtils';
-import { extractAndLogScratchpad } from '@/utils/text/xmlUtils';
+} from '@replacement/replacementUtils';
+import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
 
 // Local imports - agent components
-import { AgentConfig } from '@/agent/core/AgentConfig';
-import { AgentSetting, hasEndTag } from '@/agent/core/AgentDataclass';
-import { ModelHandler } from '@/agent/modelHandlers/ModelHandler';
+import { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
+import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import {
   AnthropicAPIResponseUsage,
   ResponseUsageFactory,
   AnthropicUsage,
-} from '@/agent/core/ResponseUsage';
-import { ToolState } from '@/agent/core/ToolState';
-import { MediaEntry } from '@/agent/utils/mediaTypes';
-import { AgentStateRound } from '@/agent/core/AgentState';
-import { K_SLICE } from '@/utils/config';
-import { objectToLogString } from '@/utils/text/stringUtils';
-import { calculateTokenPrice } from '@/utils/priceUtils';
+} from '@agent/core/ResponseUsage';
+import { ToolState } from '@agent/core/ToolState';
+import { MediaEntry } from '@agent/utils/mediaTypes';
+import { AgentStateRound } from '@agent/core/AgentState';
+import { K_SLICE } from '@utils/config';
+import { objectToLogString } from '@utils/text/stringUtils';
+import { calculateTokenPrice } from '@utils/priceUtils';
 
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -12,37 +12,33 @@ import {
 import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 
 // Local imports - error utils
-import { formatProviderError } from '../../utils/sdkErrorUtils';
+import { formatProviderError } from '@/utils/sdkErrorUtils';
 
 // Local imports - utilities
-import {
-  readFile,
-  writeFile,
-  fileExistsAndNonTrivial,
-} from '../../utils/files';
+import { readFile, writeFile, fileExistsAndNonTrivial } from '@/utils/files';
 import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
   cleanFileContent,
-} from '../../replacement/replacementUtils';
-import { extractAndLogScratchpad } from '../../utils/text/xmlUtils';
+} from '@/replacement/replacementUtils';
+import { extractAndLogScratchpad } from '@/utils/text/xmlUtils';
 
 // Local imports - agent components
-import { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
-import { ModelHandler } from './ModelHandler';
+import { AgentConfig } from '@/agent/core/AgentConfig';
+import { AgentSetting, hasEndTag } from '@/agent/core/AgentDataclass';
+import { ModelHandler } from '@/agent/modelHandlers/ModelHandler';
 import {
   AnthropicAPIResponseUsage,
   ResponseUsageFactory,
   AnthropicUsage,
-} from '../core/ResponseUsage';
-import { ToolState } from '../core/ToolState';
-import { MediaEntry } from '../utils/mediaTypes';
-import { AgentStateRound } from '../core/AgentState';
-import { K_SLICE } from '../../utils/config';
-import { objectToLogString } from '../../utils/text/stringUtils';
-import { calculateTokenPrice } from '../../utils/priceUtils';
+} from '@/agent/core/ResponseUsage';
+import { ToolState } from '@/agent/core/ToolState';
+import { MediaEntry } from '@/agent/utils/mediaTypes';
+import { AgentStateRound } from '@/agent/core/AgentState';
+import { K_SLICE } from '@/utils/config';
+import { objectToLogString } from '@/utils/text/stringUtils';
+import { calculateTokenPrice } from '@/utils/priceUtils';
 
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -17,19 +17,19 @@ import {
 } from '@google/genai';
 
 // Local imports - agent components
-import { ModelHandler } from './ModelHandler';
-import { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
-import { ToolState } from '../core/ToolState';
+import { ModelHandler } from '@/agent/modelHandlers/ModelHandler';
+import { AgentConfig } from '@/agent/core/AgentConfig';
+import { AgentSetting, hasEndTag } from '@/agent/core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '@/agent/core/AgentState';
+import { ToolState } from '@/agent/core/ToolState';
 import {
   OpenAIAPIResponseUsage,
   ResponseUsageFactory,
   GenerateContentResponseUsageMetadata,
   ExtendedCompletionUsage,
-} from '../core/ResponseUsage';
-import { MediaEntry } from '../utils/mediaTypes';
-import { AgentLogger } from '../../logger/AgentLogger';
+} from '@/agent/core/ResponseUsage';
+import { MediaEntry } from '@/agent/utils/mediaTypes';
+import { AgentLogger } from '@/logger/AgentLogger';
 
 // Local imports - utilities
 import {
@@ -37,21 +37,21 @@ import {
   writeFile,
   fileExistsAndNonTrivial,
   getFullPathFromWorkspace,
-} from '../../utils/files';
-import { fileExistsAbsolute } from '../../utils/files';
-import { formatProviderError } from '../../utils/sdkErrorUtils';
+} from '@/utils/files';
+import { fileExistsAbsolute } from '@/utils/files';
+import { formatProviderError } from '@/utils/sdkErrorUtils';
 import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
   cleanFileContent,
-} from '../../replacement/replacementUtils';
-import { extractAndLogScratchpad } from '../../utils/text/xmlUtils';
-import { getConfig } from '../../utils/config';
-import { calculateTokenPrice } from '../../utils/priceUtils';
+} from '@/replacement/replacementUtils';
+import { extractAndLogScratchpad } from '@/utils/text/xmlUtils';
+import { getConfig } from '@/utils/config';
+import { calculateTokenPrice } from '@/utils/priceUtils';
 
 // Local constant
-import { K_SLICE } from '../../utils/config';
+import { K_SLICE } from '@/utils/config';
 
 // Internal type definition
 type InternalMessagePart = {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -17,19 +17,19 @@ import {
 } from '@google/genai';
 
 // Local imports - agent components
-import { ModelHandler } from '@/agent/modelHandlers/ModelHandler';
-import { AgentConfig } from '@/agent/core/AgentConfig';
-import { AgentSetting, hasEndTag } from '@/agent/core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '@/agent/core/AgentState';
-import { ToolState } from '@/agent/core/ToolState';
+import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
+import { ToolState } from '@agent/core/ToolState';
 import {
   OpenAIAPIResponseUsage,
   ResponseUsageFactory,
   GenerateContentResponseUsageMetadata,
   ExtendedCompletionUsage,
-} from '@/agent/core/ResponseUsage';
-import { MediaEntry } from '@/agent/utils/mediaTypes';
-import { AgentLogger } from '@/logger/AgentLogger';
+} from '@agent/core/ResponseUsage';
+import { MediaEntry } from '@agent/utils/mediaTypes';
+import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
 import {
@@ -37,21 +37,21 @@ import {
   writeFile,
   fileExistsAndNonTrivial,
   getFullPathFromWorkspace,
-} from '@/utils/files';
-import { fileExistsAbsolute } from '@/utils/files';
-import { formatProviderError } from '@/utils/sdkErrorUtils';
+} from '@utils/files';
+import { fileExistsAbsolute } from '@utils/files';
+import { formatProviderError } from '@utils/sdkErrorUtils';
 import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
   cleanFileContent,
-} from '@/replacement/replacementUtils';
-import { extractAndLogScratchpad } from '@/utils/text/xmlUtils';
-import { getConfig } from '@/utils/config';
-import { calculateTokenPrice } from '@/utils/priceUtils';
+} from '@replacement/replacementUtils';
+import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
+import { getConfig } from '@utils/config';
+import { calculateTokenPrice } from '@utils/priceUtils';
 
 // Local constant
-import { K_SLICE } from '@/utils/config';
+import { K_SLICE } from '@utils/config';
 
 // Internal type definition
 type InternalMessagePart = {

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -1,5 +1,5 @@
 // Local imports - agent components
-import { ModelConfig, ModelProvider } from '@/model';
+import { ModelConfig, ModelProvider } from '@model';
 
 // Local imports - model handlers
 import {
@@ -15,11 +15,11 @@ import {
   ModelHandlerAnthropicViaOpenRouter,
   ModelHandlerOpenAI,
   ModelHandlerOpenAIResponse,
-} from '@/agent/modelHandlers';
+} from '@agent/modelHandlers';
 
 // Local imports - utils
-import { getConfig } from '@/utils/config';
-import * as logger from '@/logger/logUtils';
+import { getConfig } from '@utils/config';
+import * as logger from '@logger/logUtils';
 
 // Initialize logger
 const CHANNEL = 'ModelFactory';

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -1,5 +1,5 @@
 // Local imports - agent components
-import { ModelConfig, ModelProvider } from '../../model';
+import { ModelConfig, ModelProvider } from '@/model';
 
 // Local imports - model handlers
 import {
@@ -15,11 +15,11 @@ import {
   ModelHandlerAnthropicViaOpenRouter,
   ModelHandlerOpenAI,
   ModelHandlerOpenAIResponse,
-} from '../modelHandlers';
+} from '@/agent/modelHandlers';
 
 // Local imports - utils
-import { getConfig } from '../../utils/config';
-import * as logger from '../../logger/logUtils';
+import { getConfig } from '@/utils/config';
+import * as logger from '@/logger/logUtils';
 
 // Initialize logger
 const CHANNEL = 'ModelFactory';

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -5,10 +5,10 @@ import * as path from 'path';
 import { XMLParser } from 'fast-xml-parser';
 
 // Local imports - log
-import { AgentLogger } from '@/logger/AgentLogger';
+import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import { readFile, writeFile } from '@/utils/files';
+import { readFile, writeFile } from '@utils/files';
 import {
   addCdataToTags,
   addCdataToTagsMultiple,
@@ -16,26 +16,26 @@ import {
   extractTextFromTag,
   extractContentFromXMLbyTagMultiple,
   extractMultipleTextFromTag,
-} from '@/utils/text/xmlUtils';
+} from '@utils/text/xmlUtils';
 import {
   applyReplacements,
   getReplacementsByCategory,
   getAllReplacements,
-} from '@/replacement/replacementUtils';
+} from '@replacement/replacementUtils';
 import {
   runLatexdiffForRound,
   runLatexdiffBetweenRounds,
   LaTeXdiffResult,
-} from '@/latex/latexdiff';
-import { compileLatex2Pdf } from '@/latex/texTools';
-import { checkToolInstalled } from '@/utils/system';
-import { runLatexFormatter } from '@/latex/texFormatter';
+} from '@latex/latexdiff';
+import { compileLatex2Pdf } from '@latex/texTools';
+import { checkToolInstalled } from '@utils/system';
+import { runLatexFormatter } from '@latex/texFormatter';
 
 // Local imports - agent components
-import { AgentConfig } from '@/agent/core/AgentConfig';
-import { AgentSetting } from '@/agent/core/AgentDataclass';
-import { AgentStateGlobal, AgentStateRound } from '@/agent/core/AgentState';
-import { ProgressViewProvider } from '@/progressView/ProgressViewProvider';
+import { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentSetting } from '@agent/core/AgentDataclass';
+import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 // Local imports - types
 import { TokenUsageStats } from '@/types/UsageTypes';

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -5,10 +5,10 @@ import * as path from 'path';
 import { XMLParser } from 'fast-xml-parser';
 
 // Local imports - log
-import { AgentLogger } from '../../../logger/AgentLogger';
+import { AgentLogger } from '@/logger/AgentLogger';
 
 // Local imports - utilities
-import { readFile, writeFile } from '../../../utils/files';
+import { readFile, writeFile } from '@/utils/files';
 import {
   addCdataToTags,
   addCdataToTagsMultiple,
@@ -16,29 +16,29 @@ import {
   extractTextFromTag,
   extractContentFromXMLbyTagMultiple,
   extractMultipleTextFromTag,
-} from '../../../utils/text/xmlUtils';
+} from '@/utils/text/xmlUtils';
 import {
   applyReplacements,
   getReplacementsByCategory,
   getAllReplacements,
-} from '../../../replacement/replacementUtils';
+} from '@/replacement/replacementUtils';
 import {
   runLatexdiffForRound,
   runLatexdiffBetweenRounds,
   LaTeXdiffResult,
-} from '../../../latex/latexdiff';
-import { compileLatex2Pdf } from '../../../latex/texTools';
-import { checkToolInstalled } from '../../../utils/system';
-import { runLatexFormatter } from '../../../latex/texFormatter';
+} from '@/latex/latexdiff';
+import { compileLatex2Pdf } from '@/latex/texTools';
+import { checkToolInstalled } from '@/utils/system';
+import { runLatexFormatter } from '@/latex/texFormatter';
 
 // Local imports - agent components
-import { AgentConfig } from '../../core/AgentConfig';
-import { AgentSetting } from '../../core/AgentDataclass';
-import { AgentStateGlobal, AgentStateRound } from '../../core/AgentState';
-import { ProgressViewProvider } from '../../../progressView/ProgressViewProvider';
+import { AgentConfig } from '@/agent/core/AgentConfig';
+import { AgentSetting } from '@/agent/core/AgentDataclass';
+import { AgentStateGlobal, AgentStateRound } from '@/agent/core/AgentState';
+import { ProgressViewProvider } from '@/progressView/ProgressViewProvider';
 
 // Local imports - types
-import { TokenUsageStats } from '../../../types/UsageTypes';
+import { TokenUsageStats } from '@/types/UsageTypes';
 
 /** Generates output filename incorporating model and round information. */
 export function getOutputFileName(

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -12,10 +12,10 @@ import {
   validateAgentSetting,
   DEFAULT_AGENT_SETTINGS,
   DEFAULT_AGENT_PROMPTS,
-} from '@/agent/core/AgentDataclass';
+} from '@agent/core/AgentDataclass';
 
 // Local imports - utils
-import * as logger from '@/logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'agentLoad';
 logger.initialize(CHANNEL);

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -12,10 +12,10 @@ import {
   validateAgentSetting,
   DEFAULT_AGENT_SETTINGS,
   DEFAULT_AGENT_PROMPTS,
-} from '../core/AgentDataclass';
+} from '@/agent/core/AgentDataclass';
 
 // Local imports - utils
-import * as logger from '../../logger/logUtils';
+import * as logger from '@/logger/logUtils';
 
 const CHANNEL = 'agentLoad';
 logger.initialize(CHANNEL);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -9,26 +9,26 @@ import { glob } from 'glob';
 import {
   getBuiltInAgentsDirectory,
   getCustomAgentsDirectory,
-} from '@/frontend/agents/pathUtils';
-import { agentConfigToTaskState } from '@/utils/config';
+} from '@frontend/agents/pathUtils';
+import { agentConfigToTaskState } from '@utils/config';
 
 // Local imports - agent components
-import { AgentConfig, createAgentConfig } from '@/agent/core/AgentConfig';
-import { AgentSetting, AgentPrompt } from '@/agent/core/AgentDataclass';
-import { loadAgentSettingAndPrompts } from '@/agent/runtime/agentLoad';
-import { MODEL_CONFIGS } from '@/model/ModelRegistry';
-import { ModelFactory } from '@/agent/runtime/ModelFactory';
-import { DirectAgent } from '@/agent/implementations/DirectAgent';
-import { CoTAgent } from '@/agent/implementations/CoTAgent';
-import { MergeAgent } from '@/agent/implementations/MergeAgent';
-import { ProgressViewProvider } from '@/progressView/ProgressViewProvider';
-import { AgentLogger } from '@/logger/AgentLogger';
-import { openBuildDisplayIfTex } from '@/frontend/latex/openBuild';
+import { AgentConfig, createAgentConfig } from '@agent/core/AgentConfig';
+import { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
+import { ModelFactory } from '@agent/runtime/ModelFactory';
+import { DirectAgent } from '@agent/implementations/DirectAgent';
+import { CoTAgent } from '@agent/implementations/CoTAgent';
+import { MergeAgent } from '@agent/implementations/MergeAgent';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { AgentLogger } from '@logger/AgentLogger';
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import {
   checkExpectedOutputs,
   showInstructionWithSuppress,
-} from '@/frontend/ui/instruction';
-import { IAgent } from '@/agent/core/IAgent';
+} from '@frontend/ui/instruction';
+import { IAgent } from '@agent/core/IAgent';
 
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -9,26 +9,26 @@ import { glob } from 'glob';
 import {
   getBuiltInAgentsDirectory,
   getCustomAgentsDirectory,
-} from '../../frontend/agents/pathUtils';
-import { agentConfigToTaskState } from '../../utils/config';
+} from '@/frontend/agents/pathUtils';
+import { agentConfigToTaskState } from '@/utils/config';
 
 // Local imports - agent components
-import { AgentConfig, createAgentConfig } from '../core/AgentConfig';
-import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
-import { loadAgentSettingAndPrompts } from './agentLoad';
-import { MODEL_CONFIGS } from '../../model/ModelRegistry';
-import { ModelFactory } from './ModelFactory';
-import { DirectAgent } from '../implementations/DirectAgent';
-import { CoTAgent } from '../implementations/CoTAgent';
-import { MergeAgent } from '../implementations/MergeAgent';
-import { ProgressViewProvider } from '../../progressView/ProgressViewProvider';
-import { AgentLogger } from '../../logger/AgentLogger';
-import { openBuildDisplayIfTex } from '../../frontend/latex/openBuild';
+import { AgentConfig, createAgentConfig } from '@/agent/core/AgentConfig';
+import { AgentSetting, AgentPrompt } from '@/agent/core/AgentDataclass';
+import { loadAgentSettingAndPrompts } from '@/agent/runtime/agentLoad';
+import { MODEL_CONFIGS } from '@/model/ModelRegistry';
+import { ModelFactory } from '@/agent/runtime/ModelFactory';
+import { DirectAgent } from '@/agent/implementations/DirectAgent';
+import { CoTAgent } from '@/agent/implementations/CoTAgent';
+import { MergeAgent } from '@/agent/implementations/MergeAgent';
+import { ProgressViewProvider } from '@/progressView/ProgressViewProvider';
+import { AgentLogger } from '@/logger/AgentLogger';
+import { openBuildDisplayIfTex } from '@/frontend/latex/openBuild';
 import {
   checkExpectedOutputs,
   showInstructionWithSuppress,
-} from '../../frontend/ui/instruction';
-import { IAgent } from '../core/IAgent';
+} from '@/frontend/ui/instruction';
+import { IAgent } from '@/agent/core/IAgent';
 
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -5,12 +5,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@/logger/logUtils';
 
 // Local imports - utilities
-import { getConfig } from '../../utils/config';
-import { getWorkspacePath } from '../../utils/files';
-import { getIncludedExtensions } from '../../utils/fileTypeUtils';
+import { getConfig } from '@/utils/config';
+import { getWorkspacePath } from '@/utils/files';
+import { getIncludedExtensions } from '@/utils/fileTypeUtils';
 
 const CHANNEL = 'FrontendUtils';
 logger.initialize(CHANNEL);

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -5,12 +5,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '@/logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getConfig } from '@/utils/config';
-import { getWorkspacePath } from '@/utils/files';
-import { getIncludedExtensions } from '@/utils/fileTypeUtils';
+import { getConfig } from '@utils/config';
+import { getWorkspacePath } from '@utils/files';
+import { getIncludedExtensions } from '@utils/fileTypeUtils';
 
 const CHANNEL = 'FrontendUtils';
 logger.initialize(CHANNEL);

--- a/src/frontend/files/rules.ts
+++ b/src/frontend/files/rules.ts
@@ -3,11 +3,11 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@/logger/logUtils';
 
 // Local imports - utilities
-import { getWorkspacePath, fileExists, readFile } from '../../utils/files';
-import { fileExistsAbsolute, readFileAbsolute } from '../../utils/files';
+import { getWorkspacePath, fileExists, readFile } from '@/utils/files';
+import { fileExistsAbsolute, readFileAbsolute } from '@/utils/files';
 
 const CHANNEL = 'texraRulesUtils';
 logger.initialize(CHANNEL);

--- a/src/frontend/files/rules.ts
+++ b/src/frontend/files/rules.ts
@@ -3,11 +3,11 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Local imports - log
-import * as logger from '@/logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getWorkspacePath, fileExists, readFile } from '@/utils/files';
-import { fileExistsAbsolute, readFileAbsolute } from '@/utils/files';
+import { getWorkspacePath, fileExists, readFile } from '@utils/files';
+import { fileExistsAbsolute, readFileAbsolute } from '@utils/files';
 
 const CHANNEL = 'texraRulesUtils';
 logger.initialize(CHANNEL);

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -2,8 +2,8 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
-import { fileExists, getFullPathFromWorkspace } from '../../utils/files';
+import * as logger from '@/logger/logUtils';
+import { fileExists, getFullPathFromWorkspace } from '@/utils/files';
 
 const CHANNEL = 'OpenBuildUtils';
 logger.initialize(CHANNEL);

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -2,8 +2,8 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '@/logger/logUtils';
-import { fileExists, getFullPathFromWorkspace } from '@/utils/files';
+import * as logger from '@logger/logUtils';
+import { fileExists, getFullPathFromWorkspace } from '@utils/files';
 
 const CHANNEL = 'OpenBuildUtils';
 logger.initialize(CHANNEL);

--- a/src/frontend/ui/diffView.ts
+++ b/src/frontend/ui/diffView.ts
@@ -2,8 +2,8 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '@/logger/logUtils';
-import { REFRESH_THRESHOLD_MS } from '@/utils/config';
+import * as logger from '@logger/logUtils';
+import { REFRESH_THRESHOLD_MS } from '@utils/config';
 
 const CHANNEL = 'DiffRefresh';
 logger.initialize(CHANNEL);

--- a/src/frontend/ui/diffView.ts
+++ b/src/frontend/ui/diffView.ts
@@ -2,8 +2,8 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
-import { REFRESH_THRESHOLD_MS } from '../../utils/config';
+import * as logger from '@/logger/logUtils';
+import { REFRESH_THRESHOLD_MS } from '@/utils/config';
 
 const CHANNEL = 'DiffRefresh';
 logger.initialize(CHANNEL);

--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { getFullPathFromWorkspace, fileExists } from '@/utils/files';
-import { fileExistsAbsolute } from '@/utils/files';
+import { getFullPathFromWorkspace, fileExists } from '@utils/files';
+import { fileExistsAbsolute } from '@utils/files';
 
 /**
  * Show an instruction message that can be permanently dismissed.

--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { getFullPathFromWorkspace, fileExists } from '../../utils/files';
-import { fileExistsAbsolute } from '../../utils/files';
+import { getFullPathFromWorkspace, fileExists } from '@/utils/files';
+import { fileExistsAbsolute } from '@/utils/files';
 
 /**
  * Show an instruction message that can be permanently dismissed.

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -5,9 +5,9 @@
 // (none needed)
 
 // Local imports - models
-import { AgentConfig } from '@/agent/core/AgentConfig';
-import { TaskState } from '@/logger/TaskState';
-import { ToolConfig } from '@/agent/core/ToolConfig';
+import { AgentConfig } from '@agent/core/AgentConfig';
+import { TaskState } from '@logger/TaskState';
+import { ToolConfig } from '@agent/core/ToolConfig';
 
 import {
   SINGLE_FILE_FIELDS,

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -5,9 +5,9 @@
 // (none needed)
 
 // Local imports - models
-import { AgentConfig } from '../../agent/core/AgentConfig';
-import { TaskState } from '../../logger/TaskState';
-import { ToolConfig } from '../../agent/core/ToolConfig';
+import { AgentConfig } from '@/agent/core/AgentConfig';
+import { TaskState } from '@/logger/TaskState';
+import { ToolConfig } from '@/agent/core/ToolConfig';
 
 import {
   SINGLE_FILE_FIELDS,

--- a/src/utils/files/workspaceFileUtils.ts
+++ b/src/utils/files/workspaceFileUtils.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '@/logger/logUtils';
+import * as logger from '@logger/logUtils';
 import { fileExistsAbsolute } from './absoluteFileUtils';
 
 const CHANNEL = 'workspaceFileUtils';

--- a/src/utils/files/workspaceFileUtils.ts
+++ b/src/utils/files/workspaceFileUtils.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@/logger/logUtils';
 import { fileExistsAbsolute } from './absoluteFileUtils';
 
 const CHANNEL = 'workspaceFileUtils';

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -2,12 +2,12 @@
 import spawn from 'cross-spawn';
 
 // Local imports - log
-import * as logger from '@/logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getWorkspacePath } from '@/utils/files';
+import { getWorkspacePath } from '@utils/files';
 import { ExecResult } from '@/types/ResultTypes';
-import { extendEnvPath } from '@/utils/system/platformPaths';
+import { extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'execUtils';
 logger.initialize(CHANNEL);

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -2,12 +2,12 @@
 import spawn from 'cross-spawn';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@/logger/logUtils';
 
 // Local imports - utilities
-import { getWorkspacePath } from '../files';
-import { ExecResult } from '../../types/ResultTypes';
-import { extendEnvPath } from './platformPaths';
+import { getWorkspacePath } from '@/utils/files';
+import { ExecResult } from '@/types/ResultTypes';
+import { extendEnvPath } from '@/utils/system/platformPaths';
 
 const CHANNEL = 'execUtils';
 logger.initialize(CHANNEL);

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import glob from 'glob';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@/logger/logUtils';
 
 const CHANNEL = 'platformPaths';
 logger.initialize(CHANNEL);

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import glob from 'glob';
 
 // Local imports - log
-import * as logger from '@/logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'platformPaths';
 logger.initialize(CHANNEL);

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -1,7 +1,7 @@
 // Local imports - log
-import * as logger from '../../logger/logUtils';
-import { AgentLogger } from '../../logger/AgentLogger';
-import { K_SLICE } from '../config';
+import * as logger from '@/logger/logUtils';
+import { AgentLogger } from '@/logger/AgentLogger';
+import { K_SLICE } from '@/utils/config';
 
 const CHANNEL = 'xmlUtils';
 logger.initialize(CHANNEL);

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -1,7 +1,7 @@
 // Local imports - log
-import * as logger from '@/logger/logUtils';
-import { AgentLogger } from '@/logger/AgentLogger';
-import { K_SLICE } from '@/utils/config';
+import * as logger from '@logger/logUtils';
+import { AgentLogger } from '@logger/AgentLogger';
+import { K_SLICE } from '@utils/config';
 
 const CHANNEL = 'xmlUtils';
 logger.initialize(CHANNEL);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,11 @@
     "lib": ["ES2022", "DOM"],
     "sourceMap": false,
     "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "~/*": ["src/*"]
+    },
     "moduleResolution": "node",
     "strict": true /* enable all strict type-checking options */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,17 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
-      "~/*": ["src/*"]
+      "~/*": ["src/*"],
+      "@agent/*": ["src/agent/*"],
+      "@frontend/*": ["src/frontend/*"],
+      "@utils/*": ["src/utils/*"],
+      "@logger/*": ["src/logger/*"],
+      "@latex": ["src/latex"],
+      "@latex/*": ["src/latex/*"],
+      "@model": ["src/model"],
+      "@model/*": ["src/model/*"],
+      "@progressView/*": ["src/progressView/*"],
+      "@replacement/*": ["src/replacement/*"]
     },
     "moduleResolution": "node",
     "strict": true /* enable all strict type-checking options */,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,10 @@ const extensionConfig = {
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
     extensions: ['.ts', '.js'],
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      '~': path.resolve(__dirname, 'src'),
+    },
     fallback: {
       fs: false,
       path: require.resolve('path-browserify'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,14 @@ const extensionConfig = {
     alias: {
       '@': path.resolve(__dirname, 'src'),
       '~': path.resolve(__dirname, 'src'),
+      '@agent': path.resolve(__dirname, 'src/agent'),
+      '@frontend': path.resolve(__dirname, 'src/frontend'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
+      '@logger': path.resolve(__dirname, 'src/logger'),
+      '@latex': path.resolve(__dirname, 'src/latex'),
+      '@model': path.resolve(__dirname, 'src/model'),
+      '@progressView': path.resolve(__dirname, 'src/progressView'),
+      '@replacement': path.resolve(__dirname, 'src/replacement'),
     },
     fallback: {
       fs: false,


### PR DESCRIPTION
## Summary
- support `@` and `~` path aliases in `tsconfig.json`
- configure webpack aliases for `@` and `~`
- update various modules to use alias-based imports

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(fails: Cannot find module `@modelcontextprotocol`)*

------
https://chatgpt.com/codex/tasks/task_e_684dc09250008324acfac8b0ade68a17