### PR TITLE
Refactor private UI helpers

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -509,12 +509,12 @@ export class MessageHandlers {
 
   // Misc updates
   handleSetRecentCommits(message) {
-    fileSelect.handleRecentCommits(message);
+    fileSelect._handleRecentCommits(message);
     this._postHandle();
   }
 
   handleSetCurrentFile(message) {
-    fileSelect.handleSetCurrentFile({
+    fileSelect._handleSetCurrentFile({
       fileType: message.fileType,
       filePath: message.filePath,
     });

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -63,7 +63,7 @@ export class ActionButtonManager {
       const instruction = safeGetElementById('instruction');
       if (instruction) {
         instruction.value = '';
-        this.instructionManager.autoResizeTextarea(instruction);
+        this.instructionManager._autoResizeTextarea(instruction);
         this.state.save();
       }
     });

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -45,14 +45,14 @@ export class FileSelect {
     }
   }
 
-  addOption(select, value, text) {
+  _addOption(select, value, text) {
     const option = document.createElement('option');
     option.value = value;
     option.textContent = text;
     select.appendChild(option);
   }
 
-  setElementsDisabled(elements, disabled) {
+  _setElementsDisabled(elements, disabled) {
     elements.forEach((el) => {
       if (typeof el === 'string') {
         const elem = document.getElementById(el);
@@ -63,7 +63,7 @@ export class FileSelect {
     });
   }
 
-  handleRecentCommits(message) {
+  _handleRecentCommits(message) {
     const commitButtons = [
       'packLatexdiffvcButton',
       'cleanLatexdiffvcButton',
@@ -73,19 +73,19 @@ export class FileSelect {
     commitDiv.innerHTML = '';
 
     if (message.isGitRepo === false) {
-      this.addOption(commitDiv, '', 'Not a Git repository');
-      this.setElementsDisabled([commitDiv, ...commitButtons], true);
+      this._addOption(commitDiv, '', 'Not a Git repository');
+      this._setElementsDisabled([commitDiv, ...commitButtons], true);
     } else {
-      this.addOption(commitDiv, 'HEAD', 'HEAD');
+      this._addOption(commitDiv, 'HEAD', 'HEAD');
       message.commits.forEach((commit) => {
         const [commitHash] = commit.split(': ');
-        this.addOption(commitDiv, commitHash, commit);
+        this._addOption(commitDiv, commitHash, commit);
       });
-      this.setElementsDisabled([commitDiv, ...commitButtons], false);
+      this._setElementsDisabled([commitDiv, ...commitButtons], false);
     }
   }
 
-  handleSetCurrentFile({ fileType, filePath }) {
+  _handleSetCurrentFile({ fileType, filePath }) {
     const fileId = `${uncapitalize(fileType)}File`;
     const fileDiv = document.getElementById(fileId);
     if (!fileDiv) {

--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -8,7 +8,7 @@ export class InstructionManager {
     this.state = state;
   }
 
-  autoResizeTextarea(textarea) {
+  _autoResizeTextarea(textarea) {
     textarea.style.height = 'auto';
     const maxHeight = 400;
     const newHeight = Math.min(textarea.scrollHeight, maxHeight);
@@ -17,7 +17,7 @@ export class InstructionManager {
       textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
   }
 
-  insertTextAtCursor(textarea, text) {
+  _insertTextAtCursor(textarea, text) {
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
     const original = textarea.value;
@@ -34,19 +34,19 @@ export class InstructionManager {
       return;
     }
 
-    this.autoResizeTextarea(textarea);
+    this._autoResizeTextarea(textarea);
 
     textarea.addEventListener('input', () => {
-      this.autoResizeTextarea(textarea);
+      this._autoResizeTextarea(textarea);
       this.state?.save();
     });
 
     setupPasteListener(
       textarea,
       this.vscode,
-      (ta) => this.autoResizeTextarea(ta),
+      (ta) => this._autoResizeTextarea(ta),
       () => this.state?.save(),
-      (ta, text) => this.insertTextAtCursor(ta, text),
+      (ta, text) => this._insertTextAtCursor(ta, text),
     );
   }
 }

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -24,7 +24,7 @@ export class OutputFilesManager {
   }
 
   /** Initialize the output files list with the input file */
-  initializeOutputFiles() {
+  _initializeOutputFiles() {
     const state = this.state.get();
     const inputFileDiv = safeGetElementById(INPUT_FILE_ID);
     const outputFilesDiv = safeGetElementById(OUTPUT_FILES_ID);
@@ -73,14 +73,14 @@ export class OutputFilesManager {
     const containerVisible = container.style.display !== 'none';
 
     if (!containerVisible) {
-      this.initializeOutputFiles();
+      this._initializeOutputFiles();
     }
 
     this.fileList.toggle(OUTPUT_FILES_ID, TOGGLE_OUTPUT_FILES_ID);
   }
 
   /** Initialize the output files container based on state */
-  initializeOutputContainer() {
+  _initializeOutputContainer() {
     const container = safeGetElementById(OUTPUT_FILES_CONTAINER_ID);
     const toggleIcon = safeGetElementById(TOGGLE_OUTPUT_FILES_ID);
 

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -11,7 +11,7 @@ export class RecordingManager {
     this.isRecording = false;
   }
 
-  updateRecordingUI(recording) {
+  _updateRecordingUI(recording) {
     this.isRecording = recording;
     const recordButton = safeGetElementById('recordInstructionButton');
     if (recordButton) {
@@ -45,7 +45,7 @@ export class RecordingManager {
     });
 
     this.eventBus.addEventListener('recordingUIUpdate', (e) => {
-      this.updateRecordingUI(e.detail.recording);
+      this._updateRecordingUI(e.detail.recording);
     });
   }
 }


### PR DESCRIPTION
## Summary
- prefix internal helper methods with `_` in several webview managers
- update calls to renamed helpers

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning)*

------
https://chatgpt.com/codex/tasks/task_e_68613706f4b48324a109e9ea4553bb3c