### PR TITLE
Refactor webview utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ This document sets the common conventions for contributions. Follow these norms 
 - UI components rely on VS Code codicons for icons (see `src/progressView/index.html`). Stick to these built-in icons to maintain a native look and feel.
 - CSS for views is organized per component under `src/progressView/styles` with shared variables in `src/common/styles/common.css`. Follow this structure when adding new styles.
 - Execute VS Code commands with `safeExecuteCommand` from `src/utils/commandUtils.ts` to handle errors gracefully.
-- Register webview handlers using a command map and `registerMessageHandlers` from `src/common/modules/messageRouter.js`.
+- Register webview handlers using a command map and `registerMessageHandlers` from `src/common/modules/webviewContext.js`.
 - Use `setupPasteListener` from `src/webview/modules/pasteHandler.js` to enable clipboard image pasting in text areas.
 - Implement agents using the `IAgent` interface (`src/agent/IAgent.ts`) for a consistent lifecycle.
 - Track log groups with numeric timestamps using `addLogMessage` in `src/logger/logUtils.ts`.
@@ -54,7 +54,7 @@ This document sets the common conventions for contributions. Follow these norms 
 - Manipulate webview DOM safely using `addEventListenerSafely` from `src/common/modules/domUtils.js`.
 - Format and log errors via `logErrorMessage` in `src/utils/errorHandlingUtils.ts`.
 - Categorize log entries with the `LogMessageType` enum (`src/types/LogTypes.ts`).
-- Share modules like `messageRouter` and `vscodeApi` under `src/common/modules` across webviews.
+- Share common webview helpers like `webviewContext` under `src/common/modules`.
 - Keep result and log group interfaces under `src/types` for reuse.
 - Retrieve included file extensions through `getIncludedExtensions` in `src/utils/fileTypeUtils.ts`.
 - Initialize new agent YAML files from the provided template for a consistent structure.

--- a/src/common/modules/vscodeApi.js
+++ b/src/common/modules/vscodeApi.js
@@ -1,2 +1,0 @@
-// Initialize VS Code API
-export const vscode = acquireVsCodeApi();

--- a/src/common/modules/webviewContext.js
+++ b/src/common/modules/webviewContext.js
@@ -1,3 +1,5 @@
+export const vscode = acquireVsCodeApi();
+
 export function registerMessageHandlers(handlers) {
   window.addEventListener('message', (event) => {
     const message = event.data;

--- a/src/common/modules/webviewState.js
+++ b/src/common/modules/webviewState.js
@@ -1,4 +1,4 @@
-import { vscode } from '@common/vscodeApi.js';
+import { vscode } from '@common/webviewContext.js';
 
 /**
  * Manages persistence of state for a single webview.

--- a/src/historyView/AgentHistoryViewProvider.ts
+++ b/src/historyView/AgentHistoryViewProvider.ts
@@ -158,8 +158,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
       const domHandlersUri = getHistoryViewUri('modules/domHandlers.js');
 
       // Common module URIs
-      const vscodeApiUri = getCommonUri('modules/vscodeApi.js');
-      const messageRouterUri = getCommonUri('modules/messageRouter.js');
+      const webviewContextUri = getCommonUri('modules/webviewContext.js');
       const commonStyleUri = getCommonUri('styles/common.css');
 
       // Node modules URIs
@@ -169,8 +168,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
         scriptUri,
         styleUri,
         commonStyleUri,
-        vscodeApiUri,
-        messageRouterUri,
+        webviewContextUri,
         domHandlersUri,
         codiconUri,
       });

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -19,8 +19,7 @@
       {
         "imports": {
           "./modules/domHandlers.js": "${domHandlersUri}",
-          "@common/vscodeApi.js": "${vscodeApiUri}",
-          "@common/messageRouter.js": "${messageRouterUri}"
+          "@common/webviewContext.js": "${webviewContextUri}"
         }
       }
     </script>

--- a/src/historyView/modules/domHandlers.js
+++ b/src/historyView/modules/domHandlers.js
@@ -1,4 +1,4 @@
-import { vscode } from '@common/vscodeApi.js';
+import { vscode } from '@common/webviewContext.js';
 /* global Mark */
 
 // Track search state

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -1,5 +1,4 @@
-import { vscode } from '@common/vscodeApi.js';
-import { registerMessageHandlers } from '@common/messageRouter.js';
+import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
 import {
   renderHistoryItems,
   setupEventListeners,

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -41,7 +41,7 @@ export class ProgressViewContentProvider {
       const webviewStateUri = getCommonUri('modules/webviewState.js');
 
       // Module paths
-      const vscodeApiUri = getCommonUri('modules/vscodeApi.js');
+      const webviewContextUri = getCommonUri('modules/webviewContext.js');
       const stateManagerUri = getWebviewUri('modules/stateManager.js');
       const messageHandlersUri = getWebviewUri('modules/messageHandlers.js');
       const domHandlersUri = getWebviewUri('modules/domHandlers.js');
@@ -50,7 +50,6 @@ export class ProgressViewContentProvider {
       const templateUtilsUri = getCommonUri('modules/templateUtils.js');
       const domUtilsUri = getCommonUri('modules/domUtils.js');
       const stringUtilsUri = getCommonUri('modules/stringUtils.js');
-      const messageRouterUri = getCommonUri('modules/messageRouter.js');
 
       const codiconUri = getNodeModulesUri('@vscode/codicons/dist/codicon.css');
       const codiconsFontUri = getNodeModulesUri(
@@ -65,15 +64,14 @@ export class ProgressViewContentProvider {
         splitJsUri,
         codiconUri,
         codiconsFontUri,
-        vscodeApiUri,
         webviewStateUri,
         stateManagerUri,
         messageHandlersUri,
         domHandlersUri,
-        messageRouterUri,
         domUtilsUri,
         stringUtilsUri,
         templateUtilsUri,
+        webviewContextUri,
         constantsUri,
         logFormattersUri,
       });

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -23,12 +23,11 @@
           "./modules/domHandlers.js": "${domHandlersUri}",
           "./modules/constants.js": "${constantsUri}",
           "./modules/logFormatters.js": "${logFormattersUri}",
-          "@common/vscodeApi.js": "${vscodeApiUri}",
+          "@common/webviewContext.js": "${webviewContextUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
-          "@common/stringUtils.js": "${stringUtilsUri}",
-          "@common/messageRouter.js": "${messageRouterUri}"
+          "@common/stringUtils.js": "${stringUtilsUri}"
         }
       }
     </script>

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,4 +1,4 @@
-import { vscode } from '@common/vscodeApi.js';
+import { vscode } from '@common/webviewContext.js';
 import {
   getCurrentStream,
   setStreamStatus,

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -22,7 +22,7 @@ import {
   updateLogGroup,
 } from './logFormatters.js';
 import { COMMANDS } from './constants.js';
-import { registerMessageHandlers } from '@common/messageRouter.js';
+import { registerMessageHandlers } from '@common/webviewContext.js';
 
 const handlers = {
   [COMMANDS.UPDATE_STREAMS]: (message) => {

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -5,7 +5,7 @@ import {
   applyGroupToggleStates,
   renderToolbar,
 } from './modules/domHandlers.js';
-import { vscode } from '@common/vscodeApi.js';
+import { vscode } from '@common/webviewContext.js';
 import { COMMANDS } from './modules/constants.js';
 
 // Initialize the state when the window loads

--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -45,8 +45,7 @@ export class WebviewContentProvider {
       const templateUtilsUri = getCommonUri('modules/templateUtils.js');
       const domUtilsUri = getCommonUri('modules/domUtils.js');
       const stringUtilsUri = getCommonUri('modules/stringUtils.js');
-      const messageRouterUri = getCommonUri('modules/messageRouter.js');
-      const vscodeApiUri = getCommonUri('modules/vscodeApi.js');
+      const webviewContextUri = getCommonUri('modules/webviewContext.js');
 
       const codiconUri = getNodeModulesUri('@vscode/codicons/dist/codicon.css');
       const codiconsFontUri = getNodeModulesUri(
@@ -78,8 +77,7 @@ export class WebviewContentProvider {
         fileHandlersUri,
         uiHandlersUri,
         templateUtilsUri,
-        messageRouterUri,
-        vscodeApiUri,
+        webviewContextUri,
         codiconUri,
         codiconsFontUri,
       });

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -17,12 +17,11 @@
           "./modules/fileHandlers.js": "${fileHandlersUri}",
           "./modules/uiHandlers.js": "${uiHandlersUri}",
           "./modules/messageHandlers.js": "${messageHandlersUri}",
-          "@common/vscodeApi.js": "${vscodeApiUri}",
+          "@common/webviewContext.js": "${webviewContextUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
-          "@common/messageRouter.js": "${messageRouterUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs"
         }
       }

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -1,4 +1,4 @@
-import { vscode } from '@common/vscodeApi.js';
+import { vscode } from '@common/webviewContext.js';
 import { saveState, stateManager } from './stateManager.js';
 import { MULTIPLE_SELECTIONS } from './constants.js';
 import {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1,5 +1,4 @@
-import { vscode } from '@common/vscodeApi.js';
-import { registerMessageHandlers } from '@common/messageRouter.js';
+import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { stateManager, restoreState, saveState } from './stateManager.js';

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -1,4 +1,4 @@
-import { vscode } from '@common/vscodeApi.js';
+import { vscode } from '@common/webviewContext.js';
 import { saveState } from './stateManager.js';
 import {
   MULTIPLE_SELECTIONS,

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -1,5 +1,5 @@
 import { restoreState, saveState } from './modules/stateManager.js';
-import { vscode } from '@common/vscodeApi.js';
+import { vscode } from '@common/webviewContext.js';
 import {
   setupMessageHandlers,
   initializeDataRequests,


### PR DESCRIPTION
## Summary
- replace `vscodeApi` and `messageRouter` with unified `webviewContext`
- update webview modules and providers to import the new helper
- adjust HTML import maps for `webviewContext`
- document new helper in `AGENTS.md`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning, webpack compiled with 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_685097fcb0b88324aafaaf1901ec2526