### PR TITLE
Remove createAgentConfig helper

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -1,5 +1,5 @@
 // Local imports - agent components
-import { ToolConfig, ToolConfigSchema } from './ToolConfig';
+import { ToolConfigSchema } from './ToolConfig';
 
 import { z } from 'zod';
 
@@ -43,12 +43,3 @@ export const AgentConfigSchema = z
   });
 
 export type AgentConfig = z.infer<typeof AgentConfigSchema>;
-
-/**
- * Creates a complete AgentConfig by merging partial config with defaults.
- * @param config Partial configuration to merge with defaults
- * @returns Complete AgentConfig with all fields populated
- */
-export function createAgentConfig(config: Partial<AgentConfig>): AgentConfig {
-  return AgentConfigSchema.parse(config);
-}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -10,7 +10,7 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { agentConfigToTaskState } from '@utils/config';
 
 // Local imports - agent components
-import { createAgentConfig } from '@agent/core/AgentConfig';
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
@@ -370,7 +370,7 @@ export async function executeAgent(
     agentName,
     async () => {
       // Create full agent config
-      const fullConfig = createAgentConfig(agentConfig);
+      const fullConfig = AgentConfigSchema.parse(agentConfig);
 
       // Get model configuration
       const modelName = fullConfig.model;
@@ -437,7 +437,7 @@ export async function executeMergeAgent(
     agentName,
     async () => {
       // Create agent config for merge operation
-      const agentConfig = createAgentConfig({
+      const agentConfig = AgentConfigSchema.parse({
         agent: 'merge',
         model,
         inputFile,


### PR DESCRIPTION
## Summary
- delete `createAgentConfig` utility
- parse configs directly with `AgentConfigSchema.parse`

## Testing
- `npm run lint`
- `npm test` *(fails: unable to complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_687c1f2bf494832491e0c769aa326de0