### PR TITLE
Introduce event bus for progress updates

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -15,7 +15,7 @@ import {
   tikzPictureManager,
 } from '@latex';
 
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 import { diff_match_patch } from 'diff-match-patch';
 import type { DiffStats } from '@/types/DiffTypes';
@@ -519,61 +519,55 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       throw error;
     }
 
-    const provider = ProgressViewProvider.getInstance();
-    if (provider) {
-      const roundOutputs = this.outputHandler.outputFiles[currRound] || [];
+    const roundOutputs = this.outputHandler.outputFiles[currRound] || [];
 
-      // Map output files to their original base files
-      const baseMap = createFileMapping(
-        this.baseFiles,
-        roundOutputs,
-        'contains',
-      );
+    // Map output files to their original base files
+    const baseMap = createFileMapping(this.baseFiles, roundOutputs, 'contains');
 
-      // Map output files to previous round files if available
-      const prevMap =
-        currRound > 0
-          ? createFileMapping(
-              this.outputHandler.outputFiles[currRound - 1] || [],
-              roundOutputs,
-              'basename',
-              true,
-            )
-          : new Map<string, string>();
+    // Map output files to previous round files if available
+    const prevMap =
+      currRound > 0
+        ? createFileMapping(
+            this.outputHandler.outputFiles[currRound - 1] || [],
+            roundOutputs,
+            'basename',
+            true,
+          )
+        : new Map<string, string>();
 
-      const fileInfos = [] as any[];
-      const originMap = new Map(
-        (this.outputHandler.outputMappings[currRound] || []).map((p) => [
-          p.path,
-          p.source,
-        ]),
-      );
-      for (const file of roundOutputs) {
-        const baseFile =
-          Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
-          null;
-        const prevFile =
-          Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
-          null;
-        const originalFile = originMap.get(file) || null;
+    const fileInfos = [] as any[];
+    const originMap = new Map(
+      (this.outputHandler.outputMappings[currRound] || []).map((p) => [
+        p.path,
+        p.source,
+      ]),
+    );
+    for (const file of roundOutputs) {
+      const baseFile =
+        Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
+        null;
+      const prevFile =
+        Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
+        null;
+      const originalFile = originMap.get(file) || null;
 
-        // Use utility to determine effective base for diff computation
-        const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
-        const stats = await this.computeDiffStats(diffBase, file);
+      // Use utility to determine effective base for diff computation
+      const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
+      const stats = await this.computeDiffStats(diffBase, file);
 
-        fileInfos.push({
-          path: file,
-          base: baseFile,
-          prev: prevFile,
-          original: originalFile,
-          ...stats,
-        });
-      }
-
-      provider.addOutputFiles(this.logger.channelId, {
-        [currRound]: fileInfos,
+      fileInfos.push({
+        path: file,
+        base: baseFile,
+        prev: prevFile,
+        original: originalFile,
+        ...stats,
       });
     }
+
+    emitProgress('addOutputFiles', {
+      stream: this.logger.channelId,
+      filesByRound: { [currRound]: fileInfos },
+    });
   }
 
   /**

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -2,7 +2,7 @@
 import { randomUUID } from 'crypto';
 
 // Local imports
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { escapeHtml } from '@logger/logUtils';
 
@@ -32,7 +32,6 @@ const THINKING_TEMPLATE = (content: string) =>
 export async function streamReasoningToProgressView<T>(
   stream: AsyncIterable<T>,
   extract: (chunk: T) => string,
-  provider: ProgressViewProvider,
   logger: AgentLogger,
   streamId: string,
   groupId?: string,
@@ -40,24 +39,24 @@ export async function streamReasoningToProgressView<T>(
   const id = randomUUID();
   let content = '';
 
-  provider.addLogMessage(
-    streamId,
-    THINKING_TEMPLATE(content),
-    'info',
+  emitProgress('addLogMessage', {
+    stream: streamId,
+    message: THINKING_TEMPLATE(content),
+    level: 'info',
     groupId,
-    Date.now(),
-    'thinking',
+    timestamp: Date.now(),
+    messageType: 'thinking',
     id,
-  );
+  });
 
   for await (const chunk of stream) {
     content += extract(chunk);
-    provider.updateLogMessage(
-      streamId,
+    emitProgress('updateLogMessage', {
+      stream: streamId,
       id,
-      THINKING_TEMPLATE(content),
-      'thinking',
-    );
+      message: THINKING_TEMPLATE(content),
+      messageType: 'thinking',
+    });
   }
 
   logger.debug(`Final reasoning length: ${content.length}`, groupId);

--- a/src/agent/runtime/OutputHandler/StatisticsReporter.ts
+++ b/src/agent/runtime/OutputHandler/StatisticsReporter.ts
@@ -1,5 +1,5 @@
 import { AgentLogger } from '@logger/AgentLogger';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 import { AgentStateGlobal } from '@agent/core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
 
@@ -116,14 +116,17 @@ export class StatisticsReporter {
 
       const cost = this.modelHandler.computePrice(responseUsage);
 
-      const provider = ProgressViewProvider.getInstance();
-      if (provider && statsGroupId) {
-        provider.updateGroupUsage(this.channel, statsGroupId, {
-          inputTokens:
-            stateGlobal.totalInputTokens +
-            (stateGlobal.totalCacheCreationInputTokens ?? 0),
-          outputTokens: stateGlobal.totalOutputTokens,
-          cost,
+      if (statsGroupId) {
+        emitProgress('updateGroupUsage', {
+          stream: this.channel,
+          groupId: statsGroupId,
+          usage: {
+            inputTokens:
+              stateGlobal.totalInputTokens +
+              (stateGlobal.totalCacheCreationInputTokens ?? 0),
+            outputTokens: stateGlobal.totalOutputTokens,
+            cost,
+          },
         });
       }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -22,6 +22,7 @@ import { DirectAgent, CoTAgent, MergeAgent } from '@agent/implementations';
 import { AgentLogger } from '@logger/AgentLogger';
 
 import { emitProgress } from '@eventBus/ProgressEventBus';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import {
@@ -152,6 +153,14 @@ async function executeAgentWithLogging<T extends IAgent>(
     const config = agent.config;
     const fullStreamId = getStreamId(agentName, config.model, config.inputFile);
 
+    // Check if this stream is already running
+    const provider = ProgressViewProvider.getInstance();
+    const currentStatus = provider?.getStreamStatus(fullStreamId);
+    if (currentStatus === 'running') {
+      const errorMsg = `Task "${fullStreamId}" is already running. Please wait for it to complete or stop it first.`;
+      throw new Error(errorMsg);
+    }
+
     // Create a main task group for the entire execution
     const mainTaskGroupId = await logger.startGroup(
       `Task: ${agentName}@${config.model}`,
@@ -192,32 +201,37 @@ async function executeAgentWithLogging<T extends IAgent>(
           status: 'running',
         });
 
-        await vscode.commands.executeCommand('texra.showProgressView');
+        const viewVisible = provider?.isViewVisible() ?? false;
+        if (!viewVisible) {
+          await vscode.commands.executeCommand('texra.showProgressView');
+        }
 
-        const inputFileName = path.basename(config.inputFile);
-        const outputInfo = config.outputFiles?.length
-          ? `to ${
-              config.outputFiles.length > 1
-                ? config.outputFiles.length + ' files'
-                : path.basename(config.outputFiles[0])
-            }`
-          : '';
+        if (!provider?.isViewVisible()) {
+          const inputFileName = path.basename(config.inputFile);
+          const outputInfo = config.outputFiles?.length
+            ? `to ${
+                config.outputFiles.length > 1
+                  ? config.outputFiles.length + ' files'
+                  : path.basename(config.outputFiles[0])
+              }`
+            : '';
 
-        vscode.window
-          .showInformationMessage(
-            `TeXRA Agent Started: "${agentName}" is processing ${inputFileName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
-            {
-              modal: false,
-              detail:
-                'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
-            },
-            'Show ProgressBoard',
-          )
-          .then((selection) => {
-            if (selection === 'Show ProgressBoard') {
-              vscode.commands.executeCommand('texra.showProgressView');
-            }
-          });
+          vscode.window
+            .showInformationMessage(
+              `TeXRA Agent Started: "${agentName}" is processing ${inputFileName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
+              {
+                modal: false,
+                detail:
+                  'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
+              },
+              'Show ProgressBoard',
+            )
+            .then((selection) => {
+              if (selection === 'Show ProgressBoard') {
+                vscode.commands.executeCommand('texra.showProgressView');
+              }
+            });
+        }
 
         // Store taskState
         logger.debug(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -21,7 +21,7 @@ import { DirectAgent, CoTAgent, MergeAgent } from '@agent/implementations';
 
 import { AgentLogger } from '@logger/AgentLogger';
 
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import {
@@ -145,26 +145,12 @@ async function executeAgentWithLogging<T extends IAgent>(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   try {
-    // Get logger instance
-    const progressViewProvider = ProgressViewProvider.getInstance();
-    if (!progressViewProvider) {
-      throw new Error('ProgressViewProvider not initialized');
-    }
-
     // Create agent to get config for stream ID
     const agent = await createAgentFn();
 
     // Get the full stream ID
     const config = agent.config;
     const fullStreamId = getStreamId(agentName, config.model, config.inputFile);
-
-    // Check if this stream is already running
-    const currentStatus = progressViewProvider.getStreamStatus(fullStreamId);
-    if (currentStatus === 'running') {
-      const errorMsg = `Task "${fullStreamId}" is already running. Please wait for it to complete or stop it first.`;
-      // vscode.window.showErrorMessage(errorMsg);
-      throw new Error(errorMsg);
-    }
 
     // Create a main task group for the entire execution
     const mainTaskGroupId = await logger.startGroup(
@@ -200,41 +186,38 @@ async function executeAgentWithLogging<T extends IAgent>(
         );
 
         // Switch to this stream and set its status to running
-        progressViewProvider.setActiveStream(fullStreamId);
-        progressViewProvider.updateStreamStatus(fullStreamId, 'running');
+        emitProgress('setActiveStream', fullStreamId);
+        emitProgress('updateStreamStatus', {
+          stream: fullStreamId,
+          status: 'running',
+        });
 
-        // If the ProgressBoard isn't visible, try to show it
-        if (!progressViewProvider.isViewVisible()) {
-          await vscode.commands.executeCommand('texra.showProgressView');
+        await vscode.commands.executeCommand('texra.showProgressView');
 
-          // Prompt the user only if it remains hidden after trying to show it
-          if (!progressViewProvider.isViewVisible()) {
-            const inputFileName = path.basename(config.inputFile);
-            const outputInfo = config.outputFiles?.length
-              ? `to ${
-                  config.outputFiles.length > 1
-                    ? config.outputFiles.length + ' files'
-                    : path.basename(config.outputFiles[0])
-                }`
-              : '';
+        const inputFileName = path.basename(config.inputFile);
+        const outputInfo = config.outputFiles?.length
+          ? `to ${
+              config.outputFiles.length > 1
+                ? config.outputFiles.length + ' files'
+                : path.basename(config.outputFiles[0])
+            }`
+          : '';
 
-            vscode.window
-              .showInformationMessage(
-                `TeXRA Agent Started: "${agentName}" is processing ${inputFileName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
-                {
-                  modal: false,
-                  detail:
-                    'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
-                },
-                'Show ProgressBoard',
-              )
-              .then((selection) => {
-                if (selection === 'Show ProgressBoard') {
-                  vscode.commands.executeCommand('texra.showProgressView');
-                }
-              });
-          }
-        }
+        vscode.window
+          .showInformationMessage(
+            `TeXRA Agent Started: "${agentName}" is processing ${inputFileName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
+            {
+              modal: false,
+              detail:
+                'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
+            },
+            'Show ProgressBoard',
+          )
+          .then((selection) => {
+            if (selection === 'Show ProgressBoard') {
+              vscode.commands.executeCommand('texra.showProgressView');
+            }
+          });
 
         // Store taskState
         logger.debug(
@@ -250,10 +233,10 @@ async function executeAgentWithLogging<T extends IAgent>(
         logger.endGroup(taskDetailsGroupId, 'stopped');
 
         // Convert AgentConfig to TaskState using utility function
-        progressViewProvider.setTaskState(
-          fullStreamId,
-          agentConfigToTaskState(config),
-        );
+        emitProgress('setTaskState', {
+          streamId: fullStreamId,
+          taskState: agentConfigToTaskState(config),
+        });
         logger.debug(
           `Task state stored for stream: ${fullStreamId}`,
           mainTaskGroupId,
@@ -271,7 +254,10 @@ async function executeAgentWithLogging<T extends IAgent>(
           logger.debug(`Task completed successfully`, mainTaskGroupId);
           logger.endGroup(mainTaskGroupId, 'stopped');
           // Update status to stopped on successful completion
-          progressViewProvider.updateStreamStatus(fullStreamId, 'stopped');
+          emitProgress('updateStreamStatus', {
+            stream: fullStreamId,
+            status: 'stopped',
+          });
 
           const generated: string[] = Object.values(
             (agent as any).outputHandler?.outputFiles || {},
@@ -289,7 +275,10 @@ async function executeAgentWithLogging<T extends IAgent>(
           );
           logger.endGroup(mainTaskGroupId, 'error');
           // Update status to error if agent run fails
-          progressViewProvider.updateStreamStatus(fullStreamId, 'error');
+          emitProgress('updateStreamStatus', {
+            stream: fullStreamId,
+            status: 'error',
+          });
           throw err;
         }
       } catch (err) {

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -6,7 +6,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - agent
 import { BaseAgent } from '@agent/implementations/BaseAgent';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 const CHANNEL = 'AgentCommands';
 logger.initialize(CHANNEL);
@@ -26,10 +26,7 @@ async function handleStopAgent(stream: string) {
   }
 
   // Update the UI status
-  const progressViewProvider = ProgressViewProvider.getInstance();
-  if (progressViewProvider) {
-    progressViewProvider.updateStreamStatus(stream, 'stopped');
-  }
+  emitProgress('updateStreamStatus', { stream, status: 'stopped' });
 }
 
 export const agentCommands = {

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -81,12 +81,9 @@ async function handleCleanSingle(
   const result = await runCleanSingle(model, inputFile, agent);
   showCleanResult(result, inputFile);
 
-  const provider = ProgressViewProvider.getInstance();
-  if (provider) {
-    const streamId = getStreamId(agent, model, inputFile);
-    provider.clearOutputFiles(streamId);
-    provider.clearTaskOutput(streamId);
-  }
+  const streamId = getStreamId(agent, model, inputFile);
+  emitProgress('clearOutputFiles', streamId);
+  emitProgress('clearTaskOutput', streamId);
 }
 
 async function handleCleanMultiple(
@@ -116,12 +113,9 @@ async function handleCleanMultiple(
   const result = await runCleanMultiple(model, inputFile, agent, outputFiles);
   showCleanResult(result, inputFile);
 
-  const provider = ProgressViewProvider.getInstance();
-  if (provider) {
-    const streamId = getStreamId(agent, model, inputFile, outputFiles);
-    provider.clearOutputFiles(streamId);
-    provider.clearTaskOutput(streamId);
-  }
+  const streamId = getStreamId(agent, model, inputFile, outputFiles);
+  emitProgress('clearOutputFiles', streamId);
+  emitProgress('clearTaskOutput', streamId);
 }
 
 export async function handleClean(config: {
@@ -164,14 +158,11 @@ export async function handleClean(config: {
     showCleanResult(result, config.inputFile);
   }
 
-  const provider = ProgressViewProvider.getInstance();
-  if (provider) {
-    const streamId =
-      config.streamId ||
-      getStreamId(config.agent, config.model, config.inputFile, outputFiles);
-    provider.clearOutputFiles(streamId);
-    provider.clearTaskOutput(streamId);
-  }
+  const streamId =
+    config.streamId ||
+    getStreamId(config.agent, config.model, config.inputFile, outputFiles);
+  emitProgress('clearOutputFiles', streamId);
+  emitProgress('clearTaskOutput', streamId);
 }
 
 export const cleanCommands = {

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -78,14 +78,11 @@ async function handlePack(config: { streamId?: string; [key: string]: any }) {
   );
   showPackResult(result, config.inputFile);
 
-  const provider = ProgressViewProvider.getInstance();
-  if (provider) {
-    const streamId =
-      config.streamId ||
-      getStreamId(config.agent, config.model, config.inputFile, outputFiles);
-    provider.clearOutputFiles(streamId);
-    provider.clearTaskOutput(streamId);
-  }
+  const streamId =
+    config.streamId ||
+    getStreamId(config.agent, config.model, config.inputFile, outputFiles);
+  emitProgress('clearOutputFiles', streamId);
+  emitProgress('clearTaskOutput', streamId);
 }
 
 async function handlePackSingle(
@@ -113,12 +110,9 @@ async function handlePackSingle(
   const result = await runPackSingle(model, inputFile, agent);
   showPackResult(result, inputFile);
 
-  const provider = ProgressViewProvider.getInstance();
-  if (provider) {
-    const streamId = getStreamId(agent, model, inputFile);
-    provider.clearOutputFiles(streamId);
-    provider.clearTaskOutput(streamId);
-  }
+  const streamId = getStreamId(agent, model, inputFile);
+  emitProgress('clearOutputFiles', streamId);
+  emitProgress('clearTaskOutput', streamId);
 }
 
 async function handlePackMultiple(
@@ -149,12 +143,9 @@ async function handlePackMultiple(
   const result = await runPackMultiple(model, inputFile, agent, outputFiles);
   showPackResult(result, inputFile);
 
-  const provider = ProgressViewProvider.getInstance();
-  if (provider) {
-    const streamId = getStreamId(agent, model, inputFile, outputFiles);
-    provider.clearOutputFiles(streamId);
-    provider.clearTaskOutput(streamId);
-  }
+  const streamId = getStreamId(agent, model, inputFile, outputFiles);
+  emitProgress('clearOutputFiles', streamId);
+  emitProgress('clearTaskOutput', streamId);
 }
 
 export const packCommands = {

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -1,0 +1,54 @@
+import { EventEmitter } from 'events';
+
+export type ProgressEvent =
+  | 'addLogMessage'
+  | 'updateLogMessage'
+  | 'addLogGroup'
+  | 'updateLogGroup'
+  | 'setActiveStream'
+  | 'updateStreamStatus'
+  | 'addOutputFiles'
+  | 'clearOutputFiles'
+  | 'setTaskState'
+  | 'updateGroupUsage'
+  | 'clearTaskOutput'
+  | 'updateStreamUsage';
+
+class ProgressEventBus {
+  private emitter = new EventEmitter();
+  private buffer: { event: ProgressEvent; payload: any }[] = [];
+
+  emit(event: ProgressEvent, payload: any): void {
+    if (this.emitter.listenerCount(event) === 0) {
+      this.buffer.push({ event, payload });
+    } else {
+      this.emitter.emit(event, payload);
+    }
+  }
+
+  on(event: ProgressEvent, listener: (payload: any) => void): void {
+    this.emitter.on(event, listener);
+    const remaining: typeof this.buffer = [];
+    for (const item of this.buffer) {
+      if (item.event === event) {
+        listener(item.payload);
+      } else {
+        remaining.push(item);
+      }
+    }
+    this.buffer = remaining;
+  }
+}
+
+const bus = new ProgressEventBus();
+
+export const emitProgress = (event: ProgressEvent, payload: any): void => {
+  bus.emit(event, payload);
+};
+
+export const onProgress = (
+  event: ProgressEvent,
+  listener: (payload: any) => void,
+): void => {
+  bus.on(event, listener);
+};

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from 'events';
 
+// Maximum number of events to buffer when no listeners are registered
+const MAX_BUFFER_SIZE = 1000;
+
 export type ProgressEvent =
   | 'addLogMessage'
   | 'updateLogMessage'
@@ -21,12 +24,15 @@ class ProgressEventBus {
   emit(event: ProgressEvent, payload: any): void {
     if (this.emitter.listenerCount(event) === 0) {
       this.buffer.push({ event, payload });
+      if (this.buffer.length > MAX_BUFFER_SIZE) {
+        this.buffer.shift();
+      }
     } else {
       this.emitter.emit(event, payload);
     }
   }
 
-  on(event: ProgressEvent, listener: (payload: any) => void): void {
+  on(event: ProgressEvent, listener: (payload: any) => void): () => void {
     this.emitter.on(event, listener);
     const remaining: typeof this.buffer = [];
     for (const item of this.buffer) {
@@ -37,6 +43,7 @@ class ProgressEventBus {
       }
     }
     this.buffer = remaining;
+    return () => this.emitter.off(event, listener);
   }
 }
 
@@ -49,6 +56,6 @@ export const emitProgress = (event: ProgressEvent, payload: any): void => {
 export const onProgress = (
   event: ProgressEvent,
   listener: (payload: any) => void,
-): void => {
-  bus.on(event, listener);
+): (() => void) => {
+  return bus.on(event, listener);
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,10 +30,6 @@ export async function activate(context: vscode.ExtensionContext) {
   const progressViewProvider = new ProgressViewProvider(context);
   await progressViewProvider.initialize();
 
-  // IMPORTANT: Register ProgressViewProvider with logger FIRST, before any other operations
-  // This ensures all logs generated during activation go to the ProgressView
-  logger.setProgressViewProvider(progressViewProvider);
-
   // Log activation message to ensure the logger is working correctly
   logger.info('extension', 'TeXRA extension activated');
 

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -5,7 +5,7 @@ import Transport from 'winston-transport';
 import { randomUUID } from 'crypto';
 
 // Local imports - progressView
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 import { getConfig } from '@utils/config';
 import {
   shouldUseConsolidatedChannel,
@@ -68,17 +68,8 @@ function getMainOutputChannel(): vscode.OutputChannel {
 // Create VSCode output channel transport
 class VSCodeTransport extends Transport {
   private channel: vscode.OutputChannel;
-  private progressViewProvider?: ProgressViewProvider;
   private streamName: string;
   private useConsolidatedChannel: boolean;
-  private messageBuffer: {
-    id: string;
-    level: string;
-    message: string;
-    timestamp: number;
-    groupId?: string;
-    messageType?: 'default' | 'scratchpad' | 'thinking';
-  }[] = [];
   private groups: Map<string, TaskGroup> = new Map();
   private activeGroupId?: string;
 
@@ -86,14 +77,12 @@ class VSCodeTransport extends Transport {
     channel: vscode.OutputChannel,
     streamName: string,
     useConsolidatedChannel: boolean,
-    progressViewProvider?: ProgressViewProvider,
     opts?: Transport.TransportStreamOptions,
   ) {
     super(opts);
     this.channel = channel;
     this.streamName = streamName;
     this.useConsolidatedChannel = useConsolidatedChannel;
-    this.progressViewProvider = progressViewProvider;
   }
 
   log(info: any, callback: () => void) {
@@ -161,68 +150,18 @@ class VSCodeTransport extends Transport {
       `<span class="message-${level}">${processedMessage}</span>` +
       `</div>`;
 
-    // Write to ProgressView if available (with colors and escaped HTML)
     const numericTimestamp = new Date(timestamp).getTime();
-    if (this.progressViewProvider) {
-      this.progressViewProvider.addLogMessage(
-        this.streamName,
-        coloredFormattedMessage,
-        level as 'error' | 'warn' | 'info' | 'debug',
-        groupId,
-        numericTimestamp,
-        messageType,
-        id,
-      );
-    } else {
-      // Buffer the message if ProgressViewProvider is not available
-      this.messageBuffer.push({
-        id,
-        level,
-        message: coloredFormattedMessage,
-        timestamp: numericTimestamp,
-        groupId,
-        messageType,
-      });
-    }
+    emitProgress('addLogMessage', {
+      stream: this.streamName,
+      message: coloredFormattedMessage,
+      level: level as 'error' | 'warn' | 'info' | 'debug',
+      groupId,
+      timestamp: numericTimestamp,
+      messageType,
+      id,
+    });
 
     callback();
-  }
-
-  // Method to replay buffered messages when ProgressViewProvider becomes available
-  replayBufferedMessages(progressViewProvider: ProgressViewProvider) {
-    this.progressViewProvider = progressViewProvider;
-
-    // Skip replay for consolidated channels
-    if (this.useConsolidatedChannel) {
-      return;
-    }
-
-    // First replay any groups
-    for (const group of this.groups.values()) {
-      this.progressViewProvider.addLogGroup(
-        this.streamName,
-        group.id,
-        group.name,
-        group.startTime,
-        group.status,
-        group.endTime,
-      );
-    }
-
-    // Then replay messages, which will be associated with their groups
-    for (const msg of this.messageBuffer) {
-      this.progressViewProvider.addLogMessage(
-        this.streamName,
-        msg.message,
-        msg.level as 'error' | 'warn' | 'info' | 'debug',
-        msg.groupId,
-        msg.timestamp,
-        msg.messageType ?? 'default',
-        msg.id,
-      );
-    }
-
-    this.messageBuffer = []; // Clear buffer after replay
   }
 
   // Create a new log group and make it active
@@ -249,18 +188,15 @@ class VSCodeTransport extends Transport {
       return groupId;
     }
 
-    // Log a message to mark the group start
-    if (this.progressViewProvider) {
-      this.progressViewProvider.addLogGroup(
-        this.streamName,
-        groupId,
-        groupName,
-        now,
-        'running',
-        undefined, // No end time for a new group
-        parentGroupId, // Pass the parent group ID
-      );
-    }
+    emitProgress('addLogGroup', {
+      stream: this.streamName,
+      groupId,
+      groupName,
+      startTime: now,
+      status: 'running',
+      endTime: undefined,
+      parentGroupId,
+    });
 
     return groupId;
   }
@@ -281,14 +217,12 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    if (this.progressViewProvider) {
-      this.progressViewProvider.updateLogGroup(
-        this.streamName,
-        groupId,
-        status,
-        group.endTime,
-      );
-    }
+    emitProgress('updateLogGroup', {
+      stream: this.streamName,
+      groupId,
+      status,
+      endTime: group.endTime,
+    });
 
     if (this.activeGroupId === groupId) {
       // If this group has a parent, set that as the active group
@@ -318,17 +252,6 @@ class VSCodeTransport extends Transport {
 // Map to store loggers for different categories
 const channelLoggers = new Map<string, winston.Logger>();
 const channelTransports = new Map<string, VSCodeTransport>();
-
-let globalProgressViewProvider: ProgressViewProvider | undefined;
-
-export function setProgressViewProvider(provider: ProgressViewProvider) {
-  globalProgressViewProvider = provider;
-
-  // Replay buffered messages for all existing transports
-  for (const transport of channelTransports.values()) {
-    transport.replayBufferedMessages(provider);
-  }
-}
 
 export function initialize(defaultChannel: string): void {
   // Create default logger if it doesn't exist
@@ -361,7 +284,6 @@ function createLoggerForChannel(channel: string): winston.Logger {
     outputChannel,
     channel,
     useConsolidatedChannel,
-    globalProgressViewProvider,
   );
   channelTransports.set(channel, transport);
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -16,6 +16,7 @@ import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
 import { randomUUID } from 'crypto';
+import { onProgress } from '@eventBus/ProgressEventBus';
 
 // @ts-ignore - Import JavaScript module
 import { STATUS, COMMANDS } from './modules/constants.js';
@@ -93,6 +94,100 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
    */
   public async initialize(): Promise<void> {
     await this._stateManager.loadState();
+    onProgress('setActiveStream', (stream: string) =>
+      this.setActiveStream(stream),
+    );
+    onProgress(
+      'updateStreamStatus',
+      (p: { stream: string; status: StreamStatusType }) =>
+        this.updateStreamStatus(p.stream, p.status),
+    );
+    onProgress(
+      'addOutputFiles',
+      (p: { stream: string; filesByRound: { [key: number]: any[] } }) =>
+        this.addOutputFiles(p.stream, p.filesByRound),
+    );
+    onProgress('clearOutputFiles', (stream: string) =>
+      this.clearOutputFiles(stream),
+    );
+    onProgress(
+      'setTaskState',
+      (p: { streamId: string; taskState: TaskState }) =>
+        this.setTaskState(p.streamId, p.taskState),
+    );
+    onProgress(
+      'updateGroupUsage',
+      (p: { stream: string; groupId: string; usage: TokenUsageStats }) =>
+        this.updateGroupUsage(p.stream, p.groupId, p.usage),
+    );
+    onProgress('clearTaskOutput', (streamId: string) =>
+      this.clearTaskOutput(streamId),
+    );
+    onProgress(
+      'updateStreamUsage',
+      (p: { stream: string; usage: TokenUsageStats }) =>
+        this.updateStreamUsage(p.stream, p.usage),
+    );
+    onProgress(
+      'addLogMessage',
+      (p: {
+        stream: string;
+        message: string;
+        level: 'error' | 'warn' | 'info' | 'debug';
+        groupId?: string;
+        timestamp: number;
+        messageType: 'default' | 'scratchpad' | 'thinking';
+        id: string;
+      }) =>
+        this.addLogMessage(
+          p.stream,
+          p.message,
+          p.level,
+          p.groupId,
+          p.timestamp,
+          p.messageType,
+          p.id,
+        ),
+    );
+    onProgress(
+      'updateLogMessage',
+      (p: {
+        stream: string;
+        id: string;
+        message: string;
+        messageType: 'default' | 'scratchpad' | 'thinking';
+      }) => this.updateLogMessage(p.stream, p.id, p.message, p.messageType),
+    );
+    onProgress(
+      'addLogGroup',
+      (p: {
+        stream: string;
+        groupId: string;
+        groupName: string;
+        startTime: number;
+        status: StatusType;
+        endTime?: number;
+        parentGroupId?: string;
+      }) =>
+        this.addLogGroup(
+          p.stream,
+          p.groupId,
+          p.groupName,
+          p.startTime,
+          p.status,
+          p.endTime,
+          p.parentGroupId,
+        ),
+    );
+    onProgress(
+      'updateLogGroup',
+      (p: {
+        stream: string;
+        groupId: string;
+        status: StatusType;
+        endTime?: number;
+      }) => this.updateLogGroup(p.stream, p.groupId, p.status, p.endTime),
+    );
   }
 
   public static getInstance(): ProgressViewProvider | undefined {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -94,99 +94,125 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
    */
   public async initialize(): Promise<void> {
     await this._stateManager.loadState();
-    onProgress('setActiveStream', (stream: string) =>
-      this.setActiveStream(stream),
-    );
-    onProgress(
-      'updateStreamStatus',
-      (p: { stream: string; status: StreamStatusType }) =>
-        this.updateStreamStatus(p.stream, p.status),
-    );
-    onProgress(
-      'addOutputFiles',
-      (p: { stream: string; filesByRound: { [key: number]: any[] } }) =>
-        this.addOutputFiles(p.stream, p.filesByRound),
-    );
-    onProgress('clearOutputFiles', (stream: string) =>
-      this.clearOutputFiles(stream),
-    );
-    onProgress(
-      'setTaskState',
-      (p: { streamId: string; taskState: TaskState }) =>
-        this.setTaskState(p.streamId, p.taskState),
-    );
-    onProgress(
-      'updateGroupUsage',
-      (p: { stream: string; groupId: string; usage: TokenUsageStats }) =>
-        this.updateGroupUsage(p.stream, p.groupId, p.usage),
-    );
-    onProgress('clearTaskOutput', (streamId: string) =>
-      this.clearTaskOutput(streamId),
-    );
-    onProgress(
-      'updateStreamUsage',
-      (p: { stream: string; usage: TokenUsageStats }) =>
-        this.updateStreamUsage(p.stream, p.usage),
-    );
-    onProgress(
-      'addLogMessage',
-      (p: {
-        stream: string;
-        message: string;
-        level: 'error' | 'warn' | 'info' | 'debug';
-        groupId?: string;
-        timestamp: number;
-        messageType: 'default' | 'scratchpad' | 'thinking';
-        id: string;
-      }) =>
-        this.addLogMessage(
-          p.stream,
-          p.message,
-          p.level,
-          p.groupId,
-          p.timestamp,
-          p.messageType,
-          p.id,
+    this._disposables.push(
+      new vscode.Disposable(
+        onProgress('setActiveStream', (stream: string) =>
+          this.setActiveStream(stream),
         ),
-    );
-    onProgress(
-      'updateLogMessage',
-      (p: {
-        stream: string;
-        id: string;
-        message: string;
-        messageType: 'default' | 'scratchpad' | 'thinking';
-      }) => this.updateLogMessage(p.stream, p.id, p.message, p.messageType),
-    );
-    onProgress(
-      'addLogGroup',
-      (p: {
-        stream: string;
-        groupId: string;
-        groupName: string;
-        startTime: number;
-        status: StatusType;
-        endTime?: number;
-        parentGroupId?: string;
-      }) =>
-        this.addLogGroup(
-          p.stream,
-          p.groupId,
-          p.groupName,
-          p.startTime,
-          p.status,
-          p.endTime,
-          p.parentGroupId,
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'updateStreamStatus',
+          (p: { stream: string; status: StreamStatusType }) =>
+            this.updateStreamStatus(p.stream, p.status),
         ),
-    );
-    onProgress(
-      'updateLogGroup',
-      (p: {
-        stream: string;
-        groupId: string;
-        status: StatusType;
-        endTime?: number;
-      }) => this.updateLogGroup(p.stream, p.groupId, p.status, p.endTime),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'addOutputFiles',
+          (p: { stream: string; filesByRound: { [key: number]: any[] } }) =>
+            this.addOutputFiles(p.stream, p.filesByRound),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress('clearOutputFiles', (stream: string) =>
+          this.clearOutputFiles(stream),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'setTaskState',
+          (p: { streamId: string; taskState: TaskState }) =>
+            this.setTaskState(p.streamId, p.taskState),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'updateGroupUsage',
+          (p: { stream: string; groupId: string; usage: TokenUsageStats }) =>
+            this.updateGroupUsage(p.stream, p.groupId, p.usage),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress('clearTaskOutput', (streamId: string) =>
+          this.clearTaskOutput(streamId),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'updateStreamUsage',
+          (p: { stream: string; usage: TokenUsageStats }) =>
+            this.updateStreamUsage(p.stream, p.usage),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'addLogMessage',
+          (p: {
+            stream: string;
+            message: string;
+            level: 'error' | 'warn' | 'info' | 'debug';
+            groupId?: string;
+            timestamp: number;
+            messageType: 'default' | 'scratchpad' | 'thinking';
+            id: string;
+          }) =>
+            this.addLogMessage(
+              p.stream,
+              p.message,
+              p.level,
+              p.groupId,
+              p.timestamp,
+              p.messageType,
+              p.id,
+            ),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'updateLogMessage',
+          (p: {
+            stream: string;
+            id: string;
+            message: string;
+            messageType: 'default' | 'scratchpad' | 'thinking';
+          }) => this.updateLogMessage(p.stream, p.id, p.message, p.messageType),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'addLogGroup',
+          (p: {
+            stream: string;
+            groupId: string;
+            groupName: string;
+            startTime: number;
+            status: StatusType;
+            endTime?: number;
+            parentGroupId?: string;
+          }) =>
+            this.addLogGroup(
+              p.stream,
+              p.groupId,
+              p.groupName,
+              p.startTime,
+              p.status,
+              p.endTime,
+              p.parentGroupId,
+            ),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'updateLogGroup',
+          (p: {
+            stream: string;
+            groupId: string;
+            status: StatusType;
+            endTime?: number;
+          }) => this.updateLogGroup(p.stream, p.groupId, p.status, p.endTime),
+        ),
+      ),
     );
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
       "@historyView/*": ["src/historyView/*"],
       "@replacement/*": ["src/replacement/*"],
       "@tools/*": ["src/tools/*"],
-      "@types/*": ["src/types/*"]
+      "@types/*": ["src/types/*"],
+      "@eventBus/*": ["src/eventBus/*"]
     },
     "moduleResolution": "node",
     "strict": true /* enable all strict type-checking options */,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,7 @@ const extensionConfig = {
       '@replacement': path.resolve(__dirname, 'src/replacement'),
       '@tools': path.resolve(__dirname, 'src/tools'),
       '@types': path.resolve(__dirname, 'src/types'),
+      '@eventBus': path.resolve(__dirname, 'src/eventBus'),
     },
     fallback: {
       fs: false,


### PR DESCRIPTION
## Summary
- add `ProgressEventBus` for decoupled progress updates
- subscribe `ProgressViewProvider` to bus
- emit events from logger and backend modules instead of manipulating UI
- update housekeeping and agent commands to use the event bus
- wire up new alias in build configuration

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(webpack compiled with a warning)*

------
https://chatgpt.com/codex/tasks/task_e_685c5f0887508324b10e5cff56ca97e0