### PR TITLE
Add templates for progress view

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -120,5 +120,27 @@
         <i class="codicon"></i>
       </button>
     </template>
+    <template id="usageDisplayTemplate">
+      <span class="usage-display">
+        <i class="codicon codicon-arrow-up"></i>
+        <span class="usage-input"></span>,
+        <i class="codicon codicon-arrow-down"></i>
+        <span class="usage-output"></span>, $<span class="usage-cost"></span>
+      </span>
+    </template>
+    <template id="bulletIconTemplate">
+      <i class="codicon codicon-circle-small-filled group-bullet"></i>
+    </template>
+    <template id="streamTabTemplate">
+      <div class="tab-container">
+        <button class="tab" data-stream=""></button>
+        <button class="tab-delete" data-stream="" title="Delete stream">
+          <i class="codicon codicon-close"></i>
+        </button>
+      </div>
+    </template>
+    <template id="roundHeaderTemplate">
+      <div class="round-header"></div>
+    </template>
   </body>
 </html>

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -2,6 +2,7 @@
 import { formatTokens } from '../formatters.js';
 import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 import { vscode } from '@common/webviewContext.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Manages file list rendering.
@@ -52,10 +53,6 @@ export class FileList {
       return;
     }
 
-    // Add total usage header
-    const usageHeader = document.createElement('div');
-    usageHeader.className = 'files-usage-header';
-
     // Calculate total usage from all groups
     const totals = this.usageSummary?.computeTotal() || {
       inputTokens: 0,
@@ -64,14 +61,21 @@ export class FileList {
     };
 
     if (totals.inputTokens || totals.outputTokens || totals.cost) {
-      usageHeader.innerHTML = `
-        <span class="files-usage-label">Total Usage:</span>
-        <span class="files-usage-stats">
-          <i class="codicon codicon-arrow-up"></i> ${formatTokens(totals.inputTokens)},
-          <i class="codicon codicon-arrow-down"></i> ${formatTokens(totals.outputTokens)},
-          $${totals.cost.toFixed(3)}
-        </span>
-      `;
+      const usageHeader = document.createElement('div');
+      usageHeader.className = 'files-usage-header';
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'files-usage-label';
+      labelSpan.textContent = 'Total Usage:';
+      const stats = createFromTemplate('usageDisplayTemplate', {
+        text: {
+          '.usage-input': formatTokens(totals.inputTokens),
+          '.usage-output': formatTokens(totals.outputTokens),
+          '.usage-cost': totals.cost.toFixed(3),
+        },
+        attributes: { '': { class: 'files-usage-stats' } },
+      });
+      usageHeader.appendChild(labelSpan);
+      if (stats) usageHeader.appendChild(stats);
       container.appendChild(usageHeader);
     }
 
@@ -88,10 +92,10 @@ export class FileList {
       roundGroup.className = 'round-group';
 
       // Create round header
-      const roundHeader = document.createElement('div');
-      roundHeader.className = 'round-header';
-      roundHeader.textContent = `r${round}`;
-      roundGroup.appendChild(roundHeader);
+      const roundHeader = createFromTemplate('roundHeaderTemplate', {
+        text: { '': `r${round}` },
+      });
+      if (roundHeader) roundGroup.appendChild(roundHeader);
 
       files.forEach((file) => {
         // Skip invalid file entries
@@ -129,10 +133,20 @@ export class FileList {
 
         // Handle file stats
         if (statsSpan) {
+          statsSpan.innerHTML = '';
           if (file.added !== undefined && file.removed !== undefined) {
-            statsSpan.innerHTML = `<span class="added">+${file.added}</span><span class="removed">-${file.removed}</span>`;
+            const add = document.createElement('span');
+            add.className = 'added';
+            add.textContent = `+${file.added}`;
+            const remove = document.createElement('span');
+            remove.className = 'removed';
+            remove.textContent = `-${file.removed}`;
+            statsSpan.append(add, remove);
           } else if (file.added !== undefined) {
-            statsSpan.innerHTML = `<span class="added">+${file.added}</span>`;
+            const add = document.createElement('span');
+            add.className = 'added';
+            add.textContent = `+${file.added}`;
+            statsSpan.appendChild(add);
           } else {
             statsSpan.remove();
           }

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -1,5 +1,6 @@
 // Local imports
 import { ELEMENT_IDS } from '../constants.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Manages stream tab UI updates.
@@ -20,20 +21,24 @@ export class StreamTabs {
       console.error('StreamTabs.update: streamTabs container not found');
       return;
     }
-    tabsContainer.innerHTML = streams
-      .map((stream) => {
-        if (!stream || typeof stream !== 'string') {
-          console.warn('StreamTabs.update: invalid stream value:', stream);
-          return '';
-        }
-        return `<div class="tab-container ${stream === activeStream ? 'active' : ''}" title="${stream}">
-            <button class="tab" data-stream="${stream}" title="${stream}">${stream}</button>
-            <button class="tab-delete" data-stream="${stream}" title="Delete stream">
-              <i class="codicon codicon-close"></i>
-            </button>
-          </div>`;
-      })
-      .join('');
+    tabsContainer.innerHTML = '';
+    streams.forEach((stream) => {
+      if (!stream || typeof stream !== 'string') {
+        console.warn('StreamTabs.update: invalid stream value:', stream);
+        return;
+      }
+      const tab = createFromTemplate('streamTabTemplate', {
+        text: { '.tab': stream },
+        attributes: {
+          '.tab': { 'data-stream': stream, title: stream },
+          '.tab-delete': { 'data-stream': stream, title: 'Delete stream' },
+        },
+      });
+      if (tab) {
+        if (stream === activeStream) tab.classList.add('active');
+        tabsContainer.appendChild(tab);
+      }
+    });
 
     // Update active stream name
     const streamNameElem = document.getElementById(

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -1,7 +1,8 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { formatTokens, BULLET_MARKUP, TaskGroupLevel } from './formatters.js';
+import { formatTokens, TaskGroupLevel } from './formatters.js';
 import { ELEMENT_IDS } from './constants.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Manages usage summary display.
@@ -89,14 +90,16 @@ export class UsageGroup {
     // Find or create usage display element in the group header
     let usageElem = groupHeader.querySelector('.group-usage');
     if (!usageElem) {
-      usageElem = document.createElement('span');
-      usageElem.className = 'group-usage';
+      usageElem = createFromTemplate('usageDisplayTemplate');
+      if (usageElem) {
+        usageElem.classList.add('group-usage');
 
-      // Determine the group level by checking for the 'top-level' class
-      const level = groupHeader.classList.contains('top-level')
-        ? TaskGroupLevel.ROOT
-        : TaskGroupLevel.NESTED;
-      this.insertUsageElement(groupHeader, usageElem, level);
+        // Determine the group level by checking for the 'top-level' class
+        const level = groupHeader.classList.contains('top-level')
+          ? TaskGroupLevel.ROOT
+          : TaskGroupLevel.NESTED;
+        this.insertUsageElement(groupHeader, usageElem, level);
+      }
     }
 
     if (!usage) {
@@ -105,10 +108,12 @@ export class UsageGroup {
     }
 
     const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
-    usageElem.innerHTML =
-      `<i class="codicon codicon-arrow-up"></i> ${formatTokens(inputTokens)}, ` +
-      `<i class="codicon codicon-arrow-down"></i> ${formatTokens(outputTokens)}, ` +
-      `$${cost.toFixed(3)}`;
+    const inputEl = usageElem.querySelector('.usage-input');
+    const outputEl = usageElem.querySelector('.usage-output');
+    const costEl = usageElem.querySelector('.usage-cost');
+    if (inputEl) inputEl.textContent = formatTokens(inputTokens);
+    if (outputEl) outputEl.textContent = formatTokens(outputTokens);
+    if (costEl) costEl.textContent = cost.toFixed(3);
 
     // Persist usage on the group state so the summary can be computed
     const group = progressViewState.taskGroups.get(groupId);
@@ -182,9 +187,7 @@ export class UsageGroup {
 
     let bulletElem = groupHeader.querySelector('.group-bullet');
     if (!bulletElem) {
-      const tmpl = document.createElement('template');
-      tmpl.innerHTML = BULLET_MARKUP;
-      bulletElem = tmpl.content.firstElementChild;
+      bulletElem = createFromTemplate('bulletIconTemplate');
     }
 
     if (timeContainer) {

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -3,6 +3,16 @@ import { messageHandler } from './modules/messageHandlers.js';
 import { progressViewDomHandler } from './modules/domHandlers.js';
 import { vscode } from '@common/webviewContext.js';
 import { COMMANDS } from './modules/constants.js';
+import { validateTemplates } from '@common/templateUtils.js';
+
+const TEMPLATE_IDS = [
+  'iconButtonTemplate',
+  'fileItemTemplate',
+  'usageDisplayTemplate',
+  'bulletIconTemplate',
+  'streamTabTemplate',
+  'roundHeaderTemplate',
+];
 
 // Initialize the state when the window loads
 progressViewState.initialize();
@@ -16,6 +26,7 @@ window.addEventListener('beforeunload', () => {
 
 // Initialize event listeners and state when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
+  validateTemplates(TEMPLATE_IDS);
   progressViewDomHandler.toolbar.render();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();


### PR DESCRIPTION
## Summary
- add new progress view HTML templates
- build StreamTabs from templates
- build UsageGroup display from templates
- build FileList headers from templates
- validate templates when the webview loads

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866df24dd888324a6cda5c4478e665e