### PR TITLE
Add history item templates

### DIFF
--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -28,7 +28,8 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
-          "@common/domUtils.js": "${domUtilsUri}"
+          "@common/domUtils.js": "${domUtilsUri}",
+          "@common/templateUtils.js": "${templateUtilsUri}"
         }
       }
     </script>
@@ -73,5 +74,47 @@
         <!-- History items will be inserted here -->
       </div>
     </div>
+
+    <template id="historyItemTemplate">
+      <div class="history-item">
+        <div class="history-item-header">
+          <div class="history-timestamp"></div>
+          <div class="history-actions button-group"></div>
+        </div>
+        <div class="history-details basic-details"></div>
+      </div>
+    </template>
+
+    <template id="historyActionsTemplate">
+      <div class="history-actions button-group">
+        <button
+          class="vscode-button delete-btn"
+          title="Delete this history item"
+        >
+          <i class="codicon codicon-trash"></i>
+        </button>
+        <button
+          class="vscode-button restore-btn"
+          title="Load configuration to main view"
+        >
+          <i class="codicon codicon-reply"></i>
+        </button>
+        <button
+          class="vscode-button rerun-btn"
+          title="Execute this configuration"
+        >
+          <i class="codicon codicon-debug-rerun"></i>
+        </button>
+      </div>
+    </template>
+
+    <template id="collapsibleSectionTemplate">
+      <div class="collapsible-section">
+        <div class="collapsible">
+          <div class="history-details"></div>
+        </div>
+        <button class="toggle-button"></button>
+      </div>
+    </template>
   </body>
 </html>

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -4,6 +4,7 @@ import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
+import { renderTemplate } from '@common/templateUtils.js';
 import { historyViewState } from '../historyViewState.js';
 import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
 
@@ -13,6 +14,47 @@ import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
 export class HistoryRenderer {
   constructor(searchManager) {
     this.searchManager = searchManager;
+  }
+
+  _createItemContainer() {
+    return renderTemplate('historyItemTemplate');
+  }
+
+  _createActionButtons(id) {
+    const actions = renderTemplate('historyActionsTemplate');
+    if (!actions) return null;
+    const del = actions.querySelector('.delete-btn');
+    if (del) {
+      del.dataset.id = id;
+      del.dataset.command = COMMANDS.DELETE_AGENT;
+    }
+    const restore = actions.querySelector('.restore-btn');
+    if (restore) {
+      restore.dataset.id = id;
+      restore.dataset.command = COMMANDS.RESTORE_AGENT;
+    }
+    const rerun = actions.querySelector('.rerun-btn');
+    if (rerun) {
+      rerun.dataset.id = id;
+      rerun.dataset.command = COMMANDS.RERUN_AGENT;
+    }
+    return actions;
+  }
+
+  _createCollapsibleSection(id) {
+    const wrapper = renderTemplate('collapsibleSectionTemplate');
+    if (!wrapper) return {};
+    const collapsible = wrapper.querySelector('.collapsible');
+    const detailsContainer = wrapper.querySelector('.history-details');
+    const toggleButton = wrapper.querySelector('.toggle-button');
+    if (collapsible) {
+      collapsible.id = `content-${id}`;
+    }
+    if (toggleButton) {
+      toggleButton.dataset.id = id;
+      toggleButton.textContent = LABELS.SHOW_MORE;
+    }
+    return { collapsible, detailsContainer, toggleButton };
   }
 
   /** Render list of history items */
@@ -53,27 +95,17 @@ export class HistoryRenderer {
     const config = item.config;
     const date = new Date(item.timestamp).toLocaleString();
 
-    const container = document.createElement('div');
-    container.className = 'history-item';
+    const container = this._createItemContainer();
+    if (!container) return document.createElement('div');
 
-    const header = document.createElement('div');
-    header.className = 'history-item-header';
-    header.innerHTML = `
-      <div class="history-timestamp">${date}</div>
-      <div class="history-actions button-group">
-        <button class="vscode-button delete-btn" data-id="${item.id}" data-command="${COMMANDS.DELETE_AGENT}" title="Delete this history item">
-          <i class="codicon codicon-trash"></i>
-        </button>
-        <button class="vscode-button restore-btn" data-id="${item.id}" data-command="${COMMANDS.RESTORE_AGENT}" title="Load configuration to main view">
-          <i class="codicon codicon-reply"></i>
-        </button>
-        <button class="vscode-button rerun-btn" data-id="${item.id}" data-command="${COMMANDS.RERUN_AGENT}" title="Execute this configuration">
-          <i class="codicon codicon-debug-rerun"></i>
-        </button>
-      </div>`;
+    const timestampEl = container.querySelector('.history-timestamp');
+    if (timestampEl) timestampEl.textContent = date;
 
-    const basicDetails = document.createElement('div');
-    basicDetails.className = 'history-details';
+    const actionsPlaceholder = container.querySelector('.history-actions');
+    const actions = this._createActionButtons(item.id);
+    if (actions && actionsPlaceholder) actionsPlaceholder.replaceWith(actions);
+
+    const basicDetails = container.querySelector('.history-details');
     let basicHTML = `
       <span class="history-label">Agent:</span>
       <span class="history-value">${config.agent}</span>
@@ -106,12 +138,8 @@ export class HistoryRenderer {
     });
     basicDetails.innerHTML = basicHTML;
 
-    const collapsible = document.createElement('div');
-    collapsible.className = CLASS_NAMES.COLLAPSIBLE;
-    collapsible.id = `content-${item.id}`;
-
-    const detailsContainer = document.createElement('div');
-    detailsContainer.className = 'history-details';
+    const { collapsible, detailsContainer, toggleButton } =
+      this._createCollapsibleSection(item.id);
 
     let detailsHTML = '';
     const extraFileTypes = [
@@ -157,17 +185,10 @@ export class HistoryRenderer {
     if (detailsHTML) {
       detailsContainer.innerHTML = detailsHTML;
       collapsible.appendChild(detailsContainer);
-      const toggleButton = document.createElement('button');
-      toggleButton.className = CLASS_NAMES.TOGGLE_BUTTON;
-      toggleButton.setAttribute('data-id', item.id);
-      toggleButton.textContent = LABELS.SHOW_MORE;
-      container.appendChild(header);
-      container.appendChild(basicDetails);
       container.appendChild(collapsible);
-      container.appendChild(toggleButton);
-    } else {
-      container.appendChild(header);
-      container.appendChild(basicDetails);
+      if (toggleButton) {
+        container.appendChild(toggleButton);
+      }
     }
 
     return container;

--- a/src/webview/modules/pasteHandler.js
+++ b/src/webview/modules/pasteHandler.js
@@ -1,9 +1,6 @@
 // Image paste handling utilities
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
-// Import standardized commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-
 // Comprehensive MIME type to extension mapping
 export const IMAGE_MIME_TYPES = {
   'image/jpeg': 'jpg',

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -5,7 +5,6 @@ import {
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class RecordingManager {
   constructor(vscode, eventBus = webviewEventBus) {


### PR DESCRIPTION
## Summary
- add `<template>` blocks for history items and actions
- utilize template helpers in `HistoryRenderer`
- include template utils in import map
- fix duplicate imports so lint passes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686635a6a88c8324b4aec44541ff8685