### PR TITLE
Add Kimi K2 model

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -74,11 +74,12 @@ Strong technical and coding performance, cost-effective.
 
 High context models from Moonshot, suitable for complex reasoning and large documents.
 
-| Model ID | Key Strength / Use Case        | Relative Cost | Relative Speed | Notes                 |
-| :------- | :----------------------------- | :------------ | :------------- | :-------------------- |
-| `kimit`  | Detailed reasoning with vision | $$$           | Medium         | Kimi Thinking Preview |
-| `kimi`   | Large context, general tasks   | $$            | Medium         | 128k context          |
-| `kimiv`  | Vision-enabled variant         | $$            | Medium         | 128k context, vision  |
+| Model ID | Key Strength / Use Case         | Relative Cost | Relative Speed | Notes                 |
+| :------- | :------------------------------ | :------------ | :------------- | :-------------------- |
+| `kimit`  | Detailed reasoning with vision  | $$$           | Medium         | Kimi Thinking Preview |
+| `kimi`   | Large context, general tasks    | $$            | Medium         | 128k context          |
+| `kimiv`  | Vision-enabled variant          | $$            | Medium         | 128k context, vision  |
+| `k2`     | Advanced reasoning, Agent tasks | $$$           | Medium         | Kimi K2 0711 Preview  |
 
 ### DashScope Qwen Models
 
@@ -159,6 +160,7 @@ The specific models available by default and their identifiers (`sonnet37`, `gpt
   "qwenplus",
   "kimit",
   "kimiv",
+  "k2",
   "copilot4o"
 ]
 ```

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -79,7 +79,7 @@ High context models from Moonshot, suitable for complex reasoning and large docu
 | `kimit`  | Detailed reasoning with vision  | $$$           | Medium         | Kimi Thinking Preview |
 | `kimi`   | Large context, general tasks    | $$            | Medium         | 128k context          |
 | `kimiv`  | Vision-enabled variant          | $$            | Medium         | 128k context, vision  |
-| `k2`     | Advanced reasoning, Agent tasks | $$$           | Medium         | Kimi K2 0711 Preview  |
+| `kimi2`  | Agent tasks                     | $$$           | Medium         | Kimi K2 0711 Preview  |
 
 ### DashScope Qwen Models
 
@@ -160,7 +160,7 @@ The specific models available by default and their identifiers (`sonnet37`, `gpt
   "qwenplus",
   "kimit",
   "kimiv",
-  "k2",
+  "kimi2",
   "copilot4o"
 ]
 ```

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
                 "grok3",
                 "qwenplus",
                 "kimit",
-                "kimiv"
+                "kimiv",
+                "k2"
               ]
             },
             "default": [
@@ -91,7 +92,7 @@
               "gemini25f",
               "grok4"
             ],
-            "description": "List of available models. Model codes: opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1 (OpenAI reasoning models), gpt41/gpt4o (GPT-4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), dsv3/dsr1 (DeepSeek V3.1/R1), grok4 (Grok 4), grok3 (Grok 3), qwenplus (Qwen Plus), kimit/kimiv (Kimi Thinking/Vision)",
+            "description": "List of available models. Model codes: opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1 (OpenAI reasoning models), gpt41/gpt4o (GPT-4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), dsv3/dsr1 (DeepSeek V3.1/R1), grok4 (Grok 4), grok3 (Grok 3), qwenplus (Qwen Plus), kimit/kimiv/k2 (Kimi Thinking/Vision/K2)",
             "scope": "resource"
           }
         }
@@ -618,7 +619,8 @@
               "dsv3",
               "qwenplus",
               "kimit",
-              "Kimiv"
+              "Kimiv",
+              "K2"
             ],
             "enumDescriptions": [
               "Claude Sonnet 4T",
@@ -634,7 +636,8 @@
               "DeepSeek V3",
               "Qwen Plus",
               "Kimi Thinking",
-              "Kimi Vision"
+              "Kimi Vision",
+              "Kimi K2"
             ],
             "description": "Default model to use for merge operations",
             "order": 1

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
                 "qwenplus",
                 "kimit",
                 "kimiv",
-                "k2"
+                "kimi2"
               ]
             },
             "default": [
@@ -92,7 +92,7 @@
               "gemini25f",
               "grok4"
             ],
-            "description": "List of available models. Model codes: opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1 (OpenAI reasoning models), gpt41/gpt4o (GPT-4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), dsv3/dsr1 (DeepSeek V3.1/R1), grok4 (Grok 4), grok3 (Grok 3), qwenplus (Qwen Plus), kimit/kimiv/k2 (Kimi Thinking/Vision/K2)",
+            "description": "List of available models. Model codes: opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1 (OpenAI reasoning models), gpt41/gpt4o (GPT-4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), dsv3/dsr1 (DeepSeek V3.1/R1), grok4 (Grok 4), grok3 (Grok 3), qwenplus (Qwen Plus), kimit/kimiv/kimi2 (Kimi Thinking/Vision/K2)",
             "scope": "resource"
           }
         }
@@ -619,8 +619,8 @@
               "dsv3",
               "qwenplus",
               "kimit",
-              "Kimiv",
-              "K2"
+              "kimiv",
+              "kimi2"
             ],
             "enumDescriptions": [
               "Claude Sonnet 4T",

--- a/src/model/providers/moonshotModels.ts
+++ b/src/model/providers/moonshotModels.ts
@@ -61,4 +61,20 @@ export const MOONSHOT_MODELS: Record<string, ModelConfig> = {
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
+  k2: {
+    name: 'k2',
+    fullName: 'kimi-k2-0711-preview',
+    openrouterFullName: 'moonshotai/kimi-k2',
+    provider: ModelProvider.MOONSHOT,
+    maxOutputTokens: 64000,
+    contextWindow: 131072,
+    inputPrice: 0.57,
+    outputPrice: 2.3,
+    capabilities: {
+      ...MOONSHOT_DEFAULT_CAPABILITIES,
+      supportsVision: false,
+      supportsReasoning: true,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
 };

--- a/src/model/providers/moonshotModels.ts
+++ b/src/model/providers/moonshotModels.ts
@@ -18,7 +18,7 @@ export const MOONSHOT_MODELS: Record<string, ModelConfig> = {
   kimi: {
     name: 'kimi128k',
     fullName: 'moonshot-v1-128k',
-    openrouterFullName: 'moonshot/moonshot-v1-128k',
+    openrouterFullName: 'moonshotai/moonshot-v1-128k',
     provider: ModelProvider.MOONSHOT,
     maxOutputTokens: 640000,
     contextWindow: 128000,
@@ -33,7 +33,7 @@ export const MOONSHOT_MODELS: Record<string, ModelConfig> = {
   kimiv: {
     name: 'kimi128kv',
     fullName: 'moonshot-v1-128k-vision',
-    openrouterFullName: 'moonshot/moonshot-v1-128k-vision',
+    openrouterFullName: 'moonshotai/moonshot-v1-128k-vision',
     provider: ModelProvider.MOONSHOT,
     maxOutputTokens: 64000,
     contextWindow: 128000,
@@ -48,7 +48,7 @@ export const MOONSHOT_MODELS: Record<string, ModelConfig> = {
   kimit: {
     name: 'kimit',
     fullName: 'kimi-thinking-preview',
-    openrouterFullName: 'moonshot/kimi-thinking-preview',
+    openrouterFullName: 'moonshotai/kimi-thinking-preview',
     provider: ModelProvider.MOONSHOT,
     maxOutputTokens: 64000,
     contextWindow: 128000,

--- a/src/model/providers/moonshotModels.ts
+++ b/src/model/providers/moonshotModels.ts
@@ -61,8 +61,8 @@ export const MOONSHOT_MODELS: Record<string, ModelConfig> = {
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
-  k2: {
-    name: 'k2',
+  kimi2: {
+    name: 'kimi2',
     fullName: 'kimi-k2-0711-preview',
     openrouterFullName: 'moonshotai/kimi-k2',
     provider: ModelProvider.MOONSHOT,
@@ -73,7 +73,7 @@ export const MOONSHOT_MODELS: Record<string, ModelConfig> = {
     capabilities: {
       ...MOONSHOT_DEFAULT_CAPABILITIES,
       supportsVision: false,
-      supportsReasoning: true,
+      supportsReasoning: false,
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },


### PR DESCRIPTION
## Summary
- document Kimi K2 in model guide
- list `k2` in default model configuration
- add Kimi K2 configuration to Moonshot models

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails to show results)*

------
https://chatgpt.com/codex/tasks/task_e_68735c7e8dcc83249b33643848a414db