### PR TITLE
Refactor: centralize streamId generation

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -28,6 +28,7 @@ import {
   checkExpectedOutputs,
   showInstructionWithSuppress,
 } from '@frontend/ui/instruction';
+import { getStreamId } from '@utils/loggerUtils';
 import { IAgent } from '@agent/core/IAgent';
 
 const CHANNEL = 'executeAgent';
@@ -155,7 +156,7 @@ async function executeAgentWithLogging<T extends IAgent>(
 
     // Get the full stream ID
     const config = agent.config;
-    const fullStreamId = `${agentName}@${config.model}: ${path.basename(config.inputFile)}`;
+    const fullStreamId = getStreamId(agentName, config.model, config.inputFile);
 
     // Check if this stream is already running
     const currentStatus = progressViewProvider.getStreamStatus(fullStreamId);

--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -1,11 +1,14 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import * as path from 'path';
 
+// Local imports - progress view
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+
+// Local imports - utilities
+import { getStreamId } from '@utils/loggerUtils';
 
 // Local imports - housekeeping
 import {
@@ -18,17 +21,6 @@ import type { FileOpResult } from '@/types/ResultTypes';
 
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
-
-function getStreamId(
-  agent: string,
-  model: string,
-  inputFile: string,
-  outputFiles?: string[],
-): string {
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
-}
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -1,11 +1,14 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import * as path from 'path';
 
+// Local imports - progress view
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+
+// Local imports - utilities
+import { getStreamId } from '@utils/loggerUtils';
 
 // Local imports - housekeeping
 import { runPack, runPackSingle, runPackMultiple } from '../housekeeping';
@@ -13,17 +16,6 @@ import type { FileOpResult } from '@/types/ResultTypes';
 
 const CHANNEL = 'packCommands';
 logger.initialize(CHANNEL);
-
-function getStreamId(
-  agent: string,
-  model: string,
-  inputFile: string,
-  outputFiles?: string[],
-): string {
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
-}
 
 function showPackResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {

--- a/src/utils/loggerUtils.ts
+++ b/src/utils/loggerUtils.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'path';
+
 // Local imports
 import { getConfig } from './config';
 
@@ -91,4 +94,18 @@ export const EMOJI_BY_LEVEL: Record<string, string> = {
  */
 export function getColorForLevel(level: string): string {
   return EMOJI_BY_LEVEL[level.toLowerCase()] ?? '•';
+}
+
+/**
+ * Build a consistent stream identifier based on agent, model and input file.
+ */
+export function getStreamId(
+  agent: string,
+  model: string,
+  inputFile: string,
+  outputFiles?: string[],
+): string {
+  const agentName =
+    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
+  return `${agentName}@${model}: ${path.basename(inputFile)}`;
 }


### PR DESCRIPTION
## Summary
- add `getStreamId` helper in `loggerUtils`
- reuse `getStreamId` in pack and clean commands
- reuse `getStreamId` when executing agents

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556ea31fc883248e05de42ce33bf3d