### PR TITLE
Add reusable chevron toggle helper

### DIFF
--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -81,13 +81,14 @@ export function createIconButton({
 export function setChevronIcon(element, expanded) {
   if (!element) return;
   const iconClass = expanded ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS;
-  const iconEl =
-    element.tagName.toLowerCase() === 'i'
-      ? element
-      : element.querySelector('i') || document.createElement('i');
-  iconEl.className = iconClass;
-  if (!element.contains(iconEl)) {
-    element.innerHTML = '';
-    element.appendChild(iconEl);
+
+  if (element.tagName?.toLowerCase() === 'i') {
+    element.className = iconClass;
+    return;
   }
+
+  const chevron =
+    element.querySelector('i[class*="codicon-chevron-"]') ||
+    element.appendChild(document.createElement('i'));
+  chevron.className = iconClass;
 }

--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -1,3 +1,4 @@
+import { CHEVRON_UP_CLASS, CHEVRON_DOWN_CLASS } from './iconConstants.js';
 export function renderTemplate(templateId) {
   const template = document.getElementById(templateId);
   if (!template) {
@@ -75,4 +76,18 @@ export function createIconButton({
     element.dataset[key] = value;
   });
   return element;
+}
+
+export function setChevronIcon(element, expanded) {
+  if (!element) return;
+  const iconClass = expanded ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS;
+  const iconEl =
+    element.tagName.toLowerCase() === 'i'
+      ? element
+      : element.querySelector('i') || document.createElement('i');
+  iconEl.className = iconClass;
+  if (!element.contains(iconEl)) {
+    element.innerHTML = '';
+    element.appendChild(iconEl);
+  }
 }

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -8,10 +8,7 @@ import {
   ELEMENT_IDS,
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
-import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
+import { setChevronIcon } from '@common/templateUtils.js';
 import {
   safeGetElementValue,
   safeGetElementById,
@@ -51,7 +48,8 @@ export class MainViewState {
     );
     if (autoExtractToggle && autoExtractOptions) {
       autoExtractToggle.classList.remove('active');
-      autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+      autoExtractToggle.innerHTML = '<i class="codicon codicon-wand"></i>';
+      setChevronIcon(autoExtractToggle, false);
       autoExtractOptions.style.display = 'none';
     }
 
@@ -70,7 +68,8 @@ export class MainViewState {
     const toggleLatexdiffs = safeGetElementById(ELEMENT_IDS.TOGGLE_LATEXDIFFS);
     if (latexdiffsContent && toggleLatexdiffs) {
       latexdiffsContent.style.display = 'none';
-      toggleLatexdiffs.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
+      toggleLatexdiffs.innerHTML = '';
+      setChevronIcon(toggleLatexdiffs, false);
     }
 
     this.save();
@@ -101,7 +100,8 @@ export class MainViewState {
       );
       if (autoExtractToggle && autoExtractOptions) {
         autoExtractToggle.classList.toggle('active', hasAutoExtractChecked);
-        autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+        autoExtractToggle.innerHTML = '<i class="codicon codicon-wand"></i>';
+        setChevronIcon(autoExtractToggle, false);
         autoExtractOptions.style.display = 'none';
       }
 
@@ -116,7 +116,8 @@ export class MainViewState {
       );
       if (toggleToolConfig && toolConfigOptions) {
         toggleToolConfig.classList.toggle('active', hasToolConfigChecked);
-        toggleToolConfig.innerHTML = `<i class="codicon codicon-tools"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+        toggleToolConfig.innerHTML = '<i class="codicon codicon-tools"></i>';
+        setChevronIcon(toggleToolConfig, false);
         toolConfigOptions.style.display = 'none';
       }
 
@@ -155,9 +156,8 @@ export class MainViewState {
       if (latexdiffsContent && toggleLatexdiffs) {
         const visible = previousState.latexdiffsVisible ?? false;
         latexdiffsContent.style.display = visible ? 'block' : 'none';
-        toggleLatexdiffs.innerHTML = `<i class="${
-          visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-        }"></i>`;
+        toggleLatexdiffs.innerHTML = '';
+        setChevronIcon(toggleLatexdiffs, visible);
       }
     } else {
       this.setDefaults();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1,13 +1,8 @@
 // Local imports - webview context
-import {
-  vscode,
-  registerMessageHandlers,
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
+import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createFromTemplate, setChevronIcon } from '@common/templateUtils.js';
 import { mainViewState } from './mainViewState.js';
 import { mainViewDomHandler } from './domHandlers.js';
 
@@ -165,17 +160,6 @@ export class MainViewMessageHandler {
   }
 
   /* ---------- Private helpers ---------- */
-  _setToggleIcon(element, isVisible) {
-    if (!element) return;
-    element.innerHTML = '';
-    const icon = createFromTemplate('codiconTemplate', {
-      attributes: {
-        '': { class: isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
-      },
-    });
-    if (icon) element.appendChild(icon);
-  }
-
   _createFileItem(file) {
     const element = createFromTemplate('fileListEntryTemplate', {
       text: { '.file-name': file },
@@ -354,7 +338,7 @@ export class MainViewMessageHandler {
         }
 
         const toggleElement = this._getElement(toggleId);
-        this._setToggleIcon(toggleElement, isVisible);
+        setChevronIcon(toggleElement, isVisible);
 
         if (filesArray.length > 0 && multipleFiles) {
           multipleFiles.innerHTML = '';
@@ -556,7 +540,7 @@ export class MainViewMessageHandler {
     if (container && container.style.display === 'none') {
       container.style.display = 'block';
       const toggleIcon = this._getElement('toggleMediaFiles');
-      this._setToggleIcon(toggleIcon, true);
+      setChevronIcon(toggleIcon, true);
     }
 
     this._postHandle();

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -3,12 +3,8 @@ import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
-import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
 import { capitalize } from '@common/stringUtils.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createFromTemplate, setChevronIcon } from '@common/templateUtils.js';
 
 /**
  * Handles multi-file list DOM updates.
@@ -67,10 +63,7 @@ export class FileList {
       newFiles.forEach((file) => this.add(listId, file));
       listDiv.style.display = 'block';
       toggleIcon.innerHTML = '';
-      const icon = createFromTemplate('codiconTemplate', {
-        attributes: { '': { class: CHEVRON_UP_CLASS } },
-      });
-      if (icon) toggleIcon.appendChild(icon);
+      setChevronIcon(toggleIcon, true);
 
       const container = safeGetElementById(`${listId}Container`);
       if (container) {
@@ -93,12 +86,7 @@ export class FileList {
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
     toggleIcon.innerHTML = '';
-    const icon = createFromTemplate('codiconTemplate', {
-      attributes: {
-        '': { class: isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
-      },
-    });
-    if (icon) toggleIcon.appendChild(icon);
+    setChevronIcon(toggleIcon, isVisible);
   }
 
   /** Toggle visibility of a file list container */
@@ -121,10 +109,7 @@ export class FileList {
     const toggleIconDiv = safeGetElementById(toggleId);
     if (toggleIconDiv) {
       toggleIconDiv.innerHTML = '';
-      const icon = createFromTemplate('codiconTemplate', {
-        attributes: { '': { class: CHEVRON_DOWN_CLASS } },
-      });
-      if (icon) toggleIconDiv.appendChild(icon);
+      setChevronIcon(toggleIconDiv, false);
     }
     this._saveFn();
   }

--- a/src/webview/modules/uiManagers/LatexdiffManager.js
+++ b/src/webview/modules/uiManagers/LatexdiffManager.js
@@ -1,9 +1,6 @@
 // Local imports
 import { safeGetElementById } from '@common/domUtils.js';
-import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
+import { setChevronIcon } from '@common/templateUtils.js';
 import { mainViewState } from '../mainViewState.js';
 import { ELEMENT_IDS } from '../constants.js';
 
@@ -32,9 +29,7 @@ export class LatexdiffManager {
 
       const iconElement = toggleIcon.querySelector(ICON_SELECTOR);
       if (iconElement) {
-        iconElement.className = shouldShow
-          ? CHEVRON_UP_CLASS
-          : CHEVRON_DOWN_CLASS;
+        setChevronIcon(iconElement, shouldShow);
       }
     }
   }
@@ -50,7 +45,7 @@ export class LatexdiffManager {
 
     const iconElement = toggleIcon.querySelector(ICON_SELECTOR);
     if (iconElement) {
-      iconElement.className = isVisible ? CHEVRON_DOWN_CLASS : CHEVRON_UP_CLASS;
+      setChevronIcon(iconElement, !isVisible);
     }
 
     this.state.update({ latexdiffsVisible: !isVisible });

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -1,13 +1,9 @@
 // Local imports
 import { safeGetElementById } from '@common/domUtils.js';
-import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
+import { setChevronIcon } from '@common/templateUtils.js';
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
-import { createFromTemplate } from '@common/templateUtils.js';
 import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 
 const INPUT_FILE_ID = INPUT_FILE;
@@ -92,12 +88,7 @@ export class OutputFilesManager {
 
       container.style.display = shouldShow ? 'block' : 'none';
       toggleIcon.innerHTML = '';
-      const icon = createFromTemplate('codiconTemplate', {
-        attributes: {
-          '': { class: shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
-        },
-      });
-      if (icon) toggleIcon.appendChild(icon);
+      setChevronIcon(toggleIcon, shouldShow);
     }
   }
 }

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -1,14 +1,10 @@
 import { safeGetElementById, safeGetElementChecked } from '@common/domUtils.js';
 import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
-import {
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
   ELEMENT_IDS,
 } from '../constants.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createFromTemplate, setChevronIcon } from '@common/templateUtils.js';
 
 export class ToggleManager {
   isOptionsVisible(options) {
@@ -25,13 +21,8 @@ export class ToggleManager {
     const iconEl = createFromTemplate('codiconTemplate', {
       attributes: { '': { class: `codicon codicon-${icon}` } },
     });
-    const chevron = createFromTemplate('codiconTemplate', {
-      attributes: {
-        '': { class: visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
-      },
-    });
     if (iconEl) toggle.appendChild(iconEl);
-    if (chevron) toggle.appendChild(chevron);
+    setChevronIcon(toggle, visible);
   }
 
   updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {


### PR DESCRIPTION
## Summary
- add `setChevronIcon` helper to template utils
- use the helper in the main webview message handler
- use the helper in `ToggleManager`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866df0d27c08324b815aa8473b7eef1