### PR TITLE
Introduce FileLister service

### DIFF
--- a/src/commands/fileSelectionCommands.ts
+++ b/src/commands/fileSelectionCommands.ts
@@ -7,7 +7,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { showInfoMessage, showErrorMessage } from '../frontend/ui/messageUtils';
 import { getRelativePath } from '@utils/files';
-import { listInputFiles } from '../frontend/files/listing';
+import { listInputFiles } from '../frontend/files/fileLister';
 import { getIncludedExtensions } from '@utils/fileTypeUtils';
 import { selectFile, selectFiles } from '../frontend/files/dialog';
 const CHANNEL = 'fileSelectionCommands';
@@ -44,195 +44,87 @@ export function registerFileSelectionCommands(
   );
 }
 
-async function selectInputFile(
-  currentInputFile: string,
-): Promise<string | null> {
-  const result = await selectFile({
-    currentFile: currentInputFile,
-    openLabel: 'Select File',
-    filters: {
-      'Text files': getIncludedExtensions('input').map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
-  if (result) {
-    logger.info(CHANNEL, `Selected file: ${result}`);
-  }
-  return result;
-}
-
-async function selectInputFiles(
-  currentInputFile: string,
-): Promise<string[] | null> {
-  const includedInputExtensions = getIncludedExtensions('input', [
-    '.txt',
-    '.tex',
-    '.md',
-  ]);
-
-  try {
-    const relativePaths = await selectFiles({
-      currentFile: currentInputFile,
-      allowMany: true,
-      openLabel: 'Select Files',
-      filters: {
-        'Text files': includedInputExtensions.map((ext) =>
-          ext.replace('.', ''),
-        ),
-      },
-    });
-
-    if (!relativePaths) {
-      return null;
+function createPicker(
+  openLabel: string,
+  allowMany: true,
+  filters: () => Record<string, string[]>,
+): (currentFile?: string) => Promise<string[] | null>;
+function createPicker(
+  openLabel: string,
+  allowMany: false,
+  filters: () => Record<string, string[]>,
+): (currentFile?: string) => Promise<string | null>;
+function createPicker(
+  openLabel: string,
+  allowMany: boolean,
+  filters: () => Record<string, string[]>,
+) {
+  return async (currentFile = '') => {
+    const opts = {
+      currentFile,
+      allowMany,
+      openLabel,
+      filters: filters(),
+    };
+    const result = allowMany ? await selectFiles(opts) : await selectFile(opts);
+    if (result) {
+      const text = Array.isArray(result) ? result.join(', ') : result;
+      showInfoMessage(`Selected files: ${text}`);
+      logger.info(CHANNEL, `Selected files: ${text}`);
     }
-
-    showInfoMessage(`Selected files: ${relativePaths.join(', ')}`);
-    logger.info(CHANNEL, `Selected files: ${relativePaths.join(', ')}`);
-    return relativePaths;
-  } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error selecting files: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return null;
-  }
+    return result ?? null;
+  };
 }
 
-async function selectReferenceFiles(
-  currentReferenceFile: string,
-): Promise<string[] | null> {
-  const includedReferenceExtensions = getIncludedExtensions('reference');
-  const relativePaths = await selectFiles({
-    currentFile: currentReferenceFile,
-    allowMany: true,
-    openLabel: 'Select Ref Files',
-    filters: {
-      'Text files': includedReferenceExtensions.map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
+const selectInputFile = createPicker('Select File', false, () => ({
+  'Text files': getIncludedExtensions('input').map((ext) =>
+    ext.replace('.', ''),
+  ),
+}));
 
-  if (relativePaths) {
-    showInfoMessage(`Selected reference files: ${relativePaths.join(', ')}`);
-    logger.info(
-      CHANNEL,
-      `Selected reference files: ${relativePaths.join(', ')}`,
-    );
-  }
+const selectInputFiles = createPicker('Select Files', true, () => ({
+  'Text files': getIncludedExtensions('input').map((ext) =>
+    ext.replace('.', ''),
+  ),
+}));
 
-  return relativePaths;
-}
+const selectReferenceFiles = createPicker('Select Ref Files', true, () => ({
+  'Text files': getIncludedExtensions('reference').map((ext) =>
+    ext.replace('.', ''),
+  ),
+}));
 
-async function selectAuxiliaryFiles(
-  currentAuxiliaryFile: string,
-): Promise<string[] | null> {
-  const includedAuxiliaryExtensions = getIncludedExtensions('auxiliary');
-  const relativePaths = await selectFiles({
-    currentFile: currentAuxiliaryFile,
-    allowMany: true,
-    openLabel: 'Select Auxiliary Files',
-    filters: {
-      'Text files': includedAuxiliaryExtensions.map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
+const selectAuxiliaryFiles = createPicker(
+  'Select Auxiliary Files',
+  true,
+  () => ({
+    'Text files': getIncludedExtensions('auxiliary').map((ext) =>
+      ext.replace('.', ''),
+    ),
+  }),
+);
 
-  if (relativePaths) {
-    showInfoMessage(`Selected files: ${relativePaths.join(', ')}`);
-    logger.info(CHANNEL, `Selected files: ${relativePaths.join(', ')}`);
-  }
-  return relativePaths;
-}
+const selectMediaFiles = createPicker('Select Media', true, () => ({
+  'Image files': getIncludedExtensions('media').map((ext) =>
+    ext.replace('.', ''),
+  ),
+  'Audio files': getIncludedExtensions('audio').map((ext) =>
+    ext.replace('.', ''),
+  ),
+}));
 
-async function selectMediaFiles(
-  currentMediaFile: string,
-): Promise<string[] | null> {
-  const includedFigureExtensions = getIncludedExtensions('media');
-  const includedAudioExtensions = getIncludedExtensions('audio');
-  const relativePaths = await selectFiles({
-    currentFile: currentMediaFile,
-    allowMany: true,
-    openLabel: 'Select Media',
-    filters: {
-      'Image files': includedFigureExtensions.map((ext) =>
-        ext.replace('.', ''),
-      ),
-      'Audio files': includedAudioExtensions.map((ext) => ext.replace('.', '')),
-    },
-  });
+const selectMediaFile = createPicker('Select Media File', false, () => ({
+  Images: getIncludedExtensions('media').map((ext) => ext.replace('.', '')),
+  'Audio files': getIncludedExtensions('audio').map((ext) =>
+    ext.replace('.', ''),
+  ),
+}));
 
-  if (relativePaths) {
-    showInfoMessage(`Selected files: ${relativePaths.join(', ')}`);
-    logger.info(CHANNEL, `Selected files: ${relativePaths.join(', ')}`);
-  }
-  return relativePaths;
-}
+const selectOutputFiles = createPicker('Select Output Files', true, () => ({
+  'Text files': ['tex', 'txt', 'md'],
+}));
 
-async function selectMediaFile(): Promise<string | null> {
-  const result = await selectFile({
-    openLabel: 'Select Media File',
-    filters: {
-      Images: getIncludedExtensions('media').map((ext) => ext.replace('.', '')),
-      'Audio files': getIncludedExtensions('audio').map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
-  if (result) {
-    showInfoMessage(`Selected media file: ${result}`);
-    logger.info(CHANNEL, `Selected media file: ${result}`);
-  }
-  return result;
-}
-
-async function selectOutputFiles(
-  currentInputFile: string,
-): Promise<string[] | null> {
-  try {
-    const relativePaths = await selectFiles({
-      currentFile: currentInputFile,
-      allowMany: true,
-      openLabel: 'Select Output Files',
-      filters: {
-        'Text files': ['tex', 'txt', 'md'],
-      },
-    });
-
-    if (!relativePaths) {
-      return null;
-    }
-
-    logger.info(CHANNEL, `Selected output files: ${relativePaths.join(', ')}`);
-    vscode.window.showInformationMessage(
-      `Selected output files: ${relativePaths.join(', ')}`,
-    );
-    return relativePaths;
-  } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error selecting output files: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    vscode.window.showErrorMessage(
-      `Error selecting output files: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return null;
-  }
-}
-
-async function selectEditedFile(): Promise<string | null> {
-  const result = await selectFile({
-    openLabel: 'Select Edited File',
-    filters: {},
-  });
-  if (result) {
-    showInfoMessage(`Selected edited file: ${result}`);
-    logger.info(CHANNEL, `Selected edited file: ${result}`);
-  }
-  return result;
-}
+const selectEditedFile = createPicker('Select Edited File', false, () => ({}));
 
 async function getCurrentFile(): Promise<string | null> {
   const currentFile = vscode.window.activeTextEditor?.document;

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -1,0 +1,140 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - utilities
+import { getWorkspacePath } from '@utils/files';
+import { getConfig } from '@utils/config';
+import { getIncludedExtensions, FileType } from '@utils/fileTypeUtils';
+
+import { getFilesInDirectory, getFilesRecursively } from './listing';
+
+/**
+ * Service for listing workspace files with cached configuration.
+ */
+export class FileLister {
+  private workspacePath: string | undefined;
+  private ignoredExtensions: string[] = [];
+  private ignoredDirectories: string[] = [];
+  private ignoredKeywords: string[] = [];
+  private ignoredInputFiles: string[] = [];
+
+  constructor() {
+    this.refresh();
+  }
+
+  /** Refresh workspace path and configuration values. */
+  refresh() {
+    this.workspacePath = getWorkspacePath();
+    this.ignoredExtensions = getConfig<string[]>(
+      'files.ignored.fileExtensions',
+      [],
+    );
+    this.ignoredDirectories = getConfig<string[]>(
+      'files.ignored.directories',
+      [],
+    );
+    this.ignoredKeywords = getConfig<string[]>('files.ignored.keywords', []);
+    this.ignoredInputFiles = getConfig<string[]>(
+      'files.ignored.inputFiles',
+      [],
+    );
+  }
+
+  /** List files of the given type using cached configuration. */
+  async list(
+    type: Extract<FileType, 'input' | 'reference' | 'auxiliary' | 'media'>,
+  ): Promise<string[]> {
+    if (!this.workspacePath) {
+      return [];
+    }
+
+    const include = getIncludedExtensions(type);
+
+    switch (type) {
+      case 'auxiliary': {
+        const extraKeywords = getConfig<string[]>(
+          'files.ignored.auxiliaryKeywords',
+          [],
+        );
+        return getFilesInDirectory(
+          this.workspacePath,
+          include,
+          this.ignoredExtensions,
+          this.ignoredDirectories,
+          [...this.ignoredKeywords, ...extraKeywords],
+        );
+      }
+      case 'media': {
+        const mediaDirs = getConfig<string[]>(
+          'files.ignored.mediaDirectories',
+          [],
+        );
+        return getFilesRecursively(
+          this.workspacePath,
+          this.workspacePath,
+          include,
+          [],
+          mediaDirs,
+          this.ignoredKeywords,
+        );
+      }
+      default: {
+        // input and reference share the same logic
+        return getFilesRecursively(
+          this.workspacePath,
+          this.workspacePath,
+          include,
+          this.ignoredExtensions,
+          this.ignoredDirectories,
+          this.ignoredKeywords,
+          this.ignoredInputFiles,
+        );
+      }
+    }
+  }
+
+  /**
+   * List edited files related to the provided base file name.
+   */
+  async listEditedFiles(baseFileName: string): Promise<string[]> {
+    if (!this.workspacePath) {
+      return [];
+    }
+
+    const files = await getFilesRecursively(
+      this.workspacePath,
+      this.workspacePath,
+      getIncludedExtensions('edited'),
+      this.ignoredExtensions,
+      [...this.ignoredDirectories, 'PapersEx'],
+      this.ignoredKeywords,
+      this.ignoredInputFiles,
+    );
+
+    const baseNameMatch = baseFileName.match(/^(.*?)(?:_r\d+|$)/);
+    const baseNameBeforeRound = baseNameMatch ? baseNameMatch[1] : baseFileName;
+
+    return files.filter((file) => {
+      const fileBaseName = path.basename(file, path.extname(file));
+      return (
+        (fileBaseName.startsWith(baseFileName) &&
+          fileBaseName !== baseFileName) ||
+        (fileBaseName.startsWith(baseNameBeforeRound) &&
+          fileBaseName.match(/_r\d+/) &&
+          fileBaseName !== baseFileName)
+      );
+    });
+  }
+}
+
+export const fileLister = new FileLister();
+
+export const listInputFiles = () => fileLister.list('input');
+export const listReferenceFiles = () => fileLister.list('reference');
+export const listAuxiliaryFiles = () => fileLister.list('auxiliary');
+export const listMediaFiles = () => fileLister.list('media');
+export const listEditedFiles = (base: string) =>
+  fileLister.listEditedFiles(base);

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -8,120 +8,31 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getConfig } from '@utils/config';
-import { getWorkspacePath } from '@utils/files';
-import { getIncludedExtensions } from '@utils/fileTypeUtils';
+import { fileLister } from './fileLister';
 
 const CHANNEL = 'FrontendUtils';
 logger.initialize(CHANNEL);
-
-const IGNORED_FILE_EXTENSIONS = getConfig<string[]>(
-  'files.ignored.fileExtensions',
-);
-const IGNORED_DIRECTORIES = getConfig<string[]>('files.ignored.directories');
-const IGNORED_KEYWORDS = getConfig<string[]>('files.ignored.keywords');
 
 export function getFilesIfNotEmpty<T>(files: T[] | undefined): T[] | null {
   return files && files.length > 0 ? files : null;
 }
 
 export async function listInputFiles(): Promise<string[]> {
-  const workspacePath = getWorkspacePath();
-  if (!workspacePath) {
-    return [];
-  }
-
-  const INCLUDED_INPUT_EXTENSIONS = getIncludedExtensions('input');
-
-  return getFilesRecursively(
-    workspacePath,
-    workspacePath,
-    INCLUDED_INPUT_EXTENSIONS,
-    IGNORED_FILE_EXTENSIONS,
-    IGNORED_DIRECTORIES,
-    IGNORED_KEYWORDS,
-    getConfig<string[]>('files.ignored.inputFiles'),
-  );
+  return fileLister.list('input');
 }
 
 export const listReferenceFiles = listInputFiles;
 
 export async function listAuxiliaryFiles(): Promise<string[]> {
-  const workspacePath = getWorkspacePath();
-  if (!workspacePath) {
-    return [];
-  }
-
-  const IGNORED_AUXILIARY_KEYWORDS = getConfig<string[]>(
-    'files.ignored.auxiliaryKeywords',
-  );
-
-  const INCLUDED_AUXILIARY_EXTENSIONS = getIncludedExtensions('auxiliary');
-
-  return getFilesInDirectory(
-    workspacePath,
-    INCLUDED_AUXILIARY_EXTENSIONS,
-    IGNORED_FILE_EXTENSIONS,
-    IGNORED_DIRECTORIES,
-    [...IGNORED_KEYWORDS, ...IGNORED_AUXILIARY_KEYWORDS],
-  );
+  return fileLister.list('auxiliary');
 }
 
 export async function listMediaFiles(): Promise<string[]> {
-  const workspacePath = getWorkspacePath();
-  if (!workspacePath) {
-    return [];
-  }
-
-  const IGNORED_FIGURE_DIRECTORIES = getConfig<string[]>(
-    'files.ignored.mediaDirectories',
-  );
-
-  const INCLUDED_FIGURE_EXTENSIONS = getIncludedExtensions('media');
-
-  return getFilesRecursively(
-    workspacePath,
-    workspacePath,
-    INCLUDED_FIGURE_EXTENSIONS,
-    [],
-    IGNORED_FIGURE_DIRECTORIES,
-    IGNORED_KEYWORDS,
-  );
+  return fileLister.list('media');
 }
 
 export async function listEditedFiles(baseFileName: string): Promise<string[]> {
-  const workspacePath = getWorkspacePath();
-  if (!workspacePath) {
-    return [];
-  }
-
-  const INCLUDED_EDITED_EXTENSIONS = getIncludedExtensions('edited');
-
-  const files = await getFilesRecursively(
-    workspacePath,
-    workspacePath,
-    INCLUDED_EDITED_EXTENSIONS,
-    IGNORED_FILE_EXTENSIONS,
-    [...IGNORED_DIRECTORIES, 'PapersEx'],
-    IGNORED_KEYWORDS,
-    getConfig<string[]>('files.ignored.inputFiles'),
-  );
-
-  // Extract the base name before any round number
-  const baseNameMatch = baseFileName.match(/^(.*?)(?:_r\d+|$)/);
-  const baseNameBeforeRound = baseNameMatch ? baseNameMatch[1] : baseFileName;
-
-  return files.filter((file) => {
-    const fileBaseName = path.basename(file, path.extname(file));
-    // Check if it starts with the same base name and or has a different round number
-    return (
-      (fileBaseName.startsWith(baseFileName) &&
-        fileBaseName !== baseFileName) ||
-      (fileBaseName.startsWith(baseNameBeforeRound) &&
-        fileBaseName.match(/_r\d+/) &&
-        fileBaseName !== baseFileName)
-    );
-  });
+  return fileLister.listEditedFiles(baseFileName);
 }
 
 export async function getFilesInDirectory(

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -31,8 +31,8 @@ import {
   listAuxiliaryFiles,
   listMediaFiles,
   listEditedFiles,
-  getFilesIfNotEmpty,
-} from '../frontend/files/listing';
+} from '../frontend/files/fileLister';
+import { getFilesIfNotEmpty } from '../frontend/files/listing';
 import {
   polishTextWithAI,
   FileContext,


### PR DESCRIPTION
## Summary
- add `FileLister` class to encapsulate file listing logic
- delegate file listing helpers to the service
- refactor file selection commands with a generic picker
- update message handler to use the new service

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684e791c31fc8324a6aab7a6f34ebeeb