### PR TITLE
Refactor statistics handling

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -45,6 +45,7 @@ import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { UsageStatsManager } from '@agent/utils';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -67,6 +68,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /** Handler for output file processing and validation. */
   protected outputHandler: IOutputHandler;
   protected latexMediaManager: LatexMediaManager;
+  protected usageStats: UsageStatsManager;
 
   constructor(
     modelHandler: IModelHandler,
@@ -104,13 +106,17 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     this.outputHandler = new OutputHandler(
       this.agentSetting,
       this.agentConfig,
-      this.modelHandler,
       this.logId,
       this.baseFiles,
       this.logger,
     );
 
     this.latexMediaManager = new LatexMediaManager(this.logger);
+    this.usageStats = new UsageStatsManager(
+      this.modelHandler,
+      this.logger.channelId,
+      this.logger,
+    );
   }
 
   /**
@@ -481,7 +487,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /**
    * Processes output files for current round.
    * This method orchestrates the overall output processing flow with clear separation of concerns:
-   * 1. Statistics handling via printStatistics
+   * 1. Statistics handling via UsageStatsManager
    * 2. LaTeX diff operations via handleLatexdiffofOutput (only when endTurn is true)
    *
    * The actual file processing is handled separately in processOutputFiles.
@@ -497,7 +503,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     processGroupId?: string,
   ): Promise<string[]> {
     // Print statistics at the end of each round
-    await this.outputHandler.printStatistics(stateGlobal, processGroupId);
+    await this.usageStats.printStatistics(stateGlobal, processGroupId);
 
     // If this is the end of a turn, handle latexdiff operations as a separate step
     if (

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,5 +1,4 @@
 // Local imports - types
-import { AgentStateGlobal } from '@agent/core/AgentState';
 import { NamedOutputFile, OutputFileInfo } from './types';
 import { XmlOutputManager } from './XmlOutputManager';
 
@@ -22,12 +21,6 @@ export interface IOutputHandler {
 
   /** Run latexdiff comparisons for the current round. */
   handleLatexdiffofOutput(currRound: number, groupId?: string): Promise<void>;
-
-  /** Print token usage and cost statistics. */
-  printStatistics(
-    stateGlobal: AgentStateGlobal,
-    groupId?: string,
-  ): Promise<void>;
 
   /** Process output files from XML or direct input. */
   processOutputFiles(

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode';
 import { runLatexFormatter } from '@latex/texFormatter';
 import { XmlOutputManager } from './XmlOutputManager';
 import { LatexDiffManager } from './LatexDiffManager';
-import { StatisticsReporter } from './StatisticsReporter';
 import { DiffStatsManager } from './DiffStatsManager';
 import { NamedOutputFile } from './types';
 import type { IOutputHandler } from './IOutputHandler';
@@ -18,7 +17,6 @@ import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
-import type { IModelHandler } from '@agent/modelHandlers';
 
 // Local imports - utilities
 import { replaceInputCommands, createFileMapping } from '@utils/files';
@@ -34,7 +32,6 @@ import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 export class OutputHandler implements IOutputHandler {
   public agentSetting: AgentSetting;
   public agentConfig: AgentConfig;
-  public modelHandler: IModelHandler;
   public logId: number;
   public outputFiles: { [key: number]: string[] };
   public outputMappings: { [key: number]: NamedOutputFile[] };
@@ -44,20 +41,17 @@ export class OutputHandler implements IOutputHandler {
   protected channel: string;
   public readonly xmlManager: XmlOutputManager;
   private diffManager: LatexDiffManager;
-  private statsReporter: StatisticsReporter;
   private diffStatsManager: DiffStatsManager;
 
   constructor(
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
-    modelHandler: IModelHandler,
     logId: number,
     baseFiles: string[] = [],
     logger?: AgentLogger,
   ) {
     this.agentSetting = agentSetting;
     this.agentConfig = agentConfig;
-    this.modelHandler = modelHandler;
     this.logId = logId;
     this.outputFiles = { 0: [], 1: [] };
     this.outputMappings = { 0: [], 1: [] };
@@ -76,11 +70,6 @@ export class OutputHandler implements IOutputHandler {
       this.baseFiles,
       this.logger,
       this.channel,
-    );
-    this.statsReporter = new StatisticsReporter(
-      this.modelHandler,
-      this.channel,
-      this.logger,
     );
     this.diffStatsManager = new DiffStatsManager();
   }
@@ -283,14 +272,6 @@ export class OutputHandler implements IOutputHandler {
     });
   }
 
-  /** Prints statistics about token usage and costs */
-  public async printStatistics(
-    stateGlobal: AgentStateGlobal,
-    groupId?: string,
-  ): Promise<void> {
-    await this.statsReporter.printStatistics(stateGlobal, groupId);
-  }
-
   /**
    * Processes output files from XML or direct input.
    */
@@ -413,9 +394,6 @@ export class OutputHandler implements IOutputHandler {
     currRound: number = 0,
     roundGroupId?: string,
   ): Promise<string[]> {
-    // Print statistics at the end of each round
-    await this.printStatistics(stateGlobal, roundGroupId);
-
     return this.outputFiles[currRound] || [];
   }
 }

--- a/src/agent/utils/UsageStatsManager.ts
+++ b/src/agent/utils/UsageStatsManager.ts
@@ -1,3 +1,4 @@
+// Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentStateGlobal } from '@agent/core/AgentState';
@@ -9,9 +10,11 @@ import {
 } from '@agent/core/ResponseUsage';
 import { ResponseUsage } from 'openai/resources/responses/responses';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 
-export class StatisticsReporter {
+/**
+ * Handles printing usage statistics to the log and progress view.
+ */
+export class UsageStatsManager {
   constructor(
     private readonly modelHandler: IModelHandler,
     private readonly channel: string,

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -6,3 +6,4 @@ export * from './promptHelpers';
 export * from './outputFileUtils';
 export * from './priceUtils';
 export * from './text';
+export * from './UsageStatsManager';


### PR DESCRIPTION
## Summary
- drop StatisticsReporter from OutputHandler
- create UsageStatsManager for computing cost stats
- update BaseReflectionAgent to use UsageStatsManager
- trim IOutputHandler interface

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884847343f4832499ff483c428675a3