### PR TITLE
Refactor diff stats gathering

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -17,15 +17,8 @@ import {
 
 import { emitProgress } from '@eventBus/ProgressEventBus';
 
-import { diff_match_patch } from 'diff-match-patch';
-import type { DiffStats } from '@/types/DiffTypes';
-
 // Local imports - utilities
-import {
-  WorkspaceFS,
-  createFileMapping,
-  replaceInputCommands,
-} from '@utils/files';
+import { WorkspaceFS, replaceInputCommands } from '@utils/files';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
@@ -58,7 +51,6 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
-import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 
 // Shared constants
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
@@ -422,51 +414,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     }
   }
 
-  // Helper function to consistently count lines in text
-  private countLines(text: string): number {
-    if (text.length === 0) return 0;
-    // Handle trailing newlines consistently: subtract 1 if text ends with newline
-    return text.endsWith('\n')
-      ? text.split('\n').length - 1
-      : text.split('\n').length;
-  }
-
-  private async computeDiffStats(
-    baseFile: string | null,
-    outputFile: string,
-  ): Promise<DiffStats> {
-    try {
-      if (!baseFile) {
-        const outContent = await WorkspaceFS.readFile(outputFile);
-        const added = this.countLines(outContent);
-        // For new files, only return added count (removed should be undefined for UI)
-        return { added };
-      }
-
-      const [baseContent, outContent] = await Promise.all([
-        WorkspaceFS.readFile(baseFile),
-        WorkspaceFS.readFile(outputFile),
-      ]);
-
-      const dmp = new diff_match_patch();
-      const diffs = dmp.diff_main(baseContent, outContent);
-      let added = 0;
-      let removed = 0;
-
-      for (const [op, text] of diffs) {
-        if (op === 1) {
-          added += this.countLines(text);
-        } else if (op === -1) {
-          removed += this.countLines(text);
-        }
-      }
-
-      return { added, removed };
-    } catch {
-      return {};
-    }
-  }
-
   /**
    * Processes completion of conversation round.
    */
@@ -499,50 +446,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       throw error;
     }
 
-    const roundOutputs = this.outputHandler.outputFiles[currRound] || [];
-
-    // Map output files to their original base files
-    const baseMap = createFileMapping(this.baseFiles, roundOutputs, 'contains');
-
-    // Map output files to previous round files if available
-    const prevMap =
-      currRound > 0
-        ? createFileMapping(
-            this.outputHandler.outputFiles[currRound - 1] || [],
-            roundOutputs,
-            'basename',
-            true,
-          )
-        : new Map<string, string>();
-
-    const fileInfos = [] as any[];
-    const originMap = new Map(
-      (this.outputHandler.outputMappings[currRound] || []).map((p) => [
-        p.path,
-        p.source,
-      ]),
-    );
-    for (const file of roundOutputs) {
-      const baseFile =
-        Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
-        null;
-      const prevFile =
-        Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
-        null;
-      const originalFile = originMap.get(file) || null;
-
-      // Use utility to determine effective base for diff computation
-      const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
-      const stats = await this.computeDiffStats(diffBase, file);
-
-      fileInfos.push({
-        path: file,
-        base: baseFile,
-        prev: prevFile,
-        original: originalFile,
-        ...stats,
-      });
-    }
+    const fileInfos = await this.outputHandler.gatherOutputFileInfo(currRound);
 
     emitProgress('addOutputFiles', {
       stream: this.logger.channelId,

--- a/src/agent/output/DiffStatsManager.ts
+++ b/src/agent/output/DiffStatsManager.ts
@@ -1,0 +1,61 @@
+// Standard library imports
+// Third-party imports
+import { diff_match_patch } from 'diff-match-patch';
+
+// Local imports
+import { WorkspaceFS } from '@utils/files';
+import type { DiffStats } from '@/types/DiffTypes';
+
+/**
+ * Provides utilities for computing diff statistics between files.
+ */
+export class DiffStatsManager {
+  // Helper to consistently count lines in text
+  private countLines(text: string): number {
+    if (text.length === 0) return 0;
+    return text.endsWith('\n')
+      ? text.split('\n').length - 1
+      : text.split('\n').length;
+  }
+
+  /**
+   * Compute added and removed line counts relative to a base file.
+   * Returns an empty object when stats cannot be computed.
+   */
+  async computeDiffStats(
+    baseFile: string | null,
+    outputFile: string,
+  ): Promise<DiffStats> {
+    try {
+      if (!baseFile) {
+        const outContent = await WorkspaceFS.readFile(outputFile);
+        const added = this.countLines(outContent);
+        return { added };
+      }
+
+      const [baseContent, outContent] = await Promise.all([
+        WorkspaceFS.readFile(baseFile),
+        WorkspaceFS.readFile(outputFile),
+      ]);
+
+      const dmp = new diff_match_patch();
+      const diffs = dmp.diff_main(baseContent, outContent);
+      let added = 0;
+      let removed = 0;
+
+      for (const [op, text] of diffs) {
+        if (op === 1) {
+          added += this.countLines(text);
+        } else if (op === -1) {
+          removed += this.countLines(text);
+        }
+      }
+
+      return { added, removed };
+    } catch {
+      return {};
+    }
+  }
+}
+
+export default DiffStatsManager;

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -39,4 +39,9 @@ export interface IOutputHandler {
     stateGlobal: AgentStateGlobal,
     groupId?: string,
   ): Promise<void>;
+
+  /**
+   * Collect info about output files including diff statistics.
+   */
+  gatherOutputFileInfo(currRound: number): Promise<import('@/types/DiffTypes').OutputFileInfo[]>;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -7,9 +7,12 @@ import { runLatexFormatter } from '@latex/texFormatter';
 import { XmlOutputManager } from './XmlOutputManager';
 import { LatexDiffManager } from './LatexDiffManager';
 import { StatisticsReporter } from './StatisticsReporter';
+import DiffStatsManager from './DiffStatsManager';
 import { NamedOutputFile } from './types';
+import type { OutputFileInfo } from '@/types/DiffTypes';
 import type { IOutputHandler } from './IOutputHandler';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
+import { createFileMapping, getEffectiveBaseFile } from '@utils/files';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
@@ -34,6 +37,7 @@ export class OutputHandler implements IOutputHandler {
   private xmlManager: XmlOutputManager;
   private diffManager: LatexDiffManager;
   private statsReporter: StatisticsReporter;
+  private diffStatsManager: DiffStatsManager;
 
   constructor(
     agentSetting: AgentSetting,
@@ -70,6 +74,7 @@ export class OutputHandler implements IOutputHandler {
       this.channel,
       this.logger,
     );
+    this.diffStatsManager = new DiffStatsManager();
   }
 
   /**
@@ -186,6 +191,59 @@ export class OutputHandler implements IOutputHandler {
     groupId?: string,
   ): Promise<void> {
     await this.statsReporter.printStatistics(stateGlobal, groupId);
+  }
+
+  /**
+   * Gather information about output files for a given round.
+   * Maps each generated file to its base and previous versions and
+   * computes line diff statistics.
+   */
+  public async gatherOutputFileInfo(
+    currRound: number,
+  ): Promise<OutputFileInfo[]> {
+    const roundOutputs = this.outputFiles[currRound] || [];
+
+    const baseMap = createFileMapping(this.baseFiles, roundOutputs, 'contains');
+    const prevMap =
+      currRound > 0
+        ? createFileMapping(
+            this.outputFiles[currRound - 1] || [],
+            roundOutputs,
+            'basename',
+            true,
+          )
+        : new Map<string, string>();
+
+    const originMap = new Map(
+      (this.outputMappings[currRound] || []).map((p) => [p.path, p.source]),
+    );
+
+    const fileInfos: OutputFileInfo[] = [];
+    for (const file of roundOutputs) {
+      const baseFile =
+        Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
+        null;
+      const prevFile =
+        Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
+        null;
+      const originalFile = originMap.get(file) || null;
+
+      const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
+      const stats = await this.diffStatsManager.computeDiffStats(
+        diffBase,
+        file,
+      );
+
+      fileInfos.push({
+        path: file,
+        base: baseFile,
+        prev: prevFile,
+        original: originalFile,
+        ...stats,
+      });
+    }
+
+    return fileInfos;
   }
   /** Processes output files for current round. */
   protected async handleOutput(

--- a/src/agent/output/index.ts
+++ b/src/agent/output/index.ts
@@ -2,3 +2,4 @@ export * from './OutputHandler';
 export * from './IOutputHandler';
 export { NamedOutputFile } from './types';
 export { getOutputFileName } from '@agent/utils/outputFileUtils';
+export { default as DiffStatsManager } from './DiffStatsManager';

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -12,14 +12,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 // Types
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup, LogMessageData } from '../logger/LogTypes';
-import type { DiffStats } from '../types/DiffTypes';
-
-interface OutputFileInfo extends DiffStats {
-  path: string;
-  base?: string | null;
-  prev?: string | null;
-  original?: string;
-}
+import type { DiffStats, OutputFileInfo } from '../types/DiffTypes';
 
 /**
  * Manages persistence of progress view state to workspace storage.

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -13,7 +13,7 @@ import { getConfig } from '@utils/config';
 
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup } from '../logger/LogTypes';
-import type { DiffStats } from '../types/DiffTypes';
+import type { DiffStats, OutputFileInfo } from '../types/DiffTypes';
 import { randomUUID } from 'crypto';
 import { onProgress } from '@eventBus/ProgressEventBus';
 
@@ -32,15 +32,6 @@ type StreamStatusType =
   | typeof STATUS.STOPPED;
 
 import type { LogMessageData } from '../logger/LogTypes';
-
-// Channels that should not be persisted in workspace storage
-
-interface OutputFileInfo extends DiffStats {
-  path: string;
-  base?: string | null;
-  prev?: string | null;
-  original?: string;
-}
 
 export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private static _instance: ProgressViewProvider | undefined;

--- a/src/types/DiffTypes.ts
+++ b/src/types/DiffTypes.ts
@@ -8,3 +8,17 @@ export interface DiffStats {
   /** Number of removed lines */
   removed?: number;
 }
+
+/**
+ * Info about an output file including diff statistics and its related files.
+ */
+export interface OutputFileInfo extends DiffStats {
+  /** Path to the generated output file */
+  path: string;
+  /** Base file used for comparison */
+  base?: string | null;
+  /** Previous round file for comparison */
+  prev?: string | null;
+  /** Original source file if different */
+  original?: string | null;
+}


### PR DESCRIPTION
## Summary
- move diff stat computation to `DiffStatsManager`
- add `gatherOutputFileInfo` in `OutputHandler`
- emit output file stats from `BaseReflectionAgent`
- expose new helper types and update progress view

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: VS Code download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685efe8c81dc8324b999ecb4bba99696