### PR TITLE
Refactor: move webview state helpers into manager

### DIFF
--- a/src/common/modules/webviewState.js
+++ b/src/common/modules/webviewState.js
@@ -1,23 +1,57 @@
 import { vscode } from '@common/vscodeApi.js';
 
-export function getWebviewState() {
-  try {
-    return vscode.getState() || {};
-  } catch (e) {
-    console.error('Failed to get state:', e);
-    return {};
+/**
+ * Manages persistence of state for a single webview.
+ * Wraps the VS Code `getState` and `setState` APIs.
+ */
+export class WebviewStateManager {
+  /**
+   * @param {Record<string, any>} [defaultState] optional defaults used when no
+   * previous state exists.
+   */
+  constructor(defaultState = {}) {
+    this.defaultState = { ...defaultState };
+    try {
+      const saved = vscode.getState() || {};
+      this.state = { ...this.defaultState, ...saved };
+    } catch (e) {
+      console.error('Failed to get state:', e);
+      this.state = { ...this.defaultState };
+    }
   }
-}
 
-export function setWebviewState(state) {
-  try {
-    vscode.setState(state);
-  } catch (e) {
-    console.error('Failed to set state:', e);
+  /**
+   * Returns a copy of the current state object.
+   */
+  getState() {
+    return { ...this.state };
   }
-}
 
-export function updateWebviewState(partial) {
-  const current = getWebviewState();
-  setWebviewState({ ...current, ...partial });
+  /**
+   * Replaces the entire state and persists it via VS Code API.
+   * @param {Record<string, any>} state new state
+   */
+  setState(state) {
+    this.state = { ...state };
+    try {
+      vscode.setState(this.state);
+    } catch (e) {
+      console.error('Failed to set state:', e);
+    }
+  }
+
+  /**
+   * Applies partial updates to the state and persists the result.
+   * @param {Record<string, any>} partial partial state to merge
+   */
+  update(partial) {
+    this.setState({ ...this.state, ...partial });
+  }
+
+  /**
+   * Resets state back to the provided defaults.
+   */
+  reset() {
+    this.setState({ ...this.defaultState });
+  }
 }

--- a/src/progressView/modules/stateManager.js
+++ b/src/progressView/modules/stateManager.js
@@ -1,4 +1,6 @@
-import { getWebviewState, updateWebviewState } from '@common/webviewState.js';
+import { WebviewStateManager } from '@common/webviewState.js';
+
+const stateManager = new WebviewStateManager();
 
 // State variables
 let currentStream = '';
@@ -10,7 +12,7 @@ let groupToggleStates = new Map(); // groupId -> collapsed state
  * Initializes state from previously saved state
  */
 export function initializeState() {
-  const previousState = getWebviewState();
+  const previousState = stateManager.getState();
   if (previousState.groupToggleStates) {
     try {
       groupToggleStates = new Map(JSON.parse(previousState.groupToggleStates));
@@ -29,7 +31,7 @@ export function saveState() {
     const serializedGroupStates = JSON.stringify([
       ...groupToggleStates.entries(),
     ]);
-    updateWebviewState({
+    stateManager.update({
       groupToggleStates: serializedGroupStates,
     });
   } catch (e) {

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -1,6 +1,5 @@
 import { vscode } from '@common/vscodeApi.js';
-import { saveState } from './stateManager.js';
-import { getWebviewState, updateWebviewState } from '@common/webviewState.js';
+import { saveState, stateManager } from './stateManager.js';
 import { MULTIPLE_SELECTIONS } from './constants.js';
 import {
   addEventListenerSafely,
@@ -182,7 +181,7 @@ export function handleCheckboxChange(event) {
  */
 export function initializeOutputFiles() {
   // Get the current state
-  const state = getWebviewState();
+  const state = stateManager.getState();
 
   // Get references to the DOM elements
   const inputFileDiv = safeGetElementById('inputFile');
@@ -225,7 +224,7 @@ export function initializeOutputFiles() {
   }
 
   // Add opened files to the output files list
-  const openedFiles = getWebviewState()?.openedFiles ?? [];
+  const openedFiles = stateManager.getState()?.openedFiles ?? [];
   openedFiles.forEach((file) => {
     addFileToList('outputFiles', file);
   });
@@ -238,7 +237,7 @@ export function initializeOutputFiles() {
 
   if (outputNameOverrideInput && outputNameOverrideToggle) {
     // Get the current state from the stored state
-    const state = getWebviewState();
+    const state = stateManager.getState();
     const isOutputNameOverrideVisible =
       state && state.outputNameOverrideVisible;
 
@@ -277,7 +276,7 @@ export function toggleOutputNameOverride() {
     : '<i class="codicon codicon-chevron-right"></i>';
 
   // Store the visibility state in the vscode state
-  updateWebviewState({ outputNameOverrideVisible: !isVisible });
+  stateManager.update({ outputNameOverrideVisible: !isVisible });
 
   saveState();
 }
@@ -313,7 +312,7 @@ export function emptyMultipleFiles(containerId, toggleId) {
         '<i class="codicon codicon-chevron-right"></i>';
 
       // Update the state
-      updateWebviewState({ outputNameOverrideVisible: false });
+      stateManager.update({ outputNameOverrideVisible: false });
     }
   }
 
@@ -345,7 +344,7 @@ export function initializeOutputContainer() {
   const toggleIcon = safeGetElementById('toggleOutputFiles');
 
   if (container && toggleIcon) {
-    const state = getWebviewState();
+    const state = stateManager.getState();
     const shouldShow = state && state.outputFilesActive;
 
     container.style.display = shouldShow ? 'block' : 'none';
@@ -360,7 +359,7 @@ export function initializeLatexdiffsSection() {
   const toggleIcon = safeGetElementById('toggleLatexdiffs');
 
   if (container && toggleIcon) {
-    const state = getWebviewState();
+    const state = stateManager.getState();
     const shouldShow = state && state.latexdiffsVisible;
 
     container.style.display = shouldShow ? 'block' : 'none';
@@ -391,6 +390,6 @@ export function toggleLatexdiffs() {
       : 'codicon codicon-chevron-up';
   }
 
-  updateWebviewState({ latexdiffsVisible: !isVisible });
+  stateManager.update({ latexdiffsVisible: !isVisible });
   saveState();
 }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -2,11 +2,7 @@ import { vscode } from '@common/vscodeApi.js';
 import { registerMessageHandlers } from '@common/messageRouter.js';
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import {
-  getWebviewState,
-  updateWebviewState,
-  setWebviewState,
-} from '@common/webviewState.js';
+import { stateManager, restoreState, saveState } from './stateManager.js';
 
 import {
   updateFileSelect,
@@ -17,7 +13,6 @@ import {
   handleSetCurrentFile,
 } from './fileHandlers.js';
 
-import { restoreState, saveState } from './stateManager.js';
 import { FILE_TYPES } from './constants.js';
 
 /**
@@ -199,7 +194,7 @@ function handleStateRestoration(state) {
               });
 
               // Save state to persist changes
-              updateWebviewState({
+              stateManager.update({
                 [`${fileType}Files`]: updatedFiles,
               });
             });
@@ -210,7 +205,7 @@ function handleStateRestoration(state) {
   }
 
   // Save the prepared state
-  setWebviewState(savedState);
+  stateManager.setState(savedState);
 
   // Use the stateManager's restoreState to update UI elements from this state
   // This will handle setting all form values and updating indicators
@@ -388,7 +383,7 @@ export function setupMessageHandlers() {
         const currentBaseFile = currentBaseFileDiv.value;
         updateFileSelect('baseFile', m.files);
 
-        const state = getWebviewState();
+        const state = stateManager.getState();
         const storedBaseFile = state?.baseFile;
 
         if (storedBaseFile && m.files.includes(storedBaseFile)) {

--- a/src/webview/modules/stateManager.js
+++ b/src/webview/modules/stateManager.js
@@ -1,4 +1,6 @@
-import { getWebviewState, setWebviewState } from '@common/webviewState.js';
+import { WebviewStateManager } from '@common/webviewState.js';
+
+export const stateManager = new WebviewStateManager();
 
 import {
   MULTIPLE_SELECTIONS,
@@ -64,7 +66,7 @@ export function setDefaultState() {
 }
 
 export function restoreState() {
-  const previousState = getWebviewState();
+  const previousState = stateManager.getState();
   if (previousState) {
     const defaultValues = {
       agent: 'correct',
@@ -201,5 +203,5 @@ export function saveState() {
   // Log the state being saved for debugging
   console.log('Saving state:', state);
 
-  setWebviewState(state);
+  stateManager.update(state);
 }

--- a/src/webview/modules/stateManager.js
+++ b/src/webview/modules/stateManager.js
@@ -203,5 +203,5 @@ export function saveState() {
   // Log the state being saved for debugging
   console.log('Saving state:', state);
 
-  stateManager.update(state);
+  stateManager.setState(state);
 }


### PR DESCRIPTION
## Summary
- implement VS Code state access directly in `WebviewStateManager`
- expose a shared `stateManager` for the main webview
- update file and message handlers to use the new manager methods

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684df6e44aa08324a2e9da1dca4c67bf