### PR TITLE
Refactor diff stats into helper

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -17,11 +17,8 @@ import {
 
 import { emitProgress } from '@eventBus/ProgressEventBus';
 
-import { diff_match_patch } from 'diff-match-patch';
-import type { DiffStats } from '@/types/DiffTypes';
-
 // Local imports - utilities
-import { WorkspaceFS, createFileMapping } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
@@ -54,7 +51,6 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
-import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 
 // Shared constants
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
@@ -418,51 +414,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     }
   }
 
-  // Helper function to consistently count lines in text
-  private countLines(text: string): number {
-    if (text.length === 0) return 0;
-    // Handle trailing newlines consistently: subtract 1 if text ends with newline
-    return text.endsWith('\n')
-      ? text.split('\n').length - 1
-      : text.split('\n').length;
-  }
-
-  private async computeDiffStats(
-    baseFile: string | null,
-    outputFile: string,
-  ): Promise<DiffStats> {
-    try {
-      if (!baseFile) {
-        const outContent = await WorkspaceFS.readFile(outputFile);
-        const added = this.countLines(outContent);
-        // For new files, only return added count (removed should be undefined for UI)
-        return { added };
-      }
-
-      const [baseContent, outContent] = await Promise.all([
-        WorkspaceFS.readFile(baseFile),
-        WorkspaceFS.readFile(outputFile),
-      ]);
-
-      const dmp = new diff_match_patch();
-      const diffs = dmp.diff_main(baseContent, outContent);
-      let added = 0;
-      let removed = 0;
-
-      for (const [op, text] of diffs) {
-        if (op === 1) {
-          added += this.countLines(text);
-        } else if (op === -1) {
-          removed += this.countLines(text);
-        }
-      }
-
-      return { added, removed };
-    } catch {
-      return {};
-    }
-  }
-
   /**
    * Processes completion of conversation round.
    */
@@ -495,51 +446,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       throw error;
     }
 
-    const roundOutputs = this.outputHandler.outputFiles[currRound] || [];
-
-    // Map output files to their original base files
-    const baseMap = createFileMapping(this.baseFiles, roundOutputs, 'contains');
-
-    // Map output files to previous round files if available
-    const prevMap =
-      currRound > 0
-        ? createFileMapping(
-            this.outputHandler.outputFiles[currRound - 1] || [],
-            roundOutputs,
-            'basename',
-            true,
-          )
-        : new Map<string, string>();
-
-    const fileInfos = [] as any[];
-    const originMap = new Map(
-      (this.outputHandler.outputMappings[currRound] || []).map((p) => [
-        p.path,
-        p.source,
-      ]),
-    );
-    for (const file of roundOutputs) {
-      const baseFile =
-        Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
-        null;
-      const prevFile =
-        Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
-        null;
-      const originalFile = originMap.get(file) || null;
-
-      // Use utility to determine effective base for diff computation
-      const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
-      const stats = await this.computeDiffStats(diffBase, file);
-
-      fileInfos.push({
-        path: file,
-        base: baseFile,
-        prev: prevFile,
-        original: originalFile,
-        ...stats,
-      });
-    }
-
+    const fileInfos = await this.outputHandler.gatherOutputFileInfo(currRound);
     emitProgress('addOutputFiles', {
       stream: this.logger.channelId,
       filesByRound: { [currRound]: fileInfos },

--- a/src/agent/output/DiffStatsManager.ts
+++ b/src/agent/output/DiffStatsManager.ts
@@ -1,0 +1,48 @@
+// Local imports
+import { WorkspaceFS } from '@utils/files';
+import { diff_match_patch } from 'diff-match-patch';
+import type { DiffStats } from '@/types/DiffTypes';
+
+export class DiffStatsManager {
+  private countLines(text: string): number {
+    if (text.length === 0) return 0;
+    return text.endsWith('\n')
+      ? text.split('\n').length - 1
+      : text.split('\n').length;
+  }
+
+  public async computeDiffStats(
+    baseFile: string | null,
+    outputFile: string,
+  ): Promise<DiffStats> {
+    try {
+      if (!baseFile) {
+        const outContent = await WorkspaceFS.readFile(outputFile);
+        const added = this.countLines(outContent);
+        return { added };
+      }
+
+      const [baseContent, outContent] = await Promise.all([
+        WorkspaceFS.readFile(baseFile),
+        WorkspaceFS.readFile(outputFile),
+      ]);
+
+      const dmp = new diff_match_patch();
+      const diffs = dmp.diff_main(baseContent, outContent);
+      let added = 0;
+      let removed = 0;
+      for (const [op, text] of diffs) {
+        if (op === 1) {
+          added += this.countLines(text);
+        } else if (op === -1) {
+          removed += this.countLines(text);
+        }
+      }
+      return { added, removed };
+    } catch {
+      return {};
+    }
+  }
+}
+
+export type { DiffStats } from '@/types/DiffTypes';

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,6 +1,6 @@
 // Local imports - types
 import { AgentStateGlobal } from '@agent/core/AgentState';
-import { NamedOutputFile } from './types';
+import { NamedOutputFile, OutputFileInfo } from './types';
 
 /** Interface describing OutputHandler behavior used by agents. */
 export interface IOutputHandler {
@@ -46,4 +46,7 @@ export interface IOutputHandler {
     currRound: number,
     groupId?: string,
   ): Promise<void>;
+
+  /** Gather mapping and diff stats for output files of a round. */
+  gatherOutputFileInfo(currRound: number): Promise<OutputFileInfo[]>;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -7,6 +7,7 @@ import { runLatexFormatter } from '@latex/texFormatter';
 import { XmlOutputManager } from './XmlOutputManager';
 import { LatexDiffManager } from './LatexDiffManager';
 import { StatisticsReporter } from './StatisticsReporter';
+import { DiffStatsManager } from './DiffStatsManager';
 import { NamedOutputFile } from './types';
 import type { IOutputHandler } from './IOutputHandler';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
@@ -18,7 +19,8 @@ import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
 
 // Local imports - utilities
-import { replaceInputCommands } from '@utils/files';
+import { replaceInputCommands, createFileMapping } from '@utils/files';
+import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 
 // Local imports - types
 
@@ -37,6 +39,7 @@ export class OutputHandler implements IOutputHandler {
   private xmlManager: XmlOutputManager;
   private diffManager: LatexDiffManager;
   private statsReporter: StatisticsReporter;
+  private diffStatsManager: DiffStatsManager;
 
   constructor(
     agentSetting: AgentSetting,
@@ -73,6 +76,7 @@ export class OutputHandler implements IOutputHandler {
       this.channel,
       this.logger,
     );
+    this.diffStatsManager = new DiffStatsManager();
   }
 
   /**
@@ -161,6 +165,59 @@ export class OutputHandler implements IOutputHandler {
     groupId?: string,
   ): Promise<void> {
     await this.diffManager.handleLatexdiffofOutput(currRound, groupId);
+  }
+
+  /**
+   * Gather mapping and diff statistics for output files of a round.
+   */
+  public async gatherOutputFileInfo(currRound: number): Promise<
+    {
+      path: string;
+      base: string | null;
+      prev: string | null;
+      original: string | null;
+      added?: number;
+      removed?: number;
+    }[]
+  > {
+    const roundOutputs = this.outputFiles[currRound] || [];
+    const baseMap = createFileMapping(this.baseFiles, roundOutputs, 'contains');
+    const prevMap =
+      currRound > 0
+        ? createFileMapping(
+            this.outputFiles[currRound - 1] || [],
+            roundOutputs,
+            'basename',
+            true,
+          )
+        : new Map<string, string>();
+    const originMap = new Map(
+      (this.outputMappings[currRound] || []).map((p) => [p.path, p.source]),
+    );
+
+    const infos = [] as any[];
+    for (const file of roundOutputs) {
+      const baseFile =
+        Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
+        null;
+      const prevFile =
+        Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
+        null;
+      const originalFile = originMap.get(file) || null;
+      const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
+      const stats = await this.diffStatsManager.computeDiffStats(
+        diffBase,
+        file,
+      );
+      infos.push({
+        path: file,
+        base: baseFile,
+        prev: prevFile,
+        original: originalFile,
+        ...stats,
+      });
+    }
+    return infos;
   }
 
   /** Processes single output file with XML splitting and filtering. */

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -2,3 +2,12 @@ export interface NamedOutputFile {
   source: string;
   path: string;
 }
+
+import type { DiffStats } from '@/types/DiffTypes';
+
+export interface OutputFileInfo extends DiffStats {
+  path: string;
+  base?: string | null;
+  prev?: string | null;
+  original?: string | null;
+}


### PR DESCRIPTION
## Summary
- add `DiffStatsManager` to compute per-file diff stats
- expose gathering of output file info via `OutputHandler`
- simplify `BaseReflectionAgent` to use new helper

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: missing VS Code binaries)*

------
https://chatgpt.com/codex/tasks/task_e_685f07e03a988324b4d1da888bf2e088