### PR TITLE
Consolidate error reporting

### DIFF
--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
+import { showAndLogErrorMessage } from '@utils/errorHandlingUtils';
 
 // Local imports
 import {
@@ -142,8 +143,7 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
           });
       }
     } catch (err) {
-      logger.error(CHANNEL, `Error opening file: ${err}`);
-      vscode.window.showErrorMessage(`Failed to open file: ${err}`);
+      showAndLogErrorMessage(CHANNEL, 'Failed to open file', err);
     }
   }
 
@@ -178,8 +178,7 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
         `Created custom copy at: ${targetPath}`,
       );
     } catch (err) {
-      logger.error(CHANNEL, `Error creating custom copy: ${err}`);
-      vscode.window.showErrorMessage(`Failed to create custom copy: ${err}`);
+      showAndLogErrorMessage(CHANNEL, 'Failed to create custom copy', err);
     }
   }
 

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -8,6 +8,7 @@ import * as yaml from 'yaml';
 // Local imports - utilities
 import { loadYaml, loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import * as logger from '@logger/logUtils';
+import { showAndLogErrorMessage } from '@utils/errorHandlingUtils';
 import { getAgentPath } from '@agent/runtime/executeAgent';
 import { AgentType } from '@agent/core/AgentDataclass';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
@@ -192,12 +193,10 @@ export async function handleLoadSpecificAgent(
       `Successfully loaded agent "${agentName}". Check Debug Console for details.`,
     );
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
-    logger.error(CHANNEL, `Failed to load agent: ${errorMessage}`);
     if (err instanceof Error && err.stack) {
       logger.debug(CHANNEL, `Stack trace: ${err.stack}`);
     }
-    vscode.window.showErrorMessage(`Failed to load agent: ${errorMessage}`);
+    showAndLogErrorMessage(CHANNEL, 'Failed to load agent', err);
   }
 }
 

--- a/src/historyView/AgentHistoryViewProvider.ts
+++ b/src/historyView/AgentHistoryViewProvider.ts
@@ -9,6 +9,7 @@ import { buildWebviewHtml } from '@frontend/webview/html';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+import { showAndLogErrorMessage } from '@utils/errorHandlingUtils';
 
 const CHANNEL = 'AgentHistoryViewProvider';
 logger.initialize(CHANNEL);
@@ -193,7 +194,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
         vscode.window.showErrorMessage(`History item not found`);
       }
     } catch (error) {
-      vscode.window.showErrorMessage(`Failed to rerun agent: ${error}`);
+      showAndLogErrorMessage(CHANNEL, 'Failed to rerun agent', error);
     }
   }
 
@@ -233,10 +234,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
         vscode.window.showErrorMessage(`History item not found`);
       }
     } catch (error) {
-      logger.error(CHANNEL, `Failed to restore configuration: ${error}`);
-      vscode.window.showErrorMessage(
-        `Failed to restore configuration: ${error}`,
-      );
+      showAndLogErrorMessage(CHANNEL, 'Failed to restore configuration', error);
     }
   }
 
@@ -253,7 +251,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
         this._view.webview.postMessage({ command: 'historyCleared' });
       }
     } catch (error) {
-      vscode.window.showErrorMessage(`Failed to clear history: ${error}`);
+      showAndLogErrorMessage(CHANNEL, 'Failed to clear history', error);
     }
   }
 
@@ -277,8 +275,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
         );
       }
     } catch (error) {
-      logger.error(CHANNEL, `Failed to delete history item: ${error}`);
-      vscode.window.showErrorMessage(`Failed to delete history item: ${error}`);
+      showAndLogErrorMessage(CHANNEL, 'Failed to delete history item', error);
     }
   }
 }

--- a/src/utils/errorHandlingUtils.ts
+++ b/src/utils/errorHandlingUtils.ts
@@ -2,6 +2,7 @@
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+import * as vscode from 'vscode';
 
 /**
  * Format an error with a prefix for logging or user messages.
@@ -22,4 +23,16 @@ export function logErrorMessage(
   const message = formatError(prefix, err);
   logger.error(channel, message);
   return message;
+}
+
+/**
+ * Log the formatted error and show it to the user.
+ */
+export function showAndLogErrorMessage(
+  channel: string,
+  prefix: string,
+  err: unknown,
+): void {
+  const message = logErrorMessage(channel, prefix, err);
+  vscode.window.showErrorMessage(message);
 }


### PR DESCRIPTION
## Summary
- add `showAndLogErrorMessage` helper
- use helper in folder explorer, YAML commands, and history view

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a654b81d083249ed6eb7de1c43363