### PR TITLE
Add documentTag info to missing output logs

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -276,6 +276,7 @@ export class OutputHandler implements IOutputHandler {
       const missingOutputsData = {
         missing,
         xmlFile: xmlExists ? xmlPath : null,
+        documentTag: this.agentSetting.documentTag,
       };
 
       this.logger.info(
@@ -419,6 +420,7 @@ export class OutputHandler implements IOutputHandler {
         const missingOutputsData = {
           missing: [],
           xmlFile: outputFile,
+          documentTag: this.agentSetting.documentTag,
         };
         this.logger.info(
           JSON.stringify(missingOutputsData),

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -313,17 +313,19 @@ export class LogEntryFormatter {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
       const parsed = JSON.parse(this._unescapeHtml(content));
 
-      // Handle both old format (array) and new format (object with missing and xmlFile)
+      // Handle both old format (array) and new format (object with missing, xmlFile, documentTag)
       let missingFiles = [];
       let xmlFile = null;
+      let documentTag = null;
 
       if (Array.isArray(parsed)) {
         // Old format: just an array of missing files
         missingFiles = parsed;
       } else if (parsed && typeof parsed === 'object') {
-        // New format: object with missing files and XML file
+        // New format: object with missing files, XML file, and optional document tag
         missingFiles = parsed.missing || [];
         xmlFile = parsed.xmlFile;
+        documentTag = parsed.documentTag;
       } else {
         throw new Error('Invalid missing outputs format');
       }
@@ -344,10 +346,14 @@ export class LogEntryFormatter {
         const xmlEscaped = this._escapeHtml(xmlFile);
         const xmlFileName = xmlFile.split('/').pop() || xmlFile;
         const xmlFileNameEscaped = this._escapeHtml(xmlFileName);
+        const tagInfo = documentTag
+          ? `<span class="document-tag">(Expected &lt;${this._escapeHtml(documentTag)}&gt; block)</span>`
+          : '';
         xmlLink = `<div class="xml-link-container">
           <i class="codicon codicon-file-code"></i>
           <span>Open XML to check tag consistency:</span>
           <span class="file-link clickable-link" data-file="${xmlEscaped}">${xmlFileNameEscaped}</span>
+          ${tagInfo}
         </div>`;
       }
 

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -72,3 +72,10 @@
 .xml-link-container .codicon {
   opacity: var(--opacity-subtle);
 }
+
+/* Document tag info styling */
+.xml-link-container .document-tag {
+  color: var(--vscode-descriptionForeground);
+  opacity: 0.8;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
- record `documentTag` when expected outputs are missing
- show the expected tag in the progress view near the XML link
- style document-tag info in progress view

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68657b8ba8b883249b43754d5e43c6f9