### PR TITLE
Fix stop parameter in Responses API handler

### DIFF
--- a/docs/guide/openai-responses-api.md
+++ b/docs/guide/openai-responses-api.md
@@ -8,6 +8,7 @@ The Responses API is a recent addition to the OpenAI platform. It allows develop
 - **Input types**: Message parts use `input_text` or `input_image` objects.
 - **Output format**: Instead of `choices`, text is found in `response.output[0].content[0].text` (or `output_text`).
 - **Instructions**: The `instructions` parameter applies only to the current request. When using `previous_response_id`, you must resend any system instructions you want applied.
+- **No stop sequences**: The Responses API does not accept a `stop` parameter. If your agent requires an end tag, handle it in post-processing rather than sending it to the API.
 
 See the [OpenAI Responses documentation](https://platform.openai.com/docs/api-reference/responses) for full details.
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -127,10 +127,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       store: true,
     };
 
-    if (endTag) {
-      // Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
-      params.stop = [endTag];
-    }
+    // The Responses API does not currently support stop sequences. We keep the
+    // end tag for post-processing only and do not send it to the API.
 
     if (!this.isOReasoningModel) {
       params.temperature = temperature;
@@ -156,8 +154,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
         this.config.fullName.includes('o3') ||
         this.config.fullName.includes('o4')
       ) {
-        // stop is not supported with latest reasoning models o3 and o4-mini.
-        params.stop = undefined;
+        // Stop sequences are unsupported for o3 and o4 reasoning models.
       }
     }
 


### PR DESCRIPTION
## Summary
- remove `stop` param from OpenAI Responses handler
- document lack of `stop` support in Responses API

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684de54e5c588324afdcd1f9873ca8ad