### PR TITLE
Add codicon helper and refactor icon creation

### DIFF
--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -76,3 +76,14 @@ export function createIconButton({
   });
   return element;
 }
+
+/**
+ * Create a codicon element from the shared template.
+ * @param {string} iconClass - Codicon class name like 'codicon-mic'.
+ * @returns {HTMLElement|null} The codicon element or null if template missing.
+ */
+export function createCodicon(iconClass) {
+  return createFromTemplate('codiconTemplate', {
+    attributes: { '': { class: `codicon ${iconClass}` } },
+  });
+}

--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -79,11 +79,11 @@ export function createIconButton({
 
 /**
  * Create a codicon element from the shared template.
- * @param {string} iconClass - Codicon class name like 'codicon-mic'.
+ * @param {string} iconName - Icon name such as 'mic' or 'chevron-up'.
  * @returns {HTMLElement|null} The codicon element or null if template missing.
  */
-export function createCodicon(iconClass) {
+export function createCodicon(iconName) {
   return createFromTemplate('codiconTemplate', {
-    attributes: { '': { class: `codicon ${iconClass}` } },
+    attributes: { '': { class: `codicon codicon-${iconName}` } },
   });
 }

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -154,7 +154,7 @@ export class HistoryRenderer {
     }
 
     if (config.toolConfig) {
-      const toolsIcon = createCodicon('codicon-tools');
+      const toolsIcon = createCodicon('tools');
       detailsHTML += this._renderToolConfig(
         `${toolsIcon ? toolsIcon.outerHTML : ''} Config`,
         config.toolConfig,

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -6,7 +6,7 @@ import {
 } from '@common/domUtils.js';
 import { historyViewState } from '../historyViewState.js';
 import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createFromTemplate, createCodicon } from '@common/templateUtils.js';
 
 /**
  * Renders history items and manages per-item events.
@@ -154,8 +154,9 @@ export class HistoryRenderer {
     }
 
     if (config.toolConfig) {
+      const toolsIcon = createCodicon('codicon-tools');
       detailsHTML += this._renderToolConfig(
-        '<i class="codicon codicon-tools"></i> Config',
+        `${toolsIcon ? toolsIcon.outerHTML : ''} Config`,
         config.toolConfig,
       );
     }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1,10 +1,5 @@
 // Local imports - webview context
-import {
-  vscode,
-  registerMessageHandlers,
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
+import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { createCodicon, createFromTemplate } from '@common/templateUtils.js';
@@ -168,9 +163,7 @@ export class MainViewMessageHandler {
   _setToggleIcon(element, isVisible) {
     if (!element) return;
     element.innerHTML = '';
-    const icon = createCodicon(
-      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
-    );
+    const icon = createCodicon(isVisible ? 'chevron-up' : 'chevron-down');
     if (icon) element.appendChild(icon);
   }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -7,7 +7,7 @@ import {
 } from '@common/webviewContext.js';
 import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createCodicon, createFromTemplate } from '@common/templateUtils.js';
 import { mainViewState } from './mainViewState.js';
 import { mainViewDomHandler } from './domHandlers.js';
 
@@ -168,11 +168,9 @@ export class MainViewMessageHandler {
   _setToggleIcon(element, isVisible) {
     if (!element) return;
     element.innerHTML = '';
-    const icon = createFromTemplate('codiconTemplate', {
-      attributes: {
-        '': { class: isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
-      },
-    });
+    const icon = createCodicon(
+      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
+    );
     if (icon) element.appendChild(icon);
   }
 

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -3,10 +3,6 @@ import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
-import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
 import { capitalize } from '@common/stringUtils.js';
 import { createCodicon, createFromTemplate } from '@common/templateUtils.js';
 
@@ -67,7 +63,7 @@ export class FileList {
       newFiles.forEach((file) => this.add(listId, file));
       listDiv.style.display = 'block';
       toggleIcon.innerHTML = '';
-      const icon = createCodicon(CHEVRON_UP_CLASS);
+      const icon = createCodicon('chevron-up');
       if (icon) toggleIcon.appendChild(icon);
 
       const container = safeGetElementById(`${listId}Container`);
@@ -91,9 +87,7 @@ export class FileList {
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
     toggleIcon.innerHTML = '';
-    const icon = createCodicon(
-      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
-    );
+    const icon = createCodicon(isVisible ? 'chevron-up' : 'chevron-down');
     if (icon) toggleIcon.appendChild(icon);
   }
 
@@ -117,7 +111,7 @@ export class FileList {
     const toggleIconDiv = safeGetElementById(toggleId);
     if (toggleIconDiv) {
       toggleIconDiv.innerHTML = '';
-      const icon = createCodicon(CHEVRON_DOWN_CLASS);
+      const icon = createCodicon('chevron-down');
       if (icon) toggleIconDiv.appendChild(icon);
     }
     this._saveFn();

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -8,7 +8,7 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
 import { capitalize } from '@common/stringUtils.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createCodicon, createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Handles multi-file list DOM updates.
@@ -67,9 +67,7 @@ export class FileList {
       newFiles.forEach((file) => this.add(listId, file));
       listDiv.style.display = 'block';
       toggleIcon.innerHTML = '';
-      const icon = createFromTemplate('codiconTemplate', {
-        attributes: { '': { class: CHEVRON_UP_CLASS } },
-      });
+      const icon = createCodicon(CHEVRON_UP_CLASS);
       if (icon) toggleIcon.appendChild(icon);
 
       const container = safeGetElementById(`${listId}Container`);
@@ -93,11 +91,9 @@ export class FileList {
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
     toggleIcon.innerHTML = '';
-    const icon = createFromTemplate('codiconTemplate', {
-      attributes: {
-        '': { class: isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
-      },
-    });
+    const icon = createCodicon(
+      isVisible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
+    );
     if (icon) toggleIcon.appendChild(icon);
   }
 
@@ -121,9 +117,7 @@ export class FileList {
     const toggleIconDiv = safeGetElementById(toggleId);
     if (toggleIconDiv) {
       toggleIconDiv.innerHTML = '';
-      const icon = createFromTemplate('codiconTemplate', {
-        attributes: { '': { class: CHEVRON_DOWN_CLASS } },
-      });
+      const icon = createCodicon(CHEVRON_DOWN_CLASS);
       if (icon) toggleIconDiv.appendChild(icon);
     }
     this._saveFn();

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -7,7 +7,7 @@ import {
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createCodicon } from '@common/templateUtils.js';
 import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 
 const INPUT_FILE_ID = INPUT_FILE;
@@ -92,11 +92,9 @@ export class OutputFilesManager {
 
       container.style.display = shouldShow ? 'block' : 'none';
       toggleIcon.innerHTML = '';
-      const icon = createFromTemplate('codiconTemplate', {
-        attributes: {
-          '': { class: shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
-        },
-      });
+      const icon = createCodicon(
+        shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
+      );
       if (icon) toggleIcon.appendChild(icon);
     }
   }

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -1,9 +1,6 @@
 // Local imports
 import { safeGetElementById } from '@common/domUtils.js';
-import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
+
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
@@ -92,9 +89,7 @@ export class OutputFilesManager {
 
       container.style.display = shouldShow ? 'block' : 'none';
       toggleIcon.innerHTML = '';
-      const icon = createCodicon(
-        shouldShow ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
-      );
+      const icon = createCodicon(shouldShow ? 'chevron-up' : 'chevron-down');
       if (icon) toggleIcon.appendChild(icon);
     }
   }

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -4,7 +4,8 @@ import {
 } from '@common/domUtils.js';
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createCodicon } from '@common/templateUtils.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class RecordingManager {
   constructor(vscode, eventBus = webviewEventBus) {
@@ -20,12 +21,8 @@ export class RecordingManager {
     );
     if (recordButton) {
       recordButton.innerHTML = '';
-      const iconClass = recording
-        ? 'codicon codicon-stop-circle'
-        : 'codicon codicon-mic';
-      const icon = createFromTemplate('codiconTemplate', {
-        attributes: { '': { class: iconClass } },
-      });
+      const iconClass = recording ? 'codicon-stop-circle' : 'codicon-mic';
+      const icon = createCodicon(iconClass);
       if (icon) recordButton.appendChild(icon);
       recordButton.title = recording
         ? 'Stop recording'

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -21,8 +21,8 @@ export class RecordingManager {
     );
     if (recordButton) {
       recordButton.innerHTML = '';
-      const iconClass = recording ? 'codicon-stop-circle' : 'codicon-mic';
-      const icon = createCodicon(iconClass);
+      const iconName = recording ? 'stop-circle' : 'mic';
+      const icon = createCodicon(iconName);
       if (icon) recordButton.appendChild(icon);
       recordButton.title = recording
         ? 'Stop recording'

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -1,9 +1,5 @@
 import { safeGetElementById, safeGetElementChecked } from '@common/domUtils.js';
 import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
-import {
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
   ELEMENT_IDS,
@@ -22,10 +18,8 @@ export class ToggleManager {
   setToggleIcon(toggle, icon, visible, active) {
     toggle.classList.toggle('active', active);
     toggle.innerHTML = '';
-    const iconEl = createCodicon(`codicon-${icon}`);
-    const chevron = createCodicon(
-      visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
-    );
+    const iconEl = createCodicon(icon);
+    const chevron = createCodicon(visible ? 'chevron-up' : 'chevron-down');
     if (iconEl) toggle.appendChild(iconEl);
     if (chevron) toggle.appendChild(chevron);
   }

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -8,7 +8,7 @@ import {
   CHECK_BOXES_TOOL_USE,
   ELEMENT_IDS,
 } from '../constants.js';
-import { createFromTemplate } from '@common/templateUtils.js';
+import { createCodicon } from '@common/templateUtils.js';
 
 export class ToggleManager {
   isOptionsVisible(options) {
@@ -22,14 +22,10 @@ export class ToggleManager {
   setToggleIcon(toggle, icon, visible, active) {
     toggle.classList.toggle('active', active);
     toggle.innerHTML = '';
-    const iconEl = createFromTemplate('codiconTemplate', {
-      attributes: { '': { class: `codicon codicon-${icon}` } },
-    });
-    const chevron = createFromTemplate('codiconTemplate', {
-      attributes: {
-        '': { class: visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS },
-      },
-    });
+    const iconEl = createCodicon(`codicon-${icon}`);
+    const chevron = createCodicon(
+      visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS,
+    );
     if (iconEl) toggle.appendChild(iconEl);
     if (chevron) toggle.appendChild(chevron);
   }


### PR DESCRIPTION
## Summary
- add `createCodicon` helper for codicon template usage
- update various UI managers to use `createCodicon`

## Testing
- `npm run lint`
- `npm test` *(fails: Critical dependency warning)*

------
https://chatgpt.com/codex/tasks/task_e_6866defb5ff883249b87e2c6f30a52d9