### PR TITLE
feat: show missing output reminder in progress view

### DIFF
--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -7,6 +7,8 @@ import * as path from 'path';
 // Local imports
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { INSTRUCTION_PREFIX, globalSM } from '@utils/stateManager';
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 /**
  * Show an instruction message that can be permanently dismissed.
@@ -55,73 +57,94 @@ export async function checkExpectedOutputs(
     return;
   }
 
+  const missing: string[] = [];
   for (const file of expectedFiles) {
     const exists = path.isAbsolute(file)
       ? await AbsoluteFS.exists(file)
       : await WorkspaceFS.exists(file);
     if (!exists) {
-      const openBtn = 'Open XML';
-
-      let xmlPath: string | undefined;
-      const outputs: string[] = [];
-
-      if (agent && typeof agent === 'object') {
-        const anyAgent = agent as any;
-        if (Array.isArray(anyAgent.outputFile)) {
-          outputs.push(...anyAgent.outputFile.filter(Boolean));
-        }
-        if (anyAgent.outputHandler?.outputFiles) {
-          const fileMap = anyAgent.outputHandler.outputFiles as Record<
-            string,
-            string[]
-          >;
-          for (const roundFiles of Object.values(fileMap)) {
-            if (Array.isArray(roundFiles)) {
-              outputs.push(...roundFiles.filter(Boolean));
-            }
-          }
-        }
-      }
-
-      xmlPath = outputs.find((p) => p.endsWith('.xml') || p.endsWith('.tex'));
-      if (!xmlPath) {
-        xmlPath = file.replace(/\.[^.]+$/, '.xml');
-      }
-
-      await showInstructionWithSuppress(
-        'xmlOutputMismatch',
-        `Expected output "${path.basename(
-          file,
-        )}" was not generated. Open the XML file to check tag consistency, then run again.`,
-        [
-          {
-            title: openBtn,
-            callback: async () => {
-              if (!xmlPath) {
-                vscode.window.showWarningMessage('XML file path not found');
-                return;
-              }
-
-              const xmlExists = path.isAbsolute(xmlPath)
-                ? await AbsoluteFS.exists(xmlPath)
-                : await WorkspaceFS.exists(xmlPath);
-              if (!xmlExists) {
-                vscode.window.showWarningMessage(
-                  `XML file not found: ${path.basename(xmlPath)}`,
-                );
-                return;
-              }
-              const uri = path.isAbsolute(xmlPath)
-                ? vscode.Uri.file(xmlPath)
-                : vscode.Uri.file(WorkspaceFS.fullPath(xmlPath));
-              const doc = await vscode.workspace.openTextDocument(uri);
-              await vscode.window.showTextDocument(doc, { preview: false });
-            },
-          },
-        ],
-        false,
-      );
-      break;
+      missing.push(file);
     }
+  }
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  const openBtn = 'Open XML';
+
+  let xmlPath: string | undefined;
+  const outputs: string[] = [];
+
+  if (agent && typeof agent === 'object') {
+    const anyAgent = agent as any;
+    if (Array.isArray(anyAgent.outputFile)) {
+      outputs.push(...anyAgent.outputFile.filter(Boolean));
+    }
+    if (anyAgent.outputHandler?.outputFiles) {
+      const fileMap = anyAgent.outputHandler.outputFiles as Record<
+        string,
+        string[]
+      >;
+      for (const roundFiles of Object.values(fileMap)) {
+        if (Array.isArray(roundFiles)) {
+          outputs.push(...roundFiles.filter(Boolean));
+        }
+      }
+    }
+  }
+
+  xmlPath = outputs.find((p) => p.endsWith('.xml') || p.endsWith('.tex'));
+  if (!xmlPath && missing.length === 1) {
+    xmlPath = missing[0].replace(/\.[^.]+$/, '.xml');
+  }
+
+  await showInstructionWithSuppress(
+    'xmlOutputMismatch',
+    `Expected output ${missing
+      .map((f) => `"${path.basename(f)}"`)
+      .join(
+        ', ',
+      )} was not generated. Open the XML file to check tag consistency, then run again.`,
+    [
+      {
+        title: openBtn,
+        callback: async () => {
+          if (!xmlPath) {
+            vscode.window.showWarningMessage('XML file path not found');
+            return;
+          }
+
+          const xmlExists = path.isAbsolute(xmlPath)
+            ? await AbsoluteFS.exists(xmlPath)
+            : await WorkspaceFS.exists(xmlPath);
+          if (!xmlExists) {
+            vscode.window.showWarningMessage(
+              `XML file not found: ${path.basename(xmlPath)}`,
+            );
+            return;
+          }
+          const uri = path.isAbsolute(xmlPath)
+            ? vscode.Uri.file(xmlPath)
+            : vscode.Uri.file(WorkspaceFS.fullPath(xmlPath));
+          const doc = await vscode.workspace.openTextDocument(uri);
+          await vscode.window.showTextDocument(doc, { preview: false });
+        },
+      },
+    ],
+    false,
+  );
+
+  const agentLogger = (agent as any)?.logger as AgentLogger | undefined;
+  const groupId = agentLogger?.getActiveGroupId();
+  if (agentLogger) {
+    agentLogger.warn(
+      JSON.stringify({
+        missing: missing.map((m) => path.basename(m)),
+        xmlPath,
+      }),
+      groupId,
+      MESSAGE_TYPES.OUTPUT_REMINDER,
+    );
   }
 }

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -34,7 +34,12 @@ export interface LogMessageData {
   /** Optional group association */
   groupId?: string;
   /** Optional message category */
-  messageType?: 'default' | 'scratchpad' | 'thinking' | 'fileList';
+  messageType?:
+    | 'default'
+    | 'scratchpad'
+    | 'thinking'
+    | 'fileList'
+    | 'outputReminder';
   /** Whether verbose details should be displayed */
   verbose?: boolean;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -15,11 +15,13 @@ function isValidMessageType(
 ): type is
   | typeof MESSAGE_TYPES.THINKING
   | typeof MESSAGE_TYPES.SCRATCHPAD
-  | typeof MESSAGE_TYPES.FILE_LIST {
+  | typeof MESSAGE_TYPES.FILE_LIST
+  | typeof MESSAGE_TYPES.OUTPUT_REMINDER {
   return (
     type === MESSAGE_TYPES.THINKING ||
     type === MESSAGE_TYPES.SCRATCHPAD ||
-    type === MESSAGE_TYPES.FILE_LIST
+    type === MESSAGE_TYPES.FILE_LIST ||
+    type === MESSAGE_TYPES.OUTPUT_REMINDER
   );
 }
 

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -2,6 +2,7 @@ export const MESSAGE_TYPES = {
   THINKING: 'thinking',
   SCRATCHPAD: 'scratchpad',
   FILE_LIST: 'fileList',
+  OUTPUT_REMINDER: 'outputReminder',
   DEFAULT: 'default',
 } as const;
 

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -151,6 +151,10 @@ export class LogEntryFormatter {
       return this._formatFileList(htmlMessage, text, id);
     }
 
+    if (messageType === 'outputReminder') {
+      return this._formatOutputReminder(htmlMessage, text, id);
+    }
+
     return htmlMessage;
   }
 
@@ -293,6 +297,41 @@ export class LogEntryFormatter {
       </details>`;
     } catch (e) {
       console.error('Error parsing file list:', e);
+      return message;
+    }
+  }
+
+  _formatOutputReminder(message, content, logId) {
+    try {
+      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const parsed = JSON.parse(this._unescapeHtml(content));
+      if (!parsed || !Array.isArray(parsed.missing)) {
+        throw new Error('Invalid output reminder');
+      }
+
+      const items = parsed.missing
+        .map((f) => `<li>${this._escapeHtml(f)}</li>`)
+        .join('');
+      const link = parsed.xmlPath
+        ? `<span class="file-link clickable-link" data-file="${this._escapeHtml(
+            parsed.xmlPath,
+          )}">Open XML</span>`
+        : '';
+
+      return `<details class="output-reminder-details" open>
+        <summary>
+          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
+          <i class="codicon codicon-warning"></i>
+          <span>Missing output</span>
+        </summary>
+        <div class="output-reminder-content"${idAttr}>
+          <p>Expected output file(s) not generated:</p>
+          <ul>${items}</ul>
+          ${link}
+        </div>
+      </details>`;
+    } catch (e) {
+      console.error('Error parsing output reminder:', e);
       return message;
     }
   }

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -16,3 +16,4 @@
 @import './groups.css';
 @import './scratchpad.css';
 @import './file-list.css';
+@import './output-reminder.css';

--- a/src/progressView/styles/output-reminder.css
+++ b/src/progressView/styles/output-reminder.css
@@ -1,0 +1,39 @@
+/**
+ * Output reminder styles for ProgressView
+ */
+
+.output-reminder-details {
+  margin: var(--spacing-small) 0;
+}
+
+.output-reminder-details summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) 0;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  opacity: var(--opacity-normal);
+}
+
+.output-reminder-details summary:hover {
+  opacity: 1;
+}
+
+.output-reminder-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.output-reminder-content {
+  padding: var(--spacing-small) 0 var(--spacing-medium) var(--spacing-large);
+}
+
+.output-reminder-content ul {
+  margin: var(--spacing-small) 0;
+  padding-left: var(--spacing-large);
+}
+
+.output-reminder-content li {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- add `outputReminder` structured log message type
- render missing output warning with an Open XML link
- log aggregated missing outputs via `checkExpectedOutputs`
- include new styles for output reminders

## Testing
- `npx prettier --write src/logger/messageTypes.ts src/logger/LogTypes.ts src/logger/logUtils.ts src/progressView/modules/formatters.js src/progressView/styles/index.css src/progressView/styles/output-reminder.css src/frontend/ui/instruction.ts`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'path' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68629b7cf1a88324a5985b78297f6948