### PR TITLE
feat: add bulk latexdiff-vc runner

### DIFF
--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -42,51 +42,7 @@ export async function runLatexdiffvcMultiple(
   channel: string = CHANNEL,
 ): Promise<LaTeXdiffMultipleResult> {
   const runner = new LatexdiffRunner(channel);
-  if (!inputFiles || inputFiles.length === 0) {
-    await showLoggedMessage(channel, 'No input files provided');
-    return {
-      success: false,
-      results: { success: [], failed: [] },
-      message: 'No input files provided',
-    };
-  }
-  const results: { success: string[]; failed: string[] } = {
-    success: [],
-    failed: [],
-  };
-
-  for (const inputFile of inputFiles) {
-    try {
-      const result = await runner.runDiffVc(inputFile, commitHash);
-      if (result.success) {
-        results.success.push(inputFile);
-      } else {
-        results.failed.push(inputFile);
-      }
-    } catch (err) {
-      results.failed.push(inputFile);
-      logger.error(
-        channel,
-        `Error processing ${inputFile}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
-
-  const summary = [
-    'LaTeX diff operations completed:',
-    results.success.length > 0
-      ? `\nSuccessful:\n${results.success.join('\n')}`
-      : '',
-    results.failed.length > 0 ? `\nFailed:\n${results.failed.join('\n')}` : '',
-  ].join('');
-
-  logger.info(channel, summary);
-
-  return {
-    success: results.failed.length === 0,
-    results,
-    message: summary,
-  };
+  return runner.runDiffVcMultiple(inputFiles, commitHash);
 }
 
 export async function runLatexdiffForRound(
@@ -124,13 +80,4 @@ export async function runLatexdiffBetweenRounds(
     );
     return { success: false, message };
   }
-}
-
-export async function runLatexdiffMultiple(
-  inputFiles: string[],
-  editedFiles: string[],
-  channel: string = CHANNEL,
-): Promise<LaTeXdiffMultipleResult> {
-  const runner = new LatexdiffRunner(channel);
-  return runner.runDiffMultiple(inputFiles, editedFiles);
 }

--- a/src/latex/latexdiffRunner.ts
+++ b/src/latex/latexdiffRunner.ts
@@ -258,6 +258,73 @@ export class LatexdiffRunner {
     }
   }
 
+  async runDiffVcMultiple(
+    inputFiles: string[],
+    commitHash: string,
+  ): Promise<LaTeXdiffMultipleResult> {
+    try {
+      if (!inputFiles || inputFiles.length === 0) {
+        await showLoggedMessage(this.channel, 'No input files provided');
+        return {
+          success: false,
+          results: { success: [], failed: [] },
+          message: 'No input files provided',
+        };
+      }
+
+      const results: { success: string[]; failed: string[] } = {
+        success: [],
+        failed: [],
+      };
+
+      for (const inputFile of inputFiles) {
+        try {
+          const result = await this.runDiffVc(inputFile, commitHash);
+          if (result.success) {
+            results.success.push(inputFile);
+          } else {
+            results.failed.push(inputFile);
+          }
+        } catch (err) {
+          results.failed.push(inputFile);
+          logger.error(
+            this.channel,
+            `Error processing ${inputFile}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      const summary = [
+        'LaTeX diff operations completed:',
+        results.success.length > 0
+          ? `\nSuccessful:\n${results.success.join('\n')}`
+          : '',
+        results.failed.length > 0
+          ? `\nFailed:\n${results.failed.join('\n')}`
+          : '',
+      ].join('');
+
+      logger.info(this.channel, summary);
+
+      return {
+        success: results.failed.length === 0,
+        results,
+        message: summary,
+      };
+    } catch (err) {
+      const message = logErrorMessage(
+        this.channel,
+        'Error in runLatexdiffvcMultiple',
+        err,
+      );
+      return {
+        success: false,
+        results: { success: [], failed: [] },
+        message,
+      };
+    }
+  }
+
   async runDiffMultiple(
     inputFiles: string[],
     editedFiles: string[],


### PR DESCRIPTION
## Summary
- remove unused `runLatexdiffMultiple`
- add `runDiffVcMultiple` helper to `LatexdiffRunner`
- simplify `runLatexdiffvcMultiple` to use the new runner

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency; webpack warning)*

------
https://chatgpt.com/codex/tasks/task_e_685c205d179c83248c6cbe38c332e990