### PR TITLE
Add structured log helpers

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -472,12 +472,7 @@ export abstract class ModelHandler<U = any, R = any>
       if (mediaFileResults.some((r) => !r.ok)) {
         this.logger.warn('Some media files failed to load');
       }
-      this.logger.info(
-        JSON.stringify(mediaFileResults),
-        undefined,
-        MESSAGE_TYPES.FILE_LIST,
-        mediaFileResults,
-      );
+      this.logger.fileList(mediaFileResults);
     }
 
     return this.createMediaContent(mediaMessage);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -441,12 +441,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         if (mediaFileResults.some((r) => !r.ok)) {
           this.logger.warn('Some media files failed to load');
         }
-        this.logger.info(
-          JSON.stringify(mediaFileResults),
-          undefined,
-          MESSAGE_TYPES.FILE_LIST,
-          mediaFileResults,
-        );
+        this.logger.fileList(mediaFileResults);
       }
     }
 
@@ -562,12 +557,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         if (mediaFileResults.some((r) => !r.ok)) {
           this.logger.warn('Some media files failed to load');
         }
-        this.logger.info(
-          JSON.stringify(mediaFileResults),
-          undefined,
-          MESSAGE_TYPES.FILE_LIST,
-          mediaFileResults,
-        );
+        this.logger.fileList(mediaFileResults);
       }
     }
 

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -205,12 +205,7 @@ export class LatexDiffManager {
       }
 
       if (aggregated.length > 0) {
-        this.logger.info(
-          JSON.stringify(aggregated),
-          diffProcessGroupId,
-          MESSAGE_TYPES.LATEXDIFF,
-          aggregated,
-        );
+        this.logger.latexDiff(aggregated, diffProcessGroupId);
       } else {
         this.logger.debug('No latexdiff results to report', diffProcessGroupId);
       }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -279,12 +279,7 @@ export class OutputHandler implements IOutputHandler {
         documentTag: this.agentSetting.documentTag,
       };
 
-      this.logger.info(
-        JSON.stringify(missingOutputsData),
-        groupId,
-        MESSAGE_TYPES.MISSING_OUTPUTS,
-        missingOutputsData,
-      );
+      this.logger.missingOutputs(missingOutputsData, groupId);
     }
 
     emitProgress('updateMissingOutputs', {
@@ -423,12 +418,7 @@ export class OutputHandler implements IOutputHandler {
           xmlFile: outputFile,
           documentTag: this.agentSetting.documentTag,
         };
-        this.logger.info(
-          JSON.stringify(missingOutputsData),
-          activeGroupId,
-          MESSAGE_TYPES.MISSING_OUTPUTS,
-          missingOutputsData,
-        );
+        this.logger.missingOutputs(missingOutputsData, activeGroupId);
         emitProgress('updateMissingOutputs', {
           stream: this.channel,
           filesByRound: { [currRound]: [] },

--- a/src/agent/output/StatisticsReporter.ts
+++ b/src/agent/output/StatisticsReporter.ts
@@ -145,12 +145,7 @@ export class StatisticsReporter {
         payload.toolUseTokens = stateGlobal.totalToolUseTokens;
       }
 
-      this.logger.debug(
-        JSON.stringify(payload),
-        statsGroupId,
-        MESSAGE_TYPES.STATISTICS,
-        payload,
-      );
+      this.logger.statistics(payload, statsGroupId);
     } catch (error) {
       this.logger.error(`Error printing statistics: ${error}`, statsGroupId);
     }

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -53,12 +53,7 @@ export async function buildUserVars(
 
   // Emit aggregated file list if any files were loaded
   if (allLoadedFiles.length > 0) {
-    logger.info(
-      JSON.stringify(allLoadedFiles),
-      undefined,
-      MESSAGE_TYPES.FILE_LIST,
-      allLoadedFiles,
-    );
+    logger.fileList(allLoadedFiles);
   }
 
   return userVars;

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -4,6 +4,7 @@
 // Local imports - log
 import * as logger from './logUtils';
 import type { MessageType } from './messageTypes';
+import { MESSAGE_TYPES } from './messageTypes';
 import { sleep } from '@utils/helpers';
 import { SHORT_SLEEP_MS } from '@utils/config';
 
@@ -85,6 +86,40 @@ export class AgentLogger {
       this.isAgentLogger,
       data,
     );
+  }
+
+  /**
+   * Log a list of files that were processed.
+   */
+  fileList(files: unknown[], groupId?: string): void {
+    const summary = `Loaded ${files.length} file${files.length === 1 ? '' : 's'}`;
+    this.info(summary, groupId, MESSAGE_TYPES.FILE_LIST, files);
+  }
+
+  /**
+   * Log missing output information.
+   */
+  missingOutputs(info: unknown, groupId?: string): void {
+    const missing = (info as any).missing as unknown[] | undefined;
+    const count = missing ? missing.length : 0;
+    const summary = `${count} output file${count === 1 ? '' : 's'} missing`;
+    this.info(summary, groupId, MESSAGE_TYPES.MISSING_OUTPUTS, info);
+  }
+
+  /**
+   * Log latexdiff results.
+   */
+  latexDiff(results: unknown[], groupId?: string): void {
+    const summary = `Latexdiff results: ${results.length}`;
+    this.info(summary, groupId, MESSAGE_TYPES.LATEXDIFF, results);
+  }
+
+  /**
+   * Log statistics information.
+   */
+  statistics(stats: Record<string, number>, groupId?: string): void {
+    const summary = `Usage - input: ${stats.inputTokens ?? 0}, output: ${stats.outputTokens ?? 0}`;
+    this.info(summary, groupId, MESSAGE_TYPES.STATISTICS, stats);
   }
 
   /**


### PR DESCRIPTION
## Summary
- create helper methods on `AgentLogger` for FILE_LIST, MISSING_OUTPUTS, LATEXDIFF and STATISTICS logs
- use the helpers in user vars, model handlers, output processing and statistics reporting

## Testing
- `npm run lint`
- `npm test` *(fails: webpack succeeded but VS Code test output missing)*

------
https://chatgpt.com/codex/tasks/task_e_687bdee9184c83248eb15162ceb026ab