### PR TITLE
Add clickable references in progress view

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See [texra.ai](https://texra.ai). For detailed guides and usage instructions, vi
 - YAML and XML configuration support
 - Git integration for version control
 - ProgressBoard view for detailed logs and re-running tasks
+- Clickable references in the ProgressBoard jump to their \label definitions
 - Multiple output support and intelligent merge tools
 
 ## Architecture

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -1,11 +1,45 @@
 import * as vscode from 'vscode';
 // Local imports - utilities
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
-import { resolveFilePath } from '@utils/files';
+import { resolveFilePath, WorkspaceFS } from '@utils/files';
+import { listInputFiles, listReferenceFiles } from '@frontend/files/fileLister';
 
 export async function openFile(file: string): Promise<void> {
   const uri = vscode.Uri.file(resolveFilePath(file));
   await vscode.commands.executeCommand('vscode.open', uri);
+}
+
+export async function openLabel(label: string): Promise<void> {
+  const escape = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`\\\\label\\{${escape}\\}`, 'm');
+  const candidates = new Set([
+    ...(await listInputFiles()),
+    ...(await listReferenceFiles()),
+  ]);
+
+  for (const file of candidates) {
+    try {
+      const content = await WorkspaceFS.readFile(file);
+      const match = content.match(pattern);
+      if (match && match.index !== undefined) {
+        const doc = await vscode.workspace.openTextDocument(
+          resolveFilePath(file),
+        );
+        const pos = doc.positionAt(match.index);
+        const editor = await vscode.window.showTextDocument(doc, {
+          preview: true,
+        });
+        const range = new vscode.Range(pos, pos);
+        editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+        editor.selection = new vscode.Selection(pos, pos);
+        return;
+      }
+    } catch {
+      // ignore file read errors
+    }
+  }
+
+  vscode.window.showInformationMessage(`Label "${label}" not found.`);
 }
 
 export function registerOpenFileCommands(context: vscode.ExtensionContext) {
@@ -15,6 +49,7 @@ export function registerOpenFileCommands(context: vscode.ExtensionContext) {
       openBuildDisplayIfTex,
     ),
     vscode.commands.registerCommand('texra.openFile', openFile),
+    vscode.commands.registerCommand('texra.openLabel', openLabel),
   );
-  return { openFileCompile: openBuildDisplayIfTex, openFile };
+  return { openFileCompile: openBuildDisplayIfTex, openFile, openLabel };
 }

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -34,8 +34,9 @@ export async function openLabel(label: string): Promise<void> {
         editor.selection = new vscode.Selection(pos, pos);
         return;
       }
-    } catch {
-      // ignore file read errors
+    } catch (error) {
+      // Log but continue search - file might be inaccessible
+      console.debug(`Could not read file ${file}: ${error instanceof Error ? error.message : error}`);
     }
   }
 

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -177,6 +177,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   ACCEPT_FILE: 'acceptFile',
   MERGE_FILE: 'mergeFile',
   LATEXDIFF_FILE: 'latexdiffFile',
+  OPEN_LABEL: 'openLabel',
 };
 
 // History view specific commands

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -177,6 +177,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   ACCEPT_FILE: 'acceptFile',
   MERGE_FILE: 'mergeFile',
   LATEXDIFF_FILE: 'latexdiffFile',
+  OPEN_LABEL: 'openLabel',
 };
 
 // History view specific commands

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -49,6 +49,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       [PROGRESS_VIEW_COMMANDS.MERGE_FILE]: this.handleMergeFile.bind(this),
       [PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE]:
         this.handleLatexdiffFile.bind(this),
+      [PROGRESS_VIEW_COMMANDS.OPEN_LABEL]: this.handleOpenLabel.bind(this),
     };
   }
 
@@ -213,6 +214,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       message.base,
       message.file,
     );
+  }
+
+  private async handleOpenLabel(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    await vscode.commands.executeCommand('texra.openLabel', message.label);
   }
 
   private async handleFileOperation(

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -38,8 +38,11 @@ export const MAX_HEIGHT = 400;
 // Import standardized commands
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands.js';
 
-// Use standardized commands
-export const COMMANDS = PROGRESS_VIEW_COMMANDS;
+// Extend with commands defined since bundling may ship an outdated object
+export const COMMANDS = {
+  ...PROGRESS_VIEW_COMMANDS,
+  OPEN_LABEL: 'openLabel',
+};
 
 export const TOOLBAR_BUTTONS = [
   {

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -38,11 +38,8 @@ export const MAX_HEIGHT = 400;
 // Import standardized commands
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands.js';
 
-// Extend with commands defined since bundling may ship an outdated object
-export const COMMANDS = {
-  ...PROGRESS_VIEW_COMMANDS,
-  OPEN_LABEL: 'openLabel',
-};
+// Use standardized commands directly (OPEN_LABEL is already included)
+export const COMMANDS = PROGRESS_VIEW_COMMANDS;
 
 export const TOOLBAR_BUTTONS = [
   {

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -181,16 +181,16 @@ export class LogEntryFormatter {
       // Post-process to restore and style LaTeX references
       parsedMarkdown = parsedMarkdown.replace(
         /@@LATEX-REF:([^@]+)@@/g,
-        '<code class="latex-ref">\\ref{$1}</code>',
+        '<span class="latex-ref clickable-link" data-label="$1">\\ref{$1}</span>',
       );
 
       parsedMarkdown = parsedMarkdown.replace(
         /@@LATEX-CREF:([^@]+)@@/g,
-        '<code class="latex-ref">\\cref{$1}</code>',
+        '<span class="latex-ref clickable-link" data-label="$1">\\cref{$1}</span>',
       );
       parsedMarkdown = parsedMarkdown.replace(
         /@@LATEX-EQREF:([^@]+)@@/g,
-        '<code class="latex-ref">\\eqref{$1}</code>',
+        '<span class="latex-ref clickable-link" data-label="$1">\\eqref{$1}</span>',
       );
 
       // Create enhanced content element with better formatting

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -110,6 +110,28 @@ export class LogEntryFormatter {
   }
 
   /**
+   * Helper function to create LaTeX reference HTML
+   * @param {string} refType - The reference type (ref, cref, eqref)
+   * @param {string} label - The label value
+   * @returns {string} HTML for the clickable reference
+   */
+  _createLatexReferenceHtml(refType, label) {
+    return `<span class="latex-ref clickable-link" data-label="${label}">\\${refType}{${label}}</span>`;
+  }
+
+  /**
+   * Restore LaTeX references from placeholders to clickable elements
+   * @param {string} content - Content with placeholder references
+   * @returns {string} Content with clickable LaTeX references
+   */
+  _restoreLatexReferences(content) {
+    return content
+      .replace(/@@LATEX-REF:([^@]+)@@/g, (_, label) => this._createLatexReferenceHtml('ref', label))
+      .replace(/@@LATEX-CREF:([^@]+)@@/g, (_, label) => this._createLatexReferenceHtml('cref', label))
+      .replace(/@@LATEX-EQREF:([^@]+)@@/g, (_, label) => this._createLatexReferenceHtml('eqref', label));
+  }
+
+  /**
    * Format a log entry with Markdown rendering for special content
    * @param {Object} logMessage - The log message to format
    * @returns {string} Formatted HTML for the log message
@@ -179,19 +201,7 @@ export class LogEntryFormatter {
       let parsedMarkdown = this.md.render(content);
 
       // Post-process to restore and style LaTeX references
-      parsedMarkdown = parsedMarkdown.replace(
-        /@@LATEX-REF:([^@]+)@@/g,
-        '<span class="latex-ref clickable-link" data-label="$1">\\ref{$1}</span>',
-      );
-
-      parsedMarkdown = parsedMarkdown.replace(
-        /@@LATEX-CREF:([^@]+)@@/g,
-        '<span class="latex-ref clickable-link" data-label="$1">\\cref{$1}</span>',
-      );
-      parsedMarkdown = parsedMarkdown.replace(
-        /@@LATEX-EQREF:([^@]+)@@/g,
-        '<span class="latex-ref clickable-link" data-label="$1">\\eqref{$1}</span>',
-      );
+      parsedMarkdown = this._restoreLatexReferences(parsedMarkdown);
 
       // Create enhanced content element with better formatting
       const idAttr = logId ? ` data-log-id="${logId}"` : '';

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -133,5 +133,16 @@ export class EventsManager {
         });
       }
     });
+
+    // Handle clicks on LaTeX references within logs
+    document.addEventListener('click', (e) => {
+      const ref = e.target.closest('.latex-ref');
+      if (ref && ref.dataset.label) {
+        vscode.postMessage({
+          command: COMMANDS.OPEN_LABEL,
+          label: ref.dataset.label,
+        });
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- support OPEN_LABEL command across extension
- make LaTeX references clickable in progress view
- open the source line of a `\label` on click
- expose new command via progress view message handler
- document feature in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872db45f6408324b3c2ff20e82e246c