### PR TITLE
Add schema-based agent YAML validation

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -110,10 +110,10 @@ export interface AgentPrompt {
 /** Zod schema for AgentPrompt validation */
 export const AgentPromptSchema = z
   .object({
-    systemPrompt: z.string().optional(),
-    userPrefix: z.string().optional(),
-    userRequest: z.string().optional(),
-    userReflect: z.string().optional(),
+    systemPrompt: z.string().default(''),
+    userPrefix: z.string().default(''),
+    userRequest: z.string().default(''),
+    userReflect: z.string().default(''),
   })
   .strict();
 
@@ -126,8 +126,8 @@ export const AgentDefinitionSchema = z
   .object({
     name: z.string().min(1),
     inherits: z.string().optional(),
-    settings: AgentSettingSchema.optional(),
-    prompts: AgentPromptSchema.optional(),
+    settings: AgentSettingSchema.default({}),
+    prompts: AgentPromptSchema.default(DEFAULT_AGENT_PROMPTS),
   })
   .strict();
 

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -2,6 +2,10 @@
 import type { ToolDefinition } from '@model';
 import { z } from 'zod';
 
+/** Temperature bounds for agent generation. */
+export const MIN_TEMPERATURE = 0;
+export const MAX_TEMPERATURE = 1;
+
 /** Enum defining possible agent types */
 export enum AgentType {
   CoT = 'CoT',
@@ -26,7 +30,12 @@ export const AgentSettingSchema = z
       .string()
       .min(1, 'documentTag cannot be empty')
       .default('document'),
-    temperature: z.number().min(0).max(1).nullable().default(0.0),
+    temperature: z
+      .number()
+      .min(MIN_TEMPERATURE)
+      .max(MAX_TEMPERATURE)
+      .nullable()
+      .default(0.0),
     isRewrite: z.boolean().default(true),
 
     rounds: z.number().default(2),
@@ -124,10 +133,10 @@ export const AgentPromptSchema = z
  */
 export const AgentDefinitionSchema = z
   .object({
-    name: z.string().min(1),
+    name: z.string().trim().min(1),
     inherits: z.string().optional(),
-    settings: AgentSettingSchema.default({}),
-    prompts: AgentPromptSchema.default(DEFAULT_AGENT_PROMPTS),
+    settings: AgentSettingSchema.partial().optional(),
+    prompts: AgentPromptSchema.partial().optional(),
   })
   .strict();
 

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -119,10 +119,10 @@ export interface AgentPrompt {
 /** Zod schema for AgentPrompt validation */
 export const AgentPromptSchema = z
   .object({
-    systemPrompt: z.string().default(''),
-    userPrefix: z.string().default(''),
-    userRequest: z.string().default(''),
-    userReflect: z.string().default(''),
+    systemPrompt: z.string(),
+    userPrefix: z.string(),
+    userRequest: z.string(),
+    userReflect: z.string(),
   })
   .strict();
 
@@ -133,10 +133,10 @@ export const AgentPromptSchema = z
  */
 export const AgentDefinitionSchema = z
   .object({
-    name: z.string().trim().min(1),
+    name: z.string().trim().min(1).optional(),
     inherits: z.string().optional(),
-    settings: AgentSettingSchema.partial().optional(),
-    prompts: AgentPromptSchema.partial().optional(),
+    settings: z.record(z.unknown()).optional(),
+    prompts: z.record(z.unknown()).optional(),
   })
   .strict();
 

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -106,3 +106,29 @@ export interface AgentPrompt {
   userRequest: string;
   userReflect: string;
 }
+
+/** Zod schema for AgentPrompt validation */
+export const AgentPromptSchema = z
+  .object({
+    systemPrompt: z.string().optional(),
+    userPrefix: z.string().optional(),
+    userRequest: z.string().optional(),
+    userReflect: z.string().optional(),
+  })
+  .strict();
+
+/**
+ * Schema representing the full agent YAML definition.
+ * Includes the root name, optional inheritance target,
+ * settings block and prompt configuration.
+ */
+export const AgentDefinitionSchema = z
+  .object({
+    name: z.string().min(1),
+    inherits: z.string().optional(),
+    settings: AgentSettingSchema.optional(),
+    prompts: AgentPromptSchema.optional(),
+  })
+  .strict();
+
+export type AgentDefinition = z.infer<typeof AgentDefinitionSchema>;

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -83,8 +83,8 @@ export async function loadAgentSettingAndPrompts(
       );
 
       // Get current agent's specific settings and prompts from its YAML
-      const agentOwnSettings = (config.settings || {}) as Partial<AgentSetting>;
-      const agentOwnPrompts = (config.prompts || {}) as Partial<AgentPrompt>;
+      const agentOwnSettings = config.settings;
+      const agentOwnPrompts = config.prompts;
 
       // Merge with parent settings and prompts
       settings = deepmerge(parentSettings, agentOwnSettings, {
@@ -96,16 +96,12 @@ export async function loadAgentSettingAndPrompts(
     } else {
       // No inheritance, merge with schema defaults by parsing empty object first
       const baseSettings = AgentSettingSchema.parse({});
-      settings = deepmerge(
-        baseSettings,
-        (config.settings || {}) as Partial<AgentSetting>,
-        { arrayMerge: (_d, s) => s },
-      );
-      prompts = deepmerge(
-        DEFAULT_AGENT_PROMPTS,
-        (config.prompts || {}) as Partial<AgentPrompt>,
-        { arrayMerge: (_d, s) => s },
-      );
+      settings = deepmerge(baseSettings, config.settings, {
+        arrayMerge: (_d, s) => s,
+      });
+      prompts = deepmerge(DEFAULT_AGENT_PROMPTS, config.prompts, {
+        arrayMerge: (_d, s) => s,
+      });
     }
 
     // Validate the final, composed settings block
@@ -133,28 +129,10 @@ export async function isValidAgentYaml(
   try {
     const rawData = await loadYaml(filePath);
     const data = AgentDefinitionSchema.parse(rawData);
-    const rootName = data.name;
-    const settingsBlock = data.settings;
-    const promptsBlock = data.prompts;
+    const settingsBlock = AgentSettingSchema.parse(data.settings);
+    const rootName = data.name.trim();
 
-    if (!promptsBlock) {
-      logger.debug(
-        CHANNEL,
-        `isValidAgentYaml check failed for ${filePath}: Prompts block is missing.`,
-      );
-      return null;
-    }
-
-    if (!settingsBlock) {
-      logger.debug(
-        CHANNEL,
-        `isValidAgentYaml check failed for ${filePath}: Settings block is missing.`,
-      );
-      return null;
-    }
-
-    // All fields exist and were validated by AgentDefinitionSchema
-    return { name: rootName.trim(), settings: settingsBlock };
+    return { name: rootName, settings: settingsBlock };
   } catch (err) {
     // Handles errors from loadYaml or validateAgentSetting (e.g., invalid temp)
     logger.debug(

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -67,7 +67,7 @@ export async function loadAgentSettingAndPrompts(
     // Extract the agent's declared name from the root of the YAML, if present.
     // This is the authoritative name for this specific agent definition.
     // It's used for context or can be returned if needed, but not part of AgentSetting object.
-    const declaredAgentName = config.name;
+    const declaredAgentName = config.name?.trim() || agentNameFromFile;
     // logger.debug(CHANNEL, `Declared agent name for ${agentNameFromFile}: ${declaredAgentName}`); // Optional: for debugging
 
     const parent = config.inherits;
@@ -132,8 +132,18 @@ export async function isValidAgentYaml(
   try {
     const rawData = await loadYaml(filePath);
     const data = AgentDefinitionSchema.parse(rawData);
-    const settingsBlock = AgentSettingSchema.parse(data.settings ?? {});
-    const rootName = data.name;
+    const rootName = typeof data.name === 'string' ? data.name.trim() : '';
+
+    if (!data.settings || !data.prompts || rootName === '') {
+      logger.debug(
+        CHANNEL,
+        `isValidAgentYaml check failed for ${filePath}: Missing required blocks`,
+      );
+      return null;
+    }
+
+    const settingsBlock = AgentSettingSchema.parse(data.settings);
+    AgentPromptSchema.parse(data.prompts);
 
     return { name: rootName, settings: settingsBlock };
   } catch (err) {

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -11,6 +11,7 @@ import {
   AgentSetting,
   AgentPrompt,
   AgentSettingSchema,
+  AgentPromptSchema,
   AgentDefinitionSchema,
   DEFAULT_AGENT_PROMPTS,
 } from '@agent/core/AgentDataclass';
@@ -66,7 +67,7 @@ export async function loadAgentSettingAndPrompts(
     // Extract the agent's declared name from the root of the YAML, if present.
     // This is the authoritative name for this specific agent definition.
     // It's used for context or can be returned if needed, but not part of AgentSetting object.
-    const declaredAgentName = config.name.trim();
+    const declaredAgentName = config.name;
     // logger.debug(CHANNEL, `Declared agent name for ${agentNameFromFile}: ${declaredAgentName}`); // Optional: for debugging
 
     const parent = config.inherits;
@@ -83,8 +84,8 @@ export async function loadAgentSettingAndPrompts(
       );
 
       // Get current agent's specific settings and prompts from its YAML
-      const agentOwnSettings = config.settings;
-      const agentOwnPrompts = config.prompts;
+      const agentOwnSettings = config.settings ?? {};
+      const agentOwnPrompts = config.prompts ?? {};
 
       // Merge with parent settings and prompts
       settings = deepmerge(parentSettings, agentOwnSettings, {
@@ -96,17 +97,19 @@ export async function loadAgentSettingAndPrompts(
     } else {
       // No inheritance, merge with schema defaults by parsing empty object first
       const baseSettings = AgentSettingSchema.parse({});
-      settings = deepmerge(baseSettings, config.settings, {
+      settings = deepmerge(baseSettings, config.settings ?? {}, {
         arrayMerge: (_d, s) => s,
       });
-      prompts = deepmerge(DEFAULT_AGENT_PROMPTS, config.prompts, {
+      prompts = deepmerge(DEFAULT_AGENT_PROMPTS, config.prompts ?? {}, {
         arrayMerge: (_d, s) => s,
       });
     }
 
     // Validate the final, composed settings block
     const validatedSettings = AgentSettingSchema.parse(settings);
+    const validatedPrompts = AgentPromptSchema.parse(prompts);
     settings = validatedSettings;
+    prompts = validatedPrompts;
 
     // The function returns the validated settings block and prompts.
     // The agent's name (declaredAgentName) is known in this scope but not part of AgentSetting.
@@ -129,8 +132,8 @@ export async function isValidAgentYaml(
   try {
     const rawData = await loadYaml(filePath);
     const data = AgentDefinitionSchema.parse(rawData);
-    const settingsBlock = AgentSettingSchema.parse(data.settings);
-    const rootName = data.name.trim();
+    const settingsBlock = AgentSettingSchema.parse(data.settings ?? {});
+    const rootName = data.name;
 
     return { name: rootName, settings: settingsBlock };
   } catch (err) {

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -11,6 +11,7 @@ import {
   AgentSetting,
   AgentPrompt,
   AgentSettingSchema,
+  AgentDefinitionSchema,
   DEFAULT_AGENT_PROMPTS,
 } from '@agent/core/AgentDataclass';
 
@@ -59,18 +60,16 @@ export async function loadAgentSettingAndPrompts(
 ): Promise<[AgentSetting, AgentPrompt]> {
   try {
     const agentFile = path.join(agentPath, `${agentNameFromFile}.yaml`);
-    const config = (await loadYaml(agentFile)) as any;
+    const rawConfig = await loadYaml(agentFile);
+    const config = AgentDefinitionSchema.parse(rawConfig);
 
     // Extract the agent's declared name from the root of the YAML, if present.
     // This is the authoritative name for this specific agent definition.
     // It's used for context or can be returned if needed, but not part of AgentSetting object.
-    const declaredAgentName =
-      typeof config?.name === 'string' && config.name.trim() !== ''
-        ? config.name.trim()
-        : agentNameFromFile; // Fallback to filename if no root name declared
+    const declaredAgentName = config.name.trim();
     // logger.debug(CHANNEL, `Declared agent name for ${agentNameFromFile}: ${declaredAgentName}`); // Optional: for debugging
 
-    const parent = config?.inherits;
+    const parent = config.inherits;
 
     let settings: Partial<AgentSetting>; // Use Partial initially for merging
     let prompts: Partial<AgentPrompt>;
@@ -84,9 +83,8 @@ export async function loadAgentSettingAndPrompts(
       );
 
       // Get current agent's specific settings and prompts from its YAML
-      const agentOwnSettings = (config?.settings ||
-        {}) as Partial<AgentSetting>;
-      const agentOwnPrompts = (config?.prompts || {}) as Partial<AgentPrompt>;
+      const agentOwnSettings = (config.settings || {}) as Partial<AgentSetting>;
+      const agentOwnPrompts = (config.prompts || {}) as Partial<AgentPrompt>;
 
       // Merge with parent settings and prompts
       settings = deepmerge(parentSettings, agentOwnSettings, {
@@ -100,12 +98,12 @@ export async function loadAgentSettingAndPrompts(
       const baseSettings = AgentSettingSchema.parse({});
       settings = deepmerge(
         baseSettings,
-        (config?.settings || {}) as Partial<AgentSetting>,
+        (config.settings || {}) as Partial<AgentSetting>,
         { arrayMerge: (_d, s) => s },
       );
       prompts = deepmerge(
         DEFAULT_AGENT_PROMPTS,
-        (config?.prompts || {}) as Partial<AgentPrompt>,
+        (config.prompts || {}) as Partial<AgentPrompt>,
         { arrayMerge: (_d, s) => s },
       );
     }
@@ -133,23 +131,16 @@ export async function isValidAgentYaml(
   filePath: string,
 ): Promise<ValidAgentDefinition | null> {
   try {
-    const data = (await loadYaml(filePath)) as any;
-    const rootName = data?.name;
-    const settingsBlock = data?.settings;
-    const promptsBlock = data?.prompts;
+    const rawData = await loadYaml(filePath);
+    const data = AgentDefinitionSchema.parse(rawData);
+    const rootName = data.name;
+    const settingsBlock = data.settings;
+    const promptsBlock = data.prompts;
 
     if (!promptsBlock) {
       logger.debug(
         CHANNEL,
         `isValidAgentYaml check failed for ${filePath}: Prompts block is missing.`,
-      );
-      return null;
-    }
-
-    if (typeof rootName !== 'string' || rootName.trim() === '') {
-      logger.debug(
-        CHANNEL,
-        `isValidAgentYaml check failed for ${filePath}: Root 'name' is missing, not a string, or empty.`,
       );
       return null;
     }
@@ -162,11 +153,8 @@ export async function isValidAgentYaml(
       return null;
     }
 
-    // Validate the settings block and use the parsed result (which may include transformations)
-    const validatedSettings = AgentSettingSchema.parse(settingsBlock);
-
-    // If all checks pass, return the structure with validated settings
-    return { name: rootName.trim(), settings: validatedSettings };
+    // All fields exist and were validated by AgentDefinitionSchema
+    return { name: rootName.trim(), settings: settingsBlock };
   } catch (err) {
     // Handles errors from loadYaml or validateAgentSetting (e.g., invalid temp)
     logger.debug(


### PR DESCRIPTION
## Summary
- validate agent definitions with new `AgentDefinitionSchema`
- parse YAML using the schema in agent loader

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: TypeScript errors in existing sources)*

------
https://chatgpt.com/codex/tasks/task_e_687285d6e1cc8324985543c9700b4d43