### PR TITLE
fix: hide XML fallback errors from progress

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -372,6 +372,7 @@ export class OutputHandler implements IOutputHandler {
         this.logger.error(
           `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
           activeGroupId,
+          MESSAGE_TYPES.INTERNAL,
         );
         this.outputFiles[currRound] = [];
         this.outputMappings[currRound] = [];
@@ -413,6 +414,7 @@ export class OutputHandler implements IOutputHandler {
         this.logger.error(
           `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
           activeGroupId,
+          MESSAGE_TYPES.INTERNAL,
         );
         const missingOutputsData = {
           missing: [],

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -4,6 +4,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
@@ -51,16 +52,22 @@ export class XmlOutputManager {
       if (fallbackContent) {
         this.logger.info(
           `Successfully extracted ${documentTag} using fallback method`,
+          undefined,
+          MESSAGE_TYPES.INTERNAL,
         );
         return fallbackContent;
       }
       this.logger.error(
         `No ${documentTag} found in output file using fallback method`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       return null;
     } catch (fallbackErr) {
       this.logger.error(
         `Failed fallback extraction: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       return null;
     }
@@ -78,16 +85,22 @@ export class XmlOutputManager {
       if (fallbackDocuments && fallbackDocuments.length > 0) {
         this.logger.info(
           `Successfully extracted multiple ${documentTag} using fallback method`,
+          undefined,
+          MESSAGE_TYPES.INTERNAL,
         );
         return fallbackDocuments;
       }
       this.logger.error(
         `No ${documentTag} found in output file using fallback method`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       return null;
     } catch (err) {
       this.logger.error(
         `Failed fallback extraction: ${err instanceof Error ? err.message : String(err)}`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       return null;
     }
@@ -126,6 +139,8 @@ export class XmlOutputManager {
       }
       this.logger.warn(
         `No ${documentTag} found in parsed XML, attempting fallback extraction...`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       const fallbackContent = this.extractDocumentbyRegex(
         outputContent,
@@ -141,6 +156,8 @@ export class XmlOutputManager {
     } catch (err) {
       this.logger.warn(
         `Failed to parse XML content: ${err instanceof Error ? err.message : String(err)}, attempting fallback extraction...`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       const fallbackContent = this.extractDocumentbyRegex(
         outputContent,
@@ -184,6 +201,8 @@ export class XmlOutputManager {
       }
       this.logger.warn(
         `No ${documentTag} found in parsed XML, attempting fallback extraction...`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       const fallbackDocuments = this.extractMultipleDocumentsbyRegex(
         outputContent,
@@ -199,6 +218,8 @@ export class XmlOutputManager {
     } catch (err) {
       this.logger.warn(
         `Failed to parse XML content: ${err instanceof Error ? err.message : String(err)}, attempting fallback extraction...`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       const fallbackDocuments = this.extractMultipleDocumentsbyRegex(
         outputContent,

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -41,7 +41,8 @@ export interface LogMessageData {
     | 'thinking'
     | 'fileList'
     | 'missingOutputs'
-    | 'latexdiff';
+    | 'latexdiff'
+    | 'internal';
   /** Whether verbose details should be displayed */
   verbose?: boolean;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -125,6 +125,12 @@ class VSCodeTransport extends Transport {
       return;
     }
 
+    // Skip progress view updates for internal messages
+    if (messageType === MESSAGE_TYPES.INTERNAL) {
+      callback();
+      return;
+    }
+
     // Skip progress view updates for non-agent channels
     if (!this.isAgentChannel) {
       callback();

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -4,6 +4,8 @@ export const MESSAGE_TYPES = {
   FILE_LIST: 'fileList',
   MISSING_OUTPUTS: 'missingOutputs',
   LATEXDIFF: 'latexdiff',
+  /** Messages that should be hidden from the progress view */
+  INTERNAL: 'internal',
   DEFAULT: 'default',
 } as const;
 


### PR DESCRIPTION
## Summary
- add `INTERNAL` message type to suppress progress view logging
- omit progress view updates for logs tagged as `INTERNAL`
- log XML fallback failures at error/warn level using the new type

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test` *(fails: missing vscode)*

------
https://chatgpt.com/codex/tasks/task_e_6863e76283d08324a425813fd530d9b5