### PR TITLE
Refactor output handling utilities

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -41,7 +41,12 @@ import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import type { IModelHandler } from '@agent/modelHandlers';
 import type { ToolDefinition } from '@model';
-import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import {
+  OutputHandler,
+  NamedOutputFile,
+  IOutputHandler,
+  LatexOutputProcessor,
+} from '@agent/output';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -66,6 +71,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   protected logId: number = 0;
   /** Handler for output file processing and validation. */
   protected outputHandler: IOutputHandler;
+  protected latexOutputProcessor: LatexOutputProcessor;
   protected latexMediaManager: LatexMediaManager;
 
   constructor(
@@ -101,12 +107,20 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     // Initialize logging
     this.logId = 0;
 
+    this.latexOutputProcessor = new LatexOutputProcessor(
+      this.agentSetting,
+      this.baseFiles,
+      this.logger,
+      this.logger.channelId,
+    );
+
     this.outputHandler = new OutputHandler(
       this.agentSetting,
       this.agentConfig,
       this.modelHandler,
       this.logId,
       this.baseFiles,
+      this.latexOutputProcessor,
       this.logger,
     );
 
@@ -511,7 +525,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
       if (existingBase.some((e) => e)) {
         // Pass the process group ID to maintain proper nesting in the log hierarchy
-        await this.outputHandler.handleLatexdiffofOutput(
+        await this.latexOutputProcessor.handleLatexdiffofOutput(
           currRound,
           processGroupId,
         );

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -2,6 +2,7 @@
 import { AgentStateGlobal } from '@agent/core/AgentState';
 import { NamedOutputFile, OutputFileInfo } from './types';
 import { XmlOutputManager } from './XmlOutputManager';
+import type { LatexOutputProcessor } from './LatexOutputProcessor';
 
 /** Interface describing OutputHandler behavior used by agents. */
 export interface IOutputHandler {
@@ -14,14 +15,8 @@ export interface IOutputHandler {
   /** XML manager for parsing and splitting outputs. */
   xmlManager: XmlOutputManager;
 
-  /** Indent a single LaTeX file for readability. */
-  indentLatexFile(filePath: string): Promise<void>;
-
-  /** Indent multiple LaTeX files for readability. */
-  indentLatexFiles(filePaths: string[]): Promise<void>;
-
-  /** Run latexdiff comparisons for the current round. */
-  handleLatexdiffofOutput(currRound: number, groupId?: string): Promise<void>;
+  /** Optional LaTeX processor for formatting and diffing. */
+  latexProcessor?: LatexOutputProcessor;
 
   /** Print token usage and cost statistics. */
   printStatistics(

--- a/src/agent/output/LatexOutputProcessor.ts
+++ b/src/agent/output/LatexOutputProcessor.ts
@@ -1,0 +1,70 @@
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - utilities
+import { runLatexFormatter } from '@latex/texFormatter';
+import { LatexDiffManager } from './LatexDiffManager';
+import { AgentSetting } from '@agent/core/AgentDataclass';
+
+export class LatexOutputProcessor {
+  private diffManager?: LatexDiffManager;
+
+  constructor(
+    private readonly agentSetting: AgentSetting,
+    private readonly baseFiles: string[],
+    private readonly logger: AgentLogger,
+    private readonly channel: string,
+    private outputFiles?: { [key: number]: string[] },
+  ) {
+    if (this.outputFiles) {
+      this.diffManager = new LatexDiffManager(
+        this.agentSetting,
+        this.outputFiles,
+        this.baseFiles,
+        this.logger,
+        this.channel,
+      );
+    }
+  }
+
+  public setOutputFilesRef(outputFiles: { [key: number]: string[] }): void {
+    this.outputFiles = outputFiles;
+    this.diffManager = new LatexDiffManager(
+      this.agentSetting,
+      outputFiles,
+      this.baseFiles,
+      this.logger,
+      this.channel,
+    );
+  }
+
+  /** Indents a LaTeX file for better readability */
+  public async indentLatexFile(filePath: string): Promise<void> {
+    if (!filePath.includes('.tex')) {
+      return;
+    }
+    this.logger.debug(`Formatting ${filePath}`);
+    await runLatexFormatter(filePath);
+  }
+
+  /** Indents multiple LaTeX files for better readability */
+  public async indentLatexFiles(filePaths: string[]): Promise<void> {
+    for (const filePath of filePaths) {
+      await this.indentLatexFile(filePath);
+    }
+  }
+
+  /** Runs all latexdiff comparisons for the current round. */
+  public async handleLatexdiffofOutput(
+    currRound: number,
+    groupId?: string,
+  ): Promise<void> {
+    if (!this.diffManager) {
+      this.logger.warn(
+        'LatexOutputProcessor not initialized with output files',
+      );
+      return;
+    }
+    await this.diffManager.handleLatexdiffofOutput(currRound, groupId);
+  }
+}

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -2,12 +2,10 @@
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
 import * as path from 'path';
-import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { runLatexFormatter } from '@latex/texFormatter';
 import { XmlOutputManager } from './XmlOutputManager';
-import { LatexDiffManager } from './LatexDiffManager';
+import { LatexOutputProcessor } from './LatexOutputProcessor';
 import { StatisticsReporter } from './StatisticsReporter';
 import { DiffStatsManager } from './DiffStatsManager';
 import { NamedOutputFile } from './types';
@@ -43,7 +41,7 @@ export class OutputHandler implements IOutputHandler {
   protected logger: AgentLogger;
   protected channel: string;
   public readonly xmlManager: XmlOutputManager;
-  private diffManager: LatexDiffManager;
+  public latexProcessor?: LatexOutputProcessor;
   private statsReporter: StatisticsReporter;
   private diffStatsManager: DiffStatsManager;
 
@@ -53,6 +51,7 @@ export class OutputHandler implements IOutputHandler {
     modelHandler: IModelHandler,
     logId: number,
     baseFiles: string[] = [],
+    latexProcessor?: LatexOutputProcessor,
     logger?: AgentLogger,
   ) {
     this.agentSetting = agentSetting;
@@ -64,18 +63,15 @@ export class OutputHandler implements IOutputHandler {
     this.baseFiles = baseFiles;
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
+    this.latexProcessor = latexProcessor;
+    if (this.latexProcessor) {
+      this.latexProcessor.setOutputFilesRef(this.outputFiles);
+    }
 
     this.xmlManager = new XmlOutputManager(
       this.agentSetting,
       this.agentConfig,
       this.logger,
-    );
-    this.diffManager = new LatexDiffManager(
-      this.agentSetting,
-      this.outputFiles,
-      this.baseFiles,
-      this.logger,
-      this.channel,
     );
     this.statsReporter = new StatisticsReporter(
       this.modelHandler,
@@ -123,49 +119,6 @@ export class OutputHandler implements IOutputHandler {
       this.logger.endGroup(this.processGroupId, status);
       this.processGroupId = undefined;
     }
-  }
-
-  /**
-   * Indents a LaTeX file for better readability
-   */
-  public async indentLatexFile(filePath: string): Promise<void> {
-    if (!filePath.includes('.tex')) {
-      return;
-    }
-    this.logger.debug(`Formatting ${filePath}`);
-    await runLatexFormatter(filePath);
-  }
-
-  /**
-   * Indents multiple LaTeX files for better readability
-   */
-  public async indentLatexFiles(filePaths: string[]): Promise<void> {
-    for (const filePath of filePaths) {
-      await this.indentLatexFile(filePath);
-    }
-  }
-
-  /**
-   * Helper method to log latexdiff results with appropriate level
-   * @param result The result of a latexdiff operation
-   * @param operation Description of the operation being performed
-   * @param groupId The group ID for logging context
-   */
-
-  /**
-   * Runs all latexdiff comparisons for the current round.
-   * This is the ONLY place where latexdiff operations should be performed.
-   *
-   * Generates two types of diffs:
-   * 1. Round diffs: Between original input and current output (when in rewrite mode)
-   * 2. Between-rounds diffs: Comparing previous round to current round (when applicable)
-   *
-   */
-  public async handleLatexdiffofOutput(
-    currRound: number,
-    groupId?: string,
-  ): Promise<void> {
-    await this.diffManager.handleLatexdiffofOutput(currRound, groupId);
   }
 
   /**
@@ -317,7 +270,7 @@ export class OutputHandler implements IOutputHandler {
 
         if (processedPairs && processedPairs.length > 0) {
           const processedFiles = processedPairs.map((p) => p.path);
-          await this.indentLatexFiles(processedFiles);
+          await this.latexProcessor?.indentLatexFiles(processedFiles);
           this.logger.debug(
             `Indented multiple output files: ${processedFiles.join(',')}`,
             activeGroupId,
@@ -367,7 +320,7 @@ export class OutputHandler implements IOutputHandler {
         }
 
         if (processed && processed.path) {
-          await this.indentLatexFile(processed.path);
+          await this.latexProcessor?.indentLatexFile(processed.path);
           this.logger.debug(
             `Indented single output file: ${processed.path}`,
             activeGroupId,

--- a/src/agent/output/index.ts
+++ b/src/agent/output/index.ts
@@ -1,4 +1,5 @@
 export * from './OutputHandler';
 export * from './IOutputHandler';
+export * from './LatexOutputProcessor';
 export { NamedOutputFile } from './types';
 export { getOutputFileName } from '@agent/utils/outputFileUtils';


### PR DESCRIPTION
## Summary
- extract LaTeX-specific logic into `LatexOutputProcessor`
- compose `OutputHandler` with the new processor
- wire reflection agents to pass a `LatexOutputProcessor`
- update interfaces and exports

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Critical dependency warning from webpack)*

------
https://chatgpt.com/codex/tasks/task_e_688483e828ec8324a9a5d0834c26b08d