### PR TITLE
Replace agent type interfaces with Zod schemas

### DIFF
--- a/src/agent/types/DiffTypes.ts
+++ b/src/agent/types/DiffTypes.ts
@@ -1,10 +1,16 @@
-/**
- * Diff statistic interfaces used for file comparisons.
- */
+// Third-party imports
+import { z } from 'zod';
 
-export interface DiffStats {
-  /** Number of added lines */
-  added?: number;
-  /** Number of removed lines */
-  removed?: number;
-}
+/**
+ * Zod schema for diff statistics used in file comparisons.
+ */
+export const DiffStatsSchema = z
+  .object({
+    /** Number of added lines */
+    added: z.number().optional(),
+    /** Number of removed lines */
+    removed: z.number().optional(),
+  })
+  .strict();
+
+export type DiffStats = z.infer<typeof DiffStatsSchema>;

--- a/src/agent/types/ResultTypes.ts
+++ b/src/agent/types/ResultTypes.ts
@@ -1,25 +1,41 @@
+// Third-party imports
+import { z } from 'zod';
+
 /**
- * Common result interfaces used across utilities.
+ * Zod schema for command execution results.
  */
+export const ExecResultSchema = z
+  .object({
+    /** Indicates whether the command succeeded */
+    success: z.boolean(),
+    /** Standard output from the command, if available */
+    stdout: z.string().nullable(),
+    /** Standard error from the command, if available */
+    stderr: z.string().nullable(),
+    /** True if the command timed out */
+    timedOut: z.boolean().optional(),
+  })
+  .strict();
 
-export interface ExecResult {
-  /** Indicates whether the command succeeded */
-  success: boolean;
-  /** Standard output from the command, if available */
-  stdout: string | null;
-  /** Standard error from the command, if available */
-  stderr: string | null;
-  /** True if the command timed out */
-  timedOut?: boolean;
-}
+export type ExecResult = z.infer<typeof ExecResultSchema>;
 
-export type FileOpStatus = 'success' | 'noFiles' | 'missingParams' | 'error';
+export const FileOpStatusSchema = z.enum([
+  'success',
+  'noFiles',
+  'missingParams',
+  'error',
+] as const);
+export type FileOpStatus = z.infer<typeof FileOpStatusSchema>;
 
-export interface FileOpResult {
-  /** Outcome of the pack or clean operation */
-  status: FileOpStatus;
-  /** Output directory if files were packed */
-  outputFolder?: string;
-  /** Error message when status is "error" */
-  error?: string;
-}
+export const FileOpResultSchema = z
+  .object({
+    /** Outcome of the pack or clean operation */
+    status: FileOpStatusSchema,
+    /** Output directory if files were packed */
+    outputFolder: z.string().optional(),
+    /** Error message when status is "error" */
+    error: z.string().optional(),
+  })
+  .strict();
+
+export type FileOpResult = z.infer<typeof FileOpResultSchema>;

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -1,19 +1,30 @@
-/**
- * Token usage statistics for tracking model usage and costs.
- */
-export interface TokenUsageStats {
-  /** Number of input tokens consumed */
-  inputTokens: number;
-  /** Number of output tokens generated */
-  outputTokens: number;
-  /** Total cost in USD for the request */
-  cost: number;
-}
+// Third-party imports
+import { z } from 'zod';
 
 /**
- * Message interface for updating usage stats in the progress view.
+ * Zod schema for token usage statistics.
  */
-export interface StreamUsageMessage {
-  command: 'updateUsage';
-  usage: TokenUsageStats | undefined;
-}
+export const TokenUsageStatsSchema = z
+  .object({
+    /** Number of input tokens consumed */
+    inputTokens: z.number(),
+    /** Number of output tokens generated */
+    outputTokens: z.number(),
+    /** Total cost in USD for the request */
+    cost: z.number(),
+  })
+  .strict();
+
+export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
+
+/**
+ * Zod schema for usage update messages sent to the progress view.
+ */
+export const StreamUsageMessageSchema = z
+  .object({
+    command: z.literal('updateUsage'),
+    usage: TokenUsageStatsSchema.optional(),
+  })
+  .strict();
+
+export type StreamUsageMessage = z.infer<typeof StreamUsageMessageSchema>;

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -4,7 +4,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { executeCommand } from '@utils/system';
 import { getConfig } from '@utils/config';
-import { ExecResult } from '@agent/types/ResultTypes';
+import type { ExecResult } from '@agent/types/ResultTypes';
 
 const DEFAULT_PICTURE_ENVS =
   '(?:picture|tikzpicture|scope|DIFnomarkup)[\\w\\d*@]*';

--- a/src/progressView/ProgressStateManager.ts
+++ b/src/progressView/ProgressStateManager.ts
@@ -10,7 +10,7 @@ import { TaskState } from '@logger/TaskState';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { TaskGroup, LogMessageData } from '@logger/LogTypes';
 import type { DiffStats } from '@agent/types/DiffTypes';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -16,7 +16,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 // Types
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { TaskState } from '@logger/TaskState';
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { LogMessageData } from '@logger/LogTypes';
 
 // @ts-ignore - Import JavaScript module

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -9,7 +9,7 @@ import { getConfig } from '@utils/config';
 import { onProgress } from '@eventBus/ProgressEventBus';
 
 // Types
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { TaskState } from '@logger/TaskState';
 import { LogMessageData, TaskGroup } from '@logger/LogTypes';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';

--- a/src/progressView/interfaces/IProgressViewProvider.ts
+++ b/src/progressView/interfaces/IProgressViewProvider.ts
@@ -1,6 +1,6 @@
 // Types
 import { TaskState } from '@logger/TaskState';
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { LogMessageData } from '@logger/LogTypes';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -4,7 +4,7 @@ import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -6,7 +6,7 @@ import { ProgressViewState } from '../state/ProgressViewState';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { LogMessageData } from '@logger/LogTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -7,7 +7,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
-import { ExecResult } from '@agent/types/ResultTypes';
+import type { ExecResult } from '@agent/types/ResultTypes';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'execUtils';


### PR DESCRIPTION
## Summary
- model DiffStats, TokenUsageStats, StreamUsageMessage, ExecResult and FileOpResult using zod
- infer new type aliases from the schemas
- update imports across progress view and utilities

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872d42883088324aca29110e09f6b4d