### PR TITLE
feat: leverage mime-types library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "identifiers-arxiv": "^0.1.1",
         "katex": "^0.16.22",
         "markdown-it": "^14.1.0",
+        "mime-types": "^3.0.1",
         "node-pandoc": "^0.3.0",
         "openai": "^5.8.3",
         "pdf2pic": "^3.2.0",
@@ -39,6 +40,7 @@
         "@types/diff-match-patch": "^1.0.36",
         "@types/difflib": "^0.2.7",
         "@types/identifiers-arxiv": "^0.1.2",
+        "@types/mime-types": "^3.0.1",
         "@types/mocha": "^10.0.6",
         "@types/node": "^22.13.17",
         "@types/nunjucks": "^3.2.5",
@@ -730,6 +732,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1150,7 +1150,8 @@
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.27.0",
     "webpack": "^5.91.0",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "@types/mime-types": "^3.0.1"
   },
   "repository": {
     "type": "git",
@@ -1197,6 +1198,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.16.22",
     "markdown-it": "^14.1.0",
+    "mime-types": "^3.0.1",
     "node-pandoc": "^0.3.0",
     "openai": "^5.8.3",
     "pdf2pic": "^3.2.0",

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import { WorkspaceFS, AbsoluteFS } from '@utils/files';
+import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   getBase64EncodedMedia,
@@ -268,16 +268,8 @@ export abstract class ModelHandler<U = any, R = any>
 
   /** Determine if extension corresponds to an audio format. */
   private isAudio(ext: string): boolean {
-    return [
-      '.wav',
-      '.m4a',
-      '.mp3',
-      '.mpeg',
-      '.aiff',
-      '.aac',
-      '.ogg',
-      '.flac',
-    ].includes(ext.toLowerCase());
+    const mimeType = getMimeType(ext);
+    return mimeType !== null && mimeType.startsWith('audio/');
   }
 
   /**
@@ -288,16 +280,6 @@ export abstract class ModelHandler<U = any, R = any>
     mediaFile: string,
     ext: string,
   ): Promise<[string | string[], string, 'image']> {
-    const imageMediaTypes: { [key: string]: string } = {
-      '.jpg': 'image/jpeg',
-      '.jpeg': 'image/jpeg',
-      '.png': 'image/png',
-      '.webp': 'image/webp',
-      '.heic': 'image/heic',
-      '.heif': 'image/heif',
-      '.gif': 'image/gif',
-    };
-
     let mediaType: string;
     let mediaData: string | string[];
 
@@ -338,16 +320,19 @@ export abstract class ModelHandler<U = any, R = any>
       } else {
         mediaData = pdfResult;
       }
-    } else if (ext in imageMediaTypes) {
-      mediaType = imageMediaTypes[ext];
-      this.logger.debug(
-        `Processing as image: ${mediaFile}, type: ${mediaType}`,
-      );
-      mediaData = await getBase64EncodedMedia(mediaFile);
     } else {
-      throw new Error(
-        `Unsupported image extension: ${ext}. Image support: ${this.capabilities.supportsVision}`,
-      );
+      const mimeType = getMimeType(mediaFile);
+      if (mimeType && mimeType.startsWith('image/')) {
+        mediaType = mimeType;
+        this.logger.debug(
+          `Processing as image: ${mediaFile}, type: ${mediaType}`,
+        );
+        mediaData = await getBase64EncodedMedia(mediaFile);
+      } else {
+        throw new Error(
+          `Unsupported image extension: ${ext}. Image support: ${this.capabilities.supportsVision}`,
+        );
+      }
     }
 
     return [mediaData, mediaType, 'image'];
@@ -358,24 +343,18 @@ export abstract class ModelHandler<U = any, R = any>
     mediaFile: string,
     ext: string,
   ): Promise<[string, string, 'audio']> {
-    const audioMediaTypes: { [key: string]: string } = {
-      '.wav': 'audio/wav',
-      '.m4a': 'audio/m4a',
-      '.mp3': 'audio/mp3',
-      '.mpeg': 'audio/mpeg',
-      '.aiff': 'audio/aiff',
-      '.aac': 'audio/aac',
-      '.ogg': 'audio/ogg',
-      '.flac': 'audio/flac',
-    };
-
-    if (!(ext in audioMediaTypes) || !this.capabilities.supportsNativeAudio) {
+    const mimeType = getMimeType(mediaFile);
+    if (
+      !mimeType ||
+      !mimeType.startsWith('audio/') ||
+      !this.capabilities.supportsNativeAudio
+    ) {
       throw new Error(
         `Unsupported or disabled audio extension: ${ext}. Audio support: ${this.capabilities.supportsNativeAudio}`,
       );
     }
 
-    const mediaType = audioMediaTypes[ext];
+    const mediaType = mimeType;
     this.logger.debug(`Processing as audio: ${mediaFile}, type: ${mediaType}`);
     let mediaData = await getBase64EncodedMedia(mediaFile);
     if (Array.isArray(mediaData)) {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -34,7 +34,7 @@ import type { ToolDefinition } from '@model';
 import { toGoogleTools } from './toolConversion';
 
 // Local imports - utilities
-import { WorkspaceFS, AbsoluteFS } from '@utils/files';
+import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
 import { formatProviderError } from '@common/errors/sdkErrorUtils';
 import xmlUtils from '@utils/text/xmlUtils';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
@@ -460,31 +460,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       `Determining MIME type for extension: '${ext}' from file: ${filePath}`,
     );
 
-    // TODO: this map/function can be put somewhere else to be more DRY and reusable
-    const mimeMap: { [key: string]: string } = {
-      '.jpg': 'image/jpeg',
-      '.jpeg': 'image/jpeg',
-      '.png': 'image/png',
-      '.webp': 'image/webp',
-      '.heic': 'image/heic',
-      '.heif': 'image/heif',
-      '.gif': 'image/gif',
-      '.pdf': 'application/pdf',
-      '.wav': 'audio/wav',
-      '.mp3': 'audio/mpeg',
-      '.aac': 'audio/aac',
-      '.ogg': 'audio/ogg',
-      '.oga': 'audio/ogg',
-      '.flac': 'audio/flac',
-      '.opus': 'audio/opus',
-      '.m4a': 'audio/m4a',
-      '.mp4': 'video/mp4',
-      '.mov': 'video/quicktime',
-      '.avi': 'video/x-msvideo',
-      '.webm': 'video/webm',
-      '.mpeg': 'video/mpeg',
-    };
-    const mimeType = mimeMap[ext];
+    const mimeType = getMimeType(filePath);
     if (!mimeType) {
       this.logger.warn(
         `Cannot determine mime type for ${filePath} from extension '${ext}'.`,
@@ -494,7 +470,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         `Determined MIME type: ${mimeType} for file: ${filePath}`,
       );
     }
-    return mimeType || null;
+    return mimeType;
   }
 
   /** Creates message array for subsequent rounds, managing image content and message structure. */

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -6,3 +6,4 @@ export * from './pastedImageUtils';
 export * from './baseFileUtils';
 export * from './fileMappingUtils';
 export * from './pathUtils';
+export * from './mimeUtils';

--- a/src/utils/files/mimeUtils.ts
+++ b/src/utils/files/mimeUtils.ts
@@ -1,0 +1,11 @@
+// Third-party imports
+import mime from 'mime-types';
+
+/**
+ * Determine the MIME type for a file path or extension.
+ * Returns null when the type cannot be resolved.
+ */
+export function getMimeType(filePath: string): string | null {
+  const mimeType = mime.lookup(filePath);
+  return typeof mimeType === 'string' ? mimeType : null;
+}


### PR DESCRIPTION
## Summary
- add `mime-types` and typings
- create a helper for mime type lookup
- use the helper in `ModelHandler` and `modelHandlerGoogleGenAI`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687230463b7483248c480f84580ba8d6