### PR TITLE
Refactor history view message handling

### DIFF
--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -1,0 +1,133 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - common
+import {
+  BaseViewMessageHandler,
+  type MessageHandler,
+} from '@common/webview/BaseViewMessageHandler';
+// @ts-ignore - Import JavaScript module
+import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands';
+import { AgentHistoryManager } from './AgentHistoryManager';
+import { executeCommand } from '@commands/agent/executeCommand';
+import { agentConfigToTaskState } from '@utils/config';
+import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+
+export class HistoryViewMessageHandler extends BaseViewMessageHandler {
+  constructor(private readonly context: vscode.ExtensionContext) {
+    super('HistoryView');
+  }
+
+  protected createHandlers(): Record<string, MessageHandler> {
+    return {
+      [HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA]:
+        this.handleGetHistoryData.bind(this),
+      [HISTORY_VIEW_COMMANDS.RERUN_AGENT]: this.handleRerunAgent.bind(this),
+      [HISTORY_VIEW_COMMANDS.RESTORE_AGENT]: this.handleRestoreAgent.bind(this),
+      [HISTORY_VIEW_COMMANDS.DELETE_AGENT]: this.handleDeleteAgent.bind(this),
+      [HISTORY_VIEW_COMMANDS.CLEAR_HISTORY]: this.handleClearHistory.bind(this),
+    };
+  }
+
+  public async sendHistoryData(webview: vscode.Webview): Promise<void> {
+    const history = await AgentHistoryManager.getHistory();
+    await webview.postMessage({
+      command: HISTORY_VIEW_COMMANDS.UPDATE_HISTORY,
+      historyItems: history,
+    });
+  }
+
+  private async handleGetHistoryData(
+    _message: any,
+    view: vscode.WebviewView,
+  ): Promise<void> {
+    await this.sendHistoryData(view.webview);
+  }
+
+  private async handleRerunAgent(
+    message: any,
+    _view: vscode.WebviewView,
+  ): Promise<void> {
+    const historyId: string | undefined = message.historyId;
+    if (!historyId) return;
+
+    try {
+      const historyItem =
+        await AgentHistoryManager.getHistoryItemById(historyId);
+      if (historyItem) {
+        await vscode.window.showInformationMessage(
+          'Rerunning agent from history',
+        );
+        await executeCommand.executeCommand(historyItem.config, this.context);
+      } else {
+        await vscode.window.showErrorMessage('History item not found');
+      }
+    } catch (error) {
+      await vscode.window.showErrorMessage(`Failed to rerun agent: ${error}`);
+    }
+  }
+
+  private async handleRestoreAgent(
+    message: any,
+    _view: vscode.WebviewView,
+  ): Promise<void> {
+    const historyId: string | undefined = message.historyId;
+    if (!historyId) return;
+    try {
+      const historyItem =
+        await AgentHistoryManager.getHistoryItemById(historyId);
+      if (historyItem) {
+        const taskState = agentConfigToTaskState(historyItem.config);
+        await vscode.commands.executeCommand('texra.restoreState', taskState);
+      } else {
+        await vscode.window.showErrorMessage('History item not found');
+      }
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to restore configuration',
+        error,
+      );
+    }
+  }
+
+  private async handleDeleteAgent(
+    message: any,
+    view: vscode.WebviewView,
+  ): Promise<void> {
+    const historyId: string | undefined = message.historyId;
+    if (!historyId) return;
+    try {
+      const deleted =
+        await AgentHistoryManager.deleteHistoryItemById(historyId);
+      if (deleted) {
+        await this.sendHistoryData(view.webview);
+      } else {
+        await vscode.window.showWarningMessage(
+          `History item not found: ${historyId}`,
+        );
+      }
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to delete history item',
+        error,
+      );
+    }
+  }
+
+  private async handleClearHistory(
+    _message: any,
+    view: vscode.WebviewView,
+  ): Promise<void> {
+    try {
+      await AgentHistoryManager.clearHistory();
+      await vscode.window.showInformationMessage('Agent history cleared');
+      await view.webview.postMessage({
+        command: HISTORY_VIEW_COMMANDS.HISTORY_CLEARED,
+      });
+    } catch (error) {
+      await vscode.window.showErrorMessage(`Failed to clear history: ${error}`);
+    }
+  }
+}

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -1,23 +1,19 @@
+// Third-party imports
 import * as vscode from 'vscode';
-import { AgentHistoryManager } from './AgentHistoryManager';
-import { executeCommand } from '@commands/agent/executeCommand';
-import { agentConfigToTaskState } from '@utils/config';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
-// @ts-ignore - Import JavaScript module
-import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands';
-import { HistoryViewContentProvider } from './HistoryViewContentProvider';
-import * as logger from '@logger/logUtils';
 
-const CHANNEL = 'HistoryViewProvider';
-logger.initialize(CHANNEL);
+// Local imports - components
+import { HistoryViewContentProvider } from './HistoryViewContentProvider';
+import { HistoryViewMessageHandler } from './HistoryViewMessageHandler';
 
 export class HistoryViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'texra.historyView';
   private _view?: vscode.WebviewPanel;
   private readonly contentProvider: HistoryViewContentProvider;
+  private readonly messageHandler: HistoryViewMessageHandler;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this.contentProvider = new HistoryViewContentProvider(context);
+    this.messageHandler = new HistoryViewMessageHandler(context);
   }
 
   /**
@@ -84,48 +80,18 @@ export class HistoryViewProvider implements vscode.WebviewViewProvider {
 
     // Handle messages from the webview
     this._view.webview.onDidReceiveMessage(async (message) => {
-      await this.handleWebviewMessage(message);
+      await this.messageHandler.handleMessage(
+        message,
+        this._view as unknown as vscode.WebviewView,
+      );
     });
 
     // Set initial HTML content
     await this.updateWebviewContent();
   }
 
-  /**
-   * Handle messages from the webview
-   */
-  private handlers: Record<string, (message: any) => Promise<void> | void> = {
-    [HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA]: () => this.sendHistoryData(),
-    [HISTORY_VIEW_COMMANDS.RERUN_AGENT]: (m: any) =>
-      this.rerunAgent(m.historyId),
-    [HISTORY_VIEW_COMMANDS.RESTORE_AGENT]: (m: any) =>
-      this.restoreAgent(m.historyId),
-    [HISTORY_VIEW_COMMANDS.DELETE_AGENT]: (m: any) =>
-      this.deleteHistoryItem(m.historyId),
-    [HISTORY_VIEW_COMMANDS.CLEAR_HISTORY]: () => this.clearHistory(),
-  };
-
-  private async handleWebviewMessage(message: any) {
-    const handler = this.handlers[message.command];
-    if (handler) {
-      await handler(message);
-    }
-  }
-
-  /**
-   * Send history data to the webview
-   */
-  private async sendHistoryData() {
-    const history = await AgentHistoryManager.getHistory();
-
-    // Send data to the webview
-    if (this._view) {
-      this._view.webview.postMessage({
-        command: HISTORY_VIEW_COMMANDS.UPDATE_HISTORY,
-        historyItems: history,
-      });
-    }
-  }
+  // No additional logic needed here; all message handling is delegated
+  // to HistoryViewMessageHandler
 
   /**
    * Update the content of the webview
@@ -137,117 +103,9 @@ export class HistoryViewProvider implements vscode.WebviewViewProvider {
       );
 
       // Send history data after a short delay to ensure the webview is ready
-      setTimeout(() => this.sendHistoryData(), 100);
-    }
-  }
-
-  /**
-   * Rerun an agent with the configuration from history
-   */
-  private async rerunAgent(historyId: string) {
-    try {
-      const historyItem =
-        await AgentHistoryManager.getHistoryItemById(historyId);
-
-      if (historyItem) {
-        // Check: do we need to send a taskID or is it included in the config?
-        vscode.window.showInformationMessage(`Rerunning agent from history`);
-        await executeCommand.executeCommand(historyItem.config, this.context);
-      } else {
-        vscode.window.showErrorMessage(`History item not found`);
-      }
-    } catch (error) {
-      vscode.window.showErrorMessage(`Failed to rerun agent: ${error}`);
-    }
-  }
-
-  /**
-   * Restore an agent configuration from history to the main view
-   */
-  private async restoreAgent(historyId: string) {
-    try {
-      const historyItem =
-        await AgentHistoryManager.getHistoryItemById(historyId);
-
-      if (historyItem) {
-        logger.debug(
-          CHANNEL,
-          `Restoring configuration from history item: ${historyId}`,
-        );
-
-        const config = historyItem.config;
-
-        // Convert from AgentConfig to TaskState format using the utility function
-        // This ensures all fields including UI visibility flags are properly set
-        const taskState = agentConfigToTaskState(config);
-
-        // Log the converted taskState for debugging
-        logger.debug(
-          CHANNEL,
-          `Converted taskState: ${JSON.stringify(taskState)}`,
-        );
-
-        // Send the properly formatted taskState to the restoreState command
-        await vscode.commands.executeCommand('texra.restoreState', taskState);
-
-        // vscode.window.showInformationMessage(
-        //   `Configuration restored to main view`,
-        // );
-      } else {
-        vscode.window.showErrorMessage(`History item not found`);
-      }
-    } catch (error) {
-      await showLoggedErrorMessage(
-        CHANNEL,
-        'Failed to restore configuration',
-        error,
-      );
-    }
-  }
-
-  /**
-   * Clear all history items
-   */
-  private async clearHistory() {
-    try {
-      await AgentHistoryManager.clearHistory();
-      vscode.window.showInformationMessage('Agent history cleared');
-
-      // Notify the webview
-      if (this._view) {
-        this._view.webview.postMessage({
-          command: HISTORY_VIEW_COMMANDS.HISTORY_CLEARED,
-        });
-      }
-    } catch (error) {
-      vscode.window.showErrorMessage(`Failed to clear history: ${error}`);
-    }
-  }
-
-  /**
-   * Delete a single history item by ID
-   */
-  private async deleteHistoryItem(historyId: string) {
-    try {
-      logger.debug(CHANNEL, `Deleting history item: ${historyId}`);
-
-      // Use the AgentHistoryManager to delete the item
-      const deleted =
-        await AgentHistoryManager.deleteHistoryItemById(historyId);
-
-      if (deleted) {
-        // Update the view
-        await this.sendHistoryData();
-      } else {
-        vscode.window.showWarningMessage(
-          `History item not found: ${historyId}`,
-        );
-      }
-    } catch (error) {
-      await showLoggedErrorMessage(
-        CHANNEL,
-        'Failed to delete history item',
-        error,
+      setTimeout(
+        () => this.messageHandler.sendHistoryData(this._view!.webview),
+        100,
       );
     }
   }


### PR DESCRIPTION
## Summary
- introduce `HistoryViewMessageHandler` extending `BaseViewMessageHandler`
- move history command handling logic to the new class
- delegate message processing from `HistoryViewProvider` to the handler

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68657c89221483248df8458ef1728bad