### PR TITLE
Rename verboseOutput to debugMode

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -193,11 +193,11 @@ This setting specifies a custom root path for the TeXRA file explorer view, whic
 Control logging behavior:
 
 ```json
-"texra.logger.verboseOutput": false,
+"texra.logger.debugMode": false,
 "texra.debug.saveMessageObjects": false
 ```
 
-- `verboseOutput`: Show detailed debug messages in the logger view
+- `debugMode`: Show detailed debug messages in the logger view
 - `saveMessageObjects`: Save message JSON objects to files before API calls (for debugging)
 
 ## Environment-Specific Configuration
@@ -258,7 +258,7 @@ For better performance:
 ```json
 "texra.model.useStreaming": true,
 "texra.files.ignored.directories": ["build", "node_modules", "versions", "history"],
-"texra.logger.verboseOutput": false
+"texra.logger.debugMode": false
 ```
 
 ### Optimizing for Quality

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -56,7 +56,7 @@ The header provides a summary and actions for the selected stream:
 This scrollable area displays the detailed, timestamped logs for the selected agent run.
 
 - **Structure**: Logs are organized into expandable/collapsible groups (e.g., `Initialization`, `Round 0`, `Model Operation`, `Response Cycle`) allowing you to focus on specific stages. Click the arrow next to a group name to toggle it.
-- **Log Levels**: Messages are prefixed with levels like `INFO`, `DEBUG`, `WARN`, `ERROR` to indicate severity. Verbose debug messages (`DEBUG`) are only shown if `texra.logger.verboseOutput` is enabled in settings.
+- **Log Levels**: Messages are prefixed with levels like `INFO`, `DEBUG`, `WARN`, `ERROR` to indicate severity. Verbose debug messages (`DEBUG`) are only shown if `texra.logger.debugMode` is enabled in settings.
 - **Agent Thinking**: The log highlights model reasoning in purple **Model Thinking** blocks. These sections are flagged internally with a `thinking` type so you can easily spot when the AI is exploring ideas.
 - **Errors**: Errors are highlighted, often providing clues if something went wrong.
 

--- a/package.json
+++ b/package.json
@@ -700,7 +700,7 @@
       {
         "title": "Logger",
         "properties": {
-          "texra.logger.verboseOutput": {
+          "texra.logger.debugMode": {
             "type": "boolean",
             "default": false,
             "description": "Whether to show verbose debug messages in the logger view",

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -104,11 +104,8 @@ class VSCodeTransport extends Transport {
       this.channel.appendLine(formattedMessage);
     }
 
-    // Skip debug messages in ProgressView if verbose output is disabled
-    if (
-      level === 'debug' &&
-      !getConfig<boolean>('logger.verboseOutput', false)
-    ) {
+    // Skip debug messages in ProgressView if debug mode is disabled
+    if (level === 'debug' && !getConfig<boolean>('logger.debugMode', false)) {
       callback();
       return;
     }
@@ -140,7 +137,7 @@ class VSCodeTransport extends Transport {
         : 'default';
 
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
-    const isVerbose = getConfig<boolean>('logger.verboseOutput', false);
+    const isVerbose = getConfig<boolean>('logger.debugMode', false);
     const coloredFormattedMessage =
       `<div class="log-line ${isScratchpad ? 'scratchpad-log' : ''}" ${scratchpadAttr} ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
       `<span class="timestamp" title="${timestamp}">${emoji}${

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -522,11 +522,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    // Skip debug messages if verbose output is disabled
-    if (
-      level === 'debug' &&
-      !getConfig<boolean>('logger.verboseOutput', false)
-    ) {
+    // Skip debug messages if debug mode is disabled
+    if (level === 'debug' && !getConfig<boolean>('logger.debugMode', false)) {
       return;
     }
 
@@ -702,8 +699,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     const messages = this._logStreams.get(stream)!;
-    // Filter debug messages if verbose output is disabled
-    const displayMessages = getConfig<boolean>('logger.verboseOutput', false)
+    // Filter debug messages if debug mode is disabled
+    const displayMessages = getConfig<boolean>('logger.debugMode', false)
       ? messages
       : messages.filter((msg) => msg.level !== 'debug');
 

--- a/src/utils/sdkErrorUtils.ts
+++ b/src/utils/sdkErrorUtils.ts
@@ -39,11 +39,11 @@ import { getConfig } from './config';
 
 /**
  * Returns a human-readable message for common SDK errors.
- * In debug mode (logger.verboseOutput = true), returns the full error message.
+ * In debug mode (logger.debugMode = true), returns the full error message.
  * Otherwise, returns a graceful, user-friendly message.
  */
 export function getSdkErrorMessage(err: unknown): string {
-  const isDebugMode = getConfig<boolean>('logger.verboseOutput', false);
+  const isDebugMode = getConfig<boolean>('logger.debugMode', false);
 
   // In debug mode, always show the full error message
   if (isDebugMode) {


### PR DESCRIPTION
## Summary
- rename `texra.logger.verboseOutput` setting to `texra.logger.debugMode`
- update documentation for the renamed setting
- adjust source references to use `debugMode`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test output not shown)*

------
https://chatgpt.com/codex/tasks/task_e_68554dc40cc08324a35bfe192c7eb1c0