### PR TITLE
Improve structured logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ This document sets the common conventions for contributions. Follow these norms 
 - These helpers also provide cleanup methods to remove old files (pasted images are deleted after three days).
 - Generate names and resolve paths for pasted images through `src/utils/files/pastedImageUtils.ts`.
 - Interact with the logging system via `src/logger/logUtils`. Create a channel-specific logger with `logger.initialize(CHANNEL)` and log messages with `logger.info`, `logger.debug`, etc. Use `startGroup` and `endGroup` for nested log blocks.
+- Always supply structured data via the `data` argument for specialized messages (file lists, missing outputs, latexdiff, statistics). Avoid JSON parsing fallbacks in the ProgressView.
 - When executing external commands, prefer `executeCommand` from `src/utils/execUtils.ts` so that output is captured and routed through the logger.
 - Convert serialized objects into `TaskState` using `objectToTaskState` from `src/utils/configConversion.ts`. This applies default values such as the `sonnet4T` model.
 - Model handlers for each provider live under `src/agent/modelHandlers`. Add new handlers there and export them via `src/agent/modelHandlers/index.ts`.

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -283,6 +283,7 @@ export class OutputHandler implements IOutputHandler {
         JSON.stringify(missingOutputsData),
         groupId,
         MESSAGE_TYPES.MISSING_OUTPUTS,
+        missingOutputsData,
       );
     }
 
@@ -426,6 +427,7 @@ export class OutputHandler implements IOutputHandler {
           JSON.stringify(missingOutputsData),
           activeGroupId,
           MESSAGE_TYPES.MISSING_OUTPUTS,
+          missingOutputsData,
         );
         emitProgress('updateMissingOutputs', {
           stream: this.channel,

--- a/src/agent/output/StatisticsReporter.ts
+++ b/src/agent/output/StatisticsReporter.ts
@@ -149,6 +149,7 @@ export class StatisticsReporter {
         JSON.stringify(payload),
         statsGroupId,
         MESSAGE_TYPES.STATISTICS,
+        payload,
       );
     } catch (error) {
       this.logger.error(`Error printing statistics: ${error}`, statsGroupId);

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -237,7 +237,8 @@ export class LogEntryFormatter {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
       const parsed = data;
       if (!Array.isArray(parsed)) {
-        throw new Error('Invalid file list');
+        console.warn('Missing structured data for file list log entry');
+        return message;
       }
 
       // Group files by source for better organization
@@ -326,7 +327,8 @@ export class LogEntryFormatter {
         xmlFile = parsed.xmlFile;
         documentTag = parsed.documentTag;
       } else {
-        throw new Error('Invalid missing outputs format');
+        console.warn('Missing structured data for missing outputs log entry');
+        return message;
       }
 
       const items = missingFiles

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -235,7 +235,7 @@ export class LogEntryFormatter {
   _formatFileList(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = data ?? JSON.parse(this._unescapeHtml(content));
+      const parsed = data;
       if (!Array.isArray(parsed)) {
         throw new Error('Invalid file list');
       }
@@ -310,7 +310,7 @@ export class LogEntryFormatter {
   _formatMissingOutputs(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = data ?? JSON.parse(this._unescapeHtml(content));
+      const parsed = data;
 
       // Handle both old format (array) and new format (object with missing, xmlFile, documentTag)
       let missingFiles = [];
@@ -380,7 +380,7 @@ export class LogEntryFormatter {
   _formatLatexdiff(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = data ?? JSON.parse(this._unescapeHtml(content));
+      const parsed = data;
       const entries = Array.isArray(parsed)
         ? parsed
         : parsed && typeof parsed === 'object'
@@ -445,7 +445,7 @@ export class LogEntryFormatter {
   _formatStatistics(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = data ?? JSON.parse(this._unescapeHtml(content));
+      const parsed = data;
       if (!parsed || typeof parsed !== 'object') {
         return message;
       }


### PR DESCRIPTION
## Summary
- include `data` payload for missing outputs and statistics log entries
- rely on structured data in ProgressView formatters

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: ExecutionManager.ts type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872afe5c3f8832490d28ec98ec46c5e