### PR TITLE
Refactor webview modules to use command constants

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -172,8 +172,15 @@ export class MainViewMessageHandler {
           const updated = Array.from(
             container.querySelectorAll('.file-item'),
           ).map((el) => el.dataset.path);
+          const updateCommands = {
+            input: MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES,
+            reference: MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES,
+            auxiliary: MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES,
+            media: MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES,
+            output: MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES,
+          };
           vscode.postMessage({
-            command: `update${capitalize(fileType)}Files`,
+            command: updateCommands[fileType],
             files: updated,
           });
           mainViewState.update({ [`${fileType}Files`]: updated });
@@ -193,24 +200,24 @@ export class MainViewMessageHandler {
 
   _initializeDataRequests() {
     const dataRequests = [
-      'getTheme',
-      'getDebugMode',
-      'requestInputFile',
-      'requestReferenceFile',
-      'requestAuxiliaryFile',
-      'requestMediaFile',
-      'requestRecentCommits',
-      'requestBaseFile',
+      MAIN_VIEW_COMMANDS.GET_THEME,
+      MAIN_VIEW_COMMANDS.GET_DEBUG_MODE,
+      MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE,
+      MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE,
+      MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE,
+      MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
+      MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
+      MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE,
     ];
-    dataRequests.forEach((request) => {
-      vscode.postMessage({ command: request });
+    dataRequests.forEach((command) => {
+      vscode.postMessage({ command });
     });
 
     // Also request default output files for the current agent
     const agentElement = this._getElement('agent');
     if (agentElement && agentElement.value) {
       vscode.postMessage({
-        command: 'requestDefaultOutputFiles',
+        command: MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES,
         agent: agentElement.value,
       });
     }
@@ -367,7 +374,7 @@ export class MainViewMessageHandler {
     if (instruction && message.text) {
       instruction.value = message.text;
       vscode.postMessage({
-        command: 'showInformationMessage',
+        command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
         text: 'Instruction text has been polished!',
       });
       mainViewState.save();
@@ -387,7 +394,7 @@ export class MainViewMessageHandler {
       instruction.setSelectionRange(newCursorPos, newCursorPos);
       instruction.focus();
       vscode.postMessage({
-        command: 'showInformationMessage',
+        command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
         text: 'Instruction text transcribed!',
       });
       mainViewState.save();

--- a/src/webview/modules/pasteHandler.js
+++ b/src/webview/modules/pasteHandler.js
@@ -1,4 +1,5 @@
 // Image paste handling utilities
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 // Comprehensive MIME type to extension mapping
 export const IMAGE_MIME_TYPES = {
@@ -66,7 +67,7 @@ export async function processClipboardImage(file, mimeType, vscode) {
         const base64 = result.split(',')[1];
         if (base64) {
           vscode.postMessage({
-            command: 'clipboardImage',
+            command: MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE,
             base64,
             mediaType: mimeType,
             fileName,
@@ -83,7 +84,7 @@ export async function processClipboardImage(file, mimeType, vscode) {
     reader.onerror = () => {
       console.error(`Failed to read file: ${fileName}`);
       vscode.postMessage({
-        command: 'showInformationMessage',
+        command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
         text: `Failed to process pasted image: ${fileName}`,
       });
       resolve(null);

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -7,6 +7,7 @@ import {
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { CHECK_BOXES, MULTIPLE_SELECTIONS, ELEMENT_IDS } from '../constants.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class ActionButtonManager {
   constructor(vscodeInstance = vscode, fileList, state, instructionMgr) {
@@ -77,7 +78,7 @@ export class ActionButtonManager {
         const multipleFilesData = this._getMultipleFileData(singleFiles);
 
         this.vscode.postMessage({
-          command: 'polishInstructionText',
+          command: MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT,
           text: instruction.value,
           agent,
           model,
@@ -102,7 +103,7 @@ export class ActionButtonManager {
       });
 
       this.vscode.postMessage({
-        command: 'execute',
+        command: MAIN_VIEW_COMMANDS.EXECUTE,
         agent,
         model,
         instruction,
@@ -117,13 +118,13 @@ export class ActionButtonManager {
       const editedFile = safeGetElementValue('editedFile');
 
       this.vscode.postMessage({
-        command: 'merge',
+        command: MAIN_VIEW_COMMANDS.MERGE,
         inputFile,
         editedFile,
       });
 
       this.vscode.postMessage({
-        command: 'showInformationMessage',
+        command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
         text: `Merging files: ${inputFile} and ${editedFile}`,
       });
     });
@@ -149,8 +150,12 @@ export class ActionButtonManager {
           outputFiles.length > 0;
 
         if (useMultiple) {
+          const multipleCommand =
+            action === 'pack'
+              ? MAIN_VIEW_COMMANDS.PACK_MULTIPLE
+              : MAIN_VIEW_COMMANDS.CLEAN_MULTIPLE;
           this.vscode.postMessage({
-            command: `${action}Multiple`,
+            command: multipleCommand,
             inputFile,
             agent,
             model,
@@ -158,27 +163,31 @@ export class ActionButtonManager {
           });
 
           this.vscode.postMessage({
-            command: 'showInformationMessage',
+            command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
             text: `${capitalize(action)}ing multiple files: ${[inputFile, ...outputFiles].join(', ')}`,
           });
         } else {
           if (!inputFile || !agent || !model) {
             this.vscode.postMessage({
-              command: 'showInformationMessage',
+              command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
               text: 'Please select all required fields (input file, agent, and model)',
             });
             return;
           }
 
+          const singleCommand =
+            action === 'pack'
+              ? MAIN_VIEW_COMMANDS.PACK_SINGLE
+              : MAIN_VIEW_COMMANDS.CLEAN_SINGLE;
           this.vscode.postMessage({
-            command: `${action}Single`,
+            command: singleCommand,
             inputFile,
             agent,
             model,
           });
 
           this.vscode.postMessage({
-            command: 'showInformationMessage',
+            command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
             text: `${capitalize(action)}ing single file: ${inputFile}`,
           });
         }
@@ -193,14 +202,14 @@ export class ActionButtonManager {
       const editedFile = safeGetElementValue('editedFile');
 
       this.vscode.postMessage({
-        command: 'latexdiff',
+        command: MAIN_VIEW_COMMANDS.LATEXDIFF,
         inputFile,
         baseFile,
         editedFile,
       });
 
       this.vscode.postMessage({
-        command: 'showInformationMessage',
+        command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
         text: `Running LaTeX diff between ${baseFile} and ${editedFile}`,
       });
     });
@@ -211,14 +220,14 @@ export class ActionButtonManager {
       const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
 
       this.vscode.postMessage({
-        command: 'latexdiffvc',
+        command: MAIN_VIEW_COMMANDS.LATEXDIFFVC,
         inputFile,
         baseFile,
         commitHash,
       });
 
       this.vscode.postMessage({
-        command: 'showInformationMessage',
+        command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
         text: `Running LaTeX diff with version control: ${baseFile} at commit ${commitHash}`,
       });
     });
@@ -232,8 +241,12 @@ export class ActionButtonManager {
         const baseFile = safeGetElementValue('baseFile');
         const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
 
+        const command =
+          action === 'pack'
+            ? MAIN_VIEW_COMMANDS.PACK_LATEXDIFFVC
+            : MAIN_VIEW_COMMANDS.CLEAN_LATEXDIFFVC;
         this.vscode.postMessage({
-          command: `${action}Latexdiffvc`,
+          command,
           inputFile,
           baseFile,
           commitHash,
@@ -241,7 +254,7 @@ export class ActionButtonManager {
         });
 
         this.vscode.postMessage({
-          command: 'showInformationMessage',
+          command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
           text: `${capitalize(action)}ing LaTeX diff with version control: ${baseFile} at commit ${commitHash}`,
         });
       });
@@ -254,13 +267,13 @@ export class ActionButtonManager {
       const editedFile = safeGetElementValue('editedFile');
       if (baseFile && editedFile) {
         this.vscode.postMessage({
-          command: 'compare',
+          command: MAIN_VIEW_COMMANDS.COMPARE,
           baseFile,
           editedFile,
         });
       } else {
         this.vscode.postMessage({
-          command: 'showInformationMessage',
+          command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
           text: 'Please select both base and edited files to compare',
         });
       }
@@ -271,13 +284,13 @@ export class ActionButtonManager {
       const editedFile = safeGetElementValue('editedFile');
       if (baseFile && editedFile) {
         this.vscode.postMessage({
-          command: 'acceptEdited',
+          command: MAIN_VIEW_COMMANDS.ACCEPT_EDITED,
           baseFile,
           editedFile,
         });
       } else {
         this.vscode.postMessage({
-          command: 'showInformationMessage',
+          command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
           text: 'Please select both base and edited files to accept changes',
         });
       }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -3,6 +3,7 @@ import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 /**
  * Handles single-file dropdown updates and commit list logic.
@@ -37,7 +38,7 @@ export class FileSelect {
     if (baseFile) {
       const current = editedFileDiv.value;
       vscode.postMessage({
-        command: 'requestEditedFile',
+        command: MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE,
         baseFile,
         preserveSelection: current,
       });
@@ -100,7 +101,7 @@ export class FileSelect {
       fileDiv.dispatchEvent(new Event('change'));
     } else {
       vscode.postMessage({
-        command: 'showInformationMessage',
+        command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
         text: `The current file is not in the ${fileType} file list: ${filePath}`,
       });
     }

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -4,6 +4,7 @@ import {
 } from '@common/domUtils.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class RecordingManager {
   constructor(vscode, eventBus = webviewEventBus) {
@@ -38,7 +39,9 @@ export class RecordingManager {
     addEventListenerSafely(buttonId, 'click', () => {
       const nextState = !this.isRecording;
       this.vscode.postMessage({
-        command: nextState ? 'startRecording' : 'stopRecording',
+        command: nextState
+          ? MAIN_VIEW_COMMANDS.START_RECORDING
+          : MAIN_VIEW_COMMANDS.STOP_RECORDING,
       });
       this.eventBus.dispatchEvent(
         new CustomEvent('recordingUIUpdate', {


### PR DESCRIPTION
## Summary
- replace command strings in `ActionButtonManager.js`
- use constants for data requests and messages in `messageHandlers.js`
- replace string commands in `pasteHandler.js`
- update `RecordingManager.js` to use command constants
- replace strings in `FileSelect.js`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865a59783208324924e26c97c14cbe8