### PR TITLE
Load env vars from dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ After installing the extension, you can configure your API keys in VS Code setti
 - Gemini API key
 - Other (xAI, deepseek, OpenRouter, Qwen, Kimi, etc.) API keys
 
+You can store these keys in a `.env` file in your workspace using variables like `OPENAI_API_KEY`. TeXRA loads this file automatically at startup.
+
 ## Required Dependencies
 
 TeXRA requires several system dependencies for full functionality. See the [**Installation Guide**](https://texra.ai/guide/installation.html) in the full documentation for detailed setup instructions for your operating system.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -170,6 +170,8 @@ TeXRA requires API keys to access language models. Here's how to set them up:
 
 Alternatively, you can access the extension settings (including API key setup) by clicking the gear icon (<i class="codicon codicon-gear"></i>) in the TeXRA webview panel.
 
+TeXRA also loads environment variables from a `.env` file in your workspace. Define variables like `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` in this file to avoid entering keys manually.
+
 ![API Key Setup](/images/api-key-setup.png)
 
 ::: info Getting API Keys

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -21,6 +21,8 @@ Before you can use TeXRA's AI features, you need to provide API keys for the ser
 
 Repeat this process for each AI provider you plan to use with TeXRA.
 
+You can also place a `.env` file in your workspace with variables like `OPENAI_API_KEY`. TeXRA loads this automatically so you don't need to enter keys every time.
+
 ## Basic Workflow
 
 The typical TeXRA workflow consists of these steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cross-spawn": "^7.0.6",
         "diff-match-patch": "^1.0.5",
         "difflib": "^0.2.4",
+        "dotenv": "^16.4.5",
         "fast-xml-parser": "^5.2.5",
         "glob": "^11.0.3",
         "gpt-tokenizer": "^3.0.1",
@@ -2289,6 +2290,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -1194,6 +1194,7 @@
     "difflib": "^0.2.4",
     "fast-xml-parser": "^5.2.5",
     "glob": "^11.0.3",
+    "dotenv": "^16.4.5",
     "gpt-tokenizer": "^3.0.1",
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.16.22",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,9 +25,15 @@ import { registerCommands } from './commands';
 
 export async function activate(context: vscode.ExtensionContext) {
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-  dotenv.config({
-    path: path.join(workspaceRoot ?? context.extensionPath, '.env'),
-  });
+  
+  // Load .env file only if a workspace is open
+  if (workspaceRoot) {
+    dotenv.config({
+      path: path.join(workspaceRoot, '.env'),
+    });
+  } else {
+    logger.warn('extension', 'No workspace folder is open. Skipping .env loading.');
+  }
 
   // Initialize storage systems
   SecretManager.initialize(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,9 @@
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import * as vscode from 'vscode';
+import dotenv from 'dotenv';
 
 // Local imports - core
 import * as logger from '@logger/logUtils';
@@ -20,6 +24,11 @@ import { WatcherManager } from './explorer/WatcherManager';
 import { registerCommands } from './commands';
 
 export async function activate(context: vscode.ExtensionContext) {
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+  dotenv.config({
+    path: path.join(workspaceRoot ?? context.extensionPath, '.env'),
+  });
+
   // Initialize storage systems
   SecretManager.initialize(context);
   StorageFS.initialize(context);
@@ -46,7 +55,6 @@ export async function activate(context: vscode.ExtensionContext) {
   registerCommands(context);
 
   // Register the folder explorer with context
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
   const folderExplorer = new FolderExplorer(workspaceRoot, context);
   const explorerOps = new ExplorerOperations(workspaceRoot, context, () =>
     folderExplorer.refresh(),


### PR DESCRIPTION
## Summary
- load `.env` in extension activation
- add dotenv dependency
- document `.env` support in docs and README

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test cannot run in container)*

------
https://chatgpt.com/codex/tasks/task_e_6872398dc2c883248c5e63604b843492