### PR TITLE
Add context menu for agent YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ## 0.32.2 - 2025-07-12
 
-- Added "Add Agent to Config" context menu option in the TeX Agents view.
+- Added "Add Agent to Config" context menu option in the TeX Agents view that
+  validates the file then updates `texra.agents` without an extra prompt.
 - Improved YAML validation to handle `.YAML` files and show progress.
 
 ## 0.32.0 - 2025-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.32.2 - 2025-07-12
 
-- Added "Add Agent to Config" context menu option in the TeX Agents view that
+- Added "Add Agent to List" context menu option in the TeX Agents view that
   validates the file then updates `texra.agents` without an extra prompt.
 - Improved YAML validation to handle `.YAML` files and show progress.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - Added Grok 4 model with token limit adjustments.
 - Extended support for Grok via dedicated handler and SDK updates.
 
+## 0.32.2 - 2025-07-12
+
+- Added "Add Agent to Config" context menu option in the TeX Agents view.
+
 ## 0.32.0 - 2025-07-07
 
 - Default model fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ## 0.32.2 - 2025-07-12
 
 - Added "Add Agent to Config" context menu option in the TeX Agents view.
+- Improved YAML validation to handle `.YAML` files and show progress.
 
 ## 0.32.0 - 2025-07-07
 

--- a/docs/guide/agent-explorer.md
+++ b/docs/guide/agent-explorer.md
@@ -32,7 +32,7 @@ Available actions for **Custom Agents** include:
 - **New Folder** <i class="codicon codicon-new-folder"></i>: Creates a new folder within the selected folder. You will be prompted to rename it.
 - **Rename** <i class="codicon codicon-edit"></i>: Renames the selected custom file or folder.
 - **Delete** <i class="codicon codicon-trash"></i>: Deletes the selected custom file or folder (with confirmation).
-- **Add Agent to Config** <i class="codicon codicon-diff-added"></i>: Validates a YAML file and offers to add its agent name to `texra.agents`.
+- **Add Agent to Config** <i class="codicon codicon-diff-added"></i>: Validates a YAML file and adds its agent name to `texra.agents`.
 - **Create AI Agent** <i class="codicon codicon-sparkle"></i>: Launches a wizard that collects a short description and output style (single vs. multiple files) then generates a starter YAML using Claude. See [Strict XML Extraction](./custom-agents.md#strict-xml-extraction) for why the YAML must be precise.
 
 **Important**: These management actions (New File, New Folder, Rename, Delete) are **not available** for items within the "Built-in Agents" section.

--- a/docs/guide/agent-explorer.md
+++ b/docs/guide/agent-explorer.md
@@ -32,6 +32,7 @@ Available actions for **Custom Agents** include:
 - **New Folder** <i class="codicon codicon-new-folder"></i>: Creates a new folder within the selected folder. You will be prompted to rename it.
 - **Rename** <i class="codicon codicon-edit"></i>: Renames the selected custom file or folder.
 - **Delete** <i class="codicon codicon-trash"></i>: Deletes the selected custom file or folder (with confirmation).
+- **Add Agent to Config** <i class="codicon codicon-diff-added"></i>: Validates a YAML file and offers to add its agent name to `texra.agents`.
 - **Create AI Agent** <i class="codicon codicon-sparkle"></i>: Launches a wizard that collects a short description and output style (single vs. multiple files) then generates a starter YAML using Claude. See [Strict XML Extraction](./custom-agents.md#strict-xml-extraction) for why the YAML must be precise.
 
 **Important**: These management actions (New File, New Folder, Rename, Delete) are **not available** for items within the "Built-in Agents" section.

--- a/package.json
+++ b/package.json
@@ -903,6 +903,12 @@
         "icon": "$(trash)"
       },
       {
+        "command": "texra.folderExplorer.addToConfig",
+        "title": "Add Agent to Config",
+        "category": "TeXRA",
+        "icon": "$(diff-added)"
+      },
+      {
         "command": "texra.createAgentWithAI",
         "title": "Create AI Agent",
         "category": "TeXRA",
@@ -1099,6 +1105,11 @@
           "command": "texra.folderExplorer.delete",
           "when": "view == texra.folderExplorer && viewItem != editing",
           "group": "3_modification"
+        },
+        {
+          "command": "texra.folderExplorer.addToConfig",
+          "when": "view == texra.folderExplorer && viewItem == file",
+          "group": "4_modification"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -903,8 +903,8 @@
         "icon": "$(trash)"
       },
       {
-        "command": "texra.folderExplorer.addToConfig",
-        "title": "Add Agent to Config",
+        "command": "texra.folderExplorer.addToList",
+        "title": "Add Agent to List",
         "category": "TeXRA",
         "icon": "$(diff-added)"
       },
@@ -1107,7 +1107,7 @@
           "group": "3_modification"
         },
         {
-          "command": "texra.folderExplorer.addToConfig",
+          "command": "texra.folderExplorer.addToList",
           "when": "view == texra.folderExplorer && viewItem == file",
           "group": "4_modification"
         }

--- a/src/explorer/ExplorerCommands.ts
+++ b/src/explorer/ExplorerCommands.ts
@@ -34,8 +34,8 @@ export class ExplorerCommands {
         (uri: vscode.Uri) => this.operations.open(uri),
       ),
       vscode.commands.registerCommand(
-        'texra.folderExplorer.addToConfig',
-        (node: FileItem) => this.operations.addToConfig(node),
+        'texra.folderExplorer.addToList',
+        (node: FileItem) => this.operations.addToList(node),
       ),
     );
   }

--- a/src/explorer/ExplorerCommands.ts
+++ b/src/explorer/ExplorerCommands.ts
@@ -33,6 +33,10 @@ export class ExplorerCommands {
         'texra.folderExplorer.openFile',
         (uri: vscode.Uri) => this.operations.open(uri),
       ),
+      vscode.commands.registerCommand(
+        'texra.folderExplorer.addToConfig',
+        (node: FileItem) => this.operations.addToConfig(node),
+      ),
     );
   }
 }

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -12,6 +12,7 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { AbsoluteFS } from '@utils/files';
 import { getConfig } from '@utils/config';
 import { FileItem } from './FileItem';
+import { validateYamlAndPromptAdd } from '@frontend/agents/register';
 
 const NEW_AGENT_TEMPLATE = `# --- Agent Inheritance (Optional) ---
 # inherits: base
@@ -284,6 +285,29 @@ export class ExplorerOperations {
           err,
         );
       }
+    }
+  }
+
+  async addToConfig(item: FileItem) {
+    if (!item) {
+      return;
+    }
+
+    if (path.extname(item.resourceUri.fsPath) !== '.yaml') {
+      vscode.window.showInformationMessage(
+        'Only YAML files can be added as agents.',
+      );
+      return;
+    }
+
+    try {
+      await validateYamlAndPromptAdd(item.resourceUri.fsPath, true);
+    } catch (err) {
+      await showLoggedErrorMessage(
+        CHANNEL,
+        'Failed to add agent to configuration',
+        err,
+      );
     }
   }
 }

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -293,7 +293,7 @@ export class ExplorerOperations {
       return;
     }
 
-    if (path.extname(item.resourceUri.fsPath) !== '.yaml') {
+    if (path.extname(item.resourceUri.fsPath).toLowerCase() !== '.yaml') {
       vscode.window.showInformationMessage(
         'Only YAML files can be added as agents.',
       );
@@ -301,7 +301,13 @@ export class ExplorerOperations {
     }
 
     try {
-      await validateYamlAndPromptAdd(item.resourceUri.fsPath, true);
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Window,
+          title: 'Validating agent YAML...',
+        },
+        () => validateYamlAndPromptAdd(item.resourceUri.fsPath, true),
+      );
     } catch (err) {
       await showLoggedErrorMessage(
         CHANNEL,

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -10,7 +10,7 @@ import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 // Local imports
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { AbsoluteFS } from '@utils/files';
-import { getConfig } from '@utils/config';
+
 import { FileItem } from './FileItem';
 import { validateYamlAndPromptAdd } from '@frontend/agents/register';
 
@@ -288,7 +288,7 @@ export class ExplorerOperations {
     }
   }
 
-  async addToConfig(item: FileItem) {
+  async addToList(item: FileItem) {
     if (!item) {
       return;
     }

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -306,7 +306,7 @@ export class ExplorerOperations {
           location: vscode.ProgressLocation.Window,
           title: 'Validating agent YAML...',
         },
-        () => validateYamlAndPromptAdd(item.resourceUri.fsPath, true),
+        () => validateYamlAndPromptAdd(item.resourceUri.fsPath, true, false),
       );
     } catch (err) {
       await showLoggedErrorMessage(

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -6,9 +6,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { isValidAgentYaml } from '../agent/runtime/agentLoad';
-import { promptToAddAgentToConfig } from '@frontend/agents/register';
-import { getConfig } from '@utils/config';
+import { validateYamlAndPromptAdd } from '@frontend/agents/register';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);
@@ -32,22 +30,7 @@ export class WatcherManager {
   }
 
   private async validateYaml(filePath: string) {
-    const validationResult = await isValidAgentYaml(filePath);
-    if (validationResult) {
-      const filenameBase = path.basename(filePath, '.yaml');
-      const internalName = validationResult.name;
-      if (filenameBase !== internalName) {
-        vscode.window.showWarningMessage(
-          `Agent file '${filenameBase}.yaml' has a different internal name '${internalName}' defined in its YAML. ` +
-            `Consider renaming the file or updating the internal name in the YAML for consistency.`,
-        );
-      } else {
-        const configuredAgents = getConfig<string[]>('texra.agents', []);
-        if (!configuredAgents.includes(filenameBase)) {
-          await promptToAddAgentToConfig(filenameBase);
-        }
-      }
-    }
+    await validateYamlAndPromptAdd(filePath);
   }
 
   async setup() {

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -29,10 +29,6 @@ export class WatcherManager {
     this.refreshHandle = setTimeout(() => this.refresh(), 200);
   }
 
-  private async validateYaml(filePath: string) {
-    await validateYamlAndPromptAdd(filePath);
-  }
-
   async setup() {
     try {
       if (!this.context) {
@@ -67,10 +63,10 @@ export class WatcherManager {
 
         watcher.onDidCreate((uri) => {
           this.triggerRefresh();
-          if (path.extname(uri.fsPath) === '.yaml') {
+          if (path.extname(uri.fsPath).toLowerCase() === '.yaml') {
             const handle = setTimeout(async () => {
               try {
-                await this.validateYaml(uri.fsPath);
+                await validateYamlAndPromptAdd(uri.fsPath);
               } catch (error) {
                 logger.error(CHANNEL, `Error validating YAML: ${error}`);
               } finally {
@@ -88,8 +84,8 @@ export class WatcherManager {
         if (path.resolve(watchPath) === path.resolve(customAgentsPath ?? '')) {
           watcher.onDidChange(async (uri) => {
             this.triggerRefresh();
-            if (path.extname(uri.fsPath) === '.yaml') {
-              await this.validateYaml(uri.fsPath);
+            if (path.extname(uri.fsPath).toLowerCase() === '.yaml') {
+              await validateYamlAndPromptAdd(uri.fsPath);
             }
           });
         } else {

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -112,7 +112,7 @@ export async function validateYamlAndPromptAdd(
     return;
   }
 
-  const filenameBase = path.basename(filePath, '.yaml');
+  const filenameBase = path.basename(filePath, path.extname(filePath));
   const internalName = validationResult.name;
 
   if (filenameBase !== internalName) {

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -13,12 +13,12 @@ const CHANNEL = 'AgentRegister';
 logger.initialize(CHANNEL);
 
 /**
- * Prompt the user to add a newly created agent to the `texra.agents` setting.
- * If the agent already exists in the configuration the function silently
- * returns.
+ * Prompt to add a newly created agent to the `texra.agents` setting. When
+ * `autoAdd` is true, the agent is added without prompting.
  */
 export async function promptToAddAgentToConfig(
   agentName: string,
+  autoAdd = false,
 ): Promise<void> {
   const config = vscode.workspace.getConfiguration();
   const current = config.get<string[]>('texra.agents', []);
@@ -57,6 +57,19 @@ export async function promptToAddAgentToConfig(
     }
   }
 
+  if (autoAdd) {
+    current.push(agentName);
+    await config.update(
+      'texra.agents',
+      current,
+      vscode.ConfigurationTarget.Workspace,
+    );
+    vscode.window.showInformationMessage(
+      `Added "${agentName}" to texra.agents`,
+    );
+    return;
+  }
+
   const addButton = 'Add Agent';
   const choice = await vscode.window.showInformationMessage(
     `Agent "${agentName}" was created. Add it to 'texra.agents'?`,
@@ -87,6 +100,7 @@ export async function promptToAddAgentToConfig(
 export async function validateYamlAndPromptAdd(
   filePath: string,
   showInvalid = false,
+  prompt = true,
 ): Promise<void> {
   const validationResult = await isValidAgentYaml(filePath);
   if (!validationResult) {
@@ -111,6 +125,6 @@ export async function validateYamlAndPromptAdd(
 
   const configuredAgents = getConfig<string[]>('texra.agents', []);
   if (!configuredAgents.includes(filenameBase)) {
-    await promptToAddAgentToConfig(filenameBase);
+    await promptToAddAgentToConfig(filenameBase, !prompt);
   }
 }

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -4,7 +4,10 @@
 import * as vscode from 'vscode';
 
 // Local imports
+import * as path from 'path';
 import * as logger from '@logger/logUtils';
+import { isValidAgentYaml } from '@agent/runtime/agentLoad';
+import { getConfig } from '@utils/config';
 
 const CHANNEL = 'AgentRegister';
 logger.initialize(CHANNEL);
@@ -71,5 +74,43 @@ export async function promptToAddAgentToConfig(
     vscode.window.showInformationMessage(
       `Added "${agentName}" to texra.agents`,
     );
+  }
+}
+
+/**
+ * Validate the given YAML file as an agent definition and prompt to add
+ * the agent name to the configuration if it isn't already present.
+ *
+ * @param filePath Absolute path to the YAML file
+ * @param showInvalid Whether to warn when the YAML is invalid
+ */
+export async function validateYamlAndPromptAdd(
+  filePath: string,
+  showInvalid = false,
+): Promise<void> {
+  const validationResult = await isValidAgentYaml(filePath);
+  if (!validationResult) {
+    if (showInvalid) {
+      vscode.window.showWarningMessage(
+        'Selected file is not a valid agent YAML.',
+      );
+    }
+    return;
+  }
+
+  const filenameBase = path.basename(filePath, '.yaml');
+  const internalName = validationResult.name;
+
+  if (filenameBase !== internalName) {
+    vscode.window.showWarningMessage(
+      `Agent file '${filenameBase}.yaml' has a different internal name '${internalName}' defined in its YAML. ` +
+        `Consider renaming the file or updating the internal name in the YAML for consistency.`,
+    );
+    return;
+  }
+
+  const configuredAgents = getConfig<string[]>('texra.agents', []);
+  if (!configuredAgents.includes(filenameBase)) {
+    await promptToAddAgentToConfig(filenameBase);
   }
 }


### PR DESCRIPTION
## Summary
- add shared helper to validate agent YAML and prompt for config
- prompt users to add valid YAML to config when right-clicking agent files
- document new menu option in the Agent Explorer guide
- note change in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688354aaea188324894f29c7225edae9