### PR TITLE
Centralize progress view DOM ids

### DIFF
--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -6,6 +6,26 @@ export const STATUS = {
   READY: 'ready',
 };
 
+// DOM element IDs used across the progress view
+export const ELEMENT_IDS = {
+  LOG_CONTENT: 'logContent',
+  GENERATED_FILES: 'generatedFiles',
+  STREAM_TABS: 'streamTabs',
+  ACTIVE_STREAM_NAME: 'activeStreamName',
+  STATUS_INDICATOR: 'statusIndicator',
+  RUN_SUMMARY: 'runSummary',
+  TOOLBAR_CONTAINER: 'toolbarContainer',
+  FILE_ITEM_TEMPLATE: 'fileItemTemplate',
+  DELETE_ALL_BTN: 'deleteAllBtn',
+  STOP_STREAM_BTN: 'stopStreamBtn',
+  RUN_AGAIN_BTN: 'runAgainBtn',
+  RESTORE_STATE_BTN: 'restoreStateBtn',
+  DIFF_STREAM_BTN: 'diffStreamBtn',
+  PACK_STREAM_BTN: 'packStreamBtn',
+  CLEAN_STREAM_BTN: 'cleanStreamBtn',
+  ERASE_STREAM_BTN: 'eraseStreamBtn',
+};
+
 // Default sizes for split view
 export const SPLIT_SIZES = {
   CONTENT: 80,
@@ -23,7 +43,7 @@ export const COMMANDS = PROGRESS_VIEW_COMMANDS;
 
 export const TOOLBAR_BUTTONS = [
   {
-    id: 'stopStreamBtn',
+    id: ELEMENT_IDS.STOP_STREAM_BTN,
     icon: 'debug-stop',
     command: COMMANDS.STOP_STREAM,
     title:
@@ -32,7 +52,7 @@ export const TOOLBAR_BUTTONS = [
     disabled: true,
   },
   {
-    id: 'runAgainBtn',
+    id: ELEMENT_IDS.RUN_AGAIN_BTN,
     icon: 'debug-rerun',
     command: COMMANDS.RUN_AGAIN,
     title: 'Run this task again',
@@ -40,7 +60,7 @@ export const TOOLBAR_BUTTONS = [
     disabled: true,
   },
   {
-    id: 'restoreStateBtn',
+    id: ELEMENT_IDS.RESTORE_STATE_BTN,
     icon: 'reply',
     command: COMMANDS.RESTORE_STATE,
     title: 'Restore this configuration to the main view',
@@ -48,7 +68,7 @@ export const TOOLBAR_BUTTONS = [
     disabled: true,
   },
   {
-    id: 'diffStreamBtn',
+    id: ELEMENT_IDS.DIFF_STREAM_BTN,
     icon: 'diff-multiple',
     command: COMMANDS.DIFF_STREAM,
     title: 'Run latexdiff on existing tex files',
@@ -56,7 +76,7 @@ export const TOOLBAR_BUTTONS = [
     disabled: true,
   },
   {
-    id: 'packStreamBtn',
+    id: ELEMENT_IDS.PACK_STREAM_BTN,
     icon: 'archive',
     command: COMMANDS.PACK_STREAM,
     title: 'Pack the output for this agent into the History folder',
@@ -64,7 +84,7 @@ export const TOOLBAR_BUTTONS = [
     disabled: true,
   },
   {
-    id: 'cleanStreamBtn',
+    id: ELEMENT_IDS.CLEAN_STREAM_BTN,
     icon: 'trash',
     command: COMMANDS.CLEAN_STREAM,
     title: 'Clean the output for this agent',
@@ -72,7 +92,7 @@ export const TOOLBAR_BUTTONS = [
     disabled: true,
   },
   {
-    id: 'eraseStreamBtn',
+    id: ELEMENT_IDS.ERASE_STREAM_BTN,
     icon: 'clear-all',
     command: COMMANDS.ERASE_STREAM,
     title: 'Erase the stream output for this agent',

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,7 +1,7 @@
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
 import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
-import { COMMANDS, STATUS } from './constants.js';
+import { COMMANDS, STATUS, ELEMENT_IDS } from './constants.js';
 import { registerMessageHandlers } from '@common/webviewContext.js';
 
 // Create shorter aliases for internal use
@@ -62,7 +62,7 @@ export class ProgressViewMessageHandler {
   }
 
   handleUpdateLogs(message) {
-    const logContent = document.getElementById('logContent');
+    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (message.stream === state.getActiveStream()) {
       logContent.innerHTML = '';
       state.taskGroups.clear();
@@ -100,7 +100,7 @@ export class ProgressViewMessageHandler {
   }
 
   handleClearLogs() {
-    const logContent = document.getElementById('logContent');
+    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     logContent.innerHTML = '';
     const groupIds = [];
     const headers = Array.from(document.querySelectorAll('.log-group-header'));
@@ -113,7 +113,7 @@ export class ProgressViewMessageHandler {
 
   handleAppendLog(message) {
     if (message.stream === state.getActiveStream()) {
-      const logContent = document.getElementById('logContent');
+      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
         const el = document.createElement('div');
@@ -132,7 +132,7 @@ export class ProgressViewMessageHandler {
 
   handleAddTaskGroup(message) {
     if (message.stream === state.getActiveStream()) {
-      const logContent = document.getElementById('logContent');
+      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       dom.taskGroups.add(message.group);
       logContent.scrollTop = logContent.scrollHeight;
     }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,6 +1,7 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
+import { ELEMENT_IDS } from './constants.js';
 
 /**
  * Manages task group DOM operations.
@@ -45,7 +46,7 @@ export class TaskGroupManager {
     });
 
     // Insert the group at the right position in the parent
-    const container = document.getElementById('logContent');
+    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     let insertPosition = null;
 
     if (group.parentGroupId) {

--- a/src/progressView/modules/uiManagers/Events.js
+++ b/src/progressView/modules/uiManagers/Events.js
@@ -2,7 +2,7 @@
 import Split from 'split.js';
 // Local imports
 import { progressViewState } from '../progressViewState.js';
-import { COMMANDS, SPLIT_SIZES } from '../constants.js';
+import { COMMANDS, SPLIT_SIZES, ELEMENT_IDS } from '../constants.js';
 import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,
@@ -33,26 +33,28 @@ export class Events {
    */
   setupEventListeners() {
     // Stream tab click handler
-    document.getElementById('streamTabs').addEventListener('click', (e) => {
-      const tabButton = e.target.closest('.tab');
-      const deleteButton = e.target.closest('.tab-delete');
+    document
+      .getElementById(ELEMENT_IDS.STREAM_TABS)
+      .addEventListener('click', (e) => {
+        const tabButton = e.target.closest('.tab');
+        const deleteButton = e.target.closest('.tab-delete');
 
-      if (tabButton && tabButton.dataset.stream) {
-        vscode.postMessage({
-          command: COMMANDS.SWITCH_STREAM,
-          stream: tabButton.dataset.stream,
-        });
-      } else if (deleteButton && deleteButton.dataset.stream) {
-        vscode.postMessage({
-          command: COMMANDS.DELETE_STREAM,
-          stream: deleteButton.dataset.stream,
-        });
-      }
-    });
+        if (tabButton && tabButton.dataset.stream) {
+          vscode.postMessage({
+            command: COMMANDS.SWITCH_STREAM,
+            stream: tabButton.dataset.stream,
+          });
+        } else if (deleteButton && deleteButton.dataset.stream) {
+          vscode.postMessage({
+            command: COMMANDS.DELETE_STREAM,
+            stream: deleteButton.dataset.stream,
+          });
+        }
+      });
 
     // Toolbar click handler
     document
-      .getElementById('toolbarContainer')
+      .getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER)
       .addEventListener('click', (e) => {
         const button = e.target.closest('button[data-command]');
         if (!button || button.disabled) return;
@@ -69,7 +71,7 @@ export class Events {
     // This appears to be orphaned code from a previous design
 
     // File list button handler
-    document.getElementById('generatedFiles').addEventListener(
+    document.getElementById(ELEMENT_IDS.GENERATED_FILES).addEventListener(
       'click',
       (e) => {
         const button = e.target.closest('button');
@@ -84,7 +86,7 @@ export class Events {
     );
 
     // Delete all button handler
-    const deleteAllBtn = document.getElementById('deleteAllBtn');
+    const deleteAllBtn = document.getElementById(ELEMENT_IDS.DELETE_ALL_BTN);
     if (deleteAllBtn) {
       deleteAllBtn.addEventListener('click', () => {
         vscode.postMessage({ command: COMMANDS.DELETE_ALL });

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -1,6 +1,6 @@
 // Local imports
 import { formatTokens } from '../formatters.js';
-import { COMMANDS } from '../constants.js';
+import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 import { vscode } from '@common/webviewContext.js';
 
 /**
@@ -36,12 +36,12 @@ export class FileList {
    * @param {Object} filesByRound - Files organized by round
    */
   update(filesByRound) {
-    const container = document.getElementById('generatedFiles');
+    const container = document.getElementById(ELEMENT_IDS.GENERATED_FILES);
     if (!container) return;
 
     container.innerHTML = '';
 
-    const template = document.getElementById('fileItemTemplate');
+    const template = document.getElementById(ELEMENT_IDS.FILE_ITEM_TEMPLATE);
     if (!template) {
       console.error('File item template not found');
       return;

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -1,6 +1,6 @@
 // Local imports
 import { progressViewState } from '../progressViewState.js';
-import { STATUS, TOOLBAR_BUTTONS } from '../constants.js';
+import { STATUS, TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
 
 /**
  * Manages status display and button states.
@@ -11,36 +11,36 @@ export class Status {
       [STATUS.RUNNING]: {
         className: 'running',
         label: 'Running',
-        enable: ['stopStreamBtn', 'restoreStateBtn'],
+        enable: [ELEMENT_IDS.STOP_STREAM_BTN, ELEMENT_IDS.RESTORE_STATE_BTN],
       },
       [STATUS.ERROR]: {
         className: 'error',
         label: 'Error',
         enable: [
-          'runAgainBtn',
-          'packStreamBtn',
-          'cleanStreamBtn',
-          'restoreStateBtn',
-          'diffStreamBtn',
-          'eraseStreamBtn',
+          ELEMENT_IDS.RUN_AGAIN_BTN,
+          ELEMENT_IDS.PACK_STREAM_BTN,
+          ELEMENT_IDS.CLEAN_STREAM_BTN,
+          ELEMENT_IDS.RESTORE_STATE_BTN,
+          ELEMENT_IDS.DIFF_STREAM_BTN,
+          ELEMENT_IDS.ERASE_STREAM_BTN,
         ],
       },
       [STATUS.STOPPED]: {
         className: 'stopped',
         label: 'Stopped',
         enable: [
-          'runAgainBtn',
-          'packStreamBtn',
-          'cleanStreamBtn',
-          'restoreStateBtn',
-          'diffStreamBtn',
-          'eraseStreamBtn',
+          ELEMENT_IDS.RUN_AGAIN_BTN,
+          ELEMENT_IDS.PACK_STREAM_BTN,
+          ELEMENT_IDS.CLEAN_STREAM_BTN,
+          ELEMENT_IDS.RESTORE_STATE_BTN,
+          ELEMENT_IDS.DIFF_STREAM_BTN,
+          ELEMENT_IDS.ERASE_STREAM_BTN,
         ],
       },
       [STATUS.READY]: {
         className: 'ready',
         label: 'Ready',
-        enable: ['restoreStateBtn', 'eraseStreamBtn'],
+        enable: [ELEMENT_IDS.RESTORE_STATE_BTN, ELEMENT_IDS.ERASE_STREAM_BTN],
       },
     };
 
@@ -53,7 +53,9 @@ export class Status {
    * @param {string} status - The status to set
    */
   update(status) {
-    const statusIndicator = document.getElementById('statusIndicator');
+    const statusIndicator = document.getElementById(
+      ELEMENT_IDS.STATUS_INDICATOR,
+    );
     if (!statusIndicator) {
       console.error('Status.update: statusIndicator element not found');
       return;
@@ -68,7 +70,7 @@ export class Status {
     });
 
     // Always enable the erase button regardless of status
-    const eraseBtn = document.getElementById('eraseStreamBtn');
+    const eraseBtn = document.getElementById(ELEMENT_IDS.ERASE_STREAM_BTN);
     if (eraseBtn) eraseBtn.disabled = false;
 
     statusIndicator.className = 'status-indicator';

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -1,4 +1,5 @@
 // Local imports
+import { ELEMENT_IDS } from '../constants.js';
 
 /**
  * Manages stream tab UI updates.
@@ -14,7 +15,7 @@ export class StreamTabs {
       console.error('StreamTabs.update: streams must be an array');
       return;
     }
-    const tabsContainer = document.getElementById('streamTabs');
+    const tabsContainer = document.getElementById(ELEMENT_IDS.STREAM_TABS);
     if (!tabsContainer) {
       console.error('StreamTabs.update: streamTabs container not found');
       return;
@@ -35,7 +36,9 @@ export class StreamTabs {
       .join('');
 
     // Update active stream name
-    const streamNameElem = document.getElementById('activeStreamName');
+    const streamNameElem = document.getElementById(
+      ELEMENT_IDS.ACTIVE_STREAM_NAME,
+    );
     if (streamNameElem) {
       streamNameElem.textContent = activeStream || '';
     }

--- a/src/progressView/modules/uiManagers/Toolbar.js
+++ b/src/progressView/modules/uiManagers/Toolbar.js
@@ -1,5 +1,5 @@
 // Local imports
-import { TOOLBAR_BUTTONS } from '../constants.js';
+import { TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
 import { createIconButton } from '@common/templateUtils.js';
 
 /**
@@ -7,7 +7,7 @@ import { createIconButton } from '@common/templateUtils.js';
  */
 export class Toolbar {
   render() {
-    const container = document.getElementById('toolbarContainer');
+    const container = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
     if (!container) {
       console.error('Toolbar.render: toolbarContainer not found');
       return;

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -1,6 +1,7 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { formatTokens, BULLET_MARKUP, TaskGroupLevel } from './formatters.js';
+import { ELEMENT_IDS } from './constants.js';
 
 /**
  * Manages usage summary display.
@@ -18,7 +19,7 @@ export class UsageSummary {
   update(usage) {
     // Cache the summary element
     if (!this._summaryElem) {
-      this._summaryElem = document.getElementById('runSummary');
+      this._summaryElem = document.getElementById(ELEMENT_IDS.RUN_SUMMARY);
     }
     if (!this._summaryElem) return;
 


### PR DESCRIPTION
## Summary
- introduce `ELEMENT_IDS` in progress view constants
- reference `ELEMENT_IDS` everywhere instead of string IDs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865a0896d14832498d792735d9cb6b9