### PR TITLE
Map checkbox IDs to constants

### DIFF
--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -1,3 +1,4 @@
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Basic file types
 export const FILE_TYPES = [
   'input',
@@ -40,6 +41,17 @@ export const CHECK_BOXES = [
   ...CHECK_BOXES_AUTO_EXTRACT,
   ...CHECK_BOXES_TOOL_USE,
 ];
+
+// Map checkbox IDs to their corresponding update commands
+export const CHECKBOX_UPDATE_COMMANDS = {
+  autoExtractFigure: MAIN_VIEW_COMMANDS.UPDATE_AUTO_EXTRACT_FIGURE,
+  autoExtractTikzFigure: MAIN_VIEW_COMMANDS.UPDATE_AUTO_EXTRACT_TIKZ_FIGURE,
+  autoCompileInputPdf: MAIN_VIEW_COMMANDS.UPDATE_AUTO_COMPILE_INPUT_PDF,
+  attachTeXCount: MAIN_VIEW_COMMANDS.UPDATE_ATTACH_TEX_COUNT,
+  usePrefillFromInput: MAIN_VIEW_COMMANDS.UPDATE_USE_PREFILL_FROM_INPUT,
+  printInputPrompt: MAIN_VIEW_COMMANDS.UPDATE_PRINT_INPUT_PROMPT,
+  reflect: MAIN_VIEW_COMMANDS.UPDATE_REFLECT,
+};
 
 // Form elements with values to save
 export const VALUE_ELEMENTS = [

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -1,13 +1,18 @@
 import { vscode } from '@common/webviewContext.js';
-import { capitalize } from '@common/stringUtils.js';
+import { CHECKBOX_UPDATE_COMMANDS } from './constants.js';
 
 export function handleCheckboxChange(event) {
   const checkbox = event?.target || this;
   const checkboxId = checkbox.id;
   const isChecked = checkbox.checked;
 
+  const command = CHECKBOX_UPDATE_COMMANDS[checkboxId];
+  if (!command) {
+    return;
+  }
+
   vscode.postMessage({
-    command: `update${capitalize(checkboxId)}`,
+    command,
     value: isChecked,
   });
 }


### PR DESCRIPTION
## Summary
- map checkbox IDs to their update commands
- use the mapping in `handleCheckboxChange`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866d77fb9f48324abc066add683b62d