### PR TITLE
fix: disable suppression for XML reminder

### DIFF
--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -118,6 +118,7 @@ export async function checkExpectedOutputs(
             },
           },
         ],
+        false,
       );
       break;
     }


### PR DESCRIPTION
## Summary
- ensure the XML mismatch warning can't be dismissed permanently

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency & test output not shown)*

------
https://chatgpt.com/codex/tasks/task_e_684f1ed773308324b6e7df485fb28cf1