### PR TITLE
Fix latexdiff rendering

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -381,7 +381,7 @@ export class LogEntryFormatter {
   _formatLatexdiff(message, content, data, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      const parsed = data;
+      const parsed = data ?? JSON.parse(decodeHtml(content));
       const entries = Array.isArray(parsed)
         ? parsed
         : parsed && typeof parsed === 'object'


### PR DESCRIPTION
## Summary
- ensure latexdiff entries fall back to parsing HTML if no structured data provided

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b964897888324b0dd611bea15f879