### PR TITLE
Remove logging side effects from text utils

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -28,10 +28,7 @@ import {
 import { loadTexraRules } from '@frontend/files/rules';
 import replacementManager from '@replacement/replacementManager';
 import { checkForMassiveRepetition } from '@utils/text/repetitionUtils';
-import {
-  extractAndLogScratchpad,
-  formatAndLogContent,
-} from '@utils/text/xmlUtils';
+import { extractScratchpad, formatContent } from '@utils/text/xmlUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
@@ -246,12 +243,8 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
         // If thinking content was extracted, format and log it first
         if (thinkingContent) {
-          await formatAndLogContent(
-            thinkingContent,
-            this.logger,
-            'Thinking',
-            logGroupId,
-          );
+          const formatted = await formatContent(thinkingContent);
+          this.logger.info(`Thinking content: ${formatted}`, logGroupId);
 
           // Note: The complete thinking blocks (including signatures) have already been
           // stored in toolState.thinkingBlocks by the processThinkingBlock method
@@ -1215,11 +1208,9 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     thinkingTag: string = 'scratchpad',
     groupId?: string,
   ): Promise<void> {
-    await extractAndLogScratchpad(
-      outputContent,
-      this.logger,
-      thinkingTag,
-      groupId,
-    );
+    const formatted = await extractScratchpad(outputContent, thinkingTag);
+    if (formatted) {
+      this.logger.info(`Scratchpad content: ${formatted}`, groupId);
+    }
   }
 }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -19,7 +19,7 @@ import { WorkspaceFS } from '@utils/files';
 import { cleanFileContent } from '@replacement/replacementUtils';
 import replacementManager from '@replacement/replacementManager';
 import type { ProviderStopReason } from '../../types/StopReasonTypes';
-import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
+import { extractScratchpad } from '@utils/text/xmlUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
@@ -499,13 +499,11 @@ export class ModelHandlerAnthropic extends ModelHandler {
     let fileContent = await WorkspaceFS.readFile(outputFile);
     fileContent = cleanFileContent(fileContent);
 
-    // Extract and log any existing scratchpad content
-    await extractAndLogScratchpad(
-      fileContent,
-      this.logger,
-      'scratchpad',
-      groupId,
-    );
+    // Extract any existing scratchpad content
+    const scratchpad = await extractScratchpad(fileContent, 'scratchpad');
+    if (scratchpad) {
+      this.logger.info(`Scratchpad content: ${scratchpad}`, groupId);
+    }
 
     await WorkspaceFS.writeFile(outputFile, fileContent);
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -36,7 +36,7 @@ import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { formatProviderError } from '@utils/sdkErrorUtils';
 import { cleanFileContent } from '@replacement/replacementUtils';
 import replacementManager from '@replacement/replacementManager';
-import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
+import { extractScratchpad } from '@utils/text/xmlUtils';
 import type { ProviderStopReason } from '../../types/StopReasonTypes';
 import { getConfig } from '@utils/config';
 import { calculateTokenPrice } from '@utils/priceUtils';
@@ -815,13 +815,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
     let fileContent = await WorkspaceFS.readFile(outputFile);
     fileContent = cleanFileContent(fileContent);
 
-    // Extract and log any existing scratchpad content
-    await extractAndLogScratchpad(
-      fileContent,
-      this.logger,
-      'scratchpad',
-      groupId,
-    );
+    // Extract any existing scratchpad content
+    const scratchpad = await extractScratchpad(fileContent, 'scratchpad');
+    if (scratchpad) {
+      this.logger.info(`Scratchpad content: ${scratchpad}`, groupId);
+    }
 
     await WorkspaceFS.writeFile(outputFile, fileContent);
     this.logger.debug(`Cleaned and saved existing content to ${outputFile}.`);

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -9,7 +9,7 @@ import { countTokens } from 'gpt-tokenizer';
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
 import { cleanFileContent } from '@replacement/replacementUtils';
-import { extractAndLogScratchpad } from '@utils/text/xmlUtils';
+import { extractScratchpad } from '@utils/text/xmlUtils';
 import { formatProviderError } from '@utils/sdkErrorUtils';
 
 // Local imports - agent components
@@ -554,13 +554,11 @@ export class ModelHandlerOpenAI extends ModelHandler {
     let fileContent = await WorkspaceFS.readFile(outputFile);
     fileContent = cleanFileContent(fileContent);
 
-    // Extract and log any existing scratchpad content
-    await extractAndLogScratchpad(
-      fileContent,
-      this.logger,
-      'scratchpad',
-      groupId,
-    );
+    // Extract any existing scratchpad content
+    const scratchpad = await extractScratchpad(fileContent, 'scratchpad');
+    if (scratchpad) {
+      this.logger.info(`Scratchpad content: ${scratchpad}`, groupId);
+    }
 
     // Write file content to output file
     await WorkspaceFS.writeFile(outputFile, fileContent);

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -1,6 +1,5 @@
 // Local imports - log
 import * as logger from '@logger/logUtils';
-import { AgentLogger } from '@logger/AgentLogger';
 import { K_SLICE } from '@utils/config';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import nodePandoc from 'node-pandoc';
@@ -309,21 +308,10 @@ export function extractContentFromXMLbyTagMultiple(
  * @param contentType The type of content (e.g., 'Scratchpad', 'Thinking')
  * @param groupId Optional group ID for logging
  */
-export async function formatAndLogContent(
-  content: string,
-  agentLogger: AgentLogger,
-  contentType: string = 'Scratchpad',
-  groupId?: string,
-): Promise<void> {
+export async function formatContent(content: string): Promise<string> {
   if (!content) {
-    return;
+    return '';
   }
-
-  // Log original content for debugging
-  agentLogger.debug(
-    `Original ${contentType.toLowerCase()} content before formatting: ${content.substring(0, K_SLICE)}${content.length > K_SLICE ? '...' : ''}`,
-    groupId,
-  );
 
   // Format the content for improved rendering
   let formattedContent = content.trim();
@@ -387,37 +375,19 @@ export async function formatAndLogContent(
   }
   // .replace(/ +$/gm, ''); // Remove trailing spaces only
 
-  // agentLogger.info(formattedContent, groupId); // for debugging
-
-  // Log the formatted content
-  agentLogger.info(`${contentType} content: ${formattedContent}`, groupId);
+  return formattedContent;
 }
 
 /**
- * Extracts scratchpad content from the given output and logs it after formatting.
- * Converts LaTeX and XML notation to more readable markdown format.
+ * Extract scratchpad content from the given output and format it.
  *
  * @param outputContent The content to extract scratchpad from
- * @param logger The logger instance to use for logging the formatted content
  * @param thinkingTag The XML tag name used for the scratchpad content
- * @param groupId Optional group ID for logging
  */
-export async function extractAndLogScratchpad(
+export async function extractScratchpad(
   outputContent: string,
-  agentLogger: AgentLogger,
   thinkingTag: string = 'scratchpad',
-  groupId?: string,
-): Promise<void> {
+): Promise<string | null> {
   const extractedContent = extractTextFromTag(outputContent, thinkingTag);
-  if (extractedContent) {
-    // Always log using the canonical "Scratchpad" label so that the progress
-    // view recognises the message. The thinkingTag is still used for
-    // extraction so alternative tag names continue to work.
-    await formatAndLogContent(
-      extractedContent,
-      agentLogger,
-      'Scratchpad',
-      groupId,
-    );
-  }
+  return extractedContent ? await formatContent(extractedContent) : null;
 }


### PR DESCRIPTION
## Summary
- decouple xml utility functions from progress view logger
- update agents to log formatted scratchpad content themselves

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning, but compilation succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_685826c09ae88324a5c056aea0d362fd