### PR TITLE
Remove redundant default prompts

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -55,12 +55,6 @@ export const AgentSettingSchema = z
 export type AgentSetting = z.infer<typeof AgentSettingSchema>;
 
 /** Default prompt templates for agent interactions. */
-export const DEFAULT_AGENT_PROMPTS: AgentPrompt = {
-  systemPrompt: '',
-  userPrefix: '',
-  userRequest: '',
-  userReflect: '',
-};
 
 /**
  * Checks if content contains a valid end marker.
@@ -85,10 +79,10 @@ export function hasEndTag(
 /** Zod schema for AgentPrompt validation */
 export const AgentPromptSchema = z
   .object({
-    systemPrompt: z.string(),
-    userPrefix: z.string(),
-    userRequest: z.string(),
-    userReflect: z.string(),
+    systemPrompt: z.string().default(''),
+    userPrefix: z.string().default(''),
+    userRequest: z.string().default(''),
+    userReflect: z.string().default(''),
   })
   .strict();
 

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -14,7 +14,6 @@ import {
   AgentSettingSchema,
   AgentPromptSchema,
   AgentDefinitionSchema,
-  DEFAULT_AGENT_PROMPTS,
 } from '@agent/core/AgentDataclass';
 
 // Local imports - utils
@@ -108,10 +107,7 @@ export async function loadAgentSettingAndPrompts(
 
     // Apply defaults and validate the final settings and prompts
     const validatedSettings = AgentSettingSchema.parse(settings);
-    const promptsWithDefaults = deepmerge(DEFAULT_AGENT_PROMPTS, prompts, {
-      arrayMerge: (_d, s) => s,
-    });
-    const validatedPrompts = AgentPromptSchema.parse(promptsWithDefaults);
+    const validatedPrompts = AgentPromptSchema.parse(prompts);
     settings = validatedSettings;
     prompts = validatedPrompts;
 
@@ -146,11 +142,7 @@ export async function isValidAgentYaml(
     }
 
     const settingsBlock = AgentSettingSchema.parse(data.settings);
-    AgentPromptSchema.parse(
-      deepmerge(DEFAULT_AGENT_PROMPTS, data.prompts, {
-        arrayMerge: (_d, s) => s,
-      }),
-    );
+    AgentPromptSchema.parse(data.prompts);
     const rootName = data.name;
 
     if (rootName === '') {


### PR DESCRIPTION
## Summary
- remove `DEFAULT_AGENT_PROMPTS`
- rely on defaults within `AgentPromptSchema`
- simplify prompt parsing in `agentLoad`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bac5966d0832490ecac855545863c