### PR TITLE
Rename InstructionManager.init to setup

### DIFF
--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -25,7 +25,7 @@ export class InstructionManager {
     textarea.selectionStart = textarea.selectionEnd = start + text.length;
   }
 
-  init() {
+  setup() {
     const textarea = safeGetElementById(this.textareaId);
     if (!textarea) {
       console.warn(

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -17,7 +17,7 @@ window.addEventListener('beforeunload', () => {
 // Setup UI when DOM is loaded
 document.addEventListener('DOMContentLoaded', function () {
   webviewState.restore();
-  instructionManager.init();
+  instructionManager.setup();
   webviewDomHandler.initializeUI();
   toggleManager.updateToolConfigToggleState();
   toggleManager.updateAutoToggleState();


### PR DESCRIPTION
## Summary
- rename `InstructionManager.init()` to `setup()`
- update webview script to call `setup()`

## Testing
- `npm run format`
- `npm run lint`
- `npm test --silent` *(fails: webpack warning only)*

------
https://chatgpt.com/codex/tasks/task_e_68614b6daa1c8324a8bf72a713a4d7ed