### PR TITLE
Fix logging for response cycle

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -55,7 +55,7 @@ The header provides a summary and actions for the selected stream:
 
 This scrollable area displays the detailed, timestamped logs for the selected agent run.
 
-- **Structure**: Logs are organized into expandable/collapsible groups (e.g., `Initialization`, `Round 0`, `Model Operation`, `Response Cycle`) allowing you to focus on specific stages. Click the arrow next to a group name to toggle it.
+- **Structure**: Logs are organized into expandable/collapsible groups (e.g., `Initialization`, `Round 0`, `Model Operation`). Response cycles are logged within the corresponding round group. Click the arrow next to a group name to toggle it.
 - **Log Levels**: Messages are prefixed with levels like `INFO`, `DEBUG`, `WARN`, `ERROR` to indicate severity. Verbose debug messages (`DEBUG`) are only shown if `texra.logger.debugMode` is enabled in settings.
 - **Agent Thinking**: The log highlights model reasoning in purple **Model Thinking** blocks. These sections are flagged internally with a `thinking` type so you can easily spot when the AI is exploring ideas.
 - **Errors**: Errors are highlighted, often providing clues if something went wrong.

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -276,8 +276,8 @@ export abstract class BaseReflectionAgent implements IAgent {
     outputFile: string,
     roundGroupId?: string,
   ): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
-    // Use the round group directly for response cycle logging
-    const responseCycleGroupId = roundGroupId;
+    // Use the round group identifier for logging this cycle
+    const logGroupId = roundGroupId;
 
     try {
       let endTurn = false;
@@ -306,12 +306,12 @@ export abstract class BaseReflectionAgent implements IAgent {
             );
             this.logger.info(
               `Saved message object to ${debugFilePath}`,
-              responseCycleGroupId,
+              logGroupId,
             );
           } catch (error) {
             this.logger.error(
               `Failed to save message object: ${error}`,
-              responseCycleGroupId,
+              logGroupId,
             );
           }
         }
@@ -333,7 +333,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         if (!responseObject) {
           this.logger.warn(
             'Model response was aborted or returned no data; output may be incomplete.',
-            responseCycleGroupId,
+            logGroupId,
           );
           break;
         }
@@ -341,7 +341,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         stateRound.updateResponseTime(responseTime);
         this.logger.debug(
           `Response time: ${responseTime.toFixed(2)}s`,
-          responseCycleGroupId,
+          logGroupId,
         );
 
         // Extract and validate response
@@ -351,10 +351,10 @@ export abstract class BaseReflectionAgent implements IAgent {
             this.agentSetting.endTag,
           );
 
-        this.logger.debug(`Stop reason: ${stopReason}`, responseCycleGroupId);
+        this.logger.debug(`Stop reason: ${stopReason}`, logGroupId);
         this.logger.debug(
           `Token usage: ${JSON.stringify(responseUsage)}`,
-          responseCycleGroupId,
+          logGroupId,
         );
 
         // Extract thinking blocks directly from the response object
@@ -362,7 +362,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         // and returns content of the first thinking block for logging (if any)
         const thinkingContent = this.modelHandler.processThinkingBlock(
           responseObject,
-          responseCycleGroupId,
+          logGroupId,
           toolState,
         );
 
@@ -372,7 +372,7 @@ export abstract class BaseReflectionAgent implements IAgent {
             thinkingContent,
             this.logger,
             'Thinking',
-            responseCycleGroupId,
+            logGroupId,
           );
 
           // Note: The complete thinking blocks (including signatures) have already been
@@ -383,7 +383,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         await this.extractAndLogScratchpad(
           newResponse,
           'scratchpad',
-          responseCycleGroupId,
+          logGroupId,
         );
         // this has a potential bug if <scratchpad> is included in the prefill
 
@@ -404,21 +404,21 @@ export abstract class BaseReflectionAgent implements IAgent {
         if (repetitionResult.massiveRepetitionDetected) {
           this.logger.error(
             `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-            responseCycleGroupId,
+            logGroupId,
           );
           this.logger.error(
             `Massive repetition detected - skipping this response`,
-            responseCycleGroupId,
+            logGroupId,
           );
 
           // Debug information - print message skeleton to help diagnose the problem
           this.logger.error(
             `Message structure when repetition detected:`,
-            responseCycleGroupId,
+            logGroupId,
           );
           this.logger.error(
             JSON.stringify(messageToSkeleton(messages), null, 2),
-            responseCycleGroupId,
+            logGroupId,
           );
           break;
         }
@@ -442,15 +442,12 @@ export abstract class BaseReflectionAgent implements IAgent {
 
         // Write or append to output file
         if (!exists) {
-          this.logger.debug(
-            `Creating new file: ${outputFile}`,
-            responseCycleGroupId,
-          );
+          this.logger.debug(`Creating new file: ${outputFile}`, logGroupId);
           await WorkspaceFS.writeFile(outputFile, processedResponse);
         } else {
           this.logger.debug(
             `Appending to existing file: ${outputFile}`,
-            responseCycleGroupId,
+            logGroupId,
           );
           await WorkspaceFS.appendFile(
             outputFile,
@@ -459,14 +456,14 @@ export abstract class BaseReflectionAgent implements IAgent {
         }
 
         // Log response boundaries
-        this.logger.debug(`Response preview:`, responseCycleGroupId);
+        this.logger.debug(`Response preview:`, logGroupId);
         this.logger.debug(
           `First ${K_SLICE} chars:\n${processedResponse.slice(0, K_SLICE)}`,
-          responseCycleGroupId,
+          logGroupId,
         );
         this.logger.debug(
           `Last ${K_SLICE} chars:\n${processedResponse.slice(-K_SLICE)}`,
-          responseCycleGroupId,
+          logGroupId,
         );
 
         // Update message content
@@ -505,7 +502,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         stateRound.incrementContinuation();
         this.logger.info(
           `Starting continuation #${stateRound.continuationCount}`,
-          responseCycleGroupId,
+          logGroupId,
         );
 
         // Check if model should continue generating
@@ -519,7 +516,7 @@ export abstract class BaseReflectionAgent implements IAgent {
         ) {
           this.logger.debug(
             `Should continue - adding continuation message to conversation`,
-            responseCycleGroupId,
+            logGroupId,
           );
           if (this.modelHandler.capabilities.supportsAssistantPrefill) {
             this.modelHandler.addContinueMessageWithPrefill(

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -276,10 +276,8 @@ export abstract class BaseReflectionAgent implements IAgent {
     outputFile: string,
     roundGroupId?: string,
   ): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
-    // Create a response cycle group as a child of the round group if provided
-    const responseCycleGroupId = roundGroupId
-      ? await this.logger.startGroup(`Response Cycle`, undefined, roundGroupId)
-      : undefined;
+    // Use the round group directly for response cycle logging
+    const responseCycleGroupId = roundGroupId;
 
     try {
       let endTurn = false;
@@ -545,15 +543,8 @@ export abstract class BaseReflectionAgent implements IAgent {
         }
       }
 
-      if (responseCycleGroupId) {
-        this.logger.endGroup(responseCycleGroupId, 'stopped');
-      }
-
       return [stateRound, stateGlobal, toolState, endTurn];
     } catch (error) {
-      if (responseCycleGroupId) {
-        this.logger.endGroup(responseCycleGroupId, 'error');
-      }
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- stop creating a `Response Cycle` logger group
- mention updated logging structure in the progress board guide

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857163cc488832486aa7e24026bbdc4