### PR TITLE
Hide pack/clean buttons unless debugging

### DIFF
--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -70,6 +70,7 @@ export class WebviewMessageHandler {
     this.handlers = {
       showInformationMessage: (message) => this.handleInfoMessage(message),
       getTheme: (_m, view) => this.handleThemeRequest(view),
+      getDebugMode: (_m, view) => this.handleDebugModeRequest(view),
       modelSelected: (message, view) =>
         this.handleModelSelection(message, view),
       execute: (message) => this.handleExecute(message),
@@ -191,6 +192,11 @@ export class WebviewMessageHandler {
         ? 'dark'
         : 'light';
     webviewView.webview.postMessage({ command: 'setTheme', theme });
+  }
+
+  private handleDebugModeRequest(webviewView: vscode.WebviewView) {
+    const debugMode = getConfig<boolean>('logger.debugMode', false);
+    webviewView.webview.postMessage({ command: 'setDebugMode', debugMode });
   }
 
   private handleModelSelection(message: any, webviewView: vscode.WebviewView) {

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -423,6 +423,7 @@
                 id="packButton"
                 class="vscode-button"
                 title="Pack the output for this agent into the History folder"
+                style="display: none"
               >
                 <i class="codicon codicon-archive"></i>
               </button>
@@ -430,6 +431,7 @@
                 id="cleanButton"
                 class="vscode-button"
                 title="Clean the output for this agent"
+                style="display: none"
               >
                 <i class="codicon codicon-trash"></i>
               </button>

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -2,6 +2,7 @@ import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { stateManager, restoreState, saveState } from './stateManager.js';
+import { setDebugMode as applyDebugMode } from './uiHandlers.js';
 
 import {
   updateFileSelect,
@@ -21,6 +22,7 @@ import { FILE_TYPES } from './constants.js';
 export function initializeDataRequests() {
   const dataRequests = [
     'getTheme',
+    'getDebugMode',
     'requestInputFile',
     'requestReferenceFile',
     'requestAuxiliaryFile',
@@ -233,6 +235,10 @@ export function setupMessageHandlers() {
   const handlers = {
     setTheme: (m) => {
       document.body.className = m.theme;
+      postHandle();
+    },
+    setDebugMode: (m) => {
+      applyDebugMode(m.debugMode);
       postHandle();
     },
     modelSelected: (m) => {

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -26,6 +26,23 @@ import {
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 
+let debugMode = false;
+
+function updateDebugButtonVisibility() {
+  const packBtn = safeGetElementById('packButton');
+  const cleanBtn = safeGetElementById('cleanButton');
+  [packBtn, cleanBtn].forEach((btn) => {
+    if (btn) {
+      btn.style.display = debugMode ? '' : 'none';
+    }
+  });
+}
+
+export function setDebugMode(enabled) {
+  debugMode = !!enabled;
+  updateDebugButtonVisibility();
+}
+
 // Add this function to handle textarea auto-resize
 export function autoResizeTextarea(textarea) {
   // Reset height to auto to get the correct scrollHeight
@@ -118,6 +135,8 @@ export function setupUIHandlers() {
       });
     }
   });
+
+  updateDebugButtonVisibility();
 
   // Helper functions for common tasks
   function getOutputNameOverride() {


### PR DESCRIPTION
## Summary
- hide pack/clean controls in the main webview when debug mode is off
- request debug mode from the extension and update UI accordingly

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855571e4a0c8324a64ff8452dab2783