### PR TITLE
Refactor TaskGroup manager naming

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -403,7 +403,7 @@ export class ProgressViewProvider
       }
     }
 
-    // The TaskGroupsManager.updateGroup() method automatically saves state
+    // The TaskGroupManager.updateGroup() method automatically saves state
   }
 
   /**

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -11,12 +11,12 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
  * Manages task groups collection with persistence.
  * Handles adding, updating, and managing task groups for different streams.
  */
-export class TaskGroupsManager {
+export class TaskGroupManager {
   private _groups: Map<StreamTabId, Map<string, TaskGroup>> = new Map();
   private readonly logger: AgentLogger;
 
   constructor(private persistence: StatePersistenceManager) {
-    this.logger = new AgentLogger('TaskGroupsManager');
+    this.logger = new AgentLogger('TaskGroupManager');
   }
 
   /**

--- a/src/progressView/managers/index.ts
+++ b/src/progressView/managers/index.ts
@@ -1,5 +1,5 @@
 export { OutputFilesManager } from './OutputFilesManager';
 export { StreamTabsManager } from './StreamTabsManager';
-export { TaskGroupsManager } from './TaskGroupsManager';
+export { TaskGroupManager } from './TaskGroupManager';
 export { UsageStatsManager } from './UsageStatsManager';
 export { WebviewUpdater } from './WebviewUpdater';

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -2,7 +2,7 @@
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
 import {
   StreamTabsManager,
-  TaskGroupsManager,
+  TaskGroupManager,
   OutputFilesManager,
   UsageStatsManager,
 } from '../managers';
@@ -21,7 +21,7 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
  */
 export class ProgressViewState {
   private _streamTabs: StreamTabsManager;
-  private _taskGroups: TaskGroupsManager;
+  private _taskGroups: TaskGroupManager;
   private _outputFiles: OutputFilesManager;
   private _usageStats: UsageStatsManager;
   private _activeStream: StreamTabId = '';
@@ -36,7 +36,7 @@ export class ProgressViewState {
 
     // Initialize focused managers
     this._streamTabs = new StreamTabsManager(persistence);
-    this._taskGroups = new TaskGroupsManager(persistence);
+    this._taskGroups = new TaskGroupManager(persistence);
     this._outputFiles = new OutputFilesManager(persistence);
     this._usageStats = new UsageStatsManager(persistence);
   }
@@ -46,7 +46,7 @@ export class ProgressViewState {
     return this._streamTabs;
   }
 
-  get taskGroups(): TaskGroupsManager {
+  get taskGroups(): TaskGroupManager {
     return this._taskGroups;
   }
 


### PR DESCRIPTION
## Summary
- rename `TaskGroupsManager` to `TaskGroupManager`
- update imports to match new name
- adjust comment in `ProgressViewProvider`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865a116acb88324b9620cc9908b4ca1