### PR TITLE
Introduce IModelHandler interface

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -86,7 +86,7 @@ Documentation of TeXRA's internal APIs:
 
 - Command API
 - Extension API
-- Model handler APIs
+- Model handler APIs (`IModelHandler` interface)
 - Agent framework interfaces
 
 ## Additional Resources

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -8,7 +8,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { AgentConfig } from '../core/AgentConfig';
 import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { IAgent } from '../core/IAgent';
-import { ModelHandler } from '../modelHandlers';
+import type { IModelHandler } from '../modelHandlers';
 import { buildUserVars } from '../utils/userVars';
 
 // Local imports - utilities
@@ -19,7 +19,7 @@ import { sleep } from '@utils/helpers';
  * Minimal abstract base class providing shared setup and interruption logic.
  */
 export abstract class BaseAgent implements IAgent {
-  protected modelHandler: ModelHandler;
+  protected modelHandler: IModelHandler;
   protected agentConfig: AgentConfig;
   protected agentSetting: AgentSetting;
   protected agentPrompt: AgentPrompt;
@@ -38,7 +38,7 @@ export abstract class BaseAgent implements IAgent {
   }
 
   constructor(
-    modelHandler: ModelHandler,
+    modelHandler: IModelHandler,
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -47,7 +47,7 @@ import {
 } from '@agent/core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
-import { ModelHandler } from '@agent/modelHandlers';
+import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile } from '@agent/runtime/OutputHandler';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
@@ -76,7 +76,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   protected outputHandler: OutputHandler;
 
   constructor(
-    modelHandler: ModelHandler,
+    modelHandler: IModelHandler,
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 // Local imports - agent components
 import { DirectAgent } from './DirectAgent';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
-import { ModelHandler } from '@agent/modelHandlers';
+import type { IModelHandler } from '@agent/modelHandlers';
 import { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
 
@@ -14,7 +14,7 @@ import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
  */
 export class MergeAgent extends DirectAgent {
   constructor(
-    modelHandler: ModelHandler,
+    modelHandler: IModelHandler,
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -18,6 +18,7 @@ import {
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import type { IModelHandler } from './types/IModelHandler';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 // Local imports - agent components
@@ -55,7 +56,7 @@ interface MarkerFlags {
 /**
  * Abstract base class for model-specific handlers that manage API interactions, message processing, and response handling.
  */
-export abstract class ModelHandler {
+export abstract class ModelHandler implements IModelHandler {
   public config: ModelConfig;
   public capabilities: ModelCapabilities;
   public continueLimit: number;

--- a/src/agent/modelHandlers/index.ts
+++ b/src/agent/modelHandlers/index.ts
@@ -2,6 +2,7 @@
 
 // Base class
 export { ModelHandler } from './ModelHandler';
+export type { IModelHandler } from './types/IModelHandler';
 
 // Specific model handler implementations
 export { ModelHandlerAnthropic } from './modelHandlerAnthropic';

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -1,0 +1,159 @@
+// Local imports - log
+import type { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - agent components
+import { AgentConfig } from '../../core/AgentConfig';
+import { AgentSetting } from '../../core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '../../core/AgentState';
+import { ToolState } from '../../core/ToolState';
+import type { MediaEntry } from '../../utils/mediaTypes';
+import type { ModelConfig, ModelCapabilities } from '@model/ModelConfig';
+import type { ProviderStopReason } from './StopReasonTypes';
+
+/**
+ * Common interface implemented by all model handlers.
+ */
+export interface IModelHandler {
+  /** Model configuration used by the handler. */
+  config: ModelConfig;
+
+  /** Capabilities supported by the model. */
+  capabilities: ModelCapabilities;
+
+  /** Indicates if the model uses the OpenAI API. */
+  readonly isOpenai: boolean;
+
+  /** Indicates if the model is served by Anthropic. */
+  readonly isAnthropic: boolean;
+
+  /** Indicates if the model is served by Google. */
+  readonly isGoogle: boolean;
+
+  /** Checks if the provider implements the OpenAI API. */
+  readonly isOpenaiCompatible: boolean;
+
+  /** Set the logger instance for the handler. */
+  setLogger(logger: AgentLogger): void;
+
+  /** Retrieve an authenticated client instance. */
+  getClient(): Promise<any>;
+
+  /**
+   * Generate a response from the model.
+   * @param client Provider client instance
+   * @param messages Conversation messages
+   * @param temperature Sampling temperature
+   * @param systemPrompt Optional system prompt
+   * @param endTag Optional stop sequence
+   * @param signal Optional abort signal
+   */
+  createResponse(
+    client: any,
+    messages: any[],
+    temperature: number,
+    systemPrompt?: string,
+    endTag?: string,
+    signal?: AbortSignal,
+  ): Promise<any>;
+
+  /** Initialize the conversation for the first round. */
+  initializeMessages(
+    userPrefix: string,
+    userRequest: string,
+    mediaFiles?: string[],
+    systemPrompt?: string,
+  ): Promise<any[]>;
+
+  /** Create messages for a follow-up round. */
+  createRoundMessages(
+    messages: any[],
+    userMessage: string,
+    mediaFiles?: string[],
+  ): Promise<any[]>;
+
+  /** Format media content for provider APIs. */
+  createMediaContent(mediaMessage: MediaEntry[]): any[];
+
+  /** Extract the response text and usage from the provider response. */
+  extractResponse(
+    responseObject: any,
+    endTag: string,
+  ): [string, any, ProviderStopReason];
+
+  /** Handle continuation for models supporting prefill. */
+  addContinueMessageWithPrefill(
+    messages: any[],
+    stateRound: AgentStateRound,
+    toolState: ToolState,
+    agentSetting: AgentSetting,
+    agentConfig: AgentConfig,
+  ): void;
+
+  /** Handle continuation for models without prefill. */
+  addContinueMessageWithoutPrefill(
+    messages: any[],
+    stateRound: AgentStateRound,
+    toolState: ToolState,
+    agentSetting: AgentSetting,
+    agentConfig: AgentConfig,
+  ): void;
+
+  /** Prepare output files and prefill content. */
+  initializeOutputAndPrefill(
+    agentConfig: AgentConfig,
+    agentSetting: AgentSetting,
+    messages: any[],
+    toolState: ToolState,
+    outputFile: string,
+    prefill: string,
+    groupId?: string,
+  ): Promise<[boolean, any[]]>;
+
+  /** Compute the cost for a response. */
+  computePrice(responseUsage: any): number;
+
+  /** Compute detailed usage metrics. */
+  computeResponseUsage(responseUsage: any, responseTime: number): any;
+
+  /** Update messages when prefill is supported. */
+  updateMessageContentWithPrefill(
+    messages: any[],
+    bestConnector: string,
+    newResponse: string,
+    toolState: ToolState,
+  ): void;
+
+  /** Update messages when prefill is not supported. */
+  updateMessageContentWithoutPrefill(
+    messages: any[],
+    bestConnector: string,
+    newResponse: string,
+    toolState: ToolState,
+  ): void;
+
+  /** Determine whether generation should continue. */
+  shouldContinue(
+    stopReason: ProviderStopReason,
+    newResponse: string,
+    agentSetting: AgentSetting,
+  ): boolean;
+
+  /**
+   * Evaluate whether to end the turn and/or stop generation.
+   * @returns Tuple of [endTurn, shouldStop]
+   */
+  checkStopConditions(
+    stopReason: ProviderStopReason,
+    newResponse: string,
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    agentSetting: AgentSetting,
+  ): [boolean, boolean];
+
+  /** Extract intermediate "thinking" content from a response. */
+  processThinkingBlock(
+    responseObject: any,
+    groupId?: string,
+    toolState?: ToolState,
+  ): string | null;
+}

--- a/src/agent/runtime/OutputHandler/StatisticsReporter.ts
+++ b/src/agent/runtime/OutputHandler/StatisticsReporter.ts
@@ -1,10 +1,11 @@
 import { AgentLogger } from '@logger/AgentLogger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { AgentStateGlobal } from '@agent/core/AgentState';
+import type { IModelHandler } from '@agent/modelHandlers';
 
 export class StatisticsReporter {
   constructor(
-    private readonly modelHandler: any,
+    private readonly modelHandler: IModelHandler,
     private readonly channel: string,
     private readonly logger: AgentLogger,
   ) {}

--- a/src/agent/runtime/OutputHandler/index.ts
+++ b/src/agent/runtime/OutputHandler/index.ts
@@ -14,6 +14,7 @@ import { getOutputFileName } from '@utils/outputFileUtils';
 import { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
+import type { IModelHandler } from '@agent/modelHandlers';
 
 // Local imports - types
 
@@ -21,7 +22,7 @@ import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 export class OutputHandler {
   public agentSetting: AgentSetting;
   public agentConfig: AgentConfig;
-  public modelHandler: any;
+  public modelHandler: IModelHandler;
   public logId: number;
   public outputFiles: { [key: number]: string[] };
   public outputMappings: { [key: number]: NamedOutputFile[] };
@@ -36,7 +37,7 @@ export class OutputHandler {
   constructor(
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
-    modelHandler: any,
+    modelHandler: IModelHandler,
     logId: number,
     baseFiles: string[] = [],
     logger?: AgentLogger,

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -10,7 +10,7 @@ import { setVarFromFile } from '@frontend/files/vars';
 import { getXmlFormatFromFiles, getListOfFiles } from '@utils/promptUtils';
 import { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting } from '../core/AgentDataclass';
-import { ModelHandler } from '@agent/modelHandlers';
+import type { IModelHandler } from '@agent/modelHandlers';
 
 /**
  * Build all user variables needed for prompt rendering.
@@ -19,7 +19,7 @@ export async function buildUserVars(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
   agentPath: string,
-  modelHandler: ModelHandler,
+  modelHandler: IModelHandler,
   logger: AgentLogger,
 ): Promise<Record<string, any>> {
   const userVars: Record<string, any> = {};
@@ -40,7 +40,7 @@ export async function buildUserVars(
 
 function getBasicVars(
   agentConfig: AgentConfig,
-  modelHandler: ModelHandler,
+  modelHandler: IModelHandler,
 ): Record<string, any> {
   return {
     MODEL: agentConfig.model,


### PR DESCRIPTION
## Summary
- define `IModelHandler` for model handler capabilities and required APIs
- export the interface and implement it in `ModelHandler`
- type agents and utilities against `IModelHandler`
- update statistics reporting to use the interface
- mention `IModelHandler` in the docs

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c35a6b54c83248de13d0bb7c88f0d