### PR TITLE
Refactor LaTeX formatter config lookup

### DIFF
--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -2,7 +2,6 @@
 import * as path from 'path';
 
 // Third-party imports
-import * as vscode from 'vscode';
 import { sync as globSync } from 'glob';
 
 // Local imports - log
@@ -10,6 +9,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
+import { getConfig } from '@utils/config';
 import { executeCommand } from '@utils/system';
 import { sleep } from '@utils/helpers';
 import { checkToolInstalled } from '@utils/system';
@@ -31,8 +31,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     }
 
     // Get latexindent config from settings
-    const config = vscode.workspace.getConfiguration('texra.latex');
-    const latexindentConfig = config.get<string>('latexindentConfig');
+    const latexindentConfig = getConfig<string>('latex.latexindentConfig');
 
     // Build command array - note we're using -w (overwrite) and -s (silent)
     const command = ['latexindent', '-w', '-s'];

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -1,10 +1,8 @@
-// Third-party imports
-import * as vscode from 'vscode';
-
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
+import { getConfig } from '@utils/config';
 import { executeCommand, checkToolInstalled } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
@@ -16,8 +14,7 @@ export async function runTexFmt(filePath: string): Promise<boolean> {
       return false;
     }
 
-    const config = vscode.workspace.getConfiguration('texra.latex');
-    const texfmtConfig = config.get<string>('texfmtConfig');
+    const texfmtConfig = getConfig<string>('latex.texfmtConfig');
 
     const command = ['tex-fmt'];
     if (texfmtConfig) {


### PR DESCRIPTION
## Summary
- use `getConfig` in `latexindentpt.ts` and `texfmt.ts`
- drop direct `vscode.workspace.getConfiguration` calls

## Testing
- `npm run lint`
- `npm test` *(fails: vscode-test output but no results)*

------
https://chatgpt.com/codex/tasks/task_e_685be865ca8c83249f8a8e61dbc03f2b