### PR TITLE
feat: add statistics message type

### DIFF
--- a/src/agent/output/StatisticsReporter.ts
+++ b/src/agent/output/StatisticsReporter.ts
@@ -9,6 +9,8 @@ import {
 } from '@agent/core/ResponseUsage';
 import { ResponseUsage } from 'openai/resources/responses/responses';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { objectToLogString } from '@utils/text/stringUtils';
 
 export class StatisticsReporter {
   constructor(
@@ -24,64 +26,31 @@ export class StatisticsReporter {
     const statsGroupId = groupId ?? this.logger.getActiveGroupId();
 
     try {
-      this.logger.debug('=== Task Statistics ===', statsGroupId);
-      this.logger.debug(
-        `Total input tokens  : ${stateGlobal.totalInputTokens}`,
-        statsGroupId,
-      );
-      this.logger.debug(
-        `Total output tokens : ${stateGlobal.totalOutputTokens}`,
-        statsGroupId,
-      );
+      const usageSummary: any = {
+        inputTokens:
+          stateGlobal.totalInputTokens +
+          (stateGlobal.totalCacheCreationInputTokens ?? 0),
+        outputTokens: stateGlobal.totalOutputTokens,
+        cost: 0,
+      };
 
       if (
         this.modelHandler.capabilities.supportsPromptCaching ||
         this.modelHandler.capabilities.supportsAutoPromptCaching
       ) {
-        this.logger.debug(
-          `Total input tokens (cache read): ${stateGlobal.totalCacheReadInputTokens}`,
-          statsGroupId,
-        );
-
+        usageSummary.cacheReadTokens = stateGlobal.totalCacheReadInputTokens;
         if (this.modelHandler.capabilities.supportsPromptCaching) {
-          this.logger.debug(
-            `Total input tokens (cache create): ${stateGlobal.totalCacheCreationInputTokens}`,
-            statsGroupId,
-          );
+          usageSummary.cacheCreateTokens =
+            stateGlobal.totalCacheCreationInputTokens;
         }
-
-        let totalCacheableTokens: number;
-        if (this.modelHandler.capabilities.supportsPromptCaching) {
-          totalCacheableTokens =
-            stateGlobal.totalCacheCreationInputTokens +
-            stateGlobal.totalCacheReadInputTokens;
-        } else {
-          totalCacheableTokens = stateGlobal.totalInputTokens;
-        }
-
-        const percentageCached =
-          totalCacheableTokens > 0
-            ? (stateGlobal.totalCacheReadInputTokens / totalCacheableTokens) *
-              100
-            : 0;
-        this.logger.debug(
-          `Percentage cached: ${percentageCached.toFixed(2)}%`,
-          statsGroupId,
-        );
       }
 
       if (this.modelHandler.capabilities.supportsReasoning) {
-        this.logger.debug(
-          `Total reasoning tokens: ${stateGlobal.totalReasoningTokens}`,
-          statsGroupId,
-        );
+        usageSummary.reasoningTokens = stateGlobal.totalReasoningTokens;
       }
 
       if (stateGlobal.totalToolUseTokens > 0) {
-        this.logger.debug(
-          `Total tool use tokens: ${stateGlobal.totalToolUseTokens}`,
-          statsGroupId,
-        );
+        usageSummary.toolUseTokens = stateGlobal.totalToolUseTokens;
       }
 
       let responseUsage:
@@ -149,29 +118,26 @@ export class StatisticsReporter {
 
       const cost = this.modelHandler.computePrice(responseUsage);
 
+      usageSummary.cost = cost;
+      usageSummary.responseTime = stateGlobal.totalResponseTime;
+
       if (statsGroupId) {
         emitProgress('updateGroupUsage', {
           stream: this.channel,
           groupId: statsGroupId,
           usage: {
-            inputTokens:
-              stateGlobal.totalInputTokens +
-              (stateGlobal.totalCacheCreationInputTokens ?? 0),
-            outputTokens: stateGlobal.totalOutputTokens,
+            inputTokens: usageSummary.inputTokens,
+            outputTokens: usageSummary.outputTokens,
             cost,
           },
         });
       }
 
-      this.logger.debug(
-        `Total response time : ${stateGlobal.totalResponseTime.toFixed(1)} seconds`,
+      this.logger.info(
+        objectToLogString(usageSummary),
         statsGroupId,
+        MESSAGE_TYPES.STATISTICS,
       );
-      this.logger.debug(
-        `Total cost          : ${cost.toFixed(3)} USD`,
-        statsGroupId,
-      );
-      this.logger.debug('=======================', statsGroupId);
     } catch (error) {
       this.logger.error(`Error printing statistics: ${error}`, statsGroupId);
     }

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -4,6 +4,7 @@ export const MESSAGE_TYPES = {
   FILE_LIST: 'fileList',
   MISSING_OUTPUTS: 'missingOutputs',
   LATEXDIFF: 'latexdiff',
+  STATISTICS: 'statistics',
   /** Messages that should be hidden from the progress view */
   INTERNAL: 'internal',
   DEFAULT: 'default',

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -378,6 +378,69 @@ export class LogEntryFormatter {
     }
   }
 
+  _formatStatistics(message, content, logId) {
+    try {
+      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const parsed = JSON.parse(this._unescapeHtml(content));
+
+      const items = [];
+      if (parsed.inputTokens !== undefined) {
+        items.push(
+          `<li><i class="codicon codicon-arrow-up"></i> ${formatTokens(parsed.inputTokens)}</li>`,
+        );
+      }
+      if (parsed.outputTokens !== undefined) {
+        items.push(
+          `<li><i class="codicon codicon-arrow-down"></i> ${formatTokens(parsed.outputTokens)}</li>`,
+        );
+      }
+      if (parsed.cacheReadTokens !== undefined) {
+        items.push(
+          `<li><i class="codicon codicon-cloud-download"></i> ${formatTokens(parsed.cacheReadTokens)}</li>`,
+        );
+      }
+      if (parsed.cacheCreateTokens !== undefined) {
+        items.push(
+          `<li><i class="codicon codicon-cloud-upload"></i> ${formatTokens(parsed.cacheCreateTokens)}</li>`,
+        );
+      }
+      if (parsed.reasoningTokens !== undefined) {
+        items.push(
+          `<li><i class="codicon codicon-lightbulb"></i> ${formatTokens(parsed.reasoningTokens)}</li>`,
+        );
+      }
+      if (parsed.toolUseTokens !== undefined) {
+        items.push(
+          `<li><i class="codicon codicon-tools"></i> ${formatTokens(parsed.toolUseTokens)}</li>`,
+        );
+      }
+      if (parsed.responseTime !== undefined) {
+        items.push(
+          `<li><i class="codicon codicon-clock"></i> ${parsed.responseTime.toFixed(1)}s</li>`,
+        );
+      }
+      if (parsed.cost !== undefined) {
+        items.push(
+          `<li><i class="codicon codicon-symbol-key"></i> $${parsed.cost.toFixed(3)}</li>`,
+        );
+      }
+
+      const itemsMarkup = items.join('');
+
+      return `<details class="statistics-details">
+        <summary>
+          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
+          <i class="codicon codicon-dashboard"></i>
+          <span>Statistics</span>
+        </summary>
+        <ul class="statistics-content"${idAttr}>${itemsMarkup}</ul>
+      </details>`;
+    } catch (e) {
+      console.error('Error parsing statistics entry:', e);
+      return message;
+    }
+  }
+
   _formatLatexdiff(message, content, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';

--- a/src/progressView/modules/uiManagers/Events.js
+++ b/src/progressView/modules/uiManagers/Events.js
@@ -107,7 +107,8 @@ export class Events {
           e.target &&
           (e.target.classList.contains('special-details') ||
             e.target.classList.contains('file-list-details') ||
-            e.target.classList.contains('latexdiff-details'))
+            e.target.classList.contains('latexdiff-details') ||
+            e.target.classList.contains('statistics-details'))
         ) {
           const toggleIcon = e.target.querySelector('.toggle-icon');
           if (toggleIcon) {

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -17,3 +17,4 @@
 @import './scratchpad.css';
 @import './file-list.css';
 @import './latexdiff.css';
+@import './statistics.css';

--- a/src/progressView/styles/statistics.css
+++ b/src/progressView/styles/statistics.css
@@ -1,0 +1,31 @@
+/**
+ * Statistics styles for ProgressView
+ */
+
+.statistics-details {
+  margin: var(--spacing-small) 0;
+}
+
+.statistics-details summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) 0;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  opacity: var(--opacity-normal);
+}
+
+.statistics-details summary:hover {
+  opacity: 1;
+}
+
+.statistics-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.statistics-content {
+  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
+  list-style: none;
+}


### PR DESCRIPTION
## Summary
- add `statistics` type to messageTypes
- emit stats with new message type in `StatisticsReporter`
- format statistics entries in progress view
- toggle details for statistics blocks
- style statistics details

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68658e5e9bc08324b6e0244d159c7450