### PR TITLE
Move output toolState logic

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -41,7 +41,7 @@ import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import type { IModelHandler } from '@agent/modelHandlers';
 import type { ToolDefinition } from '@model';
-import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import { OutputHandler, IOutputHandler } from '@agent/output';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -729,19 +729,19 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     try {
       // Handle output file processing
       if (this.agentConfig.outputFiles) {
-        await this._handleToolStateForOutput(
+        await this.outputHandler.handleToolStateForOutput(
           this.agentConfig.outputFiles,
-          currRound,
           toolState,
+          this.logger.getActiveGroupId(),
         );
       } else {
         // Handle single output file from previous round
         const outputFiles = this.outputHandler.outputFiles[currRound - 1];
         if (outputFiles && outputFiles.length > 0) {
-          await this._handleToolStateForOutput(
+          await this.outputHandler.handleToolStateForOutput(
             [outputFiles[0]],
-            currRound,
             toolState,
+            this.logger.getActiveGroupId(),
           );
         }
       }
@@ -891,31 +891,5 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     }
   }
 
-  /**
-   * Updates tool state based on output files.
-   */
-  private async _handleToolStateForOutput(
-    outputFiles: string[],
-    currRound: number,
-    toolState: ToolState,
-  ): Promise<void> {
-    await this.latexMediaManager.processOutputFiles(
-      outputFiles,
-      toolState,
-      this.agentConfig.toolConfig,
-      this.modelHandler.capabilities.supportsVision,
-      this.logger.getActiveGroupId(),
-    );
-  }
-
-  /**
-   * Processes output files from XML or direct input.
-   * This method focuses solely on extracting and processing output files.
-   * It does NOT perform any latexdiff operations - those are handled separately
-   * in the handleOutput method via handleLatexdiffofOutput.
-   *
-   * @param outputFile Path to the output file to process
-   * @param currRound Current round number
-   * @param processGroupId Optional process group ID for logging
-   */
+  // Output file tool state handling moved to OutputHandler
 }

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,5 +1,6 @@
 // Local imports - types
 import { AgentStateGlobal } from '@agent/core/AgentState';
+import { ToolState } from '@agent/core/ToolState';
 import { NamedOutputFile, OutputFileInfo } from './types';
 import { XmlOutputManager } from './XmlOutputManager';
 
@@ -43,6 +44,13 @@ export interface IOutputHandler {
   validateExpectedOutputs(
     outputFile: string,
     currRound: number,
+    groupId?: string,
+  ): Promise<void>;
+
+  /** Update tool state with information from output files. */
+  handleToolStateForOutput(
+    outputFiles: string[],
+    toolState: ToolState,
     groupId?: string,
   ): Promise<void>;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports - utilities
 import { runLatexFormatter } from '@latex/texFormatter';
+import { LatexMediaManager } from '@latex';
 import { XmlOutputManager } from './XmlOutputManager';
 import { LatexDiffManager } from './LatexDiffManager';
 import { StatisticsReporter } from './StatisticsReporter';
@@ -19,6 +20,7 @@ import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
+import { ToolState } from '@agent/core/ToolState';
 
 // Local imports - utilities
 import { replaceInputCommands, createFileMapping } from '@utils/files';
@@ -46,6 +48,7 @@ export class OutputHandler implements IOutputHandler {
   private diffManager: LatexDiffManager;
   private statsReporter: StatisticsReporter;
   private diffStatsManager: DiffStatsManager;
+  private latexMediaManager: LatexMediaManager;
 
   constructor(
     agentSetting: AgentSetting,
@@ -83,6 +86,7 @@ export class OutputHandler implements IOutputHandler {
       this.logger,
     );
     this.diffStatsManager = new DiffStatsManager();
+    this.latexMediaManager = new LatexMediaManager(this.logger);
   }
 
   /**
@@ -219,6 +223,23 @@ export class OutputHandler implements IOutputHandler {
       });
     }
     return infos;
+  }
+
+  /**
+   * Update tool state with information from output files.
+   */
+  public async handleToolStateForOutput(
+    outputFiles: string[],
+    toolState: ToolState,
+    groupId?: string,
+  ): Promise<void> {
+    await this.latexMediaManager.processOutputFiles(
+      outputFiles,
+      toolState,
+      this.agentConfig.toolConfig,
+      this.modelHandler.capabilities.supportsVision,
+      groupId ?? this.logger.getActiveGroupId(),
+    );
   }
 
   public async validateExpectedOutputs(


### PR DESCRIPTION
## Summary
- manage LatexMediaManager from OutputHandler
- push media output info via OutputHandler.handleToolStateForOutput
- simplify BaseReflectionAgent calls

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884854712008324989608b726d4cdd4