### PR TITLE
Refactor progress view managers

### DIFF
--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -1,19 +1,17 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import { randomUUID } from 'crypto';
 
 // Local imports
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
-import { WorkspaceFS } from '@utils/files';
-import { objectToTaskState } from '@utils/config';
-import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
-import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
+import { StreamTabs } from './managers/StreamTabs';
+import { TaskGroups } from './managers/TaskGroups';
+import { OutputFiles } from './managers/OutputFiles';
+import { TaskStates } from './managers/TaskStates';
+import { UsageStats } from './managers/UsageStats';
 
 // Types
 import { TokenUsageStats } from '../types/UsageTypes';
-import { TaskGroup } from '../logger/LogTypes';
-import type { DiffStats } from '../types/DiffTypes';
 
 interface ColoredLogMessage {
   id: string;
@@ -22,13 +20,6 @@ interface ColoredLogMessage {
   timestamp: number;
   groupId?: string;
   messageType?: 'default' | 'scratchpad' | 'thinking';
-}
-
-interface OutputFileInfo extends DiffStats {
-  path: string;
-  base?: string | null;
-  prev?: string | null;
-  original?: string;
 }
 
 /**
@@ -40,12 +31,11 @@ export class ProgressStateManager {
   private readonly logger: AgentLogger;
 
   // State collections
-  private _logStreams: Map<string, ColoredLogMessage[]> = new Map();
-  private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
-  private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
-    new Map();
-  private _taskStates: Map<string, TaskState> = new Map();
-  private _usageStats: Map<string, TokenUsageStats> = new Map();
+  private _streamTabs: StreamTabs = new StreamTabs();
+  private _taskGroups: TaskGroups = new TaskGroups();
+  private _outputFiles: OutputFiles = new OutputFiles();
+  private _taskStates: TaskStates = new TaskStates();
+  private _usageStats: UsageStats = new UsageStats();
   private _activeStream: string = '';
 
   constructor() {
@@ -53,23 +43,23 @@ export class ProgressStateManager {
   }
 
   // Getters for state collections
-  get logStreams(): Map<string, ColoredLogMessage[]> {
-    return this._logStreams;
+  get streamTabs(): StreamTabs {
+    return this._streamTabs;
   }
 
-  get taskGroups(): Map<string, Map<string, TaskGroup>> {
+  get taskGroups(): TaskGroups {
     return this._taskGroups;
   }
 
-  get outputFiles(): Map<string, { [key: number]: OutputFileInfo[] }> {
+  get outputFiles(): OutputFiles {
     return this._outputFiles;
   }
 
-  get taskStates(): Map<string, TaskState> {
+  get taskStates(): TaskStates {
     return this._taskStates;
   }
 
-  get usageStats(): Map<string, TokenUsageStats> {
+  get usageStats(): UsageStats {
     return this._usageStats;
   }
 
@@ -113,180 +103,22 @@ export class ProgressStateManager {
     this._saveUsageStats();
   }
 
-  /**
-   * Load log streams from storage
-   */
   private async _loadLogStreams(): Promise<void> {
-    const savedState = workspaceSM.get<{
-      [key: string]: ColoredLogMessage[];
-    }>(this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS));
-
-    if (savedState) {
-      // Only load channels that should be persisted
-      this._logStreams = new Map(
-        Object.entries(savedState)
-          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-          .map(([stream, messages]) => [
-            stream,
-            messages.map((msg) => {
-              if (!msg.id) {
-                msg.id = randomUUID();
-              }
-              if (msg.timestamp === undefined) {
-                const attrMatch = msg.message.match(
-                  /data-full-timestamp="([^"]+)"/,
-                );
-                const timeString =
-                  attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
-                const timestamp = new Date(timeString).getTime();
-                msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
-              }
-              if (!msg.messageType) {
-                msg.messageType = 'default';
-              }
-              return msg;
-            }),
-          ]),
-      );
-    } else {
-      this._logStreams.clear();
-    }
+    await this._streamTabs.load();
   }
 
   /**
    * Load log groups from storage
    */
   private async _loadTaskGroups(): Promise<void> {
-    let savedGroups = workspaceSM.get<{
-      [key: string]: { [groupId: string]: TaskGroup };
-    }>(this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS));
-
-    // Migrate data stored under the old key if needed
-    if (!savedGroups) {
-      const oldGroups = workspaceSM.get<{
-        [key: string]: { [groupId: string]: TaskGroup };
-      }>(this._getWorkspaceKey('texra.logGroups'));
-      if (oldGroups) {
-        savedGroups = oldGroups;
-        await workspaceSM.update(
-          this._getWorkspaceKey('texra.logGroups'),
-          undefined,
-        );
-        this.logger.debug('Migrated log groups to task groups');
-      }
-    }
-
-    if (savedGroups) {
-      this._taskGroups = new Map(
-        Object.entries(savedGroups)
-          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-          .map(([streamId, groups]) => [
-            streamId,
-            new Map(
-              Object.entries(groups).map(([id, g]) => [
-                id,
-                {
-                  ...g,
-                  startTime:
-                    typeof g.startTime === 'string'
-                      ? new Date(g.startTime).getTime()
-                      : g.startTime,
-                  endTime:
-                    g.endTime !== undefined
-                      ? typeof g.endTime === 'string'
-                        ? new Date(g.endTime).getTime()
-                        : g.endTime
-                      : undefined,
-                },
-              ]),
-            ),
-          ]),
-      );
-    } else {
-      this._taskGroups.clear();
-    }
+    await this._taskGroups.load();
   }
 
   /**
    * Load output files and clean up any that no longer exist
    */
   private async _loadOutputFiles(): Promise<void> {
-    const savedFiles = workspaceSM.get<{
-      [key: string]: { [key: number]: OutputFileInfo[] };
-    }>(this._getWorkspaceKey(WorkspaceStateKey.OUTPUT_FILES));
-
-    if (savedFiles) {
-      const cleaned: [string, { [key: number]: OutputFileInfo[] }][] = [];
-      let totalFilesProcessed = 0;
-      let totalFilesRemoved = 0;
-
-      for (const [streamId, rounds] of Object.entries(savedFiles)) {
-        if (shouldUseConsolidatedChannel(streamId)) {
-          continue;
-        }
-
-        const roundMap: { [key: number]: OutputFileInfo[] } = {};
-        const streamFilesProcessed = Object.values(rounds).reduce(
-          (sum, files) => sum + files.length,
-          0,
-        );
-        totalFilesProcessed += streamFilesProcessed;
-
-        for (const [roundStr, infos] of Object.entries(rounds)) {
-          const roundNum = parseInt(roundStr, 10);
-          this.logger.debug(
-            `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
-          );
-
-          try {
-            const filtered = await WorkspaceFS.filterExistingFiles(infos);
-            const removedCount = infos.length - filtered.length;
-
-            if (removedCount > 0) {
-              this.logger.debug(
-                `Removed ${removedCount} missing file(s) from stream ${streamId}, round ${roundNum}`,
-              );
-              totalFilesRemoved += removedCount;
-
-              // Log which files were removed for debugging
-              const removedFiles = infos.filter(
-                (info) => !filtered.find((f) => f.path === info.path),
-              );
-              removedFiles.forEach((file) => {
-                this.logger.debug(`  - Removed missing file: ${file.path}`);
-              });
-            }
-
-            // Always preserve round structure, even if empty (for UI consistency)
-            // Only skip rounds that had no files to begin with
-            if (infos.length > 0) {
-              roundMap[roundNum] = filtered;
-            }
-          } catch (error) {
-            this.logger.warn(
-              `Error checking files in stream ${streamId}, round ${roundNum}: ${error instanceof Error ? error.message : String(error)}`,
-            );
-            // On error, preserve the original files to avoid data loss
-            roundMap[roundNum] = infos;
-          }
-        }
-
-        // Always preserve streams that had any rounds (even if they become empty)
-        if (Object.keys(rounds).length > 0) {
-          cleaned.push([streamId, roundMap]);
-        }
-      }
-
-      this._outputFiles = new Map(cleaned);
-
-      if (totalFilesRemoved > 0) {
-        this.logger.info(
-          `File cleanup completed: processed ${totalFilesProcessed} files, removed ${totalFilesRemoved} missing files`,
-        );
-      }
-    } else {
-      this._outputFiles.clear();
-    }
+    await this._outputFiles.load();
   }
 
   /**
@@ -296,10 +128,10 @@ export class ProgressStateManager {
     const savedActiveStream = workspaceSM.get<string>(
       WorkspaceStateKey.ACTIVE_LOG_STREAM,
     );
-    if (savedActiveStream && this._logStreams.has(savedActiveStream)) {
+    if (savedActiveStream && this._streamTabs.has(savedActiveStream)) {
       this._activeStream = savedActiveStream;
     } else {
-      this._activeStream = Array.from(this._logStreams.keys())[0] ?? '';
+      this._activeStream = Array.from(this._streamTabs.keys())[0] ?? '';
     }
   }
 
@@ -307,92 +139,35 @@ export class ProgressStateManager {
    * Load task states
    */
   private async _loadTaskStates(): Promise<void> {
-    const savedTaskStates = workspaceSM.get<
-      { [key: string]: Record<string, any> } | [string, Record<string, any>][]
-    >(WorkspaceStateKey.TASK_STATES);
-
-    if (savedTaskStates) {
-      if (Array.isArray(savedTaskStates)) {
-        // Backwards compatibility: convert from array format if encountered
-        this._taskStates = new Map(
-          savedTaskStates.map(([stream, state]) => [
-            stream,
-            objectToTaskState(state),
-          ]),
-        );
-      } else {
-        this._taskStates = new Map(
-          Object.entries(savedTaskStates).map(([stream, state]) => [
-            stream,
-            objectToTaskState(state),
-          ]),
-        );
-      }
-    } else {
-      this._taskStates.clear();
-    }
+    await this._taskStates.load();
   }
 
   /**
    * Load usage statistics
    */
   private async _loadUsageStats(): Promise<void> {
-    const savedUsage = workspaceSM.get<{
-      [key: string]: {
-        inputTokens: number;
-        outputTokens: number;
-        cost: number;
-      };
-    }>(WorkspaceStateKey.USAGE_STATS);
-
-    if (savedUsage) {
-      this._usageStats = new Map(Object.entries(savedUsage));
-    } else {
-      this._usageStats.clear();
-    }
+    await this._usageStats.load();
   }
 
   /**
    * Save log streams to storage
    */
   private _saveLogStreams(): void {
-    // Only save channels that should be persisted
-    const persistentStreams = Array.from(this._logStreams.entries()).filter(
-      ([channel]) => !shouldUseConsolidatedChannel(channel),
-    );
-    const stateObj = Object.fromEntries(persistentStreams);
-    workspaceSM.update(
-      this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS),
-      stateObj,
-    );
+    this._streamTabs.save();
   }
 
   /**
    * Save log groups to storage
    */
   private _saveTaskGroups(): void {
-    const persistentGroups = Array.from(this._taskGroups.entries())
-      .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-      .map(([streamId, groups]) => [
-        streamId,
-        Object.fromEntries(groups.entries()),
-      ]);
-    const groupsObj = Object.fromEntries(persistentGroups);
-    workspaceSM.update(
-      this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS),
-      groupsObj,
-    );
+    this._taskGroups.save();
   }
 
   /**
    * Save output files to storage
    */
   private _saveOutputFiles(): void {
-    const filesObj = Object.fromEntries(this._outputFiles.entries());
-    workspaceSM.update(
-      this._getWorkspaceKey(WorkspaceStateKey.OUTPUT_FILES),
-      filesObj,
-    );
+    this._outputFiles.save();
   }
 
   /**
@@ -406,23 +181,21 @@ export class ProgressStateManager {
    * Save task states
    */
   private _saveTaskStates(): void {
-    const taskStatesObj = Object.fromEntries(this._taskStates.entries());
-    workspaceSM.update(WorkspaceStateKey.TASK_STATES, taskStatesObj);
+    this._taskStates.save();
   }
 
   /**
    * Save usage statistics
    */
   private _saveUsageStats(): void {
-    const usageObj = Object.fromEntries(this._usageStats.entries());
-    workspaceSM.update(WorkspaceStateKey.USAGE_STATS, usageObj);
+    this._usageStats.save();
   }
 
   /**
    * Clear all state for a specific stream
    */
   public clearStream(stream: string): void {
-    this._logStreams.delete(stream);
+    this._streamTabs.delete(stream);
     this._taskGroups.delete(stream);
     this._outputFiles.delete(stream);
     this._taskStates.delete(stream);
@@ -433,7 +206,7 @@ export class ProgressStateManager {
    * Clear all state
    */
   public clearAll(): void {
-    this._logStreams.clear();
+    this._streamTabs.clear();
     this._taskGroups.clear();
     this._outputFiles.clear();
     this._taskStates.clear();

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -205,7 +205,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const streams = Array.from(this._stateManager.logStreams.keys());
+    const streams = Array.from(this._stateManager.streamTabs.keys());
 
     // Use stored active stream, fallback to first stream if active stream doesn't exist
     if (!streams.includes(this._stateManager.activeStream)) {
@@ -276,9 +276,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Create stream if it doesn't exist
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streamTabs.has(stream)) {
       this.logger.debug(`Adding new stream to ProgressView: ${stream}`);
-      this._stateManager.logStreams.set(stream, []);
+      this._stateManager.streamTabs.set(stream, []);
 
       // Set initial status to running for new streams
       if (!this._streamStatus.has(stream)) {
@@ -312,7 +312,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       messageType,
     };
 
-    const messages = this._stateManager.logStreams.get(stream)!;
+    const messages = this._stateManager.streamTabs.get(stream)!;
     messages.push(logMessage);
 
     if (messages.length > 1000) {
@@ -336,7 +336,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     message: string,
     messageType: 'default' | 'scratchpad' | 'thinking' = 'default',
   ): void {
-    const messages = this._stateManager.logStreams.get(stream);
+    const messages = this._stateManager.streamTabs.get(stream);
     if (!messages) {
       return;
     }
@@ -372,9 +372,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     // Ensure the stream exists so the UI can create a new tab immediately
     // this seems to be the fix for the issue where the progress view panel is not shown when a new stream is created
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streamTabs.has(stream)) {
       this.logger.debug(`Creating stream from addLogGroup: ${stream}`);
-      this._stateManager.logStreams.set(stream, []);
+      this._stateManager.streamTabs.set(stream, []);
       if (!this._streamStatus.has(stream)) {
         this.updateStreamStatus(stream, STATUS.RUNNING);
       }
@@ -464,16 +464,16 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // If no stream is provided or stream doesn't exist, use the first available stream
-    if (!stream || !this._stateManager.logStreams.has(stream)) {
-      const streams = Array.from(this._stateManager.logStreams.keys());
+    if (!stream || !this._stateManager.streamTabs.has(stream)) {
+      const streams = Array.from(this._stateManager.streamTabs.keys());
       stream = streams[0] ?? '';
     }
 
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streamTabs.has(stream)) {
       return;
     }
 
-    const messages = this._stateManager.logStreams.get(stream)!;
+    const messages = this._stateManager.streamTabs.get(stream)!;
     // Filter debug messages if debug mode is disabled
     const displayMessages = getConfig<boolean>('logger.debugMode', false)
       ? messages
@@ -505,17 +505,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     });
   }
 
-  public getLogStreams(): Map<string, ColoredLogMessage[]> {
-    return this._stateManager.logStreams;
-  }
-
-  public getTaskGroups(): Map<string, Map<string, TaskGroup>> {
-    return this._stateManager.taskGroups;
-  }
-
   public eraseStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
-      this._stateManager.logStreams.get(stream)!.length = 0;
+    if (this._stateManager.streamTabs.has(stream)) {
+      this._stateManager.streamTabs.get(stream)!.length = 0;
       this._stateManager.taskGroups.delete(stream);
       this._stateManager.outputFiles.delete(stream);
       this._stateManager.saveState();
@@ -533,8 +525,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public deleteStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
-      const streams = Array.from(this._stateManager.logStreams.keys());
+    if (this._stateManager.streamTabs.has(stream)) {
+      const streams = Array.from(this._stateManager.streamTabs.keys());
 
       // Case: This is the last stream - erase it first
       if (streams.length === 1) {
@@ -547,7 +539,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       // If the deleted stream was the active one, switch to another stream if available
       if (stream === this._stateManager.activeStream) {
         const remainingStreams = Array.from(
-          this._stateManager.logStreams.keys(),
+          this._stateManager.streamTabs.keys(),
         );
         this._stateManager.activeStream = remainingStreams[0] ?? '';
       }
@@ -563,7 +555,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streamTabs.has(stream)) {
       return;
     }
 
@@ -658,7 +650,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public setActiveStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
+    if (this._stateManager.streamTabs.has(stream)) {
       this._stateManager.activeStream = stream;
       this._stateManager.saveState();
       this._updateWebview();
@@ -777,7 +769,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     let updatedGroups = 0;
 
     // Check all streams for inconsistencies
-    for (const streamId of this._stateManager.logStreams.keys()) {
+    for (const streamId of this._stateManager.streamTabs.keys()) {
       let wasUpdated = false;
 
       // Check if stream is running and mark as interrupted

--- a/src/progressView/managers/OutputFiles.ts
+++ b/src/progressView/managers/OutputFiles.ts
@@ -1,0 +1,141 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { WorkspaceFS } from '@utils/files';
+import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
+import { AgentLogger } from '@logger/AgentLogger';
+import type { DiffStats } from '../../types/DiffTypes';
+
+interface OutputFileInfo extends DiffStats {
+  path: string;
+  base?: string | null;
+  prev?: string | null;
+  original?: string;
+}
+
+/**
+ * Manages output files per stream with persistence.
+ */
+export class OutputFiles {
+  private readonly logger = new AgentLogger('OutputFiles');
+  private _files: Map<string, { [key: number]: OutputFileInfo[] }> = new Map();
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  async load(): Promise<void> {
+    const saved = workspaceSM.get<{
+      [key: string]: { [key: number]: OutputFileInfo[] };
+    }>(this._getWorkspaceKey(WorkspaceStateKey.OUTPUT_FILES));
+
+    if (saved) {
+      const cleaned: [string, { [key: number]: OutputFileInfo[] }][] = [];
+      let totalFilesProcessed = 0;
+      let totalFilesRemoved = 0;
+
+      for (const [streamId, rounds] of Object.entries(saved)) {
+        if (shouldUseConsolidatedChannel(streamId)) {
+          continue;
+        }
+
+        const roundMap: { [key: number]: OutputFileInfo[] } = {};
+        const streamFilesProcessed = Object.values(rounds).reduce(
+          (sum, files) => sum + files.length,
+          0,
+        );
+        totalFilesProcessed += streamFilesProcessed;
+
+        for (const [roundStr, infos] of Object.entries(rounds)) {
+          const roundNum = parseInt(roundStr, 10);
+          this.logger.debug(
+            `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
+          );
+
+          try {
+            const filtered = await WorkspaceFS.filterExistingFiles(infos);
+            const removedCount = infos.length - filtered.length;
+
+            if (removedCount > 0) {
+              this.logger.debug(
+                `Removed ${removedCount} missing file(s) from stream ${streamId}, round ${roundNum}`,
+              );
+              totalFilesRemoved += removedCount;
+
+              const removedFiles = infos.filter(
+                (info) => !filtered.find((f) => f.path === info.path),
+              );
+              removedFiles.forEach((file) => {
+                this.logger.debug(`  - Removed missing file: ${file.path}`);
+              });
+            }
+
+            if (infos.length > 0) {
+              roundMap[roundNum] = filtered;
+            }
+          } catch (error) {
+            this.logger.warn(
+              `Error checking files in stream ${streamId}, round ${roundNum}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+            roundMap[roundNum] = infos;
+          }
+        }
+
+        if (Object.keys(rounds).length > 0) {
+          cleaned.push([streamId, roundMap]);
+        }
+      }
+
+      this._files = new Map(cleaned);
+
+      if (totalFilesRemoved > 0) {
+        this.logger.info(
+          `File cleanup completed: processed ${totalFilesProcessed} files, removed ${totalFilesRemoved} missing files`,
+        );
+      }
+    } else {
+      this._files.clear();
+    }
+  }
+
+  save(): void {
+    const obj = Object.fromEntries(this._files.entries());
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.OUTPUT_FILES),
+      obj,
+    );
+  }
+
+  get(stream: string): { [key: number]: OutputFileInfo[] } | undefined {
+    return this._files.get(stream);
+  }
+
+  set(stream: string, files: { [key: number]: OutputFileInfo[] }): void {
+    this._files.set(stream, files);
+  }
+
+  delete(stream: string): void {
+    this._files.delete(stream);
+  }
+
+  clear(): void {
+    this._files.clear();
+  }
+
+  entries(): IterableIterator<[string, { [key: number]: OutputFileInfo[] }]> {
+    return this._files.entries();
+  }
+
+  keys(): IterableIterator<string> {
+    return this._files.keys();
+  }
+
+  has(stream: string): boolean {
+    return this._files.has(stream);
+  }
+}

--- a/src/progressView/managers/StreamTabs.ts
+++ b/src/progressView/managers/StreamTabs.ts
@@ -1,0 +1,116 @@
+// Third-party imports
+import * as vscode from 'vscode';
+import { randomUUID } from 'crypto';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
+import { AgentLogger } from '@logger/AgentLogger';
+
+interface ColoredLogMessage {
+  id: string;
+  message: string;
+  level: 'error' | 'warn' | 'info' | 'debug';
+  timestamp: number;
+  groupId?: string;
+  messageType?: 'default' | 'scratchpad' | 'thinking';
+}
+
+/**
+ * Manages persisted stream tabs and their log messages.
+ */
+export class StreamTabs {
+  private readonly logger = new AgentLogger('StreamTabs');
+  private _streams: Map<string, ColoredLogMessage[]> = new Map();
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  async load(): Promise<void> {
+    const key = this._getWorkspaceKey(WorkspaceStateKey.STREAM_TABS);
+    let saved = workspaceSM.get<{ [key: string]: ColoredLogMessage[] }>(key);
+
+    if (!saved) {
+      const oldKey = this._getWorkspaceKey('texra.logStreams');
+      const oldSaved = workspaceSM.get<{ [key: string]: ColoredLogMessage[] }>(
+        oldKey,
+      );
+      if (oldSaved) {
+        saved = oldSaved;
+        await workspaceSM.update(oldKey, undefined);
+        this.logger.debug('Migrated log streams to stream tabs');
+      }
+    }
+
+    if (saved) {
+      this._streams = new Map(
+        Object.entries(saved)
+          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
+          .map(([stream, messages]) => [
+            stream,
+            messages.map((msg) => {
+              if (!msg.id) {
+                msg.id = randomUUID();
+              }
+              if (msg.timestamp === undefined) {
+                const attrMatch = msg.message.match(
+                  /data-full-timestamp="([^"]+)"/,
+                );
+                const timeString =
+                  attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
+                const timestamp = new Date(timeString).getTime();
+                msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
+              }
+              if (!msg.messageType) {
+                msg.messageType = 'default';
+              }
+              return msg;
+            }),
+          ]),
+      );
+    } else {
+      this._streams.clear();
+    }
+  }
+
+  save(): void {
+    const persistent = Array.from(this._streams.entries()).filter(
+      ([channel]) => !shouldUseConsolidatedChannel(channel),
+    );
+    const obj = Object.fromEntries(persistent);
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.STREAM_TABS),
+      obj,
+    );
+  }
+
+  get(stream: string): ColoredLogMessage[] | undefined {
+    return this._streams.get(stream);
+  }
+
+  set(stream: string, messages: ColoredLogMessage[]): void {
+    this._streams.set(stream, messages);
+  }
+
+  delete(stream: string): void {
+    this._streams.delete(stream);
+  }
+
+  clear(): void {
+    this._streams.clear();
+  }
+
+  entries(): IterableIterator<[string, ColoredLogMessage[]]> {
+    return this._streams.entries();
+  }
+
+  keys(): IterableIterator<string> {
+    return this._streams.keys();
+  }
+
+  has(stream: string): boolean {
+    return this._streams.has(stream);
+  }
+}

--- a/src/progressView/managers/TaskGroups.ts
+++ b/src/progressView/managers/TaskGroups.ts
@@ -1,0 +1,113 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
+import { AgentLogger } from '@logger/AgentLogger';
+import { TaskGroup } from '../../logger/LogTypes';
+
+/**
+ * Manages task groups per stream with persistence.
+ */
+export class TaskGroups {
+  private readonly logger = new AgentLogger('TaskGroups');
+  private _groups: Map<string, Map<string, TaskGroup>> = new Map();
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  async load(): Promise<void> {
+    let saved = workspaceSM.get<{
+      [key: string]: { [groupId: string]: TaskGroup };
+    }>(this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS));
+
+    if (!saved) {
+      const old = workspaceSM.get<{
+        [key: string]: { [groupId: string]: TaskGroup };
+      }>(this._getWorkspaceKey('texra.logGroups'));
+      if (old) {
+        saved = old;
+        await workspaceSM.update(
+          this._getWorkspaceKey('texra.logGroups'),
+          undefined,
+        );
+        this.logger.debug('Migrated log groups to task groups');
+      }
+    }
+
+    if (saved) {
+      this._groups = new Map(
+        Object.entries(saved)
+          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
+          .map(([streamId, groups]) => [
+            streamId,
+            new Map(
+              Object.entries(groups).map(([id, g]) => [
+                id,
+                {
+                  ...g,
+                  startTime:
+                    typeof g.startTime === 'string'
+                      ? new Date(g.startTime).getTime()
+                      : g.startTime,
+                  endTime:
+                    g.endTime !== undefined
+                      ? typeof g.endTime === 'string'
+                        ? new Date(g.endTime).getTime()
+                        : g.endTime
+                      : undefined,
+                },
+              ]),
+            ),
+          ]),
+      );
+    } else {
+      this._groups.clear();
+    }
+  }
+
+  save(): void {
+    const persistent = Array.from(this._groups.entries())
+      .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
+      .map(([streamId, groups]) => [
+        streamId,
+        Object.fromEntries(groups.entries()),
+      ]);
+    const obj = Object.fromEntries(persistent);
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS),
+      obj,
+    );
+  }
+
+  get(stream: string): Map<string, TaskGroup> | undefined {
+    return this._groups.get(stream);
+  }
+
+  set(stream: string, groups: Map<string, TaskGroup>): void {
+    this._groups.set(stream, groups);
+  }
+
+  delete(stream: string): void {
+    this._groups.delete(stream);
+  }
+
+  clear(): void {
+    this._groups.clear();
+  }
+
+  entries(): IterableIterator<[string, Map<string, TaskGroup>]> {
+    return this._groups.entries();
+  }
+
+  keys(): IterableIterator<string> {
+    return this._groups.keys();
+  }
+
+  has(stream: string): boolean {
+    return this._groups.has(stream);
+  }
+}

--- a/src/progressView/managers/TaskStates.ts
+++ b/src/progressView/managers/TaskStates.ts
@@ -1,0 +1,80 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { objectToTaskState } from '@utils/config';
+import { AgentLogger } from '@logger/AgentLogger';
+import { TaskState } from '@logger/TaskState';
+
+/**
+ * Manages task state per stream with persistence.
+ */
+export class TaskStates {
+  private readonly logger = new AgentLogger('TaskStates');
+  private _states: Map<string, TaskState> = new Map();
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  async load(): Promise<void> {
+    const saved = workspaceSM.get<
+      { [key: string]: Record<string, any> } | [string, Record<string, any>][]
+    >(this._getWorkspaceKey(WorkspaceStateKey.TASK_STATES));
+
+    if (saved) {
+      if (Array.isArray(saved)) {
+        this._states = new Map(
+          saved.map(([stream, state]) => [stream, objectToTaskState(state)]),
+        );
+      } else {
+        this._states = new Map(
+          Object.entries(saved).map(([stream, state]) => [
+            stream,
+            objectToTaskState(state),
+          ]),
+        );
+      }
+    } else {
+      this._states.clear();
+    }
+  }
+
+  save(): void {
+    const obj = Object.fromEntries(this._states.entries());
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.TASK_STATES),
+      obj,
+    );
+  }
+
+  get(stream: string): TaskState | undefined {
+    return this._states.get(stream);
+  }
+
+  set(stream: string, state: TaskState): void {
+    this._states.set(stream, state);
+  }
+
+  delete(stream: string): void {
+    this._states.delete(stream);
+  }
+
+  clear(): void {
+    this._states.clear();
+  }
+
+  entries(): IterableIterator<[string, TaskState]> {
+    return this._states.entries();
+  }
+
+  keys(): IterableIterator<string> {
+    return this._states.keys();
+  }
+
+  has(stream: string): boolean {
+    return this._states.has(stream);
+  }
+}

--- a/src/progressView/managers/UsageStats.ts
+++ b/src/progressView/managers/UsageStats.ts
@@ -1,0 +1,69 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Types
+import { TokenUsageStats } from '../../types/UsageTypes';
+
+/**
+ * Manages token usage statistics per stream.
+ */
+export class UsageStats {
+  private readonly logger = new AgentLogger('UsageStats');
+  private _stats: Map<string, TokenUsageStats> = new Map();
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  async load(): Promise<void> {
+    const saved = workspaceSM.get<{ [key: string]: TokenUsageStats }>(
+      this._getWorkspaceKey(WorkspaceStateKey.USAGE_STATS),
+    );
+    if (saved) {
+      this._stats = new Map(Object.entries(saved));
+    } else {
+      this._stats.clear();
+    }
+  }
+
+  save(): void {
+    const obj = Object.fromEntries(this._stats.entries());
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.USAGE_STATS),
+      obj,
+    );
+  }
+
+  get(stream: string): TokenUsageStats | undefined {
+    return this._stats.get(stream);
+  }
+
+  set(stream: string, stats: TokenUsageStats): void {
+    this._stats.set(stream, stats);
+  }
+
+  delete(stream: string): void {
+    this._stats.delete(stream);
+  }
+
+  clear(): void {
+    this._stats.clear();
+  }
+
+  entries(): IterableIterator<[string, TokenUsageStats]> {
+    return this._stats.entries();
+  }
+
+  keys(): IterableIterator<string> {
+    return this._stats.keys();
+  }
+
+  has(stream: string): boolean {
+    return this._stats.has(stream);
+  }
+}

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 // Simple enums for commonly used state keys
 export enum WorkspaceStateKey {
   AGENT_HISTORY = 'texra.agentHistory',
-  LOG_STREAMS = 'texra.logStreams',
+  STREAM_TABS = 'texra.streamTabs',
   TASK_GROUPS = 'texra.taskGroups',
   OUTPUT_FILES = 'texra.outputFiles',
   ACTIVE_LOG_STREAM = 'texra.activeLogStream',


### PR DESCRIPTION
## Summary
- introduce TaskGroups, OutputFiles, and TaskStates managers
- move load/save logic from ProgressStateManager into these managers
- update ProgressStateManager to use the new classes

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(webpack warning noted)*

------
https://chatgpt.com/codex/tasks/task_e_685c21b95d24832496bd5d01538cfa05