### PR TITLE
fix: remove redundant log group from DirectAgent

### DIFF
--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -49,7 +49,7 @@ export class CoTAgent extends BaseReflectionAgent {
       // Start a main output processing group if none provided
       if (!processGroupId) {
         outputProcessGroupId = await this.logger.startGroup(
-          `OutputHandler`,
+          `OutputProcessing-Round${currRound}`,
           undefined,
           this.logger.getActiveGroupId(),
         );

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -62,25 +62,16 @@ export class DirectAgent extends BaseReflectionAgent {
           outputProcessGroupId,
         );
 
-        // Create a dedicated File Processing subgroup
-        const fileProcessGroupId = await this.outputHandler.startProcessing(
-          `FileProcessing`,
-          outputProcessGroupId,
-        );
-
-        // Process output files using the parent class method but with our group ID
+        // Process output files using the parent class method
         await this.processOutputFiles(
           outputFile,
           currRound,
-          fileProcessGroupId,
+          outputProcessGroupId,
         );
         this.logger.debug(
           `Output files processed for round ${currRound}`,
-          fileProcessGroupId,
+          outputProcessGroupId,
         );
-
-        // End File Processing subgroup
-        this.outputHandler.endProcessing('stopped', fileProcessGroupId);
 
         // Note: latexdiff processing is now handled in the parent class's handleOutput method
       }


### PR DESCRIPTION
## Summary
- stop DirectAgent from creating a separate output handler group

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859878c63e883248b2d57afd0a11e8e