### PR TITLE
Fix progress view cleanup with override

### DIFF
--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -1,11 +1,13 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+
+// Local imports - utils
+import { getStreamId } from '../utils/streamUtils';
 
 // Local imports - housekeeping
 import {
@@ -18,16 +20,6 @@ import {
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
 
-function getStreamId(
-  agent: string,
-  model: string,
-  inputFile: string,
-  outputFiles?: string[],
-): string {
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
-}
 
 export function registerCleanCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -67,8 +59,9 @@ async function handleCleanSingle(
     const streamId = getStreamId(
       agent,
       model,
-      outputNameOverride || inputFile,
+      inputFile,
       undefined,
+      outputNameOverride,
     );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
@@ -110,8 +103,9 @@ async function handleCleanMultiple(
     const streamId = getStreamId(
       agent,
       model,
-      outputNameOverride || inputFile,
+      inputFile,
       outputFiles,
+      outputNameOverride,
     );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
@@ -155,8 +149,9 @@ export async function handleClean(config: any) {
     const streamId = getStreamId(
       config.agent,
       config.model,
-      config.outputNameOverride || config.inputFile,
+      config.inputFile,
       outputFiles,
+      config.outputNameOverride,
     );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);

--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -64,7 +64,12 @@ async function handleCleanSingle(
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(agent, model, inputFile);
+    const streamId = getStreamId(
+      agent,
+      model,
+      outputNameOverride || inputFile,
+      undefined,
+    );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }
@@ -102,7 +107,12 @@ async function handleCleanMultiple(
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(agent, model, inputFile, outputFiles);
+    const streamId = getStreamId(
+      agent,
+      model,
+      outputNameOverride || inputFile,
+      outputFiles,
+    );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }
@@ -145,7 +155,7 @@ export async function handleClean(config: any) {
     const streamId = getStreamId(
       config.agent,
       config.model,
-      config.inputFile,
+      config.outputNameOverride || config.inputFile,
       outputFiles,
     );
     provider.clearOutputFiles(streamId);

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -62,7 +62,7 @@ async function handlePack(config: any) {
     const streamId = getStreamId(
       config.agent,
       config.model,
-      config.inputFile,
+      config.outputNameOverride || config.inputFile,
       outputFiles,
     );
     provider.clearOutputFiles(streamId);
@@ -97,7 +97,12 @@ async function handlePackSingle(
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(agent, model, inputFile);
+    const streamId = getStreamId(
+      agent,
+      model,
+      outputNameOverride || inputFile,
+      undefined,
+    );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }
@@ -137,7 +142,12 @@ async function handlePackMultiple(
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(agent, model, inputFile, outputFiles);
+    const streamId = getStreamId(
+      agent,
+      model,
+      outputNameOverride || inputFile,
+      outputFiles,
+    );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -1,11 +1,13 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 import { ProgressViewProvider } from '../progressView/ProgressViewProvider';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+
+// Local imports - utils
+import { getStreamId } from '../utils/streamUtils';
 
 // Local imports - housekeeping
 import { runPack, runPackSingle, runPackMultiple } from '../housekeeping';
@@ -13,16 +15,6 @@ import { runPack, runPackSingle, runPackMultiple } from '../housekeeping';
 const CHANNEL = 'packCommands';
 logger.initialize(CHANNEL);
 
-function getStreamId(
-  agent: string,
-  model: string,
-  inputFile: string,
-  outputFiles?: string[],
-): string {
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
-}
 
 export function registerPackCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -62,8 +54,9 @@ async function handlePack(config: any) {
     const streamId = getStreamId(
       config.agent,
       config.model,
-      config.outputNameOverride || config.inputFile,
+      config.inputFile,
       outputFiles,
+      config.outputNameOverride,
     );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
@@ -100,8 +93,9 @@ async function handlePackSingle(
     const streamId = getStreamId(
       agent,
       model,
-      outputNameOverride || inputFile,
+      inputFile,
       undefined,
+      outputNameOverride,
     );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
@@ -145,8 +139,9 @@ async function handlePackMultiple(
     const streamId = getStreamId(
       agent,
       model,
-      outputNameOverride || inputFile,
+      inputFile,
       outputFiles,
+      outputNameOverride,
     );
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);

--- a/src/utils/streamUtils.ts
+++ b/src/utils/streamUtils.ts
@@ -1,0 +1,32 @@
+// Stream ID utilities for command operations
+
+import * as path from 'path';
+
+/**
+ * Generates a stream ID for agent operations.
+ * Stream IDs follow the pattern: agent@model: filename
+ * 
+ * @param agent - The agent name
+ * @param model - The model name
+ * @param inputFile - The input file path (used as fallback)
+ * @param outputFiles - Optional array of output files (determines _multiple suffix)
+ * @param outputNameOverride - Optional override for the filename (empty strings treated as undefined)
+ * @returns The generated stream ID
+ */
+export function getStreamId(
+  agent: string,
+  model: string,
+  inputFile: string,
+  outputFiles?: string[],
+  outputNameOverride?: string,
+): string {
+  // Determine agent name with _multiple suffix if needed
+  const agentName =
+    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
+  
+  // Use outputNameOverride if provided and not empty, otherwise use inputFile
+  // This properly handles empty strings by treating them as falsy
+  const effectiveFileName = (outputNameOverride && outputNameOverride.trim()) || inputFile;
+  
+  return `${agentName}@${model}: ${path.basename(effectiveFileName)}`;
+}


### PR DESCRIPTION
## Summary
- ensure output name override is included when building stream IDs
- adjust pack and clean commands to pass the overridden path

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no output due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684f1efa1e9083249cf0ec53f49646ff