### PR TITLE
Fix: Display media file list immediately when loaded

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - utilities
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
@@ -499,11 +500,22 @@ export abstract class ModelHandler<U = any, R = any>
     }
 
     if (mediaFileResults.length > 0) {
-      if (mediaFileResults.some((r) => !r.ok)) {
-        this.logger.warn('Some media files failed to load');
+      // Log the final processing results for progress view
+      this.logger.info(
+        JSON.stringify(mediaFileResults),
+        undefined,
+        MESSAGE_TYPES.FILE_LIST,
+      );
+
+      // Log summary message
+      const successCount = mediaFileResults.filter(r => r.ok).length;
+      const failCount = mediaFileResults.length - successCount;
+      
+      if (failCount > 0) {
+        this.logger.warn(`${successCount} media files processed successfully, ${failCount} failed`);
+      } else {
+        this.logger.info(`All ${successCount} media files processed successfully`);
       }
-      // Note: File list logging is now handled by LatexMediaManager when files are initially loaded,
-      // not here during message creation. This ensures the file list appears immediately in the UI.
     }
 
     return this.createMediaContent(mediaMessage);

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -9,7 +9,6 @@ import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   getBase64EncodedMedia,
   countPdfPages,
@@ -503,11 +502,8 @@ export abstract class ModelHandler<U = any, R = any>
       if (mediaFileResults.some((r) => !r.ok)) {
         this.logger.warn('Some media files failed to load');
       }
-      this.logger.info(
-        JSON.stringify(mediaFileResults),
-        undefined,
-        MESSAGE_TYPES.FILE_LIST,
-      );
+      // Note: File list logging is now handled by LatexMediaManager when files are initially loaded,
+      // not here during message creation. This ensures the file list appears immediately in the UI.
     }
 
     return this.createMediaContent(mediaMessage);

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -33,22 +33,23 @@ export class LatexMediaManager {
   }
 
   /**
-   * Log the loaded media files to the progress view
+   * Log the loaded media files to the progress view (initial loading status)
    */
   private logLoadedFiles(mediaFiles: string[], groupId?: string): void {
     if (mediaFiles.length === 0) {
       return;
     }
 
-    // Log a message indicating files have been loaded and are ready
+    // Log a message indicating files have been loaded and are ready for processing
     const fileCount = mediaFiles.length;
     const fileLabel = fileCount === 1 ? 'file' : 'files';
-    this.logger.info(`Loaded ${fileCount} media ${fileLabel}`, groupId);
+    this.logger.info(`Loading ${fileCount} media ${fileLabel}`, groupId);
 
-    // Also log the file list for progress view processing
+    // Log the file list with loading status for progress view processing
+    // Note: Files are logged as loading initially, final status will be updated after processing
     const mediaFileResults = mediaFiles.map((file) => ({
       path: file,
-      ok: true,
+      ok: null, // null indicates loading state, will be updated with actual results
     }));
 
     this.logger.info(
@@ -56,6 +57,32 @@ export class LatexMediaManager {
       groupId,
       MESSAGE_TYPES.FILE_LIST,
     );
+  }
+
+  /**
+   * Log the final processing results for media files to the progress view
+   */
+  public logMediaProcessingResults(mediaFileResults: Array<{ path: string; ok: boolean }>, groupId?: string): void {
+    if (mediaFileResults.length === 0) {
+      return;
+    }
+
+    // Update the progress view with final processing results
+    this.logger.info(
+      JSON.stringify(mediaFileResults),
+      groupId,
+      MESSAGE_TYPES.FILE_LIST,
+    );
+
+    // Log summary of results
+    const successCount = mediaFileResults.filter(r => r.ok).length;
+    const failCount = mediaFileResults.length - successCount;
+    
+    if (failCount > 0) {
+      this.logger.warn(`${successCount} media files processed successfully, ${failCount} failed`, groupId);
+    } else {
+      this.logger.info(`All ${successCount} media files processed successfully`, groupId);
+    }
   }
 
   /**

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - latex utils
 import { extractFigurePathsFromLatex } from './extractFigure';
@@ -29,6 +30,32 @@ export class LatexMediaManager {
     if (cfg.attachTeXCount && files.length > 0) {
       toolState.texcountStats = await getTeXCountStats(files);
     }
+  }
+
+  /**
+   * Log the loaded media files to the progress view
+   */
+  private logLoadedFiles(mediaFiles: string[], groupId?: string): void {
+    if (mediaFiles.length === 0) {
+      return;
+    }
+
+    // Log a message indicating files have been loaded and are ready
+    const fileCount = mediaFiles.length;
+    const fileLabel = fileCount === 1 ? 'file' : 'files';
+    this.logger.info(`Loaded ${fileCount} media ${fileLabel}`, groupId);
+
+    // Also log the file list for progress view processing
+    const mediaFileResults = mediaFiles.map((file) => ({
+      path: file,
+      ok: true,
+    }));
+
+    this.logger.info(
+      JSON.stringify(mediaFileResults),
+      groupId,
+      MESSAGE_TYPES.FILE_LIST,
+    );
   }
 
   /**
@@ -154,6 +181,11 @@ export class LatexMediaManager {
     if (cfg.autoCompileInputPdf) {
       await this.compilePdfs(existingFiles, toolState, groupId);
     }
+
+    // Log all loaded media files immediately after processing
+    if (toolState.mediaFiles.length > 0) {
+      this.logLoadedFiles(toolState.mediaFiles, groupId);
+    }
   }
 
   /**
@@ -203,6 +235,11 @@ export class LatexMediaManager {
 
     if (supportsVision && cfg.autoCompileInputPdf) {
       await this.compilePdfs(existingFiles, toolState, groupId);
+    }
+
+    // Log all loaded media files immediately after processing
+    if (toolState.mediaFiles.length > 0) {
+      this.logLoadedFiles(toolState.mediaFiles, groupId);
     }
   }
 }

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -20,7 +20,16 @@ import { WorkspaceFS } from '@utils/files';
  * Handles LaTeX related media extraction and compilation for agents.
  */
 export class LatexMediaManager {
+  private loggedFiles = new Set<string>();
+  
   constructor(private readonly logger: AgentLogger) {}
+
+  /**
+   * Reset the logged files tracking for a new processing session
+   */
+  public resetLoggedFiles(): void {
+    this.loggedFiles.clear();
+  }
 
   private async attachTeXCount(
     files: string[],
@@ -33,23 +42,32 @@ export class LatexMediaManager {
   }
 
   /**
-   * Log the loaded media files to the progress view (initial loading status)
+   * Log newly discovered media files immediately with loading status
    */
-  private logLoadedFiles(mediaFiles: string[], groupId?: string): void {
-    if (mediaFiles.length === 0) {
+  private logNewlyDiscoveredFiles(newFiles: string[], groupId?: string): void {
+    if (newFiles.length === 0) {
       return;
     }
 
-    // Log a message indicating files have been loaded and are ready for processing
-    const fileCount = mediaFiles.length;
+    // Filter out files that have already been logged
+    const unloggedFiles = newFiles.filter(file => !this.loggedFiles.has(file));
+    
+    if (unloggedFiles.length === 0) {
+      return;
+    }
+
+    // Mark files as logged
+    unloggedFiles.forEach(file => this.loggedFiles.add(file));
+
+    // Log a message indicating files have been discovered
+    const fileCount = unloggedFiles.length;
     const fileLabel = fileCount === 1 ? 'file' : 'files';
-    this.logger.info(`Loading ${fileCount} media ${fileLabel}`, groupId);
+    this.logger.info(`Discovered ${fileCount} media ${fileLabel}`, groupId);
 
     // Log the file list with loading status for progress view processing
-    // Note: Files are logged as loading initially, final status will be updated after processing
-    const mediaFileResults = mediaFiles.map((file) => ({
+    const mediaFileResults = unloggedFiles.map((file) => ({
       path: file,
-      ok: null, // null indicates loading state, will be updated with actual results
+      ok: null, // null indicates loading/discovery state, final status will be updated after processing
     }));
 
     this.logger.info(
@@ -122,6 +140,8 @@ export class LatexMediaManager {
     compileResults.forEach((result) => {
       if (result.status === 'fulfilled' && result.value) {
         toolState.addMediaFiles([result.value]);
+        // Log newly compiled PDF files immediately
+        this.logNewlyDiscoveredFiles([result.value], groupId);
       }
     });
   }
@@ -164,6 +184,8 @@ export class LatexMediaManager {
 
     if (extraMediaFiles.length > 0) {
       toolState.addMediaFiles(extraMediaFiles);
+      // Log newly added extra media files immediately
+      this.logNewlyDiscoveredFiles(extraMediaFiles, groupId);
     }
 
     if (cfg.autoExtractFigure) {
@@ -182,6 +204,8 @@ export class LatexMediaManager {
             groupId,
           );
           toolState.addMediaFiles(result.value);
+          // Log newly extracted figure files immediately
+          this.logNewlyDiscoveredFiles(result.value, groupId);
         }
       });
     }
@@ -197,6 +221,8 @@ export class LatexMediaManager {
           result.value.length > 0
         ) {
           toolState.addMediaFiles(result.value);
+          // Log newly compiled TikZ files immediately
+          this.logNewlyDiscoveredFiles(result.value, groupId);
         }
       });
       this.logger.debug(
@@ -209,10 +235,7 @@ export class LatexMediaManager {
       await this.compilePdfs(existingFiles, toolState, groupId);
     }
 
-    // Log all loaded media files immediately after processing
-    if (toolState.mediaFiles.length > 0) {
-      this.logLoadedFiles(toolState.mediaFiles, groupId);
-    }
+    // Note: Files are logged immediately when discovered/added above
   }
 
   /**
@@ -256,6 +279,8 @@ export class LatexMediaManager {
           result.value.length > 0
         ) {
           toolState.addMediaFiles(result.value);
+          // Log newly compiled TikZ files immediately
+          this.logNewlyDiscoveredFiles(result.value, groupId);
         }
       });
     }
@@ -264,9 +289,6 @@ export class LatexMediaManager {
       await this.compilePdfs(existingFiles, toolState, groupId);
     }
 
-    // Log all loaded media files immediately after processing
-    if (toolState.mediaFiles.length > 0) {
-      this.logLoadedFiles(toolState.mediaFiles, groupId);
-    }
+    // Note: Files are logged immediately when discovered/added above
   }
 }


### PR DESCRIPTION
## Summary
- Move file list logging from ModelHandler to LatexMediaManager
- Ensures file list appears in progress view immediately when files are loaded
- Removes delay between file loading and file list display

## Test plan
- [ ] Load media files in TeXRA
- [ ] Verify file list appears immediately in progress view
- [ ] Confirm files are still correctly sent to the model

🤖 Generated with [Claude Code](https://claude.ai/code)