### PR TITLE
Rename currentStream to activeStream

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -308,7 +308,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_STREAMS,
       streams,
-      currentStream: this._stateManager.activeStream,
+      activeStream: this._stateManager.activeStream,
     });
     this.updateLogContent(this._stateManager.activeStream);
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -13,21 +13,21 @@ const entryFormatter = new LogEntryFormatter();
 
 const handlers = {
   [COMMANDS.UPDATE_STREAMS]: (message) => {
-    state.setCurrentStream(message.currentStream);
-    dom.streamTabs.update(message.streams, message.currentStream);
+    state.setActiveStream(message.activeStream);
+    dom.streamTabs.update(message.streams, message.activeStream);
 
     // Update status based on whether there's an active stream
-    if (!message.currentStream) {
+    if (!message.activeStream) {
       dom.status.update(STATUS.READY);
     } else {
-      const streamStatus = state.streamStatuses.get(message.currentStream);
+      const streamStatus = state.streamStatuses.get(message.activeStream);
       dom.status.update(streamStatus || STATUS.STOPPED);
     }
   },
 
   [COMMANDS.UPDATE_LOGS]: (message) => {
     const logContent = document.getElementById('logContent');
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       logContent.innerHTML = '';
       state.taskGroups.clear();
       if (message.groups && message.groups.length > 0) {
@@ -76,7 +76,7 @@ const handlers = {
   },
 
   [COMMANDS.APPEND_LOG]: (message) => {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       const logContent = document.getElementById('logContent');
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
@@ -89,13 +89,13 @@ const handlers = {
   },
 
   [COMMANDS.UPDATE_LOG]: (message) => {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       dom.logEntries.update(message.logMessage);
     }
   },
 
   [COMMANDS.ADD_LOG_GROUP]: (message) => {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       const logContent = document.getElementById('logContent');
       dom.taskGroups.add(message.group);
       logContent.scrollTop = logContent.scrollHeight;
@@ -103,7 +103,7 @@ const handlers = {
   },
 
   [COMMANDS.UPDATE_LOG_GROUP]: (message) => {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       state.taskGroups.update(message.groupId, message.status, message.endTime);
       dom.taskGroups.update(message.groupId, message.status, message.endTime);
     }
@@ -118,13 +118,13 @@ const handlers = {
   },
 
   [COMMANDS.UPDATE_GROUP_USAGE]: (message) => {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       dom.usageGroup.update(message.groupId, message.usage);
     }
   },
 
   [COMMANDS.UPDATE_FILES]: (message) => {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       dom.fileList.update(message.files);
     }
   },
@@ -132,7 +132,7 @@ const handlers = {
   [COMMANDS.DELETE_STREAM]: (message) => {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
-      if (message.stream === state.getCurrentStream()) {
+      if (message.stream === state.getActiveStream()) {
         const groupIds = [];
         const headers = Array.from(
           document.querySelectorAll('.log-group-header'),

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -169,7 +169,7 @@ class StreamStatuses {
 export class ProgressViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
-    this.currentStream = '';
+    this.activeStream = '';
     this.currentGroupId = null;
 
     // Initialize managers
@@ -202,12 +202,12 @@ export class ProgressViewState {
   }
 
   // --- Current stream operations ---
-  getCurrentStream() {
-    return this.currentStream;
+  getActiveStream() {
+    return this.activeStream;
   }
 
-  setCurrentStream(stream) {
-    this.currentStream = stream;
+  setActiveStream(stream) {
+    this.activeStream = stream;
   }
 }
 

--- a/src/progressView/modules/uiManagers/Events.js
+++ b/src/progressView/modules/uiManagers/Events.js
@@ -58,10 +58,10 @@ export class Events {
         if (!button || button.disabled) return;
 
         const command = button.dataset.command;
-        const currentStream = progressViewState.getCurrentStream();
+        const activeStream = progressViewState.getActiveStream();
 
-        if (currentStream) {
-          vscode.postMessage({ command, stream: currentStream });
+        if (activeStream) {
+          vscode.postMessage({ command, stream: activeStream });
         }
       });
 

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -92,9 +92,9 @@ export class Status {
         if (el) el.disabled = false;
       });
 
-      const currentStream = progressViewState.getCurrentStream();
-      if (currentStream && status !== STATUS.READY) {
-        progressViewState.streamStatuses.set(currentStream, status);
+      const activeStream = progressViewState.getActiveStream();
+      if (activeStream && status !== STATUS.READY) {
+        progressViewState.streamStatuses.set(activeStream, status);
       }
     }
   }


### PR DESCRIPTION
## Summary
- rename currentStream variable to activeStream in progress view state
- update message handlers and UI managers to use activeStream
- send activeStream property from the ProgressViewProvider

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68613773e3fc832488d52ed4b6466e0b