### PR TITLE
feat: show stream metadata in progress tabs

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -24,6 +24,7 @@ This section lists all the agent execution streams from your current VS Code ses
 
 - **Switching Streams**: Click on a stream name (e.g., `polish@sonnet37: paper.tex`) to view its specific logs and status in the Content Area.
 - **Delete All**: The <i class="codicon codicon-trash"></i> **Delete All** button at the bottom permanently removes all streams and their logs from the ProgressBoard view for the current session.
+- **Metadata**: Each tab also shows the model, last activity time, and small icons indicating agent type and whether multiple output files were produced.
 
 ## Content Area
 

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -22,6 +22,8 @@ The ProgressBoard interface is split into two main sections (usually side-by-sid
 
 This section lists all the agent execution streams from your current VS Code session.
 
+- **Tab Layout**: The first line shows `agent: input.tex` while the second line lists the model and how long ago it was active.
+
 - **Switching Streams**: Click on a stream name (e.g., `polish@sonnet37: paper.tex`) to view its specific logs and status in the Content Area.
 - **Delete All**: The <i class="codicon codicon-trash"></i> **Delete All** button at the bottom permanently removes all streams and their logs from the ProgressBoard view for the current session.
 - **Metadata**: Each tab also shows the model, last activity time, and small icons indicating agent type and whether multiple output files were produced.

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import * as path from 'path';
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
 import { WebviewUpdater } from '../managers';
@@ -55,8 +56,11 @@ export class ProgressEventHandler {
       const outputs = taskState?.agentConfig.outputFiles || [];
       return {
         name: id,
+        agentName: taskState?.agentConfig.agent,
+        inputFile: taskState
+          ? path.basename(taskState.agentConfig.inputFile)
+          : undefined,
         model: taskState?.agentConfig.model,
-        agent: taskState?.agentConfig.agent,
         hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
         lastTimestamp,
       };

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -13,6 +13,7 @@ import { TaskState } from '@logger/TaskState';
 import { LogMessageData, TaskGroup } from '@logger/LogTypes';
 import { parseLegacyLogData } from '@logger/logUtils';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type { StreamTabInfo } from '../types';
 
 // @ts-ignore - Import JavaScript module
 import { STATUS } from '../modules/constants.js';
@@ -43,6 +44,23 @@ export class ProgressEventHandler {
     private webviewUpdater: WebviewUpdater,
   ) {
     this.logger = new AgentLogger('ProgressEventHandler');
+  }
+
+  private buildStreamInfos(): StreamTabInfo[] {
+    return this.state.streamTabs.keys().map((id) => {
+      const taskState = this.state.getTaskState(id);
+      const logs = this.state.streamTabs.get(id);
+      const lastTimestamp =
+        logs && logs.length > 0 ? logs[logs.length - 1].timestamp : undefined;
+      const outputs = taskState?.agentConfig.outputFiles || [];
+      return {
+        name: id,
+        model: taskState?.agentConfig.model,
+        agent: taskState?.agentConfig.agent,
+        hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
+        lastTimestamp,
+      };
+    });
   }
 
   /**
@@ -122,8 +140,8 @@ export class ProgressEventHandler {
     this.state.activeStream = stream;
 
     if (this.webviewUpdater.isAvailable()) {
-      const streams = this.state.streamTabs.keys();
-      this.webviewUpdater.updateStreams(streams, stream);
+      const infos = this.buildStreamInfos();
+      this.webviewUpdater.updateStreams(infos, stream);
 
       // Update log content (will be empty for new streams)
       this.updateLogContentForStream(stream);

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -119,7 +119,17 @@
         </template>
         <template id="streamTabTemplate">
           <div class="tab-container" title="">
-            <button class="tab" data-stream="" title=""></button>
+            <div class="tab-details">
+              <div class="tab-header">
+                <button class="tab" data-stream="" title=""></button>
+                <i class="agent-type"></i>
+              </div>
+              <div class="tab-meta">
+                <span class="model"></span>
+                <span class="last-active"></span>
+                <i class="multi-file"></i>
+              </div>
+            </div>
             <button class="tab-delete" data-stream="" title="Delete stream">
               <i class="codicon codicon-close"></i>
             </button>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -118,17 +118,15 @@
           <i class="codicon codicon-circle-small-filled group-bullet"></i>
         </template>
         <template id="streamTabTemplate">
-          <div class="tab-container" title="">
-            <div class="tab-details">
-              <div class="tab-header">
-                <button class="tab" data-stream="" title=""></button>
-                <i class="agent-type"></i>
-              </div>
-              <div class="tab-meta">
-                <span class="model"></span>
-                <span class="last-active"></span>
-                <i class="multi-file"></i>
-              </div>
+          <div class="tab-container" data-stream="" title="">
+            <div class="tab-main">
+              <span class="tab-title"></span>
+              <i class="agent-type"></i>
+              <i class="multi-file"></i>
+            </div>
+            <div class="tab-meta">
+              <span class="model"></span>
+              <span class="last-active"></span>
             </div>
             <button class="tab-delete" data-stream="" title="Delete stream">
               <i class="codicon codicon-close"></i>

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -9,6 +9,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { LogMessageData } from '@logger/LogTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamTabInfo } from '../types';
 
 // @ts-ignore - Import JavaScript module
 import { COMMANDS } from '../modules/constants.js';
@@ -31,7 +32,7 @@ export class WebviewUpdater {
   /**
    * Update stream tabs in the webview
    */
-  updateStreams(streams: StreamTabId[], activeStream: StreamTabId): void {
+  updateStreams(streams: StreamTabInfo[], activeStream: StreamTabId): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -188,8 +189,22 @@ export class WebviewUpdater {
     const webview = this.getWebview();
     if (!webview) return;
 
-    const streams = state.streamTabs.keys();
     const activeStream = state.activeStream;
+
+    const streams: StreamTabInfo[] = state.streamTabs.keys().map((id) => {
+      const taskState = state.getTaskState(id);
+      const logs = state.streamTabs.get(id);
+      const lastTimestamp =
+        logs && logs.length > 0 ? logs[logs.length - 1].timestamp : undefined;
+      const outputs = taskState?.agentConfig.outputFiles || [];
+      return {
+        name: id,
+        model: taskState?.agentConfig.model,
+        agent: taskState?.agentConfig.agent,
+        hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
+        lastTimestamp,
+      };
+    });
 
     // Update streams and active stream
     this.updateStreams(streams, activeStream);

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import * as path from 'path';
 
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
@@ -199,8 +200,11 @@ export class WebviewUpdater {
       const outputs = taskState?.agentConfig.outputFiles || [];
       return {
         name: id,
+        agentName: taskState?.agentConfig.agent,
+        inputFile: taskState
+          ? path.basename(taskState.agentConfig.inputFile)
+          : undefined,
         model: taskState?.agentConfig.model,
-        agent: taskState?.agentConfig.agent,
         hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
         lastTimestamp,
       };

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -36,18 +36,18 @@ export class EventsManager {
     document
       .getElementById(ELEMENT_IDS.STREAM_TABS)
       .addEventListener('click', (e) => {
-        const tabButton = e.target.closest('.tab');
+        const container = e.target.closest('.tab-container');
         const deleteButton = e.target.closest('.tab-delete');
 
-        if (tabButton && tabButton.dataset.stream) {
-          vscode.postMessage({
-            command: COMMANDS.SWITCH_STREAM,
-            stream: tabButton.dataset.stream,
-          });
-        } else if (deleteButton && deleteButton.dataset.stream) {
+        if (deleteButton && deleteButton.dataset.stream) {
           vscode.postMessage({
             command: COMMANDS.DELETE_STREAM,
             stream: deleteButton.dataset.stream,
+          });
+        } else if (container && container.dataset.stream) {
+          vscode.postMessage({
+            command: COMMANDS.SWITCH_STREAM,
+            stream: container.dataset.stream,
           });
         }
       });

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -2,6 +2,12 @@
 import { ELEMENT_IDS } from '../constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
+const AGENT_ICONS = {
+  CoT: 'terminal',
+  direct: 'lightbulb',
+  toolUse: 'tools',
+};
+
 /**
  * Manages stream tab UI updates.
  */
@@ -29,38 +35,34 @@ export class StreamTabs {
       }
       const tabEl = createFromTemplate('streamTabTemplate', {
         text: {
-          '.tab': info.name,
+          '.tab-title': `${info.agentName || ''}: ${info.inputFile || ''}`,
           '.model': info.model || '',
-          '.last-active': this._formatRelativeTime(info.lastTimestamp),
+          '.last-active': this.formatRelativeTime(info.lastTimestamp),
         },
         attributes: {
-          '.tab': { title: info.name },
+          '': { title: info.name },
           '.tab-delete': { title: 'Delete stream' },
         },
         dataset: {
-          '.tab': { stream: info.name },
+          '': { stream: info.name },
           '.tab-delete': { stream: info.name },
         },
       });
       if (!tabEl) return;
-      if (info.agent) {
-        const icon = info.agent.toLowerCase().includes('cot')
-          ? 'terminal'
-          : 'lightbulb';
-        tabEl
-          .querySelector('.agent-type')
-          .classList.add('codicon', `codicon-${icon}`);
+      const agentIcon = tabEl.querySelector('.agent-type');
+      if (agentIcon && info.agentType) {
+        const icon = AGENT_ICONS[info.agentType] || AGENT_ICONS.direct;
+        agentIcon.className = `codicon codicon-${icon} agent-type`;
       }
-      if (info.hasMultipleOutputs) {
-        tabEl
-          .querySelector('.multi-file')
-          .classList.add('codicon', 'codicon-files');
-      } else {
-        const el = tabEl.querySelector('.multi-file');
-        if (el) el.remove();
+      const multi = tabEl.querySelector('.multi-file');
+      if (multi) {
+        if (info.hasMultipleOutputs) {
+          multi.className = 'codicon codicon-files multi-file';
+        } else {
+          multi.remove();
+        }
       }
       if (info.name === activeStream) tabEl.classList.add('active');
-      tabEl.title = info.name;
       tabsContainer.appendChild(tabEl);
     });
 
@@ -73,7 +75,7 @@ export class StreamTabs {
     }
   }
 
-  _formatRelativeTime(timestamp) {
+  formatRelativeTime(timestamp) {
     if (!timestamp) return '';
     const diff = Date.now() - timestamp;
     const minutes = Math.floor(diff / 60000);

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -8,7 +8,7 @@ import { createFromTemplate } from '@common/templateUtils.js';
 export class StreamTabs {
   /**
    * Updates UI to show stream tabs and highlight the active stream
-   * @param {Array} streams - Array of stream names
+   * @param {Array} streams - Array of stream metadata objects
    * @param {string} activeStream - Currently active stream
    */
   update(streams, activeStream) {
@@ -22,22 +22,45 @@ export class StreamTabs {
       return;
     }
     tabsContainer.innerHTML = '';
-    streams.forEach((stream) => {
-      if (!stream || typeof stream !== 'string') {
-        console.warn('StreamTabs.update: invalid stream value:', stream);
+    streams.forEach((info) => {
+      if (!info || typeof info !== 'object') {
+        console.warn('StreamTabs.update: invalid stream value:', info);
         return;
       }
       const tabEl = createFromTemplate('streamTabTemplate', {
-        text: { '.tab': stream },
+        text: {
+          '.tab': info.name,
+          '.model': info.model || '',
+          '.last-active': this._formatRelativeTime(info.lastTimestamp),
+        },
         attributes: {
-          '.tab': { title: stream },
+          '.tab': { title: info.name },
           '.tab-delete': { title: 'Delete stream' },
         },
-        dataset: { '.tab': { stream }, '.tab-delete': { stream } },
+        dataset: {
+          '.tab': { stream: info.name },
+          '.tab-delete': { stream: info.name },
+        },
       });
       if (!tabEl) return;
-      if (stream === activeStream) tabEl.classList.add('active');
-      tabEl.title = stream;
+      if (info.agent) {
+        const icon = info.agent.toLowerCase().includes('cot')
+          ? 'terminal'
+          : 'lightbulb';
+        tabEl
+          .querySelector('.agent-type')
+          .classList.add('codicon', `codicon-${icon}`);
+      }
+      if (info.hasMultipleOutputs) {
+        tabEl
+          .querySelector('.multi-file')
+          .classList.add('codicon', 'codicon-files');
+      } else {
+        const el = tabEl.querySelector('.multi-file');
+        if (el) el.remove();
+      }
+      if (info.name === activeStream) tabEl.classList.add('active');
+      tabEl.title = info.name;
       tabsContainer.appendChild(tabEl);
     });
 
@@ -48,5 +71,20 @@ export class StreamTabs {
     if (streamNameElem) {
       streamNameElem.textContent = activeStream || '';
     }
+  }
+
+  _formatRelativeTime(timestamp) {
+    if (!timestamp) return '';
+    const diff = Date.now() - timestamp;
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return 'just now';
+    if (minutes === 1) return '1 min ago';
+    if (minutes < 60) return `${minutes} mins ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours === 1) return '1 hr ago';
+    if (hours < 24) return `${hours} hrs ago`;
+    const days = Math.floor(hours / 24);
+    if (days === 1) return '1 day ago';
+    return `${days} days ago`;
   }
 }

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -52,6 +52,37 @@
   width: 100%;
 }
 
+.tab-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.tab-header {
+  display: flex;
+  align-items: center;
+}
+
+.tab-header .agent-type {
+  margin-left: var(--spacing-small);
+  font-size: var(--font-size-sm);
+  opacity: var(--opacity-subtle);
+}
+
+.tab-meta {
+  display: flex;
+  gap: var(--spacing-small);
+  font-size: var(--font-size-sm);
+  padding-left: var(--spacing-medium);
+  color: var(--vscode-foreground);
+  opacity: var(--opacity-subtle);
+}
+
+.tab-meta .multi-file {
+  margin-left: auto;
+}
+
 .tab-container:hover {
   background-color: var(--vscode-list-hoverBackground);
 }

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -35,7 +35,6 @@
   padding: var(--spacing-small) var(--spacing-small);
   cursor: pointer;
   border: none;
-  background: none;
   color: var(--vscode-foreground);
   font-family: var(--font-family);
   font-size: var(--font-size-sm);
@@ -52,19 +51,22 @@
   width: 100%;
 }
 
-.tab-details {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.tab-header {
+.tab-main {
   display: flex;
   align-items: center;
+  padding: var(--spacing-small) var(--spacing-medium);
+  cursor: pointer;
 }
 
-.tab-header .agent-type {
+.tab-title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tab-main .agent-type,
+.tab-main .multi-file {
   margin-left: var(--spacing-small);
   font-size: var(--font-size-sm);
   opacity: var(--opacity-subtle);
@@ -91,34 +93,10 @@
   background-color: var(--vscode-list-activeSelectionBackground);
 }
 
-.tab-container.active .tab {
-  color: var(--vscode-list-activeSelectionForeground);
-}
-
-.tab {
-  flex: 1;
-  padding: var(--spacing-small) var(--spacing-medium);
-  cursor: pointer;
-  border: none;
-  background: none;
-  color: var(--vscode-foreground);
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-family: var(--font-family);
-  min-width: 0;
-}
-
-.tab:hover {
-  background: none;
-}
-
 .tab-delete {
   display: none;
   padding: var(--spacing-tiny);
   border: none;
-  background: none;
   color: var(--vscode-foreground);
   opacity: var(--opacity-subtle);
   cursor: pointer;
@@ -150,4 +128,21 @@
 .tab-delete:hover .codicon {
   opacity: var(--opacity-full);
   color: var(--vscode-errorForeground);
+}
+.tab-meta {
+  display: flex;
+  gap: var(--spacing-small);
+  font-size: var(--font-size-sm);
+  padding-left: var(--spacing-medium);
+  color: var(--vscode-foreground);
+  opacity: var(--opacity-subtle);
+}
+
+.tab-container:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.tab-container.active {
+  background-color: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
 }

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,0 +1,7 @@
+export interface StreamTabInfo {
+  name: string;
+  model?: string;
+  agent?: string;
+  hasMultipleOutputs?: boolean;
+  lastTimestamp?: number;
+}

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,7 +1,16 @@
 export interface StreamTabInfo {
+  /** Unique stream identifier */
   name: string;
+  /** Agent YAML name */
+  agentName?: string;
+  /** Input file basename */
+  inputFile?: string;
+  /** Model used for execution */
   model?: string;
-  agent?: string;
+  /** Agent type such as 'CoT' or 'direct' */
+  agentType?: string;
+  /** True if more than one output file */
   hasMultipleOutputs?: boolean;
+  /** Timestamp of the most recent log message */
   lastTimestamp?: number;
 }


### PR DESCRIPTION
## Summary
- display model, last activity, and icons in ProgressBoard tabs
- compute tab info in the backend and send to webview
- document new metadata indicators

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(webpack warning)*

------
https://chatgpt.com/codex/tasks/task_e_68834f7978c48324ba11ee6504664858