### PR TITLE
Use command constants in RecordingManager

### DIFF
--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -2,6 +2,7 @@ import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
 
@@ -38,7 +39,9 @@ export class RecordingManager {
     addEventListenerSafely(buttonId, 'click', () => {
       const nextState = !this.isRecording;
       this.vscode.postMessage({
-        command: nextState ? 'startRecording' : 'stopRecording',
+        command: nextState
+          ? MAIN_VIEW_COMMANDS.START_RECORDING
+          : MAIN_VIEW_COMMANDS.STOP_RECORDING,
       });
       this.eventBus.dispatchEvent(
         new CustomEvent('recordingUIUpdate', {


### PR DESCRIPTION
## Summary
- import MAIN_VIEW_COMMANDS in `RecordingManager.js`
- post standardized start/stop recording commands

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warnings but no test results)*

------
https://chatgpt.com/codex/tasks/task_e_6865a7de3f18832484aa77cc786f3e5a