### PR TITLE
Fix Progress View stream tab display issues

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -182,9 +182,8 @@ export class ProgressViewProvider
       webviewView.webview.onDidReceiveMessage(async (message) => {
         if (message.command === COMMANDS.WEBVIEW_READY) {
           this._webviewReady = true;
-          if (this._pendingUpdate) {
-            this.updateWebview();
-          }
+          // Always update webview when it becomes ready to ensure all streams are shown
+          this.updateWebview();
           return;
         }
         await this.messageHandler.handleMessage(message, webviewView);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -111,11 +111,22 @@ export class ProgressEventHandler {
    * Handle setting active stream
    */
   private handleSetActiveStream(stream: string): void {
+    // Ensure the stream exists in streamTabs so it appears in the UI
+    // This handles the case where setActiveStream is called before any logs
+    this.state.streamTabs.ensureStream(stream);
+
+    // Set initial status to running for new streams
+    if (!this._streamStatus.has(stream)) {
+      this.handleUpdateStreamStatus({ stream, status: STATUS.RUNNING });
+    }
+
     this.state.activeStream = stream;
 
     if (this.webviewUpdater.isAvailable()) {
       const streams = this.state.streamTabs.keys();
       this.webviewUpdater.updateStreams(streams, stream);
+
+      // Update log content (will be empty for new streams)
       this.updateLogContentForStream(stream);
     }
   }
@@ -291,19 +302,6 @@ export class ProgressEventHandler {
       !getConfig<boolean>('logger.debugMode', false)
     ) {
       return;
-    }
-
-    // Create stream if it doesn't exist
-    if (!this.state.streamTabs.has(stream)) {
-      this.logger.debug(`Adding new stream to ProgressView: ${stream}`);
-
-      // Set initial status to running for new streams
-      if (!this._streamStatus.has(stream)) {
-        this.handleUpdateStreamStatus({ stream, status: STATUS.RUNNING });
-      }
-
-      // Auto-focus new agent streams
-      this.handleSetActiveStream(stream);
     }
 
     this.state.streamTabs.add(stream, logMessage);

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -62,6 +62,16 @@ export class StreamTabsManager {
   }
 
   /**
+   * Create an empty stream if it doesn't exist
+   */
+  ensureStream(stream: StreamTabId): void {
+    if (!this._tabs.has(stream)) {
+      this._tabs.set(stream, []);
+      this.save();
+    }
+  }
+
+  /**
    * Delete a stream and its messages
    */
   delete(stream: StreamTabId): void {

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -213,6 +213,12 @@ export class WebviewUpdater {
       // Update usage for active stream
       const usage = state.usageStats.getStreamUsage(activeStream);
       this.updateUsage(usage);
+    } else {
+      // Clear content when no active stream
+      this.updateLogContent('', [], []);
+      this.updateFiles('', {});
+      this.updateMissingOutputs('', {});
+      this.updateUsage(undefined);
     }
 
     this.logger.debug(

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -17,8 +17,6 @@ export class TaskGroupManager {
    * @param {Object} group - Group data
    */
   add(group) {
-    progressViewState.taskGroups.set(group.id, group);
-
     // Check if this specific group (by ID) already exists in the DOM
     // This prevents duplicate groups from race conditions between UPDATE_LOGS and ADD_TASK_GROUP
     const existingGroup = document.getElementById(`group-${group.id}`);
@@ -31,13 +29,19 @@ export class TaskGroupManager {
         existingGroup.remove();
         // Continue with normal add flow to recreate it
       } else {
-        // Group already exists, but properties may have changed
-        // For now, just update status/endTime to prevent duplicates
+        // Group already exists in both DOM and state
+        // Update the state with new group data
+        progressViewState.taskGroups.set(group.id, group);
+        // For now, just update status/endTime in DOM to prevent duplicates
         // TODO: Implement full property update to handle name/startTime/parentGroupId changes
         this.update(group.id, group.status, group.endTime);
         return;
       }
     }
+
+    // Group doesn't exist in DOM (either new or was cleaned up above)
+    // Add to state
+    progressViewState.taskGroups.set(group.id, group);
 
     // Create the details container that will manage toggle state
     const detailsElem = document.createElement('details');

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -23,9 +23,20 @@ export class TaskGroupManager {
     // This prevents duplicate groups from race conditions between UPDATE_LOGS and ADD_TASK_GROUP
     const existingGroup = document.getElementById(`group-${group.id}`);
     if (existingGroup) {
-      // Group already exists, just update it instead of creating a duplicate
-      this.update(group.id, group.status, group.endTime);
-      return;
+      // Verify the group also exists in memory state
+      if (!progressViewState.taskGroups.get(group.id)) {
+        console.warn(
+          `Group ${group.id} exists in DOM but not in state - removing from DOM`,
+        );
+        existingGroup.remove();
+        // Continue with normal add flow to recreate it
+      } else {
+        // Group already exists, but properties may have changed
+        // For now, just update status/endTime to prevent duplicates
+        // TODO: Implement full property update to handle name/startTime/parentGroupId changes
+        this.update(group.id, group.status, group.endTime);
+        return;
+      }
     }
 
     // Create the details container that will manage toggle state

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -18,6 +18,16 @@ export class TaskGroupManager {
    */
   add(group) {
     progressViewState.taskGroups.set(group.id, group);
+
+    // Check if this specific group (by ID) already exists in the DOM
+    // This prevents duplicate groups from race conditions between UPDATE_LOGS and ADD_TASK_GROUP
+    const existingGroup = document.getElementById(`group-${group.id}`);
+    if (existingGroup) {
+      // Group already exists, just update it instead of creating a duplicate
+      this.update(group.id, group.status, group.endTime);
+      return;
+    }
+
     // Create the details container that will manage toggle state
     const detailsElem = document.createElement('details');
     detailsElem.className = 'log-group';


### PR DESCRIPTION
## Summary
- Stream tabs now appear immediately when tasks are launched
- Fixed duplicate task groups caused by race conditions
- Content is properly cleared when deleting the last stream tab

## Root Causes Fixed

### 1. Stream tabs not appearing immediately
The issue was that `setActiveStream` was called from `executeAgent.ts` before any log messages existed, so the stream wasn't in `streamTabs` yet. The fix adds `ensureStream()` to create empty streams when `setActiveStream` is called.

### 2. Duplicate task groups
Race condition between `UPDATE_LOGS` (which sends all groups) and individual `ADD_TASK_GROUP` events. Fixed by checking if a group already exists in the DOM before creating it.

### 3. Content not cleared when deleting last stream
`WebviewUpdater.updateAll()` only updated content when there was an active stream. Now it explicitly clears content when no active stream exists.

## Test Plan
- [x] Launch a new task and verify the stream tab appears immediately
- [x] Delete the last stream tab and verify content is cleared
- [x] Run multiple tasks concurrently and verify no duplicate task groups appear
- [x] Switch between stream tabs and verify content updates correctly

🤖 Generated with [Claude Code](https://claude.ai/code)