### PR TITLE
Fix message handler naming across modules

### DIFF
--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -5,7 +5,7 @@ import { historyViewDomHandler } from './domHandlers.js';
 /**
  * Handles messages from the extension for the history view.
  */
-export class HistoryViewMessageHandlers {
+export class HistoryViewMessageHandler {
   constructor() {
     this._cleanupFn = null;
     this._handlers = {
@@ -34,4 +34,4 @@ export class HistoryViewMessageHandlers {
   }
 }
 
-export const messageHandlers = new HistoryViewMessageHandlers();
+export const historyViewMessageHandler = new HistoryViewMessageHandler();

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -1,12 +1,12 @@
 import { vscode } from '@common/webviewContext.js';
 import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
-import { messageHandlers } from './modules/messageHandlers.js';
+import { historyViewMessageHandler } from './modules/messageHandlers.js';
 
 historyViewState.initialize();
 
 // Register handlers early so messages aren't missed
-messageHandlers.setup();
+historyViewMessageHandler.setup();
 
 document.addEventListener('DOMContentLoaded', () => {
   historyViewDomHandler.events.setupEventListeners();
@@ -16,5 +16,5 @@ document.addEventListener('DOMContentLoaded', () => {
 window.addEventListener('beforeunload', () => {
   historyViewDomHandler.events.dispose();
   historyViewDomHandler.searchManager.dispose();
-  messageHandlers.cleanup();
+  historyViewMessageHandler.cleanup();
 });

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -10,7 +10,7 @@ const dom = progressViewDomHandler;
 
 // Create formatter instances
 
-export class ProgressViewMessageHandlers {
+export class ProgressViewMessageHandler {
   constructor() {
     this._cleanupFn = null;
     this._entryFormatter = new LogEntryFormatter();
@@ -190,4 +190,4 @@ export class ProgressViewMessageHandlers {
   }
 }
 
-export const messageHandlers = new ProgressViewMessageHandlers();
+export const progressViewMessageHandler = new ProgressViewMessageHandler();

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -1,5 +1,5 @@
 import { progressViewState } from './modules/progressViewState.js';
-import { messageHandlers } from './modules/messageHandlers.js';
+import { progressViewMessageHandler } from './modules/messageHandlers.js';
 import { progressViewDomHandler } from './modules/domHandlers.js';
 import { vscode } from '@common/webviewContext.js';
 import { COMMANDS } from './modules/constants.js';
@@ -8,10 +8,10 @@ import { COMMANDS } from './modules/constants.js';
 progressViewState.initialize();
 
 // Register handlers for VSCode messages
-messageHandlers.setup();
+progressViewMessageHandler.setup();
 
 window.addEventListener('beforeunload', () => {
-  messageHandlers.cleanup();
+  progressViewMessageHandler.cleanup();
 });
 
 // Initialize event listeners and state when DOM is loaded

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -23,7 +23,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 /**
  * Handles messages from the extension and syncs the webview state.
  */
-export class MainViewMessageHandlers {
+export class MainViewMessageHandler {
   constructor() {
     this._skipNextRestoreState = false;
     this._cleanupFn = null;
@@ -578,4 +578,4 @@ export class MainViewMessageHandlers {
   }
 }
 
-export const messageHandlers = new MainViewMessageHandlers();
+export const mainViewMessageHandler = new MainViewMessageHandler();

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -1,5 +1,5 @@
 import { mainViewState } from './modules/mainViewState.js';
-import { messageHandlers } from './modules/messageHandlers.js';
+import { mainViewMessageHandler } from './modules/messageHandlers.js';
 import {
   mainViewDomHandler,
   instructionManager,
@@ -7,10 +7,10 @@ import {
 } from './modules/domHandlers.js';
 
 // Register handlers immediately so early messages aren't missed
-messageHandlers.setup({ requestData: false });
+mainViewMessageHandler.setup({ requestData: false });
 
 window.addEventListener('beforeunload', () => {
-  messageHandlers.cleanup();
+  mainViewMessageHandler.cleanup();
   mainViewDomHandler.cleanupUI();
 });
 
@@ -22,5 +22,5 @@ document.addEventListener('DOMContentLoaded', function () {
   toggleManager.updateToolConfigToggleState();
   toggleManager.updateAutoToggleState();
   toggleManager.setupDocumentListeners();
-  messageHandlers.requestInitialData();
+  mainViewMessageHandler.requestInitialData();
 });


### PR DESCRIPTION
## Summary
- rename JS message handler classes to match TypeScript names
- update exports to match instance naming conventions
- adjust webview scripts to use new names

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack warning only)*

------
https://chatgpt.com/codex/tasks/task_e_68659c3599ec83248956bfff709f281d