### PR TITLE
Organize imports across modules

### DIFF
--- a/src/AnthropicTool/base.ts
+++ b/src/AnthropicTool/base.ts
@@ -1,3 +1,4 @@
+// Local imports
 import { BetaToolUnionParam } from './types';
 
 /**

--- a/src/AnthropicTool/index.ts
+++ b/src/AnthropicTool/index.ts
@@ -5,7 +5,7 @@
  * such as the text editor tool.
  */
 
-// Import all agents and export them
+// Local imports - agents
 import { XMLValidatorAgent } from './XMLValidatorAgent';
 import { TeXLinterFixAgent } from './TeXLinterFixAgent';
 import { AnthropicToolAgent } from './AnthropicToolAgent';

--- a/src/agent/core/ResponseUsage.ts
+++ b/src/agent/core/ResponseUsage.ts
@@ -1,5 +1,6 @@
 /** Types and utilities for tracking and analyzing model API response usage metrics. */
 
+// Third-party imports
 import type { CompletionUsage } from 'openai/resources/completions';
 import type { Usage as AnthropicUsage } from '@anthropic-ai/sdk/resources/messages';
 // import type { UsageMetadata as GenerateContentResponseUsageMetadata } from '@google/genai';

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -1,4 +1,7 @@
+// Standard library imports
 import { randomUUID } from 'crypto';
+
+// Local imports
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { AgentLogger } from '@logger/AgentLogger';
 

--- a/src/agent/utils/messageUtils.ts
+++ b/src/agent/utils/messageUtils.ts
@@ -2,6 +2,7 @@
  * Utility functions for working with message objects in agent conversations.
  */
 
+// Local imports
 import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 /**

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -1,7 +1,9 @@
 // Utility functions for building user variables for prompts
 
+// Standard library imports
 import * as path from 'path';
 
+// Local imports
 import { AgentLogger } from '@logger/AgentLogger';
 import { WorkspaceFS } from '@utils/files';
 import { setVarFromFile } from '@frontend/files/vars';

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -1,4 +1,7 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 export const apiKeyCommands = {

--- a/src/commands/history/historyCommands.ts
+++ b/src/commands/history/historyCommands.ts
@@ -1,4 +1,7 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports
 import { AgentHistoryViewProvider } from '@historyView/AgentHistoryViewProvider';
 
 export const historyCommands = {

--- a/src/commands/latex/arXivCommands.ts
+++ b/src/commands/latex/arXivCommands.ts
@@ -1,5 +1,10 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Standard library imports
 import * as path from 'path';
+
+// Local imports
 import * as logger from '@logger/logUtils';
 import { downloadArxivSource, validateArxivId } from '@utils/arXivUtils';
 

--- a/src/commands/system/helpCommands.ts
+++ b/src/commands/system/helpCommands.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 import * as vscode from 'vscode';
 
 export const helpCommands = {

--- a/src/commands/system/settingsCommands.ts
+++ b/src/commands/system/settingsCommands.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 import * as vscode from 'vscode';
 
 export const settingsCommands = {

--- a/src/commands/wolfram/wolframScriptCommands.ts
+++ b/src/commands/wolfram/wolframScriptCommands.ts
@@ -1,7 +1,10 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Standard library imports
 import * as path from 'path';
 
-// local import
+// Local imports
 import {
   executeWolframCode,
   executeWolframScriptFile,

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 import * as vscode from 'vscode';
 
 export type ApiProvider = (typeof SecretManager.API_PROVIDERS)[number];

--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -1,5 +1,10 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Standard library imports
 import * as path from 'path';
+
+// Local imports
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { INSTRUCTION_PREFIX, globalSM } from '@utils/stateManager';
 

--- a/src/historyView/AgentHistoryManager.ts
+++ b/src/historyView/AgentHistoryManager.ts
@@ -1,6 +1,10 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Standard library imports
 import { randomUUID } from 'crypto';
 
+// Local imports
 import { AgentConfig } from '@agent/core/AgentConfig';
 import { workspaceSM } from '@utils/stateManager';
 

--- a/src/housekeeping/constants.ts
+++ b/src/housekeeping/constants.ts
@@ -1,3 +1,6 @@
+// Local imports
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
+
 export const EXCLUDED_DIRS = new Set([
   'figs',
   'figures',
@@ -33,9 +36,6 @@ export const TEMP_EXTENSIONS = [
   '-blx.bib',
   'Notes.bib',
 ];
-
-// Auto-generated from ModelRegistry
-import { MODEL_CONFIGS } from '@model/ModelRegistry';
 
 export const MODELS = Object.keys(MODEL_CONFIGS);
 

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -2,6 +2,7 @@
  * Shared logging interfaces used by the logger and progress view.
  */
 
+// Local imports
 import type { TokenUsageStats } from '../types/UsageTypes';
 
 export interface LogGroup {

--- a/src/model/ModelConfig.ts
+++ b/src/model/ModelConfig.ts
@@ -2,6 +2,7 @@
  * Configuration types and constants for language model interactions and capabilities.
  */
 
+// Local imports
 import { ToolConfig } from '@agent/core/ToolConfig';
 
 /**

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/copilotModels.ts
+++ b/src/model/providers/copilotModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/dashscopeModels.ts
+++ b/src/model/providers/dashscopeModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/deepseekModels.ts
+++ b/src/model/providers/deepseekModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/googleModels.ts
+++ b/src/model/providers/googleModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/moonshotModels.ts
+++ b/src/model/providers/moonshotModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/openaiModels.ts
+++ b/src/model/providers/openaiModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/openaiReasoningModels.ts
+++ b/src/model/providers/openaiReasoningModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/otherModels.ts
+++ b/src/model/providers/otherModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/model/providers/xaiModels.ts
+++ b/src/model/providers/xaiModels.ts
@@ -1,3 +1,4 @@
+// Local imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelCapabilities,

--- a/src/replacementEngine/helpers.ts
+++ b/src/replacementEngine/helpers.ts
@@ -1,6 +1,7 @@
 /**
  * Helper functions for generating replacement patterns
  */
+// Local imports
 import { capitalize } from '@frontend/ui/messageUtils';
 
 // Re-export commonly used constants

--- a/src/replacementEngine/maxRules.ts
+++ b/src/replacementEngine/maxRules.ts
@@ -1,3 +1,4 @@
+// Local imports
 import { ReplacementCategory } from './types';
 import {
   generateMathCommandShortcuts,

--- a/src/replacementEngine/rules.ts
+++ b/src/replacementEngine/rules.ts
@@ -1,3 +1,4 @@
+// Local imports
 import { ReplacementCategory } from './types';
 import {
   generateGroupedBackslashFixes,

--- a/src/replacementEngine/rulesRegex.ts
+++ b/src/replacementEngine/rulesRegex.ts
@@ -1,3 +1,4 @@
+// Local imports
 import { ReplacementCategory } from './types';
 
 // ===== Regex replacements =====


### PR DESCRIPTION
## Summary
- add descriptive comments above import blocks
- categorize standard library, third-party, and local imports

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning; VS Code test suite did not run)*

------
https://chatgpt.com/codex/tasks/task_e_6859c7fc35808324a3901a76e06a54ba