### PR TITLE
Use template utils for element creation

### DIFF
--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -30,3 +30,27 @@ export function createIconButton({
   });
   return element;
 }
+
+export function createOption({ value = '', text = '' } = {}) {
+  const option = renderTemplate('optionTemplate');
+  if (!option) return null;
+  option.value = value;
+  option.textContent = text;
+  return option;
+}
+
+export function createFileListItem(file) {
+  const element = renderTemplate('fileListItemTemplate');
+  if (!element) return null;
+  const nameSpan = element.querySelector('.file-name');
+  if (nameSpan) nameSpan.textContent = file;
+  element.dataset.path = file;
+  return element;
+}
+
+export function createIcon(iconClass) {
+  const icon = renderTemplate('iconTemplate');
+  if (!icon) return null;
+  icon.classList.add(iconClass);
+  return icon;
+}

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -27,7 +27,8 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
-          "@common/domUtils.js": "${domUtilsUri}"
+          "@common/domUtils.js": "${domUtilsUri}",
+          "@common/templateUtils.js": "${templateUtilsUri}"
         }
       }
     </script>
@@ -72,5 +73,45 @@
         <!-- History items will be inserted here -->
       </div>
     </div>
+    <template id="clearHistoryButtonTemplate">
+      <button class="vscode-button button-clear" id="clearHistoryBtn">
+        Clear All History
+      </button>
+    </template>
+    <template id="historyItemTemplate">
+      <div class="history-item">
+        <div class="history-item-header">
+          <div class="history-timestamp"></div>
+          <div class="history-actions button-group">
+            <button
+              class="vscode-button delete-btn"
+              title="Delete this history item"
+            >
+              <i class="codicon codicon-trash"></i>
+            </button>
+            <button
+              class="vscode-button restore-btn"
+              title="Load configuration to main view"
+            >
+              <i class="codicon codicon-reply"></i>
+            </button>
+            <button
+              class="vscode-button rerun-btn"
+              title="Execute this configuration"
+            >
+              <i class="codicon codicon-debug-rerun"></i>
+            </button>
+          </div>
+        </div>
+        <div class="history-details basic-details"></div>
+        <div class="collapsible">
+          <div class="history-details details-container"></div>
+        </div>
+        <button class="toggle-button"></button>
+      </div>
+    </template>
+    <template id="emptyStateTemplate">
+      <div class="empty-state"></div>
+    </template>
   </body>
 </html>

--- a/src/historyView/modules/uiManagers/historyRenderer.js
+++ b/src/historyView/modules/uiManagers/historyRenderer.js
@@ -5,6 +5,7 @@ import {
   safeGetElementById,
 } from '@common/domUtils.js';
 import { historyViewState } from '../historyViewState.js';
+import { renderTemplate } from '@common/templateUtils.js';
 
 /**
  * Renders history items and manages per-item events.
@@ -24,17 +25,22 @@ export class HistoryRenderer {
     clearButtonContainer.innerHTML = '';
 
     if (!historyItems || historyItems.length === 0) {
-      historyContainer.innerHTML =
-        '<div class="empty-state">No history items found</div>';
+      const empty = renderTemplate('emptyStateTemplate');
+      if (empty) {
+        empty.textContent = 'No history items found';
+        historyContainer.appendChild(empty);
+      }
       this.searchManager.initialize(historyContainer);
       return;
     }
 
-    clearButtonContainer.innerHTML =
-      '<button class="vscode-button button-clear" id="clearHistoryBtn">Clear All History</button>';
-    addEventListenerSafely('clearHistoryBtn', 'click', () => {
-      vscode.postMessage({ command: 'clearHistory' });
-    });
+    const clearBtn = renderTemplate('clearHistoryButtonTemplate');
+    if (clearBtn) {
+      clearButtonContainer.appendChild(clearBtn);
+      addEventListenerSafely('clearHistoryBtn', 'click', () => {
+        vscode.postMessage({ command: 'clearHistory' });
+      });
+    }
 
     const sorted = [...historyItems].sort(
       (a, b) => new Date(b.timestamp) - new Date(a.timestamp),
@@ -52,27 +58,28 @@ export class HistoryRenderer {
     const config = item.config;
     const date = new Date(item.timestamp).toLocaleString();
 
-    const container = document.createElement('div');
-    container.className = 'history-item';
+    const container = renderTemplate('historyItemTemplate');
+    if (!container) return document.createElement('div');
 
-    const header = document.createElement('div');
-    header.className = 'history-item-header';
-    header.innerHTML = `
-      <div class="history-timestamp">${date}</div>
-      <div class="history-actions button-group">
-        <button class="vscode-button delete-btn" data-id="${item.id}" data-command="deleteAgent" title="Delete this history item">
-          <i class="codicon codicon-trash"></i>
-        </button>
-        <button class="vscode-button restore-btn" data-id="${item.id}" data-command="restoreAgent" title="Load configuration to main view">
-          <i class="codicon codicon-reply"></i>
-        </button>
-        <button class="vscode-button rerun-btn" data-id="${item.id}" data-command="rerunAgent" title="Execute this configuration">
-          <i class="codicon codicon-debug-rerun"></i>
-        </button>
-      </div>`;
+    const headerTimestamp = container.querySelector('.history-timestamp');
+    if (headerTimestamp) headerTimestamp.textContent = date;
+    const delBtn = container.querySelector('.delete-btn');
+    if (delBtn) {
+      delBtn.dataset.id = item.id;
+      delBtn.dataset.command = 'deleteAgent';
+    }
+    const restoreBtn = container.querySelector('.restore-btn');
+    if (restoreBtn) {
+      restoreBtn.dataset.id = item.id;
+      restoreBtn.dataset.command = 'restoreAgent';
+    }
+    const rerunBtn = container.querySelector('.rerun-btn');
+    if (rerunBtn) {
+      rerunBtn.dataset.id = item.id;
+      rerunBtn.dataset.command = 'rerunAgent';
+    }
 
-    const basicDetails = document.createElement('div');
-    basicDetails.className = 'history-details';
+    const basicDetails = container.querySelector('.basic-details');
     let basicHTML = `
       <span class="history-label">Agent:</span>
       <span class="history-value">${config.agent}</span>
@@ -105,12 +112,12 @@ export class HistoryRenderer {
     });
     basicDetails.innerHTML = basicHTML;
 
-    const collapsible = document.createElement('div');
-    collapsible.className = 'collapsible';
-    collapsible.id = `content-${item.id}`;
+    const collapsible = container.querySelector('.collapsible');
+    if (collapsible) {
+      collapsible.id = `content-${item.id}`;
+    }
 
-    const detailsContainer = document.createElement('div');
-    detailsContainer.className = 'history-details';
+    const detailsContainer = container.querySelector('.details-container');
 
     let detailsHTML = '';
     const extraFileTypes = [
@@ -153,20 +160,16 @@ export class HistoryRenderer {
       );
     }
 
-    if (detailsHTML) {
+    const toggleButton = container.querySelector('.toggle-button');
+
+    if (detailsHTML && detailsContainer && collapsible && toggleButton) {
       detailsContainer.innerHTML = detailsHTML;
       collapsible.appendChild(detailsContainer);
-      const toggleButton = document.createElement('button');
-      toggleButton.className = 'toggle-button';
-      toggleButton.setAttribute('data-id', item.id);
+      toggleButton.dataset.id = item.id;
       toggleButton.textContent = 'Show more';
-      container.appendChild(header);
-      container.appendChild(basicDetails);
-      container.appendChild(collapsible);
-      container.appendChild(toggleButton);
     } else {
-      container.appendChild(header);
-      container.appendChild(basicDetails);
+      collapsible?.remove();
+      toggleButton?.remove();
     }
 
     return container;

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -626,5 +626,17 @@
         <i class="codicon"></i>
       </button>
     </template>
+    <template id="iconTemplate">
+      <i class="codicon"></i>
+    </template>
+    <template id="optionTemplate">
+      <option></option>
+    </template>
+    <template id="fileListItemTemplate">
+      <div class="file-item">
+        <span class="file-name"></span>
+        <span class="remove-button">-</span>
+      </div>
+    </template>
   </body>
 </html>

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -19,6 +19,7 @@ import {
   safeSetElementChecked,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
+import { createIcon } from '@common/templateUtils.js';
 
 /**
  * Manages persistent state for the main webview.
@@ -46,7 +47,11 @@ export class MainViewState {
     const autoExtractOptions = safeGetElementById('autoExtractOptions');
     if (autoExtractToggle && autoExtractOptions) {
       autoExtractToggle.classList.remove('active');
-      autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+      autoExtractToggle.innerHTML = '';
+      const wandIcon = createIcon('codicon-wand');
+      const chevron = createIcon(CHEVRON_DOWN_CLASS);
+      if (wandIcon) autoExtractToggle.appendChild(wandIcon);
+      if (chevron) autoExtractToggle.appendChild(chevron);
       autoExtractOptions.style.display = 'none';
     }
 
@@ -63,7 +68,9 @@ export class MainViewState {
     const toggleLatexdiffs = safeGetElementById('toggleLatexdiffs');
     if (latexdiffsContent && toggleLatexdiffs) {
       latexdiffsContent.style.display = 'none';
-      toggleLatexdiffs.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
+      toggleLatexdiffs.innerHTML = '';
+      const icon = createIcon(CHEVRON_DOWN_CLASS);
+      if (icon) toggleLatexdiffs.appendChild(icon);
     }
 
     this.save();
@@ -90,7 +97,11 @@ export class MainViewState {
       );
       if (autoExtractToggle && autoExtractOptions) {
         autoExtractToggle.classList.toggle('active', hasAutoExtractChecked);
-        autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+        autoExtractToggle.innerHTML = '';
+        const wandIcon = createIcon('codicon-wand');
+        const chevron = createIcon(CHEVRON_DOWN_CLASS);
+        if (wandIcon) autoExtractToggle.appendChild(wandIcon);
+        if (chevron) autoExtractToggle.appendChild(chevron);
         autoExtractOptions.style.display = 'none';
       }
 
@@ -101,7 +112,11 @@ export class MainViewState {
       );
       if (toggleToolConfig && toolConfigOptions) {
         toggleToolConfig.classList.toggle('active', hasToolConfigChecked);
-        toggleToolConfig.innerHTML = `<i class="codicon codicon-tools"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+        toggleToolConfig.innerHTML = '';
+        const toolsIcon = createIcon('codicon-tools');
+        const chevronIcon = createIcon(CHEVRON_DOWN_CLASS);
+        if (toolsIcon) toggleToolConfig.appendChild(toolsIcon);
+        if (chevronIcon) toggleToolConfig.appendChild(chevronIcon);
         toolConfigOptions.style.display = 'none';
       }
 
@@ -136,9 +151,11 @@ export class MainViewState {
       if (latexdiffsContent && toggleLatexdiffs) {
         const visible = previousState.latexdiffsVisible ?? false;
         latexdiffsContent.style.display = visible ? 'block' : 'none';
-        toggleLatexdiffs.innerHTML = `<i class="${
-          visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-        }"></i>`;
+        toggleLatexdiffs.innerHTML = '';
+        const icon = createIcon(
+          visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
+        );
+        if (icon) toggleLatexdiffs.appendChild(icon);
       }
     } else {
       this.setDefaults();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -9,6 +9,11 @@ import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { mainViewState } from './mainViewState.js';
 import { mainViewDomHandler } from './domHandlers.js';
+import {
+  renderTemplate,
+  createIcon,
+  createFileListItem,
+} from '@common/templateUtils.js';
 
 // Local imports - UI managers
 import { fileList } from './uiManagers/FileList.js';
@@ -141,20 +146,12 @@ export class MainViewMessageHandlers {
   _setToggleIcon(element, isVisible) {
     if (!element) return;
     element.innerHTML = '';
-    const icon = document.createElement('i');
-    icon.className = isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS;
-    element.appendChild(icon);
+    const icon = createIcon(isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS);
+    if (icon) element.appendChild(icon);
   }
 
   _createFileItem(file) {
-    const fileItem = document.createElement('div');
-    fileItem.className = 'file-item';
-    fileItem.dataset.path = file;
-    fileItem.textContent = file;
-    const removeButton = document.createElement('span');
-    removeButton.className = 'remove-button';
-    removeButton.textContent = '-';
-    fileItem.appendChild(removeButton);
+    const fileItem = createFileListItem(file);
     return fileItem;
   }
 

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -8,6 +8,7 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
 import { capitalize } from '@common/stringUtils.js';
+import { createIcon, createFileListItem } from '@common/templateUtils.js';
 
 /**
  * Handles multi-file list DOM updates.
@@ -31,10 +32,8 @@ export class FileList {
     const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
     if (!container || !toggleIcon) return;
 
-    const fileElement = document.createElement('div');
-    fileElement.className = 'file-item';
-    fileElement.dataset.path = file;
-    fileElement.innerHTML = `${file} <span class="remove-button">-</span>`;
+    const fileElement = createFileListItem(file);
+    if (!fileElement) return;
 
     const removeButton = fileElement.querySelector('.remove-button');
     if (removeButton) {
@@ -63,7 +62,9 @@ export class FileList {
     if (newFiles.length > 0) {
       newFiles.forEach((file) => this.add(listId, file));
       listDiv.style.display = 'block';
-      toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
+      toggleIcon.innerHTML = '';
+      const iconEl = createIcon(CHEVRON_UP_CLASS);
+      if (iconEl) toggleIcon.appendChild(iconEl);
 
       const container = safeGetElementById(`${listId}Container`);
       if (container) {
@@ -85,9 +86,9 @@ export class FileList {
     const toggleIcon = safeGetElementById(toggleId);
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
-    toggleIcon.innerHTML = `<i class="${
-      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-    }"></i>`;
+    toggleIcon.innerHTML = '';
+    const icon = createIcon(isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS);
+    if (icon) toggleIcon.appendChild(icon);
   }
 
   /** Toggle visibility of a file list container */
@@ -109,7 +110,9 @@ export class FileList {
     container.style.display = 'none';
     const toggleIconDiv = safeGetElementById(toggleId);
     if (toggleIconDiv) {
-      toggleIconDiv.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
+      toggleIconDiv.innerHTML = '';
+      const icon = createIcon(CHEVRON_DOWN_CLASS);
+      if (icon) toggleIconDiv.appendChild(icon);
     }
     this._saveFn();
   }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -2,6 +2,7 @@
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { createOption } from '@common/templateUtils.js';
 
 /**
  * Handles single-file dropdown updates and commit list logic.
@@ -46,10 +47,8 @@ export class FileSelect {
   }
 
   addOption(select, value, text) {
-    const option = document.createElement('option');
-    option.value = value;
-    option.textContent = text;
-    select.appendChild(option);
+    const option = createOption({ value, text });
+    if (option) select.appendChild(option);
   }
 
   setElementsDisabled(elements, disabled) {

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -7,6 +7,7 @@ import {
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
+import { createIcon } from '@common/templateUtils.js';
 
 const INPUT_FILE_ID = 'inputFile';
 const OUTPUT_FILES_ID = 'outputFiles';
@@ -89,9 +90,11 @@ export class OutputFilesManager {
       const shouldShow = state && state.outputFilesActive;
 
       container.style.display = shouldShow ? 'block' : 'none';
-      toggleIcon.innerHTML = `<i class="${
-        shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-      }"></i>`;
+      toggleIcon.innerHTML = '';
+      const icon = createIcon(
+        shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
+      );
+      if (icon) toggleIcon.appendChild(icon);
     }
   }
 }

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -3,6 +3,7 @@ import {
   safeGetElementById,
 } from '@common/domUtils.js';
 import { webviewEventBus } from '../eventBus.js';
+import { createIcon } from '@common/templateUtils.js';
 
 export class RecordingManager {
   constructor(vscode, eventBus = webviewEventBus) {
@@ -16,11 +17,15 @@ export class RecordingManager {
     const recordButton = safeGetElementById('recordInstructionButton');
     if (recordButton) {
       if (recording) {
-        recordButton.innerHTML = '<i class="codicon codicon-stop-circle"></i>';
+        recordButton.innerHTML = '';
+        const icon = createIcon('codicon-stop-circle');
+        if (icon) recordButton.appendChild(icon);
         recordButton.title = 'Stop recording';
         recordButton.classList.add('recording');
       } else {
-        recordButton.innerHTML = '<i class="codicon codicon-mic"></i>';
+        recordButton.innerHTML = '';
+        const icon = createIcon('codicon-mic');
+        if (icon) recordButton.appendChild(icon);
         recordButton.title = 'Record instruction with microphone';
         recordButton.classList.remove('recording');
       }

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -7,6 +7,7 @@ import {
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
 } from '../constants.js';
+import { createIcon } from '@common/templateUtils.js';
 
 export class ToggleManager {
   isOptionsVisible(options) {
@@ -19,9 +20,11 @@ export class ToggleManager {
 
   setToggleIcon(toggle, icon, visible, active) {
     toggle.classList.toggle('active', active);
-    toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="${
-      visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-    }"></i>`;
+    toggle.innerHTML = '';
+    const iconEl = createIcon(`codicon-${icon}`);
+    const chevron = createIcon(visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS);
+    if (iconEl) toggle.appendChild(iconEl);
+    if (chevron) toggle.appendChild(chevron);
   }
 
   updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {


### PR DESCRIPTION
## Summary
- add DOM helper utilities like `createOption`, `createFileListItem`, and `createIcon`
- expose new templates in `webview/index.html`
- include template utils in the history view and add templates for history items
- refactor webview modules to create elements through `templateUtils`
- update history renderer to build items from templates

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test run incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_686589c9a39083249e8d901050f4a644