### PR TITLE
Move output processing logic to OutputHandler

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -21,11 +21,7 @@ import { diff_match_patch } from 'diff-match-patch';
 import type { DiffStats } from '@/types/DiffTypes';
 
 // Local imports - utilities
-import {
-  WorkspaceFS,
-  createFileMapping,
-  replaceInputCommands,
-} from '@utils/files';
+import { WorkspaceFS, createFileMapping } from '@utils/files';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
@@ -51,7 +47,7 @@ import {
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import type { IModelHandler } from '@agent/modelHandlers';
-import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import { OutputHandler, IOutputHandler } from '@agent/output';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -1078,113 +1074,4 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    * @param currRound Current round number
    * @param processGroupId Optional process group ID for logging
    */
-  protected async processOutputFiles(
-    outputFile: string,
-    currRound: number,
-    processGroupId?: string,
-  ): Promise<void> {
-    // Use provided process group ID or get the active group ID for proper nesting
-    const activeGroupId = processGroupId || this.logger.getActiveGroupId();
-
-    if (
-      Array.isArray(this.agentConfig.outputFiles) &&
-      this.agentConfig.outputFiles.length > 0
-    ) {
-      // Multiple output files case
-      this.logger.debug(
-        `Processing multiple outputs for ${outputFile}; outputFiles: ${this.agentConfig.outputFiles}`,
-        activeGroupId,
-      );
-
-      // if the agentType is CoT, we need to process the output files
-      // Then I realize that in fact it does not make sense to have multiple output files
-      // while to extract it from a single tex file. So in this case, we really need to
-      // use XML and use XML splitting to get the output files.
-      // Which would be different than the single output file case below.
-
-      try {
-        const processedPairs =
-          await this.outputHandler.processMultipleXmlOutputs(outputFile);
-
-        if (processedPairs && processedPairs.length > 0) {
-          const processedFiles = processedPairs.map((p) => p.path);
-          await this.outputHandler.indentLatexFiles(processedFiles);
-          this.logger.debug(
-            `Indented multiple output files: ${processedFiles.join(',')}`,
-            activeGroupId,
-          );
-
-          this.outputHandler.outputFiles[currRound] = processedFiles;
-          this.outputHandler.outputMappings[currRound] = processedPairs;
-
-          // Only attempt to replace input commands if we have valid base files
-          if (this.baseFiles && this.baseFiles.length > 0) {
-            await replaceInputCommands(
-              this.baseFiles,
-              processedFiles,
-              this.logger,
-            );
-          }
-        } else {
-          this.logger.warn(
-            `No processed files were generated from ${outputFile}`,
-            activeGroupId,
-          );
-          this.outputHandler.outputFiles[currRound] = [];
-          this.outputHandler.outputMappings[currRound] = [];
-        }
-      } catch (err) {
-        this.logger.error(
-          `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
-          activeGroupId,
-        );
-        // Ensure we have an empty array at minimum to prevent undefined errors
-        this.outputHandler.outputFiles[currRound] = [];
-        this.outputHandler.outputMappings[currRound] = [];
-      }
-    } else {
-      // Single output file case
-      this.logger.debug(
-        `Processing single output for ${outputFile}`,
-        activeGroupId,
-      );
-
-      try {
-        let processed: NamedOutputFile = {
-          source: outputFile,
-          path: outputFile,
-        };
-        if (this.agentSetting.agentType === AgentType.CoT) {
-          processed =
-            await this.outputHandler.processSingleXmlOutput(outputFile);
-        }
-
-        if (processed && processed.path) {
-          // Process output file - indent LaTeX file directly
-          await this.outputHandler.indentLatexFile(processed.path);
-          this.logger.debug(
-            `Indented single output file: ${processed.path}`,
-            activeGroupId,
-          );
-
-          this.outputHandler.outputFiles[currRound] = [processed.path];
-          this.outputHandler.outputMappings[currRound] = [processed];
-        } else {
-          this.logger.warn(
-            `No processed file was generated from ${outputFile}`,
-            activeGroupId,
-          );
-          this.outputHandler.outputFiles[currRound] = [];
-          this.outputHandler.outputMappings[currRound] = [];
-        }
-      } catch (err) {
-        this.logger.error(
-          `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
-          activeGroupId,
-        );
-        this.outputHandler.outputFiles[currRound] = [];
-        this.outputHandler.outputMappings[currRound] = [];
-      }
-    }
-  }
 }

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -71,8 +71,8 @@ export class CoTAgent extends BaseReflectionAgent {
           this.agentSetting.documentTag,
         );
 
-        // Then process output files using the parent class method
-        await super.processOutputFiles(
+        // Then process output files using the output handler
+        await this.outputHandler.processOutputFiles(
           outputFile,
           currRound,
           outputProcessGroupId,

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -62,8 +62,8 @@ export class DirectAgent extends BaseReflectionAgent {
           outputProcessGroupId,
         );
 
-        // Process output files using the parent class method
-        await this.processOutputFiles(
+        // Process output files using the output handler
+        await this.outputHandler.processOutputFiles(
           outputFile,
           currRound,
           outputProcessGroupId,

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -39,4 +39,11 @@ export interface IOutputHandler {
     stateGlobal: AgentStateGlobal,
     groupId?: string,
   ): Promise<void>;
+
+  /** Process output files from XML or direct input. */
+  processOutputFiles(
+    outputFile: string,
+    currRound: number,
+    groupId?: string,
+  ): Promise<void>;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -13,9 +13,12 @@ import { getOutputFileName } from '@agent/utils/outputFileUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting } from '@agent/core/AgentDataclass';
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
+
+// Local imports - utilities
+import { replaceInputCommands } from '@utils/files';
 
 // Local imports - types
 
@@ -186,6 +189,108 @@ export class OutputHandler implements IOutputHandler {
     groupId?: string,
   ): Promise<void> {
     await this.statsReporter.printStatistics(stateGlobal, groupId);
+  }
+
+  /**
+   * Processes output files from XML or direct input.
+   * Mirrors the previous logic in BaseReflectionAgent.processOutputFiles.
+   */
+  public async processOutputFiles(
+    outputFile: string,
+    currRound: number,
+    groupId?: string,
+  ): Promise<void> {
+    const activeGroupId = groupId || this.logger.getActiveGroupId();
+
+    if (
+      Array.isArray(this.agentConfig.outputFiles) &&
+      this.agentConfig.outputFiles.length > 0
+    ) {
+      // Multiple output files case
+      this.logger.debug(
+        `Processing multiple outputs for ${outputFile}; outputFiles: ${this.agentConfig.outputFiles}`,
+        activeGroupId,
+      );
+
+      try {
+        const processedPairs = await this.processMultipleXmlOutputs(outputFile);
+
+        if (processedPairs && processedPairs.length > 0) {
+          const processedFiles = processedPairs.map((p) => p.path);
+          await this.indentLatexFiles(processedFiles);
+          this.logger.debug(
+            `Indented multiple output files: ${processedFiles.join(',')}`,
+            activeGroupId,
+          );
+
+          this.outputFiles[currRound] = processedFiles;
+          this.outputMappings[currRound] = processedPairs;
+
+          if (this.baseFiles && this.baseFiles.length > 0) {
+            await replaceInputCommands(
+              this.baseFiles,
+              processedFiles,
+              this.logger,
+            );
+          }
+        } else {
+          this.logger.warn(
+            `No processed files were generated from ${outputFile}`,
+            activeGroupId,
+          );
+          this.outputFiles[currRound] = [];
+          this.outputMappings[currRound] = [];
+        }
+      } catch (err) {
+        this.logger.error(
+          `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
+          activeGroupId,
+        );
+        this.outputFiles[currRound] = [];
+        this.outputMappings[currRound] = [];
+      }
+    } else {
+      // Single output file case
+      this.logger.debug(
+        `Processing single output for ${outputFile}`,
+        activeGroupId,
+      );
+
+      try {
+        let processed: NamedOutputFile = {
+          source: outputFile,
+          path: outputFile,
+        };
+        if (this.agentSetting.agentType === AgentType.CoT) {
+          processed = await this.processSingleXmlOutput(outputFile);
+        }
+
+        if (processed && processed.path) {
+          await this.indentLatexFile(processed.path);
+          this.logger.debug(
+            `Indented single output file: ${processed.path}`,
+            activeGroupId,
+          );
+
+          this.outputFiles[currRound] = [processed.path];
+          this.outputMappings[currRound] = [processed];
+        } else {
+          this.logger.warn(
+            `No processed file was generated from ${outputFile}`,
+            activeGroupId,
+          );
+          this.outputFiles[currRound] = [];
+          this.outputMappings[currRound] = [];
+        }
+      } catch (err) {
+        this.logger.error(
+          `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
+          activeGroupId,
+        );
+        this.outputFiles[currRound] = [];
+        this.outputMappings[currRound] = [];
+      }
+    }
   }
   /** Processes output files for current round. */
   protected async handleOutput(


### PR DESCRIPTION
## Summary
- shift `processOutputFiles` from `BaseReflectionAgent` into `OutputHandler`
- expose `processOutputFiles` via `IOutputHandler`
- update CoTAgent and DirectAgent to use the new method
- clean up unused imports

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test could not finish in container)*

------
https://chatgpt.com/codex/tasks/task_e_685ef3ae143c8324af3aadec99e8dce4