### PR TITLE
Introduce event bus for progress updates

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -1147,7 +1147,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
             await replaceInputCommands(
               this.baseFiles,
               processedFiles,
-              this.logger,
             );
           }
         } else {

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -128,13 +128,7 @@ async function getRequiredFileVars(
       agentSetting.requiredFiles,
     )) {
       if (filePath) {
-        await setVarFromFile(
-          filePath,
-          varName,
-          userVars,
-          logger,
-          'requiredFiles',
-        );
+        await setVarFromFile(filePath, varName, userVars, 'requiredFiles');
       }
     }
   }
@@ -148,7 +142,6 @@ async function getRequiredFileVars(
         fullPath,
         varName,
         userVars,
-        logger,
         'requiredFilesInternal',
         true,
       );
@@ -180,7 +173,6 @@ async function getPatternBasedFileVars(
               categoryValue,
               varName,
               userVars,
-              logger,
               `Pattern '${pattern}'`,
             );
           }
@@ -192,7 +184,6 @@ async function getPatternBasedFileVars(
                   file,
                   varName,
                   userVars,
-                  logger,
                   `Pattern '${pattern}'`,
                 );
                 if (success) {

--- a/src/events/EventBus.ts
+++ b/src/events/EventBus.ts
@@ -1,0 +1,71 @@
+import { EventEmitter } from 'events';
+
+export interface LogMessageEvent {
+  stream: string;
+  message: string;
+  level: 'error' | 'warn' | 'info' | 'debug';
+  groupId?: string;
+  timestamp: number;
+  messageType: 'default' | 'scratchpad' | 'thinking';
+  id: string;
+}
+
+export interface LogGroupEvent {
+  stream: string;
+  groupId: string;
+  groupName: string;
+  startTime: number;
+  status: 'running' | 'error' | 'stopped';
+  endTime?: number;
+  parentGroupId?: string;
+}
+
+export interface UpdateLogGroupEvent {
+  stream: string;
+  groupId: string;
+  status: 'running' | 'error' | 'stopped';
+  endTime?: number;
+}
+
+export interface TaskStatusChangeEvent {
+  stream: string;
+  status: string;
+}
+
+export type EventTypes =
+  | 'logMessage'
+  | 'addLogGroup'
+  | 'updateLogGroup'
+  | 'taskStatusChange';
+
+export class EventBus {
+  private emitter = new EventEmitter();
+  private buffers: Record<string, any[]> = {};
+
+  emit(event: EventTypes, payload: any): void {
+    if (this.emitter.listenerCount(event) === 0) {
+      if (!this.buffers[event]) {
+        this.buffers[event] = [];
+      }
+      this.buffers[event].push(payload);
+    }
+    this.emitter.emit(event, payload);
+  }
+
+  on(event: EventTypes, listener: (payload: any) => void): void {
+    // Replay buffered events if any
+    if (this.buffers[event]) {
+      for (const payload of this.buffers[event]) {
+        listener(payload);
+      }
+      delete this.buffers[event];
+    }
+    this.emitter.on(event, listener);
+  }
+
+  off(event: EventTypes, listener: (payload: any) => void): void {
+    this.emitter.off(event, listener);
+  }
+}
+
+export const eventBus = new EventBus();

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,0 +1,1 @@
+export * from './EventBus';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,10 +27,6 @@ export async function activate(context: vscode.ExtensionContext) {
   const progressViewProvider = new ProgressViewProvider(context);
   await progressViewProvider.initialize();
 
-  // IMPORTANT: Register ProgressViewProvider with logger FIRST, before any other operations
-  // This ensures all logs generated during activation go to the ProgressView
-  logger.setProgressViewProvider(progressViewProvider);
-
   // Log activation message to ensure the logger is working correctly
   logger.info('extension', 'TeXRA extension activated');
 

--- a/src/frontend/files/vars.ts
+++ b/src/frontend/files/vars.ts
@@ -2,7 +2,10 @@
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 
 // Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
+import * as log from '@logger/logUtils';
+
+const CHANNEL = 'frontend.vars';
+log.initialize(CHANNEL);
 
 /**
  * Reads a file and populates user variable fields with its path and content.
@@ -11,7 +14,6 @@ import { AgentLogger } from '@logger/AgentLogger';
  * @param filePath - Path to the file
  * @param varName - Variable name prefix (without _FILE or _CONTENT)
  * @param userVars - Object to store the populated variables
- * @param logger - Logger instance used for logging
  * @param source - String describing the origin of the file (for log messages)
  * @param absolute - Interpret filePath as absolute rather than workspace-relative
  * @returns True if the file was read successfully, false otherwise
@@ -20,7 +22,6 @@ export async function setVarFromFile(
   filePath: string,
   varName: string,
   userVars: Record<string, any>,
-  logger: AgentLogger,
   source: string,
   absolute: boolean = false,
 ): Promise<boolean> {
@@ -30,10 +31,10 @@ export async function setVarFromFile(
       : await WorkspaceFS.readFile(filePath);
     userVars[`${varName}_FILE`] = filePath;
     userVars[`${varName}_CONTENT`] = fileContent;
-    logger.info(`[${source}] Found [VAR '${varName}']: ${filePath}`);
+    log.info(CHANNEL, `[${source}] Found [VAR '${varName}']: ${filePath}`);
     return true;
   } catch (err) {
-    logger.warn(`[${source}] [VAR '${varName}'] not found: ${filePath}`);
+    log.warn(CHANNEL, `[${source}] [VAR '${varName}'] not found: ${filePath}`);
     return false;
   }
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -4,8 +4,8 @@ import * as winston from 'winston';
 import Transport from 'winston-transport';
 import { randomUUID } from 'crypto';
 
-// Local imports - progressView
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+// Local imports - events
+import { eventBus } from '@events';
 import { getConfig } from '@utils/config';
 import {
   shouldUseConsolidatedChannel,
@@ -68,17 +68,8 @@ function getMainOutputChannel(): vscode.OutputChannel {
 // Create VSCode output channel transport
 class VSCodeTransport extends Transport {
   private channel: vscode.OutputChannel;
-  private progressViewProvider?: ProgressViewProvider;
   private streamName: string;
   private useConsolidatedChannel: boolean;
-  private messageBuffer: {
-    id: string;
-    level: string;
-    message: string;
-    timestamp: number;
-    groupId?: string;
-    messageType?: 'default' | 'scratchpad' | 'thinking';
-  }[] = [];
   private groups: Map<string, LogGroup> = new Map();
   private activeGroupId?: string;
 
@@ -86,14 +77,12 @@ class VSCodeTransport extends Transport {
     channel: vscode.OutputChannel,
     streamName: string,
     useConsolidatedChannel: boolean,
-    progressViewProvider?: ProgressViewProvider,
     opts?: Transport.TransportStreamOptions,
   ) {
     super(opts);
     this.channel = channel;
     this.streamName = streamName;
     this.useConsolidatedChannel = useConsolidatedChannel;
-    this.progressViewProvider = progressViewProvider;
   }
 
   log(info: any, callback: () => void) {
@@ -161,68 +150,19 @@ class VSCodeTransport extends Transport {
       `<span class="message-${level}">${processedMessage}</span>` +
       `</div>`;
 
-    // Write to ProgressView if available (with colors and escaped HTML)
+    // Emit log message event
     const numericTimestamp = new Date(timestamp).getTime();
-    if (this.progressViewProvider) {
-      this.progressViewProvider.addLogMessage(
-        this.streamName,
-        coloredFormattedMessage,
-        level as 'error' | 'warn' | 'info' | 'debug',
-        groupId,
-        numericTimestamp,
-        messageType,
-        id,
-      );
-    } else {
-      // Buffer the message if ProgressViewProvider is not available
-      this.messageBuffer.push({
-        id,
-        level,
-        message: coloredFormattedMessage,
-        timestamp: numericTimestamp,
-        groupId,
-        messageType,
-      });
-    }
+    eventBus.emit('logMessage', {
+      stream: this.streamName,
+      message: coloredFormattedMessage,
+      level: level as 'error' | 'warn' | 'info' | 'debug',
+      groupId,
+      timestamp: numericTimestamp,
+      messageType,
+      id,
+    });
 
     callback();
-  }
-
-  // Method to replay buffered messages when ProgressViewProvider becomes available
-  replayBufferedMessages(progressViewProvider: ProgressViewProvider) {
-    this.progressViewProvider = progressViewProvider;
-
-    // Skip replay for consolidated channels
-    if (this.useConsolidatedChannel) {
-      return;
-    }
-
-    // First replay any groups
-    for (const group of this.groups.values()) {
-      this.progressViewProvider.addLogGroup(
-        this.streamName,
-        group.id,
-        group.name,
-        group.startTime,
-        group.status,
-        group.endTime,
-      );
-    }
-
-    // Then replay messages, which will be associated with their groups
-    for (const msg of this.messageBuffer) {
-      this.progressViewProvider.addLogMessage(
-        this.streamName,
-        msg.message,
-        msg.level as 'error' | 'warn' | 'info' | 'debug',
-        msg.groupId,
-        msg.timestamp,
-        msg.messageType ?? 'default',
-        msg.id,
-      );
-    }
-
-    this.messageBuffer = []; // Clear buffer after replay
   }
 
   // Create a new log group and make it active
@@ -246,18 +186,16 @@ class VSCodeTransport extends Transport {
       return groupId;
     }
 
-    // Log a message to mark the group start
-    if (this.progressViewProvider) {
-      this.progressViewProvider.addLogGroup(
-        this.streamName,
-        groupId,
-        groupName,
-        now,
-        'running',
-        undefined, // No end time for a new group
-        parentGroupId, // Pass the parent group ID
-      );
-    }
+    // Emit group start event
+    eventBus.emit('addLogGroup', {
+      stream: this.streamName,
+      groupId,
+      groupName,
+      startTime: now,
+      status: 'running',
+      endTime: undefined,
+      parentGroupId,
+    });
 
     return groupId;
   }
@@ -278,14 +216,12 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    if (this.progressViewProvider) {
-      this.progressViewProvider.updateLogGroup(
-        this.streamName,
-        groupId,
-        status,
-        group.endTime,
-      );
-    }
+    eventBus.emit('updateLogGroup', {
+      stream: this.streamName,
+      groupId,
+      status,
+      endTime: group.endTime,
+    });
 
     if (this.activeGroupId === groupId) {
       // If this group has a parent, set that as the active group
@@ -315,17 +251,6 @@ class VSCodeTransport extends Transport {
 // Map to store loggers for different categories
 const channelLoggers = new Map<string, winston.Logger>();
 const channelTransports = new Map<string, VSCodeTransport>();
-
-let globalProgressViewProvider: ProgressViewProvider | undefined;
-
-export function setProgressViewProvider(provider: ProgressViewProvider) {
-  globalProgressViewProvider = provider;
-
-  // Replay buffered messages for all existing transports
-  for (const transport of channelTransports.values()) {
-    transport.replayBufferedMessages(provider);
-  }
-}
 
 export function initialize(defaultChannel: string): void {
   // Create default logger if it doesn't exist
@@ -358,7 +283,6 @@ function createLoggerForChannel(channel: string): winston.Logger {
     outputChannel,
     channel,
     useConsolidatedChannel,
-    globalProgressViewProvider,
   );
   channelTransports.set(channel, transport);
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -16,6 +16,12 @@ import { TokenUsageStats } from '../types/UsageTypes';
 import { LogGroup } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
 import { randomUUID } from 'crypto';
+import {
+  eventBus,
+  LogMessageEvent,
+  LogGroupEvent,
+  UpdateLogGroupEvent,
+} from '@events';
 
 // @ts-ignore - Import JavaScript module
 import { STATUS, COMMANDS } from './modules/constants.js';
@@ -78,6 +84,40 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     // Set instance
     ProgressViewProvider._instance = this;
+
+    // Subscribe to logging events
+    eventBus.on('logMessage', (e: LogMessageEvent) => {
+      this.addLogMessage(
+        e.stream,
+        e.message,
+        e.level,
+        e.groupId,
+        e.timestamp,
+        e.messageType,
+        e.id,
+      );
+    });
+
+    eventBus.on('addLogGroup', (e: LogGroupEvent) => {
+      this.addLogGroup(
+        e.stream,
+        e.groupId,
+        e.groupName,
+        e.startTime,
+        e.status as StatusType,
+        e.endTime,
+        e.parentGroupId,
+      );
+    });
+
+    eventBus.on('updateLogGroup', (e: UpdateLogGroupEvent) => {
+      this.updateLogGroup(
+        e.stream,
+        e.groupId,
+        e.status as StatusType,
+        e.endTime,
+      );
+    });
 
     // Listen for workspace folder changes
     this._disposables.push(

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -3,7 +3,10 @@ import * as path from 'path';
 
 // Local imports
 import { WorkspaceFS } from './workspaceFS';
-import { AgentLogger } from '@logger/AgentLogger';
+import * as log from '@logger/logUtils';
+
+const CHANNEL = 'fileMappingUtils';
+log.initialize(CHANNEL);
 
 /**
  * Create a mapping between two file lists based on name similarity.
@@ -83,26 +86,25 @@ export function createFileMapping(
  *
  * @param baseFiles Base file paths
  * @param outputFiles Output file paths
- * @param logger Optional logger for debug messages
  */
 export async function replaceInputCommands(
   baseFiles: string[],
   outputFiles: string[],
-  logger?: AgentLogger,
 ): Promise<void> {
   if (!baseFiles?.length || !outputFiles?.length) {
-    logger?.debug('No files to process for input command replacement');
+    log.debug(CHANNEL, 'No files to process for input command replacement');
     return;
   }
 
   const baseToOutputMap = createFileMapping(baseFiles, outputFiles, 'contains');
 
   if (baseToOutputMap.size === 0) {
-    logger?.debug('No valid file mappings for input command replacement');
+    log.debug(CHANNEL, 'No valid file mappings for input command replacement');
     return;
   }
 
-  logger?.debug(
+  log.debug(
+    CHANNEL,
     `File mappings for input replacement: ${Array.from(
       baseToOutputMap.entries(),
     )
@@ -131,10 +133,11 @@ export async function replaceInputCommands(
 
       if (newContent !== content) {
         await WorkspaceFS.writeFile(outputFile, newContent);
-        logger?.debug(`Updated input commands in ${outputFile}`);
+        log.debug(CHANNEL, `Updated input commands in ${outputFile}`);
       }
     } catch (err) {
-      logger?.warn(
+      log.warn(
+        CHANNEL,
         `Error processing input commands in ${outputFile}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,9 @@
       "@historyView/*": ["src/historyView/*"],
       "@replacement/*": ["src/replacementEngine/*"],
       "@tools/*": ["src/tools/*"],
-      "@types/*": ["src/types/*"]
+      "@types/*": ["src/types/*"],
+      "@events": ["src/events"],
+      "@events/*": ["src/events/*"]
     },
     "moduleResolution": "node",
     "strict": true /* enable all strict type-checking options */,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,7 @@ const extensionConfig = {
       '@replacement': path.resolve(__dirname, 'src/replacementEngine'),
       '@tools': path.resolve(__dirname, 'src/tools'),
       '@types': path.resolve(__dirname, 'src/types'),
+      '@events': path.resolve(__dirname, 'src/events'),
     },
     fallback: {
       fs: false,


### PR DESCRIPTION
## Summary
- add `EventBus` and wire up progress view logging through it
- stream log messages via event bus in `logUtils`
- remove agent logger usage from utilities
- subscribe progress view provider to event bus
- update build configs for new alias

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a592516708324a0d55c2612e10fa2