### PR TITLE
fix: temporary logging adjustments for debugging

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -206,7 +206,7 @@ export class LatexDiffManager {
 
       if (aggregated.length > 0) {
         this.logger.info(
-          objectToLogString(aggregated),
+          JSON.stringify(aggregated),
           diffProcessGroupId,
           MESSAGE_TYPES.LATEXDIFF,
           aggregated,

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -93,14 +93,15 @@ class VSCodeTransport extends Transport {
     const formattedMessage = `${emoji} [${timestamp}] ${channelPrefix}${message}`;
 
     // Skip output channel logging for special structured messages
-    if (
-      messageType !== MESSAGE_TYPES.FILE_LIST &&
-      messageType !== MESSAGE_TYPES.MISSING_OUTPUTS &&
-      messageType !== MESSAGE_TYPES.LATEXDIFF
-    ) {
-      // Always write to the configured output channel
-      this.channel.appendLine(formattedMessage);
-    }
+    // if (
+    //   messageType !== MESSAGE_TYPES.FILE_LIST &&
+    //   messageType !== MESSAGE_TYPES.MISSING_OUTPUTS &&
+    //   messageType !== MESSAGE_TYPES.LATEXDIFF
+    // ) {
+    //   // Always write to the configured output channel
+    //   this.channel.appendLine(formattedMessage);
+    // }
+    this.channel.appendLine(formattedMessage);
 
     // Skip debug messages in ProgressView if debug mode is disabled
     if (level === 'debug' && !getConfig<boolean>('logger.debugMode', false)) {


### PR DESCRIPTION
## Summary
- Replace objectToLogString with JSON.stringify in LatexDiffManager for better debug output
- Temporarily enable all message types in VSCode output channel for debugging
- These are temporary changes to help diagnose missing latexdiff results

## Test plan
- [ ] Verify that all log messages appear in the output channel
- [ ] Check that latexdiff results are properly logged with structured data
- [ ] Confirm no errors occur with the JSON.stringify replacement

🤖 Generated with [Claude Code](https://claude.ai/code)