### PR TITLE
Improve missing output logging

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -361,7 +361,7 @@ export class OutputHandler implements IOutputHandler {
             );
           }
         } else {
-          this.logger.warn(
+          this.logger.debug(
             `No processed files were generated from ${outputFile}`,
             activeGroupId,
           );
@@ -369,7 +369,7 @@ export class OutputHandler implements IOutputHandler {
           this.outputMappings[currRound] = [];
         }
       } catch (err) {
-        this.logger.error(
+        this.logger.debug(
           `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
           activeGroupId,
         );
@@ -402,7 +402,7 @@ export class OutputHandler implements IOutputHandler {
           this.outputFiles[currRound] = [processed.path];
           this.outputMappings[currRound] = [processed];
         } else {
-          this.logger.warn(
+          this.logger.debug(
             `No processed file was generated from ${outputFile}`,
             activeGroupId,
           );
@@ -410,7 +410,7 @@ export class OutputHandler implements IOutputHandler {
           this.outputMappings[currRound] = [];
         }
       } catch (err) {
-        this.logger.error(
+        this.logger.debug(
           `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
           activeGroupId,
         );

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -54,12 +54,12 @@ export class XmlOutputManager {
         );
         return fallbackContent;
       }
-      this.logger.error(
+      this.logger.debug(
         `No ${documentTag} found in output file using fallback method`,
       );
       return null;
     } catch (fallbackErr) {
-      this.logger.error(
+      this.logger.debug(
         `Failed fallback extraction: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`,
       );
       return null;
@@ -124,7 +124,7 @@ export class XmlOutputManager {
         await WorkspaceFS.writeFile(texFile, latexDocument);
         return texFile;
       }
-      this.logger.warn(
+      this.logger.debug(
         `No ${documentTag} found in parsed XML, attempting fallback extraction...`,
       );
       const fallbackContent = this.extractDocumentbyRegex(
@@ -139,7 +139,7 @@ export class XmlOutputManager {
         `Failed to extract <${documentTag}> from ${path.basename(outputFile)}`,
       );
     } catch (err) {
-      this.logger.warn(
+      this.logger.debug(
         `Failed to parse XML content: ${err instanceof Error ? err.message : String(err)}, attempting fallback extraction...`,
       );
       const fallbackContent = this.extractDocumentbyRegex(
@@ -182,7 +182,7 @@ export class XmlOutputManager {
       if (documents) {
         return this.processMultipleLatexDocuments(documents, outputFile);
       }
-      this.logger.warn(
+      this.logger.debug(
         `No ${documentTag} found in parsed XML, attempting fallback extraction...`,
       );
       const fallbackDocuments = this.extractMultipleDocumentsbyRegex(
@@ -197,7 +197,7 @@ export class XmlOutputManager {
       }
       return [];
     } catch (err) {
-      this.logger.warn(
+      this.logger.debug(
         `Failed to parse XML content: ${err instanceof Error ? err.message : String(err)}, attempting fallback extraction...`,
       );
       const fallbackDocuments = this.extractMultipleDocumentsbyRegex(
@@ -228,13 +228,13 @@ export class XmlOutputManager {
 
     for (const doc of latexDocuments) {
       if (!doc.name || doc.name === 'unknown' || !doc.content) {
-        this.logger.warn(`Skipping document with empty name or content`);
+        this.logger.debug(`Skipping document with empty name or content`);
         continue;
       }
 
       const source = doc.name.trim();
       if (!source) {
-        this.logger.warn(
+        this.logger.debug(
           `Skipping document with empty source name after trimming`,
         );
         continue;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -3,7 +3,10 @@ import { marked } from 'marked';
 import markedKatex from 'marked-katex-extension';
 // Local imports
 import { katexMacros } from './katexMacros.js';
-import { CHEVRON_RIGHT_CLASS } from '@common/webviewContext.js';
+import {
+  CHEVRON_RIGHT_CLASS,
+  CHEVRON_DOWN_CLASS,
+} from '@common/webviewContext.js';
 import { STATUS } from './constants.js';
 
 // Constants


### PR DESCRIPTION
## Summary
- drop noisy XML extraction warnings to debug level
- silence output processing warnings
- fix progress view formatters import

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning)*

------
https://chatgpt.com/codex/tasks/task_e_6863e76283d08324a425813fd530d9b5