### PR TITLE
feat: add input status tracking

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -63,3 +63,9 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.
 
 At the bottom of the tab list, there is a "Delete All" button (<i class="codicon codicon-close-all"></i>) that allows you to clear all streams and their associated logs from the ProgressBoard view.
+
+### File Loading Status
+
+Below the log output, a **File Loading Status** section summarizes which required files and figures were successfully loaded for the active stream. Missing files are listed separately so you can quickly spot configuration problems. File names are clickable and open the file in VS Code.
+
+![File Loading Status](/images/progress-board-layout.png)

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -33,6 +33,8 @@ import {
 import type { ToolDefinition } from '@model';
 import { ToolState } from '../core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
+import { emitProgress } from '@eventBus/ProgressEventBus';
+import type { InputStatus } from '@types/InputStatus';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;
@@ -512,6 +514,17 @@ export abstract class ModelHandler<U = any, R = any>
         );
         this.logger.info(`Added: ${simplifiedMedia}`);
       }
+    }
+
+    if (addedMedia.length > 0) {
+      const status: InputStatus = {
+        required: [],
+        figures: addedMedia.map((p) => ({ path: p })),
+      };
+      emitProgress('updateInputStatus', {
+        stream: this.logger.channelId,
+        status,
+      });
     }
 
     return this.createMediaContent(mediaMessage);

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -34,7 +34,7 @@ import type { ToolDefinition } from '@model';
 import { ToolState } from '../core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { emitProgress } from '@eventBus/ProgressEventBus';
-import type { InputStatus } from '@types/InputStatus';
+import type { InputStatus } from '@/types/InputStatus';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -7,6 +7,8 @@ import * as path from 'path';
 import { AgentLogger } from '@logger/AgentLogger';
 import { WorkspaceFS } from '@utils/files';
 import { setVarFromFile } from '@frontend/files/vars';
+import { emitProgress } from '@eventBus/ProgressEventBus';
+import type { InputStatus, RequiredFileStatus } from '@types/InputStatus';
 import {
   getXmlFormatFromFiles,
   getListOfFiles,
@@ -28,10 +30,10 @@ export async function buildUserVars(
   const userVars: Record<string, any> = {};
   Object.assign(userVars, getBasicVars(agentConfig, modelHandler));
   Object.assign(userVars, await getFileVars(agentConfig));
-  Object.assign(
-    userVars,
-    await getRequiredFileVars(agentSetting, agentPath, logger),
-  );
+  const req = await getRequiredFileVars(agentSetting, agentPath, logger);
+  Object.assign(userVars, req.userVars);
+  const status: InputStatus = { required: req.status, figures: [] };
+  emitProgress('updateInputStatus', { stream: logger.channelId, status });
   Object.assign(
     userVars,
     await getPatternBasedFileVars(agentConfig, agentSetting, logger),
@@ -123,21 +125,23 @@ async function getRequiredFileVars(
   agentSetting: AgentSetting,
   agentPath: string,
   logger: AgentLogger,
-): Promise<Record<string, any>> {
+): Promise<{ userVars: Record<string, any>; status: RequiredFileStatus[] }> {
   const userVars: Record<string, any> = {};
+  const status: RequiredFileStatus[] = [];
 
   if (agentSetting.requiredFiles) {
     for (const [varName, filePath] of Object.entries(
       agentSetting.requiredFiles,
     )) {
       if (filePath) {
-        await setVarFromFile(
+        const found = await setVarFromFile(
           filePath,
           varName,
           userVars,
           logger,
           'requiredFiles',
         );
+        status.push({ path: filePath, varName, found });
       }
     }
   }
@@ -147,7 +151,7 @@ async function getRequiredFileVars(
       agentSetting.requiredFilesInternal,
     )) {
       const fullPath = path.join(agentPath, filePath);
-      await setVarFromFile(
+      const found = await setVarFromFile(
         fullPath,
         varName,
         userVars,
@@ -155,10 +159,11 @@ async function getRequiredFileVars(
         'requiredFilesInternal',
         true,
       );
+      status.push({ path: fullPath, varName, found });
     }
   }
 
-  return userVars;
+  return { userVars, status };
 }
 
 async function getPatternBasedFileVars(

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -8,7 +8,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { WorkspaceFS } from '@utils/files';
 import { setVarFromFile } from '@frontend/files/vars';
 import { emitProgress } from '@eventBus/ProgressEventBus';
-import type { InputStatus, RequiredFileStatus } from '@types/InputStatus';
+import type { InputStatus, RequiredFileStatus } from '@/types/InputStatus';
 import {
   getXmlFormatFromFiles,
   getListOfFiles,

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -15,7 +15,8 @@ export type ProgressEvent =
   | 'setTaskState'
   | 'updateGroupUsage'
   | 'clearTaskOutput'
-  | 'updateStreamUsage';
+  | 'updateStreamUsage'
+  | 'updateInputStatus';
 
 class ProgressEventBus {
   private emitter = new EventEmitter();

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -13,6 +13,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup, LogMessageData } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
+import type { InputStatus } from '../types/InputStatus';
 
 interface OutputFileInfo extends DiffStats {
   path: string;
@@ -36,6 +37,7 @@ export class ProgressStateManager {
     new Map();
   private _taskStates: Map<string, TaskState> = new Map();
   private _usageStats: Map<string, TokenUsageStats> = new Map();
+  private _inputStatus: Map<string, InputStatus> = new Map();
   private _activeStream: string = '';
 
   constructor() {
@@ -61,6 +63,10 @@ export class ProgressStateManager {
 
   get usageStats(): Map<string, TokenUsageStats> {
     return this._usageStats;
+  }
+
+  get inputStatus(): Map<string, InputStatus> {
+    return this._inputStatus;
   }
 
   get activeStream(): string {
@@ -89,6 +95,7 @@ export class ProgressStateManager {
     this._loadActiveStream();
     await this._loadTaskStates();
     await this._loadUsageStats();
+    await this._loadInputStatus();
   }
 
   /**
@@ -101,6 +108,7 @@ export class ProgressStateManager {
     this._saveActiveStream();
     this._saveTaskStates();
     this._saveUsageStats();
+    this._saveInputStatus();
   }
 
   /**
@@ -342,6 +350,20 @@ export class ProgressStateManager {
   }
 
   /**
+   * Load input status data
+   */
+  private async _loadInputStatus(): Promise<void> {
+    const saved = workspaceSM.get<{ [key: string]: InputStatus }>(
+      this._getWorkspaceKey(WorkspaceStateKey.INPUT_STATUS),
+    );
+    if (saved) {
+      this._inputStatus = new Map(Object.entries(saved));
+    } else {
+      this._inputStatus.clear();
+    }
+  }
+
+  /**
    * Save log streams to storage
    */
   private _saveLogStreams(): void {
@@ -401,6 +423,15 @@ export class ProgressStateManager {
     workspaceSM.update(WorkspaceStateKey.USAGE_STATS, usageObj);
   }
 
+  /** Save input status information */
+  private _saveInputStatus(): void {
+    const statusObj = Object.fromEntries(this._inputStatus.entries());
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.INPUT_STATUS),
+      statusObj,
+    );
+  }
+
   /**
    * Clear all state for a specific stream
    */
@@ -410,6 +441,7 @@ export class ProgressStateManager {
     this._outputFiles.delete(stream);
     this._taskStates.delete(stream);
     this._usageStats.delete(stream);
+    this._inputStatus.delete(stream);
   }
 
   /**
@@ -421,6 +453,7 @@ export class ProgressStateManager {
     this._outputFiles.clear();
     this._taskStates.clear();
     this._usageStats.clear();
+    this._inputStatus.clear();
     this._activeStream = '';
   }
 }

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -54,6 +54,7 @@ export class ProgressViewContentProvider {
       const toolbarUri = getWebviewUri('modules/uiManagers/Toolbar.js');
       const statusUri = getWebviewUri('modules/uiManagers/Status.js');
       const fileListUri = getWebviewUri('modules/uiManagers/FileList.js');
+      const inputStatusUri = getWebviewUri('modules/uiManagers/InputStatus.js');
       const eventsUri = getWebviewUri('modules/uiManagers/Events.js');
       const constantsUri = getWebviewUri('modules/constants.js');
       const katexMacrosUri = getWebviewUri('modules/katexMacros.js');
@@ -91,6 +92,7 @@ export class ProgressViewContentProvider {
         toolbarUri,
         statusUri,
         fileListUri,
+        inputStatusUri,
         eventsUri,
       });
     } catch (err) {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -14,6 +14,7 @@ import { getConfig } from '@utils/config';
 import { TokenUsageStats } from '../types/UsageTypes';
 import { TaskGroup } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
+import type { InputStatus } from '../types/InputStatus';
 import { randomUUID } from 'crypto';
 import { onProgress } from '@eventBus/ProgressEventBus';
 
@@ -135,6 +136,15 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           'updateStreamUsage',
           (p: { stream: string; usage: TokenUsageStats }) =>
             this.updateStreamUsage(p.stream, p.usage),
+        ),
+      ),
+      new vscode.Disposable(
+        onProgress(
+          'updateInputStatus',
+          (p: {
+            stream: string;
+            status: import('../types/InputStatus').InputStatus;
+          }) => this.updateInputStatus(p.stream, p.status),
         ),
       ),
       new vscode.Disposable(
@@ -319,6 +329,15 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       command: COMMANDS.UPDATE_FILES,
       stream: this._stateManager.activeStream,
       files,
+    });
+
+    const inputStatus = this._stateManager.inputStatus.get(
+      this._stateManager.activeStream,
+    );
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_INPUT_STATUS,
+      stream: this._stateManager.activeStream,
+      status: inputStatus,
     });
 
     const usage = this._stateManager.usageStats.get(
@@ -708,6 +727,28 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           });
         }
       }
+    }
+  }
+
+  public updateInputStatus(stream: string, status: InputStatus): void {
+    const existing = this._stateManager.inputStatus.get(stream) || {
+      required: [],
+      figures: [],
+    };
+    const merged = {
+      required: status.required?.length ? status.required : existing.required,
+      figures: status.figures?.length
+        ? [...existing.figures, ...status.figures]
+        : existing.figures,
+    };
+    this._stateManager.inputStatus.set(stream, merged);
+    this._stateManager.saveState();
+    if (this._view && stream === this._stateManager.activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_INPUT_STATUS,
+        stream,
+        status: merged,
+      });
     }
   }
 

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -35,6 +35,7 @@
           "./modules/uiManagers/Toolbar.js": "${toolbarUri}",
           "./modules/uiManagers/Status.js": "${statusUri}",
           "./modules/uiManagers/FileList.js": "${fileListUri}",
+          "./modules/uiManagers/InputStatus.js": "${inputStatusUri}",
           "./modules/uiManagers/Events.js": "${eventsUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
@@ -67,6 +68,7 @@
           <div id="toolbarContainer" class="header-actions button-group"></div>
         </div>
         <div id="logContent" class="log-container"></div>
+        <div id="inputStatus" class="files-container"></div>
         <div id="generatedFiles" class="files-container"></div>
         <template id="fileItemTemplate">
           <div class="file-item">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -38,6 +38,7 @@ export const COMMANDS = {
   UPDATE_FILES: 'updateFiles',
   UPDATE_USAGE: 'updateUsage',
   UPDATE_GROUP_USAGE: 'updateGroupUsage',
+  UPDATE_INPUT_STATUS: 'updateInputStatus',
   OPEN_FILE: 'openFile',
   COMPARE_ORIGINAL: 'compareOriginal',
   COMPARE_PREVIOUS: 'comparePrevious',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -7,6 +7,7 @@ import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { Status } from './uiManagers/Status.js';
 import { FileList } from './uiManagers/FileList.js';
+import { InputStatus } from './uiManagers/InputStatus.js';
 import { Events } from './uiManagers/Events.js';
 
 /**
@@ -21,6 +22,7 @@ export class ProgressViewDomHandler {
     this.usageSummary = new UsageSummary();
     this.usageGroup = new UsageGroup(this.usageSummary); // Pass shared instance
     this.fileList = new FileList(this.usageSummary); // Pass shared instance
+    this.inputStatus = new InputStatus();
     this.taskGroups = new TaskGroupsDom();
     this.logEntries = new LogEntriesDom();
     this.events = new Events();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -123,6 +123,12 @@ const handlers = {
     }
   },
 
+  [COMMANDS.UPDATE_INPUT_STATUS]: (message) => {
+    if (message.stream === state.getCurrentStream()) {
+      dom.inputStatus.update(message.status);
+    }
+  },
+
   [COMMANDS.UPDATE_FILES]: (message) => {
     if (message.stream === state.getCurrentStream()) {
       dom.fileList.update(message.files);

--- a/src/progressView/modules/uiManagers/Events.js
+++ b/src/progressView/modules/uiManagers/Events.js
@@ -83,6 +83,20 @@ export class Events {
       true,
     );
 
+    document.getElementById('inputStatus').addEventListener(
+      'click',
+      (e) => {
+        const el = e.target.closest('.input-status-file');
+        if (el && el.dataset.file) {
+          vscode.postMessage({
+            command: COMMANDS.OPEN_FILE,
+            file: el.dataset.file,
+          });
+        }
+      },
+      true,
+    );
+
     // Delete all button handler
     const deleteAllBtn = document.getElementById('deleteAllBtn');
     if (deleteAllBtn) {

--- a/src/progressView/modules/uiManagers/InputStatus.js
+++ b/src/progressView/modules/uiManagers/InputStatus.js
@@ -1,0 +1,79 @@
+// Local imports
+import {
+  CHEVRON_DOWN_CLASS,
+  CHEVRON_RIGHT_CLASS,
+} from '@common/webviewContext.js';
+
+/**
+ * Manages rendering of required file and figure status.
+ */
+export class InputStatus {
+  update(status) {
+    const container = document.getElementById('inputStatus');
+    if (!container) return;
+    container.innerHTML = '';
+    if (!status) return;
+
+    if (status.required && status.required.length > 0) {
+      container.appendChild(this._createFileSection(status.required));
+    }
+    if (status.figures && status.figures.length > 0) {
+      container.appendChild(this._createFigureSection(status.figures));
+    }
+  }
+
+  _createFileSection(items) {
+    const found = items.filter((i) => i.found);
+    const missing = items.filter((i) => !i.found);
+    const details = document.createElement('details');
+    details.className = 'special-details';
+    details.open = true;
+    details.innerHTML = `<summary><i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i><i class="codicon codicon-file-directory"></i><span>Loading Files \u2705${found.length} ${missing.length ? `\u26A0\uFE0F${missing.length} missing` : ''}</span></summary>`;
+    const content = document.createElement('div');
+    content.className = 'special-content';
+    if (missing.length > 0) {
+      content.appendChild(this._createList('Missing', missing));
+    }
+    if (found.length > 0) {
+      content.appendChild(this._createList('Found', found, false));
+    }
+    details.appendChild(content);
+    return details;
+  }
+
+  _createFigureSection(figures) {
+    const details = document.createElement('details');
+    details.className = 'special-details';
+    details.open = true;
+    details.innerHTML = `<summary><i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i><i class="codicon codicon-file-media"></i><span>Loading Figures (${figures.length})</span></summary>`;
+    const content = document.createElement('div');
+    content.className = 'special-content';
+    figures.forEach((f) => {
+      const el = document.createElement('div');
+      el.textContent = f.path;
+      el.className = 'input-status-file clickable-link';
+      el.dataset.file = f.path;
+      content.appendChild(el);
+    });
+    details.appendChild(content);
+    return details;
+  }
+
+  _createList(label, items, open = true) {
+    const d = document.createElement('details');
+    d.className = 'special-details';
+    d.open = open;
+    d.innerHTML = `<summary><i class="${open ? CHEVRON_DOWN_CLASS : CHEVRON_RIGHT_CLASS} toggle-icon"></i><span>${label} (${items.length})</span></summary>`;
+    const c = document.createElement('div');
+    c.className = 'special-content';
+    items.forEach((it) => {
+      const el = document.createElement('div');
+      el.textContent = it.path;
+      el.className = 'input-status-file clickable-link';
+      el.dataset.file = it.path;
+      c.appendChild(el);
+    });
+    d.appendChild(c);
+    return d;
+  }
+}

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -15,3 +15,4 @@
 @import './logs.css';
 @import './groups.css';
 @import './scratchpad.css';
+@import './input-status.css';

--- a/src/progressView/styles/input-status.css
+++ b/src/progressView/styles/input-status.css
@@ -1,0 +1,19 @@
+#inputStatus {
+  padding: var(--spacing-small);
+  border-top: 1px solid var(--vscode-panel-border);
+  font-size: var(--vscode-editor-font-size);
+  overflow-y: auto;
+  max-height: var(--height-medium);
+  flex-shrink: 0;
+}
+
+.input-status-file {
+  cursor: pointer;
+  color: var(--vscode-textLink-foreground);
+  white-space: nowrap;
+}
+
+.input-status-file:hover {
+  color: var(--vscode-textLink-activeForeground);
+  text-decoration: underline;
+}

--- a/src/types/InputStatus.ts
+++ b/src/types/InputStatus.ts
@@ -1,0 +1,19 @@
+/**
+ * Structured status for required files and figures used by agents.
+ */
+
+export interface RequiredFileStatus {
+  /** File path */
+  path: string;
+  /** Variable name loaded from the file */
+  varName: string;
+  /** Whether the file was found */
+  found: boolean;
+}
+
+export interface InputStatus {
+  /** Required file statuses */
+  required: RequiredFileStatus[];
+  /** Figures successfully added */
+  figures: { path: string }[];
+}

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -7,6 +7,7 @@ export enum WorkspaceStateKey {
   LOG_STREAMS = 'texra.logStreams',
   TASK_GROUPS = 'texra.taskGroups',
   OUTPUT_FILES = 'texra.outputFiles',
+  INPUT_STATUS = 'texra.inputStatus',
   ACTIVE_LOG_STREAM = 'texra.activeLogStream',
   TASK_STATES = 'texra.taskStates',
   USAGE_STATS = 'texra.usageStats',


### PR DESCRIPTION
## Summary
- add `InputStatus` structures and event
- store input status in progress state
- render loading status in ProgressBoard
- capture required file and figure statuses
- document file loading status section

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685fbd3567dc8324b2bcb9ce34f0e3ab