### PR TITLE
Fix webview module URIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,9 @@ This document sets the common conventions for contributions. Follow these norms 
 - Update cumulative usage stats with `updateUsageSummary` in `src/progressView/modules/domHandlers.js`.
 - Prefer enums or union types over plain booleans in configuration objects.
 - Build webview URIs through helpers in `src/webview/WebviewContentProvider.ts`.
+- When adding new webview modules (e.g., under `src/webview/modules/uiManagers`),
+  map them in `src/webview/index.html` and expose their URIs via
+  `WebviewContentProvider`.
 - Use `watchConfig` from `src/utils/configUtils.ts` to refresh features when configuration settings change.
 - Build DOM elements with `<template>` blocks and helpers in `src/common/modules/templateUtils.js`.
 - Manipulate webview DOM safely using `addEventListenerSafely` from `src/common/modules/domUtils.js`.

--- a/src/webview/WebviewContentProvider.ts
+++ b/src/webview/WebviewContentProvider.ts
@@ -43,6 +43,15 @@ export class WebviewContentProvider {
       const fileHandlersUri = getWebviewUri('modules/fileHandlers.js');
       const fileListUri = getWebviewUri('modules/uiManagers/FileList.js');
       const fileSelectUri = getWebviewUri('modules/uiManagers/FileSelect.js');
+      const toggleManagerUri = getWebviewUri(
+        'modules/uiManagers/ToggleManager.js',
+      );
+      const recordingManagerUri = getWebviewUri(
+        'modules/uiManagers/RecordingManager.js',
+      );
+      const instructionManagerUri = getWebviewUri(
+        'modules/uiManagers/InstructionManager.js',
+      );
       const uiHandlersUri = getWebviewUri('modules/uiHandlers.js');
       const templateUtilsUri = getCommonUri('modules/templateUtils.js');
       const domUtilsUri = getCommonUri('modules/domUtils.js');
@@ -79,6 +88,9 @@ export class WebviewContentProvider {
         fileHandlersUri,
         fileListUri,
         fileSelectUri,
+        toggleManagerUri,
+        recordingManagerUri,
+        instructionManagerUri,
         uiHandlersUri,
         templateUtilsUri,
         webviewContextUri,

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -15,8 +15,11 @@
         "imports": {
           "./modules/webviewState.js": "${webviewStateModuleUri}",
           "./modules/fileHandlers.js": "${fileHandlersUri}",
-          "./modules/uiManagers/FileList.js": "${fileListUri}",
-          "./modules/uiManagers/FileSelect.js": "${fileSelectUri}",
+          "./uiManagers/FileList.js": "${fileListUri}",
+          "./uiManagers/FileSelect.js": "${fileSelectUri}",
+          "./uiManagers/ToggleManager.js": "${toggleManagerUri}",
+          "./uiManagers/RecordingManager.js": "${recordingManagerUri}",
+          "./uiManagers/InstructionManager.js": "${instructionManagerUri}",
           "./modules/uiHandlers.js": "${uiHandlersUri}",
           "./modules/messageHandlers.js": "${messageHandlersUri}",
           "@common/webviewContext.js": "${webviewContextUri}",


### PR DESCRIPTION
## Summary
- register missing UI manager modules in the webview
- clarify AGENTS guidance about mapping new modules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b094135cc83248b616d1d54438558