### PR TITLE
Refactor messageHandlers naming

### DIFF
--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -34,4 +34,4 @@ export class HistoryViewMessageHandlers {
   }
 }
 
-export const messageHandlers = new HistoryViewMessageHandlers();
+export const historyViewMessageHandlers = new HistoryViewMessageHandlers();

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -1,12 +1,12 @@
 import { vscode } from '@common/webviewContext.js';
 import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
-import { messageHandlers } from './modules/messageHandlers.js';
+import { historyViewMessageHandlers } from './modules/messageHandlers.js';
 
 historyViewState.initialize();
 
 // Register handlers early so messages aren't missed
-messageHandlers.setup();
+historyViewMessageHandlers.setup();
 
 document.addEventListener('DOMContentLoaded', () => {
   historyViewDomHandler.events.setupEventListeners();
@@ -16,5 +16,5 @@ document.addEventListener('DOMContentLoaded', () => {
 window.addEventListener('beforeunload', () => {
   historyViewDomHandler.events.dispose();
   historyViewDomHandler.searchManager.dispose();
-  messageHandlers.cleanup();
+  historyViewMessageHandlers.cleanup();
 });

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -190,4 +190,4 @@ export class ProgressViewMessageHandlers {
   }
 }
 
-export const messageHandlers = new ProgressViewMessageHandlers();
+export const progressViewMessageHandlers = new ProgressViewMessageHandlers();

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -1,5 +1,5 @@
 import { progressViewState } from './modules/progressViewState.js';
-import { messageHandlers } from './modules/messageHandlers.js';
+import { progressViewMessageHandlers } from './modules/messageHandlers.js';
 import { progressViewDomHandler } from './modules/domHandlers.js';
 import { vscode } from '@common/webviewContext.js';
 import { COMMANDS } from './modules/constants.js';
@@ -8,10 +8,10 @@ import { COMMANDS } from './modules/constants.js';
 progressViewState.initialize();
 
 // Register handlers for VSCode messages
-messageHandlers.setup();
+progressViewMessageHandlers.setup();
 
 window.addEventListener('beforeunload', () => {
-  messageHandlers.cleanup();
+  progressViewMessageHandlers.cleanup();
 });
 
 // Initialize event listeners and state when DOM is loaded

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -578,4 +578,4 @@ export class MainViewMessageHandlers {
   }
 }
 
-export const messageHandlers = new MainViewMessageHandlers();
+export const mainViewMessageHandlers = new MainViewMessageHandlers();

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -1,5 +1,5 @@
 import { mainViewState } from './modules/mainViewState.js';
-import { messageHandlers } from './modules/messageHandlers.js';
+import { mainViewMessageHandlers } from './modules/messageHandlers.js';
 import {
   mainViewDomHandler,
   instructionManager,
@@ -7,10 +7,10 @@ import {
 } from './modules/domHandlers.js';
 
 // Register handlers immediately so early messages aren't missed
-messageHandlers.setup({ requestData: false });
+mainViewMessageHandlers.setup({ requestData: false });
 
 window.addEventListener('beforeunload', () => {
-  messageHandlers.cleanup();
+  mainViewMessageHandlers.cleanup();
   mainViewDomHandler.cleanupUI();
 });
 
@@ -22,5 +22,5 @@ document.addEventListener('DOMContentLoaded', function () {
   toggleManager.updateToolConfigToggleState();
   toggleManager.updateAutoToggleState();
   toggleManager.setupDocumentListeners();
-  messageHandlers.requestInitialData();
+  mainViewMessageHandlers.requestInitialData();
 });


### PR DESCRIPTION
## Summary
- rename messageHandlers constants for clarity
- update webview scripts to import new names
- keep formatting and linting clean

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68659c3599ec83248956bfff709f281d