### PR TITLE
Add finalizeRound for output validation

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -449,29 +449,13 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       throw error;
     }
 
-    const fileInfos = await this.outputHandler.gatherOutputFileInfo(currRound);
-
-    // Validate expected outputs if this is the end of the turn
-    if (endTurn) {
-      try {
-        await this.outputHandler.validateExpectedOutputs(
-          outputFile,
-          currRound,
-          roundGroupId,
-        );
-        this.logger.debug(
-          `Expected outputs validated for round ${currRound}`,
-          roundGroupId,
-        );
-      } catch (error) {
-        this.logger.error(
-          `Expected output validation failed after round ${currRound}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-          roundGroupId,
-        );
-      }
-    }
+    stateRound.outputFile = outputFile;
+    const fileInfos = await this.outputHandler.finalizeRound(
+      stateRound,
+      stateGlobal,
+      currRound,
+      roundGroupId,
+    );
     emitProgress('addOutputFiles', {
       stream: this.logger.channelId,
       filesByRound: { [currRound]: fileInfos },

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,5 +1,5 @@
 // Local imports - types
-import { AgentStateGlobal } from '@agent/core/AgentState';
+import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import { NamedOutputFile, OutputFileInfo } from './types';
 
 /** Interface describing OutputHandler behavior used by agents. */
@@ -56,4 +56,15 @@ export interface IOutputHandler {
     currRound: number,
     groupId?: string,
   ): Promise<void>;
+
+  /**
+   * Finalize a conversation round by collecting file info and validating
+   * expected outputs.
+   */
+  finalizeRound(
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    currRound: number,
+    roundGroupId?: string,
+  ): Promise<OutputFileInfo[]>;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -10,7 +10,7 @@ import { XmlOutputManager } from './XmlOutputManager';
 import { LatexDiffManager } from './LatexDiffManager';
 import { StatisticsReporter } from './StatisticsReporter';
 import { DiffStatsManager } from './DiffStatsManager';
-import { NamedOutputFile } from './types';
+import { NamedOutputFile, OutputFileInfo } from './types';
 import type { IOutputHandler } from './IOutputHandler';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 
@@ -290,6 +290,25 @@ export class OutputHandler implements IOutputHandler {
       stream: this.channel,
       filesByRound: { [currRound]: missing },
     });
+  }
+
+  /**
+   * Finalizes a conversation round by gathering output file information and
+   * validating expected outputs.
+   */
+  public async finalizeRound(
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    currRound: number,
+    roundGroupId?: string,
+  ): Promise<OutputFileInfo[]> {
+    const fileInfos = await this.gatherOutputFileInfo(currRound);
+    await this.validateExpectedOutputs(
+      stateRound.outputFile,
+      currRound,
+      roundGroupId,
+    );
+    return fileInfos;
   }
 
   /** Processes single output file with XML splitting and filtering. */


### PR DESCRIPTION
## Summary
- provide finalizeRound in OutputHandler for gathering file info and validating
- call finalizeRound from BaseReflectionAgent
- extend IOutputHandler with finalizeRound API

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: ExecutionManager.ts type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872871b21888324a343497f1758e026