### PR TITLE
Use command constants in webview UI managers

### DIFF
--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -8,6 +8,7 @@ import {
   FILE_TYPES,
   ELEMENTS_TO_SAVE,
 } from '../constants.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
@@ -58,7 +59,7 @@ export class FileInputManager {
     this._addListener('inputFile', 'change', (e) => {
       const inputFile = e.target.value;
       this.vscode.postMessage({
-        command: 'inputFileSelected',
+        command: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
         filePath: inputFile,
       });
     });
@@ -66,7 +67,7 @@ export class FileInputManager {
     this._addListener('referenceFile', 'change', (e) => {
       const referenceFile = e.target.value;
       this.vscode.postMessage({
-        command: 'referenceFileSelected',
+        command: MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED,
         filePath: referenceFile,
       });
     });
@@ -74,7 +75,7 @@ export class FileInputManager {
     this._addListener('baseFile', 'change', () => {
       const baseFile = safeGetElementValue('baseFile');
       this.vscode.postMessage({
-        command: 'requestEditedFile',
+        command: MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE,
         baseFile,
       });
       this.fileSelect.updateEdited(baseFile);
@@ -99,7 +100,7 @@ export class FileInputManager {
       this._addListener(buttonId, 'click', () => {
         const currentFile = safeGetElementValue(selectId);
         this.vscode.postMessage({
-          command: 'selectMultipleFiles',
+          command: MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES,
           fileType: id,
           currentFile,
         });
@@ -113,13 +114,13 @@ export class FileInputManager {
       const cap = capitalize(type);
       this._addListener(`addOpened${cap}FilesButton`, 'click', () => {
         this.vscode.postMessage({
-          command: 'addOpenedFiles',
+          command: MAIN_VIEW_COMMANDS.ADD_OPENED_FILES,
           fileType: type,
         });
       });
       this._addListener(`current${cap}FileButton`, 'click', () => {
         this.vscode.postMessage({
-          command: 'getCurrentFile',
+          command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
           fileType: type,
         });
       });
@@ -129,7 +130,7 @@ export class FileInputManager {
       this._addListener(`current${capitalize(type)}FileButton`, 'click', () => {
         const baseFile = safeGetElementValue('baseFile');
         this.vscode.postMessage({
-          command: 'getCurrentFile',
+          command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
           fileType: type,
           baseFile,
         });
@@ -161,7 +162,9 @@ export class FileInputManager {
     icons.forEach((icon) => {
       if (icon.classList.contains('codicon-git-commit')) {
         const handler = () => {
-          this.vscode.postMessage({ command: 'refreshCommits' });
+          this.vscode.postMessage({
+            command: MAIN_VIEW_COMMANDS.REFRESH_COMMITS,
+          });
         };
         icon.addEventListener('click', handler);
         this._listeners.push({ element: icon, event: 'click', handler });

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -8,6 +8,7 @@ import {
 } from '../constants.js';
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class SettingsButtonManager {
   constructor(
@@ -78,11 +79,15 @@ export class SettingsButtonManager {
 
   _setupSettingsButtons() {
     this._addListener('agentSettingsButton', 'click', () => {
-      this.vscode.postMessage({ command: 'openAgentSettings' });
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
+      });
     });
 
     this._addListener('modelSettingsButton', 'click', () => {
-      this.vscode.postMessage({ command: 'openModelSettings' });
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS,
+      });
     });
   }
 
@@ -93,9 +98,11 @@ export class SettingsButtonManager {
       if (reflectCheckbox) {
         reflectCheckbox.checked = !selectedAgent.startsWith('correct');
       }
-      this.vscode.postMessage({ command: 'requestMediaFile' });
       this.vscode.postMessage({
-        command: 'requestDefaultOutputFiles',
+        command: MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
+      });
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES,
         agent: selectedAgent,
       });
       this.state.save();
@@ -103,7 +110,7 @@ export class SettingsButtonManager {
 
     this._addListener('model', 'change', (e) => {
       this.vscode.postMessage({
-        command: 'modelSelected',
+        command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
         model: e.target.value,
       });
       this.state.save();


### PR DESCRIPTION
## Summary
- import `MAIN_VIEW_COMMANDS` in FileInputManager and SettingsButtonManager
- send commands using constants instead of string literals

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warnings from webpack, but no test results due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68658958d0908324bd342eb8ce326ea1