### PR TITLE
Infer agent types from schemas

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -52,6 +52,8 @@ export const AgentSettingSchema = z
   })
   .strict();
 
+export type AgentSetting = z.infer<typeof AgentSettingSchema>;
+
 /** Default prompt templates for agent interactions. */
 export const DEFAULT_AGENT_PROMPTS: AgentPrompt = {
   systemPrompt: '',
@@ -59,32 +61,6 @@ export const DEFAULT_AGENT_PROMPTS: AgentPrompt = {
   userRequest: '',
   userReflect: '',
 };
-
-/** Configuration interface defining agent behavior and generation parameters. */
-export interface AgentSetting {
-  /** Core settings */
-  agentType: AgentType;
-  documentTag: string;
-  temperature: number | null;
-  isRewrite: boolean;
-
-  /** Number of conversation rounds to run. */
-  rounds: number;
-
-  /** Generation settings */
-  prefills: string[];
-  outputExt: string;
-  endTag: string;
-
-  /** File configurations */
-  requiredFiles: Record<string, string>;
-  requiredFilesInternal: Record<string, string>;
-  defaultOutputFiles: string[];
-  filePatternsContain: Array<Record<string, string>>;
-
-  /** Tool definitions available to the agent */
-  tools: ToolDefinition[];
-}
 
 /**
  * Checks if content contains a valid end marker.
@@ -109,13 +85,6 @@ export function hasEndTag(
 /**
  * Configuration for agent prompts
  */
-export interface AgentPrompt {
-  systemPrompt: string;
-  userPrefix: string;
-  userRequest: string;
-  userReflect: string;
-}
-
 /** Zod schema for AgentPrompt validation */
 export const AgentPromptSchema = z
   .object({
@@ -125,6 +94,8 @@ export const AgentPromptSchema = z
     userReflect: z.string(),
   })
   .strict();
+
+export type AgentPrompt = z.infer<typeof AgentPromptSchema>;
 
 /**
  * Schema representing the full agent YAML definition.

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -6,7 +6,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - agent components
 import { AgentConfig } from '../core/AgentConfig';
-import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
+import type { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { IAgent } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';
 import { buildUserVars } from '../utils/userVars';

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -32,11 +32,8 @@ import xmlUtils from '@utils/text/xmlUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
-import {
-  AgentSetting,
-  AgentPrompt,
-  AgentType,
-} from '@agent/core/AgentDataclass';
+import { AgentType } from '@agent/core/AgentDataclass';
+import type { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import type { IModelHandler } from '@agent/modelHandlers';

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -6,7 +6,7 @@ import { DirectAgent } from './DirectAgent';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
 import { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
+import type { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
 
 /**
  * Specialized agent for merging multiple edited files into a consolidated output.

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -23,7 +23,8 @@ import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 // Local imports - agent components
 import { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
+import { hasEndTag } from '../core/AgentDataclass';
+import type { AgentSetting } from '../core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import {
   ModelConfig,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -23,7 +23,8 @@ import xmlUtils from '@utils/text/xmlUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
+import { hasEndTag } from '@agent/core/AgentDataclass';
+import type { AgentSetting } from '@agent/core/AgentDataclass';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import {
   AnthropicAPIResponseUsage,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -19,7 +19,8 @@ import {
 // Local imports - agent components
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
+import { hasEndTag } from '@agent/core/AgentDataclass';
+import type { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -14,7 +14,8 @@ import { formatProviderError } from '@common/errors/sdkErrorUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
+import { hasEndTag } from '../core/AgentDataclass';
+import type { AgentSetting } from '../core/AgentDataclass';
 import { AgentStateRound } from '../core/AgentState';
 import { ModelHandler } from './ModelHandler';
 import type { ProviderStopReason } from './types/StopReasonTypes';

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -3,7 +3,7 @@ import type { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - agent components
 import { AgentConfig } from '../../core/AgentConfig';
-import { AgentSetting } from '../../core/AgentDataclass';
+import type { AgentSetting } from '../../core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '../../core/AgentState';
 import { ToolState } from '../../core/ToolState';
 import type { MediaEntry } from '../../utils/mediaTypes';

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { AgentSetting } from '@agent/core/AgentDataclass';
+import type { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { objectToLogString } from '@utils/text/stringUtils';

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -16,7 +16,8 @@ import { getOutputFileName } from '@agent/utils/outputFileUtils';
 
 // Local imports - agent components
 import { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { AgentType } from '@agent/core/AgentDataclass';
+import type { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { XMLParser } from 'fast-xml-parser';
 
-import { AgentSetting } from '@agent/core/AgentDataclass';
+import type { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -7,9 +7,8 @@ import * as yaml from 'yaml';
 import deepmerge from 'deepmerge';
 
 // Local imports - agent components
+import type { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
 import {
-  AgentSetting,
-  AgentPrompt,
   AgentSettingSchema,
   AgentPromptSchema,
   AgentDefinitionSchema,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -11,7 +11,7 @@ import { agentConfigToTaskState } from '@utils/config';
 
 // Local imports - agent components
 import { AgentConfig, createAgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
+import type { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 
 import { MODEL_CONFIGS } from '@model/ModelRegistry';

--- a/src/agent/toolUse/ValidationFixAgent.ts
+++ b/src/agent/toolUse/ValidationFixAgent.ts
@@ -10,7 +10,7 @@ import { BaseToolUseAgent } from './BaseToolUseAgent';
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 
 // Local imports - types
-import { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
+import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
 import {
   ValidationResult,
   BaseError,

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -13,7 +13,7 @@ import {
 } from '@agent/utils/promptUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting } from '../core/AgentDataclass';
+import type { AgentSetting } from '../core/AgentDataclass';
 import type { IModelHandler } from '@agent/modelHandlers';
 
 /**


### PR DESCRIPTION
## Summary
- remove `AgentSetting` and `AgentPrompt` interfaces
- infer `AgentSetting` and `AgentPrompt` types from their zod schemas
- update imports to use the new type exports

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872d40f93dc8324ab46225e9f13153f