### PR TITLE
Refactor event bus API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ This document sets the common conventions for contributions. Follow these norms 
 - Use `setupPasteListener` from `src/webview/modules/pasteHandler.js` to enable clipboard image pasting in text areas.
 - Implement agents using the `IAgent` interface (`src/agent/IAgent.ts`) for a consistent lifecycle.
 - Track log groups with numeric timestamps using `addLogMessage` in `src/logger/logUtils.ts`.
-- Use the event bus (`emitProgress`/`onProgress` from `src/eventBus/ProgressEventBus.ts`) to publish and subscribe to progress updates instead of calling `ProgressViewProvider` methods directly.
+- Use the event bus (`bus.emit`/`bus.on` from `src/eventBus/ProgressEventBus.ts`) to publish and subscribe to progress updates instead of calling `ProgressViewProvider` methods directly.
 - Only agent streams appear in the ProgressView and get their own output channels. Other logs share the
   consolidated `TeXRA` channel and are not persisted across sessions.
 - Update cumulative usage stats with `updateUsageSummary` in `src/progressView/modules/domHandlers.js`.

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -9,7 +9,7 @@
 // Local imports - latex utils
 import { bestConnectionMethod, LatexMediaManager } from '@latex';
 
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
@@ -472,7 +472,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         );
       }
     }
-    emitProgress('addOutputFiles', {
+    bus.emit('addOutputFiles', {
       stream: this.logger.channelId,
       filesByRound: { [currRound]: fileInfos },
     });

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -2,7 +2,7 @@
 import { randomUUID } from 'crypto';
 
 // Local imports
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { encode as encodeHtml } from 'he';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -24,7 +24,7 @@ export async function streamReasoningToProgressView<T>(
   const id = randomUUID();
   let content = '';
 
-  emitProgress('addLogMessage', {
+  bus.emit('addLogMessage', {
     stream: streamId,
     logMessage: {
       id,
@@ -38,7 +38,7 @@ export async function streamReasoningToProgressView<T>(
 
   for await (const chunk of stream) {
     content += extract(chunk);
-    emitProgress('updateLogMessage', {
+    bus.emit('updateLogMessage', {
       stream: streamId,
       logMessage: {
         id,

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -24,7 +24,7 @@ import type { IModelHandler } from '@agent/modelHandlers';
 import { replaceInputCommands, createFileMapping } from '@utils/files';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 
@@ -233,7 +233,7 @@ export class OutputHandler implements IOutputHandler {
   ): Promise<void> {
     const expected = this.agentConfig.outputFiles;
     if (!expected || expected.length === 0) {
-      emitProgress('updateMissingOutputs', {
+      bus.emit('updateMissingOutputs', {
         stream: this.channel,
         filesByRound: { [currRound]: [] },
       });
@@ -282,7 +282,7 @@ export class OutputHandler implements IOutputHandler {
       this.logger.missingOutputs(missingOutputsData, groupId);
     }
 
-    emitProgress('updateMissingOutputs', {
+    bus.emit('updateMissingOutputs', {
       stream: this.channel,
       filesByRound: { [currRound]: missing },
     });
@@ -419,7 +419,7 @@ export class OutputHandler implements IOutputHandler {
           documentTag: this.agentSetting.documentTag,
         };
         this.logger.missingOutputs(missingOutputsData, activeGroupId);
-        emitProgress('updateMissingOutputs', {
+        bus.emit('updateMissingOutputs', {
           stream: this.channel,
           filesByRound: { [currRound]: [] },
         });

--- a/src/agent/output/StatisticsReporter.ts
+++ b/src/agent/output/StatisticsReporter.ts
@@ -1,5 +1,5 @@
 import { AgentLogger } from '@logger/AgentLogger';
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 import { AgentStateGlobal } from '@agent/core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
 import {
@@ -91,7 +91,7 @@ export class StatisticsReporter {
       const cost = this.modelHandler.computePrice(responseUsage);
 
       if (statsGroupId) {
-        emitProgress('updateGroupUsage', {
+        bus.emit('updateGroupUsage', {
           stream: this.channel,
           groupId: statsGroupId,
           usage: {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -22,7 +22,7 @@ import { DirectAgent, CoTAgent, MergeAgent } from '@agent/implementations';
 
 import { AgentLogger } from '@logger/AgentLogger';
 
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
@@ -199,8 +199,8 @@ async function executeAgentWithLogging<T extends IAgent>(
         );
 
         // Switch to this stream and set its status to running
-        emitProgress('setActiveStream', streamTabId);
-        emitProgress('updateStreamStatus', {
+        bus.emit('setActiveStream', streamTabId);
+        bus.emit('updateStreamStatus', {
           stream: streamTabId,
           status: 'running',
         });
@@ -251,7 +251,7 @@ async function executeAgentWithLogging<T extends IAgent>(
         logger.endGroup(taskDetailsGroupId, 'stopped');
 
         // Convert AgentConfig to TaskState using utility function
-        emitProgress('setTaskState', {
+        bus.emit('setTaskState', {
           streamTabId: streamTabId,
           executionId,
           taskState: agentConfigToTaskState(config),
@@ -273,7 +273,7 @@ async function executeAgentWithLogging<T extends IAgent>(
           logger.debug(`Task completed successfully`, mainTaskGroupId);
           logger.endGroup(mainTaskGroupId, 'stopped');
           // Update status to stopped on successful completion
-          emitProgress('updateStreamStatus', {
+          bus.emit('updateStreamStatus', {
             stream: streamTabId,
             status: 'stopped',
           });
@@ -294,7 +294,7 @@ async function executeAgentWithLogging<T extends IAgent>(
           );
           logger.endGroup(mainTaskGroupId, 'error');
           // Update status to error if agent run fails
-          emitProgress('updateStreamStatus', {
+          bus.emit('updateStreamStatus', {
             stream: streamTabId,
             status: 'error',
           });

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -6,7 +6,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - agent
 import { BaseAgent } from '@agent/implementations/BaseAgent';
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 
 const CHANNEL = 'AgentCommands';
 logger.initialize(CHANNEL);
@@ -26,7 +26,7 @@ async function handleStopAgent(stream: string) {
   }
 
   // Update the UI status
-  emitProgress('updateStreamStatus', { stream, status: 'stopped' });
+  bus.emit('updateStreamStatus', { stream, status: 'stopped' });
 }
 
 export const agentCommands = {

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -82,9 +82,9 @@ async function handleCleanSingle(
   showCleanResult(result, inputFile);
 
   const streamId = getStreamTabId(agent, model, inputFile);
-  emitProgress('clearOutputFiles', streamId);
-  emitProgress('clearMissingOutputs', streamId);
-  emitProgress('clearTaskOutput', streamId);
+  bus.emit('clearOutputFiles', streamId);
+  bus.emit('clearMissingOutputs', streamId);
+  bus.emit('clearTaskOutput', streamId);
 }
 
 async function handleCleanMultiple(
@@ -115,9 +115,9 @@ async function handleCleanMultiple(
   showCleanResult(result, inputFile);
 
   const streamId = getStreamTabId(agent, model, inputFile, outputFiles);
-  emitProgress('clearOutputFiles', streamId);
-  emitProgress('clearMissingOutputs', streamId);
-  emitProgress('clearTaskOutput', streamId);
+  bus.emit('clearOutputFiles', streamId);
+  bus.emit('clearMissingOutputs', streamId);
+  bus.emit('clearTaskOutput', streamId);
 }
 
 export async function handleClean(config: {
@@ -163,9 +163,9 @@ export async function handleClean(config: {
   const streamId =
     config.streamId ||
     getStreamTabId(config.agent, config.model, config.inputFile, outputFiles);
-  emitProgress('clearOutputFiles', streamId);
-  emitProgress('clearMissingOutputs', streamId);
-  emitProgress('clearTaskOutput', streamId);
+  bus.emit('clearOutputFiles', streamId);
+  bus.emit('clearMissingOutputs', streamId);
+  bus.emit('clearTaskOutput', streamId);
 }
 
 export const cleanCommands = {

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -81,9 +81,9 @@ async function handlePack(config: { streamId?: string; [key: string]: any }) {
   const streamId =
     config.streamId ||
     getStreamTabId(config.agent, config.model, config.inputFile, outputFiles);
-  emitProgress('clearOutputFiles', streamId);
-  emitProgress('clearMissingOutputs', streamId);
-  emitProgress('clearTaskOutput', streamId);
+  bus.emit('clearOutputFiles', streamId);
+  bus.emit('clearMissingOutputs', streamId);
+  bus.emit('clearTaskOutput', streamId);
 }
 
 async function handlePackSingle(
@@ -112,9 +112,9 @@ async function handlePackSingle(
   showPackResult(result, inputFile);
 
   const streamId = getStreamTabId(agent, model, inputFile);
-  emitProgress('clearOutputFiles', streamId);
-  emitProgress('clearMissingOutputs', streamId);
-  emitProgress('clearTaskOutput', streamId);
+  bus.emit('clearOutputFiles', streamId);
+  bus.emit('clearMissingOutputs', streamId);
+  bus.emit('clearTaskOutput', streamId);
 }
 
 async function handlePackMultiple(
@@ -146,9 +146,9 @@ async function handlePackMultiple(
   showPackResult(result, inputFile);
 
   const streamId = getStreamTabId(agent, model, inputFile, outputFiles);
-  emitProgress('clearOutputFiles', streamId);
-  emitProgress('clearMissingOutputs', streamId);
-  emitProgress('clearTaskOutput', streamId);
+  bus.emit('clearOutputFiles', streamId);
+  bus.emit('clearMissingOutputs', streamId);
+  bus.emit('clearTaskOutput', streamId);
 }
 
 export const packCommands = {

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -49,15 +49,4 @@ class ProgressEventBus {
   }
 }
 
-const bus = new ProgressEventBus();
-
-export const emitProgress = (event: ProgressEvent, payload: any): void => {
-  bus.emit(event, payload);
-};
-
-export const onProgress = (
-  event: ProgressEvent,
-  listener: (payload: any) => void,
-): (() => void) => {
-  return bus.on(event, listener);
-};
+export const bus = new ProgressEventBus();

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -6,7 +6,7 @@ import { encode as encodeHtml, decode as decodeHtml } from 'he';
 import { randomUUID } from 'crypto';
 
 // Local imports - progressView
-import { emitProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 import { getConfig } from '@utils/config';
 import { TaskGroup, LogMessageData } from './LogTypes';
 import { MESSAGE_TYPES, type MessageType } from './messageTypes';
@@ -142,7 +142,7 @@ class VSCodeTransport extends Transport {
       data: info.data,
     } satisfies import('./LogTypes').LogMessageData;
 
-    emitProgress('addLogMessage', {
+    bus.emit('addLogMessage', {
       stream: this.streamName,
       logMessage,
     });
@@ -174,7 +174,7 @@ class VSCodeTransport extends Transport {
       return groupId;
     }
 
-    emitProgress('addTaskGroup', {
+    bus.emit('addTaskGroup', {
       stream: this.streamName,
       groupId,
       groupName,
@@ -203,7 +203,7 @@ class VSCodeTransport extends Transport {
       return;
     }
 
-    emitProgress('updateTaskGroup', {
+    bus.emit('updateTaskGroup', {
       stream: this.streamName,
       groupId,
       status,

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -5,7 +5,7 @@ import { ProgressViewState } from '../state/ProgressViewState';
 import { WebviewUpdater } from '../managers';
 import { AgentLogger } from '@logger/AgentLogger';
 import { getConfig } from '@utils/config';
-import { onProgress } from '@eventBus/ProgressEventBus';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
@@ -56,58 +56,52 @@ export class ProgressEventHandler {
   setupEventListeners(): vscode.Disposable[] {
     return [
       new vscode.Disposable(
-        onProgress('setActiveStream', this.handleSetActiveStream.bind(this)),
+        bus.on('setActiveStream', this.handleSetActiveStream.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress(
-          'updateStreamStatus',
-          this.handleUpdateStreamStatus.bind(this),
-        ),
+        bus.on('updateStreamStatus', this.handleUpdateStreamStatus.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress('addOutputFiles', this.handleAddOutputFiles.bind(this)),
+        bus.on('addOutputFiles', this.handleAddOutputFiles.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress(
+        bus.on(
           'updateMissingOutputs',
           this.handleUpdateMissingOutputs.bind(this),
         ),
       ),
       new vscode.Disposable(
-        onProgress(
+        bus.on(
           'clearMissingOutputs',
           this.handleClearMissingOutputs.bind(this),
         ),
       ),
       new vscode.Disposable(
-        onProgress('clearOutputFiles', this.handleClearOutputFiles.bind(this)),
+        bus.on('clearOutputFiles', this.handleClearOutputFiles.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress('setTaskState', this.handleSetTaskState.bind(this)),
+        bus.on('setTaskState', this.handleSetTaskState.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress('updateGroupUsage', this.handleUpdateGroupUsage.bind(this)),
+        bus.on('updateGroupUsage', this.handleUpdateGroupUsage.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress('clearTaskOutput', this.handleClearTaskOutput.bind(this)),
+        bus.on('clearTaskOutput', this.handleClearTaskOutput.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress(
-          'updateStreamUsage',
-          this.handleUpdateStreamUsage.bind(this),
-        ),
+        bus.on('updateStreamUsage', this.handleUpdateStreamUsage.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress('addLogMessage', this.handleAddLogMessage.bind(this)),
+        bus.on('addLogMessage', this.handleAddLogMessage.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress('updateLogMessage', this.handleUpdateLogMessage.bind(this)),
+        bus.on('updateLogMessage', this.handleUpdateLogMessage.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress('addTaskGroup', this.handleAddTaskGroup.bind(this)),
+        bus.on('addTaskGroup', this.handleAddTaskGroup.bind(this)),
       ),
       new vscode.Disposable(
-        onProgress('updateTaskGroup', this.handleUpdateTaskGroup.bind(this)),
+        bus.on('updateTaskGroup', this.handleUpdateTaskGroup.bind(this)),
       ),
     ];
   }


### PR DESCRIPTION
## Summary
- remove emitProgress/onProgress wrappers
- export ProgressEventBus instance as `bus`
- update callers to use `bus.emit` and `bus.on`
- adjust contributor guidelines accordingly

## Testing
- `npm run lint`
- `npm test` *(fails to run fully in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_687c101242cc8324ac367e2e86e63aab