### PR TITLE
Fix rename error handling

### DIFF
--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -203,7 +203,11 @@ export class ExplorerOperations {
       try {
         await AbsoluteFS.rename(oldPath, newPath, { overwrite: false });
       } catch (err: any) {
-        if (err?.code === 'ENOENT') {
+        const fileNotFound =
+          err?.code === 'ENOENT' ||
+          (err instanceof vscode.FileSystemError &&
+            err.code === 'FileNotFound');
+        if (fileNotFound) {
           try {
             if (
               item.collapsibleState === vscode.TreeItemCollapsibleState.None


### PR DESCRIPTION
## Summary
- handle VS Code `FileSystemError` when attempting to rename nonexistent items

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685b205c90788324aa8d4e0ced1a0775