### PR TITLE
fix: restore agent icons in progress tabs

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -24,6 +24,7 @@ This section lists all the agent execution streams from your current VS Code ses
 
 - **Switching Streams**: Click on a stream name (e.g., `polish@sonnet37: paper.tex`) to view its specific logs and status in the Content Area.
 - **Delete All**: The <i class="codicon codicon-trash"></i> **Delete All** button at the bottom permanently removes all streams and their logs from the ProgressBoard view for the current session.
+- **Metadata**: Tabs display the model and when the stream was last active on a second line. Icons indicate the agent type and if multiple output files were generated.
 
 ## Content Area
 

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -24,7 +24,7 @@ This section lists all the agent execution streams from your current VS Code ses
 
 - **Switching Streams**: Click on a stream name (e.g., `polish@sonnet37: paper.tex`) to view its specific logs and status in the Content Area.
 - **Delete All**: The <i class="codicon codicon-trash"></i> **Delete All** button at the bottom permanently removes all streams and their logs from the ProgressBoard view for the current session.
-- **Metadata**: Tabs display the model and when the stream was last active on a second line. Icons indicate the agent type and if multiple output files were generated.
+- **Metadata**: Tabs display the model and when the stream was last active on a second line. Icons indicate the agent type and if multiple output files were generated. Hover over these icons to see a tooltip describing their meaning.
 
 ## Content Area
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -254,7 +254,10 @@ async function executeAgentWithLogging<T extends IAgent>(
         bus.emit('setTaskState', {
           streamTabId: streamTabId,
           executionId,
-          taskState: agentConfigToTaskState(config),
+          taskState: agentConfigToTaskState(
+            config,
+            (agent as any).agentSetting?.agentType,
+          ),
         });
         logger.debug(
           `Task state stored for stream: ${streamTabId}`,

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -1,6 +1,7 @@
 // Local imports
 import type { FileType } from '@utils/config';
 import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentType } from '@agent/core/AgentDataclass';
 
 /**
  * Interface for storing task execution state.
@@ -16,6 +17,12 @@ export interface TaskState {
    * This includes model, agent type, file selections, and tool configurations.
    */
   agentConfig: AgentConfig;
+
+  /**
+   * Type of agent (e.g., CoT, direct, toolUse). Optional for backward
+   * compatibility with older saved states.
+   */
+  agentType?: AgentType;
 
   /**
    * UI-specific state for managing file type visibility in the interface.

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -236,6 +236,11 @@ export class ProgressEventHandler {
     if (executionId) {
       this.state.setExecutionId(streamTabId, executionId);
     }
+
+    if (this.webviewUpdater.isAvailable()) {
+      const infos = buildStreamInfos(this.state);
+      this.webviewUpdater.updateStreams(infos, this.state.activeStream);
+    }
   }
 
   /**

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -6,6 +6,7 @@ import { WebviewUpdater } from '../managers';
 import { AgentLogger } from '@logger/AgentLogger';
 import { getConfig } from '@utils/config';
 import { bus } from '@eventBus/ProgressEventBus';
+import { buildStreamInfos } from '../streamInfoUtils';
 
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
@@ -13,6 +14,7 @@ import { TaskState } from '@logger/TaskState';
 import { LogMessageData, TaskGroup } from '@logger/LogTypes';
 import { parseLegacyLogData } from '@logger/logUtils';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type { StreamTabInfo } from '../types';
 
 // @ts-ignore - Import JavaScript module
 import { STATUS } from '../modules/constants.js';
@@ -122,8 +124,8 @@ export class ProgressEventHandler {
     this.state.activeStream = stream;
 
     if (this.webviewUpdater.isAvailable()) {
-      const streams = this.state.streamTabs.keys();
-      this.webviewUpdater.updateStreams(streams, stream);
+      const infos = buildStreamInfos(this.state);
+      this.webviewUpdater.updateStreams(infos, stream);
 
       // Update log content (will be empty for new streams)
       this.updateLogContentForStream(stream);

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -119,7 +119,15 @@
         </template>
         <template id="streamTabTemplate">
           <div class="tab-container" title="">
-            <button class="tab" data-stream="" title=""></button>
+            <button class="tab" data-stream="" title="">
+              <div class="tab-title"></div>
+              <div class="tab-meta">
+                <span class="model"></span>
+                <span class="last-active"></span>
+                <i class="agent-type"></i>
+                <i class="multi-file"></i>
+              </div>
+            </button>
             <button class="tab-delete" data-stream="" title="Delete stream">
               <i class="codicon codicon-close"></i>
             </button>

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -4,11 +4,13 @@ import * as vscode from 'vscode';
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
 import { AgentLogger } from '@logger/AgentLogger';
+import { buildStreamInfos } from '../streamInfoUtils';
 
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { LogMessageData } from '@logger/LogTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamTabInfo } from '../types';
 
 // @ts-ignore - Import JavaScript module
 import { COMMANDS } from '../modules/constants.js';
@@ -31,7 +33,7 @@ export class WebviewUpdater {
   /**
    * Update stream tabs in the webview
    */
-  updateStreams(streams: StreamTabId[], activeStream: StreamTabId): void {
+  updateStreams(streams: StreamTabInfo[], activeStream: StreamTabId): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -188,8 +190,9 @@ export class WebviewUpdater {
     const webview = this.getWebview();
     if (!webview) return;
 
-    const streams = state.streamTabs.keys();
     const activeStream = state.activeStream;
+
+    const streams = buildStreamInfos(state);
 
     // Update streams and active stream
     this.updateStreams(streams, activeStream);

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -54,11 +54,13 @@ export class StreamTabs {
         const key = (info.agentType || info.agent || '').toLowerCase();
         const icon = AGENT_ICONS[key] || AGENT_ICONS.direct;
         agentIcon.classList.add('codicon', `codicon-${icon}`);
+        agentIcon.title = info.agentType || info.agent || '';
       }
       const multiIcon = tabEl.querySelector('.multi-file');
       if (multiIcon) {
         if (info.hasMultipleOutputs) {
           multiIcon.classList.add('codicon', 'codicon-files');
+          multiIcon.title = 'Multiple output files';
         } else {
           multiIcon.remove();
         }

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -2,13 +2,19 @@
 import { ELEMENT_IDS } from '../constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
+const AGENT_ICONS = {
+  cot: 'terminal',
+  direct: 'lightbulb',
+  tooluse: 'tools',
+};
+
 /**
  * Manages stream tab UI updates.
  */
 export class StreamTabs {
   /**
    * Updates UI to show stream tabs and highlight the active stream
-   * @param {Array} streams - Array of stream names
+   * @param {Array} streams - Array of stream metadata objects
    * @param {string} activeStream - Currently active stream
    */
   update(streams, activeStream) {
@@ -22,22 +28,43 @@ export class StreamTabs {
       return;
     }
     tabsContainer.innerHTML = '';
-    streams.forEach((stream) => {
-      if (!stream || typeof stream !== 'string') {
-        console.warn('StreamTabs.update: invalid stream value:', stream);
+    streams.forEach((info) => {
+      if (!info || typeof info !== 'object') {
+        console.warn('StreamTabs.update: invalid stream value:', info);
         return;
       }
       const tabEl = createFromTemplate('streamTabTemplate', {
-        text: { '.tab': stream },
+        text: {
+          '.tab-title': info.label || info.name,
+          '.model': info.model || '',
+          '.last-active': this.formatRelativeTime(info.lastTimestamp),
+        },
         attributes: {
-          '.tab': { title: stream },
+          '.tab': { title: info.name },
           '.tab-delete': { title: 'Delete stream' },
         },
-        dataset: { '.tab': { stream }, '.tab-delete': { stream } },
+        dataset: {
+          '.tab': { stream: info.name },
+          '.tab-delete': { stream: info.name },
+        },
       });
       if (!tabEl) return;
-      if (stream === activeStream) tabEl.classList.add('active');
-      tabEl.title = stream;
+      const agentIcon = tabEl.querySelector('.agent-type');
+      if (agentIcon) {
+        const key = (info.agentType || info.agent || '').toLowerCase();
+        const icon = AGENT_ICONS[key] || AGENT_ICONS.direct;
+        agentIcon.classList.add('codicon', `codicon-${icon}`);
+      }
+      const multiIcon = tabEl.querySelector('.multi-file');
+      if (multiIcon) {
+        if (info.hasMultipleOutputs) {
+          multiIcon.classList.add('codicon', 'codicon-files');
+        } else {
+          multiIcon.remove();
+        }
+      }
+      if (info.name === activeStream) tabEl.classList.add('active');
+      tabEl.title = info.name;
       tabsContainer.appendChild(tabEl);
     });
 
@@ -48,5 +75,20 @@ export class StreamTabs {
     if (streamNameElem) {
       streamNameElem.textContent = activeStream || '';
     }
+  }
+
+  formatRelativeTime(timestamp) {
+    if (!timestamp) return '';
+    const diff = Date.now() - timestamp;
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return 'just now';
+    if (minutes === 1) return '1 min ago';
+    if (minutes < 60) return `${minutes} mins ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours === 1) return '1 hr ago';
+    if (hours < 24) return `${hours} hrs ago`;
+    const days = Math.floor(hours / 24);
+    if (days === 1) return '1 day ago';
+    return `${days} days ago`;
   }
 }

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -1,0 +1,28 @@
+import * as path from 'path';
+import type { ProgressViewState } from './state/ProgressViewState';
+import type { StreamTabInfo } from './types';
+
+/**
+ * Build metadata objects for all streams in the given state.
+ */
+export function buildStreamInfos(state: ProgressViewState): StreamTabInfo[] {
+  return state.streamTabs.keys().map((id) => {
+    const taskState = state.getTaskState(id);
+    const logs = state.streamTabs.get(id);
+    const lastTimestamp =
+      logs && logs.length > 0 ? logs[logs.length - 1].timestamp : undefined;
+    const outputs = taskState?.agentConfig.outputFiles || [];
+    const inputFile = taskState?.agentConfig.inputFile || '';
+    const agentName = taskState?.agentConfig.agent || id.split('@')[0];
+    const label = `${agentName}: ${path.basename(inputFile)}`;
+    return {
+      name: id,
+      label,
+      model: taskState?.agentConfig.model,
+      agent: taskState?.agentConfig.agent,
+      agentType: taskState?.agentType,
+      hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
+      lastTimestamp,
+    };
+  });
+}

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -52,6 +52,42 @@
   width: 100%;
 }
 
+.tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: var(--spacing-small) var(--spacing-medium);
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: var(--vscode-foreground);
+  text-align: left;
+  font-family: var(--font-family);
+  min-width: 0;
+}
+
+.tab-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tab-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  font-size: var(--font-size-sm);
+  color: var(--vscode-foreground);
+  opacity: var(--opacity-subtle);
+  width: 100%;
+}
+
+.tab-meta .agent-type,
+.tab-meta .multi-file {
+  margin-left: var(--spacing-small);
+}
+
 .tab-container:hover {
   background-color: var(--vscode-list-hoverBackground);
 }
@@ -62,25 +98,6 @@
 
 .tab-container.active .tab {
   color: var(--vscode-list-activeSelectionForeground);
-}
-
-.tab {
-  flex: 1;
-  padding: var(--spacing-small) var(--spacing-medium);
-  cursor: pointer;
-  border: none;
-  background: none;
-  color: var(--vscode-foreground);
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-family: var(--font-family);
-  min-width: 0;
-}
-
-.tab:hover {
-  background: none;
 }
 
 .tab-delete {

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,0 +1,10 @@
+export interface StreamTabInfo {
+  name: string;
+  /** Short label displayed in the tab UI */
+  label: string;
+  model?: string;
+  agent?: string;
+  agentType?: string;
+  hasMultipleOutputs?: boolean;
+  lastTimestamp?: number;
+}

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -8,6 +8,7 @@
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { TaskState } from '@logger/TaskState';
+import type { AgentType } from '@agent/core/AgentDataclass';
 
 import { FILE_TYPES, type FileType } from './constants';
 
@@ -31,10 +32,14 @@ function createActiveFilesFromArrays(
  * @param config The AgentConfig to convert
  * @returns A TaskState representing the same configuration
  */
-export function agentConfigToTaskState(config: AgentConfig): TaskState {
+export function agentConfigToTaskState(
+  config: AgentConfig,
+  agentType?: AgentType,
+): TaskState {
   return {
     agentConfig: config,
     activeFiles: createActiveFilesFromArrays(config),
+    ...(agentType ? { agentType } : {}),
   };
 }
 
@@ -53,6 +58,7 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
       agentConfig: AgentConfigSchema.parse(obj.agentConfig),
       activeFiles:
         obj.activeFiles || createActiveFilesFromArrays(obj.agentConfig),
+      agentType: obj.agentType,
     };
   }
 
@@ -95,7 +101,7 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   // Parse only AgentConfig-compatible fields
   try {
     const normalized = AgentConfigSchema.parse(agentConfigData);
-    const taskState = agentConfigToTaskState(normalized);
+    const taskState = agentConfigToTaskState(normalized, obj.agentType);
 
     // Add back TaskState-specific fields
     if (activeFiles) {
@@ -107,7 +113,7 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     // If parsing fails, create a minimal valid state
     console.error('Failed to parse task state, using defaults:', error);
     const defaultConfig = AgentConfigSchema.parse({});
-    const taskState = agentConfigToTaskState(defaultConfig);
+    const taskState = agentConfigToTaskState(defaultConfig, obj.agentType);
 
     // Preserve activeFiles if available
     if (activeFiles) {


### PR DESCRIPTION
## Summary
- add optional `agentType` field to `TaskState` and `StreamTabInfo`
- share stream metadata construction via `buildStreamInfos`
- send agent type when saving task state
- update stream tab rendering to use agent type

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(webpack warning)*

------
https://chatgpt.com/codex/tasks/task_e_68834f7978c48324ba11ee6504664858