### PR TITLE
feat: register agent channels on load

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -51,7 +51,7 @@ export abstract class BaseAgent implements IAgent {
     this.agentPath = agentPath;
 
     const channelId = this.getTaskId();
-    this.logger = new AgentLogger(channelId);
+    this.logger = new AgentLogger(channelId, true);
     this.modelHandler.setLogger(this.logger);
   }
 

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -11,9 +11,16 @@ import { SHORT_SLEEP_MS } from '@utils/config';
  * Uses the updated consolidated logger system.
  */
 export class AgentLogger {
-  constructor(public channelId: string) {
-    logger.initialize(this.channelId);
+  constructor(
+    public channelId: string,
+    private readonly isAgent = false,
+  ) {
+    logger.initialize(this.channelId, this.isAgent);
     this.channelId = channelId;
+  }
+
+  get isAgentLogger(): boolean {
+    return this.isAgent;
   }
 
   debug(message: string, groupId?: string): void {

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -8,10 +8,10 @@ import { randomUUID } from 'crypto';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { getConfig } from '@utils/config';
 import {
-  shouldUseConsolidatedChannel,
   getColorForLevel,
-  isAgentStream,
+  isAgentChannel,
   EMOJI_BY_LEVEL as emojis,
+  registerAgentChannel,
 } from '@utils/loggerUtils';
 import { TaskGroup } from './LogTypes';
 
@@ -70,7 +70,6 @@ class VSCodeTransport extends Transport {
   private channel: vscode.OutputChannel;
   private progressViewProvider?: ProgressViewProvider;
   private streamName: string;
-  private useConsolidatedChannel: boolean;
   private messageBuffer: {
     id: string;
     level: string;
@@ -85,14 +84,12 @@ class VSCodeTransport extends Transport {
   constructor(
     channel: vscode.OutputChannel,
     streamName: string,
-    useConsolidatedChannel: boolean,
     progressViewProvider?: ProgressViewProvider,
     opts?: Transport.TransportStreamOptions,
   ) {
     super(opts);
     this.channel = channel;
     this.streamName = streamName;
-    this.useConsolidatedChannel = useConsolidatedChannel;
     this.progressViewProvider = progressViewProvider;
   }
 
@@ -108,20 +105,16 @@ class VSCodeTransport extends Transport {
     const timeDisplay = timestamp.split(' ')[1].split('.')[0]; // Drop milliseconds for UI display
 
     // For consolidated channel, include the source channel in the message
-    const channelPrefix = this.useConsolidatedChannel
-      ? `[${this.streamName}] `
-      : '';
+    const channelPrefix = isAgentChannel(this.streamName)
+      ? ''
+      : `[${this.streamName}] `;
 
     // Plain format for output channel - no escaping needed but include better formatting
     // const formattedMessage = `${emoji} [${timestamp}] ${level.toUpperCase().padEnd(7)} ${channelPrefix}${message}`;
     const formattedMessage = `${emoji} [${timestamp}] ${channelPrefix}${message}`;
 
-    // Key behavior change: For agent streams, we ONLY write to their dedicated channel
-    // For non-agent streams, we write to the consolidated channel
-    // This prevents duplicate output in both places
-    if (this.useConsolidatedChannel || !isAgentStream(this.streamName)) {
-      this.channel.appendLine(formattedMessage);
-    }
+    // Write to the appropriate output channel (agent or consolidated)
+    this.channel.appendLine(formattedMessage);
 
     // Skip debug messages in ProgressView if debug mode is disabled
     if (level === 'debug' && !getConfig<boolean>('logger.debugMode', false)) {
@@ -130,7 +123,7 @@ class VSCodeTransport extends Transport {
     }
 
     // Skip progress view updates for consolidated channels
-    if (this.useConsolidatedChannel) {
+    if (!isAgentChannel(this.streamName)) {
       callback();
       return;
     }
@@ -193,7 +186,7 @@ class VSCodeTransport extends Transport {
     this.progressViewProvider = progressViewProvider;
 
     // Skip replay for consolidated channels
-    if (this.useConsolidatedChannel) {
+    if (!isAgentChannel(this.streamName)) {
       return;
     }
 
@@ -245,7 +238,7 @@ class VSCodeTransport extends Transport {
     this.activeGroupId = groupId;
 
     // Skip progress view updates for consolidated channels
-    if (this.useConsolidatedChannel) {
+    if (!isAgentChannel(this.streamName)) {
       return groupId;
     }
 
@@ -277,7 +270,7 @@ class VSCodeTransport extends Transport {
     group.status = status;
 
     // Skip progress view updates for consolidated channels
-    if (this.useConsolidatedChannel) {
+    if (!isAgentChannel(this.streamName)) {
       return;
     }
 
@@ -330,37 +323,34 @@ export function setProgressViewProvider(provider: ProgressViewProvider) {
   }
 }
 
-export function initialize(defaultChannel: string): void {
+export function initialize(defaultChannel: string, isAgent = false): void {
   // Create default logger if it doesn't exist
   if (!channelLoggers.has(defaultChannel)) {
-    createLoggerForChannel(defaultChannel);
+    createLoggerForChannel(defaultChannel, isAgent);
   }
 }
 
-function createLoggerForChannel(channel: string): winston.Logger {
+function createLoggerForChannel(
+  channel: string,
+  isAgent = false,
+): winston.Logger {
   // Check if channel already exists
   if (channelLoggers.has(channel)) {
     return channelLoggers.get(channel)!;
   }
 
-  const useConsolidatedChannel = shouldUseConsolidatedChannel(channel);
-
-  let outputChannel: vscode.OutputChannel;
-
-  if (useConsolidatedChannel) {
-    // Use the main TeXRA output channel for non-agent channels
-    outputChannel = getMainOutputChannel();
-  } else {
-    // Create a separate channel with the TeXRA prefix for agent channels
-    const channelName = 'TeXRA ' + channel;
-    outputChannel = vscode.window.createOutputChannel(channelName);
+  if (isAgent) {
+    registerAgentChannel(channel);
   }
+
+  const outputChannel = isAgentChannel(channel)
+    ? vscode.window.createOutputChannel('TeXRA ' + channel)
+    : getMainOutputChannel();
 
   // Create transport
   const transport = new VSCodeTransport(
     outputChannel,
     channel,
-    useConsolidatedChannel,
     globalProgressViewProvider,
   );
   channelTransports.set(channel, transport);

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -6,7 +6,8 @@ import { randomUUID } from 'crypto';
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
 import { WorkspaceFS } from '@utils/files';
 import { objectToTaskState } from '@utils/config';
-import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
+import { isAgentChannel } from '@utils/loggerUtils';
+import { registerAgentChannel } from '@utils/loggerUtils';
 import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
 
@@ -93,12 +94,28 @@ export class ProgressStateManager {
    * Load all state from workspace storage
    */
   public async loadState(): Promise<void> {
+    this._registerSavedAgentChannels();
     await this._loadLogStreams();
     await this._loadTaskGroups();
     await this._loadOutputFiles();
     this._loadActiveStream();
     await this._loadTaskStates();
     await this._loadUsageStats();
+  }
+
+  /**
+   * Register channels found in persisted log streams so that they
+   * can be loaded before any loggers are created.
+   */
+  private _registerSavedAgentChannels(): void {
+    const saved = workspaceSM.get<{ [key: string]: unknown }>(
+      this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS),
+    );
+    if (saved) {
+      for (const channel of Object.keys(saved)) {
+        registerAgentChannel(channel);
+      }
+    }
   }
 
   /**
@@ -125,7 +142,7 @@ export class ProgressStateManager {
       // Only load channels that should be persisted
       this._logStreams = new Map(
         Object.entries(savedState)
-          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
+          .filter(([channel]) => isAgentChannel(channel))
           .map(([stream, messages]) => [
             stream,
             messages.map((msg) => {
@@ -179,7 +196,7 @@ export class ProgressStateManager {
     if (savedGroups) {
       this._taskGroups = new Map(
         Object.entries(savedGroups)
-          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
+          .filter(([channel]) => isAgentChannel(channel))
           .map(([streamId, groups]) => [
             streamId,
             new Map(
@@ -221,7 +238,7 @@ export class ProgressStateManager {
       let totalFilesRemoved = 0;
 
       for (const [streamId, rounds] of Object.entries(savedFiles)) {
-        if (shouldUseConsolidatedChannel(streamId)) {
+        if (!isAgentChannel(streamId)) {
           continue;
         }
 
@@ -358,7 +375,7 @@ export class ProgressStateManager {
   private _saveLogStreams(): void {
     // Only save channels that should be persisted
     const persistentStreams = Array.from(this._logStreams.entries()).filter(
-      ([channel]) => !shouldUseConsolidatedChannel(channel),
+      ([channel]) => isAgentChannel(channel),
     );
     const stateObj = Object.fromEntries(persistentStreams);
     workspaceSM.update(
@@ -372,7 +389,7 @@ export class ProgressStateManager {
    */
   private _saveTaskGroups(): void {
     const persistentGroups = Array.from(this._taskGroups.entries())
-      .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
+      .filter(([channel]) => isAgentChannel(channel))
       .map(([streamId, groups]) => [
         streamId,
         Object.fromEntries(groups.entries()),

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -10,7 +10,7 @@ import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
 
 import { getConfig } from '@utils/config';
-import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
+import { isAgentChannel } from '@utils/loggerUtils';
 
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup } from '../logger/LogTypes';
@@ -266,7 +266,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     id: string = randomUUID(),
   ) {
     // Skip if this stream should be excluded from the progress view
-    if (shouldUseConsolidatedChannel(stream)) {
+    if (!isAgentChannel(stream)) {
       return;
     }
 
@@ -366,7 +366,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     parentGroupId?: string,
   ) {
     // Skip if this stream should be excluded from the progress view
-    if (shouldUseConsolidatedChannel(stream)) {
+    if (!isAgentChannel(stream)) {
       return;
     }
 
@@ -426,7 +426,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     endTime?: number,
   ) {
     // Skip if this stream should be excluded from the progress view
-    if (shouldUseConsolidatedChannel(stream)) {
+    if (!isAgentChannel(stream)) {
       return;
     }
 
@@ -559,7 +559,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
   public updateStreamStatus(stream: string, status: StreamStatusType) {
     // Don't track status for excluded streams
-    if (shouldUseConsolidatedChannel(stream)) {
+    if (!isAgentChannel(stream)) {
       return;
     }
 

--- a/src/utils/loggerUtils.ts
+++ b/src/utils/loggerUtils.ts
@@ -2,50 +2,24 @@
 import * as path from 'path';
 
 // Local imports
-import { getConfig } from './config';
+
+// Track channels explicitly registered as agent loggers
+const agentChannels = new Set<string>();
 
 /**
- * Determines if a stream name corresponds to an agent or contains agent information.
- * Agent streams are displayed in both the ProgressView and their own output channels.
- * Non-agent streams are consolidated into a single output channel.
+ * Register a channel as an agent logger. Agent loggers stream to
+ * the progress view and get their own output channel.
  */
-export function isAgentStream(streamName: string): boolean {
-  // Special cases that are always treated as agent streams
-  if (streamName.includes('merge')) {
-    return true;
-  }
-
-  // Get the list of agents from config
-  const agents = getConfig<string[]>('agents', [
-    'correct',
-    'polish',
-    'draw',
-    'ocr',
-    'paper2slide',
-    'paper2poster',
-    'transcribe_audio',
-    'merge',
-  ]);
-
-  // Check if the stream name starts with any agent name followed by '@' (agent@model: file format)
-  for (const agent of agents) {
-    if (
-      streamName.startsWith(`${agent}@`) ||
-      streamName.startsWith(`${agent}_multiple@`)
-    ) {
-      return true;
-    }
-  }
-  return false;
+export function registerAgentChannel(channel: string): void {
+  agentChannels.add(channel);
 }
 
 /**
- * Determines if a stream should use the consolidated output channel.
- * Agent streams get their own channel, all others (including executeAgent) use the consolidated channel.
+ * Determines if a stream corresponds to an agent logger.
+ * Channels are registered via {@link registerAgentChannel} when the logger is created.
  */
-export function shouldUseConsolidatedChannel(streamName: string): boolean {
-  // Only agent streams get dedicated channels and appear in the ProgressView
-  return !isAgentStream(streamName);
+export function isAgentChannel(channel: string): boolean {
+  return agentChannels.has(channel);
 }
 
 // Centralised emoji mapping for log levels


### PR DESCRIPTION
## Summary
- handle saved log streams before initializing loggers
- remove consolidated channel flag in VSCodeTransport

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: requires VS Code test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c36834d7883248423e5dbbc391a27