### PR TITLE
Introduce codicon constants

### DIFF
--- a/src/common/modules/iconConstants.js
+++ b/src/common/modules/iconConstants.js
@@ -1,0 +1,3 @@
+export const CHEVRON_UP_CLASS = 'codicon codicon-chevron-up';
+export const CHEVRON_DOWN_CLASS = 'codicon codicon-chevron-down';
+export const CHEVRON_RIGHT_CLASS = 'codicon codicon-chevron-right';

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -13,6 +13,10 @@ import {
 } from './logFormatters.js';
 import { STATUS, COMMANDS, SPLIT_SIZES, TOOLBAR_BUTTONS } from './constants.js';
 import { createIconButton } from '@common/templateUtils.js';
+import {
+  CHEVRON_DOWN_CLASS,
+  CHEVRON_RIGHT_CLASS,
+} from '@common/iconConstants.js';
 // Note: We'll inline the getEffectiveBaseFile function since modules can't use TS aliases
 /**
  * Get the effective base file for comparison operations.
@@ -959,7 +963,9 @@ export function setupEventListeners() {
         const toggleIcon = e.target.querySelector('.toggle-icon');
         if (toggleIcon) {
           const isOpen = e.target.open;
-          toggleIcon.className = `codicon codicon-chevron-${isOpen ? 'down' : 'right'} toggle-icon`;
+          toggleIcon.className = `${
+            isOpen ? CHEVRON_DOWN_CLASS : CHEVRON_RIGHT_CLASS
+          } toggle-icon`;
         }
       }
     },

--- a/src/progressView/modules/logFormatters.js
+++ b/src/progressView/modules/logFormatters.js
@@ -3,6 +3,7 @@ import { marked } from 'marked';
 import markedKatex from 'marked-katex-extension';
 // Local imports - constants
 import { STATUS } from './constants.js';
+import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 // Local imports - KaTeX macros
 import { katexMacros } from './katexMacros.js';
 
@@ -141,7 +142,7 @@ function formatSpecialContent(message, content, contentType, logId) {
 
     return `<details class="special-details" open>
       <summary>
-        <i class="codicon codicon-chevron-down toggle-icon"></i>
+        <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
         <i class="codicon ${icon}"></i>
         <span>${labelText}</span>
       </summary>

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -6,6 +6,7 @@ import {
   safeGetElementById,
   safeSetElementValue,
 } from '@common/domUtils.js';
+import { CHEVRON_UP_CLASS, CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 
 // Store default output file names for the currently selected agent
@@ -87,7 +88,7 @@ export function updateMultipleFileSelect(selectId, toggleId, files) {
       addFileToList(selectId, file);
     });
     selectDiv.style.display = 'block';
-    toggleIcon.innerHTML = '<i class="codicon codicon-chevron-up"></i>';
+    toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
 
     // Make sure the container is also visible
     const containerId = `${selectId}Container`;
@@ -128,9 +129,9 @@ export function setMultipleFileSelectVisibility(
   }
 
   container.style.display = isVisible ? 'block' : 'none';
-  toggleIcon.innerHTML = isVisible
-    ? '<i class="codicon codicon-chevron-up"></i>'
-    : '<i class="codicon codicon-chevron-down"></i>';
+  toggleIcon.innerHTML = `<i class="${
+    isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+  }"></i>`;
 }
 
 export function setElementsDisabled(elements, disabled) {
@@ -283,7 +284,7 @@ export function emptyMultipleFiles(containerId, toggleId) {
   container.style.display = 'none';
   const toggleIconDiv = safeGetElementById(toggleId);
   if (toggleIconDiv)
-    toggleIconDiv.innerHTML = '<i class="codicon codicon-chevron-down"></i>';
+    toggleIconDiv.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
 
   // Reset Output Filename override removed
 
@@ -319,9 +320,9 @@ export function initializeOutputContainer() {
     const shouldShow = state && state.outputFilesActive;
 
     container.style.display = shouldShow ? 'block' : 'none';
-    toggleIcon.innerHTML = shouldShow
-      ? '<i class="codicon codicon-chevron-up"></i>'
-      : '<i class="codicon codicon-chevron-down"></i>';
+    toggleIcon.innerHTML = `<i class="${
+      shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+    }"></i>`;
   }
 }
 
@@ -339,8 +340,8 @@ export function initializeLatexdiffsSection() {
     const iconElement = toggleIcon.querySelector('i');
     if (iconElement) {
       iconElement.className = shouldShow
-        ? 'codicon codicon-chevron-up'
-        : 'codicon codicon-chevron-down';
+        ? CHEVRON_UP_CLASS
+        : CHEVRON_DOWN_CLASS;
     }
   }
 }
@@ -356,9 +357,7 @@ export function toggleLatexdiffs() {
   // Update the icon class instead of replacing innerHTML to preserve the title
   const iconElement = toggleIcon.querySelector('i');
   if (iconElement) {
-    iconElement.className = isVisible
-      ? 'codicon codicon-chevron-down'
-      : 'codicon codicon-chevron-up';
+    iconElement.className = isVisible ? CHEVRON_DOWN_CLASS : CHEVRON_UP_CLASS;
   }
 
   stateManager.update({ latexdiffsVisible: !isVisible });

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -2,6 +2,7 @@ import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { stateManager, restoreState, saveState } from './stateManager.js';
+import { CHEVRON_UP_CLASS, CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { setDebugMode as applyDebugMode } from './uiHandlers.js';
 
 import {
@@ -139,9 +140,9 @@ function handleStateRestoration(state) {
       // Update the toggle indicator based on visibility
       const toggleElement = safeGetElementById(toggleId);
       if (toggleElement) {
-        toggleElement.innerHTML = isVisible
-          ? '<i class="codicon codicon-chevron-up"></i>'
-          : '<i class="codicon codicon-chevron-down"></i>';
+        toggleElement.innerHTML = `<i class="${
+          isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+        }"></i>`;
       }
 
       // Only update the file list if we have files to restore
@@ -375,7 +376,7 @@ export function setupMessageHandlers() {
         container.style.display = 'block';
         const toggleIcon = safeGetElementById('toggleMediaFiles');
         if (toggleIcon) {
-          toggleIcon.innerHTML = '<i class="codicon codicon-chevron-up"></i>';
+          toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
         }
       }
 

--- a/src/webview/modules/stateManager.js
+++ b/src/webview/modules/stateManager.js
@@ -15,6 +15,7 @@ import {
   addFileToList,
   getSelectedFiles,
 } from './fileHandlers.js';
+import { CHEVRON_UP_CLASS, CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import {
   safeGetElementValue,
   safeGetElementById,
@@ -30,8 +31,7 @@ export function setDefaultState() {
   const autoExtractOptions = safeGetElementById('autoExtractOptions');
   if (autoExtractToggle && autoExtractOptions) {
     autoExtractToggle.classList.remove('active');
-    autoExtractToggle.innerHTML =
-      '<i class="codicon codicon-wand"></i><i class="codicon codicon-chevron-down"></i>';
+    autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
     autoExtractOptions.style.display = 'none';
   }
 
@@ -49,7 +49,7 @@ export function setDefaultState() {
   const toggleLatexdiffs = safeGetElementById('toggleLatexdiffs');
   if (latexdiffsContent && toggleLatexdiffs) {
     latexdiffsContent.style.display = 'none';
-    toggleLatexdiffs.innerHTML = '<i class="codicon codicon-chevron-down"></i>';
+    toggleLatexdiffs.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
   }
 
   saveState();
@@ -79,7 +79,7 @@ export function restoreState() {
     );
     if (autoExtractToggle && autoExtractOptions) {
       autoExtractToggle.classList.toggle('active', hasAutoExtractChecked);
-      autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="codicon codicon-chevron-down"></i>`;
+      autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
       autoExtractOptions.style.display = 'none';
     }
 
@@ -91,7 +91,7 @@ export function restoreState() {
     );
     if (toggleToolConfig && toolConfigOptions) {
       toggleToolConfig.classList.toggle('active', hasToolConfigChecked);
-      toggleToolConfig.innerHTML = `<i class="codicon codicon-tools"></i><i class="codicon codicon-chevron-down"></i>`;
+      toggleToolConfig.innerHTML = `<i class="codicon codicon-tools"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
       toolConfigOptions.style.display = 'none';
     }
 
@@ -127,9 +127,9 @@ export function restoreState() {
     if (latexdiffsContent && toggleLatexdiffs) {
       const visible = previousState.latexdiffsVisible ?? false;
       latexdiffsContent.style.display = visible ? 'block' : 'none';
-      toggleLatexdiffs.innerHTML = visible
-        ? '<i class="codicon codicon-chevron-up"></i>'
-        : '<i class="codicon codicon-chevron-down"></i>';
+      toggleLatexdiffs.innerHTML = `<i class="${
+        visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+      }"></i>`;
     }
   } else {
     // If there's no previous state, set to default

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -23,6 +23,7 @@ import {
   safeGetElementValue,
   safeGetElementChecked,
 } from '@common/domUtils.js';
+import { CHEVRON_UP_CLASS, CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { capitalize } from '@common/stringUtils.js';
 
 let debugMode = false;
@@ -65,11 +66,11 @@ function updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {
   const isVisible = options.style.display === 'block';
 
   const hasChecked = checkboxIds.some((id) => safeGetElementChecked(id));
-  const direction = isVisible ? 'up' : 'down';
-
   if (toggle) {
     toggle.classList.toggle('active', hasChecked);
-    toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="codicon codicon-chevron-${direction}"></i>`;
+    toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="${
+      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+    }"></i>`;
   }
 }
 


### PR DESCRIPTION
## Summary
- centralize chevron icons in `iconConstants.js`
- use the new constants across webview handlers
- update progress view toggle logic to consume constants

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: missing VS Code and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_685a65ab13c083248b01e16c5eca65d3