### PR TITLE
Refactor log stream state to stream tabs

### DIFF
--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -23,14 +23,14 @@ interface OutputFileInfo extends DiffStats {
 
 /**
  * Manages persistence of progress view state to workspace storage.
- * Handles loading and saving of log streams, groups, output files,
+ * Handles loading and saving of stream tabs, groups, output files,
  * task states, and usage statistics.
  */
 export class ProgressStateManager {
   private readonly logger: AgentLogger;
 
   // State collections
-  private _logStreams: Map<string, LogMessageData[]> = new Map();
+  private _streamTabs: Map<string, LogMessageData[]> = new Map();
   private _taskGroups: Map<string, Map<string, TaskGroup>> = new Map();
   private _outputFiles: Map<string, { [key: number]: OutputFileInfo[] }> =
     new Map();
@@ -44,8 +44,8 @@ export class ProgressStateManager {
   }
 
   // Getters for state collections
-  get logStreams(): Map<string, LogMessageData[]> {
-    return this._logStreams;
+  get streamTabs(): Map<string, LogMessageData[]> {
+    return this._streamTabs;
   }
 
   get taskGroups(): Map<string, Map<string, TaskGroup>> {
@@ -88,7 +88,7 @@ export class ProgressStateManager {
    * Load all state from workspace storage
    */
   public async loadState(): Promise<void> {
-    await this._loadLogStreams();
+    await this._loadStreamTabs();
     await this._loadTaskGroups();
     await this._loadOutputFiles();
     this._loadActiveStream();
@@ -101,7 +101,7 @@ export class ProgressStateManager {
    * Save all state to workspace storage
    */
   public saveState(): void {
-    this._saveLogStreams();
+    this._saveStreamTabs();
     this._saveTaskGroups();
     this._saveOutputFiles();
     this._saveActiveStream();
@@ -111,16 +111,28 @@ export class ProgressStateManager {
   }
 
   /**
-   * Load log streams from storage
+   * Load stream tabs from storage
    */
-  private async _loadLogStreams(): Promise<void> {
-    const savedState = workspaceSM.get<{
+  private async _loadStreamTabs(): Promise<void> {
+    let savedState = workspaceSM.get<{
       [key: string]: LogMessageData[] | any[];
-    }>(this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS));
+    }>(this._getWorkspaceKey(WorkspaceStateKey.STREAM_TABS));
+
+    if (!savedState) {
+      const legacyKey = this._getWorkspaceKey('texra.logStreams');
+      const legacyState = workspaceSM.get<{ [key: string]: LogMessageData[] }>(
+        legacyKey,
+      );
+      if (legacyState) {
+        savedState = legacyState;
+        await workspaceSM.update(legacyKey, undefined);
+        this.logger.debug('Migrated logStreams to streamTabs');
+      }
+    }
 
     if (savedState) {
       // Only load persisted channels
-      this._logStreams = new Map(
+      this._streamTabs = new Map(
         Object.entries(savedState).map(([stream, messages]) => [
           stream,
           messages.map((msg: any) => {
@@ -151,7 +163,7 @@ export class ProgressStateManager {
         ]),
       );
     } else {
-      this._logStreams.clear();
+      this._streamTabs.clear();
     }
   }
 
@@ -290,12 +302,12 @@ export class ProgressStateManager {
    */
   private _loadActiveStream(): void {
     const savedActiveStream = workspaceSM.get<string>(
-      WorkspaceStateKey.ACTIVE_LOG_STREAM,
+      WorkspaceStateKey.ACTIVE_STREAM_TAB,
     );
-    if (savedActiveStream && this._logStreams.has(savedActiveStream)) {
+    if (savedActiveStream && this._streamTabs.has(savedActiveStream)) {
       this._activeStream = savedActiveStream;
     } else {
-      this._activeStream = Array.from(this._logStreams.keys())[0] ?? '';
+      this._activeStream = Array.from(this._streamTabs.keys())[0] ?? '';
     }
   }
 
@@ -363,13 +375,13 @@ export class ProgressStateManager {
   }
 
   /**
-   * Save log streams to storage
+   * Save stream tabs to storage
    */
-  private _saveLogStreams(): void {
-    const persistentStreams = Array.from(this._logStreams.entries());
+  private _saveStreamTabs(): void {
+    const persistentStreams = Array.from(this._streamTabs.entries());
     const stateObj = Object.fromEntries(persistentStreams);
     workspaceSM.update(
-      this._getWorkspaceKey(WorkspaceStateKey.LOG_STREAMS),
+      this._getWorkspaceKey(WorkspaceStateKey.STREAM_TABS),
       stateObj,
     );
   }
@@ -403,7 +415,7 @@ export class ProgressStateManager {
    * Save active stream
    */
   private _saveActiveStream(): void {
-    workspaceSM.update(WorkspaceStateKey.ACTIVE_LOG_STREAM, this._activeStream);
+    workspaceSM.update(WorkspaceStateKey.ACTIVE_STREAM_TAB, this._activeStream);
   }
 
   /**
@@ -437,7 +449,7 @@ export class ProgressStateManager {
    * Clear all state for a specific stream
    */
   public clearStream(stream: string): void {
-    this._logStreams.delete(stream);
+    this._streamTabs.delete(stream);
     this._taskGroups.delete(stream);
     this._outputFiles.delete(stream);
     this._taskStates.delete(stream);
@@ -449,7 +461,7 @@ export class ProgressStateManager {
    * Clear all state
    */
   public clearAll(): void {
-    this._logStreams.clear();
+    this._streamTabs.clear();
     this._taskGroups.clear();
     this._outputFiles.clear();
     this._taskStates.clear();

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -299,7 +299,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const streams = Array.from(this._stateManager.logStreams.keys());
+    const streams = Array.from(this._stateManager.streamTabs.keys());
 
     // Use stored active stream, fallback to first stream if active stream doesn't exist
     if (!streams.includes(this._stateManager.activeStream)) {
@@ -360,9 +360,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Create stream if it doesn't exist
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streamTabs.has(stream)) {
       this.logger.debug(`Adding new stream to ProgressView: ${stream}`);
-      this._stateManager.logStreams.set(stream, []);
+      this._stateManager.streamTabs.set(stream, []);
 
       // Set initial status to running for new streams
       if (!this._streamStatus.has(stream)) {
@@ -387,7 +387,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       }
     }
 
-    const messages = this._stateManager.logStreams.get(stream)!;
+    const messages = this._stateManager.streamTabs.get(stream)!;
     messages.push(log);
 
     if (messages.length > 1000) {
@@ -406,7 +406,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public updateLogMessage(stream: string, log: LogMessageData): void {
-    const messages = this._stateManager.logStreams.get(stream);
+    const messages = this._stateManager.streamTabs.get(stream);
     if (!messages) {
       return;
     }
@@ -441,9 +441,9 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   ) {
     // Ensure the stream exists so the UI can create a new tab immediately
     // this seems to be the fix for the issue where the progress view panel is not shown when a new stream is created
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streamTabs.has(stream)) {
       this.logger.debug(`Creating stream from addLogGroup: ${stream}`);
-      this._stateManager.logStreams.set(stream, []);
+      this._stateManager.streamTabs.set(stream, []);
       if (!this._streamStatus.has(stream)) {
         this.updateStreamStatus(stream, STATUS.RUNNING);
       }
@@ -528,16 +528,16 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     // If no stream is provided or stream doesn't exist, use the first available stream
-    if (!stream || !this._stateManager.logStreams.has(stream)) {
-      const streams = Array.from(this._stateManager.logStreams.keys());
+    if (!stream || !this._stateManager.streamTabs.has(stream)) {
+      const streams = Array.from(this._stateManager.streamTabs.keys());
       stream = streams[0] ?? '';
     }
 
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streamTabs.has(stream)) {
       return;
     }
 
-    const messages = this._stateManager.logStreams.get(stream)!;
+    const messages = this._stateManager.streamTabs.get(stream)!;
     // Filter debug messages if debug mode is disabled
     const displayMessages = getConfig<boolean>('logger.debugMode', false)
       ? messages
@@ -569,8 +569,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     });
   }
 
-  public getLogStreams(): Map<string, LogMessageData[]> {
-    return this._stateManager.logStreams;
+  public getStreamTabs(): Map<string, LogMessageData[]> {
+    return this._stateManager.streamTabs;
   }
 
   public getTaskGroups(): Map<string, Map<string, TaskGroup>> {
@@ -578,8 +578,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public eraseStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
-      this._stateManager.logStreams.get(stream)!.length = 0;
+    if (this._stateManager.streamTabs.has(stream)) {
+      this._stateManager.streamTabs.get(stream)!.length = 0;
       this._stateManager.taskGroups.delete(stream);
       this._stateManager.outputFiles.delete(stream);
       this._stateManager.saveState();
@@ -597,8 +597,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public deleteStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
-      const streams = Array.from(this._stateManager.logStreams.keys());
+    if (this._stateManager.streamTabs.has(stream)) {
+      const streams = Array.from(this._stateManager.streamTabs.keys());
 
       // Case: This is the last stream - erase it first
       if (streams.length === 1) {
@@ -611,7 +611,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       // If the deleted stream was the active one, switch to another stream if available
       if (stream === this._stateManager.activeStream) {
         const remainingStreams = Array.from(
-          this._stateManager.logStreams.keys(),
+          this._stateManager.streamTabs.keys(),
         );
         this._stateManager.activeStream = remainingStreams[0] ?? '';
       }
@@ -622,7 +622,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public updateStreamStatus(stream: string, status: StreamStatusType) {
-    if (!this._stateManager.logStreams.has(stream)) {
+    if (!this._stateManager.streamTabs.has(stream)) {
       return;
     }
 
@@ -717,7 +717,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   }
 
   public setActiveStream(stream: string) {
-    if (this._stateManager.logStreams.has(stream)) {
+    if (this._stateManager.streamTabs.has(stream)) {
       this._stateManager.activeStream = stream;
       this._stateManager.saveState();
       this._updateWebview();
@@ -846,7 +846,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     let updatedGroups = 0;
 
     // Check all streams for inconsistencies
-    for (const streamId of this._stateManager.logStreams.keys()) {
+    for (const streamId of this._stateManager.streamTabs.keys()) {
       let wasUpdated = false;
 
       // Check if stream is running and mark as interrupted

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -4,10 +4,10 @@ import * as vscode from 'vscode';
 // Simple enums for commonly used state keys
 export enum WorkspaceStateKey {
   AGENT_HISTORY = 'texra.agentHistory',
-  LOG_STREAMS = 'texra.logStreams',
+  STREAM_TABS = 'texra.streamTabs',
   TASK_GROUPS = 'texra.taskGroups',
   OUTPUT_FILES = 'texra.outputFiles',
-  ACTIVE_LOG_STREAM = 'texra.activeLogStream',
+  ACTIVE_STREAM_TAB = 'texra.activeStreamTab',
   TASK_STATES = 'texra.taskStates',
   TASK_IDS = 'texra.taskIds',
   USAGE_STATS = 'texra.usageStats',


### PR DESCRIPTION
## Summary
- rename `LOG_STREAMS` workspace key to `STREAM_TABS`
- rename `ACTIVE_LOG_STREAM` to `ACTIVE_STREAM_TAB`
- update `ProgressStateManager` to use `streamTabs`
- migrate old `texra.logStreams` data on load
- adjust provider to use new `streamTabs` API

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warnings but compile finishes)*

------
https://chatgpt.com/codex/tasks/task_e_6862a722d0488324bffa9e53d92f34c8