### PR TITLE
Use templates for DOM creation

### DIFF
--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -42,6 +42,17 @@ export function createFromTemplate(templateId, replacements = {}) {
   return element;
 }
 
+export function validateTemplates(templateIds) {
+  return templateIds.every((id) => {
+    const template = document.getElementById(id);
+    if (!template) {
+      console.error(`Template ${id} not found`);
+      return false;
+    }
+    return true;
+  });
+}
+
 export function createIconButton({
   id,
   icon,

--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -7,6 +7,41 @@ export function renderTemplate(templateId) {
   return template.content.firstElementChild.cloneNode(true);
 }
 
+export function createFromTemplate(templateId, replacements = {}) {
+  const element = renderTemplate(templateId);
+  if (!element) return null;
+
+  const { text = {}, attributes = {}, dataset = {} } = replacements;
+  const apply = (selector, fn) => {
+    const target = selector ? element.querySelector(selector) : element;
+    if (target) fn(target);
+  };
+
+  Object.entries(text).forEach(([selector, value]) => {
+    apply(selector, (el) => {
+      el.textContent = value;
+    });
+  });
+
+  Object.entries(attributes).forEach(([selector, attrs]) => {
+    apply(selector, (el) => {
+      Object.entries(attrs).forEach(([attr, val]) => {
+        el.setAttribute(attr, val);
+      });
+    });
+  });
+
+  Object.entries(dataset).forEach(([selector, data]) => {
+    apply(selector, (el) => {
+      Object.entries(data).forEach(([key, val]) => {
+        el.dataset[key] = val;
+      });
+    });
+  });
+
+  return element;
+}
+
 export function createIconButton({
   id,
   icon,

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -73,5 +73,31 @@
         <!-- History items will be inserted here -->
       </div>
     </div>
+    <template id="historyItemTemplate">
+      <div class="history-item">
+        <div class="history-item-header">
+          <div class="history-timestamp"></div>
+          <div class="history-actions button-group">
+            <button class="vscode-button delete-btn" title="">
+              <i class="codicon codicon-trash"></i>
+            </button>
+            <button class="vscode-button restore-btn" title="">
+              <i class="codicon codicon-reply"></i>
+            </button>
+            <button class="vscode-button rerun-btn" title="">
+              <i class="codicon codicon-debug-rerun"></i>
+            </button>
+          </div>
+        </div>
+        <div class="history-details basic-details"></div>
+        <div class="collapsible">
+          <div class="history-details extra-details"></div>
+        </div>
+        <button class="toggle-button"></button>
+      </div>
+    </template>
+    <template id="codiconTemplate">
+      <i class="codicon"></i>
+    </template>
   </body>
 </html>

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -28,7 +28,8 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
-          "@common/domUtils.js": "${domUtilsUri}"
+          "@common/domUtils.js": "${domUtilsUri}",
+          "@common/templateUtils.js": "${templateUtilsUri}"
         }
       }
     </script>

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -76,8 +76,16 @@ export class HistoryRenderer {
     if (!container) return document.createElement('div');
 
     const basicDetails = container.querySelector('.basic-details');
-    const collapsible = container.querySelector('.collapsible');
+    const collapsible = container.querySelector(`.${CLASS_NAMES.COLLAPSIBLE}`);
     const detailsContainer = container.querySelector('.extra-details');
+    const toggleButton = container.querySelector(
+      `.${CLASS_NAMES.TOGGLE_BUTTON}`,
+    );
+
+    if (!basicDetails || !collapsible || !detailsContainer || !toggleButton) {
+      console.warn('[HistoryRenderer] Invalid history item template');
+      return document.createElement('div');
+    }
 
     let basicHTML = `
       <span class="history-label">Agent:</span>
@@ -156,7 +164,7 @@ export class HistoryRenderer {
       detailsContainer.innerHTML = detailsHTML;
     } else {
       collapsible.remove();
-      container.querySelector('.toggle-button').remove();
+      toggleButton.remove();
     }
 
     return container;

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -6,6 +6,7 @@ import {
 } from '@common/domUtils.js';
 import { historyViewState } from '../historyViewState.js';
 import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Renders history items and manages per-item events.
@@ -53,27 +54,29 @@ export class HistoryRenderer {
     const config = item.config;
     const date = new Date(item.timestamp).toLocaleString();
 
-    const container = document.createElement('div');
-    container.className = 'history-item';
+    const container = createFromTemplate('historyItemTemplate', {
+      text: {
+        '.history-timestamp': date,
+        '.toggle-button': LABELS.SHOW_MORE,
+      },
+      attributes: {
+        '.collapsible': { id: `content-${item.id}` },
+        '.delete-btn': { title: 'Delete this history item' },
+        '.restore-btn': { title: 'Load configuration to main view' },
+        '.rerun-btn': { title: 'Execute this configuration' },
+      },
+      dataset: {
+        '.delete-btn': { id: item.id, command: COMMANDS.DELETE_AGENT },
+        '.restore-btn': { id: item.id, command: COMMANDS.RESTORE_AGENT },
+        '.rerun-btn': { id: item.id, command: COMMANDS.RERUN_AGENT },
+        '.toggle-button': { id: item.id },
+      },
+    });
 
-    const header = document.createElement('div');
-    header.className = 'history-item-header';
-    header.innerHTML = `
-      <div class="history-timestamp">${date}</div>
-      <div class="history-actions button-group">
-        <button class="vscode-button delete-btn" data-id="${item.id}" data-command="${COMMANDS.DELETE_AGENT}" title="Delete this history item">
-          <i class="codicon codicon-trash"></i>
-        </button>
-        <button class="vscode-button restore-btn" data-id="${item.id}" data-command="${COMMANDS.RESTORE_AGENT}" title="Load configuration to main view">
-          <i class="codicon codicon-reply"></i>
-        </button>
-        <button class="vscode-button rerun-btn" data-id="${item.id}" data-command="${COMMANDS.RERUN_AGENT}" title="Execute this configuration">
-          <i class="codicon codicon-debug-rerun"></i>
-        </button>
-      </div>`;
+    const basicDetails = container.querySelector('.basic-details');
+    const collapsible = container.querySelector('.collapsible');
+    const detailsContainer = container.querySelector('.extra-details');
 
-    const basicDetails = document.createElement('div');
-    basicDetails.className = 'history-details';
     let basicHTML = `
       <span class="history-label">Agent:</span>
       <span class="history-value">${config.agent}</span>
@@ -105,13 +108,6 @@ export class HistoryRenderer {
       }
     });
     basicDetails.innerHTML = basicHTML;
-
-    const collapsible = document.createElement('div');
-    collapsible.className = CLASS_NAMES.COLLAPSIBLE;
-    collapsible.id = `content-${item.id}`;
-
-    const detailsContainer = document.createElement('div');
-    detailsContainer.className = 'history-details';
 
     let detailsHTML = '';
     const extraFileTypes = [
@@ -157,17 +153,9 @@ export class HistoryRenderer {
     if (detailsHTML) {
       detailsContainer.innerHTML = detailsHTML;
       collapsible.appendChild(detailsContainer);
-      const toggleButton = document.createElement('button');
-      toggleButton.className = CLASS_NAMES.TOGGLE_BUTTON;
-      toggleButton.setAttribute('data-id', item.id);
-      toggleButton.textContent = LABELS.SHOW_MORE;
-      container.appendChild(header);
-      container.appendChild(basicDetails);
-      container.appendChild(collapsible);
-      container.appendChild(toggleButton);
     } else {
-      container.appendChild(header);
-      container.appendChild(basicDetails);
+      collapsible.remove();
+      container.querySelector('.toggle-button').remove();
     }
 
     return container;

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -73,6 +73,8 @@ export class HistoryRenderer {
       },
     });
 
+    if (!container) return document.createElement('div');
+
     const basicDetails = container.querySelector('.basic-details');
     const collapsible = container.querySelector('.collapsible');
     const detailsContainer = container.querySelector('.extra-details');
@@ -152,7 +154,6 @@ export class HistoryRenderer {
 
     if (detailsHTML) {
       detailsContainer.innerHTML = detailsHTML;
-      collapsible.appendChild(detailsContainer);
     } else {
       collapsible.remove();
       container.querySelector('.toggle-button').remove();

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -630,10 +630,10 @@
         <i class="codicon"></i>
       </button>
     </template>
-    <template id="optionTemplate">
+    <template id="selectOptionTemplate">
       <option value=""></option>
     </template>
-    <template id="fileListItemTemplate">
+    <template id="fileListEntryTemplate">
       <div class="file-item" data-path="">
         <span class="file-name"></span>
         <span class="remove-button">-</span>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -630,5 +630,17 @@
         <i class="codicon"></i>
       </button>
     </template>
+    <template id="optionTemplate">
+      <option value=""></option>
+    </template>
+    <template id="fileListItemTemplate">
+      <div class="file-item" data-path="">
+        <span class="file-name"></span>
+        <span class="remove-button">-</span>
+      </div>
+    </template>
+    <template id="codiconTemplate">
+      <i class="codicon"></i>
+    </template>
   </body>
 </html>

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -151,10 +151,21 @@ export class MainViewMessageHandler {
   }
 
   _createFileItem(file) {
-    return createFromTemplate('fileListItemTemplate', {
+    const element = createFromTemplate('fileListEntryTemplate', {
       text: { '.file-name': file },
       dataset: { '': { path: file } },
     });
+    if (element) return element;
+
+    const fileItem = document.createElement('div');
+    fileItem.className = 'file-item';
+    fileItem.dataset.path = file;
+    fileItem.textContent = file;
+    const removeButton = document.createElement('span');
+    removeButton.className = 'remove-button';
+    removeButton.textContent = '-';
+    fileItem.appendChild(removeButton);
+    return fileItem;
   }
 
   _setupFileListHandler(fileType, container) {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -7,6 +7,7 @@ import {
 } from '@common/webviewContext.js';
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 import { mainViewState } from './mainViewState.js';
 import { mainViewDomHandler } from './domHandlers.js';
 
@@ -141,21 +142,19 @@ export class MainViewMessageHandler {
   _setToggleIcon(element, isVisible) {
     if (!element) return;
     element.innerHTML = '';
-    const icon = document.createElement('i');
-    icon.className = isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS;
-    element.appendChild(icon);
+    const icon = createFromTemplate('codiconTemplate', {
+      attributes: {
+        '': { class: isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
+      },
+    });
+    if (icon) element.appendChild(icon);
   }
 
   _createFileItem(file) {
-    const fileItem = document.createElement('div');
-    fileItem.className = 'file-item';
-    fileItem.dataset.path = file;
-    fileItem.textContent = file;
-    const removeButton = document.createElement('span');
-    removeButton.className = 'remove-button';
-    removeButton.textContent = '-';
-    fileItem.appendChild(removeButton);
-    return fileItem;
+    return createFromTemplate('fileListItemTemplate', {
+      text: { '.file-name': file },
+      dataset: { '': { path: file } },
+    });
   }
 
   _setupFileListHandler(fileType, container) {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -160,11 +160,17 @@ export class MainViewMessageHandler {
     const fileItem = document.createElement('div');
     fileItem.className = 'file-item';
     fileItem.dataset.path = file;
-    fileItem.textContent = file;
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'file-name';
+    nameSpan.textContent = file;
+    fileItem.appendChild(nameSpan);
+
     const removeButton = document.createElement('span');
     removeButton.className = 'remove-button';
     removeButton.textContent = '-';
     fileItem.appendChild(removeButton);
+
     return fileItem;
   }
 

--- a/src/webview/modules/pasteHandler.js
+++ b/src/webview/modules/pasteHandler.js
@@ -1,9 +1,6 @@
 // Image paste handling utilities
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
-// Import standardized commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-
 // Comprehensive MIME type to extension mapping
 export const IMAGE_MIME_TYPES = {
   'image/jpeg': 'jpg',

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -32,10 +32,12 @@ export class FileList {
     const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
     if (!container || !toggleIcon) return;
 
-    const fileElement = createFromTemplate('fileListItemTemplate', {
+    const fileElement = createFromTemplate('fileListEntryTemplate', {
       text: { '.file-name': file },
       dataset: { '': { path: file } },
     });
+
+    if (!fileElement) return;
 
     const removeButton = fileElement.querySelector('.remove-button');
     if (removeButton) {

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -8,6 +8,7 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
 import { capitalize } from '@common/stringUtils.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Handles multi-file list DOM updates.
@@ -31,10 +32,10 @@ export class FileList {
     const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
     if (!container || !toggleIcon) return;
 
-    const fileElement = document.createElement('div');
-    fileElement.className = 'file-item';
-    fileElement.dataset.path = file;
-    fileElement.innerHTML = `${file} <span class="remove-button">-</span>`;
+    const fileElement = createFromTemplate('fileListItemTemplate', {
+      text: { '.file-name': file },
+      dataset: { '': { path: file } },
+    });
 
     const removeButton = fileElement.querySelector('.remove-button');
     if (removeButton) {
@@ -63,7 +64,11 @@ export class FileList {
     if (newFiles.length > 0) {
       newFiles.forEach((file) => this.add(listId, file));
       listDiv.style.display = 'block';
-      toggleIcon.innerHTML = `<i class="${CHEVRON_UP_CLASS}"></i>`;
+      toggleIcon.innerHTML = '';
+      const icon = createFromTemplate('codiconTemplate', {
+        attributes: { '': { class: CHEVRON_UP_CLASS } },
+      });
+      if (icon) toggleIcon.appendChild(icon);
 
       const container = safeGetElementById(`${listId}Container`);
       if (container) {
@@ -85,9 +90,13 @@ export class FileList {
     const toggleIcon = safeGetElementById(toggleId);
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
-    toggleIcon.innerHTML = `<i class="${
-      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-    }"></i>`;
+    toggleIcon.innerHTML = '';
+    const icon = createFromTemplate('codiconTemplate', {
+      attributes: {
+        '': { class: isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
+      },
+    });
+    if (icon) toggleIcon.appendChild(icon);
   }
 
   /** Toggle visibility of a file list container */
@@ -109,7 +118,11 @@ export class FileList {
     container.style.display = 'none';
     const toggleIconDiv = safeGetElementById(toggleId);
     if (toggleIconDiv) {
-      toggleIconDiv.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
+      toggleIconDiv.innerHTML = '';
+      const icon = createFromTemplate('codiconTemplate', {
+        attributes: { '': { class: CHEVRON_DOWN_CLASS } },
+      });
+      if (icon) toggleIconDiv.appendChild(icon);
     }
     this._saveFn();
   }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -49,7 +49,7 @@ export class FileSelect {
   }
 
   addOption(select, value, text) {
-    const option = createFromTemplate('optionTemplate', {
+    const option = createFromTemplate('selectOptionTemplate', {
       text: { '': text },
       attributes: { '': { value } },
     });

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,6 +1,7 @@
 // Local imports
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -27,9 +28,9 @@ export class FileSelect {
       console.warn(`[FileSelect] Element with id '${id}' not found`);
       return;
     }
-    selectDiv.innerHTML =
-      '<option value="">None</option>' +
-      files.map((f) => `<option value="${f}">${f}</option>`).join('');
+    selectDiv.innerHTML = '';
+    this.addOption(selectDiv, '', 'None');
+    files.forEach((f) => this.addOption(selectDiv, f, f));
   }
 
   updateEdited(baseFile) {
@@ -48,10 +49,11 @@ export class FileSelect {
   }
 
   addOption(select, value, text) {
-    const option = document.createElement('option');
-    option.value = value;
-    option.textContent = text;
-    select.appendChild(option);
+    const option = createFromTemplate('optionTemplate', {
+      text: { '': text },
+      attributes: { '': { value } },
+    });
+    if (option) select.appendChild(option);
   }
 
   setElementsDisabled(elements, disabled) {

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -7,6 +7,7 @@ import {
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 const INPUT_FILE_ID = 'inputFile';
 const OUTPUT_FILES_ID = 'outputFiles';
@@ -89,9 +90,13 @@ export class OutputFilesManager {
       const shouldShow = state && state.outputFilesActive;
 
       container.style.display = shouldShow ? 'block' : 'none';
-      toggleIcon.innerHTML = `<i class="${
-        shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-      }"></i>`;
+      toggleIcon.innerHTML = '';
+      const icon = createFromTemplate('codiconTemplate', {
+        attributes: {
+          '': { class: shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
+        },
+      });
+      if (icon) toggleIcon.appendChild(icon);
     }
   }
 }

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -5,7 +5,7 @@ import {
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 export class RecordingManager {
   constructor(vscode, eventBus = webviewEventBus) {
@@ -20,15 +20,18 @@ export class RecordingManager {
       ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON,
     );
     if (recordButton) {
-      if (recording) {
-        recordButton.innerHTML = '<i class="codicon codicon-stop-circle"></i>';
-        recordButton.title = 'Stop recording';
-        recordButton.classList.add('recording');
-      } else {
-        recordButton.innerHTML = '<i class="codicon codicon-mic"></i>';
-        recordButton.title = 'Record instruction with microphone';
-        recordButton.classList.remove('recording');
-      }
+      recordButton.innerHTML = '';
+      const iconClass = recording
+        ? 'codicon codicon-stop-circle'
+        : 'codicon codicon-mic';
+      const icon = createFromTemplate('codiconTemplate', {
+        attributes: { '': { class: iconClass } },
+      });
+      if (icon) recordButton.appendChild(icon);
+      recordButton.title = recording
+        ? 'Stop recording'
+        : 'Record instruction with microphone';
+      recordButton.classList.toggle('recording', recording);
     }
   }
 

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -8,6 +8,7 @@ import {
   CHECK_BOXES_TOOL_USE,
   ELEMENT_IDS,
 } from '../constants.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 export class ToggleManager {
   isOptionsVisible(options) {
@@ -20,9 +21,17 @@ export class ToggleManager {
 
   setToggleIcon(toggle, icon, visible, active) {
     toggle.classList.toggle('active', active);
-    toggle.innerHTML = `<i class="codicon codicon-${icon}"></i><i class="${
-      visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-    }"></i>`;
+    toggle.innerHTML = '';
+    const iconEl = createFromTemplate('codiconTemplate', {
+      attributes: { '': { class: `codicon codicon-${icon}` } },
+    });
+    const chevron = createFromTemplate('codiconTemplate', {
+      attributes: {
+        '': { class: visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
+      },
+    });
+    if (iconEl) toggle.appendChild(iconEl);
+    if (chevron) toggle.appendChild(chevron);
   }
 
   updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {


### PR DESCRIPTION
## Summary
- add generic `createFromTemplate` helper
- define reusable templates for options, file list entries, and history items
- build UI components from templates instead of constructing markup manually
- fix duplicate import in paste handler

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866359a9a7c8324a74c8069cda183fa