### PR TITLE
Refactor webview handlers into managers

### DIFF
--- a/src/webview/modules/eventBus.js
+++ b/src/webview/modules/eventBus.js
@@ -1,0 +1,1 @@
+export const webviewEventBus = new EventTarget();

--- a/src/webview/modules/global.d.ts
+++ b/src/webview/modules/global.d.ts
@@ -2,7 +2,6 @@
 
 declare global {
   interface Window {
-    updateRecordingUI?: (recording: boolean) => void;
     _skipNextRestoreState?: boolean;
   }
 }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -17,6 +17,7 @@ import {
   handleSetCurrentFile,
   setAgentDefaultOutputFiles,
 } from './fileHandlers.js';
+import { webviewEventBus } from './eventBus.js';
 
 import { FILE_TYPES } from './constants.js';
 
@@ -278,23 +279,23 @@ export function setupMessageHandlers() {
         webviewState.save();
       }
       // Reset recording UI state
-      if (window.updateRecordingUI) {
-        window.updateRecordingUI(false);
-      }
+      webviewEventBus.dispatchEvent(
+        new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
+      );
       postHandle();
     },
     recordingStarted: () => {
       // Recording has started successfully
-      if (window.updateRecordingUI) {
-        window.updateRecordingUI(true);
-      }
+      webviewEventBus.dispatchEvent(
+        new CustomEvent('recordingUIUpdate', { detail: { recording: true } }),
+      );
       postHandle();
     },
     recordingError: (m) => {
       // Reset UI on error
-      if (window.updateRecordingUI) {
-        window.updateRecordingUI(false);
-      }
+      webviewEventBus.dispatchEvent(
+        new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
+      );
       postHandle();
     },
     setInputFile: (m) => {

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -27,6 +27,7 @@ import { capitalize } from '@common/stringUtils.js';
 import { InstructionManager } from './uiManagers/InstructionManager.js';
 import { ToggleManager } from './uiManagers/ToggleManager.js';
 import { RecordingManager } from './uiManagers/RecordingManager.js';
+import { webviewEventBus } from './eventBus.js';
 
 export const instructionManager = new InstructionManager(
   'instruction',
@@ -34,7 +35,7 @@ export const instructionManager = new InstructionManager(
   webviewState,
 );
 export const toggleManager = new ToggleManager();
-export const recordingManager = new RecordingManager(vscode);
+export const recordingManager = new RecordingManager(vscode, webviewEventBus);
 
 let debugMode = false;
 

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -23,11 +23,18 @@ import {
   safeGetElementValue,
   safeGetElementChecked,
 } from '@common/domUtils.js';
-import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
 import { capitalize } from '@common/stringUtils.js';
+import { InstructionManager } from './uiManagers/InstructionManager.js';
+import { ToggleManager } from './uiManagers/ToggleManager.js';
+import { RecordingManager } from './uiManagers/RecordingManager.js';
+
+export const instructionManager = new InstructionManager(
+  'instruction',
+  vscode,
+  webviewState,
+);
+export const toggleManager = new ToggleManager();
+export const recordingManager = new RecordingManager(vscode);
 
 let debugMode = false;
 
@@ -44,87 +51,6 @@ function updateDebugButtonVisibility() {
 export function setDebugMode(enabled) {
   debugMode = !!enabled;
   updateDebugButtonVisibility();
-}
-
-// Add this function to handle textarea auto-resize
-export function autoResizeTextarea(textarea) {
-  // Reset height to auto to get the correct scrollHeight
-  textarea.style.height = 'auto';
-  const maxHeight = 400;
-
-  // Calculate the new height
-  const newHeight = Math.min(textarea.scrollHeight, maxHeight);
-
-  // Set new height
-  textarea.style.height = newHeight + 'px';
-
-  // Show/hide scrollbar based on content height
-  textarea.style.overflowY =
-    textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
-}
-
-function updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {
-  const toggle = safeGetElementById(toggleId);
-  const options = safeGetElementById(optionsId);
-  const isVisible = options.style.display === 'block';
-
-  const hasChecked = checkboxIds.some((id) => safeGetElementChecked(id));
-  if (toggle) {
-    toggle.classList.toggle('active', hasChecked);
-    toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="${
-      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-    }"></i>`;
-  }
-}
-
-export function updateAutoToggleState() {
-  updateDropdownToggleState(
-    'toggleAutoExtract',
-    'autoExtractOptions',
-    CHECK_BOXES_AUTO_EXTRACT,
-    'wand',
-  );
-}
-
-export function updateToolConfigToggleState() {
-  updateDropdownToggleState(
-    'toggleToolConfig',
-    'toolConfigOptions',
-    CHECK_BOXES_TOOL_USE,
-    'tools',
-  );
-}
-
-/**
- * Setup document-level event listeners
- */
-export function setupDocumentListeners() {
-  // Close dropdowns when clicking outside
-  document.addEventListener('click', (e) => {
-    const toolConfigOptions = safeGetElementById('toolConfigOptions');
-    const autoExtractOptions = safeGetElementById('autoExtractOptions');
-    const toggleToolConfig = safeGetElementById('toggleToolConfig');
-    const toggleAutoExtract = safeGetElementById('toggleAutoExtract');
-
-    if (
-      !toggleToolConfig?.contains(e.target) &&
-      !toolConfigOptions?.contains(e.target)
-    ) {
-      if (toolConfigOptions) {
-        toolConfigOptions.style.display = 'none';
-        updateToolConfigToggleState();
-      }
-    }
-    if (
-      !toggleAutoExtract?.contains(e.target) &&
-      !autoExtractOptions?.contains(e.target)
-    ) {
-      if (autoExtractOptions) {
-        autoExtractOptions.style.display = 'none';
-        updateAutoToggleState();
-      }
-    }
-  });
 }
 
 export function setupUIHandlers() {
@@ -186,7 +112,7 @@ export function setupUIHandlers() {
     const isVisible = autoExtractOptions.style.display === 'block';
 
     autoExtractOptions.style.display = isVisible ? 'none' : 'block';
-    updateAutoToggleState();
+    toggleManager.updateAutoToggleState();
   });
 
   addEventListenerSafely('toggleToolConfig', 'click', function (e) {
@@ -195,20 +121,20 @@ export function setupUIHandlers() {
     const isVisible = toolConfigOptions.style.display === 'block';
 
     toolConfigOptions.style.display = isVisible ? 'none' : 'block';
-    updateToolConfigToggleState();
+    toggleManager.updateToolConfigToggleState();
   });
 
   // Add checkbox change listeners for auto-extract options
   CHECK_BOXES_AUTO_EXTRACT.forEach((id) => {
     addEventListenerSafely(id, 'change', function () {
-      updateAutoToggleState();
+      toggleManager.updateAutoToggleState();
       handleCheckboxChange.call(this);
     });
   });
 
   CHECK_BOXES_TOOL_USE.forEach((id) => {
     addEventListenerSafely(id, 'change', function () {
-      updateToolConfigToggleState();
+      toggleManager.updateToolConfigToggleState();
       handleCheckboxChange.call(this);
     });
   });
@@ -324,7 +250,7 @@ export function setupUIHandlers() {
     const instruction = safeGetElementById('instruction');
     if (instruction) {
       instruction.value = '';
-      autoResizeTextarea(instruction);
+      instructionManager.autoResizeTextarea(instruction);
       webviewState.save();
     }
   });
@@ -354,37 +280,7 @@ export function setupUIHandlers() {
     }
   });
 
-  // Recording state management
-  let isRecording = false;
-
-  function updateRecordingUI(recording) {
-    isRecording = recording;
-    const recordButton = safeGetElementById('recordInstructionButton');
-    if (recordButton) {
-      if (recording) {
-        recordButton.innerHTML = '<i class="codicon codicon-stop-circle"></i>';
-        recordButton.title = 'Stop recording';
-        recordButton.classList.add('recording');
-      } else {
-        recordButton.innerHTML = '<i class="codicon codicon-mic"></i>';
-        recordButton.title = 'Record instruction with microphone';
-        recordButton.classList.remove('recording');
-      }
-    }
-  }
-
-  addEventListenerSafely('recordInstructionButton', 'click', function () {
-    if (isRecording) {
-      vscode.postMessage({ command: 'stopRecording' });
-      updateRecordingUI(false);
-    } else {
-      vscode.postMessage({ command: 'startRecording' });
-      updateRecordingUI(true);
-    }
-  });
-
-  // Export the updateRecordingUI function for use in message handlers
-  window.updateRecordingUI = updateRecordingUI;
+  recordingManager.setupRecordButton();
 
   addEventListenerSafely('executeButton', 'click', function () {
     const agent = safeGetElementValue('agent');

--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -27,7 +27,12 @@ export class InstructionManager {
 
   init() {
     const textarea = safeGetElementById(this.textareaId);
-    if (!textarea) return;
+    if (!textarea) {
+      console.warn(
+        `[InstructionManager] Element with id '${this.textareaId}' not found`,
+      );
+      return;
+    }
 
     this.autoResizeTextarea(textarea);
 

--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -1,0 +1,47 @@
+import { setupPasteListener } from '../pasteHandler.js';
+import { safeGetElementById } from '@common/domUtils.js';
+
+export class InstructionManager {
+  constructor(textareaId, vscode, state) {
+    this.textareaId = textareaId;
+    this.vscode = vscode;
+    this.state = state;
+  }
+
+  autoResizeTextarea(textarea) {
+    textarea.style.height = 'auto';
+    const maxHeight = 400;
+    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+    textarea.style.height = `${newHeight}px`;
+    textarea.style.overflowY =
+      textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }
+
+  insertTextAtCursor(textarea, text) {
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const original = textarea.value;
+    textarea.value = original.slice(0, start) + text + original.slice(end);
+    textarea.selectionStart = textarea.selectionEnd = start + text.length;
+  }
+
+  init() {
+    const textarea = safeGetElementById(this.textareaId);
+    if (!textarea) return;
+
+    this.autoResizeTextarea(textarea);
+
+    textarea.addEventListener('input', () => {
+      this.autoResizeTextarea(textarea);
+      this.state?.save();
+    });
+
+    setupPasteListener(
+      textarea,
+      this.vscode,
+      (ta) => this.autoResizeTextarea(ta),
+      () => this.state?.save(),
+      (ta, text) => this.insertTextAtCursor(ta, text),
+    );
+  }
+}

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -1,0 +1,44 @@
+import {
+  addEventListenerSafely,
+  safeGetElementById,
+} from '@common/domUtils.js';
+
+export class RecordingManager {
+  constructor(vscode) {
+    this.vscode = vscode;
+    this.isRecording = false;
+  }
+
+  updateRecordingUI(recording) {
+    this.isRecording = recording;
+    const recordButton = safeGetElementById('recordInstructionButton');
+    if (recordButton) {
+      if (recording) {
+        recordButton.innerHTML = '<i class="codicon codicon-stop-circle"></i>';
+        recordButton.title = 'Stop recording';
+        recordButton.classList.add('recording');
+      } else {
+        recordButton.innerHTML = '<i class="codicon codicon-mic"></i>';
+        recordButton.title = 'Record instruction with microphone';
+        recordButton.classList.remove('recording');
+      }
+    }
+  }
+
+  setupRecordButton() {
+    const button = safeGetElementById('recordInstructionButton');
+    if (!button) return;
+
+    addEventListenerSafely(button, 'click', () => {
+      if (this.isRecording) {
+        this.vscode.postMessage({ command: 'stopRecording' });
+        this.updateRecordingUI(false);
+      } else {
+        this.vscode.postMessage({ command: 'startRecording' });
+        this.updateRecordingUI(true);
+      }
+    });
+
+    window.updateRecordingUI = (recording) => this.updateRecordingUI(recording);
+  }
+}

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -33,13 +33,15 @@ export class RecordingManager {
     if (!button) return;
 
     addEventListenerSafely(buttonId, 'click', () => {
-      if (this.isRecording) {
-        this.vscode.postMessage({ command: 'stopRecording' });
-        this.updateRecordingUI(false);
-      } else {
-        this.vscode.postMessage({ command: 'startRecording' });
-        this.updateRecordingUI(true);
-      }
+      const nextState = !this.isRecording;
+      this.vscode.postMessage({
+        command: nextState ? 'startRecording' : 'stopRecording',
+      });
+      this.eventBus.dispatchEvent(
+        new CustomEvent('recordingUIUpdate', {
+          detail: { recording: nextState },
+        }),
+      );
     });
 
     this.eventBus.addEventListener('recordingUIUpdate', (e) => {

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -2,10 +2,12 @@ import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
+import { webviewEventBus } from '../eventBus.js';
 
 export class RecordingManager {
-  constructor(vscode) {
+  constructor(vscode, eventBus = webviewEventBus) {
     this.vscode = vscode;
+    this.eventBus = eventBus;
     this.isRecording = false;
   }
 
@@ -26,10 +28,11 @@ export class RecordingManager {
   }
 
   setupRecordButton() {
-    const button = safeGetElementById('recordInstructionButton');
+    const buttonId = 'recordInstructionButton';
+    const button = safeGetElementById(buttonId);
     if (!button) return;
 
-    addEventListenerSafely(button, 'click', () => {
+    addEventListenerSafely(buttonId, 'click', () => {
       if (this.isRecording) {
         this.vscode.postMessage({ command: 'stopRecording' });
         this.updateRecordingUI(false);
@@ -39,6 +42,8 @@ export class RecordingManager {
       }
     });
 
-    window.updateRecordingUI = (recording) => this.updateRecordingUI(recording);
+    this.eventBus.addEventListener('recordingUIUpdate', (e) => {
+      this.updateRecordingUI(e.detail.recording);
+    });
   }
 }

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -9,18 +9,34 @@ import {
 } from '../constants.js';
 
 export class ToggleManager {
+  isOptionsVisible(options) {
+    return options.style.display === 'block';
+  }
+
+  hasAnyChecked(checkboxIds) {
+    return checkboxIds.some((id) => safeGetElementChecked(id));
+  }
+
+  setToggleIcon(toggle, icon, visible, active) {
+    toggle.classList.toggle('active', active);
+    toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="${
+      visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+    }"></i>`;
+  }
+
   updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {
     const toggle = safeGetElementById(toggleId);
     const options = safeGetElementById(optionsId);
-    const isVisible = options.style.display === 'block';
-
-    const hasChecked = checkboxIds.some((id) => safeGetElementChecked(id));
-    if (toggle) {
-      toggle.classList.toggle('active', hasChecked);
-      toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="${
-        isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-      }"></i>`;
+    if (!toggle || !options) {
+      console.warn(
+        `[ToggleManager] Missing elements for ${toggleId} or ${optionsId}`,
+      );
+      return;
     }
+
+    const visible = this.isOptionsVisible(options);
+    const hasChecked = this.hasAnyChecked(checkboxIds);
+    this.setToggleIcon(toggle, icon, visible, hasChecked);
   }
 
   updateAutoToggleState() {

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -1,0 +1,71 @@
+import { safeGetElementById, safeGetElementChecked } from '@common/domUtils.js';
+import {
+  CHEVRON_UP_CLASS,
+  CHEVRON_DOWN_CLASS,
+} from '@common/webviewContext.js';
+import {
+  CHECK_BOXES_AUTO_EXTRACT,
+  CHECK_BOXES_TOOL_USE,
+} from '../constants.js';
+
+export class ToggleManager {
+  updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {
+    const toggle = safeGetElementById(toggleId);
+    const options = safeGetElementById(optionsId);
+    const isVisible = options.style.display === 'block';
+
+    const hasChecked = checkboxIds.some((id) => safeGetElementChecked(id));
+    if (toggle) {
+      toggle.classList.toggle('active', hasChecked);
+      toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="${
+        isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+      }"></i>`;
+    }
+  }
+
+  updateAutoToggleState() {
+    this.updateDropdownToggleState(
+      'toggleAutoExtract',
+      'autoExtractOptions',
+      CHECK_BOXES_AUTO_EXTRACT,
+      'wand',
+    );
+  }
+
+  updateToolConfigToggleState() {
+    this.updateDropdownToggleState(
+      'toggleToolConfig',
+      'toolConfigOptions',
+      CHECK_BOXES_TOOL_USE,
+      'tools',
+    );
+  }
+
+  setupDocumentListeners() {
+    document.addEventListener('click', (e) => {
+      const toolConfigOptions = safeGetElementById('toolConfigOptions');
+      const autoExtractOptions = safeGetElementById('autoExtractOptions');
+      const toggleToolConfig = safeGetElementById('toggleToolConfig');
+      const toggleAutoExtract = safeGetElementById('toggleAutoExtract');
+
+      if (
+        !toggleToolConfig?.contains(e.target) &&
+        !toolConfigOptions?.contains(e.target)
+      ) {
+        if (toolConfigOptions) {
+          toolConfigOptions.style.display = 'none';
+          this.updateToolConfigToggleState();
+        }
+      }
+      if (
+        !toggleAutoExtract?.contains(e.target) &&
+        !autoExtractOptions?.contains(e.target)
+      ) {
+        if (autoExtractOptions) {
+          autoExtractOptions.style.display = 'none';
+          this.updateAutoToggleState();
+        }
+      }
+    });
+  }
+}

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -6,20 +6,9 @@ import {
 } from './modules/messageHandlers.js';
 import {
   setupUIHandlers,
-  updateAutoToggleState,
-  updateToolConfigToggleState,
-  autoResizeTextarea,
-  setupDocumentListeners,
+  instructionManager,
+  toggleManager,
 } from './modules/uiHandlers.js';
-import { setupPasteListener } from './modules/pasteHandler.js';
-
-function insertTextAtCursor(textarea, text) {
-  const start = textarea.selectionStart;
-  const end = textarea.selectionEnd;
-  const original = textarea.value;
-  textarea.value = original.slice(0, start) + text + original.slice(end);
-  textarea.selectionStart = textarea.selectionEnd = start + text.length;
-}
 
 // Initialize data requests when window loads
 window.onload = function () {
@@ -28,28 +17,7 @@ window.onload = function () {
   // Set default state for new folders
   webviewState.restore();
 
-  // Setup auto-resize for instruction textarea
-  const instruction = document.getElementById('instruction');
-  if (instruction) {
-    // Initial resize
-    autoResizeTextarea(instruction);
-
-    // Add input and change event listeners
-    instruction.addEventListener('input', () => {
-      autoResizeTextarea(instruction);
-      // Make sure changes to the textarea get saved in the state
-      webviewState.save();
-    });
-
-    // Setup paste event listener for image handling
-    setupPasteListener(
-      instruction,
-      vscode,
-      autoResizeTextarea,
-      () => webviewState.save(),
-      insertTextAtCursor,
-    );
-  }
+  instructionManager.init();
 };
 
 // Setup message handlers
@@ -58,11 +26,7 @@ setupMessageHandlers();
 // Setup UI when DOM is loaded
 document.addEventListener('DOMContentLoaded', function () {
   setupUIHandlers();
-
-  // Update initial toggle states
-  updateToolConfigToggleState();
-  updateAutoToggleState();
-
-  // Setup document-level event listeners
-  setupDocumentListeners();
+  toggleManager.updateToolConfigToggleState();
+  toggleManager.updateAutoToggleState();
+  toggleManager.setupDocumentListeners();
 });


### PR DESCRIPTION
## Summary
- create `uiManagers` directory for modular webview logic
- move instruction textarea handlers into `InstructionManager`
- extract dropdown and checkbox updates to `ToggleManager`
- manage recording controls via `RecordingManager`
- adjust `uiHandlers` to instantiate these managers
- update `script.js` to use the new APIs

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af52bebc4832490837f750112e9f0