### PR TITLE
Fix duplicate stream id helper

### DIFF
--- a/src/commands/cleanCommands.ts
+++ b/src/commands/cleanCommands.ts
@@ -14,21 +14,11 @@ import {
   runCleanBuild,
   runCleanOutput,
 } from '../housekeeping';
+import { getStreamId } from '@utils/streamUtils';
 import type { FileOpResult } from '@/types/ResultTypes';
 
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
-
-function getStreamId(
-  agent: string,
-  model: string,
-  inputFile: string,
-  outputFiles?: string[],
-): string {
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
-}
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {

--- a/src/commands/packCommands.ts
+++ b/src/commands/packCommands.ts
@@ -9,21 +9,11 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - housekeeping
 import { runPack, runPackSingle, runPackMultiple } from '../housekeeping';
+import { getStreamId } from '@utils/streamUtils';
 import type { FileOpResult } from '@/types/ResultTypes';
 
 const CHANNEL = 'packCommands';
 logger.initialize(CHANNEL);
-
-function getStreamId(
-  agent: string,
-  model: string,
-  inputFile: string,
-  outputFiles?: string[],
-): string {
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
-}
 
 function showPackResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {

--- a/src/utils/streamUtils.ts
+++ b/src/utils/streamUtils.ts
@@ -1,0 +1,26 @@
+// Third-party imports
+import * as path from 'path';
+
+// Utility functions for stream identifiers
+
+/**
+ * Generate a stream identifier for logging and progress tracking.
+ * Appends `_multiple` to the agent name when more than one output file
+ * is provided.
+ *
+ * @param agent - Name of the agent
+ * @param model - Model identifier
+ * @param inputFile - Path to the input file
+ * @param outputFiles - Optional list of output files
+ * @returns Formatted stream ID
+ */
+export function getStreamId(
+  agent: string,
+  model: string,
+  inputFile: string,
+  outputFiles?: string[],
+): string {
+  const agentName =
+    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
+  return `${agentName}@${model}: ${path.basename(inputFile)}`;
+}


### PR DESCRIPTION
## Summary
- remove duplicated `getStreamId` function from commands
- add shared helper in `streamUtils`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556ea31fc883248e05de42ce33bf3d