### PR TITLE
Add interface for OutputHandler

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -48,7 +48,7 @@ import {
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import type { IModelHandler } from '@agent/modelHandlers';
-import { OutputHandler, NamedOutputFile } from '@agent/output';
+import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import { messageToSkeleton } from '@agent/utils/messageUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -73,7 +73,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   protected useScratchpad: boolean = false;
   protected logId: number = 0;
   /** Handler for output file processing and validation. */
-  protected outputHandler: OutputHandler;
+  protected outputHandler: IOutputHandler;
 
   constructor(
     modelHandler: IModelHandler,

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,0 +1,42 @@
+// Local imports - types
+import { AgentStateGlobal } from '@agent/core/AgentState';
+import { NamedOutputFile } from './types';
+
+/** Interface describing OutputHandler behavior used by agents. */
+export interface IOutputHandler {
+  /** Map of generated output files by round. */
+  outputFiles: { [key: number]: string[] };
+
+  /** Mapping of source to processed output files by round. */
+  outputMappings: { [key: number]: NamedOutputFile[] };
+
+  /** Indent a single LaTeX file for readability. */
+  indentLatexFile(filePath: string): Promise<void>;
+
+  /** Indent multiple LaTeX files for readability. */
+  indentLatexFiles(filePaths: string[]): Promise<void>;
+
+  /** Filter and clean up raw XML content. */
+  processXmlContent(content: string): Promise<string>;
+
+  /** Run latexdiff comparisons for the current round. */
+  handleLatexdiffofOutput(currRound: number, groupId?: string): Promise<void>;
+
+  /** Split and process a single XML output file. */
+  processSingleXmlOutput(outputFile: string): Promise<NamedOutputFile>;
+
+  /** Split and process multiple XML output files. */
+  processMultipleXmlOutputs(outputFile: string): Promise<NamedOutputFile[]>;
+
+  /** Ensure the XML structure in the file is well formed. */
+  ensureCorrectXmlStructure(
+    filePath: string,
+    documentTag: string,
+  ): Promise<void>;
+
+  /** Print token usage and cost statistics. */
+  printStatistics(
+    stateGlobal: AgentStateGlobal,
+    groupId?: string,
+  ): Promise<void>;
+}

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -8,6 +8,7 @@ import { XmlOutputManager } from './XmlOutputManager';
 import { LatexDiffManager } from './LatexDiffManager';
 import { StatisticsReporter } from './StatisticsReporter';
 import { NamedOutputFile } from './types';
+import type { IOutputHandler } from './IOutputHandler';
 import { getOutputFileName } from '@utils/outputFileUtils';
 
 // Local imports - agent components
@@ -19,7 +20,7 @@ import type { IModelHandler } from '@agent/modelHandlers';
 // Local imports - types
 
 /** Handles output file processing and validation for agent responses. */
-export class OutputHandler {
+export class OutputHandler implements IOutputHandler {
   public agentSetting: AgentSetting;
   public agentConfig: AgentConfig;
   public modelHandler: IModelHandler;

--- a/src/agent/output/index.ts
+++ b/src/agent/output/index.ts
@@ -1,3 +1,4 @@
 export * from './OutputHandler';
+export * from './IOutputHandler';
 export { NamedOutputFile } from './types';
 export { getOutputFileName } from '@utils/outputFileUtils';


### PR DESCRIPTION
## Summary
- define `IOutputHandler` describing the OutputHandler API
- implement the interface in `OutputHandler`
- export the interface from `output/index.ts`
- use `IOutputHandler` in `BaseReflectionAgent`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d5f28663883248639d9b313d18b10