### PR TITLE
feat: show diff error tooltips

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -34,11 +34,16 @@ export class LatexDiffManager {
       );
     } else {
       if (result.message && result.message.includes('document environment')) {
-        this.logger.debug(`Skipping ${operation}: ${result.message}`, groupId);
+        this.logger.debug(
+          `Skipping ${operation}: ${result.message}`,
+          groupId,
+          MESSAGE_TYPES.INTERNAL,
+        );
       } else {
         this.logger.warn(
           `Failed to generate ${operation}: ${result.message}`,
           groupId,
+          MESSAGE_TYPES.INTERNAL,
         );
       }
     }
@@ -54,6 +59,7 @@ export class LatexDiffManager {
       revised: string;
       output: string;
       status: 'success' | 'error';
+      message?: string;
     }> = [];
 
     try {
@@ -117,6 +123,7 @@ export class LatexDiffManager {
               ? path.join(path.dirname(baseFile), result.diffFileName)
               : '',
             status: result.success ? 'success' : 'error',
+            message: result.success ? undefined : result.message,
           });
           if (result.success && result.diffFileName) {
             const diffPath = path.join(
@@ -179,6 +186,7 @@ export class LatexDiffManager {
               ? path.join(path.dirname(prevOutputFile), result.diffFileName)
               : '',
             status: result.success ? 'success' : 'error',
+            message: result.success ? undefined : result.message,
           });
           if (result.success && result.diffFileName) {
             const diffPath = path.join(

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -10,7 +10,10 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { objectToLogString } from '@utils/text/stringUtils';
 
 // Local imports - utilities
-import { logErrorMessage } from '@common/errors/errorHandlingUtils';
+import {
+  logErrorMessage,
+  formatError,
+} from '@common/errors/errorHandlingUtils';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
 
@@ -136,14 +139,13 @@ export class LaTeXdiffService {
         message: `LaTeXdiff completed successfully: ${diffFileName}`,
       };
     } catch (err) {
-      const message = logErrorMessage(
-        this.channel,
-        'Error running LaTeX diff',
-        err,
-      );
+      const message = formatError('Error running LaTeX diff', err);
+      logger.error(this.channel, message, undefined, MESSAGE_TYPES.INTERNAL);
       logger.debug(
         this.channel,
         `Latexdiff failed: ${inputFile} -> ${editedFile}`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
       );
       return { success: false, message };
     }
@@ -178,11 +180,8 @@ export class LaTeXdiffService {
         message: `LaTeXdiff VC completed successfully: ${path.basename(diffFileName)}`,
       };
     } catch (err) {
-      const message = logErrorMessage(
-        this.channel,
-        'Error running LaTeX diff VC',
-        err,
-      );
+      const message = formatError('Error running LaTeX diff VC', err);
+      logger.error(this.channel, message, undefined, MESSAGE_TYPES.INTERNAL);
       return { success: false, message };
     }
   }
@@ -239,11 +238,8 @@ export class LaTeXdiffService {
         message: summary,
       };
     } catch (err) {
-      const message = logErrorMessage(
-        this.channel,
-        'Error in runDiffVcMultiple',
-        err,
-      );
+      const message = formatError('Error in runDiffVcMultiple', err);
+      logger.error(this.channel, message, undefined, MESSAGE_TYPES.INTERNAL);
       return {
         success: false,
         results: { success: [], failed: [] },
@@ -269,11 +265,8 @@ export class LaTeXdiffService {
       logger.warn(this.channel, message);
       return { success: false, message };
     } catch (err) {
-      const message = logErrorMessage(
-        this.channel,
-        'Error in runDiffForRound',
-        err,
-      );
+      const message = formatError('Error in runDiffForRound', err);
+      logger.error(this.channel, message, undefined, MESSAGE_TYPES.INTERNAL);
       return { success: false, message };
     }
   }
@@ -306,11 +299,8 @@ export class LaTeXdiffService {
       logger.warn(this.channel, message);
       return { success: false, message };
     } catch (err) {
-      const message = logErrorMessage(
-        this.channel,
-        'Error in runDiffBetweenRounds',
-        err,
-      );
+      const message = formatError('Error in runDiffBetweenRounds', err);
+      logger.error(this.channel, message, undefined, MESSAGE_TYPES.INTERNAL);
       return { success: false, message };
     }
   }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -401,6 +401,7 @@ export class LogEntryFormatter {
         const basePath = String(d.base ?? '');
         const revisedPath = String(d.revised ?? '');
         const outputPath = String(d.output ?? '');
+        const message = d.message ? String(d.message) : '';
 
         const baseEsc = this._escapeHtml(basePath);
         const revisedEsc = this._escapeHtml(revisedPath);
@@ -416,7 +417,11 @@ export class LogEntryFormatter {
           icon = 'codicon-error';
         }
 
-        items += `<li><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${baseEsc}">${this._escapeHtml(
+        const titleAttr = message
+          ? ` title="${this._escapeHtml(message)}"`
+          : '';
+
+        items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${this._escapeHtml(
           baseName,
         )}</span> &rarr; <span class="file-link clickable-link" data-file="${revisedEsc}">${this._escapeHtml(
           revisedName,


### PR DESCRIPTION
## Summary
- hide LaTeXdiff warnings from the progress log
- carry diff error messages with results
- surface diff errors via tooltip in the progress view

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warning, webpack compiled with warning)*

------
https://chatgpt.com/codex/tasks/task_e_6867ace780d083249f7c1a19604433c7