### PR TITLE
Refactor webview DOM handler

### DIFF
--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -20,67 +20,75 @@ export const instructionManager = new InstructionManager(
 export const toggleManager = new ToggleManager();
 export const recordingManager = new RecordingManager(vscode, webviewEventBus);
 
-let fileInputManager;
-let actionButtonManager;
-let settingsButtonManager;
+/**
+ * Coordinates UI managers for the main webview.
+ */
+export class WebviewDomHandler {
+  constructor() {
+    this.fileInputManager = null;
+    this.actionButtonManager = null;
+    this.settingsButtonManager = null;
+    this.debugMode = false;
+  }
 
-let debugMode = false;
+  _updateDebugButtonVisibility() {
+    const packBtn = document.getElementById('packButton');
+    const cleanBtn = document.getElementById('cleanButton');
+    [packBtn, cleanBtn].forEach((btn) => {
+      if (btn) {
+        btn.style.display = this.debugMode ? '' : 'none';
+      }
+    });
+  }
 
-function updateDebugButtonVisibility() {
-  const packBtn = document.getElementById('packButton');
-  const cleanBtn = document.getElementById('cleanButton');
-  [packBtn, cleanBtn].forEach((btn) => {
-    if (btn) {
-      btn.style.display = debugMode ? '' : 'none';
+  setDebugMode(enabled) {
+    this.debugMode = !!enabled;
+    this._updateDebugButtonVisibility();
+  }
+
+  initializeUI() {
+    this._updateDebugButtonVisibility();
+
+    this.fileInputManager = new FileInputManager(
+      vscode,
+      webviewState,
+      fileList,
+      fileSelect,
+      outputFilesManager,
+    );
+    this.actionButtonManager = new ActionButtonManager(
+      vscode,
+      fileList,
+      webviewState,
+      instructionManager,
+    );
+    this.settingsButtonManager = new SettingsButtonManager(
+      vscode,
+      toggleManager,
+      latexdiffManager,
+      webviewState,
+    );
+
+    this.fileInputManager.setup();
+    this.actionButtonManager.setup();
+    this.settingsButtonManager.setup();
+    recordingManager.setupRecordButton();
+  }
+
+  cleanupUI() {
+    if (this.fileInputManager) {
+      this.fileInputManager.cleanup();
+      this.fileInputManager = null;
     }
-  });
-}
-
-export function setDebugMode(enabled) {
-  debugMode = !!enabled;
-  updateDebugButtonVisibility();
-}
-
-export function initializeUI() {
-  updateDebugButtonVisibility();
-
-  fileInputManager = new FileInputManager(
-    vscode,
-    webviewState,
-    fileList,
-    fileSelect,
-    outputFilesManager,
-  );
-  actionButtonManager = new ActionButtonManager(
-    vscode,
-    fileList,
-    webviewState,
-    instructionManager,
-  );
-  settingsButtonManager = new SettingsButtonManager(
-    vscode,
-    toggleManager,
-    latexdiffManager,
-    webviewState,
-  );
-
-  fileInputManager.setup();
-  actionButtonManager.setup();
-  settingsButtonManager.setup();
-  recordingManager.setupRecordButton();
-}
-
-export function cleanupUI() {
-  if (fileInputManager) {
-    fileInputManager.cleanup();
-    fileInputManager = null;
-  }
-  if (actionButtonManager) {
-    actionButtonManager.cleanup();
-    actionButtonManager = null;
-  }
-  if (settingsButtonManager) {
-    settingsButtonManager.cleanup();
-    settingsButtonManager = null;
+    if (this.actionButtonManager) {
+      this.actionButtonManager.cleanup();
+      this.actionButtonManager = null;
+    }
+    if (this.settingsButtonManager) {
+      this.settingsButtonManager.cleanup();
+      this.settingsButtonManager = null;
+    }
   }
 }
+
+export const webviewDomHandler = new WebviewDomHandler();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -8,7 +8,7 @@ import {
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { webviewState } from './webviewState.js';
-import { setDebugMode as applyDebugMode } from './domHandlers.js';
+import { webviewDomHandler } from './domHandlers.js';
 
 // Local imports - UI managers
 import { fileList } from './uiManagers/FileList.js';
@@ -326,7 +326,7 @@ export class MessageHandlers {
   }
 
   handleSetDebugMode(message) {
-    applyDebugMode(message.debugMode);
+    webviewDomHandler.setDebugMode(message.debugMode);
     this._postHandle();
   }
 

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -1,8 +1,7 @@
 import { webviewState } from './modules/webviewState.js';
 import { messageHandlers } from './modules/messageHandlers.js';
 import {
-  initializeUI,
-  cleanupUI,
+  webviewDomHandler,
   instructionManager,
   toggleManager,
 } from './modules/domHandlers.js';
@@ -12,14 +11,14 @@ messageHandlers.setup({ requestData: false });
 
 window.addEventListener('beforeunload', () => {
   messageHandlers.cleanup();
-  cleanupUI();
+  webviewDomHandler.cleanupUI();
 });
 
 // Setup UI when DOM is loaded
 document.addEventListener('DOMContentLoaded', function () {
   webviewState.restore();
   instructionManager.init();
-  initializeUI();
+  webviewDomHandler.initializeUI();
   toggleManager.updateToolConfigToggleState();
   toggleManager.updateAutoToggleState();
   toggleManager.setupDocumentListeners();


### PR DESCRIPTION
## Summary
- encapsulate debug state and UI managers in `WebviewDomHandler`
- use the new singleton in the webview script and message handlers

## Testing
- `npm run lint`
- `npm test` *(fails: no output due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68613831e7a8832498433da7101a03cb