### PR TITLE
Introduce base agent abstraction

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -1,0 +1,133 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - agent components
+import { AgentConfig } from '../core/AgentConfig';
+import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
+import { IAgent } from '../core/IAgent';
+import { ModelHandler } from '../modelHandlers';
+import { buildUserVars } from '../utils/userVars';
+
+// Local imports - utilities
+import { SHORT_SLEEP_MS } from '@utils/config';
+import { sleep } from '@utils/helpers';
+
+/**
+ * Minimal abstract base class providing shared setup and interruption logic.
+ */
+export abstract class BaseAgent implements IAgent {
+  protected modelHandler: ModelHandler;
+  protected agentConfig: AgentConfig;
+  protected agentSetting: AgentSetting;
+  protected agentPrompt: AgentPrompt;
+  protected agentPath: string;
+  protected logger: AgentLogger;
+  protected runGroupId?: string;
+  protected userVars: Record<string, any> = {};
+  protected client: any;
+  protected isInterrupted = false;
+  protected abortController: AbortController | null = null;
+
+  private static runningAgents: Map<string, BaseAgent> = new Map();
+
+  public get config(): AgentConfig {
+    return this.agentConfig;
+  }
+
+  constructor(
+    modelHandler: ModelHandler,
+    agentConfig: AgentConfig,
+    agentSetting: AgentSetting,
+    agentPrompt: AgentPrompt,
+    agentPath: string,
+  ) {
+    this.modelHandler = modelHandler;
+    this.agentConfig = agentConfig;
+    this.agentSetting = agentSetting;
+    this.agentPrompt = agentPrompt;
+    this.agentPath = agentPath;
+
+    const channelId = this.getTaskId();
+    this.logger = new AgentLogger(channelId);
+    this.modelHandler.setLogger(this.logger);
+    BaseAgent.runningAgents.set(channelId, this);
+  }
+
+  /** Initialize the API client. */
+  protected async initializeClient(): Promise<void> {
+    this.client = await this.modelHandler.getClient();
+    await sleep(SHORT_SLEEP_MS);
+  }
+
+  /** Compute a unique task identifier for logging. */
+  protected getTaskId(): string {
+    const baseName = path.basename(this.agentConfig.inputFile);
+    const agentName =
+      Array.isArray(this.agentConfig.outputFiles) &&
+      this.agentConfig.outputFiles.length > 1
+        ? `${this.agentConfig.agent}_multiple`
+        : this.agentConfig.agent;
+    return `${agentName}@${this.agentConfig.model}: ${baseName}`;
+  }
+
+  /** Gather variables used for prompt rendering. */
+  protected async getUserVars(): Promise<Record<string, any>> {
+    return buildUserVars(
+      this.agentConfig,
+      this.agentSetting,
+      this.agentPath,
+      this.modelHandler,
+      this.logger,
+    );
+  }
+
+  /** Perform asynchronous initialization work. */
+  public async init(parentGroupId?: string): Promise<void> {
+    const initGroupId = await this.logger.startGroup(
+      `Init`,
+      undefined,
+      parentGroupId,
+    );
+    try {
+      this.userVars = await this.getUserVars();
+      this.logger.endGroup(initGroupId, 'stopped');
+    } catch (error) {
+      this.logger.endGroup(initGroupId, 'error');
+      throw error;
+    }
+  }
+
+  /** Interrupt the agent's execution. */
+  public interrupt(): void {
+    this.isInterrupted = true;
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.logger.info(
+      'Agent execution interrupted by user. Active request aborted; partial output may remain.',
+    );
+  }
+
+  /** Check if the agent should stop due to user interruption. */
+  protected checkInterruption(): boolean {
+    if (this.isInterrupted) {
+      this.logger.info('Stopping due to user interruption');
+      return true;
+    }
+    return false;
+  }
+
+  public static getRunningAgent(streamId: string): BaseAgent | undefined {
+    return BaseAgent.runningAgents.get(streamId);
+  }
+
+  protected cleanup(): void {
+    const channelId = this.getTaskId();
+    BaseAgent.runningAgents.delete(channelId);
+  }
+
+  abstract run(): Promise<void>;
+}

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -53,7 +53,6 @@ export abstract class BaseAgent implements IAgent {
     const channelId = this.getTaskId();
     this.logger = new AgentLogger(channelId);
     this.modelHandler.setLogger(this.logger);
-    BaseAgent.runningAgents.set(channelId, this);
   }
 
   /** Initialize the API client. */
@@ -92,7 +91,21 @@ export abstract class BaseAgent implements IAgent {
       parentGroupId,
     );
     try {
+      this.logger.debug(
+        `AgentConfig: ${JSON.stringify(this.agentConfig)}`,
+        initGroupId,
+      );
+      this.logger.debug(
+        `AgentSetting: ${JSON.stringify(this.agentSetting)}`,
+        initGroupId,
+      );
+      this.logger.debug(
+        `ModelConfig: ${JSON.stringify(this.modelHandler.config)}`,
+        initGroupId,
+      );
+
       this.userVars = await this.getUserVars();
+      BaseAgent.runningAgents.set(this.getTaskId(), this);
       this.logger.endGroup(initGroupId, 'stopped');
     } catch (error) {
       this.logger.endGroup(initGroupId, 'error');

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -45,7 +45,7 @@ import { ToolState } from '@agent/core/ToolState';
 import { ModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile } from '@agent/runtime/OutputHandler';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
-import { BaseAgent } from './BaseAgent';
+import { BaseAgent } from '@agent/implementations/BaseAgent';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -1219,19 +1219,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         this.outputHandler.outputMappings[currRound] = [];
       }
     }
-  }
-
-  /**
-   * Interrupts the agent's execution
-   */
-  public interrupt(): void {
-    this.isInterrupted = true;
-    if (this.abortController) {
-      this.abortController.abort();
-    }
-    this.logger.info(
-      'Agent execution interrupted by user. Active request aborted; partial output may remain.',
-    );
   }
 
   /** Extracts and logs scratchpad content from output. */

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -5,7 +5,6 @@ import * as path from 'path';
 // (none needed)
 
 // Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - latex utils
 import {
@@ -33,7 +32,6 @@ import {
   extractAndLogScratchpad,
   formatAndLogContent,
 } from '@utils/text/xmlUtils';
-import { sleep } from '@utils/helpers';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
@@ -47,55 +45,29 @@ import { ToolState } from '@agent/core/ToolState';
 import { ModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile } from '@agent/runtime/OutputHandler';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
-import { buildUserVars } from '@agent/utils/userVars';
-import { IAgent } from '@agent/core/IAgent';
+import { BaseAgent } from './BaseAgent';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 
 // Shared constants
-import {
-  K_SLICE,
-  SHORT_SLEEP_MS,
-  REPETITION_DETECTION_THRESHOLD,
-} from '@utils/config';
+import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
 
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.
  * Provides core functionality for processing inputs, managing state, and handling outputs
  * across multiple conversation rounds.
  */
-export abstract class BaseReflectionAgent implements IAgent {
-  protected modelHandler: ModelHandler;
-  protected agentConfig: AgentConfig;
-  protected agentSetting: AgentSetting;
-  protected agentPrompt: AgentPrompt;
-  protected agentPath: string;
+export abstract class BaseReflectionAgent extends BaseAgent {
   /** File paths for each round's raw model output. */
   protected outputFile: string[];
   protected outputFiles: { [key: number]: string[] };
   protected baseFiles: string[];
-  protected client: any;
   protected useScratchpad: boolean = false;
   protected logId: number = 0;
-  protected logger: AgentLogger;
   /** Handler for output file processing and validation. */
   protected outputHandler: OutputHandler;
-  /** Cached user variables to avoid recomputation */
-  protected userVars: Record<string, any>;
-  /** Group ID for the main run group, used as parent for subgroups */
-  protected runGroupId?: string;
-  private isInterrupted: boolean = false;
-  private abortController: AbortController | null = null;
-
-  // Static map to track running agents by their stream ID
-  private static runningAgents: Map<string, BaseReflectionAgent> = new Map();
-
-  /** Public getter for agent configuration */
-  public get config(): AgentConfig {
-    return this.agentConfig;
-  }
 
   constructor(
     modelHandler: ModelHandler,
@@ -104,18 +76,7 @@ export abstract class BaseReflectionAgent implements IAgent {
     agentPrompt: AgentPrompt,
     agentPath: string,
   ) {
-    this.modelHandler = modelHandler;
-    this.agentConfig = agentConfig;
-    this.agentSetting = agentSetting;
-    this.agentPrompt = agentPrompt;
-    this.agentPath = agentPath;
-
-    // Initialize logger with unique channel ID
-    const channelId = this.getTaskId();
-    this.logger = new AgentLogger(channelId);
-
-    // Update model handler's logger
-    this.modelHandler.setLogger(this.logger);
+    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
 
     // Initialize basic attributes
     const numRounds = this.getNumberOfRounds();
@@ -127,7 +88,6 @@ export abstract class BaseReflectionAgent implements IAgent {
     this.baseFiles = this.agentConfig.outputFiles || [
       this.agentConfig.inputFile,
     ];
-    this.userVars = {};
 
     // Check scratchpad usage
     // this is not so neat
@@ -150,94 +110,12 @@ export abstract class BaseReflectionAgent implements IAgent {
       this.baseFiles,
       this.logger,
     );
-
-    // Register this agent instance
-    BaseReflectionAgent.runningAgents.set(channelId, this);
-  }
-
-  /**
-   * Initializes the client asynchronously.
-   * Must be called before using any client operations.
-   */
-  protected async initializeClient(): Promise<void> {
-    this.client = await this.modelHandler.getClient();
-    // wait briefly to avoid rate limit issues
-    await sleep(SHORT_SLEEP_MS);
-  }
-
-  /**
-   * Gets unique task ID from output name override or input filename.
-   * @returns Task ID string used for logging and output naming
-   */
-  private getTaskId(): string {
-    const baseName = path.basename(this.agentConfig.inputFile);
-    // Use the potentially modified agent name (with _multiple suffix if applicable)
-    const agentName =
-      Array.isArray(this.agentConfig.outputFiles) &&
-      this.agentConfig.outputFiles.length > 1
-        ? `${this.agentConfig.agent}_multiple`
-        : this.agentConfig.agent;
-    return `${agentName}@${this.agentConfig.model}: ${baseName}`;
-  }
-
-  /**
-   * Initializes user variables that require async operations.
-   * Must be called after constructor before using the agent.
-   */
-  public async init(parentGroupId?: string): Promise<void> {
-    // Create an initialization group for better log organization
-    const initGroupId = await this.logger.startGroup(
-      `Init`,
-      undefined,
-      parentGroupId,
-    );
-
-    try {
-      // Log configuration details in the initialization group
-      this.logger.debug(
-        `AgentConfig: ${JSON.stringify(this.agentConfig)}`,
-        initGroupId,
-      );
-      this.logger.debug(
-        `AgentSetting: ${JSON.stringify(this.agentSetting)}`,
-        initGroupId,
-      );
-      this.logger.debug(
-        `ModelConfig: ${JSON.stringify(this.modelHandler.config)}`,
-        initGroupId,
-      );
-
-      // Initialize user variables
-      this.userVars = await this.getUserVars();
-
-      // End the initialization group with success status
-      this.logger.endGroup(initGroupId, 'stopped');
-    } catch (error) {
-      // End the group with error status if initialization fails
-      this.logger.endGroup(initGroupId, 'error');
-      throw error;
-    }
   }
 
   /**
    * Generates output file path for specified conversation round.
    */
   protected abstract getOutputFile(currRound: number): string;
-
-  /**
-   * Collects variables for prompt rendering from various sources.
-   * @returns Combined dictionary of variables for prompt templates
-   */
-  protected async getUserVars(): Promise<Record<string, any>> {
-    // this.logger.debug(`Obtaining dynamic variables...`);
-    return buildUserVars(
-      this.agentConfig,
-      this.agentSetting,
-      this.agentPath,
-      this.modelHandler,
-      this.logger,
-    );
-  }
 
   /**
    * Returns the configured number of conversation rounds.
@@ -1354,34 +1232,6 @@ export abstract class BaseReflectionAgent implements IAgent {
     this.logger.info(
       'Agent execution interrupted by user. Active request aborted; partial output may remain.',
     );
-  }
-
-  /**
-   * Checks if the agent should stop due to interruption
-   */
-  private checkInterruption(): boolean {
-    if (this.isInterrupted) {
-      this.logger.info('Stopping due to user interruption');
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Gets a running agent by its stream ID
-   */
-  public static getRunningAgent(
-    streamId: string,
-  ): BaseReflectionAgent | undefined {
-    return BaseReflectionAgent.runningAgents.get(streamId);
-  }
-
-  /**
-   * Removes a running agent from tracking
-   */
-  private cleanup(): void {
-    const channelId = this.getTaskId();
-    BaseReflectionAgent.runningAgents.delete(channelId);
   }
 
   /** Extracts and logs scratchpad content from output. */

--- a/src/agent/implementations/index.ts
+++ b/src/agent/implementations/index.ts
@@ -2,3 +2,4 @@ export * from './BaseReflectionAgent';
 export * from './DirectAgent';
 export * from './CoTAgent';
 export * from './MergeAgent';
+export * from './BaseAgent';

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - agent
-import { BaseReflectionAgent } from '@agent/implementations/BaseReflectionAgent';
+import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 const CHANNEL = 'AgentCommands';
@@ -19,7 +19,7 @@ export function registerAgentCommands(context: vscode.ExtensionContext) {
 
 async function handleStopAgent(stream: string) {
   // Get the running agent instance
-  const agent = BaseReflectionAgent.getRunningAgent(stream);
+  const agent = BaseAgent.getRunningAgent(stream);
   if (agent) {
     // Interrupt the agent's execution
     agent.interrupt();


### PR DESCRIPTION
## Summary
- create `BaseAgent` with common setup and interruption logic
- extend `BaseReflectionAgent` from the new base class
- adjust command helpers to use the shared agent map
- re-export `BaseAgent` for other modules

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68570447f8488324b9fe2b24aa3ab7d2