### PR TITLE
Rename event managers

### DIFF
--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -18,7 +18,10 @@ export class HistoryViewContentProvider extends BaseViewContentProvider {
       // History view specific modules
       domHandlersUri: this.getWebviewUri(webview, 'modules/domHandlers.js'),
       constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
-      eventsUri: this.getWebviewUri(webview, 'modules/uiManagers/Events.js'),
+      eventsUri: this.getWebviewUri(
+        webview,
+        'modules/uiManagers/HistoryEventsManager.js',
+      ),
       historyRendererUri: this.getWebviewUri(
         webview,
         'modules/uiManagers/HistoryRenderer.js',

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -20,7 +20,7 @@
         "imports": {
           "./modules/domHandlers.js": "${domHandlersUri}",
           "./modules/constants.js": "${constantsUri}",
-          "./modules/uiManagers/Events.js": "${eventsUri}",
+          "./modules/uiManagers/HistoryEventsManager.js": "${eventsUri}",
           "./modules/uiManagers/HistoryRenderer.js": "${historyRendererUri}",
           "./modules/historyViewState.js": "${historyViewStateUri}",
           "./modules/uiManagers/SearchManager.js": "${searchManagerUri}",

--- a/src/historyView/modules/domHandlers.js
+++ b/src/historyView/modules/domHandlers.js
@@ -1,7 +1,7 @@
 // Local imports
 import { HistoryRenderer } from './uiManagers/HistoryRenderer.js';
 import { SearchManager } from './uiManagers/SearchManager.js';
-import { HistoryEvents } from './uiManagers/Events.js';
+import { HistoryEventsManager } from './uiManagers/HistoryEventsManager.js';
 import { historyViewState } from './historyViewState.js';
 
 /**
@@ -11,7 +11,7 @@ export class HistoryViewDomHandler {
   constructor() {
     this.searchManager = new SearchManager(historyViewState);
     this.renderer = new HistoryRenderer(this.searchManager);
-    this.events = new HistoryEvents(this.searchManager);
+    this.events = new HistoryEventsManager(this.searchManager);
   }
 }
 

--- a/src/historyView/modules/uiManagers/HistoryEventsManager.js
+++ b/src/historyView/modules/uiManagers/HistoryEventsManager.js
@@ -4,7 +4,7 @@ import { ELEMENT_IDS } from '../constants.js';
 /**
  * Registers global event listeners for the history view.
  */
-export class HistoryEvents {
+export class HistoryEventsManager {
   constructor(searchManager) {
     this.searchManager = searchManager;
     this.handlers = [];

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -43,7 +43,10 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
         webview,
         'modules/uiManagers/FileList.js',
       ),
-      eventsUri: this.getWebviewUri(webview, 'modules/uiManagers/Events.js'),
+      eventsUri: this.getWebviewUri(
+        webview,
+        'modules/uiManagers/EventsManager.js',
+      ),
     };
   }
 }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -35,7 +35,7 @@
           "./modules/uiManagers/Toolbar.js": "${toolbarUri}",
           "./modules/uiManagers/Status.js": "${statusUri}",
           "./modules/uiManagers/FileList.js": "${fileListUri}",
-          "./modules/uiManagers/Events.js": "${eventsUri}",
+          "./modules/uiManagers/EventsManager.js": "${eventsUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/webview/commands.js": "${commandsUri}",

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -7,7 +7,7 @@ import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { Status } from './uiManagers/Status.js';
 import { FileList } from './uiManagers/FileList.js';
-import { Events } from './uiManagers/Events.js';
+import { EventsManager } from './uiManagers/EventsManager.js';
 
 /**
  * Manages all DOM operations for the progress view.
@@ -23,7 +23,7 @@ export class ProgressViewDomHandler {
     this.fileList = new FileList(this.usageSummary); // Pass shared instance
     this.taskGroups = new TaskGroupManager();
     this.logEntries = new LogEntryManager();
-    this.events = new Events();
+    this.events = new EventsManager();
   }
 }
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -12,7 +12,7 @@ import {
 /**
  * Manages event handling and state application.
  */
-export class Events {
+export class EventsManager {
   /**
    * Apply saved toggle states to any groups already in the DOM
    */


### PR DESCRIPTION
## Summary
- rename `Events.js` to `EventsManager.js` in Progress view
- rename `Events.js` to `HistoryEventsManager.js` in History view
- update imports and URI mappings

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68665941cc548324961248bd8c729127