### PR TITLE
Centralize element IDs in webview modules

### DIFF
--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -56,3 +56,32 @@ export const VALUE_ELEMENTS = [
 
 // All elements that need to be saved
 export const ELEMENTS_TO_SAVE = [...VALUE_ELEMENTS, ...CHECK_BOXES];
+
+// Named element IDs used throughout the UI
+export const ELEMENT_IDS = {
+  PACK_BUTTON: 'packButton',
+  CLEAN_BUTTON: 'cleanButton',
+  MAGIC_POLISH_BUTTON: 'magicPolishButton',
+  ERASE_INSTRUCTION_BUTTON: 'eraseInstructionButton',
+  RECORD_INSTRUCTION_BUTTON: 'recordInstructionButton',
+  EXECUTE_BUTTON: 'executeButton',
+  MERGE_BUTTON: 'mergeButton',
+  COMPARE_BUTTON: 'compareButton',
+  ACCEPT_BUTTON: 'acceptButton',
+  LATEXDIFF_BUTTON: 'latexdiffButton',
+  LATEXDIFF_VC_BUTTON: 'latexdiffvcButton',
+  PACK_LATEXDIFF_VC_BUTTON: 'packLatexdiffvcButton',
+  CLEAN_LATEXDIFF_VC_BUTTON: 'cleanLatexdiffvcButton',
+  AGENT_SETTINGS_BUTTON: 'agentSettingsButton',
+  MODEL_SETTINGS_BUTTON: 'modelSettingsButton',
+  TOGGLE_AUTO_EXTRACT: 'toggleAutoExtract',
+  AUTO_EXTRACT_OPTIONS: 'autoExtractOptions',
+  TOGGLE_TOOL_CONFIG: 'toggleToolConfig',
+  TOOL_CONFIG_OPTIONS: 'toolConfigOptions',
+  TOGGLE_LATEXDIFFS: 'toggleLatexdiffs',
+  LATEXDIFFS_CONTENT: 'latexdiffsContent',
+  COMMIT_SELECT: 'commit',
+  OUTPUT_FILES: 'outputFiles',
+  OUTPUT_FILES_CONTAINER: 'outputFilesContainer',
+  INSTRUCTION: 'instruction',
+};

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -11,6 +11,7 @@ import { FileInputManager } from './uiManagers/FileInputManager.js';
 import { ActionButtonManager } from './uiManagers/ActionButtonManager.js';
 import { SettingsButtonManager } from './uiManagers/SettingsButtonManager.js';
 import { webviewEventBus } from './eventBus.js';
+import { ELEMENT_IDS } from './constants.js';
 
 export const instructionManager = new InstructionManager(
   'instruction',
@@ -32,8 +33,8 @@ export class MainViewDomHandler {
   }
 
   _updateDebugButtonVisibility() {
-    const packBtn = document.getElementById('packButton');
-    const cleanBtn = document.getElementById('cleanButton');
+    const packBtn = document.getElementById(ELEMENT_IDS.PACK_BUTTON);
+    const cleanBtn = document.getElementById(ELEMENT_IDS.CLEAN_BUTTON);
     [packBtn, cleanBtn].forEach((btn) => {
       if (btn) {
         btn.style.display = this.debugMode ? '' : 'none';

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -5,6 +5,7 @@ import {
   VALUE_ELEMENTS,
   CHECK_BOXES_TOOL_USE,
   CHECK_BOXES_AUTO_EXTRACT,
+  ELEMENT_IDS,
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
@@ -42,8 +43,12 @@ export class MainViewState {
 
   /** Initialize UI with default state */
   setDefaults() {
-    const autoExtractToggle = safeGetElementById('toggleAutoExtract');
-    const autoExtractOptions = safeGetElementById('autoExtractOptions');
+    const autoExtractToggle = safeGetElementById(
+      ELEMENT_IDS.TOGGLE_AUTO_EXTRACT,
+    );
+    const autoExtractOptions = safeGetElementById(
+      ELEMENT_IDS.AUTO_EXTRACT_OPTIONS,
+    );
     if (autoExtractToggle && autoExtractOptions) {
       autoExtractToggle.classList.remove('active');
       autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
@@ -59,8 +64,10 @@ export class MainViewState {
       }
     });
 
-    const latexdiffsContent = safeGetElementById('latexdiffsContent');
-    const toggleLatexdiffs = safeGetElementById('toggleLatexdiffs');
+    const latexdiffsContent = safeGetElementById(
+      ELEMENT_IDS.LATEXDIFFS_CONTENT,
+    );
+    const toggleLatexdiffs = safeGetElementById(ELEMENT_IDS.TOGGLE_LATEXDIFFS);
     if (latexdiffsContent && toggleLatexdiffs) {
       latexdiffsContent.style.display = 'none';
       toggleLatexdiffs.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
@@ -83,8 +90,12 @@ export class MainViewState {
         safeSetElementChecked(id, previousState[id] ?? false);
       });
 
-      const autoExtractToggle = safeGetElementById('toggleAutoExtract');
-      const autoExtractOptions = safeGetElementById('autoExtractOptions');
+      const autoExtractToggle = safeGetElementById(
+        ELEMENT_IDS.TOGGLE_AUTO_EXTRACT,
+      );
+      const autoExtractOptions = safeGetElementById(
+        ELEMENT_IDS.AUTO_EXTRACT_OPTIONS,
+      );
       const hasAutoExtractChecked = CHECK_BOXES_AUTO_EXTRACT.some((id) =>
         safeGetElementChecked(id),
       );
@@ -94,8 +105,12 @@ export class MainViewState {
         autoExtractOptions.style.display = 'none';
       }
 
-      const toggleToolConfig = safeGetElementById('toggleToolConfig');
-      const toolConfigOptions = safeGetElementById('toolConfigOptions');
+      const toggleToolConfig = safeGetElementById(
+        ELEMENT_IDS.TOGGLE_TOOL_CONFIG,
+      );
+      const toolConfigOptions = safeGetElementById(
+        ELEMENT_IDS.TOOL_CONFIG_OPTIONS,
+      );
       const hasToolConfigChecked = CHECK_BOXES_TOOL_USE.some((id) =>
         safeGetElementChecked(id),
       );
@@ -131,8 +146,12 @@ export class MainViewState {
         }
       });
 
-      const latexdiffsContent = safeGetElementById('latexdiffsContent');
-      const toggleLatexdiffs = safeGetElementById('toggleLatexdiffs');
+      const latexdiffsContent = safeGetElementById(
+        ELEMENT_IDS.LATEXDIFFS_CONTENT,
+      );
+      const toggleLatexdiffs = safeGetElementById(
+        ELEMENT_IDS.TOGGLE_LATEXDIFFS,
+      );
       if (latexdiffsContent && toggleLatexdiffs) {
         const visible = previousState.latexdiffsVisible ?? false;
         latexdiffsContent.style.display = visible ? 'block' : 'none';
@@ -151,7 +170,8 @@ export class MainViewState {
   save() {
     const state = {
       latexdiffsVisible:
-        safeGetElementById('latexdiffsContent')?.style.display === 'block',
+        safeGetElementById(ELEMENT_IDS.LATEXDIFFS_CONTENT)?.style.display ===
+        'block',
     };
 
     VALUE_ELEMENTS.forEach((id) => {

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -6,7 +6,7 @@ import {
   safeGetElementChecked,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
-import { CHECK_BOXES, MULTIPLE_SELECTIONS } from '../constants.js';
+import { CHECK_BOXES, MULTIPLE_SELECTIONS, ELEMENT_IDS } from '../constants.js';
 
 export class ActionButtonManager {
   constructor(vscodeInstance = vscode, fileList, state, instructionMgr) {
@@ -51,7 +51,7 @@ export class ActionButtonManager {
         isActive && filesDiv ? this.fileList.getSelected(filesDiv) : [];
 
       multipleFilesData[id] =
-        id !== 'outputFiles' && singleFile
+        id !== ELEMENT_IDS.OUTPUT_FILES && singleFile
           ? files.filter((file) => file !== singleFile)
           : files;
     });
@@ -59,8 +59,8 @@ export class ActionButtonManager {
   }
 
   _setupInstructionButtons() {
-    this._addListener('eraseInstructionButton', 'click', () => {
-      const instruction = safeGetElementById('instruction');
+    this._addListener(ELEMENT_IDS.ERASE_INSTRUCTION_BUTTON, 'click', () => {
+      const instruction = safeGetElementById(ELEMENT_IDS.INSTRUCTION);
       if (instruction) {
         instruction.value = '';
         this.instructionManager.autoResizeTextarea(instruction);
@@ -68,8 +68,8 @@ export class ActionButtonManager {
       }
     });
 
-    this._addListener('magicPolishButton', 'click', () => {
-      const instruction = safeGetElementById('instruction');
+    this._addListener(ELEMENT_IDS.MAGIC_POLISH_BUTTON, 'click', () => {
+      const instruction = safeGetElementById(ELEMENT_IDS.INSTRUCTION);
       if (instruction && instruction.value.trim()) {
         const agent = safeGetElementValue('agent');
         const model = safeGetElementValue('model');
@@ -89,10 +89,10 @@ export class ActionButtonManager {
   }
 
   _setupExecuteButtons() {
-    this._addListener('executeButton', 'click', () => {
+    this._addListener(ELEMENT_IDS.EXECUTE_BUTTON, 'click', () => {
       const agent = safeGetElementValue('agent');
       const model = safeGetElementValue('model');
-      const instruction = safeGetElementValue('instruction');
+      const instruction = safeGetElementValue(ELEMENT_IDS.INSTRUCTION);
       const singleFiles = this._getSingleFileData();
       const multipleFilesData = this._getMultipleFileData(singleFiles);
 
@@ -112,7 +112,7 @@ export class ActionButtonManager {
       });
     });
 
-    this._addListener('mergeButton', 'click', () => {
+    this._addListener(ELEMENT_IDS.MERGE_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
       const editedFile = safeGetElementValue('editedFile');
 
@@ -128,16 +128,21 @@ export class ActionButtonManager {
       });
     });
 
-    ['pack', 'clean'].forEach((action) => {
-      this._addListener(`${action}Button`, 'click', () => {
+    [
+      { id: ELEMENT_IDS.PACK_BUTTON, action: 'pack' },
+      { id: ELEMENT_IDS.CLEAN_BUTTON, action: 'clean' },
+    ].forEach(({ id, action }) => {
+      this._addListener(id, 'click', () => {
         const { inputFile } = this._getSingleFileData(['input']);
         const agent = safeGetElementValue('agent');
         const model = safeGetElementValue('model');
 
         const outputFiles = this.fileList.getSelected(
-          safeGetElementById('outputFiles'),
+          safeGetElementById(ELEMENT_IDS.OUTPUT_FILES),
         );
-        const container = safeGetElementById('outputFilesContainer');
+        const container = safeGetElementById(
+          ELEMENT_IDS.OUTPUT_FILES_CONTAINER,
+        );
         const useMultiple =
           container &&
           container.style.display !== 'none' &&
@@ -182,7 +187,7 @@ export class ActionButtonManager {
   }
 
   _setupLatexdiffButtons() {
-    this._addListener('latexdiffButton', 'click', () => {
+    this._addListener(ELEMENT_IDS.LATEXDIFF_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
       const baseFile = safeGetElementValue('baseFile');
       const editedFile = safeGetElementValue('editedFile');
@@ -200,10 +205,10 @@ export class ActionButtonManager {
       });
     });
 
-    this._addListener('latexdiffvcButton', 'click', () => {
+    this._addListener(ELEMENT_IDS.LATEXDIFF_VC_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
       const baseFile = safeGetElementValue('baseFile');
-      const commitHash = safeGetElementValue('commit');
+      const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
 
       this.vscode.postMessage({
         command: 'latexdiffvc',
@@ -218,11 +223,14 @@ export class ActionButtonManager {
       });
     });
 
-    ['pack', 'clean'].forEach((action) => {
-      this._addListener(`${action}LatexdiffvcButton`, 'click', () => {
+    [
+      { id: ELEMENT_IDS.PACK_LATEXDIFF_VC_BUTTON, action: 'pack' },
+      { id: ELEMENT_IDS.CLEAN_LATEXDIFF_VC_BUTTON, action: 'clean' },
+    ].forEach(({ id, action }) => {
+      this._addListener(id, 'click', () => {
         const { inputFile } = this._getSingleFileData(['input']);
         const baseFile = safeGetElementValue('baseFile');
-        const commitHash = safeGetElementValue('commit');
+        const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
 
         this.vscode.postMessage({
           command: `${action}Latexdiffvc`,
@@ -241,7 +249,7 @@ export class ActionButtonManager {
   }
 
   _setupCompareButtons() {
-    this._addListener('compareButton', 'click', () => {
+    this._addListener(ELEMENT_IDS.COMPARE_BUTTON, 'click', () => {
       const baseFile = safeGetElementValue('baseFile');
       const editedFile = safeGetElementValue('editedFile');
       if (baseFile && editedFile) {
@@ -258,7 +266,7 @@ export class ActionButtonManager {
       }
     });
 
-    this._addListener('acceptButton', 'click', () => {
+    this._addListener(ELEMENT_IDS.ACCEPT_BUTTON, 'click', () => {
       const baseFile = safeGetElementValue('baseFile');
       const editedFile = safeGetElementValue('editedFile');
       if (baseFile && editedFile) {

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,6 +1,7 @@
 // Local imports
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
+import { ELEMENT_IDS } from '../constants.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 
 /**
@@ -65,11 +66,11 @@ export class FileSelect {
 
   handleRecentCommits(message) {
     const commitButtons = [
-      'packLatexdiffvcButton',
-      'cleanLatexdiffvcButton',
-      'latexdiffvcButton',
+      ELEMENT_IDS.PACK_LATEXDIFF_VC_BUTTON,
+      ELEMENT_IDS.CLEAN_LATEXDIFF_VC_BUTTON,
+      ELEMENT_IDS.LATEXDIFF_VC_BUTTON,
     ];
-    const commitDiv = document.getElementById('commit');
+    const commitDiv = document.getElementById(ELEMENT_IDS.COMMIT_SELECT);
     commitDiv.innerHTML = '';
 
     if (message.isGitRepo === false) {

--- a/src/webview/modules/uiManagers/LatexdiffManager.js
+++ b/src/webview/modules/uiManagers/LatexdiffManager.js
@@ -5,9 +5,10 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
 import { mainViewState } from '../mainViewState.js';
+import { ELEMENT_IDS } from '../constants.js';
 
-const LATEXDIFF_CONTENT_ID = 'latexdiffsContent';
-const TOGGLE_LATEXDIFFS_ID = 'toggleLatexdiffs';
+const LATEXDIFF_CONTENT_ID = ELEMENT_IDS.LATEXDIFFS_CONTENT;
+const TOGGLE_LATEXDIFFS_ID = ELEMENT_IDS.TOGGLE_LATEXDIFFS;
 const ICON_SELECTOR = 'i';
 
 /**

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -2,6 +2,7 @@ import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
+import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
 
 export class RecordingManager {
@@ -13,7 +14,9 @@ export class RecordingManager {
 
   updateRecordingUI(recording) {
     this.isRecording = recording;
-    const recordButton = safeGetElementById('recordInstructionButton');
+    const recordButton = safeGetElementById(
+      ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON,
+    );
     if (recordButton) {
       if (recording) {
         recordButton.innerHTML = '<i class="codicon codicon-stop-circle"></i>';
@@ -28,7 +31,7 @@ export class RecordingManager {
   }
 
   setupRecordButton() {
-    const buttonId = 'recordInstructionButton';
+    const buttonId = ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON;
     const button = safeGetElementById(buttonId);
     if (!button) return;
 

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -9,6 +9,7 @@ import {
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { ELEMENT_IDS } from '../constants.js';
 
 export class SettingsButtonManager {
   constructor(
@@ -36,9 +37,9 @@ export class SettingsButtonManager {
   }
 
   _setupToggles() {
-    this._addListener('toggleAutoExtract', 'click', (e) => {
+    this._addListener(ELEMENT_IDS.TOGGLE_AUTO_EXTRACT, 'click', (e) => {
       e.stopPropagation();
-      const options = safeGetElementById('autoExtractOptions');
+      const options = safeGetElementById(ELEMENT_IDS.AUTO_EXTRACT_OPTIONS);
       if (options) {
         const visible = options.style.display === 'block';
         options.style.display = visible ? 'none' : 'block';
@@ -46,9 +47,9 @@ export class SettingsButtonManager {
       this.toggleManager.updateAutoToggleState();
     });
 
-    this._addListener('toggleToolConfig', 'click', (e) => {
+    this._addListener(ELEMENT_IDS.TOGGLE_TOOL_CONFIG, 'click', (e) => {
       e.stopPropagation();
-      const options = safeGetElementById('toolConfigOptions');
+      const options = safeGetElementById(ELEMENT_IDS.TOOL_CONFIG_OPTIONS);
       if (options) {
         const visible = options.style.display === 'block';
         options.style.display = visible ? 'none' : 'block';
@@ -72,19 +73,19 @@ export class SettingsButtonManager {
       this._addListener(id, 'change', handleCheckboxChange);
     });
 
-    this._addListener('toggleLatexdiffs', 'click', () => {
+    this._addListener(ELEMENT_IDS.TOGGLE_LATEXDIFFS, 'click', () => {
       this.latexdiffManager.toggleLatexdiffs();
     });
   }
 
   _setupSettingsButtons() {
-    this._addListener('agentSettingsButton', 'click', () => {
+    this._addListener(ELEMENT_IDS.AGENT_SETTINGS_BUTTON, 'click', () => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
       });
     });
 
-    this._addListener('modelSettingsButton', 'click', () => {
+    this._addListener(ELEMENT_IDS.MODEL_SETTINGS_BUTTON, 'click', () => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS,
       });

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -6,6 +6,7 @@ import {
 import {
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
+  ELEMENT_IDS,
 } from '../constants.js';
 
 export class ToggleManager {
@@ -41,8 +42,8 @@ export class ToggleManager {
 
   updateAutoToggleState() {
     this.updateDropdownToggleState(
-      'toggleAutoExtract',
-      'autoExtractOptions',
+      ELEMENT_IDS.TOGGLE_AUTO_EXTRACT,
+      ELEMENT_IDS.AUTO_EXTRACT_OPTIONS,
       CHECK_BOXES_AUTO_EXTRACT,
       'wand',
     );
@@ -50,8 +51,8 @@ export class ToggleManager {
 
   updateToolConfigToggleState() {
     this.updateDropdownToggleState(
-      'toggleToolConfig',
-      'toolConfigOptions',
+      ELEMENT_IDS.TOGGLE_TOOL_CONFIG,
+      ELEMENT_IDS.TOOL_CONFIG_OPTIONS,
       CHECK_BOXES_TOOL_USE,
       'tools',
     );
@@ -59,10 +60,18 @@ export class ToggleManager {
 
   setupDocumentListeners() {
     document.addEventListener('click', (e) => {
-      const toolConfigOptions = safeGetElementById('toolConfigOptions');
-      const autoExtractOptions = safeGetElementById('autoExtractOptions');
-      const toggleToolConfig = safeGetElementById('toggleToolConfig');
-      const toggleAutoExtract = safeGetElementById('toggleAutoExtract');
+      const toolConfigOptions = safeGetElementById(
+        ELEMENT_IDS.TOOL_CONFIG_OPTIONS,
+      );
+      const autoExtractOptions = safeGetElementById(
+        ELEMENT_IDS.AUTO_EXTRACT_OPTIONS,
+      );
+      const toggleToolConfig = safeGetElementById(
+        ELEMENT_IDS.TOGGLE_TOOL_CONFIG,
+      );
+      const toggleAutoExtract = safeGetElementById(
+        ELEMENT_IDS.TOGGLE_AUTO_EXTRACT,
+      );
 
       if (
         !toggleToolConfig?.contains(e.target) &&


### PR DESCRIPTION
## Summary
- define `ELEMENT_IDS` map in constants
- use `ELEMENT_IDS` in dom handler and UI managers
- map LaTeX diff IDs via constants

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865a095e8a883248fc19bffa3f16f04