### PR TITLE
Add templates to progress view

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -103,6 +103,32 @@
             </span>
           </div>
         </template>
+        <template id="usageTemplate">
+          <span class="group-usage">
+            <i class="codicon codicon-arrow-up"></i>
+            <span class="usage-input"></span>,
+            <i class="codicon codicon-arrow-down"></i>
+            <span class="usage-output"></span>, $<span
+              class="usage-cost"
+            ></span>
+          </span>
+        </template>
+        <template id="bulletTemplate">
+          <i class="codicon codicon-circle-small-filled group-bullet"></i>
+        </template>
+        <template id="streamTabTemplate">
+          <div class="tab-container" title="">
+            <button class="tab" data-stream="" title=""></button>
+            <button class="tab-delete" data-stream="" title="Delete stream">
+              <i class="codicon codicon-close"></i>
+            </button>
+          </div>
+        </template>
+        <template id="roundHeaderTemplate">
+          <div class="round-group">
+            <div class="round-header"></div>
+          </div>
+        </template>
       </div>
       <div class="tabs split">
         <div id="streamTabs" class="tabs-content">

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -2,6 +2,7 @@
 import { formatTokens } from '../formatters.js';
 import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 import { vscode } from '@common/webviewContext.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Manages file list rendering.
@@ -83,15 +84,10 @@ export class FileList {
       const files = filesByRound[round];
       if (!files || files.length === 0) return;
 
-      // Create round group container
-      const roundGroup = document.createElement('div');
-      roundGroup.className = 'round-group';
-
-      // Create round header
-      const roundHeader = document.createElement('div');
-      roundHeader.className = 'round-header';
-      roundHeader.textContent = `r${round}`;
-      roundGroup.appendChild(roundHeader);
+      const roundGroup = createFromTemplate('roundHeaderTemplate');
+      if (!roundGroup) return;
+      const roundHeader = roundGroup.querySelector('.round-header');
+      if (roundHeader) roundHeader.textContent = `r${round}`;
 
       files.forEach((file) => {
         // Skip invalid file entries

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -1,5 +1,6 @@
 // Local imports
 import { ELEMENT_IDS } from '../constants.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Manages stream tab UI updates.
@@ -20,20 +21,25 @@ export class StreamTabs {
       console.error('StreamTabs.update: streamTabs container not found');
       return;
     }
-    tabsContainer.innerHTML = streams
-      .map((stream) => {
-        if (!stream || typeof stream !== 'string') {
-          console.warn('StreamTabs.update: invalid stream value:', stream);
-          return '';
-        }
-        return `<div class="tab-container ${stream === activeStream ? 'active' : ''}" title="${stream}">
-            <button class="tab" data-stream="${stream}" title="${stream}">${stream}</button>
-            <button class="tab-delete" data-stream="${stream}" title="Delete stream">
-              <i class="codicon codicon-close"></i>
-            </button>
-          </div>`;
-      })
-      .join('');
+    tabsContainer.innerHTML = '';
+    streams.forEach((stream) => {
+      if (!stream || typeof stream !== 'string') {
+        console.warn('StreamTabs.update: invalid stream value:', stream);
+        return;
+      }
+      const tabEl = createFromTemplate('streamTabTemplate', {
+        text: { '.tab': stream },
+        attributes: {
+          '.tab': { title: stream },
+          '.tab-delete': { title: 'Delete stream' },
+        },
+        dataset: { '.tab': { stream }, '.tab-delete': { stream } },
+      });
+      if (!tabEl) return;
+      if (stream === activeStream) tabEl.classList.add('active');
+      tabEl.title = stream;
+      tabsContainer.appendChild(tabEl);
+    });
 
     // Update active stream name
     const streamNameElem = document.getElementById(

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -2,6 +2,7 @@
 import { progressViewState } from './progressViewState.js';
 import { formatTokens, BULLET_MARKUP, TaskGroupLevel } from './formatters.js';
 import { ELEMENT_IDS } from './constants.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Manages usage summary display.
@@ -89,9 +90,11 @@ export class UsageGroup {
     // Find or create usage display element in the group header
     let usageElem = groupHeader.querySelector('.group-usage');
     if (!usageElem) {
-      usageElem = document.createElement('span');
-      usageElem.className = 'group-usage';
-
+      usageElem = createFromTemplate('usageTemplate');
+      if (!usageElem) {
+        console.error('UsageGroup.update: usageTemplate not found');
+        return;
+      }
       // Determine the group level by checking for the 'top-level' class
       const level = groupHeader.classList.contains('top-level')
         ? TaskGroupLevel.ROOT
@@ -99,16 +102,23 @@ export class UsageGroup {
       this.insertUsageElement(groupHeader, usageElem, level);
     }
 
+    if (!usageElem) return;
+
+    const inputEl = usageElem.querySelector('.usage-input');
+    const outputEl = usageElem.querySelector('.usage-output');
+    const costEl = usageElem.querySelector('.usage-cost');
+
     if (!usage) {
-      usageElem.textContent = '';
+      if (inputEl) inputEl.textContent = '';
+      if (outputEl) outputEl.textContent = '';
+      if (costEl) costEl.textContent = '';
       return;
     }
 
     const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
-    usageElem.innerHTML =
-      `<i class="codicon codicon-arrow-up"></i> ${formatTokens(inputTokens)}, ` +
-      `<i class="codicon codicon-arrow-down"></i> ${formatTokens(outputTokens)}, ` +
-      `$${cost.toFixed(3)}`;
+    if (inputEl) inputEl.textContent = formatTokens(inputTokens);
+    if (outputEl) outputEl.textContent = formatTokens(outputTokens);
+    if (costEl) costEl.textContent = cost.toFixed(3);
 
     // Persist usage on the group state so the summary can be computed
     const group = progressViewState.taskGroups.get(groupId);
@@ -182,29 +192,37 @@ export class UsageGroup {
 
     let bulletElem = groupHeader.querySelector('.group-bullet');
     if (!bulletElem) {
-      const tmpl = document.createElement('template');
-      tmpl.innerHTML = BULLET_MARKUP;
-      bulletElem = tmpl.content.firstElementChild;
+      bulletElem = createFromTemplate('bulletTemplate');
     }
+
+    // If bullet template is missing, skip adding it
+    const hasBullet = !!bulletElem;
 
     if (timeContainer) {
       if (level.headerOrder === 'time-first') {
         // For root level groups: time comes first, then usage
-        timeContainer.parentNode.insertBefore(
-          bulletElem,
-          timeContainer.nextSibling,
-        );
+        if (hasBullet) {
+          timeContainer.parentNode.insertBefore(
+            bulletElem,
+            timeContainer.nextSibling,
+          );
+        }
         timeContainer.parentNode.insertBefore(
           usageElem,
-          bulletElem.nextSibling,
+          hasBullet ? bulletElem.nextSibling : timeContainer.nextSibling,
         );
       } else {
         // For nested groups: usage comes first, then time
         groupHeader.insertBefore(usageElem, timeContainer);
-        groupHeader.insertBefore(bulletElem, timeContainer);
+        if (hasBullet) {
+          groupHeader.insertBefore(bulletElem, timeContainer);
+        }
       }
     } else {
       groupHeader.appendChild(usageElem);
+      if (hasBullet) {
+        groupHeader.appendChild(bulletElem);
+      }
     }
   }
 }

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -3,6 +3,7 @@ import { messageHandler } from './modules/messageHandlers.js';
 import { progressViewDomHandler } from './modules/domHandlers.js';
 import { vscode } from '@common/webviewContext.js';
 import { COMMANDS } from './modules/constants.js';
+import { validateTemplates } from '@common/templateUtils.js';
 
 // Initialize the state when the window loads
 progressViewState.initialize();
@@ -16,6 +17,14 @@ window.addEventListener('beforeunload', () => {
 
 // Initialize event listeners and state when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
+  validateTemplates([
+    'fileItemTemplate',
+    'iconButtonTemplate',
+    'usageTemplate',
+    'bulletTemplate',
+    'streamTabTemplate',
+    'roundHeaderTemplate',
+  ]);
   progressViewDomHandler.toolbar.render();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();


### PR DESCRIPTION
## Summary
- add templates for usage, bullet, stream tab, and round headers
- render stream tabs, file rounds, and usage info from templates
- validate templates on load
- handle missing usage template and bullet icon

## Testing
- `npm run format`
- `npm run lint` (with warnings)
- `npm test` (webpack compiled with a warning)


------
https://chatgpt.com/codex/tasks/task_e_6866df24dd888324a6cda5c4478e665e