### PR TITLE
Add schema defaults for agent validation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-20250514"
+          model: 'claude-opus-4-20250514'
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
             actions: read
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-20250514"
+          model: 'claude-opus-4-20250514'
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -2,6 +2,10 @@
 import type { ToolDefinition } from '@model';
 import { z } from 'zod';
 
+/** Temperature bounds for agent generation. */
+export const MIN_TEMPERATURE = 0;
+export const MAX_TEMPERATURE = 1;
+
 /** Enum defining possible agent types */
 export enum AgentType {
   CoT = 'CoT',
@@ -26,7 +30,12 @@ export const AgentSettingSchema = z
       .string()
       .min(1, 'documentTag cannot be empty')
       .default('document'),
-    temperature: z.number().min(0).max(1).nullable().default(0.0),
+    temperature: z
+      .number()
+      .min(MIN_TEMPERATURE)
+      .max(MAX_TEMPERATURE)
+      .nullable()
+      .default(0.0),
     isRewrite: z.boolean().default(true),
 
     rounds: z.number().default(2),
@@ -106,3 +115,29 @@ export interface AgentPrompt {
   userRequest: string;
   userReflect: string;
 }
+
+/** Zod schema for AgentPrompt validation */
+export const AgentPromptSchema = z
+  .object({
+    systemPrompt: z.string(),
+    userPrefix: z.string(),
+    userRequest: z.string(),
+    userReflect: z.string(),
+  })
+  .strict();
+
+/**
+ * Schema representing the full agent YAML definition.
+ * Includes the root name, optional inheritance target,
+ * settings block and prompt configuration.
+ */
+export const AgentDefinitionSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    inherits: z.string().optional(),
+    settings: z.record(z.unknown()).optional(),
+    prompts: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
+export type AgentDefinition = z.infer<typeof AgentDefinitionSchema>;

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -11,6 +11,8 @@ import {
   AgentSetting,
   AgentPrompt,
   AgentSettingSchema,
+  AgentPromptSchema,
+  AgentDefinitionSchema,
   DEFAULT_AGENT_PROMPTS,
 } from '@agent/core/AgentDataclass';
 
@@ -59,21 +61,19 @@ export async function loadAgentSettingAndPrompts(
 ): Promise<[AgentSetting, AgentPrompt]> {
   try {
     const agentFile = path.join(agentPath, `${agentNameFromFile}.yaml`);
-    const config = (await loadYaml(agentFile)) as any;
+    const rawConfig = await loadYaml(agentFile);
+    const config = AgentDefinitionSchema.parse(rawConfig);
 
     // Extract the agent's declared name from the root of the YAML, if present.
     // This is the authoritative name for this specific agent definition.
     // It's used for context or can be returned if needed, but not part of AgentSetting object.
-    const declaredAgentName =
-      typeof config?.name === 'string' && config.name.trim() !== ''
-        ? config.name.trim()
-        : agentNameFromFile; // Fallback to filename if no root name declared
+    const declaredAgentName = config.name;
     // logger.debug(CHANNEL, `Declared agent name for ${agentNameFromFile}: ${declaredAgentName}`); // Optional: for debugging
 
-    const parent = config?.inherits;
+    const parent = config.inherits;
 
-    let settings: Partial<AgentSetting>; // Use Partial initially for merging
-    let prompts: Partial<AgentPrompt>;
+    let settings: Partial<AgentSetting> = {};
+    let prompts: Partial<AgentPrompt> = {};
 
     if (parent) {
       // Load parent settings and prompts recursively
@@ -84,9 +84,8 @@ export async function loadAgentSettingAndPrompts(
       );
 
       // Get current agent's specific settings and prompts from its YAML
-      const agentOwnSettings = (config?.settings ||
-        {}) as Partial<AgentSetting>;
-      const agentOwnPrompts = (config?.prompts || {}) as Partial<AgentPrompt>;
+      const agentOwnSettings = config.settings ?? {};
+      const agentOwnPrompts = config.prompts ?? {};
 
       // Merge with parent settings and prompts
       settings = deepmerge(parentSettings, agentOwnSettings, {
@@ -96,23 +95,23 @@ export async function loadAgentSettingAndPrompts(
         arrayMerge: (_d, s) => s,
       });
     } else {
-      // No inheritance, merge with schema defaults by parsing empty object first
-      const baseSettings = AgentSettingSchema.parse({});
-      settings = deepmerge(
-        baseSettings,
-        (config?.settings || {}) as Partial<AgentSetting>,
-        { arrayMerge: (_d, s) => s },
-      );
-      prompts = deepmerge(
-        DEFAULT_AGENT_PROMPTS,
-        (config?.prompts || {}) as Partial<AgentPrompt>,
-        { arrayMerge: (_d, s) => s },
-      );
+      // No inheritance, just take own settings and prompts
+      settings = deepmerge({}, config.settings ?? {}, {
+        arrayMerge: (_d, s) => s,
+      });
+      prompts = deepmerge({}, config.prompts ?? {}, {
+        arrayMerge: (_d, s) => s,
+      });
     }
 
-    // Validate the final, composed settings block
+    // Apply defaults and validate the final settings and prompts
     const validatedSettings = AgentSettingSchema.parse(settings);
+    const promptsWithDefaults = deepmerge(DEFAULT_AGENT_PROMPTS, prompts, {
+      arrayMerge: (_d, s) => s,
+    });
+    const validatedPrompts = AgentPromptSchema.parse(promptsWithDefaults);
     settings = validatedSettings;
+    prompts = validatedPrompts;
 
     // The function returns the validated settings block and prompts.
     // The agent's name (declaredAgentName) is known in this scope but not part of AgentSetting.
@@ -133,42 +132,36 @@ export async function isValidAgentYaml(
   filePath: string,
 ): Promise<ValidAgentDefinition | null> {
   try {
-    const data = (await loadYaml(filePath)) as any;
-    const rootName = data?.name;
-    const settingsBlock = data?.settings;
-    const promptsBlock = data?.prompts;
+    const rawData = await loadYaml(filePath);
+    const data = AgentDefinitionSchema.parse(rawData);
 
-    if (!promptsBlock) {
+    if (!data.settings || !data.prompts) {
       logger.debug(
         CHANNEL,
-        `isValidAgentYaml check failed for ${filePath}: Prompts block is missing.`,
+        `isValidAgentYaml check failed for ${filePath}: missing settings or prompts block`,
       );
       return null;
     }
 
-    if (typeof rootName !== 'string' || rootName.trim() === '') {
+    const settingsBlock = AgentSettingSchema.parse(data.settings);
+    const promptsBlock = AgentPromptSchema.parse(
+      deepmerge(DEFAULT_AGENT_PROMPTS, data.prompts, {
+        arrayMerge: (_d, s) => s,
+      }),
+    );
+    const rootName = data.name.trim();
+
+    if (rootName === '') {
       logger.debug(
         CHANNEL,
-        `isValidAgentYaml check failed for ${filePath}: Root 'name' is missing, not a string, or empty.`,
+        `isValidAgentYaml check failed for ${filePath}: name is empty`,
       );
       return null;
     }
 
-    if (!settingsBlock) {
-      logger.debug(
-        CHANNEL,
-        `isValidAgentYaml check failed for ${filePath}: Settings block is missing.`,
-      );
-      return null;
-    }
-
-    // Validate the settings block and use the parsed result (which may include transformations)
-    const validatedSettings = AgentSettingSchema.parse(settingsBlock);
-
-    // If all checks pass, return the structure with validated settings
-    return { name: rootName.trim(), settings: validatedSettings };
+    // return structure with validated settings
+    return { name: rootName, settings: settingsBlock };
   } catch (err) {
-    // Handles errors from loadYaml or validateAgentSetting (e.g., invalid temp)
     logger.debug(
       CHANNEL,
       `isValidAgentYaml check failed for ${filePath}: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary
- enforce defaults in `AgentPromptSchema` and `AgentDefinitionSchema`
- parse validated settings and prompts without type casts
- simplify YAML validation logic

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: TypeScript errors in existing sources)*

------
https://chatgpt.com/codex/tasks/task_e_687285d6e1cc8324985543c9700b4d43