### PR TITLE
Add LATEXDIFF log type and UI formatting

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { createFileMapping } from '@utils/files';
 import { compileLatex2Pdf } from '@latex/texTools';
 import { checkToolInstalled } from '@utils/system';
@@ -98,6 +99,18 @@ export class LatexDiffManager {
             currRound,
           );
           this.logLatexdiffResult(result, 'round-diff', diffProcessGroupId);
+          this.logger.info(
+            JSON.stringify({
+              base: baseFile,
+              revised: outputFile,
+              output: result.diffFileName
+                ? path.join(path.dirname(baseFile), result.diffFileName)
+                : '',
+              status: result.success ? 'success' : 'error',
+            }),
+            diffProcessGroupId,
+            MESSAGE_TYPES.LATEXDIFF,
+          );
           if (result.success && result.diffFileName) {
             const diffPath = path.join(
               path.dirname(baseFile),
@@ -151,6 +164,18 @@ export class LatexDiffManager {
             result,
             'between-rounds-diff',
             diffProcessGroupId,
+          );
+          this.logger.info(
+            JSON.stringify({
+              base: prevOutputFile,
+              revised: currOutputFile,
+              output: result.diffFileName
+                ? path.join(path.dirname(prevOutputFile), result.diffFileName)
+                : '',
+              status: result.success ? 'success' : 'error',
+            }),
+            diffProcessGroupId,
+            MESSAGE_TYPES.LATEXDIFF,
           );
           if (result.success && result.diffFileName) {
             const diffPath = path.join(

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { objectToLogString } from '@utils/text/stringUtils';
 import { createFileMapping } from '@utils/files';
 import { compileLatex2Pdf } from '@latex/texTools';
 import { checkToolInstalled } from '@utils/system';
@@ -100,7 +101,7 @@ export class LatexDiffManager {
           );
           this.logLatexdiffResult(result, 'round-diff', diffProcessGroupId);
           this.logger.info(
-            JSON.stringify({
+            objectToLogString({
               base: baseFile,
               revised: outputFile,
               output: result.diffFileName
@@ -166,7 +167,7 @@ export class LatexDiffManager {
             diffProcessGroupId,
           );
           this.logger.info(
-            JSON.stringify({
+            objectToLogString({
               base: prevOutputFile,
               revised: currOutputFile,
               output: result.diffFileName

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -33,10 +33,14 @@ export class LatexDiffManager {
         groupId,
       );
     } else {
-      this.logger.warn(
-        `Failed to generate ${operation}: ${result.message}`,
-        groupId,
-      );
+      if (result.message && result.message.includes('document environment')) {
+        this.logger.debug(`Skipping ${operation}: ${result.message}`, groupId);
+      } else {
+        this.logger.warn(
+          `Failed to generate ${operation}: ${result.message}`,
+          groupId,
+        );
+      }
     }
   }
 
@@ -45,6 +49,12 @@ export class LatexDiffManager {
     groupId?: string,
   ): Promise<void> {
     const diffProcessGroupId = groupId ?? this.logger.getActiveGroupId();
+    const aggregated: Array<{
+      base: string;
+      revised: string;
+      output: string;
+      status: 'success' | 'error';
+    }> = [];
 
     try {
       if (!(await checkToolInstalled('latexdiff'))) {
@@ -100,18 +110,14 @@ export class LatexDiffManager {
             currRound,
           );
           this.logLatexdiffResult(result, 'round-diff', diffProcessGroupId);
-          this.logger.info(
-            objectToLogString({
-              base: baseFile,
-              revised: outputFile,
-              output: result.diffFileName
-                ? path.join(path.dirname(baseFile), result.diffFileName)
-                : '',
-              status: result.success ? 'success' : 'error',
-            }),
-            diffProcessGroupId,
-            MESSAGE_TYPES.LATEXDIFF,
-          );
+          aggregated.push({
+            base: baseFile,
+            revised: outputFile,
+            output: result.diffFileName
+              ? path.join(path.dirname(baseFile), result.diffFileName)
+              : '',
+            status: result.success ? 'success' : 'error',
+          });
           if (result.success && result.diffFileName) {
             const diffPath = path.join(
               path.dirname(baseFile),
@@ -166,18 +172,14 @@ export class LatexDiffManager {
             'between-rounds-diff',
             diffProcessGroupId,
           );
-          this.logger.info(
-            objectToLogString({
-              base: prevOutputFile,
-              revised: currOutputFile,
-              output: result.diffFileName
-                ? path.join(path.dirname(prevOutputFile), result.diffFileName)
-                : '',
-              status: result.success ? 'success' : 'error',
-            }),
-            diffProcessGroupId,
-            MESSAGE_TYPES.LATEXDIFF,
-          );
+          aggregated.push({
+            base: prevOutputFile,
+            revised: currOutputFile,
+            output: result.diffFileName
+              ? path.join(path.dirname(prevOutputFile), result.diffFileName)
+              : '',
+            status: result.success ? 'success' : 'error',
+          });
           if (result.success && result.diffFileName) {
             const diffPath = path.join(
               path.dirname(prevOutputFile),
@@ -192,6 +194,14 @@ export class LatexDiffManager {
             );
           }
         }
+      }
+
+      if (aggregated.length > 0) {
+        this.logger.info(
+          objectToLogString(aggregated),
+          diffProcessGroupId,
+          MESSAGE_TYPES.LATEXDIFF,
+        );
       }
     } catch (err) {
       this.logger.error(

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - utilities
 import { logErrorMessage } from '@common/errors/errorHandlingUtils';
@@ -67,6 +68,8 @@ export class LaTeXdiffService {
     suffix = '_diff',
     runIndent = true,
   ): Promise<LaTeXdiffResult> {
+    let diffFileName = '';
+    let outputPath = '';
     try {
       // Validate inputs
       if (!inputFile) {
@@ -91,23 +94,29 @@ export class LaTeXdiffService {
         };
       }
 
+      diffFileName = this.fileNameManager.generateDiffFileName(
+        inputFile,
+        editedFile,
+        suffix,
+      );
+      outputPath = path.join(path.dirname(inputFile), diffFileName);
+
       logger.info(
         this.channel,
-        `Running latexdiff for ${inputFile} and ${editedFile}`,
+        JSON.stringify({
+          base: inputFile,
+          revised: editedFile,
+          output: outputPath,
+          status: 'running',
+        }),
+        undefined,
+        MESSAGE_TYPES.LATEXDIFF,
       );
 
       // Format files if requested
       if (runIndent) {
         await this.formatFiles([inputFile, editedFile]);
       }
-
-      // Generate output filename
-      const diffFileName = this.fileNameManager.generateDiffFileName(
-        inputFile,
-        editedFile,
-        suffix,
-      );
-      const outputPath = path.join(path.dirname(inputFile), diffFileName);
 
       // Execute latexdiff command
       const result = await this.commandExecutor.executeDiff(
@@ -122,6 +131,18 @@ export class LaTeXdiffService {
       await WorkspaceFS.writeFile(outputPath, result.stdout);
       await this.fileProcessor.processDiffFile(outputPath);
 
+      logger.info(
+        this.channel,
+        JSON.stringify({
+          base: inputFile,
+          revised: editedFile,
+          output: outputPath,
+          status: 'success',
+        }),
+        undefined,
+        MESSAGE_TYPES.LATEXDIFF,
+      );
+
       return {
         success: true,
         diffFileName,
@@ -132,6 +153,17 @@ export class LaTeXdiffService {
         this.channel,
         'Error running LaTeX diff',
         err,
+      );
+      logger.error(
+        this.channel,
+        JSON.stringify({
+          base: inputFile,
+          revised: editedFile,
+          output: outputPath,
+          status: 'error',
+        }),
+        undefined,
+        MESSAGE_TYPES.LATEXDIFF,
       );
       return { success: false, message };
     }

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -102,16 +102,9 @@ export class LaTeXdiffService {
       );
       outputPath = path.join(path.dirname(inputFile), diffFileName);
 
-      logger.info(
+      logger.debug(
         this.channel,
-        objectToLogString({
-          base: inputFile,
-          revised: editedFile,
-          output: outputPath,
-          status: 'running',
-        }),
-        undefined,
-        MESSAGE_TYPES.LATEXDIFF,
+        `Running latexdiff for ${inputFile} and ${editedFile}`,
       );
 
       // Format files if requested
@@ -132,16 +125,9 @@ export class LaTeXdiffService {
       await WorkspaceFS.writeFile(outputPath, result.stdout);
       await this.fileProcessor.processDiffFile(outputPath);
 
-      logger.info(
+      logger.debug(
         this.channel,
-        objectToLogString({
-          base: inputFile,
-          revised: editedFile,
-          output: outputPath,
-          status: 'success',
-        }),
-        undefined,
-        MESSAGE_TYPES.LATEXDIFF,
+        `Latexdiff succeeded: ${inputFile} -> ${editedFile}`,
       );
 
       return {
@@ -155,16 +141,9 @@ export class LaTeXdiffService {
         'Error running LaTeX diff',
         err,
       );
-      logger.error(
+      logger.debug(
         this.channel,
-        objectToLogString({
-          base: inputFile,
-          revised: editedFile,
-          output: outputPath,
-          status: 'error',
-        }),
-        undefined,
-        MESSAGE_TYPES.LATEXDIFF,
+        `Latexdiff failed: ${inputFile} -> ${editedFile}`,
       );
       return { success: false, message };
     }

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { objectToLogString } from '@utils/text/stringUtils';
 
 // Local imports - utilities
 import { logErrorMessage } from '@common/errors/errorHandlingUtils';
@@ -103,7 +104,7 @@ export class LaTeXdiffService {
 
       logger.info(
         this.channel,
-        JSON.stringify({
+        objectToLogString({
           base: inputFile,
           revised: editedFile,
           output: outputPath,
@@ -133,7 +134,7 @@ export class LaTeXdiffService {
 
       logger.info(
         this.channel,
-        JSON.stringify({
+        objectToLogString({
           base: inputFile,
           revised: editedFile,
           output: outputPath,
@@ -156,7 +157,7 @@ export class LaTeXdiffService {
       );
       logger.error(
         this.channel,
-        JSON.stringify({
+        objectToLogString({
           base: inputFile,
           revised: editedFile,
           output: outputPath,

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -40,7 +40,8 @@ export interface LogMessageData {
     | 'scratchpad'
     | 'thinking'
     | 'fileList'
-    | 'missingOutputs';
+    | 'missingOutputs'
+    | 'latexdiff';
   /** Whether verbose details should be displayed */
   verbose?: boolean;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -16,12 +16,14 @@ function isValidMessageType(
   | typeof MESSAGE_TYPES.THINKING
   | typeof MESSAGE_TYPES.SCRATCHPAD
   | typeof MESSAGE_TYPES.FILE_LIST
-  | typeof MESSAGE_TYPES.MISSING_OUTPUTS {
+  | typeof MESSAGE_TYPES.MISSING_OUTPUTS
+  | typeof MESSAGE_TYPES.LATEXDIFF {
   return (
     type === MESSAGE_TYPES.THINKING ||
     type === MESSAGE_TYPES.SCRATCHPAD ||
     type === MESSAGE_TYPES.FILE_LIST ||
-    type === MESSAGE_TYPES.MISSING_OUTPUTS
+    type === MESSAGE_TYPES.MISSING_OUTPUTS ||
+    type === MESSAGE_TYPES.LATEXDIFF
   );
 }
 
@@ -124,7 +126,8 @@ class VSCodeTransport extends Transport {
     // Skip output channel logging for special structured messages
     if (
       messageType !== MESSAGE_TYPES.FILE_LIST &&
-      messageType !== MESSAGE_TYPES.MISSING_OUTPUTS
+      messageType !== MESSAGE_TYPES.MISSING_OUTPUTS &&
+      messageType !== MESSAGE_TYPES.LATEXDIFF
     ) {
       // Always write to the configured output channel
       this.channel.appendLine(formattedMessage);

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -10,21 +10,8 @@ import { getConfig } from '@utils/config';
 import { TaskGroup } from './LogTypes';
 import { MESSAGE_TYPES, type MessageType } from './messageTypes';
 
-function isValidMessageType(
-  type: unknown,
-): type is
-  | typeof MESSAGE_TYPES.THINKING
-  | typeof MESSAGE_TYPES.SCRATCHPAD
-  | typeof MESSAGE_TYPES.FILE_LIST
-  | typeof MESSAGE_TYPES.MISSING_OUTPUTS
-  | typeof MESSAGE_TYPES.LATEXDIFF {
-  return (
-    type === MESSAGE_TYPES.THINKING ||
-    type === MESSAGE_TYPES.SCRATCHPAD ||
-    type === MESSAGE_TYPES.FILE_LIST ||
-    type === MESSAGE_TYPES.MISSING_OUTPUTS ||
-    type === MESSAGE_TYPES.LATEXDIFF
-  );
+function isValidMessageType(type: unknown): type is MessageType {
+  return Object.values(MESSAGE_TYPES).includes(type as MessageType);
 }
 
 const { combine, timestamp } = winston.format;
@@ -126,8 +113,7 @@ class VSCodeTransport extends Transport {
     // Skip output channel logging for special structured messages
     if (
       messageType !== MESSAGE_TYPES.FILE_LIST &&
-      messageType !== MESSAGE_TYPES.MISSING_OUTPUTS &&
-      messageType !== MESSAGE_TYPES.LATEXDIFF
+      messageType !== MESSAGE_TYPES.MISSING_OUTPUTS
     ) {
       // Always write to the configured output channel
       this.channel.appendLine(formattedMessage);

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -3,6 +3,7 @@ export const MESSAGE_TYPES = {
   SCRATCHPAD: 'scratchpad',
   FILE_LIST: 'fileList',
   MISSING_OUTPUTS: 'missingOutputs',
+  LATEXDIFF: 'latexdiff',
   DEFAULT: 'default',
 } as const;
 

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -155,6 +155,10 @@ export class LogEntryFormatter {
       return this._formatMissingOutputs(htmlMessage, text, id);
     }
 
+    if (messageType === 'latexdiff') {
+      return this._formatLatexdiff(htmlMessage, text, id);
+    }
+
     return htmlMessage;
   }
 
@@ -357,6 +361,53 @@ export class LogEntryFormatter {
       </details>`;
     } catch (e) {
       console.error('Error parsing missing outputs:', e);
+      return message;
+    }
+  }
+
+  _formatLatexdiff(message, content, logId) {
+    try {
+      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const parsed = JSON.parse(this._unescapeHtml(content));
+      const entries = Array.isArray(parsed) ? parsed : [parsed];
+
+      let items = '';
+      entries.forEach((d) => {
+        const basePath = String(d.base ?? '');
+        const revisedPath = String(d.revised ?? '');
+        const outputPath = String(d.output ?? '');
+
+        const baseEsc = this._escapeHtml(basePath);
+        const revisedEsc = this._escapeHtml(revisedPath);
+        const outputEsc = this._escapeHtml(outputPath);
+
+        const baseName = basePath.split('/').pop() || basePath;
+        const revisedName = revisedPath.split('/').pop() || revisedPath;
+
+        const icon = d.status === 'success' ? 'codicon-check' : 'codicon-error';
+
+        items += `<li><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${baseEsc}">${this._escapeHtml(
+          baseName,
+        )}</span> &rarr; <span class="file-link clickable-link" data-file="${revisedEsc}">${this._escapeHtml(
+          revisedName,
+        )}</span> (<span class="file-link clickable-link" data-file="${outputEsc}">diff</span>)</li>`;
+      });
+
+      const summary =
+        entries.length === 1
+          ? 'Latexdiff result'
+          : `Latexdiff results (${entries.length})`;
+
+      return `<details class="latexdiff-details" open>
+        <summary>
+          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
+          <i class="codicon codicon-diff"></i>
+          <span>${summary}</span>
+        </summary>
+        <ul class="latexdiff-content"${idAttr}>${items}</ul>
+      </details>`;
+    } catch (e) {
+      console.error('Error parsing latexdiff entry:', e);
       return message;
     }
   }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -369,7 +369,15 @@ export class LogEntryFormatter {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
       const parsed = JSON.parse(this._unescapeHtml(content));
-      const entries = Array.isArray(parsed) ? parsed : [parsed];
+      const entries = Array.isArray(parsed)
+        ? parsed
+        : parsed && typeof parsed === 'object'
+          ? [parsed]
+          : [];
+
+      if (entries.length === 0) {
+        return message;
+      }
 
       let items = '';
       entries.forEach((d) => {
@@ -384,7 +392,12 @@ export class LogEntryFormatter {
         const baseName = basePath.split('/').pop() || basePath;
         const revisedName = revisedPath.split('/').pop() || revisedPath;
 
-        const icon = d.status === 'success' ? 'codicon-check' : 'codicon-error';
+        let icon = 'codicon-question';
+        if (d.status === 'success') {
+          icon = 'codicon-check';
+        } else if (d.status === 'error') {
+          icon = 'codicon-error';
+        }
 
         items += `<li><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${baseEsc}">${this._escapeHtml(
           baseName,

--- a/src/progressView/modules/uiManagers/Events.js
+++ b/src/progressView/modules/uiManagers/Events.js
@@ -106,7 +106,8 @@ export class Events {
         if (
           e.target &&
           (e.target.classList.contains('special-details') ||
-            e.target.classList.contains('file-list-details'))
+            e.target.classList.contains('file-list-details') ||
+            e.target.classList.contains('latexdiff-details'))
         ) {
           const toggleIcon = e.target.querySelector('.toggle-icon');
           if (toggleIcon) {

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -16,3 +16,4 @@
 @import './groups.css';
 @import './scratchpad.css';
 @import './file-list.css';
+@import './latexdiff.css';

--- a/src/progressView/styles/latexdiff.css
+++ b/src/progressView/styles/latexdiff.css
@@ -1,0 +1,42 @@
+/**
+ * Latexdiff log styles for ProgressView
+ */
+
+.latexdiff-details {
+  margin: var(--spacing-small) 0;
+}
+
+.latexdiff-details summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) 0;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  opacity: var(--opacity-normal);
+}
+
+.latexdiff-details summary:hover {
+  opacity: 1;
+}
+
+.latexdiff-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.latexdiff-content {
+  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
+  list-style: none;
+}
+
+.latexdiff-content li {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.latexdiff-details summary .toggle-icon {
+  opacity: var(--opacity-subtle);
+  font-size: var(--font-size-sm);
+}


### PR DESCRIPTION
## Summary
- introduce `LATEXDIFF` message type
- render latexdiff logs as expandable blocks
- style latexdiff blocks in ProgressView
- emit structured latexdiff messages from LaTeXdiff routines
- display these entries in LatexDiffManager

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning)*

------
https://chatgpt.com/codex/tasks/task_e_6863d47a8a58832495c9f2ef8f85e380