### PR TITLE
Rename webview message handler classes

### DIFF
--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -5,7 +5,7 @@ import { historyViewDomHandler } from './domHandlers.js';
 /**
  * Handles messages from the extension for the history view.
  */
-export class HistoryMessageHandlers {
+export class HistoryViewMessageHandlers {
   constructor() {
     this._cleanupFn = null;
     this._handlers = {
@@ -34,4 +34,4 @@ export class HistoryMessageHandlers {
   }
 }
 
-export const messageHandlers = new HistoryMessageHandlers();
+export const messageHandlers = new HistoryViewMessageHandlers();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -10,7 +10,7 @@ const dom = progressViewDomHandler;
 
 // Create formatter instances
 
-export class ProgressMessageHandlers {
+export class ProgressViewMessageHandlers {
   constructor() {
     this._cleanupFn = null;
     this._entryFormatter = new LogEntryFormatter();
@@ -190,4 +190,4 @@ export class ProgressMessageHandlers {
   }
 }
 
-export const messageHandlers = new ProgressMessageHandlers();
+export const messageHandlers = new ProgressViewMessageHandlers();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -23,7 +23,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 /**
  * Handles messages from the extension and syncs the webview state.
  */
-export class MessageHandlers {
+export class MainViewMessageHandlers {
   constructor() {
     this._skipNextRestoreState = false;
     this._cleanupFn = null;
@@ -578,4 +578,4 @@ export class MessageHandlers {
   }
 }
 
-export const messageHandlers = new MessageHandlers();
+export const messageHandlers = new MainViewMessageHandlers();


### PR DESCRIPTION
## Summary
- rename MessageHandlers to MainViewMessageHandlers
- rename ProgressMessageHandlers to ProgressViewMessageHandlers
- rename HistoryMessageHandlers to HistoryViewMessageHandlers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68657c9f00bc8324ab7852aabadea260