### PR TITLE
Introduce FileList and FileSelect managers

### DIFF
--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -41,6 +41,8 @@ export class WebviewContentProvider {
       const webviewStateModuleUri = getWebviewUri('modules/webviewState.js');
       const messageHandlersUri = getWebviewUri('modules/messageHandlers.js');
       const fileHandlersUri = getWebviewUri('modules/fileHandlers.js');
+      const fileListUri = getWebviewUri('modules/uiManagers/FileList.js');
+      const fileSelectUri = getWebviewUri('modules/uiManagers/FileSelect.js');
       const uiHandlersUri = getWebviewUri('modules/uiHandlers.js');
       const templateUtilsUri = getCommonUri('modules/templateUtils.js');
       const domUtilsUri = getCommonUri('modules/domUtils.js');
@@ -75,6 +77,8 @@ export class WebviewContentProvider {
         webviewStateModuleUri,
         messageHandlersUri,
         fileHandlersUri,
+        fileListUri,
+        fileSelectUri,
         uiHandlersUri,
         templateUtilsUri,
         webviewContextUri,

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -15,6 +15,8 @@
         "imports": {
           "./modules/webviewState.js": "${webviewStateModuleUri}",
           "./modules/fileHandlers.js": "${fileHandlersUri}",
+          "./modules/uiManagers/FileList.js": "${fileListUri}",
+          "./modules/uiManagers/FileSelect.js": "${fileSelectUri}",
           "./modules/uiHandlers.js": "${uiHandlersUri}",
           "./modules/messageHandlers.js": "${messageHandlersUri}",
           "@common/webviewContext.js": "${webviewContextUri}",

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -1,184 +1,13 @@
 import { vscode } from '@common/webviewContext.js';
 import { webviewState } from './webviewState.js';
-import { MULTIPLE_SELECTIONS } from './constants.js';
-import {
-  addEventListenerSafely,
-  safeGetElementById,
-  safeSetElementValue,
-} from '@common/domUtils.js';
+import { fileList } from './uiManagers/FileList.js';
+import { fileSelect } from './uiManagers/FileSelect.js';
+import { safeGetElementById } from '@common/domUtils.js';
 import {
   CHEVRON_UP_CLASS,
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
-
-// Store default output file names for the currently selected agent
-let agentDefaultOutputFiles = [];
-
-export function setAgentDefaultOutputFiles(files) {
-  agentDefaultOutputFiles = Array.isArray(files) ? files : [];
-}
-
-export function getAgentDefaultOutputFiles() {
-  return agentDefaultOutputFiles;
-}
-
-export function updateFileSelect(id, files) {
-  const selectDiv = document.getElementById(id);
-  if (!selectDiv) {
-    console.error(`[FileHandlers] Element with id '${id}' not found`);
-    return;
-  }
-  selectDiv.innerHTML =
-    '<option value="">None</option>' +
-    files.map((file) => `<option value="${file}">${file}</option>`).join('');
-}
-
-export function updateEditedFileSelect(baseFile) {
-  const editedFileDiv = safeGetElementById('editedFile');
-  if (!editedFileDiv) return;
-
-  if (baseFile) {
-    // Store current edited file selection
-    const currentEditedFile = editedFileDiv.value;
-
-    // Request updated list of edited files
-    vscode.postMessage({
-      command: 'requestEditedFile',
-      baseFile: baseFile,
-      preserveSelection: currentEditedFile, // Pass current selection to preserve it if still valid
-    });
-  } else {
-    // Only clear if there's no base file
-    updateFileSelect('editedFile', []);
-  }
-}
-
-export function addFileToList(containerId, file) {
-  const container = safeGetElementById(containerId);
-  const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
-  if (!container || !toggleIcon) return;
-
-  const fileElement = document.createElement('div');
-  fileElement.className = 'file-item';
-  fileElement.dataset.path = file;
-  fileElement.innerHTML = `${file} <span class="remove-button">-</span>`;
-
-  const removeButton = fileElement.querySelector('.remove-button');
-  if (removeButton) {
-    addEventListenerSafely(removeButton, 'click', () => {
-      container.removeChild(fileElement);
-      if (container.children.length === 0) {
-        emptyMultipleFiles(containerId, `toggle${capitalize(containerId)}`);
-      }
-      // Save state after removing the file to persist changes
-      webviewState.save();
-    });
-  }
-  container.appendChild(fileElement);
-}
-
-export function updateMultipleFileSelect(selectId, toggleId, files) {
-  const selectDiv = safeGetElementById(selectId);
-  const toggleIcon = safeGetElementById(toggleId);
-  if (!selectDiv || !toggleIcon) return;
-
-  const existingFiles = getSelectedFiles(selectDiv);
-  const newFiles = files.filter((file) => !existingFiles.includes(file));
-
-  if (newFiles.length > 0) {
-    newFiles.forEach((file) => {
-      addFileToList(selectId, file);
-    });
-    selectDiv.style.display = 'block';
-    toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
-
-    // Make sure the container is also visible
-    const containerId = `${selectId}Container`;
-    const container = safeGetElementById(containerId);
-    if (container) {
-      container.style.display = 'block';
-    }
-  }
-  webviewState.save();
-}
-
-export function getSelectedFiles(multipleFilesDiv) {
-  const fileElements = multipleFilesDiv.querySelectorAll('.file-item');
-  return Array.from(fileElements).map((el) => el.dataset.path || '');
-}
-
-export function hideEmptyMultipleFileSelects() {
-  MULTIPLE_SELECTIONS.forEach((id) => {
-    const selectDiv = safeGetElementById(id);
-    if (!selectDiv) return;
-    const toggleId = `toggle${capitalize(id)}`;
-    if (selectDiv.children.length === 0) {
-      setMultipleFileSelectVisibility(id, toggleId, false);
-    }
-  });
-}
-
-export function setMultipleFileSelectVisibility(
-  containerId,
-  toggleId,
-  isVisible,
-) {
-  const container = safeGetElementById(`${containerId}Container`);
-  const toggleIcon = safeGetElementById(toggleId);
-  if (!container || !toggleIcon) {
-    console.error(`Container or toggle icon not found for ${containerId}`);
-    return;
-  }
-
-  container.style.display = isVisible ? 'block' : 'none';
-  toggleIcon.innerHTML = `<i class="${
-    isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-  }"></i>`;
-}
-
-export function setElementsDisabled(elements, disabled) {
-  elements.forEach((element) => {
-    if (typeof element === 'string') {
-      const elementDiv = document.getElementById(element);
-      if (elementDiv) {
-        elementDiv.disabled = disabled;
-      }
-    } else {
-      element.disabled = disabled;
-    }
-  });
-}
-
-export function addOptionToSelect(select, value, text) {
-  const option = document.createElement('option');
-  option.value = value;
-  option.textContent = text;
-  select.appendChild(option);
-}
-
-export function handleRecentCommits(message) {
-  const commitButtons = [
-    'packLatexdiffvcButton',
-    'cleanLatexdiffvcButton',
-    'latexdiffvcButton',
-  ];
-  const commitDiv = document.getElementById('commit');
-  commitDiv.innerHTML = '';
-
-  if (message.isGitRepo === false) {
-    addOptionToSelect(commitDiv, '', 'Not a Git repository');
-    setElementsDisabled([commitDiv, ...commitButtons], true);
-  } else {
-    addOptionToSelect(commitDiv, 'HEAD', 'HEAD');
-    message.commits.forEach((commit) => {
-      const [commitHash, ...commitMessageParts] = commit.split(': ');
-      // const commitMessage = commitMessageParts.join(': ');
-      addOptionToSelect(commitDiv, commitHash, commit);
-    });
-    setElementsDisabled([commitDiv, ...commitButtons], false);
-  }
-}
+import { capitalize } from '@common/stringUtils.js';
 
 export function handleCheckboxChange(event) {
   const checkbox = event?.target || this;
@@ -214,30 +43,30 @@ export function initializeOutputFiles() {
 
       // Then add each file
       state.outputFiles.forEach((file) => {
-        addFileToList('outputFiles', file);
+        fileList.add('outputFiles', file);
       });
     } else if (
-      getAgentDefaultOutputFiles().length > 0 &&
+      fileSelect.getAgentDefaultOutputFiles().length > 0 &&
       (!state.outputFiles || state.outputFiles.length === 0)
     ) {
       // Use agent default output files if provided
       outputFilesDiv.innerHTML = '';
-      getAgentDefaultOutputFiles().forEach((file) => {
-        addFileToList('outputFiles', file);
+      fileSelect.getAgentDefaultOutputFiles().forEach((file) => {
+        fileList.add('outputFiles', file);
       });
     } else {
       // Clear the list
       outputFilesDiv.innerHTML = '';
 
       // Add the current input file as output
-      addFileToList('outputFiles', inputFileDiv.value);
+      fileList.add('outputFiles', inputFileDiv.value);
 
       // Also add any input files from the multiple input files list
       if (state.inputFiles && state.inputFiles.length > 0) {
         state.inputFiles.forEach((file) => {
           if (file !== inputFile) {
             // Avoid duplicates
-            addFileToList('outputFiles', file);
+            fileList.add('outputFiles', file);
           }
         });
       }
@@ -250,7 +79,7 @@ export function initializeOutputFiles() {
   // Add opened files to the output files list
   const openedFiles = webviewState.get()?.openedFiles ?? [];
   openedFiles.forEach((file) => {
-    addFileToList('outputFiles', file);
+    fileList.add('outputFiles', file);
   });
 
   // Output filename override removed
@@ -263,54 +92,10 @@ export function toggleOutputFiles() {
     safeGetElementById('outputFilesContainer').style.display !== 'none';
 
   if (containerVisible) {
-    toggleMultipleFiles('outputFiles', 'toggleOutputFiles');
+    fileList.toggle('outputFiles', 'toggleOutputFiles');
   } else {
     initializeOutputFiles();
-    toggleMultipleFiles('outputFiles', 'toggleOutputFiles');
-  }
-}
-
-export function toggleMultipleFiles(containerId, toggleId) {
-  const container = safeGetElementById(`${containerId}Container`);
-  if (!container) return;
-  const isVisible = container.style.display !== 'none';
-  setMultipleFileSelectVisibility(containerId, toggleId, !isVisible);
-  webviewState.save();
-}
-
-export function emptyMultipleFiles(containerId, toggleId) {
-  const listDiv = safeGetElementById(containerId);
-  const container = safeGetElementById(`${containerId}Container`);
-  if (!listDiv || !container) return;
-
-  listDiv.innerHTML = '';
-  container.style.display = 'none';
-  const toggleIconDiv = safeGetElementById(toggleId);
-  if (toggleIconDiv)
-    toggleIconDiv.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
-
-  // Reset Output Filename override removed
-
-  webviewState.save();
-}
-
-export function handleSetCurrentFile({ fileType, filePath }) {
-  const fileId = `${uncapitalize(fileType)}File`;
-  const fileDiv = document.getElementById(fileId);
-  if (!fileDiv) {
-    console.warn(`Element with id '${fileId}' not found`);
-    return;
-  }
-
-  const options = Array.from(fileDiv.options);
-  if (options.some((option) => option.value === filePath)) {
-    safeSetElementValue(fileId, filePath);
-    fileDiv.dispatchEvent(new Event('change'));
-  } else {
-    vscode.postMessage({
-      command: 'showInformationMessage',
-      text: `The current file is not in the ${fileType} file list: ${filePath}`,
-    });
+    fileList.toggle('outputFiles', 'toggleOutputFiles');
   }
 }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -8,15 +8,8 @@ import {
 } from '@common/webviewContext.js';
 import { setDebugMode as applyDebugMode } from './uiHandlers.js';
 
-import {
-  updateFileSelect,
-  updateEditedFileSelect,
-  updateMultipleFileSelect,
-  getSelectedFiles,
-  handleRecentCommits,
-  handleSetCurrentFile,
-  setAgentDefaultOutputFiles,
-} from './fileHandlers.js';
+import { fileList } from './uiManagers/FileList.js';
+import { fileSelect } from './uiManagers/FileSelect.js';
 
 import { FILE_TYPES } from './constants.js';
 
@@ -236,7 +229,7 @@ export function setupMessageHandlers() {
     checkRestoredBaseFile: () => {
       const restoredBaseFileDiv = safeGetElementById('baseFile');
       if (restoredBaseFileDiv && restoredBaseFileDiv.value) {
-        updateEditedFileSelect(restoredBaseFileDiv.value);
+        fileSelect.updateEdited(restoredBaseFileDiv.value);
       }
       postHandle();
     },
@@ -298,23 +291,23 @@ export function setupMessageHandlers() {
       postHandle();
     },
     setInputFile: (m) => {
-      updateFileSelect('inputFile', m.files);
+      fileSelect.update('inputFile', m.files);
       postHandle();
     },
     setReferenceFile: (m) => {
-      updateFileSelect('referenceFile', m.files);
+      fileSelect.update('referenceFile', m.files);
       postHandle();
     },
     setAuxiliaryFile: (m) => {
-      updateFileSelect('auxiliaryFile', m.files);
+      fileSelect.update('auxiliaryFile', m.files);
       postHandle();
     },
     setMediaFile: (m) => {
-      updateFileSelect('mediaFile', m.files);
+      fileSelect.update('mediaFile', m.files);
       postHandle();
     },
     setEditedFile: (m) => {
-      updateFileSelect('editedFile', m.files);
+      fileSelect.update('editedFile', m.files);
       postHandle();
     },
     inputFileSelected: (m) => {
@@ -338,37 +331,29 @@ export function setupMessageHandlers() {
       postHandle();
     },
     setDefaultOutputFiles: (m) => {
-      setAgentDefaultOutputFiles(m.files || []);
+      fileSelect.setAgentDefaultOutputFiles(m.files || []);
       postHandle();
     },
     setInputFiles: (m) => {
-      updateMultipleFileSelect('inputFiles', 'toggleInputFiles', m.files);
+      fileList.update('inputFiles', 'toggleInputFiles', m.files);
       postHandle();
     },
     setReferenceFiles: (m) => {
-      updateMultipleFileSelect(
-        'referenceFiles',
-        'toggleReferenceFiles',
-        m.files,
-      );
+      fileList.update('referenceFiles', 'toggleReferenceFiles', m.files);
       postHandle();
     },
     setAuxiliaryFiles: (m) => {
-      updateMultipleFileSelect(
-        'auxiliaryFiles',
-        'toggleAuxiliaryFiles',
-        m.files,
-      );
+      fileList.update('auxiliaryFiles', 'toggleAuxiliaryFiles', m.files);
       postHandle();
     },
     setMediaFiles: (m) => {
-      updateMultipleFileSelect('mediaFiles', 'toggleMediaFiles', m.files);
+      fileList.update('mediaFiles', 'toggleMediaFiles', m.files);
       postHandle();
     },
     addMediaFile: (m) => {
       const listDiv = safeGetElementById('mediaFiles');
-      const existingFiles = listDiv ? getSelectedFiles(listDiv) : [];
-      updateMultipleFileSelect('mediaFiles', 'toggleMediaFiles', [
+      const existingFiles = listDiv ? fileList.getSelected(listDiv) : [];
+      fileList.update('mediaFiles', 'toggleMediaFiles', [
         ...existingFiles,
         m.file,
       ]);
@@ -386,15 +371,18 @@ export function setupMessageHandlers() {
       postHandle();
     },
     setOutputFiles: (m) => {
-      updateMultipleFileSelect('outputFiles', 'toggleOutputFiles', m.files);
+      fileList.update('outputFiles', 'toggleOutputFiles', m.files);
       postHandle();
     },
     setRecentCommits: (m) => {
-      handleRecentCommits(m);
+      fileSelect.handleRecentCommits(m);
       postHandle();
     },
     setCurrentFile: (m) => {
-      handleSetCurrentFile({ fileType: m.fileType, filePath: m.filePath });
+      fileSelect.handleSetCurrentFile({
+        fileType: m.fileType,
+        filePath: m.filePath,
+      });
       postHandle();
     },
     setOpenedFiles: (m) => {
@@ -412,7 +400,7 @@ export function setupMessageHandlers() {
           }
         }
 
-        updateMultipleFileSelect(multipleFileId, toggleId, filesToAdd);
+        fileList.update(multipleFileId, toggleId, filesToAdd);
       }
       postHandle();
     },
@@ -420,7 +408,7 @@ export function setupMessageHandlers() {
       const currentBaseFileDiv = safeGetElementById('baseFile');
       if (currentBaseFileDiv) {
         const currentBaseFile = currentBaseFileDiv.value;
-        updateFileSelect('baseFile', m.files);
+        fileSelect.update('baseFile', m.files);
 
         const state = webviewState.get();
         const storedBaseFile = state?.baseFile;
@@ -435,7 +423,7 @@ export function setupMessageHandlers() {
           currentBaseFileDiv.value = currentBaseFile;
         }
 
-        updateEditedFileSelect(currentBaseFileDiv.value);
+        fileSelect.updateEdited(currentBaseFileDiv.value);
       }
       postHandle();
     },

--- a/src/webview/modules/uiHandlers.js
+++ b/src/webview/modules/uiHandlers.js
@@ -9,14 +9,12 @@ import {
   FILE_TYPES,
 } from './constants.js';
 import {
-  updateEditedFileSelect,
-  getSelectedFiles,
   handleCheckboxChange,
-  toggleMultipleFiles,
   toggleOutputFiles,
-  emptyMultipleFiles,
   toggleLatexdiffs,
 } from './fileHandlers.js';
+import { fileList } from './uiManagers/FileList.js';
+import { fileSelect } from './uiManagers/FileSelect.js';
 import {
   safeGetElementById,
   addEventListenerSafely,
@@ -168,7 +166,7 @@ export function setupUIHandlers() {
 
       // Get all files if container is visible
       const filesDiv = safeGetElementById(id);
-      const files = isActive && filesDiv ? getSelectedFiles(filesDiv) : [];
+      const files = isActive && filesDiv ? fileList.getSelected(filesDiv) : [];
 
       // Filter out single file if it exists (except for outputFiles)
       multipleFilesData[id] =
@@ -299,7 +297,7 @@ export function setupUIHandlers() {
 
     // Empty button handler
     addEventListenerSafely(emptyButtonId, 'click', () =>
-      emptyMultipleFiles(id, toggleId),
+      fileList.empty(id, toggleId),
     );
   });
 
@@ -441,7 +439,9 @@ export function setupUIHandlers() {
       const model = safeGetElementValue('model');
 
       // Get output files
-      const outputFiles = getSelectedFiles(safeGetElementById('outputFiles'));
+      const outputFiles = fileList.getSelected(
+        safeGetElementById('outputFiles'),
+      );
 
       // Check if we should use multiple or single mode
       const outputFilesContainer = safeGetElementById('outputFilesContainer');
@@ -606,7 +606,7 @@ export function setupUIHandlers() {
       command: 'requestEditedFile',
       baseFile: baseFile,
     });
-    updateEditedFileSelect(baseFile);
+    fileSelect.updateEdited(baseFile);
   });
 
   MULTIPLE_SELECTIONS.forEach((id) => {
@@ -615,7 +615,7 @@ export function setupUIHandlers() {
       if (id === 'outputFiles') {
         toggleOutputFiles();
       } else {
-        toggleMultipleFiles(id, toggleId);
+        fileList.toggle(id, toggleId);
       }
     });
   });

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -14,7 +14,11 @@ import { capitalize } from '@common/stringUtils.js';
  * Handles multi-file list DOM updates.
  */
 export class FileList {
-  /** Add a file entry to a list container */
+  /**
+   * Add a file entry to a list container
+   * @param {string} containerId - ID of the list element
+   * @param {string} file - File path to add
+   */
   add(containerId, file) {
     const container = safeGetElementById(containerId);
     const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
@@ -28,17 +32,24 @@ export class FileList {
     const removeButton = fileElement.querySelector('.remove-button');
     if (removeButton) {
       addEventListenerSafely(removeButton, 'click', () => {
-        container.removeChild(fileElement);
-        if (container.children.length === 0) {
-          this.empty(containerId, `toggle${capitalize(containerId)}`);
+        if (container.contains(fileElement)) {
+          container.removeChild(fileElement);
+          if (container.children.length === 0) {
+            this.empty(containerId, `toggle${capitalize(containerId)}`);
+          }
+          webviewState.save();
         }
-        webviewState.save();
       });
     }
     container.appendChild(fileElement);
   }
 
-  /** Update a multi-file list, showing the toggle when files exist */
+  /**
+   * Update a multi-file list, showing the toggle when files exist
+   * @param {string} listId - ID of the list element
+   * @param {string} toggleId - ID of the toggle icon element
+   * @param {string[]} files - Files to display
+   */
   update(listId, toggleId, files) {
     const listDiv = safeGetElementById(listId);
     const toggleIcon = safeGetElementById(toggleId);
@@ -60,27 +71,37 @@ export class FileList {
     webviewState.save();
   }
 
-  /** Return an array of selected file paths */
+  /**
+   * Return an array of selected file paths
+   * @param {HTMLElement} container - Container element
+   * @returns {string[]}
+   */
   getSelected(container) {
     const fileElements = container.querySelectorAll('.file-item');
     return Array.from(fileElements).map((el) => el.dataset.path || '');
   }
 
-  /** Show or hide a file list container */
+  /**
+   * Show or hide a file list container
+   * @param {string} containerId - Base ID of the container
+   * @param {string} toggleId - ID of the toggle icon element
+   * @param {boolean} isVisible - Whether the container should be visible
+   */
   setVisibility(containerId, toggleId, isVisible) {
     const container = safeGetElementById(`${containerId}Container`);
     const toggleIcon = safeGetElementById(toggleId);
-    if (!container || !toggleIcon) {
-      console.error(`Container or toggle icon not found for ${containerId}`);
-      return;
-    }
+    if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
     toggleIcon.innerHTML = `<i class="${
       isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
     }"></i>`;
   }
 
-  /** Toggle visibility of a file list container */
+  /**
+   * Toggle visibility of a file list container
+   * @param {string} containerId - Base ID of the container
+   * @param {string} toggleId - ID of the toggle icon element
+   */
   toggle(containerId, toggleId) {
     const container = safeGetElementById(`${containerId}Container`);
     if (!container) return;
@@ -89,7 +110,11 @@ export class FileList {
     webviewState.save();
   }
 
-  /** Empty all files from a container and hide it */
+  /**
+   * Empty all files from a container and hide it
+   * @param {string} containerId - Base ID of the container
+   * @param {string} toggleId - ID of the toggle icon element
+   */
   empty(containerId, toggleId) {
     const listDiv = safeGetElementById(containerId);
     const container = safeGetElementById(`${containerId}Container`);
@@ -104,7 +129,10 @@ export class FileList {
     webviewState.save();
   }
 
-  /** Hide empty lists from the provided id array */
+  /**
+   * Hide empty lists from the provided id array
+   * @param {string[]} ids - IDs of list elements
+   */
   hideEmpty(ids) {
     ids.forEach((id) => {
       const selectDiv = safeGetElementById(id);

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -1,0 +1,120 @@
+// Local imports
+import { webviewState } from '../webviewState.js';
+import {
+  addEventListenerSafely,
+  safeGetElementById,
+} from '@common/domUtils.js';
+import {
+  CHEVRON_UP_CLASS,
+  CHEVRON_DOWN_CLASS,
+} from '@common/webviewContext.js';
+import { capitalize } from '@common/stringUtils.js';
+
+/**
+ * Handles multi-file list DOM updates.
+ */
+export class FileList {
+  /** Add a file entry to a list container */
+  add(containerId, file) {
+    const container = safeGetElementById(containerId);
+    const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
+    if (!container || !toggleIcon) return;
+
+    const fileElement = document.createElement('div');
+    fileElement.className = 'file-item';
+    fileElement.dataset.path = file;
+    fileElement.innerHTML = `${file} <span class="remove-button">-</span>`;
+
+    const removeButton = fileElement.querySelector('.remove-button');
+    if (removeButton) {
+      addEventListenerSafely(removeButton, 'click', () => {
+        container.removeChild(fileElement);
+        if (container.children.length === 0) {
+          this.empty(containerId, `toggle${capitalize(containerId)}`);
+        }
+        webviewState.save();
+      });
+    }
+    container.appendChild(fileElement);
+  }
+
+  /** Update a multi-file list, showing the toggle when files exist */
+  update(listId, toggleId, files) {
+    const listDiv = safeGetElementById(listId);
+    const toggleIcon = safeGetElementById(toggleId);
+    if (!listDiv || !toggleIcon) return;
+
+    const existing = this.getSelected(listDiv);
+    const newFiles = files.filter((f) => !existing.includes(f));
+
+    if (newFiles.length > 0) {
+      newFiles.forEach((file) => this.add(listId, file));
+      listDiv.style.display = 'block';
+      toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
+
+      const container = safeGetElementById(`${listId}Container`);
+      if (container) {
+        container.style.display = 'block';
+      }
+    }
+    webviewState.save();
+  }
+
+  /** Return an array of selected file paths */
+  getSelected(container) {
+    const fileElements = container.querySelectorAll('.file-item');
+    return Array.from(fileElements).map((el) => el.dataset.path || '');
+  }
+
+  /** Show or hide a file list container */
+  setVisibility(containerId, toggleId, isVisible) {
+    const container = safeGetElementById(`${containerId}Container`);
+    const toggleIcon = safeGetElementById(toggleId);
+    if (!container || !toggleIcon) {
+      console.error(`Container or toggle icon not found for ${containerId}`);
+      return;
+    }
+    container.style.display = isVisible ? 'block' : 'none';
+    toggleIcon.innerHTML = `<i class="${
+      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+    }"></i>`;
+  }
+
+  /** Toggle visibility of a file list container */
+  toggle(containerId, toggleId) {
+    const container = safeGetElementById(`${containerId}Container`);
+    if (!container) return;
+    const isVisible = container.style.display !== 'none';
+    this.setVisibility(containerId, toggleId, !isVisible);
+    webviewState.save();
+  }
+
+  /** Empty all files from a container and hide it */
+  empty(containerId, toggleId) {
+    const listDiv = safeGetElementById(containerId);
+    const container = safeGetElementById(`${containerId}Container`);
+    if (!listDiv || !container) return;
+
+    listDiv.innerHTML = '';
+    container.style.display = 'none';
+    const toggleIconDiv = safeGetElementById(toggleId);
+    if (toggleIconDiv) {
+      toggleIconDiv.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
+    }
+    webviewState.save();
+  }
+
+  /** Hide empty lists from the provided id array */
+  hideEmpty(ids) {
+    ids.forEach((id) => {
+      const selectDiv = safeGetElementById(id);
+      if (!selectDiv) return;
+      const toggleId = `toggle${capitalize(id)}`;
+      if (selectDiv.children.length === 0) {
+        this.setVisibility(id, toggleId, false);
+      }
+    });
+  }
+}
+
+export const fileList = new FileList();

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -2,34 +2,43 @@
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { webviewState } from '../webviewState.js';
 
 /**
  * Handles single-file dropdown updates and commit list logic.
  */
 export class FileSelect {
   constructor() {
-    this._agentDefaults = [];
+    this._agentDefaults = webviewState.get()?.agentDefaultOutputFiles ?? [];
   }
 
   setAgentDefaultOutputFiles(files) {
     this._agentDefaults = Array.isArray(files) ? files : [];
+    webviewState.update({ agentDefaultOutputFiles: this._agentDefaults });
+    webviewState.save();
   }
 
   getAgentDefaultOutputFiles() {
     return this._agentDefaults;
   }
 
+  /**
+   * Update a single-file select element
+   * @param {string} id - The select element ID
+   * @param {string[]} files - Options to populate
+   */
   update(id, files) {
-    const selectDiv = document.getElementById(id);
-    if (!selectDiv) {
-      console.error(`[FileSelect] Element with id '${id}' not found`);
-      return;
-    }
+    const selectDiv = safeGetElementById(id);
+    if (!selectDiv) return;
     selectDiv.innerHTML =
       '<option value="">None</option>' +
       files.map((f) => `<option value="${f}">${f}</option>`).join('');
   }
 
+  /**
+   * Request edited file list when base file changes
+   * @param {string} baseFile - Currently selected base file
+   */
   updateEdited(baseFile) {
     const editedFileDiv = safeGetElementById('editedFile');
     if (!editedFileDiv) return;
@@ -45,6 +54,12 @@ export class FileSelect {
     }
   }
 
+  /**
+   * Append an option element to a select
+   * @param {HTMLSelectElement} select
+   * @param {string} value
+   * @param {string} text
+   */
   addOption(select, value, text) {
     const option = document.createElement('option');
     option.value = value;
@@ -52,6 +67,11 @@ export class FileSelect {
     select.appendChild(option);
   }
 
+  /**
+   * Enable or disable a list of elements
+   * @param {(HTMLElement|string)[]} elements
+   * @param {boolean} disabled
+   */
   setElementsDisabled(elements, disabled) {
     elements.forEach((el) => {
       if (typeof el === 'string') {
@@ -63,6 +83,10 @@ export class FileSelect {
     });
   }
 
+  /**
+   * Populate commit dropdown with recent commits
+   * @param {object} message
+   */
   handleRecentCommits(message) {
     const commitButtons = [
       'packLatexdiffvcButton',
@@ -85,6 +109,12 @@ export class FileSelect {
     }
   }
 
+  /**
+   * Highlight the current file in its dropdown
+   * @param {object} param0
+   * @param {string} param0.fileType
+   * @param {string} param0.filePath
+   */
   handleSetCurrentFile({ fileType, filePath }) {
     const fileId = `${uncapitalize(fileType)}File`;
     const fileDiv = document.getElementById(fileId);

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,0 +1,109 @@
+// Local imports
+import { vscode } from '@common/webviewContext.js';
+import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
+import { capitalize, uncapitalize } from '@common/stringUtils.js';
+
+/**
+ * Handles single-file dropdown updates and commit list logic.
+ */
+export class FileSelect {
+  constructor() {
+    this._agentDefaults = [];
+  }
+
+  setAgentDefaultOutputFiles(files) {
+    this._agentDefaults = Array.isArray(files) ? files : [];
+  }
+
+  getAgentDefaultOutputFiles() {
+    return this._agentDefaults;
+  }
+
+  update(id, files) {
+    const selectDiv = document.getElementById(id);
+    if (!selectDiv) {
+      console.error(`[FileSelect] Element with id '${id}' not found`);
+      return;
+    }
+    selectDiv.innerHTML =
+      '<option value="">None</option>' +
+      files.map((f) => `<option value="${f}">${f}</option>`).join('');
+  }
+
+  updateEdited(baseFile) {
+    const editedFileDiv = safeGetElementById('editedFile');
+    if (!editedFileDiv) return;
+    if (baseFile) {
+      const current = editedFileDiv.value;
+      vscode.postMessage({
+        command: 'requestEditedFile',
+        baseFile,
+        preserveSelection: current,
+      });
+    } else {
+      this.update('editedFile', []);
+    }
+  }
+
+  addOption(select, value, text) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = text;
+    select.appendChild(option);
+  }
+
+  setElementsDisabled(elements, disabled) {
+    elements.forEach((el) => {
+      if (typeof el === 'string') {
+        const elem = document.getElementById(el);
+        if (elem) elem.disabled = disabled;
+      } else {
+        el.disabled = disabled;
+      }
+    });
+  }
+
+  handleRecentCommits(message) {
+    const commitButtons = [
+      'packLatexdiffvcButton',
+      'cleanLatexdiffvcButton',
+      'latexdiffvcButton',
+    ];
+    const commitDiv = document.getElementById('commit');
+    commitDiv.innerHTML = '';
+
+    if (message.isGitRepo === false) {
+      this.addOption(commitDiv, '', 'Not a Git repository');
+      this.setElementsDisabled([commitDiv, ...commitButtons], true);
+    } else {
+      this.addOption(commitDiv, 'HEAD', 'HEAD');
+      message.commits.forEach((commit) => {
+        const [commitHash] = commit.split(': ');
+        this.addOption(commitDiv, commitHash, commit);
+      });
+      this.setElementsDisabled([commitDiv, ...commitButtons], false);
+    }
+  }
+
+  handleSetCurrentFile({ fileType, filePath }) {
+    const fileId = `${uncapitalize(fileType)}File`;
+    const fileDiv = document.getElementById(fileId);
+    if (!fileDiv) {
+      console.warn(`Element with id '${fileId}' not found`);
+      return;
+    }
+
+    const options = Array.from(fileDiv.options);
+    if (options.some((o) => o.value === filePath)) {
+      safeSetElementValue(fileId, filePath);
+      fileDiv.dispatchEvent(new Event('change'));
+    } else {
+      vscode.postMessage({
+        command: 'showInformationMessage',
+        text: `The current file is not in the ${fileType} file list: ${filePath}`,
+      });
+    }
+  }
+}
+
+export const fileSelect = new FileSelect();

--- a/src/webview/modules/webviewState.js
+++ b/src/webview/modules/webviewState.js
@@ -6,12 +6,7 @@ import {
   CHECK_BOXES_TOOL_USE,
   CHECK_BOXES_AUTO_EXTRACT,
 } from './constants.js';
-import {
-  hideEmptyMultipleFileSelects,
-  setMultipleFileSelectVisibility,
-  addFileToList,
-  getSelectedFiles,
-} from './fileHandlers.js';
+import { fileList } from './uiManagers/FileList.js';
 import {
   CHEVRON_UP_CLASS,
   CHEVRON_DOWN_CLASS,
@@ -57,7 +52,7 @@ export class WebviewState {
 
     MULTIPLE_SELECTIONS.forEach((id) => {
       const toggleId = `toggle${capitalize(id)}`;
-      setMultipleFileSelectVisibility(id, toggleId, false);
+      fileList.setVisibility(id, toggleId, false);
       const listDiv = safeGetElementById(id);
       if (listDiv) {
         listDiv.innerHTML = '';
@@ -124,15 +119,15 @@ export class WebviewState {
 
         if (filesArray && filesArray.length > 0) {
           filesArray.forEach((file) => {
-            addFileToList(id, file);
+            fileList.add(id, file);
           });
-          setMultipleFileSelectVisibility(
+          fileList.setVisibility(
             id,
             toggleId,
             isVisible !== undefined ? isVisible : true,
           );
         } else {
-          setMultipleFileSelectVisibility(id, toggleId, false);
+          fileList.setVisibility(id, toggleId, false);
         }
       });
 
@@ -149,7 +144,7 @@ export class WebviewState {
       this.setDefaults();
     }
 
-    hideEmptyMultipleFileSelects();
+    fileList.hideEmpty(MULTIPLE_SELECTIONS);
   }
 
   /** Persist current UI state */
@@ -176,7 +171,7 @@ export class WebviewState {
       const containerDiv = safeGetElementById(`${id}Container`);
       state[`${id}Visible`] =
         containerDiv && containerDiv.style.display === 'block';
-      state[id] = getSelectedFiles(elementDiv);
+      state[id] = fileList.getSelected(elementDiv);
     });
 
     this.stateManager.setState(state);

--- a/src/webview/modules/webviewState.js
+++ b/src/webview/modules/webviewState.js
@@ -7,6 +7,7 @@ import {
   CHECK_BOXES_AUTO_EXTRACT,
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
+import { fileSelect } from './uiManagers/FileSelect.js';
 import {
   CHEVRON_UP_CLASS,
   CHEVRON_DOWN_CLASS,
@@ -65,6 +66,8 @@ export class WebviewState {
       latexdiffsContent.style.display = 'none';
       toggleLatexdiffs.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
     }
+
+    fileSelect.setAgentDefaultOutputFiles([]);
 
     this.save();
   }
@@ -140,6 +143,10 @@ export class WebviewState {
           visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
         }"></i>`;
       }
+
+      fileSelect.setAgentDefaultOutputFiles(
+        previousState.agentDefaultOutputFiles ?? [],
+      );
     } else {
       this.setDefaults();
     }
@@ -173,6 +180,8 @@ export class WebviewState {
         containerDiv && containerDiv.style.display === 'block';
       state[id] = fileList.getSelected(elementDiv);
     });
+
+    state.agentDefaultOutputFiles = fileSelect.getAgentDefaultOutputFiles();
 
     this.stateManager.setState(state);
   }


### PR DESCRIPTION
## Summary
- create `FileList` and `FileSelect` manager classes
- move multi-file DOM logic into FileList
- move single-file select updates and commit dropdown logic into FileSelect
- refactor webview modules to use the new managers
- register new scripts in the webview provider and import map
- trim old helpers from `fileHandlers.js`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af66b2df88324a7b0445d8ee91d09