### PR TITLE
Fix latexdiff logging

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -95,7 +95,8 @@ class VSCodeTransport extends Transport {
     // Skip output channel logging for special structured messages
     if (
       messageType !== MESSAGE_TYPES.FILE_LIST &&
-      messageType !== MESSAGE_TYPES.MISSING_OUTPUTS
+      messageType !== MESSAGE_TYPES.MISSING_OUTPUTS &&
+      messageType !== MESSAGE_TYPES.LATEXDIFF
     ) {
       // Always write to the configured output channel
       this.channel.appendLine(formattedMessage);


### PR DESCRIPTION
## Summary
- skip logging LATEXDIFF data to the output channel

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b964897888324b0dd611bea15f879