### PR TITLE
Align usage types across model handlers

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -56,7 +56,9 @@ interface MarkerFlags {
 /**
  * Abstract base class for model-specific handlers that manage API interactions, message processing, and response handling.
  */
-export abstract class ModelHandler implements IModelHandler {
+export abstract class ModelHandler<U = any, R = any>
+  implements IModelHandler<U, R>
+{
   public config: ModelConfig;
   public capabilities: ModelCapabilities;
   public continueLimit: number;
@@ -691,13 +693,13 @@ export abstract class ModelHandler implements IModelHandler {
    * Calculates API usage cost based on token counts and provider pricing.
    * @returns Total cost in provider's currency units
    */
-  abstract computePrice(responseUsage: any): number;
+  abstract computePrice(responseUsage: U): number;
 
   /**
    * Computes detailed usage metrics from model response.
    * @returns Provider-specific response usage object
    */
-  abstract computeResponseUsage(responseUsage: any, responseTime: number): any;
+  abstract computeResponseUsage(responseUsage: U, responseTime: number): R;
 
   /**
    * Updates model message content with response for models with prefill support.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -43,7 +43,10 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
  */
 
 // The new implicit prompt caching is worth checking out (can eliminate many controls of previous caching)
-export class ModelHandlerAnthropic extends ModelHandler {
+export class ModelHandlerAnthropic extends ModelHandler<
+  AnthropicUsage,
+  AnthropicAPIResponseUsage
+> {
   /** Initializes an Anthropic API client using the configured API key. */
   async getClient(): Promise<Anthropic> {
     const apiKey = await this.getApiKey();

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -146,7 +146,10 @@ function convertMessagesToGoogleContentHistory(
 /**
  * Handler for Google models using the native @google/genai SDK and Chat API.
  */
-export class ModelHandlerGoogleGenAI extends ModelHandler {
+export class ModelHandlerGoogleGenAI extends ModelHandler<
+  GenerateContentResponseUsageMetadata | null,
+  OpenAIAPIResponseUsage
+> {
   private googleClient: GoogleGenAI | null = null;
 
   async getClient(): Promise<GoogleGenAI> {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -33,7 +33,10 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 /**
  * OpenAI-specific handlers.
  */
-export class ModelHandlerOpenAI extends ModelHandler {
+export class ModelHandlerOpenAI extends ModelHandler<
+  ExtendedCompletionUsage | null,
+  OpenAIAPIResponseUsage
+> {
   /** Returns OpenAI client with configured API key. */
   async getClient(): Promise<OpenAI> {
     const apiKey = await this.getApiKey();

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -13,7 +13,7 @@ import type { ProviderStopReason } from './StopReasonTypes';
 /**
  * Common interface implemented by all model handlers.
  */
-export interface IModelHandler {
+export interface IModelHandler<U = any, R = any> {
   /** Model configuration used by the handler. */
   config: ModelConfig;
 
@@ -110,10 +110,10 @@ export interface IModelHandler {
   ): Promise<[boolean, any[]]>;
 
   /** Compute the cost for a response. */
-  computePrice(responseUsage: any): number;
+  computePrice(responseUsage: U): number;
 
   /** Compute detailed usage metrics. */
-  computeResponseUsage(responseUsage: any, responseTime: number): any;
+  computeResponseUsage(responseUsage: U, responseTime: number): R;
 
   /** Update messages when prefill is supported. */
   updateMessageContentWithPrefill(

--- a/src/agent/output/StatisticsReporter.ts
+++ b/src/agent/output/StatisticsReporter.ts
@@ -2,6 +2,13 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { emitProgress } from '@eventBus/ProgressEventBus';
 import { AgentStateGlobal } from '@agent/core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
+import {
+  ExtendedCompletionUsage,
+  AnthropicUsage,
+  GenerateContentResponseUsageMetadata,
+} from '@agent/core/ResponseUsage';
+import { ResponseUsage } from 'openai/resources/responses/responses';
+import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
 
 export class StatisticsReporter {
   constructor(
@@ -77,12 +84,32 @@ export class StatisticsReporter {
         );
       }
 
-      let responseUsage: any = {};
-      if (this.modelHandler.isOpenai) {
+      let responseUsage:
+        | ExtendedCompletionUsage
+        | AnthropicUsage
+        | GenerateContentResponseUsageMetadata
+        | ResponseUsage = {} as any;
+
+      if (this.modelHandler instanceof ModelHandlerOpenAIResponse) {
+        responseUsage = {
+          input_tokens: stateGlobal.totalInputTokens,
+          output_tokens: stateGlobal.totalOutputTokens,
+          total_tokens:
+            stateGlobal.totalInputTokens + stateGlobal.totalOutputTokens,
+          input_tokens_details: {
+            cached_tokens: stateGlobal.totalCacheReadInputTokens,
+          },
+          output_tokens_details: {
+            reasoning_tokens: stateGlobal.totalReasoningTokens,
+          },
+        };
+      } else if (this.modelHandler.isOpenai) {
         if (this.modelHandler.capabilities.supportsAutoPromptCaching) {
           responseUsage = {
             prompt_tokens: stateGlobal.totalInputTokens,
             completion_tokens: stateGlobal.totalOutputTokens,
+            total_tokens:
+              stateGlobal.totalInputTokens + stateGlobal.totalOutputTokens,
             prompt_tokens_details: {
               cached_tokens: stateGlobal.totalCacheReadInputTokens,
             },
@@ -94,9 +121,11 @@ export class StatisticsReporter {
           responseUsage = {
             prompt_tokens: stateGlobal.totalInputTokens,
             completion_tokens: stateGlobal.totalOutputTokens,
+            total_tokens:
+              stateGlobal.totalInputTokens + stateGlobal.totalOutputTokens,
             reasoning_tokens: stateGlobal.totalReasoningTokens,
             cached_tokens: stateGlobal.totalCacheReadInputTokens,
-          };
+          } as ExtendedCompletionUsage;
         }
       } else if (this.modelHandler.isAnthropic) {
         responseUsage = {
@@ -105,12 +134,16 @@ export class StatisticsReporter {
           cache_read_input_tokens: stateGlobal.totalCacheReadInputTokens,
           cache_creation_input_tokens:
             stateGlobal.totalCacheCreationInputTokens,
+          server_tool_use: null,
+          service_tier: null,
         };
       } else if (this.modelHandler.isGoogle) {
         responseUsage = {
-          promptTokens: stateGlobal.totalInputTokens,
-          completionTokens: stateGlobal.totalOutputTokens,
-          toolUseTokenCount: stateGlobal.totalToolUseTokens,
+          promptTokenCount: stateGlobal.totalInputTokens,
+          candidatesTokenCount: stateGlobal.totalOutputTokens,
+          toolUsePromptTokenCount: stateGlobal.totalToolUseTokens,
+          thoughtsTokenCount: stateGlobal.totalReasoningTokens,
+          cachedContentTokenCount: stateGlobal.totalCacheReadInputTokens,
         };
       }
 


### PR DESCRIPTION
## Summary
- make `IModelHandler` and `ModelHandler` generic
- specialize usage types for OpenAI, Anthropic and Google handlers
- provide correctly typed usage objects in `StatisticsReporter`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebbf88a0c8324aaa589cf6353736a