### PR TITLE
refactor: unify webview command constants

### DIFF
--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -171,6 +171,7 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   // File operations
   OPEN_FILE: 'openFile',
+  OPEN_FILE_COMPILE: 'openFileCompile',
   COMPARE_ORIGINAL: 'compareOriginal',
   COMPARE_PREVIOUS: 'comparePrevious',
   ACCEPT_FILE: 'acceptFile',

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -229,7 +229,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
         ? 'dark'
         : 'light';
-    webviewView.webview.postMessage({ command: 'setTheme', theme });
+    webviewView.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.THEME_SET,
+      theme,
+    });
   }
 
   private async handleDebugModeRequest(
@@ -237,7 +240,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const debugMode = getConfig<boolean>('logger.debugMode', false);
-    webviewView.webview.postMessage({ command: 'setDebugMode', debugMode });
+    webviewView.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
+      debugMode,
+    });
   }
 
   private async handleModelSelection(
@@ -246,7 +252,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   ): Promise<void> {
     if (message.model) {
       webviewView.webview.postMessage({
-        command: 'modelSelected',
+        command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
         model: message.model,
       });
     }

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+// Local imports - commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 const CHANNEL = 'DiffManager';
 logger.initialize(CHANNEL);
@@ -46,7 +48,7 @@ export class DiffManager {
       ? await vscode.commands.executeCommand<string[]>('texra.getRecentCommits')
       : [];
     webviewView.webview.postMessage({
-      command: 'setRecentCommits',
+      command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
       commits,
       isGitRepo,
     });
@@ -61,12 +63,12 @@ export class DiffManager {
         'texra.getRecentCommits',
       );
       webviewView.webview.postMessage({
-        command: 'setRecentCommits',
+        command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
         commits: commitsRefresh,
       });
     } else {
       webviewView.webview.postMessage({
-        command: 'setRecentCommits',
+        command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
         isGitRepo: false,
       });
     }

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -21,6 +21,9 @@ import {
   listEditedFiles,
 } from '@frontend/files/fileLister';
 
+// Local imports - commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
 // Local imports - agent
 import { getAgentPath } from '@agent/runtime/executeAgent';
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
@@ -58,7 +61,7 @@ export class FileManager {
     );
     if (editedFile) {
       webviewView.webview.postMessage({
-        command: 'editedFileSelected',
+        command: MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED,
         filePath: editedFile,
       });
     }
@@ -136,7 +139,7 @@ export class FileManager {
     const agent = message.agent;
     if (!agent) {
       webviewView.webview.postMessage({
-        command: 'setDefaultOutputFiles',
+        command: MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES,
         files: [],
       });
       return;
@@ -149,7 +152,7 @@ export class FileManager {
         ? settings.defaultOutputFiles
         : [];
       webviewView.webview.postMessage({
-        command: 'setDefaultOutputFiles',
+        command: MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES,
         files,
       });
     } catch (err) {
@@ -158,7 +161,7 @@ export class FileManager {
         `Error requesting default output files: ${err instanceof Error ? err.message : String(err)}`,
       );
       webviewView.webview.postMessage({
-        command: 'setDefaultOutputFiles',
+        command: MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES,
         files: [],
       });
     }
@@ -257,7 +260,7 @@ export class FileManager {
             currentFileName !== baseFileName
           ) {
             webviewView.webview.postMessage({
-              command: 'setCurrentFile',
+              command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
               filePath: currentOpenFile,
               fileType,
             });
@@ -273,7 +276,7 @@ export class FileManager {
         }
       } else {
         webviewView.webview.postMessage({
-          command: 'setCurrentFile',
+          command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
           filePath: currentOpenFile,
           fileType,
         });
@@ -291,7 +294,7 @@ export class FileManager {
   ): Promise<void> {
     const openedFiles = await this.getOpenedFiles();
     webviewView.webview.postMessage({
-      command: 'setOpenedFiles',
+      command: MAIN_VIEW_COMMANDS.SET_OPENED_FILES,
       files: openedFiles,
       fileType,
       shouldFilter: true,
@@ -373,7 +376,7 @@ export class FileManager {
   ): Promise<void> {
     const baseFiles = await listInputFiles();
     webviewView.webview.postMessage({
-      command: 'setBaseFile',
+      command: MAIN_VIEW_COMMANDS.SET_BASE_FILE,
       files: baseFiles,
       preserveBaseFile: true,
     });

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -14,6 +14,8 @@ import {
   FileContext,
 } from '@utils/text/textEnhancementUtils';
 import { sleep } from '@utils/helpers';
+// Local imports - commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 const CHANNEL = 'InstructionManager';
 logger.initialize(CHANNEL);
@@ -105,7 +107,7 @@ export class InstructionManager {
           await sleep(300);
           if (result.success) {
             webviewView.webview.postMessage({
-              command: 'instructionTextPolished',
+              command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED,
               text: result.text,
             });
           } else {
@@ -197,7 +199,7 @@ export class InstructionManager {
       await StorageFS.write(relativePath, Buffer.from(base64, 'base64'));
       await StorageFS.cleanupOldFiles(PASTED_DIR, 3 * 24 * 60 * 60 * 1000);
       webviewView.webview.postMessage({
-        command: 'addMediaFile',
+        command: MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE,
         file: fileName,
       });
     } catch (err) {

--- a/src/webview/managers/RecordingManager.ts
+++ b/src/webview/managers/RecordingManager.ts
@@ -9,6 +9,8 @@ import {
   startRecording,
   stopRecordingAndTranscribe,
 } from '@frontend/media/audio';
+// Local imports - commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 const CHANNEL = 'RecordingManager';
 logger.initialize(CHANNEL);
@@ -20,11 +22,13 @@ export class RecordingManager {
     try {
       const result = await startRecording(this.context);
       if (result.success) {
-        webviewView.webview.postMessage({ command: 'recordingStarted' });
+        webviewView.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.RECORDING_STARTED,
+        });
       } else if (result.error) {
         vscode.window.showErrorMessage(result.error);
         webviewView.webview.postMessage({
-          command: 'recordingError',
+          command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
           error: result.error,
         });
       }
@@ -37,7 +41,7 @@ export class RecordingManager {
         `Error in start: ${error instanceof Error ? error.message : String(error)}`,
       );
       webviewView.webview.postMessage({
-        command: 'recordingError',
+        command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }
@@ -55,13 +59,13 @@ export class RecordingManager {
           const result = await stopRecordingAndTranscribe(this.context);
           if (result.success) {
             webviewView.webview.postMessage({
-              command: 'instructionTextTranscribed',
+              command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED,
               text: result.text,
             });
           } else if (result.error) {
             vscode.window.showErrorMessage(result.error);
             webviewView.webview.postMessage({
-              command: 'recordingError',
+              command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
               error: result.error,
             });
           }
@@ -76,7 +80,7 @@ export class RecordingManager {
         `Error in stop: ${error instanceof Error ? error.message : String(error)}`,
       );
       webviewView.webview.postMessage({
-        command: 'recordingError',
+        command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -47,67 +47,84 @@ export class MainViewMessageHandler {
 
   _createThemeHandlers() {
     return {
-      setTheme: (m) => this.handleSetTheme(m),
-      setDebugMode: (m) => this.handleSetDebugMode(m),
-      modelSelected: (m) => this.handleModelSelected(m),
+      [MAIN_VIEW_COMMANDS.THEME_SET]: (m) => this.handleSetTheme(m),
+      [MAIN_VIEW_COMMANDS.DEBUG_MODE_SET]: (m) => this.handleSetDebugMode(m),
+      [MAIN_VIEW_COMMANDS.MODEL_SELECTED]: (m) => this.handleModelSelected(m),
     };
   }
 
   _createStateHandlers() {
     return {
-      restoreState: (m) => this.handleRestoreState(m),
-      checkRestoredBaseFile: () => this.handleCheckRestoredBaseFile(),
+      [MAIN_VIEW_COMMANDS.STATE_RESTORE]: (m) => this.handleRestoreState(m),
+      [MAIN_VIEW_COMMANDS.CHECK_RESTORED_BASE_FILE]: () =>
+        this.handleCheckRestoredBaseFile(),
     };
   }
 
   _createInstructionHandlers() {
     return {
-      instructionTextPolished: (m) => this.handleInstructionTextPolished(m),
-      instructionTextTranscribed: (m) =>
+      [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED]: (m) =>
+        this.handleInstructionTextPolished(m),
+      [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED]: (m) =>
         this.handleInstructionTextTranscribed(m),
     };
   }
 
   _createRecordingHandlers() {
     return {
-      recordingStarted: () => this.handleRecordingStarted(),
-      recordingError: () => this.handleRecordingError(),
+      [MAIN_VIEW_COMMANDS.RECORDING_STARTED]: () =>
+        this.handleRecordingStarted(),
+      [MAIN_VIEW_COMMANDS.RECORDING_ERROR]: () => this.handleRecordingError(),
     };
   }
 
   _createSingleFileHandlers() {
     return {
-      setInputFile: (m) => this.handleSetInputFile(m),
-      setReferenceFile: (m) => this.handleSetReferenceFile(m),
-      setAuxiliaryFile: (m) => this.handleSetAuxiliaryFile(m),
-      setMediaFile: (m) => this.handleSetMediaFile(m),
-      setEditedFile: (m) => this.handleSetEditedFile(m),
-      inputFileSelected: (m) => this.handleInputFileSelected(m),
-      referenceFileSelected: (m) => this.handleReferenceFileSelected(m),
-      auxiliaryFileSelected: (m) => this.handleAuxiliaryFileSelected(m),
-      mediaFileSelected: (m) => this.handleMediaFileSelected(m),
-      editedFileSelected: (m) => this.handleEditedFileSelected(m),
-      setDefaultOutputFiles: (m) => this.handleSetDefaultOutputFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_INPUT_FILE]: (m) => this.handleSetInputFile(m),
+      [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILE]: (m) =>
+        this.handleSetReferenceFile(m),
+      [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILE]: (m) =>
+        this.handleSetAuxiliaryFile(m),
+      [MAIN_VIEW_COMMANDS.SET_MEDIA_FILE]: (m) => this.handleSetMediaFile(m),
+      [MAIN_VIEW_COMMANDS.SET_EDITED_FILE]: (m) => this.handleSetEditedFile(m),
+      [MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED]: (m) =>
+        this.handleInputFileSelected(m),
+      [MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED]: (m) =>
+        this.handleReferenceFileSelected(m),
+      [MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED]: (m) =>
+        this.handleAuxiliaryFileSelected(m),
+      [MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED]: (m) =>
+        this.handleMediaFileSelected(m),
+      [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: (m) =>
+        this.handleEditedFileSelected(m),
+      [MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES]: (m) =>
+        this.handleSetDefaultOutputFiles(m),
     };
   }
 
   _createMultiFileHandlers() {
     return {
-      setInputFiles: (m) => this.handleSetInputFiles(m),
-      setReferenceFiles: (m) => this.handleSetReferenceFiles(m),
-      setAuxiliaryFiles: (m) => this.handleSetAuxiliaryFiles(m),
-      setMediaFiles: (m) => this.handleSetMediaFiles(m),
-      addMediaFile: (m) => this.handleAddMediaFile(m),
-      setOutputFiles: (m) => this.handleSetOutputFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: (m) => this.handleSetInputFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES]: (m) =>
+        this.handleSetReferenceFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES]: (m) =>
+        this.handleSetAuxiliaryFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: (m) => this.handleSetMediaFiles(m),
+      [MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE]: (m) => this.handleAddMediaFile(m),
+      [MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES]: (m) =>
+        this.handleSetOutputFiles(m),
     };
   }
 
   _createMiscHandlers() {
     return {
-      setRecentCommits: (m) => this.handleSetRecentCommits(m),
-      setCurrentFile: (m) => this.handleSetCurrentFile(m),
-      setOpenedFiles: (m) => this.handleSetOpenedFiles(m),
-      setBaseFile: (m) => this.handleSetBaseFile(m),
+      [MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS]: (m) =>
+        this.handleSetRecentCommits(m),
+      [MAIN_VIEW_COMMANDS.SET_CURRENT_FILE]: (m) =>
+        this.handleSetCurrentFile(m),
+      [MAIN_VIEW_COMMANDS.SET_OPENED_FILES]: (m) =>
+        this.handleSetOpenedFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_BASE_FILE]: (m) => this.handleSetBaseFile(m),
     };
   }
 

--- a/src/webview/modules/pasteHandler.js
+++ b/src/webview/modules/pasteHandler.js
@@ -1,9 +1,6 @@
 // Image paste handling utilities
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
-// Import standardized commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-
 // Comprehensive MIME type to extension mapping
 export const IMAGE_MIME_TYPES = {
   'image/jpeg': 'jpg',

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -2,7 +2,6 @@ import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';


### PR DESCRIPTION
## Summary
- sync `OPEN_FILE_COMPILE` constant in JS commands
- use command constants when posting messages in `MainViewMessageHandler`
- replace literal command strings in webview managers with constants
- refactor webview `messageHandlers` to map handlers with constants
- remove duplicate imports in `RecordingManager.js` and `pasteHandler.js`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866332fd210832484837cb15e60e4a6