### PR TITLE
Add missing output warnings

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -62,4 +62,8 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.
 
+### Generated Files
+
+Below the log area, TeXRA lists files produced in each round. If an expected file doesn't appear, a warning entry provides a button to open the XML output so you can check tag consistency before running again.
+
 At the bottom of the tab list, there is a "Delete All" button (<i class="codicon codicon-close-all"></i>) that allows you to clear all streams and their associated logs from the ProgressBoard view.

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -263,7 +263,12 @@ async function executeAgentWithLogging<T extends IAgent>(
             mainTaskGroupId,
           );
           await agent.run();
-          await checkExpectedOutputs(config.outputFiles, context, agent);
+          await checkExpectedOutputs(
+            config.outputFiles,
+            context,
+            agent,
+            fullStreamId,
+          );
           // Mark the task as completed successfully
           logger.debug(`Task completed successfully`, mainTaskGroupId);
           logger.endGroup(mainTaskGroupId, 'stopped');

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -11,6 +11,7 @@ export type ProgressEvent =
   | 'setActiveStream'
   | 'updateStreamStatus'
   | 'addOutputFiles'
+  | 'addMissingOutputs'
   | 'clearOutputFiles'
   | 'setTaskState'
   | 'updateGroupUsage'

--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 // Local imports
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { INSTRUCTION_PREFIX, globalSM } from '@utils/stateManager';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 /**
  * Show an instruction message that can be permanently dismissed.
@@ -51,18 +52,18 @@ export async function checkExpectedOutputs(
   expectedFiles: string[] | null | undefined,
   context: vscode.ExtensionContext,
   agent?: unknown,
+  streamId?: string,
 ): Promise<void> {
   if (!expectedFiles || expectedFiles.length === 0) {
     return;
   }
+  const missing: { round: number; file: string; xml: string }[] = [];
 
   for (const file of expectedFiles) {
     const exists = path.isAbsolute(file)
       ? await AbsoluteFS.exists(file)
       : await WorkspaceFS.exists(file);
     if (!exists) {
-      const openBtn = 'Open XML';
-
       let xmlPath: string | undefined;
       const outputs: string[] = [];
 
@@ -89,40 +90,50 @@ export async function checkExpectedOutputs(
         xmlPath = file.replace(/\.[^.]+$/, '.xml');
       }
 
-      await showInstructionWithSuppress(
-        'xmlOutputMismatch',
-        `Expected output "${path.basename(
-          file,
-        )}" was not generated. Open the XML file to check tag consistency, then run again.`,
-        [
-          {
-            title: openBtn,
-            callback: async () => {
-              if (!xmlPath) {
-                vscode.window.showWarningMessage('XML file path not found');
-                return;
-              }
-
-              const xmlExists = path.isAbsolute(xmlPath)
-                ? await AbsoluteFS.exists(xmlPath)
-                : await WorkspaceFS.exists(xmlPath);
-              if (!xmlExists) {
-                vscode.window.showWarningMessage(
-                  `XML file not found: ${path.basename(xmlPath)}`,
-                );
-                return;
-              }
-              const uri = path.isAbsolute(xmlPath)
-                ? vscode.Uri.file(xmlPath)
-                : vscode.Uri.file(WorkspaceFS.fullPath(xmlPath));
-              const doc = await vscode.workspace.openTextDocument(uri);
-              await vscode.window.showTextDocument(doc, { preview: false });
-            },
-          },
-        ],
-        false,
-      );
-      break;
+      const match = file.match(/_r(\d+)/);
+      const round = match ? parseInt(match[1], 10) : 0;
+      missing.push({ round, file: path.basename(file), xml: xmlPath });
     }
+  }
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  const first = missing[0];
+  await showInstructionWithSuppress(
+    'xmlOutputMismatch',
+    `Expected output "${first.file}" was not generated. Open the XML file to check tag consistency, then run again.`,
+    [
+      {
+        title: 'Open XML',
+        callback: async () => {
+          const xmlExists = path.isAbsolute(first.xml)
+            ? await AbsoluteFS.exists(first.xml)
+            : await WorkspaceFS.exists(first.xml);
+          if (!xmlExists) {
+            vscode.window.showWarningMessage(
+              `XML file not found: ${path.basename(first.xml)}`,
+            );
+            return;
+          }
+          const uri = path.isAbsolute(first.xml)
+            ? vscode.Uri.file(first.xml)
+            : vscode.Uri.file(WorkspaceFS.fullPath(first.xml));
+          const doc = await vscode.workspace.openTextDocument(uri);
+          await vscode.window.showTextDocument(doc, { preview: false });
+        },
+      },
+    ],
+    false,
+  );
+
+  if (streamId) {
+    const map: Record<number, { file: string; xml: string }[]> = {};
+    for (const item of missing) {
+      if (!map[item.round]) map[item.round] = [];
+      map[item.round].push({ file: item.file, xml: item.xml });
+    }
+    emitProgress('addMissingOutputs', { stream: streamId, filesByRound: map });
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -42,6 +42,11 @@ interface OutputFileInfo extends DiffStats {
   original?: string;
 }
 
+interface MissingOutputInfo {
+  file: string;
+  xml: string;
+}
+
 export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private static _instance: ProgressViewProvider | undefined;
   private _view?: vscode.WebviewView;
@@ -53,6 +58,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private readonly _viewTitle: string;
   private _viewDisposables: vscode.Disposable[] = [];
   private _streamStatus: Map<string, StreamStatusType> = new Map();
+  private _missingOutputs: Map<string, { [key: number]: MissingOutputInfo[] }> =
+    new Map();
   private _webviewReady = false;
   private _pendingUpdate = false;
   private readonly logger: AgentLogger;
@@ -185,6 +192,15 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           }) => this.updateLogGroup(p.stream, p.groupId, p.status, p.endTime),
         ),
       ),
+      new vscode.Disposable(
+        onProgress(
+          'addMissingOutputs',
+          (p: {
+            stream: string;
+            filesByRound: { [key: number]: MissingOutputInfo[] };
+          }) => this.addMissingOutputs(p.stream, p.filesByRound),
+        ),
+      ),
     );
   }
 
@@ -315,10 +331,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     // Send output files for current stream
     const files =
       this._stateManager.outputFiles.get(this._stateManager.activeStream) || {};
+    const missing =
+      this._missingOutputs.get(this._stateManager.activeStream) || {};
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_FILES,
       stream: this._stateManager.activeStream,
       files,
+      missing,
     });
 
     const usage = this._stateManager.usageStats.get(
@@ -561,10 +580,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     // Send output files for this stream
     const files = this._stateManager.outputFiles.get(stream) || {};
+    const missing = this._missingOutputs.get(stream) || {};
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_FILES,
       stream: stream,
       files,
+      missing,
     });
   }
 
@@ -651,6 +672,27 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         command: COMMANDS.UPDATE_FILES,
         stream,
         files: merged,
+        missing: this._missingOutputs.get(stream) || {},
+      });
+    }
+  }
+
+  public addMissingOutputs(
+    stream: string,
+    filesByRound: { [key: number]: MissingOutputInfo[] },
+  ): void {
+    const existing = this._missingOutputs.get(stream) || {};
+    const merged = { ...existing };
+    for (const [r, infos] of Object.entries(filesByRound)) {
+      const round = parseInt(r, 10);
+      merged[round] = (merged[round] || []).concat(infos);
+    }
+    this._missingOutputs.set(stream, merged);
+    if (this._view && stream === this._stateManager.activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.ADD_MISSING_OUTPUTS,
+        stream,
+        missing: merged,
       });
     }
   }
@@ -664,12 +706,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   public clearOutputFiles(stream: string): void {
     if (this._stateManager.outputFiles.has(stream)) {
       this._stateManager.outputFiles.delete(stream);
+      this._missingOutputs.delete(stream);
       this._stateManager.saveState();
       if (this._view && stream === this._stateManager.activeStream) {
         this._view.webview.postMessage({
           command: COMMANDS.UPDATE_FILES,
           stream,
           files: {},
+          missing: {},
         });
       }
     }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -102,6 +102,16 @@
             </span>
           </div>
         </template>
+        <template id="missingItemTemplate">
+          <div class="missing-item">
+            <span class="missing-text"></span>
+            <span class="file-actions button-group">
+              <button class="vscode-button open-xml-btn" title="Open XML">
+                <i class="codicon codicon-file-text"></i>
+              </button>
+            </span>
+          </div>
+        </template>
       </div>
       <div class="tabs split">
         <div id="streamTabs" class="tabs-content">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -36,6 +36,7 @@ export const COMMANDS = {
   UPDATE_LOG_GROUP: 'updateLogGroup',
   UPDATE_STATUS: 'updateStatus',
   UPDATE_FILES: 'updateFiles',
+  ADD_MISSING_OUTPUTS: 'addMissingOutputs',
   UPDATE_USAGE: 'updateUsage',
   UPDATE_GROUP_USAGE: 'updateGroupUsage',
   OPEN_FILE: 'openFile',

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -125,7 +125,13 @@ const handlers = {
 
   [COMMANDS.UPDATE_FILES]: (message) => {
     if (message.stream === state.getCurrentStream()) {
-      dom.fileList.update(message.files);
+      dom.fileList.update(message.files, message.missing);
+    }
+  },
+
+  [COMMANDS.ADD_MISSING_OUTPUTS]: (message) => {
+    if (message.stream === state.getCurrentStream()) {
+      dom.fileList.addMissing(message.missing);
     }
   },
 

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -9,6 +9,8 @@ import { vscode } from '@common/webviewContext.js';
 export class FileList {
   constructor(usageSummary = null) {
     this.usageSummary = usageSummary;
+    this.filesByRound = {};
+    this.missingByRound = {};
   }
   /**
    * Get the effective base file for comparison operations.
@@ -35,19 +37,23 @@ export class FileList {
    * Update the generated files list
    * @param {Object} filesByRound - Files organized by round
    */
-  update(filesByRound) {
+  update(filesByRound, missingByRound = {}) {
+    this.filesByRound = filesByRound || {};
+    this.missingByRound = missingByRound || {};
+
     const container = document.getElementById('generatedFiles');
     if (!container) return;
 
     container.innerHTML = '';
 
     const template = document.getElementById('fileItemTemplate');
-    if (!template) {
+    const missingTemplate = document.getElementById('missingItemTemplate');
+    if (!template || !missingTemplate) {
       console.error('File item template not found');
       return;
     }
 
-    if (!filesByRound || Object.keys(filesByRound).length === 0) {
+    if (!this.filesByRound || Object.keys(this.filesByRound).length === 0) {
       container.textContent = 'No generated files';
       return;
     }
@@ -75,13 +81,14 @@ export class FileList {
       container.appendChild(usageHeader);
     }
 
-    const rounds = Object.keys(filesByRound)
+    const rounds = Object.keys(this.filesByRound)
       .map((r) => parseInt(r, 10))
       .sort((a, b) => a - b);
 
     rounds.forEach((round) => {
-      const files = filesByRound[round];
-      if (!files || files.length === 0) return;
+      const files = this.filesByRound[round] || [];
+      const missing = this.missingByRound[round] || [];
+      if (files.length === 0 && missing.length === 0) return;
 
       // Create round group container
       const roundGroup = document.createElement('div');
@@ -149,6 +156,19 @@ export class FileList {
         this.updateFileButtons(clone, file, effectiveBase);
 
         roundGroup.appendChild(clone);
+      });
+
+      // Render missing outputs for this round
+      missing.forEach((item) => {
+        const mClone = missingTemplate.content.cloneNode(true);
+        const textSpan = mClone.querySelector('.missing-text');
+        const openBtn = mClone.querySelector('.open-xml-btn');
+        if (textSpan) textSpan.textContent = `Missing: ${item.file}`;
+        if (openBtn) {
+          openBtn.dataset.command = COMMANDS.OPEN_FILE;
+          openBtn.dataset.file = item.xml;
+        }
+        roundGroup.appendChild(mClone);
       });
 
       // Append the round group to the container
@@ -252,5 +272,19 @@ export class FileList {
         });
       };
     }
+  }
+
+  /**
+   * Add missing outputs and re-render
+   * @param {Object} missingByRound - Missing files organized by round
+   */
+  addMissing(missingByRound) {
+    for (const [r, list] of Object.entries(missingByRound || {})) {
+      const round = parseInt(r, 10);
+      this.missingByRound[round] = (this.missingByRound[round] || []).concat(
+        list,
+      );
+    }
+    this.update(this.filesByRound, this.missingByRound);
   }
 }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -273,6 +273,16 @@
   font-size: var(--font-size-sm);
 }
 
+/* Missing output entry */
+.missing-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  color: var(--vscode-inputValidation-infoForeground);
+  font-size: var(--font-size-sm);
+  padding: 1px 0;
+}
+
 /* Group usage display styling */
 .group-usage {
   color: var(--vscode-descriptionForeground);


### PR DESCRIPTION
## Summary
- show missing output warnings in progress board generated-files section
- emit `addMissingOutputs` event from `checkExpectedOutputs`
- update `ProgressViewProvider` and webview to display warnings per round
- document generated files section with new behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack runs but tests cannot complete)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5d6f368832483b83ca33ef1d111