### PR TITLE
Refactor ProgressState into managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ releases/
 .cursor/rules
 **/.claude/settings.local.json
 webview-common/
+.vscode-test/

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -1,35 +1,19 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import { randomUUID } from 'crypto';
 
 // Local imports
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
-import { WorkspaceFS } from '@utils/files';
 import { objectToTaskState } from '@utils/config';
-import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
+import {
+  StreamsManager,
+  GroupsManager,
+  FilesManager,
+  UsageManager,
+} from './state';
 
 // Types
-import { TokenUsageStats } from '../types/UsageTypes';
-import { TaskGroup } from '../logger/LogTypes';
-import type { DiffStats } from '../types/DiffTypes';
-
-interface ColoredLogMessage {
-  id: string;
-  message: string;
-  level: 'error' | 'warn' | 'info' | 'debug';
-  timestamp: number;
-  groupId?: string;
-  messageType?: 'default' | 'scratchpad' | 'thinking';
-}
-
-interface OutputFileInfo extends DiffStats {
-  path: string;
-  base?: string | null;
-  prev?: string | null;
-  original?: string;
-}
 
 /**
  * Manages persistence of progress view state to workspace storage.
@@ -40,267 +24,49 @@ export class ProgressStateManager {
   private readonly logger: AgentLogger;
 
   // State collections
-  private _logStreams: Map<string, ColoredLogMessage[]> = new Map();
-  private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
-  private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
-    new Map();
+  public readonly streams = new StreamsManager();
+  public readonly groups = new GroupsManager();
+  public readonly files = new FilesManager();
+  public readonly usage = new UsageManager();
   private _taskStates: Map<string, TaskState> = new Map();
-  private _usageStats: Map<string, TokenUsageStats> = new Map();
-  private _activeStream: string = '';
 
   constructor() {
     this.logger = new AgentLogger('ProgressStateManager');
   }
 
-  // Getters for state collections
-  get logStreams(): Map<string, ColoredLogMessage[]> {
-    return this._logStreams;
-  }
-
-  get taskGroups(): Map<string, Map<string, TaskGroup>> {
-    return this._taskGroups;
-  }
-
-  get outputFiles(): Map<string, { [key: number]: OutputFileInfo[] }> {
-    return this._outputFiles;
-  }
-
+  // Getters for task state collection
   get taskStates(): Map<string, TaskState> {
     return this._taskStates;
   }
 
-  get usageStats(): Map<string, TokenUsageStats> {
-    return this._usageStats;
-  }
-
   get activeStream(): string {
-    return this._activeStream;
+    return this.streams.active;
   }
 
   set activeStream(stream: string) {
-    this._activeStream = stream;
-  }
-
-  /**
-   * Get workspace-specific storage key
-   */
-  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+    this.streams.active = stream;
   }
 
   /**
    * Load all state from workspace storage
    */
   public async loadState(): Promise<void> {
-    await this._loadLogStreams();
-    await this._loadTaskGroups();
-    await this._loadOutputFiles();
-    this._loadActiveStream();
+    await this.streams.load();
+    await this.groups.load();
+    await this.files.load();
     await this._loadTaskStates();
-    await this._loadUsageStats();
+    await this.usage.load();
   }
 
   /**
    * Save all state to workspace storage
    */
   public saveState(): void {
-    this._saveLogStreams();
-    this._saveTaskGroups();
-    this._saveOutputFiles();
-    this._saveActiveStream();
+    this.streams.save();
+    this.groups.save();
+    this.files.save();
     this._saveTaskStates();
-    this._saveUsageStats();
-  }
-
-  /**
-   * Load log streams from storage
-   */
-  private async _loadLogStreams(): Promise<void> {
-    const savedState = workspaceSM.get<{
-      [key: string]: ColoredLogMessage[];
-    }>(this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS));
-
-    if (savedState) {
-      // Only load channels that should be persisted
-      this._logStreams = new Map(
-        Object.entries(savedState)
-          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-          .map(([stream, messages]) => [
-            stream,
-            messages.map((msg) => {
-              if (!msg.id) {
-                msg.id = randomUUID();
-              }
-              if (msg.timestamp === undefined) {
-                const attrMatch = msg.message.match(
-                  /data-full-timestamp="([^"]+)"/,
-                );
-                const timeString =
-                  attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
-                const timestamp = new Date(timeString).getTime();
-                msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
-              }
-              if (!msg.messageType) {
-                msg.messageType = 'default';
-              }
-              return msg;
-            }),
-          ]),
-      );
-    } else {
-      this._logStreams.clear();
-    }
-  }
-
-  /**
-   * Load log groups from storage
-   */
-  private async _loadTaskGroups(): Promise<void> {
-    let savedGroups = workspaceSM.get<{
-      [key: string]: { [groupId: string]: TaskGroup };
-    }>(this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS));
-
-    // Migrate data stored under the old key if needed
-    if (!savedGroups) {
-      const oldGroups = workspaceSM.get<{
-        [key: string]: { [groupId: string]: TaskGroup };
-      }>(this._getWorkspaceKey('texra.logGroups'));
-      if (oldGroups) {
-        savedGroups = oldGroups;
-        await workspaceSM.update(
-          this._getWorkspaceKey('texra.logGroups'),
-          undefined,
-        );
-        this.logger.debug('Migrated log groups to task groups');
-      }
-    }
-
-    if (savedGroups) {
-      this._taskGroups = new Map(
-        Object.entries(savedGroups)
-          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-          .map(([streamId, groups]) => [
-            streamId,
-            new Map(
-              Object.entries(groups).map(([id, g]) => [
-                id,
-                {
-                  ...g,
-                  startTime:
-                    typeof g.startTime === 'string'
-                      ? new Date(g.startTime).getTime()
-                      : g.startTime,
-                  endTime:
-                    g.endTime !== undefined
-                      ? typeof g.endTime === 'string'
-                        ? new Date(g.endTime).getTime()
-                        : g.endTime
-                      : undefined,
-                },
-              ]),
-            ),
-          ]),
-      );
-    } else {
-      this._taskGroups.clear();
-    }
-  }
-
-  /**
-   * Load output files and clean up any that no longer exist
-   */
-  private async _loadOutputFiles(): Promise<void> {
-    const savedFiles = workspaceSM.get<{
-      [key: string]: { [key: number]: OutputFileInfo[] };
-    }>(this._getWorkspaceKey(WorkspaceStateKey.OUTPUT_FILES));
-
-    if (savedFiles) {
-      const cleaned: [string, { [key: number]: OutputFileInfo[] }][] = [];
-      let totalFilesProcessed = 0;
-      let totalFilesRemoved = 0;
-
-      for (const [streamId, rounds] of Object.entries(savedFiles)) {
-        if (shouldUseConsolidatedChannel(streamId)) {
-          continue;
-        }
-
-        const roundMap: { [key: number]: OutputFileInfo[] } = {};
-        const streamFilesProcessed = Object.values(rounds).reduce(
-          (sum, files) => sum + files.length,
-          0,
-        );
-        totalFilesProcessed += streamFilesProcessed;
-
-        for (const [roundStr, infos] of Object.entries(rounds)) {
-          const roundNum = parseInt(roundStr, 10);
-          this.logger.debug(
-            `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
-          );
-
-          try {
-            const filtered = await WorkspaceFS.filterExistingFiles(infos);
-            const removedCount = infos.length - filtered.length;
-
-            if (removedCount > 0) {
-              this.logger.debug(
-                `Removed ${removedCount} missing file(s) from stream ${streamId}, round ${roundNum}`,
-              );
-              totalFilesRemoved += removedCount;
-
-              // Log which files were removed for debugging
-              const removedFiles = infos.filter(
-                (info) => !filtered.find((f) => f.path === info.path),
-              );
-              removedFiles.forEach((file) => {
-                this.logger.debug(`  - Removed missing file: ${file.path}`);
-              });
-            }
-
-            // Always preserve round structure, even if empty (for UI consistency)
-            // Only skip rounds that had no files to begin with
-            if (infos.length > 0) {
-              roundMap[roundNum] = filtered;
-            }
-          } catch (error) {
-            this.logger.warn(
-              `Error checking files in stream ${streamId}, round ${roundNum}: ${error instanceof Error ? error.message : String(error)}`,
-            );
-            // On error, preserve the original files to avoid data loss
-            roundMap[roundNum] = infos;
-          }
-        }
-
-        // Always preserve streams that had any rounds (even if they become empty)
-        if (Object.keys(rounds).length > 0) {
-          cleaned.push([streamId, roundMap]);
-        }
-      }
-
-      this._outputFiles = new Map(cleaned);
-
-      if (totalFilesRemoved > 0) {
-        this.logger.info(
-          `File cleanup completed: processed ${totalFilesProcessed} files, removed ${totalFilesRemoved} missing files`,
-        );
-      }
-    } else {
-      this._outputFiles.clear();
-    }
-  }
-
-  /**
-   * Load active stream
-   */
-  private _loadActiveStream(): void {
-    const savedActiveStream = workspaceSM.get<string>(
-      WorkspaceStateKey.ACTIVE_LOG_STREAM,
-    );
-    if (savedActiveStream && this._logStreams.has(savedActiveStream)) {
-      this._activeStream = savedActiveStream;
-    } else {
-      this._activeStream = Array.from(this._logStreams.keys())[0] ?? '';
-    }
+    this.usage.save();
   }
 
   /**
@@ -334,75 +100,6 @@ export class ProgressStateManager {
   }
 
   /**
-   * Load usage statistics
-   */
-  private async _loadUsageStats(): Promise<void> {
-    const savedUsage = workspaceSM.get<{
-      [key: string]: {
-        inputTokens: number;
-        outputTokens: number;
-        cost: number;
-      };
-    }>(WorkspaceStateKey.USAGE_STATS);
-
-    if (savedUsage) {
-      this._usageStats = new Map(Object.entries(savedUsage));
-    } else {
-      this._usageStats.clear();
-    }
-  }
-
-  /**
-   * Save log streams to storage
-   */
-  private _saveLogStreams(): void {
-    // Only save channels that should be persisted
-    const persistentStreams = Array.from(this._logStreams.entries()).filter(
-      ([channel]) => !shouldUseConsolidatedChannel(channel),
-    );
-    const stateObj = Object.fromEntries(persistentStreams);
-    workspaceSM.update(
-      this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS),
-      stateObj,
-    );
-  }
-
-  /**
-   * Save log groups to storage
-   */
-  private _saveTaskGroups(): void {
-    const persistentGroups = Array.from(this._taskGroups.entries())
-      .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-      .map(([streamId, groups]) => [
-        streamId,
-        Object.fromEntries(groups.entries()),
-      ]);
-    const groupsObj = Object.fromEntries(persistentGroups);
-    workspaceSM.update(
-      this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS),
-      groupsObj,
-    );
-  }
-
-  /**
-   * Save output files to storage
-   */
-  private _saveOutputFiles(): void {
-    const filesObj = Object.fromEntries(this._outputFiles.entries());
-    workspaceSM.update(
-      this._getWorkspaceKey(WorkspaceStateKey.OUTPUT_FILES),
-      filesObj,
-    );
-  }
-
-  /**
-   * Save active stream
-   */
-  private _saveActiveStream(): void {
-    workspaceSM.update(WorkspaceStateKey.ACTIVE_LOG_STREAM, this._activeStream);
-  }
-
-  /**
    * Save task states
    */
   private _saveTaskStates(): void {
@@ -411,33 +108,24 @@ export class ProgressStateManager {
   }
 
   /**
-   * Save usage statistics
-   */
-  private _saveUsageStats(): void {
-    const usageObj = Object.fromEntries(this._usageStats.entries());
-    workspaceSM.update(WorkspaceStateKey.USAGE_STATS, usageObj);
-  }
-
-  /**
    * Clear all state for a specific stream
    */
   public clearStream(stream: string): void {
-    this._logStreams.delete(stream);
-    this._taskGroups.delete(stream);
-    this._outputFiles.delete(stream);
+    this.streams.clear(stream);
+    this.groups.clear(stream);
+    this.files.clear(stream);
     this._taskStates.delete(stream);
-    this._usageStats.delete(stream);
+    this.usage.clear(stream);
   }
 
   /**
    * Clear all state
    */
   public clearAll(): void {
-    this._logStreams.clear();
-    this._taskGroups.clear();
-    this._outputFiles.clear();
+    this.streams.clearAll();
+    this.groups.clearAll();
+    this.files.clearAll();
     this._taskStates.clear();
-    this._usageStats.clear();
-    this._activeStream = '';
+    this.usage.clearAll();
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -205,7 +205,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const streams = Array.from(this._stateManager.logStreams.keys());
+    const streams = Array.from(this._stateManager.streams.map.keys());
 
     // Use stored active stream, fallback to first stream if active stream doesn't exist
     if (!streams.includes(this._stateManager.activeStream)) {
@@ -221,14 +221,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     // Send output files for current stream
     const files =
-      this._stateManager.outputFiles.get(this._stateManager.activeStream) || {};
+      this._stateManager.files.map.get(this._stateManager.activeStream) || {};
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_FILES,
       stream: this._stateManager.activeStream,
       files,
     });
 
-    const usage = this._stateManager.usageStats.get(
+    const usage = this._stateManager.usage.map.get(
       this._stateManager.activeStream,
     );
     this._view.webview.postMessage({
@@ -276,9 +276,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Create stream if it doesn't exist
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streams.map.has(stream)) {
       this.logger.debug(`Adding new stream to ProgressView: ${stream}`);
-      this._stateManager.logStreams.set(stream, []);
+      this._stateManager.streams.map.set(stream, []);
 
       // Set initial status to running for new streams
       if (!this._streamStatus.has(stream)) {
@@ -312,7 +312,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       messageType,
     };
 
-    const messages = this._stateManager.logStreams.get(stream)!;
+    const messages = this._stateManager.streams.map.get(stream)!;
     messages.push(logMessage);
 
     if (messages.length > 1000) {
@@ -336,7 +336,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     message: string,
     messageType: 'default' | 'scratchpad' | 'thinking' = 'default',
   ): void {
-    const messages = this._stateManager.logStreams.get(stream);
+    const messages = this._stateManager.streams.map.get(stream);
     if (!messages) {
       return;
     }
@@ -372,9 +372,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     // Ensure the stream exists so the UI can create a new tab immediately
     // this seems to be the fix for the issue where the progress view panel is not shown when a new stream is created
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streams.map.has(stream)) {
       this.logger.debug(`Creating stream from addLogGroup: ${stream}`);
-      this._stateManager.logStreams.set(stream, []);
+      this._stateManager.streams.map.set(stream, []);
       if (!this._streamStatus.has(stream)) {
         this.updateStreamStatus(stream, STATUS.RUNNING);
       }
@@ -387,11 +387,11 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Create stream groups mapping if it doesn't exist
-    if (!this._stateManager.taskGroups.has(stream)) {
-      this._stateManager.taskGroups.set(stream, new Map());
+    if (!this._stateManager.groups.map.has(stream)) {
+      this._stateManager.groups.map.set(stream, new Map());
     }
 
-    const streamGroups = this._stateManager.taskGroups.get(stream)!;
+    const streamGroups = this._stateManager.groups.map.get(stream)!;
     streamGroups.set(groupId, {
       id: groupId,
       name: groupName,
@@ -430,7 +430,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const streamGroups = this._stateManager.taskGroups.get(stream);
+    const streamGroups = this._stateManager.groups.map.get(stream);
     if (!streamGroups) {
       return;
     }
@@ -464,23 +464,23 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // If no stream is provided or stream doesn't exist, use the first available stream
-    if (!stream || !this._stateManager.logStreams.has(stream)) {
-      const streams = Array.from(this._stateManager.logStreams.keys());
+    if (!stream || !this._stateManager.streams.map.has(stream)) {
+      const streams = Array.from(this._stateManager.streams.map.keys());
       stream = streams[0] ?? '';
     }
 
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streams.map.has(stream)) {
       return;
     }
 
-    const messages = this._stateManager.logStreams.get(stream)!;
+    const messages = this._stateManager.streams.map.get(stream)!;
     // Filter debug messages if debug mode is disabled
     const displayMessages = getConfig<boolean>('logger.debugMode', false)
       ? messages
       : messages.filter((msg) => msg.level !== 'debug');
 
     // Get groups for this stream
-    const groups = this._stateManager.taskGroups.get(stream) || new Map();
+    const groups = this._stateManager.groups.map.get(stream) || new Map();
 
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_LOGS,
@@ -497,7 +497,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     });
 
     // Send output files for this stream
-    const files = this._stateManager.outputFiles.get(stream) || {};
+    const files = this._stateManager.files.map.get(stream) || {};
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_FILES,
       stream: stream,
@@ -506,18 +506,18 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public getLogStreams(): Map<string, ColoredLogMessage[]> {
-    return this._stateManager.logStreams;
+    return this._stateManager.streams.map;
   }
 
   public getTaskGroups(): Map<string, Map<string, TaskGroup>> {
-    return this._stateManager.taskGroups;
+    return this._stateManager.groups.map;
   }
 
   public eraseStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
-      this._stateManager.logStreams.get(stream)!.length = 0;
-      this._stateManager.taskGroups.delete(stream);
-      this._stateManager.outputFiles.delete(stream);
+    if (this._stateManager.streams.map.has(stream)) {
+      this._stateManager.streams.map.get(stream)!.length = 0;
+      this._stateManager.groups.map.delete(stream);
+      this._stateManager.files.map.delete(stream);
       this._stateManager.saveState();
       this.updateLogContent(stream);
     }
@@ -533,8 +533,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public deleteStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
-      const streams = Array.from(this._stateManager.logStreams.keys());
+    if (this._stateManager.streams.map.has(stream)) {
+      const streams = Array.from(this._stateManager.streams.map.keys());
 
       // Case: This is the last stream - erase it first
       if (streams.length === 1) {
@@ -547,7 +547,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       // If the deleted stream was the active one, switch to another stream if available
       if (stream === this._stateManager.activeStream) {
         const remainingStreams = Array.from(
-          this._stateManager.logStreams.keys(),
+          this._stateManager.streams.map.keys(),
         );
         this._stateManager.activeStream = remainingStreams[0] ?? '';
       }
@@ -563,7 +563,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streams.map.has(stream)) {
       return;
     }
 
@@ -584,9 +584,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     stream: string,
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): void {
-    const existing = this._stateManager.outputFiles.get(stream) || {};
+    const existing = this._stateManager.files.map.get(stream) || {};
     const merged = { ...existing, ...filesByRound };
-    this._stateManager.outputFiles.set(stream, merged);
+    this._stateManager.files.map.set(stream, merged);
     this._stateManager.saveState();
     if (this._view && stream === this._stateManager.activeStream) {
       this._view.webview.postMessage({
@@ -600,12 +600,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   public getOutputFiles(
     stream: string,
   ): { [key: number]: OutputFileInfo[] } | undefined {
-    return this._stateManager.outputFiles.get(stream);
+    return this._stateManager.files.map.get(stream);
   }
 
   public clearOutputFiles(stream: string): void {
-    if (this._stateManager.outputFiles.has(stream)) {
-      this._stateManager.outputFiles.delete(stream);
+    if (this._stateManager.files.map.has(stream)) {
+      this._stateManager.files.map.delete(stream);
       this._stateManager.saveState();
       if (this._view && stream === this._stateManager.activeStream) {
         this._view.webview.postMessage({
@@ -618,7 +618,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public updateStreamUsage(stream: string, usage: TokenUsageStats): void {
-    this._stateManager.usageStats.set(stream, usage);
+    this._stateManager.usage.map.set(stream, usage);
     this._stateManager.saveState();
     if (this._view && stream === this._stateManager.activeStream) {
       this._view.webview.postMessage({
@@ -633,7 +633,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     groupId: string,
     usage: TokenUsageStats,
   ): void {
-    const streamGroups = this._stateManager.taskGroups.get(stream);
+    const streamGroups = this._stateManager.groups.map.get(stream);
     if (streamGroups) {
       const group = streamGroups.get(groupId);
       if (group) {
@@ -654,11 +654,11 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public getStreamUsage(stream: string): TokenUsageStats | undefined {
-    return this._stateManager.usageStats.get(stream);
+    return this._stateManager.usage.map.get(stream);
   }
 
   public setActiveStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
+    if (this._stateManager.streams.map.has(stream)) {
       this._stateManager.activeStream = stream;
       this._stateManager.saveState();
       this._updateWebview();
@@ -744,7 +744,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       );
 
       // Update all active groups for this stream
-      const streamGroups = this._stateManager.taskGroups.get(streamId);
+      const streamGroups = this._stateManager.groups.map.get(streamId);
       if (streamGroups) {
         const activeGroups = Array.from(streamGroups.entries()).filter(
           ([_, group]) => !group.endTime || group.status === STATUS.RUNNING,
@@ -777,7 +777,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     let updatedGroups = 0;
 
     // Check all streams for inconsistencies
-    for (const streamId of this._stateManager.logStreams.keys()) {
+    for (const streamId of this._stateManager.streams.map.keys()) {
       let wasUpdated = false;
 
       // Check if stream is running and mark as interrupted
@@ -796,7 +796,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       }
 
       // Check for running groups that need to be marked as interrupted
-      const streamGroups = this._stateManager.taskGroups.get(streamId);
+      const streamGroups = this._stateManager.groups.map.get(streamId);
       if (streamGroups) {
         const activeGroups = Array.from(streamGroups.entries()).filter(
           ([_, group]) => !group.endTime || group.status === STATUS.RUNNING,

--- a/src/progressView/state/BaseStateManager.ts
+++ b/src/progressView/state/BaseStateManager.ts
@@ -1,0 +1,20 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WorkspaceStateKey } from '@utils/stateManager';
+
+/**
+ * Base interface for progress view state managers.
+ */
+export abstract class BaseStateManager {
+  protected _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  abstract load(): Promise<void>;
+  abstract save(): void;
+  abstract clear(stream: string): void;
+  abstract clearAll(): void;
+}

--- a/src/progressView/state/FilesManager.ts
+++ b/src/progressView/state/FilesManager.ts
@@ -1,0 +1,124 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { WorkspaceFS } from '@utils/files';
+import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Types
+import type { DiffStats } from '../../types/DiffTypes';
+
+interface OutputFileInfo extends DiffStats {
+  path: string;
+  base?: string | null;
+  prev?: string | null;
+  original?: string;
+}
+
+/**
+ * Manages generated output files for streams.
+ */
+export class FilesManager {
+  public readonly map: Map<string, { [key: number]: OutputFileInfo[] }> =
+    new Map();
+  private readonly logger = new AgentLogger('FilesManager');
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  async load(): Promise<void> {
+    const savedFiles = workspaceSM.get<{
+      [key: string]: { [key: number]: OutputFileInfo[] };
+    }>(this._getWorkspaceKey(WorkspaceStateKey.OUTPUT_FILES));
+
+    if (savedFiles) {
+      const cleaned: [string, { [key: number]: OutputFileInfo[] }][] = [];
+      let totalFilesProcessed = 0;
+      let totalFilesRemoved = 0;
+
+      for (const [streamId, rounds] of Object.entries(savedFiles)) {
+        if (shouldUseConsolidatedChannel(streamId)) {
+          continue;
+        }
+
+        const roundMap: { [key: number]: OutputFileInfo[] } = {};
+        const streamFilesProcessed = Object.values(rounds).reduce(
+          (sum, files) => sum + files.length,
+          0,
+        );
+        totalFilesProcessed += streamFilesProcessed;
+
+        for (const [roundStr, infos] of Object.entries(rounds)) {
+          const roundNum = parseInt(roundStr, 10);
+          this.logger.debug(
+            `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
+          );
+
+          try {
+            const filtered = await WorkspaceFS.filterExistingFiles(infos);
+            const removedCount = infos.length - filtered.length;
+
+            if (removedCount > 0) {
+              this.logger.debug(
+                `Removed ${removedCount} missing file(s) from stream ${streamId}, round ${roundNum}`,
+              );
+              totalFilesRemoved += removedCount;
+
+              const removedFiles = infos.filter(
+                (info) => !filtered.find((f) => f.path === info.path),
+              );
+              removedFiles.forEach((file) => {
+                this.logger.debug(`  - Removed missing file: ${file.path}`);
+              });
+            }
+
+            if (infos.length > 0) {
+              roundMap[roundNum] = filtered;
+            }
+          } catch (error) {
+            this.logger.warn(
+              `Error checking files in stream ${streamId}, round ${roundNum}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            roundMap[roundNum] = infos;
+          }
+        }
+
+        if (Object.keys(rounds).length > 0) {
+          cleaned.push([streamId, roundMap]);
+        }
+      }
+
+      this.map.clear();
+      for (const [streamId, data] of cleaned) {
+        this.map.set(streamId, data);
+      }
+
+      if (totalFilesRemoved > 0) {
+        this.logger.info(
+          `File cleanup completed: processed ${totalFilesProcessed} files, removed ${totalFilesRemoved} missing files`,
+        );
+      }
+    } else {
+      this.map.clear();
+    }
+  }
+
+  save(): void {
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.OUTPUT_FILES),
+      Object.fromEntries(this.map.entries()),
+    );
+  }
+
+  clear(stream: string): void {
+    this.map.delete(stream);
+  }
+
+  clearAll(): void {
+    this.map.clear();
+  }
+}

--- a/src/progressView/state/FilesManager.ts
+++ b/src/progressView/state/FilesManager.ts
@@ -1,11 +1,11 @@
 // Third-party imports
-import * as vscode from 'vscode';
 
 // Local imports
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
 import { WorkspaceFS } from '@utils/files';
 import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 import { AgentLogger } from '@logger/AgentLogger';
+import { BaseStateManager } from './BaseStateManager';
 
 // Types
 import type { DiffStats } from '../../types/DiffTypes';
@@ -20,15 +20,10 @@ interface OutputFileInfo extends DiffStats {
 /**
  * Manages generated output files for streams.
  */
-export class FilesManager {
+export class FilesManager extends BaseStateManager {
   public readonly map: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
   private readonly logger = new AgentLogger('FilesManager');
-
-  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
-  }
 
   async load(): Promise<void> {
     const savedFiles = workspaceSM.get<{

--- a/src/progressView/state/GroupsManager.ts
+++ b/src/progressView/state/GroupsManager.ts
@@ -1,0 +1,92 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Types
+import type { TaskGroup } from '../../logger/LogTypes';
+
+/**
+ * Manages task group information for log streams.
+ */
+export class GroupsManager {
+  public readonly map: Map<string, Map<string, TaskGroup>> = new Map();
+  private readonly logger = new AgentLogger('GroupsManager');
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  async load(): Promise<void> {
+    let savedGroups = workspaceSM.get<{
+      [key: string]: { [groupId: string]: TaskGroup };
+    }>(this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS));
+
+    if (!savedGroups) {
+      const oldGroups = workspaceSM.get<{
+        [key: string]: { [groupId: string]: TaskGroup };
+      }>(this._getWorkspaceKey('texra.logGroups'));
+      if (oldGroups) {
+        savedGroups = oldGroups;
+        await workspaceSM.update(
+          this._getWorkspaceKey('texra.logGroups'),
+          undefined,
+        );
+        this.logger.debug('Migrated log groups to task groups');
+      }
+    }
+
+    if (savedGroups) {
+      this.map.clear();
+      for (const [streamId, groups] of Object.entries(savedGroups)) {
+        if (shouldUseConsolidatedChannel(streamId)) {
+          continue;
+        }
+        const groupMap = new Map<string, TaskGroup>();
+        for (const [id, g] of Object.entries(groups)) {
+          groupMap.set(id, {
+            ...g,
+            startTime:
+              typeof g.startTime === 'string'
+                ? new Date(g.startTime).getTime()
+                : g.startTime,
+            endTime:
+              g.endTime !== undefined
+                ? typeof g.endTime === 'string'
+                  ? new Date(g.endTime).getTime()
+                  : g.endTime
+                : undefined,
+          });
+        }
+        this.map.set(streamId, groupMap);
+      }
+    } else {
+      this.map.clear();
+    }
+  }
+
+  save(): void {
+    const persistent = Array.from(this.map.entries())
+      .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
+      .map(([streamId, groups]) => [
+        streamId,
+        Object.fromEntries(groups.entries()),
+      ]);
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS),
+      Object.fromEntries(persistent),
+    );
+  }
+
+  clear(stream: string): void {
+    this.map.delete(stream);
+  }
+
+  clearAll(): void {
+    this.map.clear();
+  }
+}

--- a/src/progressView/state/GroupsManager.ts
+++ b/src/progressView/state/GroupsManager.ts
@@ -1,10 +1,10 @@
 // Third-party imports
-import * as vscode from 'vscode';
 
 // Local imports
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
 import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 import { AgentLogger } from '@logger/AgentLogger';
+import { BaseStateManager } from './BaseStateManager';
 
 // Types
 import type { TaskGroup } from '../../logger/LogTypes';
@@ -12,14 +12,9 @@ import type { TaskGroup } from '../../logger/LogTypes';
 /**
  * Manages task group information for log streams.
  */
-export class GroupsManager {
+export class GroupsManager extends BaseStateManager {
   public readonly map: Map<string, Map<string, TaskGroup>> = new Map();
   private readonly logger = new AgentLogger('GroupsManager');
-
-  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
-  }
 
   async load(): Promise<void> {
     let savedGroups = workspaceSM.get<{

--- a/src/progressView/state/StreamsManager.ts
+++ b/src/progressView/state/StreamsManager.ts
@@ -1,0 +1,109 @@
+// Third-party imports
+import * as vscode from 'vscode';
+import { randomUUID } from 'crypto';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Types
+
+interface ColoredLogMessage {
+  id: string;
+  message: string;
+  level: 'error' | 'warn' | 'info' | 'debug';
+  timestamp: number;
+  groupId?: string;
+  messageType?: 'default' | 'scratchpad' | 'thinking';
+}
+
+/**
+ * Manages log streams and the active stream.
+ */
+export class StreamsManager {
+  public readonly map: Map<string, ColoredLogMessage[]> = new Map();
+  private _active = '';
+  private readonly logger = new AgentLogger('StreamsManager');
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  get active(): string {
+    return this._active;
+  }
+
+  set active(stream: string) {
+    this._active = stream;
+  }
+
+  async load(): Promise<void> {
+    const saved = workspaceSM.get<{
+      [key: string]: ColoredLogMessage[];
+    }>(this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS));
+
+    if (saved) {
+      this.map.clear();
+      for (const [stream, messages] of Object.entries(saved)) {
+        if (shouldUseConsolidatedChannel(stream)) {
+          continue;
+        }
+        const processed = messages.map((msg) => {
+          if (!msg.id) {
+            msg.id = randomUUID();
+          }
+          if (msg.timestamp === undefined) {
+            const attrMatch = msg.message.match(
+              /data-full-timestamp="([^"]+)"/,
+            );
+            const timeString =
+              attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
+            const ts = new Date(timeString).getTime();
+            msg.timestamp = isNaN(ts) ? Date.now() : ts;
+          }
+          if (!msg.messageType) {
+            msg.messageType = 'default';
+          }
+          return msg;
+        });
+        this.map.set(stream, processed);
+      }
+    } else {
+      this.map.clear();
+    }
+
+    const savedActive = workspaceSM.get<string>(
+      WorkspaceStateKey.ACTIVE_LOG_STREAM,
+    );
+    if (savedActive && this.map.has(savedActive)) {
+      this._active = savedActive;
+    } else {
+      this._active = Array.from(this.map.keys())[0] ?? '';
+    }
+  }
+
+  save(): void {
+    const persistent = Array.from(this.map.entries()).filter(
+      ([channel]) => !shouldUseConsolidatedChannel(channel),
+    );
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS),
+      Object.fromEntries(persistent),
+    );
+    workspaceSM.update(WorkspaceStateKey.ACTIVE_LOG_STREAM, this._active);
+  }
+
+  clear(stream: string): void {
+    this.map.delete(stream);
+    if (this._active === stream) {
+      this._active = '';
+    }
+  }
+
+  clearAll(): void {
+    this.map.clear();
+    this._active = '';
+  }
+}

--- a/src/progressView/state/StreamsManager.ts
+++ b/src/progressView/state/StreamsManager.ts
@@ -1,11 +1,11 @@
 // Third-party imports
-import * as vscode from 'vscode';
 import { randomUUID } from 'crypto';
 
 // Local imports
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
 import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 import { AgentLogger } from '@logger/AgentLogger';
+import { BaseStateManager } from './BaseStateManager';
 
 // Types
 
@@ -21,15 +21,10 @@ interface ColoredLogMessage {
 /**
  * Manages log streams and the active stream.
  */
-export class StreamsManager {
+export class StreamsManager extends BaseStateManager {
   public readonly map: Map<string, ColoredLogMessage[]> = new Map();
   private _active = '';
   private readonly logger = new AgentLogger('StreamsManager');
-
-  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
-  }
 
   get active(): string {
     return this._active;
@@ -97,9 +92,6 @@ export class StreamsManager {
 
   clear(stream: string): void {
     this.map.delete(stream);
-    if (this._active === stream) {
-      this._active = '';
-    }
   }
 
   clearAll(): void {

--- a/src/progressView/state/UsageManager.ts
+++ b/src/progressView/state/UsageManager.ts
@@ -1,0 +1,56 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Types
+import type { TokenUsageStats } from '../../types/UsageTypes';
+
+/**
+ * Manages token usage statistics for streams.
+ */
+export class UsageManager {
+  public readonly map: Map<string, TokenUsageStats> = new Map();
+  private readonly logger = new AgentLogger('UsageManager');
+
+  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
+  }
+
+  async load(): Promise<void> {
+    const savedUsage = workspaceSM.get<{
+      [key: string]: {
+        inputTokens: number;
+        outputTokens: number;
+        cost: number;
+      };
+    }>(WorkspaceStateKey.USAGE_STATS);
+
+    if (savedUsage) {
+      this.map.clear();
+      for (const [stream, stats] of Object.entries(savedUsage)) {
+        this.map.set(stream, stats);
+      }
+    } else {
+      this.map.clear();
+    }
+  }
+
+  save(): void {
+    workspaceSM.update(
+      WorkspaceStateKey.USAGE_STATS,
+      Object.fromEntries(this.map.entries()),
+    );
+  }
+
+  clear(stream: string): void {
+    this.map.delete(stream);
+  }
+
+  clearAll(): void {
+    this.map.clear();
+  }
+}

--- a/src/progressView/state/UsageManager.ts
+++ b/src/progressView/state/UsageManager.ts
@@ -1,9 +1,9 @@
 // Third-party imports
-import * as vscode from 'vscode';
 
 // Local imports
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
+import { BaseStateManager } from './BaseStateManager';
 
 // Types
 import type { TokenUsageStats } from '../../types/UsageTypes';
@@ -11,14 +11,9 @@ import type { TokenUsageStats } from '../../types/UsageTypes';
 /**
  * Manages token usage statistics for streams.
  */
-export class UsageManager {
+export class UsageManager extends BaseStateManager {
   public readonly map: Map<string, TokenUsageStats> = new Map();
   private readonly logger = new AgentLogger('UsageManager');
-
-  private _getWorkspaceKey(key: WorkspaceStateKey | string): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    return workspaceFolder ? `${key}.${workspaceFolder.uri.fsPath}` : key;
-  }
 
   async load(): Promise<void> {
     const savedUsage = workspaceSM.get<{
@@ -27,7 +22,7 @@ export class UsageManager {
         outputTokens: number;
         cost: number;
       };
-    }>(WorkspaceStateKey.USAGE_STATS);
+    }>(this._getWorkspaceKey(WorkspaceStateKey.USAGE_STATS));
 
     if (savedUsage) {
       this.map.clear();
@@ -41,7 +36,7 @@ export class UsageManager {
 
   save(): void {
     workspaceSM.update(
-      WorkspaceStateKey.USAGE_STATS,
+      this._getWorkspaceKey(WorkspaceStateKey.USAGE_STATS),
       Object.fromEntries(this.map.entries()),
     );
   }

--- a/src/progressView/state/index.ts
+++ b/src/progressView/state/index.ts
@@ -2,3 +2,4 @@ export { StreamsManager } from './StreamsManager';
 export { GroupsManager } from './GroupsManager';
 export { FilesManager } from './FilesManager';
 export { UsageManager } from './UsageManager';
+export { BaseStateManager } from './BaseStateManager';

--- a/src/progressView/state/index.ts
+++ b/src/progressView/state/index.ts
@@ -1,0 +1,4 @@
+export { StreamsManager } from './StreamsManager';
+export { GroupsManager } from './GroupsManager';
+export { FilesManager } from './FilesManager';
+export { UsageManager } from './UsageManager';


### PR DESCRIPTION
## Summary
- split persistence into StreamsManager, GroupsManager, FilesManager and UsageManager
- refactor ProgressStateManager to use new manager classes
- update ProgressViewProvider to reference the manager instances

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test requires VS Code download)*

------
https://chatgpt.com/codex/tasks/task_e_685c3ad983e08324b4918dc4fc3ee54e