### PR TITLE
Move ToolDefinitionSchema

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -1,5 +1,6 @@
 // Local imports - model types
 import type { ToolDefinition } from '@model';
+import { ToolDefinitionSchema } from '@model';
 import { z } from 'zod';
 
 /** Temperature bounds for agent generation. */
@@ -12,15 +13,6 @@ export enum AgentType {
   Direct = 'direct',
   ToolUse = 'toolUse',
 }
-
-/** Zod schema for ToolDefinition validation */
-export const ToolDefinitionSchema = z
-  .object({
-    name: z.string(),
-    description: z.string().optional(),
-    parameters: z.record(z.unknown()).optional(),
-  })
-  .strict();
 
 /** Zod schema for AgentSetting validation */
 export const AgentSettingSchema = z

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -1,14 +1,16 @@
-/**
- * Generic description of a tool/function that a provider can execute.
- * Fields beyond `name` are provider specific.
- */
-export interface ToolDefinition {
-  /** Name of the tool or function */
-  name: string;
-  /** Optional description for the model */
-  description?: string;
-  /** Parameter schema or provider specific metadata */
-  parameters?: Record<string, unknown>;
-  /** Additional provider-specific fields */
-  [key: string]: unknown;
-}
+// Third-party imports
+import { z } from 'zod';
+
+/** Zod schema describing a tool/function that a provider can execute. */
+export const ToolDefinitionSchema = z
+  .object({
+    /** Name of the tool or function */
+    name: z.string(),
+    /** Optional description for the model */
+    description: z.string().optional(),
+    /** Parameter schema or provider specific metadata */
+    parameters: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
+export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;


### PR DESCRIPTION
## Summary
- move ToolDefinitionSchema into the model layer
- infer ToolDefinition type from the schema
- update AgentSettingSchema to import the schema

## Testing
- `npm run lint`
- `npm test` *(fails: vscode-test blocked by environment)*

------
https://chatgpt.com/codex/tasks/task_e_6872da1cc57c83248a161471605e4890