### PR TITLE
Add task ID tracking

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -144,6 +144,7 @@ async function executeAgentWithLogging<T extends IAgent>(
   agentName: string,
   createAgentFn: () => Promise<T>,
   context: vscode.ExtensionContext,
+  taskId?: string,
 ): Promise<void> {
   try {
     // Create agent to get config for stream ID
@@ -249,6 +250,7 @@ async function executeAgentWithLogging<T extends IAgent>(
         // Convert AgentConfig to TaskState using utility function
         emitProgress('setTaskState', {
           streamId: fullStreamId,
+          taskId,
           taskState: agentConfigToTaskState(config),
         });
         logger.debug(
@@ -352,6 +354,7 @@ async function executeAgentWithLogging<T extends IAgent>(
 export async function executeAgent(
   agentConfig: Partial<AgentConfig>,
   context: vscode.ExtensionContext,
+  taskId?: string,
 ): Promise<void> {
   // Ensure required fields
   if (!agentConfig.model || !agentConfig.agent) {
@@ -412,6 +415,7 @@ export async function executeAgent(
       );
     },
     context,
+    taskId,
   );
 }
 
@@ -423,6 +427,7 @@ export async function executeMergeAgent(
   inputFile: string,
   editedFile: string,
   context: vscode.ExtensionContext,
+  taskId?: string,
 ): Promise<void> {
   const agentName = 'merge';
 
@@ -469,5 +474,6 @@ export async function executeMergeAgent(
       );
     },
     context,
+    taskId,
   );
 }

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -24,10 +24,10 @@ export const executeCommand = {
   ) => {
     try {
       // Save the agent configuration to history (silently)
-      await AgentHistoryManager.addToHistory(config);
+      const taskId = await AgentHistoryManager.addToHistory(config);
 
       // Run the agent directly
-      await executeAgent(config, context);
+      await executeAgent(config, context, taskId);
     } catch (err) {
       throw err;
     }

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -35,6 +35,7 @@ export class ProgressStateManager {
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
   private _taskStates: Map<string, TaskState> = new Map();
+  private _taskIds: Map<string, string> = new Map();
   private _usageStats: Map<string, TokenUsageStats> = new Map();
   private _activeStream: string = '';
 
@@ -57,6 +58,10 @@ export class ProgressStateManager {
 
   get taskStates(): Map<string, TaskState> {
     return this._taskStates;
+  }
+
+  get taskIds(): Map<string, string> {
+    return this._taskIds;
   }
 
   get usageStats(): Map<string, TokenUsageStats> {
@@ -88,6 +93,7 @@ export class ProgressStateManager {
     await this._loadOutputFiles();
     this._loadActiveStream();
     await this._loadTaskStates();
+    this._loadTaskIds();
     await this._loadUsageStats();
   }
 
@@ -100,6 +106,7 @@ export class ProgressStateManager {
     this._saveOutputFiles();
     this._saveActiveStream();
     this._saveTaskStates();
+    this._saveTaskIds();
     this._saveUsageStats();
   }
 
@@ -322,6 +329,17 @@ export class ProgressStateManager {
     }
   }
 
+  private _loadTaskIds(): void {
+    const saved = workspaceSM.get<{ [key: string]: string }>(
+      WorkspaceStateKey.TASK_IDS,
+    );
+    if (saved) {
+      this._taskIds = new Map(Object.entries(saved));
+    } else {
+      this._taskIds.clear();
+    }
+  }
+
   /**
    * Load usage statistics
    */
@@ -393,6 +411,11 @@ export class ProgressStateManager {
     workspaceSM.update(WorkspaceStateKey.TASK_STATES, taskStatesObj);
   }
 
+  private _saveTaskIds(): void {
+    const idsObj = Object.fromEntries(this._taskIds.entries());
+    workspaceSM.update(WorkspaceStateKey.TASK_IDS, idsObj);
+  }
+
   /**
    * Save usage statistics
    */
@@ -409,6 +432,7 @@ export class ProgressStateManager {
     this._taskGroups.delete(stream);
     this._outputFiles.delete(stream);
     this._taskStates.delete(stream);
+    this._taskIds.delete(stream);
     this._usageStats.delete(stream);
   }
 
@@ -420,6 +444,7 @@ export class ProgressStateManager {
     this._taskGroups.clear();
     this._outputFiles.clear();
     this._taskStates.clear();
+    this._taskIds.clear();
     this._usageStats.clear();
     this._activeStream = '';
   }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -114,8 +114,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       new vscode.Disposable(
         onProgress(
           'setTaskState',
-          (p: { streamId: string; taskState: TaskState }) =>
-            this.setTaskState(p.streamId, p.taskState),
+          (p: { streamId: string; taskId?: string; taskState: TaskState }) =>
+            this.setTaskState(p.streamId, p.taskState, p.taskId),
         ),
       ),
       new vscode.Disposable(
@@ -723,14 +723,25 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  public setTaskState(streamId: string, taskState: TaskState): void {
+  public setTaskState(
+    streamId: string,
+    taskState: TaskState,
+    taskId?: string,
+  ): void {
     this.logger.debug(`Setting taskState for stream: ${streamId}`);
     // this.logger.debug(`Task state: ${JSON.stringify(taskState)}`);
     this._stateManager.taskStates.set(streamId, taskState);
+    if (taskId) {
+      this._stateManager.taskIds.set(streamId, taskId);
+    }
     this.saveTaskStates();
     this.logger.debug(
       `Current taskStates: ${JSON.stringify(Array.from(this._stateManager.taskStates.entries()))}`,
     );
+  }
+
+  public getTaskId(streamId: string): string | undefined {
+    return this._stateManager.taskIds.get(streamId);
   }
 
   public getTaskState(streamId: string): TaskState | undefined {

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -9,6 +9,7 @@ export enum WorkspaceStateKey {
   OUTPUT_FILES = 'texra.outputFiles',
   ACTIVE_LOG_STREAM = 'texra.activeLogStream',
   TASK_STATES = 'texra.taskStates',
+  TASK_IDS = 'texra.taskIds',
   USAGE_STATS = 'texra.usageStats',
 }
 


### PR DESCRIPTION
## Summary
- return history ID when executing an agent and pass it to `executeAgent`
- propagate optional `taskId` through runtime execution
- store taskId with stream state in the progress board
- persist taskId via a new `TASK_IDS` workspace state key

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack warning but no results)*

------
https://chatgpt.com/codex/tasks/task_e_68613f7b2318832486e0dba53326a838