### PR TITLE
Refactor webview message handler

### DIFF
--- a/src/common/modules/webviewContext.js
+++ b/src/common/modules/webviewContext.js
@@ -1,13 +1,15 @@
 export const vscode = acquireVsCodeApi();
 
 export function registerMessageHandlers(handlers) {
-  window.addEventListener('message', (event) => {
+  const listener = (event) => {
     const message = event.data;
     const handler = handlers[message.command];
     if (handler) {
       handler(message);
     }
-  });
+  };
+  window.addEventListener('message', listener);
+  return () => window.removeEventListener('message', listener);
 }
 
 export const CHEVRON_UP_CLASS = 'codicon codicon-chevron-up';

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -27,6 +27,8 @@ export class MessageHandlers {
 
     // Cached DOM elements
     this._instructionEl = null;
+    // Track file list event handlers for cleanup
+    this._fileListHandlers = {};
 
     this._handlers = {
       ...this._createThemeHandlers(),
@@ -116,9 +118,48 @@ export class MessageHandlers {
       this._cleanupFn();
       this._cleanupFn = null;
     }
+    Object.values(this._fileListHandlers).forEach(({ container, handler }) => {
+      container.removeEventListener('click', handler);
+    });
+    this._fileListHandlers = {};
+    this._instructionEl = null;
   }
 
   /* ---------- Private helpers ---------- */
+  _setToggleIcon(element, isVisible) {
+    if (!element) return;
+    element.innerHTML = '';
+    const icon = document.createElement('i');
+    icon.className = isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS;
+    element.appendChild(icon);
+  }
+
+  _setupFileListHandler(fileType, container) {
+    if (!container || this._fileListHandlers[fileType]) return;
+    const handler = (e) => {
+      if (
+        e.target instanceof HTMLElement &&
+        e.target.classList.contains('remove-button')
+      ) {
+        e.stopPropagation();
+        const item = e.target.closest('.file-item');
+        if (item) {
+          item.remove();
+          const updated = Array.from(
+            container.querySelectorAll('.file-item'),
+          ).map((el) => el.dataset.path);
+          vscode.postMessage({
+            command: `update${capitalize(fileType)}Files`,
+            files: updated,
+          });
+          webviewState.update({ [`${fileType}Files`]: updated });
+        }
+      }
+    };
+    container.addEventListener('click', handler);
+    this._fileListHandlers[fileType] = { container, handler };
+  }
+
   _initializeDataRequests() {
     const dataRequests = [
       'getTheme',
@@ -224,11 +265,7 @@ export class MessageHandlers {
         }
 
         const toggleElement = safeGetElementById(toggleId);
-        if (toggleElement) {
-          toggleElement.innerHTML = `<i class="${
-            isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-          }"></i>`;
-        }
+        this._setToggleIcon(toggleElement, isVisible);
 
         if (filesArray.length > 0 && multipleFiles) {
           multipleFiles.innerHTML = '';
@@ -238,25 +275,8 @@ export class MessageHandlers {
             fileItem.dataset.path = file;
             fileItem.innerHTML = `${file} <span class="remove-button">-</span>`;
             multipleFiles.appendChild(fileItem);
-
-            const removeButton = fileItem.querySelector('.remove-button');
-            if (removeButton) {
-              removeButton.addEventListener('click', (e) => {
-                e.stopPropagation();
-                fileItem.remove();
-                const updatedFiles = Array.from(
-                  multipleFiles.querySelectorAll('.file-item'),
-                ).map((item) => item.dataset.path);
-                vscode.postMessage({
-                  command: `update${capitalize(fileType)}Files`,
-                  files: updatedFiles,
-                });
-                webviewState.update({
-                  [`${fileType}Files`]: updatedFiles,
-                });
-              });
-            }
           });
+          this._setupFileListHandler(fileType, multipleFiles);
         }
       }
     }
@@ -273,6 +293,10 @@ export class MessageHandlers {
   /* ---------- Command handlers ---------- */
   // Theme & debug
   handleSetTheme(message) {
+    if (!message || typeof message.theme !== 'string') {
+      console.warn('Invalid theme message:', message);
+      return;
+    }
     document.body.className = message.theme;
     this._postHandle();
   }
@@ -412,21 +436,31 @@ export class MessageHandlers {
   // Multi-file updates
   handleSetInputFiles(message) {
     fileList.update('inputFiles', 'toggleInputFiles', message.files);
+    this._setupFileListHandler('input', safeGetElementById('inputFiles'));
     this._postHandle();
   }
 
   handleSetReferenceFiles(message) {
     fileList.update('referenceFiles', 'toggleReferenceFiles', message.files);
+    this._setupFileListHandler(
+      'reference',
+      safeGetElementById('referenceFiles'),
+    );
     this._postHandle();
   }
 
   handleSetAuxiliaryFiles(message) {
     fileList.update('auxiliaryFiles', 'toggleAuxiliaryFiles', message.files);
+    this._setupFileListHandler(
+      'auxiliary',
+      safeGetElementById('auxiliaryFiles'),
+    );
     this._postHandle();
   }
 
   handleSetMediaFiles(message) {
     fileList.update('mediaFiles', 'toggleMediaFiles', message.files);
+    this._setupFileListHandler('media', safeGetElementById('mediaFiles'));
     this._postHandle();
   }
 
@@ -437,14 +471,13 @@ export class MessageHandlers {
       ...existingFiles,
       message.file,
     ]);
+    this._setupFileListHandler('media', listDiv);
 
     const container = safeGetElementById('mediaFilesContainer');
     if (container && container.style.display === 'none') {
       container.style.display = 'block';
       const toggleIcon = safeGetElementById('toggleMediaFiles');
-      if (toggleIcon) {
-        toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
-      }
+      this._setToggleIcon(toggleIcon, true);
     }
 
     this._postHandle();
@@ -452,6 +485,7 @@ export class MessageHandlers {
 
   handleSetOutputFiles(message) {
     fileList.update('outputFiles', 'toggleOutputFiles', message.files);
+    this._setupFileListHandler('output', safeGetElementById('outputFiles'));
     this._postHandle();
   }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1,13 +1,16 @@
-import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
-import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { webviewState } from './webviewState.js';
+// Local imports - webview context
 import {
+  vscode,
+  registerMessageHandlers,
   CHEVRON_UP_CLASS,
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
+import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
+import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { webviewState } from './webviewState.js';
 import { setDebugMode as applyDebugMode } from './uiHandlers.js';
 
+// Local imports - UI managers
 import { fileList } from './uiManagers/FileList.js';
 import { fileSelect } from './uiManagers/FileSelect.js';
 import { webviewEventBus } from './eventBus.js';
@@ -15,420 +18,456 @@ import { webviewEventBus } from './eventBus.js';
 import { FILE_TYPES } from './constants.js';
 
 /**
- * Initialize data requests on window load
+ * Handles messages from the extension and syncs the webview state.
  */
-export function initializeDataRequests() {
-  const dataRequests = [
-    'getTheme',
-    'getDebugMode',
-    'requestInputFile',
-    'requestReferenceFile',
-    'requestAuxiliaryFile',
-    'requestMediaFile',
-    'requestRecentCommits',
-    'requestBaseFile',
-  ];
+export class MessageHandlers {
+  constructor() {
+    this._skipNextRestoreState = false;
+    this._handlers = {
+      // Theme & debug
+      setTheme: (m) => this.handleSetTheme(m),
+      setDebugMode: (m) => this.handleSetDebugMode(m),
+      modelSelected: (m) => this.handleModelSelected(m),
 
-  dataRequests.forEach((request) => {
-    vscode.postMessage({ command: request });
-  });
-}
+      // State restoration
+      restoreState: (m) => this.handleRestoreState(m),
+      checkRestoredBaseFile: () => this.handleCheckRestoredBaseFile(),
 
-/**
- * Handle state restoration from log view
- */
-function handleStateRestoration(state) {
-  console.log('Restoring state:', state);
+      // Instruction updates
+      instructionTextPolished: (m) => this.handleInstructionTextPolished(m),
+      instructionTextTranscribed: (m) =>
+        this.handleInstructionTextTranscribed(m),
 
-  // Restore basic form elements
-  if (state.agent) safeSetElementValue('agent', state.agent);
-  if (state.model) safeSetElementValue('model', state.model);
+      // Recording
+      recordingStarted: () => this.handleRecordingStarted(),
+      recordingError: () => this.handleRecordingError(),
 
-  // Fix instruction restoration - needs to use the correct ID
-  const instructionContent = state.instruction || '';
-  const instruction = safeGetElementById('instruction');
-  if (instruction) {
-    instruction.value = instructionContent;
-    // Also trigger any associated events/validation
-    instruction.dispatchEvent(new Event('input'));
+      // Single file updates
+      setInputFile: (m) => this.handleSetInputFile(m),
+      setReferenceFile: (m) => this.handleSetReferenceFile(m),
+      setAuxiliaryFile: (m) => this.handleSetAuxiliaryFile(m),
+      setMediaFile: (m) => this.handleSetMediaFile(m),
+      setEditedFile: (m) => this.handleSetEditedFile(m),
+      inputFileSelected: (m) => this.handleInputFileSelected(m),
+      referenceFileSelected: (m) => this.handleReferenceFileSelected(m),
+      auxiliaryFileSelected: (m) => this.handleAuxiliaryFileSelected(m),
+      mediaFileSelected: (m) => this.handleMediaFileSelected(m),
+      editedFileSelected: (m) => this.handleEditedFileSelected(m),
+      setDefaultOutputFiles: (m) => this.handleSetDefaultOutputFiles(m),
+
+      // Multi-file updates
+      setInputFiles: (m) => this.handleSetInputFiles(m),
+      setReferenceFiles: (m) => this.handleSetReferenceFiles(m),
+      setAuxiliaryFiles: (m) => this.handleSetAuxiliaryFiles(m),
+      setMediaFiles: (m) => this.handleSetMediaFiles(m),
+      addMediaFile: (m) => this.handleAddMediaFile(m),
+      setOutputFiles: (m) => this.handleSetOutputFiles(m),
+
+      // Misc updates
+      setRecentCommits: (m) => this.handleSetRecentCommits(m),
+      setCurrentFile: (m) => this.handleSetCurrentFile(m),
+      setOpenedFiles: (m) => this.handleSetOpenedFiles(m),
+      setBaseFile: (m) => this.handleSetBaseFile(m),
+    };
   }
 
-  // Restore single file selections
-  if (state.inputFile) safeSetElementValue('inputFile', state.inputFile);
-  if (state.referenceFile)
-    safeSetElementValue('referenceFile', state.referenceFile);
-  if (state.auxiliaryFile)
-    safeSetElementValue('auxiliaryFile', state.auxiliaryFile);
-  if (state.mediaFile) safeSetElementValue('mediaFile', state.mediaFile);
-  // Output filename override removed
+  /** Register handlers and request initial data. */
+  setup() {
+    registerMessageHandlers(this._handlers);
+    this._initializeDataRequests();
+  }
 
-  // Prepare the state to save with all necessary properties
-  const toolConfig = state.toolConfig || {};
-  const savedState = {
-    // Basic properties
-    agent: state.agent,
-    model: state.model,
-    instruction: instructionContent, // Use the resolved instruction content
+  /* ---------- Private helpers ---------- */
+  _initializeDataRequests() {
+    const dataRequests = [
+      'getTheme',
+      'getDebugMode',
+      'requestInputFile',
+      'requestReferenceFile',
+      'requestAuxiliaryFile',
+      'requestMediaFile',
+      'requestRecentCommits',
+      'requestBaseFile',
+    ];
+    dataRequests.forEach((request) => {
+      vscode.postMessage({ command: request });
+    });
+  }
 
-    // File selections
-    inputFile: state.inputFile,
-    referenceFile: state.referenceFile,
-    auxiliaryFile: state.auxiliaryFile,
-    mediaFile: state.mediaFile,
+  _handleStateRestoration(state) {
+    console.log('Restoring state:', state);
 
-    // Tool config settings - flattened from either direct or toolConfig property
-    reflect: state.reflect || (toolConfig ? toolConfig.reflect : false),
-    autoExtractFigure:
-      state.autoExtractFigure ||
-      (toolConfig ? toolConfig.autoExtractFigure : false),
-    autoExtractTikzFigure:
-      state.autoExtractTikzFigure ||
-      (toolConfig ? toolConfig.autoExtractTikzFigure : false),
-    attachTeXCount:
-      state.attachTeXCount || (toolConfig ? toolConfig.attachTeXCount : false),
-    usePrefillFromInput:
-      state.usePrefillFromInput ||
-      (toolConfig ? toolConfig.usePrefillFromInput : false),
-    printInputPrompt:
-      state.printInputPrompt ||
-      (toolConfig ? toolConfig.printInputPrompt : false),
-    autoCompileInputPdf:
-      state.autoCompileInputPdf ||
-      (toolConfig ? toolConfig.autoCompileInputPdf : false),
-  };
+    if (state.agent) safeSetElementValue('agent', state.agent);
+    if (state.model) safeSetElementValue('model', state.model);
 
-  // Process multiple file selections
-  for (const fileType of FILE_TYPES) {
-    // Handle both formats (inputFiles and multipleInputFiles)
-    const filesArray =
-      state[`${fileType}Files`] ||
-      state[`multiple${capitalize(fileType)}Files`] ||
-      [];
-    const isVisible =
-      state[`${fileType}FilesActive`] ||
-      state[`multiple${capitalize(fileType)}FilesActive`] ||
-      false;
-    const toggleId = `toggle${capitalize(fileType)}Files`;
-    const containerId = `${fileType}FilesContainer`;
+    const instructionContent = state.instruction || '';
+    const instruction = safeGetElementById('instruction');
+    if (instruction) {
+      instruction.value = instructionContent;
+      instruction.dispatchEvent(new Event('input'));
+    }
 
-    // Save to the state object for later use by restoreState
-    const targetArrayName = `${fileType}Files`;
-    const visibilityName = `${targetArrayName}Active`;
-    savedState[targetArrayName] = filesArray;
-    savedState[visibilityName] = isVisible;
+    if (state.inputFile) safeSetElementValue('inputFile', state.inputFile);
+    if (state.referenceFile)
+      safeSetElementValue('referenceFile', state.referenceFile);
+    if (state.auxiliaryFile)
+      safeSetElementValue('auxiliaryFile', state.auxiliaryFile);
+    if (state.mediaFile) safeSetElementValue('mediaFile', state.mediaFile);
 
-    // Get current UI state to see if we have existing files
-    const multipleFilesId = `${fileType}Files`;
-    const multipleFiles = safeGetElementById(multipleFilesId);
-    const existingFiles = multipleFiles
-      ? Array.from(multipleFiles.querySelectorAll('.file-item')).map(
-          (item) => item.dataset.path,
-        )
-      : [];
+    const toolConfig = state.toolConfig || {};
+    const savedState = {
+      agent: state.agent,
+      model: state.model,
+      instruction: instructionContent,
+      inputFile: state.inputFile,
+      referenceFile: state.referenceFile,
+      auxiliaryFile: state.auxiliaryFile,
+      mediaFile: state.mediaFile,
+      reflect: state.reflect || (toolConfig ? toolConfig.reflect : false),
+      autoExtractFigure:
+        state.autoExtractFigure ||
+        (toolConfig ? toolConfig.autoExtractFigure : false),
+      autoExtractTikzFigure:
+        state.autoExtractTikzFigure ||
+        (toolConfig ? toolConfig.autoExtractTikzFigure : false),
+      attachTeXCount:
+        state.attachTeXCount ||
+        (toolConfig ? toolConfig.attachTeXCount : false),
+      usePrefillFromInput:
+        state.usePrefillFromInput ||
+        (toolConfig ? toolConfig.usePrefillFromInput : false),
+      printInputPrompt:
+        state.printInputPrompt ||
+        (toolConfig ? toolConfig.printInputPrompt : false),
+      autoCompileInputPdf:
+        state.autoCompileInputPdf ||
+        (toolConfig ? toolConfig.autoCompileInputPdf : false),
+    };
 
-    // Only clear and update if we have files to restore or visibility has changed
-    if (filesArray.length > 0 || isVisible) {
-      // Show or hide the multi file container if visibility is specified
-      const container = safeGetElementById(containerId);
-      if (container) {
-        container.style.display = isVisible ? 'block' : 'none';
-      }
+    for (const fileType of FILE_TYPES) {
+      const filesArray =
+        state[`${fileType}Files`] ||
+        state[`multiple${capitalize(fileType)}Files`] ||
+        [];
+      const isVisible =
+        state[`${fileType}FilesActive`] ||
+        state[`multiple${capitalize(fileType)}FilesActive`] ||
+        false;
+      const toggleId = `toggle${capitalize(fileType)}Files`;
+      const containerId = `${fileType}FilesContainer`;
 
-      // Update the toggle indicator based on visibility
-      const toggleElement = safeGetElementById(toggleId);
-      if (toggleElement) {
-        toggleElement.innerHTML = `<i class="${
-          isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-        }"></i>`;
-      }
+      const targetArrayName = `${fileType}Files`;
+      const visibilityName = `${targetArrayName}Active`;
+      savedState[targetArrayName] = filesArray;
+      savedState[visibilityName] = isVisible;
 
-      // Only update the file list if we have files to restore
-      if (filesArray.length > 0 && multipleFiles) {
-        // Clear existing content
-        multipleFiles.innerHTML = '';
+      const multipleFilesId = `${fileType}Files`;
+      const multipleFiles = safeGetElementById(multipleFilesId);
+      const existingFiles = multipleFiles
+        ? Array.from(multipleFiles.querySelectorAll('.file-item')).map(
+            (item) => item.dataset.path,
+          )
+        : [];
 
-        // Add each file
-        filesArray.forEach((file) => {
-          const fileItem = document.createElement('div');
-          fileItem.className = 'file-item';
-          fileItem.dataset.path = file;
-          fileItem.innerHTML = `${file} <span class="remove-button">-</span>`;
-          multipleFiles.appendChild(fileItem);
+      if (filesArray.length > 0 || isVisible) {
+        const container = safeGetElementById(containerId);
+        if (container) {
+          container.style.display = isVisible ? 'block' : 'none';
+        }
 
-          // Add event listeners for the remove button
-          const removeButton = fileItem.querySelector('.remove-button');
-          if (removeButton) {
-            removeButton.addEventListener('click', (e) => {
-              e.stopPropagation();
-              fileItem.remove();
+        const toggleElement = safeGetElementById(toggleId);
+        if (toggleElement) {
+          toggleElement.innerHTML = `<i class="${
+            isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
+          }"></i>`;
+        }
 
-              // Update the state
-              const updatedFiles = Array.from(
-                multipleFiles.querySelectorAll('.file-item'),
-              ).map((item) => item.dataset.path);
+        if (filesArray.length > 0 && multipleFiles) {
+          multipleFiles.innerHTML = '';
+          filesArray.forEach((file) => {
+            const fileItem = document.createElement('div');
+            fileItem.className = 'file-item';
+            fileItem.dataset.path = file;
+            fileItem.innerHTML = `${file} <span class="remove-button">-</span>`;
+            multipleFiles.appendChild(fileItem);
 
-              // Send message to update the state
-              vscode.postMessage({
-                command: `update${capitalize(fileType)}Files`,
-                files: updatedFiles,
+            const removeButton = fileItem.querySelector('.remove-button');
+            if (removeButton) {
+              removeButton.addEventListener('click', (e) => {
+                e.stopPropagation();
+                fileItem.remove();
+                const updatedFiles = Array.from(
+                  multipleFiles.querySelectorAll('.file-item'),
+                ).map((item) => item.dataset.path);
+                vscode.postMessage({
+                  command: `update${capitalize(fileType)}Files`,
+                  files: updatedFiles,
+                });
+                webviewState.update({
+                  [`${fileType}Files`]: updatedFiles,
+                });
               });
-
-              // Save state to persist changes
-              webviewState.update({
-                [`${fileType}Files`]: updatedFiles,
-              });
-            });
-          }
-        });
+            }
+          });
+        }
       }
+    }
+
+    webviewState.set(savedState);
+    webviewState.restore();
+    this._skipNextRestoreState = true;
+  }
+
+  _postHandle() {
+    if (this._skipNextRestoreState) {
+      this._skipNextRestoreState = false;
+    } else {
+      webviewState.restore();
     }
   }
 
-  // Save the prepared state
-  webviewState.set(savedState);
+  /* ---------- Command handlers ---------- */
+  // Theme & debug
+  handleSetTheme(message) {
+    document.body.className = message.theme;
+    this._postHandle();
+  }
 
-  // Restore UI elements from the saved state
-  // This will handle setting all form values and updating indicators
-  webviewState.restore();
+  handleSetDebugMode(message) {
+    applyDebugMode(message.debugMode);
+    this._postHandle();
+  }
 
-  // Let the user know we've restored their configuration
-  // vscode.postMessage({
-  //   command: 'showInformationMessage',
-  //   text: 'Configuration restored from selected task',
-  // });
+  handleModelSelected(message) {
+    safeSetElementValue('model', message.model);
+    this._postHandle();
+  }
 
-  // Prevent the automatic restoreState that would happen at the end of the message handler
-  window._skipNextRestoreState = true;
-}
+  // State restoration
+  handleRestoreState(message) {
+    this._handleStateRestoration(message.state);
+    this._postHandle();
+  }
 
-function postHandle() {
-  if (window._skipNextRestoreState) {
-    window._skipNextRestoreState = false;
-  } else {
-    webviewState.restore();
+  handleCheckRestoredBaseFile() {
+    const restoredBaseFileDiv = safeGetElementById('baseFile');
+    if (restoredBaseFileDiv && restoredBaseFileDiv.value) {
+      fileSelect.updateEdited(restoredBaseFileDiv.value);
+    }
+    this._postHandle();
+  }
+
+  // Instruction updates
+  handleInstructionTextPolished(message) {
+    const instruction = safeGetElementById('instruction');
+    if (instruction && message.text) {
+      instruction.value = message.text;
+      vscode.postMessage({
+        command: 'showInformationMessage',
+        text: 'Instruction text has been polished!',
+      });
+      webviewState.save();
+    }
+    this._postHandle();
+  }
+
+  handleInstructionTextTranscribed(message) {
+    const instruction = safeGetElementById('instruction');
+    if (instruction && message.text) {
+      const startPos = instruction.selectionStart;
+      const endPos = instruction.selectionEnd;
+      const textBefore = instruction.value.substring(0, startPos);
+      const textAfter = instruction.value.substring(endPos);
+      instruction.value = textBefore + message.text + textAfter;
+      const newCursorPos = startPos + message.text.length;
+      instruction.setSelectionRange(newCursorPos, newCursorPos);
+      instruction.focus();
+      vscode.postMessage({
+        command: 'showInformationMessage',
+        text: 'Instruction text transcribed!',
+      });
+      webviewState.save();
+    }
+    webviewEventBus.dispatchEvent(
+      new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
+    );
+    this._postHandle();
+  }
+
+  // Recording
+  handleRecordingStarted() {
+    webviewEventBus.dispatchEvent(
+      new CustomEvent('recordingUIUpdate', { detail: { recording: true } }),
+    );
+    this._postHandle();
+  }
+
+  handleRecordingError() {
+    webviewEventBus.dispatchEvent(
+      new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
+    );
+    this._postHandle();
+  }
+
+  // Single file updates
+  handleSetInputFile(message) {
+    fileSelect.update('inputFile', message.files);
+    this._postHandle();
+  }
+
+  handleSetReferenceFile(message) {
+    fileSelect.update('referenceFile', message.files);
+    this._postHandle();
+  }
+
+  handleSetAuxiliaryFile(message) {
+    fileSelect.update('auxiliaryFile', message.files);
+    this._postHandle();
+  }
+
+  handleSetMediaFile(message) {
+    fileSelect.update('mediaFile', message.files);
+    this._postHandle();
+  }
+
+  handleSetEditedFile(message) {
+    fileSelect.update('editedFile', message.files);
+    this._postHandle();
+  }
+
+  handleInputFileSelected(message) {
+    safeSetElementValue('inputFile', message.filePath);
+    this._postHandle();
+  }
+
+  handleReferenceFileSelected(message) {
+    safeSetElementValue('referenceFile', message.filePath);
+    this._postHandle();
+  }
+
+  handleAuxiliaryFileSelected(message) {
+    safeSetElementValue('auxiliaryFile', message.filePath);
+    this._postHandle();
+  }
+
+  handleMediaFileSelected(message) {
+    safeSetElementValue('mediaFile', message.filePath);
+    this._postHandle();
+  }
+
+  handleEditedFileSelected(message) {
+    safeSetElementValue('editedFile', message.filePath);
+    this._postHandle();
+  }
+
+  handleSetDefaultOutputFiles(message) {
+    fileSelect.setAgentDefaultOutputFiles(message.files || []);
+    this._postHandle();
+  }
+
+  // Multi-file updates
+  handleSetInputFiles(message) {
+    fileList.update('inputFiles', 'toggleInputFiles', message.files);
+    this._postHandle();
+  }
+
+  handleSetReferenceFiles(message) {
+    fileList.update('referenceFiles', 'toggleReferenceFiles', message.files);
+    this._postHandle();
+  }
+
+  handleSetAuxiliaryFiles(message) {
+    fileList.update('auxiliaryFiles', 'toggleAuxiliaryFiles', message.files);
+    this._postHandle();
+  }
+
+  handleSetMediaFiles(message) {
+    fileList.update('mediaFiles', 'toggleMediaFiles', message.files);
+    this._postHandle();
+  }
+
+  handleAddMediaFile(message) {
+    const listDiv = safeGetElementById('mediaFiles');
+    const existingFiles = listDiv ? fileList.getSelected(listDiv) : [];
+    fileList.update('mediaFiles', 'toggleMediaFiles', [
+      ...existingFiles,
+      message.file,
+    ]);
+
+    const container = safeGetElementById('mediaFilesContainer');
+    if (container && container.style.display === 'none') {
+      container.style.display = 'block';
+      const toggleIcon = safeGetElementById('toggleMediaFiles');
+      if (toggleIcon) {
+        toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
+      }
+    }
+
+    this._postHandle();
+  }
+
+  handleSetOutputFiles(message) {
+    fileList.update('outputFiles', 'toggleOutputFiles', message.files);
+    this._postHandle();
+  }
+
+  // Misc updates
+  handleSetRecentCommits(message) {
+    fileSelect.handleRecentCommits(message);
+    this._postHandle();
+  }
+
+  handleSetCurrentFile(message) {
+    fileSelect.handleSetCurrentFile({
+      fileType: message.fileType,
+      filePath: message.filePath,
+    });
+    this._postHandle();
+  }
+
+  handleSetOpenedFiles(message) {
+    if (message.fileType) {
+      const fileType = message.fileType.replace('Files', '');
+      const singleFileId = `${uncapitalize(fileType)}File`;
+      const multipleFileId = `${uncapitalize(fileType)}Files`;
+      const toggleId = `toggle${capitalize(fileType)}Files`;
+
+      let filesToAdd = message.files ?? [];
+      if (message.shouldFilter) {
+        const singleFileSelect = safeGetElementById(singleFileId);
+        if (singleFileSelect && singleFileSelect.value) {
+          filesToAdd = filesToAdd.filter((f) => f !== singleFileSelect.value);
+        }
+      }
+
+      fileList.update(multipleFileId, toggleId, filesToAdd);
+    }
+    this._postHandle();
+  }
+
+  handleSetBaseFile(message) {
+    const currentBaseFileDiv = safeGetElementById('baseFile');
+    if (currentBaseFileDiv) {
+      const currentBaseFile = currentBaseFileDiv.value;
+      fileSelect.update('baseFile', message.files);
+
+      const state = webviewState.get();
+      const storedBaseFile = state?.baseFile;
+
+      if (storedBaseFile && message.files.includes(storedBaseFile)) {
+        currentBaseFileDiv.value = storedBaseFile;
+      } else if (
+        message.preserveBaseFile &&
+        currentBaseFile &&
+        message.files.includes(currentBaseFile)
+      ) {
+        currentBaseFileDiv.value = currentBaseFile;
+      }
+
+      fileSelect.updateEdited(currentBaseFileDiv.value);
+    }
+    this._postHandle();
   }
 }
 
-export function setupMessageHandlers() {
-  const handlers = {
-    setTheme: (m) => {
-      document.body.className = m.theme;
-      postHandle();
-    },
-    setDebugMode: (m) => {
-      applyDebugMode(m.debugMode);
-      postHandle();
-    },
-    modelSelected: (m) => {
-      safeSetElementValue('model', m.model);
-      postHandle();
-    },
-    restoreState: (m) => {
-      handleStateRestoration(m.state);
-      postHandle();
-    },
-    checkRestoredBaseFile: () => {
-      const restoredBaseFileDiv = safeGetElementById('baseFile');
-      if (restoredBaseFileDiv && restoredBaseFileDiv.value) {
-        fileSelect.updateEdited(restoredBaseFileDiv.value);
-      }
-      postHandle();
-    },
-    instructionTextPolished: (m) => {
-      const instruction = safeGetElementById('instruction');
-      if (instruction && m.text) {
-        instruction.value = m.text;
-        vscode.postMessage({
-          command: 'showInformationMessage',
-          text: 'Instruction text has been polished!',
-        });
-        webviewState.save();
-      }
-      postHandle();
-    },
-    instructionTextTranscribed: (m) => {
-      const instruction = safeGetElementById('instruction');
-      if (instruction && m.text) {
-        // Insert text at cursor position instead of replacing all text
-        const startPos = instruction.selectionStart;
-        const endPos = instruction.selectionEnd;
-        const textBefore = instruction.value.substring(0, startPos);
-        const textAfter = instruction.value.substring(endPos);
-
-        // Insert the transcribed text at cursor position
-        instruction.value = textBefore + m.text + textAfter;
-
-        // Set cursor position after the inserted text
-        const newCursorPos = startPos + m.text.length;
-        instruction.setSelectionRange(newCursorPos, newCursorPos);
-
-        // Focus the instruction field
-        instruction.focus();
-
-        vscode.postMessage({
-          command: 'showInformationMessage',
-          text: 'Instruction text transcribed!',
-        });
-        webviewState.save();
-      }
-      // Reset recording UI state
-      webviewEventBus.dispatchEvent(
-        new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
-      );
-      postHandle();
-    },
-    recordingStarted: () => {
-      // Recording has started successfully
-      webviewEventBus.dispatchEvent(
-        new CustomEvent('recordingUIUpdate', { detail: { recording: true } }),
-      );
-      postHandle();
-    },
-    recordingError: (m) => {
-      // Reset UI on error
-      webviewEventBus.dispatchEvent(
-        new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
-      );
-      postHandle();
-    },
-    setInputFile: (m) => {
-      fileSelect.update('inputFile', m.files);
-      postHandle();
-    },
-    setReferenceFile: (m) => {
-      fileSelect.update('referenceFile', m.files);
-      postHandle();
-    },
-    setAuxiliaryFile: (m) => {
-      fileSelect.update('auxiliaryFile', m.files);
-      postHandle();
-    },
-    setMediaFile: (m) => {
-      fileSelect.update('mediaFile', m.files);
-      postHandle();
-    },
-    setEditedFile: (m) => {
-      fileSelect.update('editedFile', m.files);
-      postHandle();
-    },
-    inputFileSelected: (m) => {
-      safeSetElementValue('inputFile', m.filePath);
-      postHandle();
-    },
-    referenceFileSelected: (m) => {
-      safeSetElementValue('referenceFile', m.filePath);
-      postHandle();
-    },
-    auxiliaryFileSelected: (m) => {
-      safeSetElementValue('auxiliaryFile', m.filePath);
-      postHandle();
-    },
-    mediaFileSelected: (m) => {
-      safeSetElementValue('mediaFile', m.filePath);
-      postHandle();
-    },
-    editedFileSelected: (m) => {
-      safeSetElementValue('editedFile', m.filePath);
-      postHandle();
-    },
-    setDefaultOutputFiles: (m) => {
-      fileSelect.setAgentDefaultOutputFiles(m.files || []);
-      postHandle();
-    },
-    setInputFiles: (m) => {
-      fileList.update('inputFiles', 'toggleInputFiles', m.files);
-      postHandle();
-    },
-    setReferenceFiles: (m) => {
-      fileList.update('referenceFiles', 'toggleReferenceFiles', m.files);
-      postHandle();
-    },
-    setAuxiliaryFiles: (m) => {
-      fileList.update('auxiliaryFiles', 'toggleAuxiliaryFiles', m.files);
-      postHandle();
-    },
-    setMediaFiles: (m) => {
-      fileList.update('mediaFiles', 'toggleMediaFiles', m.files);
-      postHandle();
-    },
-    addMediaFile: (m) => {
-      const listDiv = safeGetElementById('mediaFiles');
-      const existingFiles = listDiv ? fileList.getSelected(listDiv) : [];
-      fileList.update('mediaFiles', 'toggleMediaFiles', [
-        ...existingFiles,
-        m.file,
-      ]);
-
-      // Ensure the media files container is visible
-      const container = safeGetElementById('mediaFilesContainer');
-      if (container && container.style.display === 'none') {
-        container.style.display = 'block';
-        const toggleIcon = safeGetElementById('toggleMediaFiles');
-        if (toggleIcon) {
-          toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
-        }
-      }
-
-      postHandle();
-    },
-    setOutputFiles: (m) => {
-      fileList.update('outputFiles', 'toggleOutputFiles', m.files);
-      postHandle();
-    },
-    setRecentCommits: (m) => {
-      fileSelect.handleRecentCommits(m);
-      postHandle();
-    },
-    setCurrentFile: (m) => {
-      fileSelect.handleSetCurrentFile({
-        fileType: m.fileType,
-        filePath: m.filePath,
-      });
-      postHandle();
-    },
-    setOpenedFiles: (m) => {
-      if (m.fileType) {
-        const fileType = m.fileType.replace('Files', '');
-        const singleFileId = `${uncapitalize(fileType)}File`;
-        const multipleFileId = `${uncapitalize(fileType)}Files`;
-        const toggleId = `toggle${capitalize(fileType)}Files`;
-
-        let filesToAdd = m.files ?? [];
-        if (m.shouldFilter) {
-          const singleFileSelect = safeGetElementById(singleFileId);
-          if (singleFileSelect && singleFileSelect.value) {
-            filesToAdd = filesToAdd.filter((f) => f !== singleFileSelect.value);
-          }
-        }
-
-        fileList.update(multipleFileId, toggleId, filesToAdd);
-      }
-      postHandle();
-    },
-    setBaseFile: (m) => {
-      const currentBaseFileDiv = safeGetElementById('baseFile');
-      if (currentBaseFileDiv) {
-        const currentBaseFile = currentBaseFileDiv.value;
-        fileSelect.update('baseFile', m.files);
-
-        const state = webviewState.get();
-        const storedBaseFile = state?.baseFile;
-
-        if (storedBaseFile && m.files.includes(storedBaseFile)) {
-          currentBaseFileDiv.value = storedBaseFile;
-        } else if (
-          m.preserveBaseFile &&
-          currentBaseFile &&
-          m.files.includes(currentBaseFile)
-        ) {
-          currentBaseFileDiv.value = currentBaseFile;
-        }
-
-        fileSelect.updateEdited(currentBaseFileDiv.value);
-      }
-      postHandle();
-    },
-  };
-
-  registerMessageHandlers(handlers);
-}
+export const messageHandlers = new MessageHandlers();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -23,26 +23,54 @@ import { FILE_TYPES } from './constants.js';
 export class MessageHandlers {
   constructor() {
     this._skipNextRestoreState = false;
+    this._cleanupFn = null;
+
+    // Cached DOM elements
+    this._instructionEl = null;
+
     this._handlers = {
-      // Theme & debug
+      ...this._createThemeHandlers(),
+      ...this._createStateHandlers(),
+      ...this._createInstructionHandlers(),
+      ...this._createRecordingHandlers(),
+      ...this._createSingleFileHandlers(),
+      ...this._createMultiFileHandlers(),
+      ...this._createMiscHandlers(),
+    };
+  }
+
+  _createThemeHandlers() {
+    return {
       setTheme: (m) => this.handleSetTheme(m),
       setDebugMode: (m) => this.handleSetDebugMode(m),
       modelSelected: (m) => this.handleModelSelected(m),
+    };
+  }
 
-      // State restoration
+  _createStateHandlers() {
+    return {
       restoreState: (m) => this.handleRestoreState(m),
       checkRestoredBaseFile: () => this.handleCheckRestoredBaseFile(),
+    };
+  }
 
-      // Instruction updates
+  _createInstructionHandlers() {
+    return {
       instructionTextPolished: (m) => this.handleInstructionTextPolished(m),
       instructionTextTranscribed: (m) =>
         this.handleInstructionTextTranscribed(m),
+    };
+  }
 
-      // Recording
+  _createRecordingHandlers() {
+    return {
       recordingStarted: () => this.handleRecordingStarted(),
       recordingError: () => this.handleRecordingError(),
+    };
+  }
 
-      // Single file updates
+  _createSingleFileHandlers() {
+    return {
       setInputFile: (m) => this.handleSetInputFile(m),
       setReferenceFile: (m) => this.handleSetReferenceFile(m),
       setAuxiliaryFile: (m) => this.handleSetAuxiliaryFile(m),
@@ -54,16 +82,22 @@ export class MessageHandlers {
       mediaFileSelected: (m) => this.handleMediaFileSelected(m),
       editedFileSelected: (m) => this.handleEditedFileSelected(m),
       setDefaultOutputFiles: (m) => this.handleSetDefaultOutputFiles(m),
+    };
+  }
 
-      // Multi-file updates
+  _createMultiFileHandlers() {
+    return {
       setInputFiles: (m) => this.handleSetInputFiles(m),
       setReferenceFiles: (m) => this.handleSetReferenceFiles(m),
       setAuxiliaryFiles: (m) => this.handleSetAuxiliaryFiles(m),
       setMediaFiles: (m) => this.handleSetMediaFiles(m),
       addMediaFile: (m) => this.handleAddMediaFile(m),
       setOutputFiles: (m) => this.handleSetOutputFiles(m),
+    };
+  }
 
-      // Misc updates
+  _createMiscHandlers() {
+    return {
       setRecentCommits: (m) => this.handleSetRecentCommits(m),
       setCurrentFile: (m) => this.handleSetCurrentFile(m),
       setOpenedFiles: (m) => this.handleSetOpenedFiles(m),
@@ -73,8 +107,15 @@ export class MessageHandlers {
 
   /** Register handlers and request initial data. */
   setup() {
-    registerMessageHandlers(this._handlers);
+    this._cleanupFn = registerMessageHandlers(this._handlers);
     this._initializeDataRequests();
+  }
+
+  cleanup() {
+    if (this._cleanupFn) {
+      this._cleanupFn();
+      this._cleanupFn = null;
+    }
   }
 
   /* ---------- Private helpers ---------- */
@@ -96,12 +137,22 @@ export class MessageHandlers {
 
   _handleStateRestoration(state) {
     console.log('Restoring state:', state);
+    const savedState = {};
+    this._restoreFormFields(state, savedState);
+    this._restoreFileArrays(state, savedState);
+    webviewState.set(savedState);
+    webviewState.restore();
+    this._skipNextRestoreState = true;
+  }
 
+  _restoreFormFields(state, savedState) {
     if (state.agent) safeSetElementValue('agent', state.agent);
     if (state.model) safeSetElementValue('model', state.model);
 
     const instructionContent = state.instruction || '';
-    const instruction = safeGetElementById('instruction');
+    const instruction =
+      this._instructionEl ||
+      (this._instructionEl = safeGetElementById('instruction'));
     if (instruction) {
       instruction.value = instructionContent;
       instruction.dispatchEvent(new Event('input'));
@@ -115,7 +166,7 @@ export class MessageHandlers {
     if (state.mediaFile) safeSetElementValue('mediaFile', state.mediaFile);
 
     const toolConfig = state.toolConfig || {};
-    const savedState = {
+    Object.assign(savedState, {
       agent: state.agent,
       model: state.model,
       instruction: instructionContent,
@@ -142,8 +193,10 @@ export class MessageHandlers {
       autoCompileInputPdf:
         state.autoCompileInputPdf ||
         (toolConfig ? toolConfig.autoCompileInputPdf : false),
-    };
+    });
+  }
 
+  _restoreFileArrays(state, savedState) {
     for (const fileType of FILE_TYPES) {
       const filesArray =
         state[`${fileType}Files`] ||
@@ -153,8 +206,6 @@ export class MessageHandlers {
         state[`${fileType}FilesActive`] ||
         state[`multiple${capitalize(fileType)}FilesActive`] ||
         false;
-      const toggleId = `toggle${capitalize(fileType)}Files`;
-      const containerId = `${fileType}FilesContainer`;
 
       const targetArrayName = `${fileType}Files`;
       const visibilityName = `${targetArrayName}Active`;
@@ -163,13 +214,10 @@ export class MessageHandlers {
 
       const multipleFilesId = `${fileType}Files`;
       const multipleFiles = safeGetElementById(multipleFilesId);
-      const existingFiles = multipleFiles
-        ? Array.from(multipleFiles.querySelectorAll('.file-item')).map(
-            (item) => item.dataset.path,
-          )
-        : [];
-
       if (filesArray.length > 0 || isVisible) {
+        const containerId = `${fileType}FilesContainer`;
+        const toggleId = `toggle${capitalize(fileType)}Files`;
+
         const container = safeGetElementById(containerId);
         if (container) {
           container.style.display = isVisible ? 'block' : 'none';
@@ -212,10 +260,6 @@ export class MessageHandlers {
         }
       }
     }
-
-    webviewState.set(savedState);
-    webviewState.restore();
-    this._skipNextRestoreState = true;
   }
 
   _postHandle() {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -27,6 +27,7 @@ export class MessageHandlers {
 
     // Cached DOM elements
     this._instructionEl = null;
+    this._elementCache = new Map();
     // Track file list event handlers for cleanup
     this._fileListHandlers = {};
 
@@ -107,9 +108,16 @@ export class MessageHandlers {
     };
   }
 
-  /** Register handlers and request initial data. */
-  setup() {
+  /** Register handlers and optionally request initial data. */
+  setup(options = {}) {
+    const { requestData = true } = options;
     this._cleanupFn = registerMessageHandlers(this._handlers);
+    if (requestData) {
+      this._initializeDataRequests();
+    }
+  }
+
+  requestInitialData() {
     this._initializeDataRequests();
   }
 
@@ -123,6 +131,7 @@ export class MessageHandlers {
     });
     this._fileListHandlers = {};
     this._instructionEl = null;
+    this._elementCache.clear();
   }
 
   /* ---------- Private helpers ---------- */
@@ -132,6 +141,18 @@ export class MessageHandlers {
     const icon = document.createElement('i');
     icon.className = isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS;
     element.appendChild(icon);
+  }
+
+  _createFileItem(file) {
+    const fileItem = document.createElement('div');
+    fileItem.className = 'file-item';
+    fileItem.dataset.path = file;
+    fileItem.textContent = file;
+    const removeButton = document.createElement('span');
+    removeButton.className = 'remove-button';
+    removeButton.textContent = '-';
+    fileItem.appendChild(removeButton);
+    return fileItem;
   }
 
   _setupFileListHandler(fileType, container) {
@@ -158,6 +179,13 @@ export class MessageHandlers {
     };
     container.addEventListener('click', handler);
     this._fileListHandlers[fileType] = { container, handler };
+  }
+
+  _getElement(id) {
+    if (!this._elementCache.has(id)) {
+      this._elementCache.set(id, safeGetElementById(id));
+    }
+    return this._elementCache.get(id);
   }
 
   _initializeDataRequests() {
@@ -193,7 +221,7 @@ export class MessageHandlers {
     const instructionContent = state.instruction || '';
     const instruction =
       this._instructionEl ||
-      (this._instructionEl = safeGetElementById('instruction'));
+      (this._instructionEl = this._getElement('instruction'));
     if (instruction) {
       instruction.value = instructionContent;
       instruction.dispatchEvent(new Event('input'));
@@ -254,27 +282,23 @@ export class MessageHandlers {
       savedState[visibilityName] = isVisible;
 
       const multipleFilesId = `${fileType}Files`;
-      const multipleFiles = safeGetElementById(multipleFilesId);
+      const multipleFiles = this._getElement(multipleFilesId);
       if (filesArray.length > 0 || isVisible) {
         const containerId = `${fileType}FilesContainer`;
         const toggleId = `toggle${capitalize(fileType)}Files`;
 
-        const container = safeGetElementById(containerId);
+        const container = this._getElement(containerId);
         if (container) {
           container.style.display = isVisible ? 'block' : 'none';
         }
 
-        const toggleElement = safeGetElementById(toggleId);
+        const toggleElement = this._getElement(toggleId);
         this._setToggleIcon(toggleElement, isVisible);
 
         if (filesArray.length > 0 && multipleFiles) {
           multipleFiles.innerHTML = '';
           filesArray.forEach((file) => {
-            const fileItem = document.createElement('div');
-            fileItem.className = 'file-item';
-            fileItem.dataset.path = file;
-            fileItem.innerHTML = `${file} <span class="remove-button">-</span>`;
-            multipleFiles.appendChild(fileItem);
+            multipleFiles.appendChild(this._createFileItem(file));
           });
           this._setupFileListHandler(fileType, multipleFiles);
         }
@@ -318,7 +342,7 @@ export class MessageHandlers {
   }
 
   handleCheckRestoredBaseFile() {
-    const restoredBaseFileDiv = safeGetElementById('baseFile');
+    const restoredBaseFileDiv = this._getElement('baseFile');
     if (restoredBaseFileDiv && restoredBaseFileDiv.value) {
       fileSelect.updateEdited(restoredBaseFileDiv.value);
     }
@@ -327,7 +351,7 @@ export class MessageHandlers {
 
   // Instruction updates
   handleInstructionTextPolished(message) {
-    const instruction = safeGetElementById('instruction');
+    const instruction = this._getElement('instruction');
     if (instruction && message.text) {
       instruction.value = message.text;
       vscode.postMessage({
@@ -340,7 +364,7 @@ export class MessageHandlers {
   }
 
   handleInstructionTextTranscribed(message) {
-    const instruction = safeGetElementById('instruction');
+    const instruction = this._getElement('instruction');
     if (instruction && message.text) {
       const startPos = instruction.selectionStart;
       const endPos = instruction.selectionEnd;
@@ -436,36 +460,30 @@ export class MessageHandlers {
   // Multi-file updates
   handleSetInputFiles(message) {
     fileList.update('inputFiles', 'toggleInputFiles', message.files);
-    this._setupFileListHandler('input', safeGetElementById('inputFiles'));
+    this._setupFileListHandler('input', this._getElement('inputFiles'));
     this._postHandle();
   }
 
   handleSetReferenceFiles(message) {
     fileList.update('referenceFiles', 'toggleReferenceFiles', message.files);
-    this._setupFileListHandler(
-      'reference',
-      safeGetElementById('referenceFiles'),
-    );
+    this._setupFileListHandler('reference', this._getElement('referenceFiles'));
     this._postHandle();
   }
 
   handleSetAuxiliaryFiles(message) {
     fileList.update('auxiliaryFiles', 'toggleAuxiliaryFiles', message.files);
-    this._setupFileListHandler(
-      'auxiliary',
-      safeGetElementById('auxiliaryFiles'),
-    );
+    this._setupFileListHandler('auxiliary', this._getElement('auxiliaryFiles'));
     this._postHandle();
   }
 
   handleSetMediaFiles(message) {
     fileList.update('mediaFiles', 'toggleMediaFiles', message.files);
-    this._setupFileListHandler('media', safeGetElementById('mediaFiles'));
+    this._setupFileListHandler('media', this._getElement('mediaFiles'));
     this._postHandle();
   }
 
   handleAddMediaFile(message) {
-    const listDiv = safeGetElementById('mediaFiles');
+    const listDiv = this._getElement('mediaFiles');
     const existingFiles = listDiv ? fileList.getSelected(listDiv) : [];
     fileList.update('mediaFiles', 'toggleMediaFiles', [
       ...existingFiles,
@@ -473,10 +491,10 @@ export class MessageHandlers {
     ]);
     this._setupFileListHandler('media', listDiv);
 
-    const container = safeGetElementById('mediaFilesContainer');
+    const container = this._getElement('mediaFilesContainer');
     if (container && container.style.display === 'none') {
       container.style.display = 'block';
-      const toggleIcon = safeGetElementById('toggleMediaFiles');
+      const toggleIcon = this._getElement('toggleMediaFiles');
       this._setToggleIcon(toggleIcon, true);
     }
 
@@ -485,7 +503,7 @@ export class MessageHandlers {
 
   handleSetOutputFiles(message) {
     fileList.update('outputFiles', 'toggleOutputFiles', message.files);
-    this._setupFileListHandler('output', safeGetElementById('outputFiles'));
+    this._setupFileListHandler('output', this._getElement('outputFiles'));
     this._postHandle();
   }
 
@@ -512,7 +530,7 @@ export class MessageHandlers {
 
       let filesToAdd = message.files ?? [];
       if (message.shouldFilter) {
-        const singleFileSelect = safeGetElementById(singleFileId);
+        const singleFileSelect = this._getElement(singleFileId);
         if (singleFileSelect && singleFileSelect.value) {
           filesToAdd = filesToAdd.filter((f) => f !== singleFileSelect.value);
         }
@@ -524,7 +542,7 @@ export class MessageHandlers {
   }
 
   handleSetBaseFile(message) {
-    const currentBaseFileDiv = safeGetElementById('baseFile');
+    const currentBaseFileDiv = this._getElement('baseFile');
     if (currentBaseFileDiv) {
       const currentBaseFile = currentBaseFileDiv.value;
       fileSelect.update('baseFile', message.files);

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -6,18 +6,17 @@ import {
   toggleManager,
 } from './modules/uiHandlers.js';
 
-// Initialize data requests when window loads
-window.onload = function () {
-  messageHandlers.setup();
+// Register handlers immediately so early messages aren't missed
+messageHandlers.setup();
 
-  // Set default state for new folders
-  webviewState.restore();
-
-  instructionManager.init();
-};
+window.addEventListener('beforeunload', () => {
+  messageHandlers.cleanup();
+});
 
 // Setup UI when DOM is loaded
 document.addEventListener('DOMContentLoaded', function () {
+  webviewState.restore();
+  instructionManager.init();
   setupUIHandlers();
   toggleManager.updateToolConfigToggleState();
   toggleManager.updateAutoToggleState();

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -1,9 +1,5 @@
 import { webviewState } from './modules/webviewState.js';
-import { vscode } from '@common/webviewContext.js';
-import {
-  setupMessageHandlers,
-  initializeDataRequests,
-} from './modules/messageHandlers.js';
+import { messageHandlers } from './modules/messageHandlers.js';
 import {
   setupUIHandlers,
   instructionManager,
@@ -12,16 +8,13 @@ import {
 
 // Initialize data requests when window loads
 window.onload = function () {
-  initializeDataRequests();
+  messageHandlers.setup();
 
   // Set default state for new folders
   webviewState.restore();
 
   instructionManager.init();
 };
-
-// Setup message handlers
-setupMessageHandlers();
 
 // Setup UI when DOM is loaded
 document.addEventListener('DOMContentLoaded', function () {

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -7,7 +7,7 @@ import {
 } from './modules/uiHandlers.js';
 
 // Register handlers immediately so early messages aren't missed
-messageHandlers.setup();
+messageHandlers.setup({ requestData: false });
 
 window.addEventListener('beforeunload', () => {
   messageHandlers.cleanup();
@@ -21,4 +21,5 @@ document.addEventListener('DOMContentLoaded', function () {
   toggleManager.updateToolConfigToggleState();
   toggleManager.updateAutoToggleState();
   toggleManager.setupDocumentListeners();
+  messageHandlers.requestInitialData();
 });


### PR DESCRIPTION
## Summary
- reorganize message handler module into a class
- provide setup() to register command handlers and request initial data
- call the new setup method from the webview script

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test requires additional environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_685b12911af88324a50af7adcecef724