### PR TITLE
Move generateNonce to frontend

### DIFF
--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -14,3 +14,4 @@ export * from './agents/register';
 export * from './secrets';
 export * from './setup';
 export * from './media/img';
+export * from './nonce';

--- a/src/frontend/nonce.ts
+++ b/src/frontend/nonce.ts
@@ -1,0 +1,15 @@
+// Utility functions for frontend
+
+/**
+ * Generate a nonce string for Webview content security policies.
+ * @param length Length of the generated nonce
+ */
+export function generateNonce(length = 32): string {
+  const possible =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let text = '';
+  for (let i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}

--- a/src/frontend/webview/html.ts
+++ b/src/frontend/webview/html.ts
@@ -1,6 +1,11 @@
+// Standard library imports
 import * as fs from 'fs';
+
+// VS Code imports
 import * as vscode from 'vscode';
-import { generateNonce } from '../../utils/helpers';
+
+// Local imports
+import { generateNonce } from '../nonce';
 
 /**
  * Build HTML content for a webview by replacing placeholder tokens.

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -7,17 +7,3 @@
 export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
-/**
- * Generate a nonce string for Webview content security policies.
- * @param length Length of the generated nonce
- */
-export function generateNonce(length = 32): string {
-  const possible =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let text = '';
-  for (let i = 0; i < length; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
-}


### PR DESCRIPTION
## Summary
- move `generateNonce` from `src/utils/helpers.ts` to `src/frontend/nonce.ts`
- update imports in webview HTML builder
- re-export nonce function from frontend index

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684dc86bc1548324b010898089f0d1f6