### PR TITLE
Use he encode/decode in progress view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ This document sets the common conventions for contributions. Follow these norms 
   - Use direct access patterns: `state.taskGroups.get()` instead of `state.getTaskGroup()`
   - Keep method names simple - context comes from the class name (`set()`, `get()`, `clear()`)
   - Follow the pattern seen in `src/progressView/modules/progressViewState.js` and `domHandlers.js`
+- Prefer direct use of `encodeHtml` and `decodeHtml` from `he` instead of wrapper helpers like `_escapeHtml`. Apply this when confident to avoid repeated refactoring.
 - When modularizing webview code, ALL module dependencies must be explicitly mapped in the import map:
   - Each module imported by ANY module in the dependency tree needs its own URI and import map entry
   - This includes transitive dependencies (modules imported by imported modules)

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -42,7 +42,8 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
-          "@common/stringUtils.js": "${stringUtilsUri}"
+          "@common/stringUtils.js": "${stringUtilsUri}",
+          "he": "https://esm.sh/he@1.2.0"
         }
       }
     </script>

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1,6 +1,7 @@
 // Third-party imports
 import MarkdownIt from 'markdown-it';
 import markdownItKatex from '@vscode/markdown-it-katex';
+import { encode as encodeHtml, decode as decodeHtml } from 'he';
 // Local imports
 import { katexMacros } from './katexMacros.js';
 import {
@@ -164,28 +165,10 @@ export class LogEntryFormatter {
     return htmlMessage;
   }
 
-  _escapeHtml(text) {
-    return text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#039;');
-  }
-
-  _unescapeHtml(text) {
-    return text
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#039;/g, "'")
-      .replace(/&amp;/g, '&');
-  }
-
   _formatSpecialContent(message, content, contentType, logId) {
     try {
       // Unescape HTML entities that were escaped during logging
-      content = this._unescapeHtml(content);
+      content = decodeHtml(content);
 
       // Pre-process LaTeX references to protect them from markdown parsing
       content = content.replace(/\\\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
@@ -256,11 +239,11 @@ export class LogEntryFormatter {
         files.forEach((f) => {
           const icon = f.ok ? 'codicon-check' : 'codicon-warning';
           const filePath = String(f.path ?? '');
-          const escaped = this._escapeHtml(filePath);
+          const escaped = encodeHtml(filePath);
 
           // Extract just the filename for display
           const fileName = filePath.split('/').pop() || filePath;
-          const fileNameEscaped = this._escapeHtml(fileName);
+          const fileNameEscaped = encodeHtml(fileName);
 
           // Build metadata string
           let metadata = '';
@@ -334,9 +317,9 @@ export class LogEntryFormatter {
       const items = missingFiles
         .map((f) => {
           const filePath = String(f);
-          const escaped = this._escapeHtml(filePath);
+          const escaped = encodeHtml(filePath);
           const fileName = filePath.split('/').pop() || filePath;
-          const fileNameEscaped = this._escapeHtml(fileName);
+          const fileNameEscaped = encodeHtml(fileName);
           return `<li title="${escaped}"><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span></li>`;
         })
         .join('');
@@ -344,11 +327,11 @@ export class LogEntryFormatter {
       // Add XML file link if available
       let xmlLink = '';
       if (xmlFile) {
-        const xmlEscaped = this._escapeHtml(xmlFile);
+        const xmlEscaped = encodeHtml(xmlFile);
         const xmlFileName = xmlFile.split('/').pop() || xmlFile;
-        const xmlFileNameEscaped = this._escapeHtml(xmlFileName);
+        const xmlFileNameEscaped = encodeHtml(xmlFileName);
         const tagInfo = documentTag
-          ? `<span class="document-tag">(Expected &lt;${this._escapeHtml(documentTag)}&gt; block)</span>`
+          ? `<span class="document-tag">(Expected &lt;${encodeHtml(documentTag)}&gt; block)</span>`
           : '';
         xmlLink = `<div class="xml-link-container">
           <i class="codicon codicon-file-code"></i>
@@ -400,9 +383,9 @@ export class LogEntryFormatter {
         const outputPath = String(d.output ?? '');
         const message = d.message ? String(d.message) : '';
 
-        const baseEsc = this._escapeHtml(basePath);
-        const revisedEsc = this._escapeHtml(revisedPath);
-        const outputEsc = this._escapeHtml(outputPath);
+        const baseEsc = encodeHtml(basePath);
+        const revisedEsc = encodeHtml(revisedPath);
+        const outputEsc = encodeHtml(outputPath);
 
         const baseName = basePath.split('/').pop() || basePath;
         const revisedName = revisedPath.split('/').pop() || revisedPath;
@@ -414,13 +397,11 @@ export class LogEntryFormatter {
           icon = 'codicon-error';
         }
 
-        const titleAttr = message
-          ? ` title="${this._escapeHtml(message)}"`
-          : '';
+        const titleAttr = message ? ` title="${encodeHtml(message)}"` : '';
 
-        items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${this._escapeHtml(
+        items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
           baseName,
-        )}</span> &rarr; <span class="file-link clickable-link" data-file="${revisedEsc}">${this._escapeHtml(
+        )}</span> &rarr; <span class="file-link clickable-link" data-file="${revisedEsc}">${encodeHtml(
           revisedName,
         )}</span> (<span class="file-link clickable-link" data-file="${outputEsc}">diff</span>)</li>`;
       });


### PR DESCRIPTION
## Summary
- document direct use of `he` helpers in repo guidelines
- drop wrapper methods in progress view formatter and call `encodeHtml`/`decodeHtml` directly

## Testing
- `npm run format`
- `npm run lint`
- `npm test` (webpack warning)


------
https://chatgpt.com/codex/tasks/task_e_6872ce90ba7c8324afabe639ca11f9f5