### PR TITLE
fix: allow overwrite when moving files

### DIFF
--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -142,7 +142,7 @@ export class WorkspaceFS {
         return;
       }
 
-      await vscode.workspace.fs.rename(sourceUri, destUri);
+      await vscode.workspace.fs.rename(sourceUri, destUri, { overwrite: true });
       logger.info(CHANNEL, `Successfully moved: ${source} to ${destination}`);
     } catch (err) {
       await showLoggedErrorMessage(


### PR DESCRIPTION
## Summary
- allow overwriting destination when moving files

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test not executed in container)*

------
https://chatgpt.com/codex/tasks/task_e_685c02bac6848324ba72562a9caae3e4