### PR TITLE
feat: modularize message handlers

### DIFF
--- a/src/historyView/AgentHistoryViewProvider.ts
+++ b/src/historyView/AgentHistoryViewProvider.ts
@@ -167,6 +167,9 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
         'modules/historyViewState.js',
       );
       const searchManagerUri = getHistoryViewUri('modules/searchManager.js');
+      const messageHandlersUri = getHistoryViewUri(
+        'modules/messageHandlers.js',
+      );
 
       // Common module URIs
       const domUtilsUri = getCommonUri('modules/domUtils.js');
@@ -189,6 +192,7 @@ export class AgentHistoryViewProvider implements vscode.WebviewViewProvider {
         historyRendererUri,
         historyViewStateUri,
         searchManagerUri,
+        messageHandlersUri,
         domUtilsUri,
       });
     } catch (error) {

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -23,6 +23,7 @@
           "./modules/historyRenderer.js": "${historyRendererUri}",
           "./modules/historyViewState.js": "${historyViewStateUri}",
           "./modules/searchManager.js": "${searchManagerUri}",
+          "./modules/messageHandlers.js": "${messageHandlersUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}"

--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -1,0 +1,37 @@
+// Local imports
+import { registerMessageHandlers } from '@common/webviewContext.js';
+import { historyViewDomHandler } from './domHandlers.js';
+
+/**
+ * Handles messages from the extension for the history view.
+ */
+export class HistoryMessageHandlers {
+  constructor() {
+    this._cleanupFn = null;
+    this._handlers = {
+      updateHistory: (m) => this.handleUpdateHistory(m),
+      historyCleared: () => this.handleHistoryCleared(),
+    };
+  }
+
+  setup() {
+    this._cleanupFn = registerMessageHandlers(this._handlers);
+  }
+
+  cleanup() {
+    if (this._cleanupFn) {
+      this._cleanupFn();
+      this._cleanupFn = null;
+    }
+  }
+
+  handleUpdateHistory(message) {
+    historyViewDomHandler.renderer.render(message.historyItems);
+  }
+
+  handleHistoryCleared() {
+    historyViewDomHandler.renderer.render([]);
+  }
+}
+
+export const messageHandlers = new HistoryMessageHandlers();

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -1,24 +1,20 @@
-import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
+import { vscode } from '@common/webviewContext.js';
 import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
+import { messageHandlers } from './modules/messageHandlers.js';
 
 historyViewState.initialize();
+
+// Register handlers early so messages aren't missed
+messageHandlers.setup();
 
 document.addEventListener('DOMContentLoaded', () => {
   historyViewDomHandler.events.setupEventListeners();
   vscode.postMessage({ command: 'getHistoryData' });
 });
 
-window.addEventListener('unload', () => {
+window.addEventListener('beforeunload', () => {
   historyViewDomHandler.events.dispose();
   historyViewDomHandler.searchManager.dispose();
-});
-
-registerMessageHandlers({
-  updateHistory: (message) => {
-    historyViewDomHandler.renderer.render(message.historyItems);
-  },
-  historyCleared: () => {
-    historyViewDomHandler.renderer.render([]);
-  },
+  messageHandlers.cleanup();
 });

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -9,10 +9,44 @@ const state = progressViewState;
 const dom = progressViewDomHandler;
 
 // Create formatter instances
-const entryFormatter = new LogEntryFormatter();
 
-const handlers = {
-  [COMMANDS.UPDATE_STREAMS]: (message) => {
+export class ProgressMessageHandlers {
+  constructor() {
+    this._cleanupFn = null;
+    this._entryFormatter = new LogEntryFormatter();
+    this._handlers = this._createHandlers();
+  }
+
+  _createHandlers() {
+    return {
+      [COMMANDS.UPDATE_STREAMS]: (m) => this.handleUpdateStreams(m),
+      [COMMANDS.UPDATE_LOGS]: (m) => this.handleUpdateLogs(m),
+      [COMMANDS.CLEAR_LOGS]: () => this.handleClearLogs(),
+      [COMMANDS.APPEND_LOG]: (m) => this.handleAppendLog(m),
+      [COMMANDS.UPDATE_LOG]: (m) => this.handleUpdateLog(m),
+      [COMMANDS.ADD_LOG_GROUP]: (m) => this.handleAddLogGroup(m),
+      [COMMANDS.UPDATE_LOG_GROUP]: (m) => this.handleUpdateLogGroup(m),
+      [COMMANDS.UPDATE_STATUS]: (m) => this.handleUpdateStatus(m),
+      [COMMANDS.UPDATE_USAGE]: (m) => this.handleUpdateUsage(m),
+      [COMMANDS.UPDATE_GROUP_USAGE]: (m) => this.handleUpdateGroupUsage(m),
+      [COMMANDS.UPDATE_FILES]: (m) => this.handleUpdateFiles(m),
+      [COMMANDS.DELETE_STREAM]: (m) => this.handleDeleteStream(m),
+      [COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
+    };
+  }
+
+  setup() {
+    this._cleanupFn = registerMessageHandlers(this._handlers);
+  }
+
+  cleanup() {
+    if (this._cleanupFn) {
+      this._cleanupFn();
+      this._cleanupFn = null;
+    }
+  }
+
+  handleUpdateStreams(message) {
     state.setCurrentStream(message.currentStream);
     dom.streamTabs.update(message.streams, message.currentStream);
 
@@ -23,9 +57,9 @@ const handlers = {
       const streamStatus = state.streamStatuses.get(message.currentStream);
       dom.status.update(streamStatus || STATUS.STOPPED);
     }
-  },
+  }
 
-  [COMMANDS.UPDATE_LOGS]: (message) => {
+  handleUpdateLogs(message) {
     const logContent = document.getElementById('logContent');
     if (message.stream === state.getCurrentStream()) {
       logContent.innerHTML = '';
@@ -47,12 +81,12 @@ const handlers = {
         if (msg.groupId) {
           if (!dom.logEntries.append(msg)) {
             const el = document.createElement('div');
-            el.innerHTML = entryFormatter.format(msg);
+            el.innerHTML = this._entryFormatter.format(msg);
             logContent.appendChild(el.firstElementChild);
           }
         } else {
           const el = document.createElement('div');
-          el.innerHTML = entryFormatter.format(msg);
+          el.innerHTML = this._entryFormatter.format(msg);
           logContent.appendChild(el.firstElementChild);
         }
       });
@@ -61,9 +95,9 @@ const handlers = {
       // Recalculate cumulative usage after loading groups
       dom.usageSummary.update();
     }
-  },
+  }
 
-  [COMMANDS.CLEAR_LOGS]: () => {
+  handleClearLogs() {
     const logContent = document.getElementById('logContent');
     logContent.innerHTML = '';
     const groupIds = [];
@@ -73,63 +107,63 @@ const handlers = {
     }
     state.taskGroups.clear();
     state.toggleStates.clear(groupIds);
-  },
+  }
 
-  [COMMANDS.APPEND_LOG]: (message) => {
+  handleAppendLog(message) {
     if (message.stream === state.getCurrentStream()) {
       const logContent = document.getElementById('logContent');
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
         const el = document.createElement('div');
-        el.innerHTML = entryFormatter.format(message.logMessage);
+        el.innerHTML = this._entryFormatter.format(message.logMessage);
         logContent.appendChild(el.firstElementChild);
       }
       logContent.scrollTop = logContent.scrollHeight;
     }
-  },
+  }
 
-  [COMMANDS.UPDATE_LOG]: (message) => {
+  handleUpdateLog(message) {
     if (message.stream === state.getCurrentStream()) {
       dom.logEntries.update(message.logMessage);
     }
-  },
+  }
 
-  [COMMANDS.ADD_LOG_GROUP]: (message) => {
+  handleAddLogGroup(message) {
     if (message.stream === state.getCurrentStream()) {
       const logContent = document.getElementById('logContent');
       dom.taskGroups.add(message.group);
       logContent.scrollTop = logContent.scrollHeight;
     }
-  },
+  }
 
-  [COMMANDS.UPDATE_LOG_GROUP]: (message) => {
+  handleUpdateLogGroup(message) {
     if (message.stream === state.getCurrentStream()) {
       state.taskGroups.update(message.groupId, message.status, message.endTime);
       dom.taskGroups.update(message.groupId, message.status, message.endTime);
     }
-  },
+  }
 
-  [COMMANDS.UPDATE_STATUS]: (message) => {
+  handleUpdateStatus(message) {
     dom.status.update(message.status);
-  },
+  }
 
-  [COMMANDS.UPDATE_USAGE]: (message) => {
+  handleUpdateUsage(message) {
     dom.usageSummary.update(message.usage);
-  },
+  }
 
-  [COMMANDS.UPDATE_GROUP_USAGE]: (message) => {
+  handleUpdateGroupUsage(message) {
     if (message.stream === state.getCurrentStream()) {
       dom.usageGroup.update(message.groupId, message.usage);
     }
-  },
+  }
 
-  [COMMANDS.UPDATE_FILES]: (message) => {
+  handleUpdateFiles(message) {
     if (message.stream === state.getCurrentStream()) {
       dom.fileList.update(message.files);
     }
-  },
+  }
 
-  [COMMANDS.DELETE_STREAM]: (message) => {
+  handleDeleteStream(message) {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
       if (message.stream === state.getCurrentStream()) {
@@ -143,16 +177,11 @@ const handlers = {
         state.toggleStates.clear(groupIds);
       }
     }
-  },
+  }
 
-  [COMMANDS.DELETE_ALL]: () => {
+  handleDeleteAll() {
     state.toggleStates.clearAll();
-  },
-};
-
-/**
- * Sets up the message handler for messages from the extension
- */
-export function setupMessageHandlers() {
-  registerMessageHandlers(handlers);
+  }
 }
+
+export const messageHandlers = new ProgressMessageHandlers();

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -1,5 +1,5 @@
 import { progressViewState } from './modules/progressViewState.js';
-import { setupMessageHandlers } from './modules/messageHandlers.js';
+import { messageHandlers } from './modules/messageHandlers.js';
 import { progressViewDomHandler } from './modules/domHandlers.js';
 import { vscode } from '@common/webviewContext.js';
 import { COMMANDS } from './modules/constants.js';
@@ -7,8 +7,12 @@ import { COMMANDS } from './modules/constants.js';
 // Initialize the state when the window loads
 progressViewState.initialize();
 
-// Setup message handlers for VSCode messages
-setupMessageHandlers();
+// Register handlers for VSCode messages
+messageHandlers.setup();
+
+window.addEventListener('beforeunload', () => {
+  messageHandlers.cleanup();
+});
 
 // Initialize event listeners and state when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- convert progress view message handlers to a class with setup/cleanup
- update progress view script to use the new class
- add message handler module for history view and use it in the script
- expose history view module via import map and provider

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Could not run due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68613760c944832487c463bcaf698732