### PR TITLE
Expand SDK error handling

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -2,11 +2,7 @@
 // (none needed)
 
 // Third-party imports
-import OpenAI, {
-  RateLimitError,
-  NotFoundError,
-  PermissionDeniedError,
-} from 'openai';
+import OpenAI from 'openai';
 import { ChatCompletionContentPart } from 'openai/resources/chat/completions';
 import { countTokens } from 'gpt-tokenizer';
 
@@ -14,6 +10,7 @@ import { countTokens } from 'gpt-tokenizer';
 import { readFile, writeFile, fileExistsAndNonTrivial } from '@utils/files';
 import { cleanFileContent } from '../../replacement/replacementUtils';
 import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
+import { formatProviderError } from '@utils/sdkErrorUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '../core/AgentConfig';
@@ -180,16 +177,10 @@ export class ModelHandlerOpenAI extends ModelHandler {
         // in the future if we pass stream to outside (signal: controller.signal)), calling stream.controller.abort() will abort the stream; which will be very useful for our stop button (controller.abort();)
         // we should also make sure partial results can be returned in the presence of errors!
       } catch (err) {
-        if (
-          err instanceof NotFoundError ||
-          err instanceof RateLimitError ||
-          err instanceof PermissionDeniedError
-        ) {
-          throw err;
-        }
         this.logger.error(
-          `Error in createResponse(streaming): ${err instanceof Error ? err.message : String(err)}`,
+          formatProviderError('Error in createResponse(streaming)', err),
         );
+        throw err;
       }
       return response;
     } else {
@@ -199,9 +190,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
         });
         return response;
       } catch (err) {
-        this.logger.error(
-          `Error in createResponse: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        this.logger.error(formatProviderError('Error in createResponse', err));
         throw err;
       }
     }

--- a/src/utils/sdkErrorUtils.ts
+++ b/src/utils/sdkErrorUtils.ts
@@ -6,6 +6,12 @@ import {
   AuthenticationError as OpenAIAuthenticationError,
   PermissionDeniedError as OpenAIPermissionDeniedError,
   RateLimitError as OpenAIRateLimitError,
+  BadRequestError as OpenAIBadRequestError,
+  NotFoundError as OpenAINotFoundError,
+  ConflictError as OpenAIConflictError,
+  UnprocessableEntityError as OpenAIUnprocessableEntityError,
+  InternalServerError as OpenAIInternalServerError,
+  APIUserAbortError as OpenAIUserAbortError,
 } from 'openai';
 import {
   APIConnectionError as AnthropicConnectionError,
@@ -14,13 +20,22 @@ import {
   AuthenticationError as AnthropicAuthenticationError,
   PermissionDeniedError as AnthropicPermissionDeniedError,
   RateLimitError as AnthropicRateLimitError,
+  BadRequestError as AnthropicBadRequestError,
+  NotFoundError as AnthropicNotFoundError,
+  ConflictError as AnthropicConflictError,
+  UnprocessableEntityError as AnthropicUnprocessableEntityError,
+  InternalServerError as AnthropicInternalServerError,
+  APIUserAbortError as AnthropicUserAbortError,
 } from '@anthropic-ai/sdk';
 
 // Local imports
 import { getConfig } from './config';
 
-// Google GenAI errors are not formally exported, but the SDK assigns
-// the names 'ClientError' and 'ServerError'. We detect them via name.
+// Google GenAI errors are still not exported as of v1.5.1 of the SDK,
+// but the runtime uses the names `ClientError` and `ServerError`.
+// We detect them via those names when inspecting the error object.
+// The OpenAI Responses API reuses the standard OpenAI error classes so
+// no additional imports are required.
 
 /**
  * Returns a human-readable message for common SDK errors.
@@ -47,11 +62,43 @@ export function getSdkErrorMessage(err: unknown): string {
     [AnthropicAuthenticationError, 'Authentication failed.'],
     [OpenAIPermissionDeniedError, 'Permission denied.'],
     [AnthropicPermissionDeniedError, 'Permission denied.'],
+    [OpenAIBadRequestError, 'Bad request.'],
+    [AnthropicBadRequestError, 'Bad request.'],
+    [OpenAINotFoundError, 'Resource not found.'],
+    [AnthropicNotFoundError, 'Resource not found.'],
+    [OpenAIConflictError, 'Conflict error.'],
+    [AnthropicConflictError, 'Conflict error.'],
+    [OpenAIUnprocessableEntityError, 'Unprocessable entity.'],
+    [AnthropicUnprocessableEntityError, 'Unprocessable entity.'],
+    [OpenAIInternalServerError, 'Internal server error.'],
+    [AnthropicInternalServerError, 'Internal server error.'],
+    [OpenAIUserAbortError, 'Request aborted.'],
+    [AnthropicUserAbortError, 'Request aborted.'],
   ];
 
   for (const [ErrorClass, message] of errorMapping) {
     if (err instanceof ErrorClass) {
       return message;
+    }
+  }
+  const maybeCode = err as { code?: number; status?: number } | undefined;
+  const code = maybeCode?.code ?? maybeCode?.status;
+  if (typeof code === 'number') {
+    const codeMapping: Record<number, string> = {
+      400: 'Bad request.',
+      401: 'Authentication failed.',
+      403: 'Permission denied.',
+      404: 'Resource not found.',
+      409: 'Conflict error.',
+      422: 'Unprocessable entity.',
+      429: 'Rate limit exceeded.',
+      500: 'Internal server error.',
+      503: 'Service unavailable.',
+      504: 'Deadline exceeded.',
+    };
+    const mapped = codeMapping[code];
+    if (mapped) {
+      return mapped;
     }
   }
   if (err instanceof OpenAIAPIError || err instanceof AnthropicAPIError) {


### PR DESCRIPTION
## Summary
- clarify GenAI fallback comment and add code-based mapping
- log and rethrow errors in the OpenAI handler the same way as other providers

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find module `@modelcontextprotocol/sdk/client/index.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684e83ae96e08324b1d28d8cd41ff7b3