### PR TITLE
Align progress view with TaskGroup rename

### DIFF
--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -5,7 +5,7 @@
 // Local imports
 import type { TokenUsageStats } from '../types/UsageTypes';
 
-export interface LogGroup {
+export interface TaskGroup {
   /** Unique identifier for the group */
   id: string;
   /** Display name of the group */

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -13,7 +13,7 @@ import {
   isAgentStream,
   EMOJI_BY_LEVEL as emojis,
 } from '@utils/loggerUtils';
-import { LogGroup } from './LogTypes';
+import { TaskGroup } from './LogTypes';
 
 // Message type for ProgressView entries
 export type MessageType = 'thinking' | 'scratchpad' | 'default';
@@ -79,7 +79,7 @@ class VSCodeTransport extends Transport {
     groupId?: string;
     messageType?: 'default' | 'scratchpad' | 'thinking';
   }[] = [];
-  private groups: Map<string, LogGroup> = new Map();
+  private groups: Map<string, TaskGroup> = new Map();
   private activeGroupId?: string;
 
   constructor(
@@ -310,7 +310,7 @@ class VSCodeTransport extends Transport {
   }
 
   // Get a group by ID
-  getGroup(groupId: string): LogGroup | undefined {
+  getGroup(groupId: string): TaskGroup | undefined {
     return this.groups.get(groupId);
   }
 }

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -12,7 +12,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
 import { TokenUsageStats } from '../types/UsageTypes';
-import { LogGroup } from '../logger/LogTypes';
+import { TaskGroup } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
 
 interface ColoredLogMessage {
@@ -41,7 +41,7 @@ export class ProgressStateManager {
 
   // State collections
   private _logStreams: Map<string, ColoredLogMessage[]> = new Map();
-  private _logGroups: Map<string, Map<string, LogGroup>> = new Map();
+  private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
   private _taskStates: Map<string, TaskState> = new Map();
@@ -57,8 +57,8 @@ export class ProgressStateManager {
     return this._logStreams;
   }
 
-  get logGroups(): Map<string, Map<string, LogGroup>> {
-    return this._logGroups;
+  get taskGroups(): Map<string, Map<string, TaskGroup>> {
+    return this._taskGroups;
   }
 
   get outputFiles(): Map<string, { [key: number]: OutputFileInfo[] }> {
@@ -94,7 +94,7 @@ export class ProgressStateManager {
    */
   public async loadState(): Promise<void> {
     await this._loadLogStreams();
-    await this._loadLogGroups();
+    await this._loadTaskGroups();
     await this._loadOutputFiles();
     this._loadActiveStream();
     await this._loadTaskStates();
@@ -106,7 +106,7 @@ export class ProgressStateManager {
    */
   public saveState(): void {
     this._saveLogStreams();
-    this._saveLogGroups();
+    this._saveTaskGroups();
     this._saveOutputFiles();
     this._saveActiveStream();
     this._saveTaskStates();
@@ -156,13 +156,13 @@ export class ProgressStateManager {
   /**
    * Load log groups from storage
    */
-  private async _loadLogGroups(): Promise<void> {
+  private async _loadTaskGroups(): Promise<void> {
     const savedGroups = workspaceSM.get<{
-      [key: string]: { [groupId: string]: LogGroup };
-    }>(this._getWorkspaceKey(WorkspaceStateKey.LOG_GROUPS));
+      [key: string]: { [groupId: string]: TaskGroup };
+    }>(this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS));
 
     if (savedGroups) {
-      this._logGroups = new Map(
+      this._taskGroups = new Map(
         Object.entries(savedGroups)
           .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
           .map(([streamId, groups]) => [
@@ -188,7 +188,7 @@ export class ProgressStateManager {
           ]),
       );
     } else {
-      this._logGroups.clear();
+      this._taskGroups.clear();
     }
   }
 
@@ -355,8 +355,8 @@ export class ProgressStateManager {
   /**
    * Save log groups to storage
    */
-  private _saveLogGroups(): void {
-    const persistentGroups = Array.from(this._logGroups.entries())
+  private _saveTaskGroups(): void {
+    const persistentGroups = Array.from(this._taskGroups.entries())
       .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
       .map(([streamId, groups]) => [
         streamId,
@@ -364,7 +364,7 @@ export class ProgressStateManager {
       ]);
     const groupsObj = Object.fromEntries(persistentGroups);
     workspaceSM.update(
-      this._getWorkspaceKey(WorkspaceStateKey.LOG_GROUPS),
+      this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS),
       groupsObj,
     );
   }
@@ -408,7 +408,7 @@ export class ProgressStateManager {
    */
   public clearStream(stream: string): void {
     this._logStreams.delete(stream);
-    this._logGroups.delete(stream);
+    this._taskGroups.delete(stream);
     this._outputFiles.delete(stream);
     this._taskStates.delete(stream);
     this._usageStats.delete(stream);
@@ -419,7 +419,7 @@ export class ProgressStateManager {
    */
   public clearAll(): void {
     this._logStreams.clear();
-    this._logGroups.clear();
+    this._taskGroups.clear();
     this._outputFiles.clear();
     this._taskStates.clear();
     this._usageStats.clear();

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -13,7 +13,7 @@ import { getConfig } from '@utils/config';
 import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 
 import { TokenUsageStats } from '../types/UsageTypes';
-import { LogGroup } from '../logger/LogTypes';
+import { TaskGroup } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
 import { randomUUID } from 'crypto';
 
@@ -387,11 +387,11 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Create stream groups mapping if it doesn't exist
-    if (!this._stateManager.logGroups.has(stream)) {
-      this._stateManager.logGroups.set(stream, new Map());
+    if (!this._stateManager.taskGroups.has(stream)) {
+      this._stateManager.taskGroups.set(stream, new Map());
     }
 
-    const streamGroups = this._stateManager.logGroups.get(stream)!;
+    const streamGroups = this._stateManager.taskGroups.get(stream)!;
     streamGroups.set(groupId, {
       id: groupId,
       name: groupName,
@@ -430,7 +430,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const streamGroups = this._stateManager.logGroups.get(stream);
+    const streamGroups = this._stateManager.taskGroups.get(stream);
     if (!streamGroups) {
       return;
     }
@@ -480,7 +480,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       : messages.filter((msg) => msg.level !== 'debug');
 
     // Get groups for this stream
-    const groups = this._stateManager.logGroups.get(stream) || new Map();
+    const groups = this._stateManager.taskGroups.get(stream) || new Map();
 
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_LOGS,
@@ -509,14 +509,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     return this._stateManager.logStreams;
   }
 
-  public getLogGroups(): Map<string, Map<string, LogGroup>> {
-    return this._stateManager.logGroups;
+  public getTaskGroups(): Map<string, Map<string, TaskGroup>> {
+    return this._stateManager.taskGroups;
   }
 
   public eraseStream(stream: string) {
     if (this._stateManager.logStreams.has(stream)) {
       this._stateManager.logStreams.get(stream)!.length = 0;
-      this._stateManager.logGroups.delete(stream);
+      this._stateManager.taskGroups.delete(stream);
       this._stateManager.outputFiles.delete(stream);
       this._stateManager.saveState();
       this.updateLogContent(stream);
@@ -633,7 +633,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     groupId: string,
     usage: TokenUsageStats,
   ): void {
-    const streamGroups = this._stateManager.logGroups.get(stream);
+    const streamGroups = this._stateManager.taskGroups.get(stream);
     if (streamGroups) {
       const group = streamGroups.get(groupId);
       if (group) {
@@ -744,7 +744,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       );
 
       // Update all active groups for this stream
-      const streamGroups = this._stateManager.logGroups.get(streamId);
+      const streamGroups = this._stateManager.taskGroups.get(streamId);
       if (streamGroups) {
         const activeGroups = Array.from(streamGroups.entries()).filter(
           ([_, group]) => !group.endTime || group.status === STATUS.RUNNING,
@@ -796,7 +796,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       }
 
       // Check for running groups that need to be marked as interrupted
-      const streamGroups = this._stateManager.logGroups.get(streamId);
+      const streamGroups = this._stateManager.taskGroups.get(streamId);
       if (streamGroups) {
         const activeGroups = Array.from(streamGroups.entries()).filter(
           ([_, group]) => !group.endTime || group.status === STATUS.RUNNING,

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 export enum WorkspaceStateKey {
   AGENT_HISTORY = 'texra.agentHistory',
   LOG_STREAMS = 'texra.logStreams',
-  LOG_GROUPS = 'texra.logGroups',
+  TASK_GROUPS = 'texra.taskGroups',
   OUTPUT_FILES = 'texra.outputFiles',
   ACTIVE_LOG_STREAM = 'texra.activeLogStream',
   TASK_STATES = 'texra.taskStates',


### PR DESCRIPTION
## Summary
- rename `LogGroup` interface to `TaskGroup`
- refactor state manager and provider to use `taskGroups`
- update workspace state key to `TASK_GROUPS`

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails to compile TypeScript due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685af4e572f8832493f4a863f90c2c3b