### PR TITLE
Use provider stop reason types

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -18,6 +18,7 @@ import {
 } from '@frontend/media/img';
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
+import type { ProviderStopReason } from '@types/StopReasonTypes';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 // Local imports - agent components
@@ -532,7 +533,7 @@ export abstract class ModelHandler {
 
   /** Detects stop markers in model output. */
   protected detectStopMarkers(
-    stopReason: string,
+    stopReason: ProviderStopReason,
     response: string,
     setting: AgentSetting,
   ): MarkerFlags {
@@ -549,7 +550,7 @@ export abstract class ModelHandler {
    * @returns Tuple of [endTurn: should end current turn, shouldStop: should stop conversation]
    */
   public checkStopConditions(
-    stopReason: string,
+    stopReason: ProviderStopReason,
     newResponse: string,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
@@ -646,7 +647,7 @@ export abstract class ModelHandler {
   abstract extractResponse(
     responseObject: any,
     endTag: string,
-  ): [string, any, string];
+  ): [string, any, ProviderStopReason];
 
   /**
    * Manages continuation for truncated responses in multi-turn conversations with prefill support.
@@ -725,7 +726,7 @@ export abstract class ModelHandler {
    * @returns Boolean indicating if generation should continue
    */
   abstract shouldContinue(
-    stopReason: string,
+    stopReason: ProviderStopReason,
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -18,6 +18,7 @@ import { formatProviderError } from '@utils/sdkErrorUtils';
 import { WorkspaceFileManager } from '@utils/files';
 import { cleanFileContent } from '@replacement/replacementUtils';
 import replacementManager from '@replacement/replacementManager';
+import type { ProviderStopReason } from '@types/StopReasonTypes';
 import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
 
 // Local imports - agent components
@@ -352,7 +353,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
   extractResponse(
     responseObject: BetaMessage,
     endTag: string,
-  ): [string, AnthropicUsage, string] {
+  ): [string, AnthropicUsage, ProviderStopReason] {
     // Check for empty response
     if (responseObject.usage.output_tokens === 3) {
       // Anthropic specific empty response check
@@ -829,7 +830,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
 
   /** Determines if generation should continue based on stop reason and end tag presence. */
   shouldContinue(
-    stopReason: string,
+    stopReason: ProviderStopReason,
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean {

--- a/src/agent/modelHandlers/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogle.ts
@@ -12,6 +12,7 @@ import {
   GenerateContentResponseUsageMetadata,
 } from '../core/ResponseUsage';
 import type { CompletionUsage } from 'openai/resources/completions';
+import type { ProviderStopReason } from '@types/StopReasonTypes';
 
 /**
  * Handler for Google models using OpenAI-compatible API.
@@ -87,7 +88,7 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
 
   /** Determines if generation should continue based on response content. */
   shouldContinue(
-    stopReason: string,
+    stopReason: ProviderStopReason,
     newResponse: string,
     agentSetting: any,
   ): boolean {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -38,6 +38,7 @@ import { formatProviderError } from '@utils/sdkErrorUtils';
 import { cleanFileContent } from '@replacement/replacementUtils';
 import replacementManager from '@replacement/replacementManager';
 import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
+import type { ProviderStopReason } from '@types/StopReasonTypes';
 import { getConfig } from '@utils/config';
 import { calculateTokenPrice } from '@utils/priceUtils';
 
@@ -564,7 +565,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
   extractResponse(
     responseObject: GenerateContentResponse,
     endTag: string,
-  ): [string, GenerateContentResponseUsageMetadata | undefined, string] {
+  ): [
+    string,
+    GenerateContentResponseUsageMetadata | undefined,
+    ProviderStopReason,
+  ] {
     if (!responseObject) {
       this.logger.error(`Invalid (null) response object received.`);
       return ['', undefined, 'UNKNOWN_EMPTY_RESPONSE'];
@@ -857,7 +862,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
   }
 
   shouldContinue(
-    stopReason: string,
+    stopReason: ProviderStopReason,
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -17,6 +17,7 @@ import { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
 import { AgentStateRound } from '../core/AgentState';
 import { ModelHandler } from './ModelHandler';
+import type { ProviderStopReason } from '@types/StopReasonTypes';
 import {
   OpenAIAPIResponseUsage,
   ResponseUsageFactory,
@@ -387,7 +388,10 @@ export class ModelHandlerOpenAI extends ModelHandler {
   }
 
   /** Extracts response text and usage statistics from API response. */
-  extractResponse(responseObject: any, endTag: string): [string, any, string] {
+  extractResponse(
+    responseObject: any,
+    endTag: string,
+  ): [string, any, ProviderStopReason] {
     if (!responseObject.choices?.length) {
       this.logger.debug(
         `Response object: ${objectToLogString(responseObject)}`,
@@ -804,7 +808,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
 
   /** Determines if generation should continue based on response content. */
   shouldContinue(
-    stopReason: string,
+    stopReason: ProviderStopReason,
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -18,6 +18,7 @@ import { ResponseUsageFactory } from '../core/ResponseUsage';
 import { calculateTokenPrice } from '@utils/priceUtils';
 import { ToolState } from '../core/ToolState';
 import { K_SLICE } from '@utils/config';
+import type { ProviderStopReason } from '@types/StopReasonTypes';
 
 // import { ResponseCreateParams } from 'openai/src/resources/responses/response';
 // this is incorrect now, but would be nice to use
@@ -225,7 +226,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
   extractResponse(
     responseObject: Response,
     endTag: string,
-  ): [string, ResponseUsage | undefined, string] {
+  ): [string, ResponseUsage | undefined, ProviderStopReason] {
     const usage = responseObject.usage || {
       input_tokens: 0,
       output_tokens: 0,

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -8,6 +8,7 @@ import OpenAI from 'openai';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
 import { K_SLICE } from '@utils/config';
+import type { ProviderStopReason } from '@types/StopReasonTypes';
 
 /**
  * Handler for xAI models using OpenAI-compatible API.
@@ -85,7 +86,10 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
   }
 
   /** Extracts response text and usage statistics from API response. */
-  extractResponse(responseObject: any, endTag: string): [string, any, string] {
+  extractResponse(
+    responseObject: any,
+    endTag: string,
+  ): [string, any, ProviderStopReason] {
     const [responseText, usage, stopReason] = super.extractResponse(
       responseObject,
       endTag,

--- a/src/types/StopReasonTypes.ts
+++ b/src/types/StopReasonTypes.ts
@@ -1,0 +1,32 @@
+// Third-party imports
+import type { StopReason as AnthropicStopReason } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { FinishReason as GoogleFinishReason } from '@google/genai/dist/genai';
+
+// Local imports - none
+
+/** OpenAI finish reasons for chat completions. */
+export type OpenAIFinishReason =
+  | 'stop'
+  | 'length'
+  | 'tool_calls'
+  | 'content_filter'
+  | 'function_call'
+  | null;
+
+/** OpenAI finish reasons for text completions. */
+export type OpenAICompletionFinishReason = 'stop' | 'length' | 'content_filter';
+
+/** Stop reasons defined in the Model Context Protocol SDK. */
+export type MCPStopReason = 'endTurn' | 'stopSequence' | 'maxTokens';
+
+/**
+ * Union type covering all known provider stop reasons.
+ * Additional string values are allowed for providers without explicit enums.
+ */
+export type ProviderStopReason =
+  | OpenAIFinishReason
+  | OpenAICompletionFinishReason
+  | AnthropicStopReason
+  | GoogleFinishReason
+  | MCPStopReason
+  | string;


### PR DESCRIPTION
## Summary
- type stop reasons with ProviderStopReason union
- support native provider enums across model handlers

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Module '@utils/files' has no exported member 'WorkspaceFileManager')*

------
https://chatgpt.com/codex/tasks/task_e_6855ab4ae8c0832493055fafc48bbfa2