### PR TITLE
Add provider tool conversions

### DIFF
--- a/docs/reference/tool-format.md
+++ b/docs/reference/tool-format.md
@@ -1,0 +1,24 @@
+# Tool Definition Format
+
+Some model providers allow calling functions ("tools") during generation.
+Model handlers supporting this feature accept a `tools` array when creating a response.
+
+Each tool definition must include at least a `name`.
+Additional fields depend on the provider. A typical OpenAI-style entry looks like:
+
+```ts
+const tools: ToolDefinition[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'searchWeb',
+      description: 'Perform a web search',
+      parameters: {
+        /* JSON schema */
+      },
+    },
+  },
+];
+```
+
+See your provider's documentation for the exact schema.

--- a/docs/reference/tool-format.md
+++ b/docs/reference/tool-format.md
@@ -4,18 +4,15 @@ Some model providers allow calling functions ("tools") during generation.
 Model handlers supporting this feature accept a `tools` array when creating a response.
 
 Each tool definition must include at least a `name`.
-Additional fields depend on the provider. A typical OpenAI-style entry looks like:
+Additional fields depend on the provider. A typical entry looks like:
 
 ```ts
 const tools: ToolDefinition[] = [
   {
-    type: 'function',
-    function: {
-      name: 'searchWeb',
-      description: 'Perform a web search',
-      parameters: {
-        /* JSON schema */
-      },
+    name: 'searchWeb',
+    description: 'Perform a web search',
+    parameters: {
+      /* JSON schema */
     },
   },
 ];

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -1,3 +1,6 @@
+// Local imports - model types
+import type { ToolDefinition } from '@model';
+
 /** Enum defining possible agent types */
 export enum AgentType {
   CoT = 'CoT',
@@ -18,6 +21,7 @@ export const DEFAULT_AGENT_SETTINGS: AgentSetting = {
   requiredFilesInternal: {},
   defaultOutputFiles: [],
   filePatternsContain: [],
+  tools: undefined,
   isRewrite: true,
 };
 
@@ -50,6 +54,9 @@ export interface AgentSetting {
   requiredFilesInternal: Record<string, string>;
   defaultOutputFiles: string[];
   filePatternsContain: Array<Record<string, string>>;
+
+  /** Tool definitions available to the agent */
+  tools?: ToolDefinition[];
 }
 
 /**

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -51,6 +51,7 @@ import {
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import type { IModelHandler } from '@agent/modelHandlers';
+import type { ToolDefinition } from '@model';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
@@ -204,6 +205,9 @@ export abstract class BaseReflectionAgent extends BaseAgent {
             systemPrompt,
             this.agentSetting.endTag,
             this.abortController.signal,
+            this.modelHandler.capabilities.supportsFunctionCalling
+              ? this.agentSetting.tools
+              : undefined,
           );
         } finally {
           this.abortController = null;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -30,6 +30,7 @@ import {
   ModelProvider,
   ModelCapabilities,
 } from '@model/ModelConfig';
+import type { ToolDefinition } from '@model';
 import { ToolState } from '../core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 
@@ -611,6 +612,7 @@ export abstract class ModelHandler<U = any, R = any>
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<any>;
 
   /**

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -37,6 +37,8 @@ import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import type { ToolDefinition } from '@model';
+import { toAnthropicTools } from './toolConversion';
 
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.
@@ -63,6 +65,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<BetaMessage> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -76,6 +79,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
       stop_sequences: endTag ? [endTag] : undefined,
       system: systemPrompt,
     };
+
+    if (tools && tools.length > 0) {
+      options.tools = toAnthropicTools(tools) as any;
+      (options as any).tool_choice = 'auto';
+    }
 
     // Enable thinking for any models that support reasoning
     if (this.capabilities.supportsReasoning) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -81,8 +81,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
     };
 
     if (tools && tools.length > 0) {
-      options.tools = toAnthropicTools(tools) as any;
-      (options as any).tool_choice = 'auto';
+      options.tools = toAnthropicTools(tools);
+      (options as MessageCreateParams).tool_choice = { type: 'auto' };
     }
 
     // Enable thinking for any models that support reasoning

--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -8,6 +8,7 @@ import OpenAI from 'openai';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
+import type { ToolDefinition } from '@model';
 
 // Local imports - utilities
 import { convertContentToString } from '@agent/utils/text/messageUtils';
@@ -83,6 +84,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<any> {
     // Preprocess messages for DashScope compatibility
     const processedMessages = this.preprocessMessages(messages);
@@ -110,6 +112,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
       systemPrompt,
       endTag,
       signal,
+      tools,
     );
   }
 

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -7,6 +7,7 @@ import OpenAI from 'openai';
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
+import type { ToolDefinition } from '@model';
 
 // Local imports - utilities
 import { convertContentToString } from '@agent/utils/text/messageUtils';
@@ -216,6 +217,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<any> {
     // Preprocess messages to merge consecutive messages and convert content to strings
     const processedMessages = this.preprocessMessages(messages);
@@ -243,6 +245,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
       systemPrompt,
       endTag,
       signal,
+      tools,
     );
   }
 }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -30,6 +30,8 @@ import {
 } from '@agent/core/ResponseUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { AgentLogger } from '@logger/AgentLogger';
+import type { ToolDefinition } from '@model';
+import { toGoogleTools } from './toolConversion';
 
 // Local imports - utilities
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
@@ -169,6 +171,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<GenerateContentResponse> {
     if (messages.length === 0) {
       this.logger.error('Cannot create response from empty messages array.');
@@ -223,6 +226,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] },
       }),
     };
+
+    if (tools && tools.length > 0) {
+      (chatParams.config as any).tools = toGoogleTools(tools);
+    }
 
     if (this.capabilities.supportsTokenCounting) {
       try {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -10,7 +10,7 @@ import {
   FinishReason,
   File,
   createPartFromUri,
-  GenerationConfig,
+  GenerateContentConfig,
   type CreateChatParameters,
   type SendMessageParameters,
   type UploadFileParameters,
@@ -205,7 +205,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       throw new Error('Last message conversion resulted in empty parts.');
     }
 
-    const generationConfig: GenerationConfig = {
+    const generationConfig: GenerateContentConfig = {
       temperature: temperature,
       maxOutputTokens: this.config.maxOutputTokens ?? 8192,
       ...(endTag && { stopSequences: [endTag] }),
@@ -218,6 +218,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       generationConfig.thinkingConfig = { includeThoughts: true };
     }
 
+    if (tools && tools.length > 0) {
+      generationConfig.tools = toGoogleTools(tools);
+    }
+
     const chatParams: CreateChatParameters = {
       model: this.config.fullName,
       history: chatHistory,
@@ -226,10 +230,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] },
       }),
     };
-
-    if (tools && tools.length > 0) {
-      (chatParams.config as any).tools = toGoogleTools(tools);
-    }
 
     if (this.capabilities.supportsTokenCounting) {
       try {

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -8,6 +8,7 @@ import OpenAI from 'openai';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
+import type { ToolDefinition } from '@model';
 
 // Local imports - utilities
 import { convertContentToString } from '@agent/utils/text/messageUtils';
@@ -138,6 +139,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<any> {
     // Preprocess messages for Kimi compatibility
     const processedMessages = this.preprocessMessages(messages);
@@ -200,6 +202,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
       systemPrompt,
       endTag,
       signal,
+      tools,
     );
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -18,6 +18,8 @@ import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
 import { AgentStateRound } from '../core/AgentState';
 import { ModelHandler } from './ModelHandler';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import { toOpenAITools } from './toolConversion';
+import type { ToolDefinition } from '@model';
 import {
   OpenAIAPIResponseUsage,
   ResponseUsageFactory,
@@ -55,6 +57,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<any> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -81,6 +84,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
           this.config.capabilities.reasoningEffort,
         ) as any; // Cast to any for compatibility with different API providers
       }
+    }
+    if (tools && tools.length > 0) {
+      kwargs.tools = toOpenAITools(tools);
+      kwargs.tool_choice = 'auto';
     }
     if (this.config.fullName.includes('deepseek-chat')) {
       // for deepseek models,  this and context window are not the same for openrouter models and the official api. so we need to set max_tokens manually if the official api is used

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -19,6 +19,7 @@ import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { ToolState } from '../core/ToolState';
 import { K_SLICE } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import type { ToolDefinition } from '@model';
 
 // import { ResponseCreateParams } from 'openai/src/resources/responses/response';
 // this is incorrect now, but would be nice to use
@@ -73,6 +74,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    _tools?: ToolDefinition[],
   ): Promise<Response> {
     const useStreaming = this.getStreamingConfig();
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -8,6 +8,8 @@ import OpenAI from 'openai';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
 import { K_SLICE } from '@utils/config';
+import type { ToolDefinition } from '@model';
+import { toOpenAITools } from './toolConversion';
 
 /**
  * Handler for models accessed through OpenRouter.
@@ -32,6 +34,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<any> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -58,6 +61,11 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
         };
         kwargs.include_reasoning = true;
       }
+    }
+
+    if (tools && tools.length > 0) {
+      kwargs.tools = toOpenAITools(tools);
+      kwargs.tool_choice = 'auto';
     }
 
     if (endTag) {

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -3,10 +3,14 @@ import type { ToolDefinition } from '@model';
 
 // Third-party imports
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';
-import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages/messages';
+import type {
+  Tool as AnthropicTool,
+  ToolUnion,
+} from '@anthropic-ai/sdk/resources/messages/messages';
 import type {
   Tool as GeminiTool,
   FunctionDeclaration,
+  Schema,
 } from '@google/genai/dist/genai';
 
 /** Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format. */
@@ -22,8 +26,8 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 }
 
 /** Convert generic ToolDefinition objects to Anthropic Tool format. */
-export function toAnthropicTools(defs: ToolDefinition[]): AnthropicTool[] {
-  return defs.map((d) => ({
+export function toAnthropicTools(defs: ToolDefinition[]): ToolUnion[] {
+  return defs.map<ToolUnion>((d) => ({
     name: d.name,
     description: d.description,
     input_schema: (d.parameters ?? {}) as AnthropicTool['input_schema'],
@@ -32,12 +36,19 @@ export function toAnthropicTools(defs: ToolDefinition[]): AnthropicTool[] {
 
 /** Convert generic ToolDefinition objects to Google Gemini Tool format. */
 export function toGoogleTools(defs: ToolDefinition[]): GeminiTool[] {
-  return defs.map((d) => {
-    const decl: FunctionDeclaration = {
-      name: d.name,
-      description: d.description,
-      parameters: d.parameters as any,
-    };
-    return { functionDeclarations: [decl] };
-  });
+  if (defs.length === 0) {
+    return [];
+  }
+
+  const declarations: FunctionDeclaration[] = defs.map((d) => ({
+    name: d.name,
+    description: d.description,
+    parameters: d.parameters as Schema | undefined,
+  }));
+
+  return [
+    {
+      functionDeclarations: declarations,
+    },
+  ];
 }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -1,0 +1,43 @@
+// Local imports - types
+import type { ToolDefinition } from '@model';
+
+// Third-party imports
+import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages/messages';
+import type {
+  Tool as GeminiTool,
+  FunctionDeclaration,
+} from '@google/genai/dist/genai';
+
+/** Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format. */
+export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
+  return defs.map((d) => ({
+    type: 'function',
+    function: {
+      name: d.name,
+      description: d.description,
+      parameters: d.parameters,
+    },
+  }));
+}
+
+/** Convert generic ToolDefinition objects to Anthropic Tool format. */
+export function toAnthropicTools(defs: ToolDefinition[]): AnthropicTool[] {
+  return defs.map((d) => ({
+    name: d.name,
+    description: d.description,
+    input_schema: (d.parameters ?? {}) as AnthropicTool['input_schema'],
+  }));
+}
+
+/** Convert generic ToolDefinition objects to Google Gemini Tool format. */
+export function toGoogleTools(defs: ToolDefinition[]): GeminiTool[] {
+  return defs.map((d) => {
+    const decl: FunctionDeclaration = {
+      name: d.name,
+      description: d.description,
+      parameters: d.parameters as any,
+    };
+    return { functionDeclarations: [decl] };
+  });
+}

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -7,7 +7,7 @@ import { AgentSetting } from '../../core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '../../core/AgentState';
 import { ToolState } from '../../core/ToolState';
 import type { MediaEntry } from '../../utils/mediaTypes';
-import type { ModelConfig, ModelCapabilities } from '@model/ModelConfig';
+import type { ModelConfig, ModelCapabilities, ToolDefinition } from '@model';
 import type { ProviderStopReason } from './StopReasonTypes';
 
 /**
@@ -54,6 +54,7 @@ export interface IModelHandler<U = any, R = any> {
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
+    tools?: ToolDefinition[],
   ): Promise<any>;
 
   /** Initialize the conversation for the first round. */

--- a/src/agent/toolUse/ValidationFixAgent.ts
+++ b/src/agent/toolUse/ValidationFixAgent.ts
@@ -20,6 +20,7 @@ import { LinterMessage } from '@frontend/latex/linter';
 import { WorkspaceFS } from '@utils/files';
 import * as linterUtils from '@frontend/latex/linter';
 import type { IToolUseAgent } from './IToolUseAgent';
+import type { ToolDefinition } from '@model';
 
 export type ValidatorType = 'latexLinter' | 'xmlValidator';
 
@@ -70,9 +71,14 @@ export class ValidationFixAgent<T extends ValidatorType>
       this.validator === 'latexLinter'
         ? ['text_editor', 'diagnostics']
         : ['text_editor'];
-    const configured = settings.tools
-      ? settings.tools.map((t) => t.name)
-      : defaultTools;
+    let configured: string[] = defaultTools;
+      if (Array.isArray(settings.tools) && settings.tools.length > 0) {
+        if (typeof settings.tools[0] === 'string') {
+          configured = settings.tools as unknown as string[];
+        } else {
+          configured = (settings.tools as ToolDefinition[]).map((t) => t.name);
+        }
+      }
     this.setConfiguredTools(configured);
   }
 

--- a/src/agent/toolUse/ValidationFixAgent.ts
+++ b/src/agent/toolUse/ValidationFixAgent.ts
@@ -70,7 +70,10 @@ export class ValidationFixAgent<T extends ValidatorType>
       this.validator === 'latexLinter'
         ? ['text_editor', 'diagnostics']
         : ['text_editor'];
-    this.setConfiguredTools((settings as any).tools || defaultTools);
+    const configured = settings.tools
+      ? settings.tools.map((t) => t.name)
+      : defaultTools;
+    this.setConfiguredTools(configured);
   }
 
   private getYamlName(): string {

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -1,0 +1,14 @@
+/**
+ * Generic description of a tool/function that a provider can execute.
+ * Fields beyond `name` are provider specific.
+ */
+export interface ToolDefinition {
+  /** Name of the tool or function */
+  name: string;
+  /** Optional description for the model */
+  description?: string;
+  /** Parameter schema or provider specific metadata */
+  parameters?: Record<string, unknown>;
+  /** Additional provider-specific fields */
+  [key: string]: unknown;
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,2 +1,3 @@
 export * from './ModelConfig';
 export * from './ModelRegistry';
+export * from './ToolDefinition';


### PR DESCRIPTION
## Summary
- include optional tools in `AgentSetting`
- document tool format with shorter lines
- add converters for OpenAI, Anthropic and Google GemAI
- pass converted tools when creating responses

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685ef212c8648324a2b0f583a24115d3