### PR TITLE
feat: track progress by taskId

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -31,6 +31,8 @@ export abstract class BaseAgent implements IAgent {
   protected isInterrupted = false;
   protected abortController: AbortController | null = null;
 
+  protected taskId: string;
+
   private static runningAgents: Map<string, BaseAgent> = new Map();
 
   public get config(): AgentConfig {
@@ -43,15 +45,17 @@ export abstract class BaseAgent implements IAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    taskId: string,
   ) {
     this.modelHandler = modelHandler;
     this.agentConfig = agentConfig;
     this.agentSetting = agentSetting;
     this.agentPrompt = agentPrompt;
     this.agentPath = agentPath;
+    this.taskId = taskId;
 
     const channelId = this.getTaskId();
-    this.logger = new AgentLogger(channelId, true);
+    this.logger = new AgentLogger(channelId, true, taskId);
     this.modelHandler.setLogger(this.logger);
   }
 
@@ -105,7 +109,7 @@ export abstract class BaseAgent implements IAgent {
       );
 
       this.userVars = await this.getUserVars();
-      BaseAgent.runningAgents.set(this.getTaskId(), this);
+      BaseAgent.runningAgents.set(this.taskId, this);
       this.logger.endGroup(initGroupId, 'stopped');
     } catch (error) {
       this.logger.endGroup(initGroupId, 'error');
@@ -138,8 +142,7 @@ export abstract class BaseAgent implements IAgent {
   }
 
   protected cleanup(): void {
-    const channelId = this.getTaskId();
-    BaseAgent.runningAgents.delete(channelId);
+    BaseAgent.runningAgents.delete(this.taskId);
   }
 
   abstract run(): Promise<void>;

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -75,8 +75,16 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    taskId: string,
   ) {
-    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
+    super(
+      modelHandler,
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      agentPath,
+      taskId,
+    );
 
     // Initialize basic attributes
     const numRounds = this.getNumberOfRounds();

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -19,8 +19,16 @@ export class MergeAgent extends DirectAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    taskId: string,
   ) {
-    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
+    super(
+      modelHandler,
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      agentPath,
+      taskId,
+    );
     this.outputFile = [this.getOutputFile(0), this.getOutputFile(1)];
   }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -1,6 +1,7 @@
 // Standard library imports
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { randomUUID } from 'crypto';
 
 // Third-party imports
 import { glob } from 'glob';
@@ -46,6 +47,7 @@ type AgentConstructor = {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    taskId: string,
   ): IAgent;
 };
 
@@ -144,6 +146,7 @@ async function executeAgentWithLogging<T extends IAgent>(
   agentName: string,
   createAgentFn: () => Promise<T>,
   context: vscode.ExtensionContext,
+  taskId: string,
 ): Promise<void> {
   try {
     // Create agent to get config for stream ID
@@ -151,13 +154,14 @@ async function executeAgentWithLogging<T extends IAgent>(
 
     // Get the full stream ID
     const config = agent.config;
-    const fullStreamId = getStreamId(agentName, config.model, config.inputFile);
+    const streamName = getStreamId(agentName, config.model, config.inputFile);
+    const streamId = taskId;
 
     // Check if this stream is already running
     const provider = ProgressViewProvider.getInstance();
-    const currentStatus = provider?.getStreamStatus(fullStreamId);
+    const currentStatus = provider?.getStreamStatus(streamId);
     if (currentStatus === 'running') {
-      const errorMsg = `Task "${fullStreamId}" is already running. Please wait for it to complete or stop it first.`;
+      const errorMsg = `Task "${streamName}" is already running. Please wait for it to complete or stop it first.`;
       throw new Error(errorMsg);
     }
 
@@ -175,14 +179,14 @@ async function executeAgentWithLogging<T extends IAgent>(
       );
 
       logger.info(
-        `Starting task execution for ${fullStreamId}`,
+        `Starting task execution for ${streamName}`,
         taskDetailsGroupId,
       );
       logger.info(`Input file: ${config.inputFile}`, taskDetailsGroupId);
 
       try {
         logger.debug(
-          `Creating stream with ID: ${fullStreamId}`,
+          `Creating stream with ID: ${streamId} (${streamName})`,
           taskDetailsGroupId,
         );
         logger.debug(
@@ -195,9 +199,9 @@ async function executeAgentWithLogging<T extends IAgent>(
         );
 
         // Switch to this stream and set its status to running
-        emitProgress('setActiveStream', fullStreamId);
+        emitProgress('setActiveStream', streamId);
         emitProgress('updateStreamStatus', {
-          stream: fullStreamId,
+          stream: streamId,
           status: 'running',
         });
 
@@ -235,7 +239,7 @@ async function executeAgentWithLogging<T extends IAgent>(
 
         // Store taskState
         logger.debug(
-          `Storing taskState for stream: ${fullStreamId}`,
+          `Storing taskState for stream: ${streamName}`,
           taskDetailsGroupId,
         );
         logger.debug(
@@ -248,11 +252,11 @@ async function executeAgentWithLogging<T extends IAgent>(
 
         // Convert AgentConfig to TaskState using utility function
         emitProgress('setTaskState', {
-          streamId: fullStreamId,
+          streamId: streamId,
           taskState: agentConfigToTaskState(config),
         });
         logger.debug(
-          `Task state stored for stream: ${fullStreamId}`,
+          `Task state stored for stream: ${streamName}`,
           mainTaskGroupId,
         );
 
@@ -269,7 +273,7 @@ async function executeAgentWithLogging<T extends IAgent>(
           logger.endGroup(mainTaskGroupId, 'stopped');
           // Update status to stopped on successful completion
           emitProgress('updateStreamStatus', {
-            stream: fullStreamId,
+            stream: streamId,
             status: 'stopped',
           });
 
@@ -290,7 +294,7 @@ async function executeAgentWithLogging<T extends IAgent>(
           logger.endGroup(mainTaskGroupId, 'error');
           // Update status to error if agent run fails
           emitProgress('updateStreamStatus', {
-            stream: fullStreamId,
+            stream: streamId,
             status: 'error',
           });
           throw err;
@@ -352,6 +356,7 @@ async function executeAgentWithLogging<T extends IAgent>(
 export async function executeAgent(
   agentConfig: Partial<AgentConfig>,
   context: vscode.ExtensionContext,
+  taskId: string,
 ): Promise<void> {
   // Ensure required fields
   if (!agentConfig.model || !agentConfig.agent) {
@@ -409,9 +414,11 @@ export async function executeAgent(
         agentSetting,
         agentPrompt,
         agentPath,
+        taskId,
       );
     },
     context,
+    taskId,
   );
 }
 
@@ -425,6 +432,7 @@ export async function executeMergeAgent(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   const agentName = 'merge';
+  const taskId = randomUUID();
 
   await executeAgentWithLogging(
     agentName,
@@ -466,8 +474,10 @@ export async function executeMergeAgent(
         agentSetting,
         agentPrompt,
         agentPath,
+        taskId,
       );
     },
     context,
+    taskId,
   );
 }

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -24,10 +24,10 @@ export const executeCommand = {
   ) => {
     try {
       // Save the agent configuration to history (silently)
-      await AgentHistoryManager.addToHistory(config);
+      const taskId = await AgentHistoryManager.addToHistory(config);
 
       // Run the agent directly
-      await executeAgent(config, context);
+      await executeAgent(config, context, taskId);
     } catch (err) {
       throw err;
     }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -17,9 +17,10 @@ export class AgentLogger {
   constructor(
     public channelId: string,
     isAgentLogger = false,
+    taskId?: string,
   ) {
     this.isAgentLogger = isAgentLogger;
-    logger.initialize(this.channelId, this.isAgentLogger);
+    logger.initialize(this.channelId, this.isAgentLogger, taskId);
     this.channelId = channelId;
   }
 

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -86,6 +86,7 @@ function getMainOutputChannel(): vscode.OutputChannel {
 class VSCodeTransport extends Transport {
   private channel: vscode.OutputChannel;
   private streamName: string;
+  private taskId: string;
   private isAgentChannel: boolean;
   private groups: Map<string, TaskGroup> = new Map();
   private activeGroupId?: string;
@@ -93,12 +94,14 @@ class VSCodeTransport extends Transport {
   constructor(
     channel: vscode.OutputChannel,
     streamName: string,
+    taskId: string,
     isAgentChannel: boolean,
     opts?: Transport.TransportStreamOptions,
   ) {
     super(opts);
     this.channel = channel;
     this.streamName = streamName;
+    this.taskId = taskId;
     this.isAgentChannel = isAgentChannel;
   }
 
@@ -158,7 +161,7 @@ class VSCodeTransport extends Transport {
     } satisfies import('./LogTypes').LogMessageData;
 
     emitProgress('addLogMessage', {
-      stream: this.streamName,
+      stream: this.taskId,
       logMessage,
     });
 
@@ -190,7 +193,7 @@ class VSCodeTransport extends Transport {
     }
 
     emitProgress('addLogGroup', {
-      stream: this.streamName,
+      stream: this.taskId,
       groupId,
       groupName,
       startTime: now,
@@ -219,7 +222,7 @@ class VSCodeTransport extends Transport {
     }
 
     emitProgress('updateLogGroup', {
-      stream: this.streamName,
+      stream: this.taskId,
       groupId,
       status,
       endTime: group.endTime,
@@ -254,16 +257,21 @@ class VSCodeTransport extends Transport {
 const channelLoggers = new Map<string, winston.Logger>();
 const channelTransports = new Map<string, VSCodeTransport>();
 
-export function initialize(defaultChannel: string, isAgent = false): void {
+export function initialize(
+  defaultChannel: string,
+  isAgent = false,
+  taskId?: string,
+): void {
   // Create default logger if it doesn't exist
   if (!channelLoggers.has(defaultChannel)) {
-    createLoggerForChannel(defaultChannel, isAgent);
+    createLoggerForChannel(defaultChannel, isAgent, taskId);
   }
 }
 
 function createLoggerForChannel(
   channel: string,
   isAgent = false,
+  taskId?: string,
 ): winston.Logger {
   // Check if channel already exists
   if (channelLoggers.has(channel)) {
@@ -275,7 +283,12 @@ function createLoggerForChannel(
     : getMainOutputChannel();
 
   // Create transport
-  const transport = new VSCodeTransport(outputChannel, channel, isAgent);
+  const transport = new VSCodeTransport(
+    outputChannel,
+    channel,
+    taskId ?? channel,
+    isAgent,
+  );
   channelTransports.set(channel, transport);
 
   const logger = winston.createLogger({

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -16,6 +16,7 @@ import { TaskGroup } from '../logger/LogTypes';
 import type { DiffStats } from '../types/DiffTypes';
 import { randomUUID } from 'crypto';
 import { onProgress } from '@eventBus/ProgressEventBus';
+import { getStreamId } from '@logger/streamUtils';
 
 // @ts-ignore - Import JavaScript module
 import { STATUS, COMMANDS } from './modules/constants.js';
@@ -298,11 +299,26 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const streams = Array.from(this._stateManager.logStreams.keys());
+    const streams = Array.from(this._stateManager.logStreams.keys()).map(
+      (id) => {
+        const state = this._stateManager.taskStates.get(id);
+        const name = state
+          ? getStreamId(
+              state.agent,
+              state.model,
+              state.inputFile,
+              state.outputFiles,
+            )
+          : id;
+        return { id, name };
+      },
+    );
+
+    const streamIds = streams.map((s) => s.id);
 
     // Use stored active stream, fallback to first stream if active stream doesn't exist
-    if (!streams.includes(this._stateManager.activeStream)) {
-      this._stateManager.activeStream = streams[0] ?? '';
+    if (!streamIds.includes(this._stateManager.activeStream)) {
+      this._stateManager.activeStream = streamIds[0] ?? '';
     }
 
     this._view.webview.postMessage({

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -14,6 +14,9 @@ const entryFormatter = new LogEntryFormatter();
 const handlers = {
   [COMMANDS.UPDATE_STREAMS]: (message) => {
     state.setCurrentStream(message.currentStream);
+    if (Array.isArray(message.streams)) {
+      state.streamNames = new Map(message.streams.map((s) => [s.id, s.name]));
+    }
     dom.streamTabs.update(message.streams, message.currentStream);
 
     // Update status based on whether there's an active stream

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -176,6 +176,7 @@ export class ProgressViewState {
     this.taskGroups = new TaskGroups();
     this.toggleStates = new ToggleStates(() => this.save());
     this.streamStatuses = new StreamStatuses();
+    this.streamNames = new Map();
   }
 
   /** Load saved state from VS Code storage. */

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -21,13 +21,13 @@ export class StreamTabs {
     }
     tabsContainer.innerHTML = streams
       .map((stream) => {
-        if (!stream || typeof stream !== 'string') {
+        if (!stream || typeof stream !== 'object') {
           console.warn('StreamTabs.update: invalid stream value:', stream);
           return '';
         }
-        return `<div class="tab-container ${stream === activeStream ? 'active' : ''}" title="${stream}">
-            <button class="tab" data-stream="${stream}" title="${stream}">${stream}</button>
-            <button class="tab-delete" data-stream="${stream}" title="Delete stream">
+        return `<div class="tab-container ${stream.id === activeStream ? 'active' : ''}" title="${stream.name}">
+            <button class="tab" data-stream="${stream.id}" title="${stream.name}">${stream.name}</button>
+            <button class="tab-delete" data-stream="${stream.id}" title="Delete stream">
               <i class="codicon codicon-close"></i>
             </button>
           </div>`;
@@ -37,7 +37,8 @@ export class StreamTabs {
     // Update current stream name
     const streamNameElem = document.getElementById('currentStreamName');
     if (streamNameElem) {
-      streamNameElem.textContent = activeStream || '';
+      const active = streams.find((s) => s.id === activeStream);
+      streamNameElem.textContent = active ? active.name : '';
     }
   }
 }


### PR DESCRIPTION
## Summary
- return taskId from `AgentHistoryManager.addToHistory`
- persist taskId in command handler and pass to runtime
- emit progress events keyed by taskId
- compute stream names from task state for webview
- display friendly names while using taskId internally

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686120a2ab848324bab89bc869dc5ed4