### PR TITLE
fix: use codicons for empty toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ This document sets the common conventions for contributions. Follow these norms 
 - When targeting the OpenAI Responses API, use `ModelHandlerOpenAIResponse`. This API does not support stop sequences, so handle any end-tag logic in post-processing.
 - Maintain text cleanup rules in the `src/replacement` modules.
 - UI components rely on VS Code codicons for icons (see `src/progressView/index.html`). Stick to these built-in icons to maintain a native look and feel.
+- When toggling sections in webviews, use codicons for the chevron instead of plain characters. For a collapsed state,
+  render `<i class="codicon codicon-chevron-down"></i>`.
 - CSS for views is organized per component under `src/progressView/styles` with shared variables in `src/common/styles/common.css`. Follow this structure when adding new styles.
 - Execute VS Code commands with `safeExecuteCommand` from `src/utils/commandUtils.ts` to handle errors gracefully.
 - Register webview handlers using a command map and `registerMessageHandlers` from `src/common/modules/webviewContext.js`.

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -282,7 +282,8 @@ export function emptyMultipleFiles(containerId, toggleId) {
   listDiv.innerHTML = '';
   container.style.display = 'none';
   const toggleIconDiv = safeGetElementById(toggleId);
-  if (toggleIconDiv) toggleIconDiv.textContent = '▼';
+  if (toggleIconDiv)
+    toggleIconDiv.innerHTML = '<i class="codicon codicon-chevron-down"></i>';
 
   // Reset Output Filename override removed
 


### PR DESCRIPTION
## Summary
- update `emptyMultipleFiles` to show the down chevron codicon
- document chevron usage in AGENTS guidelines

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859579476c483248df94f11b5b8d335