### PR TITLE
Replace relative paths with TypeScript aliases

### DIFF
--- a/src/AnthropicTool/AnthropicToolAgent.ts
+++ b/src/AnthropicTool/AnthropicToolAgent.ts
@@ -15,7 +15,7 @@ import { BaseError, ValidationResult } from './types';
 
 // Local imports - utils
 import * as workspaceFileUtils from '@utils/files';
-import { getApiKey as getSecretApiKey, ApiProvider } from '../frontend/secrets';
+import { getApiKey as getSecretApiKey, ApiProvider } from '@frontend/secrets';
 import { getConfig } from '@utils/config';
 
 // Local imports - logging

--- a/src/AnthropicTool/TeXLinterFixAgent.ts
+++ b/src/AnthropicTool/TeXLinterFixAgent.ts
@@ -6,11 +6,11 @@ import { ToolResult } from './base';
 
 // Local imports - types
 import { ValidationResult } from './types';
-import { LinterMessage } from '../frontend/latex/linter';
+import { LinterMessage } from '@frontend/latex/linter';
 
 // Local imports - utils
 import * as workspaceFileUtils from '@utils/files';
-import * as linterUtils from '../frontend/latex/linter';
+import * as linterUtils from '@frontend/latex/linter';
 
 // Local imports - Logging
 import * as logger from '@logger/logUtils';

--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -10,8 +10,8 @@ import {
   getBuiltInAgentsDirectory,
   getCustomAgentsDirectory,
   getOrPromptForCustomAgentsDirectory,
-} from './frontend/agents/pathUtils';
-import { promptToAddAgentToConfig } from './frontend/agents/register';
+} from '@frontend/agents/pathUtils';
+import { promptToAddAgentToConfig } from '@frontend/agents/register';
 import { isValidAgentYaml } from './agent/runtime/agentLoad';
 import { fileExistsAbsolute } from '@utils/files';
 import { getConfig } from '@utils/config';

--- a/src/ViewProvider.ts
+++ b/src/ViewProvider.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - webview
 import { WebviewMessageHandler } from './webview/MessageHandler';
 import { WebviewContentProvider } from './webview/WebviewContentProvider';
-import { anyApiKeyExists } from './frontend/secrets';
+import { anyApiKeyExists } from '@frontend/secrets';
 import { watchConfig } from '@utils/config';
 
 export class TeXRAViewProvider implements vscode.WebviewViewProvider {

--- a/src/WolframTool/wolframAlphaUtils.ts
+++ b/src/WolframTool/wolframAlphaUtils.ts
@@ -2,7 +2,7 @@
 import axios from 'axios';
 
 // local import
-import { getApiKey } from '../frontend/secrets';
+import { getApiKey } from '@frontend/secrets';
 
 interface WolframValves {
   WOLFRAM_APP_ID: string;

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 // Local imports - agent components
 import { DirectAgent } from './DirectAgent';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
-import { ModelHandler } from '../modelHandlers';
+import { ModelHandler } from '@agent/modelHandlers';
 import { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -15,13 +15,10 @@ import {
   getBase64EncodedMedia,
   countPdfPages,
   processPdf2Png,
-} from '../../frontend/media/img';
+} from '@frontend/media/img';
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
-import {
-  getApiKey as getSecretApiKey,
-  ApiProvider,
-} from '../../frontend/secrets';
+import { getApiKey as getSecretApiKey, ApiProvider } from '@frontend/secrets';
 
 // Local imports - agent components
 import { AgentConfig } from '../core/AgentConfig';
@@ -31,7 +28,7 @@ import {
   ModelConfig,
   ModelProvider,
   ModelCapabilities,
-} from '../../model/ModelConfig';
+} from '@model/ModelConfig';
 import { ToolState } from '../core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -12,7 +12,7 @@ import { countTokens } from 'gpt-tokenizer';
 
 // Local imports - utilities
 import { readFile, writeFile, fileExistsAndNonTrivial } from '@utils/files';
-import { cleanFileContent } from '../../replacement/replacementUtils';
+import { cleanFileContent } from '@replacement/replacementUtils';
 import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
 
 // Local imports - agent components

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -4,11 +4,11 @@ import * as path from 'path';
 
 import { AgentLogger } from '@logger/AgentLogger';
 import { readFile } from '@utils/files';
-import { setVarFromFile } from '../../frontend/files/vars';
+import { setVarFromFile } from '@frontend/files/vars';
 import { getXmlFormatFromFiles, getListOfFiles } from '@utils/promptUtils';
 import { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting } from '../core/AgentDataclass';
-import { ModelHandler } from '../modelHandlers';
+import { ModelHandler } from '@agent/modelHandlers';
 
 /**
  * Build all user variables needed for prompt rendering.

--- a/src/commands/apiKeyCommands.ts
+++ b/src/commands/apiKeyCommands.ts
@@ -5,7 +5,7 @@ import {
   getApiKeySecretName,
   setSecret,
   deleteSecret,
-} from '../frontend/secrets';
+} from '@frontend/secrets';
 
 export const apiKeyCommands = {
   setApiKey: 'texra.setApiKey',

--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -14,7 +14,7 @@ import {
   readFile,
   writeFile,
 } from '@utils/files';
-import { registerDiffRefresh } from '../frontend/ui/diffView';
+import { registerDiffRefresh } from '@frontend/ui/diffView';
 import { DIFF_REGISTRATION_DELAY_MS } from '@utils/config';
 
 const CHANNEL = 'CompareCommands';

--- a/src/commands/figCommands.ts
+++ b/src/commands/figCommands.ts
@@ -11,11 +11,11 @@ import * as logger from '@logger/logUtils';
 import { getRelativePath, getWorkspacePath } from '@utils/files';
 
 // Local imports - latex utils
-import { extractFigurePathsFromLatex } from '../latex/extractFigure';
+import { extractFigurePathsFromLatex } from '@latex/extractFigure';
 import {
   extractTikzPicturesWithLabels,
   extractAndCompileTikzPicturesWithLabels,
-} from '../latex/tikzpicture';
+} from '@latex/tikzpicture';
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/fileSelectionCommands.ts
+++ b/src/commands/fileSelectionCommands.ts
@@ -5,11 +5,11 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { showInfoMessage, showErrorMessage } from '../frontend/ui/messageUtils';
+import { showInfoMessage, showErrorMessage } from '@frontend/ui/messageUtils';
 import { getRelativePath } from '@utils/files';
-import { listInputFiles } from '../frontend/files/listing';
+import { listInputFiles } from '@frontend/files/listing';
 import { getIncludedExtensions } from '@utils/fileTypeUtils';
-import { selectFile, selectFiles } from '../frontend/files/dialog';
+import { selectFile, selectFiles } from '@frontend/files/dialog';
 const CHANNEL = 'fileSelectionCommands';
 logger.initialize(CHANNEL);
 

--- a/src/commands/imageCommands.ts
+++ b/src/commands/imageCommands.ts
@@ -11,7 +11,7 @@ import {
   getBase64EncodedMedia,
   processPdf2Png,
   singlePagePdf2Png,
-} from '../frontend/media/img';
+} from '@frontend/media/img';
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/latexCommands.ts
+++ b/src/commands/latexCommands.ts
@@ -11,11 +11,11 @@ import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
-} from '../replacement/replacementUtils';
+} from '@replacement/replacementUtils';
 
 // Local imports - latex utils
-import { runLatexFormatter } from '../latex/texFormatter';
-import { getTeXCount } from '../latex/texcount';
+import { runLatexFormatter } from '@latex/texFormatter';
+import { getTeXCount } from '@latex/texcount';
 
 // Local imports - commands
 import { fileSelectionCommands } from './fileSelectionCommands';

--- a/src/commands/latexdiffCommands.ts
+++ b/src/commands/latexdiffCommands.ts
@@ -10,7 +10,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { getWorkspacePath } from '@utils/files';
 import { fileExists } from '@utils/files';
-import { openBuildDisplayIfTex } from '../frontend/latex/openBuild';
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 
 // Local imports - latex utils
 import {
@@ -18,7 +18,7 @@ import {
   runLatexdiffvc,
   runLatexdiffForRound,
   runLatexdiffBetweenRounds,
-} from '../latex/latexdiff';
+} from '@latex/latexdiff';
 import { checkToolInstalled } from '@utils/system';
 
 // Local imports - housekeeping

--- a/src/commands/linterCommands.ts
+++ b/src/commands/linterCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utils
-import { getLinterMessages } from '../frontend/latex/linter';
+import { getLinterMessages } from '@frontend/latex/linter';
 import { getRelativePath } from '@utils/files';
 import { sleep } from '@utils/helpers';
 

--- a/src/commands/openFileCommands.ts
+++ b/src/commands/openFileCommands.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { openBuildDisplayIfTex } from '../frontend/latex/openBuild';
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 
 export function registerOpenFileCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(

--- a/src/commands/tests/connectionTests.ts
+++ b/src/commands/tests/connectionTests.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import {
   bestConnectionMethod,
   bestConnectionMethodAnthropic,
-} from '../../latex/textConnection';
+} from '@latex/textConnection';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/commands/yamlCommands.ts
+++ b/src/commands/yamlCommands.ts
@@ -13,7 +13,7 @@ import {
 import * as logger from '@logger/logUtils';
 import { getAgentPath } from '../agent/runtime/executeAgent';
 import { AgentType } from '../agent/core/AgentDataclass';
-import { showInstructionWithSuppress } from '../frontend/ui/instruction';
+import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,10 +3,10 @@ import * as vscode from 'vscode';
 
 // Local imports - core
 import * as logger from '@logger/logUtils';
-import { initializeSecrets } from './frontend/secrets';
-import { copyDefaultAgents, configureLatexSettings } from './frontend/setup';
 import { watchConfig } from '@utils/config';
-import { disposeDiffRefresh } from './frontend/ui/diffView';
+import { initializeSecrets } from '@frontend/secrets';
+import { copyDefaultAgents, configureLatexSettings } from '@frontend/setup';
+import { disposeDiffRefresh } from '@frontend/ui/diffView';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';

--- a/src/historyView/AgentHistoryViewProvider.ts
+++ b/src/historyView/AgentHistoryViewProvider.ts
@@ -5,7 +5,7 @@ import { AgentHistoryManager } from './AgentHistoryManager';
 import { executeCommand } from '../commands/executeCommand';
 
 import { agentConfigToTaskState } from '@utils/config';
-import { buildWebviewHtml } from '../frontend/webview/html';
+import { buildWebviewHtml } from '@frontend/webview/html';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/housekeeping/constants.ts
+++ b/src/housekeeping/constants.ts
@@ -35,7 +35,7 @@ export const TEMP_EXTENSIONS = [
 ];
 
 // Auto-generated from ModelRegistry
-import { MODEL_CONFIGS } from '../model/ModelRegistry';
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
 
 export const MODELS = Object.keys(MODEL_CONFIGS);
 

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -11,7 +11,7 @@ import * as logger from '@logger/logUtils';
 import { deleteFile, readDirectory } from '@utils/files';
 import { fileExistsAbsolute } from '@utils/files';
 import { getConfig } from '@utils/config';
-import { runLatexFormatter } from '../latex/texFormatter';
+import { runLatexFormatter } from '@latex/texFormatter';
 
 // Local imports - housekeeping
 import { EXCLUDED_DIRS } from './constants';

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -22,7 +22,7 @@ import {
   applyReplacements,
   getAllReplacements,
   getAllReplacementsRegex,
-} from '../replacement/replacementUtils';
+} from '@replacement/replacementUtils';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/textConnection.ts
+++ b/src/latex/textConnection.ts
@@ -7,7 +7,7 @@ import { formatProviderError } from '@utils/sdkErrorUtils';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
-import { getApiKey as getSecretApiKey, ApiProvider } from '../frontend/secrets';
+import { getApiKey as getSecretApiKey, ApiProvider } from '@frontend/secrets';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
-import { buildWebviewHtml } from '../frontend/webview/html';
+import { buildWebviewHtml } from '@frontend/webview/html';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);

--- a/src/replacement/replacementHelpers.ts
+++ b/src/replacement/replacementHelpers.ts
@@ -1,7 +1,7 @@
 /**
  * Helper functions for generating replacement patterns
  */
-import { capitalize } from '../frontend/ui/messageUtils';
+import { capitalize } from '@frontend/ui/messageUtils';
 
 // ===== Shared Constants =====
 

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -13,7 +13,7 @@ import { formatProviderError } from '../sdkErrorUtils';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getApiKey } from '../../frontend/secrets';
+import { getApiKey } from '@frontend/secrets';
 import { extractTextFromTag } from './xmlUtils';
 import { getConfig } from '../config';
 

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -23,7 +23,7 @@ import {
   getPastedImageFullPath,
   PASTED_DIR,
 } from '@utils/files/pastedImageUtils';
-import { capitalize, uncapitalize } from '../frontend/ui/messageUtils';
+import { capitalize, uncapitalize } from '@frontend/ui/messageUtils';
 import { getConfig } from '@utils/config';
 import {
   listInputFiles,
@@ -32,7 +32,7 @@ import {
   listMediaFiles,
   listEditedFiles,
   getFilesIfNotEmpty,
-} from '../frontend/files/listing';
+} from '@frontend/files/listing';
 import {
   polishTextWithAI,
   FileContext,

--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -8,7 +8,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { getConfig } from '@utils/config';
-import { buildWebviewHtml } from '../frontend/webview/html';
+import { buildWebviewHtml } from '@frontend/webview/html';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);


### PR DESCRIPTION
## Summary
- switch remaining `../..` frontend and latex imports to alias notation
- update other imports for model, replacement, and agent utilities

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684e7f3d602883248d33762f031a379e