### PR TITLE
Add structured data support for log messages

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -476,6 +476,7 @@ export abstract class ModelHandler<U = any, R = any>
         JSON.stringify(mediaFileResults),
         undefined,
         MESSAGE_TYPES.FILE_LIST,
+        mediaFileResults,
       );
     }
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -445,6 +445,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           JSON.stringify(mediaFileResults),
           undefined,
           MESSAGE_TYPES.FILE_LIST,
+          mediaFileResults,
         );
       }
     }
@@ -565,6 +566,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           JSON.stringify(mediaFileResults),
           undefined,
           MESSAGE_TYPES.FILE_LIST,
+          mediaFileResults,
         );
       }
     }

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -209,6 +209,7 @@ export class LatexDiffManager {
           objectToLogString(aggregated),
           diffProcessGroupId,
           MESSAGE_TYPES.LATEXDIFF,
+          aggregated,
         );
       }
     } catch (err) {

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -57,6 +57,7 @@ export async function buildUserVars(
       JSON.stringify(allLoadedFiles),
       undefined,
       MESSAGE_TYPES.FILE_LIST,
+      allLoadedFiles,
     );
   }
 

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { objectToLogString } from '@utils/text/stringUtils';
 
 // Local imports - utilities
 import {

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -23,43 +23,67 @@ export class AgentLogger {
     this.channelId = channelId;
   }
 
-  debug(message: string, groupId?: string, messageType?: MessageType): void {
+  debug(
+    message: string,
+    groupId?: string,
+    messageType?: MessageType,
+    data?: unknown,
+  ): void {
     logger.debug(
       this.channelId,
       message,
       groupId,
       messageType,
       this.isAgentLogger,
+      data,
     );
   }
 
-  info(message: string, groupId?: string, messageType?: MessageType): void {
+  info(
+    message: string,
+    groupId?: string,
+    messageType?: MessageType,
+    data?: unknown,
+  ): void {
     logger.info(
       this.channelId,
       message,
       groupId,
       messageType,
       this.isAgentLogger,
+      data,
     );
   }
 
-  warn(message: string, groupId?: string, messageType?: MessageType): void {
+  warn(
+    message: string,
+    groupId?: string,
+    messageType?: MessageType,
+    data?: unknown,
+  ): void {
     logger.warn(
       this.channelId,
       message,
       groupId,
       messageType,
       this.isAgentLogger,
+      data,
     );
   }
 
-  error(message: string, groupId?: string, messageType?: MessageType): void {
+  error(
+    message: string,
+    groupId?: string,
+    messageType?: MessageType,
+    data?: unknown,
+  ): void {
     logger.error(
       this.channelId,
       message,
       groupId,
       messageType,
       this.isAgentLogger,
+      data,
     );
   }
 

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -46,4 +46,6 @@ export interface LogMessageData {
     | 'internal';
   /** Whether verbose details should be displayed */
   verbose?: boolean;
+  /** Optional structured data associated with the entry */
+  data?: unknown;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -136,6 +136,7 @@ class VSCodeTransport extends Transport {
       groupId,
       messageType: msgType,
       verbose: isVerbose,
+      data: info.data,
     } satisfies import('./LogTypes').LogMessageData;
 
     emitProgress('addLogMessage', {
@@ -329,6 +330,7 @@ function logWithGroup(
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
+  data?: unknown,
 ): void {
   const logger = getOrCreateLogger(channel, isAgent);
   const transport = channelTransports.get(channel);
@@ -337,7 +339,7 @@ function logWithGroup(
   const actualGroupId = groupId || transport?.getActiveGroupId();
 
   // @ts-ignore - We're adding a custom property to the winston log
-  logger[level](message, { groupId: actualGroupId, messageType });
+  logger[level](message, { groupId: actualGroupId, messageType, data });
 }
 
 // Simplified logging methods that use channel as channel name
@@ -347,8 +349,9 @@ export const debug = (
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
+  data?: unknown,
 ): void => {
-  logWithGroup(channel, 'debug', message, groupId, messageType, isAgent);
+  logWithGroup(channel, 'debug', message, groupId, messageType, isAgent, data);
 };
 
 export const info = (
@@ -357,8 +360,9 @@ export const info = (
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
+  data?: unknown,
 ): void => {
-  logWithGroup(channel, 'info', message, groupId, messageType, isAgent);
+  logWithGroup(channel, 'info', message, groupId, messageType, isAgent, data);
 };
 
 export const warn = (
@@ -367,8 +371,9 @@ export const warn = (
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
+  data?: unknown,
 ): void => {
-  logWithGroup(channel, 'warn', message, groupId, messageType, isAgent);
+  logWithGroup(channel, 'warn', message, groupId, messageType, isAgent, data);
 };
 
 export const error = (
@@ -377,8 +382,9 @@ export const error = (
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
+  data?: unknown,
 ): void => {
-  logWithGroup(channel, 'error', message, groupId, messageType, isAgent);
+  logWithGroup(channel, 'error', message, groupId, messageType, isAgent, data);
 };
 
 function getOrCreateLogger(channel: string, isAgent = false): winston.Logger {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -332,6 +332,9 @@ export class ProgressEventHandler {
     if (logMessage.messageType) {
       existing.messageType = logMessage.messageType;
     }
+    if (logMessage.data !== undefined) {
+      existing.data = logMessage.data;
+    }
 
     if (
       this.webviewUpdater.isAvailable() &&

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -114,7 +114,7 @@ export class LogEntryFormatter {
    * @returns {string} Formatted HTML for the log message
    */
   format(logMessage) {
-    const { id, text, level, timestamp, groupId, messageType, verbose } =
+    const { id, text, level, timestamp, groupId, messageType, verbose, data } =
       logMessage;
 
     const emoji = EMOJI_BY_LEVEL[level] || '•';
@@ -146,19 +146,19 @@ export class LogEntryFormatter {
     }
 
     if (messageType === 'fileList') {
-      return this._formatFileList(htmlMessage, text, id);
+      return this._formatFileList(htmlMessage, text, data, id);
     }
 
     if (messageType === 'missingOutputs') {
-      return this._formatMissingOutputs(htmlMessage, text, id);
+      return this._formatMissingOutputs(htmlMessage, text, data, id);
     }
 
     if (messageType === 'latexdiff') {
-      return this._formatLatexdiff(htmlMessage, text, id);
+      return this._formatLatexdiff(htmlMessage, text, data, id);
     }
 
     if (messageType === 'statistics') {
-      return this._formatStatistics(htmlMessage, text, id);
+      return this._formatStatistics(htmlMessage, text, data, id);
     }
 
     return htmlMessage;
@@ -232,10 +232,10 @@ export class LogEntryFormatter {
     }
   }
 
-  _formatFileList(message, content, logId) {
+  _formatFileList(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = JSON.parse(this._unescapeHtml(content));
+      const parsed = data ?? JSON.parse(this._unescapeHtml(content));
       if (!Array.isArray(parsed)) {
         throw new Error('Invalid file list');
       }
@@ -307,10 +307,10 @@ export class LogEntryFormatter {
     }
   }
 
-  _formatMissingOutputs(message, content, logId) {
+  _formatMissingOutputs(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = JSON.parse(this._unescapeHtml(content));
+      const parsed = data ?? JSON.parse(this._unescapeHtml(content));
 
       // Handle both old format (array) and new format (object with missing, xmlFile, documentTag)
       let missingFiles = [];
@@ -377,10 +377,10 @@ export class LogEntryFormatter {
     }
   }
 
-  _formatLatexdiff(message, content, logId) {
+  _formatLatexdiff(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = JSON.parse(this._unescapeHtml(content));
+      const parsed = data ?? JSON.parse(this._unescapeHtml(content));
       const entries = Array.isArray(parsed)
         ? parsed
         : parsed && typeof parsed === 'object'
@@ -442,10 +442,10 @@ export class LogEntryFormatter {
     }
   }
 
-  _formatStatistics(message, content, logId) {
+  _formatStatistics(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = JSON.parse(this._unescapeHtml(content));
+      const parsed = data ?? JSON.parse(this._unescapeHtml(content));
       if (!parsed || typeof parsed !== 'object') {
         return message;
       }


### PR DESCRIPTION
## Summary
- extend `LogMessageData` with optional `data` field
- allow logger helpers to pass structured data
- display special log types using provided data
- include data when logging file lists and LaTeX diff results

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: ExecutionManager.ts type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872848cf90883249c37d329ce71a654