### PR TITLE
Add missing-output warnings to ProgressBoard

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -63,3 +63,7 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.
 
 At the bottom of the tab list, there is a "Delete All" button (<i class="codicon codicon-close-all"></i>) that allows you to clear all streams and their associated logs from the ProgressBoard view.
+
+### Generated Files
+
+Below the log output, each round shows the files produced by the agent. If an expected file was not created, a warning appears for that round with a button to open the corresponding XML source. Inspect the XML to fix tag issues and re-run the agent.

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -263,7 +263,12 @@ async function executeAgentWithLogging<T extends IAgent>(
             mainTaskGroupId,
           );
           await agent.run();
-          await checkExpectedOutputs(config.outputFiles, context, agent);
+          await checkExpectedOutputs(
+            config.outputFiles,
+            context,
+            agent,
+            fullStreamId,
+          );
           // Mark the task as completed successfully
           logger.debug(`Task completed successfully`, mainTaskGroupId);
           logger.endGroup(mainTaskGroupId, 'stopped');

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -11,6 +11,7 @@ export type ProgressEvent =
   | 'setActiveStream'
   | 'updateStreamStatus'
   | 'addOutputFiles'
+  | 'addMissingOutput'
   | 'clearOutputFiles'
   | 'setTaskState'
   | 'updateGroupUsage'

--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 // Local imports
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { INSTRUCTION_PREFIX, globalSM } from '@utils/stateManager';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 /**
  * Show an instruction message that can be permanently dismissed.
@@ -51,11 +52,13 @@ export async function checkExpectedOutputs(
   expectedFiles: string[] | null | undefined,
   context: vscode.ExtensionContext,
   agent?: unknown,
+  streamId?: string,
 ): Promise<void> {
   if (!expectedFiles || expectedFiles.length === 0) {
     return;
   }
 
+  let shown = false;
   for (const file of expectedFiles) {
     const exists = path.isAbsolute(file)
       ? await AbsoluteFS.exists(file)
@@ -89,40 +92,48 @@ export async function checkExpectedOutputs(
         xmlPath = file.replace(/\.[^.]+$/, '.xml');
       }
 
-      await showInstructionWithSuppress(
-        'xmlOutputMismatch',
-        `Expected output "${path.basename(
-          file,
-        )}" was not generated. Open the XML file to check tag consistency, then run again.`,
-        [
-          {
-            title: openBtn,
-            callback: async () => {
-              if (!xmlPath) {
-                vscode.window.showWarningMessage('XML file path not found');
-                return;
-              }
+      if (streamId && xmlPath) {
+        const match = /_r(\d+)/.exec(file) || /_r(\d+)/.exec(xmlPath);
+        const round = match ? parseInt(match[1], 10) : 0;
+        emitProgress('addMissingOutput', { stream: streamId, round, xmlPath });
+      }
 
-              const xmlExists = path.isAbsolute(xmlPath)
-                ? await AbsoluteFS.exists(xmlPath)
-                : await WorkspaceFS.exists(xmlPath);
-              if (!xmlExists) {
-                vscode.window.showWarningMessage(
-                  `XML file not found: ${path.basename(xmlPath)}`,
-                );
-                return;
-              }
-              const uri = path.isAbsolute(xmlPath)
-                ? vscode.Uri.file(xmlPath)
-                : vscode.Uri.file(WorkspaceFS.fullPath(xmlPath));
-              const doc = await vscode.workspace.openTextDocument(uri);
-              await vscode.window.showTextDocument(doc, { preview: false });
+      if (!shown) {
+        await showInstructionWithSuppress(
+          'xmlOutputMismatch',
+          `Expected output "${path.basename(
+            file,
+          )}" was not generated. Open the XML file to check tag consistency, then run again.`,
+          [
+            {
+              title: openBtn,
+              callback: async () => {
+                if (!xmlPath) {
+                  vscode.window.showWarningMessage('XML file path not found');
+                  return;
+                }
+
+                const xmlExists = path.isAbsolute(xmlPath)
+                  ? await AbsoluteFS.exists(xmlPath)
+                  : await WorkspaceFS.exists(xmlPath);
+                if (!xmlExists) {
+                  vscode.window.showWarningMessage(
+                    `XML file not found: ${path.basename(xmlPath)}`,
+                  );
+                  return;
+                }
+                const uri = path.isAbsolute(xmlPath)
+                  ? vscode.Uri.file(xmlPath)
+                  : vscode.Uri.file(WorkspaceFS.fullPath(xmlPath));
+                const doc = await vscode.workspace.openTextDocument(uri);
+                await vscode.window.showTextDocument(doc, { preview: false });
+              },
             },
-          },
-        ],
-        false,
-      );
-      break;
+          ],
+          false,
+        );
+        shown = true;
+      }
     }
   }
 }

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -34,6 +34,7 @@ export class ProgressStateManager {
   private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
+  private _missingOutputs: Map<string, Map<number, string>> = new Map();
   private _taskStates: Map<string, TaskState> = new Map();
   private _usageStats: Map<string, TokenUsageStats> = new Map();
   private _activeStream: string = '';
@@ -53,6 +54,10 @@ export class ProgressStateManager {
 
   get outputFiles(): Map<string, { [key: number]: OutputFileInfo[] }> {
     return this._outputFiles;
+  }
+
+  get missingOutputs(): Map<string, Map<number, string>> {
+    return this._missingOutputs;
   }
 
   get taskStates(): Map<string, TaskState> {
@@ -86,6 +91,7 @@ export class ProgressStateManager {
     await this._loadLogStreams();
     await this._loadTaskGroups();
     await this._loadOutputFiles();
+    await this._loadMissingOutputs();
     this._loadActiveStream();
     await this._loadTaskStates();
     await this._loadUsageStats();
@@ -98,6 +104,7 @@ export class ProgressStateManager {
     this._saveLogStreams();
     this._saveTaskGroups();
     this._saveOutputFiles();
+    this._saveMissingOutputs();
     this._saveActiveStream();
     this._saveTaskStates();
     this._saveUsageStats();
@@ -279,6 +286,31 @@ export class ProgressStateManager {
   }
 
   /**
+   * Load missing outputs from storage
+   */
+  private async _loadMissingOutputs(): Promise<void> {
+    const savedMissing = workspaceSM.get<{
+      [key: string]: { [key: number]: string };
+    }>(this._getWorkspaceKey(WorkspaceStateKey.MISSING_OUTPUTS));
+
+    if (savedMissing) {
+      this._missingOutputs = new Map(
+        Object.entries(savedMissing).map(([streamId, rounds]) => [
+          streamId,
+          new Map(
+            Object.entries(rounds).map(([roundStr, xml]) => [
+              parseInt(roundStr, 10),
+              xml,
+            ]),
+          ),
+        ]),
+      );
+    } else {
+      this._missingOutputs.clear();
+    }
+  }
+
+  /**
    * Load active stream
    */
   private _loadActiveStream(): void {
@@ -379,6 +411,20 @@ export class ProgressStateManager {
   }
 
   /**
+   * Save missing outputs to storage
+   */
+  private _saveMissingOutputs(): void {
+    const missingObj: Record<string, Record<number, string>> = {};
+    for (const [stream, rounds] of this._missingOutputs.entries()) {
+      missingObj[stream] = Object.fromEntries(rounds.entries());
+    }
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.MISSING_OUTPUTS),
+      missingObj,
+    );
+  }
+
+  /**
    * Save active stream
    */
   private _saveActiveStream(): void {
@@ -408,6 +454,7 @@ export class ProgressStateManager {
     this._logStreams.delete(stream);
     this._taskGroups.delete(stream);
     this._outputFiles.delete(stream);
+    this._missingOutputs.delete(stream);
     this._taskStates.delete(stream);
     this._usageStats.delete(stream);
   }
@@ -419,6 +466,7 @@ export class ProgressStateManager {
     this._logStreams.clear();
     this._taskGroups.clear();
     this._outputFiles.clear();
+    this._missingOutputs.clear();
     this._taskStates.clear();
     this._usageStats.clear();
     this._activeStream = '';

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -107,6 +107,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         ),
       ),
       new vscode.Disposable(
+        onProgress(
+          'addMissingOutput',
+          (p: { stream: string; round: number; xmlPath: string }) =>
+            this.addMissingOutput(p.stream, p.round, p.xmlPath),
+        ),
+      ),
+      new vscode.Disposable(
         onProgress('clearOutputFiles', (stream: string) =>
           this.clearOutputFiles(stream),
         ),
@@ -319,6 +326,15 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       command: COMMANDS.UPDATE_FILES,
       stream: this._stateManager.activeStream,
       files,
+    });
+
+    const missing =
+      this._stateManager.missingOutputs.get(this._stateManager.activeStream) ||
+      new Map();
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_MISSING_OUTPUTS,
+      stream: this._stateManager.activeStream,
+      missing: Object.fromEntries(missing.entries()),
     });
 
     const usage = this._stateManager.usageStats.get(
@@ -566,6 +582,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       stream: stream,
       files,
     });
+
+    const missing = this._stateManager.missingOutputs.get(stream) || new Map();
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_MISSING_OUTPUTS,
+      stream,
+      missing: Object.fromEntries(missing.entries()),
+    });
   }
 
   public getLogStreams(): Map<string, LogMessageData[]> {
@@ -655,21 +678,49 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  public addMissingOutput(
+    stream: string,
+    round: number,
+    xmlPath: string,
+  ): void {
+    const existing = this._stateManager.missingOutputs.get(stream) || new Map();
+    existing.set(round, xmlPath);
+    this._stateManager.missingOutputs.set(stream, existing);
+    this._stateManager.saveState();
+    if (this._view && stream === this._stateManager.activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_MISSING_OUTPUTS,
+        stream,
+        missing: Object.fromEntries(existing.entries()),
+      });
+    }
+  }
+
   public getOutputFiles(
     stream: string,
   ): { [key: number]: OutputFileInfo[] } | undefined {
     return this._stateManager.outputFiles.get(stream);
   }
 
+  public getMissingOutputs(stream: string): Map<number, string> | undefined {
+    return this._stateManager.missingOutputs.get(stream);
+  }
+
   public clearOutputFiles(stream: string): void {
     if (this._stateManager.outputFiles.has(stream)) {
       this._stateManager.outputFiles.delete(stream);
+      this._stateManager.missingOutputs.delete(stream);
       this._stateManager.saveState();
       if (this._view && stream === this._stateManager.activeStream) {
         this._view.webview.postMessage({
           command: COMMANDS.UPDATE_FILES,
           stream,
           files: {},
+        });
+        this._view.webview.postMessage({
+          command: COMMANDS.UPDATE_MISSING_OUTPUTS,
+          stream,
+          missing: {},
         });
       }
     }

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -36,6 +36,7 @@ export const COMMANDS = {
   UPDATE_LOG_GROUP: 'updateLogGroup',
   UPDATE_STATUS: 'updateStatus',
   UPDATE_FILES: 'updateFiles',
+  UPDATE_MISSING_OUTPUTS: 'updateMissingOutputs',
   UPDATE_USAGE: 'updateUsage',
   UPDATE_GROUP_USAGE: 'updateGroupUsage',
   OPEN_FILE: 'openFile',

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -129,6 +129,12 @@ const handlers = {
     }
   },
 
+  [COMMANDS.UPDATE_MISSING_OUTPUTS]: (message) => {
+    if (message.stream === state.getCurrentStream()) {
+      dom.fileList.updateMissingOutputs(message.missing);
+    }
+  },
+
   [COMMANDS.DELETE_STREAM]: (message) => {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -9,6 +9,8 @@ import { vscode } from '@common/webviewContext.js';
 export class FileList {
   constructor(usageSummary = null) {
     this.usageSummary = usageSummary;
+    this.missingOutputs = {};
+    this.currentFiles = {};
   }
   /**
    * Get the effective base file for comparison operations.
@@ -36,6 +38,7 @@ export class FileList {
    * @param {Object} filesByRound - Files organized by round
    */
   update(filesByRound) {
+    this.currentFiles = filesByRound || {};
     const container = document.getElementById('generatedFiles');
     if (!container) return;
 
@@ -92,6 +95,24 @@ export class FileList {
       roundHeader.className = 'round-header';
       roundHeader.textContent = `r${round}`;
       roundGroup.appendChild(roundHeader);
+
+      const missingPath = this.missingOutputs[round];
+      if (missingPath) {
+        const warn = document.createElement('div');
+        warn.className = 'missing-output-warning';
+        warn.innerHTML = `<i class="codicon codicon-warning"></i> Missing output`;
+        const btn = document.createElement('button');
+        btn.className = 'vscode-button';
+        btn.textContent = 'Open XML';
+        btn.onclick = () => {
+          vscode.postMessage({
+            command: COMMANDS.OPEN_FILE,
+            file: missingPath,
+          });
+        };
+        warn.appendChild(btn);
+        roundGroup.appendChild(warn);
+      }
 
       files.forEach((file) => {
         // Skip invalid file entries
@@ -252,5 +273,14 @@ export class FileList {
         });
       };
     }
+  }
+
+  /**
+   * Update missing output mapping and refresh list
+   * @param {Object} missingByRound
+   */
+  updateMissingOutputs(missingByRound) {
+    this.missingOutputs = missingByRound || {};
+    this.update(this.currentFiles);
   }
 }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -311,3 +311,20 @@
     margin-left: auto;
   }
 }
+
+/* Warning for missing outputs */
+.missing-output-warning {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) var(--spacing-small);
+  margin-bottom: var(--spacing-small);
+  color: var(--vscode-inputValidation-warningForeground, #cca700);
+  background-color: var(
+    --vscode-inputValidation-warningBackground,
+    transparent
+  );
+  border: 1px solid var(--vscode-inputValidation-warningBorder, transparent);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
+}

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -7,6 +7,7 @@ export enum WorkspaceStateKey {
   LOG_STREAMS = 'texra.logStreams',
   TASK_GROUPS = 'texra.taskGroups',
   OUTPUT_FILES = 'texra.outputFiles',
+  MISSING_OUTPUTS = 'texra.missingOutputs',
   ACTIVE_LOG_STREAM = 'texra.activeLogStream',
   TASK_STATES = 'texra.taskStates',
   USAGE_STATS = 'texra.usageStats',


### PR DESCRIPTION
## Summary
- track missing output files in `ProgressStateManager`
- allow frontend to report missing outputs per round
- forward missing-output data through provider and webview handlers
- display warnings in file list with button to open XML
- document new warning in progress board guide

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning and exit)*

------
https://chatgpt.com/codex/tasks/task_e_685fbc2f7ce48324835fefe49ca538e7