### PR TITLE
Add managers index and update imports

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { StatePersistenceManager } from './persistence/StatePersistenceManager';
 import { ProgressViewState } from './state/ProgressViewState';
 import { ProgressEventHandler } from './events/ProgressEventHandler';
-import { WebviewUpdater } from './managers/WebviewUpdater';
+import { WebviewUpdater } from './managers';
 
 // Local imports - existing components
 import { ProgressViewContentProvider } from './ProgressViewContentProvider';

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
-import { WebviewUpdater } from '../managers/WebviewUpdater';
+import { WebviewUpdater } from '../managers';
 import { AgentLogger } from '@logger/AgentLogger';
 import { getConfig } from '@utils/config';
 import { onProgress } from '@eventBus/ProgressEventBus';

--- a/src/progressView/managers/index.ts
+++ b/src/progressView/managers/index.ts
@@ -1,0 +1,5 @@
+export { OutputFilesManager } from './OutputFilesManager';
+export { StreamTabsManager } from './StreamTabsManager';
+export { TaskGroupsManager } from './TaskGroupsManager';
+export { UsageStatsManager } from './UsageStatsManager';
+export { WebviewUpdater } from './WebviewUpdater';

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -1,9 +1,11 @@
 // Local imports
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
-import { StreamTabsManager } from '../managers/StreamTabsManager';
-import { TaskGroupsManager } from '../managers/TaskGroupsManager';
-import { OutputFilesManager } from '../managers/OutputFilesManager';
-import { UsageStatsManager } from '../managers/UsageStatsManager';
+import {
+  StreamTabsManager,
+  TaskGroupsManager,
+  OutputFilesManager,
+  UsageStatsManager,
+} from '../managers';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { objectToTaskState } from '@utils/config';
 import { AgentLogger } from '@logger/AgentLogger';


### PR DESCRIPTION
## Summary
- centralize exports for progress view managers
- update progress view modules to import from the new managers index

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686588bf7728832493c28e014a0cf10c