### PR TITLE
Add statistics log type

### DIFF
--- a/src/agent/output/StatisticsReporter.ts
+++ b/src/agent/output/StatisticsReporter.ts
@@ -9,6 +9,7 @@ import {
 } from '@agent/core/ResponseUsage';
 import { ResponseUsage } from 'openai/resources/responses/responses';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 export class StatisticsReporter {
   constructor(
@@ -24,66 +25,6 @@ export class StatisticsReporter {
     const statsGroupId = groupId ?? this.logger.getActiveGroupId();
 
     try {
-      this.logger.debug('=== Task Statistics ===', statsGroupId);
-      this.logger.debug(
-        `Total input tokens  : ${stateGlobal.totalInputTokens}`,
-        statsGroupId,
-      );
-      this.logger.debug(
-        `Total output tokens : ${stateGlobal.totalOutputTokens}`,
-        statsGroupId,
-      );
-
-      if (
-        this.modelHandler.capabilities.supportsPromptCaching ||
-        this.modelHandler.capabilities.supportsAutoPromptCaching
-      ) {
-        this.logger.debug(
-          `Total input tokens (cache read): ${stateGlobal.totalCacheReadInputTokens}`,
-          statsGroupId,
-        );
-
-        if (this.modelHandler.capabilities.supportsPromptCaching) {
-          this.logger.debug(
-            `Total input tokens (cache create): ${stateGlobal.totalCacheCreationInputTokens}`,
-            statsGroupId,
-          );
-        }
-
-        let totalCacheableTokens: number;
-        if (this.modelHandler.capabilities.supportsPromptCaching) {
-          totalCacheableTokens =
-            stateGlobal.totalCacheCreationInputTokens +
-            stateGlobal.totalCacheReadInputTokens;
-        } else {
-          totalCacheableTokens = stateGlobal.totalInputTokens;
-        }
-
-        const percentageCached =
-          totalCacheableTokens > 0
-            ? (stateGlobal.totalCacheReadInputTokens / totalCacheableTokens) *
-              100
-            : 0;
-        this.logger.debug(
-          `Percentage cached: ${percentageCached.toFixed(2)}%`,
-          statsGroupId,
-        );
-      }
-
-      if (this.modelHandler.capabilities.supportsReasoning) {
-        this.logger.debug(
-          `Total reasoning tokens: ${stateGlobal.totalReasoningTokens}`,
-          statsGroupId,
-        );
-      }
-
-      if (stateGlobal.totalToolUseTokens > 0) {
-        this.logger.debug(
-          `Total tool use tokens: ${stateGlobal.totalToolUseTokens}`,
-          statsGroupId,
-        );
-      }
-
       let responseUsage:
         | ExtendedCompletionUsage
         | AnthropicUsage
@@ -163,15 +104,22 @@ export class StatisticsReporter {
         });
       }
 
+      const payload = {
+        inputTokens: stateGlobal.totalInputTokens,
+        outputTokens: stateGlobal.totalOutputTokens,
+        cacheReadInputTokens: stateGlobal.totalCacheReadInputTokens,
+        cacheCreationInputTokens: stateGlobal.totalCacheCreationInputTokens,
+        reasoningTokens: stateGlobal.totalReasoningTokens,
+        toolUseTokens: stateGlobal.totalToolUseTokens,
+        elapsedTime: Number(stateGlobal.totalResponseTime.toFixed(1)),
+        cost: Number(cost.toFixed(3)),
+      };
+
       this.logger.debug(
-        `Total response time : ${stateGlobal.totalResponseTime.toFixed(1)} seconds`,
+        JSON.stringify(payload),
         statsGroupId,
+        MESSAGE_TYPES.STATISTICS,
       );
-      this.logger.debug(
-        `Total cost          : ${cost.toFixed(3)} USD`,
-        statsGroupId,
-      );
-      this.logger.debug('=======================', statsGroupId);
     } catch (error) {
       this.logger.error(`Error printing statistics: ${error}`, statsGroupId);
     }

--- a/src/agent/output/StatisticsReporter.ts
+++ b/src/agent/output/StatisticsReporter.ts
@@ -104,16 +104,46 @@ export class StatisticsReporter {
         });
       }
 
-      const payload = {
+      const payload: Record<string, number> = {
         inputTokens: stateGlobal.totalInputTokens,
         outputTokens: stateGlobal.totalOutputTokens,
-        cacheReadInputTokens: stateGlobal.totalCacheReadInputTokens,
-        cacheCreationInputTokens: stateGlobal.totalCacheCreationInputTokens,
-        reasoningTokens: stateGlobal.totalReasoningTokens,
-        toolUseTokens: stateGlobal.totalToolUseTokens,
         elapsedTime: Number(stateGlobal.totalResponseTime.toFixed(1)),
         cost: Number(cost.toFixed(3)),
       };
+
+      if (
+        this.modelHandler.capabilities.supportsPromptCaching ||
+        this.modelHandler.capabilities.supportsAutoPromptCaching
+      ) {
+        payload.cacheReadInputTokens = stateGlobal.totalCacheReadInputTokens;
+
+        if (this.modelHandler.capabilities.supportsPromptCaching) {
+          payload.cacheCreationInputTokens =
+            stateGlobal.totalCacheCreationInputTokens;
+        }
+
+        const totalCacheableTokens = this.modelHandler.capabilities
+          .supportsPromptCaching
+          ? stateGlobal.totalCacheCreationInputTokens +
+            stateGlobal.totalCacheReadInputTokens
+          : stateGlobal.totalInputTokens;
+
+        const percentageCached =
+          totalCacheableTokens > 0
+            ? (stateGlobal.totalCacheReadInputTokens / totalCacheableTokens) *
+              100
+            : 0;
+
+        payload.percentageCached = Number(percentageCached.toFixed(2));
+      }
+
+      if (this.modelHandler.capabilities.supportsReasoning) {
+        payload.reasoningTokens = stateGlobal.totalReasoningTokens;
+      }
+
+      if (stateGlobal.totalToolUseTokens > 0) {
+        payload.toolUseTokens = stateGlobal.totalToolUseTokens;
+      }
 
       this.logger.debug(
         JSON.stringify(payload),

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -42,6 +42,7 @@ export interface LogMessageData {
     | 'fileList'
     | 'missingOutputs'
     | 'latexdiff'
+    | 'statistics'
     | 'internal';
   /** Whether verbose details should be displayed */
   verbose?: boolean;

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -4,6 +4,7 @@ export const MESSAGE_TYPES = {
   FILE_LIST: 'fileList',
   MISSING_OUTPUTS: 'missingOutputs',
   LATEXDIFF: 'latexdiff',
+  STATISTICS: 'statistics',
   /** Messages that should be hidden from the progress view */
   INTERNAL: 'internal',
   DEFAULT: 'default',

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -162,6 +162,10 @@ export class LogEntryFormatter {
       return this._formatLatexdiff(htmlMessage, text, id);
     }
 
+    if (messageType === 'statistics') {
+      return this._formatStatistics(htmlMessage, text, id);
+    }
+
     return htmlMessage;
   }
 
@@ -434,6 +438,63 @@ export class LogEntryFormatter {
       </details>`;
     } catch (e) {
       console.error('Error parsing latexdiff entry:', e);
+      return message;
+    }
+  }
+
+  _formatStatistics(message, content, logId) {
+    try {
+      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const parsed = JSON.parse(this._unescapeHtml(content));
+      if (!parsed || typeof parsed !== 'object') {
+        return message;
+      }
+
+      const items = [];
+      const pushItem = (icon, value, suffix = '') => {
+        items.push(
+          `<li><i class="codicon ${icon}"></i> ${value}${suffix}</li>`,
+        );
+      };
+
+      if (parsed.inputTokens !== undefined) {
+        pushItem('codicon-arrow-up', formatTokens(parsed.inputTokens));
+      }
+      if (parsed.outputTokens !== undefined) {
+        pushItem('codicon-arrow-down', formatTokens(parsed.outputTokens));
+      }
+      if (parsed.cacheReadInputTokens) {
+        pushItem('codicon-history', formatTokens(parsed.cacheReadInputTokens));
+      }
+      if (parsed.cacheCreationInputTokens) {
+        pushItem('codicon-save', formatTokens(parsed.cacheCreationInputTokens));
+      }
+      if (parsed.reasoningTokens) {
+        pushItem(
+          'codicon-comment-discussion',
+          formatTokens(parsed.reasoningTokens),
+        );
+      }
+      if (parsed.toolUseTokens) {
+        pushItem('codicon-tools', formatTokens(parsed.toolUseTokens));
+      }
+      if (parsed.elapsedTime !== undefined) {
+        pushItem('codicon-clock', parsed.elapsedTime, 's');
+      }
+      if (parsed.cost !== undefined) {
+        pushItem('codicon-rocket', `$${parsed.cost.toFixed(3)}`);
+      }
+
+      return `<details class="statistics-details" open>
+        <summary>
+          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
+          <i class="codicon codicon-dashboard"></i>
+          <span>Statistics</span>
+        </summary>
+        <ul class="statistics-content"${idAttr}>${items.join('')}</ul>
+      </details>`;
+    } catch (e) {
+      console.error('Error parsing statistics:', e);
       return message;
     }
   }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -463,19 +463,25 @@ export class LogEntryFormatter {
       if (parsed.outputTokens !== undefined) {
         pushItem('codicon-arrow-down', formatTokens(parsed.outputTokens));
       }
-      if (parsed.cacheReadInputTokens) {
+      if (parsed.cacheReadInputTokens !== undefined) {
         pushItem('codicon-history', formatTokens(parsed.cacheReadInputTokens));
       }
-      if (parsed.cacheCreationInputTokens) {
+      if (parsed.cacheCreationInputTokens !== undefined) {
         pushItem('codicon-save', formatTokens(parsed.cacheCreationInputTokens));
       }
-      if (parsed.reasoningTokens) {
+      if (parsed.percentageCached !== undefined) {
+        pushItem(
+          'codicon-graph-line',
+          `${parsed.percentageCached.toFixed(2)}%`,
+        );
+      }
+      if (parsed.reasoningTokens !== undefined) {
         pushItem(
           'codicon-comment-discussion',
           formatTokens(parsed.reasoningTokens),
         );
       }
-      if (parsed.toolUseTokens) {
+      if (parsed.toolUseTokens !== undefined) {
         pushItem('codicon-tools', formatTokens(parsed.toolUseTokens));
       }
       if (parsed.elapsedTime !== undefined) {


### PR DESCRIPTION
## Summary
- support STATISTICS as a message type
- allow statistics in LogMessageData
- log summarized statistics JSON in `StatisticsReporter`
- render statistics messages in progress view

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686591359a1083249ed1e43d8c123676