### PR TITLE
Introduce replacement manager

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -27,11 +27,7 @@ import {
   writePromptToXml,
 } from '@utils/promptUtils';
 import { loadTexraRules } from '@frontend/files/rules';
-import {
-  applyReplacements,
-  getAllReplacements,
-  getAllReplacementsRegex,
-} from '@replacement/replacementUtils';
+import replacementManager from '@replacement/replacementManager';
 import { checkForMassiveRepetition } from '@utils/text/repetitionUtils';
 import {
   extractAndLogScratchpad,
@@ -428,19 +424,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         }
 
         // Chain response processing operations
-        let processedResponse = newResponse;
-        processedResponse = applyReplacements(
-          processedResponse,
-          getAllReplacements(),
-        ).trim();
-        processedResponse = applyReplacements(
-          processedResponse,
-          getAllReplacementsRegex(),
-        ).trim();
-        processedResponse = applyReplacements(
-          processedResponse,
-          getAllReplacements(),
-        ).trim();
+        const processedResponse = replacementManager.applyAll(newResponse);
 
         toolState.updateLastResponse(processedResponse);
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -16,12 +16,8 @@ import { formatProviderError } from '@utils/sdkErrorUtils';
 
 // Local imports - utilities
 import { readFile, writeFile, fileExistsAndNonTrivial } from '@utils/files';
-import {
-  applyReplacements,
-  getAllReplacements,
-  getAllReplacementsRegex,
-  cleanFileContent,
-} from '@replacement/replacementUtils';
+import { cleanFileContent } from '@replacement/replacementUtils';
+import replacementManager from '@replacement/replacementManager';
 import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
 
 // Local imports - agent components
@@ -398,11 +394,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       newResponse += `\n${endTag}`;
     }
 
-    newResponse = applyReplacements(newResponse, getAllReplacements()).trim();
-    newResponse = applyReplacements(
-      newResponse,
-      getAllReplacementsRegex(),
-    ).trim();
+    newResponse = replacementManager.applyAll(newResponse);
 
     return [newResponse, responseObject.usage, stopReason || 'stop'];
   }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -40,12 +40,8 @@ import {
 } from '@utils/files';
 import { fileExistsAbsolute } from '@utils/files';
 import { formatProviderError } from '@utils/sdkErrorUtils';
-import {
-  applyReplacements,
-  getAllReplacements,
-  getAllReplacementsRegex,
-  cleanFileContent,
-} from '@replacement/replacementUtils';
+import { cleanFileContent } from '@replacement/replacementUtils';
+import replacementManager from '@replacement/replacementManager';
 import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
 import { getConfig } from '@utils/config';
 import { calculateTokenPrice } from '@utils/priceUtils';
@@ -612,11 +608,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       );
     }
 
-    responseText = applyReplacements(responseText, getAllReplacements()).trim();
-    responseText = applyReplacements(
-      responseText,
-      getAllReplacementsRegex(),
-    ).trim();
+    responseText = replacementManager.applyAll(responseText);
 
     const usage = responseObject.usageMetadata;
     const stopReason: FinishReason =

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -20,8 +20,8 @@ import {
 import {
   applyReplacements,
   getReplacementsByCategory,
-  getAllReplacements,
 } from '@replacement/replacementUtils';
+import replacementManager from '@replacement/replacementManager';
 import {
   runLatexdiffForRound,
   runLatexdiffBetweenRounds,
@@ -156,7 +156,7 @@ export class OutputHandler {
 
   /** Processes XML content by filtering tags and applying replacements. */
   public async processXmlContent(content: string): Promise<string> {
-    content = applyReplacements(content, getAllReplacements()).trim();
+    content = replacementManager.applyNonRegex(content);
 
     const latexXmlReplacements = getReplacementsByCategory('latex_xml');
     if (latexXmlReplacements) {

--- a/src/commands/latexCommands.ts
+++ b/src/commands/latexCommands.ts
@@ -7,11 +7,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { getRelativePath } from '@utils/files';
 import { sleep } from '@utils/helpers';
-import {
-  applyReplacements,
-  getAllReplacements,
-  getAllReplacementsRegex,
-} from '../replacement/replacementUtils';
+import replacementManager from '../replacement/replacementManager';
 
 // Local imports - latex utils
 import { runLatexFormatter } from '../latex/texFormatter';
@@ -58,19 +54,7 @@ async function handleApplyReplacements(): Promise<void> {
     const text = document.getText();
 
     // Apply replacements
-    let processedText = text;
-    processedText = applyReplacements(
-      processedText,
-      getAllReplacements(),
-    ).trim();
-    processedText = applyReplacements(
-      processedText,
-      getAllReplacementsRegex(),
-    ).trim();
-    processedText = applyReplacements(
-      processedText,
-      getAllReplacements(),
-    ).trim();
+    const processedText = replacementManager.applyAll(text);
 
     // Update document content
     const fullRange = new vscode.Range(

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -18,11 +18,7 @@ import { logErrorMessage } from '@utils/errorHandlingUtils';
 import { runLatexFormatter } from './texFormatter';
 
 // Local imports - replacement utils
-import {
-  applyReplacements,
-  getAllReplacements,
-  getAllReplacementsRegex,
-} from '../replacement/replacementUtils';
+import replacementManager from '../replacement/replacementManager';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -291,13 +287,7 @@ async function processDiffFile(
     }
 
     // Apply standard replacements from the replacementUtils at the end of processing
-    // First apply normal replacements
-    newContent = applyReplacements(newContent, getAllReplacements()).trim();
-    // Then apply regex replacements (which include LATEXDIFF_MARKUP_REPLACEMENTS)
-    newContent = applyReplacements(
-      newContent,
-      getAllReplacementsRegex(),
-    ).trim();
+    newContent = replacementManager.applyAll(newContent);
 
     await writeFile(diffFileName, newContent);
     // logger.debug(channel, `Line breaks added to ${diffFileName}`);

--- a/src/replacement/replacementManager.ts
+++ b/src/replacement/replacementManager.ts
@@ -1,0 +1,38 @@
+// Local imports - replacement utilities
+import {
+  applyReplacements,
+  getAllReplacements,
+  getAllReplacementsRegex,
+} from './replacementUtils';
+
+/**
+ * Provides high-level APIs for applying text replacement rules.
+ */
+export const replacementManager = {
+  /**
+   * Apply all non-regex replacement rules.
+   */
+  applyNonRegex(text: string): string {
+    return applyReplacements(text, getAllReplacements()).trim();
+  },
+
+  /**
+   * Apply all regex-based replacement rules.
+   */
+  applyRegex(text: string): string {
+    return applyReplacements(text, getAllReplacementsRegex()).trim();
+  },
+
+  /**
+   * Apply the full set of replacement rules. Non-regex replacements are
+   * executed before and after regex replacements to resolve any nested
+   * transformations.
+   */
+  applyAll(text: string): string {
+    let processed = this.applyNonRegex(text);
+    processed = this.applyRegex(processed);
+    return this.applyNonRegex(processed);
+  },
+};
+
+export default replacementManager;


### PR DESCRIPTION
## Summary
- add `replacementManager` with high-level replacement helpers
- use the manager in agent modules and LaTeX utilities

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684e83f6e6248324b58c171bd56c0b31