### PR TITLE
Hide special messages in Progress view

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -3,7 +3,7 @@ import { marked } from 'marked';
 import markedKatex from 'marked-katex-extension';
 // Local imports
 import { katexMacros } from './katexMacros.js';
-import { CHEVRON_DOWN_CLASS } from '@common/webviewContext.js';
+import { CHEVRON_RIGHT_CLASS } from '@common/webviewContext.js';
 import { STATUS } from './constants.js';
 
 // Constants
@@ -211,9 +211,9 @@ export class LogEntryFormatter {
       const labelText = isThinking ? 'Thinking' : 'Scratchpad';
       const icon = isThinking ? 'codicon-lightbulb' : 'codicon-pencil';
 
-      return `<details class="special-details" open>
+      return `<details class="special-details">
         <summary>
-          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
+          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon ${icon}"></i>
           <span>${labelText}</span>
         </summary>
@@ -287,9 +287,9 @@ export class LogEntryFormatter {
       }
       summary += ')';
 
-      return `<details class="file-list-details" open>
+      return `<details class="file-list-details">
         <summary>
-          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
+          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon codicon-list-tree"></i>
           <span>${summary}</span>
         </summary>
@@ -346,9 +346,9 @@ export class LogEntryFormatter {
 
       const summary = `Missing outputs (${missingFiles.length})`;
 
-      return `<details class="file-list-details" open>
+      return `<details class="file-list-details">
         <summary>
-          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
+          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon codicon-warning"></i>
           <span>${summary}</span>
         </summary>


### PR DESCRIPTION
## Summary
- fold special log sections by default in Progress view

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: cannot find module 'vscode' for TS compilation)*

------
https://chatgpt.com/codex/tasks/task_e_6863d68b9aa88324b7937bec578e18ae