### PR TITLE
Rename active stream state

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -308,7 +308,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._view.webview.postMessage({
       command: COMMANDS.UPDATE_STREAMS,
       streams,
-      currentStream: this._stateManager.activeStream,
+      activeStream: this._stateManager.activeStream,
     });
     this.updateLogContent(this._stateManager.activeStream);
 

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -56,7 +56,7 @@
       <div class="content-area split">
         <div class="log-header">
           <div class="header-left">
-            <span id="currentStreamName"></span>
+            <span id="activeStreamName"></span>
             <span
               id="statusIndicator"
               class="status-indicator stopped"

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -47,21 +47,21 @@ export class ProgressMessageHandlers {
   }
 
   handleUpdateStreams(message) {
-    state.setCurrentStream(message.currentStream);
-    dom.streamTabs.update(message.streams, message.currentStream);
+    state.setActiveStream(message.activeStream);
+    dom.streamTabs.update(message.streams, message.activeStream);
 
     // Update status based on whether there's an active stream
-    if (!message.currentStream) {
+    if (!message.activeStream) {
       dom.status.update(STATUS.READY);
     } else {
-      const streamStatus = state.streamStatuses.get(message.currentStream);
+      const streamStatus = state.streamStatuses.get(message.activeStream);
       dom.status.update(streamStatus || STATUS.STOPPED);
     }
   }
 
   handleUpdateLogs(message) {
     const logContent = document.getElementById('logContent');
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       logContent.innerHTML = '';
       state.taskGroups.clear();
       if (message.groups && message.groups.length > 0) {
@@ -110,7 +110,7 @@ export class ProgressMessageHandlers {
   }
 
   handleAppendLog(message) {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       const logContent = document.getElementById('logContent');
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
@@ -123,13 +123,13 @@ export class ProgressMessageHandlers {
   }
 
   handleUpdateLog(message) {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       dom.logEntries.update(message.logMessage);
     }
   }
 
   handleAddLogGroup(message) {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       const logContent = document.getElementById('logContent');
       dom.taskGroups.add(message.group);
       logContent.scrollTop = logContent.scrollHeight;
@@ -137,7 +137,7 @@ export class ProgressMessageHandlers {
   }
 
   handleUpdateLogGroup(message) {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       state.taskGroups.update(message.groupId, message.status, message.endTime);
       dom.taskGroups.update(message.groupId, message.status, message.endTime);
     }
@@ -152,13 +152,13 @@ export class ProgressMessageHandlers {
   }
 
   handleUpdateGroupUsage(message) {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       dom.usageGroup.update(message.groupId, message.usage);
     }
   }
 
   handleUpdateFiles(message) {
-    if (message.stream === state.getCurrentStream()) {
+    if (message.stream === state.getActiveStream()) {
       dom.fileList.update(message.files);
     }
   }
@@ -166,7 +166,7 @@ export class ProgressMessageHandlers {
   handleDeleteStream(message) {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
-      if (message.stream === state.getCurrentStream()) {
+      if (message.stream === state.getActiveStream()) {
         const groupIds = [];
         const headers = Array.from(
           document.querySelectorAll('.log-group-header'),

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -169,7 +169,7 @@ class StreamStatuses {
 export class ProgressViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
-    this.currentStream = '';
+    this.activeStream = '';
     this.currentGroupId = null;
 
     // Initialize managers
@@ -201,13 +201,13 @@ export class ProgressViewState {
     }
   }
 
-  // --- Current stream operations ---
-  getCurrentStream() {
-    return this.currentStream;
+  // --- Active stream operations ---
+  getActiveStream() {
+    return this.activeStream;
   }
 
-  setCurrentStream(stream) {
-    this.currentStream = stream;
+  setActiveStream(stream) {
+    this.activeStream = stream;
   }
 }
 

--- a/src/progressView/modules/uiManagers/Events.js
+++ b/src/progressView/modules/uiManagers/Events.js
@@ -58,10 +58,10 @@ export class Events {
         if (!button || button.disabled) return;
 
         const command = button.dataset.command;
-        const currentStream = progressViewState.getCurrentStream();
+        const activeStream = progressViewState.getActiveStream();
 
-        if (currentStream) {
-          vscode.postMessage({ command, stream: currentStream });
+        if (activeStream) {
+          vscode.postMessage({ command, stream: activeStream });
         }
       });
 

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -92,9 +92,9 @@ export class Status {
         if (el) el.disabled = false;
       });
 
-      const currentStream = progressViewState.getCurrentStream();
-      if (currentStream && status !== STATUS.READY) {
-        progressViewState.streamStatuses.set(currentStream, status);
+      const activeStream = progressViewState.getActiveStream();
+      if (activeStream && status !== STATUS.READY) {
+        progressViewState.streamStatuses.set(activeStream, status);
       }
     }
   }

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -34,8 +34,8 @@ export class StreamTabs {
       })
       .join('');
 
-    // Update current stream name
-    const streamNameElem = document.getElementById('currentStreamName');
+    // Update active stream name
+    const streamNameElem = document.getElementById('activeStreamName');
     if (streamNameElem) {
       streamNameElem.textContent = activeStream || '';
     }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -87,7 +87,7 @@
   min-width: 0;
 }
 
-#currentStreamName,
+#activeStreamName,
 #runSummary {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- rename `currentStream` to `activeStream` in progress view state
- use new getter/setter across progress view modules
- send `activeStream` from `ProgressViewProvider`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861490ba4dc83249f0b47a79bc4d9a3