### PR TITLE
Replace custom merging with deepmerge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@vscode/markdown-it-katex": "^1.1.1",
         "axios": "^1.10.0",
         "cross-spawn": "^7.0.6",
+        "deepmerge": "^4.3.1",
         "diff-match-patch": "^1.0.5",
         "difflib": "^0.2.4",
         "fast-xml-parser": "^5.2.5",
@@ -2276,6 +2277,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1191,6 +1191,7 @@
     "@vscode/markdown-it-katex": "^1.1.1",
     "axios": "^1.10.0",
     "cross-spawn": "^7.0.6",
+    "deepmerge": "^4.3.1",
     "diff-match-patch": "^1.0.5",
     "difflib": "^0.2.4",
     "fast-xml-parser": "^5.2.5",

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
+import deepmerge from 'deepmerge';
 
 // Local imports - agent components
 import {
@@ -49,34 +50,6 @@ export async function loadYaml(absolutePath: string): Promise<object> {
   }
 }
 
-/** Recursively merges two dictionaries with override values. */
-export function mergeDicts(
-  base: { [key: string]: any },
-  override: { [key: string]: any },
-): { [key: string]: any } {
-  try {
-    const result = { ...base };
-    for (const [key, value] of Object.entries(override)) {
-      if (
-        value &&
-        typeof value === 'object' &&
-        !Array.isArray(value) &&
-        key in result
-      ) {
-        result[key] = mergeDicts(result[key], value);
-      } else {
-        result[key] = value;
-      }
-    }
-    return result;
-  } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error merging dictionaries: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    throw err;
-  }
-}
-
 /**
  * Loads agent settings and prompts with inheritance support.
  * Merges with parent configurations if specified in the inherits field.
@@ -117,17 +90,23 @@ export async function loadAgentSettingAndPrompts(
       const agentOwnPrompts = (config?.prompts || {}) as Partial<AgentPrompt>;
 
       // Merge with parent settings and prompts
-      settings = mergeDicts(parentSettings, agentOwnSettings);
-      prompts = mergeDicts(parentPrompts, agentOwnPrompts);
+      settings = deepmerge(parentSettings, agentOwnSettings, {
+        arrayMerge: (_d, s) => s,
+      });
+      prompts = deepmerge(parentPrompts, agentOwnPrompts, {
+        arrayMerge: (_d, s) => s,
+      });
     } else {
       // No inheritance, use current agent's settings and prompts directly, merged with defaults
-      settings = mergeDicts(
+      settings = deepmerge(
         DEFAULT_AGENT_SETTINGS, // DEFAULT_AGENT_SETTINGS no longer has a 'name' property
         (config?.settings || {}) as Partial<AgentSetting>,
+        { arrayMerge: (_d, s) => s },
       );
-      prompts = mergeDicts(
+      prompts = deepmerge(
         DEFAULT_AGENT_PROMPTS,
         (config?.prompts || {}) as Partial<AgentPrompt>,
+        { arrayMerge: (_d, s) => s },
       );
     }
 


### PR DESCRIPTION
## Summary
- remove manual `mergeDicts` function
- use `deepmerge` with array overwrite when loading agent configs
- add `deepmerge` dependency

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency warnings from webpack but test harness exits without error)*

------
https://chatgpt.com/codex/tasks/task_e_68724f589a8c8324b771b201e34edd97