### PR TITLE
feat: pass message type through logging

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -51,7 +51,6 @@ import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile } from '@agent/runtime/OutputHandler';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
-import { createInfoSpan } from '@agent/modelHandlers/streamUtils';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -253,7 +252,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         // If thinking content was extracted, format and log it first
         if (thinkingContent) {
           const formatted = await xmlUtils.formatContent(thinkingContent);
-          this.logger.info(createInfoSpan(formatted, 'thinking'), logGroupId);
+          this.logger.info(formatted, logGroupId, 'thinking');
 
           // Note: The complete thinking blocks (including signatures) have already been
           // stored in toolState.thinkingBlocks by the processThinkingBlock method
@@ -265,10 +264,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           'scratchpad',
         );
         if (scratchpad) {
-          this.logger.info(
-            createInfoSpan(scratchpad, 'scratchpad'),
-            logGroupId,
-          );
+          this.logger.info(scratchpad, logGroupId, 'scratchpad');
         }
         // this has a potential bug if <scratchpad> is included in the prefill
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -51,6 +51,7 @@ import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile } from '@agent/runtime/OutputHandler';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -252,7 +253,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         // If thinking content was extracted, format and log it first
         if (thinkingContent) {
           const formatted = await xmlUtils.formatContent(thinkingContent);
-          this.logger.info(formatted, logGroupId, 'thinking');
+          this.logger.info(formatted, logGroupId, MESSAGE_TYPES.THINKING);
 
           // Note: The complete thinking blocks (including signatures) have already been
           // stored in toolState.thinkingBlocks by the processThinkingBlock method
@@ -264,7 +265,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           'scratchpad',
         );
         if (scratchpad) {
-          this.logger.info(scratchpad, logGroupId, 'scratchpad');
+          this.logger.info(scratchpad, logGroupId, MESSAGE_TYPES.SCRATCHPAD);
         }
         // this has a potential bug if <scratchpad> is included in the prefill
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -32,7 +32,6 @@ import {
 } from '@agent/core/ResponseUsage';
 import { ToolState } from '@agent/core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { createInfoSpan } from './streamUtils';
 import { AgentStateRound } from '@agent/core/AgentState';
 import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
@@ -506,7 +505,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(createInfoSpan(scratchpad, 'scratchpad'), groupId);
+      this.logger.info(scratchpad, groupId, 'scratchpad');
     }
 
     await WorkspaceFS.writeFile(outputFile, fileContent);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -36,6 +36,7 @@ import { AgentStateRound } from '@agent/core/AgentState';
 import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { calculateTokenPrice } from '@utils/priceUtils';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.
@@ -505,7 +506,7 @@ export class ModelHandlerAnthropic extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, 'scratchpad');
+      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     await WorkspaceFS.writeFile(outputFile, fileContent);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -18,7 +18,6 @@ import {
 
 // Local imports - agent components
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
-import { createInfoSpan } from './streamUtils';
 import { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
@@ -823,7 +822,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(createInfoSpan(scratchpad, 'scratchpad'), groupId);
+      this.logger.info(scratchpad, groupId, 'scratchpad');
     }
 
     await WorkspaceFS.writeFile(outputFile, fileContent);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -36,6 +36,7 @@ import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { formatProviderError } from '@utils/sdkErrorUtils';
 import xmlUtils from '@utils/text/xmlUtils';
 import { calculateTokenPrice } from '@utils/priceUtils';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 import { cleanFileContent } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
@@ -822,7 +823,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, 'scratchpad');
+      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     await WorkspaceFS.writeFile(outputFile, fileContent);

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -28,7 +28,6 @@ import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { calculateTokenPrice } from '@utils/priceUtils';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { createInfoSpan } from './streamUtils';
 
 /**
  * OpenAI-specific handlers.
@@ -561,7 +560,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(createInfoSpan(scratchpad, 'scratchpad'), groupId);
+      this.logger.info(scratchpad, groupId, 'scratchpad');
     }
 
     // Write file content to output file

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -28,6 +28,7 @@ import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { calculateTokenPrice } from '@utils/priceUtils';
 import { MediaEntry } from '@agent/utils/mediaTypes';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 /**
  * OpenAI-specific handlers.
@@ -560,7 +561,7 @@ export class ModelHandlerOpenAI extends ModelHandler {
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, 'scratchpad');
+      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     // Write file content to output file

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -5,29 +5,14 @@ import { randomUUID } from 'crypto';
 import { emitProgress } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { escapeHtml } from '@logger/logUtils';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 /**
  * Create a span element for special log content.
  * @param content - The text to wrap.
  * @param type - The message type value.
  */
-export function createInfoSpan(
-  content: string,
-  type: 'thinking' | 'scratchpad',
-): string {
-  if (!content || typeof content !== 'string') {
-    throw new Error('Content must be a non-empty string');
-  }
-  if (type !== 'thinking' && type !== 'scratchpad') {
-    throw new Error('Type must be either "thinking" or "scratchpad"');
-  }
-
-  const safeContent = escapeHtml(content);
-  return `<span class="message-info" data-message-type="${type}">${safeContent}</span>`;
-}
-
-const THINKING_TEMPLATE = (content: string) =>
-  createInfoSpan(content, 'thinking');
+const escapeContent = (content: string): string => escapeHtml(content);
 
 export async function streamReasoningToProgressView<T>(
   stream: AsyncIterable<T>,
@@ -41,11 +26,11 @@ export async function streamReasoningToProgressView<T>(
 
   emitProgress('addLogMessage', {
     stream: streamId,
-    message: THINKING_TEMPLATE(content),
+    message: escapeContent(content),
     level: 'info',
     groupId,
     timestamp: Date.now(),
-    messageType: 'thinking',
+    messageType: MESSAGE_TYPES.THINKING,
     id,
   });
 
@@ -54,8 +39,8 @@ export async function streamReasoningToProgressView<T>(
     emitProgress('updateLogMessage', {
       stream: streamId,
       id,
-      message: THINKING_TEMPLATE(content),
-      messageType: 'thinking',
+      message: escapeContent(content),
+      messageType: MESSAGE_TYPES.THINKING,
     });
   }
 

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -3,6 +3,7 @@
 
 // Local imports - log
 import * as logger from './logUtils';
+import type { MessageType } from './logUtils';
 import { sleep } from '@utils/helpers';
 import { SHORT_SLEEP_MS } from '@utils/config';
 
@@ -16,20 +17,20 @@ export class AgentLogger {
     this.channelId = channelId;
   }
 
-  debug(message: string, groupId?: string): void {
-    logger.debug(this.channelId, message, groupId);
+  debug(message: string, groupId?: string, messageType?: MessageType): void {
+    logger.debug(this.channelId, message, groupId, messageType);
   }
 
-  info(message: string, groupId?: string): void {
-    logger.info(this.channelId, message, groupId);
+  info(message: string, groupId?: string, messageType?: MessageType): void {
+    logger.info(this.channelId, message, groupId, messageType);
   }
 
-  warn(message: string, groupId?: string): void {
-    logger.warn(this.channelId, message, groupId);
+  warn(message: string, groupId?: string, messageType?: MessageType): void {
+    logger.warn(this.channelId, message, groupId, messageType);
   }
 
-  error(message: string, groupId?: string): void {
-    logger.error(this.channelId, message, groupId);
+  error(message: string, groupId?: string, messageType?: MessageType): void {
+    logger.error(this.channelId, message, groupId, messageType);
   }
 
   /**

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -3,7 +3,7 @@
 
 // Local imports - log
 import * as logger from './logUtils';
-import type { MessageType } from './logUtils';
+import type { MessageType } from './messageTypes';
 import { sleep } from '@utils/helpers';
 import { SHORT_SLEEP_MS } from '@utils/config';
 

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -14,12 +14,12 @@ import {
   EMOJI_BY_LEVEL as emojis,
 } from '@utils/loggerUtils';
 import { TaskGroup } from './LogTypes';
+import { MESSAGE_TYPES, type MessageType } from './messageTypes';
 
-// Message type for ProgressView entries
-export type MessageType = 'thinking' | 'scratchpad' | 'default';
-
-function isValidMessageType(type: unknown): type is 'thinking' | 'scratchpad' {
-  return type === 'thinking' || type === 'scratchpad';
+function isValidMessageType(
+  type: unknown,
+): type is typeof MESSAGE_TYPES.THINKING | typeof MESSAGE_TYPES.SCRATCHPAD {
+  return type === MESSAGE_TYPES.THINKING || type === MESSAGE_TYPES.SCRATCHPAD;
 }
 
 const { combine, timestamp } = winston.format;
@@ -128,7 +128,7 @@ class VSCodeTransport extends Transport {
 
     const msgType: MessageType = isValidMessageType(messageType)
       ? messageType
-      : 'default';
+      : MESSAGE_TYPES.DEFAULT;
 
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
     const isVerbose = getConfig<boolean>('logger.debugMode', false);

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -18,7 +18,7 @@ import { TaskGroup } from './LogTypes';
 // Message type for ProgressView entries
 export type MessageType = 'thinking' | 'scratchpad' | 'default';
 
-function isValidMessageType(type: string): type is 'thinking' | 'scratchpad' {
+function isValidMessageType(type: unknown): type is 'thinking' | 'scratchpad' {
   return type === 'thinking' || type === 'scratchpad';
 }
 
@@ -86,7 +86,7 @@ class VSCodeTransport extends Transport {
   }
 
   log(info: any, callback: () => void) {
-    const { level, message, timestamp } = info;
+    const { level, message, timestamp, messageType } = info;
     // Use the provided groupId or fall back to the activeGroupId if available
     const groupId = info.groupId || this.activeGroupId;
 
@@ -124,15 +124,11 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    const hasInfoSpan = /data-message-type="(?:thinking|scratchpad)"/.test(
-      message,
-    );
-    const processedMessage = hasInfoSpan ? message : escapeHtml(message);
+    const processedMessage = escapeHtml(message);
 
-    // Detect message type from data-message-type attribute
-    const typeMatch = message.match(/data-message-type="(.*?)"/);
-    const messageType: MessageType =
-      typeMatch && isValidMessageType(typeMatch[1]) ? typeMatch[1] : 'default';
+    const msgType: MessageType = isValidMessageType(messageType)
+      ? messageType
+      : 'default';
 
     // Colored format for ProgressView using CSS classes, but with shorter timestamp display
     const isVerbose = getConfig<boolean>('logger.debugMode', false);
@@ -157,7 +153,7 @@ class VSCodeTransport extends Transport {
       level: level as 'error' | 'warn' | 'info' | 'debug',
       groupId,
       timestamp: numericTimestamp,
-      messageType,
+      messageType: msgType,
       id,
     });
 
@@ -354,6 +350,7 @@ function logWithGroup(
   level: string,
   message: string,
   groupId?: string,
+  messageType?: MessageType,
 ): void {
   const logger = getOrCreateLogger(channel);
   const transport = channelTransports.get(channel);
@@ -362,7 +359,7 @@ function logWithGroup(
   const actualGroupId = groupId || transport?.getActiveGroupId();
 
   // @ts-ignore - We're adding a custom property to the winston log
-  logger[level](message, { groupId: actualGroupId });
+  logger[level](message, { groupId: actualGroupId, messageType });
 }
 
 // Simplified logging methods that use channel as channel name
@@ -370,32 +367,36 @@ export const debug = (
   channel: string,
   message: string,
   groupId?: string,
+  messageType?: MessageType,
 ): void => {
-  logWithGroup(channel, 'debug', message, groupId);
+  logWithGroup(channel, 'debug', message, groupId, messageType);
 };
 
 export const info = (
   channel: string,
   message: string,
   groupId?: string,
+  messageType?: MessageType,
 ): void => {
-  logWithGroup(channel, 'info', message, groupId);
+  logWithGroup(channel, 'info', message, groupId, messageType);
 };
 
 export const warn = (
   channel: string,
   message: string,
   groupId?: string,
+  messageType?: MessageType,
 ): void => {
-  logWithGroup(channel, 'warn', message, groupId);
+  logWithGroup(channel, 'warn', message, groupId, messageType);
 };
 
 export const error = (
   channel: string,
   message: string,
   groupId?: string,
+  messageType?: MessageType,
 ): void => {
-  logWithGroup(channel, 'error', message, groupId);
+  logWithGroup(channel, 'error', message, groupId, messageType);
 };
 
 function getOrCreateLogger(channel: string): winston.Logger {

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -1,0 +1,7 @@
+export const MESSAGE_TYPES = {
+  THINKING: 'thinking',
+  SCRATCHPAD: 'scratchpad',
+  DEFAULT: 'default',
+} as const;
+
+export type MessageType = (typeof MESSAGE_TYPES)[keyof typeof MESSAGE_TYPES];

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -111,35 +111,14 @@ export class LogEntryFormatter {
   format(logMessage) {
     const message = logMessage.message;
 
-    let type = logMessage.messageType;
-    if (!type) {
-      const attrMatch = message.match(/data-message-type="(.*?)"/);
-      if (attrMatch) type = attrMatch[1];
-    }
+    const type = logMessage.messageType;
 
     if (type === 'thinking' || type === 'scratchpad') {
-      const content = this._extractSpecialContent(message, type);
-      if (content) {
-        const label = type === 'thinking' ? 'Thinking' : 'Scratchpad';
-        return this._formatSpecialContent(
-          message,
-          content,
-          label,
-          logMessage.id,
-        );
-      }
+      const label = type === 'thinking' ? 'Thinking' : 'Scratchpad';
+      return this._formatSpecialContent(message, message, label, logMessage.id);
     }
 
     return message;
-  }
-
-  _extractSpecialContent(message, type) {
-    const regex = new RegExp(
-      `<span class="message-info"[^>]*data-message-type="${type}"[^>]*>(.*?)</span>`,
-      's',
-    );
-    const match = message.match(regex);
-    return match ? match[1] : null;
   }
 
   _unescapeHtml(text) {

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -115,10 +115,18 @@ export class LogEntryFormatter {
 
     if (type === 'thinking' || type === 'scratchpad') {
       const label = type === 'thinking' ? 'Thinking' : 'Scratchpad';
-      return this._formatSpecialContent(message, message, label, logMessage.id);
+      const content = this._extractContent(message);
+      return this._formatSpecialContent(message, content, label, logMessage.id);
     }
 
     return message;
+  }
+
+  _extractContent(message) {
+    const match = message.match(
+      /<span class="message-[^"]*">([\s\S]*?)<\/span>/,
+    );
+    return match ? match[1] : message;
   }
 
   _unescapeHtml(text) {


### PR DESCRIPTION
## Summary
- support specifying log message type in `AgentLogger`
- propagate message type through `logUtils`
- simplify message formatting for progress view
- log scratchpad/thinking output using the new parameter

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cf2520aa883249c93af46b0046fd5