### PR TITLE
Add template-based file item helper

### DIFF
--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -32,8 +32,18 @@ export function createIconButton({
 }
 
 export function createFileItem(path) {
-  const element = renderTemplate('fileItemTemplate');
-  if (!element) return null;
+  let element = renderTemplate('fileItemTemplate');
+  if (!element) {
+    element = document.createElement('div');
+    element.className = 'file-item';
+    element.dataset.path = path;
+    element.textContent = path;
+    const removeButton = document.createElement('span');
+    removeButton.className = 'remove-button';
+    removeButton.textContent = '-';
+    element.appendChild(removeButton);
+    return element;
+  }
   element.dataset.path = path;
   const pathEl = element.querySelector('.file-path');
   if (pathEl) {

--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -30,3 +30,16 @@ export function createIconButton({
   });
   return element;
 }
+
+export function createFileItem(path) {
+  const element = renderTemplate('fileItemTemplate');
+  if (!element) return null;
+  element.dataset.path = path;
+  const pathEl = element.querySelector('.file-path');
+  if (pathEl) {
+    pathEl.textContent = path;
+  } else {
+    element.prepend(document.createTextNode(path));
+  }
+  return element;
+}

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -625,6 +625,12 @@
         </div>
       </div>
     </div>
+    <template id="fileItemTemplate">
+      <div class="file-item">
+        <span class="file-path"></span>
+        <span class="remove-button">-</span>
+      </div>
+    </template>
     <template id="iconButtonTemplate">
       <button class="vscode-button">
         <i class="codicon"></i>

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -16,6 +16,7 @@ import { fileSelect } from './uiManagers/FileSelect.js';
 import { webviewEventBus } from './eventBus.js';
 
 import { FILE_TYPES } from './constants.js';
+import { createFileItem } from '@common/templateUtils.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -147,15 +148,7 @@ export class MainViewMessageHandler {
   }
 
   _createFileItem(file) {
-    const fileItem = document.createElement('div');
-    fileItem.className = 'file-item';
-    fileItem.dataset.path = file;
-    fileItem.textContent = file;
-    const removeButton = document.createElement('span');
-    removeButton.className = 'remove-button';
-    removeButton.textContent = '-';
-    fileItem.appendChild(removeButton);
-    return fileItem;
+    return createFileItem(file);
   }
 
   _setupFileListHandler(fileType, container) {

--- a/src/webview/modules/pasteHandler.js
+++ b/src/webview/modules/pasteHandler.js
@@ -1,9 +1,6 @@
 // Image paste handling utilities
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
-// Import standardized commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-
 // Comprehensive MIME type to extension mapping
 export const IMAGE_MIME_TYPES = {
   'image/jpeg': 'jpg',

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -8,6 +8,7 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
 import { capitalize } from '@common/stringUtils.js';
+import { createFileItem } from '@common/templateUtils.js';
 
 /**
  * Handles multi-file list DOM updates.
@@ -31,10 +32,8 @@ export class FileList {
     const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
     if (!container || !toggleIcon) return;
 
-    const fileElement = document.createElement('div');
-    fileElement.className = 'file-item';
-    fileElement.dataset.path = file;
-    fileElement.innerHTML = `${file} <span class="remove-button">-</span>`;
+    const fileElement = createFileItem(file);
+    if (!fileElement) return;
 
     const removeButton = fileElement.querySelector('.remove-button');
     if (removeButton) {

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -5,7 +5,6 @@ import {
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class RecordingManager {
   constructor(vscode, eventBus = webviewEventBus) {


### PR DESCRIPTION
## Summary
- add generic `createFileItem` helper
- define `fileItemTemplate` in main view HTML
- generate file list entries from the template
- remove duplicate imports causing lint errors

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686635a144d883248c7b0247f70fd3ec