### PR TITLE
Refactor file listing to new service

### DIFF
--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -13,24 +13,29 @@ import { selectFile, selectFiles } from '@frontend/files/dialog';
 const CHANNEL = 'fileSelectionCommands';
 logger.initialize(CHANNEL);
 
-interface PickerOptions {
-  allowMany: boolean;
+interface PickerOptions<Many extends boolean> {
+  allowMany: Many;
   openLabel: string;
   filters: () => { [name: string]: string[] };
 }
 
-function createPicker(options: PickerOptions) {
-  return async (currentFile?: string): Promise<string[] | string | null> => {
+function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
+  return async (
+    currentFile?: string,
+  ): Promise<Many extends true ? string[] | null : string | null> => {
     try {
-      const result = await (options.allowMany ? selectFiles : selectFile)({
+      const baseOpts = {
         currentFile,
-        allowMany: options.allowMany,
         openLabel: options.openLabel,
         filters: options.filters(),
-      });
+      };
+
+      const result = options.allowMany
+        ? await selectFiles({ ...baseOpts, allowMany: true })
+        : await selectFile(baseOpts);
 
       if (!result) {
-        return null;
+        return null as any;
       }
 
       const message = Array.isArray(result)
@@ -38,12 +43,12 @@ function createPicker(options: PickerOptions) {
         : `Selected file: ${result}`;
       showInfoMessage(message);
       logger.info(CHANNEL, message);
-      return result;
+      return result as any;
     } catch (err) {
       const msg = `Error selecting files: ${err instanceof Error ? err.message : String(err)}`;
       logger.error(CHANNEL, msg);
       showErrorMessage(msg);
-      return null;
+      return null as any;
     }
   };
 }

--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -7,11 +7,46 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { showInfoMessage, showErrorMessage } from '@frontend/ui/messageUtils';
 import { WorkspaceFS } from '@utils/files';
-import { listInputFiles } from '@frontend/files/listing';
+import { listInputFiles } from '@frontend/files/fileLister';
 import { getIncludedExtensions } from '@utils/fileTypeUtils';
 import { selectFile, selectFiles } from '@frontend/files/dialog';
 const CHANNEL = 'fileSelectionCommands';
 logger.initialize(CHANNEL);
+
+interface PickerOptions {
+  allowMany: boolean;
+  openLabel: string;
+  filters: () => { [name: string]: string[] };
+}
+
+function createPicker(options: PickerOptions) {
+  return async (currentFile?: string): Promise<string[] | string | null> => {
+    try {
+      const result = await (options.allowMany ? selectFiles : selectFile)({
+        currentFile,
+        allowMany: options.allowMany,
+        openLabel: options.openLabel,
+        filters: options.filters(),
+      });
+
+      if (!result) {
+        return null;
+      }
+
+      const message = Array.isArray(result)
+        ? `Selected files: ${result.join(', ')}`
+        : `Selected file: ${result}`;
+      showInfoMessage(message);
+      logger.info(CHANNEL, message);
+      return result;
+    } catch (err) {
+      const msg = `Error selecting files: ${err instanceof Error ? err.message : String(err)}`;
+      logger.error(CHANNEL, msg);
+      showErrorMessage(msg);
+      return null;
+    }
+  };
+}
 
 export function registerFileSelectionCommands(
   context: vscode.ExtensionContext,
@@ -44,149 +79,69 @@ export function registerFileSelectionCommands(
   );
 }
 
-async function selectInputFile(
-  currentInputFile: string,
-): Promise<string | null> {
-  const result = await selectFile({
-    currentFile: currentInputFile,
-    openLabel: 'Select File',
-    filters: {
-      'Text files': getIncludedExtensions('input').map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
-  if (result) {
-    logger.info(CHANNEL, `Selected file: ${result}`);
-  }
-  return result;
-}
+const selectInputFile = createPicker({
+  allowMany: false,
+  openLabel: 'Select File',
+  filters: () => ({
+    'Text files': getIncludedExtensions('input').map((ext) =>
+      ext.replace('.', ''),
+    ),
+  }),
+});
 
-async function selectInputFiles(
-  currentInputFile: string,
-): Promise<string[] | null> {
-  const includedInputExtensions = getIncludedExtensions('input', [
-    '.txt',
-    '.tex',
-    '.md',
-  ]);
+const selectInputFiles = createPicker({
+  allowMany: true,
+  openLabel: 'Select Files',
+  filters: () => ({
+    'Text files': getIncludedExtensions('input', ['.txt', '.tex', '.md']).map(
+      (ext) => ext.replace('.', ''),
+    ),
+  }),
+});
 
-  try {
-    const relativePaths = await selectFiles({
-      currentFile: currentInputFile,
-      allowMany: true,
-      openLabel: 'Select Files',
-      filters: {
-        'Text files': includedInputExtensions.map((ext) =>
-          ext.replace('.', ''),
-        ),
-      },
-    });
+const selectReferenceFiles = createPicker({
+  allowMany: true,
+  openLabel: 'Select Ref Files',
+  filters: () => ({
+    'Text files': getIncludedExtensions('reference').map((ext) =>
+      ext.replace('.', ''),
+    ),
+  }),
+});
 
-    if (!relativePaths) {
-      return null;
-    }
+const selectAuxiliaryFiles = createPicker({
+  allowMany: true,
+  openLabel: 'Select Auxiliary Files',
+  filters: () => ({
+    'Text files': getIncludedExtensions('auxiliary').map((ext) =>
+      ext.replace('.', ''),
+    ),
+  }),
+});
 
-    showInfoMessage(`Selected files: ${relativePaths.join(', ')}`);
-    logger.info(CHANNEL, `Selected files: ${relativePaths.join(', ')}`);
-    return relativePaths;
-  } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error selecting files: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return null;
-  }
-}
+const selectMediaFiles = createPicker({
+  allowMany: true,
+  openLabel: 'Select Media',
+  filters: () => ({
+    'Image files': getIncludedExtensions('media').map((ext) =>
+      ext.replace('.', ''),
+    ),
+    'Audio files': getIncludedExtensions('audio').map((ext) =>
+      ext.replace('.', ''),
+    ),
+  }),
+});
 
-async function selectReferenceFiles(
-  currentReferenceFile: string,
-): Promise<string[] | null> {
-  const includedReferenceExtensions = getIncludedExtensions('reference');
-  const relativePaths = await selectFiles({
-    currentFile: currentReferenceFile,
-    allowMany: true,
-    openLabel: 'Select Ref Files',
-    filters: {
-      'Text files': includedReferenceExtensions.map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
-
-  if (relativePaths) {
-    showInfoMessage(`Selected reference files: ${relativePaths.join(', ')}`);
-    logger.info(
-      CHANNEL,
-      `Selected reference files: ${relativePaths.join(', ')}`,
-    );
-  }
-
-  return relativePaths;
-}
-
-async function selectAuxiliaryFiles(
-  currentAuxiliaryFile: string,
-): Promise<string[] | null> {
-  const includedAuxiliaryExtensions = getIncludedExtensions('auxiliary');
-  const relativePaths = await selectFiles({
-    currentFile: currentAuxiliaryFile,
-    allowMany: true,
-    openLabel: 'Select Auxiliary Files',
-    filters: {
-      'Text files': includedAuxiliaryExtensions.map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
-
-  if (relativePaths) {
-    showInfoMessage(`Selected files: ${relativePaths.join(', ')}`);
-    logger.info(CHANNEL, `Selected files: ${relativePaths.join(', ')}`);
-  }
-  return relativePaths;
-}
-
-async function selectMediaFiles(
-  currentMediaFile: string,
-): Promise<string[] | null> {
-  const includedFigureExtensions = getIncludedExtensions('media');
-  const includedAudioExtensions = getIncludedExtensions('audio');
-  const relativePaths = await selectFiles({
-    currentFile: currentMediaFile,
-    allowMany: true,
-    openLabel: 'Select Media',
-    filters: {
-      'Image files': includedFigureExtensions.map((ext) =>
-        ext.replace('.', ''),
-      ),
-      'Audio files': includedAudioExtensions.map((ext) => ext.replace('.', '')),
-    },
-  });
-
-  if (relativePaths) {
-    showInfoMessage(`Selected files: ${relativePaths.join(', ')}`);
-    logger.info(CHANNEL, `Selected files: ${relativePaths.join(', ')}`);
-  }
-  return relativePaths;
-}
-
-async function selectMediaFile(): Promise<string | null> {
-  const result = await selectFile({
-    openLabel: 'Select Media File',
-    filters: {
-      Images: getIncludedExtensions('media').map((ext) => ext.replace('.', '')),
-      'Audio files': getIncludedExtensions('audio').map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
-  if (result) {
-    showInfoMessage(`Selected media file: ${result}`);
-    logger.info(CHANNEL, `Selected media file: ${result}`);
-  }
-  return result;
-}
+const selectMediaFile = createPicker({
+  allowMany: false,
+  openLabel: 'Select Media File',
+  filters: () => ({
+    Images: getIncludedExtensions('media').map((ext) => ext.replace('.', '')),
+    'Audio files': getIncludedExtensions('audio').map((ext) =>
+      ext.replace('.', ''),
+    ),
+  }),
+});
 
 async function selectOutputFiles(
   currentInputFile: string,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { copyDefaultAgents, configureLatexSettings } from '@frontend/setup';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { StorageFS } from '@utils/files';
 import { initializeStateManagers } from '@utils/stateManager';
+import { FileLister } from '@frontend/files/fileLister';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -20,6 +21,7 @@ export async function activate(context: vscode.ExtensionContext) {
   SecretManager.initialize(context);
   StorageFS.initialize(context);
   initializeStateManagers(context);
+  FileLister.initialize(context);
 
   // Create the log view provider
   const progressViewProvider = new ProgressViewProvider(context);

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -53,24 +53,27 @@ export class FileLister {
     this.ignoredFileExtensions = getConfig<string[]>(
       'files.ignored.fileExtensions',
       [],
-    );
+    ).map((e) => e.toLowerCase());
     this.ignoredDirectories = getConfig<string[]>(
       'files.ignored.directories',
       [],
-    );
-    this.ignoredKeywords = getConfig<string[]>('files.ignored.keywords', []);
+    ).map((d) => d.toLowerCase());
+    this.ignoredKeywords = getConfig<string[]>(
+      'files.ignored.keywords',
+      [],
+    ).map((k) => k.toLowerCase());
     this.ignoredInputFiles = getConfig<string[]>(
       'files.ignored.inputFiles',
       [],
-    );
+    ).map((f) => f.toLowerCase());
     this.ignoredAuxKeywords = getConfig<string[]>(
       'files.ignored.auxiliaryKeywords',
       [],
-    );
+    ).map((k) => k.toLowerCase());
     this.ignoredMediaDirs = getConfig<string[]>(
       'files.ignored.mediaDirectories',
       [],
-    );
+    ).map((d) => d.toLowerCase());
   }
 
   private get workspace(): string | null {

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -1,0 +1,161 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
+// Local imports - utilities
+import { getConfig, watchConfig } from '@utils/config';
+import { WorkspaceFS } from '@utils/files';
+import { getIncludedExtensions, FileType } from '@utils/fileTypeUtils';
+import { getFilesInDirectory, getFilesRecursively } from './listing';
+
+const CHANNEL = 'FileLister';
+logger.initialize(CHANNEL);
+
+export type ListableFileType = Exclude<FileType, 'audio'>;
+
+export class FileLister {
+  private static instance: FileLister | null = null;
+
+  public static initialize(context: vscode.ExtensionContext): void {
+    this.getInstance();
+    watchConfig(context, 'texra.files', () => this.getInstance().refresh());
+    vscode.workspace.onDidChangeWorkspaceFolders(() =>
+      this.getInstance().refresh(),
+    );
+  }
+
+  public static getInstance(): FileLister {
+    if (!this.instance) {
+      this.instance = new FileLister();
+    }
+    return this.instance;
+  }
+
+  private workspacePath: string | undefined;
+  private ignoredFileExtensions: string[] = [];
+  private ignoredDirectories: string[] = [];
+  private ignoredKeywords: string[] = [];
+  private ignoredInputFiles: string[] = [];
+  private ignoredAuxKeywords: string[] = [];
+  private ignoredMediaDirs: string[] = [];
+
+  private constructor() {
+    this.refresh();
+  }
+
+  public refresh(): void {
+    this.workspacePath = WorkspaceFS.getPath();
+    this.ignoredFileExtensions = getConfig<string[]>(
+      'files.ignored.fileExtensions',
+      [],
+    );
+    this.ignoredDirectories = getConfig<string[]>(
+      'files.ignored.directories',
+      [],
+    );
+    this.ignoredKeywords = getConfig<string[]>('files.ignored.keywords', []);
+    this.ignoredInputFiles = getConfig<string[]>(
+      'files.ignored.inputFiles',
+      [],
+    );
+    this.ignoredAuxKeywords = getConfig<string[]>(
+      'files.ignored.auxiliaryKeywords',
+      [],
+    );
+    this.ignoredMediaDirs = getConfig<string[]>(
+      'files.ignored.mediaDirectories',
+      [],
+    );
+  }
+
+  private get workspace(): string | null {
+    return this.workspacePath ?? null;
+  }
+
+  public async list(fileType: ListableFileType): Promise<string[]> {
+    const workspace = this.workspace;
+    if (!workspace) {
+      logger.warn(CHANNEL, 'No workspace folder found');
+      return [];
+    }
+
+    switch (fileType) {
+      case 'input':
+      case 'reference':
+        return getFilesRecursively(
+          workspace,
+          workspace,
+          getIncludedExtensions(fileType),
+          this.ignoredFileExtensions,
+          this.ignoredDirectories,
+          this.ignoredKeywords,
+          this.ignoredInputFiles,
+        );
+      case 'auxiliary':
+        return getFilesInDirectory(
+          workspace,
+          getIncludedExtensions('auxiliary'),
+          this.ignoredFileExtensions,
+          this.ignoredDirectories,
+          [...this.ignoredKeywords, ...this.ignoredAuxKeywords],
+        );
+      case 'media':
+        return getFilesRecursively(
+          workspace,
+          workspace,
+          getIncludedExtensions('media'),
+          [],
+          this.ignoredMediaDirs,
+          this.ignoredKeywords,
+        );
+      case 'edited':
+        // Handled separately
+        return [];
+    }
+  }
+
+  public async listEditedFiles(baseFileName: string): Promise<string[]> {
+    const workspace = this.workspace;
+    if (!workspace) {
+      logger.warn(CHANNEL, 'No workspace folder found');
+      return [];
+    }
+
+    const files = await getFilesRecursively(
+      workspace,
+      workspace,
+      getIncludedExtensions('edited'),
+      this.ignoredFileExtensions,
+      [...this.ignoredDirectories, 'PapersEx'],
+      this.ignoredKeywords,
+      this.ignoredInputFiles,
+    );
+
+    const baseNameMatch = baseFileName.match(/^(.*?)(?:_r\d+|$)/);
+    const baseNameBeforeRound = baseNameMatch ? baseNameMatch[1] : baseFileName;
+
+    return files.filter((file) => {
+      const fileBase = path.basename(file, path.extname(file));
+      return (
+        (fileBase.startsWith(baseFileName) && fileBase !== baseFileName) ||
+        (fileBase.startsWith(baseNameBeforeRound) &&
+          /_r\d+/.test(fileBase) &&
+          fileBase !== baseFileName)
+      );
+    });
+  }
+}
+
+const lister = FileLister.getInstance();
+
+export const listInputFiles = () => lister.list('input');
+export const listReferenceFiles = () => lister.list('reference');
+export const listAuxiliaryFiles = () => lister.list('auxiliary');
+export const listMediaFiles = () => lister.list('media');
+export const listEditedFiles = (baseName: string) =>
+  lister.listEditedFiles(baseName);

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -19,8 +19,17 @@ export async function getFilesInDirectory(
   excludeKeywords: string[] = [],
 ): Promise<string[]> {
   const dirEntries = await AbsoluteFS.readDir(dir);
+
+  const normalizedIncludeExt = includeExtensions.map((e) => e.toLowerCase());
+  const normalizedExcludeExt = excludeExtensions.map((e) => e.toLowerCase());
+  const normalizedExcludeKeywords = excludeKeywords.map((k) => k.toLowerCase());
+  const normalizedExcludeDirs = new Set(
+    excludeDirectories.map((d) => d.toLowerCase()),
+  );
+
   const files = await Promise.all(
     dirEntries.map(async ([name, type]) => {
+      const nameLower = name.toLowerCase();
       const fullPath = path.join(dir, name);
       const stat = await AbsoluteFS.stat(fullPath);
       const isSymbolicLink =
@@ -30,11 +39,13 @@ export async function getFilesInDirectory(
       if (
         (type === vscode.FileType.File || isSymbolicLink) &&
         !name.startsWith('.') &&
-        (includeExtensions.length === 0 ||
-          includeExtensions.some((ext) => name.endsWith(ext))) &&
-        !excludeExtensions.some((ext) => name.endsWith(ext)) &&
-        !excludeKeywords.some((keyword) => name.includes(keyword)) &&
-        !excludeDirectories.includes(path.dirname(name))
+        (normalizedIncludeExt.length === 0 ||
+          normalizedIncludeExt.some((ext) => nameLower.endsWith(ext))) &&
+        !normalizedExcludeExt.some((ext) => nameLower.endsWith(ext)) &&
+        !normalizedExcludeKeywords.some((keyword) =>
+          nameLower.includes(keyword),
+        ) &&
+        !normalizedExcludeDirs.has(path.dirname(name).toLowerCase())
       ) {
         return name;
       }
@@ -56,16 +67,24 @@ export async function getFilesRecursively(
   excludeFiles: string[] = [],
 ): Promise<string[]> {
   const dirEntries = await AbsoluteFS.readDir(dir);
-
-  const normalizedExcludeDirs = new Set(excludeDirectories);
+  const normalizedIncludeExt = includeExtensions.map((e) => e.toLowerCase());
+  const normalizedExcludeExt = excludeExtensions.map((e) => e.toLowerCase());
+  const normalizedExcludeDirs = new Set(
+    excludeDirectories.map((d) => d.toLowerCase()),
+  );
+  const normalizedExcludeKeywords = excludeKeywords.map((k) => k.toLowerCase());
+  const normalizedExcludeFiles = excludeFiles.map((f) => f.toLowerCase());
 
   const files = await Promise.all(
     dirEntries.map(async ([name, type]) => {
+      const nameLower = name.toLowerCase();
       const fullPath = path.join(dir, name);
       const relativePath = path.relative(root, fullPath);
 
       const pathParts = relativePath.split(path.sep);
-      if (pathParts.some((part) => normalizedExcludeDirs.has(part))) {
+      if (
+        pathParts.some((part) => normalizedExcludeDirs.has(part.toLowerCase()))
+      ) {
         return [];
       }
 
@@ -82,7 +101,7 @@ export async function getFilesRecursively(
         (type === vscode.FileType.Directory ||
           (isSymbolicLink && isDirectory)) &&
         !name.startsWith('.') &&
-        !normalizedExcludeDirs.has(name)
+        !normalizedExcludeDirs.has(nameLower)
       ) {
         return await getFilesRecursively(
           fullPath,
@@ -96,11 +115,13 @@ export async function getFilesRecursively(
       } else if (
         (type === vscode.FileType.File || (isSymbolicLink && isFile)) &&
         !name.startsWith('.') &&
-        (includeExtensions.length === 0 ||
-          includeExtensions.some((ext) => name.endsWith(ext))) &&
-        !excludeExtensions.some((ext) => name.endsWith(ext)) &&
-        !excludeKeywords.some((keyword) => name.includes(keyword)) &&
-        !excludeFiles.includes(name)
+        (normalizedIncludeExt.length === 0 ||
+          normalizedIncludeExt.some((ext) => nameLower.endsWith(ext))) &&
+        !normalizedExcludeExt.some((ext) => nameLower.endsWith(ext)) &&
+        !normalizedExcludeKeywords.some((keyword) =>
+          nameLower.includes(keyword),
+        ) &&
+        !normalizedExcludeFiles.includes(nameLower)
       ) {
         return [relativePath];
       }

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - utilities
+import { AbsoluteFS } from '@utils/files';
+
 export function getFilesIfNotEmpty<T>(files: T[] | undefined): T[] | null {
   return files && files.length > 0 ? files : null;
 }
@@ -15,13 +18,11 @@ export async function getFilesInDirectory(
   excludeDirectories: string[] = [],
   excludeKeywords: string[] = [],
 ): Promise<string[]> {
-  const dirEntries = await vscode.workspace.fs.readDirectory(
-    vscode.Uri.file(dir),
-  );
+  const dirEntries = await AbsoluteFS.readDir(dir);
   const files = await Promise.all(
     dirEntries.map(async ([name, type]) => {
       const fullPath = path.join(dir, name);
-      const stat = await vscode.workspace.fs.stat(vscode.Uri.file(fullPath));
+      const stat = await AbsoluteFS.stat(fullPath);
       const isSymbolicLink =
         (stat.type & vscode.FileType.SymbolicLink) ===
         vscode.FileType.SymbolicLink;
@@ -54,13 +55,9 @@ export async function getFilesRecursively(
   excludeKeywords: string[] = [],
   excludeFiles: string[] = [],
 ): Promise<string[]> {
-  const dirEntries = await vscode.workspace.fs.readDirectory(
-    vscode.Uri.file(dir),
-  );
+  const dirEntries = await AbsoluteFS.readDir(dir);
 
-  const normalizedExcludeDirs = new Set(
-    excludeDirectories.map((d) => d.toLowerCase()),
-  );
+  const normalizedExcludeDirs = new Set(excludeDirectories);
 
   const files = await Promise.all(
     dirEntries.map(async ([name, type]) => {
@@ -68,13 +65,11 @@ export async function getFilesRecursively(
       const relativePath = path.relative(root, fullPath);
 
       const pathParts = relativePath.split(path.sep);
-      if (
-        pathParts.some((part) => normalizedExcludeDirs.has(part.toLowerCase()))
-      ) {
+      if (pathParts.some((part) => normalizedExcludeDirs.has(part))) {
         return [];
       }
 
-      const stat = await vscode.workspace.fs.stat(vscode.Uri.file(fullPath));
+      const stat = await AbsoluteFS.stat(fullPath);
       const isSymbolicLink =
         (stat.type & vscode.FileType.SymbolicLink) ===
         vscode.FileType.SymbolicLink;
@@ -87,7 +82,7 @@ export async function getFilesRecursively(
         (type === vscode.FileType.Directory ||
           (isSymbolicLink && isDirectory)) &&
         !name.startsWith('.') &&
-        !normalizedExcludeDirs.has(name.toLowerCase())
+        !normalizedExcludeDirs.has(name)
       ) {
         return await getFilesRecursively(
           fullPath,
@@ -102,12 +97,8 @@ export async function getFilesRecursively(
         (type === vscode.FileType.File || (isSymbolicLink && isFile)) &&
         !name.startsWith('.') &&
         (includeExtensions.length === 0 ||
-          includeExtensions.some((ext) =>
-            name.toLowerCase().endsWith(ext.toLowerCase()),
-          )) &&
-        !excludeExtensions.some((ext) =>
-          name.toLowerCase().endsWith(ext.toLowerCase()),
-        ) &&
+          includeExtensions.some((ext) => name.endsWith(ext))) &&
+        !excludeExtensions.some((ext) => name.endsWith(ext)) &&
         !excludeKeywords.some((keyword) => name.includes(keyword)) &&
         !excludeFiles.includes(name)
       ) {

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -4,124 +4,8 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
-
-// Local imports - utilities
-import { getConfig } from '@utils/config';
-import { WorkspaceFS } from '@utils/files';
-import { getIncludedExtensions } from '@utils/fileTypeUtils';
-
-const CHANNEL = 'FrontendUtils';
-logger.initialize(CHANNEL);
-
-const IGNORED_FILE_EXTENSIONS = getConfig<string[]>(
-  'files.ignored.fileExtensions',
-);
-const IGNORED_DIRECTORIES = getConfig<string[]>('files.ignored.directories');
-const IGNORED_KEYWORDS = getConfig<string[]>('files.ignored.keywords');
-
 export function getFilesIfNotEmpty<T>(files: T[] | undefined): T[] | null {
   return files && files.length > 0 ? files : null;
-}
-
-export async function listInputFiles(): Promise<string[]> {
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
-    return [];
-  }
-
-  const INCLUDED_INPUT_EXTENSIONS = getIncludedExtensions('input');
-
-  return getFilesRecursively(
-    workspacePath,
-    workspacePath,
-    INCLUDED_INPUT_EXTENSIONS,
-    IGNORED_FILE_EXTENSIONS,
-    IGNORED_DIRECTORIES,
-    IGNORED_KEYWORDS,
-    getConfig<string[]>('files.ignored.inputFiles'),
-  );
-}
-
-export const listReferenceFiles = listInputFiles;
-
-export async function listAuxiliaryFiles(): Promise<string[]> {
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
-    return [];
-  }
-
-  const IGNORED_AUXILIARY_KEYWORDS = getConfig<string[]>(
-    'files.ignored.auxiliaryKeywords',
-  );
-
-  const INCLUDED_AUXILIARY_EXTENSIONS = getIncludedExtensions('auxiliary');
-
-  return getFilesInDirectory(
-    workspacePath,
-    INCLUDED_AUXILIARY_EXTENSIONS,
-    IGNORED_FILE_EXTENSIONS,
-    IGNORED_DIRECTORIES,
-    [...IGNORED_KEYWORDS, ...IGNORED_AUXILIARY_KEYWORDS],
-  );
-}
-
-export async function listMediaFiles(): Promise<string[]> {
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
-    return [];
-  }
-
-  const IGNORED_FIGURE_DIRECTORIES = getConfig<string[]>(
-    'files.ignored.mediaDirectories',
-  );
-
-  const INCLUDED_FIGURE_EXTENSIONS = getIncludedExtensions('media');
-
-  return getFilesRecursively(
-    workspacePath,
-    workspacePath,
-    INCLUDED_FIGURE_EXTENSIONS,
-    [],
-    IGNORED_FIGURE_DIRECTORIES,
-    IGNORED_KEYWORDS,
-  );
-}
-
-export async function listEditedFiles(baseFileName: string): Promise<string[]> {
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
-    return [];
-  }
-
-  const INCLUDED_EDITED_EXTENSIONS = getIncludedExtensions('edited');
-
-  const files = await getFilesRecursively(
-    workspacePath,
-    workspacePath,
-    INCLUDED_EDITED_EXTENSIONS,
-    IGNORED_FILE_EXTENSIONS,
-    [...IGNORED_DIRECTORIES, 'PapersEx'],
-    IGNORED_KEYWORDS,
-    getConfig<string[]>('files.ignored.inputFiles'),
-  );
-
-  // Extract the base name before any round number
-  const baseNameMatch = baseFileName.match(/^(.*?)(?:_r\d+|$)/);
-  const baseNameBeforeRound = baseNameMatch ? baseNameMatch[1] : baseFileName;
-
-  return files.filter((file) => {
-    const fileBaseName = path.basename(file, path.extname(file));
-    // Check if it starts with the same base name and or has a different round number
-    return (
-      (fileBaseName.startsWith(baseFileName) &&
-        fileBaseName !== baseFileName) ||
-      (fileBaseName.startsWith(baseNameBeforeRound) &&
-        fileBaseName.match(/_r\d+/) &&
-        fileBaseName !== baseFileName)
-    );
-  });
 }
 
 export async function getFilesInDirectory(
@@ -174,7 +58,6 @@ export async function getFilesRecursively(
     vscode.Uri.file(dir),
   );
 
-  // Convert all directory names to lowercase for case-insensitive comparison
   const normalizedExcludeDirs = new Set(
     excludeDirectories.map((d) => d.toLowerCase()),
   );
@@ -184,7 +67,6 @@ export async function getFilesRecursively(
       const fullPath = path.join(dir, name);
       const relativePath = path.relative(root, fullPath);
 
-      // Check if any parent directory should be excluded
       const pathParts = relativePath.split(path.sep);
       if (
         pathParts.some((part) => normalizedExcludeDirs.has(part.toLowerCase()))

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,3 +1,4 @@
+export * from './files/fileLister';
 export * from './files/listing';
 export * from './files/dialog';
 export * from './files/vars';

--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -321,6 +321,22 @@ export class AbsoluteFS {
       return false;
     }
   }
+
+  /**
+   * Check if path is a symbolic link
+   */
+  public static async isSymbolicLink(filePath: string): Promise<boolean> {
+    this.validatePath(filePath, 'isSymbolicLink');
+    try {
+      const stats = await this.stat(filePath);
+      return (
+        (stats.type & vscode.FileType.SymbolicLink) ===
+        vscode.FileType.SymbolicLink
+      );
+    } catch {
+      return false;
+    }
+  }
 }
 
 export default AbsoluteFS;

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -26,8 +26,8 @@ import {
   listAuxiliaryFiles,
   listMediaFiles,
   listEditedFiles,
-  getFilesIfNotEmpty,
-} from '@frontend/files/listing';
+} from '@frontend/files/fileLister';
+import { getFilesIfNotEmpty } from '@frontend/files/listing';
 import {
   polishTextWithAI,
   FileContext,


### PR DESCRIPTION
## Summary
- add FileLister singleton to centralize workspace file discovery
- trim listing.ts down to generic traversal helpers
- introduce `createPicker` factory for file selection commands
- update MessageHandler and extension activation for new service

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_6857ce93b728832495927c42b315d7c1