### PR TITLE
Fix handling of generated output files

### DIFF
--- a/src/agent/BaseReflectionAgent.ts
+++ b/src/agent/BaseReflectionAgent.ts
@@ -693,11 +693,16 @@ export abstract class BaseReflectionAgent implements IAgent {
         const prevFile =
           Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
           null;
+        const origEntry =
+          this.outputHandler.generatedFiles[currRound]?.find(
+            (g) => g.path === file,
+          ) || null;
         const stats = await this.computeDiffStats(baseFile, file);
         fileInfos.push({
           path: file,
           base: baseFile,
           prev: prevFile,
+          orig: origEntry?.orig || null,
           ...stats,
         });
       }

--- a/src/agent/OutputHandler.ts
+++ b/src/agent/OutputHandler.ts
@@ -71,6 +71,7 @@ export class OutputHandler {
   public modelHandler: any;
   public logId: number;
   public outputFiles: { [key: number]: string[] };
+  public generatedFiles: { [key: number]: { path: string; orig: string }[] };
   public baseFiles: string[];
   public processGroupId?: string;
   protected logger: AgentLogger;
@@ -89,6 +90,7 @@ export class OutputHandler {
     this.modelHandler = modelHandler;
     this.logId = logId;
     this.outputFiles = { 0: [], 1: [] };
+    this.generatedFiles = {};
     this.baseFiles = baseFiles;
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
@@ -205,7 +207,7 @@ export class OutputHandler {
    * @returns Map of source files to their best matching target files
    * @private
    */
-  public createFileMapping(
+  public static createFileMapping(
     sourceFiles: string[],
     targetFiles: string[],
     matchStrategy: 'basename' | 'contains' = 'basename',
@@ -273,6 +275,23 @@ export class OutputHandler {
     }
 
     return fileMapping;
+  }
+
+  /**
+   * Instance wrapper for createFileMapping for backward compatibility.
+   */
+  public createFileMapping(
+    sourceFiles: string[],
+    targetFiles: string[],
+    matchStrategy: 'basename' | 'contains' = 'basename',
+    roundAware: boolean = false,
+  ): Map<string, string> {
+    return OutputHandler.createFileMapping(
+      sourceFiles,
+      targetFiles,
+      matchStrategy,
+      roundAware,
+    );
   }
 
   /** Updates \input commands in output files to reference new file paths. */
@@ -609,6 +628,12 @@ export class OutputHandler {
       const latexDocument = extractContentFromXMLbyTag(root, documentTag);
       if (latexDocument) {
         await writeFile(texFile, latexDocument);
+        const roundMatch = outputFile.match(/_r(\d+)_/);
+        const currRound = roundMatch ? parseInt(roundMatch[1]) : 0;
+        if (!this.generatedFiles[currRound]) {
+          this.generatedFiles[currRound] = [];
+        }
+        this.generatedFiles[currRound].push({ path: texFile, orig: texFile });
         return texFile;
       } else {
         this.logger.warn(
@@ -621,6 +646,12 @@ export class OutputHandler {
         );
         if (fallbackContent) {
           await writeFile(texFile, fallbackContent);
+          const roundMatch = outputFile.match(/_r(\d+)_/);
+          const currRound = roundMatch ? parseInt(roundMatch[1]) : 0;
+          if (!this.generatedFiles[currRound]) {
+            this.generatedFiles[currRound] = [];
+          }
+          this.generatedFiles[currRound].push({ path: texFile, orig: texFile });
           return texFile;
         }
         return texFile;
@@ -636,6 +667,12 @@ export class OutputHandler {
       );
       if (fallbackContent) {
         await writeFile(texFile, fallbackContent);
+        const roundMatch = outputFile.match(/_r(\d+)_/);
+        const currRound = roundMatch ? parseInt(roundMatch[1]) : 0;
+        if (!this.generatedFiles[currRound]) {
+          this.generatedFiles[currRound] = [];
+        }
+        this.generatedFiles[currRound].push({ path: texFile, orig: texFile });
         return texFile;
       }
       // Re-throw the original error if fallback also failed
@@ -712,6 +749,7 @@ export class OutputHandler {
     outputFile: string,
   ): Promise<string[]> {
     const outputFiles: string[] = [];
+    const dir = path.dirname(outputFile);
     const outputParts = path.basename(outputFile).split('_');
     const agent = outputParts.at(-3) ?? '';
     const model = outputParts.at(-1)?.split('.')[0] ?? '';
@@ -748,6 +786,13 @@ export class OutputHandler {
       );
       await writeFile(texFile, doc.content.trim());
       outputFiles.push(texFile);
+      if (!this.generatedFiles[currRound]) {
+        this.generatedFiles[currRound] = [];
+      }
+      this.generatedFiles[currRound].push({
+        path: texFile,
+        orig: path.join(dir, source),
+      });
       this.logger.debug(`TeX file written: ${texFile}`);
     }
 

--- a/src/agent/executeAgent.ts
+++ b/src/agent/executeAgent.ts
@@ -272,7 +272,18 @@ async function executeAgentWithLogging<T extends IAgent>(
           // Update status to stopped on successful completion
           progressViewProvider.updateStreamStatus(fullStreamId, 'stopped');
 
-          if (config.outputFiles && config.outputFiles.length > 0) {
+          const generatedOutputs = Object.values(
+            ((agent as any).outputHandler?.generatedFiles || {}) as {
+              [key: number]: { path: string }[];
+            },
+          )
+            .flat()
+            .map((g) => g.path);
+          if (generatedOutputs.length > 0) {
+            for (const out of generatedOutputs) {
+              await openBuildDisplayIfTex(out, { preserveFocus: true });
+            }
+          } else if (config.outputFiles && config.outputFiles.length > 0) {
             for (const out of config.outputFiles) {
               await openBuildDisplayIfTex(out, { preserveFocus: true });
             }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '../logger/logUtils';
 import { ProgressViewProvider } from './ProgressViewProvider';
+import { OutputHandler } from '../agent/OutputHandler';
 
 import { taskStateToAgentConfig } from '../utils/configConversion';
 
@@ -103,9 +104,21 @@ export class ProgressViewMessageHandler {
     const generated = this.provider.getOutputFiles(stream);
     const allFiles = new Set<string>(taskState.outputFiles || []);
     if (generated) {
-      Object.values(generated).forEach((infos) =>
-        infos.forEach((info) => allFiles.add(info.path)),
+      const infos = Object.values(generated).flat();
+      const originals = infos.map((i) => i.orig || i.base || i.path);
+      const paths = infos.map((i) => i.path);
+      const mapping = OutputHandler.createFileMapping(
+        originals,
+        paths,
+        'contains',
       );
+      if (mapping.size > 0) {
+        for (const orig of mapping.keys()) {
+          allFiles.add(orig);
+        }
+      } else {
+        originals.forEach((o) => allFiles.add(o));
+      }
     }
 
     await vscode.commands.executeCommand(command, {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -48,6 +48,7 @@ interface OutputFileInfo extends DiffStats {
   path: string;
   base?: string | null;
   prev?: string | null;
+  orig?: string | null;
 }
 
 export class ProgressViewProvider implements vscode.WebviewViewProvider {


### PR DESCRIPTION
## Summary
- track original file names when splitting LLM-generated outputs
- store original names in the progress provider and use them for packing
- open generated output files after agent runs
- reuse generic file mapping logic when aggregating output paths

## Testing
- `npm run format`
- `npm run lint` (with warnings)
- `npm test` *(webpack compiled but tests could not run)*

------
https://chatgpt.com/codex/tasks/task_e_684be6a209648324962768e8080eba7a