### PR TITLE
Fix delete warning after packing

### DIFF
--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -143,8 +143,9 @@ export async function runPackSingle(
     filePatterns,
     TEMP_EXTENSIONS,
   );
+  const skip = new Set([...movedFiles, ...copiedFiles]);
   for (const file of tempFiles) {
-    if (file !== inputFile) {
+    if (!skip.has(file)) {
       await WorkspaceFS.delete(file);
     }
   }

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -7,7 +7,10 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from './absoluteFS';
-import { showLoggedErrorMessage, showLoggedMessage } from '@utils/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@utils/errorHandlingUtils';
 
 const CHANNEL = 'workspaceFS';
 logger.initialize(CHANNEL);
@@ -102,10 +105,17 @@ export class WorkspaceFS {
       logger.debug(CHANNEL, `Deleted: ${filePath}`);
     } catch (err) {
       if (err instanceof vscode.FileSystemError) {
-        logger.warn(CHANNEL, `Unable to delete ${filePath}. It may be in use.`);
-        vscode.window.showWarningMessage(
-          `Unable to delete ${filePath}. It may be in use.`,
-        );
+        if (err.code === 'FileNotFound') {
+          logger.debug(CHANNEL, `File not found when deleting: ${filePath}`);
+        } else {
+          logger.warn(
+            CHANNEL,
+            `Unable to delete ${filePath}. It may be in use.`,
+          );
+          vscode.window.showWarningMessage(
+            `Unable to delete ${filePath}. It may be in use.`,
+          );
+        }
       } else {
         await showLoggedErrorMessage(
           CHANNEL,


### PR DESCRIPTION
## Summary
- avoid deleting files that were already moved when packing
- log a debug message if delete receives FileNotFound

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ad271efb88324977ff501b6b15cab