### PR TITLE
Refactor ID generation with nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "katex": "^0.16.22",
         "markdown-it": "^14.1.0",
         "mime-types": "^3.0.1",
+        "nanoid": "^5.1.5",
         "node-pandoc": "^0.3.0",
         "openai": "^5.8.3",
         "pdf2pic": "^3.2.0",
@@ -4604,6 +4605,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1202,6 +1202,7 @@
     "katex": "^0.16.22",
     "markdown-it": "^14.1.0",
     "mime-types": "^3.0.1",
+    "nanoid": "^5.1.5",
     "node-pandoc": "^0.3.0",
     "openai": "^5.8.3",
     "pdf2pic": "^3.2.0",

--- a/src/frontend/nonce.ts
+++ b/src/frontend/nonce.ts
@@ -1,15 +1,13 @@
+// Third-party imports
+import { nanoid } from 'nanoid';
+
 // Utility functions for frontend
 
 /**
  * Generate a nonce string for Webview content security policies.
  * @param length Length of the generated nonce
  */
+
 export function generateNonce(length = 32): string {
-  const possible =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let text = '';
-  for (let i = 0; i < length; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
+  return nanoid(length);
 }

--- a/src/utils/files/pastedImageUtils.ts
+++ b/src/utils/files/pastedImageUtils.ts
@@ -1,6 +1,9 @@
 // Standard library imports
 import * as path from 'path';
 
+// Third-party imports
+import { nanoid } from 'nanoid';
+
 // Local imports
 import { StorageFS } from './storageFS';
 
@@ -36,6 +39,6 @@ export function getPastedImageDisplayName(fullPath: string): string {
  */
 export function generatePastedImageName(extension: string): string {
   const timestamp = Date.now();
-  const random = Math.random().toString(16).slice(2, 8);
+  const random = nanoid(6);
   return `${PASTED_PREFIX}${timestamp}_${random}.${extension}`;
 }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -35,7 +35,8 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
-          "sortablejs": "https://cdn.skypack.dev/sortablejs"
+          "sortablejs": "https://cdn.skypack.dev/sortablejs",
+          "nanoid": "https://cdn.skypack.dev/nanoid"
         }
       }
     </script>

--- a/src/webview/modules/pasteHandler.js
+++ b/src/webview/modules/pasteHandler.js
@@ -1,5 +1,6 @@
 // Image paste handling utilities
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { nanoid } from 'nanoid';
 
 // Comprehensive MIME type to extension mapping
 export const IMAGE_MIME_TYPES = {
@@ -35,7 +36,7 @@ export const IMAGE_MIME_TYPES = {
  */
 export function generatePastedImageName(extension) {
   const timestamp = Date.now();
-  const random = Math.random().toString(16).slice(2, 8);
+  const random = nanoid(6);
   return `pasted_${timestamp}_${random}.${extension}`;
 }
 


### PR DESCRIPTION
## Summary
- install `nanoid`
- use `nanoid` in `generatePastedImageName`
- use `nanoid` in `generateNonce`
- use `nanoid` for webview paste filenames
- map `nanoid` in main view import map

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: output truncated but no errors shown)*

------
https://chatgpt.com/codex/tasks/task_e_68725edf61c08324bd94fd0f161fc6ad