### PR TITLE
Use command constant in history view script

### DIFF
--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -2,6 +2,7 @@ import { vscode } from '@common/webviewContext.js';
 import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
 import { messageHandler } from './modules/messageHandlers.js';
+import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 historyViewState.initialize();
 
@@ -10,7 +11,7 @@ messageHandler.setup();
 
 document.addEventListener('DOMContentLoaded', () => {
   historyViewDomHandler.events.setupEventListeners();
-  vscode.postMessage({ command: 'getHistoryData' });
+  vscode.postMessage({ command: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA });
 });
 
 window.addEventListener('beforeunload', () => {


### PR DESCRIPTION
## Summary
- import `HISTORY_VIEW_COMMANDS` in the History view script
- use the new constant when requesting history data

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails to run VS Code tests due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6865a127940483248afcfe4882d715fe