### PR TITLE
Switch to Zod defaults

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -1,5 +1,9 @@
 // Local imports - agent components
-import { ToolConfig, ToolConfigSchema } from './ToolConfig';
+import {
+  ToolConfig,
+  ToolConfigSchema,
+  DEFAULT_TOOL_CONFIG,
+} from './ToolConfig';
 import { z } from 'zod';
 
 /** Configuration interface for controlling agent execution and file handling. */
@@ -26,50 +30,12 @@ export interface AgentConfig {
 }
 
 /**
- * Default configuration for task execution and tool usage
- */
-export const DEFAULT_AGENT_CONFIG: AgentConfig = {
-  model: 'gemini25p',
-  agent: 'correct',
-  instruction: '',
-  inputFile: '',
-  inputFiles: [],
-  referenceFile: null,
-  referenceFiles: [],
-  auxiliaryFile: null,
-  auxiliaryFiles: [],
-  mediaFile: null,
-  mediaFiles: [],
-  outputFiles: null,
-  editedFile: null,
-  toolConfig: {
-    reflect: false,
-    usePrefillFromInput: false,
-    autoExtractFigure: false,
-    autoExtractTikzFigure: false,
-    attachTeXCount: false,
-    printInputPrompt: false,
-    autoCompileInputPdf: false,
-  },
-};
-
-/**
  * Creates a complete AgentConfig by merging partial config with defaults.
  * @param config Partial configuration to merge with defaults
  * @returns Complete AgentConfig with all fields populated
  */
 export function createAgentConfig(config: Partial<AgentConfig>): AgentConfig {
-  // Merge provided config with defaults, ensuring nested toolConfig is merged deeply
-  const mergedToolConfig: ToolConfig = {
-    ...DEFAULT_AGENT_CONFIG.toolConfig,
-    ...(config.toolConfig ?? {}),
-  };
-
-  return {
-    ...DEFAULT_AGENT_CONFIG,
-    ...config,
-    toolConfig: mergedToolConfig,
-  };
+  return AgentConfigSchema.parse(config);
 }
 
 /**
@@ -85,24 +51,24 @@ export const validateOutputFiles = (cfg: AgentConfig): boolean => {
 };
 
 /** Zod schema for validating AgentConfig objects */
-export const AgentConfigSchema: z.ZodSchema<AgentConfig> = z
+export const AgentConfigSchema = z
   .object({
-    model: z.string(),
-    agent: z.string(),
-    instruction: z.string(),
+    model: z.string().default('gemini25p'),
+    agent: z.string().default('correct'),
+    instruction: z.string().default(''),
 
-    inputFile: z.string(),
-    inputFiles: z.array(z.string()).nullable(),
-    referenceFile: z.string().nullable(),
-    referenceFiles: z.array(z.string()).nullable(),
-    auxiliaryFile: z.string().nullable(),
-    auxiliaryFiles: z.array(z.string()).nullable(),
-    mediaFile: z.string().nullable(),
-    mediaFiles: z.array(z.string()).nullable(),
-    outputFiles: z.array(z.string()).nullable(),
-    editedFile: z.string().nullable(),
+    inputFile: z.string().default(''),
+    inputFiles: z.array(z.string()).nullable().default([]),
+    referenceFile: z.string().nullable().default(null),
+    referenceFiles: z.array(z.string()).nullable().default([]),
+    auxiliaryFile: z.string().nullable().default(null),
+    auxiliaryFiles: z.array(z.string()).nullable().default([]),
+    mediaFile: z.string().nullable().default(null),
+    mediaFiles: z.array(z.string()).nullable().default([]),
+    outputFiles: z.array(z.string()).nullable().default(null),
+    editedFile: z.string().nullable().default(null),
 
-    toolConfig: ToolConfigSchema,
+    toolConfig: ToolConfigSchema.default(DEFAULT_TOOL_CONFIG),
   })
   .strict()
   .refine(validateOutputFiles, {

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -15,13 +15,13 @@ export interface AgentConfig {
 
   // Input/Output configuration
   inputFile: string;
-  inputFiles: string[] | null;
+  inputFiles: string[];
   referenceFile: string | null;
-  referenceFiles: string[] | null;
+  referenceFiles: string[];
   auxiliaryFile: string | null;
-  auxiliaryFiles: string[] | null;
+  auxiliaryFiles: string[];
   mediaFile: string | null;
-  mediaFiles: string[] | null;
+  mediaFiles: string[];
   outputFiles: string[] | null;
   editedFile: string | null;
 
@@ -58,13 +58,13 @@ export const AgentConfigSchema = z
     instruction: z.string().default(''),
 
     inputFile: z.string().default(''),
-    inputFiles: z.array(z.string()).nullable().default([]),
+    inputFiles: z.array(z.string()).default([]),
     referenceFile: z.string().nullable().default(null),
-    referenceFiles: z.array(z.string()).nullable().default([]),
+    referenceFiles: z.array(z.string()).default([]),
     auxiliaryFile: z.string().nullable().default(null),
-    auxiliaryFiles: z.array(z.string()).nullable().default([]),
+    auxiliaryFiles: z.array(z.string()).default([]),
     mediaFile: z.string().nullable().default(null),
-    mediaFiles: z.array(z.string()).nullable().default([]),
+    mediaFiles: z.array(z.string()).default([]),
     outputFiles: z.array(z.string()).nullable().default(null),
     editedFile: z.string().nullable().default(null),
 

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -39,7 +39,7 @@ export const AgentSettingSchema = z
     defaultOutputFiles: z.array(z.string()).default([]),
     filePatternsContain: z.array(z.record(z.string())).default([]),
 
-    tools: z.array(ToolDefinitionSchema).optional(),
+    tools: z.array(ToolDefinitionSchema).optional().default([]),
   })
   .strict();
 

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -21,41 +21,27 @@ export const ToolDefinitionSchema = z
 /** Zod schema for AgentSetting validation */
 export const AgentSettingSchema = z
   .object({
-    agentType: z.nativeEnum(AgentType),
-    documentTag: z.string().min(1, 'documentTag cannot be empty'),
-    temperature: z.number().min(0).max(1).nullable(),
-    isRewrite: z.boolean(),
+    agentType: z.nativeEnum(AgentType).default(AgentType.CoT),
+    documentTag: z
+      .string()
+      .min(1, 'documentTag cannot be empty')
+      .default('document'),
+    temperature: z.number().min(0).max(1).nullable().default(0.0),
+    isRewrite: z.boolean().default(true),
 
-    rounds: z.number().optional(),
-    prefills: z.array(z.string()),
-    outputExt: z.string(),
-    endTag: z.string(),
+    rounds: z.number().optional().default(2),
+    prefills: z.array(z.string()).default([]),
+    outputExt: z.string().default('txt'),
+    endTag: z.string().default('</latex_document>'),
 
-    requiredFiles: z.record(z.string()),
-    requiredFilesInternal: z.record(z.string()),
-    defaultOutputFiles: z.array(z.string()),
-    filePatternsContain: z.array(z.record(z.string())),
+    requiredFiles: z.record(z.string()).default({}),
+    requiredFilesInternal: z.record(z.string()).default({}),
+    defaultOutputFiles: z.array(z.string()).default([]),
+    filePatternsContain: z.array(z.record(z.string())).default([]),
 
     tools: z.array(ToolDefinitionSchema).optional(),
   })
   .strict();
-
-/** Base configuration for agent behavior with default values. */
-export const DEFAULT_AGENT_SETTINGS: AgentSetting = {
-  agentType: AgentType.CoT,
-  documentTag: 'document',
-  temperature: 0.0,
-  rounds: 2,
-  prefills: [],
-  outputExt: 'txt',
-  endTag: '</latex_document>',
-  requiredFiles: {},
-  requiredFilesInternal: {},
-  defaultOutputFiles: [],
-  filePatternsContain: [],
-  tools: undefined,
-  isRewrite: true,
-};
 
 /** Default prompt templates for agent interactions. */
 export const DEFAULT_AGENT_PROMPTS: AgentPrompt = {

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -29,7 +29,7 @@ export const AgentSettingSchema = z
     temperature: z.number().min(0).max(1).nullable().default(0.0),
     isRewrite: z.boolean().default(true),
 
-    rounds: z.number().optional().default(2),
+    rounds: z.number().default(2),
     prefills: z.array(z.string()).default([]),
     outputExt: z.string().default('txt'),
     endTag: z.string().default('</latex_document>'),
@@ -39,7 +39,7 @@ export const AgentSettingSchema = z
     defaultOutputFiles: z.array(z.string()).default([]),
     filePatternsContain: z.array(z.record(z.string())).default([]),
 
-    tools: z.array(ToolDefinitionSchema).optional().default([]),
+    tools: z.array(ToolDefinitionSchema).default([]),
   })
   .strict();
 
@@ -60,7 +60,7 @@ export interface AgentSetting {
   isRewrite: boolean;
 
   /** Number of conversation rounds to run. */
-  rounds?: number;
+  rounds: number;
 
   /** Generation settings */
   prefills: string[];
@@ -74,7 +74,7 @@ export interface AgentSetting {
   filePatternsContain: Array<Record<string, string>>;
 
   /** Tool definitions available to the agent */
-  tools?: ToolDefinition[];
+  tools: ToolDefinition[];
 }
 
 /**

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -12,14 +12,25 @@ export interface ToolConfig {
 }
 
 /** Zod schema for validating ToolConfig objects */
+export const DEFAULT_TOOL_CONFIG: ToolConfig = {
+  reflect: false,
+  usePrefillFromInput: false,
+  autoExtractFigure: false,
+  autoExtractTikzFigure: false,
+  attachTeXCount: false,
+  printInputPrompt: false,
+  autoCompileInputPdf: false,
+};
+
 export const ToolConfigSchema = z
   .object({
-    reflect: z.boolean(),
-    usePrefillFromInput: z.boolean(),
-    autoExtractFigure: z.boolean(),
-    autoExtractTikzFigure: z.boolean(),
-    attachTeXCount: z.boolean(),
-    printInputPrompt: z.boolean(),
-    autoCompileInputPdf: z.boolean(),
+    reflect: z.boolean().default(false),
+    usePrefillFromInput: z.boolean().default(false),
+    autoExtractFigure: z.boolean().default(false),
+    autoExtractTikzFigure: z.boolean().default(false),
+    attachTeXCount: z.boolean().default(false),
+    printInputPrompt: z.boolean().default(false),
+    autoCompileInputPdf: z.boolean().default(false),
   })
-  .strict();
+  .strict()
+  .default(DEFAULT_TOOL_CONFIG);

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -96,8 +96,13 @@ export async function loadAgentSettingAndPrompts(
         arrayMerge: (_d, s) => s,
       });
     } else {
-      // No inheritance, use current agent's settings directly
-      settings = (config?.settings || {}) as Partial<AgentSetting>;
+      // No inheritance, merge with schema defaults by parsing empty object first
+      const baseSettings = AgentSettingSchema.parse({});
+      settings = deepmerge(
+        baseSettings,
+        (config?.settings || {}) as Partial<AgentSetting>,
+        { arrayMerge: (_d, s) => s },
+      );
       prompts = deepmerge(
         DEFAULT_AGENT_PROMPTS,
         (config?.prompts || {}) as Partial<AgentPrompt>,

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -11,7 +11,6 @@ import {
   AgentSetting,
   AgentPrompt,
   AgentSettingSchema,
-  DEFAULT_AGENT_SETTINGS,
   DEFAULT_AGENT_PROMPTS,
 } from '@agent/core/AgentDataclass';
 
@@ -97,12 +96,8 @@ export async function loadAgentSettingAndPrompts(
         arrayMerge: (_d, s) => s,
       });
     } else {
-      // No inheritance, use current agent's settings and prompts directly, merged with defaults
-      settings = deepmerge(
-        DEFAULT_AGENT_SETTINGS, // DEFAULT_AGENT_SETTINGS no longer has a 'name' property
-        (config?.settings || {}) as Partial<AgentSetting>,
-        { arrayMerge: (_d, s) => s },
-      );
+      // No inheritance, use current agent's settings directly
+      settings = (config?.settings || {}) as Partial<AgentSetting>;
       prompts = deepmerge(
         DEFAULT_AGENT_PROMPTS,
         (config?.prompts || {}) as Partial<AgentPrompt>,

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -5,9 +5,9 @@
 // (none needed)
 
 // Local imports - models
-import { AgentConfig, DEFAULT_AGENT_CONFIG } from '@agent/core/AgentConfig';
+import { AgentConfig, AgentConfigSchema } from '@agent/core/AgentConfig';
 import { TaskState } from '@logger/TaskState';
-import { ToolConfig } from '@agent/core/ToolConfig';
+import { ToolConfig, ToolConfigSchema } from '@agent/core/ToolConfig';
 
 import {
   SINGLE_FILE_FIELDS,
@@ -105,25 +105,8 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
  * @returns A TaskState representing the same configuration
  */
 export function objectToTaskState(obj: Record<string, any>): TaskState {
-  // Initialize with required properties
-  const taskState: Partial<TaskState> = {
-    // Basic task info
-    agent: obj.agent || 'correct',
-    model: obj.model || 'gemini25p',
-    instruction: obj.instruction || '',
-  };
-
-  // Add single and multi-file selections
-  copyFields(taskState, obj, SINGLE_FILE_FIELDS, '', { skipOutputFile: true });
-  copyFields(taskState, obj, MULTIPLE_FILE_FIELDS, []);
-
-  // Set active file visibility
-  taskState.activeFiles = createActiveFilesFromArrays(obj);
-
-  // Add tool config settings - check both direct property and toolConfig
-  copyToolFlags(taskState, obj, false);
-
-  return taskState as TaskState;
+  const normalized = AgentConfigSchema.parse(obj);
+  return agentConfigToTaskState(normalized);
 }
 
 /**
@@ -143,8 +126,8 @@ export function taskStateToAgentConfig(taskState: TaskState): AgentConfig {
     // Edited file (not part of TaskState)
     editedFile: null,
 
-    // Start with a copy of the default tool configuration to avoid value drift
-    toolConfig: { ...DEFAULT_AGENT_CONFIG.toolConfig },
+    // Initialize tool configuration with schema defaults
+    toolConfig: ToolConfigSchema.parse({}),
   };
 
   // Add single and multi-file selections


### PR DESCRIPTION
## Summary
- define defaults in `ToolConfigSchema`
- embed default values in `AgentConfigSchema` and `AgentSettingSchema`
- parse partial configs using these schemas
- simplify `loadAgentSettingAndPrompts` and conversion utilities

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68725dd709008324b0076fb1cbfa2840