### PR TITLE
Refactor imports to use path aliases

### DIFF
--- a/src/AnthropicTool/AnthropicToolAgent.ts
+++ b/src/AnthropicTool/AnthropicToolAgent.ts
@@ -6,7 +6,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { MessageCreateParams } from '@anthropic-ai/sdk/resources/messages';
 
 // Local imports - error utils
-import { getSdkErrorMessage } from '../utils/sdkErrorUtils';
+import { getSdkErrorMessage } from '@utils/sdkErrorUtils';
 
 // Local imports - core
 import { TextEditorTool } from './TextEditorTool';
@@ -14,12 +14,12 @@ import { ToolResult } from './base';
 import { BaseError, ValidationResult } from './types';
 
 // Local imports - utils
-import * as workspaceFileUtils from '../utils/files';
+import * as workspaceFileUtils from '@utils/files';
 import { getApiKey as getSecretApiKey, ApiProvider } from '../frontend/secrets';
-import { getConfig } from '../utils/config';
+import { getConfig } from '@utils/config';
 
 // Local imports - logging
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'AnthropicToolAgent';
 logger.initialize(CHANNEL);

--- a/src/AnthropicTool/TeXLinterFixAgent.ts
+++ b/src/AnthropicTool/TeXLinterFixAgent.ts
@@ -9,11 +9,11 @@ import { ValidationResult } from './types';
 import { LinterMessage } from '../frontend/latex/linter';
 
 // Local imports - utils
-import * as workspaceFileUtils from '../utils/files';
+import * as workspaceFileUtils from '@utils/files';
 import * as linterUtils from '../frontend/latex/linter';
 
 // Local imports - Logging
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'TeXLinterFixAgent';
 logger.initialize(CHANNEL);

--- a/src/AnthropicTool/TextEditorTool.ts
+++ b/src/AnthropicTool/TextEditorTool.ts
@@ -13,10 +13,10 @@ import {
 } from './types';
 
 // Local imports - utilities
-import * as workspaceFileUtils from '../utils/files';
+import * as workspaceFileUtils from '@utils/files';
 
 // Local imports - Log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Constants
 const CHANNEL = 'TextEditorTool';

--- a/src/AnthropicTool/XMLValidatorAgent.ts
+++ b/src/AnthropicTool/XMLValidatorAgent.ts
@@ -7,13 +7,13 @@ import { XMLValidator } from 'fast-xml-parser';
 import { AnthropicToolAgent } from './AnthropicToolAgent';
 
 // Local imports - utils
-import * as workspaceFileUtils from '../utils/files';
+import * as workspaceFileUtils from '@utils/files';
 
 // Local imports - types
 import { XMLValidationError, ValidationResult } from './types';
 
 // Local imports - Logging
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'XMLValidatorAgent';
 logger.initialize(CHANNEL);

--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 // Third-party imports
 import * as vscode from 'vscode';
-import * as logger from './logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports
 import {
@@ -13,8 +13,8 @@ import {
 } from './frontend/agents/pathUtils';
 import { promptToAddAgentToConfig } from './frontend/agents/register';
 import { isValidAgentYaml } from './agent/runtime/agentLoad';
-import { fileExistsAbsolute } from './utils/files';
-import { getConfig } from './utils/config';
+import { fileExistsAbsolute } from '@utils/files';
+import { getConfig } from '@utils/config';
 
 const NEW_AGENT_TEMPLATE = `# --- Agent Inheritance (Optional) ---
 # inherits: base

--- a/src/ViewProvider.ts
+++ b/src/ViewProvider.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { WebviewMessageHandler } from './webview/MessageHandler';
 import { WebviewContentProvider } from './webview/WebviewContentProvider';
 import { anyApiKeyExists } from './frontend/secrets';
-import { watchConfig } from './utils/config';
+import { watchConfig } from '@utils/config';
 
 export class TeXRAViewProvider implements vscode.WebviewViewProvider {
   private messageHandler: WebviewMessageHandler;

--- a/src/WolframTool/wolframScriptUtils.ts
+++ b/src/WolframTool/wolframScriptUtils.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { executeCommand, checkToolInstalled } from '../utils/system';
+import { executeCommand, checkToolInstalled } from '@utils/system';
 
 // Wolfram configuration is now in toolUtils.ts
 

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -5,7 +5,7 @@
 // (none needed)
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - agent components
 import {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -33,7 +33,7 @@ import {
   ModelCapabilities,
 } from '../../model/ModelConfig';
 import { ToolState } from '../core/ToolState';
-import { MediaEntry } from '@utils/mediaTypes';
+import { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -5,19 +5,19 @@ import * as path from 'path';
 // (none needed)
 
 // Local imports - log
-import { AgentLogger } from '../../logger/AgentLogger';
+import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import { fileExists } from '../../utils/files';
-import { fileExistsAbsolute } from '../../utils/files/absoluteFileUtils';
-import { getPastedImageDisplayName } from '../../utils/files/pastedImageUtils';
+import { fileExists } from '@utils/files';
+import { fileExistsAbsolute } from '@utils/files/absoluteFileUtils';
+import { getPastedImageDisplayName } from '@utils/files/pastedImageUtils';
 import {
   getBase64EncodedMedia,
   countPdfPages,
   processPdf2Png,
 } from '../../frontend/media/img';
-import { checkMultipleToolsInstalled } from '../../utils/system';
-import { getConfig } from '../../utils/config';
+import { checkMultipleToolsInstalled } from '@utils/system';
+import { getConfig } from '@utils/config';
 import {
   getApiKey as getSecretApiKey,
   ApiProvider,
@@ -33,7 +33,7 @@ import {
   ModelCapabilities,
 } from '../../model/ModelConfig';
 import { ToolState } from '../core/ToolState';
-import { MediaEntry } from '../utils/mediaTypes';
+import { MediaEntry } from '@utils/mediaTypes';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;

--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
-import { MediaEntry } from '@utils/mediaTypes';
+import { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - utilities
 import { convertContentToString } from '@utils/text/messageUtils';

--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -7,11 +7,11 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
-import { MediaEntry } from '../utils/mediaTypes';
+import { MediaEntry } from '@utils/mediaTypes';
 
 // Local imports - utilities
-import { convertContentToString } from '../../utils/text/messageUtils';
-import { MESSAGE_PREVIEW_LENGTH } from '../../utils/config';
+import { convertContentToString } from '@utils/text/messageUtils';
+import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 /**
  * Handler for DashScope Qwen models using OpenAI-compatible API.

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -9,8 +9,8 @@ import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
 
 // Local imports - utilities
-import { convertContentToString } from '../../utils/text/messageUtils';
-import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '../../utils/config';
+import { convertContentToString } from '@utils/text/messageUtils';
+import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 // TODO: prompt_cache_hit_tokens can also be used here to correct the price and response usage computation in the base class (just overwrite the computePrice and computeResponseUsage methods with a revalues responseUsage.prompt_tokens_details?.cached_tokens and then call the super methods)
 // DEEPSEEK RESPONSE USAGE FORMAT:

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
-import { MediaEntry } from '@utils/mediaTypes';
+import { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - utilities
 import { convertContentToString } from '@utils/text/messageUtils';

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -7,11 +7,11 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
-import { MediaEntry } from '../utils/mediaTypes';
+import { MediaEntry } from '@utils/mediaTypes';
 
 // Local imports - utilities
-import { convertContentToString } from '../../utils/text/messageUtils';
-import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '../../utils/config';
+import { convertContentToString } from '@utils/text/messageUtils';
+import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -11,13 +11,9 @@ import { ChatCompletionContentPart } from 'openai/resources/chat/completions';
 import { countTokens } from 'gpt-tokenizer';
 
 // Local imports - utilities
-import {
-  readFile,
-  writeFile,
-  fileExistsAndNonTrivial,
-} from '../../utils/files';
+import { readFile, writeFile, fileExistsAndNonTrivial } from '@utils/files';
 import { cleanFileContent } from '../../replacement/replacementUtils';
-import { extractAndLogScratchpad } from '../../utils/text/xmlUtils';
+import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '../core/AgentConfig';
@@ -30,10 +26,10 @@ import {
   ExtendedCompletionUsage,
 } from '../core/ResponseUsage';
 import { ToolState } from '../core/ToolState';
-import { K_SLICE } from '../../utils/config';
-import { objectToLogString } from '../../utils/text/stringUtils';
-import { calculateTokenPrice } from '../../utils/priceUtils';
-import { MediaEntry } from '../utils/mediaTypes';
+import { K_SLICE } from '@utils/config';
+import { objectToLogString } from '@utils/text/stringUtils';
+import { calculateTokenPrice } from '@utils/priceUtils';
+import { MediaEntry } from '@utils/mediaTypes';
 
 /**
  * OpenAI-specific handlers.

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -29,7 +29,7 @@ import { ToolState } from '../core/ToolState';
 import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { calculateTokenPrice } from '@utils/priceUtils';
-import { MediaEntry } from '@utils/mediaTypes';
+import { MediaEntry } from '@agent/utils/mediaTypes';
 
 /**
  * OpenAI-specific handlers.

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -15,9 +15,9 @@ import type {
 // Local imports - base handler
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ResponseUsageFactory } from '../core/ResponseUsage';
-import { calculateTokenPrice } from '../../utils/priceUtils';
+import { calculateTokenPrice } from '@utils/priceUtils';
 import { ToolState } from '../core/ToolState';
-import { K_SLICE } from '../../utils/config';
+import { K_SLICE } from '@utils/config';
 
 // import { ResponseCreateParams } from 'openai/src/resources/responses/response';
 // this is incorrect now, but would be nice to use

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
-import { K_SLICE } from '../../utils/config';
+import { K_SLICE } from '@utils/config';
 
 /**
  * Handler for models accessed through OpenRouter.

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
-import { K_SLICE } from '../../utils/config';
+import { K_SLICE } from '@utils/config';
 
 /**
  * Handler for xAI models using OpenAI-compatible API.

--- a/src/agent/utils/messageUtils.ts
+++ b/src/agent/utils/messageUtils.ts
@@ -2,7 +2,7 @@
  * Utility functions for working with message objects in agent conversations.
  */
 
-import { MESSAGE_PREVIEW_LENGTH } from '../../utils/config';
+import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 /**
  * Creates a skeleton representation of a message object for debugging.

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -2,10 +2,10 @@
 
 import * as path from 'path';
 
-import { AgentLogger } from '../../logger/AgentLogger';
-import { readFile } from '../../utils/files';
+import { AgentLogger } from '@logger/AgentLogger';
+import { readFile } from '@utils/files';
 import { setVarFromFile } from '../../frontend/files/vars';
-import { getXmlFormatFromFiles, getListOfFiles } from '../../utils/promptUtils';
+import { getXmlFormatFromFiles, getListOfFiles } from '@utils/promptUtils';
 import { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting } from '../core/AgentDataclass';
 import { ModelHandler } from '../modelHandlers';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,7 +29,7 @@ import { registerProgressViewCommands } from './commands/progressViewCommands';
 import { registerHelpCommands } from './commands/helpCommands';
 import { registerOpenFileCommands } from './commands/openFileCommands';
 
-import * as logger from './logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'Registration';
 logger.initialize(CHANNEL);

--- a/src/commands/agentCommands.ts
+++ b/src/commands/agentCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - agent
 import { BaseReflectionAgent } from '../agent/implementations/BaseReflectionAgent';

--- a/src/commands/arXivCommands.ts
+++ b/src/commands/arXivCommands.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as logger from '../logger/logUtils';
-import { downloadArxivSource, validateArxivId } from '../utils/arXivUtils';
+import * as logger from '@logger/logUtils';
+import { downloadArxivSource, validateArxivId } from '@utils/arXivUtils';
 
 const CHANNEL = 'arXivCommands';
 

--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - housekeeping
 import {

--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import {
@@ -13,9 +13,9 @@ import {
   fileExists,
   readFile,
   writeFile,
-} from '../utils/files';
+} from '@utils/files';
 import { registerDiffRefresh } from '../frontend/ui/diffView';
-import { DIFF_REGISTRATION_DELAY_MS } from '../utils/config';
+import { DIFF_REGISTRATION_DELAY_MS } from '@utils/config';
 
 const CHANNEL = 'CompareCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/figCommands.ts
+++ b/src/commands/figCommands.ts
@@ -5,10 +5,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getRelativePath, getWorkspacePath } from '../utils/files';
+import { getRelativePath, getWorkspacePath } from '@utils/files';
 
 // Local imports - latex utils
 import { extractFigurePathsFromLatex } from '../latex/extractFigure';

--- a/src/commands/fileSelectionCommands.ts
+++ b/src/commands/fileSelectionCommands.ts
@@ -2,13 +2,13 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { showInfoMessage, showErrorMessage } from '../frontend/ui/messageUtils';
-import { getRelativePath } from '../utils/files';
+import { getRelativePath } from '@utils/files';
 import { listInputFiles } from '../frontend/files/listing';
-import { getIncludedExtensions } from '../utils/fileTypeUtils';
+import { getIncludedExtensions } from '@utils/fileTypeUtils';
 import { selectFile, selectFiles } from '../frontend/files/dialog';
 const CHANNEL = 'fileSelectionCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/gitCommands.ts
+++ b/src/commands/gitCommands.ts
@@ -5,8 +5,8 @@ import spawn from 'cross-spawn';
 import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { getConfig } from '../utils/config';
-import { getWorkspacePath } from '../utils/files';
+import { getConfig } from '@utils/config';
+import { getWorkspacePath } from '@utils/files';
 
 export function registerGitCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(

--- a/src/commands/imageCommands.ts
+++ b/src/commands/imageCommands.ts
@@ -2,10 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getRelativePath } from '../utils/files';
+import { getRelativePath } from '@utils/files';
 import {
   countPdfPages,
   getBase64EncodedMedia,

--- a/src/commands/latexCommands.ts
+++ b/src/commands/latexCommands.ts
@@ -2,11 +2,11 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getRelativePath } from '../utils/files';
-import { sleep } from '../utils/helpers';
+import { getRelativePath } from '@utils/files';
+import { sleep } from '@utils/helpers';
 import {
   applyReplacements,
   getAllReplacements,

--- a/src/commands/latexdiffCommands.ts
+++ b/src/commands/latexdiffCommands.ts
@@ -5,11 +5,11 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getWorkspacePath } from '../utils/files';
-import { fileExists } from '../utils/files';
+import { getWorkspacePath } from '@utils/files';
+import { fileExists } from '@utils/files';
 import { openBuildDisplayIfTex } from '../frontend/latex/openBuild';
 
 // Local imports - latex utils
@@ -19,7 +19,7 @@ import {
   runLatexdiffForRound,
   runLatexdiffBetweenRounds,
 } from '../latex/latexdiff';
-import { checkToolInstalled } from '../utils/system';
+import { checkToolInstalled } from '@utils/system';
 
 // Local imports - housekeeping
 import {

--- a/src/commands/linterCommands.ts
+++ b/src/commands/linterCommands.ts
@@ -2,12 +2,12 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utils
 import { getLinterMessages } from '../frontend/latex/linter';
-import { getRelativePath } from '../utils/files';
-import { sleep } from '../utils/helpers';
+import { getRelativePath } from '@utils/files';
+import { sleep } from '@utils/helpers';
 
 // Local imports - core
 import { TeXLinterFixAgent } from '../AnthropicTool';

--- a/src/commands/mergeCommands.ts
+++ b/src/commands/mergeCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { getConfig } from '../utils/config';
+import { getConfig } from '@utils/config';
 
 // Local imports - agent
 import { executeMergeAgent } from '../agent/runtime/executeAgent';

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - housekeeping
 import { runPack, runPackSingle, runPackMultiple } from '../housekeeping';

--- a/src/commands/progressViewCommands.ts
+++ b/src/commands/progressViewCommands.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
-import { AgentLogger } from '../logger/AgentLogger';
+import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utils
-import { safeExecuteCommand } from '../utils/system';
+import { safeExecuteCommand } from '@utils/system';
 
 const CHANNEL = 'progressViewCommands';
 const logger = new AgentLogger(CHANNEL);

--- a/src/commands/stateRestoreCommand.ts
+++ b/src/commands/stateRestoreCommand.ts
@@ -2,8 +2,8 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
-import { objectToTaskState } from '../utils/config';
+import * as logger from '@logger/logUtils';
+import { objectToTaskState } from '@utils/config';
 
 const CHANNEL = 'stateRestoreCommand';
 logger.initialize(CHANNEL);

--- a/src/commands/testCommands.ts
+++ b/src/commands/testCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports
 import { handleTestConnection } from './tests/connectionTests';

--- a/src/commands/tests/connectionTests.ts
+++ b/src/commands/tests/connectionTests.ts
@@ -8,7 +8,7 @@ import {
 } from '../../latex/textConnection';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/textEditorCommands.ts
+++ b/src/commands/textEditorCommands.ts
@@ -2,13 +2,13 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - Anthropic Tool
 import { TextEditorTool, ToolCallInput } from '../AnthropicTool';
 
 // Local imports - utilities
-import { getRelativePath } from '../utils/files';
+import { getRelativePath } from '@utils/files';
 
 const CHANNEL = 'TextEditorCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/wolframScriptCommands.ts
+++ b/src/commands/wolframScriptCommands.ts
@@ -6,8 +6,8 @@ import {
   executeWolframCode,
   executeWolframScriptFile,
 } from '../WolframTool/wolframScriptUtils';
-import { checkToolInstalled } from '../utils/system';
-import { MAX_PREVIEW_LENGTH } from '../utils/config';
+import { checkToolInstalled } from '@utils/system';
+import { MAX_PREVIEW_LENGTH } from '@utils/config';
 
 export const wolframScriptCommands = {
   testWolframScript: 'texra.testWolframScript',

--- a/src/commands/xmlCommands.ts
+++ b/src/commands/xmlCommands.ts
@@ -3,14 +3,14 @@ import * as vscode from 'vscode';
 import { XMLParser } from 'fast-xml-parser';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - core
 import { XMLValidatorAgent } from '../AnthropicTool';
 
 // Local imports - utils
-import { getRelativePath } from '../utils/files';
-import { sleep } from '../utils/helpers';
+import { getRelativePath } from '@utils/files';
+import { sleep } from '@utils/helpers';
 
 const CHANNEL = 'XmlCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/yamlCommands.ts
+++ b/src/commands/yamlCommands.ts
@@ -10,7 +10,7 @@ import {
   loadYaml,
   loadAgentSettingAndPrompts,
 } from '../agent/runtime/agentLoad';
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 import { getAgentPath } from '../agent/runtime/executeAgent';
 import { AgentType } from '../agent/core/AgentDataclass';
 import { showInstructionWithSuppress } from '../frontend/ui/instruction';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,10 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - core
-import * as logger from './logger/logUtils';
+import * as logger from '@logger/logUtils';
 import { initializeSecrets } from './frontend/secrets';
 import { copyDefaultAgents, configureLatexSettings } from './frontend/setup';
-import { watchConfig } from './utils/config';
+import { watchConfig } from '@utils/config';
 import { disposeDiffRefresh } from './frontend/ui/diffView';
 
 // Local imports - components

--- a/src/frontend/agents/pathUtils.ts
+++ b/src/frontend/agents/pathUtils.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
-import { getConfig } from '../../utils/config';
+import * as logger from '@logger/logUtils';
+import { getConfig } from '@utils/config';
 
 const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -4,7 +4,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'AgentRegister';
 logger.initialize(CHANNEL);

--- a/src/frontend/files/dialog.ts
+++ b/src/frontend/files/dialog.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { getRelativePath } from '../../utils/files';
+import { getRelativePath } from '@utils/files';
 import { showErrorMessage } from '../ui/messageUtils';
 
 export interface FileDialogOptions {

--- a/src/frontend/files/vars.ts
+++ b/src/frontend/files/vars.ts
@@ -1,8 +1,8 @@
 // Local imports - utilities
-import { readFile, readFileAbsolute } from '../../utils/files';
+import { readFile, readFileAbsolute } from '@utils/files';
 
 // Local imports - log
-import { AgentLogger } from '../../logger/AgentLogger';
+import { AgentLogger } from '@logger/AgentLogger';
 
 /**
  * Reads a file and populates user variable fields with its path and content.

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -2,9 +2,9 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
-import { getFullPathFromWorkspace } from '../../utils/files';
-import { sleep } from '../../utils/helpers';
+import * as logger from '@logger/logUtils';
+import { getFullPathFromWorkspace } from '@utils/files';
+import { sleep } from '@utils/helpers';
 
 const CHANNEL = 'LinterUtils';
 logger.initialize(CHANNEL);

--- a/src/frontend/media/img.ts
+++ b/src/frontend/media/img.ts
@@ -8,16 +8,16 @@ import { PDFDocument } from '@cantoo/pdf-lib';
 import { fromPath } from 'pdf2pic';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import {
   readFileBytesSync,
   fileExists,
   getFullPathFromWorkspace,
-} from '../../utils/files';
-import { fileExistsAbsolute } from '../../utils/files/absoluteFileUtils';
-import { checkMultipleToolsInstalled } from '../../utils/system';
+} from '@utils/files';
+import { fileExistsAbsolute } from '@utils/files/absoluteFileUtils';
+import { checkMultipleToolsInstalled } from '@utils/system';
 
 const CHANNEL = 'ImgUtils';
 logger.initialize(CHANNEL);

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 /**
  * Copies default agent files from the extension resources to the global storage directory

--- a/src/frontend/ui/messageUtils.ts
+++ b/src/frontend/ui/messageUtils.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import { capitalize, uncapitalize } from '../../utils/text/stringUtils';
+import { capitalize, uncapitalize } from '@utils/text/stringUtils';
 
 export const showInfoMessage = vscode.window.showInformationMessage;
 export const showWarningMessage = vscode.window.showWarningMessage;

--- a/src/historyView/AgentHistoryViewProvider.ts
+++ b/src/historyView/AgentHistoryViewProvider.ts
@@ -4,11 +4,11 @@ import * as vscode from 'vscode';
 import { AgentHistoryManager } from './AgentHistoryManager';
 import { executeCommand } from '../commands/executeCommand';
 
-import { agentConfigToTaskState } from '../utils/config';
+import { agentConfigToTaskState } from '@utils/config';
 import { buildWebviewHtml } from '../frontend/webview/html';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'AgentHistoryViewProvider';
 logger.initialize(CHANNEL);

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import {
@@ -13,7 +13,7 @@ import {
   readDirectory,
   fileExists,
   findFileInBuild,
-} from '../utils/files';
+} from '@utils/files';
 
 // Local imports - housekeeping
 import {

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -5,12 +5,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { deleteFile, readDirectory } from '../utils/files';
-import { fileExistsAbsolute } from '../utils/files';
-import { getConfig } from '../utils/config';
+import { deleteFile, readDirectory } from '@utils/files';
+import { fileExistsAbsolute } from '@utils/files';
+import { getConfig } from '@utils/config';
 import { runLatexFormatter } from '../latex/texFormatter';
 
 // Local imports - housekeeping

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import {
@@ -14,7 +14,7 @@ import {
   findFileInBuild,
   createDirectory,
   fileExists,
-} from '../utils/files';
+} from '@utils/files';
 
 // Local imports - housekeeping
 import { TEMP_EXTENSIONS } from './constants';

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import {
@@ -15,7 +15,7 @@ import {
   findFileInBuild,
   createDirectory,
   fileExists,
-} from '../utils/files';
+} from '@utils/files';
 
 // Local imports - housekeeping
 import { PACK_EXTENSIONS, TEMP_EXTENSIONS, HISTORY_DIR } from './constants';

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -1,5 +1,5 @@
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -2,10 +2,10 @@
 import * as path from 'path';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { readFile, fileExists } from '../utils/files';
+import { readFile, fileExists } from '@utils/files';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -6,13 +6,13 @@ import * as vscode from 'vscode';
 import { sync as globSync } from 'glob';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { deleteFile, getWorkspacePath } from '../../utils/files';
-import { executeCommand } from '../../utils/system';
-import { sleep } from '../../utils/helpers';
-import { checkToolInstalled } from '../../utils/system';
+import { deleteFile, getWorkspacePath } from '@utils/files';
+import { executeCommand } from '@utils/system';
+import { sleep } from '@utils/helpers';
+import { checkToolInstalled } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -2,10 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { executeCommand, checkToolInstalled } from '../../utils/system';
+import { executeCommand, checkToolInstalled } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -5,14 +5,14 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { readFile, writeFile, fileExists } from '../utils/files';
-import { executeCommand } from '../utils/system';
+import { readFile, writeFile, fileExists } from '@utils/files';
+import { executeCommand } from '@utils/system';
 import { ExecResult } from '../types/ResultTypes';
-import { getConfig } from '../utils/config';
-import { logErrorMessage } from '../utils/errorHandlingUtils';
+import { getConfig } from '@utils/config';
+import { logErrorMessage } from '@utils/errorHandlingUtils';
 
 // Local imports - latex utils
 import { runLatexFormatter } from './texFormatter';

--- a/src/latex/texFormatter.ts
+++ b/src/latex/texFormatter.ts
@@ -3,7 +3,7 @@ import { runLatexIndent } from './formatter/latexindentpt';
 import { runTexFmt } from './formatter/texfmt';
 
 // Local imports - utilities
-import { getConfig } from '../utils/config';
+import { getConfig } from '@utils/config';
 
 export async function runLatexFormatter(filePath: string): Promise<boolean> {
   const formatter = getConfig<string>('latex.formatter', 'latexindent');

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -5,12 +5,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { executeCommand } from '../utils/system';
-import { getConfig } from '../utils/config';
-import { getWorkspacePath, createDirectory } from '../utils/files';
+import { executeCommand } from '@utils/system';
+import { getConfig } from '@utils/config';
+import { getWorkspacePath, createDirectory } from '@utils/files';
 // No additional imports needed
 
 const CHANNEL = 'LaTeXCommands';

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -1,9 +1,9 @@
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { fileExists, readFile } from '../utils/files';
-import { executeCommand, checkToolInstalled } from '../utils/system';
+import { fileExists, readFile } from '@utils/files';
+import { executeCommand, checkToolInstalled } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/textConnection.ts
+++ b/src/latex/textConnection.ts
@@ -3,10 +3,10 @@ import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
 
 // Local imports - error utils
-import { formatProviderError } from '../utils/sdkErrorUtils';
+import { formatProviderError } from '@utils/sdkErrorUtils';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 import { getApiKey as getSecretApiKey, ApiProvider } from '../frontend/secrets';
 
 const CHANNEL = 'LaTeXCommands';

--- a/src/latex/tikzpicture.ts
+++ b/src/latex/tikzpicture.ts
@@ -5,17 +5,12 @@ import * as path from 'path';
 import * as nunjucks from 'nunjucks';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import {
-  readFile,
-  fileExists,
-  writeFile,
-  createDirectory,
-} from '../utils/files';
-import { renderPrompt } from '../utils/promptUtils';
-import { getConfig } from '../utils/config';
+import { readFile, fileExists, writeFile, createDirectory } from '@utils/files';
+import { renderPrompt } from '@utils/promptUtils';
+import { getConfig } from '@utils/config';
 
 // Local imports - latex utils
 import { compileLatex2Pdf } from './texTools';

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -3,8 +3,8 @@
 
 // Local imports - log
 import * as logger from './logUtils';
-import { sleep } from '../utils/helpers';
-import { SHORT_SLEEP_MS } from '../utils/config';
+import { sleep } from '@utils/helpers';
+import { SHORT_SLEEP_MS } from '@utils/config';
 
 /**
  * Encapsulates logging functionality for agents with a dedicated channel.

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -1,5 +1,5 @@
 // Local imports - constants
-import type { FileType } from '../utils/config';
+import type { FileType } from '@utils/config';
 
 /** Interface for storing task execution state */
 export interface TaskState {

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -5,13 +5,13 @@ import Transport from 'winston-transport';
 
 // Local imports - progressView
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
-import { getConfig } from '../utils/config';
+import { getConfig } from '@utils/config';
 import {
   shouldUseConsolidatedChannel,
   getColorForLevel,
   isAgentStream,
   EMOJI_BY_LEVEL as emojis,
-} from '../utils/loggerUtils';
+} from '@utils/loggerUtils';
 import { LogGroup } from '../types/LogTypes';
 
 const { combine, timestamp } = winston.format;

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -4,7 +4,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 import { buildWebviewHtml } from '../frontend/webview/html';
 
 const CHANNEL = 'Webview';

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -2,10 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 import { ProgressViewProvider } from './ProgressViewProvider';
 
-import { taskStateToAgentConfig } from '../utils/config';
+import { taskStateToAgentConfig } from '@utils/config';
 
 // @ts-ignore - Import JavaScript module
 import { COMMANDS } from './modules/constants.js';

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -5,16 +5,16 @@ import * as vscode from 'vscode';
 import { ProgressViewContentProvider } from './ProgressViewContentProvider';
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 
-import { TaskState } from '../logger/TaskState';
-import { AgentLogger } from '../logger/AgentLogger';
+import { TaskState } from '@logger/TaskState';
+import { AgentLogger } from '@logger/AgentLogger';
 
-import { getConfig } from '../utils/config';
-import { objectToTaskState } from '../utils/config';
-import { filterExistingFiles } from '../utils/files';
+import { getConfig } from '@utils/config';
+import { objectToTaskState } from '@utils/config';
+import { filterExistingFiles } from '@utils/files';
 import {
   shouldExcludeFromProgressView,
   shouldPersistStream,
-} from '../utils/loggerUtils';
+} from '@utils/loggerUtils';
 
 import { TokenUsageStats } from '../types/UsageTypes';
 import { LogGroup } from '../types/LogTypes';

--- a/src/replacement/replacementAdvanced.ts
+++ b/src/replacement/replacementAdvanced.ts
@@ -3,7 +3,7 @@
  */
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'ReplacementUtils';
 logger.initialize(CHANNEL);

--- a/src/replacement/replacementUtils.ts
+++ b/src/replacement/replacementUtils.ts
@@ -3,10 +3,10 @@
  */
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Import vscode workspace configuration
-import { getConfig } from '../utils/config';
+import { getConfig } from '@utils/config';
 
 const CHANNEL = 'ReplacementUtils';
 logger.initialize(CHANNEL);

--- a/src/utils/arXivUtils.ts
+++ b/src/utils/arXivUtils.ts
@@ -5,7 +5,7 @@ import * as https from 'https';
 import * as arxivIdentifiers from 'identifiers-arxiv';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utils
 import {

--- a/src/utils/errorHandlingUtils.ts
+++ b/src/utils/errorHandlingUtils.ts
@@ -1,7 +1,7 @@
 // Utility functions for consistent error logging and formatting
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 /**
  * Format an error with a prefix for logging or user messages.

--- a/src/utils/files/workspaceStorageUtils.ts
+++ b/src/utils/files/workspaceStorageUtils.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const STORAGE_PREFIX = 'storage://';
 const CHANNEL = 'workspaceStorageUtils';

--- a/src/utils/promptUtils.ts
+++ b/src/utils/promptUtils.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as nunjucks from 'nunjucks';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { readFile, writeFile } from './files';

--- a/src/utils/system/commandUtils.ts
+++ b/src/utils/system/commandUtils.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'commandUtils';
 logger.initialize(CHANNEL);

--- a/src/utils/text/repetitionUtils.ts
+++ b/src/utils/text/repetitionUtils.ts
@@ -6,7 +6,7 @@ import { diff_match_patch } from 'diff-match-patch';
 import * as difflib from 'difflib';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 import {
   REPETITION_DETECTION_THRESHOLD,
   REPETITION_PREVIEW_LENGTH,

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import { formatProviderError } from '../sdkErrorUtils';
 
 // Local imports - log
-import * as logger from '../../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { getApiKey } from '../../frontend/secrets';

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -6,25 +6,25 @@ import * as vscode from 'vscode';
 import { workspace } from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utils
-import { safeExecuteCommand } from '../utils/system';
+import { safeExecuteCommand } from '@utils/system';
 
 // Local imports - utilities
-import { getWorkspacePath, getRelativePath } from '../utils/files';
+import { getWorkspacePath, getRelativePath } from '@utils/files';
 import {
   createStorageDirectory,
   writeBinaryFileToStorage,
   cleanupStorageDirectory,
-} from '../utils/files/workspaceStorageUtils';
+} from '@utils/files/workspaceStorageUtils';
 import {
   isPastedImage,
   getPastedImageFullPath,
   PASTED_DIR,
-} from '../utils/files/pastedImageUtils';
+} from '@utils/files/pastedImageUtils';
 import { capitalize, uncapitalize } from '../frontend/ui/messageUtils';
-import { getConfig } from '../utils/config';
+import { getConfig } from '@utils/config';
 import {
   listInputFiles,
   listReferenceFiles,
@@ -36,8 +36,8 @@ import {
 import {
   polishTextWithAI,
   FileContext,
-} from '../utils/text/textEnhancementUtils';
-import { sleep } from '../utils/helpers';
+} from '@utils/text/textEnhancementUtils';
+import { sleep } from '@utils/helpers';
 
 // Local imports - agent
 import { ToolConfig } from '../agent/core/ToolConfig';

--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -4,10 +4,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import * as logger from '../logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getConfig } from '../utils/config';
+import { getConfig } from '@utils/config';
 import { buildWebviewHtml } from '../frontend/webview/html';
 
 const CHANNEL = 'Webview';


### PR DESCRIPTION
## Summary
- use `@logger` and `@utils` aliases instead of relative paths
- format and lint repo

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js' during compile-tests)*

------
https://chatgpt.com/codex/tasks/task_e_684e74036fcc83248a2c964fdf522050