### PR TITLE
Fix logging level for user interruptions

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -119,7 +119,7 @@ export abstract class BaseAgent implements IAgent {
     if (this.abortController) {
       this.abortController.abort();
     }
-    this.logger.info(
+    this.logger.error(
       'Agent execution interrupted by user. Active request aborted; partial output may remain.',
     );
   }


### PR DESCRIPTION
## Summary
- treat user interruptions as an error message

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68592200f96883249126ff9993ea8bcf