### PR TITLE
Refactor logger to use explicit agent flag

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -51,7 +51,7 @@ export abstract class BaseAgent implements IAgent {
     this.agentPath = agentPath;
 
     const channelId = this.getTaskId();
-    this.logger = new AgentLogger(channelId);
+    this.logger = new AgentLogger(channelId, true);
     this.modelHandler.setLogger(this.logger);
   }
 

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -12,8 +12,14 @@ import { SHORT_SLEEP_MS } from '@utils/config';
  * Uses the updated consolidated logger system.
  */
 export class AgentLogger {
-  constructor(public channelId: string) {
-    logger.initialize(this.channelId);
+  public readonly isAgentLogger: boolean;
+
+  constructor(
+    public channelId: string,
+    isAgentLogger = false,
+  ) {
+    this.isAgentLogger = isAgentLogger;
+    logger.initialize(this.channelId, this.isAgentLogger);
     this.channelId = channelId;
   }
 

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -24,19 +24,43 @@ export class AgentLogger {
   }
 
   debug(message: string, groupId?: string, messageType?: MessageType): void {
-    logger.debug(this.channelId, message, groupId, messageType);
+    logger.debug(
+      this.channelId,
+      message,
+      groupId,
+      messageType,
+      this.isAgentLogger,
+    );
   }
 
   info(message: string, groupId?: string, messageType?: MessageType): void {
-    logger.info(this.channelId, message, groupId, messageType);
+    logger.info(
+      this.channelId,
+      message,
+      groupId,
+      messageType,
+      this.isAgentLogger,
+    );
   }
 
   warn(message: string, groupId?: string, messageType?: MessageType): void {
-    logger.warn(this.channelId, message, groupId, messageType);
+    logger.warn(
+      this.channelId,
+      message,
+      groupId,
+      messageType,
+      this.isAgentLogger,
+    );
   }
 
   error(message: string, groupId?: string, messageType?: MessageType): void {
-    logger.error(this.channelId, message, groupId, messageType);
+    logger.error(
+      this.channelId,
+      message,
+      groupId,
+      messageType,
+      this.isAgentLogger,
+    );
   }
 
   /**
@@ -53,7 +77,13 @@ export class AgentLogger {
   ): Promise<string> {
     // brief delay to ensure log order
     await sleep(SHORT_SLEEP_MS);
-    return logger.startGroup(this.channelId, groupName, id, parentGroupId);
+    return logger.startGroup(
+      this.channelId,
+      groupName,
+      id,
+      parentGroupId,
+      this.isAgentLogger,
+    );
   }
 
   /**

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -7,12 +7,7 @@ import { randomUUID } from 'crypto';
 // Local imports - progressView
 import { emitProgress } from '@eventBus/ProgressEventBus';
 import { getConfig } from '@utils/config';
-import {
-  shouldUseConsolidatedChannel,
-  getColorForLevel,
-  isAgentStream,
-  EMOJI_BY_LEVEL as emojis,
-} from '@utils/loggerUtils';
+import { getColorForLevel, EMOJI_BY_LEVEL as emojis } from '@utils/loggerUtils';
 import { TaskGroup } from './LogTypes';
 import { MESSAGE_TYPES, type MessageType } from './messageTypes';
 
@@ -69,20 +64,20 @@ function getMainOutputChannel(): vscode.OutputChannel {
 class VSCodeTransport extends Transport {
   private channel: vscode.OutputChannel;
   private streamName: string;
-  private useConsolidatedChannel: boolean;
+  private isAgentChannel: boolean;
   private groups: Map<string, TaskGroup> = new Map();
   private activeGroupId?: string;
 
   constructor(
     channel: vscode.OutputChannel,
     streamName: string,
-    useConsolidatedChannel: boolean,
+    isAgentChannel: boolean,
     opts?: Transport.TransportStreamOptions,
   ) {
     super(opts);
     this.channel = channel;
     this.streamName = streamName;
-    this.useConsolidatedChannel = useConsolidatedChannel;
+    this.isAgentChannel = isAgentChannel;
   }
 
   log(info: any, callback: () => void) {
@@ -96,21 +91,15 @@ class VSCodeTransport extends Transport {
     // Full format is: YYYY-MM-DD HH:mm:ss.SSS
     const timeDisplay = timestamp.split(' ')[1].split('.')[0]; // Drop milliseconds for UI display
 
-    // For consolidated channel, include the source channel in the message
-    const channelPrefix = this.useConsolidatedChannel
-      ? `[${this.streamName}] `
-      : '';
+    // For non-agent channels include the source name in the message
+    const channelPrefix = this.isAgentChannel ? '' : `[${this.streamName}] `;
 
     // Plain format for output channel - no escaping needed but include better formatting
     // const formattedMessage = `${emoji} [${timestamp}] ${level.toUpperCase().padEnd(7)} ${channelPrefix}${message}`;
     const formattedMessage = `${emoji} [${timestamp}] ${channelPrefix}${message}`;
 
-    // Key behavior change: For agent streams, we ONLY write to their dedicated channel
-    // For non-agent streams, we write to the consolidated channel
-    // This prevents duplicate output in both places
-    if (this.useConsolidatedChannel || !isAgentStream(this.streamName)) {
-      this.channel.appendLine(formattedMessage);
-    }
+    // Always write to the configured output channel
+    this.channel.appendLine(formattedMessage);
 
     // Skip debug messages in ProgressView if debug mode is disabled
     if (level === 'debug' && !getConfig<boolean>('logger.debugMode', false)) {
@@ -118,8 +107,8 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    // Skip progress view updates for consolidated channels
-    if (this.useConsolidatedChannel) {
+    // Skip progress view updates for non-agent channels
+    if (!this.isAgentChannel) {
       callback();
       return;
     }
@@ -179,8 +168,8 @@ class VSCodeTransport extends Transport {
 
     this.activeGroupId = groupId;
 
-    // Skip progress view updates for consolidated channels
-    if (this.useConsolidatedChannel) {
+    // Skip progress view updates for non-agent channels
+    if (!this.isAgentChannel) {
       return groupId;
     }
 
@@ -208,8 +197,8 @@ class VSCodeTransport extends Transport {
     group.endTime = now;
     group.status = status;
 
-    // Skip progress view updates for consolidated channels
-    if (this.useConsolidatedChannel) {
+    // Skip progress view updates for non-agent channels
+    if (!this.isAgentChannel) {
       return;
     }
 
@@ -249,38 +238,28 @@ class VSCodeTransport extends Transport {
 const channelLoggers = new Map<string, winston.Logger>();
 const channelTransports = new Map<string, VSCodeTransport>();
 
-export function initialize(defaultChannel: string): void {
+export function initialize(defaultChannel: string, isAgent = false): void {
   // Create default logger if it doesn't exist
   if (!channelLoggers.has(defaultChannel)) {
-    createLoggerForChannel(defaultChannel);
+    createLoggerForChannel(defaultChannel, isAgent);
   }
 }
 
-function createLoggerForChannel(channel: string): winston.Logger {
+function createLoggerForChannel(
+  channel: string,
+  isAgent = false,
+): winston.Logger {
   // Check if channel already exists
   if (channelLoggers.has(channel)) {
     return channelLoggers.get(channel)!;
   }
 
-  const useConsolidatedChannel = shouldUseConsolidatedChannel(channel);
-
-  let outputChannel: vscode.OutputChannel;
-
-  if (useConsolidatedChannel) {
-    // Use the main TeXRA output channel for non-agent channels
-    outputChannel = getMainOutputChannel();
-  } else {
-    // Create a separate channel with the TeXRA prefix for agent channels
-    const channelName = 'TeXRA ' + channel;
-    outputChannel = vscode.window.createOutputChannel(channelName);
-  }
+  const outputChannel: vscode.OutputChannel = isAgent
+    ? vscode.window.createOutputChannel('TeXRA ' + channel)
+    : getMainOutputChannel();
 
   // Create transport
-  const transport = new VSCodeTransport(
-    outputChannel,
-    channel,
-    useConsolidatedChannel,
-  );
+  const transport = new VSCodeTransport(outputChannel, channel, isAgent);
   channelTransports.set(channel, transport);
 
   const logger = winston.createLogger({
@@ -307,7 +286,7 @@ export function startGroup(
 ): string {
   const transport = channelTransports.get(channel);
   if (!transport) {
-    const logger = createLoggerForChannel(channel);
+    const logger = createLoggerForChannel(channel, false);
     const newTransport = channelTransports.get(channel)!;
     return newTransport.startGroup(groupName, id, parentGroupId);
   }
@@ -401,7 +380,7 @@ export const error = (
 
 function getOrCreateLogger(channel: string): winston.Logger {
   if (!channelLoggers.has(channel)) {
-    return createLoggerForChannel(channel);
+    return createLoggerForChannel(channel, false);
   }
   return channelLoggers.get(channel)!;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -283,10 +283,11 @@ export function startGroup(
   groupName: string,
   id: string = randomUUID(),
   parentGroupId?: string,
+  isAgent = false,
 ): string {
   const transport = channelTransports.get(channel);
   if (!transport) {
-    const logger = createLoggerForChannel(channel, false);
+    createLoggerForChannel(channel, isAgent);
     const newTransport = channelTransports.get(channel)!;
     return newTransport.startGroup(groupName, id, parentGroupId);
   }
@@ -330,8 +331,9 @@ function logWithGroup(
   message: string,
   groupId?: string,
   messageType?: MessageType,
+  isAgent = false,
 ): void {
-  const logger = getOrCreateLogger(channel);
+  const logger = getOrCreateLogger(channel, isAgent);
   const transport = channelTransports.get(channel);
 
   // If no groupId provided, use the active group
@@ -347,8 +349,9 @@ export const debug = (
   message: string,
   groupId?: string,
   messageType?: MessageType,
+  isAgent = false,
 ): void => {
-  logWithGroup(channel, 'debug', message, groupId, messageType);
+  logWithGroup(channel, 'debug', message, groupId, messageType, isAgent);
 };
 
 export const info = (
@@ -356,8 +359,9 @@ export const info = (
   message: string,
   groupId?: string,
   messageType?: MessageType,
+  isAgent = false,
 ): void => {
-  logWithGroup(channel, 'info', message, groupId, messageType);
+  logWithGroup(channel, 'info', message, groupId, messageType, isAgent);
 };
 
 export const warn = (
@@ -365,8 +369,9 @@ export const warn = (
   message: string,
   groupId?: string,
   messageType?: MessageType,
+  isAgent = false,
 ): void => {
-  logWithGroup(channel, 'warn', message, groupId, messageType);
+  logWithGroup(channel, 'warn', message, groupId, messageType, isAgent);
 };
 
 export const error = (
@@ -374,13 +379,14 @@ export const error = (
   message: string,
   groupId?: string,
   messageType?: MessageType,
+  isAgent = false,
 ): void => {
-  logWithGroup(channel, 'error', message, groupId, messageType);
+  logWithGroup(channel, 'error', message, groupId, messageType, isAgent);
 };
 
-function getOrCreateLogger(channel: string): winston.Logger {
+function getOrCreateLogger(channel: string, isAgent = false): winston.Logger {
   if (!channelLoggers.has(channel)) {
-    return createLoggerForChannel(channel, false);
+    return createLoggerForChannel(channel, isAgent);
   }
   return channelLoggers.get(channel)!;
 }

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -6,7 +6,6 @@ import { randomUUID } from 'crypto';
 import { WorkspaceStateKey, workspaceSM } from '@utils/stateManager';
 import { WorkspaceFS } from '@utils/files';
 import { objectToTaskState } from '@utils/config';
-import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
 
@@ -122,31 +121,29 @@ export class ProgressStateManager {
     }>(this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS));
 
     if (savedState) {
-      // Only load channels that should be persisted
+      // Only load persisted channels
       this._logStreams = new Map(
-        Object.entries(savedState)
-          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-          .map(([stream, messages]) => [
-            stream,
-            messages.map((msg) => {
-              if (!msg.id) {
-                msg.id = randomUUID();
-              }
-              if (msg.timestamp === undefined) {
-                const attrMatch = msg.message.match(
-                  /data-full-timestamp="([^"]+)"/,
-                );
-                const timeString =
-                  attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
-                const timestamp = new Date(timeString).getTime();
-                msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
-              }
-              if (!msg.messageType) {
-                msg.messageType = 'default';
-              }
-              return msg;
-            }),
-          ]),
+        Object.entries(savedState).map(([stream, messages]) => [
+          stream,
+          messages.map((msg) => {
+            if (!msg.id) {
+              msg.id = randomUUID();
+            }
+            if (msg.timestamp === undefined) {
+              const attrMatch = msg.message.match(
+                /data-full-timestamp="([^"]+)"/,
+              );
+              const timeString =
+                attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
+              const timestamp = new Date(timeString).getTime();
+              msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
+            }
+            if (!msg.messageType) {
+              msg.messageType = 'default';
+            }
+            return msg;
+          }),
+        ]),
       );
     } else {
       this._logStreams.clear();
@@ -178,29 +175,27 @@ export class ProgressStateManager {
 
     if (savedGroups) {
       this._taskGroups = new Map(
-        Object.entries(savedGroups)
-          .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-          .map(([streamId, groups]) => [
-            streamId,
-            new Map(
-              Object.entries(groups).map(([id, g]) => [
-                id,
-                {
-                  ...g,
-                  startTime:
-                    typeof g.startTime === 'string'
-                      ? new Date(g.startTime).getTime()
-                      : g.startTime,
-                  endTime:
-                    g.endTime !== undefined
-                      ? typeof g.endTime === 'string'
-                        ? new Date(g.endTime).getTime()
-                        : g.endTime
-                      : undefined,
-                },
-              ]),
-            ),
-          ]),
+        Object.entries(savedGroups).map(([streamId, groups]) => [
+          streamId,
+          new Map(
+            Object.entries(groups).map(([id, g]) => [
+              id,
+              {
+                ...g,
+                startTime:
+                  typeof g.startTime === 'string'
+                    ? new Date(g.startTime).getTime()
+                    : g.startTime,
+                endTime:
+                  g.endTime !== undefined
+                    ? typeof g.endTime === 'string'
+                      ? new Date(g.endTime).getTime()
+                      : g.endTime
+                    : undefined,
+              },
+            ]),
+          ),
+        ]),
       );
     } else {
       this._taskGroups.clear();
@@ -221,10 +216,6 @@ export class ProgressStateManager {
       let totalFilesRemoved = 0;
 
       for (const [streamId, rounds] of Object.entries(savedFiles)) {
-        if (shouldUseConsolidatedChannel(streamId)) {
-          continue;
-        }
-
         const roundMap: { [key: number]: OutputFileInfo[] } = {};
         const streamFilesProcessed = Object.values(rounds).reduce(
           (sum, files) => sum + files.length,
@@ -356,10 +347,7 @@ export class ProgressStateManager {
    * Save log streams to storage
    */
   private _saveLogStreams(): void {
-    // Only save channels that should be persisted
-    const persistentStreams = Array.from(this._logStreams.entries()).filter(
-      ([channel]) => !shouldUseConsolidatedChannel(channel),
-    );
+    const persistentStreams = Array.from(this._logStreams.entries());
     const stateObj = Object.fromEntries(persistentStreams);
     workspaceSM.update(
       this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS),
@@ -371,12 +359,9 @@ export class ProgressStateManager {
    * Save log groups to storage
    */
   private _saveTaskGroups(): void {
-    const persistentGroups = Array.from(this._taskGroups.entries())
-      .filter(([channel]) => !shouldUseConsolidatedChannel(channel))
-      .map(([streamId, groups]) => [
-        streamId,
-        Object.fromEntries(groups.entries()),
-      ]);
+    const persistentGroups = Array.from(this._taskGroups.entries()).map(
+      ([streamId, groups]) => [streamId, Object.fromEntries(groups.entries())],
+    );
     const groupsObj = Object.fromEntries(persistentGroups);
     workspaceSM.update(
       this._getWorkspaceKey(WorkspaceStateKey.TASK_GROUPS),

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -10,7 +10,6 @@ import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
 
 import { getConfig } from '@utils/config';
-import { shouldUseConsolidatedChannel } from '@utils/loggerUtils';
 
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup } from '../logger/LogTypes';
@@ -386,11 +385,6 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     messageType: 'default' | 'scratchpad' | 'thinking' = 'default',
     id: string = randomUUID(),
   ) {
-    // Skip if this stream should be excluded from the progress view
-    if (shouldUseConsolidatedChannel(stream)) {
-      return;
-    }
-
     // Skip debug messages if debug mode is disabled
     if (level === 'debug' && !getConfig<boolean>('logger.debugMode', false)) {
       return;
@@ -486,11 +480,6 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     endTime?: number,
     parentGroupId?: string,
   ) {
-    // Skip if this stream should be excluded from the progress view
-    if (shouldUseConsolidatedChannel(stream)) {
-      return;
-    }
-
     // Ensure the stream exists so the UI can create a new tab immediately
     // this seems to be the fix for the issue where the progress view panel is not shown when a new stream is created
     if (!this._stateManager.logStreams.has(stream)) {
@@ -546,11 +535,6 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     status: StatusType,
     endTime?: number,
   ) {
-    // Skip if this stream should be excluded from the progress view
-    if (shouldUseConsolidatedChannel(stream)) {
-      return;
-    }
-
     const streamGroups = this._stateManager.taskGroups.get(stream);
     if (!streamGroups) {
       return;
@@ -679,11 +663,6 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public updateStreamStatus(stream: string, status: StreamStatusType) {
-    // Don't track status for excluded streams
-    if (shouldUseConsolidatedChannel(stream)) {
-      return;
-    }
-
     if (!this._stateManager.logStreams.has(stream)) {
       return;
     }

--- a/src/utils/loggerUtils.ts
+++ b/src/utils/loggerUtils.ts
@@ -2,51 +2,6 @@
 import * as path from 'path';
 
 // Local imports
-import { getConfig } from './config';
-
-/**
- * Determines if a stream name corresponds to an agent or contains agent information.
- * Agent streams are displayed in both the ProgressView and their own output channels.
- * Non-agent streams are consolidated into a single output channel.
- */
-export function isAgentStream(streamName: string): boolean {
-  // Special cases that are always treated as agent streams
-  if (streamName.includes('merge')) {
-    return true;
-  }
-
-  // Get the list of agents from config
-  const agents = getConfig<string[]>('agents', [
-    'correct',
-    'polish',
-    'draw',
-    'ocr',
-    'paper2slide',
-    'paper2poster',
-    'transcribe_audio',
-    'merge',
-  ]);
-
-  // Check if the stream name starts with any agent name followed by '@' (agent@model: file format)
-  for (const agent of agents) {
-    if (
-      streamName.startsWith(`${agent}@`) ||
-      streamName.startsWith(`${agent}_multiple@`)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Determines if a stream should use the consolidated output channel.
- * Agent streams get their own channel, all others (including executeAgent) use the consolidated channel.
- */
-export function shouldUseConsolidatedChannel(streamName: string): boolean {
-  // Only agent streams get dedicated channels and appear in the ProgressView
-  return !isAgentStream(streamName);
-}
 
 // Centralised emoji mapping for log levels
 export const EMOJI_BY_LEVEL: Record<string, string> = {


### PR DESCRIPTION
## Summary
- add `isAgentLogger` flag to `AgentLogger`
- expose `isAgent` when initializing log channels
- route progress events based on the logger type
- simplify progress view state persistence
- clean up obsolete agent stream checks

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d52acf748832492de34ab2d9dfb90