### PR TITLE
feat: display output status in progress view

### DIFF
--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -7,6 +7,8 @@ import * as path from 'path';
 // Local imports
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { INSTRUCTION_PREFIX, globalSM } from '@utils/stateManager';
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 /**
  * Show an instruction message that can be permanently dismissed.
@@ -55,13 +57,13 @@ export async function checkExpectedOutputs(
     return;
   }
 
+  const missing: { file: string; xml?: string }[] = [];
+
   for (const file of expectedFiles) {
     const exists = path.isAbsolute(file)
       ? await AbsoluteFS.exists(file)
       : await WorkspaceFS.exists(file);
     if (!exists) {
-      const openBtn = 'Open XML';
-
       let xmlPath: string | undefined;
       const outputs: string[] = [];
 
@@ -88,40 +90,16 @@ export async function checkExpectedOutputs(
         xmlPath = file.replace(/\.[^.]+$/, '.xml');
       }
 
-      await showInstructionWithSuppress(
-        'xmlOutputMismatch',
-        `Expected output "${path.basename(
-          file,
-        )}" was not generated. Open the XML file to check tag consistency, then run again.`,
-        [
-          {
-            title: openBtn,
-            callback: async () => {
-              if (!xmlPath) {
-                vscode.window.showWarningMessage('XML file path not found');
-                return;
-              }
-
-              const xmlExists = path.isAbsolute(xmlPath)
-                ? await AbsoluteFS.exists(xmlPath)
-                : await WorkspaceFS.exists(xmlPath);
-              if (!xmlExists) {
-                vscode.window.showWarningMessage(
-                  `XML file not found: ${path.basename(xmlPath)}`,
-                );
-                return;
-              }
-              const uri = path.isAbsolute(xmlPath)
-                ? vscode.Uri.file(xmlPath)
-                : vscode.Uri.file(WorkspaceFS.fullPath(xmlPath));
-              const doc = await vscode.workspace.openTextDocument(uri);
-              await vscode.window.showTextDocument(doc, { preview: false });
-            },
-          },
-        ],
-        false,
-      );
-      break;
+      missing.push({ file, xml: xmlPath });
     }
+  }
+
+  if (missing.length > 0) {
+    const logger: AgentLogger | undefined = (agent as any)?.logger;
+    logger?.info(
+      JSON.stringify(missing),
+      undefined,
+      MESSAGE_TYPES.OUTPUT_STATUS,
+    );
   }
 }

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -34,7 +34,12 @@ export interface LogMessageData {
   /** Optional group association */
   groupId?: string;
   /** Optional message category */
-  messageType?: 'default' | 'scratchpad' | 'thinking' | 'fileList';
+  messageType?:
+    | 'default'
+    | 'scratchpad'
+    | 'thinking'
+    | 'fileList'
+    | 'outputStatus';
   /** Whether verbose details should be displayed */
   verbose?: boolean;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -15,11 +15,13 @@ function isValidMessageType(
 ): type is
   | typeof MESSAGE_TYPES.THINKING
   | typeof MESSAGE_TYPES.SCRATCHPAD
-  | typeof MESSAGE_TYPES.FILE_LIST {
+  | typeof MESSAGE_TYPES.FILE_LIST
+  | typeof MESSAGE_TYPES.OUTPUT_STATUS {
   return (
     type === MESSAGE_TYPES.THINKING ||
     type === MESSAGE_TYPES.SCRATCHPAD ||
-    type === MESSAGE_TYPES.FILE_LIST
+    type === MESSAGE_TYPES.FILE_LIST ||
+    type === MESSAGE_TYPES.OUTPUT_STATUS
   );
 }
 
@@ -119,8 +121,11 @@ class VSCodeTransport extends Transport {
     // const formattedMessage = `${emoji} [${timestamp}] ${level.toUpperCase().padEnd(7)} ${channelPrefix}${message}`;
     const formattedMessage = `${emoji} [${timestamp}] ${channelPrefix}${message}`;
 
-    // Skip output channel logging for FILE_LIST messages - they have their own UI
-    if (messageType !== MESSAGE_TYPES.FILE_LIST) {
+    // Skip output channel logging for FILE_LIST and OUTPUT_STATUS messages - they have their own UI
+    if (
+      messageType !== MESSAGE_TYPES.FILE_LIST &&
+      messageType !== MESSAGE_TYPES.OUTPUT_STATUS
+    ) {
       // Always write to the configured output channel
       this.channel.appendLine(formattedMessage);
     }

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -2,6 +2,7 @@ export const MESSAGE_TYPES = {
   THINKING: 'thinking',
   SCRATCHPAD: 'scratchpad',
   FILE_LIST: 'fileList',
+  OUTPUT_STATUS: 'outputStatus',
   DEFAULT: 'default',
 } as const;
 

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -34,6 +34,7 @@ export class ProgressStateManager {
   private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
+  private _outputChecks: Map<string, { [key: number]: any[] }> = new Map();
   private _taskStates: Map<string, TaskState> = new Map();
   private _usageStats: Map<string, TokenUsageStats> = new Map();
   private _activeStream: string = '';
@@ -53,6 +54,10 @@ export class ProgressStateManager {
 
   get outputFiles(): Map<string, { [key: number]: OutputFileInfo[] }> {
     return this._outputFiles;
+  }
+
+  get outputChecks(): Map<string, { [key: number]: any[] }> {
+    return this._outputChecks;
   }
 
   get taskStates(): Map<string, TaskState> {
@@ -86,6 +91,7 @@ export class ProgressStateManager {
     await this._loadLogStreams();
     await this._loadTaskGroups();
     await this._loadOutputFiles();
+    await this._loadOutputChecks();
     this._loadActiveStream();
     await this._loadTaskStates();
     await this._loadUsageStats();
@@ -98,6 +104,7 @@ export class ProgressStateManager {
     this._saveLogStreams();
     this._saveTaskGroups();
     this._saveOutputFiles();
+    this._saveOutputChecks();
     this._saveActiveStream();
     this._saveTaskStates();
     this._saveUsageStats();
@@ -278,6 +285,18 @@ export class ProgressStateManager {
     }
   }
 
+  private async _loadOutputChecks(): Promise<void> {
+    const saved = workspaceSM.get<{
+      [key: string]: { [key: number]: any[] };
+    }>(this._getWorkspaceKey('texra.outputChecks'));
+
+    if (saved) {
+      this._outputChecks = new Map(Object.entries(saved));
+    } else {
+      this._outputChecks.clear();
+    }
+  }
+
   /**
    * Load active stream
    */
@@ -378,6 +397,11 @@ export class ProgressStateManager {
     );
   }
 
+  private _saveOutputChecks(): void {
+    const checksObj = Object.fromEntries(this._outputChecks.entries());
+    workspaceSM.update(this._getWorkspaceKey('texra.outputChecks'), checksObj);
+  }
+
   /**
    * Save active stream
    */
@@ -408,6 +432,7 @@ export class ProgressStateManager {
     this._logStreams.delete(stream);
     this._taskGroups.delete(stream);
     this._outputFiles.delete(stream);
+    this._outputChecks.delete(stream);
     this._taskStates.delete(stream);
     this._usageStats.delete(stream);
   }
@@ -419,6 +444,7 @@ export class ProgressStateManager {
     this._logStreams.clear();
     this._taskGroups.clear();
     this._outputFiles.clear();
+    this._outputChecks.clear();
     this._taskStates.clear();
     this._usageStats.clear();
     this._activeStream = '';

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -54,6 +54,9 @@ export class ProgressViewContentProvider {
       const toolbarUri = getWebviewUri('modules/uiManagers/Toolbar.js');
       const statusUri = getWebviewUri('modules/uiManagers/Status.js');
       const fileListUri = getWebviewUri('modules/uiManagers/FileList.js');
+      const outputStatusUri = getWebviewUri(
+        'modules/uiManagers/OutputStatus.js',
+      );
       const eventsUri = getWebviewUri('modules/uiManagers/Events.js');
       const constantsUri = getWebviewUri('modules/constants.js');
       const katexMacrosUri = getWebviewUri('modules/katexMacros.js');
@@ -91,6 +94,7 @@ export class ProgressViewContentProvider {
         toolbarUri,
         statusUri,
         fileListUri,
+        outputStatusUri,
         eventsUri,
       });
     } catch (err) {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -321,6 +321,15 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       files,
     });
 
+    const checks =
+      this._stateManager.outputChecks.get(this._stateManager.activeStream) ||
+      {};
+    this._view.webview.postMessage({
+      command: COMMANDS.UPDATE_OUTPUT_STATUS,
+      stream: this._stateManager.activeStream,
+      checks,
+    });
+
     const usage = this._stateManager.usageStats.get(
       this._stateManager.activeStream,
     );
@@ -388,6 +397,22 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     const messages = this._stateManager.logStreams.get(stream)!;
     messages.push(log);
+
+    if (log.messageType === 'outputStatus' && log.groupId) {
+      const groups = this._stateManager.taskGroups.get(stream);
+      const round = groups?.get(log.groupId)?.name?.match(/^r(\d+)$/);
+      const roundNum = round ? parseInt(round[1], 10) : undefined;
+      if (roundNum !== undefined) {
+        try {
+          const parsed = JSON.parse(log.text);
+          if (Array.isArray(parsed)) {
+            this.addOutputChecks(stream, roundNum, parsed);
+          }
+        } catch (e) {
+          // ignore parse errors
+        }
+      }
+    }
 
     if (messages.length > 1000) {
       messages.splice(0, messages.length - 1000);
@@ -581,6 +606,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       this._stateManager.logStreams.get(stream)!.length = 0;
       this._stateManager.taskGroups.delete(stream);
       this._stateManager.outputFiles.delete(stream);
+      this._stateManager.outputChecks.delete(stream);
       this._stateManager.saveState();
       this.updateLogContent(stream);
     }
@@ -655,21 +681,59 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  public addOutputChecks(stream: string, round: number, checks: any[]): void {
+    const existing = this._stateManager.outputChecks.get(stream) || {};
+    existing[round] = checks;
+    this._stateManager.outputChecks.set(stream, existing);
+    this._stateManager.saveState();
+    if (this._view && stream === this._stateManager.activeStream) {
+      this._view.webview.postMessage({
+        command: COMMANDS.UPDATE_OUTPUT_STATUS,
+        stream,
+        checks: existing,
+      });
+    }
+  }
+
   public getOutputFiles(
     stream: string,
   ): { [key: number]: OutputFileInfo[] } | undefined {
     return this._stateManager.outputFiles.get(stream);
   }
 
+  public getOutputChecks(stream: string): { [key: number]: any[] } | undefined {
+    return this._stateManager.outputChecks.get(stream);
+  }
+
+  public clearOutputChecks(stream: string): void {
+    if (this._stateManager.outputChecks.has(stream)) {
+      this._stateManager.outputChecks.delete(stream);
+      this._stateManager.saveState();
+      if (this._view && stream === this._stateManager.activeStream) {
+        this._view.webview.postMessage({
+          command: COMMANDS.UPDATE_OUTPUT_STATUS,
+          stream,
+          checks: {},
+        });
+      }
+    }
+  }
+
   public clearOutputFiles(stream: string): void {
     if (this._stateManager.outputFiles.has(stream)) {
       this._stateManager.outputFiles.delete(stream);
+      this._stateManager.outputChecks.delete(stream);
       this._stateManager.saveState();
       if (this._view && stream === this._stateManager.activeStream) {
         this._view.webview.postMessage({
           command: COMMANDS.UPDATE_FILES,
           stream,
           files: {},
+        });
+        this._view.webview.postMessage({
+          command: COMMANDS.UPDATE_OUTPUT_STATUS,
+          stream,
+          checks: {},
         });
       }
     }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -35,6 +35,7 @@
           "./modules/uiManagers/Toolbar.js": "${toolbarUri}",
           "./modules/uiManagers/Status.js": "${statusUri}",
           "./modules/uiManagers/FileList.js": "${fileListUri}",
+          "./modules/uiManagers/OutputStatus.js": "${outputStatusUri}",
           "./modules/uiManagers/Events.js": "${eventsUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
@@ -68,6 +69,7 @@
         </div>
         <div id="logContent" class="log-container"></div>
         <div id="generatedFiles" class="files-container"></div>
+        <div id="outputStatus" class="output-status-container"></div>
         <template id="fileItemTemplate">
           <div class="file-item">
             <span class="file-name">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -36,6 +36,7 @@ export const COMMANDS = {
   UPDATE_LOG_GROUP: 'updateLogGroup',
   UPDATE_STATUS: 'updateStatus',
   UPDATE_FILES: 'updateFiles',
+  UPDATE_OUTPUT_STATUS: 'updateOutputStatus',
   UPDATE_USAGE: 'updateUsage',
   UPDATE_GROUP_USAGE: 'updateGroupUsage',
   OPEN_FILE: 'openFile',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -7,6 +7,7 @@ import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { Status } from './uiManagers/Status.js';
 import { FileList } from './uiManagers/FileList.js';
+import { OutputStatus } from './uiManagers/OutputStatus.js';
 import { Events } from './uiManagers/Events.js';
 
 /**
@@ -21,6 +22,7 @@ export class ProgressViewDomHandler {
     this.usageSummary = new UsageSummary();
     this.usageGroup = new UsageGroup(this.usageSummary); // Pass shared instance
     this.fileList = new FileList(this.usageSummary); // Pass shared instance
+    this.outputStatus = new OutputStatus();
     this.taskGroups = new TaskGroupsDom();
     this.logEntries = new LogEntriesDom();
     this.events = new Events();

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -151,6 +151,10 @@ export class LogEntryFormatter {
       return this._formatFileList(htmlMessage, text, id);
     }
 
+    if (messageType === 'outputStatus') {
+      return this._formatOutputStatus(htmlMessage, text, id);
+    }
+
     return htmlMessage;
   }
 
@@ -293,6 +297,40 @@ export class LogEntryFormatter {
       </details>`;
     } catch (e) {
       console.error('Error parsing file list:', e);
+      return message;
+    }
+  }
+
+  _formatOutputStatus(message, content, logId) {
+    try {
+      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const parsed = JSON.parse(this._unescapeHtml(content));
+      if (!Array.isArray(parsed)) {
+        throw new Error('Invalid output status');
+      }
+      let items = '';
+      parsed.forEach((o) => {
+        if (!o || !o.file) return;
+        const fileName = o.file.split('/').pop() || o.file;
+        const escaped = this._escapeHtml(fileName);
+        const link = o.xml
+          ? ` <span class="xml-link clickable-link" data-file="${this._escapeHtml(
+              o.xml,
+            )}">Open XML</span>`
+          : '';
+        items += `<li><i class="codicon codicon-warning"></i> ${escaped}${link}</li>`;
+      });
+
+      return `<details class="file-list-details" open>
+        <summary>
+          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
+          <i class="codicon codicon-alert"></i>
+          <span>Missing Outputs</span>
+        </summary>
+        <ul class="file-list-content"${idAttr}>${items}</ul>
+      </details>`;
+    } catch (e) {
+      console.error('Error parsing output status:', e);
       return message;
     }
   }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -129,6 +129,12 @@ const handlers = {
     }
   },
 
+  [COMMANDS.UPDATE_OUTPUT_STATUS]: (message) => {
+    if (message.stream === state.getCurrentStream()) {
+      dom.outputStatus.update(message.checks);
+    }
+  },
+
   [COMMANDS.DELETE_STREAM]: (message) => {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);

--- a/src/progressView/modules/uiManagers/Events.js
+++ b/src/progressView/modules/uiManagers/Events.js
@@ -129,6 +129,13 @@ export class Events {
           file: link.dataset.file,
         });
       }
+      const xml = e.target.closest('.xml-link');
+      if (xml && xml.dataset.file) {
+        vscode.postMessage({
+          command: COMMANDS.OPEN_FILE,
+          file: xml.dataset.file,
+        });
+      }
     });
   }
 }

--- a/src/progressView/modules/uiManagers/OutputStatus.js
+++ b/src/progressView/modules/uiManagers/OutputStatus.js
@@ -1,0 +1,67 @@
+// Local imports
+import { vscode } from '@common/webviewContext.js';
+
+/**
+ * Manages display of output check results.
+ */
+export class OutputStatus {
+  update(checksByRound) {
+    const container = document.getElementById('outputStatus');
+    if (!container) return;
+
+    container.innerHTML = '';
+    if (!checksByRound || Object.keys(checksByRound).length === 0) {
+      return;
+    }
+
+    const rounds = Object.keys(checksByRound)
+      .map((r) => parseInt(r, 10))
+      .sort((a, b) => a - b);
+
+    rounds.forEach((round) => {
+      const items = checksByRound[round];
+      if (!Array.isArray(items) || items.length === 0) return;
+
+      const group = document.createElement('div');
+      group.className = 'output-status-group';
+
+      const header = document.createElement('div');
+      header.className = 'output-status-header';
+      header.textContent = `r${round}`;
+      group.appendChild(header);
+
+      const list = document.createElement('ul');
+      list.className = 'output-status-list';
+
+      items.forEach((it) => {
+        if (!it || !it.file) return;
+        const li = document.createElement('li');
+        const fileName = it.file.split('/').pop() || it.file;
+        li.innerHTML = `<i class="codicon codicon-warning"></i> ${this._escapeHtml(
+          fileName,
+        )}`;
+        if (it.xml) {
+          const link = document.createElement('span');
+          link.textContent = 'Open XML';
+          link.className = 'xml-link clickable-link';
+          link.dataset.file = it.xml;
+          li.appendChild(document.createTextNode(' '));
+          li.appendChild(link);
+        }
+        list.appendChild(li);
+      });
+
+      group.appendChild(list);
+      container.appendChild(group);
+    });
+  }
+
+  _escapeHtml(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -173,6 +173,25 @@
   flex-shrink: 0;
 }
 
+.output-status-container {
+  padding: var(--spacing-small);
+  border-top: 1px solid var(--vscode-panel-border);
+  font-size: var(--vscode-editor-font-size);
+  overflow-y: auto;
+  max-height: var(--height-small);
+  flex-shrink: 0;
+}
+
+.output-status-header {
+  font-weight: bold;
+  margin-top: var(--spacing-small);
+  margin-bottom: var(--spacing-tiny);
+}
+.output-status-list {
+  margin-left: var(--spacing-small);
+  margin-bottom: var(--spacing-small);
+}
+
 /* Files usage header */
 .files-usage-header {
   display: flex;


### PR DESCRIPTION
## Summary
- add `OUTPUT_STATUS` log message type
- log missing outputs via the agent logger
- render output status messages with clickable XML links
- manage output status per round in ProgressView state
- expose and display output status in the Progress view UI

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test not runnable)*

------
https://chatgpt.com/codex/tasks/task_e_6861236dd974832490c823e1b33b3429