### PR TITLE
Introduce PromptManager for unified prompts

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -14,15 +14,11 @@ import { bus } from '@eventBus/ProgressEventBus';
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
 import {
-  renderPrompt,
+  PromptManager,
+  getPrefillForRound,
   getFirstKCharsFromDocument,
   writePromptToXml,
-} from '@agent/utils/promptUtils';
-
-import {
-  getSystemPromptWithRules,
-  getPrefillForRound,
-} from '@agent/utils/promptHelpers';
+} from '@agent/utils';
 
 // Local imports - UI
 
@@ -156,9 +152,10 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
         const exists = await WorkspaceFS.exists(outputFile);
         const startTime = Date.now();
-        const systemPrompt = await getSystemPromptWithRules(
-          this.agentPrompt.systemPrompt,
+        const { systemPrompt } = await PromptManager.renderInitialPrompts(
+          this.agentPrompt,
           this.userVars,
+          toolState,
         );
 
         // Save message object to file for debugging if enabled in settings
@@ -587,11 +584,12 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       const messages: any[] = [];
 
       // Set up initial prompts
-      const [systemPrompt, userRequest, userPrefix] = await Promise.all([
-        getSystemPromptWithRules(this.agentPrompt.systemPrompt, this.userVars),
-        renderPrompt(this.agentPrompt.userRequest, this.userVars),
-        renderPrompt(this.agentPrompt.userPrefix, this.userVars),
-      ]);
+      const { systemPrompt, userRequest, userPrefix } =
+        await PromptManager.renderInitialPrompts(
+          this.agentPrompt,
+          this.userVars,
+          toolState,
+        );
 
       let prefixWithStats = userPrefix;
       if (toolState.texcountStats) {
@@ -757,14 +755,11 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       const stateRound = new AgentStateRound(currRound);
 
       // Prepare round message
-      const userRequestReflect = await renderPrompt(
-        this.agentPrompt.userReflect,
+      const userMessage = await PromptManager.renderReflectionPrompt(
+        this.agentPrompt,
         this.userVars,
+        toolState,
       );
-      let userMessage = userRequestReflect ? `${userRequestReflect}\n` : '';
-      if (toolState.texcountStats) {
-        userMessage = `${toolState.texcountStats}${userMessage}`;
-      }
 
       // Only proceed if there's actual content
       if (!userMessage.trim()) {

--- a/src/agent/utils/PromptManager.ts
+++ b/src/agent/utils/PromptManager.ts
@@ -1,0 +1,51 @@
+// Local imports
+import { renderPrompt } from './promptUtils';
+import { getSystemPromptWithRules } from './promptHelpers';
+import { AgentPrompt } from '../core/AgentDataclass';
+import { ToolState } from '../core/ToolState';
+
+/** Utility class for rendering prompts for agents. */
+export class PromptManager {
+  /**
+   * Render system prompt, user request and user prefix for the initial round.
+   */
+  static async renderInitialPrompts(
+    agentPrompt: AgentPrompt,
+    userVars: Record<string, any>,
+    toolState: ToolState,
+  ): Promise<{
+    systemPrompt: string;
+    userRequest: string;
+    userPrefix: string;
+  }> {
+    const [systemPrompt, userRequest, userPrefix] = await Promise.all([
+      getSystemPromptWithRules(agentPrompt.systemPrompt, userVars),
+      renderPrompt(agentPrompt.userRequest, userVars),
+      renderPrompt(agentPrompt.userPrefix, userVars),
+    ]);
+    return {
+      systemPrompt,
+      userRequest,
+      userPrefix,
+    };
+  }
+
+  /**
+   * Render the reflection prompt for a follow-up round.
+   */
+  static async renderReflectionPrompt(
+    agentPrompt: AgentPrompt,
+    userVars: Record<string, any>,
+    toolState: ToolState,
+  ): Promise<string> {
+    const userRequestReflect = await renderPrompt(
+      agentPrompt.userReflect,
+      userVars,
+    );
+    let userMessage = userRequestReflect ? `${userRequestReflect}\n` : '';
+    if (toolState.texcountStats) {
+      userMessage = `${toolState.texcountStats}${userMessage}`;
+    }
+    return userMessage;
+  }
+}

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -3,6 +3,7 @@ export * from './userVars';
 export * from './mediaTypes';
 export * from './promptUtils';
 export * from './promptHelpers';
+export * from './PromptManager';
 export * from './outputFileUtils';
 export * from './priceUtils';
 export * from './text';


### PR DESCRIPTION
## Summary
- create `PromptManager` helper for building agent prompts
- update `BaseReflectionAgent` to use `PromptManager`
- export the new helper via `src/agent/utils`

## Testing
- `npm run format`
- `npm run lint`
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688484a6ac8c83248708bc8d5cd89340