### PR TITLE
Show API provider key status

### DIFF
--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import {
-  API_PROVIDERS,
   ApiProvider,
   getApiKeySecretName,
   setSecret,
   deleteSecret,
+  getApiProviderQuickPickItems,
 } from '@frontend/secrets';
 
 export const apiKeyCommands = {
@@ -18,9 +18,12 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
     apiKeyCommands.setApiKey,
     async () => {
       // First select the provider
-      const provider = await vscode.window.showQuickPick(API_PROVIDERS, {
+      const providerItems = await getApiProviderQuickPickItems();
+      const providerPick = await vscode.window.showQuickPick(providerItems, {
         placeHolder: 'Select API provider',
       });
+
+      const provider = providerPick?.provider;
 
       if (!provider) {
         return;
@@ -54,9 +57,12 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
   const removeApiKeyCommand = vscode.commands.registerCommand(
     apiKeyCommands.removeApiKey,
     async () => {
-      const provider = await vscode.window.showQuickPick(API_PROVIDERS, {
+      const providerItems = await getApiProviderQuickPickItems();
+      const providerPick = await vscode.window.showQuickPick(providerItems, {
         placeHolder: 'Select API provider to remove key',
       });
+
+      const provider = providerPick?.provider;
 
       if (!provider) {
         return;

--- a/src/frontend/secrets.ts
+++ b/src/frontend/secrets.ts
@@ -116,14 +116,15 @@ export interface ApiProviderQuickPickItem extends vscode.QuickPickItem {
 export async function getApiProviderQuickPickItems(): Promise<
   ApiProviderQuickPickItem[]
 > {
-  const items: ApiProviderQuickPickItem[] = [];
-  for (const provider of API_PROVIDERS) {
-    const exists = await apiKeyExists(provider);
-    items.push({
-      label: provider,
-      description: exists ? 'key set' : 'not set',
-      provider,
-    });
-  }
-  return items;
+  const checks = API_PROVIDERS.map(async (provider) => ({
+    provider,
+    exists: await apiKeyExists(provider),
+  }));
+
+  const results = await Promise.all(checks);
+  return results.map(({ provider, exists }) => ({
+    label: provider,
+    description: exists ? 'key set' : 'not set',
+    provider,
+  }));
 }

--- a/src/frontend/secrets.ts
+++ b/src/frontend/secrets.ts
@@ -89,3 +89,41 @@ export async function anyApiKeyExists(): Promise<boolean> {
 
   return false;
 }
+
+/**
+ * Check if an API key exists for a given provider
+ * @param provider The API provider to check
+ * @returns true if the API key exists in secrets or environment variables
+ */
+export async function apiKeyExists(provider: ApiProvider): Promise<boolean> {
+  const secretKey = await getSecret(getApiKeySecretName(provider));
+  if (secretKey) {
+    return true;
+  }
+
+  const envKey = `${provider.toUpperCase()}_API_KEY`;
+  return Boolean(process.env[envKey]);
+}
+
+export interface ApiProviderQuickPickItem extends vscode.QuickPickItem {
+  provider: ApiProvider;
+}
+
+/**
+ * Build quick pick items listing API providers with key status
+ * @returns Quick pick items with provider name and key status
+ */
+export async function getApiProviderQuickPickItems(): Promise<
+  ApiProviderQuickPickItem[]
+> {
+  const items: ApiProviderQuickPickItem[] = [];
+  for (const provider of API_PROVIDERS) {
+    const exists = await apiKeyExists(provider);
+    items.push({
+      label: provider,
+      description: exists ? 'key set' : 'not set',
+      provider,
+    });
+  }
+  return items;
+}


### PR DESCRIPTION
## Summary
- display whether API keys exist when selecting a provider
- expose helper functions to build provider quick pick items

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685556480e8c8324a1cd226a46479436