### PR TITLE
Fix duplicate _multiple agent entry

### DIFF
--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -20,7 +20,11 @@ export async function promptToAddAgentToConfig(
   const config = vscode.workspace.getConfiguration();
   const current = config.get<string[]>('texra.agents', []);
 
-  if (current.includes(agentName)) {
+  const baseName = agentName.endsWith('_multiple')
+    ? agentName.replace(/_multiple$/, '')
+    : agentName;
+
+  if (current.includes(agentName) || current.includes(baseName)) {
     logger.debug(CHANNEL, `Agent "${agentName}" already in configuration`);
     return;
   }

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -23,10 +23,27 @@ export async function promptToAddAgentToConfig(
   const baseName = agentName.endsWith('_multiple')
     ? agentName.replace(/_multiple$/, '')
     : agentName;
+  const multipleName = agentName.endsWith('_multiple') ? agentName : `${agentName}_multiple`;
 
-  if (current.includes(agentName) || current.includes(baseName)) {
+  // Check if agent already exists (exact match)
+  if (current.includes(agentName)) {
     logger.debug(CHANNEL, `Agent "${agentName}" already in configuration`);
     return;
+  }
+
+  // Check if the base/multiple counterpart already exists
+  if (agentName.endsWith('_multiple')) {
+    // Adding a _multiple variant, check if base agent exists
+    if (current.includes(baseName)) {
+      logger.debug(CHANNEL, `Base agent "${baseName}" already in configuration, skipping "${agentName}"`);
+      return;
+    }
+  } else {
+    // Adding a base agent, check if _multiple variant exists  
+    if (current.includes(multipleName)) {
+      logger.debug(CHANNEL, `Multiple variant "${multipleName}" already in configuration, skipping "${agentName}"`);
+      return;
+    }
   }
 
   const addButton = 'Add Agent';


### PR DESCRIPTION
## Summary
- avoid adding `_multiple` variant if base agent already registered

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68527e183df08324acfec5d0b4a75b38