### PR TITLE
feat: link xml file when single output fails

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -414,6 +414,19 @@ export class OutputHandler implements IOutputHandler {
           `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
           activeGroupId,
         );
+        const missingOutputsData = {
+          missing: [],
+          xmlFile: outputFile,
+        };
+        this.logger.info(
+          JSON.stringify(missingOutputsData),
+          activeGroupId,
+          MESSAGE_TYPES.MISSING_OUTPUTS,
+        );
+        emitProgress('updateMissingOutputs', {
+          stream: this.channel,
+          filesByRound: { [currRound]: [] },
+        });
         this.outputFiles[currRound] = [];
         this.outputMappings[currRound] = [];
       }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -344,6 +344,10 @@ export class LogEntryFormatter {
         </div>`;
       }
 
+      if (missingFiles.length === 0 && xmlFile) {
+        return xmlLink;
+      }
+
       const summary = `Missing outputs (${missingFiles.length})`;
 
       return `<details class="file-list-details" open>


### PR DESCRIPTION
## Summary
- show an "Open XML" link when single output processing fails
- display only XML link if no outputs are missing

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6863d9bf498083249eb00607ce953868