### PR TITLE
Add constants module for history view

### DIFF
--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -17,6 +17,7 @@ export class HistoryViewContentProvider extends BaseViewContentProvider {
 
       // History view specific modules
       domHandlersUri: this.getWebviewUri(webview, 'modules/domHandlers.js'),
+      constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
       eventsUri: this.getWebviewUri(webview, 'modules/uiManagers/Events.js'),
       historyRendererUri: this.getWebviewUri(
         webview,

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -19,6 +19,7 @@
       {
         "imports": {
           "./modules/domHandlers.js": "${domHandlersUri}",
+          "./modules/constants.js": "${constantsUri}",
           "./modules/uiManagers/Events.js": "${eventsUri}",
           "./modules/uiManagers/HistoryRenderer.js": "${historyRendererUri}",
           "./modules/historyViewState.js": "${historyViewStateUri}",

--- a/src/historyView/modules/constants.js
+++ b/src/historyView/modules/constants.js
@@ -1,0 +1,34 @@
+// Constants for History View
+
+// Import standardized commands
+import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
+
+// Export command map for convenience
+export const COMMANDS = HISTORY_VIEW_COMMANDS;
+
+// DOM element IDs
+export const ELEMENT_IDS = {
+  SEARCH_INPUT: 'searchInput',
+  PREV_MATCH: 'prevMatch',
+  NEXT_MATCH: 'nextMatch',
+  MATCH_COUNT: 'matchCount',
+  CLEAR_BUTTON_CONTAINER: 'clearButtonContainer',
+  HISTORY_CONTAINER: 'historyContainer',
+  CLEAR_HISTORY_BTN: 'clearHistoryBtn',
+};
+
+// CSS class names used across modules
+export const CLASS_NAMES = {
+  COLLAPSIBLE: 'collapsible',
+  EXPANDED: 'expanded',
+  TOGGLE_BUTTON: 'toggle-button',
+  CURRENT_MATCH: 'current-match',
+};
+
+// Text labels and messages
+export const LABELS = {
+  SHOW_MORE: 'Show more',
+  SHOW_LESS: 'Show less',
+  EMPTY_STATE: 'No history items found',
+  CLEAR_ALL_HISTORY: 'Clear All History',
+};

--- a/src/historyView/modules/uiManagers/Events.js
+++ b/src/historyView/modules/uiManagers/Events.js
@@ -1,4 +1,5 @@
 import { addEventListenerSafely } from '@common/domUtils.js';
+import { ELEMENT_IDS } from '../constants.js';
 
 /**
  * Registers global event listeners for the history view.
@@ -18,12 +19,12 @@ export class HistoryEvents {
   }
 
   setupEventListeners() {
-    const searchInput = document.getElementById('searchInput');
+    const searchInput = document.getElementById(ELEMENT_IDS.SEARCH_INPUT);
     const searchHandler = this._debounce((e) => {
       const term = e.target.value.trim();
       this.searchManager.search(term);
     }, 300);
-    addEventListenerSafely('searchInput', 'input', searchHandler);
+    addEventListenerSafely(ELEMENT_IDS.SEARCH_INPUT, 'input', searchHandler);
     if (searchInput) {
       this.handlers.push({
         element: searchInput,
@@ -33,8 +34,8 @@ export class HistoryEvents {
     }
 
     const prevHandler = () => this.searchManager.navigatePrev();
-    addEventListenerSafely('prevMatch', 'click', prevHandler);
-    const prevEl = document.getElementById('prevMatch');
+    addEventListenerSafely(ELEMENT_IDS.PREV_MATCH, 'click', prevHandler);
+    const prevEl = document.getElementById(ELEMENT_IDS.PREV_MATCH);
     if (prevEl)
       this.handlers.push({
         element: prevEl,
@@ -43,8 +44,8 @@ export class HistoryEvents {
       });
 
     const nextHandler = () => this.searchManager.navigateNext();
-    addEventListenerSafely('nextMatch', 'click', nextHandler);
-    const nextEl = document.getElementById('nextMatch');
+    addEventListenerSafely(ELEMENT_IDS.NEXT_MATCH, 'click', nextHandler);
+    const nextEl = document.getElementById(ELEMENT_IDS.NEXT_MATCH);
     if (nextEl)
       this.handlers.push({
         element: nextEl,
@@ -62,7 +63,7 @@ export class HistoryEvents {
         }
       }
     };
-    addEventListenerSafely('searchInput', 'keydown', keyHandler);
+    addEventListenerSafely(ELEMENT_IDS.SEARCH_INPUT, 'keydown', keyHandler);
     if (searchInput) {
       this.handlers.push({
         element: searchInput,

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -5,6 +5,7 @@ import {
   safeGetElementById,
 } from '@common/domUtils.js';
 import { historyViewState } from '../historyViewState.js';
+import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
 
 /**
  * Renders history items and manages per-item events.
@@ -16,24 +17,24 @@ export class HistoryRenderer {
 
   /** Render list of history items */
   render(historyItems) {
-    const historyContainer = safeGetElementById('historyContainer');
-    const clearButtonContainer = safeGetElementById('clearButtonContainer');
+    const historyContainer = safeGetElementById(ELEMENT_IDS.HISTORY_CONTAINER);
+    const clearButtonContainer = safeGetElementById(
+      ELEMENT_IDS.CLEAR_BUTTON_CONTAINER,
+    );
     if (!historyContainer || !clearButtonContainer) return;
 
     historyContainer.innerHTML = '';
     clearButtonContainer.innerHTML = '';
 
     if (!historyItems || historyItems.length === 0) {
-      historyContainer.innerHTML =
-        '<div class="empty-state">No history items found</div>';
+      historyContainer.innerHTML = `<div class="empty-state">${LABELS.EMPTY_STATE}</div>`;
       this.searchManager.initialize(historyContainer);
       return;
     }
 
-    clearButtonContainer.innerHTML =
-      '<button class="vscode-button button-clear" id="clearHistoryBtn">Clear All History</button>';
-    addEventListenerSafely('clearHistoryBtn', 'click', () => {
-      vscode.postMessage({ command: 'clearHistory' });
+    clearButtonContainer.innerHTML = `<button class="vscode-button button-clear" id="${ELEMENT_IDS.CLEAR_HISTORY_BTN}">${LABELS.CLEAR_ALL_HISTORY}</button>`;
+    addEventListenerSafely(ELEMENT_IDS.CLEAR_HISTORY_BTN, 'click', () => {
+      vscode.postMessage({ command: COMMANDS.CLEAR_HISTORY });
     });
 
     const sorted = [...historyItems].sort(
@@ -60,13 +61,13 @@ export class HistoryRenderer {
     header.innerHTML = `
       <div class="history-timestamp">${date}</div>
       <div class="history-actions button-group">
-        <button class="vscode-button delete-btn" data-id="${item.id}" data-command="deleteAgent" title="Delete this history item">
+        <button class="vscode-button delete-btn" data-id="${item.id}" data-command="${COMMANDS.DELETE_AGENT}" title="Delete this history item">
           <i class="codicon codicon-trash"></i>
         </button>
-        <button class="vscode-button restore-btn" data-id="${item.id}" data-command="restoreAgent" title="Load configuration to main view">
+        <button class="vscode-button restore-btn" data-id="${item.id}" data-command="${COMMANDS.RESTORE_AGENT}" title="Load configuration to main view">
           <i class="codicon codicon-reply"></i>
         </button>
-        <button class="vscode-button rerun-btn" data-id="${item.id}" data-command="rerunAgent" title="Execute this configuration">
+        <button class="vscode-button rerun-btn" data-id="${item.id}" data-command="${COMMANDS.RERUN_AGENT}" title="Execute this configuration">
           <i class="codicon codicon-debug-rerun"></i>
         </button>
       </div>`;
@@ -106,7 +107,7 @@ export class HistoryRenderer {
     basicDetails.innerHTML = basicHTML;
 
     const collapsible = document.createElement('div');
-    collapsible.className = 'collapsible';
+    collapsible.className = CLASS_NAMES.COLLAPSIBLE;
     collapsible.id = `content-${item.id}`;
 
     const detailsContainer = document.createElement('div');
@@ -157,9 +158,9 @@ export class HistoryRenderer {
       detailsContainer.innerHTML = detailsHTML;
       collapsible.appendChild(detailsContainer);
       const toggleButton = document.createElement('button');
-      toggleButton.className = 'toggle-button';
+      toggleButton.className = CLASS_NAMES.TOGGLE_BUTTON;
       toggleButton.setAttribute('data-id', item.id);
-      toggleButton.textContent = 'Show more';
+      toggleButton.textContent = LABELS.SHOW_MORE;
       container.appendChild(header);
       container.appendChild(basicDetails);
       container.appendChild(collapsible);
@@ -199,9 +200,9 @@ export class HistoryRenderer {
   }
 
   setupItemEventListeners() {
-    const container = safeGetElementById('historyContainer');
+    const container = safeGetElementById(ELEMENT_IDS.HISTORY_CONTAINER);
     if (!container) return;
-    addEventListenerSafely('historyContainer', 'click', (e) => {
+    addEventListenerSafely(ELEMENT_IDS.HISTORY_CONTAINER, 'click', (e) => {
       const btn = e.target.closest('button[data-command]');
       if (btn) {
         const command = btn.dataset.command;
@@ -209,13 +210,13 @@ export class HistoryRenderer {
         vscode.postMessage({ command, historyId });
         return;
       }
-      const toggle = e.target.closest('.toggle-button');
+      const toggle = e.target.closest(`.${CLASS_NAMES.TOGGLE_BUTTON}`);
       if (toggle) {
         const id = toggle.getAttribute('data-id');
         const content = safeGetElementById(`content-${id}`);
         if (!content) return;
-        const expanded = content.classList.toggle('expanded');
-        toggle.textContent = expanded ? 'Show less' : 'Show more';
+        const expanded = content.classList.toggle(CLASS_NAMES.EXPANDED);
+        toggle.textContent = expanded ? LABELS.SHOW_LESS : LABELS.SHOW_MORE;
         historyViewState.toggleStates.set(id, expanded);
       }
     });
@@ -225,14 +226,16 @@ export class HistoryRenderer {
     const entries = historyViewState.toggleStates.entries();
     for (const [id, expanded] of entries) {
       const content = document.getElementById(`content-${id}`);
-      const toggle = document.querySelector(`.toggle-button[data-id="${id}"]`);
+      const toggle = document.querySelector(
+        `.${CLASS_NAMES.TOGGLE_BUTTON}[data-id="${id}"]`,
+      );
       if (content && toggle) {
         if (expanded) {
-          content.classList.add('expanded');
-          toggle.textContent = 'Show less';
+          content.classList.add(CLASS_NAMES.EXPANDED);
+          toggle.textContent = LABELS.SHOW_LESS;
         } else {
-          content.classList.remove('expanded');
-          toggle.textContent = 'Show more';
+          content.classList.remove(CLASS_NAMES.EXPANDED);
+          toggle.textContent = LABELS.SHOW_MORE;
         }
       }
     }

--- a/src/historyView/modules/uiManagers/SearchManager.js
+++ b/src/historyView/modules/uiManagers/SearchManager.js
@@ -1,6 +1,7 @@
 /* global Mark */
 import { safeGetElementById } from '@common/domUtils.js';
 import { historyViewState } from '../historyViewState.js';
+import { CLASS_NAMES, ELEMENT_IDS, LABELS } from '../constants.js';
 
 /**
  * Handles search functionality using mark.js.
@@ -54,8 +55,8 @@ export class SearchManager {
 
   navigateNext() {
     if (this.state.totalMatches === 0) return;
-    const current = document.querySelector('mark.current-match');
-    if (current) current.classList.remove('current-match');
+    const current = document.querySelector(`mark.${CLASS_NAMES.CURRENT_MATCH}`);
+    if (current) current.classList.remove(CLASS_NAMES.CURRENT_MATCH);
     const nextIndex = (this.state.searchIndex + 1) % this.state.totalMatches;
     this.state.setSearchIndex(nextIndex);
     this.scrollToCurrentMatch();
@@ -63,8 +64,8 @@ export class SearchManager {
 
   navigatePrev() {
     if (this.state.totalMatches === 0) return;
-    const current = document.querySelector('mark.current-match');
-    if (current) current.classList.remove('current-match');
+    const current = document.querySelector(`mark.${CLASS_NAMES.CURRENT_MATCH}`);
+    if (current) current.classList.remove(CLASS_NAMES.CURRENT_MATCH);
     const prevIndex =
       (this.state.searchIndex - 1 + this.state.totalMatches) %
       this.state.totalMatches;
@@ -76,7 +77,7 @@ export class SearchManager {
     if (this.state.totalMatches === 0) return;
     const marks = document.querySelectorAll('mark');
     if (marks.length > this.state.searchIndex) {
-      marks[this.state.searchIndex].classList.add('current-match');
+      marks[this.state.searchIndex].classList.add(CLASS_NAMES.CURRENT_MATCH);
       marks[this.state.searchIndex].scrollIntoView({
         behavior: 'smooth',
         block: 'center',
@@ -86,7 +87,7 @@ export class SearchManager {
   }
 
   updateMatchCountDisplay() {
-    const el = safeGetElementById('matchCount');
+    const el = safeGetElementById(ELEMENT_IDS.MATCH_COUNT);
     if (!el) return;
     const total = this.state.totalMatches;
     if (total === 0) {
@@ -97,33 +98,39 @@ export class SearchManager {
   }
 
   expandAllCollapsibleSections() {
-    document.querySelectorAll('.collapsible').forEach((section) => {
-      if (!section.classList.contains('expanded')) {
-        section.classList.add('expanded');
-        const id = section.id.replace('content-', '');
-        const toggle = document.querySelector(
-          `.toggle-button[data-id="${id}"]`,
-        );
-        if (toggle) {
-          toggle.textContent = 'Show less';
+    document
+      .querySelectorAll(`.${CLASS_NAMES.COLLAPSIBLE}`)
+      .forEach((section) => {
+        if (!section.classList.contains(CLASS_NAMES.EXPANDED)) {
+          section.classList.add(CLASS_NAMES.EXPANDED);
+          const id = section.id.replace('content-', '');
+          const toggle = document.querySelector(
+            `.${CLASS_NAMES.TOGGLE_BUTTON}[data-id="${id}"]`,
+          );
+          if (toggle) {
+            toggle.textContent = LABELS.SHOW_LESS;
+          }
         }
-      }
-    });
+      });
   }
 
   applySavedToggleStates() {
-    document.querySelectorAll('.collapsible').forEach((section) => {
-      const id = section.id.replace('content-', '');
-      const expanded = this.state.toggleStates.get(id);
-      const toggle = document.querySelector(`.toggle-button[data-id="${id}"]`);
-      if (expanded) {
-        section.classList.add('expanded');
-        if (toggle) toggle.textContent = 'Show less';
-      } else {
-        section.classList.remove('expanded');
-        if (toggle) toggle.textContent = 'Show more';
-      }
-    });
+    document
+      .querySelectorAll(`.${CLASS_NAMES.COLLAPSIBLE}`)
+      .forEach((section) => {
+        const id = section.id.replace('content-', '');
+        const expanded = this.state.toggleStates.get(id);
+        const toggle = document.querySelector(
+          `.${CLASS_NAMES.TOGGLE_BUTTON}[data-id="${id}"]`,
+        );
+        if (expanded) {
+          section.classList.add(CLASS_NAMES.EXPANDED);
+          if (toggle) toggle.textContent = LABELS.SHOW_LESS;
+        } else {
+          section.classList.remove(CLASS_NAMES.EXPANDED);
+          if (toggle) toggle.textContent = LABELS.SHOW_MORE;
+        }
+      });
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- centralize command names and UI strings for history view
- use new constants in history view modules
- expose constants through `HistoryViewContentProvider`
- map constants module in history view HTML

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686591e5faf48324b11d9868831ad7d8