### PR TITLE
Rename task DOM classes

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,7 +1,7 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { LogEntryFormatter } from './formatters.js';
-import { TaskGroupsDom, LogEntriesDom } from './taskManagers.js';
+import { TaskGroupManager, LogEntryManager } from './taskManagers.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
@@ -21,8 +21,8 @@ export class ProgressViewDomHandler {
     this.usageSummary = new UsageSummary();
     this.usageGroup = new UsageGroup(this.usageSummary); // Pass shared instance
     this.fileList = new FileList(this.usageSummary); // Pass shared instance
-    this.taskGroups = new TaskGroupsDom();
-    this.logEntries = new LogEntriesDom();
+    this.taskGroups = new TaskGroupManager();
+    this.logEntries = new LogEntryManager();
     this.events = new Events();
   }
 }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -5,7 +5,7 @@ import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
 /**
  * Manages task group DOM operations.
  */
-export class TaskGroupsDom {
+export class TaskGroupManager {
   constructor() {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
@@ -267,7 +267,7 @@ export class TaskGroupsDom {
 /**
  * Manages individual log entry DOM operations.
  */
-export class LogEntriesDom {
+export class LogEntryManager {
   constructor() {
     this.entryFormatter = new LogEntryFormatter();
   }


### PR DESCRIPTION
## Summary
- rename `TaskGroupsDom` -> `TaskGroupManager`
- rename `LogEntriesDom` -> `LogEntryManager`
- update imports in progress view DOM handler

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no output due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686158e9d83c832486448c34b9088a18