### PR TITLE
feat(history): template-based rendering

### DIFF
--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -97,6 +97,20 @@
         <button class="toggle-button"></button>
       </div>
     </template>
+    <template id="basicDetailTemplate">
+      <span class="history-label"></span>
+      <span class="history-value"></span>
+    </template>
+    <template id="extraDetailTemplate">
+      <span class="history-label"></span>
+      <span class="history-value"></span>
+    </template>
+    <template id="clearHistoryButtonTemplate">
+      <button class="vscode-button button-clear"></button>
+    </template>
+    <template id="emptyStateTemplate">
+      <div class="empty-state"></div>
+    </template>
     <template id="codiconTemplate">
       <i class="codicon"></i>
     </template>

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -28,15 +28,24 @@ export class HistoryRenderer {
     clearButtonContainer.innerHTML = '';
 
     if (!historyItems || historyItems.length === 0) {
-      historyContainer.innerHTML = `<div class="empty-state">${LABELS.EMPTY_STATE}</div>`;
+      const placeholder = createFromTemplate('emptyStateTemplate', {
+        text: { '': LABELS.EMPTY_STATE },
+      });
+      if (placeholder) historyContainer.appendChild(placeholder);
       this.searchManager.initialize(historyContainer);
       return;
     }
 
-    clearButtonContainer.innerHTML = `<button class="vscode-button button-clear" id="${ELEMENT_IDS.CLEAR_HISTORY_BTN}">${LABELS.CLEAR_ALL_HISTORY}</button>`;
-    addEventListenerSafely(ELEMENT_IDS.CLEAR_HISTORY_BTN, 'click', () => {
-      vscode.postMessage({ command: COMMANDS.CLEAR_HISTORY });
+    const clearBtn = createFromTemplate('clearHistoryButtonTemplate', {
+      text: { '': LABELS.CLEAR_ALL_HISTORY },
+      attributes: { '': { id: ELEMENT_IDS.CLEAR_HISTORY_BTN } },
     });
+    if (clearBtn) {
+      clearButtonContainer.appendChild(clearBtn);
+      addEventListenerSafely(ELEMENT_IDS.CLEAR_HISTORY_BTN, 'click', () => {
+        vscode.postMessage({ command: COMMANDS.CLEAR_HISTORY });
+      });
+    }
 
     const sorted = [...historyItems].sort(
       (a, b) => new Date(b.timestamp) - new Date(a.timestamp),
@@ -87,13 +96,19 @@ export class HistoryRenderer {
       return document.createElement('div');
     }
 
-    let basicHTML = `
-      <span class="history-label">Agent:</span>
-      <span class="history-value">${config.agent}</span>
-      <span class="history-label">Model:</span>
-      <span class="history-value">${config.model}</span>
-      <span class="history-label">Instruction:</span>
-      <span class="history-value">${config.instruction || 'None'}</span>`;
+    const addBasic = (label, value) => {
+      const row = createFromTemplate('basicDetailTemplate');
+      if (!row) return;
+      const labelEl = row.querySelector('.history-label');
+      const valueEl = row.querySelector('.history-value');
+      if (labelEl) labelEl.textContent = label;
+      if (valueEl) valueEl.textContent = String(value);
+      basicDetails.appendChild(row);
+    };
+
+    addBasic('Agent:', config.agent);
+    addBasic('Model:', config.model);
+    addBasic('Instruction:', config.instruction || 'None');
 
     const basicFileTypes = [
       { type: 'input', singular: 'InputFile', plural: 'InputFiles' },
@@ -103,23 +118,25 @@ export class HistoryRenderer {
       const single = config[`${type}File`];
       const multiple = config[`${type}Files`];
       if (single) {
-        basicHTML += `
-          <span class="history-label">${singular}:</span>
-          <span class="history-value">${single}</span>`;
+        addBasic(`${singular}:`, single);
       } else if (type === 'input') {
-        basicHTML += `
-          <span class="history-label">${singular}:</span>
-          <span class="history-value">None</span>`;
+        addBasic(`${singular}:`, 'None');
       }
       if (multiple && multiple.length > 0) {
-        basicHTML += `
-          <span class="history-label">${plural}:</span>
-          <span class="history-value">${multiple.join(', ')}</span>`;
+        addBasic(`${plural}:`, multiple.join(', '));
       }
     });
-    basicDetails.innerHTML = basicHTML;
 
-    let detailsHTML = '';
+    const addExtra = (label, value) => {
+      const row = createFromTemplate('extraDetailTemplate');
+      if (!row) return;
+      const labelEl = row.querySelector('.history-label');
+      const valueEl = row.querySelector('.history-value');
+      if (labelEl) labelEl.textContent = label;
+      if (valueEl) valueEl.textContent = String(value);
+      detailsContainer.appendChild(row);
+    };
+
     const extraFileTypes = [
       {
         type: 'reference',
@@ -136,33 +153,26 @@ export class HistoryRenderer {
       const single = config[`${type}File`];
       const multiple = config[`${type}Files`];
       if (single) {
-        detailsHTML += `
-          <span class="history-label">${singular}:</span>
-          <span class="history-value">${single}</span>`;
+        addExtra(`${singular}:`, single);
       }
       if (multiple && multiple.length > 0) {
-        detailsHTML += `
-          <span class="history-label">${plural}:</span>
-          <span class="history-value">${multiple.join(', ')}</span>`;
+        addExtra(`${plural}:`, multiple.join(', '));
       }
     });
 
     if (config.outputFiles && config.outputFiles.length > 0) {
-      detailsHTML += `
-        <span class="history-label">Output Files:</span>
-        <span class="history-value">${config.outputFiles.join(', ')}</span>`;
+      addExtra('Output Files:', config.outputFiles.join(', '));
     }
 
     if (config.toolConfig) {
-      detailsHTML += this._renderToolConfig(
+      const configRow = this._renderToolConfig(
         '<i class="codicon codicon-tools"></i> Config',
         config.toolConfig,
       );
+      if (configRow) detailsContainer.appendChild(configRow);
     }
 
-    if (detailsHTML) {
-      detailsContainer.innerHTML = detailsHTML;
-    } else {
+    if (detailsContainer.childElementCount === 0) {
       collapsible.remove();
       toggleButton.remove();
     }
@@ -171,18 +181,31 @@ export class HistoryRenderer {
   }
 
   _renderToolConfig(label, obj, exclude = []) {
-    if (!obj) return '';
+    if (!obj) return null;
     const entries = Object.entries(obj).filter(([key, value]) => {
       if (exclude.includes(key)) return false;
       if (value == null) return false;
       if (Array.isArray(value) && value.length === 0) return false;
       return true;
     });
-    if (entries.length === 0) return '';
-    let html = `
-      <span class="history-label">${label}:</span>
-      <div class="history-value config-section">`;
+    if (entries.length === 0) return null;
+
+    const row = createFromTemplate('extraDetailTemplate');
+    if (!row) return null;
+    const labelEl = row.querySelector('.history-label');
+    const valueEl = row.querySelector('.history-value');
+    if (labelEl) labelEl.innerHTML = label;
+    if (!valueEl) return row;
+
+    const section = document.createElement('div');
+    section.className = 'config-section';
     entries.forEach(([key, value]) => {
+      const item = document.createElement('div');
+      item.className = 'config-item';
+      const keySpan = document.createElement('span');
+      keySpan.className = 'config-key';
+      keySpan.textContent = `${key}:`;
+      item.appendChild(keySpan);
       const display = Array.isArray(value)
         ? value.join(', ')
         : typeof value === 'boolean'
@@ -190,10 +213,11 @@ export class HistoryRenderer {
             ? 'Yes'
             : 'No'
           : value;
-      html += `<div class="config-item"><span class="config-key">${key}:</span> ${display}</div>`;
+      item.appendChild(document.createTextNode(display));
+      section.appendChild(item);
     });
-    html += `</div>`;
-    return html;
+    valueEl.appendChild(section);
+    return row;
   }
 
   setupItemEventListeners() {

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -97,13 +97,13 @@ export class HistoryRenderer {
     }
 
     const addBasic = (label, value) => {
-      const row = createFromTemplate('basicDetailTemplate');
-      if (!row) return;
-      const labelEl = row.querySelector('.history-label');
-      const valueEl = row.querySelector('.history-value');
-      if (labelEl) labelEl.textContent = label;
-      if (valueEl) valueEl.textContent = String(value);
-      basicDetails.appendChild(row);
+      const row = createFromTemplate('basicDetailTemplate', {
+        text: {
+          '.history-label': label,
+          '.history-value': String(value),
+        },
+      });
+      if (row) basicDetails.appendChild(row);
     };
 
     addBasic('Agent:', config.agent);
@@ -128,13 +128,13 @@ export class HistoryRenderer {
     });
 
     const addExtra = (label, value) => {
-      const row = createFromTemplate('extraDetailTemplate');
-      if (!row) return;
-      const labelEl = row.querySelector('.history-label');
-      const valueEl = row.querySelector('.history-value');
-      if (labelEl) labelEl.textContent = label;
-      if (valueEl) valueEl.textContent = String(value);
-      detailsContainer.appendChild(row);
+      const row = createFromTemplate('extraDetailTemplate', {
+        text: {
+          '.history-label': label,
+          '.history-value': String(value),
+        },
+      });
+      if (row) detailsContainer.appendChild(row);
     };
 
     const extraFileTypes = [
@@ -190,11 +190,11 @@ export class HistoryRenderer {
     });
     if (entries.length === 0) return null;
 
-    const row = createFromTemplate('extraDetailTemplate');
+    const row = createFromTemplate('extraDetailTemplate', {
+      text: { '.history-label': label },
+    });
     if (!row) return null;
-    const labelEl = row.querySelector('.history-label');
     const valueEl = row.querySelector('.history-value');
-    if (labelEl) labelEl.innerHTML = label;
     if (!valueEl) return row;
 
     const section = document.createElement('div');
@@ -204,7 +204,7 @@ export class HistoryRenderer {
       item.className = 'config-item';
       const keySpan = document.createElement('span');
       keySpan.className = 'config-key';
-      keySpan.textContent = `${key}:`;
+      keySpan.textContent = `${key}: `;
       item.appendChild(keySpan);
       const display = Array.isArray(value)
         ? value.join(', ')
@@ -227,13 +227,13 @@ export class HistoryRenderer {
       const btn = e.target.closest('button[data-command]');
       if (btn) {
         const command = btn.dataset.command;
-        const historyId = btn.getAttribute('data-id');
+        const historyId = btn.dataset.id;
         vscode.postMessage({ command, historyId });
         return;
       }
       const toggle = e.target.closest(`.${CLASS_NAMES.TOGGLE_BUTTON}`);
       if (toggle) {
-        const id = toggle.getAttribute('data-id');
+        const id = toggle.dataset.id;
         const content = safeGetElementById(`content-${id}`);
         if (!content) return;
         const expanded = content.classList.toggle(CLASS_NAMES.EXPANDED);


### PR DESCRIPTION
## Summary
- add new DOM templates for history view elements
- clone these templates in HistoryRenderer
- update HistoryRenderer to build details with DOM operations

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866df45b5b88324bbb705aeff979d6f