### PR TITLE
feat: introduce output/model handler interfaces

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -44,7 +44,11 @@ import {
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import { ModelHandler } from '@agent/modelHandlers';
-import { OutputHandler, NamedOutputFile } from '@agent/runtime/OutputHandler';
+import {
+  OutputHandler,
+  NamedOutputFile,
+  IOutputHandler,
+} from '@agent/runtime/OutputHandler';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { createInfoSpan } from '@agent/modelHandlers/streamUtils';
@@ -69,7 +73,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   protected useScratchpad: boolean = false;
   protected logId: number = 0;
   /** Handler for output file processing and validation. */
-  protected outputHandler: OutputHandler;
+  protected outputHandler: IOutputHandler;
 
   constructor(
     modelHandler: ModelHandler,

--- a/src/agent/modelHandlers/index.ts
+++ b/src/agent/modelHandlers/index.ts
@@ -2,6 +2,7 @@
 
 // Base class
 export { ModelHandler } from './ModelHandler';
+export type { IModelHandler } from './types/IModelHandler';
 
 // Specific model handler implementations
 export { ModelHandlerAnthropic } from './modelHandlerAnthropic';

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -1,0 +1,110 @@
+import type { AgentConfig } from '../core/AgentConfig';
+import type { AgentSetting } from '../core/AgentDataclass';
+import type { AgentStateRound } from '../core/AgentState';
+import type { ToolState } from '../core/ToolState';
+import type { MediaEntry } from '@agent/utils/mediaTypes';
+import type { ModelConfig, ModelCapabilities } from '@model/ModelConfig';
+import type { ProviderStopReason } from './StopReasonTypes';
+
+/**
+ * Contract implemented by all model handlers.
+ */
+export interface IModelHandler {
+  /** Model configuration */
+  config: ModelConfig;
+  /** Capability information for the model */
+  capabilities: ModelCapabilities;
+  /** Max number of continue calls per round */
+  continueLimit: number;
+  /** Max input tokens allowed */
+  inputTokenLimit: number;
+  /** Factor for output token limit relative to input */
+  maxOutputTokensFactor: number;
+
+  /** Whether the provider uses an OpenAI compatible API */
+  readonly isOpenaiCompatible: boolean;
+  /** True if the model is from Anthropic */
+  readonly isAnthropic: boolean;
+  /** True if the model is from OpenAI */
+  readonly isOpenai: boolean;
+  /** True if the model is from Google */
+  readonly isGoogle: boolean;
+  /** True if the model is a full O-Reasoning model */
+  readonly isOReasoningModelFull: boolean;
+  /** True if the model is any O-Reasoning model */
+  readonly isOReasoningModel: boolean;
+
+  // Abstract methods from ModelHandler
+  getClient(): Promise<any>;
+  createResponse(
+    client: any,
+    messages: any[],
+    temperature: number,
+    systemPrompt?: string,
+    endTag?: string,
+    signal?: AbortSignal,
+  ): Promise<any>;
+  initializeMessages(
+    userPrefix: string,
+    userRequest: string,
+    mediaFiles?: string[],
+    systemPrompt?: string,
+  ): Promise<any[]>;
+  createRoundMessages(
+    messages: any[],
+    userMessage: string,
+    mediaFiles?: string[],
+  ): Promise<any[]>;
+  createMediaContent(mediaMessage: MediaEntry[]): any[];
+  extractResponse(
+    responseObject: any,
+    endTag: string,
+  ): [string, any, ProviderStopReason];
+  addContinueMessageWithPrefill(
+    messages: any[],
+    stateRound: AgentStateRound,
+    toolState: ToolState,
+    agentSetting: AgentSetting,
+    agentConfig: AgentConfig,
+  ): void;
+  addContinueMessageWithoutPrefill(
+    messages: any[],
+    stateRound: AgentStateRound,
+    toolState: ToolState,
+    agentSetting: AgentSetting,
+    agentConfig: AgentConfig,
+  ): void;
+  initializeOutputAndPrefill(
+    agentConfig: AgentConfig,
+    agentSetting: AgentSetting,
+    messages: any[],
+    toolState: ToolState,
+    outputFile: string,
+    prefill: string,
+    groupId?: string,
+  ): Promise<[boolean, any[]]>;
+  computePrice(responseUsage: any): number;
+  computeResponseUsage(responseUsage: any, responseTime: number): any;
+  updateMessageContentWithPrefill(
+    messages: any[],
+    bestConnector: string,
+    newResponse: string,
+    toolState: ToolState,
+  ): void;
+  updateMessageContentWithoutPrefill(
+    messages: any[],
+    bestConnector: string,
+    newResponse: string,
+    toolState: ToolState,
+  ): void;
+  shouldContinue(
+    stopReason: ProviderStopReason,
+    newResponse: string,
+    agentSetting: AgentSetting,
+  ): boolean;
+  processThinkingBlock(
+    responseObject: any,
+    groupId?: string,
+    toolState?: ToolState,
+  ): string | null;
+}

--- a/src/agent/runtime/OutputHandler/IOutputHandler.ts
+++ b/src/agent/runtime/OutputHandler/IOutputHandler.ts
@@ -1,0 +1,29 @@
+import type { AgentStateGlobal } from '@agent/core/AgentState';
+import type { NamedOutputFile } from './types';
+
+/**
+ * Public API surface for {@link OutputHandler}.
+ */
+export interface IOutputHandler {
+  /** Mapping of round index to output file paths. */
+  outputFiles: { [key: number]: string[] };
+  /** Mapping of round index to named output files. */
+  outputMappings: { [key: number]: NamedOutputFile[] };
+
+  startProcessing(processName: string, roundGroupId?: string): Promise<string>;
+  endProcessing(status?: 'error' | 'stopped', groupId?: string): void;
+  indentLatexFile(filePath: string): Promise<void>;
+  indentLatexFiles(filePaths: string[]): Promise<void>;
+  processXmlContent(content: string): Promise<string>;
+  handleLatexdiffofOutput(currRound: number, groupId?: string): Promise<void>;
+  processSingleXmlOutput(outputFile: string): Promise<NamedOutputFile>;
+  processMultipleXmlOutputs(outputFile: string): Promise<NamedOutputFile[]>;
+  ensureCorrectXmlStructure(
+    filePath: string,
+    documentTag: string,
+  ): Promise<void>;
+  printStatistics(
+    stateGlobal: AgentStateGlobal,
+    groupId?: string,
+  ): Promise<void>;
+}

--- a/src/agent/runtime/OutputHandler/StatisticsReporter.ts
+++ b/src/agent/runtime/OutputHandler/StatisticsReporter.ts
@@ -1,10 +1,11 @@
 import { AgentLogger } from '@logger/AgentLogger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { AgentStateGlobal } from '@agent/core/AgentState';
+import type { IModelHandler } from '@agent/modelHandlers';
 
 export class StatisticsReporter {
   constructor(
-    private readonly modelHandler: any,
+    private readonly modelHandler: IModelHandler,
     private readonly channel: string,
     private readonly logger: AgentLogger,
   ) {}

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -8,20 +8,22 @@ import { XmlOutputManager } from './XmlOutputManager';
 import { LatexDiffManager } from './LatexDiffManager';
 import { StatisticsReporter } from './StatisticsReporter';
 import { NamedOutputFile } from './types';
+import type { IOutputHandler } from './IOutputHandler';
 import { getOutputFileName } from '@utils/outputFileUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
+import type { IModelHandler } from '@agent/modelHandlers';
 
 // Local imports - types
 
 /** Handles output file processing and validation for agent responses. */
-export class OutputHandler {
+export class OutputHandler implements IOutputHandler {
   public agentSetting: AgentSetting;
   public agentConfig: AgentConfig;
-  public modelHandler: any;
+  public modelHandler: IModelHandler;
   public logId: number;
   public outputFiles: { [key: number]: string[] };
   public outputMappings: { [key: number]: NamedOutputFile[] };
@@ -36,7 +38,7 @@ export class OutputHandler {
   constructor(
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
-    modelHandler: any,
+    modelHandler: IModelHandler,
     logId: number,
     baseFiles: string[] = [],
     logger?: AgentLogger,
@@ -203,3 +205,4 @@ export class OutputHandler {
 
 export { NamedOutputFile };
 export { getOutputFileName } from '@utils/outputFileUtils';
+export type { IOutputHandler } from './IOutputHandler';


### PR DESCRIPTION
## Summary
- define `IModelHandler` capturing properties and abstract methods from `ModelHandler`
- export the interface via modelHandlers index
- add `IOutputHandler` interface and implement it in `OutputHandler`
- type `StatisticsReporter` and `BaseReflectionAgent` against the new interfaces

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685be9d5736083248a4e9da84623b2f7