### PR TITLE
Remove unused output override option

### DIFF
--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -140,13 +140,6 @@ When reflection is enabled, you may also see:
 
 - Round 1: `paper_polish_r1_sonnet37.tex`
 
-### Custom Output Names
-
-For specific needs, you can override the default naming:
-
-1. Click the ">" toggle next to "Output Filename"
-2. Enter your custom filename (including extension) in the revealed input field.
-
 ## File Management Commands
 
 TeXRA provides several commands for managing generated files, accessible from the main interface or the ProgressBoard:

--- a/docs/guide/multiple-output.md
+++ b/docs/guide/multiple-output.md
@@ -18,12 +18,11 @@ The TeXRA UI provides dedicated sections for managing multiple files:
 <!-- ![Multiple Files UI Placeholder](/images/multiple-files-ui.png) _(Placeholder: Screenshot highlighting Input Files & Multiple Outputs sections)_ -->
 
 - **Input Files**: Use the "▼" toggle to add multiple source files. These are typically concatenated and provided as context to the selected agent.
-- **Multiple Outputs**:
-  - Use the "▼" toggle to activate multiple output mode.
-  - Use the "+" button (<i class="codicon codicon-add"></i>) to list the _exact filenames_ you expect the agent to generate. **Order matters** if the agent references them by position.
-  - The list can be cleared (<i class="codicon codicon-trash"></i>).
-  - If this section is _not_ toggled/activated, TeXRA expects the agent to produce only a single output file, named based on the primary input file.
-- **Output Filename Override**: When _not_ using Multiple Outputs, you can specify a custom name for the single output file here. This is ignored if Multiple Outputs is active.
+  - **Multiple Outputs**:
+    - Use the "▼" toggle to activate multiple output mode.
+    - Use the "+" button (<i class="codicon codicon-add"></i>) to list the _exact filenames_ you expect the agent to generate. **Order matters** if the agent references them by position.
+    - The list can be cleared (<i class="codicon codicon-trash"></i>).
+    - If this section is _not_ toggled/activated, TeXRA expects the agent to produce only a single output file, named based on the primary input file.
 
 _(See [File Management](./file-management.md) for general UI controls.)_
 

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -17,7 +17,6 @@ export const DEFAULT_AGENT_CONFIG: AgentConfig = {
   mediaFile: null,
   mediaFiles: [],
   outputFiles: null,
-  outputNameOverride: null,
   editedFile: null,
   toolConfig: {} as ToolConfig,
 };
@@ -39,7 +38,6 @@ export interface AgentConfig {
   mediaFile: string | null;
   mediaFiles: string[] | null;
   outputFiles: string[] | null;
-  outputNameOverride: string | null;
   editedFile: string | null;
 
   // Tool configuration

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -170,9 +170,7 @@ export abstract class BaseReflectionAgent implements IAgent {
    * @returns Task ID string used for logging and output naming
    */
   private getTaskId(): string {
-    const baseName = path.basename(
-      this.agentConfig.outputNameOverride || this.agentConfig.inputFile,
-    );
+    const baseName = path.basename(this.agentConfig.inputFile);
     // Use the potentially modified agent name (with _multiple suffix if applicable)
     const agentName =
       Array.isArray(this.agentConfig.outputFiles) &&

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -14,8 +14,7 @@ export class CoTAgent extends BaseReflectionAgent {
    * @returns Formatted output file path incorporating model and round information
    */
   protected getOutputFile(currRound: number): string {
-    const baseOutputFile =
-      this.agentConfig.outputNameOverride || this.agentConfig.inputFile;
+    const baseOutputFile = this.agentConfig.inputFile;
     const fileExtension = this.useScratchpad
       ? 'xml'
       : this.agentSetting.outputExt;

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -14,8 +14,7 @@ export class DirectAgent extends BaseReflectionAgent {
    * @returns Formatted output file path incorporating model and round information
    */
   protected getOutputFile(currRound: number): string {
-    const baseOutputFile =
-      this.agentConfig.outputNameOverride || this.agentConfig.inputFile;
+    const baseOutputFile = this.agentConfig.inputFile;
     return getOutputFileName(
       baseOutputFile,
       this.agentConfig.agent,

--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -65,11 +65,10 @@ async function handleCleanSingle(
   inputFile: string,
   agent: string,
   model: string,
-  outputNameOverride: string = '',
 ) {
   logger.debug(
     CHANNEL,
-    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}, outputNameOverride=${outputNameOverride}`,
+    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}`,
   );
 
   if (!inputFile || !agent || !model) {
@@ -82,11 +81,7 @@ async function handleCleanSingle(
     );
     return;
   }
-  const result = await runCleanSingle(
-    model,
-    outputNameOverride || inputFile,
-    agent,
-  );
+  const result = await runCleanSingle(model, inputFile, agent);
   showCleanResult(result, inputFile);
 
   const provider = ProgressViewProvider.getInstance();
@@ -102,11 +97,10 @@ async function handleCleanMultiple(
   agent: string,
   model: string,
   outputFiles: string[] = [],
-  outputNameOverride?: string,
 ) {
   logger.debug(
     CHANNEL,
-    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}, outputNameOverride=${outputNameOverride}`,
+    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}`,
   );
   logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
 
@@ -121,16 +115,7 @@ async function handleCleanMultiple(
     return;
   }
 
-  const inputFilesWithOverride = outputNameOverride
-    ? [outputNameOverride, ...outputFiles]
-    : outputFiles;
-
-  const result = await runCleanMultiple(
-    model,
-    inputFile,
-    agent,
-    inputFilesWithOverride,
-  );
+  const result = await runCleanMultiple(model, inputFile, agent, outputFiles);
   showCleanResult(result, inputFile);
 
   const provider = ProgressViewProvider.getInstance();

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -80,7 +80,6 @@ async function handlePack(config: any) {
     config.inputFile,
     config.agent,
     outputFiles,
-    config.outputNameOverride,
   );
   showPackResult(result, config.inputFile);
 
@@ -101,11 +100,10 @@ async function handlePackSingle(
   inputFile: string,
   agent: string,
   model: string,
-  outputNameOverride?: string,
 ) {
   logger.debug(
     CHANNEL,
-    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}, outputNameOverride=${outputNameOverride}`,
+    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}`,
   );
 
   if (!inputFile || !agent || !model) {
@@ -119,9 +117,8 @@ async function handlePackSingle(
     return;
   }
 
-  const fileToPack = outputNameOverride || inputFile;
-  const result = await runPackSingle(model, fileToPack, agent);
-  showPackResult(result, fileToPack);
+  const result = await runPackSingle(model, inputFile, agent);
+  showPackResult(result, inputFile);
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
@@ -136,11 +133,10 @@ async function handlePackMultiple(
   agent: string,
   model: string,
   outputFiles: string[] = [],
-  outputNameOverride?: string,
 ) {
   logger.debug(
     CHANNEL,
-    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}, outputNameOverride=${outputNameOverride}`,
+    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}`,
   );
   logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
 
@@ -155,13 +151,7 @@ async function handlePackMultiple(
     return;
   }
 
-  const result = await runPackMultiple(
-    model,
-    inputFile,
-    agent,
-    outputFiles,
-    outputNameOverride,
-  );
+  const result = await runPackMultiple(model, inputFile, agent, outputFiles);
   showPackResult(result, inputFile);
 
   const provider = ProgressViewProvider.getInstance();

--- a/src/historyView/modules/domHandlers.js
+++ b/src/historyView/modules/domHandlers.js
@@ -181,14 +181,6 @@ function createHistoryItemElement(item) {
     `;
   }
 
-  // Add output name override
-  if (config.outputNameOverride) {
-    detailsHTML += `
-      <span class="history-label">Output Name:</span>
-      <span class="history-value">${config.outputNameOverride}</span>
-    `;
-  }
-
   // Add tool config section
   if (config.toolConfig) {
     detailsHTML += renderToolConfig(

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -160,15 +160,14 @@ export async function runPackMultiple(
   inputFile: string,
   agent: string,
   inputFiles: string[],
-  outputNameOverride?: string,
 ): Promise<FileOpResult> {
   logger.debug(
     CHANNEL,
-    `Starting multiple packing with model=${model}, inputFile=${inputFile}, agent=${agent}, outputNameOverride=${outputNameOverride}`,
+    `Starting multiple packing with model=${model}, inputFile=${inputFile}, agent=${agent}`,
   );
   logger.debug(CHANNEL, `Additional files: ${inputFiles.join(', ')}`);
 
-  const fileToPack = outputNameOverride || inputFile;
+  const fileToPack = inputFile;
   const baseName = path.parse(fileToPack).name;
   const outputDir = path.dirname(fileToPack);
 
@@ -252,11 +251,10 @@ export async function runPack(
   inputFile: string,
   agent: string,
   outputFiles: string[] = [],
-  outputNameOverride?: string,
 ): Promise<FileOpResult> {
   logger.debug(
     CHANNEL,
-    `Starting pack with model=${model}, inputFile=${inputFile}, agent=${agent}, outputNameOverride=${outputNameOverride}`,
+    `Starting pack with model=${model}, inputFile=${inputFile}, agent=${agent}`,
   );
   logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
 
@@ -270,14 +268,8 @@ export async function runPack(
 
   // Use multiple mode if there are output files
   if (outputFiles.length > 0) {
-    return await runPackMultiple(
-      model,
-      inputFile,
-      agent,
-      outputFiles,
-      outputNameOverride,
-    );
+    return await runPackMultiple(model, inputFile, agent, outputFiles);
   } else {
-    return await runPackSingle(model, inputFile, agent, outputNameOverride);
+    return await runPackSingle(model, inputFile, agent);
   }
 }

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -13,7 +13,6 @@ export interface TaskState {
   referenceFile: string;
   auxiliaryFile: string;
   mediaFile: string;
-  outputNameOverride: string;
 
   // Multiple file selections
   inputFiles: string[];
@@ -36,7 +35,4 @@ export interface TaskState {
   usePrefillFromInput: boolean;
   printInputPrompt: boolean;
   autoCompileInputPdf: boolean;
-
-  // Output name override visibility
-  outputNameOverrideVisible: boolean;
 }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -119,7 +119,6 @@ export class ProgressViewMessageHandler {
       agent: taskState.agent,
       model: taskState.model,
       inputFile: taskState.inputFile,
-      outputNameOverride: taskState.outputNameOverride,
       outputFiles: outputFilesArray,
       activeFiles: {
         output: outputFilesArray.length > 0,
@@ -187,7 +186,6 @@ export class ProgressViewMessageHandler {
       agent: taskState.agent,
       model: taskState.model,
       inputFile: taskState.inputFile,
-      outputNameOverride: taskState.outputNameOverride,
       outputFiles: taskState.outputFiles,
       outputFilesActive: taskState.activeFiles.output,
     });

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -80,10 +80,6 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
     agent: config.agent,
     model: config.model,
     instruction: config.instruction || '',
-
-    // Output name override visibility
-    outputNameOverride: config.outputNameOverride || '',
-    outputNameOverrideVisible: !!config.outputNameOverride,
   };
 
   // Add single and multi-file selections
@@ -115,11 +111,6 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     agent: obj.agent || 'correct',
     model: obj.model || 'sonnet4T',
     instruction: obj.instruction || '',
-
-    // Output name override visibility
-    outputNameOverride: obj.outputNameOverride || '',
-    outputNameOverrideVisible:
-      obj.outputNameOverrideVisible || !!obj.outputNameOverride || false,
   };
 
   // Add single and multi-file selections
@@ -161,9 +152,6 @@ export function taskStateToAgentConfig(taskState: TaskState): AgentConfig {
     skipOutputFile: true,
   });
   copyActiveFileLists(agentConfig, taskState);
-
-  // Special case for outputNameOverride since it needs null rather than empty string
-  agentConfig.outputNameOverride = taskState.outputNameOverride || null;
 
   // Add tool config settings
   const allConfigFields = [...AUTO_EXTRACT_FIELDS, ...TOOL_CONFIG_FIELDS];

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -203,7 +203,7 @@ export class WebviewMessageHandler {
   }
 
   private async handleExecute(message: any) {
-    if (message.inputFile || message.outputNameOverride) {
+    if (message.inputFile) {
       const toolConfig: ToolConfig = {
         // Auto extract settings
         autoExtractFigure: message.autoExtractFigure,
@@ -243,16 +243,13 @@ export class WebviewMessageHandler {
             )
           : null,
         outputFiles: getFilesIfNotEmpty(message.outputFiles),
-        outputNameOverride: message.outputNameOverride,
         editedFile: null,
         toolConfig,
       };
 
       await vscode.commands.executeCommand('texra.execute', agentConfig);
     } else {
-      vscode.window.showErrorMessage(
-        'Please select an input file or provide an output name override.',
-      );
+      vscode.window.showErrorMessage('Please select an input file.');
     }
   }
 
@@ -500,7 +497,6 @@ export class WebviewMessageHandler {
       message.inputFile,
       message.agent,
       message.model,
-      message.outputNameOverride,
     );
   }
 
@@ -525,7 +521,6 @@ export class WebviewMessageHandler {
       message.agent,
       message.model,
       message.outputFiles,
-      message.outputNameOverride,
     );
   }
 

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -351,27 +351,7 @@
             >
               <div class="multiple-files-content">
                 <div id="outputFiles" class="multiple-files-list"></div>
-                <div
-                  class="output-filename-override"
-                  style="margin-top: var(--spacing-medium)"
-                >
-                  <div
-                    class="file-select-label-group"
-                    title="Optional: Customize the output filename (including extension)"
-                  >
-                    <span id="toggleOutputNameOverride" class="toggle-icon"
-                      ><i class="codicon codicon-chevron-right"></i
-                    ></span>
-                    <span class="optional-label">Output Filename</span>
-                    <input
-                      type="text"
-                      id="outputNameOverride"
-                      class="vscode-input"
-                      placeholder="(including extension)"
-                      style="display: none"
-                    />
-                  </div>
-                </div>
+                <!-- Output filename override removed -->
               </div>
             </div>
           </div>

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -50,8 +50,6 @@ export const VALUE_ELEMENTS = [
   ...SINGLE_FILE_ELEMENTS,
   // instruction
   'instruction',
-  // output
-  'outputNameOverride',
   // git
   'commit',
 ];

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -249,25 +249,7 @@ export function initializeOutputFiles() {
     addFileToList('outputFiles', file);
   });
 
-  // Make sure the Output Filename toggle works when Multiple Outputs is enabled
-  const outputNameOverrideInput = safeGetElementById('outputNameOverride');
-  const outputNameOverrideToggle = safeGetElementById(
-    'toggleOutputNameOverride',
-  );
-
-  if (outputNameOverrideInput && outputNameOverrideToggle) {
-    // Get the current state from the stored state
-    const state = stateManager.getState();
-    const isOutputNameOverrideVisible =
-      state && state.outputNameOverrideVisible;
-
-    // Restore the output name override toggle state
-    if (isOutputNameOverrideVisible) {
-      outputNameOverrideInput.style.display = 'inline-block';
-      outputNameOverrideToggle.innerHTML =
-        '<i class="codicon codicon-chevron-left"></i>';
-    }
-  }
+  // Output filename override removed
 
   saveState();
 }
@@ -282,23 +264,6 @@ export function toggleOutputFiles() {
     initializeOutputFiles();
     toggleMultipleFiles('outputFiles', 'toggleOutputFiles');
   }
-}
-
-export function toggleOutputNameOverride() {
-  const input = safeGetElementById('outputNameOverride');
-  const toggleIcon = safeGetElementById('toggleOutputNameOverride');
-  if (!input || !toggleIcon) return;
-
-  const isVisible = input.style.display !== 'none';
-  input.style.display = isVisible ? 'none' : 'inline-block';
-  toggleIcon.innerHTML = isVisible
-    ? '<i class="codicon codicon-chevron-left"></i>'
-    : '<i class="codicon codicon-chevron-right"></i>';
-
-  // Store the visibility state in the vscode state
-  stateManager.update({ outputNameOverrideVisible: !isVisible });
-
-  saveState();
 }
 
 export function toggleMultipleFiles(containerId, toggleId) {
@@ -319,22 +284,7 @@ export function emptyMultipleFiles(containerId, toggleId) {
   const toggleIconDiv = safeGetElementById(toggleId);
   if (toggleIconDiv) toggleIconDiv.textContent = '▼';
 
-  // Reset Output Filename override if we're emptying output files
-  if (containerId === 'outputFiles') {
-    const outputNameOverrideInput = safeGetElementById('outputNameOverride');
-    const outputNameOverrideToggle = safeGetElementById(
-      'toggleOutputNameOverride',
-    );
-
-    if (outputNameOverrideInput && outputNameOverrideToggle) {
-      outputNameOverrideInput.style.display = 'none';
-      outputNameOverrideToggle.innerHTML =
-        '<i class="codicon codicon-chevron-right"></i>';
-
-      // Update the state
-      stateManager.update({ outputNameOverrideVisible: false });
-    }
-  }
+  // Reset Output Filename override removed
 
   saveState();
 }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -60,25 +60,7 @@ function handleStateRestoration(state) {
   if (state.auxiliaryFile)
     safeSetElementValue('auxiliaryFile', state.auxiliaryFile);
   if (state.mediaFile) safeSetElementValue('mediaFile', state.mediaFile);
-  if (state.outputNameOverride)
-    safeSetElementValue('outputNameOverride', state.outputNameOverride);
-
-  // Handle output name override visibility
-  const outputNameOverride = safeGetElementById('outputNameOverride');
-  const toggleOutputNameOverrideDiv = safeGetElementById(
-    'toggleOutputNameOverride',
-  );
-  if (state.outputNameOverrideVisible) {
-    if (outputNameOverride) outputNameOverride.style.display = 'inline-block';
-    if (toggleOutputNameOverrideDiv)
-      toggleOutputNameOverrideDiv.innerHTML =
-        '<i class="codicon codicon-chevron-left"></i>';
-  } else {
-    if (outputNameOverride) outputNameOverride.style.display = 'none';
-    if (toggleOutputNameOverrideDiv)
-      toggleOutputNameOverrideDiv.innerHTML =
-        '<i class="codicon codicon-chevron-right"></i>';
-  }
+  // Output filename override removed
 
   // Prepare the state to save with all necessary properties
   const toolConfig = state.toolConfig || {};
@@ -93,8 +75,6 @@ function handleStateRestoration(state) {
     referenceFile: state.referenceFile,
     auxiliaryFile: state.auxiliaryFile,
     mediaFile: state.mediaFile,
-    outputNameOverride: state.outputNameOverride,
-    outputNameOverrideVisible: state.outputNameOverrideVisible,
 
     // Tool config settings - flattened from either direct or toolConfig property
     reflect: state.reflect || (toolConfig ? toolConfig.reflect : false),

--- a/src/webview/modules/stateManager.js
+++ b/src/webview/modules/stateManager.js
@@ -25,16 +25,6 @@ import {
 import { capitalize } from '@common/stringUtils.js';
 
 export function setDefaultState() {
-  // Hide output name override by default
-  const outputNameOverride = document.getElementById('outputNameOverride');
-  const toggleOutputNameOverrideDiv = document.getElementById(
-    'toggleOutputNameOverride',
-  );
-  if (outputNameOverride) outputNameOverride.style.display = 'none';
-  if (toggleOutputNameOverrideDiv)
-    toggleOutputNameOverrideDiv.innerHTML =
-      '<i class="codicon codicon-chevron-right"></i>';
-
   // Initialize auto-extract toggle with default state
   const autoExtractToggle = safeGetElementById('toggleAutoExtract');
   const autoExtractOptions = safeGetElementById('autoExtractOptions');
@@ -132,26 +122,6 @@ export function restoreState() {
       }
     });
 
-    const outputNameOverride = document.getElementById('outputNameOverride');
-    const toggleOutputNameOverrideDiv = document.getElementById(
-      'toggleOutputNameOverride',
-    );
-    if (previousState.outputNameOverrideVisible) {
-      if (outputNameOverride) outputNameOverride.style.display = 'inline-block';
-      if (toggleOutputNameOverrideDiv)
-        toggleOutputNameOverrideDiv.innerHTML =
-          '<i class="codicon codicon-chevron-left"></i>';
-      safeSetElementValue(
-        'outputNameOverride',
-        previousState.outputNameOverride ?? '',
-      );
-    } else {
-      if (outputNameOverride) outputNameOverride.style.display = 'none';
-      if (toggleOutputNameOverrideDiv)
-        toggleOutputNameOverrideDiv.innerHTML =
-          '<i class="codicon codicon-chevron-right"></i>';
-    }
-
     const latexdiffsContent = safeGetElementById('latexdiffsContent');
     const toggleLatexdiffs = safeGetElementById('toggleLatexdiffs');
     if (latexdiffsContent && toggleLatexdiffs) {
@@ -174,10 +144,6 @@ export function saveState() {
   const state = {
     latexdiffsVisible:
       safeGetElementById('latexdiffsContent')?.style.display === 'block',
-    outputNameOverrideVisible:
-      safeGetElementById('outputNameOverride')?.style.display ===
-      'inline-block',
-    outputNameOverride: safeGetElementValue('outputNameOverride'),
   };
 
   VALUE_ELEMENTS.forEach((id) => {

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -14,7 +14,6 @@ import {
   handleCheckboxChange,
   toggleMultipleFiles,
   toggleOutputFiles,
-  toggleOutputNameOverride,
   emptyMultipleFiles,
   toggleLatexdiffs,
 } from './fileHandlers.js';
@@ -118,15 +117,6 @@ export function setupUIHandlers() {
       });
     }
   });
-
-  // Helper functions for common tasks
-  function getOutputNameOverride() {
-    const outputNameOverrideDiv = safeGetElementById('outputNameOverride');
-    return outputNameOverrideDiv &&
-      outputNameOverrideDiv.style.display !== 'none'
-      ? outputNameOverrideDiv.value.trim()
-      : null;
-  }
 
   // Get values for single file inputs (input, reference, auxiliary, media)
   function getSingleFileData(
@@ -247,12 +237,9 @@ export function setupUIHandlers() {
 
   addEventListenerSafely('inputFile', 'change', function () {
     const inputFile = this.value;
-    const outputNameOverride =
-      safeGetElementById('outputNameOverride')?.value.trim() || null;
     vscode.postMessage({
       command: 'inputFileSelected',
       filePath: inputFile,
-      outputNameOverride: outputNameOverride,
     });
   });
 
@@ -340,8 +327,6 @@ export function setupUIHandlers() {
         ...singleFiles,
         // Toggle status and multiple files
         ...multipleFilesData,
-        // Output override
-        outputNameOverride: getOutputNameOverride(),
       });
     }
   });
@@ -374,8 +359,6 @@ export function setupUIHandlers() {
       ...multipleFilesData,
       // checkboxes (auto extract options and tool config)
       ...checkboxValues,
-      // output override
-      outputNameOverride: getOutputNameOverride(),
     });
   });
 
@@ -418,7 +401,6 @@ export function setupUIHandlers() {
           inputFile,
           agent,
           model,
-          outputNameOverride: getOutputNameOverride(),
           outputFiles,
         });
 
@@ -440,7 +422,6 @@ export function setupUIHandlers() {
           inputFile,
           agent,
           model,
-          outputNameOverride: getOutputNameOverride(),
         });
 
         vscode.postMessage({
@@ -533,22 +514,10 @@ export function setupUIHandlers() {
 
   // Special case for instruction as it uses 'input' event
   addEventListenerSafely('instruction', 'input', saveState);
-  addEventListenerSafely('outputNameOverride', 'input', saveState);
 
   new Sortable(safeGetElementById('outputFiles'), {
     animation: 150,
     onEnd: saveState,
-  });
-
-  // Output Filename toggle only works when inside Multiple Outputs container
-  addEventListenerSafely('toggleOutputNameOverride', 'click', function () {
-    const outputFilesContainer = safeGetElementById('outputFilesContainer');
-    if (
-      outputFilesContainer &&
-      outputFilesContainer.style.display === 'block'
-    ) {
-      toggleOutputNameOverride();
-    }
   });
 
   // Add event listeners for file operations (add opened files, get current file)


### PR DESCRIPTION
## Summary
- drop `outputNameOverride` handling from webview and backend
- remove related config fields and clean up docs

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68555c720b448324b22a5d37e2dac702