### PR TITLE
Rename main view provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   ],
   "activationEvents": [
     "onView:texra.mainView",
+    "onView:texra.folderExplorer",
+    "onView:texra.progressView",
     "onColorTheme"
   ],
   "main": "./dist/extension.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "Data Science"
   ],
   "activationEvents": [
-    "onView:texra",
+    "onView:texra.mainView",
     "onColorTheme"
   ],
   "main": "./dist/extension.js",

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -8,7 +8,7 @@ import { SecretManager } from '@frontend/secretManager';
 import { watchConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
-export class TeXRAViewProvider implements vscode.WebviewViewProvider {
+export class MainViewProvider implements vscode.WebviewViewProvider {
   private messageHandler: MainViewMessageHandler;
   private contentProvider: MainViewContentProvider;
   private fileWatcher: vscode.FileSystemWatcher | undefined;
@@ -27,7 +27,7 @@ export class TeXRAViewProvider implements vscode.WebviewViewProvider {
 
   private registerCommandHandlers() {
     // Only register commands if they haven't been registered yet
-    if (!TeXRAViewProvider.commandsRegistered) {
+    if (!MainViewProvider.commandsRegistered) {
       // Create a promise to check if the command exists and register if it doesn't
       const registerCommandPromise = vscode.commands
         .getCommands(true)
@@ -38,10 +38,10 @@ export class TeXRAViewProvider implements vscode.WebviewViewProvider {
                 return this.webviewView;
               }),
             );
-            TeXRAViewProvider.commandsRegistered = true;
+            MainViewProvider.commandsRegistered = true;
             return true;
           }
-          TeXRAViewProvider.commandsRegistered = true;
+          MainViewProvider.commandsRegistered = true;
           return false;
         });
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,7 +8,7 @@ import { registerPackCommands } from '@commands/housekeeping/packCommands';
 import { registerCleanCommands } from '@commands/housekeeping/cleanCommands';
 import { registerMergeCommands } from '@commands/agent/mergeCommands';
 import { registerExecuteCommand } from '@commands/agent/executeCommand';
-import { TeXRAViewProvider } from './ViewProvider';
+import { MainViewProvider } from './MainViewProvider';
 import { registerLatexCommands } from '@commands/latex/latexCommands';
 import { registerImageCommands } from '@commands/latex/imageCommands';
 import { registerFigureCommands } from '@commands/latex/figCommands';
@@ -75,7 +75,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(
       'texra.mainView',
-      new TeXRAViewProvider(context),
+      new MainViewProvider(context),
       {
         webviewOptions: {
           retainContextWhenHidden: true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Configure LaTeX settings if LaTeX Workshop is installed
   configureLatexSettings();
 
-  // Register commands first - this will create and store the TeXRAViewProvider
+  // Register commands first - this will create and store the MainViewProvider
   registerCommands(context);
 
   // Register the folder explorer with context


### PR DESCRIPTION
## Summary
- rename `ViewProvider.ts` to `MainViewProvider.ts`
- update class name to `MainViewProvider`
- adjust imports and comments
- trigger activation on `texra.mainView`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: spawn error?)*

------
https://chatgpt.com/codex/tasks/task_e_6865a93082a8832499727f4e7eeb66d4