### PR TITLE
Replace AgentConfig interface with inferred type

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -1,48 +1,14 @@
 // Local imports - agent components
-import {
-  ToolConfig,
-  ToolConfigSchema,
-  DEFAULT_TOOL_CONFIG,
-} from './ToolConfig';
+import { ToolConfigSchema, DEFAULT_TOOL_CONFIG } from './ToolConfig';
 import { z } from 'zod';
-
-/** Configuration interface for controlling agent execution and file handling. */
-export interface AgentConfig {
-  // Core configuration
-  model: string;
-  agent: string;
-  instruction: string;
-
-  // Input/Output configuration
-  inputFile: string;
-  inputFiles: string[] | null;
-  referenceFile: string | null;
-  referenceFiles: string[] | null;
-  auxiliaryFile: string | null;
-  auxiliaryFiles: string[] | null;
-  mediaFile: string | null;
-  mediaFiles: string[] | null;
-  outputFiles: string[] | null;
-  editedFile: string | null;
-
-  // Tool configuration
-  toolConfig: ToolConfig;
-}
-
-/**
- * Creates a complete AgentConfig by merging partial config with defaults.
- * @param config Partial configuration to merge with defaults
- * @returns Complete AgentConfig with all fields populated
- */
-export function createAgentConfig(config: Partial<AgentConfig>): AgentConfig {
-  return AgentConfigSchema.parse(config);
-}
 
 /**
  * Checks that the number of output files does not exceed the number of input files.
  * Extracted as a separate function for clarity and reusability.
  */
-export const validateOutputFiles = (cfg: AgentConfig): boolean => {
+export const validateOutputFiles = (
+  cfg: Record<string, any>,
+): boolean => {
   if (cfg.outputFiles) {
     const inputs = [cfg.inputFile, ...(cfg.inputFiles || [])];
     return cfg.outputFiles.length <= inputs.length;
@@ -76,3 +42,14 @@ export const AgentConfigSchema = z
       'Number of output files must not be greater than the number of input files.',
     path: ['outputFiles'],
   });
+
+export type AgentConfig = z.infer<typeof AgentConfigSchema>;
+
+/**
+ * Creates a complete AgentConfig by merging partial config with defaults.
+ * @param config Partial configuration to merge with defaults
+ * @returns Complete AgentConfig with all fields populated
+ */
+export function createAgentConfig(config: Partial<AgentConfig>): AgentConfig {
+  return AgentConfigSchema.parse(config);
+}

--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -1,5 +1,5 @@
 // Local imports - agent components
-import { AgentConfig } from './AgentConfig';
+import type { AgentConfig } from './AgentConfig';
 
 /**
  * Minimal interface implemented by all agent types.

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - agent components
-import { AgentConfig } from '../core/AgentConfig';
+import type { AgentConfig } from '../core/AgentConfig';
 import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { IAgent } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -31,7 +31,7 @@ import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 import xmlUtils from '@utils/text/xmlUtils';
 
 // Local imports - agent components
-import { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import {
   AgentSetting,
   AgentPrompt,

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { DirectAgent } from './DirectAgent';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
-import { AgentConfig } from '../core/AgentConfig';
+import type { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
 
 /**

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -22,7 +22,7 @@ import type { IModelHandler } from './types/IModelHandler';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 // Local imports - agent components
-import { AgentConfig } from '../core/AgentConfig';
+import type { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -22,7 +22,7 @@ import type { ProviderStopReason } from './types/StopReasonTypes';
 import xmlUtils from '@utils/text/xmlUtils';
 
 // Local imports - agent components
-import { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -18,7 +18,7 @@ import {
 
 // Local imports - agent components
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
-import { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -13,7 +13,7 @@ import xmlUtils from '@utils/text/xmlUtils';
 import { formatProviderError } from '@common/errors/sdkErrorUtils';
 
 // Local imports - agent components
-import { AgentConfig } from '../core/AgentConfig';
+import type { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
 import { AgentStateRound } from '../core/AgentState';
 import { ModelHandler } from './ModelHandler';

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -2,7 +2,7 @@
 import type { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - agent components
-import { AgentConfig } from '../../core/AgentConfig';
+import type { AgentConfig } from '../../core/AgentConfig';
 import { AgentSetting } from '../../core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '../../core/AgentState';
 import { ToolState } from '../../core/ToolState';

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -15,7 +15,7 @@ import type { IOutputHandler } from './IOutputHandler';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 
 // Local imports - agent components
-import { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { XMLParser } from 'fast-xml-parser';
 
 import { AgentSetting } from '@agent/core/AgentDataclass';
-import { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { WorkspaceFS } from '@utils/files';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -10,7 +10,8 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { agentConfigToTaskState } from '@utils/config';
 
 // Local imports - agent components
-import { AgentConfig, createAgentConfig } from '@agent/core/AgentConfig';
+import { createAgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -12,7 +12,7 @@ import {
   getListOfFiles,
 } from '@agent/utils/promptUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { AgentConfig } from '../core/AgentConfig';
+import type { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting } from '../core/AgentDataclass';
 import type { IModelHandler } from '@agent/modelHandlers';
 

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent components
-import { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
 
 // Local imports - history

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { randomUUID } from 'crypto';
 
 // Local imports
-import { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { workspaceSM } from '@common/state/stateManager';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -5,7 +5,8 @@
 // (none needed)
 
 // Local imports - models
-import { AgentConfig, AgentConfigSchema } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { TaskState } from '@logger/TaskState';
 
 import { FILE_TYPES, type FileType } from './constants';
@@ -71,7 +72,10 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
 
   // Build toolConfig from extracted fields (backward compatibility)
   // Ensure toolConfig is an object, handling cases where it might be malformed
-  if (!agentConfigData.toolConfig || typeof agentConfigData.toolConfig !== 'object') {
+  if (
+    !agentConfigData.toolConfig ||
+    typeof agentConfigData.toolConfig !== 'object'
+  ) {
     agentConfigData.toolConfig = {};
   }
 
@@ -104,12 +108,12 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     console.error('Failed to parse task state, using defaults:', error);
     const defaultConfig = AgentConfigSchema.parse({});
     const taskState = agentConfigToTaskState(defaultConfig);
-    
+
     // Preserve activeFiles if available
     if (activeFiles) {
       taskState.activeFiles = activeFiles;
     }
-    
+
     return taskState;
   }
 }

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -14,7 +14,7 @@ import { getFilesIfNotEmpty } from '@frontend/files/listing';
 
 // Local imports - agent
 import { ToolConfig } from '@agent/core/ToolConfig';
-import { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);


### PR DESCRIPTION
## Summary
- refactor AgentConfig to use `z.infer` type
- update imports to use `import type`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872d4055f008324921d1602d418dfa2