### PR TITLE
Refactor media extraction into LatexMediaManager

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -535,15 +535,14 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       }
 
       const extraMedia: string[] = [];
-      if (
-        this.modelHandler.capabilities.supportsVision &&
-        this.agentConfig.mediaFile &&
-        !toolState.mediaFiles.includes(this.agentConfig.mediaFile)
-      ) {
-        extraMedia.push(this.agentConfig.mediaFile);
-      }
-      if (this.agentConfig.mediaFiles) {
-        extraMedia.push(...this.agentConfig.mediaFiles);
+      if (this.modelHandler.capabilities.supportsVision) {
+        if (this.agentConfig.mediaFile &&
+          !toolState.mediaFiles.includes(this.agentConfig.mediaFile)) {
+          extraMedia.push(this.agentConfig.mediaFile);
+        }
+        if (this.agentConfig.mediaFiles) {
+          extraMedia.push(...this.agentConfig.mediaFiles);
+        }
       }
 
       await this.latexMediaManager.processInputFiles(

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+// (none needed)
 
 // Third-party imports
 // (none needed)
@@ -7,13 +7,7 @@ import * as path from 'path';
 // Local imports - log
 
 // Local imports - latex utils
-import {
-  extractFigurePathsFromLatex,
-  bestConnectionMethod,
-  getTeXCountStats,
-  compileLatex2Pdf,
-  tikzPictureManager,
-} from '@latex';
+import { bestConnectionMethod, LatexMediaManager } from '@latex';
 
 import { emitProgress } from '@eventBus/ProgressEventBus';
 
@@ -69,6 +63,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   protected logId: number = 0;
   /** Handler for output file processing and validation. */
   protected outputHandler: IOutputHandler;
+  protected latexMediaManager: LatexMediaManager;
 
   constructor(
     modelHandler: IModelHandler,
@@ -111,6 +106,8 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       this.baseFiles,
       this.logger,
     );
+
+    this.latexMediaManager = new LatexMediaManager(this.logger);
   }
 
   /**
@@ -529,11 +526,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     );
 
     try {
-      // Handle tex count if enabled
-      if (this.agentConfig.toolConfig.attachTeXCount) {
-        toolState.texcountStats = await getTeXCountStats(inputFiles);
-      }
-
       // Handle prefill from input if enabled
       if (this.agentConfig.toolConfig.usePrefillFromInput) {
         toolState.firstKCharsFromInput = await getFirstKCharsFromDocument(
@@ -542,69 +534,26 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         );
       }
 
-      // Handle figure extraction for vision-capable models
-      if (this.modelHandler.capabilities.supportsVision) {
-        if (
-          this.agentConfig.mediaFile &&
-          !toolState.mediaFiles.includes(this.agentConfig.mediaFile)
-        ) {
-          toolState.addMediaFiles([this.agentConfig.mediaFile]);
-        }
-        if (this.agentConfig.mediaFiles) {
-          toolState.addMediaFiles(this.agentConfig.mediaFiles);
-        }
-
-        if (this.agentConfig.toolConfig.autoExtractFigure) {
-          const extractedFigures = await extractFigurePathsFromLatex(
-            this.agentConfig.inputFile,
-          );
-          if (extractedFigures) {
-            this.logger.info(
-              `Extracted ${extractedFigures.length} figures from ${this.agentConfig.inputFile}. Figures: ${extractedFigures.join(', ')}`,
-              round0GroupId,
-            );
-            toolState.addMediaFiles(extractedFigures);
-          }
-        }
-
-        if (this.agentConfig.toolConfig.autoExtractTikzFigure) {
-          for (const inputFile of inputFiles) {
-            const extractedTikzFigures =
-              await tikzPictureManager.compile(inputFile);
-            if (extractedTikzFigures) {
-              toolState.addMediaFiles(extractedTikzFigures);
-            }
-          }
-        }
-
-        if (this.agentConfig.toolConfig.autoCompileInputPdf) {
-          for (const inputFile of inputFiles) {
-            if (!inputFile.toLowerCase().endsWith('.tex')) {
-              continue;
-            }
-            const buildDir = path.join(path.dirname(inputFile), 'build');
-            const compiled = await compileLatex2Pdf(
-              inputFile,
-              undefined,
-              buildDir,
-              true, // prefer latexmk when available
-            );
-            if (compiled) {
-              const pdfFile = path.join(
-                buildDir,
-                path.basename(inputFile).replace(/\.tex$/, '.pdf'),
-              );
-              if (await WorkspaceFS.exists(pdfFile)) {
-                this.logger.info(
-                  `Compiled PDF for ${inputFile}: ${pdfFile}`,
-                  round0GroupId,
-                );
-                toolState.addMediaFiles([pdfFile]);
-              }
-            }
-          }
-        }
+      const extraMedia: string[] = [];
+      if (
+        this.modelHandler.capabilities.supportsVision &&
+        this.agentConfig.mediaFile &&
+        !toolState.mediaFiles.includes(this.agentConfig.mediaFile)
+      ) {
+        extraMedia.push(this.agentConfig.mediaFile);
       }
+      if (this.agentConfig.mediaFiles) {
+        extraMedia.push(...this.agentConfig.mediaFiles);
+      }
+
+      await this.latexMediaManager.processInputFiles(
+        inputFiles,
+        toolState,
+        this.agentConfig.toolConfig,
+        this.modelHandler.capabilities.supportsVision,
+        extraMedia,
+        round0GroupId,
+      );
 
       const messages: any[] = [];
 
@@ -921,54 +870,13 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     currRound: number,
     toolState: ToolState,
   ): Promise<void> {
-    if (this.agentConfig.toolConfig.attachTeXCount) {
-      toolState.texcountStats = await getTeXCountStats(outputFiles);
-    }
-
-    if (
-      this.modelHandler.capabilities.supportsVision &&
-      this.agentConfig.toolConfig.autoExtractTikzFigure
-    ) {
-      for (const outputFile of outputFiles) {
-        this.logger.debug(`Extracting TikZ figures from ${outputFile}`);
-        const extractedTikzFigures =
-          await tikzPictureManager.compile(outputFile);
-        if (extractedTikzFigures) {
-          toolState.addMediaFiles(extractedTikzFigures);
-        }
-      }
-    }
-
-    if (
-      this.modelHandler.capabilities.supportsVision &&
-      this.agentConfig.toolConfig.autoCompileInputPdf
-    ) {
-      for (const outputFile of outputFiles) {
-        if (!outputFile.toLowerCase().endsWith('.tex')) {
-          continue;
-        }
-        const buildDir = path.join(path.dirname(outputFile), 'build');
-        const compiled = await compileLatex2Pdf(
-          outputFile,
-          undefined,
-          buildDir,
-          true,
-        );
-        if (compiled) {
-          const pdfFile = path.join(
-            buildDir,
-            path.basename(outputFile).replace(/\.tex$/, '.pdf'),
-          );
-          if (await WorkspaceFS.exists(pdfFile)) {
-            this.logger.info(
-              `Compiled PDF for ${outputFile}: ${pdfFile}`,
-              this.logger.getActiveGroupId(),
-            );
-            toolState.addMediaFiles([pdfFile]);
-          }
-        }
-      }
-    }
+    await this.latexMediaManager.processOutputFiles(
+      outputFiles,
+      toolState,
+      this.agentConfig.toolConfig,
+      this.modelHandler.capabilities.supportsVision,
+      this.logger.getActiveGroupId(),
+    );
   }
 
   /**

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -250,7 +250,6 @@ export class OutputHandler implements IOutputHandler {
 
   /**
    * Processes output files from XML or direct input.
-   * Mirrors the previous logic in BaseReflectionAgent.processOutputFiles.
    */
   public async processOutputFiles(
     outputFile: string,

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -5,12 +5,10 @@ import * as path from 'path';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - latex utils
-import {
-  extractFigurePathsFromLatex,
-  tikzPictureManager,
-  compileLatex2Pdf,
-  getTeXCountStats,
-} from '@latex';
+import { extractFigurePathsFromLatex } from './extractFigure';
+import { tikzPictureManager } from './TikzPictureManager';
+import { compileLatex2Pdf } from './texTools';
+import { getTeXCountStats } from './texcount';
 
 // Local imports - agent components
 import { ToolState } from '@agent/core/ToolState';
@@ -31,6 +29,47 @@ export class LatexMediaManager {
     if (cfg.attachTeXCount && files.length > 0) {
       toolState.texcountStats = await getTeXCountStats(files);
     }
+  }
+
+  /**
+   * Compile LaTeX files to PDF and add them to the tool state.
+   */
+  private async compilePdfs(
+    files: string[],
+    toolState: ToolState,
+    groupId?: string,
+  ): Promise<void> {
+    const texFiles = files.filter((file) =>
+      file.toLowerCase().endsWith('.tex'),
+    );
+    const compileResults = await Promise.allSettled(
+      texFiles.map(async (file) => {
+        const buildDir = path.join(path.dirname(file), 'build');
+        await WorkspaceFS.ensureDir(buildDir);
+        const compiled = await compileLatex2Pdf(
+          file,
+          undefined,
+          buildDir,
+          true,
+        );
+        if (compiled) {
+          const pdfFile = path.join(
+            buildDir,
+            path.basename(file).replace(/\.tex$/, '.pdf'),
+          );
+          if (await WorkspaceFS.exists(pdfFile)) {
+            this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
+            return pdfFile;
+          }
+        }
+        return undefined;
+      }),
+    );
+    compileResults.forEach((result) => {
+      if (result.status === 'fulfilled' && result.value) {
+        toolState.addMediaFiles([result.value]);
+      }
+    });
   }
 
   /**
@@ -109,37 +148,7 @@ export class LatexMediaManager {
     }
 
     if (cfg.autoCompileInputPdf) {
-      const texFiles = existingFiles.filter((file) =>
-        file.toLowerCase().endsWith('.tex'),
-      );
-      const compileResults = await Promise.allSettled(
-        texFiles.map(async (file) => {
-          const buildDir = path.join(path.dirname(file), 'build');
-          await WorkspaceFS.ensureDir(buildDir);
-          const compiled = await compileLatex2Pdf(
-            file,
-            undefined,
-            buildDir,
-            true,
-          );
-          if (compiled) {
-            const pdfFile = path.join(
-              buildDir,
-              path.basename(file).replace(/\.tex$/, '.pdf'),
-            );
-            if (await WorkspaceFS.exists(pdfFile)) {
-              this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
-              return pdfFile;
-            }
-          }
-          return undefined;
-        }),
-      );
-      compileResults.forEach((result) => {
-        if (result.status === 'fulfilled' && result.value) {
-          toolState.addMediaFiles([result.value]);
-        }
-      });
+      await this.compilePdfs(existingFiles, toolState, groupId);
     }
   }
 
@@ -189,37 +198,7 @@ export class LatexMediaManager {
     }
 
     if (supportsVision && cfg.autoCompileInputPdf) {
-      const texFiles = existingFiles.filter((file) =>
-        file.toLowerCase().endsWith('.tex'),
-      );
-      const compileResults = await Promise.allSettled(
-        texFiles.map(async (file) => {
-          const buildDir = path.join(path.dirname(file), 'build');
-          await WorkspaceFS.ensureDir(buildDir);
-          const compiled = await compileLatex2Pdf(
-            file,
-            undefined,
-            buildDir,
-            true,
-          );
-          if (compiled) {
-            const pdfFile = path.join(
-              buildDir,
-              path.basename(file).replace(/\.tex$/, '.pdf'),
-            );
-            if (await WorkspaceFS.exists(pdfFile)) {
-              this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
-              return pdfFile;
-            }
-          }
-          return undefined;
-        }),
-      );
-      compileResults.forEach((result) => {
-        if (result.status === 'fulfilled' && result.value) {
-          toolState.addMediaFiles([result.value]);
-        }
-      });
+      await this.compilePdfs(existingFiles, toolState, groupId);
     }
   }
 }

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -1,0 +1,149 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - latex utils
+import {
+  extractFigurePathsFromLatex,
+  tikzPictureManager,
+  compileLatex2Pdf,
+  getTeXCountStats,
+} from '@latex';
+
+// Local imports - agent components
+import { ToolState } from '@agent/core/ToolState';
+import { ToolConfig } from '@agent/core/ToolConfig';
+import { WorkspaceFS } from '@utils/files';
+
+/**
+ * Handles LaTeX related media extraction and compilation for agents.
+ */
+export class LatexMediaManager {
+  constructor(private readonly logger: AgentLogger) {}
+
+  /**
+   * Process input files to extract figures, compile TikZ pictures and PDFs.
+   * Adds resulting media paths to the provided ToolState.
+   */
+  async processInputFiles(
+    inputFiles: string[],
+    toolState: ToolState,
+    cfg: ToolConfig,
+    supportsVision: boolean,
+    extraMediaFiles: string[] = [],
+    groupId?: string,
+  ): Promise<void> {
+    if (cfg.attachTeXCount) {
+      toolState.texcountStats = await getTeXCountStats(inputFiles);
+    }
+
+    if (!supportsVision) {
+      return;
+    }
+
+    if (extraMediaFiles.length > 0) {
+      toolState.addMediaFiles(extraMediaFiles);
+    }
+
+    if (cfg.autoExtractFigure) {
+      for (const file of inputFiles) {
+        const extracted = await extractFigurePathsFromLatex(file);
+        if (extracted && extracted.length > 0) {
+          this.logger.info(
+            `Extracted ${extracted.length} figures from ${file}`,
+            groupId,
+          );
+          toolState.addMediaFiles(extracted);
+        }
+      }
+    }
+
+    if (cfg.autoExtractTikzFigure) {
+      for (const file of inputFiles) {
+        const tikzFigures = await tikzPictureManager.compile(file);
+        if (tikzFigures && tikzFigures.length > 0) {
+          toolState.addMediaFiles(tikzFigures);
+        }
+      }
+    }
+
+    if (cfg.autoCompileInputPdf) {
+      for (const file of inputFiles) {
+        if (!file.toLowerCase().endsWith('.tex')) {
+          continue;
+        }
+        const buildDir = path.join(path.dirname(file), 'build');
+        const compiled = await compileLatex2Pdf(
+          file,
+          undefined,
+          buildDir,
+          true,
+        );
+        if (compiled) {
+          const pdfFile = path.join(
+            buildDir,
+            path.basename(file).replace(/\.tex$/, '.pdf'),
+          );
+          if (await WorkspaceFS.exists(pdfFile)) {
+            this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
+            toolState.addMediaFiles([pdfFile]);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Process output files to compile TikZ pictures and PDFs, attach texcount.
+   */
+  async processOutputFiles(
+    outputFiles: string[],
+    toolState: ToolState,
+    cfg: ToolConfig,
+    supportsVision: boolean,
+    groupId?: string,
+  ): Promise<void> {
+    if (cfg.attachTeXCount) {
+      toolState.texcountStats = await getTeXCountStats(outputFiles);
+    }
+
+    if (supportsVision && cfg.autoExtractTikzFigure) {
+      for (const outputFile of outputFiles) {
+        const tikzFigures = await tikzPictureManager.compile(outputFile);
+        if (tikzFigures && tikzFigures.length > 0) {
+          toolState.addMediaFiles(tikzFigures);
+        }
+      }
+    }
+
+    if (supportsVision && cfg.autoCompileInputPdf) {
+      for (const outputFile of outputFiles) {
+        if (!outputFile.toLowerCase().endsWith('.tex')) {
+          continue;
+        }
+        const buildDir = path.join(path.dirname(outputFile), 'build');
+        const compiled = await compileLatex2Pdf(
+          outputFile,
+          undefined,
+          buildDir,
+          true,
+        );
+        if (compiled) {
+          const pdfFile = path.join(
+            buildDir,
+            path.basename(outputFile).replace(/\.tex$/, '.pdf'),
+          );
+          if (await WorkspaceFS.exists(pdfFile)) {
+            this.logger.info(
+              `Compiled PDF for ${outputFile}: ${pdfFile}`,
+              groupId,
+            );
+            toolState.addMediaFiles([pdfFile]);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -23,6 +23,16 @@ import { WorkspaceFS } from '@utils/files';
 export class LatexMediaManager {
   constructor(private readonly logger: AgentLogger) {}
 
+  private async attachTeXCount(
+    files: string[],
+    toolState: ToolState,
+    cfg: ToolConfig,
+  ): Promise<void> {
+    if (cfg.attachTeXCount && files.length > 0) {
+      toolState.texcountStats = await getTeXCountStats(files);
+    }
+  }
+
   /**
    * Process input files to extract figures, compile TikZ pictures and PDFs.
    * Adds resulting media paths to the provided ToolState.
@@ -35,9 +45,25 @@ export class LatexMediaManager {
     extraMediaFiles: string[] = [],
     groupId?: string,
   ): Promise<void> {
-    if (cfg.attachTeXCount) {
-      toolState.texcountStats = await getTeXCountStats(inputFiles);
+    if (!inputFiles || inputFiles.length === 0) {
+      return;
     }
+
+    const existingFilesInfo = await Promise.all(
+      inputFiles.map(async (file) => ({
+        file,
+        exists: await WorkspaceFS.exists(file),
+      })),
+    );
+    const existingFiles = existingFilesInfo
+      .filter((f) => f.exists)
+      .map((f) => f.file);
+
+    if (existingFiles.length === 0) {
+      return;
+    }
+
+    await this.attachTeXCount(existingFiles, toolState, cfg);
 
     if (!supportsVision) {
       return;
@@ -48,50 +74,72 @@ export class LatexMediaManager {
     }
 
     if (cfg.autoExtractFigure) {
-      for (const file of inputFiles) {
-        const extracted = await extractFigurePathsFromLatex(file);
-        if (extracted && extracted.length > 0) {
+      const figureResults = await Promise.allSettled(
+        existingFiles.map((file) => extractFigurePathsFromLatex(file)),
+      );
+      figureResults.forEach((result, idx) => {
+        if (
+          result.status === 'fulfilled' &&
+          result.value &&
+          result.value.length > 0
+        ) {
+          const file = existingFiles[idx];
           this.logger.info(
-            `Extracted ${extracted.length} figures from ${file}`,
+            `Extracted ${result.value.length} figures from ${file}`,
             groupId,
           );
-          toolState.addMediaFiles(extracted);
+          toolState.addMediaFiles(result.value);
         }
-      }
+      });
     }
 
     if (cfg.autoExtractTikzFigure) {
-      for (const file of inputFiles) {
-        const tikzFigures = await tikzPictureManager.compile(file);
-        if (tikzFigures && tikzFigures.length > 0) {
-          toolState.addMediaFiles(tikzFigures);
+      const tikzResults = await Promise.allSettled(
+        existingFiles.map((file) => tikzPictureManager.compile(file)),
+      );
+      tikzResults.forEach((result) => {
+        if (
+          result.status === 'fulfilled' &&
+          result.value &&
+          result.value.length > 0
+        ) {
+          toolState.addMediaFiles(result.value);
         }
-      }
+      });
     }
 
     if (cfg.autoCompileInputPdf) {
-      for (const file of inputFiles) {
-        if (!file.toLowerCase().endsWith('.tex')) {
-          continue;
-        }
-        const buildDir = path.join(path.dirname(file), 'build');
-        const compiled = await compileLatex2Pdf(
-          file,
-          undefined,
-          buildDir,
-          true,
-        );
-        if (compiled) {
-          const pdfFile = path.join(
+      const texFiles = existingFiles.filter((file) =>
+        file.toLowerCase().endsWith('.tex'),
+      );
+      const compileResults = await Promise.allSettled(
+        texFiles.map(async (file) => {
+          const buildDir = path.join(path.dirname(file), 'build');
+          await WorkspaceFS.ensureDir(buildDir);
+          const compiled = await compileLatex2Pdf(
+            file,
+            undefined,
             buildDir,
-            path.basename(file).replace(/\.tex$/, '.pdf'),
+            true,
           );
-          if (await WorkspaceFS.exists(pdfFile)) {
-            this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
-            toolState.addMediaFiles([pdfFile]);
+          if (compiled) {
+            const pdfFile = path.join(
+              buildDir,
+              path.basename(file).replace(/\.tex$/, '.pdf'),
+            );
+            if (await WorkspaceFS.exists(pdfFile)) {
+              this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
+              return pdfFile;
+            }
           }
+          return undefined;
+        }),
+      );
+      compileResults.forEach((result) => {
+        if (result.status === 'fulfilled' && result.value) {
+          toolState.addMediaFiles([result.value]);
         }
-      }
+      });
     }
   }
 
@@ -105,45 +153,73 @@ export class LatexMediaManager {
     supportsVision: boolean,
     groupId?: string,
   ): Promise<void> {
-    if (cfg.attachTeXCount) {
-      toolState.texcountStats = await getTeXCountStats(outputFiles);
+    if (!outputFiles || outputFiles.length === 0) {
+      return;
     }
 
+    const existingFilesInfo = await Promise.all(
+      outputFiles.map(async (file) => ({
+        file,
+        exists: await WorkspaceFS.exists(file),
+      })),
+    );
+    const existingFiles = existingFilesInfo
+      .filter((f) => f.exists)
+      .map((f) => f.file);
+
+    if (existingFiles.length === 0) {
+      return;
+    }
+
+    await this.attachTeXCount(existingFiles, toolState, cfg);
+
     if (supportsVision && cfg.autoExtractTikzFigure) {
-      for (const outputFile of outputFiles) {
-        const tikzFigures = await tikzPictureManager.compile(outputFile);
-        if (tikzFigures && tikzFigures.length > 0) {
-          toolState.addMediaFiles(tikzFigures);
+      const tikzResults = await Promise.allSettled(
+        existingFiles.map((file) => tikzPictureManager.compile(file)),
+      );
+      tikzResults.forEach((result) => {
+        if (
+          result.status === 'fulfilled' &&
+          result.value &&
+          result.value.length > 0
+        ) {
+          toolState.addMediaFiles(result.value);
         }
-      }
+      });
     }
 
     if (supportsVision && cfg.autoCompileInputPdf) {
-      for (const outputFile of outputFiles) {
-        if (!outputFile.toLowerCase().endsWith('.tex')) {
-          continue;
-        }
-        const buildDir = path.join(path.dirname(outputFile), 'build');
-        const compiled = await compileLatex2Pdf(
-          outputFile,
-          undefined,
-          buildDir,
-          true,
-        );
-        if (compiled) {
-          const pdfFile = path.join(
+      const texFiles = existingFiles.filter((file) =>
+        file.toLowerCase().endsWith('.tex'),
+      );
+      const compileResults = await Promise.allSettled(
+        texFiles.map(async (file) => {
+          const buildDir = path.join(path.dirname(file), 'build');
+          await WorkspaceFS.ensureDir(buildDir);
+          const compiled = await compileLatex2Pdf(
+            file,
+            undefined,
             buildDir,
-            path.basename(outputFile).replace(/\.tex$/, '.pdf'),
+            true,
           );
-          if (await WorkspaceFS.exists(pdfFile)) {
-            this.logger.info(
-              `Compiled PDF for ${outputFile}: ${pdfFile}`,
-              groupId,
+          if (compiled) {
+            const pdfFile = path.join(
+              buildDir,
+              path.basename(file).replace(/\.tex$/, '.pdf'),
             );
-            toolState.addMediaFiles([pdfFile]);
+            if (await WorkspaceFS.exists(pdfFile)) {
+              this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
+              return pdfFile;
+            }
           }
+          return undefined;
+        }),
+      );
+      compileResults.forEach((result) => {
+        if (result.status === 'fulfilled' && result.value) {
+          toolState.addMediaFiles([result.value]);
         }
-      }
+      });
     }
   }
 }

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -21,3 +21,6 @@ export { getTeXCountStats } from './texcount';
 export { LaTeXdiffService } from './latexdiff';
 
 export { ArxivSourceProcessor, arxivProcessor } from './arxivProcessor';
+
+// Export media manager
+export { LatexMediaManager } from './LatexMediaManager';


### PR DESCRIPTION
## Summary
- add `LatexMediaManager` for TikZ extraction, figure detection and PDF compilation
- use `LatexMediaManager` from `BaseReflectionAgent`
- update `OutputHandler` docs
- export manager from latex index

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warnings but test command executes)*

------
https://chatgpt.com/codex/tasks/task_e_685f0b675f108324bf9d8d7b77202bae