### PR TITLE
Fix history view command constants

### DIFF
--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -1,6 +1,7 @@
 // Local imports
 import { registerMessageHandlers } from '@common/webviewContext.js';
 import { historyViewDomHandler } from './domHandlers.js';
+import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 /**
  * Handles messages from the extension for the history view.
@@ -9,8 +10,10 @@ export class HistoryViewMessageHandler {
   constructor() {
     this._cleanupFn = null;
     this._handlers = {
-      updateHistory: (m) => this.handleUpdateHistory(m),
-      historyCleared: () => this.handleHistoryCleared(),
+      [HISTORY_VIEW_COMMANDS.UPDATE_HISTORY]: (m) =>
+        this.handleUpdateHistory(m),
+      [HISTORY_VIEW_COMMANDS.HISTORY_CLEARED]: () =>
+        this.handleHistoryCleared(),
     };
   }
 

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -2,6 +2,7 @@ import { vscode } from '@common/webviewContext.js';
 import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
 import { messageHandler } from './modules/messageHandlers.js';
+import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 historyViewState.initialize();
 
@@ -10,7 +11,7 @@ messageHandler.setup();
 
 document.addEventListener('DOMContentLoaded', () => {
   historyViewDomHandler.events.setupEventListeners();
-  vscode.postMessage({ command: 'getHistoryData' });
+  vscode.postMessage({ command: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA });
 });
 
 window.addEventListener('beforeunload', () => {


### PR DESCRIPTION
## Summary
- import `HISTORY_VIEW_COMMANDS` in history view webview
- use command constants in message handlers and startup script

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865a0cf42988324990a035dcefcffca