### PR TITLE
docs: clarify streaming toggle for Google

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -185,9 +185,12 @@ Configure streaming in VS Code Settings:
 "texra.model.useStreamingAnthropicReasoning": false,
 
 // Specific toggle for OpenAI reasoning models
-"texra.model.useStreamingOpenAIReasoning": false
+"texra.model.useStreamingOpenAIReasoning": false,
 
-// Similar configuration for Google/DeepSeek/OpenRouter models
+// Specific toggle for Google models
+"texra.model.useStreamingGoogle": false
+
+// Similar configuration exists for DeepSeek and OpenRouter models
 ```
 
 ## Next Steps

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
           "texra.model.useStreamingGoogle": {
             "type": "boolean",
             "default": false,
-            "description": "Enable streaming for Google models via OpenAI-compatible API. Overrides the global useStreaming setting.",
+            "description": "Enable streaming for Google models. Works with both the OpenAI-compatible API and the native GenAI SDK. Overrides the global useStreaming setting.",
             "scope": "resource"
           },
           "texra.model.useStreamingXai": {


### PR DESCRIPTION
## Summary
- clarify streaming toggle description for Google models
- document Google provider streaming config

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686525a542bc832495d5dde70c505abc