### PR TITLE
feat: add file loading status panel

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -63,3 +63,7 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.
 
 At the bottom of the tab list, there is a "Delete All" button (<i class="codicon codicon-close-all"></i>) that allows you to clear all streams and their associated logs from the ProgressBoard view.
+
+### File Loading Status
+
+Below the log output the **File Loading Status** panel summarizes which required files were found and which are missing. It also lists any figures extracted from your documents. Expand the sections to see individual paths.

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -20,6 +20,7 @@ import { getConfig } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type { IModelHandler } from './types/IModelHandler';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 // Local imports - agent components
 import { AgentConfig } from '../core/AgentConfig';
@@ -508,6 +509,10 @@ export abstract class ModelHandler implements IModelHandler {
           getPastedImageDisplayName(m),
         );
         this.logger.info(`Added: ${simplifiedMedia}`);
+        emitProgress('updateInputStatus', {
+          stream: this.logger.channelId,
+          status: { figures: simplifiedMedia },
+        });
       }
     }
 

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -14,6 +14,8 @@ import {
 import { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting } from '../core/AgentDataclass';
 import type { IModelHandler } from '@agent/modelHandlers';
+import type { InputStatus, RequiredFileStatus } from '../../types/InputStatus';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 /**
  * Build all user variables needed for prompt rendering.
@@ -26,18 +28,23 @@ export async function buildUserVars(
   logger: AgentLogger,
 ): Promise<Record<string, any>> {
   const userVars: Record<string, any> = {};
+  const inputStatus: InputStatus = { required: [], figures: [] };
   Object.assign(userVars, getBasicVars(agentConfig, modelHandler));
   Object.assign(userVars, await getFileVars(agentConfig));
-  Object.assign(
-    userVars,
-    await getRequiredFileVars(agentSetting, agentPath, logger),
-  );
+  const req = await getRequiredFileVars(agentSetting, agentPath, logger);
+  Object.assign(userVars, req.vars);
+  inputStatus.required.push(...req.status);
   Object.assign(
     userVars,
     await getPatternBasedFileVars(agentConfig, agentSetting, logger),
   );
   Object.assign(userVars, getOutputFilesOrder(agentConfig, agentSetting));
   Object.assign(userVars, getToolFlags(agentConfig, agentSetting));
+
+  emitProgress('updateInputStatus', {
+    stream: logger.channelId,
+    status: inputStatus,
+  });
   return userVars;
 }
 
@@ -123,21 +130,23 @@ async function getRequiredFileVars(
   agentSetting: AgentSetting,
   agentPath: string,
   logger: AgentLogger,
-): Promise<Record<string, any>> {
+): Promise<{ vars: Record<string, any>; status: RequiredFileStatus[] }> {
   const userVars: Record<string, any> = {};
+  const status: RequiredFileStatus[] = [];
 
   if (agentSetting.requiredFiles) {
     for (const [varName, filePath] of Object.entries(
       agentSetting.requiredFiles,
     )) {
       if (filePath) {
-        await setVarFromFile(
+        const found = await setVarFromFile(
           filePath,
           varName,
           userVars,
           logger,
           'requiredFiles',
         );
+        status.push({ path: filePath, varName, found });
       }
     }
   }
@@ -147,7 +156,7 @@ async function getRequiredFileVars(
       agentSetting.requiredFilesInternal,
     )) {
       const fullPath = path.join(agentPath, filePath);
-      await setVarFromFile(
+      const found = await setVarFromFile(
         fullPath,
         varName,
         userVars,
@@ -155,10 +164,11 @@ async function getRequiredFileVars(
         'requiredFilesInternal',
         true,
       );
+      status.push({ path: fullPath, varName, found });
     }
   }
 
-  return userVars;
+  return { vars: userVars, status };
 }
 
 async function getPatternBasedFileVars(

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -15,7 +15,8 @@ export type ProgressEvent =
   | 'setTaskState'
   | 'updateGroupUsage'
   | 'clearTaskOutput'
-  | 'updateStreamUsage';
+  | 'updateStreamUsage'
+  | 'updateInputStatus';
 
 class ProgressEventBus {
   private emitter = new EventEmitter();

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -13,6 +13,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup, LogMessageData } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
+import type { InputStatus } from '../types/InputStatus';
 
 interface OutputFileInfo extends DiffStats {
   path: string;
@@ -36,6 +37,7 @@ export class ProgressStateManager {
     new Map();
   private _taskStates: Map<string, TaskState> = new Map();
   private _usageStats: Map<string, TokenUsageStats> = new Map();
+  private _inputStatus: Map<string, InputStatus> = new Map();
   private _activeStream: string = '';
 
   constructor() {
@@ -61,6 +63,10 @@ export class ProgressStateManager {
 
   get usageStats(): Map<string, TokenUsageStats> {
     return this._usageStats;
+  }
+
+  get inputStatus(): Map<string, InputStatus> {
+    return this._inputStatus;
   }
 
   get activeStream(): string {
@@ -89,6 +95,7 @@ export class ProgressStateManager {
     this._loadActiveStream();
     await this._loadTaskStates();
     await this._loadUsageStats();
+    await this._loadInputStatus();
   }
 
   /**
@@ -101,6 +108,7 @@ export class ProgressStateManager {
     this._saveActiveStream();
     this._saveTaskStates();
     this._saveUsageStats();
+    this._saveInputStatus();
   }
 
   /**
@@ -341,6 +349,17 @@ export class ProgressStateManager {
     }
   }
 
+  private async _loadInputStatus(): Promise<void> {
+    const saved = workspaceSM.get<{ [key: string]: InputStatus }>(
+      this._getWorkspaceKey(WorkspaceStateKey.INPUT_STATUS),
+    );
+    if (saved) {
+      this._inputStatus = new Map(Object.entries(saved));
+    } else {
+      this._inputStatus.clear();
+    }
+  }
+
   /**
    * Save log streams to storage
    */
@@ -401,6 +420,14 @@ export class ProgressStateManager {
     workspaceSM.update(WorkspaceStateKey.USAGE_STATS, usageObj);
   }
 
+  private _saveInputStatus(): void {
+    const statusObj = Object.fromEntries(this._inputStatus.entries());
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.INPUT_STATUS),
+      statusObj,
+    );
+  }
+
   /**
    * Clear all state for a specific stream
    */
@@ -410,6 +437,7 @@ export class ProgressStateManager {
     this._outputFiles.delete(stream);
     this._taskStates.delete(stream);
     this._usageStats.delete(stream);
+    this._inputStatus.delete(stream);
   }
 
   /**
@@ -421,6 +449,7 @@ export class ProgressStateManager {
     this._outputFiles.clear();
     this._taskStates.clear();
     this._usageStats.clear();
+    this._inputStatus.clear();
     this._activeStream = '';
   }
 }

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -54,6 +54,7 @@ export class ProgressViewContentProvider {
       const toolbarUri = getWebviewUri('modules/uiManagers/Toolbar.js');
       const statusUri = getWebviewUri('modules/uiManagers/Status.js');
       const fileListUri = getWebviewUri('modules/uiManagers/FileList.js');
+      const inputStatusUri = getWebviewUri('modules/uiManagers/InputStatus.js');
       const eventsUri = getWebviewUri('modules/uiManagers/Events.js');
       const constantsUri = getWebviewUri('modules/constants.js');
       const katexMacrosUri = getWebviewUri('modules/katexMacros.js');
@@ -91,6 +92,7 @@ export class ProgressViewContentProvider {
         toolbarUri,
         statusUri,
         fileListUri,
+        inputStatusUri,
         eventsUri,
       });
     } catch (err) {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -14,6 +14,7 @@ import { getConfig } from '@utils/config';
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
+import type { InputStatus } from '../types/InputStatus';
 import { randomUUID } from 'crypto';
 import { onProgress } from '@eventBus/ProgressEventBus';
 
@@ -135,6 +136,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           'updateStreamUsage',
           (p: { stream: string; usage: TokenUsageStats }) =>
             this.updateStreamUsage(p.stream, p.usage),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'updateInputStatus',
+          (p: { stream: string; status: InputStatus }) =>
+            this.updateInputStatus(p.stream, p.status),
         ),
       ),
       new vscode.Disposable(
@@ -327,6 +335,15 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_USAGE,
       usage,
+    });
+
+    const inputStatus = this._stateManager.inputStatus.get(
+      this._stateManager.activeStream,
+    );
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_INPUT_STATUS,
+      stream: this._stateManager.activeStream,
+      status: inputStatus,
     });
 
     // Update status for current stream
@@ -566,6 +583,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       stream: stream,
       files,
     });
+
+    const inputStatus = this._stateManager.inputStatus.get(stream);
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_INPUT_STATUS,
+      stream,
+      status: inputStatus,
+    });
   }
 
   public getLogStreams(): Map<string, LogMessageData[]> {
@@ -682,6 +706,28 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._view.webview.postMessage({
         command: COMMANDS.UPDATE_USAGE,
         usage,
+      });
+    }
+  }
+
+  public updateInputStatus(stream: string, status: InputStatus): void {
+    const existing = this._stateManager.inputStatus.get(stream) || {
+      required: [],
+      figures: [],
+    };
+    const merged = {
+      required: status.required ?? existing.required,
+      figures: Array.from(
+        new Set([...(existing.figures || []), ...(status.figures || [])]),
+      ),
+    };
+    this._stateManager.inputStatus.set(stream, merged);
+    this._stateManager.saveState();
+    if (this._view && stream === this._stateManager.activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_INPUT_STATUS,
+        stream,
+        status: merged,
       });
     }
   }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -35,6 +35,7 @@
           "./modules/uiManagers/Toolbar.js": "${toolbarUri}",
           "./modules/uiManagers/Status.js": "${statusUri}",
           "./modules/uiManagers/FileList.js": "${fileListUri}",
+          "./modules/uiManagers/InputStatus.js": "${inputStatusUri}",
           "./modules/uiManagers/Events.js": "${eventsUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
@@ -67,6 +68,7 @@
           <div id="toolbarContainer" class="header-actions button-group"></div>
         </div>
         <div id="logContent" class="log-container"></div>
+        <div id="inputStatus" class="input-status"></div>
         <div id="generatedFiles" class="files-container"></div>
         <template id="fileItemTemplate">
           <div class="file-item">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -38,6 +38,7 @@ export const COMMANDS = {
   UPDATE_FILES: 'updateFiles',
   UPDATE_USAGE: 'updateUsage',
   UPDATE_GROUP_USAGE: 'updateGroupUsage',
+  UPDATE_INPUT_STATUS: 'updateInputStatus',
   OPEN_FILE: 'openFile',
   COMPARE_ORIGINAL: 'compareOriginal',
   COMPARE_PREVIOUS: 'comparePrevious',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -7,6 +7,7 @@ import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { Status } from './uiManagers/Status.js';
 import { FileList } from './uiManagers/FileList.js';
+import { InputStatus } from './uiManagers/InputStatus.js';
 import { Events } from './uiManagers/Events.js';
 
 /**
@@ -21,6 +22,7 @@ export class ProgressViewDomHandler {
     this.usageSummary = new UsageSummary();
     this.usageGroup = new UsageGroup(this.usageSummary); // Pass shared instance
     this.fileList = new FileList(this.usageSummary); // Pass shared instance
+    this.inputStatus = new InputStatus();
     this.taskGroups = new TaskGroupsDom();
     this.logEntries = new LogEntriesDom();
     this.events = new Events();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -123,6 +123,12 @@ const handlers = {
     }
   },
 
+  [COMMANDS.UPDATE_INPUT_STATUS]: (message) => {
+    if (message.stream === state.getCurrentStream()) {
+      dom.inputStatus.update(message.status);
+    }
+  },
+
   [COMMANDS.UPDATE_FILES]: (message) => {
     if (message.stream === state.getCurrentStream()) {
       dom.fileList.update(message.files);

--- a/src/progressView/modules/uiManagers/InputStatus.js
+++ b/src/progressView/modules/uiManagers/InputStatus.js
@@ -1,0 +1,66 @@
+export class InputStatus {
+  update(status) {
+    const container = document.getElementById('inputStatus');
+    if (!container) return;
+    container.innerHTML = '';
+    if (!status) return;
+
+    const required = Array.isArray(status.required) ? status.required : [];
+    const figures = Array.isArray(status.figures) ? status.figures : [];
+
+    const found = required.filter((r) => r.found);
+    const missing = required.filter((r) => !r.found);
+
+    const summary = document.createElement('div');
+    summary.className = 'input-summary';
+    summary.innerHTML = `
+      <span class="input-label"><i class="codicon codicon-folder"></i> File Loading Status</span>
+      <span class="input-counts">
+        <span class="success-count">${found.length} found</span>
+        <span class="missing-count">${missing.length} missing</span>
+      </span>`;
+    container.appendChild(summary);
+
+    if (missing.length > 0) {
+      const det = document.createElement('details');
+      det.className = 'special-details';
+      det.open = true;
+      det.innerHTML = `
+        <summary><i class="codicon codicon-chevron-down toggle-icon"></i> Missing Files (${missing.length})</summary>
+        <ul class="special-content file-status-list"></ul>`;
+      const list = det.querySelector('ul');
+      missing.forEach((m) => {
+        const li = document.createElement('li');
+        li.textContent = `${m.path} (${m.varName})`;
+        list.appendChild(li);
+      });
+      container.appendChild(det);
+    }
+
+    if (found.length > 0) {
+      const det = document.createElement('details');
+      det.className = 'special-details';
+      det.innerHTML = `
+        <summary><i class="codicon codicon-chevron-right toggle-icon"></i> Found Files (${found.length})</summary>
+        <ul class="special-content file-status-list"></ul>`;
+      const list = det.querySelector('ul');
+      found.forEach((f) => {
+        const li = document.createElement('li');
+        li.textContent = `${f.path} (${f.varName})`;
+        list.appendChild(li);
+      });
+      container.appendChild(det);
+    }
+
+    if (figures.length > 0) {
+      const det = document.createElement('details');
+      det.className = 'special-details';
+      det.innerHTML = `
+        <summary><i class="codicon codicon-chevron-right toggle-icon"></i> Added Figures (${figures.length})</summary>
+        <div class="special-content figure-list"></div>`;
+      const div = det.querySelector('.figure-list');
+      div.textContent = figures.join(', ');
+      container.appendChild(det);
+    }
+  }
+}

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -15,3 +15,4 @@
 @import './logs.css';
 @import './groups.css';
 @import './scratchpad.css';
+@import './inputStatus.css';

--- a/src/progressView/styles/inputStatus.css
+++ b/src/progressView/styles/inputStatus.css
@@ -1,0 +1,20 @@
+.input-status {
+  padding: var(--spacing-small);
+  border-top: 1px solid var(--vscode-panel-border);
+  font-size: var(--vscode-editor-font-size);
+}
+
+.input-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-small);
+}
+
+.input-summary .input-label {
+  font-weight: 600;
+}
+
+.input-summary .input-counts {
+  opacity: var(--opacity-subtle);
+}

--- a/src/types/InputStatus.ts
+++ b/src/types/InputStatus.ts
@@ -1,0 +1,10 @@
+export interface RequiredFileStatus {
+  path: string;
+  varName: string;
+  found: boolean;
+}
+
+export interface InputStatus {
+  required: RequiredFileStatus[];
+  figures: string[];
+}

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -10,6 +10,7 @@ export enum WorkspaceStateKey {
   ACTIVE_LOG_STREAM = 'texra.activeLogStream',
   TASK_STATES = 'texra.taskStates',
   USAGE_STATS = 'texra.usageStats',
+  INPUT_STATUS = 'texra.inputStatus',
 }
 
 export enum GlobalStateKey {


### PR DESCRIPTION
## Summary
- introduce `InputStatus` types and event bus message
- collect file loading info and figures for tasks
- render summary via new InputStatus UI component
- persist input status in progress state and expose to webview
- document File Loading Status panel

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb525868083249192841846691c2c