### PR TITLE
Move settings and history buttons to VS Code editor title bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -955,7 +955,14 @@
       {
         "command": "texra.showAgentHistory",
         "title": "Show Agent Execution History",
-        "category": "TeXRA"
+        "category": "TeXRA",
+        "icon": "$(history)"
+      },
+      {
+        "command": "texra.openSettings",
+        "title": "Open TeXRA Settings",
+        "category": "TeXRA",
+        "icon": "$(settings-gear)"
       },
       {
         "command": "texra.showProgressView",
@@ -1052,6 +1059,16 @@
           "command": "texra.createAgentWithAI",
           "when": "view == texra.folderExplorer",
           "group": "navigation"
+        },
+        {
+          "command": "texra.openSettings",
+          "when": "view == texra.mainView",
+          "group": "navigation@1"
+        },
+        {
+          "command": "texra.showAgentHistory",
+          "when": "view == texra.mainView",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,6 +29,7 @@ import { registerCompareCommands } from './commands/compareCommands';
 import { registerHelpCommands } from './commands/helpCommands';
 import { registerProgressViewCommands } from '@commands/progress/progressViewCommands';
 import { registerOpenFileCommands } from '@commands/files/openFileCommands';
+import { registerSettingsCommands } from './commands/settingsCommands';
 
 import * as logger from '@logger/logUtils';
 
@@ -69,6 +70,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     progressView: registerProgressViewCommands(context),
     openFile: registerOpenFileCommands(context),
     help: registerHelpCommands(context),
+    settings: registerSettingsCommands(context),
   };
 
   // Register webview provider
@@ -112,3 +114,4 @@ export { compareCommands } from './commands/compareCommands';
 export { helpCommands } from './commands/helpCommands';
 export { agentCreatorCommands } from '@commands/agentCreatorCommands';
 export { registerOpenFileCommands as openFileCommands } from '@commands/files/openFileCommands';
+export { settingsCommands } from './commands/settingsCommands';

--- a/src/commands/settingsCommands.ts
+++ b/src/commands/settingsCommands.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+
+export const settingsCommands = {
+  openSettings: 'texra.openSettings',
+};
+
+export function registerSettingsCommands(context: vscode.ExtensionContext) {
+  const openSettingsCommand = vscode.commands.registerCommand(
+    settingsCommands.openSettings,
+    async () => {
+      // Open VS Code settings with TeXRA filter
+      await vscode.commands.executeCommand(
+        'workbench.action.openSettings',
+        '@ext:texra-ai.texra',
+      );
+    },
+  );
+
+  context.subscriptions.push(openSettingsCommand);
+
+  return { openSettingsCommand };
+}

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -420,20 +420,6 @@
             </div>
             <div class="instruction-header-actions button-group">
               <button
-                id="settingsButton"
-                class="vscode-button"
-                title="Open Extension Settings"
-              >
-                <i class="codicon codicon-gear"></i>
-              </button>
-              <button
-                id="historyButton"
-                class="vscode-button"
-                title="Open Agent Execution History"
-              >
-                <i class="codicon codicon-history"></i>
-              </button>
-              <button
                 id="packButton"
                 class="vscode-button"
                 title="Pack the output for this agent into the History folder"

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -595,20 +595,6 @@ export function setupUIHandlers() {
     toggleLatexdiffs();
   });
 
-  // Add event listener for history button
-  addEventListenerSafely('historyButton', 'click', function () {
-    vscode.postMessage({
-      command: 'showAgentHistory',
-    });
-  });
-
-  // Add event listener for settings button
-  addEventListenerSafely('settingsButton', 'click', function () {
-    vscode.postMessage({
-      command: 'openSettings',
-    });
-  });
-
   // Compare and Accept button handlers
   addEventListenerSafely('compareButton', 'click', function () {
     const baseFile = safeGetElementValue('baseFile');


### PR DESCRIPTION
## Summary
- Moved settings and history buttons from the webview to VS Code's native editor title bar
- Created new `texra.openSettings` command to open extension settings
- Added appropriate icons to both commands

## Changes
1. **package.json**:
   - Added `texra.openSettings` command with settings-gear icon
   - Added history icon to existing `texra.showAgentHistory` command
   - Added both commands to `view/title` menu for `texra.mainView`

2. **Command Implementation**:
   - Created `src/commands/settingsCommands.ts` to handle the settings command
   - Registered the new command in the main commands file

3. **Webview Cleanup**:
   - Removed settings and history buttons from `src/webview/index.html`
   - Removed corresponding event handlers from `src/webview/modules/uiHandlers.js`

## Benefits
- More consistent with VS Code UI patterns
- Cleaner webview interface
- Buttons are now in a standard location that users expect
- Frees up space in the webview for content

## Test plan
- [x] Extension builds successfully
- [x] Settings button opens VS Code settings filtered to TeXRA
- [x] History button opens the agent execution history view
- [x] Buttons appear correctly in the title bar of texra.mainView
- [ ] No console errors when clicking the buttons
- [x] Webview loads without the removed buttons

🤖 Generated with [Claude Code](https://claude.ai/code)