### PR TITLE
Check pdflatex before LaTeX compile

### DIFF
--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { executeCommand } from '@utils/system';
+import { executeCommand, checkToolInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 // No additional imports needed
@@ -30,6 +30,11 @@ export async function compileLatex2Pdf(
   channel: string = CHANNEL,
   outputDirectory?: string,
 ): Promise<boolean> {
+  // Ensure pdflatex is available before attempting compilation
+  if (!(await checkToolInstalled('pdflatex'))) {
+    return false;
+  }
+
   try {
     const outDir = outputDirectory || path.dirname(latexFile);
     await WorkspaceFS.createDir(outDir);


### PR DESCRIPTION
## Summary
- verify `pdflatex` is installed before running `compileLatex2Pdf`

## Testing
- `npm run lint`
- `npm test` *(fails to run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_685be8fcea608324977f30a172dd4cd2