### PR TITLE
Refactor progressView activeStream access

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -49,7 +49,7 @@ export class ProgressViewMessageHandler {
   }
 
   handleUpdateStreams(message) {
-    state.setActiveStream(message.activeStream);
+    state.activeStream = message.activeStream;
     dom.streamTabs.update(message.streams, message.activeStream);
 
     // Update status based on whether there's an active stream
@@ -63,7 +63,7 @@ export class ProgressViewMessageHandler {
 
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    if (message.stream === state.getActiveStream()) {
+    if (message.stream === state.activeStream) {
       logContent.innerHTML = '';
       state.taskGroups.clear();
       if (message.groups && message.groups.length > 0) {
@@ -112,7 +112,7 @@ export class ProgressViewMessageHandler {
   }
 
   handleAppendLog(message) {
-    if (message.stream === state.getActiveStream()) {
+    if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
@@ -125,13 +125,13 @@ export class ProgressViewMessageHandler {
   }
 
   handleUpdateLog(message) {
-    if (message.stream === state.getActiveStream()) {
+    if (message.stream === state.activeStream) {
       dom.logEntries.update(message.logMessage);
     }
   }
 
   handleAddTaskGroup(message) {
-    if (message.stream === state.getActiveStream()) {
+    if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       dom.taskGroups.add(message.group);
       logContent.scrollTop = logContent.scrollHeight;
@@ -139,7 +139,7 @@ export class ProgressViewMessageHandler {
   }
 
   handleUpdateTaskGroup(message) {
-    if (message.stream === state.getActiveStream()) {
+    if (message.stream === state.activeStream) {
       state.taskGroups.update(message.groupId, message.status, message.endTime);
       dom.taskGroups.update(message.groupId, message.status, message.endTime);
     }
@@ -154,13 +154,13 @@ export class ProgressViewMessageHandler {
   }
 
   handleUpdateGroupUsage(message) {
-    if (message.stream === state.getActiveStream()) {
+    if (message.stream === state.activeStream) {
       dom.usageGroup.update(message.groupId, message.usage);
     }
   }
 
   handleUpdateFiles(message) {
-    if (message.stream === state.getActiveStream()) {
+    if (message.stream === state.activeStream) {
       dom.fileList.update(message.files);
     }
   }
@@ -172,7 +172,7 @@ export class ProgressViewMessageHandler {
   handleDeleteStream(message) {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
-      if (message.stream === state.getActiveStream()) {
+      if (message.stream === state.activeStream) {
         const groupIds = [];
         const headers = Array.from(
           document.querySelectorAll('.log-group-header'),

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -200,15 +200,6 @@ export class ProgressViewState {
       console.error('Failed to save state:', e);
     }
   }
-
-  // --- Active stream operations ---
-  getActiveStream() {
-    return this.activeStream;
-  }
-
-  setActiveStream(stream) {
-    this.activeStream = stream;
-  }
 }
 
 export const progressViewState = new ProgressViewState();

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -60,7 +60,7 @@ export class EventsManager {
         if (!button || button.disabled) return;
 
         const command = button.dataset.command;
-        const activeStream = progressViewState.getActiveStream();
+        const activeStream = progressViewState.activeStream;
 
         if (activeStream) {
           vscode.postMessage({ command, stream: activeStream });

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -98,7 +98,7 @@ export class Status {
         if (el) el.disabled = false;
       });
 
-      const activeStream = progressViewState.getActiveStream();
+      const activeStream = progressViewState.activeStream;
       if (activeStream && status !== STATUS.READY) {
         progressViewState.streamStatuses.set(activeStream, status);
       }


### PR DESCRIPTION
## Summary
- remove trivial active stream getter/setter
- reference `activeStream` property directly in message handler and managers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c2248719c832487c155aadcab9992