### PR TITLE
Use axios for arXiv file downloads

### DIFF
--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -46,11 +46,16 @@ export class ArxivSourceProcessor {
     return null;
   }
 
-  public async downloadFile(url: string, destPath: string): Promise<void> {
+  public async downloadFile(
+    url: string,
+    destPath: string,
+    timeout = 30000,
+  ): Promise<void> {
     try {
       const response = await axios.get(url, {
         responseType: 'stream',
         validateStatus: () => true,
+        timeout,
       });
 
       if (response.status === 404) {

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -48,7 +48,10 @@ export class ArxivSourceProcessor {
 
   public async downloadFile(url: string, destPath: string): Promise<void> {
     try {
-      const response = await axios.get(url, { responseType: 'stream' });
+      const response = await axios.get(url, {
+        responseType: 'stream',
+        validateStatus: () => true,
+      });
 
       if (response.status === 404) {
         throw new Error('Source not available for this arXiv ID');

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -1,6 +1,7 @@
 // Standard library imports
 import * as path from 'path';
-import * as https from 'https';
+import axios from 'axios';
+import { pipeline } from 'node:stream/promises';
 
 // Third-party imports
 import * as arxivIdentifiers from 'identifiers-arxiv';
@@ -45,36 +46,30 @@ export class ArxivSourceProcessor {
     return null;
   }
 
-  public downloadFile(url: string, destPath: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const file = AbsoluteFS.createWriteStream(destPath);
+  public async downloadFile(url: string, destPath: string): Promise<void> {
+    try {
+      const response = await axios.get(url, { responseType: 'stream' });
 
-      https
-        .get(url, (response) => {
-          if (response.statusCode === 404) {
-            reject(new Error('Source not available for this arXiv ID'));
-            return;
-          }
+      if (response.status === 404) {
+        throw new Error('Source not available for this arXiv ID');
+      }
 
-          if (response.statusCode !== 200) {
-            reject(
-              new Error(`Failed to download: HTTP ${response.statusCode}`),
-            );
-            return;
-          }
+      if (response.status !== 200) {
+        throw new Error(`Failed to download: HTTP ${response.status}`);
+      }
 
-          response.pipe(file);
-
-          file.on('finish', () => {
-            file.close();
-            resolve();
-          });
-        })
-        .on('error', (err) => {
-          AbsoluteFS.unlink(destPath, () => {});
-          reject(err);
-        });
-    });
+      await pipeline(
+        response.data as NodeJS.ReadableStream,
+        AbsoluteFS.createWriteStream(destPath),
+      );
+    } catch (err) {
+      try {
+        await AbsoluteFS.delete(destPath);
+      } catch {
+        // ignore errors deleting destPath
+      }
+      throw err;
+    }
   }
 
   public async extractTarFile(


### PR DESCRIPTION
## Summary
- simplify `ArxivSourceProcessor.downloadFile` using axios and stream pipeline

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687237d299848324bc8e86fd58710196