### PR TITLE
Refine ProgressBoard special blocks

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -57,7 +57,7 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 
 - **Structure**: Logs are organized into expandable/collapsible groups (e.g., `Initialization`, `Round 0`, `Model Operation`). Response cycles are logged within the corresponding round group. Click the arrow next to a group name to toggle it.
 - **Log Levels**: Messages are prefixed with levels like `INFO`, `DEBUG`, `WARN`, `ERROR` to indicate severity. Verbose debug messages (`DEBUG`) are only shown if `texra.logger.debugMode` is enabled in settings.
-- **Agent Thinking**: The log highlights model reasoning in purple **Model Thinking** blocks. These sections are flagged internally with a `thinking` type so you can easily spot when the AI is exploring ideas.
+- **Agent Thinking**: The log highlights model reasoning in purple **Thinking** blocks. These sections are flagged internally with a `thinking` type so you can easily spot when the AI is exploring ideas.
 - **Errors**: Errors are highlighted, often providing clues if something went wrong.
 
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -107,8 +107,16 @@ function formatSpecialContent(message, content, contentType) {
       .replace(/\s+/g, '-')
       .replace(':', '');
 
-    // Always return just the special content box, hiding the log line wrapper entirely
-    return `<div class="special-content ${cssClass}">${parsedMarkdown}</div>`;
+    const label = contentType.replace('content:', '').trim();
+    const icon = cssClass.includes('scratchpad')
+      ? 'codicon-pencil'
+      : 'codicon-lightbulb';
+
+    return `\
+<details class="special-details">\
+  <summary class="${cssClass}"><i class="codicon ${icon}"></i> ${label}</summary>\
+  <div class="special-content ${cssClass}">${parsedMarkdown}</div>\
+</details>`;
   } catch (e) {
     console.error('Error parsing markdown:', e);
     // Fallback to original content

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -23,6 +23,15 @@ marked.setOptions({
 });
 
 /**
+ * Generate a sanitized CSS class string from a content type label
+ * @param {string} contentType - The content type to convert
+ * @returns {string} Normalized class name
+ */
+function generateCssClass(contentType) {
+  return contentType.toLowerCase().replace(/\s+/g, '-').replace(':', '');
+}
+
+/**
  * Format a log entry with Markdown rendering for special content
  * @param {Object} logMessage - The log message to format
  * @returns {string} Formatted HTML for the log message
@@ -102,10 +111,7 @@ function formatSpecialContent(message, content, contentType) {
     parsedMarkdown = parsedMarkdown.trim();
 
     // Create enhanced content element with better formatting
-    const cssClass = contentType
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(':', '');
+    const cssClass = generateCssClass(contentType);
 
     const label = contentType.replace('content:', '').trim();
     const icon = cssClass.includes('scratchpad')

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -250,7 +250,6 @@
 .scratchpad-content h1 + h1,
 .scratchpad-content h2 + h2,
 .scratchpad-content h3 + h3,
-.scratchpad-content h4 + h4,
-.scratchpad-content p + p {
+.scratchpad-content h4 + h4 {
   margin-top: 0.3em;
 }

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -3,45 +3,42 @@
  * Markdown and content formatting for scratchpad entries
  */
 
-/* Base styles for content display (shared between scratchpad and thinking) */
-.special-content,
-.scratchpad-content,
-.thinking-content {
-  --special-color: var(--vscode-panel-border);
-  --label: '';
-  background-color: var(--vscode-editor-background);
-  border-radius: calc(var(--border-radius) * 2);
-  padding: var(--spacing-medium) var(--spacing-large);
+/* Special block container */
+.special-details {
   margin: var(--spacing-small) 0;
-  overflow: auto;
+  border-radius: var(--border-radius-large);
+  background-color: var(--vscode-editor-background);
+  border: var(--border-thin) solid var(--vscode-panel-border);
+}
+
+.special-details summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-small) var(--spacing-medium);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  border-radius: var(--border-radius-large);
+}
+
+.special-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.special-details .special-content {
+  padding: var(--spacing-medium) var(--spacing-large);
+  border-top: var(--border-thin) solid var(--vscode-panel-border);
   max-height: var(--height-xxlarge);
-  position: relative;
-  border-left: var(--border-xlarge) solid var(--special-color);
+  overflow: auto;
 }
 
-.special-content::before {
-  content: var(--label);
-  position: absolute;
-  top: 0;
-  right: var(--spacing-small);
-  background-color: var(--special-color);
-  color: white;
-  padding: var(--spacing-tiny) var(--spacing-small);
-  border-radius: 0 0 var(--border-radius) var(--border-radius);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
+.special-details summary.scratchpad-content .codicon {
+  color: var(--vscode-activityBarBadge-background, #007acc);
 }
 
-/* Scratchpad content */
-.scratchpad-content {
-  --special-color: var(--vscode-activityBarBadge-background, #007acc);
-  --label: 'Scratchpad';
-}
-
-/* Thinking content */
-.thinking-content {
-  --special-color: var(--vscode-symbolIcon-snippetForeground, #8250df);
-  --label: 'Model Thinking';
+.special-details summary.thinking-content .codicon {
+  color: var(--vscode-symbolIcon-snippetForeground, #8250df);
 }
 
 /* Style markdown elements in scratchpad */


### PR DESCRIPTION
## Summary
- redesign special scratchpad and thinking blocks with collapsible `<details>`
- color label icons for scratchpad and thinking
- drop "Model" from the thinking label in docs

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning but completes)*

------
https://chatgpt.com/codex/tasks/task_e_685843d3132c8324ba87e32e3aef96cd