### PR TITLE
Fix agent config arrays

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -15,13 +15,13 @@ export interface AgentConfig {
 
   // Input/Output configuration
   inputFile: string;
-  inputFiles: string[];
+  inputFiles: string[] | null;
   referenceFile: string | null;
-  referenceFiles: string[];
+  referenceFiles: string[] | null;
   auxiliaryFile: string | null;
-  auxiliaryFiles: string[];
+  auxiliaryFiles: string[] | null;
   mediaFile: string | null;
-  mediaFiles: string[];
+  mediaFiles: string[] | null;
   outputFiles: string[] | null;
   editedFile: string | null;
 
@@ -58,13 +58,13 @@ export const AgentConfigSchema = z
     instruction: z.string().default(''),
 
     inputFile: z.string().default(''),
-    inputFiles: z.array(z.string()).default([]),
+    inputFiles: z.array(z.string()).nullable().default([]),
     referenceFile: z.string().nullable().default(null),
-    referenceFiles: z.array(z.string()).default([]),
+    referenceFiles: z.array(z.string()).nullable().default([]),
     auxiliaryFile: z.string().nullable().default(null),
-    auxiliaryFiles: z.array(z.string()).default([]),
+    auxiliaryFiles: z.array(z.string()).nullable().default([]),
     mediaFile: z.string().nullable().default(null),
-    mediaFiles: z.array(z.string()).default([]),
+    mediaFiles: z.array(z.string()).nullable().default([]),
     outputFiles: z.array(z.string()).nullable().default(null),
     editedFile: z.string().nullable().default(null),
 

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -7,6 +7,10 @@ import * as vscode from 'vscode';
 // Local imports - utilities
 import { AbsoluteFS } from '@utils/files';
 
+export function getFilesIfNotEmpty<T>(files: T[] | undefined): T[] | null {
+  return files && files.length > 0 ? files : null;
+}
+
 export async function getFilesInDirectory(
   dir: string,
   includeExtensions: string[] = [],

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -7,10 +7,6 @@ import * as vscode from 'vscode';
 // Local imports - utilities
 import { AbsoluteFS } from '@utils/files';
 
-export function getFilesIfNotEmpty<T>(files: T[] | undefined): T[] | null {
-  return files && files.length > 0 ? files : null;
-}
-
 export async function getFilesInDirectory(
   dir: string,
   includeExtensions: string[] = [],

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -6,7 +6,6 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utils
 import { capitalize } from '@frontend/ui/messageUtils';
-import { getFilesIfNotEmpty } from '@frontend/files/listing';
 import {
   isPastedImage,
   getPastedImageFullPath,
@@ -51,20 +50,21 @@ export class ExecutionManager {
       model: message.model,
       instruction: message.instruction,
       inputFile: message.inputFile,
-      inputFiles: getFilesIfNotEmpty(message.inputFiles),
+      inputFiles: message.inputFiles ?? [],
       referenceFile: message.referenceFile,
-      referenceFiles: getFilesIfNotEmpty(message.referenceFiles),
+      referenceFiles: message.referenceFiles ?? [],
       auxiliaryFile: message.auxiliaryFile,
-      auxiliaryFiles: getFilesIfNotEmpty(message.auxiliaryFiles),
+      auxiliaryFiles: message.auxiliaryFiles ?? [],
       mediaFile: mapMediaPath(message.mediaFile),
       mediaFiles: message.mediaFiles
-        ? getFilesIfNotEmpty(
-            message.mediaFiles
-              .map(mapMediaPath)
-              .filter((f: string | null): f is string => f !== null),
-          )
-        : null,
-      outputFiles: getFilesIfNotEmpty(message.outputFiles),
+        ? message.mediaFiles
+            .map(mapMediaPath)
+            .filter((f: string | null): f is string => f !== null)
+        : [],
+      outputFiles:
+        message.outputFiles && message.outputFiles.length > 0
+          ? message.outputFiles
+          : null,
       editedFile: null,
       toolConfig,
     };

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -10,6 +10,7 @@ import {
   isPastedImage,
   getPastedImageFullPath,
 } from '@utils/files/pastedImageUtils';
+import { getFilesIfNotEmpty } from '@frontend/files/listing';
 
 // Local imports - agent
 import { ToolConfig } from '@agent/core/ToolConfig';
@@ -50,17 +51,19 @@ export class ExecutionManager {
       model: message.model,
       instruction: message.instruction,
       inputFile: message.inputFile,
-      inputFiles: message.inputFiles ?? [],
+      inputFiles: getFilesIfNotEmpty(message.inputFiles),
       referenceFile: message.referenceFile,
-      referenceFiles: message.referenceFiles ?? [],
+      referenceFiles: getFilesIfNotEmpty(message.referenceFiles),
       auxiliaryFile: message.auxiliaryFile,
-      auxiliaryFiles: message.auxiliaryFiles ?? [],
+      auxiliaryFiles: getFilesIfNotEmpty(message.auxiliaryFiles),
       mediaFile: mapMediaPath(message.mediaFile),
       mediaFiles: message.mediaFiles
-        ? message.mediaFiles
-            .map(mapMediaPath)
-            .filter((f: string | null): f is string => f !== null)
-        : [],
+        ? getFilesIfNotEmpty(
+            message.mediaFiles
+              .map(mapMediaPath)
+              .filter((f: string | null): f is string => f !== null),
+          )
+        : null,
       outputFiles:
         message.outputFiles && message.outputFiles.length > 0
           ? message.outputFiles


### PR DESCRIPTION
## Summary
- remove `getFilesIfNotEmpty` helper
- update `ExecutionManager` to build arrays without it

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6872ba60b6ac8324a0a6f8017aaa9fb2