### PR TITLE
Implement unified message type handling

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -47,6 +47,7 @@ import { ModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile } from '@agent/runtime/OutputHandler';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
+import { createInfoSpan } from '@agent/modelHandlers/streamUtils';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -248,18 +249,23 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         // If thinking content was extracted, format and log it first
         if (thinkingContent) {
           const formatted = await xmlUtils.formatContent(thinkingContent);
-          this.logger.info(`Thinking content: ${formatted}`, logGroupId);
+          this.logger.info(createInfoSpan(formatted, 'thinking'), logGroupId);
 
           // Note: The complete thinking blocks (including signatures) have already been
           // stored in toolState.thinkingBlocks by the processThinkingBlock method
         }
 
-        // Extract thinking from XML tags in the response text
-        await this.extractAndLogScratchpad(
+        // Extract scratchpad content directly from the response text
+        const scratchpad = await xmlUtils.extractScratchpad(
           newResponse,
           'scratchpad',
-          logGroupId,
         );
+        if (scratchpad) {
+          this.logger.info(
+            createInfoSpan(scratchpad, 'scratchpad'),
+            logGroupId,
+          );
+        }
         // this has a potential bug if <scratchpad> is included in the prefill
 
         // Compute statistics and update states
@@ -1204,21 +1210,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         this.outputHandler.outputFiles[currRound] = [];
         this.outputHandler.outputMappings[currRound] = [];
       }
-    }
-  }
-
-  /** Extracts and logs scratchpad content from output. */
-  protected async extractAndLogScratchpad(
-    outputContent: string,
-    thinkingTag: string = 'scratchpad',
-    groupId?: string,
-  ): Promise<void> {
-    const formatted = await xmlUtils.extractScratchpad(
-      outputContent,
-      thinkingTag,
-    );
-    if (formatted) {
-      this.logger.info(`Scratchpad content: ${formatted}`, groupId);
     }
   }
 }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -32,6 +32,7 @@ import {
 } from '@agent/core/ResponseUsage';
 import { ToolState } from '@agent/core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
+import { createInfoSpan } from './streamUtils';
 import { AgentStateRound } from '@agent/core/AgentState';
 import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
@@ -505,7 +506,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(`Scratchpad content: ${scratchpad}`, groupId);
+      this.logger.info(createInfoSpan(scratchpad, 'scratchpad'), groupId);
     }
 
     await WorkspaceFS.writeFile(outputFile, fileContent);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -18,6 +18,7 @@ import {
 
 // Local imports - agent components
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import { createInfoSpan } from './streamUtils';
 import { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
@@ -822,7 +823,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(`Scratchpad content: ${scratchpad}`, groupId);
+      this.logger.info(createInfoSpan(scratchpad, 'scratchpad'), groupId);
     }
 
     await WorkspaceFS.writeFile(outputFile, fileContent);

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -28,6 +28,7 @@ import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { calculateTokenPrice } from '@utils/priceUtils';
 import { MediaEntry } from '@agent/utils/mediaTypes';
+import { createInfoSpan } from './streamUtils';
 
 /**
  * OpenAI-specific handlers.
@@ -560,7 +561,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(`Scratchpad content: ${scratchpad}`, groupId);
+      this.logger.info(createInfoSpan(scratchpad, 'scratchpad'), groupId);
     }
 
     // Write file content to output file

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { AgentLogger } from '@logger/AgentLogger';
+import { escapeHtml } from '@logger/logUtils';
 
 /**
  * Create a span element for special log content.
@@ -11,7 +12,8 @@ export function createInfoSpan(
   content: string,
   type: 'thinking' | 'scratchpad',
 ): string {
-  return `<span class="message-info" data-message-type="${type}">${content}</span>`;
+  const safeContent = escapeHtml(content);
+  return `<span class="message-info" data-message-type="${type}">${safeContent}</span>`;
 }
 
 const THINKING_TEMPLATE = (content: string) =>

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -2,8 +2,20 @@ import { randomUUID } from 'crypto';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { AgentLogger } from '@logger/AgentLogger';
 
+/**
+ * Create a span element for special log content.
+ * @param content - The text to wrap.
+ * @param type - The message type value.
+ */
+export function createInfoSpan(
+  content: string,
+  type: 'thinking' | 'scratchpad',
+): string {
+  return `<span class="message-info" data-message-type="${type}">${content}</span>`;
+}
+
 const THINKING_TEMPLATE = (content: string) =>
-  `<span class="message-info">Thinking content: ${content}</span>`;
+  createInfoSpan(content, 'thinking');
 
 export async function streamReasoningToProgressView<T>(
   stream: AsyncIterable<T>,

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -12,6 +12,13 @@ export function createInfoSpan(
   content: string,
   type: 'thinking' | 'scratchpad',
 ): string {
+  if (!content || typeof content !== 'string') {
+    throw new Error('Content must be a non-empty string');
+  }
+  if (type !== 'thinking' && type !== 'scratchpad') {
+    throw new Error('Type must be either "thinking" or "scratchpad"');
+  }
+
   const safeContent = escapeHtml(content);
   return `<span class="message-info" data-message-type="${type}">${safeContent}</span>`;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -131,28 +131,19 @@ class VSCodeTransport extends Transport {
     // Escape HTML tags in message for ProgressView
     const escapedMessage = escapeHtml(message);
 
-    // Check if this is a scratchpad message
-    const isScratchpad =
-      level === 'info' && message.includes('Scratchpad content:');
-
-    // Check if this is a thinking message
-    const isThinking =
-      level === 'info' && message.includes('Thinking content:');
-
-    // Add a data attribute for scratchpad messages to help with styling and processing
-    const scratchpadAttr = isScratchpad ? 'data-is-scratchpad="true"' : '';
-
-    const messageType = isScratchpad
-      ? 'scratchpad'
-      : isThinking
-        ? 'thinking'
+    // Detect message type from data-message-type attribute
+    const typeMatch = message.match(/data-message-type="(.*?)"/);
+    const messageType =
+      typeMatch &&
+      (typeMatch[1] === 'scratchpad' || typeMatch[1] === 'thinking')
+        ? (typeMatch[1] as 'scratchpad' | 'thinking')
         : 'default';
 
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
     const isVerbose = getConfig<boolean>('logger.debugMode', false);
     const id = randomUUID();
     const coloredFormattedMessage =
-      `<div class="log-line ${isScratchpad ? 'scratchpad-log' : ''}" data-log-id="${id}" ${scratchpadAttr} ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
+      `<div class="log-line" data-log-id="${id}" ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
       `<span class="timestamp" title="${timestamp}">${emoji}${
         isVerbose ? ` [${timeDisplay}]` : ''
       }</span> ` +

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -15,6 +15,13 @@ import {
 } from '@utils/loggerUtils';
 import { LogGroup } from './LogTypes';
 
+// Message type for ProgressView entries
+export type MessageType = 'thinking' | 'scratchpad' | 'default';
+
+function isValidMessageType(type: string): type is 'thinking' | 'scratchpad' {
+  return type === 'thinking' || type === 'scratchpad';
+}
+
 const { combine, timestamp } = winston.format;
 
 // Define log levels
@@ -135,11 +142,8 @@ class VSCodeTransport extends Transport {
 
     // Detect message type from data-message-type attribute
     const typeMatch = message.match(/data-message-type="(.*?)"/);
-    const messageType =
-      typeMatch &&
-      (typeMatch[1] === 'scratchpad' || typeMatch[1] === 'thinking')
-        ? (typeMatch[1] as 'scratchpad' | 'thinking')
-        : 'default';
+    const messageType: MessageType =
+      typeMatch && isValidMessageType(typeMatch[1]) ? typeMatch[1] : 'default';
 
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
     const isVerbose = getConfig<boolean>('logger.debugMode', false);

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -128,8 +128,10 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    // Escape HTML tags in message for ProgressView
-    const escapedMessage = escapeHtml(message);
+    const hasInfoSpan = /data-message-type="(?:thinking|scratchpad)"/.test(
+      message,
+    );
+    const processedMessage = hasInfoSpan ? message : escapeHtml(message);
 
     // Detect message type from data-message-type attribute
     const typeMatch = message.match(/data-message-type="(.*?)"/);
@@ -152,7 +154,7 @@ class VSCodeTransport extends Transport {
             .toUpperCase()
             .padEnd(8)}</span> `
         : '') +
-      `<span class="message-${level}">${escapedMessage}</span>` +
+      `<span class="message-${level}">${processedMessage}</span>` +
       `</div>`;
 
     // Write to ProgressView if available (with colors and escaped HTML)

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -63,7 +63,7 @@ export function formatLogEntry(logMessage) {
 
 function extractSpecialContent(message, type) {
   const regex = new RegExp(
-    `<span class="message-info"[^>]*data-message-type="${type}">(.*?)</span>`,
+    `<span class="message-info"[^>]*data-message-type="${type}"[^>]*>(.*?)</span>`,
     's',
   );
   const match = message.match(regex);

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -42,49 +42,32 @@ marked.use(
  * @returns {string} Formatted HTML for the log message
  */
 export function formatLogEntry(logMessage) {
-  let message = logMessage.message;
+  const message = logMessage.message;
 
-  // Show thinking content before scratchpad content
-  if (
-    logMessage.messageType === 'thinking' ||
-    message.includes('Thinking content:')
-  ) {
-    // Extract the actual thinking content
-    const thinkingMatch = message.match(
-      /<span class="message-info">Thinking content:\s*(.*?)<\/span>/s,
-    );
-    if (thinkingMatch && thinkingMatch[1]) {
-      const content = thinkingMatch[1];
-      return formatSpecialContent(
-        message,
-        content,
-        'Thinking content:',
-        logMessage.id,
-      );
-    }
+  let type = logMessage.messageType;
+  if (!type) {
+    const attrMatch = message.match(/data-message-type="(.*?)"/);
+    if (attrMatch) type = attrMatch[1];
   }
 
-  // Check for scratchpad content
-  if (
-    logMessage.messageType === 'scratchpad' ||
-    message.includes('data-is-scratchpad="true"')
-  ) {
-    // Extract the actual scratchpad content
-    const scratchpadMatch = message.match(
-      /<span class="message-info">Scratchpad content:\s*(.*?)<\/span>/s,
-    );
-    if (scratchpadMatch && scratchpadMatch[1]) {
-      const content = scratchpadMatch[1];
-      return formatSpecialContent(
-        message,
-        content,
-        'Scratchpad content:',
-        logMessage.id,
-      );
+  if (type === 'thinking' || type === 'scratchpad') {
+    const content = extractSpecialContent(message, type);
+    if (content) {
+      const label = type === 'thinking' ? 'Thinking' : 'Scratchpad';
+      return formatSpecialContent(message, content, label, logMessage.id);
     }
   }
 
   return message;
+}
+
+function extractSpecialContent(message, type) {
+  const regex = new RegExp(
+    `<span class="message-info"[^>]*data-message-type="${type}">(.*?)</span>`,
+    's',
+  );
+  const match = message.match(regex);
+  return match ? match[1] : null;
 }
 
 function unescapeHtml(text) {

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -204,20 +204,6 @@
   color: var(--vscode-editorInfo-foreground, #75beff);
 }
 
-/* Special styling for scratchpad log entries */
-.scratchpad-log {
-  margin-top: var(--spacing-medium);
-  margin-bottom: var(--spacing-small); /* Reduced spacing after log header */
-  background-color: var(--vscode-editor-background);
-  border-radius: var(--border-radius-large) var(--border-radius-large) 0 0; /* Rounded corners only on top */
-  overflow: hidden;
-}
-
-.scratchpad-log .timestamp,
-.scratchpad-log .level-info {
-  opacity: var(--opacity-subtle);
-}
-
 /* Additional enhancements for scratchpad content */
 .special-content p:first-child {
   margin-top: 0;


### PR DESCRIPTION
## Summary
- centralize thinking/scratchpad span creation via `createInfoSpan`
- tag thinking and scratchpad log entries with `data-message-type`
- detect message type using the new attribute in `logUtils`
- simplify formatter logic in progress view
- remove unused scratchpad extraction helper
- drop `scratchpad-log` styling to keep formatting minimal

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack warning, no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_6859c678586483248b16bae6220d6a01