### PR TITLE
Centralize history view constants

### DIFF
--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -34,6 +34,7 @@ export class HistoryViewContentProvider extends BaseViewContentProvider {
         webview,
         'modules/messageHandlers.js',
       ),
+      constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
     };
   }
 }

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -24,6 +24,7 @@
           "./modules/historyViewState.js": "${historyViewStateUri}",
           "./modules/uiManagers/searchManager.js": "${searchManagerUri}",
           "./modules/messageHandlers.js": "${messageHandlersUri}",
+          "./modules/constants.js": "${constantsUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",

--- a/src/historyView/modules/constants.js
+++ b/src/historyView/modules/constants.js
@@ -1,0 +1,15 @@
+export const CSS_CLASSES = {
+  COLLAPSIBLE: 'collapsible',
+  EXPANDED: 'expanded',
+  TOGGLE_BUTTON: 'toggle-button',
+  CURRENT_MATCH: 'current-match',
+};
+
+export const BUTTON_TEXT = {
+  SHOW_MORE: 'Show more',
+  SHOW_LESS: 'Show less',
+};
+
+import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
+
+export const COMMANDS = HISTORY_VIEW_COMMANDS;

--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -1,6 +1,7 @@
 // Local imports
 import { registerMessageHandlers } from '@common/webviewContext.js';
 import { historyViewDomHandler } from './domHandlers.js';
+import { COMMANDS } from './constants.js';
 
 /**
  * Handles messages from the extension for the history view.
@@ -9,8 +10,8 @@ export class HistoryViewMessageHandlers {
   constructor() {
     this._cleanupFn = null;
     this._handlers = {
-      updateHistory: (m) => this.handleUpdateHistory(m),
-      historyCleared: () => this.handleHistoryCleared(),
+      [COMMANDS.UPDATE_HISTORY]: (m) => this.handleUpdateHistory(m),
+      [COMMANDS.HISTORY_CLEARED]: () => this.handleHistoryCleared(),
     };
   }
 

--- a/src/historyView/modules/uiManagers/historyRenderer.js
+++ b/src/historyView/modules/uiManagers/historyRenderer.js
@@ -5,6 +5,7 @@ import {
   safeGetElementById,
 } from '@common/domUtils.js';
 import { historyViewState } from '../historyViewState.js';
+import { COMMANDS, CSS_CLASSES, BUTTON_TEXT } from '../constants.js';
 
 /**
  * Renders history items and manages per-item events.
@@ -33,7 +34,7 @@ export class HistoryRenderer {
     clearButtonContainer.innerHTML =
       '<button class="vscode-button button-clear" id="clearHistoryBtn">Clear All History</button>';
     addEventListenerSafely('clearHistoryBtn', 'click', () => {
-      vscode.postMessage({ command: 'clearHistory' });
+      vscode.postMessage({ command: COMMANDS.CLEAR_HISTORY });
     });
 
     const sorted = [...historyItems].sort(
@@ -60,13 +61,13 @@ export class HistoryRenderer {
     header.innerHTML = `
       <div class="history-timestamp">${date}</div>
       <div class="history-actions button-group">
-        <button class="vscode-button delete-btn" data-id="${item.id}" data-command="deleteAgent" title="Delete this history item">
+        <button class="vscode-button delete-btn" data-id="${item.id}" data-command="${COMMANDS.DELETE_AGENT}" title="Delete this history item">
           <i class="codicon codicon-trash"></i>
         </button>
-        <button class="vscode-button restore-btn" data-id="${item.id}" data-command="restoreAgent" title="Load configuration to main view">
+        <button class="vscode-button restore-btn" data-id="${item.id}" data-command="${COMMANDS.RESTORE_AGENT}" title="Load configuration to main view">
           <i class="codicon codicon-reply"></i>
         </button>
-        <button class="vscode-button rerun-btn" data-id="${item.id}" data-command="rerunAgent" title="Execute this configuration">
+        <button class="vscode-button rerun-btn" data-id="${item.id}" data-command="${COMMANDS.RERUN_AGENT}" title="Execute this configuration">
           <i class="codicon codicon-debug-rerun"></i>
         </button>
       </div>`;
@@ -106,7 +107,7 @@ export class HistoryRenderer {
     basicDetails.innerHTML = basicHTML;
 
     const collapsible = document.createElement('div');
-    collapsible.className = 'collapsible';
+    collapsible.className = CSS_CLASSES.COLLAPSIBLE;
     collapsible.id = `content-${item.id}`;
 
     const detailsContainer = document.createElement('div');
@@ -157,9 +158,9 @@ export class HistoryRenderer {
       detailsContainer.innerHTML = detailsHTML;
       collapsible.appendChild(detailsContainer);
       const toggleButton = document.createElement('button');
-      toggleButton.className = 'toggle-button';
+      toggleButton.className = CSS_CLASSES.TOGGLE_BUTTON;
       toggleButton.setAttribute('data-id', item.id);
-      toggleButton.textContent = 'Show more';
+      toggleButton.textContent = BUTTON_TEXT.SHOW_MORE;
       container.appendChild(header);
       container.appendChild(basicDetails);
       container.appendChild(collapsible);
@@ -209,13 +210,15 @@ export class HistoryRenderer {
         vscode.postMessage({ command, historyId });
         return;
       }
-      const toggle = e.target.closest('.toggle-button');
+      const toggle = e.target.closest(`.${CSS_CLASSES.TOGGLE_BUTTON}`);
       if (toggle) {
         const id = toggle.getAttribute('data-id');
         const content = safeGetElementById(`content-${id}`);
         if (!content) return;
-        const expanded = content.classList.toggle('expanded');
-        toggle.textContent = expanded ? 'Show less' : 'Show more';
+        const expanded = content.classList.toggle(CSS_CLASSES.EXPANDED);
+        toggle.textContent = expanded
+          ? BUTTON_TEXT.SHOW_LESS
+          : BUTTON_TEXT.SHOW_MORE;
         historyViewState.toggleStates.set(id, expanded);
       }
     });
@@ -225,14 +228,16 @@ export class HistoryRenderer {
     const entries = historyViewState.toggleStates.entries();
     for (const [id, expanded] of entries) {
       const content = document.getElementById(`content-${id}`);
-      const toggle = document.querySelector(`.toggle-button[data-id="${id}"]`);
+      const toggle = document.querySelector(
+        `.${CSS_CLASSES.TOGGLE_BUTTON}[data-id="${id}"]`,
+      );
       if (content && toggle) {
         if (expanded) {
-          content.classList.add('expanded');
-          toggle.textContent = 'Show less';
+          content.classList.add(CSS_CLASSES.EXPANDED);
+          toggle.textContent = BUTTON_TEXT.SHOW_LESS;
         } else {
-          content.classList.remove('expanded');
-          toggle.textContent = 'Show more';
+          content.classList.remove(CSS_CLASSES.EXPANDED);
+          toggle.textContent = BUTTON_TEXT.SHOW_MORE;
         }
       }
     }

--- a/src/historyView/modules/uiManagers/searchManager.js
+++ b/src/historyView/modules/uiManagers/searchManager.js
@@ -1,6 +1,7 @@
 /* global Mark */
 import { safeGetElementById } from '@common/domUtils.js';
 import { historyViewState } from '../historyViewState.js';
+import { CSS_CLASSES, BUTTON_TEXT } from '../constants.js';
 
 /**
  * Handles search functionality using mark.js.
@@ -54,8 +55,8 @@ export class SearchManager {
 
   navigateNext() {
     if (this.state.totalMatches === 0) return;
-    const current = document.querySelector('mark.current-match');
-    if (current) current.classList.remove('current-match');
+    const current = document.querySelector(`mark.${CSS_CLASSES.CURRENT_MATCH}`);
+    if (current) current.classList.remove(CSS_CLASSES.CURRENT_MATCH);
     const nextIndex = (this.state.searchIndex + 1) % this.state.totalMatches;
     this.state.setSearchIndex(nextIndex);
     this.scrollToCurrentMatch();
@@ -63,8 +64,8 @@ export class SearchManager {
 
   navigatePrev() {
     if (this.state.totalMatches === 0) return;
-    const current = document.querySelector('mark.current-match');
-    if (current) current.classList.remove('current-match');
+    const current = document.querySelector(`mark.${CSS_CLASSES.CURRENT_MATCH}`);
+    if (current) current.classList.remove(CSS_CLASSES.CURRENT_MATCH);
     const prevIndex =
       (this.state.searchIndex - 1 + this.state.totalMatches) %
       this.state.totalMatches;
@@ -76,7 +77,7 @@ export class SearchManager {
     if (this.state.totalMatches === 0) return;
     const marks = document.querySelectorAll('mark');
     if (marks.length > this.state.searchIndex) {
-      marks[this.state.searchIndex].classList.add('current-match');
+      marks[this.state.searchIndex].classList.add(CSS_CLASSES.CURRENT_MATCH);
       marks[this.state.searchIndex].scrollIntoView({
         behavior: 'smooth',
         block: 'center',
@@ -97,33 +98,39 @@ export class SearchManager {
   }
 
   expandAllCollapsibleSections() {
-    document.querySelectorAll('.collapsible').forEach((section) => {
-      if (!section.classList.contains('expanded')) {
-        section.classList.add('expanded');
-        const id = section.id.replace('content-', '');
-        const toggle = document.querySelector(
-          `.toggle-button[data-id="${id}"]`,
-        );
-        if (toggle) {
-          toggle.textContent = 'Show less';
+    document
+      .querySelectorAll(`.${CSS_CLASSES.COLLAPSIBLE}`)
+      .forEach((section) => {
+        if (!section.classList.contains(CSS_CLASSES.EXPANDED)) {
+          section.classList.add(CSS_CLASSES.EXPANDED);
+          const id = section.id.replace('content-', '');
+          const toggle = document.querySelector(
+            `.${CSS_CLASSES.TOGGLE_BUTTON}[data-id="${id}"]`,
+          );
+          if (toggle) {
+            toggle.textContent = BUTTON_TEXT.SHOW_LESS;
+          }
         }
-      }
-    });
+      });
   }
 
   applySavedToggleStates() {
-    document.querySelectorAll('.collapsible').forEach((section) => {
-      const id = section.id.replace('content-', '');
-      const expanded = this.state.toggleStates.get(id);
-      const toggle = document.querySelector(`.toggle-button[data-id="${id}"]`);
-      if (expanded) {
-        section.classList.add('expanded');
-        if (toggle) toggle.textContent = 'Show less';
-      } else {
-        section.classList.remove('expanded');
-        if (toggle) toggle.textContent = 'Show more';
-      }
-    });
+    document
+      .querySelectorAll(`.${CSS_CLASSES.COLLAPSIBLE}`)
+      .forEach((section) => {
+        const id = section.id.replace('content-', '');
+        const expanded = this.state.toggleStates.get(id);
+        const toggle = document.querySelector(
+          `.${CSS_CLASSES.TOGGLE_BUTTON}[data-id="${id}"]`,
+        );
+        if (expanded) {
+          section.classList.add(CSS_CLASSES.EXPANDED);
+          if (toggle) toggle.textContent = BUTTON_TEXT.SHOW_LESS;
+        } else {
+          section.classList.remove(CSS_CLASSES.EXPANDED);
+          if (toggle) toggle.textContent = BUTTON_TEXT.SHOW_MORE;
+        }
+      });
   }
 
   dispose() {

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -2,6 +2,7 @@ import { vscode } from '@common/webviewContext.js';
 import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
 import { messageHandlers } from './modules/messageHandlers.js';
+import { COMMANDS } from './modules/constants.js';
 
 historyViewState.initialize();
 
@@ -10,7 +11,7 @@ messageHandlers.setup();
 
 document.addEventListener('DOMContentLoaded', () => {
   historyViewDomHandler.events.setupEventListeners();
-  vscode.postMessage({ command: 'getHistoryData' });
+  vscode.postMessage({ command: COMMANDS.GET_HISTORY_DATA });
 });
 
 window.addEventListener('beforeunload', () => {


### PR DESCRIPTION
## Summary
- define `src/historyView/modules/constants.js`
- import CSS class and command constants across history view modules
- update `HistoryViewContentProvider` and `index.html` to expose the constants module
- use constants for markup and messages

## Testing
- `npm run format`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68658cbefc40832491543d95b9c5741c