### PR TITLE
Add task ID tracking for agent runs

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -144,6 +144,7 @@ async function executeAgentWithLogging<T extends IAgent>(
   agentName: string,
   createAgentFn: () => Promise<T>,
   context: vscode.ExtensionContext,
+  taskId?: string,
 ): Promise<void> {
   try {
     // Create agent to get config for stream ID
@@ -249,6 +250,7 @@ async function executeAgentWithLogging<T extends IAgent>(
         // Convert AgentConfig to TaskState using utility function
         emitProgress('setTaskState', {
           streamId: fullStreamId,
+          taskId,
           taskState: agentConfigToTaskState(config),
         });
         logger.debug(
@@ -352,6 +354,7 @@ async function executeAgentWithLogging<T extends IAgent>(
 export async function executeAgent(
   agentConfig: Partial<AgentConfig>,
   context: vscode.ExtensionContext,
+  taskId?: string,
 ): Promise<void> {
   // Ensure required fields
   if (!agentConfig.model || !agentConfig.agent) {
@@ -412,6 +415,7 @@ export async function executeAgent(
       );
     },
     context,
+    taskId,
   );
 }
 
@@ -469,5 +473,6 @@ export async function executeMergeAgent(
       );
     },
     context,
+    undefined,
   );
 }

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -24,10 +24,10 @@ export const executeCommand = {
   ) => {
     try {
       // Save the agent configuration to history (silently)
-      await AgentHistoryManager.addToHistory(config);
+      const taskId = await AgentHistoryManager.addToHistory(config);
 
-      // Run the agent directly
-      await executeAgent(config, context);
+      // Run the agent directly, passing through the task ID
+      await executeAgent(config, context, taskId);
     } catch (err) {
       throw err;
     }

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -35,6 +35,7 @@ export class ProgressStateManager {
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
   private _taskStates: Map<string, TaskState> = new Map();
+  private _taskIds: Map<string, string> = new Map();
   private _usageStats: Map<string, TokenUsageStats> = new Map();
   private _activeStream: string = '';
 
@@ -57,6 +58,10 @@ export class ProgressStateManager {
 
   get taskStates(): Map<string, TaskState> {
     return this._taskStates;
+  }
+
+  get taskIds(): Map<string, string> {
+    return this._taskIds;
   }
 
   get usageStats(): Map<string, TokenUsageStats> {
@@ -88,6 +93,7 @@ export class ProgressStateManager {
     await this._loadOutputFiles();
     this._loadActiveStream();
     await this._loadTaskStates();
+    await this._loadTaskIds();
     await this._loadUsageStats();
   }
 
@@ -100,6 +106,7 @@ export class ProgressStateManager {
     this._saveOutputFiles();
     this._saveActiveStream();
     this._saveTaskStates();
+    this._saveTaskIds();
     this._saveUsageStats();
   }
 
@@ -323,6 +330,20 @@ export class ProgressStateManager {
   }
 
   /**
+   * Load task IDs
+   */
+  private async _loadTaskIds(): Promise<void> {
+    const savedIds = workspaceSM.get<{ [key: string]: string }>(
+      this._getWorkspaceKey(WorkspaceStateKey.TASK_IDS),
+    );
+    if (savedIds) {
+      this._taskIds = new Map(Object.entries(savedIds));
+    } else {
+      this._taskIds.clear();
+    }
+  }
+
+  /**
    * Load usage statistics
    */
   private async _loadUsageStats(): Promise<void> {
@@ -394,6 +415,17 @@ export class ProgressStateManager {
   }
 
   /**
+   * Save task IDs
+   */
+  private _saveTaskIds(): void {
+    const taskIdsObj = Object.fromEntries(this._taskIds.entries());
+    workspaceSM.update(
+      this._getWorkspaceKey(WorkspaceStateKey.TASK_IDS),
+      taskIdsObj,
+    );
+  }
+
+  /**
    * Save usage statistics
    */
   private _saveUsageStats(): void {
@@ -409,6 +441,7 @@ export class ProgressStateManager {
     this._taskGroups.delete(stream);
     this._outputFiles.delete(stream);
     this._taskStates.delete(stream);
+    this._taskIds.delete(stream);
     this._usageStats.delete(stream);
   }
 
@@ -420,6 +453,7 @@ export class ProgressStateManager {
     this._taskGroups.clear();
     this._outputFiles.clear();
     this._taskStates.clear();
+    this._taskIds.clear();
     this._usageStats.clear();
     this._activeStream = '';
   }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -114,8 +114,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       new vscode.Disposable(
         onProgress(
           'setTaskState',
-          (p: { streamId: string; taskState: TaskState }) =>
-            this.setTaskState(p.streamId, p.taskState),
+          (p: { streamId: string; taskId?: string; taskState: TaskState }) =>
+            this.setTaskState(p.streamId, p.taskState, p.taskId),
         ),
       ),
       new vscode.Disposable(
@@ -723,14 +723,25 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  public setTaskState(streamId: string, taskState: TaskState): void {
+  public setTaskState(
+    streamId: string,
+    taskState: TaskState,
+    taskId?: string,
+  ): void {
     this.logger.debug(`Setting taskState for stream: ${streamId}`);
     // this.logger.debug(`Task state: ${JSON.stringify(taskState)}`);
     this._stateManager.taskStates.set(streamId, taskState);
+    if (taskId) {
+      this._stateManager.taskIds.set(streamId, taskId);
+    }
     this.saveTaskStates();
     this.logger.debug(
       `Current taskStates: ${JSON.stringify(Array.from(this._stateManager.taskStates.entries()))}`,
     );
+  }
+
+  public getTaskId(streamId: string): string | undefined {
+    return this._stateManager.taskIds.get(streamId);
   }
 
   public getTaskState(streamId: string): TaskState | undefined {

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -9,6 +9,7 @@ export enum WorkspaceStateKey {
   OUTPUT_FILES = 'texra.outputFiles',
   ACTIVE_LOG_STREAM = 'texra.activeLogStream',
   TASK_STATES = 'texra.taskStates',
+  TASK_IDS = 'texra.taskIds',
   USAGE_STATS = 'texra.usageStats',
 }
 


### PR DESCRIPTION
## Summary
- capture the history ID when executing agents
- pass this ID through the runtime so it can be stored
- persist task IDs in ProgressStateManager
- update ProgressViewProvider to handle task IDs
- support optional ID parameter for executeAgent

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68613f7b2318832486e0dba53326a838