### PR TITLE
Fix display of single output files

### DIFF
--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -521,7 +521,12 @@ export class OutputHandler {
     const content = await WorkspaceFS.readFile(processedOutputFile);
     await WorkspaceFS.writeFile(processedOutputFile, content);
 
-    return { source: original || outputFile, path: processedOutputFile };
+    // Use the extracted document name when available. Otherwise use the
+    // generated TeX filename so the progress view displays the .tex file.
+    return {
+      source: original || path.basename(processedOutputFile),
+      path: processedOutputFile,
+    };
   }
 
   /** Processes multiple output files with XML splitting and filtering. */


### PR DESCRIPTION
## Summary
- use .tex filename when single XML output lacks a document name

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning; tests require environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_685705114a5483249ed0927216f72c71