### PR TITLE
fix: align logging messages

### DIFF
--- a/src/frontend/files/vars.ts
+++ b/src/frontend/files/vars.ts
@@ -30,10 +30,10 @@ export async function setVarFromFile(
       : await WorkspaceFS.readFile(filePath);
     userVars[`${varName}_FILE`] = filePath;
     userVars[`${varName}_CONTENT`] = fileContent;
-    logger.info(`Found from [${source}] the [VAR '${varName}']: ${filePath}`);
+    logger.info(`[${source}] Found [VAR '${varName}']: ${filePath}`);
     return true;
   } catch (err) {
-    logger.warn(`[${source}] ${filePath} not found from [VAR '${varName}'].`);
+    logger.warn(`[${source}] [VAR '${varName}'] not found: ${filePath}`);
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- unify log message format for setVarFromFile

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no results)*

------
https://chatgpt.com/codex/tasks/task_e_685921aab9388324b57f36d7d0c9d9e6