### PR TITLE
refactor: infer agent types from schemas

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -52,6 +52,8 @@ export const AgentSettingSchema = z
   })
   .strict();
 
+export type AgentSetting = z.infer<typeof AgentSettingSchema>;
+
 /** Default prompt templates for agent interactions. */
 export const DEFAULT_AGENT_PROMPTS: AgentPrompt = {
   systemPrompt: '',
@@ -59,32 +61,6 @@ export const DEFAULT_AGENT_PROMPTS: AgentPrompt = {
   userRequest: '',
   userReflect: '',
 };
-
-/** Configuration interface defining agent behavior and generation parameters. */
-export interface AgentSetting {
-  /** Core settings */
-  agentType: AgentType;
-  documentTag: string;
-  temperature: number | null;
-  isRewrite: boolean;
-
-  /** Number of conversation rounds to run. */
-  rounds: number;
-
-  /** Generation settings */
-  prefills: string[];
-  outputExt: string;
-  endTag: string;
-
-  /** File configurations */
-  requiredFiles: Record<string, string>;
-  requiredFilesInternal: Record<string, string>;
-  defaultOutputFiles: string[];
-  filePatternsContain: Array<Record<string, string>>;
-
-  /** Tool definitions available to the agent */
-  tools: ToolDefinition[];
-}
 
 /**
  * Checks if content contains a valid end marker.
@@ -106,16 +82,6 @@ export function hasEndTag(
   return endTagLists.some((tag) => tag && fileContent.includes(tag));
 }
 
-/**
- * Configuration for agent prompts
- */
-export interface AgentPrompt {
-  systemPrompt: string;
-  userPrefix: string;
-  userRequest: string;
-  userReflect: string;
-}
-
 /** Zod schema for AgentPrompt validation */
 export const AgentPromptSchema = z
   .object({
@@ -125,6 +91,8 @@ export const AgentPromptSchema = z
     userReflect: z.string(),
   })
   .strict();
+
+export type AgentPrompt = z.infer<typeof AgentPromptSchema>;
 
 /**
  * Schema representing the full agent YAML definition.


### PR DESCRIPTION
## Summary
- remove interface declarations for `AgentSetting` and `AgentPrompt`
- infer these types directly from their zod schemas

## Testing
- `npm run format`
- `npm run lint`
- `npm run compile-tests`
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872da0f5bf083248551708b2f4bffbc