### PR TITLE
feat: render latex in progress view

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,8 +3,11 @@
 .cursor
 .cursor/*
 .cursorignore
+
 .pre-commit-config.yaml
 .DS_Store
+resources/.DS_Store
+
 .vscode/**
 .vscode-test/**
 out/**
@@ -21,7 +24,6 @@ tsconfig.json
 **/*.map
 **/*.ts
 **/.vscode-test.*
-.DS_Store
 venv/**
 docs/**
 prototypes/**
@@ -30,8 +32,10 @@ CLAUDE.md
 
 !node_modules/@vscode/codicons/dist/**
 !node_modules/split.js/**
-.DS_Store
-resources/.DS_Store
+!node_modules/katex/dist/fonts/**
+!node_modules/katex/dist/katex.min.css
+!node_modules/katex/dist/katex.mjs
+
 !resources/**
 !src/webview/*.js
 !src/webview/*.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "glob": "^11.0.3",
         "gpt-tokenizer": "^3.0.1",
         "identifiers-arxiv": "^0.1.1",
+        "katex": "^0.16.9",
         "marked": "^15.0.12",
         "node-pandoc": "^0.3.0",
         "openai": "^5.6.0",
@@ -3961,6 +3962,31 @@
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
+      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -1181,6 +1181,7 @@
     "glob": "^11.0.3",
     "gpt-tokenizer": "^3.0.1",
     "identifiers-arxiv": "^0.1.1",
+    "katex": "^0.16.9",
     "marked": "^15.0.12",
     "node-pandoc": "^0.3.0",
     "openai": "^5.6.0",

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -50,6 +50,8 @@ export class ProgressViewContentProvider {
       const templateUtilsUri = getCommonUri('modules/templateUtils.js');
       const domUtilsUri = getCommonUri('modules/domUtils.js');
       const stringUtilsUri = getCommonUri('modules/stringUtils.js');
+      const katexJsUri = getNodeModulesUri('katex/dist/katex.mjs');
+      const katexCssUri = getNodeModulesUri('katex/dist/katex.min.css');
 
       const codiconUri = getNodeModulesUri('@vscode/codicons/dist/codicon.css');
       const codiconsFontUri = getNodeModulesUri(
@@ -64,6 +66,8 @@ export class ProgressViewContentProvider {
         splitJsUri,
         codiconUri,
         codiconsFontUri,
+        katexJsUri,
+        katexCssUri,
         webviewStateUri,
         stateManagerUri,
         messageHandlersUri,

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -50,9 +50,10 @@ export class ProgressViewContentProvider {
       const templateUtilsUri = getCommonUri('modules/templateUtils.js');
       const domUtilsUri = getCommonUri('modules/domUtils.js');
       const stringUtilsUri = getCommonUri('modules/stringUtils.js');
+
       const katexJsUri = getNodeModulesUri('katex/dist/katex.mjs');
       const katexCssUri = getNodeModulesUri('katex/dist/katex.min.css');
-
+      const katexFontsUri = getNodeModulesUri('katex/dist/fonts');
       const codiconUri = getNodeModulesUri('@vscode/codicons/dist/codicon.css');
       const codiconsFontUri = getNodeModulesUri(
         '@vscode/codicons/dist/codicon.ttf',
@@ -68,6 +69,7 @@ export class ProgressViewContentProvider {
         codiconsFontUri,
         katexJsUri,
         katexCssUri,
+        // katexFontsUri,
         webviewStateUri,
         stateManagerUri,
         messageHandlersUri,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -134,6 +134,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         vscode.Uri.joinPath(this._extensionUri, 'src', 'progressView'),
         vscode.Uri.joinPath(this._extensionUri, 'src', 'common', 'styles'),
         vscode.Uri.joinPath(this._extensionUri, 'src', 'common', 'modules'),
+        vscode.Uri.joinPath(
+          this._extensionUri,
+          'node_modules',
+          'katex',
+          'dist',
+        ),
         vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'split.js'),
         vscode.Uri.joinPath(
           this._extensionUri,

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="${commonStyleUri}" />
     <link rel="stylesheet" href="${styleUri}" />
     <link rel="stylesheet" href="${codiconUri}" />
+    <link rel="stylesheet" href="${katexCssUri}" />
     <style>
       /* Removed duplicate log group styles - these are already defined in groups.css */
     </style>
@@ -27,7 +28,8 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
-          "@common/stringUtils.js": "${stringUtilsUri}"
+          "@common/stringUtils.js": "${stringUtilsUri}",
+          "katex": "${katexJsUri}"
         }
       }
     </script>

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -1,4 +1,5 @@
 import { marked } from 'marked';
+import { renderToString } from 'katex';
 import { getLogGroup, setLogGroup } from './stateManager.js';
 import { STATUS } from './constants.js';
 
@@ -21,6 +22,27 @@ marked.setOptions({
   headerIds: false, // Don't add id attributes to headers
   mangle: false, // Don't mangle email addresses
 });
+
+// Render LaTeX formulas using KaTeX
+function renderMath(html) {
+  return (
+    html
+      // Display equations $$...$$ or \[...\]
+      .replace(/\$\$([\s\S]+?)\$\$/g, (_, eq) =>
+        renderToString(eq, { displayMode: true }),
+      )
+      .replace(/\\\[([\s\S]+?)\\\]/g, (_, eq) =>
+        renderToString(eq, { displayMode: true }),
+      )
+      // Inline equations $...$ or \(...\)
+      .replace(/\$(?!\$)([^$]+?)\$/g, (_, eq) =>
+        renderToString(eq, { displayMode: false }),
+      )
+      .replace(/\\\(([^)]+)\\\)/g, (_, eq) =>
+        renderToString(eq, { displayMode: false }),
+      )
+  );
+}
 
 /**
  * Generate a sanitized CSS class string from a content type label
@@ -109,6 +131,7 @@ function formatSpecialContent(message, content, contentType) {
 
     // Remove extra whitespace at start and end of content
     parsedMarkdown = parsedMarkdown.trim();
+    parsedMarkdown = renderMath(parsedMarkdown);
 
     // Create enhanced content element with better formatting
     const cssClass = generateCssClass(contentType);

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -1,5 +1,5 @@
 import { marked } from 'marked';
-import { renderToString } from 'katex';
+import katex from 'katex';
 import { getLogGroup, setLogGroup } from './stateManager.js';
 import { STATUS } from './constants.js';
 
@@ -28,19 +28,39 @@ function renderMath(html) {
   return (
     html
       // Display equations $$...$$ or \[...\]
-      .replace(/\$\$([\s\S]+?)\$\$/g, (_, eq) =>
-        renderToString(eq, { displayMode: true }),
-      )
-      .replace(/\\\[([\s\S]+?)\\\]/g, (_, eq) =>
-        renderToString(eq, { displayMode: true }),
-      )
+      .replace(/\$\$([\s\S]+?)\$\$/g, (_, eq) => {
+        try {
+          return katex.renderToString(eq, { displayMode: true });
+        } catch (e) {
+          console.warn('KaTeX rendering failed for display equation:', e);
+          return `$$${eq}$$`; // Return original if rendering fails
+        }
+      })
+      .replace(/\\\[([\s\S]+?)\\\]/g, (_, eq) => {
+        try {
+          return katex.renderToString(eq, { displayMode: true });
+        } catch (e) {
+          console.warn('KaTeX rendering failed for display equation:', e);
+          return `\\[${eq}\\]`; // Return original if rendering fails
+        }
+      })
       // Inline equations $...$ or \(...\)
-      .replace(/\$(?!\$)([^$]+?)\$/g, (_, eq) =>
-        renderToString(eq, { displayMode: false }),
-      )
-      .replace(/\\\(([^)]+)\\\)/g, (_, eq) =>
-        renderToString(eq, { displayMode: false }),
-      )
+      .replace(/\$(?!\$)([^$]+?)\$/g, (_, eq) => {
+        try {
+          return katex.renderToString(eq, { displayMode: false });
+        } catch (e) {
+          console.warn('KaTeX rendering failed for inline equation:', e);
+          return `$${eq}$`; // Return original if rendering fails
+        }
+      })
+      .replace(/\\\(([\s\S]+?)\\\)/g, (_, eq) => {
+        try {
+          return katex.renderToString(eq, { displayMode: false });
+        } catch (e) {
+          console.warn('KaTeX rendering failed for inline equation:', e);
+          return `\\(${eq}\\)`; // Return original if rendering fails
+        }
+      })
   );
 }
 


### PR DESCRIPTION
## Summary
- import katex
- include katex scripts in the progress view
- render math expressions in ThinkingContent and Scratchpad messages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68592950a24c83249e70b73314ec9054