### PR TITLE
Merge progress stream filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ This document sets the common conventions for contributions. Follow these norms 
 - Use `setupPasteListener` from `src/webview/modules/pasteHandler.js` to enable clipboard image pasting in text areas.
 - Implement agents using the `IAgent` interface (`src/agent/IAgent.ts`) for a consistent lifecycle.
 - Track log groups with numeric timestamps using `addLogMessage` in `src/logger/logUtils.ts`.
+- Only agent streams appear in the ProgressView and get their own output channels. Other logs share the
+  consolidated `TeXRA` channel and are not persisted across sessions.
 - Update cumulative usage stats with `updateUsageSummary` in `src/progressView/modules/domHandlers.js`.
 - Prefer enums or union types over plain booleans in configuration objects.
 - Build webview URIs through helpers in `src/webview/WebviewContentProvider.ts`.

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto';
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
 import { WorkspaceFS } from '@utils/files';
 import { objectToTaskState } from '@utils/config';
-import { shouldPersistStream } from '@utils/loggerUtils';
+import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
 
@@ -125,7 +125,7 @@ export class ProgressStateManager {
       // Only load channels that should be persisted
       this._logStreams = new Map(
         Object.entries(savedState)
-          .filter(([channel]) => shouldPersistStream(channel))
+          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
           .map(([stream, messages]) => [
             stream,
             messages.map((msg) => {
@@ -164,7 +164,7 @@ export class ProgressStateManager {
     if (savedGroups) {
       this._logGroups = new Map(
         Object.entries(savedGroups)
-          .filter(([channel]) => shouldPersistStream(channel))
+          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
           .map(([streamId, groups]) => [
             streamId,
             new Map(
@@ -206,7 +206,7 @@ export class ProgressStateManager {
       let totalFilesRemoved = 0;
 
       for (const [streamId, rounds] of Object.entries(savedFiles)) {
-        if (!shouldPersistStream(streamId)) {
+        if (shouldUseConsolidatedChannel(streamId)) {
           continue;
         }
 
@@ -343,7 +343,7 @@ export class ProgressStateManager {
   private _saveLogStreams(): void {
     // Only save channels that should be persisted
     const persistentStreams = Array.from(this._logStreams.entries()).filter(
-      ([channel]) => shouldPersistStream(channel),
+      ([channel]) => !shouldUseConsolidatedChannel(channel),
     );
     const stateObj = Object.fromEntries(persistentStreams);
     workspaceSM.update(
@@ -357,7 +357,7 @@ export class ProgressStateManager {
    */
   private _saveLogGroups(): void {
     const persistentGroups = Array.from(this._logGroups.entries())
-      .filter(([channel]) => shouldPersistStream(channel))
+      .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
       .map(([streamId, groups]) => [
         streamId,
         Object.fromEntries(groups.entries()),

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -10,10 +10,7 @@ import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
 
 import { getConfig } from '@utils/config';
-import {
-  shouldExcludeFromProgressView,
-  shouldPersistStream,
-} from '@utils/loggerUtils';
+import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 
 import { TokenUsageStats } from '../types/UsageTypes';
 import { LogGroup } from '../logger/LogTypes';
@@ -269,7 +266,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     id: string = randomUUID(),
   ) {
     // Skip if this stream should be excluded from the progress view
-    if (shouldExcludeFromProgressView(stream)) {
+    if (shouldUseConsolidatedChannel(stream)) {
       return;
     }
 
@@ -369,7 +366,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     parentGroupId?: string,
   ) {
     // Skip if this stream should be excluded from the progress view
-    if (shouldExcludeFromProgressView(stream)) {
+    if (shouldUseConsolidatedChannel(stream)) {
       return;
     }
 
@@ -429,7 +426,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     endTime?: number,
   ) {
     // Skip if this stream should be excluded from the progress view
-    if (shouldExcludeFromProgressView(stream)) {
+    if (shouldUseConsolidatedChannel(stream)) {
       return;
     }
 
@@ -562,7 +559,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   public updateStreamStatus(stream: string, status: StreamStatusType) {
     // Don't track status for excluded streams
-    if (shouldExcludeFromProgressView(stream)) {
+    if (shouldUseConsolidatedChannel(stream)) {
       return;
     }
 

--- a/src/utils/loggerUtils.ts
+++ b/src/utils/loggerUtils.ts
@@ -40,44 +40,12 @@ export function isAgentStream(streamName: string): boolean {
 }
 
 /**
- * Determines if a stream should be excluded from the ProgressView
- * (only shown in consolidated output channel).
- */
-export function shouldExcludeFromProgressView(streamName: string): boolean {
-  // If it's an agent stream, it should be included in the ProgressView
-  if (isAgentStream(streamName)) {
-    return false;
-  }
-
-  // All other streams (including executeAgent) are excluded from ProgressView
-  return true;
-}
-
-/**
  * Determines if a stream should use the consolidated output channel.
  * Agent streams get their own channel, all others (including executeAgent) use the consolidated channel.
  */
 export function shouldUseConsolidatedChannel(streamName: string): boolean {
-  // Special case: executeAgent should use the consolidated channel
-  if (streamName === 'executeAgent') {
-    return true;
-  }
-
-  // Opposite of isAgentStream for all other cases
+  // Only agent streams get dedicated channels and appear in the ProgressView
   return !isAgentStream(streamName);
-}
-
-/**
- * Determines if a stream should be persisted in workspace storage.
- * We only persist streams that are agent streams
- */
-export function shouldPersistStream(streamName: string): boolean {
-  // Don't persist streams excluded from ProgressView
-  if (shouldExcludeFromProgressView(streamName)) {
-    return false;
-  }
-
-  return true;
 }
 
 // Centralised emoji mapping for log levels


### PR DESCRIPTION
## Summary
- document agent stream persistence in AGENTS.md
- remove leftover wrapper for progress view filtering

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(with webpack warning)*


------
https://chatgpt.com/codex/tasks/task_e_685a46e5cf2883249b09b8cf79f164d8