### PR TITLE
refactor: complete migration from WorkspaceFileManager to WorkspaceFS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ adding new code or refactoring existing modules:
   simpler and more obvious.
 - When submitting a PR, describe any design issues found and how the refactoring
   addresses them. Favor deep modules with minimal, clear APIs.
+- When your refactoring include a large number of renames, use search tools to make sure you are not missing any files or paths where changes need to be made.
 
 ## Documentation
 

--- a/src/AnthropicTool/AnthropicToolAgent.ts
+++ b/src/AnthropicTool/AnthropicToolAgent.ts
@@ -14,7 +14,7 @@ import { ToolResult } from './base';
 import { BaseError, ValidationResult } from './types';
 
 // Local imports - utils
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 import { getConfig } from '@utils/config';
 
@@ -82,7 +82,7 @@ export abstract class AnthropicToolAgent<
 
     try {
       // Verify the file exists before starting
-      const fileExists = await WorkspaceFileManager.fileExists(filePath);
+      const fileExists = await WorkspaceFS.exists(filePath);
       if (!fileExists) {
         logger.error(CHANNEL, `File does not exist: ${filePath}`);
         vscode.window.showErrorMessage(`File does not exist: ${filePath}`);
@@ -112,7 +112,7 @@ export abstract class AnthropicToolAgent<
       );
 
       // Read file content for context
-      const content = await WorkspaceFileManager.readFile(filePath);
+      const content = await WorkspaceFS.readFile(filePath);
 
       // Get the context around the error
       let errorContext = '';
@@ -202,7 +202,7 @@ export abstract class AnthropicToolAgent<
   ): Promise<ToolResult> {
     try {
       // Verify the file exists before starting
-      const fileExists = await WorkspaceFileManager.fileExists(filePath);
+      const fileExists = await WorkspaceFS.exists(filePath);
       if (!fileExists) {
         logger.error(CHANNEL, `File does not exist: ${filePath}`);
         vscode.window.showErrorMessage(`File does not exist: ${filePath}`);
@@ -234,7 +234,7 @@ export abstract class AnthropicToolAgent<
       }
 
       // Read file content for error context
-      let content = await WorkspaceFileManager.readFile(filePath);
+      let content = await WorkspaceFS.readFile(filePath);
 
       // Get initial error context
       let errorContext = '';
@@ -345,7 +345,7 @@ export abstract class AnthropicToolAgent<
             );
 
             // Read updated content and get new error context
-            content = await WorkspaceFileManager.readFile(filePath);
+            content = await WorkspaceFS.readFile(filePath);
             if (newValidationResult.error) {
               errorContext = getErrorContext(
                 content,

--- a/src/AnthropicTool/TeXLinterFixAgent.ts
+++ b/src/AnthropicTool/TeXLinterFixAgent.ts
@@ -9,7 +9,7 @@ import { ValidationResult } from './types';
 import { LinterMessage } from '@frontend/latex/linter';
 
 // Local imports - utils
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import * as linterUtils from '@frontend/latex/linter';
 
 // Local imports - Logging

--- a/src/AnthropicTool/TextEditorTool.ts
+++ b/src/AnthropicTool/TextEditorTool.ts
@@ -13,7 +13,7 @@ import {
 } from './types';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 // Local imports - Log
 import * as logger from '@logger/logUtils';
@@ -160,7 +160,7 @@ export class TextEditorTool extends BaseAnthropicTool {
     filePath: string,
   ): Promise<void> {
     // Check if the path exists (except for create command)
-    const exists = await WorkspaceFileManager.fileExists(filePath);
+    const exists = await WorkspaceFS.exists(filePath);
 
     if (!exists && command !== 'create') {
       throw new ToolError(
@@ -178,9 +178,7 @@ export class TextEditorTool extends BaseAnthropicTool {
     try {
       if (exists) {
         const stats = await vscode.workspace.fs.stat(
-          vscode.Uri.file(
-            WorkspaceFileManager.getFullPathFromWorkspace(filePath),
-          ),
+          vscode.Uri.file(WorkspaceFS.fullPath(filePath)),
         );
 
         if (stats.type === vscode.FileType.Directory && command !== 'view') {
@@ -210,9 +208,7 @@ export class TextEditorTool extends BaseAnthropicTool {
     try {
       // Check if the path is a directory
       const stats = await vscode.workspace.fs.stat(
-        vscode.Uri.file(
-          WorkspaceFileManager.getFullPathFromWorkspace(filePath),
-        ),
+        vscode.Uri.file(WorkspaceFS.fullPath(filePath)),
       );
 
       if (stats.type === vscode.FileType.Directory) {
@@ -223,7 +219,7 @@ export class TextEditorTool extends BaseAnthropicTool {
         }
 
         // Get directory contents
-        const dirContents = await WorkspaceFileManager.readDirectory(filePath);
+        const dirContents = await WorkspaceFS.readDir(filePath);
         const formattedContents = dirContents
           .map(([fileName, fileType]) => {
             const type =
@@ -238,7 +234,7 @@ export class TextEditorTool extends BaseAnthropicTool {
       }
 
       // Read file contents
-      let fileContent = await WorkspaceFileManager.readFile(filePath);
+      let fileContent = await WorkspaceFS.readFile(filePath);
       let initLine = 1;
 
       // Handle view range if provided
@@ -309,7 +305,7 @@ export class TextEditorTool extends BaseAnthropicTool {
       }
 
       // Write file content
-      await WorkspaceFileManager.writeFile(filePath, content);
+      await WorkspaceFS.writeFile(filePath, content);
 
       return new ToolResult({
         output: `File created successfully at: ${filePath}`,
@@ -333,7 +329,7 @@ export class TextEditorTool extends BaseAnthropicTool {
   ): Promise<ToolResult> {
     try {
       // Read file content
-      const fileContent = await WorkspaceFileManager.readFile(filePath);
+      const fileContent = await WorkspaceFS.readFile(filePath);
 
       // Expand tabs in content and search string
       const expandedFileContent = fileContent.replace(/\t/g, '    ');
@@ -371,7 +367,7 @@ export class TextEditorTool extends BaseAnthropicTool {
         expandedOldStr,
         expandedNewStr,
       );
-      await WorkspaceFileManager.writeFile(filePath, newFileContent);
+      await WorkspaceFS.writeFile(filePath, newFileContent);
 
       // Create a snippet of the edited section
       const textBeforeReplacement =
@@ -419,7 +415,7 @@ export class TextEditorTool extends BaseAnthropicTool {
   ): Promise<ToolResult> {
     try {
       // Read file content
-      const fileContent = await WorkspaceFileManager.readFile(filePath);
+      const fileContent = await WorkspaceFS.readFile(filePath);
 
       // Expand tabs in content and new string
       const expandedFileContent = fileContent.replace(/\t/g, '    ');
@@ -456,7 +452,7 @@ export class TextEditorTool extends BaseAnthropicTool {
 
       // Write new content to file
       const newFileContent = newFileLines.join('\n');
-      await WorkspaceFileManager.writeFile(filePath, newFileContent);
+      await WorkspaceFS.writeFile(filePath, newFileContent);
 
       // Prepare success message
       const snippetText = snippetLines.join('\n');
@@ -496,7 +492,7 @@ export class TextEditorTool extends BaseAnthropicTool {
 
       // Restore previous content
       const oldContent = history.pop()!;
-      await WorkspaceFileManager.writeFile(filePath, oldContent);
+      await WorkspaceFS.writeFile(filePath, oldContent);
 
       // If the history is now empty, delete the entry
       if (history.length === 0) {
@@ -560,9 +556,9 @@ export class TextEditorTool extends BaseAnthropicTool {
    */
   private async ensureDirectoryExists(dirPath: string): Promise<void> {
     try {
-      const exists = await WorkspaceFileManager.fileExists(dirPath);
+      const exists = await WorkspaceFS.exists(dirPath);
       if (!exists) {
-        await WorkspaceFileManager.createDirectory(dirPath);
+        await WorkspaceFS.createDir(dirPath);
       }
     } catch (error) {
       throw new ToolError(

--- a/src/AnthropicTool/XMLValidatorAgent.ts
+++ b/src/AnthropicTool/XMLValidatorAgent.ts
@@ -7,7 +7,7 @@ import { XMLValidator } from 'fast-xml-parser';
 import { AnthropicToolAgent } from './AnthropicToolAgent';
 
 // Local imports - utils
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 // Local imports - types
 import { XMLValidationError, ValidationResult } from './types';
@@ -31,7 +31,7 @@ export class XMLValidatorAgent extends AnthropicToolAgent<XMLValidationError> {
   ): Promise<ValidationResult<XMLValidationError>> {
     try {
       // Read the file content
-      const content = await WorkspaceFileManager.readFile(filePath);
+      const content = await WorkspaceFS.readFile(filePath);
 
       // Use fast-xml-parser's XMLValidator to validate the XML
       const validationResult = XMLValidator.validate(content, {

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -20,7 +20,7 @@ import { diff_match_patch } from 'diff-match-patch';
 import type { DiffStats } from '@/types/DiffTypes';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
@@ -289,7 +289,7 @@ export abstract class BaseReflectionAgent implements IAgent {
           break;
         }
 
-        const exists = await WorkspaceFileManager.fileExists(outputFile);
+        const exists = await WorkspaceFS.exists(outputFile);
         const startTime = Date.now();
         const systemPrompt = await this.getSystemPromptWithRules();
 
@@ -302,7 +302,7 @@ export abstract class BaseReflectionAgent implements IAgent {
           const outputFileBaseName = outputFile.replace('.xml', '');
           const debugFilePath = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
           try {
-            await WorkspaceFileManager.writeFile(
+            await WorkspaceFS.writeFile(
               debugFilePath,
               JSON.stringify(messages, null, 2),
             );
@@ -448,13 +448,13 @@ export abstract class BaseReflectionAgent implements IAgent {
             `Creating new file: ${outputFile}`,
             responseCycleGroupId,
           );
-          await WorkspaceFileManager.writeFile(outputFile, processedResponse);
+          await WorkspaceFS.writeFile(outputFile, processedResponse);
         } else {
           this.logger.debug(
             `Appending to existing file: ${outputFile}`,
             responseCycleGroupId,
           );
-          await WorkspaceFileManager.appendFile(
+          await WorkspaceFS.appendFile(
             outputFile,
             bestConnector + processedResponse,
           );
@@ -584,15 +584,15 @@ export abstract class BaseReflectionAgent implements IAgent {
   ): Promise<DiffStats> {
     try {
       if (!baseFile) {
-        const outContent = await WorkspaceFileManager.readFile(outputFile);
+        const outContent = await WorkspaceFS.readFile(outputFile);
         const added = this.countLines(outContent);
         // For new files, only return added count (removed should be undefined for UI)
         return { added };
       }
 
       const [baseContent, outContent] = await Promise.all([
-        WorkspaceFileManager.readFile(baseFile),
-        WorkspaceFileManager.readFile(outputFile),
+        WorkspaceFS.readFile(baseFile),
+        WorkspaceFS.readFile(outputFile),
       ]);
 
       const dmp = new diff_match_patch();
@@ -736,9 +736,7 @@ export abstract class BaseReflectionAgent implements IAgent {
       this.outputHandler.outputFiles[currRound].length > 0
     ) {
       const existingBase = await Promise.all(
-        this.baseFiles.map(
-          async (f) => await WorkspaceFileManager.fileExists(f),
-        ),
+        this.baseFiles.map(async (f) => await WorkspaceFS.exists(f)),
       );
 
       if (existingBase.some((e) => e)) {
@@ -850,7 +848,7 @@ export abstract class BaseReflectionAgent implements IAgent {
                 buildDir,
                 path.basename(inputFile).replace(/\.tex$/, '.pdf'),
               );
-              if (await WorkspaceFileManager.fileExists(pdfFile)) {
+              if (await WorkspaceFS.exists(pdfFile)) {
                 this.logger.info(
                   `Compiled PDF for ${inputFile}: ${pdfFile}`,
                   round0GroupId,
@@ -1214,7 +1212,7 @@ export abstract class BaseReflectionAgent implements IAgent {
             buildDir,
             path.basename(outputFile).replace(/\.tex$/, '.pdf'),
           );
-          if (await WorkspaceFileManager.fileExists(pdfFile)) {
+          if (await WorkspaceFS.exists(pdfFile)) {
             this.logger.info(
               `Compiled PDF for ${outputFile}: ${pdfFile}`,
               this.logger.getActiveGroupId(),

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { fileExistsAbsolute } from '@utils/files/absoluteFileUtils';
 import { getPastedImageDisplayName } from '@utils/files/pastedImageUtils';
 import {
@@ -423,7 +423,7 @@ export abstract class ModelHandler {
       const isAbsolutePath = path.isAbsolute(mediaFile);
       const fileExistsResult = isAbsolutePath
         ? await fileExistsAbsolute(mediaFile)
-        : await WorkspaceFileManager.fileExists(mediaFile);
+        : await WorkspaceFS.exists(mediaFile);
 
       if (!fileExistsResult) {
         this.logger.error(`File not found: ${mediaFile}`);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -15,7 +15,7 @@ import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 import { formatProviderError } from '@utils/sdkErrorUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { cleanFileContent } from '@replacement/replacementUtils';
 import replacementManager from '@replacement/replacementManager';
 import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
@@ -452,7 +452,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
   ): Promise<[boolean, MessageParam[]]> {
     let endTurn = false;
 
-    if (!(await WorkspaceFileManager.fileExistsAndNonTrivial(outputFile))) {
+    if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
       if (
         agentConfig.toolConfig.usePrefillFromInput &&
         toolState.firstKCharsFromInput
@@ -467,9 +467,9 @@ export class ModelHandlerAnthropic extends ModelHandler {
           toolState.accumulatedOutput.includes('<scratchpad>') &&
           prefill === '<scratchpad>' // this is not so neat
         ) {
-          await WorkspaceFileManager.writeFile(outputFile, prefill);
+          await WorkspaceFS.writeFile(outputFile, prefill);
         } else if (agentSetting.outputExt === 'xml') {
-          await WorkspaceFileManager.writeFile(outputFile, prefill + '\n');
+          await WorkspaceFS.writeFile(outputFile, prefill + '\n');
         }
         messages.push({
           role: 'assistant',
@@ -495,7 +495,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
     }
 
     // Get prefill from existing and non-trivial file
-    let fileContent = await WorkspaceFileManager.readFile(outputFile);
+    let fileContent = await WorkspaceFS.readFile(outputFile);
     fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
@@ -506,7 +506,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       groupId,
     );
 
-    await WorkspaceFileManager.writeFile(outputFile, fileContent);
+    await WorkspaceFS.writeFile(outputFile, fileContent);
 
     // Update the toolState with the actual file content
     toolState.updateAccumulatedOutput(fileContent);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -32,7 +32,7 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { fileExistsAbsolute } from '@utils/files';
 import { formatProviderError } from '@utils/sdkErrorUtils';
 import { cleanFileContent } from '@replacement/replacementUtils';
@@ -370,8 +370,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       );
       for (const mediaFile of mediaFiles) {
         try {
-          const absolutePath =
-            WorkspaceFileManager.getFullPathFromWorkspace(mediaFile);
+          const absolutePath = WorkspaceFS.fullPath(mediaFile);
           if (!fileExistsAbsolute(absolutePath)) {
             this.logger.error(`File does not exist: ${absolutePath}`);
             continue;
@@ -489,8 +488,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       );
       for (const mediaFile of mediaFiles) {
         try {
-          const absolutePath =
-            WorkspaceFileManager.getFullPathFromWorkspace(mediaFile);
+          const absolutePath = WorkspaceFS.fullPath(mediaFile);
           if (!fileExistsAbsolute(absolutePath)) {
             this.logger.error(`File does not exist: ${absolutePath}`);
             continue;
@@ -775,7 +773,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       `Initializing output and prefill for ${outputFile}. Prefill content: "${prefill.slice(0, 100)}..."`,
     );
 
-    if (!(await WorkspaceFileManager.fileExistsAndNonTrivial(outputFile))) {
+    if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
       this.logger.debug(
         `Output file ${outputFile} does not exist or is empty.`,
       );
@@ -810,7 +808,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     this.logger.debug(
       `Output file ${outputFile} exists and is non-trivial. Reading content.`,
     );
-    let fileContent = await WorkspaceFileManager.readFile(outputFile);
+    let fileContent = await WorkspaceFS.readFile(outputFile);
     fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
@@ -821,7 +819,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       groupId,
     );
 
-    await WorkspaceFileManager.writeFile(outputFile, fileContent);
+    await WorkspaceFS.writeFile(outputFile, fileContent);
     this.logger.debug(`Cleaned and saved existing content to ${outputFile}.`);
     messages.push({
       role: 'assistant',

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -7,7 +7,7 @@ import { ChatCompletionContentPart } from 'openai/resources/chat/completions';
 import { countTokens } from 'gpt-tokenizer';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { cleanFileContent } from '@replacement/replacementUtils';
 import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
 import { formatProviderError } from '@utils/sdkErrorUtils';
@@ -517,7 +517,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
   ): Promise<[boolean, any[]]> {
     let endTurn = false;
 
-    if (!(await WorkspaceFileManager.fileExistsAndNonTrivial(outputFile))) {
+    if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
       if (
         agentConfig.toolConfig.usePrefillFromInput &&
         toolState.firstKCharsFromInput
@@ -547,7 +547,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
     }
 
     // Get prefill from existing and non-trivial file
-    let fileContent = await WorkspaceFileManager.readFile(outputFile);
+    let fileContent = await WorkspaceFS.readFile(outputFile);
     fileContent = cleanFileContent(fileContent);
 
     // Extract and log any existing scratchpad content
@@ -559,7 +559,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
     );
 
     // Write file content to output file
-    await WorkspaceFileManager.writeFile(outputFile, fileContent);
+    await WorkspaceFS.writeFile(outputFile, fileContent);
 
     messages.push({
       role: 'assistant',
@@ -599,10 +599,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
       toolState.updateAccumulatedOutput(fileContent);
     } else {
       toolState.updateAccumulatedOutput(prefill + fileContent);
-      await WorkspaceFileManager.writeFile(
-        outputFile,
-        toolState.accumulatedOutput,
-      );
+      await WorkspaceFS.writeFile(outputFile, toolState.accumulatedOutput);
     }
     const state = new AgentStateRound(0);
     toolState.lastResponse = toolState.accumulatedOutput;

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -8,7 +8,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import {
   addCdataToTags,
   addCdataToTagsMultiple,
@@ -328,14 +328,14 @@ export class OutputHandler {
       }
 
       try {
-        const content = await WorkspaceFileManager.readFile(outputFile);
+        const content = await WorkspaceFS.readFile(outputFile);
         // Replace \input commands with references to the new file paths
         const newContent = content.replace(/\\input{([^}]+)}/g, (match, p1) =>
           baseToOutput.has(p1) ? `\\input{${baseToOutput.get(p1)}}` : match,
         );
 
         if (newContent !== content) {
-          await WorkspaceFileManager.writeFile(outputFile, newContent);
+          await WorkspaceFS.writeFile(outputFile, newContent);
           this.logger.debug(`Updated input commands in ${outputFile}`);
         }
       } catch (err) {
@@ -511,15 +511,15 @@ export class OutputHandler {
       this.agentSetting.documentTag,
     );
 
-    const xmlContent = await WorkspaceFileManager.readFile(outputFile);
+    const xmlContent = await WorkspaceFS.readFile(outputFile);
     let original = '';
     const nameMatch = xmlContent.match(/<document[^>]*name="(.*?)"[^>]*>/);
     if (nameMatch && nameMatch[1]) {
       original = nameMatch[1].trim();
     }
 
-    const content = await WorkspaceFileManager.readFile(processedOutputFile);
-    await WorkspaceFileManager.writeFile(processedOutputFile, content);
+    const content = await WorkspaceFS.readFile(processedOutputFile);
+    await WorkspaceFS.writeFile(processedOutputFile, content);
 
     return { source: original || outputFile, path: processedOutputFile };
   }
@@ -611,7 +611,7 @@ export class OutputHandler {
     const { dir, name, ext } = path.parse(outputFile);
     const texFile = path.join(dir, `${name}.tex`);
 
-    let outputContent = await WorkspaceFileManager.readFile(outputFile);
+    let outputContent = await WorkspaceFS.readFile(outputFile);
 
     const tagsToWrap = [documentTag, thinkingTag];
     outputContent = addCdataToTags(outputContent, tagsToWrap);
@@ -628,7 +628,7 @@ export class OutputHandler {
 
       const latexDocument = extractContentFromXMLbyTag(root, documentTag);
       if (latexDocument) {
-        await WorkspaceFileManager.writeFile(texFile, latexDocument);
+        await WorkspaceFS.writeFile(texFile, latexDocument);
         return texFile;
       } else {
         this.logger.warn(
@@ -640,7 +640,7 @@ export class OutputHandler {
           documentTag,
         );
         if (fallbackContent) {
-          await WorkspaceFileManager.writeFile(texFile, fallbackContent);
+          await WorkspaceFS.writeFile(texFile, fallbackContent);
           return texFile;
         }
         return texFile;
@@ -655,7 +655,7 @@ export class OutputHandler {
         documentTag,
       );
       if (fallbackContent) {
-        await WorkspaceFileManager.writeFile(texFile, fallbackContent);
+        await WorkspaceFS.writeFile(texFile, fallbackContent);
         return texFile;
       }
       // Re-throw the original error if fallback also failed
@@ -672,7 +672,7 @@ export class OutputHandler {
     documentTag: string,
     thinkingTag: string = 'scratchpad',
   ): Promise<NamedOutputFile[]> {
-    let outputContent = await WorkspaceFileManager.readFile(outputFile);
+    let outputContent = await WorkspaceFS.readFile(outputFile);
 
     const tagsToWrap = [thinkingTag, 'document'];
     outputContent = addCdataToTagsMultiple(outputContent, tagsToWrap);
@@ -764,7 +764,7 @@ export class OutputHandler {
         extension,
         currRound,
       );
-      await WorkspaceFileManager.writeFile(texFile, doc.content.trim());
+      await WorkspaceFS.writeFile(texFile, doc.content.trim());
       outputFiles.push({ source, path: texFile });
       this.logger.debug(
         `XML Source: ${source} -> TeX file written: ${texFile}`,
@@ -781,7 +781,7 @@ export class OutputHandler {
     documentTag: string,
   ): Promise<void> {
     this.logger.debug(`Ensuring correct XML structure: ${filePath}`);
-    let content = await WorkspaceFileManager.readFile(filePath);
+    let content = await WorkspaceFS.readFile(filePath);
 
     content = await this.processXmlContent(content);
 
@@ -803,7 +803,7 @@ export class OutputHandler {
         }
       }
     }
-    await WorkspaceFileManager.writeFile(filePath, content);
+    await WorkspaceFS.writeFile(filePath, content);
   }
 
   /** Prints statistics about token usage and costs */

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -3,7 +3,7 @@
 import * as path from 'path';
 
 import { AgentLogger } from '@logger/AgentLogger';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { setVarFromFile } from '@frontend/files/vars';
 import { getXmlFormatFromFiles, getListOfFiles } from '@utils/promptUtils';
 import { AgentConfig } from '../core/AgentConfig';
@@ -77,7 +77,7 @@ async function getFileVars(
   for (const [prefix, filePath] of Object.entries(singleFileMappings)) {
     userVars[`${prefix}_FILE`] = filePath;
     userVars[`${prefix}_CONTENT`] = filePath
-      ? await WorkspaceFileManager.readFile(filePath)
+      ? await WorkspaceFS.readFile(filePath)
       : null;
   }
 

--- a/src/commands/compareCommands.ts
+++ b/src/commands/compareCommands.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import { DIFF_REGISTRATION_DELAY_MS } from '@utils/config';
 
@@ -43,20 +43,16 @@ async function handleCompare(
     }
 
     // Create URIs for both files
-    const baseUri = vscode.Uri.file(
-      WorkspaceFileManager.getFullPathFromWorkspace(fileToUse),
-    );
-    const editedUri = vscode.Uri.file(
-      WorkspaceFileManager.getFullPathFromWorkspace(editedFile),
-    );
+    const baseUri = vscode.Uri.file(WorkspaceFS.fullPath(fileToUse));
+    const editedUri = vscode.Uri.file(WorkspaceFS.fullPath(editedFile));
 
     // Verify both files exist
-    if (!(await WorkspaceFileManager.fileExists(fileToUse))) {
+    if (!(await WorkspaceFS.exists(fileToUse))) {
       vscode.window.showErrorMessage(`Base file not found: ${fileToUse}`);
       return;
     }
 
-    if (!(await WorkspaceFileManager.fileExists(editedFile))) {
+    if (!(await WorkspaceFS.exists(editedFile))) {
       vscode.window.showErrorMessage(`Edited file not found: ${editedFile}`);
       return;
     }
@@ -133,18 +129,18 @@ async function handleAcceptEdited(
     }
 
     // Verify both files exist
-    if (!(await WorkspaceFileManager.fileExists(fileToUse))) {
+    if (!(await WorkspaceFS.exists(fileToUse))) {
       vscode.window.showErrorMessage(`Base file not found: ${fileToUse}`);
       return;
     }
 
-    if (!(await WorkspaceFileManager.fileExists(editedFile))) {
+    if (!(await WorkspaceFS.exists(editedFile))) {
       vscode.window.showErrorMessage(`Edited file not found: ${editedFile}`);
       return;
     }
 
     // Read content from edited file using workspace utilities
-    const editedContent = await WorkspaceFileManager.readFile(editedFile);
+    const editedContent = await WorkspaceFS.readFile(editedFile);
 
     // Confirm with user
     const baseFileName = path.basename(fileToUse);
@@ -162,7 +158,7 @@ async function handleAcceptEdited(
     }
 
     // Write content to base file using workspace utilities
-    await WorkspaceFileManager.writeFile(fileToUse, editedContent);
+    await WorkspaceFS.writeFile(fileToUse, editedContent);
 
     vscode.window.showInformationMessage(
       `Successfully replaced '${baseFileName}' with content from '${editedFileName}'`,

--- a/src/commands/figCommands.ts
+++ b/src/commands/figCommands.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 // Local imports - latex utils
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
@@ -54,9 +54,7 @@ async function handleExtractFigurePaths(): Promise<void> {
       return;
     }
 
-    const filePath = WorkspaceFileManager.getRelativePath(
-      editor.document.fileName,
-    );
+    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
     logger.debug(CHANNEL, `Processing LaTeX file: ${filePath}`);
 
     // Extract figure paths
@@ -104,9 +102,7 @@ async function handleExtractTikzFigures(): Promise<void> {
       return;
     }
 
-    const filePath = WorkspaceFileManager.getRelativePath(
-      editor.document.fileName,
-    );
+    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
     logger.debug(
       CHANNEL,
       `Processing LaTeX file for TikZ figures: ${filePath}`,
@@ -167,9 +163,7 @@ async function handleCompileTikzFigures(): Promise<void> {
       return;
     }
 
-    const filePath = WorkspaceFileManager.getRelativePath(
-      editor.document.fileName,
-    );
+    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
     logger.debug(
       CHANNEL,
       `Processing LaTeX file for TikZ compilation: ${filePath}`,
@@ -208,10 +202,7 @@ async function handleCompileTikzFigures(): Promise<void> {
           if (selected) {
             // Open the selected PDF
             const uri = vscode.Uri.file(
-              path.join(
-                WorkspaceFileManager.getWorkspacePath() ?? '',
-                selected.file,
-              ),
+              path.join(WorkspaceFS.getPath() ?? '', selected.file),
             );
             await vscode.commands.executeCommand('vscode.open', uri);
           }

--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -6,7 +6,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { showInfoMessage, showErrorMessage } from '@frontend/ui/messageUtils';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { listInputFiles } from '@frontend/files/listing';
 import { getIncludedExtensions } from '@utils/fileTypeUtils';
 import { selectFile, selectFiles } from '@frontend/files/dialog';
@@ -237,7 +237,7 @@ async function selectEditedFile(): Promise<string | null> {
 async function getCurrentFile(): Promise<string | null> {
   const currentFile = vscode.window.activeTextEditor?.document;
   if (currentFile && currentFile.uri.scheme === 'file') {
-    return WorkspaceFileManager.getRelativePath(currentFile.uri.fsPath);
+    return WorkspaceFS.relativePath(currentFile.uri.fsPath);
   }
   return null;
 }

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports - utilities
 import { getConfig } from '@utils/config';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 export function registerGitCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -16,7 +16,7 @@ export function registerGitCommands(context: vscode.ExtensionContext) {
 }
 
 async function isGitRepository(): Promise<boolean> {
-  const workspacePath = WorkspaceFileManager.getWorkspacePath();
+  const workspacePath = WorkspaceFS.getPath();
   if (workspacePath) {
     const result = spawn.sync('git', ['rev-parse', '--is-inside-work-tree'], {
       cwd: workspacePath,
@@ -32,7 +32,7 @@ async function getRecentCommits(): Promise<string[] | null> {
     return null;
   }
 
-  const workspacePath = WorkspaceFileManager.getWorkspacePath();
+  const workspacePath = WorkspaceFS.getPath();
   if (workspacePath) {
     const numberOfCommits = getConfig('git.numberOfCommitsToShow', 20);
     const result = spawn.sync(

--- a/src/commands/imageCommands.ts
+++ b/src/commands/imageCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import {
   countPdfPages,
   getBase64EncodedMedia,
@@ -51,9 +51,7 @@ async function handleCountPdfPages(): Promise<void> {
       return;
     }
 
-    const selectedFile = WorkspaceFileManager.getRelativePath(
-      fileUris[0].fsPath,
-    );
+    const selectedFile = WorkspaceFS.relativePath(fileUris[0].fsPath);
     logger.debug(CHANNEL, `Processing PDF file: ${selectedFile}`);
 
     const pageCount = await countPdfPages(selectedFile);
@@ -89,9 +87,7 @@ async function handleEncodeImageToBase64(): Promise<string | undefined> {
       return undefined;
     }
 
-    const selectedFile = WorkspaceFileManager.getRelativePath(
-      fileUris[0].fsPath,
-    );
+    const selectedFile = WorkspaceFS.relativePath(fileUris[0].fsPath);
     logger.debug(CHANNEL, `Processing image file: ${selectedFile}`);
 
     const base64String = await getBase64EncodedMedia(selectedFile);
@@ -133,9 +129,7 @@ async function handleConvertPdfToImages(): Promise<
       return undefined;
     }
 
-    const selectedFile = WorkspaceFileManager.getRelativePath(
-      fileUris[0].fsPath,
-    );
+    const selectedFile = WorkspaceFS.relativePath(fileUris[0].fsPath);
     logger.debug(CHANNEL, `Processing PDF file: ${selectedFile}`);
 
     // Get quality from user
@@ -208,9 +202,7 @@ async function handleTestPdfToImage(): Promise<string | undefined> {
       return undefined;
     }
 
-    const selectedFile = WorkspaceFileManager.getRelativePath(
-      fileUris[0].fsPath,
-    );
+    const selectedFile = WorkspaceFS.relativePath(fileUris[0].fsPath);
     logger.debug(CHANNEL, `Testing PDF to PNG conversion for: ${selectedFile}`);
 
     // Get page number from user

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { sleep } from '@utils/helpers';
 import replacementManager from '@replacement/replacementManager';
 
@@ -135,9 +135,7 @@ async function handleGetTeXCount(): Promise<void> {
       return;
     }
 
-    const filePath = WorkspaceFileManager.getRelativePath(
-      editor.document.fileName,
-    );
+    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
     logger.debug(CHANNEL, `Getting tex count for: ${filePath}`);
 
     // Ask if user wants to merge included files

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 
 // Local imports - latex utils
@@ -91,7 +91,7 @@ async function handleLatexdiff(
       path.dirname(fileToUse),
       result.diffFileName,
     );
-    if (!(await WorkspaceFileManager.fileExists(filePathRelative))) {
+    if (!(await WorkspaceFS.exists(filePathRelative))) {
       vscode.window.showErrorMessage(
         `Diff file could not be found. Expected path: ${filePathRelative}`,
       );
@@ -130,7 +130,7 @@ async function handleLatexdiffvc(
       path.dirname(fileToUse),
       result.diffFileName,
     );
-    if (!(await WorkspaceFileManager.fileExists(filePathRelative))) {
+    if (!(await WorkspaceFS.exists(filePathRelative))) {
       vscode.window.showErrorMessage(
         `Diff file could not be found. Expected path: ${filePathRelative}`,
       );
@@ -269,7 +269,7 @@ async function handleRunLatexdiff(config: any) {
     logger.debug(CHANNEL, `Using agent name chunk: ${agentNameChunk}`);
 
     // Get workspace path
-    const workspacePath = WorkspaceFileManager.getWorkspacePath();
+    const workspacePath = WorkspaceFS.getPath();
     if (!workspacePath) {
       throw new Error('No workspace path found');
     }

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -6,7 +6,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utils
 import { getLinterMessages } from '@frontend/latex/linter';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { sleep } from '@utils/helpers';
 
 // Local imports - core
@@ -36,7 +36,7 @@ export async function handleShowLinterMessages(): Promise<void> {
 
     // Convert absolute file path to workspace-relative path
     const absolutePath = editor.document.fileName;
-    const relativePath = WorkspaceFileManager.getRelativePath(absolutePath);
+    const relativePath = WorkspaceFS.relativePath(absolutePath);
     logger.debug(CHANNEL, `Getting linter messages for ${relativePath}`);
 
     // Get linter messages
@@ -87,7 +87,7 @@ export async function handleCountLinterMessages(): Promise<void> {
 
     // Convert absolute file path to workspace-relative path
     const absolutePath = editor.document.fileName;
-    const relativePath = WorkspaceFileManager.getRelativePath(absolutePath);
+    const relativePath = WorkspaceFS.relativePath(absolutePath);
     logger.debug(CHANNEL, `Counting linter messages for ${relativePath}`);
 
     // Get linter messages - now uses the async version to ensure build is triggered
@@ -159,7 +159,7 @@ export async function handleFixLinterIssues(): Promise<void> {
 
     // Convert absolute file path to workspace-relative path
     const absolutePath = editor.document.fileName;
-    const relativePath = WorkspaceFileManager.getRelativePath(absolutePath);
+    const relativePath = WorkspaceFS.relativePath(absolutePath);
     logger.debug(CHANNEL, `Fixing linter issues for ${relativePath}`);
 
     // Check if there are any linter issues

--- a/src/commands/textEditorCommands.ts
+++ b/src/commands/textEditorCommands.ts
@@ -8,7 +8,7 @@ import * as logger from '@logger/logUtils';
 import { TextEditorTool, ToolCallInput } from '../AnthropicTool';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'TextEditorCommands';
 logger.initialize(CHANNEL);
@@ -37,9 +37,7 @@ async function handleTestTextEditor(): Promise<void> {
       return;
     }
 
-    const filePath = WorkspaceFileManager.getRelativePath(
-      editor.document.fileName,
-    );
+    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
     logger.info(CHANNEL, `Testing text editor tool with file: ${filePath}`);
 
     // Get command to test

--- a/src/commands/xmlCommands.ts
+++ b/src/commands/xmlCommands.ts
@@ -9,7 +9,7 @@ import * as logger from '@logger/logUtils';
 import { XMLValidatorAgent } from '../AnthropicTool';
 
 // Local imports - utils
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { sleep } from '@utils/helpers';
 
 const CHANNEL = 'XmlCommands';
@@ -112,9 +112,7 @@ export async function handleValidateAndFixXml(): Promise<void> {
     await editor.document.save();
 
     // Get the file path
-    const filePath = WorkspaceFileManager.getRelativePath(
-      editor.document.fileName,
-    );
+    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
 
     // Use the validator to fix any XML errors
     logger.info(CHANNEL, `Starting XML validation for ${filePath}`);

--- a/src/frontend/files/dialog.ts
+++ b/src/frontend/files/dialog.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { showErrorMessage } from '../ui/messageUtils';
 
 export interface FileDialogOptions {
@@ -57,7 +57,7 @@ export async function selectFiles(
   });
 
   return fileUris && fileUris.length > 0
-    ? fileUris.map((uri) => WorkspaceFileManager.getRelativePath(uri.fsPath))
+    ? fileUris.map((uri) => WorkspaceFS.relativePath(uri.fsPath))
     : null;
 }
 

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -9,7 +9,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { getConfig } from '@utils/config';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { getIncludedExtensions } from '@utils/fileTypeUtils';
 
 const CHANNEL = 'FrontendUtils';
@@ -26,7 +26,7 @@ export function getFilesIfNotEmpty<T>(files: T[] | undefined): T[] | null {
 }
 
 export async function listInputFiles(): Promise<string[]> {
-  const workspacePath = WorkspaceFileManager.getWorkspacePath();
+  const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
     return [];
   }
@@ -47,7 +47,7 @@ export async function listInputFiles(): Promise<string[]> {
 export const listReferenceFiles = listInputFiles;
 
 export async function listAuxiliaryFiles(): Promise<string[]> {
-  const workspacePath = WorkspaceFileManager.getWorkspacePath();
+  const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
     return [];
   }
@@ -68,7 +68,7 @@ export async function listAuxiliaryFiles(): Promise<string[]> {
 }
 
 export async function listMediaFiles(): Promise<string[]> {
-  const workspacePath = WorkspaceFileManager.getWorkspacePath();
+  const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
     return [];
   }
@@ -90,7 +90,7 @@ export async function listMediaFiles(): Promise<string[]> {
 }
 
 export async function listEditedFiles(baseFileName: string): Promise<string[]> {
-  const workspacePath = WorkspaceFileManager.getWorkspacePath();
+  const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
     return [];
   }

--- a/src/frontend/files/rules.ts
+++ b/src/frontend/files/rules.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { fileExistsAbsolute, readFileAbsolute } from '@utils/files';
 
 const CHANNEL = 'texraRulesUtils';
@@ -18,11 +18,11 @@ logger.initialize(CHANNEL);
  */
 export async function loadTexraRules(): Promise<string> {
   try {
-    const workspacePath = WorkspaceFileManager.getWorkspacePath();
+    const workspacePath = WorkspaceFS.getPath();
     const rulesFile = '.texrarules';
 
-    if (workspacePath && (await WorkspaceFileManager.fileExists(rulesFile))) {
-      const content = await WorkspaceFileManager.readFile(rulesFile);
+    if (workspacePath && (await WorkspaceFS.exists(rulesFile))) {
+      const content = await WorkspaceFS.readFile(rulesFile);
       if (content.trim()) {
         logger.debug(CHANNEL, `Loaded workspace ${rulesFile}`);
         return content.trim();

--- a/src/frontend/files/vars.ts
+++ b/src/frontend/files/vars.ts
@@ -1,5 +1,5 @@
 // Local imports - utilities
-import { WorkspaceFileManager, readFileAbsolute } from '@utils/files';
+import { WorkspaceFS, readFileAbsolute } from '@utils/files';
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
@@ -27,7 +27,7 @@ export async function setVarFromFile(
   try {
     const fileContent = absolute
       ? await readFileAbsolute(filePath)
-      : await WorkspaceFileManager.readFile(filePath);
+      : await WorkspaceFS.readFile(filePath);
     userVars[`${varName}_FILE`] = filePath;
     userVars[`${varName}_CONTENT`] = fileContent;
     logger.info(`Found from [${source}] the [VAR '${varName}']: ${filePath}`);

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { sleep } from '@utils/helpers';
 
 const CHANNEL = 'LinterUtils';
@@ -30,7 +30,7 @@ export async function triggerLaTeXBuild(filePath: string): Promise<void> {
     }
 
     // Get the full path and create URI for the specific file
-    const fullPath = WorkspaceFileManager.getFullPathFromWorkspace(filePath);
+    const fullPath = WorkspaceFS.fullPath(filePath);
     const fileUri = vscode.Uri.file(fullPath);
 
     // First, make sure the file is open in an editor
@@ -101,7 +101,7 @@ export async function triggerLaTeXBuild(filePath: string): Promise<void> {
 export function getDiagnostics(filePath: string): vscode.Diagnostic[] {
   try {
     // Convert relative path to absolute path
-    const fullPath = WorkspaceFileManager.getFullPathFromWorkspace(filePath);
+    const fullPath = WorkspaceFS.fullPath(filePath);
 
     // Convert to Uri to match diagnostics format
     const fileUri = vscode.Uri.file(fullPath);

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'OpenBuildUtils';
 logger.initialize(CHANNEL);
@@ -19,14 +19,12 @@ export async function openAndBuildIfTex(
   options: { preserveFocus?: boolean } = {},
 ): Promise<void> {
   try {
-    if (!(await WorkspaceFileManager.fileExists(file))) {
+    if (!(await WorkspaceFS.exists(file))) {
       vscode.window.showErrorMessage(`File not found: ${file}`);
       return;
     }
 
-    const uri = vscode.Uri.file(
-      WorkspaceFileManager.getFullPathFromWorkspace(file),
-    );
+    const uri = vscode.Uri.file(WorkspaceFS.fullPath(file));
     const doc = await vscode.workspace.openTextDocument(uri);
     await vscode.window.showTextDocument(doc, {
       preview: false,

--- a/src/frontend/media/img.ts
+++ b/src/frontend/media/img.ts
@@ -11,7 +11,7 @@ import { fromPath } from 'pdf2pic';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { fileExistsAbsolute } from '@utils/files/absoluteFileUtils';
 import { checkMultipleToolsInstalled } from '@utils/system';
 
@@ -61,7 +61,7 @@ export async function getBase64EncodedMedia(
     // Check if file exists
     const fileExistsResult = isAbsolutePath
       ? await fileExistsAbsolute(mediaPath)
-      : await WorkspaceFileManager.fileExists(mediaPath);
+      : await WorkspaceFS.exists(mediaPath);
 
     if (!fileExistsResult) {
       logger.error(CHANNEL, `Image file not found: ${mediaPath}`);
@@ -71,7 +71,7 @@ export async function getBase64EncodedMedia(
     // Read the image file as bytes
     const mediaBytes = isAbsolutePath
       ? fs.readFileSync(mediaPath)
-      : WorkspaceFileManager.readFileBytesSync(mediaPath);
+      : WorkspaceFS.readFileBytesSync(mediaPath);
 
     // Convert to base64
     const base64String = mediaBytes.toString('base64');
@@ -100,7 +100,7 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
     // Check if file exists
     const fileExistsResult = isAbsolutePath
       ? await fileExistsAbsolute(pdfPath)
-      : await WorkspaceFileManager.fileExists(pdfPath);
+      : await WorkspaceFS.exists(pdfPath);
 
     if (!fileExistsResult) {
       logger.error(CHANNEL, `PDF file not found: ${pdfPath}`);
@@ -110,7 +110,7 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
     // Read the PDF file using pdf-lib
     const pdfBytes = isAbsolutePath
       ? fs.readFileSync(pdfPath)
-      : WorkspaceFileManager.readFileBytesSync(pdfPath);
+      : WorkspaceFS.readFileBytesSync(pdfPath);
     const pdfDoc = await PDFDocument.load(pdfBytes, {
       updateMetadata: false,
       ignoreEncryption: true,
@@ -166,15 +166,13 @@ export async function singlePagePdf2Png(
     // Verify file exists
     const fileExistsResult = isAbsolutePath
       ? await fileExistsAbsolute(pdfPath)
-      : await WorkspaceFileManager.fileExists(pdfPath);
+      : await WorkspaceFS.exists(pdfPath);
 
     if (!fileExistsResult) {
       throw new Error(`PDF file not found: ${pdfPath}`);
     }
 
-    const fullPath = isAbsolutePath
-      ? pdfPath
-      : WorkspaceFileManager.getFullPathFromWorkspace(pdfPath);
+    const fullPath = isAbsolutePath ? pdfPath : WorkspaceFS.fullPath(pdfPath);
     logger.debug(CHANNEL, `Full path to PDF: ${fullPath}`);
 
     // Ensure the temporary directory exists
@@ -297,7 +295,7 @@ export async function processPdf2Png(
     // Verify file exists
     const fileExistsResult = isAbsolutePath
       ? await fileExistsAbsolute(pdfPath)
-      : await WorkspaceFileManager.fileExists(pdfPath);
+      : await WorkspaceFS.exists(pdfPath);
 
     if (!fileExistsResult) {
       logger.debug(CHANNEL, `PDF file not found: ${pdfPath}`);

--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { fileExistsAbsolute } from '@utils/files';
 
 /**
@@ -56,7 +56,7 @@ export async function checkExpectedOutputs(
   for (const file of expectedFiles) {
     const exists = path.isAbsolute(file)
       ? await fileExistsAbsolute(file)
-      : await WorkspaceFileManager.fileExists(file);
+      : await WorkspaceFS.exists(file);
     if (!exists) {
       const openBtn = 'Open XML';
 
@@ -103,7 +103,7 @@ export async function checkExpectedOutputs(
 
               const xmlExists = path.isAbsolute(xmlPath)
                 ? await fileExistsAbsolute(xmlPath)
-                : await WorkspaceFileManager.fileExists(xmlPath);
+                : await WorkspaceFS.exists(xmlPath);
               if (!xmlExists) {
                 vscode.window.showWarningMessage(
                   `XML file not found: ${path.basename(xmlPath)}`,
@@ -112,9 +112,7 @@ export async function checkExpectedOutputs(
               }
               const uri = path.isAbsolute(xmlPath)
                 ? vscode.Uri.file(xmlPath)
-                : vscode.Uri.file(
-                    WorkspaceFileManager.getFullPathFromWorkspace(xmlPath),
-                  );
+                : vscode.Uri.file(WorkspaceFS.fullPath(xmlPath));
               const doc = await vscode.workspace.openTextDocument(uri);
               await vscode.window.showTextDocument(doc, { preview: false });
             },

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -11,7 +11,7 @@ import * as logger from '@logger/logUtils';
 import type { FileOpResult } from '@/types/ResultTypes';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 // Local imports - housekeeping
 import {
@@ -60,7 +60,7 @@ export async function runCleanSingle(
   const filesToDelete: string[] = [];
   for (const pattern of filePatterns) {
     for (const ext of extensions) {
-      const filePath = await WorkspaceFileManager.findFileInBuild(
+      const filePath = await WorkspaceFS.findFileInBuild(
         inputDir,
         pattern,
         ext,
@@ -83,7 +83,7 @@ export async function runCleanSingle(
     try {
       logger.debug(CHANNEL, `Files to delete:\n${filesToDelete.join('\n')}`);
       for (const filePath of filesToDelete) {
-        await WorkspaceFileManager.deleteFile(filePath);
+        await WorkspaceFS.delete(filePath);
       }
       logger.info(CHANNEL, `Cleanup complete for ${inputFile}`);
       result = { status: 'success' };
@@ -148,19 +148,18 @@ export async function runCleanBuild(): Promise<void> {
 
   async function cleanBuildDir(directory: string) {
     const buildDir = path.join(directory, 'build');
-    if (await WorkspaceFileManager.fileExists(buildDir)) {
+    if (await WorkspaceFS.exists(buildDir)) {
       try {
-        const entries = await WorkspaceFileManager.readDirectory(buildDir);
+        const entries = await WorkspaceFS.readDir(buildDir);
         // First delete all files
         for (const [name, type] of entries) {
           const fullPath = path.join(buildDir, name);
           if (type === vscode.FileType.File) {
-            await WorkspaceFileManager.deleteFile(fullPath);
+            await WorkspaceFS.delete(fullPath);
           } else if (type === vscode.FileType.Directory) {
-            const subEntries =
-              await WorkspaceFileManager.readDirectory(fullPath);
+            const subEntries = await WorkspaceFS.readDir(fullPath);
             if (subEntries.length === 0) {
-              await WorkspaceFileManager.deleteFile(fullPath);
+              await WorkspaceFS.delete(fullPath);
               logger.debug(CHANNEL, `Removed empty directory: ${fullPath}`);
             }
             for (const [name, type] of subEntries) {
@@ -171,7 +170,7 @@ export async function runCleanBuild(): Promise<void> {
                 );
                 const size = stats.size;
                 if (size === 0) {
-                  await WorkspaceFileManager.deleteFile(subPath);
+                  await WorkspaceFS.delete(subPath);
                   logger.debug(CHANNEL, `Removed empty directory: ${subPath}`);
                 }
               }
@@ -179,8 +178,7 @@ export async function runCleanBuild(): Promise<void> {
           }
         }
         // Check if build directory itself is empty
-        const remainingEntries =
-          await WorkspaceFileManager.readDirectory(buildDir);
+        const remainingEntries = await WorkspaceFS.readDir(buildDir);
         if (remainingEntries.length === 0) {
           await vscode.workspace.fs.delete(vscode.Uri.file(buildDir), {
             recursive: true,
@@ -200,7 +198,7 @@ export async function runCleanBuild(): Promise<void> {
 
   async function processDirectory(dirPath: string) {
     try {
-      const entries = await WorkspaceFileManager.readDirectory(dirPath);
+      const entries = await WorkspaceFS.readDir(dirPath);
       for (const [name, type] of entries) {
         if (
           type === vscode.FileType.Directory &&
@@ -242,7 +240,7 @@ export async function runCleanOutput(): Promise<void> {
 
   const processDirectory = async (dirPath: string) => {
     try {
-      const entries = await WorkspaceFileManager.readDirectory(dirPath);
+      const entries = await WorkspaceFS.readDir(dirPath);
       for (const [name, type] of entries) {
         if (EXCLUDED_DIRS.has(name.toLowerCase())) {
           continue;
@@ -271,7 +269,7 @@ export async function runCleanOutput(): Promise<void> {
   await processDirectory('.');
 
   for (const file of filesToDelete) {
-    await WorkspaceFileManager.deleteFile(file);
+    await WorkspaceFS.delete(file);
   }
 
   logger.info(CHANNEL, 'All AI Generated Output files cleaned');

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { fileExistsAbsolute } from '@utils/files';
 import { getConfig } from '@utils/config';
 import { runLatexFormatter } from '@latex/texFormatter';
@@ -58,7 +58,7 @@ export async function indentLatexFilesInDirectory(
 
   const processDirectory = async (dirPath: string) => {
     try {
-      const entries = await WorkspaceFileManager.readDirectory(dirPath);
+      const entries = await WorkspaceFS.readDir(dirPath);
       for (const [name, type] of entries) {
         if (EXCLUDED_DIRS.has(name.toLowerCase())) {
           continue;
@@ -102,7 +102,7 @@ export async function indentLatexFilesInDirectory(
     // Clean up temporary files recursively
     const processCleanup = async (dirPath: string) => {
       try {
-        const entries = await WorkspaceFileManager.readDirectory(dirPath);
+        const entries = await WorkspaceFS.readDir(dirPath);
         for (const [name, type] of entries) {
           if (EXCLUDED_DIRS.has(name.toLowerCase())) {
             continue;
@@ -124,7 +124,7 @@ export async function indentLatexFilesInDirectory(
               name === 'indent.log'
             ) {
               logger.debug(CHANNEL, `Found cleanup file: ${fullPath}`);
-              await WorkspaceFileManager.deleteFile(fullPath);
+              await WorkspaceFS.delete(fullPath);
             }
           }
         }

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 // Local imports - housekeeping
 import { TEMP_EXTENSIONS } from './constants';
@@ -43,7 +43,7 @@ export async function runPackLatexdiffvc(
   // Find files to process
   for (const pattern of filePatterns) {
     for (const ext of ['.tex', '.pdf']) {
-      const filePath = await WorkspaceFileManager.findFileInBuild(
+      const filePath = await WorkspaceFS.findFileInBuild(
         inputDir,
         pattern,
         ext,
@@ -58,7 +58,7 @@ export async function runPackLatexdiffvc(
             path.dirname(filePath),
             `${pattern}${tempExt}`,
           );
-          if (await WorkspaceFileManager.fileExists(tempFile)) {
+          if (await WorkspaceFS.exists(tempFile)) {
             logger.debug(CHANNEL, `Found temporary file: ${tempFile}`);
             filesToDelete.push(tempFile);
           }
@@ -71,7 +71,7 @@ export async function runPackLatexdiffvc(
     if (clean) {
       // Delete all files if clean mode
       for (const file of [...filesToProcess, ...filesToDelete]) {
-        await WorkspaceFileManager.deleteFile(file);
+        await WorkspaceFS.delete(file);
       }
       logger.info(CHANNEL, 'Cleanup complete.');
       vscode.window.showInformationMessage('LaTeXdiff files cleaned');
@@ -90,11 +90,11 @@ export async function runPackLatexdiffvc(
         // Move main files
         for (const file of filesToProcess) {
           if (!anyFilesPacked) {
-            await WorkspaceFileManager.createDirectory(outputFolder);
+            await WorkspaceFS.createDir(outputFolder);
             logger.debug(CHANNEL, `Created output directory: ${outputFolder}`);
             anyFilesPacked = true;
           }
-          await WorkspaceFileManager.moveFile(
+          await WorkspaceFS.move(
             file,
             path.join(outputFolder, path.basename(file)),
           );
@@ -102,7 +102,7 @@ export async function runPackLatexdiffvc(
 
         // Delete temporary files
         for (const file of filesToDelete) {
-          await WorkspaceFileManager.deleteFile(file);
+          await WorkspaceFS.delete(file);
         }
 
         if (anyFilesPacked) {
@@ -180,7 +180,7 @@ export async function runCleanLatexdiffvc(
   for (const pattern of filePatterns) {
     // Find main files (.tex and .pdf)
     for (const ext of ['.tex', '.pdf']) {
-      const filePath = await WorkspaceFileManager.findFileInBuild(
+      const filePath = await WorkspaceFS.findFileInBuild(
         inputDir,
         pattern,
         ext,
@@ -193,7 +193,7 @@ export async function runCleanLatexdiffvc(
 
     // Find all temporary files
     for (const tempExt of TEMP_EXTENSIONS) {
-      const filePath = await WorkspaceFileManager.findFileInBuild(
+      const filePath = await WorkspaceFS.findFileInBuild(
         inputDir,
         pattern,
         tempExt,
@@ -208,7 +208,7 @@ export async function runCleanLatexdiffvc(
   if (filesToDelete.length > 0) {
     // Delete all found files
     for (const file of filesToDelete) {
-      await WorkspaceFileManager.deleteFile(file);
+      await WorkspaceFS.delete(file);
     }
     logger.info(CHANNEL, 'Cleanup complete.');
     vscode.window.showInformationMessage('LaTeXdiff files cleaned');

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -11,7 +11,7 @@ import type { FileOpResult } from '@/types/ResultTypes';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 // Local imports - housekeeping
 import { PACK_EXTENSIONS, TEMP_EXTENSIONS, HISTORY_DIR } from './constants';
@@ -59,7 +59,7 @@ export async function runPackSingle(
   // Find files to move or copy
   for (const pattern of filePatterns) {
     for (const ext of PACK_EXTENSIONS) {
-      const filePath = await WorkspaceFileManager.findFileInBuild(
+      const filePath = await WorkspaceFS.findFileInBuild(
         inputDir,
         pattern,
         ext,
@@ -104,7 +104,7 @@ export async function runPackSingle(
     logger.debug(CHANNEL, `Output folder: ${outputFolder}`);
 
     try {
-      await WorkspaceFileManager.createDirectory(outputFolder);
+      await WorkspaceFS.createDir(outputFolder);
       logger.debug(CHANNEL, `Created output directory: ${outputFolder}`);
 
       // Move and copy files
@@ -112,12 +112,12 @@ export async function runPackSingle(
       for (const file of movedFiles) {
         const destination = path.join(outputFolder, path.basename(file));
         operations.push(`Moving: ${file} -> ${destination}`);
-        await WorkspaceFileManager.moveFile(file, destination);
+        await WorkspaceFS.move(file, destination);
       }
       for (const file of copiedFiles) {
         const destination = path.join(outputFolder, path.basename(file));
         operations.push(`Copying: ${file} -> ${destination}`);
-        await WorkspaceFileManager.copyFile(file, destination);
+        await WorkspaceFS.copy(file, destination);
       }
       if (operations.length > 0 && !onlyInputFilePacked) {
         logger.info(CHANNEL, `Files packed into ${outputFolder}`);
@@ -142,13 +142,13 @@ export async function runPackSingle(
   // Clean up temporary files
   for (const pattern of filePatterns) {
     for (const ext of TEMP_EXTENSIONS) {
-      const filePath = await WorkspaceFileManager.findFileInBuild(
+      const filePath = await WorkspaceFS.findFileInBuild(
         inputDir,
         pattern,
         ext,
       );
       if (filePath && filePath !== inputFile) {
-        await WorkspaceFileManager.deleteFile(filePath);
+        await WorkspaceFS.delete(filePath);
       }
     }
   }
@@ -218,12 +218,12 @@ export async function runPackMultiple(
 
     for (const pattern of additionalPatterns) {
       const filePath = path.join(outputDir, pattern);
-      if (await WorkspaceFileManager.fileExists(filePath)) {
+      if (await WorkspaceFS.exists(filePath)) {
         if (!anyFilesPacked) {
-          await WorkspaceFileManager.createDirectory(commonOutputFolder);
+          await WorkspaceFS.createDir(commonOutputFolder);
         }
         logger.debug(CHANNEL, `Found additional XML file: ${filePath}`);
-        await WorkspaceFileManager.moveFile(
+        await WorkspaceFS.move(
           filePath,
           path.join(commonOutputFolder, pattern),
         );

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -62,7 +62,7 @@ export async function extractFigurePathsFromLatex(
     ];
 
     // Read file content
-    const content = await WorkspaceFileManager.readFile(latexFile);
+    const content = await WorkspaceFS.readFile(latexFile);
 
     // Parse graphicspaths
     const paths = parseGraphicspath(content);
@@ -99,7 +99,7 @@ export async function extractFigurePathsFromLatex(
             // Handle subdirectory case by attempting two different path resolutions:
             // 1. Standard way - relative to the main latex directory
             const relPathStandard = path.relative(latexDir, pathToCheck);
-            if (await WorkspaceFileManager.fileExists(relPathStandard)) {
+            if (await WorkspaceFS.exists(relPathStandard)) {
               figurePaths.push(relPathStandard);
               break;
             }
@@ -111,7 +111,7 @@ export async function extractFigurePathsFromLatex(
             );
             if (
               basePath !== latexDir &&
-              (await WorkspaceFileManager.fileExists(relPathToBase))
+              (await WorkspaceFS.exists(relPathToBase))
             ) {
               figurePaths.push(relPathToBase);
               break;

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -9,7 +9,7 @@ import { sync as globSync } from 'glob';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { executeCommand } from '@utils/system';
 import { sleep } from '@utils/helpers';
 import { checkToolInstalled } from '@utils/system';
@@ -24,7 +24,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
       return false;
     }
 
-    const workspacePath = WorkspaceFileManager.getWorkspacePath();
+    const workspacePath = WorkspaceFS.getPath();
     if (!workspacePath) {
       logger.error(CHANNEL, 'No workspace path found');
       return false;
@@ -83,7 +83,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
 
       for (const backupFile of backupFiles) {
         try {
-          await WorkspaceFileManager.deleteFile(backupFile);
+          await WorkspaceFS.delete(backupFile);
           logger.debug(CHANNEL, `Removed backup file: ${backupFile}`);
         } catch (err) {
           logger.warn(
@@ -97,7 +97,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     // Clean up indent.log
     const indentLogPath = path.join(path.dirname(filePath), 'indent.log');
     try {
-      await WorkspaceFileManager.deleteFile(indentLogPath);
+      await WorkspaceFS.delete(indentLogPath);
       logger.debug(CHANNEL, 'Removed indent.log');
     } catch (err) {
       // Ignore error if indent.log doesn't exist

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { executeCommand } from '@utils/system';
 import { ExecResult } from '../types/ResultTypes';
 import { getConfig } from '@utils/config';
@@ -205,7 +205,7 @@ async function processDiffFile(
   channel: string = CHANNEL,
 ): Promise<void> {
   try {
-    const content = await WorkspaceFileManager.readFile(diffFileName);
+    const content = await WorkspaceFS.readFile(diffFileName);
 
     // Process the content to remove labels from star environments
     let processedContent = content;
@@ -289,7 +289,7 @@ async function processDiffFile(
     // Apply standard replacements from the replacementUtils at the end of processing
     newContent = replacementManager.applyAll(newContent);
 
-    await WorkspaceFileManager.writeFile(diffFileName, newContent);
+    await WorkspaceFS.writeFile(diffFileName, newContent);
     // logger.debug(channel, `Line breaks added to ${diffFileName}`);
   } catch (err) {
     logger.error(
@@ -337,7 +337,7 @@ async function processTikzPictureEndings(
   filePath: string,
   channel: string = CHANNEL,
 ): Promise<void> {
-  const content = await WorkspaceFileManager.readFile(filePath);
+  const content = await WorkspaceFS.readFile(filePath);
 
   let newContent = content;
   const patterns = [
@@ -383,7 +383,7 @@ async function processTikzPictureEndings(
   // maybe above do more evil than correcting the issue...
   // So they are commented out for now
 
-  await WorkspaceFileManager.writeFile(filePath, newContent);
+  await WorkspaceFS.writeFile(filePath, newContent);
   // logger.debug(channel, `Tikzpicture endings fixed in ${filePath}`);
 }
 
@@ -402,8 +402,8 @@ export async function runLatexdiff(
 
     // Check if both files exist
     if (
-      !(await WorkspaceFileManager.fileExists(inputFile)) ||
-      !(await WorkspaceFileManager.fileExists(editedFile))
+      !(await WorkspaceFS.exists(inputFile)) ||
+      !(await WorkspaceFS.exists(editedFile))
     ) {
       const message = `One or both files do not exist. Input: ${inputFile}, Edited: ${editedFile}`;
       logger.warn(channel, message);
@@ -432,8 +432,8 @@ export async function runLatexdiff(
     }
 
     // Files are now relative to workspace, no need for extra path joining
-    const inputContent = await WorkspaceFileManager.readFile(inputFile);
-    const editedContent = await WorkspaceFileManager.readFile(editedFile);
+    const inputContent = await WorkspaceFS.readFile(inputFile);
+    const editedContent = await WorkspaceFS.readFile(editedFile);
 
     const documentChecks = [
       { file: inputFile, content: inputContent },
@@ -518,7 +518,7 @@ export async function runLatexdiff(
     }
 
     // Write the output to the diff file
-    await WorkspaceFileManager.writeFile(outputPath, result.stdout);
+    await WorkspaceFS.writeFile(outputPath, result.stdout);
 
     await processDiffFile(outputPath);
     await processTikzPictureEndings(outputPath);
@@ -541,7 +541,7 @@ export async function runLatexdiffvc(
 ): Promise<LaTeXdiffResult> {
   try {
     // Use readFile which now handles workspace paths
-    const inputContent = await WorkspaceFileManager.readFile(inputFile);
+    const inputContent = await WorkspaceFS.readFile(inputFile);
 
     if (
       !inputContent.includes('\\begin{document}') ||
@@ -660,8 +660,8 @@ export async function runLatexdiffForRound(
 ): Promise<LaTeXdiffResult> {
   try {
     if (
-      (await WorkspaceFileManager.fileExists(baseFile)) &&
-      (await WorkspaceFileManager.fileExists(outputFile))
+      (await WorkspaceFS.exists(baseFile)) &&
+      (await WorkspaceFS.exists(outputFile))
     ) {
       return await runLatexdiff(baseFile, outputFile, '_diff', false);
     } else {
@@ -686,8 +686,8 @@ export async function runLatexdiffBetweenRounds(
 ): Promise<LaTeXdiffResult> {
   try {
     if (
-      (await WorkspaceFileManager.fileExists(outputFile1)) &&
-      (await WorkspaceFileManager.fileExists(outputFile2))
+      (await WorkspaceFS.exists(outputFile1)) &&
+      (await WorkspaceFS.exists(outputFile2))
     ) {
       const firstRoundMatch = outputFile1.match(/_r(\d+)_/);
       const secondRoundMatch = outputFile2.match(/_r(\d+)_/);

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -10,7 +10,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { executeCommand } from '@utils/system';
 import { getConfig } from '@utils/config';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 // No additional imports needed
 
 const CHANNEL = 'LaTeXCommands';
@@ -32,7 +32,7 @@ export async function compileLatex2Pdf(
 ): Promise<boolean> {
   try {
     const outDir = outputDirectory || path.dirname(latexFile);
-    await WorkspaceFileManager.createDirectory(outDir);
+    await WorkspaceFS.createDir(outDir);
 
     // Get TikZ input directory from configuration
     const tikzInputDirectory = getConfig<string>(
@@ -54,7 +54,7 @@ export async function compileLatex2Pdf(
 
     // Add the workspace path if configured to do so
     if (includeWorkspace) {
-      const workspacePath = WorkspaceFileManager.getWorkspacePath();
+      const workspacePath = WorkspaceFS.getPath();
       if (workspacePath) {
         texInputs += `${workspacePath}:`;
       }

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -2,7 +2,7 @@
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { executeCommand, checkToolInstalled } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
@@ -15,7 +15,7 @@ logger.initialize(CHANNEL);
  */
 async function hasChinesePackages(filePath: string): Promise<boolean> {
   try {
-    const content = await WorkspaceFileManager.readFile(filePath);
+    const content = await WorkspaceFS.readFile(filePath);
     const chinesePackages = [
       'xeCJK',
       'ctexart',
@@ -62,7 +62,7 @@ export async function getTeXCount(
     const allOutputs: string[] = [];
 
     for (const filePath of paths) {
-      if (!(await WorkspaceFileManager.fileExists(filePath))) {
+      if (!(await WorkspaceFS.exists(filePath))) {
         logger.warn(channel, `File ${filePath} does not exist.`);
         continue;
       }

--- a/src/latex/tikzpicture.ts
+++ b/src/latex/tikzpicture.ts
@@ -8,7 +8,7 @@ import * as nunjucks from 'nunjucks';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { renderPrompt } from '@utils/promptUtils';
 import { getConfig } from '@utils/config';
 
@@ -55,7 +55,7 @@ export async function extractTikzPicturesWithLabels(
   channel: string = CHANNEL,
 ): Promise<[string, string[]][]> {
   try {
-    const content = await WorkspaceFileManager.readFile(latexFile);
+    const content = await WorkspaceFS.readFile(latexFile);
 
     // Regular expressions to match figure environments and tikzpictures
     const figurePattern =
@@ -117,7 +117,7 @@ export async function createStandaloneLatexWithLabels(
     const filePath = path.join(buildDir, filename);
 
     // Write file
-    await WorkspaceFileManager.writeFile(filePath, standaloneContent);
+    await WorkspaceFS.writeFile(filePath, standaloneContent);
     logger.debug(channel, `Created standalone LaTeX file: ${filePath}`);
 
     return filePath;
@@ -145,7 +145,7 @@ export async function extractAndCompileTikzPicturesWithLabels(
     const inputDir = path.dirname(latexFile);
     const inputName = path.parse(path.basename(latexFile)).name;
     const buildDir = path.join(inputDir, 'build', inputName);
-    await WorkspaceFileManager.createDirectory(buildDir);
+    await WorkspaceFS.createDir(buildDir);
 
     logger.debug(channel, `Extracting TikZ pictures from ${latexFile}`);
     const labeledTikzPictures = await extractTikzPicturesWithLabels(
@@ -181,7 +181,7 @@ export async function extractAndCompileTikzPicturesWithLabels(
         await compileLatex2Pdf(texFile, channel);
 
         const pdfFile = texFile.replace(/\.tex$/, '.pdf');
-        if (await WorkspaceFileManager.fileExists(pdfFile)) {
+        if (await WorkspaceFS.exists(pdfFile)) {
           compiledFiles.push(pdfFile);
           logger.debug(channel, `Successfully compiled: ${pdfFile}`);
         }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -10,7 +10,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 
 import { getConfig } from '@utils/config';
 import { objectToTaskState } from '@utils/config';
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import {
   shouldExcludeFromProgressView,
   shouldPersistStream,
@@ -225,8 +225,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           );
 
           try {
-            const filtered =
-              await WorkspaceFileManager.filterExistingFiles(infos);
+            const filtered = await WorkspaceFS.filterExistingFiles(infos);
             const removedCount = infos.length - filtered.length;
 
             if (removedCount > 0) {

--- a/src/utils/arXivUtils.ts
+++ b/src/utils/arXivUtils.ts
@@ -8,7 +8,7 @@ import * as arxivIdentifiers from 'identifiers-arxiv';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utils
-import { WorkspaceFileManager } from './files';
+import { WorkspaceFS } from './files';
 import { executeCommand } from './system';
 import { indentLatexFilesInDirectory } from '@housekeeping/indent';
 
@@ -157,26 +157,25 @@ export async function downloadArxivSource(
   }
 
   // Get workspace path
-  const workspacePath = WorkspaceFileManager.getWorkspacePath();
+  const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
     throw new Error('No workspace folder is open');
   }
 
   // Create PapersEx directory if it doesn't exist
   const papersExDir = 'PapersEx';
-  if (!(await WorkspaceFileManager.fileExists(papersExDir))) {
-    await WorkspaceFileManager.createDirectory(papersExDir);
+  if (!(await WorkspaceFS.exists(papersExDir))) {
+    await WorkspaceFS.createDir(papersExDir);
   }
 
   // Create a specific directory for this paper
   const paperDirRelative = path.join(papersExDir, arxivId.replace(/\//g, '_'));
-  if (!(await WorkspaceFileManager.fileExists(paperDirRelative))) {
-    await WorkspaceFileManager.createDirectory(paperDirRelative);
+  if (!(await WorkspaceFS.exists(paperDirRelative))) {
+    await WorkspaceFS.createDir(paperDirRelative);
   }
 
   // Get the full paths for operations that need them
-  const paperDirFull =
-    WorkspaceFileManager.getFullPathFromWorkspace(paperDirRelative);
+  const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
   const tarFileName = `${arxivId.replace(/\//g, '_')}.tar.gz`;
   const tarFilePath = path.join(paperDirFull, tarFileName);
 
@@ -206,9 +205,7 @@ export async function downloadArxivSource(
   }
 
   // Clean up the tar file
-  await WorkspaceFileManager.deleteFile(
-    path.join(paperDirRelative, tarFileName),
-  );
+  await WorkspaceFS.delete(path.join(paperDirRelative, tarFileName));
 
   // Indent LaTeX files if autoIndent is enabled
   if (autoIndent) {

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -114,10 +114,7 @@ export class WorkspaceFS {
     }
   }
 
-  public static async move(
-    source: string,
-    destination: string,
-  ): Promise<void> {
+  public static async move(source: string, destination: string): Promise<void> {
     logger.debug(CHANNEL, `Moving file from ${source} to ${destination}`);
     try {
       const fullSourcePath = this.fullPath(source);
@@ -144,10 +141,7 @@ export class WorkspaceFS {
     }
   }
 
-  public static async copy(
-    source: string,
-    destination: string,
-  ): Promise<void> {
+  public static async copy(source: string, destination: string): Promise<void> {
     logger.debug(CHANNEL, `Copying file from ${source} to ${destination}`);
     try {
       const fullSourcePath = this.fullPath(source);
@@ -295,9 +289,7 @@ export class WorkspaceFS {
     return await fileExistsAbsolute(fullPath);
   }
 
-  public static async existsAndNonTrivial(
-    filePath: string,
-  ): Promise<boolean> {
+  public static async existsAndNonTrivial(filePath: string): Promise<boolean> {
     return (
       (await this.exists(filePath)) &&
       (await this.readFile(filePath)).length > 15

--- a/src/utils/promptUtils.ts
+++ b/src/utils/promptUtils.ts
@@ -8,7 +8,7 @@ import * as nunjucks from 'nunjucks';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from './files';
+import { WorkspaceFS } from './files';
 import { getAgentFirstNameChunk } from '@housekeeping/utils';
 
 const CHANNEL = 'promptUtils';
@@ -21,7 +21,7 @@ logger.initialize(CHANNEL);
  */
 export async function getXmlFormatFromFile(file: string): Promise<string> {
   try {
-    const content = await WorkspaceFileManager.readFile(file);
+    const content = await WorkspaceFS.readFile(file);
     return `<document name="${file}">\n${content}\n</document>`;
   } catch (err) {
     logger.error(
@@ -140,7 +140,7 @@ export async function getFirstKCharsFromDocument(
   k: number,
 ): Promise<string | null> {
   try {
-    const content = await WorkspaceFileManager.readFile(inputFile);
+    const content = await WorkspaceFS.readFile(inputFile);
     return content ? content.slice(0, k).trim() : null;
   } catch (err) {
     logger.error(
@@ -175,7 +175,7 @@ export async function writePromptToXml(
     logger.debug(CHANNEL, `Writing input prompt to ${outputFile}`);
 
     const fullPrompt = `\n<system>${systemPrompt}</system>\n\n${userPrefix}\n${userRequest}\n`;
-    await WorkspaceFileManager.writeFile(outputFile, fullPrompt);
+    await WorkspaceFS.writeFile(outputFile, fullPrompt);
 
     return outputFile;
   } catch (err) {

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -5,7 +5,7 @@ import spawn from 'cross-spawn';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { ExecResult } from '@/types/ResultTypes';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
@@ -42,7 +42,7 @@ export async function executeCommand(
   } = {},
 ): Promise<ExecResult> {
   try {
-    const workspacePath = WorkspaceFileManager.getWorkspacePath();
+    const workspacePath = WorkspaceFS.getPath();
     if (!workspacePath) {
       throw new Error('No workspace path found');
     }

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -12,7 +12,7 @@ import * as logger from '@logger/logUtils';
 import { safeExecuteCommand } from '@utils/system';
 
 // Local imports - utilities
-import { WorkspaceFileManager } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import {
   createStorageDirectory,
   writeBinaryFileToStorage,
@@ -687,7 +687,7 @@ export class WebviewMessageHandler {
   }
 
   private async getOpenedFiles(): Promise<string[]> {
-    const workspacePath = WorkspaceFileManager.getWorkspacePath();
+    const workspacePath = WorkspaceFS.getPath();
     if (!workspacePath) {
       logger.warn(CHANNEL, 'No workspace path found for opened files');
       return [];
@@ -713,7 +713,7 @@ export class WebviewMessageHandler {
   private async selectOutputFiles(
     currentInputFile: string,
   ): Promise<string[] | null> {
-    const workspacePath = WorkspaceFileManager.getWorkspacePath();
+    const workspacePath = WorkspaceFS.getPath();
     if (!workspacePath) {
       logger.error(CHANNEL, 'No workspace folder open');
       vscode.window.showErrorMessage('No workspace folder open');
@@ -743,7 +743,7 @@ export class WebviewMessageHandler {
       }
 
       const relativePaths = fileUris.map((uri) =>
-        WorkspaceFileManager.getRelativePath(uri.fsPath),
+        WorkspaceFS.relativePath(uri.fsPath),
       );
       logger.info(
         CHANNEL,


### PR DESCRIPTION
## Summary
- Migrated all 40+ files from the old WorkspaceFileManager API to the new simplified WorkspaceFS API
- Updated all imports and method calls throughout the codebase
- Fixed TypeScript compilation errors that were blocking the build

## Changes
This PR completes the migration that was started in commits 8d3b2c5b and c045baa6, where WorkspaceFileManager was refactored to WorkspaceFS but not all files were updated to use the new API.

### API Changes
- `WorkspaceFileManager.getWorkspacePath()` → `WorkspaceFS.getPath()`
- `WorkspaceFileManager.getRelativePath()` → `WorkspaceFS.relativePath()`
- `WorkspaceFileManager.getFullPathFromWorkspace()` → `WorkspaceFS.fullPath()`
- `WorkspaceFileManager.readFile()` → `WorkspaceFS.readFile()`
- `WorkspaceFileManager.writeFile()` → `WorkspaceFS.writeFile()`
- `WorkspaceFileManager.deleteFile()` → `WorkspaceFS.delete()`
- `WorkspaceFileManager.fileExists()` → `WorkspaceFS.exists()`
- And many more simplified method names

## Test plan
- [x] TypeScript compilation passes without errors
- [x] All existing functionality using the file system should work as before
- [ ] Manual testing of file operations in the extension

🤖 Generated with [Claude Code](https://claude.ai/code)