### PR TITLE
Fix folder explorer file watching

### DIFF
--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -16,6 +16,8 @@ import { FileItem } from './FileItem';
 const NEW_AGENT_TEMPLATE = `# --- Agent Inheritance (Optional) ---
 # inherits: base
 
+name: my_agent
+
 # --- Agent Settings ---
 settings:
   agentType: CoT

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -16,6 +16,8 @@ logger.initialize(CHANNEL);
 export class WatcherManager {
   private disposables: vscode.FileSystemWatcher[] = [];
   private refreshHandle: NodeJS.Timeout | undefined;
+  private validationHandles: NodeJS.Timeout[] = [];
+  private static readonly VALIDATION_DELAY = 300;
 
   constructor(
     private context: vscode.ExtensionContext | undefined,
@@ -83,16 +85,20 @@ export class WatcherManager {
         watcher.onDidCreate((uri) => {
           this.triggerRefresh();
           if (path.extname(uri.fsPath) === '.yaml') {
-            setTimeout(() => this.validateYaml(uri.fsPath), 300);
+            const handle = setTimeout(
+              () => void this.validateYaml(uri.fsPath),
+              WatcherManager.VALIDATION_DELAY,
+            );
+            this.validationHandles.push(handle);
           }
         });
         watcher.onDidDelete(() => this.triggerRefresh());
 
         if (path.resolve(watchPath) === path.resolve(customAgentsPath ?? '')) {
-          watcher.onDidChange((uri) => {
+          watcher.onDidChange(async (uri) => {
             this.triggerRefresh();
             if (path.extname(uri.fsPath) === '.yaml') {
-              this.validateYaml(uri.fsPath);
+              await this.validateYaml(uri.fsPath);
             }
           });
         } else {
@@ -110,6 +116,12 @@ export class WatcherManager {
   }
 
   dispose() {
+    if (this.refreshHandle) {
+      clearTimeout(this.refreshHandle);
+      this.refreshHandle = undefined;
+    }
+    this.validationHandles.forEach((h) => clearTimeout(h));
+    this.validationHandles = [];
     this.disposables.forEach((d) => d.dispose());
     this.disposables = [];
   }

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -29,6 +29,25 @@ export class WatcherManager {
     this.refreshHandle = setTimeout(() => this.refresh(), 200);
   }
 
+  private async validateYaml(filePath: string) {
+    const validationResult = await isValidAgentYaml(filePath);
+    if (validationResult) {
+      const filenameBase = path.basename(filePath, '.yaml');
+      const internalName = validationResult.name;
+      if (filenameBase !== internalName) {
+        vscode.window.showWarningMessage(
+          `Agent file '${filenameBase}.yaml' has a different internal name '${internalName}' defined in its YAML. ` +
+            `Consider renaming the file or updating the internal name in the YAML for consistency.`,
+        );
+      } else {
+        const configuredAgents = getConfig<string[]>('texra.agents', []);
+        if (!configuredAgents.includes(filenameBase)) {
+          await promptToAddAgentToConfig(filenameBase);
+        }
+      }
+    }
+  }
+
   async setup() {
     try {
       if (!this.context) {
@@ -52,7 +71,7 @@ export class WatcherManager {
       for (const watchPath of pathsToWatch) {
         if (!watchPath) continue;
 
-        const pattern = new vscode.RelativePattern(watchPath, '**/*.yaml');
+        const pattern = new vscode.RelativePattern(watchPath, '**/*');
         const watcher = vscode.workspace.createFileSystemWatcher(
           pattern,
           false,
@@ -61,36 +80,19 @@ export class WatcherManager {
         );
         this.disposables.push(watcher);
 
-        watcher.onDidCreate(() => this.triggerRefresh());
+        watcher.onDidCreate((uri) => {
+          this.triggerRefresh();
+          if (path.extname(uri.fsPath) === '.yaml') {
+            setTimeout(() => this.validateYaml(uri.fsPath), 300);
+          }
+        });
         watcher.onDidDelete(() => this.triggerRefresh());
 
         if (path.resolve(watchPath) === path.resolve(customAgentsPath ?? '')) {
-          watcher.onDidChange(async (uri) => {
+          watcher.onDidChange((uri) => {
             this.triggerRefresh();
-
-            const filePath = uri.fsPath;
-            if (!filePath.endsWith('.yaml')) {
-              return;
-            }
-
-            const validationResult = await isValidAgentYaml(filePath);
-            if (validationResult) {
-              const filenameBase = path.basename(filePath, '.yaml');
-              const internalName = validationResult.name;
-              if (filenameBase !== internalName) {
-                vscode.window.showWarningMessage(
-                  `Agent file '${filenameBase}.yaml' has a different internal name '${internalName}' defined in its YAML. ` +
-                    `Consider renaming the file or updating the internal name in the YAML for consistency.`,
-                );
-              } else {
-                const configuredAgents = getConfig<string[]>(
-                  'texra.agents',
-                  [],
-                );
-                if (!configuredAgents.includes(filenameBase)) {
-                  await promptToAddAgentToConfig(filenameBase);
-                }
-              }
+            if (path.extname(uri.fsPath) === '.yaml') {
+              this.validateYaml(uri.fsPath);
             }
           });
         } else {

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -85,10 +85,18 @@ export class WatcherManager {
         watcher.onDidCreate((uri) => {
           this.triggerRefresh();
           if (path.extname(uri.fsPath) === '.yaml') {
-            const handle = setTimeout(
-              () => void this.validateYaml(uri.fsPath),
-              WatcherManager.VALIDATION_DELAY,
-            );
+            const handle = setTimeout(async () => {
+              try {
+                await this.validateYaml(uri.fsPath);
+              } catch (error) {
+                logger.error(CHANNEL, `Error validating YAML: ${error}`);
+              } finally {
+                this.validationHandles = this.validationHandles.filter(
+                  (h) => h !== handle,
+                );
+              }
+            }, WatcherManager.VALIDATION_DELAY);
+
             this.validationHandles.push(handle);
           }
         });


### PR DESCRIPTION
## Summary
- monitor all files for explorer refresh
- add `name` field in new agent template
- validate YAML a bit later after creation

## Testing
- `npm run lint`
- `npm test` *(fails: unknown)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685cf04ef32c832497827addf87299eb