### PR TITLE
Implement structured log messages

### DIFF
--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -26,21 +26,25 @@ export async function streamReasoningToProgressView<T>(
 
   emitProgress('addLogMessage', {
     stream: streamId,
-    message: escapeContent(content),
-    level: 'info',
-    groupId,
-    timestamp: Date.now(),
-    messageType: MESSAGE_TYPES.THINKING,
-    id,
+    logMessage: {
+      id,
+      text: escapeContent(content),
+      level: 'info',
+      timestamp: Date.now(),
+      groupId,
+      messageType: MESSAGE_TYPES.THINKING,
+    },
   });
 
   for await (const chunk of stream) {
     content += extract(chunk);
     emitProgress('updateLogMessage', {
       stream: streamId,
-      id,
-      message: escapeContent(content),
-      messageType: MESSAGE_TYPES.THINKING,
+      logMessage: {
+        id,
+        text: escapeContent(content),
+        messageType: MESSAGE_TYPES.THINKING,
+      },
     });
   }
 

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -21,3 +21,20 @@ export interface TaskGroup {
   /** Optional usage stats attached to the group */
   usage?: TokenUsageStats;
 }
+
+export interface LogMessageData {
+  /** Unique identifier for this log entry */
+  id: string;
+  /** Raw message text */
+  text: string;
+  /** Severity level */
+  level: 'error' | 'warn' | 'info' | 'debug';
+  /** Unix timestamp (ms) */
+  timestamp: number;
+  /** Optional group association */
+  groupId?: string;
+  /** Optional message category */
+  messageType?: 'default' | 'scratchpad' | 'thinking';
+  /** Whether verbose details should be displayed */
+  verbose?: boolean;
+}

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -92,7 +92,6 @@ class VSCodeTransport extends Transport {
 
     // Extract parts of the timestamp for display formatting
     // Full format is: YYYY-MM-DD HH:mm:ss.SSS
-    const timeDisplay = timestamp.split(' ')[1].split('.')[0]; // Drop milliseconds for UI display
 
     // For non-agent channels include the source name in the message
     const channelPrefix = this.isAgentChannel ? '' : `[${this.streamName}] `;
@@ -122,31 +121,23 @@ class VSCodeTransport extends Transport {
       ? messageType
       : MESSAGE_TYPES.DEFAULT;
 
-    // Colored format for ProgressView using CSS classes, but with shorter timestamp display
     const isVerbose = getConfig<boolean>('logger.debugMode', false);
     const id = randomUUID();
-    const coloredFormattedMessage =
-      `<div class="log-line" data-log-id="${id}" ${groupId ? `data-group-id="${groupId}"` : ''} data-full-timestamp="${timestamp}">` +
-      `<span class="timestamp" title="${timestamp}">${emoji}${
-        isVerbose ? ` [${timeDisplay}]` : ''
-      }</span> ` +
-      (isVerbose
-        ? `<span class="level-${level}">${level
-            .toUpperCase()
-            .padEnd(8)}</span> `
-        : '') +
-      `<span class="message-${level}">${processedMessage}</span>` +
-      `</div>`;
-
     const numericTimestamp = new Date(timestamp).getTime();
+
+    const logMessage = {
+      id,
+      text: processedMessage,
+      level: level as 'error' | 'warn' | 'info' | 'debug',
+      timestamp: numericTimestamp,
+      groupId,
+      messageType: msgType,
+      verbose: isVerbose,
+    } satisfies import('./LogTypes').LogMessageData;
+
     emitProgress('addLogMessage', {
       stream: this.streamName,
-      message: coloredFormattedMessage,
-      level: level as 'error' | 'warn' | 'info' | 'debug',
-      groupId,
-      timestamp: numericTimestamp,
-      messageType: msgType,
-      id,
+      logMessage,
     });
 
     callback();

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -11,17 +11,8 @@ import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
 import { TokenUsageStats } from '../types/UsageTypes';
-import { TaskGroup } from '../logger/LogTypes';
+import { TaskGroup, LogMessageData } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
-
-interface ColoredLogMessage {
-  id: string;
-  message: string;
-  level: 'error' | 'warn' | 'info' | 'debug';
-  timestamp: number;
-  groupId?: string;
-  messageType?: 'default' | 'scratchpad' | 'thinking';
-}
 
 interface OutputFileInfo extends DiffStats {
   path: string;
@@ -39,7 +30,7 @@ export class ProgressStateManager {
   private readonly logger: AgentLogger;
 
   // State collections
-  private _logStreams: Map<string, ColoredLogMessage[]> = new Map();
+  private _logStreams: Map<string, LogMessageData[]> = new Map();
   private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
@@ -52,7 +43,7 @@ export class ProgressStateManager {
   }
 
   // Getters for state collections
-  get logStreams(): Map<string, ColoredLogMessage[]> {
+  get logStreams(): Map<string, LogMessageData[]> {
     return this._logStreams;
   }
 
@@ -117,7 +108,7 @@ export class ProgressStateManager {
    */
   private async _loadLogStreams(): Promise<void> {
     const savedState = workspaceSM.get<{
-      [key: string]: ColoredLogMessage[];
+      [key: string]: LogMessageData[] | any[];
     }>(this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS));
 
     if (savedState) {
@@ -125,23 +116,30 @@ export class ProgressStateManager {
       this._logStreams = new Map(
         Object.entries(savedState).map(([stream, messages]) => [
           stream,
-          messages.map((msg) => {
+          messages.map((msg: any) => {
             if (!msg.id) {
               msg.id = randomUUID();
             }
+            if (msg.text === undefined && msg.message !== undefined) {
+              msg.text = msg.message;
+            }
             if (msg.timestamp === undefined) {
-              const attrMatch = msg.message.match(
-                /data-full-timestamp="([^"]+)"/,
-              );
+              const attrMatch =
+                typeof msg.text === 'string'
+                  ? msg.text.match(/data-full-timestamp="([^"]+)"/)
+                  : null;
               const timeString =
-                attrMatch?.[1] || (msg.message.match(/\[(.*?)\]/)?.[1] ?? '');
+                attrMatch?.[1] ||
+                (typeof msg.text === 'string'
+                  ? (msg.text.match(/\[(.*?)\]/)?.[1] ?? '')
+                  : '');
               const timestamp = new Date(timeString).getTime();
               msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
             }
             if (!msg.messageType) {
               msg.messageType = 'default';
             }
-            return msg;
+            return msg as LogMessageData;
           }),
         ]),
       );

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -31,14 +31,7 @@ type StreamStatusType =
   | typeof STATUS.ERROR
   | typeof STATUS.STOPPED;
 
-interface ColoredLogMessage {
-  id: string;
-  message: string;
-  level: 'error' | 'warn' | 'info' | 'debug';
-  timestamp: number;
-  groupId?: string;
-  messageType?: 'default' | 'scratchpad' | 'thinking';
-}
+import type { LogMessageData } from '../logger/LogTypes';
 
 // Channels that should not be persisted in workspace storage
 
@@ -147,35 +140,15 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       new vscode.Disposable(
         onProgress(
           'addLogMessage',
-          (p: {
-            stream: string;
-            message: string;
-            level: 'error' | 'warn' | 'info' | 'debug';
-            groupId?: string;
-            timestamp: number;
-            messageType: 'default' | 'scratchpad' | 'thinking';
-            id: string;
-          }) =>
-            this.addLogMessage(
-              p.stream,
-              p.message,
-              p.level,
-              p.groupId,
-              p.timestamp,
-              p.messageType,
-              p.id,
-            ),
+          (p: { stream: string; logMessage: LogMessageData }) =>
+            this.addLogMessage(p.stream, p.logMessage),
         ),
       ),
       new vscode.Disposable(
         onProgress(
           'updateLogMessage',
-          (p: {
-            stream: string;
-            id: string;
-            message: string;
-            messageType: 'default' | 'scratchpad' | 'thinking';
-          }) => this.updateLogMessage(p.stream, p.id, p.message, p.messageType),
+          (p: { stream: string; logMessage: LogMessageData }) =>
+            this.updateLogMessage(p.stream, p.logMessage),
         ),
       ),
       new vscode.Disposable(
@@ -376,17 +349,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._pendingUpdate = false;
   }
 
-  public addLogMessage(
-    stream: string,
-    message: string,
-    level: 'error' | 'warn' | 'info' | 'debug' = 'info',
-    groupId?: string,
-    timestamp: number = Date.now(),
-    messageType: 'default' | 'scratchpad' | 'thinking' = 'default',
-    id: string = randomUUID(),
-  ) {
+  public addLogMessage(stream: string, log: LogMessageData) {
     // Skip debug messages if debug mode is disabled
-    if (level === 'debug' && !getConfig<boolean>('logger.debugMode', false)) {
+    if (
+      log.level === 'debug' &&
+      !getConfig<boolean>('logger.debugMode', false)
+    ) {
       return;
     }
 
@@ -418,17 +386,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       }
     }
 
-    const logMessage: ColoredLogMessage = {
-      id,
-      message,
-      level,
-      timestamp,
-      groupId,
-      messageType,
-    };
-
     const messages = this._stateManager.logStreams.get(stream)!;
-    messages.push(logMessage);
+    messages.push(log);
 
     if (messages.length > 1000) {
       messages.splice(0, messages.length - 1000);
@@ -440,27 +399,26 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._view.webview.postMessage({
         command: COMMANDS.APPEND_LOG,
         stream: stream,
-        logMessage,
+        logMessage: log,
       });
     }
   }
 
-  public updateLogMessage(
-    stream: string,
-    id: string,
-    message: string,
-    messageType: 'default' | 'scratchpad' | 'thinking' = 'default',
-  ): void {
+  public updateLogMessage(stream: string, log: LogMessageData): void {
     const messages = this._stateManager.logStreams.get(stream);
     if (!messages) {
       return;
     }
-    const existing = messages.find((m) => m.id === id);
+    const existing = messages.find((m) => m.id === log.id);
     if (!existing) {
       return;
     }
-    existing.message = message;
-    existing.messageType = messageType;
+    if (log.text !== undefined) {
+      existing.text = log.text;
+    }
+    if (log.messageType) {
+      existing.messageType = log.messageType;
+    }
     this._stateManager.saveState();
     if (this._view && stream === this._stateManager.activeStream) {
       this._view.webview.postMessage({
@@ -610,7 +568,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     });
   }
 
-  public getLogStreams(): Map<string, ColoredLogMessage[]> {
+  public getLogStreams(): Map<string, LogMessageData[]> {
     return this._stateManager.logStreams;
   }
 
@@ -834,14 +792,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     for (const streamId of runningStreams) {
       // Mark stream as cancelled
       this._streamStatus.set(streamId, STATUS_CANCELLED);
-      this.addLogMessage(
-        streamId,
-        'Task cancelled due to extension deactivation.',
-        'warn',
-        undefined,
-        Date.now(),
-        'default',
-      );
+      this.addLogMessage(streamId, {
+        id: randomUUID(),
+        text: 'Task cancelled due to extension deactivation.',
+        level: 'warn',
+        timestamp: Date.now(),
+        messageType: 'default',
+      });
 
       // Update all active groups for this stream
       const streamGroups = this._stateManager.taskGroups.get(streamId);
@@ -883,14 +840,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       // Check if stream is running and mark as interrupted
       if (this._streamStatus.get(streamId) === STATUS.RUNNING) {
         this._streamStatus.set(streamId, STATUS_INTERRUPTED);
-        this.addLogMessage(
-          streamId,
-          'Task was interrupted due to extension restart.',
-          'warn',
-          undefined,
-          Date.now(),
-          'default',
-        );
+        this.addLogMessage(streamId, {
+          id: randomUUID(),
+          text: 'Task was interrupted due to extension restart.',
+          level: 'warn',
+          timestamp: Date.now(),
+          messageType: 'default',
+        });
         wasUpdated = true;
         updatedStreams++;
       }
@@ -905,14 +861,15 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         if (activeGroups.length > 0) {
           // Log inconsistent state if stream wasn't running but has running groups
           if (!wasUpdated) {
-            this.addLogMessage(
-              streamId,
-              `Found inconsistent state: stream status is ${this._streamStatus.get(streamId)} but has running groups.`,
-              'warn',
-              undefined,
-              Date.now(),
-              'default',
-            );
+            this.addLogMessage(streamId, {
+              id: randomUUID(),
+              text: `Found inconsistent state: stream status is ${this._streamStatus.get(
+                streamId,
+              )} but has running groups.`,
+              level: 'warn',
+              timestamp: Date.now(),
+              messageType: 'default',
+            });
             updatedStreams++;
           }
 

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,6 +1,6 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { LogEntryFormatter, MessageTimestampExtractor } from './formatters.js';
+import { LogEntryFormatter } from './formatters.js';
 import { TaskGroupsDom, LogEntriesDom } from './taskManagers.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
@@ -31,4 +31,4 @@ export class ProgressViewDomHandler {
 export const progressViewDomHandler = new ProgressViewDomHandler();
 
 // Export formatter classes for reuse
-export { LogEntryFormatter, MessageTimestampExtractor };
+export { LogEntryFormatter };

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -10,6 +10,13 @@ import { STATUS } from './constants.js';
 export const BULLET_MARKUP =
   '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
 
+export const EMOJI_BY_LEVEL = {
+  error: '🔴',
+  warn: '🟡',
+  info: '🟢',
+  debug: '🔍',
+};
+
 /**
  * Represents different task group hierarchy levels with associated behaviors
  */
@@ -109,24 +116,38 @@ export class LogEntryFormatter {
    * @returns {string} Formatted HTML for the log message
    */
   format(logMessage) {
-    const message = logMessage.message;
+    const { id, text, level, timestamp, groupId, messageType, verbose } =
+      logMessage;
 
-    const type = logMessage.messageType;
+    const emoji = EMOJI_BY_LEVEL[level] || '•';
+    const date = new Date(timestamp);
+    const timeDisplay = date
+      .toISOString()
+      .split('T')[1]
+      .replace('Z', '')
+      .split('.')[0];
+    const fullTimestamp = date.toISOString();
 
-    if (type === 'thinking' || type === 'scratchpad') {
-      const label = type === 'thinking' ? 'Thinking' : 'Scratchpad';
-      const content = this._extractContent(message);
-      return this._formatSpecialContent(message, content, label, logMessage.id);
+    const prefix = `<div class="log-line" data-log-id="${id}" ${
+      groupId ? `data-group-id="${groupId}"` : ''
+    } data-full-timestamp="${fullTimestamp}">`;
+    const levelMarkup = verbose
+      ? `<span class="level-${level}">${level.toUpperCase().padEnd(8)}</span> `
+      : '';
+    const htmlMessage =
+      prefix +
+      `<span class="timestamp" title="${fullTimestamp}">${emoji}${
+        verbose ? ` [${timeDisplay}]` : ''
+      }</span> ` +
+      levelMarkup +
+      `<span class="message-${level}">${text}</span>` +
+      `</div>`;
+    if (messageType === 'thinking' || messageType === 'scratchpad') {
+      const label = messageType === 'thinking' ? 'Thinking' : 'Scratchpad';
+      return this._formatSpecialContent(htmlMessage, text, label, id);
     }
 
-    return message;
-  }
-
-  _extractContent(message) {
-    const match = message.match(
-      /<span class="message-[^"]*">([\s\S]*?)<\/span>/,
-    );
-    return match ? match[1] : message;
+    return htmlMessage;
   }
 
   _unescapeHtml(text) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,10 +1,6 @@
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
-import {
-  progressViewDomHandler,
-  LogEntryFormatter,
-  MessageTimestampExtractor,
-} from './domHandlers.js';
+import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
 import { COMMANDS, STATUS } from './constants.js';
 import { registerMessageHandlers } from '@common/webviewContext.js';
 
@@ -14,7 +10,6 @@ const dom = progressViewDomHandler;
 
 // Create formatter instances
 const entryFormatter = new LogEntryFormatter();
-const timestampExtractor = new MessageTimestampExtractor();
 
 const handlers = {
   [COMMANDS.UPDATE_STREAMS]: (message) => {
@@ -45,16 +40,9 @@ const handlers = {
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.add(g));
       }
-      const sortedMessages = [...message.messages].sort((a, b) => {
-        if (a.timestamp !== undefined && b.timestamp !== undefined) {
-          return a.timestamp - b.timestamp;
-        }
-        if (a.timestamp !== undefined) return -1;
-        if (b.timestamp !== undefined) return 1;
-        const aTs = timestampExtractor.extract(a.message);
-        const bTs = timestampExtractor.extract(b.message);
-        return aTs.localeCompare(bTs);
-      });
+      const sortedMessages = [...message.messages].sort(
+        (a, b) => a.timestamp - b.timestamp,
+      );
       sortedMessages.forEach((msg) => {
         if (msg.groupId) {
           if (!dom.logEntries.append(msg)) {

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,10 +1,6 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import {
-  TaskGroupHeaderFormatter,
-  LogEntryFormatter,
-  MessageTimestampExtractor,
-} from './formatters.js';
+import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
 
 /**
  * Manages task group DOM operations.
@@ -12,7 +8,6 @@ import {
 export class TaskGroupsDom {
   constructor() {
     this.headerFormatter = new TaskGroupHeaderFormatter();
-    this.timestampExtractor = new MessageTimestampExtractor();
     this.previousActiveGroupId = null;
   }
 
@@ -77,20 +72,9 @@ export class TaskGroupsDom {
           else if (sibling.classList.contains('log-line')) {
             // Extract full timestamp from data attribute if available
             const msgFullTimestamp = sibling.dataset.fullTimestamp;
-            let msgTime;
-
-            if (msgFullTimestamp) {
-              msgTime = new Date(msgFullTimestamp);
-            } else {
-              // Fallback to extracting time from content
-              const msgTimestamp = this.timestampExtractor.extract(
-                sibling.outerHTML,
-              );
-              // Use a dummy date for time-only comparison
-              msgTime = msgTimestamp.includes('-')
-                ? new Date(msgTimestamp)
-                : new Date(`2000-01-01 ${msgTimestamp}`);
-            }
+            const msgTime = msgFullTimestamp
+              ? new Date(msgFullTimestamp)
+              : new Date();
 
             if (group.startTime < msgTime.getTime()) {
               insertPosition = sibling;
@@ -286,7 +270,6 @@ export class TaskGroupsDom {
 export class LogEntriesDom {
   constructor() {
     this.entryFormatter = new LogEntryFormatter();
-    this.timestampExtractor = new MessageTimestampExtractor();
   }
 
   /**
@@ -306,12 +289,7 @@ export class LogEntriesDom {
         const logLineElement = messageElement.firstElementChild;
 
         // Extract timestamp from the message for chronological ordering
-        const msgDate = logMessage.timestamp
-          ? new Date(logMessage.timestamp)
-          : null;
-        const msgTimestamp =
-          msgDate?.toISOString() ||
-          this.timestampExtractor.extract(logMessage.message);
+        const msgDate = new Date(logMessage.timestamp);
 
         // Find where to insert this message chronologically
         let insertPosition = null;
@@ -330,21 +308,9 @@ export class LogEntriesDom {
                 const startTime = parseInt(groupStartTime, 10);
                 // If the message timestamp is earlier than the group start time,
                 // insert before this group
-                if (msgDate) {
-                  if (msgDate.getTime() < startTime) {
-                    insertPosition = child;
-                    break;
-                  }
-                } else {
-                  // Fallback to text comparison if no msgDate
-                  const timeText = startTimeElem.textContent.replace(
-                    /^[^0-9]*/,
-                    '',
-                  );
-                  if (msgTimestamp < timeText) {
-                    insertPosition = child;
-                    break;
-                  }
+                if (msgDate.getTime() < startTime) {
+                  insertPosition = child;
+                  break;
                 }
               }
             }
@@ -353,31 +319,9 @@ export class LogEntriesDom {
           else if (child.classList.contains('log-line')) {
             // Try to get the full timestamp from data attribute
             const childFullTimestamp = child.dataset.fullTimestamp;
-
             if (childFullTimestamp) {
               const childDate = new Date(childFullTimestamp);
-
-              if (msgDate && childDate) {
-                if (msgDate < childDate) {
-                  insertPosition = child;
-                  break;
-                }
-              } else {
-                // Fallback to string comparison
-                const childTimestamp = this.timestampExtractor.extract(
-                  child.outerHTML,
-                );
-                if (msgTimestamp < childTimestamp) {
-                  insertPosition = child;
-                  break;
-                }
-              }
-            } else {
-              // Fallback to original behavior
-              const childTimestamp = this.timestampExtractor.extract(
-                child.outerHTML,
-              );
-              if (msgTimestamp < childTimestamp) {
+              if (msgDate < childDate) {
                 insertPosition = child;
                 break;
               }


### PR DESCRIPTION
## Summary
- define `LogMessageData` interface for progress logging
- emit structured log objects from logger
- update progress view provider and state manager to persist new objects
- adjust frontend scripts to build HTML from structured data

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d68b411bc832491461686bf4e07ff