### PR TITLE
Fix progress view cleanup with output override

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -1,5 +1,6 @@
 // Standard library imports
 import * as path from 'path';
+import { getStreamId } from '@utils/streamUtils';
 import * as vscode from 'vscode';
 
 // Third-party imports
@@ -155,7 +156,7 @@ async function executeAgentWithLogging<T extends IAgent>(
 
     // Get the full stream ID
     const config = agent.config;
-    const fullStreamId = `${agentName}@${config.model}: ${path.basename(config.inputFile)}`;
+    const fullStreamId = getStreamId(agentName, config.model, config.inputFile);
 
     // Check if this stream is already running
     const currentStatus = progressViewProvider.getStreamStatus(fullStreamId);

--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import * as path from 'path';
+
+import { getStreamId } from '@utils/streamUtils';
 
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
@@ -17,17 +18,6 @@ import {
 
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
-
-function getStreamId(
-  agent: string,
-  model: string,
-  inputFile: string,
-  outputFiles?: string[],
-): string {
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
-}
 
 export function registerCleanCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -64,7 +54,13 @@ async function handleCleanSingle(
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(agent, model, inputFile);
+    const streamId = getStreamId(
+      agent,
+      model,
+      inputFile,
+      undefined,
+      outputNameOverride,
+    );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }
@@ -102,7 +98,13 @@ async function handleCleanMultiple(
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(agent, model, inputFile, outputFiles);
+    const streamId = getStreamId(
+      agent,
+      model,
+      inputFile,
+      outputFiles,
+      outputNameOverride,
+    );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }
@@ -147,6 +149,7 @@ export async function handleClean(config: any) {
       config.model,
       config.inputFile,
       outputFiles,
+      config.outputNameOverride,
     );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import * as path from 'path';
+
+import { getStreamId } from '@utils/streamUtils';
 
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
@@ -12,17 +13,6 @@ import { runPack, runPackSingle, runPackMultiple } from '../housekeeping';
 
 const CHANNEL = 'packCommands';
 logger.initialize(CHANNEL);
-
-function getStreamId(
-  agent: string,
-  model: string,
-  inputFile: string,
-  outputFiles?: string[],
-): string {
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
-}
 
 export function registerPackCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -64,6 +54,7 @@ async function handlePack(config: any) {
       config.model,
       config.inputFile,
       outputFiles,
+      config.outputNameOverride,
     );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
@@ -97,7 +88,13 @@ async function handlePackSingle(
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(agent, model, inputFile);
+    const streamId = getStreamId(
+      agent,
+      model,
+      inputFile,
+      undefined,
+      outputNameOverride,
+    );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }
@@ -137,7 +134,13 @@ async function handlePackMultiple(
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(agent, model, inputFile, outputFiles);
+    const streamId = getStreamId(
+      agent,
+      model,
+      inputFile,
+      outputFiles,
+      outputNameOverride,
+    );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }

--- a/src/utils/streamUtils.ts
+++ b/src/utils/streamUtils.ts
@@ -1,0 +1,22 @@
+import * as path from 'path';
+
+/**
+ * Generate a unique stream ID for progress view entries.
+ *
+ * @param agent The agent name
+ * @param model The model name
+ * @param inputFile The main input file path
+ * @param outputFiles Additional output files for multiple mode
+ * @param outputNameOverride Optional override for the output file name
+ */
+export function getStreamId(
+  agent: string,
+  model: string,
+  inputFile: string,
+  outputFiles: string[] = [],
+  outputNameOverride = '',
+): string {
+  const agentName = outputFiles.length > 1 ? `${agent}_multiple` : agent;
+  const baseName = path.basename(outputNameOverride || inputFile);
+  return `${agentName}@${model}: ${baseName}`;
+}


### PR DESCRIPTION
## Summary
- track output name override when generating stream identifiers
- clear output files correctly after packing or cleaning tasks
- extract common `getStreamId` helper and reuse it in command modules

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f1efa1e9083249cf0ec53f49646ff