### PR TITLE
Add history item templates

### DIFF
--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -30,3 +30,7 @@ export function createIconButton({
   });
   return element;
 }
+
+export function createHistoryItem() {
+  return renderTemplate('historyItemTemplate');
+}

--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -4,7 +4,12 @@ export function renderTemplate(templateId) {
     console.warn(`Template ${templateId} not found`);
     return null;
   }
-  return template.content.firstElementChild.cloneNode(true);
+  const element = template.content.firstElementChild;
+  if (!element) {
+    console.warn(`Template ${templateId} has no content`);
+    return null;
+  }
+  return element.cloneNode(true);
 }
 
 export function createIconButton({
@@ -21,7 +26,9 @@ export function createIconButton({
   if (iconEl) {
     iconEl.classList.add(`codicon-${icon}`);
   }
-  element.id = id;
+  if (id) {
+    element.id = id;
+  }
   element.className = className;
   element.title = title;
   element.disabled = disabled;

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -28,6 +28,7 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
+          "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}"
         }
       }
@@ -72,6 +73,24 @@
       <div id="historyContainer" class="history-container">
         <!-- History items will be inserted here -->
       </div>
+      <template id="historyItemTemplate">
+        <div class="history-item">
+          <div class="history-item-header">
+            <div class="history-timestamp"></div>
+            <div class="history-actions button-group"></div>
+          </div>
+          <div class="history-details basic-details"></div>
+          <div class="collapsible">
+            <div class="history-details"></div>
+          </div>
+          <button class="toggle-button"></button>
+        </div>
+      </template>
+      <template id="iconButtonTemplate">
+        <button class="vscode-button">
+          <i class="codicon"></i>
+        </button>
+      </template>
     </div>
   </body>
 </html>

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -4,6 +4,7 @@ import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
+import { createHistoryItem, createIconButton } from '@common/templateUtils.js';
 import { historyViewState } from '../historyViewState.js';
 import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
 
@@ -53,27 +54,47 @@ export class HistoryRenderer {
     const config = item.config;
     const date = new Date(item.timestamp).toLocaleString();
 
-    const container = document.createElement('div');
-    container.className = 'history-item';
+    const container = createHistoryItem();
+    if (!container) return document.createElement('div');
 
-    const header = document.createElement('div');
-    header.className = 'history-item-header';
-    header.innerHTML = `
-      <div class="history-timestamp">${date}</div>
-      <div class="history-actions button-group">
-        <button class="vscode-button delete-btn" data-id="${item.id}" data-command="${COMMANDS.DELETE_AGENT}" title="Delete this history item">
-          <i class="codicon codicon-trash"></i>
-        </button>
-        <button class="vscode-button restore-btn" data-id="${item.id}" data-command="${COMMANDS.RESTORE_AGENT}" title="Load configuration to main view">
-          <i class="codicon codicon-reply"></i>
-        </button>
-        <button class="vscode-button rerun-btn" data-id="${item.id}" data-command="${COMMANDS.RERUN_AGENT}" title="Execute this configuration">
-          <i class="codicon codicon-debug-rerun"></i>
-        </button>
-      </div>`;
+    const timestampEl = container.querySelector('.history-timestamp');
+    if (timestampEl) timestampEl.textContent = date;
 
-    const basicDetails = document.createElement('div');
-    basicDetails.className = 'history-details';
+    const actions = container.querySelector('.history-actions');
+    if (actions) {
+      actions.innerHTML = '';
+      const buttons = [
+        {
+          icon: 'trash',
+          className: 'vscode-button delete-btn',
+          title: 'Delete this history item',
+          command: COMMANDS.DELETE_AGENT,
+        },
+        {
+          icon: 'reply',
+          className: 'vscode-button restore-btn',
+          title: 'Load configuration to main view',
+          command: COMMANDS.RESTORE_AGENT,
+        },
+        {
+          icon: 'debug-rerun',
+          className: 'vscode-button rerun-btn',
+          title: 'Execute this configuration',
+          command: COMMANDS.RERUN_AGENT,
+        },
+      ];
+      buttons.forEach((def) => {
+        const btn = createIconButton({
+          icon: def.icon,
+          className: def.className,
+          title: def.title,
+          dataset: { id: item.id, command: def.command },
+        });
+        if (btn) actions.appendChild(btn);
+      });
+    }
+
+    const basicDetails = container.querySelector('.basic-details');
     let basicHTML = `
       <span class="history-label">Agent:</span>
       <span class="history-value">${config.agent}</span>
@@ -106,12 +127,11 @@ export class HistoryRenderer {
     });
     basicDetails.innerHTML = basicHTML;
 
-    const collapsible = document.createElement('div');
-    collapsible.className = CLASS_NAMES.COLLAPSIBLE;
-    collapsible.id = `content-${item.id}`;
-
-    const detailsContainer = document.createElement('div');
-    detailsContainer.className = 'history-details';
+    const collapsible = container.querySelector(`.${CLASS_NAMES.COLLAPSIBLE}`);
+    const detailsContainer = collapsible?.querySelector('.history-details');
+    if (collapsible) {
+      collapsible.id = `content-${item.id}`;
+    }
 
     let detailsHTML = '';
     const extraFileTypes = [
@@ -154,20 +174,17 @@ export class HistoryRenderer {
       );
     }
 
-    if (detailsHTML) {
+    const toggleButton = container.querySelector(
+      `.${CLASS_NAMES.TOGGLE_BUTTON}`,
+    );
+
+    if (detailsHTML && collapsible && detailsContainer && toggleButton) {
       detailsContainer.innerHTML = detailsHTML;
-      collapsible.appendChild(detailsContainer);
-      const toggleButton = document.createElement('button');
-      toggleButton.className = CLASS_NAMES.TOGGLE_BUTTON;
-      toggleButton.setAttribute('data-id', item.id);
+      toggleButton.dataset.id = item.id;
       toggleButton.textContent = LABELS.SHOW_MORE;
-      container.appendChild(header);
-      container.appendChild(basicDetails);
-      container.appendChild(collapsible);
-      container.appendChild(toggleButton);
     } else {
-      container.appendChild(header);
-      container.appendChild(basicDetails);
+      if (collapsible) collapsible.remove();
+      if (toggleButton) toggleButton.remove();
     }
 
     return container;

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -42,7 +42,8 @@ export class HistoryRenderer {
       (a, b) => new Date(b.timestamp) - new Date(a.timestamp),
     );
     sorted.forEach((item) => {
-      historyContainer.appendChild(this._createHistoryItemElement(item));
+      const el = this._createHistoryItemElement(item);
+      if (el) historyContainer.appendChild(el);
     });
 
     this.setupItemEventListeners();
@@ -55,7 +56,10 @@ export class HistoryRenderer {
     const date = new Date(item.timestamp).toLocaleString();
 
     const container = createHistoryItem();
-    if (!container) return document.createElement('div');
+    if (!container) {
+      console.error('History item template missing');
+      return null;
+    }
 
     const timestampEl = container.querySelector('.history-timestamp');
     if (timestampEl) timestampEl.textContent = date;
@@ -125,7 +129,9 @@ export class HistoryRenderer {
           <span class="history-value">${multiple.join(', ')}</span>`;
       }
     });
-    basicDetails.innerHTML = basicHTML;
+    if (basicDetails) {
+      basicDetails.innerHTML = basicHTML;
+    }
 
     const collapsible = container.querySelector(`.${CLASS_NAMES.COLLAPSIBLE}`);
     const detailsContainer = collapsible?.querySelector('.history-details');

--- a/src/webview/modules/pasteHandler.js
+++ b/src/webview/modules/pasteHandler.js
@@ -1,9 +1,6 @@
 // Image paste handling utilities
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
-// Import standardized commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-
 // Comprehensive MIME type to extension mapping
 export const IMAGE_MIME_TYPES = {
   'image/jpeg': 'jpg',

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -5,7 +5,6 @@ import {
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class RecordingManager {
   constructor(vscode, eventBus = webviewEventBus) {


### PR DESCRIPTION
## Summary
- add template definitions for history entries in History View
- support cloning history item template via `createHistoryItem`
- render history items using templates instead of constructing HTML strings
- fix duplicate imports to satisfy lint

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686634df1d44832494a75339ebdc3da2