### PR TITLE
Update progress view cleanup logic

### DIFF
--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -118,7 +118,10 @@ async function handleCleanMultiple(
   }
 }
 
-export async function handleClean(config: any) {
+export async function handleClean(config: {
+  streamId?: string;
+  [key: string]: any;
+}) {
   logger.debug(
     CHANNEL,
     `Clean command called with config: ${JSON.stringify(config)}`,
@@ -158,12 +161,9 @@ export async function handleClean(config: any) {
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(
-      config.agent,
-      config.model,
-      config.inputFile,
-      outputFiles,
-    );
+    const streamId =
+      config.streamId ||
+      getStreamId(config.agent, config.model, config.inputFile, outputFiles);
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -50,7 +50,7 @@ export function registerPackCommands(context: vscode.ExtensionContext) {
   );
 }
 
-async function handlePack(config: any) {
+async function handlePack(config: { streamId?: string; [key: string]: any }) {
   logger.debug(
     CHANNEL,
     `Pack command called with config: ${JSON.stringify(config)}`,
@@ -77,12 +77,9 @@ async function handlePack(config: any) {
 
   const provider = ProgressViewProvider.getInstance();
   if (provider) {
-    const streamId = getStreamId(
-      config.agent,
-      config.model,
-      config.inputFile,
-      outputFiles,
-    );
+    const streamId =
+      config.streamId ||
+      getStreamId(config.agent, config.model, config.inputFile, outputFiles);
     provider.clearOutputFiles(streamId);
     provider.clearTaskOutput(streamId);
   }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -116,6 +116,7 @@ export class ProgressViewMessageHandler {
     const outputFilesArray = Array.from(allFiles);
 
     await vscode.commands.executeCommand(command, {
+      streamId: stream,
       agent: taskState.agent,
       model: taskState.model,
       inputFile: taskState.inputFile,


### PR DESCRIPTION
## Summary
- carry streamId from progress view to pack/clean commands
- clear output files using provided streamId

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68592a7475f88324a70874e3110f8605