### PR TITLE
Remove wrapper functions for fileLister

### DIFF
--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -7,7 +7,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { showInfoMessage, showErrorMessage } from '@frontend/ui/messageUtils';
 import { WorkspaceFS } from '@utils/files';
-import { listInputFiles } from '@frontend/files/fileLister';
+import { fileLister } from '@frontend/files/fileLister';
 import { getIncludedExtensions } from '@common/files/fileTypeUtils';
 import { selectFile, selectFiles } from '@frontend/files/dialog';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
@@ -208,11 +208,11 @@ async function selectBaseFile(): Promise<string | null> {
 }
 
 async function refreshInputFiles(): Promise<string[]> {
-  return await listInputFiles();
+  return await fileLister.list('input');
 }
 
 async function refreshBaseFiles(): Promise<string[]> {
-  return await listInputFiles();
+  return await fileLister.list('input');
 }
 
 export const fileSelectionCommands = {

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 // Local imports - utilities
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { resolveFilePath, WorkspaceFS } from '@utils/files';
-import { listInputFiles, listReferenceFiles } from '@frontend/files/fileLister';
+import { fileLister } from '@frontend/files/fileLister';
 
 export async function openFile(file: string): Promise<void> {
   const uri = vscode.Uri.file(resolveFilePath(file));
@@ -13,8 +13,8 @@ export async function openLabel(label: string): Promise<void> {
   const escape = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const pattern = new RegExp(`\\\\label\\{${escape}\\}`, 'm');
   const candidates = new Set([
-    ...(await listInputFiles()),
-    ...(await listReferenceFiles()),
+    ...(await fileLister.list('input')),
+    ...(await fileLister.list('reference')),
   ]);
 
   for (const file of candidates) {

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -154,11 +154,4 @@ export class FileLister {
   }
 }
 
-const lister = FileLister.getInstance();
-
-export const listInputFiles = () => lister.list('input');
-export const listReferenceFiles = () => lister.list('reference');
-export const listAuxiliaryFiles = () => lister.list('auxiliary');
-export const listMediaFiles = () => lister.list('media');
-export const listEditedFiles = (baseName: string) =>
-  lister.listEditedFiles(baseName);
+export const fileLister = FileLister.getInstance();

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -13,13 +13,7 @@ import { showLoggedMessage } from '@common/errors/errorHandlingUtils';
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
-import {
-  listInputFiles,
-  listReferenceFiles,
-  listAuxiliaryFiles,
-  listMediaFiles,
-  listEditedFiles,
-} from '@frontend/files/fileLister';
+import { fileLister } from '@frontend/files/fileLister';
 
 // Local imports - commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
@@ -75,7 +69,8 @@ export class FileManager {
       message.filePath,
       path.extname(message.filePath),
     );
-    const filteredEditedFiles = await listEditedFiles(baseFileNameForInput);
+    const filteredEditedFiles =
+      await fileLister.listEditedFiles(baseFileNameForInput);
     this.postFileUpdate(webviewView, 'Edited', filteredEditedFiles);
   }
 
@@ -101,11 +96,11 @@ export class FileManager {
     const files = await (async () => {
       switch (fileType) {
         case 'Reference':
-          return await listReferenceFiles();
+          return await fileLister.list('reference');
         case 'Auxiliary':
-          return await listAuxiliaryFiles();
+          return await fileLister.list('auxiliary');
         case 'Media':
-          return await listMediaFiles();
+          return await fileLister.list('media');
         default:
           return [];
       }
@@ -123,13 +118,13 @@ export class FileManager {
         message.baseFile,
         path.extname(message.baseFile),
       );
-      allEditedFiles = await listEditedFiles(baseFileNameForEdited);
+      allEditedFiles = await fileLister.listEditedFiles(baseFileNameForEdited);
     }
     this.postFileUpdate(webviewView, 'Edited', allEditedFiles);
   }
 
   async handleRequestBaseFile(webviewView: vscode.WebviewView): Promise<void> {
-    this.postFileUpdate(webviewView, 'Base', await listInputFiles());
+    this.postFileUpdate(webviewView, 'Base', await fileLister.list('input'));
   }
 
   async handleRequestDefaultOutputFiles(
@@ -221,10 +216,10 @@ export class FileManager {
 
   async handleRefreshAllFiles(webviewView: vscode.WebviewView): Promise<void> {
     const refreshedFiles = {
-      input: await listInputFiles(),
-      reference: await listReferenceFiles(),
-      auxiliary: await listAuxiliaryFiles(),
-      media: await listMediaFiles(),
+      input: await fileLister.list('input'),
+      reference: await fileLister.list('reference'),
+      auxiliary: await fileLister.list('auxiliary'),
+      media: await fileLister.list('media'),
     };
 
     Object.entries(refreshedFiles).forEach(([type, files]) => {
@@ -374,7 +369,7 @@ export class FileManager {
   private async updateBaseFileSelect(
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    const baseFiles = await listInputFiles();
+    const baseFiles = await fileLister.list('input');
     webviewView.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_BASE_FILE,
       files: baseFiles,


### PR DESCRIPTION
## Summary
- simplify `fileLister` API by exporting the instance only
- refactor import sites to call `fileLister.list` or `fileLister.listEditedFiles`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: requires vscode test runner)*

------
https://chatgpt.com/codex/tasks/task_e_687c0fb655b48324904200bc15c993b5