### PR TITLE
Fix output tracking for multi-file agents

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -45,7 +45,7 @@ import {
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import { ModelHandler } from '@agent/modelHandlers';
-import { OutputHandler } from '@agent/runtime/OutputHandler';
+import { OutputHandler, NamedOutputFile } from '@agent/runtime/OutputHandler';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
 import { buildUserVars } from '@agent/utils/userVars';
 import { IAgent } from '@agent/core/IAgent';
@@ -1280,6 +1280,7 @@ export abstract class BaseReflectionAgent implements IAgent {
             activeGroupId,
           );
           this.outputHandler.outputFiles[currRound] = [];
+          this.outputHandler.outputMappings[currRound] = [];
         }
       } catch (err) {
         this.logger.error(
@@ -1288,6 +1289,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         );
         // Ensure we have an empty array at minimum to prevent undefined errors
         this.outputHandler.outputFiles[currRound] = [];
+        this.outputHandler.outputMappings[currRound] = [];
       }
     } else {
       // Single output file case
@@ -1297,30 +1299,32 @@ export abstract class BaseReflectionAgent implements IAgent {
       );
 
       try {
-        let processedFile = outputFile;
+        let processed: NamedOutputFile = {
+          source: outputFile,
+          path: outputFile,
+        };
         if (this.agentSetting.agentType === AgentType.CoT) {
-          processedFile =
+          processed =
             await this.outputHandler.processSingleXmlOutput(outputFile);
         }
 
-        if (processedFile) {
+        if (processed && processed.path) {
           // Process output file - indent LaTeX file directly
-          await this.outputHandler.indentLatexFile(processedFile);
+          await this.outputHandler.indentLatexFile(processed.path);
           this.logger.debug(
-            `Indented single output file: ${processedFile}`,
+            `Indented single output file: ${processed.path}`,
             activeGroupId,
           );
 
-          this.outputHandler.outputFiles[currRound] = [processedFile];
-          this.outputHandler.outputMappings[currRound] = [
-            { source: outputFile, path: processedFile },
-          ];
+          this.outputHandler.outputFiles[currRound] = [processed.path];
+          this.outputHandler.outputMappings[currRound] = [processed];
         } else {
           this.logger.warn(
             `No processed file was generated from ${outputFile}`,
             activeGroupId,
           );
           this.outputHandler.outputFiles[currRound] = [];
+          this.outputHandler.outputMappings[currRound] = [];
         }
       } catch (err) {
         this.logger.error(
@@ -1328,6 +1332,7 @@ export abstract class BaseReflectionAgent implements IAgent {
           activeGroupId,
         );
         this.outputHandler.outputFiles[currRound] = [];
+        this.outputHandler.outputMappings[currRound] = [];
       }
     }
   }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -52,6 +52,7 @@ import { IAgent } from '@agent/core/IAgent';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
+import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 
 // Shared constants
 import {
@@ -682,12 +683,17 @@ export abstract class BaseReflectionAgent implements IAgent {
         const prevFile =
           Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
           null;
-        const stats = await this.computeDiffStats(baseFile, file);
+        const originalFile = originMap.get(file) || null;
+
+        // Use utility to determine effective base for diff computation
+        const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
+        const stats = await this.computeDiffStats(diffBase, file);
+
         fileInfos.push({
           path: file,
           base: baseFile,
           prev: prevFile,
-          original: originMap.get(file) || null,
+          original: originalFile,
           ...stats,
         });
       }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -669,6 +669,12 @@ export abstract class BaseReflectionAgent implements IAgent {
           : new Map<string, string>();
 
       const fileInfos = [] as any[];
+      const originMap = new Map(
+        (this.outputHandler.outputMappings[currRound] || []).map((p) => [
+          p.path,
+          p.source,
+        ]),
+      );
       for (const file of roundOutputs) {
         const baseFile =
           Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
@@ -681,6 +687,7 @@ export abstract class BaseReflectionAgent implements IAgent {
           path: file,
           base: baseFile,
           prev: prevFile,
+          original: originMap.get(file) || null,
           ...stats,
         });
       }
@@ -1246,11 +1253,11 @@ export abstract class BaseReflectionAgent implements IAgent {
       // Which would be different than the single output file case below.
 
       try {
-        const processedFiles =
+        const processedPairs =
           await this.outputHandler.processMultipleXmlOutputs(outputFile);
 
-        if (processedFiles && processedFiles.length > 0) {
-          // Process output files - indent LaTeX files directly
+        if (processedPairs && processedPairs.length > 0) {
+          const processedFiles = processedPairs.map((p) => p.path);
           await this.outputHandler.indentLatexFiles(processedFiles);
           this.logger.debug(
             `Indented multiple output files: ${processedFiles.join(',')}`,
@@ -1258,6 +1265,7 @@ export abstract class BaseReflectionAgent implements IAgent {
           );
 
           this.outputHandler.outputFiles[currRound] = processedFiles;
+          this.outputHandler.outputMappings[currRound] = processedPairs;
 
           // Only attempt to replace input commands if we have valid base files
           if (this.baseFiles && this.baseFiles.length > 0) {
@@ -1304,6 +1312,9 @@ export abstract class BaseReflectionAgent implements IAgent {
           );
 
           this.outputHandler.outputFiles[currRound] = [processedFile];
+          this.outputHandler.outputMappings[currRound] = [
+            { source: outputFile, path: processedFile },
+          ];
         } else {
           this.logger.warn(
             `No processed file was generated from ${outputFile}`,

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -64,6 +64,12 @@ export function getOutputFileName(
   return outputFile;
 }
 
+/** Pair of original source name and generated output path. */
+export interface NamedOutputFile {
+  source: string;
+  path: string;
+}
+
 /** Handles output file processing and validation for agent responses. */
 export class OutputHandler {
   public agentSetting: AgentSetting;
@@ -71,6 +77,7 @@ export class OutputHandler {
   public modelHandler: any;
   public logId: number;
   public outputFiles: { [key: number]: string[] };
+  public outputMappings: { [key: number]: NamedOutputFile[] };
   public baseFiles: string[];
   public processGroupId?: string;
   protected logger: AgentLogger;
@@ -89,6 +96,7 @@ export class OutputHandler {
     this.modelHandler = modelHandler;
     this.logId = logId;
     this.outputFiles = { 0: [], 1: [] };
+    this.outputMappings = { 0: [], 1: [] };
     this.baseFiles = baseFiles;
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
@@ -507,7 +515,7 @@ export class OutputHandler {
   /** Processes multiple output files with XML splitting and filtering. */
   public async processMultipleXmlOutputs(
     outputFile: string,
-  ): Promise<string[]> {
+  ): Promise<NamedOutputFile[]> {
     this.logger.debug(
       `Splitting multiple scratchpad output XML: ${outputFile}`,
     );
@@ -651,7 +659,7 @@ export class OutputHandler {
     outputFile: string,
     documentTag: string,
     thinkingTag: string = 'scratchpad',
-  ): Promise<string[]> {
+  ): Promise<NamedOutputFile[]> {
     let outputContent = await readFile(outputFile);
 
     const tagsToWrap = [thinkingTag, 'document'];
@@ -710,8 +718,8 @@ export class OutputHandler {
   async processMultipleLatexDocuments(
     latexDocuments: Array<{ content: string; name: string }>,
     outputFile: string,
-  ): Promise<string[]> {
-    const outputFiles: string[] = [];
+  ): Promise<NamedOutputFile[]> {
+    const outputFiles: NamedOutputFile[] = [];
     const outputParts = path.basename(outputFile).split('_');
     const agent = outputParts.at(-3) ?? '';
     const model = outputParts.at(-1)?.split('.')[0] ?? '';
@@ -747,7 +755,7 @@ export class OutputHandler {
         currRound,
       );
       await writeFile(texFile, doc.content.trim());
-      outputFiles.push(texFile);
+      outputFiles.push({ source, path: texFile });
       this.logger.debug(`TeX file written: ${texFile}`);
     }
 

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -501,15 +501,27 @@ export class OutputHandler {
   }
 
   /** Processes single output file with XML splitting and filtering. */
-  public async processSingleXmlOutput(outputFile: string): Promise<string> {
+  public async processSingleXmlOutput(
+    outputFile: string,
+  ): Promise<NamedOutputFile> {
     this.logger.debug(`Splitting scratchpad output XML: ${outputFile}`);
+
     const processedOutputFile = await this.splitScratchpadOutputXml(
       outputFile,
       this.agentSetting.documentTag,
     );
+
+    const xmlContent = await readFile(outputFile);
+    let original = '';
+    const nameMatch = xmlContent.match(/<document[^>]*name="(.*?)"[^>]*>/);
+    if (nameMatch && nameMatch[1]) {
+      original = nameMatch[1].trim();
+    }
+
     const content = await readFile(processedOutputFile);
     await writeFile(processedOutputFile, content);
-    return processedOutputFile;
+
+    return { source: original || outputFile, path: processedOutputFile };
   }
 
   /** Processes multiple output files with XML splitting and filtering. */

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -272,10 +272,13 @@ async function executeAgentWithLogging<T extends IAgent>(
           // Update status to stopped on successful completion
           progressViewProvider.updateStreamStatus(fullStreamId, 'stopped');
 
-          if (config.outputFiles && config.outputFiles.length > 0) {
-            for (const out of config.outputFiles) {
-              await openBuildDisplayIfTex(out, { preserveFocus: true });
-            }
+          const generated: string[] = Object.values(
+            (agent as any).outputHandler?.outputFiles || {},
+          )
+            .flat()
+            .filter(Boolean) as string[];
+          for (const out of generated) {
+            await openBuildDisplayIfTex(out, { preserveFocus: true });
           }
         } catch (err) {
           // Mark the task as failed

--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -26,6 +26,7 @@ logger.initialize(CHANNEL);
 export function registerCompareCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.compare', handleCompare),
+    vscode.commands.registerCommand('texra.acceptEdited', handleAcceptEdited),
   );
 }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -102,9 +102,16 @@ export class ProgressViewMessageHandler {
 
     const generated = this.provider.getOutputFiles(stream);
     const allFiles = new Set<string>(taskState.outputFiles || []);
+    const outputMappings: { source: string; path: string }[] = [];
     if (generated) {
       Object.values(generated).forEach((infos) =>
-        infos.forEach((info) => allFiles.add(info.path)),
+        infos.forEach((info) => {
+          const source = info.original || info.path;
+          allFiles.add(source);
+          if (info.original) {
+            outputMappings.push({ source, path: info.path });
+          }
+        }),
       );
     }
 
@@ -115,6 +122,7 @@ export class ProgressViewMessageHandler {
       outputNameOverride: taskState.outputNameOverride,
       outputFiles: Array.from(allFiles),
       outputFilesActive: taskState.activeFiles.output,
+      outputMappings,
     });
   }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -97,32 +97,32 @@ export class ProgressViewMessageHandler {
       logger.warn(CHANNEL, `No taskState found for stream: ${stream}`);
       return;
     }
-    logger.debug(CHANNEL, `Found taskState for stream: ${stream}`);
-    logger.debug(CHANNEL, `Task state: ${JSON.stringify(taskState)}`);
+    // logger.debug(CHANNEL, `Found taskState for stream: ${stream}`);
+    // logger.debug(CHANNEL, `Task state: ${JSON.stringify(taskState)}`);
 
     const generated = this.provider.getOutputFiles(stream);
     const allFiles = new Set<string>(taskState.outputFiles || []);
-    const outputMappings: { source: string; path: string }[] = [];
     if (generated) {
       Object.values(generated).forEach((infos) =>
         infos.forEach((info) => {
-          const source = info.original || info.path;
-          allFiles.add(source);
-          if (info.original) {
-            outputMappings.push({ source, path: info.path });
-          }
+          // Use original name if available, otherwise use the generated path
+          const fileToAdd = info.original || info.path;
+          allFiles.add(fileToAdd);
         }),
       );
     }
+
+    const outputFilesArray = Array.from(allFiles);
 
     await vscode.commands.executeCommand(command, {
       agent: taskState.agent,
       model: taskState.model,
       inputFile: taskState.inputFile,
       outputNameOverride: taskState.outputNameOverride,
-      outputFiles: Array.from(allFiles),
-      outputFilesActive: taskState.activeFiles.output,
-      outputMappings,
+      outputFiles: outputFilesArray,
+      activeFiles: {
+        output: outputFilesArray.length > 0,
+      },
     });
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -48,6 +48,7 @@ interface OutputFileInfo extends DiffStats {
   path: string;
   base?: string | null;
   prev?: string | null;
+  original?: string;
 }
 
 export class ProgressViewProvider implements vscode.WebviewViewProvider {

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -17,12 +17,12 @@ import {
   getStatusIcon,
   formatDuration,
   formatTokens,
-  formatGroupHeaderElements,
   getGroupHeaderClass,
   BULLET_MARKUP,
 } from './logFormatters.js';
 import { STATUS, COMMANDS, SPLIT_SIZES, TOOLBAR_BUTTONS } from './constants.js';
 import { createIconButton } from '@common/templateUtils.js';
+import { getEffectiveBaseFile } from '@utils/files/baseFileUtils.js';
 
 const STATUS_MAP = {
   [STATUS.RUNNING]: {
@@ -377,8 +377,13 @@ export function updateFileList(filesByRound) {
       const diffBtn = fragment.querySelector('.diff-btn');
       const prevBtn = fragment.querySelector('.prev-btn');
 
-      const basename = info.path.split('/').pop();
-      const dirPath = info.path.slice(0, info.path.length - basename.length);
+      // Use original name if available, otherwise use generated path
+      const displayPath = info.original || info.path;
+      const basename = displayPath.split('/').pop();
+      const dirPath = displayPath.slice(
+        0,
+        displayPath.length - basename.length,
+      );
 
       if (dirEl) dirEl.textContent = dirPath;
       if (baseEl) baseEl.textContent = basename;
@@ -402,12 +407,17 @@ export function updateFileList(filesByRound) {
       }
 
       if (compareBtn) {
-        if (info.base) {
+        const baseFile = getEffectiveBaseFile(
+          info.base,
+          info.original,
+          info.path,
+        );
+        if (baseFile) {
           compareBtn.addEventListener('click', () => {
             vscode.postMessage({
               command: COMMANDS.COMPARE_ORIGINAL,
               file: info.path,
-              base: info.base,
+              base: baseFile,
             });
           });
         } else {
@@ -416,12 +426,17 @@ export function updateFileList(filesByRound) {
       }
 
       if (acceptBtn) {
-        if (info.base) {
+        const baseFile = getEffectiveBaseFile(
+          info.base,
+          info.original,
+          info.path,
+        );
+        if (baseFile) {
           acceptBtn.addEventListener('click', () => {
             vscode.postMessage({
               command: COMMANDS.ACCEPT_FILE,
               file: info.path,
-              base: info.base,
+              base: baseFile,
             });
           });
         } else {
@@ -430,12 +445,17 @@ export function updateFileList(filesByRound) {
       }
 
       if (mergeBtn) {
-        if (info.base) {
+        const baseFile = getEffectiveBaseFile(
+          info.base,
+          info.original,
+          info.path,
+        );
+        if (baseFile) {
           mergeBtn.addEventListener('click', () => {
             vscode.postMessage({
               command: COMMANDS.MERGE_FILE,
               file: info.path,
-              base: info.base,
+              base: baseFile,
             });
           });
         } else {
@@ -444,12 +464,17 @@ export function updateFileList(filesByRound) {
       }
 
       if (diffBtn) {
-        if (info.base) {
+        const baseFile = getEffectiveBaseFile(
+          info.base,
+          info.original,
+          info.path,
+        );
+        if (baseFile) {
           diffBtn.addEventListener('click', () => {
             vscode.postMessage({
               command: COMMANDS.LATEXDIFF_FILE,
               file: info.path,
-              base: info.base,
+              base: baseFile,
               prev: info.prev,
             });
           });

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -22,7 +22,27 @@ import {
 } from './logFormatters.js';
 import { STATUS, COMMANDS, SPLIT_SIZES, TOOLBAR_BUTTONS } from './constants.js';
 import { createIconButton } from '@common/templateUtils.js';
-import { getEffectiveBaseFile } from '@utils/files/baseFileUtils.js';
+// Note: We'll inline the getEffectiveBaseFile function since modules can't use TS aliases
+/**
+ * Get the effective base file for comparison operations.
+ * @param {string|null|undefined} base - The explicit base file path
+ * @param {string|null|undefined} original - The original source file path
+ * @param {string} current - The current generated file path
+ * @returns {string|null} The effective base file path or null
+ */
+function getEffectiveBaseFile(base, original, current) {
+  // Use explicit base if available
+  if (base) {
+    return base;
+  }
+
+  // Use original as base if it exists and differs from current
+  if (original && original !== current) {
+    return original;
+  }
+
+  return null;
+}
 
 const STATUS_MAP = {
   [STATUS.RUNNING]: {

--- a/src/utils/files/baseFileUtils.ts
+++ b/src/utils/files/baseFileUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * Utilities for determining effective base files for comparisons and operations.
+ */
+
+/**
+ * Get the effective base file for comparison operations.
+ * Returns the explicit base file if available, otherwise falls back to the original
+ * file if it differs from the current file.
+ *
+ * @param base - The explicit base file path (may be null)
+ * @param original - The original source file path (may be null)
+ * @param current - The current generated file path
+ * @returns The effective base file path or null if no suitable base exists
+ */
+export function getEffectiveBaseFile(
+  base: string | null | undefined,
+  original: string | null | undefined,
+  current: string,
+): string | null {
+  // Use explicit base if available
+  if (base) {
+    return base;
+  }
+
+  // Use original as base if it exists and differs from current
+  if (original && original !== current) {
+    return original;
+  }
+
+  return null;
+}

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -2,3 +2,4 @@ export * from './workspaceFileUtils';
 export * from './absoluteFileUtils';
 export * from './workspaceStorageUtils';
 export * from './pastedImageUtils';
+export * from './baseFileUtils';


### PR DESCRIPTION
## Summary
- track original document names for generated files
- persist mapping of source names to generated paths
- open generated files after agent run
- expose original names in progress view
- pass original output names when packing from ProgressBoard

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ed3a998e483248e97739981785094