### PR TITLE
Fix progress view display and refactor file type checks

### DIFF
--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -522,9 +522,9 @@ export class OutputHandler {
     await WorkspaceFS.writeFile(processedOutputFile, content);
 
     // Use the extracted document name when available. Otherwise use the
-    // generated TeX filename so the progress view displays the .tex file.
+    // input file path for consistent display with multiple file outputs.
     return {
-      source: original || path.basename(processedOutputFile),
+      source: original || this.agentConfig.inputFile,
       path: processedOutputFile,
     };
   }

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -31,10 +31,7 @@ export async function getFilesInDirectory(
     dirEntries.map(async ([name, type]) => {
       const nameLower = name.toLowerCase();
       const fullPath = path.join(dir, name);
-      const stat = await AbsoluteFS.stat(fullPath);
-      const isSymbolicLink =
-        (stat.type & vscode.FileType.SymbolicLink) ===
-        vscode.FileType.SymbolicLink;
+      const isSymbolicLink = await AbsoluteFS.isSymbolicLink(fullPath);
 
       if (
         (type === vscode.FileType.File || isSymbolicLink) &&
@@ -88,14 +85,9 @@ export async function getFilesRecursively(
         return [];
       }
 
-      const stat = await AbsoluteFS.stat(fullPath);
-      const isSymbolicLink =
-        (stat.type & vscode.FileType.SymbolicLink) ===
-        vscode.FileType.SymbolicLink;
-      const isDirectory =
-        (stat.type & vscode.FileType.Directory) === vscode.FileType.Directory;
-      const isFile =
-        (stat.type & vscode.FileType.File) === vscode.FileType.File;
+      const isSymbolicLink = await AbsoluteFS.isSymbolicLink(fullPath);
+      const isDirectory = await AbsoluteFS.isDir(fullPath);
+      const isFile = await AbsoluteFS.isFile(fullPath);
 
       if (
         (type === vscode.FileType.Directory ||


### PR DESCRIPTION
## Summary
- Fix single file output display in progress view to show original input filename
- Refactor listing.ts to use AbsoluteFS utility methods for cleaner code

## Changes

### 1. Progress View Single File Display Fix
- Modified `processSingleXmlOutput` to use the input filename instead of generated filename with agent/model postfix
- This provides consistency with multiple file outputs where clean filenames are shown
- Fixes issue where single file outputs showed names like "Seq-MC_polish_r0_gpt41.tex"

### 2. File Type Check Refactoring  
- Replaced manual bitwise operations with AbsoluteFS utility methods:
  - `isSymbolicLink()` instead of manual bitwise check
  - `isDir()` instead of manual FileType.Directory check
  - `isFile()` instead of manual FileType.File check
- Removed redundant `stat()` calls that were no longer needed
- Improves code readability and consistency

## Test plan
- [x] Verify single file outputs display correctly in progress view
- [x] Verify multiple file outputs still display correctly  
- [x] Verify file listing still works correctly with symbolic links
- [x] Code compiles without errors
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)