### PR TITLE
fix: hide compare actions when no base file

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -402,23 +402,31 @@ export function updateFileList(filesByRound) {
       }
 
       if (compareBtn) {
-        compareBtn.addEventListener('click', () => {
-          vscode.postMessage({
-            command: COMMANDS.COMPARE_ORIGINAL,
-            file: info.path,
-            base: info.base,
+        if (info.base) {
+          compareBtn.addEventListener('click', () => {
+            vscode.postMessage({
+              command: COMMANDS.COMPARE_ORIGINAL,
+              file: info.path,
+              base: info.base,
+            });
           });
-        });
+        } else {
+          compareBtn.remove();
+        }
       }
 
       if (acceptBtn) {
-        acceptBtn.addEventListener('click', () => {
-          vscode.postMessage({
-            command: COMMANDS.ACCEPT_FILE,
-            file: info.path,
-            base: info.base,
+        if (info.base) {
+          acceptBtn.addEventListener('click', () => {
+            vscode.postMessage({
+              command: COMMANDS.ACCEPT_FILE,
+              file: info.path,
+              base: info.base,
+            });
           });
-        });
+        } else {
+          acceptBtn.remove();
+        }
       }
 
       if (mergeBtn) {

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -430,13 +430,17 @@ export function updateFileList(filesByRound) {
       }
 
       if (mergeBtn) {
-        mergeBtn.addEventListener('click', () => {
-          vscode.postMessage({
-            command: COMMANDS.MERGE_FILE,
-            file: info.path,
-            base: info.base,
+        if (info.base) {
+          mergeBtn.addEventListener('click', () => {
+            vscode.postMessage({
+              command: COMMANDS.MERGE_FILE,
+              file: info.path,
+              base: info.base,
+            });
           });
-        });
+        } else {
+          mergeBtn.remove();
+        }
       }
 
       if (diffBtn) {

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -444,14 +444,18 @@ export function updateFileList(filesByRound) {
       }
 
       if (diffBtn) {
-        diffBtn.addEventListener('click', () => {
-          vscode.postMessage({
-            command: COMMANDS.LATEXDIFF_FILE,
-            file: info.path,
-            base: info.base,
-            prev: info.prev,
+        if (info.base) {
+          diffBtn.addEventListener('click', () => {
+            vscode.postMessage({
+              command: COMMANDS.LATEXDIFF_FILE,
+              file: info.path,
+              base: info.base,
+              prev: info.prev,
+            });
           });
-        });
+        } else {
+          diffBtn.remove();
+        }
       }
 
       if (prevBtn) {

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -217,6 +217,10 @@
   font-size: var(--font-size-sm);
   color: var(--vscode-descriptionForeground);
 }
+/* Remove left spacing when only one stat is shown */
+.file-stats span:first-child {
+  margin-left: 0;
+}
 
 .file-dir {
   opacity: var(--opacity-subtle);


### PR DESCRIPTION
## Summary
- don't show compare or accept actions when a generated file has no base file

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find module '@modelcontextprotocol/sdk/client/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684eb4505bb4832484c47fb64c86a840