### PR TITLE
Refactor file mapping logic

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -19,7 +19,11 @@ import { diff_match_patch } from 'diff-match-patch';
 import type { DiffStats } from '@/types/DiffTypes';
 
 // Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
+import {
+  WorkspaceFS,
+  createFileMapping,
+  replaceInputCommands,
+} from '@utils/files';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
@@ -522,7 +526,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       const roundOutputs = this.outputHandler.outputFiles[currRound] || [];
 
       // Map output files to their original base files
-      const baseMap = this.outputHandler.createFileMapping(
+      const baseMap = createFileMapping(
         this.baseFiles,
         roundOutputs,
         'contains',
@@ -531,7 +535,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       // Map output files to previous round files if available
       const prevMap =
         currRound > 0
-          ? this.outputHandler.createFileMapping(
+          ? createFileMapping(
               this.outputHandler.outputFiles[currRound - 1] || [],
               roundOutputs,
               'basename',
@@ -1141,9 +1145,10 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
           // Only attempt to replace input commands if we have valid base files
           if (this.baseFiles && this.baseFiles.length > 0) {
-            await this.outputHandler.replaceInputCommands(
+            await replaceInputCommands(
               this.baseFiles,
               processedFiles,
+              this.logger,
             );
           }
         } else {

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -8,7 +8,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
+import { WorkspaceFS, createFileMapping } from '@utils/files';
 import {
   addCdataToTags,
   addCdataToTagsMultiple,
@@ -205,148 +205,6 @@ export class OutputHandler {
   }
 
   /**
-   * Creates a mapping between two sets of files based on name similarity
-   * @param sourceFiles Source files array
-   * @param targetFiles Target files array
-   * @param matchStrategy 'basename' for exact basename matching or 'contains' for substring matching
-   * @param roundAware If true, ignores round numbers in filenames for matching
-   * @returns Map of source files to their best matching target files
-   * @private
-   */
-  public createFileMapping(
-    sourceFiles: string[],
-    targetFiles: string[],
-    matchStrategy: 'basename' | 'contains' = 'basename',
-    roundAware: boolean = false,
-  ): Map<string, string> {
-    const fileMapping = new Map<string, string>();
-
-    if (!sourceFiles?.length || !targetFiles?.length) {
-      return fileMapping;
-    }
-
-    for (const targetFile of targetFiles) {
-      if (!targetFile || typeof targetFile !== 'string') {
-        continue;
-      }
-
-      const targetBaseName = path.basename(targetFile);
-
-      // Find the best matching source file for this target file
-      let bestMatch: string | null = null;
-      let bestMatchScore = 0;
-
-      for (const sourceFile of sourceFiles) {
-        if (!sourceFile || typeof sourceFile !== 'string') {
-          continue;
-        }
-
-        const sourceBaseName = path.basename(sourceFile);
-
-        // Extract the main filename without extension for comparison
-        const sourceName = path.parse(sourceBaseName).name;
-        const targetName = path.parse(targetBaseName).name;
-
-        // Handle round-aware matching if needed
-        const sourceNameNormalized = roundAware
-          ? sourceName.split('_r')[0]
-          : sourceName;
-        const targetNameNormalized = roundAware
-          ? targetName.split('_r')[0]
-          : targetName;
-
-        let isMatch = false;
-        let matchScore = 0;
-
-        if (matchStrategy === 'basename') {
-          // For exact basename matching
-          isMatch = sourceNameNormalized === targetNameNormalized;
-          matchScore = isMatch ? sourceNameNormalized.length : 0;
-        } else if (matchStrategy === 'contains') {
-          // For substring matching
-          isMatch = targetBaseName.includes(sourceName);
-          matchScore = isMatch ? sourceName.length : 0;
-        }
-
-        if (isMatch && matchScore > bestMatchScore) {
-          bestMatchScore = matchScore;
-          bestMatch = sourceFile;
-        }
-      }
-
-      // If we found a match, add it to our map
-      if (bestMatch) {
-        fileMapping.set(bestMatch, targetFile);
-      }
-    }
-
-    return fileMapping;
-  }
-
-  /** Updates \input commands in output files to reference new file paths. */
-  public async replaceInputCommands(
-    baseFiles: string[],
-    outputFiles: string[],
-  ): Promise<void> {
-    if (!baseFiles?.length || !outputFiles?.length) {
-      this.logger.debug('No files to process for input command replacement');
-      return;
-    }
-
-    // Create a mapping between base files and output files
-    const baseToOutputMap = this.createFileMapping(
-      baseFiles,
-      outputFiles,
-      'contains',
-    );
-
-    if (baseToOutputMap.size === 0) {
-      this.logger.debug('No valid file mappings for input command replacement');
-      return;
-    }
-
-    this.logger.debug(
-      `File mappings for input replacement: ${Array.from(
-        baseToOutputMap.entries(),
-      )
-        .map(
-          ([base, output]) =>
-            `${path.basename(base)} -> ${path.basename(output)}`,
-        )
-        .join(', ')}`,
-    );
-
-    // Create a map for basename lookups
-    const baseToOutput = new Map<string, string>();
-    for (const [baseFile, outputFile] of baseToOutputMap.entries()) {
-      baseToOutput.set(path.basename(baseFile), path.basename(outputFile));
-    }
-
-    for (const outputFile of outputFiles) {
-      if (!outputFile) {
-        continue;
-      }
-
-      try {
-        const content = await WorkspaceFS.readFile(outputFile);
-        // Replace \input commands with references to the new file paths
-        const newContent = content.replace(/\\input{([^}]+)}/g, (match, p1) =>
-          baseToOutput.has(p1) ? `\\input{${baseToOutput.get(p1)}}` : match,
-        );
-
-        if (newContent !== content) {
-          await WorkspaceFS.writeFile(outputFile, newContent);
-          this.logger.debug(`Updated input commands in ${outputFile}`);
-        }
-      } catch (err) {
-        this.logger.warn(
-          `Error processing input commands in ${outputFile}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
-  }
-
-  /**
    * Runs all latexdiff comparisons for the current round.
    * This is the ONLY place where latexdiff operations should be performed.
    *
@@ -389,7 +247,7 @@ export class OutputHandler {
       );
 
       // Create a mapping between base files and output files
-      const baseToOutputMap = this.createFileMapping(
+      const baseToOutputMap = createFileMapping(
         this.baseFiles,
         outputFiles,
         'contains',
@@ -446,7 +304,7 @@ export class OutputHandler {
         const prevOutputFiles = this.outputFiles[currRound - 1] || [];
 
         // Create a mapping between previous round files and current round files
-        const prevToCurrentMap = this.createFileMapping(
+        const prevToCurrentMap = createFileMapping(
           prevOutputFiles,
           outputFiles,
           'basename',

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -1,0 +1,142 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports
+import { WorkspaceFS } from './workspaceFS';
+import { AgentLogger } from '@logger/AgentLogger';
+
+/**
+ * Create a mapping between two file lists based on name similarity.
+ *
+ * @param sourceFiles The source file paths
+ * @param targetFiles The target file paths
+ * @param matchStrategy 'basename' for exact basename matching or 'contains' for substring matching
+ * @param roundAware Ignore round numbers in filenames when true
+ * @returns Map of source files to their best matching target files
+ */
+export function createFileMapping(
+  sourceFiles: string[],
+  targetFiles: string[],
+  matchStrategy: 'basename' | 'contains' = 'basename',
+  roundAware: boolean = false,
+): Map<string, string> {
+  const fileMapping = new Map<string, string>();
+
+  if (!sourceFiles?.length || !targetFiles?.length) {
+    return fileMapping;
+  }
+
+  for (const targetFile of targetFiles) {
+    if (!targetFile || typeof targetFile !== 'string') {
+      continue;
+    }
+
+    const targetBaseName = path.basename(targetFile);
+
+    let bestMatch: string | null = null;
+    let bestMatchScore = 0;
+
+    for (const sourceFile of sourceFiles) {
+      if (!sourceFile || typeof sourceFile !== 'string') {
+        continue;
+      }
+
+      const sourceBaseName = path.basename(sourceFile);
+
+      const sourceName = path.parse(sourceBaseName).name;
+      const targetName = path.parse(targetBaseName).name;
+
+      const sourceNameNormalized = roundAware
+        ? sourceName.split('_r')[0]
+        : sourceName;
+      const targetNameNormalized = roundAware
+        ? targetName.split('_r')[0]
+        : targetName;
+
+      let isMatch = false;
+      let matchScore = 0;
+
+      if (matchStrategy === 'basename') {
+        isMatch = sourceNameNormalized === targetNameNormalized;
+        matchScore = isMatch ? sourceNameNormalized.length : 0;
+      } else if (matchStrategy === 'contains') {
+        isMatch = targetBaseName.includes(sourceName);
+        matchScore = isMatch ? sourceName.length : 0;
+      }
+
+      if (isMatch && matchScore > bestMatchScore) {
+        bestMatchScore = matchScore;
+        bestMatch = sourceFile;
+      }
+    }
+
+    if (bestMatch) {
+      fileMapping.set(bestMatch, targetFile);
+    }
+  }
+
+  return fileMapping;
+}
+
+/**
+ * Update \input commands in output files to reference new file paths.
+ *
+ * @param baseFiles Base file paths
+ * @param outputFiles Output file paths
+ * @param logger Optional logger for debug messages
+ */
+export async function replaceInputCommands(
+  baseFiles: string[],
+  outputFiles: string[],
+  logger?: AgentLogger,
+): Promise<void> {
+  if (!baseFiles?.length || !outputFiles?.length) {
+    logger?.debug('No files to process for input command replacement');
+    return;
+  }
+
+  const baseToOutputMap = createFileMapping(baseFiles, outputFiles, 'contains');
+
+  if (baseToOutputMap.size === 0) {
+    logger?.debug('No valid file mappings for input command replacement');
+    return;
+  }
+
+  logger?.debug(
+    `File mappings for input replacement: ${Array.from(
+      baseToOutputMap.entries(),
+    )
+      .map(
+        ([base, output]) =>
+          `${path.basename(base)} -> ${path.basename(output)}`,
+      )
+      .join(', ')}`,
+  );
+
+  const baseToOutput = new Map<string, string>();
+  for (const [baseFile, outputFile] of baseToOutputMap.entries()) {
+    baseToOutput.set(path.basename(baseFile), path.basename(outputFile));
+  }
+
+  for (const outputFile of outputFiles) {
+    if (!outputFile) {
+      continue;
+    }
+
+    try {
+      const content = await WorkspaceFS.readFile(outputFile);
+      const newContent = content.replace(/\\input{([^}]+)}/g, (match, p1) =>
+        baseToOutput.has(p1) ? `\\input{${baseToOutput.get(p1)}}` : match,
+      );
+
+      if (newContent !== content) {
+        await WorkspaceFS.writeFile(outputFile, newContent);
+        logger?.debug(`Updated input commands in ${outputFile}`);
+      }
+    } catch (err) {
+      logger?.warn(
+        `Error processing input commands in ${outputFile}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -4,3 +4,4 @@ export { StorageFS, GlobalStorageFS } from './storageFS';
 export { RelativeFS } from './relativeFS';
 export * from './pastedImageUtils';
 export * from './baseFileUtils';
+export * from './fileMappingUtils';


### PR DESCRIPTION
## Summary
- extract `createFileMapping` and `replaceInputCommands` to `fileMappingUtils`
- update `OutputHandler` to use new util
- update `BaseReflectionAgent` to import and use mapping helpers

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68580df0bc888324b6542381e6bdc339