### PR TITLE
chore: bump version to 0.31.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texra",
-  "version": "0.31.7",
+  "version": "0.31.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texra",
-      "version": "0.31.7",
+      "version": "0.31.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.31.7",
+  "version": "0.31.8",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.94.0"


### PR DESCRIPTION
## Summary
- Automated version bump from 0.31.7 to 0.31.8 after release
- Updates package.json and package-lock.json

This PR was created because the automated workflow couldn't create PRs due to repository permissions.

🤖 Generated by GitHub Actions workflow