### PR TITLE
fix: allow array categories in file patterns

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -46,7 +46,15 @@ export const AgentSettingSchema = z
     requiredFiles: z.record(z.string()).default({}),
     requiredFilesInternal: z.record(z.string()).default({}),
     defaultOutputFiles: z.array(z.string()).default([]),
-    filePatternsContain: z.array(z.record(z.string())).default([]),
+    filePatternsContain: z
+      .array(
+        z.object({
+          pattern: z.string(),
+          varName: z.string(),
+          categories: z.array(z.string()).default([]),
+        }),
+      )
+      .default([]),
 
     tools: z.array(ToolDefinitionSchema).default([]),
   })


### PR DESCRIPTION
## Summary
- update filePatternsContain schema to accept arrays of strings for categories

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b87428e0883248bea282b6c20c6b6