### PR TITLE
Replace agent result interfaces with Zod schemas

### DIFF
--- a/src/agent/types/DiffTypes.ts
+++ b/src/agent/types/DiffTypes.ts
@@ -1,10 +1,13 @@
 /**
- * Diff statistic interfaces used for file comparisons.
+ * Diff statistic schema used for file comparisons.
  */
+import { z } from 'zod';
 
-export interface DiffStats {
+export const DiffStatsSchema = z.object({
   /** Number of added lines */
-  added?: number;
+  added: z.number().optional(),
   /** Number of removed lines */
-  removed?: number;
-}
+  removed: z.number().optional(),
+});
+
+export type DiffStats = z.infer<typeof DiffStatsSchema>;

--- a/src/agent/types/ResultTypes.ts
+++ b/src/agent/types/ResultTypes.ts
@@ -1,25 +1,35 @@
 /**
- * Common result interfaces used across utilities.
+ * Common result schemas used across utilities.
  */
+import { z } from 'zod';
 
-export interface ExecResult {
+export const ExecResultSchema = z.object({
   /** Indicates whether the command succeeded */
-  success: boolean;
+  success: z.boolean(),
   /** Standard output from the command, if available */
-  stdout: string | null;
+  stdout: z.string().nullable(),
   /** Standard error from the command, if available */
-  stderr: string | null;
+  stderr: z.string().nullable(),
   /** True if the command timed out */
-  timedOut?: boolean;
-}
+  timedOut: z.boolean().optional(),
+});
+
+export type ExecResult = z.infer<typeof ExecResultSchema>;
 
 export type FileOpStatus = 'success' | 'noFiles' | 'missingParams' | 'error';
 
-export interface FileOpResult {
+export const FileOpResultSchema = z.object({
   /** Outcome of the pack or clean operation */
-  status: FileOpStatus;
+  status: z.union([
+    z.literal('success'),
+    z.literal('noFiles'),
+    z.literal('missingParams'),
+    z.literal('error'),
+  ]),
   /** Output directory if files were packed */
-  outputFolder?: string;
+  outputFolder: z.string().optional(),
   /** Error message when status is "error" */
-  error?: string;
-}
+  error: z.string().optional(),
+});
+
+export type FileOpResult = z.infer<typeof FileOpResultSchema>;

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -1,19 +1,25 @@
 /**
  * Token usage statistics for tracking model usage and costs.
  */
-export interface TokenUsageStats {
+import { z } from 'zod';
+
+export const TokenUsageStatsSchema = z.object({
   /** Number of input tokens consumed */
-  inputTokens: number;
+  inputTokens: z.number(),
   /** Number of output tokens generated */
-  outputTokens: number;
+  outputTokens: z.number(),
   /** Total cost in USD for the request */
-  cost: number;
-}
+  cost: z.number(),
+});
+
+export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 
 /**
  * Message interface for updating usage stats in the progress view.
  */
-export interface StreamUsageMessage {
-  command: 'updateUsage';
-  usage: TokenUsageStats | undefined;
-}
+export const StreamUsageMessageSchema = z.object({
+  command: z.literal('updateUsage'),
+  usage: TokenUsageStatsSchema.optional(),
+});
+
+export type StreamUsageMessage = z.infer<typeof StreamUsageMessageSchema>;

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -4,7 +4,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { executeCommand } from '@utils/system';
 import { getConfig } from '@utils/config';
-import { ExecResult } from '@agent/types/ResultTypes';
+import type { ExecResult } from '@agent/types/ResultTypes';
 
 const DEFAULT_PICTURE_ENVS =
   '(?:picture|tikzpicture|scope|DIFnomarkup)[\\w\\d*@]*';

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -16,7 +16,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 // Types
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { TaskState } from '@logger/TaskState';
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { LogMessageData } from '@logger/LogTypes';
 
 // @ts-ignore - Import JavaScript module

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -8,7 +8,7 @@ import { getConfig } from '@utils/config';
 import { onProgress } from '@eventBus/ProgressEventBus';
 
 // Types
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { TaskState } from '@logger/TaskState';
 import { LogMessageData, TaskGroup } from '@logger/LogTypes';
 import { parseLegacyLogData } from '@logger/logUtils';

--- a/src/progressView/interfaces/IProgressViewProvider.ts
+++ b/src/progressView/interfaces/IProgressViewProvider.ts
@@ -1,6 +1,6 @@
 // Types
 import { TaskState } from '@logger/TaskState';
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { LogMessageData } from '@logger/LogTypes';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -4,7 +4,7 @@ import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -6,7 +6,7 @@ import { ProgressViewState } from '../state/ProgressViewState';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
-import { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { LogMessageData } from '@logger/LogTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -7,7 +7,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
-import { ExecResult } from '@agent/types/ResultTypes';
+import type { ExecResult } from '@agent/types/ResultTypes';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'execUtils';


### PR DESCRIPTION
## Summary
- define `zod` schemas for DiffStats, TokenUsageStats, StreamUsageMessage, ExecResult and FileOpResult
- infer types from schemas and update imports
- make imports type-only in managers and utilities

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687be25f7e608324a2e6fa6eaa173b70