### PR TITLE
fix: improve latexdiff formatter

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -397,7 +397,7 @@ export class LogEntryFormatter {
         const basePath = String(d.base ?? '');
         const revisedPath = String(d.revised ?? '');
         const outputPath = String(d.output ?? '');
-        const message = d.message ? String(d.message) : '';
+        const msg = d.message ? String(d.message) : '';
 
         const baseEsc = encodeHtml(basePath);
         const revisedEsc = encodeHtml(revisedPath);
@@ -413,7 +413,7 @@ export class LogEntryFormatter {
           icon = 'codicon-error';
         }
 
-        const titleAttr = message ? ` title="${encodeHtml(message)}"` : '';
+        const titleAttr = msg ? ` title="${encodeHtml(msg)}"` : '';
 
         items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
           baseName,


### PR DESCRIPTION
## Summary
- prevent variable shadowing in latexdiff formatter

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b9dc841e08324ba2c75fa88b037be