### PR TITLE
fix: clear stale missing outputs

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -63,3 +63,7 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.
 
 At the bottom of the tab list, there is a "Delete All" button (<i class="codicon codicon-close-all"></i>) that allows you to clear all streams and their associated logs from the ProgressBoard view.
+
+### Generated Files
+
+When a round generates `.tex` output, the files appear under a header like `r0` or `r1`. If an expected file is missing, the round section shows a yellow warning with an **Open XML** button. Clicking the button opens the XML file so you can inspect tag issues that prevented generation.

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -263,7 +263,12 @@ async function executeAgentWithLogging<T extends IAgent>(
             mainTaskGroupId,
           );
           await agent.run();
-          await checkExpectedOutputs(config.outputFiles, context, agent);
+          await checkExpectedOutputs(
+            config.outputFiles,
+            context,
+            agent,
+            fullStreamId,
+          );
           // Mark the task as completed successfully
           logger.debug(`Task completed successfully`, mainTaskGroupId);
           logger.endGroup(mainTaskGroupId, 'stopped');

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -11,6 +11,7 @@ export type ProgressEvent =
   | 'setActiveStream'
   | 'updateStreamStatus'
   | 'addOutputFiles'
+  | 'addMissingOutput'
   | 'clearOutputFiles'
   | 'setTaskState'
   | 'updateGroupUsage'

--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 // Local imports
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { INSTRUCTION_PREFIX, globalSM } from '@utils/stateManager';
+import { emitProgress } from '@eventBus/ProgressEventBus';
 
 /**
  * Show an instruction message that can be permanently dismissed.
@@ -51,12 +52,13 @@ export async function checkExpectedOutputs(
   expectedFiles: string[] | null | undefined,
   context: vscode.ExtensionContext,
   agent?: unknown,
+  streamId?: string,
 ): Promise<void> {
   if (!expectedFiles || expectedFiles.length === 0) {
     return;
   }
 
-  for (const file of expectedFiles) {
+  for (const [idx, file] of expectedFiles.entries()) {
     const exists = path.isAbsolute(file)
       ? await AbsoluteFS.exists(file)
       : await WorkspaceFS.exists(file);
@@ -122,6 +124,15 @@ export async function checkExpectedOutputs(
         ],
         false,
       );
+      if (streamId && xmlPath) {
+        const match = /_r(\d+)/.exec(file) || /_r(\d+)/.exec(xmlPath);
+        const round = match ? parseInt(match[1], 10) : idx;
+        emitProgress('addMissingOutput', {
+          stream: streamId,
+          round,
+          xmlPath,
+        });
+      }
       break;
     }
   }

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -34,6 +34,7 @@ export class ProgressStateManager {
   private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
+  private _missingOutputs: Map<string, Map<number, string>> = new Map();
   private _taskStates: Map<string, TaskState> = new Map();
   private _usageStats: Map<string, TokenUsageStats> = new Map();
   private _activeStream: string = '';
@@ -53,6 +54,10 @@ export class ProgressStateManager {
 
   get outputFiles(): Map<string, { [key: number]: OutputFileInfo[] }> {
     return this._outputFiles;
+  }
+
+  get missingOutputs(): Map<string, Map<number, string>> {
+    return this._missingOutputs;
   }
 
   get taskStates(): Map<string, TaskState> {
@@ -86,6 +91,7 @@ export class ProgressStateManager {
     await this._loadLogStreams();
     await this._loadTaskGroups();
     await this._loadOutputFiles();
+    await this._loadMissingOutputs();
     this._loadActiveStream();
     await this._loadTaskStates();
     await this._loadUsageStats();
@@ -98,6 +104,7 @@ export class ProgressStateManager {
     this._saveLogStreams();
     this._saveTaskGroups();
     this._saveOutputFiles();
+    this._saveMissingOutputs();
     this._saveActiveStream();
     this._saveTaskStates();
     this._saveUsageStats();
@@ -279,6 +286,26 @@ export class ProgressStateManager {
   }
 
   /**
+   * Load missing output XML paths
+   */
+  private async _loadMissingOutputs(): Promise<void> {
+    const saved = workspaceSM.get<{
+      [key: string]: { [key: number]: string };
+    }>(this._getWorkspaceKey(WorkspaceStateKey.MISSING_OUTPUTS));
+
+    if (saved) {
+      this._missingOutputs = new Map(
+        Object.entries(saved).map(([stream, rounds]) => [
+          stream,
+          new Map(Object.entries(rounds).map(([r, p]) => [parseInt(r, 10), p])),
+        ]),
+      );
+    } else {
+      this._missingOutputs.clear();
+    }
+  }
+
+  /**
    * Load active stream
    */
   private _loadActiveStream(): void {
@@ -379,6 +406,22 @@ export class ProgressStateManager {
   }
 
   /**
+   * Save missing output XML paths
+   */
+  private _saveMissingOutputs(): void {
+    const missingObj = Object.fromEntries(
+      Array.from(this._missingOutputs.entries()).map(([stream, rounds]) => [
+        stream,
+        Object.fromEntries(rounds.entries()),
+      ]),
+    );
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.MISSING_OUTPUTS),
+      missingObj,
+    );
+  }
+
+  /**
    * Save active stream
    */
   private _saveActiveStream(): void {
@@ -408,6 +451,7 @@ export class ProgressStateManager {
     this._logStreams.delete(stream);
     this._taskGroups.delete(stream);
     this._outputFiles.delete(stream);
+    this._missingOutputs.delete(stream);
     this._taskStates.delete(stream);
     this._usageStats.delete(stream);
   }
@@ -419,6 +463,7 @@ export class ProgressStateManager {
     this._logStreams.clear();
     this._taskGroups.clear();
     this._outputFiles.clear();
+    this._missingOutputs.clear();
     this._taskStates.clear();
     this._usageStats.clear();
     this._activeStream = '';

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -107,6 +107,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
         ),
       ),
       new vscode.Disposable(
+        onProgress(
+          'addMissingOutput',
+          (p: { stream: string; round: number; xmlPath: string }) =>
+            this.addMissingOutput(p.stream, p.round, p.xmlPath),
+        ),
+      ),
+      new vscode.Disposable(
         onProgress('clearOutputFiles', (stream: string) =>
           this.clearOutputFiles(stream),
         ),
@@ -315,10 +322,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     // Send output files for current stream
     const files =
       this._stateManager.outputFiles.get(this._stateManager.activeStream) || {};
+    const missing =
+      this._stateManager.missingOutputs.get(this._stateManager.activeStream) ||
+      new Map();
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_FILES,
       stream: this._stateManager.activeStream,
       files,
+      missingOutputs: Object.fromEntries(missing.entries()),
     });
 
     const usage = this._stateManager.usageStats.get(
@@ -561,10 +572,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     // Send output files for this stream
     const files = this._stateManager.outputFiles.get(stream) || {};
+    const missing = this._stateManager.missingOutputs.get(stream) || new Map();
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_FILES,
       stream: stream,
       files,
+      missingOutputs: Object.fromEntries(missing.entries()),
     });
   }
 
@@ -647,10 +660,33 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._stateManager.outputFiles.set(stream, merged);
     this._stateManager.saveState();
     if (this._view && stream === this._stateManager.activeStream) {
+      const missing =
+        this._stateManager.missingOutputs.get(stream) || new Map();
       this._view.webview.postMessage({
         command: COMMANDS.UPDATE_FILES,
         stream,
         files: merged,
+        missingOutputs: Object.fromEntries(missing.entries()),
+      });
+    }
+  }
+
+  public addMissingOutput(
+    stream: string,
+    round: number,
+    xmlPath: string,
+  ): void {
+    const existing = this._stateManager.missingOutputs.get(stream) || new Map();
+    existing.set(round, xmlPath);
+    this._stateManager.missingOutputs.set(stream, existing);
+    this._stateManager.saveState();
+    if (this._view && stream === this._stateManager.activeStream) {
+      const files = this._stateManager.outputFiles.get(stream) || {};
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_FILES,
+        stream,
+        files,
+        missingOutputs: Object.fromEntries(existing.entries()),
       });
     }
   }
@@ -662,14 +698,16 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public clearOutputFiles(stream: string): void {
-    if (this._stateManager.outputFiles.has(stream)) {
-      this._stateManager.outputFiles.delete(stream);
+    const hadFiles = this._stateManager.outputFiles.delete(stream);
+    const hadMissing = this._stateManager.missingOutputs.delete(stream);
+    if (hadFiles || hadMissing) {
       this._stateManager.saveState();
       if (this._view && stream === this._stateManager.activeStream) {
         this._view.webview.postMessage({
           command: COMMANDS.UPDATE_FILES,
           stream,
           files: {},
+          missingOutputs: {},
         });
       }
     }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -125,7 +125,7 @@ const handlers = {
 
   [COMMANDS.UPDATE_FILES]: (message) => {
     if (message.stream === state.getCurrentStream()) {
-      dom.fileList.update(message.files);
+      dom.fileList.update(message.files, message.missingOutputs);
     }
   },
 

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -35,7 +35,7 @@ export class FileList {
    * Update the generated files list
    * @param {Object} filesByRound - Files organized by round
    */
-  update(filesByRound) {
+  update(filesByRound, missingOutputs = {}) {
     const container = document.getElementById('generatedFiles');
     if (!container) return;
 
@@ -92,6 +92,25 @@ export class FileList {
       roundHeader.className = 'round-header';
       roundHeader.textContent = `r${round}`;
       roundGroup.appendChild(roundHeader);
+
+      const missingPath = missingOutputs[round];
+      if (missingPath) {
+        const warn = document.createElement('div');
+        warn.className = 'missing-output-warning';
+        warn.innerHTML =
+          '<i class="codicon codicon-warning"></i> Expected output missing';
+        const btn = document.createElement('button');
+        btn.className = 'vscode-button';
+        btn.textContent = 'Open XML';
+        btn.onclick = () => {
+          vscode.postMessage({
+            command: COMMANDS.OPEN_FILE,
+            file: missingPath,
+          });
+        };
+        warn.appendChild(btn);
+        roundGroup.appendChild(warn);
+      }
 
       files.forEach((file) => {
         // Skip invalid file entries

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -261,6 +261,19 @@
   border-radius: var(--border-radius-small);
 }
 
+.missing-output-warning {
+  padding: var(--spacing-small);
+  background-color: var(
+    --vscode-inputValidation-warningBackground,
+    rgba(255, 200, 0, 0.2)
+  );
+  color: var(--vscode-inputValidation-warningForeground);
+  margin-bottom: var(--spacing-small);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
 .added {
   color: var(--vscode-charts-green, green);
   margin-left: var(--spacing-small);

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -7,6 +7,7 @@ export enum WorkspaceStateKey {
   LOG_STREAMS = 'texra.logStreams',
   TASK_GROUPS = 'texra.taskGroups',
   OUTPUT_FILES = 'texra.outputFiles',
+  MISSING_OUTPUTS = 'texra.missingOutputs',
   ACTIVE_LOG_STREAM = 'texra.activeLogStream',
   TASK_STATES = 'texra.taskStates',
   USAGE_STATS = 'texra.usageStats',


### PR DESCRIPTION
## Summary
- preserve new missing-output warnings when clearing file state
- infer round number from filenames when logging missing outputs

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fbc2f7ce48324835fefe49ca538e7