### PR TITLE
Centralize element IDs

### DIFF
--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -8,13 +8,20 @@ export const FILE_TYPES = [
 ];
 
 // Single file element IDs
+export const INPUT_FILE = 'inputFile';
+export const REFERENCE_FILE = 'referenceFile';
+export const AUXILIARY_FILE = 'auxiliaryFile';
+export const MEDIA_FILE = 'mediaFile';
+export const EDITED_FILE = 'editedFile';
+export const BASE_FILE = 'baseFile';
+
 export const SINGLE_FILE_ELEMENTS = [
-  'inputFile',
-  'referenceFile',
-  'auxiliaryFile',
-  'mediaFile',
-  'editedFile',
-  'baseFile',
+  INPUT_FILE,
+  REFERENCE_FILE,
+  AUXILIARY_FILE,
+  MEDIA_FILE,
+  EDITED_FILE,
+  BASE_FILE,
 ];
 
 // Multiple file selection element IDs (derived from FILE_TYPES)
@@ -83,5 +90,6 @@ export const ELEMENT_IDS = {
   COMMIT_SELECT: 'commit',
   OUTPUT_FILES: 'outputFiles',
   OUTPUT_FILES_CONTAINER: 'outputFilesContainer',
+  TOGGLE_OUTPUT_FILES: 'toggleOutputFiles',
   INSTRUCTION: 'instruction',
 };

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -16,7 +16,16 @@ import { fileList } from './uiManagers/FileList.js';
 import { fileSelect } from './uiManagers/FileSelect.js';
 import { webviewEventBus } from './eventBus.js';
 
-import { FILE_TYPES } from './constants.js';
+import {
+  FILE_TYPES,
+  INPUT_FILE,
+  REFERENCE_FILE,
+  AUXILIARY_FILE,
+  MEDIA_FILE,
+  EDITED_FILE,
+  BASE_FILE,
+  ELEMENT_IDS,
+} from './constants.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -279,12 +288,12 @@ export class MainViewMessageHandler {
       instruction.dispatchEvent(new Event('input'));
     }
 
-    if (state.inputFile) safeSetElementValue('inputFile', state.inputFile);
+    if (state.inputFile) safeSetElementValue(INPUT_FILE, state.inputFile);
     if (state.referenceFile)
-      safeSetElementValue('referenceFile', state.referenceFile);
+      safeSetElementValue(REFERENCE_FILE, state.referenceFile);
     if (state.auxiliaryFile)
-      safeSetElementValue('auxiliaryFile', state.auxiliaryFile);
-    if (state.mediaFile) safeSetElementValue('mediaFile', state.mediaFile);
+      safeSetElementValue(AUXILIARY_FILE, state.auxiliaryFile);
+    if (state.mediaFile) safeSetElementValue(MEDIA_FILE, state.mediaFile);
 
     const toolConfig = state.toolConfig || {};
     Object.assign(savedState, {
@@ -394,7 +403,7 @@ export class MainViewMessageHandler {
   }
 
   handleCheckRestoredBaseFile() {
-    const restoredBaseFileDiv = this._getElement('baseFile');
+    const restoredBaseFileDiv = this._getElement(BASE_FILE);
     if (restoredBaseFileDiv && restoredBaseFileDiv.value) {
       fileSelect.updateEdited(restoredBaseFileDiv.value);
     }
@@ -455,52 +464,52 @@ export class MainViewMessageHandler {
 
   // Single file updates
   handleSetInputFile(message) {
-    fileSelect.update('inputFile', message.files);
+    fileSelect.update(INPUT_FILE, message.files);
     this._postHandle();
   }
 
   handleSetReferenceFile(message) {
-    fileSelect.update('referenceFile', message.files);
+    fileSelect.update(REFERENCE_FILE, message.files);
     this._postHandle();
   }
 
   handleSetAuxiliaryFile(message) {
-    fileSelect.update('auxiliaryFile', message.files);
+    fileSelect.update(AUXILIARY_FILE, message.files);
     this._postHandle();
   }
 
   handleSetMediaFile(message) {
-    fileSelect.update('mediaFile', message.files);
+    fileSelect.update(MEDIA_FILE, message.files);
     this._postHandle();
   }
 
   handleSetEditedFile(message) {
-    fileSelect.update('editedFile', message.files);
+    fileSelect.update(EDITED_FILE, message.files);
     this._postHandle();
   }
 
   handleInputFileSelected(message) {
-    safeSetElementValue('inputFile', message.filePath);
+    safeSetElementValue(INPUT_FILE, message.filePath);
     this._postHandle();
   }
 
   handleReferenceFileSelected(message) {
-    safeSetElementValue('referenceFile', message.filePath);
+    safeSetElementValue(REFERENCE_FILE, message.filePath);
     this._postHandle();
   }
 
   handleAuxiliaryFileSelected(message) {
-    safeSetElementValue('auxiliaryFile', message.filePath);
+    safeSetElementValue(AUXILIARY_FILE, message.filePath);
     this._postHandle();
   }
 
   handleMediaFileSelected(message) {
-    safeSetElementValue('mediaFile', message.filePath);
+    safeSetElementValue(MEDIA_FILE, message.filePath);
     this._postHandle();
   }
 
   handleEditedFileSelected(message) {
-    safeSetElementValue('editedFile', message.filePath);
+    safeSetElementValue(EDITED_FILE, message.filePath);
     this._postHandle();
   }
 
@@ -554,8 +563,15 @@ export class MainViewMessageHandler {
   }
 
   handleSetOutputFiles(message) {
-    fileList.update('outputFiles', 'toggleOutputFiles', message.files);
-    this._setupFileListHandler('output', this._getElement('outputFiles'));
+    fileList.update(
+      ELEMENT_IDS.OUTPUT_FILES,
+      ELEMENT_IDS.TOGGLE_OUTPUT_FILES,
+      message.files,
+    );
+    this._setupFileListHandler(
+      'output',
+      this._getElement(ELEMENT_IDS.OUTPUT_FILES),
+    );
     this._postHandle();
   }
 
@@ -594,10 +610,10 @@ export class MainViewMessageHandler {
   }
 
   handleSetBaseFile(message) {
-    const currentBaseFileDiv = this._getElement('baseFile');
+    const currentBaseFileDiv = this._getElement(BASE_FILE);
     if (currentBaseFileDiv) {
       const currentBaseFile = currentBaseFileDiv.value;
-      fileSelect.update('baseFile', message.files);
+      fileSelect.update(BASE_FILE, message.files);
 
       const state = mainViewState.get();
       const storedBaseFile = state?.baseFile;

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -6,7 +6,13 @@ import {
   safeGetElementChecked,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
-import { CHECK_BOXES, MULTIPLE_SELECTIONS, ELEMENT_IDS } from '../constants.js';
+import {
+  CHECK_BOXES,
+  MULTIPLE_SELECTIONS,
+  ELEMENT_IDS,
+  BASE_FILE,
+  EDITED_FILE,
+} from '../constants.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class ActionButtonManager {
@@ -115,7 +121,7 @@ export class ActionButtonManager {
 
     this._addListener(ELEMENT_IDS.MERGE_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
-      const editedFile = safeGetElementValue('editedFile');
+      const editedFile = safeGetElementValue(EDITED_FILE);
 
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.MERGE,
@@ -198,8 +204,8 @@ export class ActionButtonManager {
   _setupLatexdiffButtons() {
     this._addListener(ELEMENT_IDS.LATEXDIFF_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
-      const baseFile = safeGetElementValue('baseFile');
-      const editedFile = safeGetElementValue('editedFile');
+      const baseFile = safeGetElementValue(BASE_FILE);
+      const editedFile = safeGetElementValue(EDITED_FILE);
 
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.LATEXDIFF,
@@ -216,7 +222,7 @@ export class ActionButtonManager {
 
     this._addListener(ELEMENT_IDS.LATEXDIFF_VC_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
-      const baseFile = safeGetElementValue('baseFile');
+      const baseFile = safeGetElementValue(BASE_FILE);
       const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
 
       this.vscode.postMessage({
@@ -238,7 +244,7 @@ export class ActionButtonManager {
     ].forEach(({ id, action }) => {
       this._addListener(id, 'click', () => {
         const { inputFile } = this._getSingleFileData(['input']);
-        const baseFile = safeGetElementValue('baseFile');
+        const baseFile = safeGetElementValue(BASE_FILE);
         const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
 
         const command =
@@ -263,8 +269,8 @@ export class ActionButtonManager {
 
   _setupCompareButtons() {
     this._addListener(ELEMENT_IDS.COMPARE_BUTTON, 'click', () => {
-      const baseFile = safeGetElementValue('baseFile');
-      const editedFile = safeGetElementValue('editedFile');
+      const baseFile = safeGetElementValue(BASE_FILE);
+      const editedFile = safeGetElementValue(EDITED_FILE);
       if (baseFile && editedFile) {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.COMPARE,
@@ -280,8 +286,8 @@ export class ActionButtonManager {
     });
 
     this._addListener(ELEMENT_IDS.ACCEPT_BUTTON, 'click', () => {
-      const baseFile = safeGetElementValue('baseFile');
-      const editedFile = safeGetElementValue('editedFile');
+      const baseFile = safeGetElementValue(BASE_FILE);
+      const editedFile = safeGetElementValue(EDITED_FILE);
       if (baseFile && editedFile) {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.ACCEPT_EDITED,

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -7,6 +7,12 @@ import {
   MULTIPLE_SELECTIONS,
   FILE_TYPES,
   ELEMENTS_TO_SAVE,
+  INPUT_FILE,
+  REFERENCE_FILE,
+  AUXILIARY_FILE,
+  MEDIA_FILE,
+  EDITED_FILE,
+  BASE_FILE,
 } from '../constants.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { fileList } from './FileList.js';
@@ -56,7 +62,7 @@ export class FileInputManager {
   }
 
   _setupSingleFileSelectors() {
-    this._addListener('inputFile', 'change', (e) => {
+    this._addListener(INPUT_FILE, 'change', (e) => {
       const inputFile = e.target.value;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
@@ -64,7 +70,7 @@ export class FileInputManager {
       });
     });
 
-    this._addListener('referenceFile', 'change', (e) => {
+    this._addListener(REFERENCE_FILE, 'change', (e) => {
       const referenceFile = e.target.value;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED,
@@ -72,8 +78,8 @@ export class FileInputManager {
       });
     });
 
-    this._addListener('baseFile', 'change', () => {
-      const baseFile = safeGetElementValue('baseFile');
+    this._addListener(BASE_FILE, 'change', () => {
+      const baseFile = safeGetElementValue(BASE_FILE);
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE,
         baseFile,
@@ -92,7 +98,7 @@ export class FileInputManager {
   _setupMultipleFileButtons() {
     const selectors = FILE_TYPES.map((type) => ({
       id: `${capitalize(type)}Files`,
-      selectId: type === 'output' ? 'inputFile' : `${type}File`,
+      selectId: type === 'output' ? INPUT_FILE : `${type}File`,
     }));
 
     selectors.forEach(({ id, selectId }) => {
@@ -128,7 +134,7 @@ export class FileInputManager {
 
     ['base', 'edited'].forEach((type) => {
       this._addListener(`current${capitalize(type)}FileButton`, 'click', () => {
-        const baseFile = safeGetElementValue('baseFile');
+        const baseFile = safeGetElementValue(BASE_FILE);
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
           fileType: type,

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -2,7 +2,7 @@
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
-import { ELEMENT_IDS } from '../constants.js';
+import { ELEMENT_IDS, EDITED_FILE } from '../constants.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
@@ -34,7 +34,7 @@ export class FileSelect {
   }
 
   updateEdited(baseFile) {
-    const editedFileDiv = safeGetElementById('editedFile');
+    const editedFileDiv = safeGetElementById(EDITED_FILE);
     if (!editedFileDiv) return;
     if (baseFile) {
       const current = editedFileDiv.value;
@@ -44,7 +44,7 @@ export class FileSelect {
         preserveSelection: current,
       });
     } else {
-      this.update('editedFile', []);
+      this.update(EDITED_FILE, []);
     }
   }
 

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -8,11 +8,12 @@ import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
 import { createFromTemplate } from '@common/templateUtils.js';
+import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 
-const INPUT_FILE_ID = 'inputFile';
-const OUTPUT_FILES_ID = 'outputFiles';
-const OUTPUT_FILES_CONTAINER_ID = 'outputFilesContainer';
-const TOGGLE_OUTPUT_FILES_ID = 'toggleOutputFiles';
+const INPUT_FILE_ID = INPUT_FILE;
+const OUTPUT_FILES_ID = ELEMENT_IDS.OUTPUT_FILES;
+const OUTPUT_FILES_CONTAINER_ID = ELEMENT_IDS.OUTPUT_FILES_CONTAINER;
+const TOGGLE_OUTPUT_FILES_ID = ELEMENT_IDS.TOGGLE_OUTPUT_FILES;
 
 /**
  * Manages output files UI logic.


### PR DESCRIPTION
## Summary
- add constants for single file elements
- use constants throughout file managers and handlers
- add toggleOutputFiles constant

## Testing
- `npm run format`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866d78de4a88324814d4a55b0ff8d8e