### PR TITLE
Switch progress logs to structured objects

### DIFF
--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -4,15 +4,8 @@ import { randomUUID } from 'crypto';
 // Local imports
 import { emitProgress } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import { escapeHtml } from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-
-/**
- * Create a span element for special log content.
- * @param content - The text to wrap.
- * @param type - The message type value.
- */
-const escapeContent = (content: string): string => escapeHtml(content);
+import type { LogMessageData } from '@logger/LogTypes';
 
 export async function streamReasoningToProgressView<T>(
   stream: AsyncIterable<T>,
@@ -24,23 +17,25 @@ export async function streamReasoningToProgressView<T>(
   const id = randomUUID();
   let content = '';
 
+  const baseData: LogMessageData = {
+    id,
+    text: content,
+    level: 'info',
+    timestamp: Date.now(),
+    groupId,
+    messageType: MESSAGE_TYPES.THINKING,
+  };
+
   emitProgress('addLogMessage', {
     stream: streamId,
-    message: escapeContent(content),
-    level: 'info',
-    groupId,
-    timestamp: Date.now(),
-    messageType: MESSAGE_TYPES.THINKING,
-    id,
+    message: baseData,
   });
 
   for await (const chunk of stream) {
     content += extract(chunk);
     emitProgress('updateLogMessage', {
       stream: streamId,
-      id,
-      message: escapeContent(content),
-      messageType: MESSAGE_TYPES.THINKING,
+      message: { ...baseData, text: content },
     });
   }
 

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -21,3 +21,18 @@ export interface TaskGroup {
   /** Optional usage stats attached to the group */
   usage?: TokenUsageStats;
 }
+
+export interface LogMessageData {
+  /** Unique identifier for this log entry */
+  id: string;
+  /** Raw message text */
+  text: string;
+  /** Severity level */
+  level: 'error' | 'warn' | 'info' | 'debug';
+  /** Unix timestamp (ms) */
+  timestamp: number;
+  /** Optional group association */
+  groupId?: string;
+  /** Optional message category */
+  messageType?: 'default' | 'scratchpad' | 'thinking';
+}

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -13,7 +13,7 @@ import {
   isAgentStream,
   EMOJI_BY_LEVEL as emojis,
 } from '@utils/loggerUtils';
-import { TaskGroup } from './LogTypes';
+import { TaskGroup, LogMessageData } from './LogTypes';
 import { MESSAGE_TYPES, type MessageType } from './messageTypes';
 
 function isValidMessageType(
@@ -124,37 +124,24 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    const processedMessage = escapeHtml(message);
-
     const msgType: MessageType = isValidMessageType(messageType)
       ? messageType
       : MESSAGE_TYPES.DEFAULT;
 
-    // Colored format for ProgressView using CSS classes, but with shorter timestamp display
-    const isVerbose = getConfig<boolean>('logger.debugMode', false);
     const id = randomUUID();
-    const coloredFormattedMessage =
-      `<div class="log-line" data-log-id="${id}" ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
-      `<span class="timestamp" title="${timestamp}">${emoji}${
-        isVerbose ? ` [${timeDisplay}]` : ''
-      }</span> ` +
-      (isVerbose
-        ? `<span class="level-${level}">${level
-            .toUpperCase()
-            .padEnd(8)}</span> `
-        : '') +
-      `<span class="message-${level}">${processedMessage}</span>` +
-      `</div>`;
-
     const numericTimestamp = new Date(timestamp).getTime();
+    const logData: LogMessageData = {
+      id,
+      text: message,
+      level: level as 'error' | 'warn' | 'info' | 'debug',
+      timestamp: numericTimestamp,
+      groupId,
+      messageType: msgType,
+    };
+
     emitProgress('addLogMessage', {
       stream: this.streamName,
-      message: coloredFormattedMessage,
-      level: level as 'error' | 'warn' | 'info' | 'debug',
-      groupId,
-      timestamp: numericTimestamp,
-      messageType: msgType,
-      id,
+      message: logData,
     });
 
     callback();

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -14,15 +14,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
-
-interface ColoredLogMessage {
-  id: string;
-  message: string;
-  level: 'error' | 'warn' | 'info' | 'debug';
-  timestamp: number;
-  groupId?: string;
-  messageType?: 'default' | 'scratchpad' | 'thinking';
-}
+import type { LogMessageData } from '../logger/LogTypes';
 
 interface OutputFileInfo extends DiffStats {
   path: string;
@@ -40,7 +32,7 @@ export class ProgressStateManager {
   private readonly logger: AgentLogger;
 
   // State collections
-  private _logStreams: Map<string, ColoredLogMessage[]> = new Map();
+  private _logStreams: Map<string, LogMessageData[]> = new Map();
   private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
@@ -53,7 +45,7 @@ export class ProgressStateManager {
   }
 
   // Getters for state collections
-  get logStreams(): Map<string, ColoredLogMessage[]> {
+  get logStreams(): Map<string, LogMessageData[]> {
     return this._logStreams;
   }
 
@@ -118,7 +110,7 @@ export class ProgressStateManager {
    */
   private async _loadLogStreams(): Promise<void> {
     const savedState = workspaceSM.get<{
-      [key: string]: ColoredLogMessage[];
+      [key: string]: LogMessageData[];
     }>(this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS));
 
     if (savedState) {
@@ -128,24 +120,15 @@ export class ProgressStateManager {
           .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
           .map(([stream, messages]) => [
             stream,
-            messages.map((msg) => {
-              if (!msg.id) {
-                msg.id = randomUUID();
-              }
-              if (msg.timestamp === undefined) {
-                const attrMatch = msg.message.match(
-                  /data-full-timestamp="([^"]+)"/,
-                );
-                const timeString =
-                  attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
-                const timestamp = new Date(timeString).getTime();
-                msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
-              }
-              if (!msg.messageType) {
-                msg.messageType = 'default';
-              }
-              return msg;
-            }),
+            messages.map((msg) => ({
+              id: msg.id ?? randomUUID(),
+              text: (msg as any).text ?? (msg as any).message ?? '',
+              level: msg.level,
+              timestamp:
+                typeof msg.timestamp === 'number' ? msg.timestamp : Date.now(),
+              groupId: msg.groupId,
+              messageType: msg.messageType ?? 'default',
+            })),
           ]),
       );
     } else {

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -130,7 +130,7 @@ export class ProgressStateManager {
                 const timeString =
                   attrMatch?.[1] || (rawText.match(/\[(.*?)\]/)?.[1] ?? '');
                 const parsed = new Date(timeString).getTime();
-                ts = isNaN(parsed) ? 0 : parsed;
+                ts = isNaN(parsed) ? Date.now() : parsed;
               }
               return {
                 id: msg.id ?? randomUUID(),

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -120,15 +120,27 @@ export class ProgressStateManager {
           .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
           .map(([stream, messages]) => [
             stream,
-            messages.map((msg) => ({
-              id: msg.id ?? randomUUID(),
-              text: (msg as any).text ?? (msg as any).message ?? '',
-              level: msg.level,
-              timestamp:
-                typeof msg.timestamp === 'number' ? msg.timestamp : Date.now(),
-              groupId: msg.groupId,
-              messageType: msg.messageType ?? 'default',
-            })),
+            messages.map((msg) => {
+              const rawText = (msg as any).text ?? (msg as any).message ?? '';
+              let ts = msg.timestamp;
+              if (ts === undefined) {
+                const attrMatch = rawText.match(
+                  /data-full-timestamp="([^"]+)"/,
+                );
+                const timeString =
+                  attrMatch?.[1] || (rawText.match(/\[(.*?)\]/)?.[1] ?? '');
+                const parsed = new Date(timeString).getTime();
+                ts = isNaN(parsed) ? 0 : parsed;
+              }
+              return {
+                id: msg.id ?? randomUUID(),
+                text: rawText,
+                level: msg.level,
+                timestamp: ts,
+                groupId: msg.groupId,
+                messageType: msg.messageType ?? 'default',
+              } as LogMessageData;
+            }),
           ]),
       );
     } else {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -13,7 +13,7 @@ import { getConfig } from '@utils/config';
 import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 
 import { TokenUsageStats } from '../types/UsageTypes';
-import { TaskGroup } from '../logger/LogTypes';
+import { TaskGroup, LogMessageData } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
 import { randomUUID } from 'crypto';
 import { onProgress } from '@eventBus/ProgressEventBus';
@@ -31,15 +31,6 @@ type StreamStatusType =
   | typeof STATUS.RUNNING
   | typeof STATUS.ERROR
   | typeof STATUS.STOPPED;
-
-interface ColoredLogMessage {
-  id: string;
-  message: string;
-  level: 'error' | 'warn' | 'info' | 'debug';
-  timestamp: number;
-  groupId?: string;
-  messageType?: 'default' | 'scratchpad' | 'thinking';
-}
 
 // Channels that should not be persisted in workspace storage
 
@@ -148,35 +139,28 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       new vscode.Disposable(
         onProgress(
           'addLogMessage',
-          (p: {
-            stream: string;
-            message: string;
-            level: 'error' | 'warn' | 'info' | 'debug';
-            groupId?: string;
-            timestamp: number;
-            messageType: 'default' | 'scratchpad' | 'thinking';
-            id: string;
-          }) =>
+          (p: { stream: string; message: LogMessageData }) =>
             this.addLogMessage(
               p.stream,
-              p.message,
-              p.level,
-              p.groupId,
-              p.timestamp,
-              p.messageType,
-              p.id,
+              p.message.text,
+              p.message.level,
+              p.message.groupId,
+              p.message.timestamp,
+              p.message.messageType,
+              p.message.id,
             ),
         ),
       ),
       new vscode.Disposable(
         onProgress(
           'updateLogMessage',
-          (p: {
-            stream: string;
-            id: string;
-            message: string;
-            messageType: 'default' | 'scratchpad' | 'thinking';
-          }) => this.updateLogMessage(p.stream, p.id, p.message, p.messageType),
+          (p: { stream: string; message: LogMessageData }) =>
+            this.updateLogMessage(
+              p.stream,
+              p.message.id,
+              p.message.text,
+              p.message.messageType,
+            ),
         ),
       ),
       new vscode.Disposable(
@@ -424,9 +408,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       }
     }
 
-    const logMessage: ColoredLogMessage = {
+    const logMessage: LogMessageData = {
       id,
-      message,
+      text: message,
       level,
       timestamp,
       groupId,
@@ -465,7 +449,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     if (!existing) {
       return;
     }
-    existing.message = message;
+    existing.text = message;
     existing.messageType = messageType;
     this._stateManager.saveState();
     if (this._view && stream === this._stateManager.activeStream) {
@@ -626,7 +610,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     });
   }
 
-  public getLogStreams(): Map<string, ColoredLogMessage[]> {
+  public getLogStreams(): Map<string, LogMessageData[]> {
     return this._stateManager.logStreams;
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -452,7 +452,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     existing.text = message;
     existing.messageType = messageType;
     this._stateManager.saveState();
-    if (this._view && stream === this._stateManager.activeStream) {
+    if (this._view) {
       this._view.webview.postMessage({
         command: COMMANDS.UPDATE_LOG,
         stream,

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,6 +1,6 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { LogEntryFormatter } from './formatters.js';
+import { LogEntryFormatter, MessageTimestampExtractor } from './formatters.js';
 import { TaskGroupsDom, LogEntriesDom } from './taskManagers.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
@@ -31,4 +31,4 @@ export class ProgressViewDomHandler {
 export const progressViewDomHandler = new ProgressViewDomHandler();
 
 // Export formatter classes for reuse
-export { LogEntryFormatter };
+export { LogEntryFormatter, MessageTimestampExtractor };

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,6 +1,6 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { LogEntryFormatter, MessageTimestampExtractor } from './formatters.js';
+import { LogEntryFormatter } from './formatters.js';
 import { TaskGroupsDom, LogEntriesDom } from './taskManagers.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
@@ -31,4 +31,4 @@ export class ProgressViewDomHandler {
 export const progressViewDomHandler = new ProgressViewDomHandler();
 
 // Export formatter classes for reuse
-export { LogEntryFormatter, MessageTimestampExtractor };
+export { LogEntryFormatter };

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -81,6 +81,22 @@ export class MessageTimestampExtractor {
 /**
  * Handles log entry formatting with markdown support.
  */
+const EMOJI_BY_LEVEL = {
+  error: '🔴',
+  warn: '🟡',
+  info: '🟢',
+  debug: '🔍',
+};
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 export class LogEntryFormatter {
   constructor() {
     this._initializeMarkdown();
@@ -109,44 +125,30 @@ export class LogEntryFormatter {
    * @returns {string} Formatted HTML for the log message
    */
   format(logMessage) {
-    const message = logMessage.message;
-
-    const type = logMessage.messageType;
-
-    if (type === 'thinking' || type === 'scratchpad') {
-      const label = type === 'thinking' ? 'Thinking' : 'Scratchpad';
-      const content = this._extractContent(message);
-      return this._formatSpecialContent(message, content, label, logMessage.id);
+    const { id, text, level, timestamp, groupId, messageType } = logMessage;
+    if (messageType === 'thinking' || messageType === 'scratchpad') {
+      const label = messageType === 'thinking' ? 'Thinking' : 'Scratchpad';
+      return this._formatSpecialContent(text, label, id, timestamp, groupId);
     }
 
-    return message;
-  }
-
-  _extractContent(message) {
-    const match = message.match(
-      /<span class="message-[^"]*">([\s\S]*?)<\/span>/,
+    const emoji = EMOJI_BY_LEVEL[level] || '•';
+    const fullTs = new Date(timestamp).toISOString();
+    const timeDisplay = fullTs.split('T')[1].split('.')[0];
+    const escaped = escapeHtml(text);
+    const groupAttr = groupId ? ` data-group-id="${groupId}"` : '';
+    return (
+      `<div class="log-line" data-log-id="${id}"${groupAttr} data-full-timestamp="${fullTs}">` +
+      `<span class="timestamp" title="${fullTs}">${emoji} [${timeDisplay}]</span> ` +
+      `<span class="message-${level}">${escaped}</span>` +
+      `</div>`
     );
-    return match ? match[1] : message;
   }
 
-  _unescapeHtml(text) {
-    return text
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#039;/g, "'")
-      .replace(/&amp;/g, '&');
-  }
-
-  _formatSpecialContent(message, content, contentType, logId) {
+  _formatSpecialContent(content, contentType, logId, timestamp, groupId) {
     try {
-      // Unescape HTML entities that were escaped during logging
-      content = this._unescapeHtml(content);
-
-      // Pre-process LaTeX references to protect them from markdown parsing
-      content = content.replace(/\\\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
-      content = content.replace(/\\\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
-      content = content.replace(/\\\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
+      content = content.replace(/\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
+      content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
+      content = content.replace(/\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
 
       // Process content as markdown
       let parsedMarkdown = marked.parse(content);
@@ -168,12 +170,13 @@ export class LogEntryFormatter {
 
       // Create enhanced content element with better formatting
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      // Determine label and icon based on content type
+      const groupAttr = groupId ? ` data-group-id="${groupId}"` : '';
+      const fullTs = new Date(timestamp).toISOString();
       const isThinking = contentType.includes('Thinking');
       const labelText = isThinking ? 'Thinking' : 'Scratchpad';
       const icon = isThinking ? 'codicon-lightbulb' : 'codicon-pencil';
 
-      return `<details class="special-details" open>
+      return `<details class="special-details log-line"${groupAttr} data-full-timestamp="${fullTs}" open>
         <summary>
           <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
           <i class="codicon ${icon}"></i>
@@ -184,7 +187,7 @@ export class LogEntryFormatter {
     } catch (e) {
       console.error('Error parsing markdown:', e);
       // Fallback to original content
-      return message;
+      return escapeHtml(content);
     }
   }
 }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -97,6 +97,15 @@ function escapeHtml(text) {
     .replace(/'/g, '&#039;');
 }
 
+function unescapeHtml(text) {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
 export class LogEntryFormatter {
   constructor() {
     this._initializeMarkdown();
@@ -146,9 +155,10 @@ export class LogEntryFormatter {
 
   _formatSpecialContent(content, contentType, logId, timestamp, groupId) {
     try {
-      content = content.replace(/\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
-      content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
-      content = content.replace(/\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
+      content = unescapeHtml(content);
+      content = content.replace(/\\\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
+      content = content.replace(/\\\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
+      content = content.replace(/\\\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
 
       // Process content as markdown
       let parsedMarkdown = marked.parse(content);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,6 +1,10 @@
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
-import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
+import {
+  progressViewDomHandler,
+  LogEntryFormatter,
+  MessageTimestampExtractor,
+} from './domHandlers.js';
 import { COMMANDS, STATUS } from './constants.js';
 import { registerMessageHandlers } from '@common/webviewContext.js';
 
@@ -10,6 +14,7 @@ const dom = progressViewDomHandler;
 
 // Create formatter instances
 const entryFormatter = new LogEntryFormatter();
+const timestampExtractor = new MessageTimestampExtractor();
 
 const handlers = {
   [COMMANDS.UPDATE_STREAMS]: (message) => {
@@ -40,9 +45,16 @@ const handlers = {
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.add(g));
       }
-      const sortedMessages = [...message.messages].sort(
-        (a, b) => a.timestamp - b.timestamp,
-      );
+      const sortedMessages = [...message.messages].sort((a, b) => {
+        if (a.timestamp !== undefined && b.timestamp !== undefined) {
+          return a.timestamp - b.timestamp;
+        }
+        if (a.timestamp !== undefined) return -1;
+        if (b.timestamp !== undefined) return 1;
+        const aTs = timestampExtractor.extract(a.text || a.message);
+        const bTs = timestampExtractor.extract(b.text || b.message);
+        return aTs.localeCompare(bTs);
+      });
       sortedMessages.forEach((msg) => {
         if (msg.groupId) {
           if (!dom.logEntries.append(msg)) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,10 +1,6 @@
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
-import {
-  progressViewDomHandler,
-  LogEntryFormatter,
-  MessageTimestampExtractor,
-} from './domHandlers.js';
+import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
 import { COMMANDS, STATUS } from './constants.js';
 import { registerMessageHandlers } from '@common/webviewContext.js';
 
@@ -14,7 +10,6 @@ const dom = progressViewDomHandler;
 
 // Create formatter instances
 const entryFormatter = new LogEntryFormatter();
-const timestampExtractor = new MessageTimestampExtractor();
 
 const handlers = {
   [COMMANDS.UPDATE_STREAMS]: (message) => {
@@ -45,16 +40,9 @@ const handlers = {
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.add(g));
       }
-      const sortedMessages = [...message.messages].sort((a, b) => {
-        if (a.timestamp !== undefined && b.timestamp !== undefined) {
-          return a.timestamp - b.timestamp;
-        }
-        if (a.timestamp !== undefined) return -1;
-        if (b.timestamp !== undefined) return 1;
-        const aTs = timestampExtractor.extract(a.message);
-        const bTs = timestampExtractor.extract(b.message);
-        return aTs.localeCompare(bTs);
-      });
+      const sortedMessages = [...message.messages].sort(
+        (a, b) => a.timestamp - b.timestamp,
+      );
       sortedMessages.forEach((msg) => {
         if (msg.groupId) {
           if (!dom.logEntries.append(msg)) {

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -330,7 +330,7 @@ export class LogEntriesDom {
                 const startTime = parseInt(groupStartTime, 10);
                 // If the message timestamp is earlier than the group start time,
                 // insert before this group
-                if (msgDate.getTime() < startTime) {
+                if (msgDate && msgDate.getTime() < startTime) {
                   insertPosition = child;
                   break;
                 }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,6 +1,10 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
+import {
+  TaskGroupHeaderFormatter,
+  LogEntryFormatter,
+  MessageTimestampExtractor,
+} from './formatters.js';
 
 /**
  * Manages task group DOM operations.
@@ -8,6 +12,7 @@ import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
 export class TaskGroupsDom {
   constructor() {
     this.headerFormatter = new TaskGroupHeaderFormatter();
+    this.timestampExtractor = new MessageTimestampExtractor();
     this.previousActiveGroupId = null;
   }
 
@@ -71,9 +76,18 @@ export class TaskGroupsDom {
           // If sibling is a log message, check if group should come before it
           else if (sibling.classList.contains('log-line')) {
             const msgFullTimestamp = sibling.dataset.fullTimestamp;
-            const msgTime = msgFullTimestamp
-              ? new Date(msgFullTimestamp)
-              : new Date(0);
+            let msgTime;
+
+            if (msgFullTimestamp) {
+              msgTime = new Date(msgFullTimestamp);
+            } else {
+              const msgTimestamp = this.timestampExtractor.extract(
+                sibling.outerHTML,
+              );
+              msgTime = msgTimestamp.includes('-')
+                ? new Date(msgTimestamp)
+                : new Date(`2000-01-01 ${msgTimestamp}`);
+            }
 
             if (group.startTime < msgTime.getTime()) {
               insertPosition = sibling;
@@ -269,6 +283,7 @@ export class TaskGroupsDom {
 export class LogEntriesDom {
   constructor() {
     this.entryFormatter = new LogEntryFormatter();
+    this.timestampExtractor = new MessageTimestampExtractor();
   }
 
   /**
@@ -288,8 +303,15 @@ export class LogEntriesDom {
         const logLineElement = messageElement.firstElementChild;
 
         // Extract timestamp from the message for chronological ordering
-        const msgDate = new Date(logMessage.timestamp);
-        const msgTimestamp = msgDate.toISOString();
+        const msgDate =
+          typeof logMessage.timestamp === 'number'
+            ? new Date(logMessage.timestamp)
+            : null;
+        const msgTimestamp =
+          msgDate?.toISOString() ||
+          this.timestampExtractor.extract(
+            logMessage.text || logMessage.message,
+          );
 
         // Find where to insert this message chronologically
         let insertPosition = null;
@@ -320,7 +342,23 @@ export class LogEntriesDom {
             const childFullTimestamp = child.dataset.fullTimestamp;
             if (childFullTimestamp) {
               const childDate = new Date(childFullTimestamp);
-              if (msgDate < childDate) {
+              if (msgDate && msgDate < childDate) {
+                insertPosition = child;
+                break;
+              } else if (!msgDate) {
+                const childTimestamp = this.timestampExtractor.extract(
+                  child.outerHTML,
+                );
+                if (msgTimestamp < childTimestamp) {
+                  insertPosition = child;
+                  break;
+                }
+              }
+            } else {
+              const childTimestamp = this.timestampExtractor.extract(
+                child.outerHTML,
+              );
+              if (msgTimestamp < childTimestamp) {
                 insertPosition = child;
                 break;
               }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,10 +1,6 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import {
-  TaskGroupHeaderFormatter,
-  LogEntryFormatter,
-  MessageTimestampExtractor,
-} from './formatters.js';
+import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
 
 /**
  * Manages task group DOM operations.
@@ -12,7 +8,6 @@ import {
 export class TaskGroupsDom {
   constructor() {
     this.headerFormatter = new TaskGroupHeaderFormatter();
-    this.timestampExtractor = new MessageTimestampExtractor();
     this.previousActiveGroupId = null;
   }
 
@@ -75,22 +70,10 @@ export class TaskGroupsDom {
           }
           // If sibling is a log message, check if group should come before it
           else if (sibling.classList.contains('log-line')) {
-            // Extract full timestamp from data attribute if available
             const msgFullTimestamp = sibling.dataset.fullTimestamp;
-            let msgTime;
-
-            if (msgFullTimestamp) {
-              msgTime = new Date(msgFullTimestamp);
-            } else {
-              // Fallback to extracting time from content
-              const msgTimestamp = this.timestampExtractor.extract(
-                sibling.outerHTML,
-              );
-              // Use a dummy date for time-only comparison
-              msgTime = msgTimestamp.includes('-')
-                ? new Date(msgTimestamp)
-                : new Date(`2000-01-01 ${msgTimestamp}`);
-            }
+            const msgTime = msgFullTimestamp
+              ? new Date(msgFullTimestamp)
+              : new Date(0);
 
             if (group.startTime < msgTime.getTime()) {
               insertPosition = sibling;
@@ -286,7 +269,6 @@ export class TaskGroupsDom {
 export class LogEntriesDom {
   constructor() {
     this.entryFormatter = new LogEntryFormatter();
-    this.timestampExtractor = new MessageTimestampExtractor();
   }
 
   /**
@@ -306,12 +288,8 @@ export class LogEntriesDom {
         const logLineElement = messageElement.firstElementChild;
 
         // Extract timestamp from the message for chronological ordering
-        const msgDate = logMessage.timestamp
-          ? new Date(logMessage.timestamp)
-          : null;
-        const msgTimestamp =
-          msgDate?.toISOString() ||
-          this.timestampExtractor.extract(logMessage.message);
+        const msgDate = new Date(logMessage.timestamp);
+        const msgTimestamp = msgDate.toISOString();
 
         // Find where to insert this message chronologically
         let insertPosition = null;
@@ -330,54 +308,19 @@ export class LogEntriesDom {
                 const startTime = parseInt(groupStartTime, 10);
                 // If the message timestamp is earlier than the group start time,
                 // insert before this group
-                if (msgDate) {
-                  if (msgDate.getTime() < startTime) {
-                    insertPosition = child;
-                    break;
-                  }
-                } else {
-                  // Fallback to text comparison if no msgDate
-                  const timeText = startTimeElem.textContent.replace(
-                    /^[^0-9]*/,
-                    '',
-                  );
-                  if (msgTimestamp < timeText) {
-                    insertPosition = child;
-                    break;
-                  }
+                if (msgDate.getTime() < startTime) {
+                  insertPosition = child;
+                  break;
                 }
               }
             }
           }
           // If this is a log message, extract its timestamp
           else if (child.classList.contains('log-line')) {
-            // Try to get the full timestamp from data attribute
             const childFullTimestamp = child.dataset.fullTimestamp;
-
             if (childFullTimestamp) {
               const childDate = new Date(childFullTimestamp);
-
-              if (msgDate && childDate) {
-                if (msgDate < childDate) {
-                  insertPosition = child;
-                  break;
-                }
-              } else {
-                // Fallback to string comparison
-                const childTimestamp = this.timestampExtractor.extract(
-                  child.outerHTML,
-                );
-                if (msgTimestamp < childTimestamp) {
-                  insertPosition = child;
-                  break;
-                }
-              }
-            } else {
-              // Fallback to original behavior
-              const childTimestamp = this.timestampExtractor.extract(
-                child.outerHTML,
-              );
-              if (msgTimestamp < childTimestamp) {
+              if (msgDate < childDate) {
                 insertPosition = child;
                 break;
               }


### PR DESCRIPTION
## Summary
- introduce `LogMessageData` interface
- send structured log objects from logger
- update ProgressViewProvider to handle new payload
- simplify ProgressStateManager storage
- render logs on the frontend using `LogEntryFormatter`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test requires GUI)*

------
https://chatgpt.com/codex/tasks/task_e_685d4abd16d083249140fba09e971d56