### PR TITLE
Refactor log HTML escaping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "fast-xml-parser": "^5.2.5",
         "glob": "^11.0.3",
         "gpt-tokenizer": "^3.0.1",
+        "he": "^1.2.0",
         "identifiers-arxiv": "^0.1.1",
         "katex": "^0.16.22",
         "markdown-it": "^14.1.0",
@@ -41,6 +42,7 @@
         "@types/cross-spawn": "^6.0.6",
         "@types/diff-match-patch": "^1.0.36",
         "@types/difflib": "^0.2.7",
+        "@types/he": "^1.2.3",
         "@types/identifiers-arxiv": "^0.1.2",
         "@types/mime-types": "^3.0.1",
         "@types/mocha": "^10.0.6",
@@ -726,6 +728,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/he": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
+      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3446,7 +3455,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "he": "bin/he"

--- a/package.json
+++ b/package.json
@@ -1136,6 +1136,7 @@
     "@types/nunjucks": "^3.2.5",
     "@types/shell-quote": "^1.7.5",
     "@types/vscode": "^1.93.0",
+    "@types/he": "^1.2.3",
     "@typescript-eslint/eslint-plugin": "^8.27.0",
     "@typescript-eslint/parser": "^8.27.0",
     "@vscode/test-cli": "^0.0.10",
@@ -1206,6 +1207,7 @@
     "pdf2pic": "^3.2.0",
     "sortablejs": "^1.15.6",
     "split.js": "^1.6.5",
+    "he": "^1.2.0",
     "tar": "^7.4.3",
     "winston": "^3.17.0",
     "yaml": "^2.8.0"

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 // Local imports
 import { emitProgress } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import { escapeHtml } from '@logger/logUtils';
+import { encodeHtml } from 'he';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 /**
@@ -12,7 +12,7 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
  * @param content - The text to wrap.
  * @param type - The message type value.
  */
-const escapeContent = (content: string): string => escapeHtml(content);
+const escapeContent = (content: string): string => encodeHtml(content);
 
 export async function streamReasoningToProgressView<T>(
   stream: AsyncIterable<T>,

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 // Local imports
 import { emitProgress } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import { encodeHtml } from 'he';
+import { encode as encodeHtml } from 'he';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 /**

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 import * as winston from 'winston';
 import Transport from 'winston-transport';
+import { encode as encodeHtml, decode as decodeHtml } from 'he';
 import { randomUUID } from 'crypto';
 
 // Local imports - progressView
@@ -44,22 +45,12 @@ export function getColorForLevel(level: string): string {
 
 // Helper function to escape HTML tags
 export function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
+  return encodeHtml(text);
 }
 
 // Helper function to unescape HTML tags
 export function unescapeHtml(text: string): string {
-  return text
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#039;/g, "'")
-    .replace(/&amp;/g, '&');
+  return decodeHtml(text);
 }
 
 // Main TeXRA output channel for non-agent logs

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -43,15 +43,6 @@ export function getColorForLevel(level: string): string {
 
 // Group State
 
-// Helper function to escape HTML tags
-export function escapeHtml(text: string): string {
-  return encodeHtml(text);
-}
-
-// Helper function to unescape HTML tags
-export function unescapeHtml(text: string): string {
-  return decodeHtml(text);
-}
 
 // Main TeXRA output channel for non-agent logs
 let mainOutputChannel: vscode.OutputChannel | null = null;
@@ -128,7 +119,7 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    const processedMessage = escapeHtml(message);
+    const processedMessage = encodeHtml(message);
 
     const msgType: MessageType = isValidMessageType(messageType)
       ? messageType


### PR DESCRIPTION
## Summary
- use `he` library for HTML entity encoding/decoding
- add `he` and `@types/he` dependencies

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails to print result due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_687249d3bb888324b4d2aa12cf409943