### PR TITLE
Rename main webview handler

### DIFF
--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -23,7 +23,7 @@ export const recordingManager = new RecordingManager(vscode, webviewEventBus);
 /**
  * Coordinates UI managers for the main webview.
  */
-export class WebviewDomHandler {
+export class MainViewDomHandler {
   constructor() {
     this.fileInputManager = null;
     this.actionButtonManager = null;
@@ -91,4 +91,4 @@ export class WebviewDomHandler {
   }
 }
 
-export const webviewDomHandler = new WebviewDomHandler();
+export const mainViewDomHandler = new MainViewDomHandler();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -8,7 +8,7 @@ import {
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { mainViewState } from './mainViewState.js';
-import { webviewDomHandler } from './domHandlers.js';
+import { mainViewDomHandler } from './domHandlers.js';
 
 // Local imports - UI managers
 import { fileList } from './uiManagers/FileList.js';
@@ -338,7 +338,7 @@ export class MessageHandlers {
   }
 
   handleSetDebugMode(message) {
-    webviewDomHandler.setDebugMode(message.debugMode);
+    mainViewDomHandler.setDebugMode(message.debugMode);
     this._postHandle();
   }
 

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -1,7 +1,7 @@
 import { mainViewState } from './modules/mainViewState.js';
 import { messageHandlers } from './modules/messageHandlers.js';
 import {
-  webviewDomHandler,
+  mainViewDomHandler,
   instructionManager,
   toggleManager,
 } from './modules/domHandlers.js';
@@ -11,14 +11,14 @@ messageHandlers.setup({ requestData: false });
 
 window.addEventListener('beforeunload', () => {
   messageHandlers.cleanup();
-  webviewDomHandler.cleanupUI();
+  mainViewDomHandler.cleanupUI();
 });
 
 // Setup UI when DOM is loaded
 document.addEventListener('DOMContentLoaded', function () {
   mainViewState.restore();
   instructionManager.setup();
-  webviewDomHandler.initializeUI();
+  mainViewDomHandler.initializeUI();
   toggleManager.updateToolConfigToggleState();
   toggleManager.updateAutoToggleState();
   toggleManager.setupDocumentListeners();


### PR DESCRIPTION
## Summary
- rename the handler exported from `domHandlers.js` to `MainViewDomHandler`
- update imports in `script.js` and `messageHandlers.js`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68657cd7c17883248437c00bccf9f60a