### PR TITLE
Add latexmk preference and adjust pdf compilation

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -196,16 +196,19 @@ If any component is missing, TeXRA will typically show an error message indicati
 ### Common Installation Issues
 
 1. **Extension Not Loading**:
+
    - Check VS Code's minimum version requirement (1.94.2+)
    - Look for errors in the Output panel (select "TeXRA" in the dropdown)
    - Try reinstalling the extension
 
 2. **LaTeX Processing Errors**:
    - Verify LaTeX is in your system PATH
-   - Run `pdflatex --version` in terminal to confirm installation
-   - Check if required LaTeX packages are installed
+
+- Run `latexmk --version` (or `pdflatex --version`) in terminal to confirm installation
+- Check if required LaTeX packages are installed
 
 3. **Image Processing Errors**:
+
    - Confirm GraphicsMagick/ImageMagick is properly installed
    - Verify Ghostscript is installed and accessible
    - Check PATH environment variables

--- a/docs/guide/latex-compilation.md
+++ b/docs/guide/latex-compilation.md
@@ -12,7 +12,7 @@ You need a functional LaTeX distribution installed, such as:
 
 Getting LaTeX set up correctly can sometimes feel like wrestling an octopus, but it's necessary for features like compiling diffs and TikZ previews.
 
-Ensure that the `pdflatex` command (or your preferred LaTeX engine) is accessible from your system's command line.
+Ensure that the `latexmk` command is available (preferred for TeXRA) or at least `pdflatex`. These should be accessible from your system's command line.
 
 See the main [Installation Guide](./installation.md) for more details on installing LaTeX and other essential dependencies like Perl (required for `latexdiff`).
 

--- a/docs/guide/tool-integration.md
+++ b/docs/guide/tool-integration.md
@@ -23,7 +23,7 @@ TeXRA can use `texcount` (often included with LaTeX) to provide document statist
 Processing visual elements for analysis and inclusion.
 
 - **Extraction:** TeXRA can automatically find figure references (`\includegraphics`) and extract TikZ environments from your LaTeX source. See the [TikZ Figures guide](./tikz-figures.md) and the "Auto Extract" options in the UI ([File Management guide](./file-management.md#auto-extraction-features)).
-- **Conversion/Compilation:** Tools like `pdflatex`, `GraphicsMagick`/`ImageMagick`, and `Ghostscript` are used behind the scenes to compile extracted TikZ code and convert PDFs/images into formats suitable for the LLM (previews for you, data for the AI). Installation of these external dependencies is covered in the [Installation guide](./installation.md). Configuration options are in [VS Code Settings](./configuration.md#latex-configuration).
+- **Conversion/Compilation:** Tools like `latexmk` (preferred when available) or `pdflatex`, along with `GraphicsMagick`/`ImageMagick` and `Ghostscript`, are used behind the scenes to compile extracted TikZ code and convert PDFs/images into formats suitable for the LLM (previews for you, data for the AI). Installation of these external dependencies is covered in the [Installation guide](./installation.md). Configuration options are in [VS Code Settings](./configuration.md#latex-configuration).
 
 ### 3. Document Analysis
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -11,16 +11,19 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **Check VS Code compatibility**:
+
    - Ensure you're running VS Code version 1.96.2 or newer
    - Update VS Code if needed
 
 2. **Verify installation**:
+
    - Go to Extensions view (Ctrl+Shift+X)
    - Search for "TeXRA"
    - If not installed or disabled, install or enable it
    - Try reinstalling from the VSIX file
 
 3. **Check error logs**:
+
    - Open Output panel (Ctrl+Shift+U)
    - Select "TeXRA" from the dropdown menu
    - Look for specific error messages
@@ -39,7 +42,7 @@ Even the best research assistants (human or AI) have off days. This guide helps 
    Run these commands in your terminal to check installations:
 
    ```bash
-   pdflatex --version
+   latexmk --version  # or pdflatex --version
    perl --version
    gm version  # For GraphicsMagick
    gs --version  # For Ghostscript
@@ -52,6 +55,7 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 - When launching VS Code from the system menu or Finder, it may inherit a minimal PATH. TeXRA automatically searches common locations such as Homebrew, Linuxbrew, TeX&nbsp;Live and MiKTeX bins (newer TeX&nbsp;Live releases are preferred). Opening VS Code from a configured terminal provides the most reliable environment.
 
 3. **Manual installation**:
+
    - Follow the detailed installation steps in the [Installation Guide](/guide/installation)
    - Use the recommended installation methods for your OS
 
@@ -68,15 +72,18 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **Verify API keys**:
+
    - Open TeXRA in VS Code
    - Click "Set API Key" option
    - Re-enter your API keys carefully
 
 2. **Check API key validity**:
+
    - Verify your API keys are active in the provider dashboards
    - Check for any billing issues or usage limits
 
 3. **Network issues**:
+
    - Ensure your network allows connections to API endpoints
    - Check if you need to configure proxy settings
 
@@ -91,10 +98,12 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **OpenRouter configuration**:
+
    - Verify your OpenRouter API key is correctly set
    - Check that `texra.model.useOpenRouter` is set to `true`
 
 2. **Model availability**:
+
    - Ensure the requested model is available via OpenRouter
    - Check the OpenRouter dashboard for model status
 
@@ -111,15 +120,18 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **Verify LaTeX installation**:
+
    - Ensure your LaTeX distribution is properly installed
    - Check if required packages are installed
    - Run `tlmgr list --only-installed` (TeX Live) or check MiKTeX Package Manager
 
 2. **Document validation**:
+
    - Verify the document compiles correctly outside of TeXRA
    - Fix any LaTeX errors in the original document
 
 3. **Package dependencies**:
+
    - Some LaTeX packages might be missing
    - Install required packages using your LaTeX package manager
 
@@ -134,10 +146,12 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **TikZ package installation**:
+
    - Verify TikZ and PGF packages are installed
    - Check for other required TikZ libraries
 
 2. **Template configuration**:
+
    - Customize the TikZ template in settings to include necessary packages:
 
    ```json
@@ -145,6 +159,7 @@ Even the best research assistants (human or AI) have off days. This guide helps 
    ```
 
 3. **Path configuration**:
+
    - Set the correct TikZ input directory:
 
    ```json
@@ -162,14 +177,17 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **GraphicsMagick/ImageMagick**:
+
    - Verify installation with `gm version` or `convert -version`
    - Reinstall if necessary
 
 2. **Ghostscript**:
+
    - Check installation with `gs --version`
    - Ensure compatible version (9.52 recommended for Windows)
 
 3. **Permission issues**:
+
    - Ensure write permissions in output directories
    - Check temporary directory permissions
 
@@ -186,10 +204,12 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **Check API quotas and limits**:
+
    - Verify you haven't exceeded usage limits
    - Check billing status for your API account
 
 2. **Response timeout**:
+
    - For large documents, the model might timeout
    - Try breaking down the task into smaller chunks
    - Enable streaming for long responses:
@@ -199,6 +219,7 @@ Even the best research assistants (human or AI) have off days. This guide helps 
    ```
 
 3. **Context length**:
+
    - Documents might exceed the model's context window
    - Use models with larger context windows for big documents
    - Split large documents into smaller parts
@@ -215,15 +236,18 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **Improve instructions**:
+
    - Be more specific in your instructions
    - Provide clear examples of desired outputs
    - Specify what should and shouldn't be changed
 
 2. **Enable reflection**:
+
    - Turn on the "Reflect" option to allow the model to review its work
    - This often improves output quality significantly
 
 3. **Use better models**:
+
    - Upgrade to more capable models for complex tasks
    - Try Claude 3 Opus or GPT-4o for highest quality
    - Match the model to your specific task
@@ -241,14 +265,17 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **Workspace configuration**:
+
    - Ensure you're working within a VS Code workspace
    - Open a folder rather than individual files
 
 2. **File path issues**:
+
    - Avoid very long file paths or special characters
    - Use relative paths within the workspace
 
 3. **File list not updating**:
+
    - Click the refresh icon next to the file type
    - Restart VS Code if file lists remain outdated
    - Check file extension settings to ensure your files are included:
@@ -271,15 +298,18 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **Check file paths**:
+
    - Verify where TeXRA is saving output files
    - Look in the same directory as the input file
    - Check the ProgressBoard log for file paths
 
 2. **Permission issues**:
+
    - Ensure you have write permissions in the output directory
    - Try running VS Code with administrator/sudo privileges
 
 3. **Naming conflicts**:
+
    - Check if output files exist but with unexpected names
    - Look for files with pattern: `original_filename_agent_r0_model.extension`
 
@@ -294,6 +324,7 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **Incomplete generation**:
+
    - Check if the AI reached the token limit
    - Enable streaming for more reliable completion:
 
@@ -302,11 +333,13 @@ Even the best research assistants (human or AI) have off days. This guide helps 
    ```
 
 2. **XML parsing issues**:
+
    - TeXRA uses XML to structure its output (e.g., `<document>...</document>`).
    - Malformed XML (e.g., missing closing tags like `</document>`) generated by the LLM can cause extraction failures.
    - **Solution:** Check the raw output file (e.g., `*_r0_*.xml`) for XML structure problems. Manually add missing closing tags or fix other structural errors, then re-run any necessary processing or manually extract the content.
 
 3. **Encoding problems**:
+
    - Ensure consistent text encoding (UTF-8 recommended)
    - Check for special characters that might cause issues
 
@@ -343,11 +376,13 @@ Even the best research assistants (human or AI) have off days. This guide helps 
 **Solutions**:
 
 1. **LaTeX compatibility**:
+
    - Ensure both documents use compatible LaTeX commands
    - Some complex LaTeX constructs might cause diff issues
    - Simplify documents if necessary
 
 2. **latexdiff installation**:
+
    - Verify latexdiff is installed: `latexdiff --version`
    - Install or update if needed:
 
@@ -358,6 +393,7 @@ Even the best research assistants (human or AI) have off days. This guide helps 
    ```
 
 3. **File encoding**:
+
    - Ensure consistent encoding across files (UTF-8 recommended)
    - Check for special characters that might cause issues
 
@@ -417,15 +453,18 @@ The ProgressBoard is your main debugging tool. See the [ProgressBoard Guide](../
 Key points for troubleshooting:
 
 1. **Access ProgressBoard**:
+
    - Look for "TeXRA ProgressBoard" in the panel at the bottom of VS Code
    - If not visible, open it via the Command Palette: "TeXRA: Show ProgressBoard"
 
 2. **Interpreting logs**:
+
    - Green entries: Information and successful operations
    - Yellow entries: Warnings that might affect performance
    - Red entries: Errors that need attention
 
 3. **Finding specific information**:
+
    - Use the search function to find relevant messages
    - Look for task IDs to track specific operations
    - Expand nested entries to see detailed information
@@ -439,10 +478,12 @@ Key points for troubleshooting:
 If you can't resolve an issue using this guide:
 
 1. **Check GitHub issues**:
+
    - Search existing issues on the [TeXRA repository](https://github.com/texra-ai/texra-issues/issues)
    - Look for similar problems and solutions
 
 2. **Report new issues**:
+
    - Provide detailed information about your environment
    - Include steps to reproduce the problem
    - Attach relevant log excerpts from ProgressBoard

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -1065,6 +1065,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           outputFile,
           undefined,
           buildDir,
+          true,
         );
         if (compiled) {
           const pdfFile = path.join(

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -26,9 +26,12 @@ export async function compileLatex2Pdf(
   latexFile: string,
   channel: string = CHANNEL,
   outputDirectory?: string,
+  useLatexmk: boolean = false,
 ): Promise<boolean> {
-  // Ensure pdflatex is available before attempting compilation
-  if (!(await checkToolInstalled('pdflatex'))) {
+  const useLatexmkInstalled = useLatexmk
+    ? await checkToolInstalled('latexmk', false)
+    : false;
+  if (!useLatexmkInstalled && !(await checkToolInstalled('pdflatex'))) {
     return false;
   }
 
@@ -78,12 +81,20 @@ export async function compileLatex2Pdf(
       logger.debug(channel, `Setting TEXINPUTS to: ${texInputs}`);
     }
 
-    const command = [
-      'pdflatex',
-      '-interaction=nonstopmode',
-      `-output-directory="${outDir}"`,
-      `"${latexFile}"`,
-    ];
+    const command = useLatexmkInstalled
+      ? [
+          'latexmk',
+          '-pdf',
+          '-interaction=nonstopmode',
+          `-output-directory="${outDir}"`,
+          `"${latexFile}"`,
+        ]
+      : [
+          'pdflatex',
+          '-interaction=nonstopmode',
+          `-output-directory="${outDir}"`,
+          `"${latexFile}"`,
+        ];
 
     const result = await executeCommand(command, { channel, env });
     if (result.success) {

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -71,6 +71,12 @@ const PDFLATEX_INSTRUCTIONS =
   '- Ubuntu: sudo apt-get install texlive-full\n' +
   '- Windows: Install through MiKTeX or TeX Live package manager';
 
+const LATEXMK_INSTRUCTIONS =
+  'Installation instructions:\n' +
+  '- Mac: brew install latexmk\n' +
+  '- Ubuntu: sudo apt-get install latexmk\n' +
+  '- Windows: Install through MiKTeX or TeX Live package manager';
+
 // All tool configurations in one place
 const TOOL_CONFIGS: Record<string, ToolConfig> = {
   // ImageMagick tools
@@ -125,6 +131,12 @@ const TOOL_CONFIGS: Record<string, ToolConfig> = {
     errorMessage:
       'texcount is not installed. Please install it to use this feature.\n' +
       TEXCOUNT_INSTRUCTIONS,
+    openDocsCommand: 'texra.openDoc,installation',
+  },
+  latexmk: {
+    errorMessage:
+      'latexmk is not installed. Please install it to use this feature.\n' +
+      LATEXMK_INSTRUCTIONS,
     openDocsCommand: 'texra.openDoc,installation',
   },
   pdflatex: {


### PR DESCRIPTION
## Summary
- prefer `latexmk` when available in `compileLatex2Pdf`
- mention latexmk in installation and tool docs
- compile output PDFs sequentially when `autoCompileInputPdf` is enabled

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(inconclusive: VS Code tests produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_685e3f485ad083248ad056392a814bb7