### PR TITLE
Add ToolUse agent implementation

### DIFF
--- a/resources/tool_use_agents/basic_tool_use.yaml
+++ b/resources/tool_use_agents/basic_tool_use.yaml
@@ -1,0 +1,9 @@
+name: basic_tool_use
+settings:
+  agentType: toolUse
+prompts:
+  systemPrompt: |
+    You can request external tools to help answer questions.
+  userPrefix: |
+    Analyze {{FILE}} and decide what tool actions are needed.
+  userRequest: Provide your analysis and requested tool calls.

--- a/resources/tool_use_agents/diagnostics_example.yaml
+++ b/resources/tool_use_agents/diagnostics_example.yaml
@@ -1,0 +1,11 @@
+name: diagnostics_example
+settings:
+  agentType: toolUse
+  tools:
+    - diagnostics
+prompts:
+  systemPrompt: |
+    Use the diagnostics tool to inspect the provided file.
+  userPrefix: |
+    The file of interest is {{FILE}}.
+  userRequest: Report any issues you find using the tool.

--- a/src/agent/implementations/ToolUseAgent.ts
+++ b/src/agent/implementations/ToolUseAgent.ts
@@ -1,0 +1,136 @@
+// Local imports - agent components
+import { BaseAgent } from './BaseAgent';
+import { renderPrompt } from '../utils/promptUtils';
+import { ToolState } from '../core/ToolState';
+import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
+import xmlUtils from '@utils/text/xmlUtils';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { emitProgress } from '@eventBus/ProgressEventBus';
+
+/**
+ * Simple agent to make a single tool use request and log the result.
+ */
+export class ToolUseAgent extends BaseAgent {
+  /**
+   * Extract tool use entries from a response object.
+   */
+  private extractToolUses(response: any): any[] {
+    const toolUses: any[] = [];
+    if (response && Array.isArray(response.content)) {
+      for (const item of response.content) {
+        if (item.type === 'tool_use') {
+          toolUses.push(item);
+        }
+      }
+    }
+    const openAIToolCalls = response?.choices?.[0]?.message?.tool_calls;
+    if (Array.isArray(openAIToolCalls)) {
+      toolUses.push(...openAIToolCalls);
+    }
+    return toolUses;
+  }
+
+  public async run(): Promise<void> {
+    this.runGroupId = await this.logger.startGroup(
+      `Run: ${this.agentConfig.agent}@${this.agentConfig.model}`,
+    );
+
+    try {
+      await this.init(this.runGroupId);
+      await this.initializeClient();
+
+      const [systemPrompt, userPrefix, userRequest] = await Promise.all([
+        renderPrompt(this.agentPrompt.systemPrompt, this.userVars),
+        renderPrompt(this.agentPrompt.userPrefix, this.userVars),
+        renderPrompt(this.agentPrompt.userRequest, this.userVars),
+      ]);
+
+      const messages = await this.modelHandler.initializeMessages(
+        userPrefix,
+        userRequest,
+        this.agentConfig.mediaFiles || undefined,
+        systemPrompt,
+      );
+
+      const toolState = new ToolState();
+      const stateRound = new AgentStateRound(0);
+      const stateGlobal = new AgentStateGlobal();
+
+      const startTime = Date.now();
+      this.abortController = new AbortController();
+      let responseObject: any;
+      try {
+        responseObject = await this.modelHandler.createResponse(
+          this.client,
+          messages,
+          this.agentSetting.temperature || 0.0,
+          systemPrompt,
+          this.agentSetting.endTag,
+          this.abortController.signal,
+        );
+      } finally {
+        this.abortController = null;
+      }
+
+      if (!responseObject) {
+        this.logger.warn(
+          'Model response was aborted or returned no data; output may be incomplete.',
+          this.runGroupId,
+        );
+        return;
+      }
+
+      const responseTime = (Date.now() - startTime) / 1000;
+      stateRound.updateResponseTime(responseTime);
+
+      const [textResponse, responseUsage] = this.modelHandler.extractResponse(
+        responseObject,
+        this.agentSetting.endTag,
+      );
+
+      const apiUsage = this.modelHandler.computeResponseUsage(
+        responseUsage,
+        responseTime,
+      );
+      stateRound.updateTokenCounts(apiUsage);
+      stateGlobal.updateFromCurrRound(stateRound);
+
+      const thinking = this.modelHandler.processThinkingBlock(
+        responseObject,
+        this.runGroupId,
+        toolState,
+      );
+      if (thinking) {
+        const formatted = await xmlUtils.formatContent(thinking);
+        this.logger.info(formatted, this.runGroupId, MESSAGE_TYPES.THINKING);
+      }
+
+      for (const toolUse of this.extractToolUses(responseObject)) {
+        this.logger.info(JSON.stringify(toolUse, null, 2), this.runGroupId);
+      }
+
+      if (textResponse) {
+        this.logger.info(textResponse, this.runGroupId);
+      }
+
+      emitProgress('updateGroupUsage', {
+        stream: this.logger.channelId,
+        groupId: this.runGroupId,
+        usage: {
+          inputTokens: apiUsage.totalInputTokens,
+          outputTokens: apiUsage.totalOutputTokens,
+          cost: apiUsage.cost,
+        },
+      });
+
+      this.logger.endGroup(this.runGroupId, 'stopped');
+    } catch (error) {
+      if (this.runGroupId) {
+        this.logger.endGroup(this.runGroupId, 'error');
+      }
+      throw error;
+    } finally {
+      this.cleanup();
+    }
+  }
+}

--- a/src/agent/implementations/index.ts
+++ b/src/agent/implementations/index.ts
@@ -3,3 +3,4 @@ export * from './DirectAgent';
 export * from './CoTAgent';
 export * from './MergeAgent';
 export * from './BaseAgent';
+export * from './ToolUseAgent';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -17,7 +17,12 @@ import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ModelFactory } from '@agent/runtime/ModelFactory';
 
-import { DirectAgent, CoTAgent, MergeAgent } from '@agent/implementations';
+import {
+  DirectAgent,
+  CoTAgent,
+  MergeAgent,
+  ToolUseAgent,
+} from '@agent/implementations';
 
 import { AgentLogger } from '@logger/AgentLogger';
 
@@ -119,6 +124,7 @@ function getAgentClass(settings: AgentSetting): AgentConstructor {
   const agentTypeMapping: Record<string, AgentConstructor> = {
     direct: DirectAgent,
     CoT: CoTAgent,
+    toolUse: ToolUseAgent,
   };
   return agentTypeMapping[settings.agentType] || DirectAgent;
 }


### PR DESCRIPTION
## Summary
- implement `ToolUseAgent` for single tool-use calls
- expose new agent via implementation index and runtime factory
- add example YAML configs for tool-use agents

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb04cf84083249040ebd2ca3c889a