### PR TITLE
Add statistics log styling

### DIFF
--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -109,7 +109,8 @@ export class EventsManager {
           e.target &&
           (e.target.classList.contains('special-details') ||
             e.target.classList.contains('file-list-details') ||
-            e.target.classList.contains('latexdiff-details'))
+            e.target.classList.contains('latexdiff-details') ||
+            e.target.classList.contains('statistics-details'))
         ) {
           const toggleIcon = e.target.querySelector('.toggle-icon');
           if (toggleIcon) {

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -17,3 +17,4 @@
 @import './scratchpad.css';
 @import './file-list.css';
 @import './latexdiff.css';
+@import './statistics.css';

--- a/src/progressView/styles/statistics.css
+++ b/src/progressView/styles/statistics.css
@@ -1,0 +1,42 @@
+/**
+ * Statistics log styles for ProgressView
+ */
+
+.statistics-details {
+  margin: var(--spacing-small) 0;
+}
+
+.statistics-details summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) 0;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  opacity: var(--opacity-normal);
+}
+
+.statistics-details summary:hover {
+  opacity: 1;
+}
+
+.statistics-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.statistics-content {
+  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
+  list-style: none;
+}
+
+.statistics-content li {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.statistics-details summary .toggle-icon {
+  opacity: var(--opacity-subtle);
+  font-size: var(--font-size-sm);
+}


### PR DESCRIPTION
## Summary
- add css for statistics entries
- import new styles in ProgressView
- update toggle handler to support statistics blocks

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cbffb2c7c83248f387d806edba839