### PR TITLE
Remove XML wrapper methods

### DIFF
--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -66,7 +66,7 @@ export class CoTAgent extends BaseReflectionAgent {
         );
 
         // First fix XML structure
-        await this.outputHandler.ensureCorrectXmlStructure(
+        await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
           outputFile,
           this.agentSetting.documentTag,
         );

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,6 +1,7 @@
 // Local imports - types
 import { AgentStateGlobal } from '@agent/core/AgentState';
 import { NamedOutputFile, OutputFileInfo } from './types';
+import { XmlOutputManager } from './XmlOutputManager';
 
 /** Interface describing OutputHandler behavior used by agents. */
 export interface IOutputHandler {
@@ -10,29 +11,17 @@ export interface IOutputHandler {
   /** Mapping of source to processed output files by round. */
   outputMappings: { [key: number]: NamedOutputFile[] };
 
+  /** XML manager for parsing and splitting outputs. */
+  xmlManager: XmlOutputManager;
+
   /** Indent a single LaTeX file for readability. */
   indentLatexFile(filePath: string): Promise<void>;
 
   /** Indent multiple LaTeX files for readability. */
   indentLatexFiles(filePaths: string[]): Promise<void>;
 
-  /** Filter and clean up raw XML content. */
-  processXmlContent(content: string): Promise<string>;
-
   /** Run latexdiff comparisons for the current round. */
   handleLatexdiffofOutput(currRound: number, groupId?: string): Promise<void>;
-
-  /** Split and process a single XML output file. */
-  processSingleXmlOutput(outputFile: string): Promise<NamedOutputFile>;
-
-  /** Split and process multiple XML output files. */
-  processMultipleXmlOutputs(outputFile: string): Promise<NamedOutputFile[]>;
-
-  /** Ensure the XML structure in the file is well formed. */
-  ensureCorrectXmlStructure(
-    filePath: string,
-    documentTag: string,
-  ): Promise<void>;
 
   /** Print token usage and cost statistics. */
   printStatistics(

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -42,7 +42,7 @@ export class OutputHandler implements IOutputHandler {
   public processGroupId?: string;
   protected logger: AgentLogger;
   protected channel: string;
-  private xmlManager: XmlOutputManager;
+  public readonly xmlManager: XmlOutputManager;
   private diffManager: LatexDiffManager;
   private statsReporter: StatisticsReporter;
   private diffStatsManager: DiffStatsManager;
@@ -143,11 +143,6 @@ export class OutputHandler implements IOutputHandler {
     for (const filePath of filePaths) {
       await this.indentLatexFile(filePath);
     }
-  }
-
-  /** Processes XML content by filtering tags and applying replacements. */
-  public async processXmlContent(content: string): Promise<string> {
-    return this.xmlManager.processXmlContent(content);
   }
 
   /**
@@ -288,26 +283,6 @@ export class OutputHandler implements IOutputHandler {
     });
   }
 
-  /** Processes single output file with XML splitting and filtering. */
-  public async processSingleXmlOutput(
-    outputFile: string,
-  ): Promise<NamedOutputFile> {
-    return this.xmlManager.processSingleXmlOutput(outputFile);
-  }
-
-  /** Processes multiple output files with XML splitting and filtering. */
-  public async processMultipleXmlOutputs(
-    outputFile: string,
-  ): Promise<NamedOutputFile[]> {
-    return this.xmlManager.processMultipleXmlOutputs(outputFile);
-  }
-  async ensureCorrectXmlStructure(
-    filePath: string,
-    documentTag: string,
-  ): Promise<void> {
-    await this.xmlManager.ensureCorrectXmlStructure(filePath, documentTag);
-  }
-
   /** Prints statistics about token usage and costs */
   public async printStatistics(
     stateGlobal: AgentStateGlobal,
@@ -337,7 +312,8 @@ export class OutputHandler implements IOutputHandler {
       );
 
       try {
-        const processedPairs = await this.processMultipleXmlOutputs(outputFile);
+        const processedPairs =
+          await this.xmlManager.processMultipleXmlOutputs(outputFile);
 
         if (processedPairs && processedPairs.length > 0) {
           const processedFiles = processedPairs.map((p) => p.path);
@@ -387,7 +363,7 @@ export class OutputHandler implements IOutputHandler {
           path: outputFile,
         };
         if (this.agentSetting.agentType === AgentType.CoT) {
-          processed = await this.processSingleXmlOutput(outputFile);
+          processed = await this.xmlManager.processSingleXmlOutput(outputFile);
         }
 
         if (processed && processed.path) {


### PR DESCRIPTION
## Summary
- delete redundant XML wrappers from `OutputHandler`
- expose `xmlManager` directly through the handler
- update CoT agent and interface to use `xmlManager` directly

## Testing
- `npm run lint`
- `npm test` *(fails: VS Code download blocked)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687c1005160c8324aff6e59cbb95b11a