### PR TITLE
fix: restore latexdiff rendering

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -8,8 +8,9 @@ import { randomUUID } from 'crypto';
 // Local imports - progressView
 import { emitProgress } from '@eventBus/ProgressEventBus';
 import { getConfig } from '@utils/config';
-import { TaskGroup } from './LogTypes';
+import { TaskGroup, LogMessageData } from './LogTypes';
 import { MESSAGE_TYPES, type MessageType } from './messageTypes';
+import { AgentLogger } from './AgentLogger';
 
 function isValidMessageType(type: unknown): type is MessageType {
   return Object.values(MESSAGE_TYPES).includes(type as MessageType);
@@ -386,6 +387,49 @@ export const error = (
 ): void => {
   logWithGroup(channel, 'error', message, groupId, messageType, isAgent, data);
 };
+
+/**
+ * Parse legacy JSON content from the log message text when structured data is
+ * missing. Parsed results are stored back into the log object so that future
+ * lookups don't require re-parsing.
+ */
+export function parseLegacyLogData(
+  logMessage: LogMessageData,
+  logger?: AgentLogger,
+  forceParse = false,
+): unknown | undefined {
+  if (!forceParse && logMessage.data !== undefined) {
+    return logMessage.data;
+  }
+
+  const type = logMessage.messageType;
+  const legacyTypes = new Set<string>([
+    MESSAGE_TYPES.FILE_LIST,
+    MESSAGE_TYPES.MISSING_OUTPUTS,
+    MESSAGE_TYPES.LATEXDIFF,
+    MESSAGE_TYPES.STATISTICS,
+  ]);
+
+  if (type && legacyTypes.has(type) && logMessage.text) {
+    try {
+      const decoded = decodeHtml(logMessage.text);
+      const parsed = JSON.parse(decoded);
+
+      if (typeof parsed === 'object' && parsed !== null) {
+        logMessage.data = parsed;
+        return parsed;
+      }
+    } catch (err) {
+      logger?.warn(
+        `Failed to parse legacy log data: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  return undefined;
+}
 
 function getOrCreateLogger(channel: string, isAgent = false): winston.Logger {
   if (!channelLoggers.has(channel)) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -1,7 +1,5 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import { decode as decodeHtml } from 'he';
-
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
 import { WebviewUpdater } from '../managers';
@@ -13,7 +11,7 @@ import { onProgress } from '@eventBus/ProgressEventBus';
 import { TokenUsageStats } from '@agent/types/UsageTypes';
 import { TaskState } from '@logger/TaskState';
 import { LogMessageData, TaskGroup } from '@logger/LogTypes';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { parseLegacyLogData } from '@logger/logUtils';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 
 // @ts-ignore - Import JavaScript module
@@ -52,43 +50,6 @@ export class ProgressEventHandler {
    * missing. Parsed results are stored back into the log object so that future
    * lookups don't require re-parsing.
    */
-  private parseLegacyData(
-    logMessage: LogMessageData,
-    forceParse = false,
-  ): unknown | undefined {
-    if (!forceParse && logMessage.data !== undefined) {
-      return logMessage.data;
-    }
-
-    const type = logMessage.messageType;
-    const legacyTypes = new Set<string>([
-      MESSAGE_TYPES.FILE_LIST,
-      MESSAGE_TYPES.MISSING_OUTPUTS,
-      MESSAGE_TYPES.LATEXDIFF,
-      MESSAGE_TYPES.STATISTICS,
-    ]);
-
-    if (type && legacyTypes.has(type) && logMessage.text) {
-      try {
-        const decoded = decodeHtml(logMessage.text);
-        const parsed = JSON.parse(decoded);
-
-        // Sanity check that parsed value is an object or array
-        if (typeof parsed === 'object' && parsed !== null) {
-          logMessage.data = parsed;
-          return parsed;
-        }
-      } catch (err) {
-        this.logger.warn(
-          `Failed to parse legacy log data: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      }
-    }
-    return undefined;
-  }
-
   /**
    * Setup all event bus listeners
    */
@@ -340,7 +301,7 @@ export class ProgressEventHandler {
   }): void {
     const { stream, logMessage } = data;
 
-    this.parseLegacyData(logMessage);
+    parseLegacyLogData(logMessage, this.logger);
 
     // Skip debug messages if debug mode is disabled
     if (
@@ -382,7 +343,7 @@ export class ProgressEventHandler {
       existing.data = logMessage.data;
     } else {
       // Re-parse the updated text even if existing data is present
-      this.parseLegacyData(existing, true);
+      parseLegacyLogData(existing, this.logger, true);
     }
 
     if (

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -5,8 +5,7 @@ import { randomUUID } from 'crypto';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
-import { decode as decodeHtml } from 'he';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { parseLegacyLogData } from '@logger/logUtils';
 
 // Types
 import { LogMessageData } from '@logger/LogTypes';
@@ -22,39 +21,6 @@ export class StreamTabsManager {
 
   constructor(private persistence: StatePersistenceManager) {
     this.logger = new AgentLogger('StreamTabsManager');
-  }
-
-  /**
-   * Parse legacy JSON content from the log message text when structured data is
-   * missing.
-   */
-  private parseLegacyData(logMessage: LogMessageData): void {
-    if (logMessage.data !== undefined) {
-      return;
-    }
-
-    const legacyTypes = new Set<string>([
-      MESSAGE_TYPES.FILE_LIST,
-      MESSAGE_TYPES.MISSING_OUTPUTS,
-      MESSAGE_TYPES.LATEXDIFF,
-      MESSAGE_TYPES.STATISTICS,
-    ]);
-
-    if (legacyTypes.has(logMessage.messageType ?? '') && logMessage.text) {
-      try {
-        const decoded = decodeHtml(logMessage.text);
-        const parsed = JSON.parse(decoded);
-        if (typeof parsed === 'object' && parsed !== null) {
-          logMessage.data = parsed;
-        }
-      } catch (err) {
-        this.logger.warn(
-          `Failed to parse legacy log data: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      }
-    }
   }
 
   /**
@@ -186,11 +152,11 @@ export class StreamTabsManager {
             const timestamp = new Date(timeString).getTime();
             msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
           }
-          if (!msg.messageType) {
-            msg.messageType = 'default';
-          }
           const log = msg as LogMessageData;
-          this.parseLegacyData(log);
+          parseLegacyLogData(log, this.logger);
+          if (!log.messageType) {
+            log.messageType = 'default';
+          }
           return log;
         });
 

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -5,6 +5,8 @@ import { randomUUID } from 'crypto';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
+import { decode as decodeHtml } from 'he';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Types
 import { LogMessageData } from '@logger/LogTypes';
@@ -20,6 +22,39 @@ export class StreamTabsManager {
 
   constructor(private persistence: StatePersistenceManager) {
     this.logger = new AgentLogger('StreamTabsManager');
+  }
+
+  /**
+   * Parse legacy JSON content from the log message text when structured data is
+   * missing.
+   */
+  private parseLegacyData(logMessage: LogMessageData): void {
+    if (logMessage.data !== undefined) {
+      return;
+    }
+
+    const legacyTypes = new Set<string>([
+      MESSAGE_TYPES.FILE_LIST,
+      MESSAGE_TYPES.MISSING_OUTPUTS,
+      MESSAGE_TYPES.LATEXDIFF,
+      MESSAGE_TYPES.STATISTICS,
+    ]);
+
+    if (legacyTypes.has(logMessage.messageType ?? '') && logMessage.text) {
+      try {
+        const decoded = decodeHtml(logMessage.text);
+        const parsed = JSON.parse(decoded);
+        if (typeof parsed === 'object' && parsed !== null) {
+          logMessage.data = parsed;
+        }
+      } catch (err) {
+        this.logger.warn(
+          `Failed to parse legacy log data: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
   }
 
   /**
@@ -154,7 +189,9 @@ export class StreamTabsManager {
           if (!msg.messageType) {
             msg.messageType = 'default';
           }
-          return msg as LogMessageData;
+          const log = msg as LogMessageData;
+          this.parseLegacyData(log);
+          return log;
         });
 
         processedStreams.set(stream, processedMessages);


### PR DESCRIPTION
## Summary
- parse legacy log data when loading persisted streams so special entries render correctly

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b887cd33483248bacb2a5bd61888b