### PR TITLE
fix: resolve progress view vertical scrolling overflow

### DIFF
--- a/src/progressView/styles/base.css
+++ b/src/progressView/styles/base.css
@@ -26,6 +26,7 @@ body {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
   overflow: hidden;
 }
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -4,13 +4,15 @@
  */
 
 .log-container {
-  flex: 1;
+  flex: 1 1 auto;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--spacing-tiny) var(--spacing-medium);
   min-width: 0;
   min-height: 0;
   font-family: var(--font-family);
   font-size: var(--font-size);
+  position: relative;
 }
 
 .log-line {
@@ -168,6 +170,7 @@
   font-size: var(--vscode-editor-font-size);
   overflow-y: auto;
   max-height: var(--height-large);
+  flex-shrink: 0;
 }
 
 /* Files usage header */

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -29,8 +29,8 @@
 
 .special-details .special-content {
   padding: var(--spacing-small) 0 var(--spacing-medium) var(--spacing-large);
-  max-height: var(--height-xxlarge);
-  overflow: auto;
+  /* Remove max-height to prevent nested scrollbars */
+  overflow: visible;
 }
 
 /* Toggle icon styling */


### PR DESCRIPTION
## Summary
- Fixed vertical scrolling overflow issue in progress view where scroll area extended beyond visible content
- Prevented nested scrollbars that were causing layout issues
- Ensured proper flex container constraints for stable scrolling behavior

## Changes
1. **base.css**: Added `min-height: 0` to `.content-area` to properly constrain flex children
2. **logs.css**: 
   - Modified `.log-container` with explicit flex values (`flex: 1 1 auto`)
   - Added `overflow-x: hidden` to prevent horizontal overflow
   - Added `position: relative` to establish containing block
   - Added `flex-shrink: 0` to `.files-container` to prevent collapsing
3. **scratchpad.css**: Changed `.special-content` from `overflow: auto` to `overflow: visible` to prevent nested scrollbars

## Test Plan
- [x] Tested with long markdown content in scratchpad
- [x] Verified scroll bounds stay within visible area
- [x] Confirmed no nested scrollbars appear
- [x] Checked that file container remains visible when present

🤖 Generated with [Claude Code](https://claude.ai/code)