### PR TITLE
Fix BaseViewMessageHandler theme/debug command constants

### DIFF
--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
+import { COMMON_COMMANDS } from './commands';
 
 export type MessageHandler = (
   message: any,
@@ -78,7 +79,7 @@ export abstract class BaseViewMessageHandler {
     }
 
     webviewView.webview.postMessage({
-      command: 'setTheme',
+      command: COMMON_COMMANDS.THEME_SET,
       theme: message.theme,
     });
   }
@@ -91,7 +92,7 @@ export abstract class BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     webviewView.webview.postMessage({
-      command: 'setDebugMode',
+      command: COMMON_COMMANDS.DEBUG_MODE_SET,
       debugMode: message.debugMode,
     });
   }


### PR DESCRIPTION
## Summary
- import `COMMON_COMMANDS` in BaseViewMessageHandler
- replace `'setTheme'` and `'setDebugMode'` strings with command constants

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865a7f64b748324823ce1c705144004