### PR TITLE
Minimize progress view styling for cleaner UI

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -946,4 +946,19 @@ export function setupEventListeners() {
     gutterSize: 5,
     cursor: 'col-resize',
   });
+
+  // Handle special-details toggle events
+  document.addEventListener(
+    'toggle',
+    (e) => {
+      if (e.target && e.target.classList.contains('special-details')) {
+        const toggleIcon = e.target.querySelector('.toggle-icon');
+        if (toggleIcon) {
+          const isOpen = e.target.open;
+          toggleIcon.className = `codicon codicon-chevron-${isOpen ? 'down' : 'right'} toggle-icon`;
+        }
+      }
+    },
+    true,
+  );
 }

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -120,7 +120,7 @@ function formatSpecialContent(message, content, contentType) {
 
     return `\
 <details class="special-details">\
-  <summary class="${cssClass}"><i class="codicon ${icon}"></i> ${label}</summary>\
+  <summary class="${cssClass}"><i class="codicon codicon-chevron-down toggle-icon"></i> <i class="codicon ${icon}"></i> ${label}</summary>\
   <div class="special-content ${cssClass}">${parsedMarkdown}</div>\
 </details>`;
   } catch (e) {

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -119,7 +119,7 @@ function formatSpecialContent(message, content, contentType) {
       : 'codicon-lightbulb';
 
     return `\
-<details class="special-details">\
+<details class="special-details" open>\
   <summary class="${cssClass}"><i class="codicon codicon-chevron-down toggle-icon"></i> <i class="codicon ${icon}"></i> ${label}</summary>\
   <div class="special-content ${cssClass}">${parsedMarkdown}</div>\
 </details>`;

--- a/src/progressView/styles/base.css
+++ b/src/progressView/styles/base.css
@@ -61,7 +61,7 @@ body {
     opacity: var(--opacity-subtle);
   }
   50% {
-    transform: scale(1.1);
+    ar: scale(1.1);
     opacity: var(--opacity-full);
   }
   100% {

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -34,7 +34,6 @@
 }
 
 .log-group-content {
-  margin-left: var(--spacing-medium);
   padding-left: var(--spacing-small);
   border-left: var(--border-thin) dashed
     var(--vscode-editorGroupHeader-tabsBorder);

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -33,16 +33,10 @@
   overflow: auto;
 }
 
-/* Chevron icon for toggle state */
+/* Toggle icon styling */
 .special-details summary .toggle-icon {
-  transition: opacity 0.2s ease;
   opacity: var(--opacity-subtle);
   font-size: var(--font-size-sm);
-}
-
-/* Change chevron icon when details is open */
-.special-details[open] summary .toggle-icon::before {
-  content: '\eab4'; /* codicon-chevron-up */
 }
 
 /* Style markdown elements in scratchpad */

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -3,23 +3,24 @@
  * Markdown and content formatting for scratchpad entries
  */
 
-/* Special block container */
+/* Special block container - minimalist style */
 .special-details {
   margin: var(--spacing-small) 0;
-  border-radius: var(--border-radius-large);
-  background-color: var(--vscode-editor-background);
-  border: var(--border-thin) solid var(--vscode-panel-border);
 }
 
 .special-details summary {
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  padding: var(--spacing-small) var(--spacing-medium);
+  padding: var(--spacing-tiny) 0;
   cursor: pointer;
   list-style: none;
   user-select: none;
-  border-radius: var(--border-radius-large);
+  opacity: var(--opacity-normal);
+}
+
+.special-details summary:hover {
+  opacity: 1;
 }
 
 .special-details summary::-webkit-details-marker {
@@ -27,18 +28,21 @@
 }
 
 .special-details .special-content {
-  padding: var(--spacing-medium) var(--spacing-large);
-  border-top: var(--border-thin) solid var(--vscode-panel-border);
+  padding: var(--spacing-small) 0 var(--spacing-medium) var(--spacing-large);
   max-height: var(--height-xxlarge);
   overflow: auto;
 }
 
-.special-details summary.scratchpad-content .codicon {
-  color: var(--vscode-activityBarBadge-background, #007acc);
+/* Chevron icon for toggle state */
+.special-details summary .toggle-icon {
+  transition: opacity 0.2s ease;
+  opacity: var(--opacity-subtle);
+  font-size: var(--font-size-sm);
 }
 
-.special-details summary.thinking-content .codicon {
-  color: var(--vscode-symbolIcon-snippetForeground, #8250df);
+/* Change chevron icon when details is open */
+.special-details[open] summary .toggle-icon::before {
+  content: '\eab4'; /* codicon-chevron-up */
 }
 
 /* Style markdown elements in scratchpad */


### PR DESCRIPTION
## Summary
- Removed extra indentation from top-level log groups to align with VS Code's native styling
- Simplified thinking/scratchpad sections with a more minimalist design
- Improved visual hierarchy by removing unnecessary styling elements

## Changes
1. **Fixed top-level group indentation**: Removed the base `margin-left` from `.log-group-content` so top-level groups align properly with the left edge
2. **Minimalist thinking/scratchpad sections**:
   - Removed background boxes and borders
   - Removed colored icons (now using default color)
   - Added chevron toggle icons that switch between down/up states
   - Reduced padding for a cleaner look

## Test plan
- [ ] Verify top-level log groups align with the left edge
- [ ] Check that nested groups still have proper indentation
- [ ] Test thinking/scratchpad sections expand/collapse with chevron icons
- [ ] Ensure the minimalist design works well in both light and dark themes

🤖 Generated with [Claude Code](https://claude.ai/code)