### PR TITLE
Fix progress view file union for packing

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -105,9 +105,10 @@ export class ProgressViewMessageHandler {
     if (generated) {
       Object.values(generated).forEach((infos) =>
         infos.forEach((info) => {
-          // Use original name if available, otherwise use the generated path
-          const fileToAdd = info.original || info.path;
-          allFiles.add(fileToAdd);
+          allFiles.add(info.path);
+          if (info.original) {
+            allFiles.add(info.original);
+          }
         }),
       );
     }


### PR DESCRIPTION
## Summary
- send both generated and original output files when packing or cleaning from progress view

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851a13fee908324a74b781c11f23a31