### PR TITLE
Refactor webview handlers into dedicated managers

### DIFF
--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -41,7 +41,7 @@ export class WebviewMessageHandler {
     this.settingsManager = new SettingsManager();
     this.recordingManager = new RecordingManager(context);
     this.fileManager = new FileManager(context);
-    this.executionManager = new ExecutionManager(this.fileManager);
+    this.executionManager = new ExecutionManager();
     this.diffManager = new DiffManager();
     this.instructionManager = new InstructionManager(context);
     this.handlers = {

--- a/src/webview/MessageHandler.ts
+++ b/src/webview/MessageHandler.ts
@@ -1,51 +1,27 @@
 // Standard library imports
-import * as path from 'path';
-
 // Third-party imports
 import * as vscode from 'vscode';
-import { workspace } from 'vscode';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
 // Local imports - utils
 import { safeExecuteCommand } from '@utils/system';
-import {
-  showLoggedErrorMessage,
-  showLoggedMessage,
-} from '@utils/errorHandlingUtils';
+import { getConfig } from '@utils/config';
 
 // Local imports - utilities
-import { WorkspaceFS, StorageFS } from '@utils/files';
-import {
-  isPastedImage,
-  getPastedImageFullPath,
-  PASTED_DIR,
-} from '@utils/files/pastedImageUtils';
 import { capitalize, uncapitalize } from '@frontend/ui/messageUtils';
-import { getConfig } from '@utils/config';
-import {
-  listInputFiles,
-  listReferenceFiles,
-  listAuxiliaryFiles,
-  listMediaFiles,
-  listEditedFiles,
-} from '@frontend/files/fileLister';
-import { getFilesIfNotEmpty } from '@frontend/files/listing';
-import {
-  polishTextWithAI,
-  FileContext,
-} from '@utils/text/textEnhancementUtils';
-import { sleep } from '@utils/helpers';
 // Local imports - managers
-import { SettingsManager } from './managers/SettingsManager';
-import { RecordingManager } from './managers/RecordingManager';
+import {
+  SettingsManager,
+  RecordingManager,
+  FileManager,
+  ExecutionManager,
+  DiffManager,
+  InstructionManager,
+} from './managers';
 
 // Local imports - agent
-import { ToolConfig } from '@agent/core/ToolConfig';
-import { AgentConfig } from '@agent/core/AgentConfig';
-import { getAgentPath } from '@agent/runtime/executeAgent';
-import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 
 const CHANNEL = 'MessageHandler';
 
@@ -56,113 +32,123 @@ export class WebviewMessageHandler {
   >;
   private readonly settingsManager: SettingsManager;
   private readonly recordingManager: RecordingManager;
+  private readonly fileManager: FileManager;
+  private readonly executionManager: ExecutionManager;
+  private readonly diffManager: DiffManager;
+  private readonly instructionManager: InstructionManager;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this.settingsManager = new SettingsManager();
     this.recordingManager = new RecordingManager(context);
-    // Defer the cleanup operation to avoid potential race conditions
-    // This gives time for StorageFS to be properly initialized
-    setTimeout(() => {
-      StorageFS.ensureDir(PASTED_DIR)
-        .then(() => {
-          return StorageFS.cleanupOldFiles(PASTED_DIR, 3 * 24 * 60 * 60 * 1000);
-        })
-        .catch((e) =>
-          logger.warn(
-            CHANNEL,
-            `Error during initial cleanup: ${e instanceof Error ? e.message : String(e)}`,
-          ),
-        );
-    }, 100);
+    this.fileManager = new FileManager(context);
+    this.executionManager = new ExecutionManager(this.fileManager);
+    this.diffManager = new DiffManager();
+    this.instructionManager = new InstructionManager(context);
     this.handlers = {
       showInformationMessage: (message) => this.handleInfoMessage(message),
       getTheme: (_m, view) => this.handleThemeRequest(view),
       getDebugMode: (_m, view) => this.handleDebugModeRequest(view),
       modelSelected: (message, view) =>
         this.handleModelSelection(message, view),
-      execute: (message) => this.handleExecute(message),
-      merge: (message) => this.handleMerge(message),
-      compare: (message) => this.handleCompare(message),
-      acceptEdited: (message) => this.handleAcceptEdited(message),
+      execute: (message) => this.executionManager.handleExecute(message),
+      merge: (message) => this.executionManager.handleMerge(message),
+      compare: (message) => this.executionManager.handleCompare(message),
+      acceptEdited: (message) =>
+        this.executionManager.handleAcceptEdited(message),
       // File selection cases
       selectInputFile: (message, view) =>
-        this.handleFileSelection(message, view),
+        this.fileManager.handleFileSelection(message, view),
       selectReferenceFile: (message, view) =>
-        this.handleFileSelection(message, view),
+        this.fileManager.handleFileSelection(message, view),
       selectAuxiliaryFile: (message, view) =>
-        this.handleFileSelection(message, view),
+        this.fileManager.handleFileSelection(message, view),
       selectMediaFile: (message, view) =>
-        this.handleFileSelection(message, view),
-      selectEditedFile: (_m, view) => this.handleEditedFileSelection(view),
+        this.fileManager.handleFileSelection(message, view),
+      selectEditedFile: (_m, view) =>
+        this.fileManager.handleEditedFileSelection(view),
       // File selected cases
       inputFileSelected: (message, view) =>
-        this.handleInputFileSelected(message, view),
+        this.fileManager.handleInputFileSelected(message, view),
       referenceFileSelected: (message) =>
-        this.handleGenericFileSelected(message),
+        this.fileManager.handleGenericFileSelected(message),
       auxiliaryFileSelected: (message) =>
-        this.handleGenericFileSelected(message),
-      mediaFileSelected: (message) => this.handleGenericFileSelected(message),
-      editedFileSelected: (message) => this.handleGenericFileSelected(message),
+        this.fileManager.handleGenericFileSelected(message),
+      mediaFileSelected: (message) =>
+        this.fileManager.handleGenericFileSelected(message),
+      editedFileSelected: (message) =>
+        this.fileManager.handleGenericFileSelected(message),
       // Request file cases
-      requestInputFile: (_m, view) => this.handleRequestInputFile(view),
+      requestInputFile: (_m, view) =>
+        this.fileManager.handleRequestInputFile(view),
       requestReferenceFile: (message, view) =>
-        this.handleRequestFile(message, view),
+        this.fileManager.handleRequestFile(message, view),
       requestAuxiliaryFile: (message, view) =>
-        this.handleRequestFile(message, view),
+        this.fileManager.handleRequestFile(message, view),
       requestMediaFile: (message, view) =>
-        this.handleRequestFile(message, view),
+        this.fileManager.handleRequestFile(message, view),
       requestEditedFile: (message, view) =>
-        this.handleRequestEditedFile(message, view),
-      requestBaseFile: (_m, view) => this.handleRequestBaseFile(view),
+        this.fileManager.handleRequestEditedFile(message, view),
+      requestBaseFile: (_m, view) =>
+        this.fileManager.handleRequestBaseFile(view),
       requestDefaultOutputFiles: (message, view) =>
-        this.handleRequestDefaultOutputFiles(message, view),
+        this.fileManager.handleRequestDefaultOutputFiles(message, view),
       // Handle file list updates from webview
       updateInputFiles: (message, view) =>
-        this.handleUpdateFiles(message, view),
+        this.fileManager.handleUpdateFiles(message, view),
       updateReferenceFiles: (message, view) =>
-        this.handleUpdateFiles(message, view),
+        this.fileManager.handleUpdateFiles(message, view),
       updateAuxiliaryFiles: (message, view) =>
-        this.handleUpdateFiles(message, view),
+        this.fileManager.handleUpdateFiles(message, view),
       updateMediaFiles: (message, view) =>
-        this.handleUpdateFiles(message, view),
+        this.fileManager.handleUpdateFiles(message, view),
       updateOutputFiles: (message, view) =>
-        this.handleUpdateFiles(message, view),
+        this.fileManager.handleUpdateFiles(message, view),
       // Multiple file selection cases
       setInputFiles: (message, view) =>
-        this.handleSetMultipleFiles(message, view),
+        this.fileManager.handleSetMultipleFiles(message, view),
       setReferenceFiles: (message, view) =>
-        this.handleSetMultipleFiles(message, view),
+        this.fileManager.handleSetMultipleFiles(message, view),
       setAuxiliaryFiles: (message, view) =>
-        this.handleSetMultipleFiles(message, view),
+        this.fileManager.handleSetMultipleFiles(message, view),
       setMediaFiles: (message, view) =>
-        this.handleSetMultipleFiles(message, view),
+        this.fileManager.handleSetMultipleFiles(message, view),
       selectMultipleFiles: (message, view) =>
-        this.handleSelectMultipleFiles(message, view),
-      refreshAllFiles: (_m, view) => this.handleRefreshAllFiles(view),
+        this.fileManager.handleSelectMultipleFiles(message, view),
+      refreshAllFiles: (_m, view) =>
+        this.fileManager.handleRefreshAllFiles(view),
       // Housekeeping cases
-      cleanOutput: (message) => this.handleHousekeeping(message),
-      cleanBuild: (message) => this.handleHousekeeping(message),
-      indentTeX: (message) => this.handleHousekeeping(message),
-      packSingle: (message) => this.handleSingleOperation(message),
-      cleanSingle: (message) => this.handleSingleOperation(message),
-      packMultiple: (message) => this.handleMultipleOperation(message),
-      cleanMultiple: (message) => this.handleMultipleOperation(message),
+      cleanOutput: (message) =>
+        this.executionManager.handleHousekeeping(message),
+      cleanBuild: (message) =>
+        this.executionManager.handleHousekeeping(message),
+      indentTeX: (message) => this.executionManager.handleHousekeeping(message),
+      packSingle: (message) =>
+        this.executionManager.handleSingleOperation(message),
+      cleanSingle: (message) =>
+        this.executionManager.handleSingleOperation(message),
+      packMultiple: (message) =>
+        this.executionManager.handleMultipleOperation(message),
+      cleanMultiple: (message) =>
+        this.executionManager.handleMultipleOperation(message),
       // Latex diff cases
-      latexdiff: (message) => this.handleLatexdiff(message),
-      latexdiffvc: (message) => this.handleLatexdiffvc(message),
-      requestRecentCommits: (_m, view) => this.handleRequestRecentCommits(view),
-      refreshCommits: (_m, view) => this.handleRefreshCommits(view),
-      packLatexdiffvc: (message) => this.handleLatexdiffvcOperation(message),
-      cleanLatexdiffvc: (message) => this.handleLatexdiffvcOperation(message),
+      latexdiff: (message) => this.diffManager.handleLatexdiff(message),
+      latexdiffvc: (message) => this.diffManager.handleLatexdiffvc(message),
+      requestRecentCommits: (_m, view) =>
+        this.diffManager.handleRequestRecentCommits(view),
+      refreshCommits: (_m, view) => this.diffManager.handleRefreshCommits(view),
+      packLatexdiffvc: (message) =>
+        this.diffManager.handleLatexdiffvcOperation(message),
+      cleanLatexdiffvc: (message) =>
+        this.diffManager.handleLatexdiffvcOperation(message),
       // VS Code logic cases
       getCurrentFile: (message, view) =>
-        this.handleGetCurrentFile(message, view),
+        this.fileManager.handleGetCurrentFile(message, view),
       addOpenedFiles: (message, view) =>
-        this.handleAddOpenedFiles(message.fileType, view),
+        this.fileManager.handleAddOpenedFiles(message.fileType, view),
       polishInstructionText: (message, view) =>
-        this.handlePolishInstructionText(message, view),
+        this.instructionManager.handlePolishInstructionText(message, view),
       transcribeInstruction: (_m, view) =>
-        this.handleTranscribeInstruction(view),
+        this.instructionManager.handleTranscribeInstruction(view),
       startRecording: (_m, view) => this.recordingManager.start(view),
       stopRecording: (_m, view) => this.recordingManager.stop(view),
       showAgentHistory: () => this.handleShowAgentHistory(),
@@ -170,7 +156,7 @@ export class WebviewMessageHandler {
       openAgentSettings: () => this.settingsManager.openAgentSettings(),
       openModelSettings: () => this.settingsManager.openModelSettings(),
       clipboardImage: (message, view) =>
-        this.handleClipboardImage(message, view),
+        this.instructionManager.handleClipboardImage(message, view),
     };
   }
 
@@ -207,723 +193,6 @@ export class WebviewMessageHandler {
         command: 'modelSelected',
         model: message.model,
       });
-    }
-  }
-
-  private async handleExecute(message: any) {
-    if (message.inputFile) {
-      const toolConfig: ToolConfig = {
-        // Auto extract settings
-        autoExtractFigure: message.autoExtractFigure,
-        autoExtractTikzFigure: message.autoExtractTikzFigure,
-        // Tool config settings
-        reflect: message.reflect,
-        attachTeXCount: message.attachTeXCount,
-        usePrefillFromInput: message.usePrefillFromInput,
-        printInputPrompt: message.printInputPrompt,
-        autoCompileInputPdf: message.autoCompileInputPdf,
-      };
-
-      const mapMediaPath = (f: string | null): string | null => {
-        if (!f) return null;
-        if (isPastedImage(f)) {
-          return getPastedImageFullPath(f);
-        }
-        return f;
-      };
-
-      const agentConfig: AgentConfig = {
-        agent: message.agent,
-        model: message.model,
-        instruction: message.instruction,
-        inputFile: message.inputFile,
-        inputFiles: getFilesIfNotEmpty(message.inputFiles),
-        referenceFile: message.referenceFile,
-        referenceFiles: getFilesIfNotEmpty(message.referenceFiles),
-        auxiliaryFile: message.auxiliaryFile,
-        auxiliaryFiles: getFilesIfNotEmpty(message.auxiliaryFiles),
-        mediaFile: mapMediaPath(message.mediaFile),
-        mediaFiles: message.mediaFiles
-          ? getFilesIfNotEmpty(
-              message.mediaFiles
-                .map(mapMediaPath)
-                .filter((f: string | null): f is string => f !== null),
-            )
-          : null,
-        outputFiles: getFilesIfNotEmpty(message.outputFiles),
-        editedFile: null,
-        toolConfig,
-      };
-
-      await vscode.commands.executeCommand('texra.execute', agentConfig);
-    } else {
-      vscode.window.showErrorMessage('Please select an input file.');
-    }
-  }
-
-  private async handleMerge(message: any) {
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.baseFile,
-      message.editedFile,
-    );
-  }
-
-  private async handleCompare(message: any) {
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.baseFile,
-      message.editedFile,
-    );
-  }
-
-  private async handleAcceptEdited(message: any) {
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.baseFile,
-      message.editedFile,
-    );
-  }
-
-  private async handleFileSelection(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    const singleFileType = message.command.replace('select', '');
-    logger.debug(CHANNEL, `Selecting ${singleFileType}`);
-
-    const file = await vscode.commands.executeCommand<string>(
-      `texra.${message.command}`,
-    );
-    if (file) {
-      logger.debug(CHANNEL, `Selected ${singleFileType}: ${file}`);
-      webviewView.webview.postMessage({
-        command: `${uncapitalize(singleFileType)}Selected`,
-        filePath: file,
-      });
-    }
-  }
-
-  private async handleEditedFileSelection(webviewView: vscode.WebviewView) {
-    const editedFile = await vscode.commands.executeCommand<string>(
-      'texra.selectEditedFile',
-    );
-    if (editedFile) {
-      webviewView.webview.postMessage({
-        command: 'editedFileSelected',
-        filePath: editedFile,
-      });
-    }
-  }
-
-  private async handleInputFileSelected(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    // vscode.window.showInformationMessage(`Selected file: ${message.filePath}`);
-    const baseFileNameForInput = path.basename(
-      message.filePath,
-      path.extname(message.filePath),
-    );
-    const filteredEditedFiles = await listEditedFiles(baseFileNameForInput);
-    this.postFileUpdate(webviewView, 'Edited', filteredEditedFiles);
-  }
-
-  private handleGenericFileSelected(message: any) {
-    vscode.window.showInformationMessage(
-      `${message.command}: ${message.filePath}`,
-    );
-  }
-
-  private async handleRequestInputFile(webviewView: vscode.WebviewView) {
-    const refreshedInputFiles =
-      (await vscode.commands.executeCommand<string[]>(
-        'texra.refreshInputFiles',
-      )) || [];
-    this.postFileUpdate(webviewView, 'Input', refreshedInputFiles);
-  }
-
-  private async handleRequestFile(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    const fileType = message.command.replace('request', '').replace('File', '');
-    const files = await (async () => {
-      switch (fileType) {
-        case 'Reference':
-          return await listReferenceFiles();
-        case 'Auxiliary':
-          return await listAuxiliaryFiles();
-        case 'Media':
-          return await listMediaFiles();
-        default:
-          return [];
-      }
-    })();
-    this.postFileUpdate(webviewView, fileType, files);
-  }
-
-  private async handleRequestEditedFile(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    let allEditedFiles: string[] = [];
-    if (message.baseFile) {
-      const baseFileNameForEdited = path.basename(
-        message.baseFile,
-        path.extname(message.baseFile),
-      );
-      allEditedFiles = await listEditedFiles(baseFileNameForEdited);
-    }
-    this.postFileUpdate(webviewView, 'Edited', allEditedFiles);
-  }
-
-  private async handleRequestBaseFile(webviewView: vscode.WebviewView) {
-    this.postFileUpdate(webviewView, 'Base', await listInputFiles());
-  }
-
-  private async handleRequestDefaultOutputFiles(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    const agent = message.agent;
-    if (!agent) {
-      webviewView.webview.postMessage({
-        command: 'setDefaultOutputFiles',
-        files: [],
-      });
-      return;
-    }
-
-    try {
-      const agentPath = await getAgentPath(agent, this.context);
-      const [settings] = await loadAgentSettingAndPrompts(agentPath, agent);
-
-      const files = Array.isArray(settings?.defaultOutputFiles)
-        ? settings.defaultOutputFiles
-        : [];
-
-      webviewView.webview.postMessage({
-        command: 'setDefaultOutputFiles',
-        files,
-      });
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error requesting default output files: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      // Send fallback message so the webview clears any stale defaults
-      webviewView.webview.postMessage({
-        command: 'setDefaultOutputFiles',
-        files: [],
-      });
-    }
-  }
-
-  private handleSetMultipleFiles(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    if (message.files?.length > 0) {
-      webviewView.webview.postMessage({
-        command: message.command,
-        files: message.files,
-      });
-    }
-  }
-
-  private async handleSelectMultipleFiles(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    const fileType = message.fileType;
-    let selectedFiles: string[] | null = null;
-
-    try {
-      if (fileType === 'OutputFiles') {
-        selectedFiles = await this.selectOutputFiles(message.currentFile);
-      } else {
-        const currentFileForMultiple = message.currentFile;
-        // Extract the base type without the 'Files' suffix
-        const baseType = fileType.replace('Files', '');
-
-        selectedFiles = await vscode.commands.executeCommand<string[]>(
-          `texra.select${baseType}Files`,
-          currentFileForMultiple,
-        );
-
-        if (selectedFiles === undefined) {
-          console.warn(
-            `Command texra.select${baseType}Files returned undefined`,
-          );
-          selectedFiles = null;
-        }
-      }
-
-      if (selectedFiles) {
-        webviewView.webview.postMessage({
-          command: `set${fileType}`,
-          files: selectedFiles,
-        });
-      }
-    } catch (error) {
-      logger.error(
-        CHANNEL,
-        `Error in handleSelectMultipleFiles: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      vscode.window.showErrorMessage(
-        `Error selecting ${fileType}: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-    }
-  }
-
-  private async handleRefreshAllFiles(webviewView: vscode.WebviewView) {
-    const refreshedFiles = {
-      input: await listInputFiles(),
-      reference: await listReferenceFiles(),
-      auxiliary: await listAuxiliaryFiles(),
-      media: await listMediaFiles(),
-    };
-
-    Object.entries(refreshedFiles).forEach(([type, files]) => {
-      this.postFileUpdate(webviewView, capitalize(type), files);
-    });
-
-    await this.updateBaseFileSelect(webviewView);
-  }
-
-  private handleHousekeeping(message: any) {
-    vscode.commands.executeCommand(`texra.${message.command}`);
-  }
-
-  private handleSingleOperation(message: any) {
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.agent,
-      message.model,
-    );
-  }
-
-  private handleMultipleOperation(message: any) {
-    const operation = message.command.startsWith('pack')
-      ? 'Packing'
-      : 'Cleaning';
-
-    // Validate outputFiles is an array before joining
-    const outputFilesStr = Array.isArray(message.outputFiles)
-      ? message.outputFiles.join(', ')
-      : '';
-
-    logger.info(
-      CHANNEL,
-      `${capitalize(operation)} multiple files: ${message.inputFile}, ${outputFilesStr}`,
-    );
-
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.agent,
-      message.model,
-      message.outputFiles,
-    );
-  }
-
-  private handleLatexdiff(message: any) {
-    vscode.commands.executeCommand(
-      'texra.latexdiff',
-      message.inputFile,
-      message.baseFile,
-      message.editedFile,
-    );
-  }
-
-  private handleLatexdiffvc(message: any) {
-    vscode.commands.executeCommand(
-      'texra.latexdiffvc',
-      message.inputFile,
-      message.baseFile,
-      message.commitHash,
-    );
-  }
-
-  private handleLatexdiffvcOperation(message: any) {
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.baseFile,
-      message.commitHash,
-      message.clean,
-    );
-  }
-
-  private async handleRequestRecentCommits(webviewView: vscode.WebviewView) {
-    const isGitRepo = await vscode.commands.executeCommand<boolean>(
-      'texra.isGitRepository',
-    );
-    const commits = isGitRepo
-      ? await vscode.commands.executeCommand<string[]>('texra.getRecentCommits')
-      : [];
-    webviewView.webview.postMessage({
-      command: 'setRecentCommits',
-      commits,
-      isGitRepo,
-    });
-  }
-
-  private async handleRefreshCommits(webviewView: vscode.WebviewView) {
-    const isGitRepoRefresh = await vscode.commands.executeCommand<boolean>(
-      'texra.isGitRepository',
-    );
-    if (isGitRepoRefresh) {
-      const commits_refresh = await vscode.commands.executeCommand<string[]>(
-        'texra.getRecentCommits',
-      );
-      webviewView.webview.postMessage({
-        command: 'setRecentCommits',
-        commits: commits_refresh,
-      });
-    } else {
-      webviewView.webview.postMessage({
-        command: 'setRecentCommits',
-        isGitRepo: false,
-      });
-    }
-  }
-
-  private async handleGetCurrentFile(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    const fileType = message.fileType || 'input';
-    const currentOpenFile = await vscode.commands.executeCommand<string>(
-      'texra.getCurrentFile',
-    );
-    if (currentOpenFile) {
-      if (fileType === 'edited') {
-        const baseFile = message.baseFile;
-        if (baseFile) {
-          const baseFileName = path.basename(baseFile, path.extname(baseFile));
-          const currentFileName = path.basename(
-            currentOpenFile,
-            path.extname(currentOpenFile),
-          );
-          if (
-            currentFileName.startsWith(baseFileName) &&
-            currentFileName !== baseFileName
-          ) {
-            webviewView.webview.postMessage({
-              command: 'setCurrentFile',
-              filePath: currentOpenFile,
-              fileType: fileType,
-            });
-          } else {
-            vscode.window.showInformationMessage(
-              'The current file is not a valid edited version of the base file.',
-            );
-          }
-        } else {
-          vscode.window.showInformationMessage(
-            'Please select a base file first.',
-          );
-        }
-      } else {
-        webviewView.webview.postMessage({
-          command: 'setCurrentFile',
-          filePath: currentOpenFile,
-          fileType: fileType,
-        });
-      }
-    } else {
-      vscode.window.showInformationMessage(
-        'No file is currently open or the file is not part of the workspace.',
-      );
-    }
-  }
-
-  private async handleAddOpenedFiles(
-    fileType: string,
-    webviewView: vscode.WebviewView,
-  ) {
-    const openedFiles = await this.getOpenedFiles();
-
-    // Send opened files to webview with a flag to filter out already selected files
-    webviewView.webview.postMessage({
-      command: 'setOpenedFiles',
-      files: openedFiles,
-      fileType: fileType,
-      shouldFilter: true,
-    });
-  }
-
-  private async postFileUpdate(
-    webviewView: vscode.WebviewView,
-    fileType: string,
-    files: string[],
-  ) {
-    webviewView.webview.postMessage({
-      command: `set${capitalize(fileType)}File`,
-      files,
-    });
-  }
-
-  private async updateBaseFileSelect(webviewView: vscode.WebviewView) {
-    const baseFiles = await listInputFiles();
-    // logger.debug(CHANNEL, `Updating base files: ${baseFiles.join(', ')}`);
-    webviewView.webview.postMessage({
-      command: 'setBaseFile',
-      files: baseFiles,
-      preserveBaseFile: true,
-    });
-  }
-
-  private async getOpenedFiles(): Promise<string[]> {
-    const workspacePath = WorkspaceFS.getPath();
-    if (!workspacePath) {
-      logger.warn(CHANNEL, 'No workspace path found for opened files');
-      return [];
-    }
-
-    // Get model names from configuration using getConfig utility
-    const modelNames = getConfig<string[]>('models', []);
-
-    const openedDocuments = workspace.textDocuments;
-    const relevantFiles = openedDocuments
-      .filter((doc) => doc.uri.scheme === 'file')
-      .map((doc) => workspace.asRelativePath(doc.uri.fsPath, false))
-      // Filter out files with names matching *_${model_name}*
-      .filter((filePath) => {
-        const fileName = path.basename(filePath);
-        return !modelNames.some((model) => fileName.includes(`_${model}`));
-      });
-
-    logger.debug(CHANNEL, `Found opened files: ${relevantFiles.join(', ')}`);
-    return relevantFiles;
-  }
-
-  private async selectOutputFiles(
-    currentInputFile: string,
-  ): Promise<string[] | null> {
-    const workspacePath = WorkspaceFS.getPath();
-    if (!workspacePath) {
-      await showLoggedMessage(CHANNEL, 'No workspace folder open');
-      return null;
-    }
-
-    const defaultUri = currentInputFile
-      ? vscode.Uri.file(
-          path.dirname(path.join(workspacePath, currentInputFile)),
-        )
-      : vscode.Uri.file(workspacePath);
-
-    try {
-      const fileUris = await vscode.window.showOpenDialog({
-        canSelectMany: true,
-        openLabel: 'Select Output Files',
-        canSelectFiles: true,
-        canSelectFolders: false,
-        defaultUri: defaultUri,
-        filters: {
-          'Text files': ['tex', 'txt', 'md'],
-        },
-      });
-
-      if (!fileUris || fileUris.length === 0) {
-        return null;
-      }
-
-      const relativePaths = fileUris.map((uri) =>
-        WorkspaceFS.relativePath(uri.fsPath),
-      );
-      logger.info(
-        CHANNEL,
-        `Selected output files: ${relativePaths.join(', ')}`,
-      );
-      vscode.window.showInformationMessage(
-        `Selected output files: ${relativePaths.join(', ')}`,
-      );
-      return relativePaths;
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error selecting output files: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      vscode.window.showErrorMessage(
-        `Error selecting output files: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return null;
-    }
-  }
-
-  private async handlePolishInstructionText(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    try {
-      // Initialize file context with agent information
-      const fileContext: FileContext = {
-        agent: message.agent || undefined,
-      };
-
-      // Helper to check if a string value is valid and not empty/none
-      const isValidFile = (file?: string): boolean =>
-        !!file && file !== 'None' && file !== '';
-
-      // Helper to add a single file to context if valid
-      const addSingleFileIfValid = (
-        contextKey: keyof FileContext,
-        messageKey: string,
-      ) => {
-        if (isValidFile(message[messageKey])) {
-          (fileContext as any)[contextKey] = message[messageKey];
-        }
-      };
-
-      // Helper to add multiple files to context if valid and toggle is active
-      const addMultipleFilesIfValid = (
-        contextKey: keyof FileContext,
-        toggleKey: string,
-      ) => {
-        if (
-          message[toggleKey] &&
-          message[contextKey] &&
-          Array.isArray(message[contextKey]) &&
-          message[contextKey].length > 0
-        ) {
-          (fileContext as any)[contextKey] = message[contextKey];
-        }
-      };
-
-      // Add single files
-      addSingleFileIfValid('inputFile', 'inputFile');
-      addSingleFileIfValid('referenceFile', 'referenceFile');
-      addSingleFileIfValid('auxiliaryFile', 'auxiliaryFile');
-      addSingleFileIfValid('mediaFile', 'mediaFile');
-
-      // Add multiple files if their toggle is active
-      addMultipleFilesIfValid('inputFiles', 'inputFilesActive');
-      addMultipleFilesIfValid('referenceFiles', 'referenceFilesActive');
-      addMultipleFilesIfValid('auxiliaryFiles', 'auxiliaryFilesActive');
-      addMultipleFilesIfValid('mediaFiles', 'mediaFilesActive');
-      addMultipleFilesIfValid('outputFiles', 'outputFilesActive');
-
-      // Show progress notification with incremental updates
-      vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: 'Polishing your instruction text',
-          cancellable: false,
-        },
-        async (progress) => {
-          try {
-            // Initial progress update
-            progress.report({ message: 'Preparing text and context...' });
-
-            // Short delay to show first progress step
-            await sleep(300);
-
-            // Update progress
-            progress.report({
-              message: 'Sending to AI for polishing...',
-              increment: 30,
-            });
-
-            // Call the utility function to polish the text with file context
-            const result = await polishTextWithAI(message.text, fileContext);
-
-            // Final progress update
-            progress.report({ message: 'Applying changes...', increment: 60 });
-
-            // Short delay to show final progress step
-            await sleep(300);
-
-            if (result.success) {
-              // Send the polished text back to the webview
-              webviewView.webview.postMessage({
-                command: 'instructionTextPolished',
-                text: result.text,
-              });
-            } else {
-              // Show error message
-              vscode.window.showErrorMessage(
-                result.error || 'Error polishing text',
-              );
-            }
-          } catch (error) {
-            vscode.window.showErrorMessage(
-              `Error polishing text: ${error instanceof Error ? error.message : 'Unknown error'}`,
-            );
-            logger.error(
-              CHANNEL,
-              `Error in handlePolishInstructionText: ${error instanceof Error ? error.message : String(error)}`,
-            );
-          }
-        },
-      );
-    } catch (error) {
-      vscode.window.showErrorMessage(
-        `Error setting up text polishing: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-      logger.error(
-        CHANNEL,
-        `Error setting up text polishing: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
-
-  private async handleTranscribeInstruction(_webviewView: vscode.WebviewView) {
-    // Legacy handler - no longer used but kept for backward compatibility
-    vscode.window.showInformationMessage(
-      'Please use the new recording interface with start/stop controls.',
-    );
-  }
-
-  private async handleUpdateFiles(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    const command = message.command;
-    const fileType = command.replace('update', ''); // e.g., 'InputFiles'
-    const files = message.files || [];
-
-    logger.debug(CHANNEL, `Updating ${fileType} with ${files.length} files`);
-
-    // Since we're just maintaining state and the files are stored in the webview state,
-    // we don't need to do anything else here. The webview manages its own state
-    // and we've already processed the remove action by saving it in the state.
-
-    // Echo back the updated list to confirm receipt
-    webviewView.webview.postMessage({
-      command: `set${fileType}`,
-      files: files,
-    });
-  }
-
-  private async handleClipboardImage(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ) {
-    try {
-      const { base64, mediaType, fileName } = message;
-      if (!base64 || !mediaType || !fileName) {
-        return;
-      }
-      await StorageFS.ensureDir(PASTED_DIR);
-      const relativePath = path.join(PASTED_DIR, fileName);
-      await StorageFS.write(relativePath, Buffer.from(base64, 'base64'));
-      await StorageFS.cleanupOldFiles(PASTED_DIR, 3 * 24 * 60 * 60 * 1000);
-      webviewView.webview.postMessage({
-        command: 'addMediaFile',
-        file: fileName,
-      });
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error handling clipboard image: ${err instanceof Error ? err.message : String(err)}`,
-      );
     }
   }
 

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -1,0 +1,74 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
+const CHANNEL = 'DiffManager';
+logger.initialize(CHANNEL);
+
+export class DiffManager {
+  handleLatexdiff(message: any): void {
+    vscode.commands.executeCommand(
+      'texra.latexdiff',
+      message.inputFile,
+      message.baseFile,
+      message.editedFile,
+    );
+  }
+
+  handleLatexdiffvc(message: any): void {
+    vscode.commands.executeCommand(
+      'texra.latexdiffvc',
+      message.inputFile,
+      message.baseFile,
+      message.commitHash,
+    );
+  }
+
+  handleLatexdiffvcOperation(message: any): void {
+    vscode.commands.executeCommand(
+      `texra.${message.command}`,
+      message.inputFile,
+      message.baseFile,
+      message.commitHash,
+      message.clean,
+    );
+  }
+
+  async handleRequestRecentCommits(
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const isGitRepo = await vscode.commands.executeCommand<boolean>(
+      'texra.isGitRepository',
+    );
+    const commits = isGitRepo
+      ? await vscode.commands.executeCommand<string[]>('texra.getRecentCommits')
+      : [];
+    webviewView.webview.postMessage({
+      command: 'setRecentCommits',
+      commits,
+      isGitRepo,
+    });
+  }
+
+  async handleRefreshCommits(webviewView: vscode.WebviewView): Promise<void> {
+    const isGitRepoRefresh = await vscode.commands.executeCommand<boolean>(
+      'texra.isGitRepository',
+    );
+    if (isGitRepoRefresh) {
+      const commitsRefresh = await vscode.commands.executeCommand<string[]>(
+        'texra.getRecentCommits',
+      );
+      webviewView.webview.postMessage({
+        command: 'setRecentCommits',
+        commits: commitsRefresh,
+      });
+    } else {
+      webviewView.webview.postMessage({
+        command: 'setRecentCommits',
+        isGitRepo: false,
+      });
+    }
+  }
+}

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -20,11 +20,7 @@ const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
 
 export class ExecutionManager {
-  constructor(
-    private readonly fileManager: {
-      selectOutputFiles(currentInputFile: string): Promise<string[] | null>;
-    },
-  ) {}
+  constructor() {}
 
   async handleExecute(message: any): Promise<void> {
     if (!message.inputFile) {
@@ -129,19 +125,12 @@ export class ExecutionManager {
       `${capitalize(operation)} multiple files: ${message.inputFile}, ${outputFilesStr}`,
     );
 
-    let outputFiles = message.outputFiles as string[] | null;
-    if (!outputFiles || outputFiles.length === 0) {
-      outputFiles = await this.fileManager.selectOutputFiles(
-        message.currentFile,
-      );
-    }
-
     vscode.commands.executeCommand(
       `texra.${message.command}`,
       message.inputFile,
       message.agent,
       message.model,
-      outputFiles,
+      message.outputFiles,
     );
   }
 }

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -1,0 +1,147 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
+// Local imports - utils
+import { capitalize } from '@frontend/ui/messageUtils';
+import { getFilesIfNotEmpty } from '@frontend/files/listing';
+import {
+  isPastedImage,
+  getPastedImageFullPath,
+} from '@utils/files/pastedImageUtils';
+
+// Local imports - agent
+import { ToolConfig } from '@agent/core/ToolConfig';
+import { AgentConfig } from '@agent/core/AgentConfig';
+
+const CHANNEL = 'ExecutionManager';
+logger.initialize(CHANNEL);
+
+export class ExecutionManager {
+  constructor(
+    private readonly fileManager: {
+      selectOutputFiles(currentInputFile: string): Promise<string[] | null>;
+    },
+  ) {}
+
+  async handleExecute(message: any): Promise<void> {
+    if (!message.inputFile) {
+      vscode.window.showErrorMessage('Please select an input file.');
+      return;
+    }
+
+    const toolConfig: ToolConfig = {
+      autoExtractFigure: message.autoExtractFigure,
+      autoExtractTikzFigure: message.autoExtractTikzFigure,
+      reflect: message.reflect,
+      attachTeXCount: message.attachTeXCount,
+      usePrefillFromInput: message.usePrefillFromInput,
+      printInputPrompt: message.printInputPrompt,
+      autoCompileInputPdf: message.autoCompileInputPdf,
+    };
+
+    const mapMediaPath = (f: string | null): string | null => {
+      if (!f) return null;
+      if (isPastedImage(f)) {
+        return getPastedImageFullPath(f);
+      }
+      return f;
+    };
+
+    const agentConfig: AgentConfig = {
+      agent: message.agent,
+      model: message.model,
+      instruction: message.instruction,
+      inputFile: message.inputFile,
+      inputFiles: getFilesIfNotEmpty(message.inputFiles),
+      referenceFile: message.referenceFile,
+      referenceFiles: getFilesIfNotEmpty(message.referenceFiles),
+      auxiliaryFile: message.auxiliaryFile,
+      auxiliaryFiles: getFilesIfNotEmpty(message.auxiliaryFiles),
+      mediaFile: mapMediaPath(message.mediaFile),
+      mediaFiles: message.mediaFiles
+        ? getFilesIfNotEmpty(
+            message.mediaFiles
+              .map(mapMediaPath)
+              .filter((f: string | null): f is string => f !== null),
+          )
+        : null,
+      outputFiles: getFilesIfNotEmpty(message.outputFiles),
+      editedFile: null,
+      toolConfig,
+    };
+
+    await vscode.commands.executeCommand('texra.execute', agentConfig);
+  }
+
+  handleMerge(message: any): void {
+    vscode.commands.executeCommand(
+      `texra.${message.command}`,
+      message.inputFile,
+      message.baseFile,
+      message.editedFile,
+    );
+  }
+
+  handleCompare(message: any): void {
+    vscode.commands.executeCommand(
+      `texra.${message.command}`,
+      message.inputFile,
+      message.baseFile,
+      message.editedFile,
+    );
+  }
+
+  handleAcceptEdited(message: any): void {
+    vscode.commands.executeCommand(
+      `texra.${message.command}`,
+      message.inputFile,
+      message.baseFile,
+      message.editedFile,
+    );
+  }
+
+  handleHousekeeping(message: any): void {
+    vscode.commands.executeCommand(`texra.${message.command}`);
+  }
+
+  handleSingleOperation(message: any): void {
+    vscode.commands.executeCommand(
+      `texra.${message.command}`,
+      message.inputFile,
+      message.agent,
+      message.model,
+    );
+  }
+
+  async handleMultipleOperation(message: any): Promise<void> {
+    const operation = message.command.startsWith('pack')
+      ? 'Packing'
+      : 'Cleaning';
+    const outputFilesStr = Array.isArray(message.outputFiles)
+      ? message.outputFiles.join(', ')
+      : '';
+
+    logger.info(
+      CHANNEL,
+      `${capitalize(operation)} multiple files: ${message.inputFile}, ${outputFilesStr}`,
+    );
+
+    let outputFiles = message.outputFiles as string[] | null;
+    if (!outputFiles || outputFiles.length === 0) {
+      outputFiles = await this.fileManager.selectOutputFiles(
+        message.currentFile,
+      );
+    }
+
+    vscode.commands.executeCommand(
+      `texra.${message.command}`,
+      message.inputFile,
+      message.agent,
+      message.model,
+      outputFiles,
+    );
+  }
+}

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -182,7 +182,7 @@ export class FileManager {
 
     try {
       if (fileType === 'OutputFiles') {
-        selectedFiles = await this.selectOutputFiles(message.inputFile);
+        selectedFiles = await this.selectOutputFiles(message.currentFile);
       } else {
         const currentFileForMultiple = message.currentFile;
         const baseType = fileType.replace('Files', '');

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -7,6 +7,8 @@ import { workspace } from 'vscode';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+import { uncapitalize } from '@frontend/ui/messageUtils';
+import { showLoggedMessage } from '@utils/errorHandlingUtils';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
@@ -42,7 +44,7 @@ export class FileManager {
     if (file) {
       logger.debug(CHANNEL, `Selected ${singleFileType}: ${file}`);
       webviewView.webview.postMessage({
-        command: `${singleFileType.charAt(0).toLowerCase()}${singleFileType.slice(1)}Selected`,
+        command: `${uncapitalize(singleFileType)}Selected`,
         filePath: file,
       });
     }
@@ -180,7 +182,7 @@ export class FileManager {
 
     try {
       if (fileType === 'OutputFiles') {
-        selectedFiles = await this.selectOutputFiles(message.currentFile);
+        selectedFiles = await this.selectOutputFiles(message.inputFile);
       } else {
         const currentFileForMultiple = message.currentFile;
         const baseType = fileType.replace('Files', '');
@@ -189,7 +191,8 @@ export class FileManager {
           currentFileForMultiple,
         );
         if (selectedFiles === undefined) {
-          console.warn(
+          logger.warn(
+            CHANNEL,
             `Command texra.select${baseType}Files returned undefined`,
           );
           selectedFiles = null;
@@ -310,7 +313,7 @@ export class FileManager {
   async selectOutputFiles(currentInputFile: string): Promise<string[] | null> {
     const workspacePath = WorkspaceFS.getPath();
     if (!workspacePath) {
-      await vscode.window.showInformationMessage('No workspace folder open');
+      await showLoggedMessage(CHANNEL, 'No workspace folder open');
       return null;
     }
 

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -1,0 +1,399 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+import { workspace } from 'vscode';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
+// Local imports - utilities
+import { WorkspaceFS } from '@utils/files';
+import { getConfig } from '@utils/config';
+import {
+  listInputFiles,
+  listReferenceFiles,
+  listAuxiliaryFiles,
+  listMediaFiles,
+  listEditedFiles,
+} from '@frontend/files/fileLister';
+
+// Local imports - agent
+import { getAgentPath } from '@agent/runtime/executeAgent';
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
+
+const CHANNEL = 'FileManager';
+logger.initialize(CHANNEL);
+
+export class FileManager {
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  async handleFileSelection(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const singleFileType = message.command.replace('select', '');
+    logger.debug(CHANNEL, `Selecting ${singleFileType}`);
+
+    const file = await vscode.commands.executeCommand<string>(
+      `texra.${message.command}`,
+    );
+    if (file) {
+      logger.debug(CHANNEL, `Selected ${singleFileType}: ${file}`);
+      webviewView.webview.postMessage({
+        command: `${singleFileType.charAt(0).toLowerCase()}${singleFileType.slice(1)}Selected`,
+        filePath: file,
+      });
+    }
+  }
+
+  async handleEditedFileSelection(
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const editedFile = await vscode.commands.executeCommand<string>(
+      'texra.selectEditedFile',
+    );
+    if (editedFile) {
+      webviewView.webview.postMessage({
+        command: 'editedFileSelected',
+        filePath: editedFile,
+      });
+    }
+  }
+
+  async handleInputFileSelected(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const baseFileNameForInput = path.basename(
+      message.filePath,
+      path.extname(message.filePath),
+    );
+    const filteredEditedFiles = await listEditedFiles(baseFileNameForInput);
+    this.postFileUpdate(webviewView, 'Edited', filteredEditedFiles);
+  }
+
+  handleGenericFileSelected(message: any): void {
+    vscode.window.showInformationMessage(
+      `${message.command}: ${message.filePath}`,
+    );
+  }
+
+  async handleRequestInputFile(webviewView: vscode.WebviewView): Promise<void> {
+    const refreshedInputFiles =
+      (await vscode.commands.executeCommand<string[]>(
+        'texra.refreshInputFiles',
+      )) || [];
+    this.postFileUpdate(webviewView, 'Input', refreshedInputFiles);
+  }
+
+  async handleRequestFile(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const fileType = message.command.replace('request', '').replace('File', '');
+    const files = await (async () => {
+      switch (fileType) {
+        case 'Reference':
+          return await listReferenceFiles();
+        case 'Auxiliary':
+          return await listAuxiliaryFiles();
+        case 'Media':
+          return await listMediaFiles();
+        default:
+          return [];
+      }
+    })();
+    this.postFileUpdate(webviewView, fileType, files);
+  }
+
+  async handleRequestEditedFile(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    let allEditedFiles: string[] = [];
+    if (message.baseFile) {
+      const baseFileNameForEdited = path.basename(
+        message.baseFile,
+        path.extname(message.baseFile),
+      );
+      allEditedFiles = await listEditedFiles(baseFileNameForEdited);
+    }
+    this.postFileUpdate(webviewView, 'Edited', allEditedFiles);
+  }
+
+  async handleRequestBaseFile(webviewView: vscode.WebviewView): Promise<void> {
+    this.postFileUpdate(webviewView, 'Base', await listInputFiles());
+  }
+
+  async handleRequestDefaultOutputFiles(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const agent = message.agent;
+    if (!agent) {
+      webviewView.webview.postMessage({
+        command: 'setDefaultOutputFiles',
+        files: [],
+      });
+      return;
+    }
+
+    try {
+      const agentPath = await getAgentPath(agent, this.context);
+      const [settings] = await loadAgentSettingAndPrompts(agentPath, agent);
+      const files = Array.isArray(settings?.defaultOutputFiles)
+        ? settings.defaultOutputFiles
+        : [];
+      webviewView.webview.postMessage({
+        command: 'setDefaultOutputFiles',
+        files,
+      });
+    } catch (err) {
+      logger.error(
+        CHANNEL,
+        `Error requesting default output files: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      webviewView.webview.postMessage({
+        command: 'setDefaultOutputFiles',
+        files: [],
+      });
+    }
+  }
+
+  handleSetMultipleFiles(message: any, webviewView: vscode.WebviewView): void {
+    if (message.files?.length > 0) {
+      webviewView.webview.postMessage({
+        command: message.command,
+        files: message.files,
+      });
+    }
+  }
+
+  async handleSelectMultipleFiles(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const fileType = message.fileType;
+    let selectedFiles: string[] | null = null;
+
+    try {
+      if (fileType === 'OutputFiles') {
+        selectedFiles = await this.selectOutputFiles(message.currentFile);
+      } else {
+        const currentFileForMultiple = message.currentFile;
+        const baseType = fileType.replace('Files', '');
+        selectedFiles = await vscode.commands.executeCommand<string[]>(
+          `texra.select${baseType}Files`,
+          currentFileForMultiple,
+        );
+        if (selectedFiles === undefined) {
+          console.warn(
+            `Command texra.select${baseType}Files returned undefined`,
+          );
+          selectedFiles = null;
+        }
+      }
+
+      if (selectedFiles) {
+        webviewView.webview.postMessage({
+          command: `set${fileType}`,
+          files: selectedFiles,
+        });
+      }
+    } catch (error) {
+      logger.error(
+        CHANNEL,
+        `Error in handleSelectMultipleFiles: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      vscode.window.showErrorMessage(
+        `Error selecting ${fileType}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
+  async handleRefreshAllFiles(webviewView: vscode.WebviewView): Promise<void> {
+    const refreshedFiles = {
+      input: await listInputFiles(),
+      reference: await listReferenceFiles(),
+      auxiliary: await listAuxiliaryFiles(),
+      media: await listMediaFiles(),
+    };
+
+    Object.entries(refreshedFiles).forEach(([type, files]) => {
+      this.postFileUpdate(
+        webviewView,
+        type.charAt(0).toUpperCase() + type.slice(1),
+        files,
+      );
+    });
+
+    await this.updateBaseFileSelect(webviewView);
+  }
+
+  async handleGetCurrentFile(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const fileType = message.fileType || 'input';
+    const currentOpenFile = await vscode.commands.executeCommand<string>(
+      'texra.getCurrentFile',
+    );
+    if (currentOpenFile) {
+      if (fileType === 'edited') {
+        const baseFile = message.baseFile;
+        if (baseFile) {
+          const baseFileName = path.basename(baseFile, path.extname(baseFile));
+          const currentFileName = path.basename(
+            currentOpenFile,
+            path.extname(currentOpenFile),
+          );
+          if (
+            currentFileName.startsWith(baseFileName) &&
+            currentFileName !== baseFileName
+          ) {
+            webviewView.webview.postMessage({
+              command: 'setCurrentFile',
+              filePath: currentOpenFile,
+              fileType,
+            });
+          } else {
+            vscode.window.showInformationMessage(
+              'The current file is not a valid edited version of the base file.',
+            );
+          }
+        } else {
+          vscode.window.showInformationMessage(
+            'Please select a base file first.',
+          );
+        }
+      } else {
+        webviewView.webview.postMessage({
+          command: 'setCurrentFile',
+          filePath: currentOpenFile,
+          fileType,
+        });
+      }
+    } else {
+      vscode.window.showInformationMessage(
+        'No file is currently open or the file is not part of the workspace.',
+      );
+    }
+  }
+
+  async handleAddOpenedFiles(
+    fileType: string,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const openedFiles = await this.getOpenedFiles();
+    webviewView.webview.postMessage({
+      command: 'setOpenedFiles',
+      files: openedFiles,
+      fileType,
+      shouldFilter: true,
+    });
+  }
+
+  async handleUpdateFiles(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const command = message.command;
+    const fileType = command.replace('update', '');
+    const files = message.files || [];
+
+    logger.debug(CHANNEL, `Updating ${fileType} with ${files.length} files`);
+    webviewView.webview.postMessage({ command: `set${fileType}`, files });
+  }
+
+  async selectOutputFiles(currentInputFile: string): Promise<string[] | null> {
+    const workspacePath = WorkspaceFS.getPath();
+    if (!workspacePath) {
+      await vscode.window.showInformationMessage('No workspace folder open');
+      return null;
+    }
+
+    const defaultUri = currentInputFile
+      ? vscode.Uri.file(
+          path.dirname(path.join(workspacePath, currentInputFile)),
+        )
+      : vscode.Uri.file(workspacePath);
+
+    try {
+      const fileUris = await vscode.window.showOpenDialog({
+        canSelectMany: true,
+        openLabel: 'Select Output Files',
+        canSelectFiles: true,
+        canSelectFolders: false,
+        defaultUri,
+        filters: { 'Text files': ['tex', 'txt', 'md'] },
+      });
+
+      if (!fileUris || fileUris.length === 0) {
+        return null;
+      }
+
+      const relativePaths = fileUris.map((uri) =>
+        WorkspaceFS.relativePath(uri.fsPath),
+      );
+      logger.info(
+        CHANNEL,
+        `Selected output files: ${relativePaths.join(', ')}`,
+      );
+      vscode.window.showInformationMessage(
+        `Selected output files: ${relativePaths.join(', ')}`,
+      );
+      return relativePaths;
+    } catch (err) {
+      logger.error(
+        CHANNEL,
+        `Error selecting output files: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      vscode.window.showErrorMessage(
+        `Error selecting output files: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
+  private async postFileUpdate(
+    webviewView: vscode.WebviewView,
+    fileType: string,
+    files: string[],
+  ): Promise<void> {
+    webviewView.webview.postMessage({ command: `set${fileType}File`, files });
+  }
+
+  private async updateBaseFileSelect(
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const baseFiles = await listInputFiles();
+    webviewView.webview.postMessage({
+      command: 'setBaseFile',
+      files: baseFiles,
+      preserveBaseFile: true,
+    });
+  }
+
+  private async getOpenedFiles(): Promise<string[]> {
+    const workspacePath = WorkspaceFS.getPath();
+    if (!workspacePath) {
+      logger.warn(CHANNEL, 'No workspace path found for opened files');
+      return [];
+    }
+
+    const modelNames = getConfig<string[]>('models', []);
+    const openedDocuments = workspace.textDocuments;
+    const relevantFiles = openedDocuments
+      .filter((doc) => doc.uri.scheme === 'file')
+      .map((doc) => workspace.asRelativePath(doc.uri.fsPath, false))
+      .filter((filePath) => {
+        const fileName = path.basename(filePath);
+        return !modelNames.some((model) => fileName.includes(`_${model}`));
+      });
+
+    logger.debug(CHANNEL, `Found opened files: ${relevantFiles.join(', ')}`);
+    return relevantFiles;
+  }
+}

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -1,0 +1,156 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
+// Local imports - utilities
+import * as path from 'path';
+
+import { StorageFS } from '@utils/files';
+import { PASTED_DIR } from '@utils/files/pastedImageUtils';
+import {
+  polishTextWithAI,
+  FileContext,
+} from '@utils/text/textEnhancementUtils';
+import { sleep } from '@utils/helpers';
+
+const CHANNEL = 'InstructionManager';
+logger.initialize(CHANNEL);
+
+export class InstructionManager {
+  constructor(private readonly _context: vscode.ExtensionContext) {
+    setTimeout(() => {
+      StorageFS.ensureDir(PASTED_DIR)
+        .then(() =>
+          StorageFS.cleanupOldFiles(PASTED_DIR, 3 * 24 * 60 * 60 * 1000),
+        )
+        .catch((e) =>
+          logger.warn(
+            CHANNEL,
+            `Error during initial cleanup: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+    }, 100);
+  }
+
+  async handlePolishInstructionText(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    try {
+      const fileContext: FileContext = { agent: message.agent || undefined };
+      const isValidFile = (file?: string): boolean =>
+        !!file && file !== 'None' && file !== '';
+      const addSingleFileIfValid = (
+        contextKey: keyof FileContext,
+        messageKey: string,
+      ) => {
+        if (isValidFile(message[messageKey])) {
+          (fileContext as any)[contextKey] = message[messageKey];
+        }
+      };
+      const addMultipleFilesIfValid = (
+        contextKey: keyof FileContext,
+        toggleKey: string,
+      ) => {
+        if (
+          message[toggleKey] &&
+          message[contextKey] &&
+          Array.isArray(message[contextKey]) &&
+          message[contextKey].length > 0
+        ) {
+          (fileContext as any)[contextKey] = message[contextKey];
+        }
+      };
+
+      addSingleFileIfValid('inputFile', 'inputFile');
+      addSingleFileIfValid('referenceFile', 'referenceFile');
+      addSingleFileIfValid('auxiliaryFile', 'auxiliaryFile');
+      addSingleFileIfValid('mediaFile', 'mediaFile');
+      addMultipleFilesIfValid('inputFiles', 'inputFilesActive');
+      addMultipleFilesIfValid('referenceFiles', 'referenceFilesActive');
+      addMultipleFilesIfValid('auxiliaryFiles', 'auxiliaryFilesActive');
+      addMultipleFilesIfValid('mediaFiles', 'mediaFilesActive');
+      addMultipleFilesIfValid('outputFiles', 'outputFilesActive');
+
+      vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Polishing your instruction text',
+          cancellable: false,
+        },
+        async (progress) => {
+          try {
+            progress.report({ message: 'Preparing text and context...' });
+            await sleep(300);
+            progress.report({
+              message: 'Sending to AI for polishing...',
+              increment: 30,
+            });
+            const result = await polishTextWithAI(message.text, fileContext);
+            progress.report({ message: 'Applying changes...', increment: 60 });
+            await sleep(300);
+            if (result.success) {
+              webviewView.webview.postMessage({
+                command: 'instructionTextPolished',
+                text: result.text,
+              });
+            } else {
+              vscode.window.showErrorMessage(
+                result.error || 'Error polishing text',
+              );
+            }
+          } catch (error) {
+            vscode.window.showErrorMessage(
+              `Error polishing text: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+            logger.error(
+              CHANNEL,
+              `Error in handlePolishInstructionText: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        },
+      );
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        `Error setting up text polishing: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      logger.error(
+        CHANNEL,
+        `Error setting up text polishing: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  handleTranscribeInstruction(_view: vscode.WebviewView): void {
+    vscode.window.showInformationMessage(
+      'Please use the new recording interface with start/stop controls.',
+    );
+  }
+
+  async handleClipboardImage(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    try {
+      const { base64, mediaType, fileName } = message;
+      if (!base64 || !mediaType || !fileName) {
+        return;
+      }
+      await StorageFS.ensureDir(PASTED_DIR);
+      const relativePath = path.join(PASTED_DIR, fileName);
+      await StorageFS.write(relativePath, Buffer.from(base64, 'base64'));
+      await StorageFS.cleanupOldFiles(PASTED_DIR, 3 * 24 * 60 * 60 * 1000);
+      webviewView.webview.postMessage({
+        command: 'addMediaFile',
+        file: fileName,
+      });
+    } catch (err) {
+      logger.error(
+        CHANNEL,
+        `Error handling clipboard image: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/src/webview/managers/index.ts
+++ b/src/webview/managers/index.ts
@@ -1,0 +1,6 @@
+export { RecordingManager } from './RecordingManager';
+export { SettingsManager } from './SettingsManager';
+export { FileManager } from './FileManager';
+export { ExecutionManager } from './ExecutionManager';
+export { DiffManager } from './DiffManager';
+export { InstructionManager } from './InstructionManager';


### PR DESCRIPTION
## Summary
- factor out file handling logic into `FileManager`
- extract execution flows into `ExecutionManager`
- manage latexdiff and commit requests in `DiffManager`
- handle instruction polishing and clipboard images in `InstructionManager`
- wire the new managers through `WebviewMessageHandler`
- export all managers via `src/webview/managers/index.ts`

## Testing
- `npm run lint`
- `npm test` *(fails: Critical dependency warnings during webpack build)*

------
https://chatgpt.com/codex/tasks/task_e_685c0274e2388324b4de75968fa2e57a