### PR TITLE
Refactor response cycle to new module

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -1,0 +1,286 @@
+// Standard library imports
+// (none needed)
+
+// Third-party imports
+// (none needed)
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+// Local imports - latex utils
+import { bestConnectionMethod } from '@latex';
+
+// Local imports - utilities
+import { WorkspaceFS } from '@utils/files';
+import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
+import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
+import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
+import replacementEngine from '@replacement/engine';
+import xmlUtils from '@utils/text/xmlUtils';
+
+// Local imports - agent components
+import type { AgentConfig } from './AgentConfig';
+import type { AgentSetting, AgentPrompt } from './AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from './AgentState';
+import { ToolState } from './ToolState';
+import type { IModelHandler } from '@agent/modelHandlers';
+
+// Shared constants
+import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
+import { getConfig } from '@utils/config';
+
+/**
+ * Options required to run a single response cycle.
+ */
+export interface ResponseCycleOptions {
+  modelHandler: IModelHandler;
+  agentSetting: AgentSetting;
+  agentConfig: AgentConfig;
+  agentPrompt: AgentPrompt;
+  userVars: Record<string, any>;
+  logger: AgentLogger;
+  client: any;
+  checkInterruption: () => Promise<boolean> | boolean;
+  setAbortController: (ctrl: AbortController | null) => void;
+}
+
+/**
+ * Executes a response cycle.
+ * @returns Tuple of [round state, global state, tool state, completion flag]
+ */
+export async function runResponseCycle(
+  options: ResponseCycleOptions,
+  messages: any[],
+  stateRound: AgentStateRound,
+  stateGlobal: AgentStateGlobal,
+  toolState: ToolState,
+  outputFile: string,
+  roundGroupId?: string,
+): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
+  const {
+    modelHandler,
+    agentSetting,
+    agentConfig,
+    agentPrompt,
+    userVars,
+    logger,
+    client,
+    checkInterruption,
+    setAbortController,
+  } = options;
+
+  const taskGroupId = roundGroupId;
+
+  let endTurn = false;
+  while (!endTurn) {
+    if (await checkInterruption()) {
+      break;
+    }
+
+    const exists = await WorkspaceFS.exists(outputFile);
+    const startTime = Date.now();
+    const systemPrompt = await getSystemPromptWithRules(
+      agentPrompt.systemPrompt,
+      userVars,
+    );
+
+    const shouldSaveMessageObjects = getConfig(
+      'debug.saveMessageObjects',
+      false,
+    );
+    if (shouldSaveMessageObjects) {
+      const outputFileBaseName = outputFile.replace('.xml', '');
+      const debugFilePath = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
+      try {
+        await WorkspaceFS.writeFile(
+          debugFilePath,
+          JSON.stringify(messages, null, 2),
+        );
+        logger.info(`Saved message object to ${debugFilePath}`, taskGroupId);
+      } catch (error) {
+        logger.error(`Failed to save message object: ${error}`, taskGroupId);
+      }
+    }
+
+    const abortController = new AbortController();
+    setAbortController(abortController);
+    let responseObject;
+    try {
+      responseObject = await modelHandler.createResponse(
+        client,
+        messages,
+        agentSetting.temperature || 0.0,
+        systemPrompt,
+        agentSetting.endTag,
+        abortController.signal,
+        modelHandler.capabilities.supportsFunctionCalling
+          ? agentSetting.tools
+          : undefined,
+      );
+    } finally {
+      setAbortController(null);
+    }
+    if (!responseObject) {
+      logger.warn(
+        'Model response was aborted or returned no data; output may be incomplete.',
+        taskGroupId,
+      );
+      break;
+    }
+    const responseTime = (Date.now() - startTime) / 1000;
+    stateRound.updateResponseTime(responseTime);
+    logger.debug(`Response time: ${responseTime.toFixed(2)}s`, taskGroupId);
+
+    const [newResponse, responseUsage, stopReason] =
+      modelHandler.extractResponse(responseObject, agentSetting.endTag);
+
+    logger.debug(`Stop reason: ${stopReason}`, taskGroupId);
+    logger.debug(`Token usage: ${JSON.stringify(responseUsage)}`, taskGroupId);
+
+    const thinkingContent = modelHandler.processThinkingBlock(
+      responseObject,
+      taskGroupId,
+      toolState,
+    );
+
+    if (thinkingContent) {
+      const formatted = await xmlUtils.formatContent(thinkingContent);
+      logger.info(formatted, taskGroupId, MESSAGE_TYPES.THINKING);
+    }
+
+    const scratchpad = await xmlUtils.extractScratchpad(
+      newResponse,
+      'scratchpad',
+    );
+    if (scratchpad) {
+      logger.info(scratchpad, taskGroupId, MESSAGE_TYPES.SCRATCHPAD);
+    }
+
+    const APIUsage = modelHandler.computeResponseUsage(
+      responseUsage,
+      responseTime,
+    );
+    stateRound.updateTokenCounts(APIUsage);
+    stateGlobal.updateFromCurrRound(stateRound);
+
+    const repetitionResult = checkForMassiveRepetition(
+      toolState.lastResponse,
+      newResponse,
+    );
+    if (repetitionResult.massiveRepetitionDetected) {
+      logger.error(
+        `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
+        taskGroupId,
+      );
+      logger.error(
+        'Massive repetition detected - skipping this response',
+        taskGroupId,
+      );
+      logger.error('Message structure when repetition detected:', taskGroupId);
+      logger.error(
+        JSON.stringify(messageToSkeleton(messages), null, 2),
+        taskGroupId,
+      );
+      break;
+    }
+
+    const processedResponse = replacementEngine.applyAll(newResponse);
+    toolState.updateLastResponse(processedResponse);
+
+    const result = await bestConnectionMethod(
+      toolState.lastResponse.slice(-K_SLICE),
+      processedResponse.slice(0, K_SLICE),
+    );
+    const bestConnector = result.connector;
+
+    toolState.updateAccumulatedOutput(
+      toolState.accumulatedOutput + bestConnector + processedResponse,
+    );
+
+    if (!exists) {
+      logger.debug(`Creating new file: ${outputFile}`, taskGroupId);
+      await WorkspaceFS.writeFile(outputFile, processedResponse);
+    } else {
+      logger.debug(`Appending to existing file: ${outputFile}`, taskGroupId);
+      await WorkspaceFS.appendFile(
+        outputFile,
+        bestConnector + processedResponse,
+      );
+    }
+
+    logger.debug('Response preview:', taskGroupId);
+    logger.debug(
+      `First ${K_SLICE} chars:\n${processedResponse.slice(0, K_SLICE)}`,
+      taskGroupId,
+    );
+    logger.debug(
+      `Last ${K_SLICE} chars:\n${processedResponse.slice(-K_SLICE)}`,
+      taskGroupId,
+    );
+
+    if (modelHandler.capabilities.supportsAssistantPrefill) {
+      modelHandler.updateMessageContentWithPrefill(
+        messages,
+        bestConnector,
+        processedResponse,
+        toolState,
+      );
+    } else {
+      modelHandler.updateMessageContentWithoutPrefill(
+        messages,
+        bestConnector,
+        processedResponse,
+        toolState,
+      );
+    }
+
+    const [shouldEndTurn, shouldStop] = modelHandler.checkStopConditions(
+      stopReason,
+      processedResponse,
+      stateRound,
+      stateGlobal,
+      agentSetting,
+    );
+    endTurn = shouldEndTurn;
+    if (shouldStop) {
+      break;
+    }
+
+    stateRound.incrementContinuation();
+    logger.info(
+      `Starting continuation #${stateRound.continuationCount}`,
+      taskGroupId,
+    );
+
+    if (
+      modelHandler.shouldContinue(stopReason, processedResponse, agentSetting)
+    ) {
+      logger.debug(
+        'Should continue - adding continuation message to conversation',
+        taskGroupId,
+      );
+      if (modelHandler.capabilities.supportsAssistantPrefill) {
+        modelHandler.addContinueMessageWithPrefill(
+          messages,
+          stateRound,
+          toolState,
+          agentSetting,
+          agentConfig,
+        );
+        continue;
+      } else {
+        modelHandler.addContinueMessageWithoutPrefill(
+          messages,
+          stateRound,
+          toolState,
+          agentSetting,
+          agentConfig,
+        );
+        continue;
+      }
+    }
+  }
+
+  return [stateRound, stateGlobal, toolState, endTurn];
+}

--- a/src/agent/core/index.ts
+++ b/src/agent/core/index.ts
@@ -5,3 +5,4 @@ export * from './ToolConfig';
 export * from './ToolState';
 export * from './ResponseUsage';
 export * from './IAgent';
+export * from './ResponseCycle';

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -7,7 +7,7 @@
 // Local imports - log
 
 // Local imports - latex utils
-import { bestConnectionMethod, LatexMediaManager } from '@latex';
+import { LatexMediaManager } from '@latex';
 
 import { bus } from '@eventBus/ProgressEventBus';
 
@@ -24,12 +24,6 @@ import {
   getPrefillForRound,
 } from '@agent/utils/promptHelpers';
 
-// Local imports - UI
-
-import replacementEngine from '@replacement/engine';
-import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
-import xmlUtils from '@utils/text/xmlUtils';
-
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import {
@@ -39,18 +33,17 @@ import {
 } from '@agent/core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
+import { runResponseCycle } from '@agent/core/ResponseCycle';
 import type { IModelHandler } from '@agent/modelHandlers';
 import type { ToolDefinition } from '@model';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
-import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
 
 // Shared constants
-import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
+import { K_SLICE } from '@utils/config';
 
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.
@@ -123,298 +116,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    */
   protected getNumberOfRounds(): number {
     return this.agentSetting.rounds ?? 2;
-  }
-
-  /**
-   * Manages single response cycle with model interaction.
-   * @param messages Current conversation messages
-   * @param stateRound Current round state
-   * @param stateGlobal Global conversation state
-   * @param toolState Tool-specific state
-   * @param outputFile Current output file path
-   * @param roundGroupId Optional parent round group ID
-   * @returns Updated states and completion flag
-   */
-  private async processResponseCycle(
-    messages: any[],
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
-    toolState: ToolState,
-    outputFile: string,
-    roundGroupId?: string,
-  ): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
-    // Use the round group identifier for logging this cycle
-    const taskGroupId = roundGroupId;
-
-    try {
-      let endTurn = false;
-      while (!endTurn) {
-        // Check for interruption before each cycle
-        if (await this.checkInterruption()) {
-          break;
-        }
-
-        const exists = await WorkspaceFS.exists(outputFile);
-        const startTime = Date.now();
-        const systemPrompt = await getSystemPromptWithRules(
-          this.agentPrompt.systemPrompt,
-          this.userVars,
-        );
-
-        // Save message object to file for debugging if enabled in settings
-        const shouldSaveMessageObjects = getConfig(
-          'debug.saveMessageObjects',
-          false,
-        );
-        if (shouldSaveMessageObjects) {
-          const outputFileBaseName = outputFile.replace('.xml', '');
-          const debugFilePath = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
-          try {
-            await WorkspaceFS.writeFile(
-              debugFilePath,
-              JSON.stringify(messages, null, 2),
-            );
-            this.logger.info(
-              `Saved message object to ${debugFilePath}`,
-              taskGroupId,
-            );
-          } catch (error) {
-            this.logger.error(
-              `Failed to save message object: ${error}`,
-              taskGroupId,
-            );
-          }
-        }
-
-        this.abortController = new AbortController();
-        let responseObject;
-        try {
-          responseObject = await this.modelHandler.createResponse(
-            this.client,
-            messages,
-            this.agentSetting.temperature || 0.0,
-            systemPrompt,
-            this.agentSetting.endTag,
-            this.abortController.signal,
-            this.modelHandler.capabilities.supportsFunctionCalling
-              ? this.agentSetting.tools
-              : undefined,
-          );
-        } finally {
-          this.abortController = null;
-        }
-        if (!responseObject) {
-          this.logger.warn(
-            'Model response was aborted or returned no data; output may be incomplete.',
-            taskGroupId,
-          );
-          break;
-        }
-        const responseTime = (Date.now() - startTime) / 1000;
-        stateRound.updateResponseTime(responseTime);
-        this.logger.debug(
-          `Response time: ${responseTime.toFixed(2)}s`,
-          taskGroupId,
-        );
-
-        // Extract and validate response
-        const [newResponse, responseUsage, stopReason] =
-          this.modelHandler.extractResponse(
-            responseObject,
-            this.agentSetting.endTag,
-          );
-
-        this.logger.debug(`Stop reason: ${stopReason}`, taskGroupId);
-        this.logger.debug(
-          `Token usage: ${JSON.stringify(responseUsage)}`,
-          taskGroupId,
-        );
-
-        // Extract thinking blocks directly from the response object
-        // This updates toolState with all thinking/redacted_thinking blocks
-        // and returns content of the first thinking block for logging (if any)
-        const thinkingContent = this.modelHandler.processThinkingBlock(
-          responseObject,
-          taskGroupId,
-          toolState,
-        );
-
-        // If thinking content was extracted, format and log it first
-        if (thinkingContent) {
-          const formatted = await xmlUtils.formatContent(thinkingContent);
-          this.logger.info(formatted, taskGroupId, MESSAGE_TYPES.THINKING);
-
-          // Note: The complete thinking blocks (including signatures) have already been
-          // stored in toolState.thinkingBlocks by the processThinkingBlock method
-        }
-
-        // Extract scratchpad content directly from the response text
-        const scratchpad = await xmlUtils.extractScratchpad(
-          newResponse,
-          'scratchpad',
-        );
-        if (scratchpad) {
-          this.logger.info(scratchpad, taskGroupId, MESSAGE_TYPES.SCRATCHPAD);
-        }
-        // this has a potential bug if <scratchpad> is included in the prefill
-
-        // Compute statistics and update states
-        const APIUsage = this.modelHandler.computeResponseUsage(
-          responseUsage,
-          responseTime,
-        );
-
-        stateRound.updateTokenCounts(APIUsage);
-        stateGlobal.updateFromCurrRound(stateRound);
-
-        // Early exit for repetition
-        const repetitionResult = checkForMassiveRepetition(
-          toolState.lastResponse,
-          newResponse,
-        );
-        if (repetitionResult.massiveRepetitionDetected) {
-          this.logger.error(
-            `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-            taskGroupId,
-          );
-          this.logger.error(
-            `Massive repetition detected - skipping this response`,
-            taskGroupId,
-          );
-
-          // Debug information - print message skeleton to help diagnose the problem
-          this.logger.error(
-            `Message structure when repetition detected:`,
-            taskGroupId,
-          );
-          this.logger.error(
-            JSON.stringify(messageToSkeleton(messages), null, 2),
-            taskGroupId,
-          );
-          break;
-        }
-
-        // Chain response processing operations
-        const processedResponse = replacementEngine.applyAll(newResponse);
-
-        toolState.updateLastResponse(processedResponse);
-
-        // Process response connection with proper slicing
-        const result = await bestConnectionMethod(
-          toolState.lastResponse.slice(-K_SLICE),
-          processedResponse.slice(0, K_SLICE),
-        );
-        const bestConnector = result.connector;
-
-        // Update state and file atomically
-        toolState.updateAccumulatedOutput(
-          toolState.accumulatedOutput + bestConnector + processedResponse,
-        );
-
-        // Write or append to output file
-        if (!exists) {
-          this.logger.debug(`Creating new file: ${outputFile}`, taskGroupId);
-          await WorkspaceFS.writeFile(outputFile, processedResponse);
-        } else {
-          this.logger.debug(
-            `Appending to existing file: ${outputFile}`,
-            taskGroupId,
-          );
-          await WorkspaceFS.appendFile(
-            outputFile,
-            bestConnector + processedResponse,
-          );
-        }
-
-        // Log response boundaries
-        this.logger.debug(`Response preview:`, taskGroupId);
-        this.logger.debug(
-          `First ${K_SLICE} chars:\n${processedResponse.slice(0, K_SLICE)}`,
-          taskGroupId,
-        );
-        this.logger.debug(
-          `Last ${K_SLICE} chars:\n${processedResponse.slice(-K_SLICE)}`,
-          taskGroupId,
-        );
-
-        // Update message content
-        // maybe we should separate this into the case of with or without support for assistant prefill since they have different logic...
-        if (this.modelHandler.capabilities.supportsAssistantPrefill) {
-          this.modelHandler.updateMessageContentWithPrefill(
-            messages,
-            bestConnector,
-            processedResponse,
-            toolState,
-          );
-        } else {
-          this.modelHandler.updateMessageContentWithoutPrefill(
-            messages,
-            bestConnector,
-            processedResponse,
-            toolState,
-          );
-        }
-
-        // Check stop conditions
-        const [shouldEndTurn, shouldStop] =
-          this.modelHandler.checkStopConditions(
-            stopReason,
-            processedResponse,
-            stateRound,
-            stateGlobal,
-            this.agentSetting,
-          );
-        endTurn = shouldEndTurn;
-        if (shouldStop) {
-          break;
-        }
-
-        // Handle continuation
-        stateRound.incrementContinuation();
-        this.logger.info(
-          `Starting continuation #${stateRound.continuationCount}`,
-          taskGroupId,
-        );
-
-        // Check if model should continue generating
-        // why is this not included in the checkStopConditions function?
-        if (
-          this.modelHandler.shouldContinue(
-            stopReason,
-            processedResponse,
-            this.agentSetting,
-          )
-        ) {
-          this.logger.debug(
-            `Should continue - adding continuation message to conversation`,
-            taskGroupId,
-          );
-          if (this.modelHandler.capabilities.supportsAssistantPrefill) {
-            this.modelHandler.addContinueMessageWithPrefill(
-              messages,
-              stateRound,
-              toolState,
-              this.agentSetting,
-              this.agentConfig,
-            );
-            continue;
-          } else {
-            this.modelHandler.addContinueMessageWithoutPrefill(
-              messages,
-              stateRound,
-              toolState,
-              this.agentSetting,
-              this.agentConfig,
-            );
-            continue;
-          }
-        }
-      }
-
-      return [stateRound, stateGlobal, toolState, endTurn];
-    } catch (error) {
-      throw error;
-    }
   }
 
   /**
@@ -643,13 +344,26 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           updatedStateGlobal,
           updatedToolState,
           newEndTurn,
-        ] = await this.processResponseCycle(
+        ] = await runResponseCycle(
+          {
+            modelHandler: this.modelHandler,
+            agentSetting: this.agentSetting,
+            agentConfig: this.agentConfig,
+            agentPrompt: this.agentPrompt,
+            userVars: this.userVars,
+            logger: this.logger,
+            client: this.client,
+            checkInterruption: () => this.checkInterruption(),
+            setAbortController: (ctrl) => {
+              this.abortController = ctrl;
+            },
+          },
           updatedMessages,
           stateRound,
           stateGlobal,
           toolState,
           this.outputFile[currRound],
-          round0GroupId, // Pass the round group ID to processResponseCycle
+          round0GroupId,
         );
         finalEndTurn = newEndTurn;
 
@@ -799,7 +513,20 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           updatedStateGlobal,
           updatedToolState,
           newEndTurn,
-        ] = await this.processResponseCycle(
+        ] = await runResponseCycle(
+          {
+            modelHandler: this.modelHandler,
+            agentSetting: this.agentSetting,
+            agentConfig: this.agentConfig,
+            agentPrompt: this.agentPrompt,
+            userVars: this.userVars,
+            logger: this.logger,
+            client: this.client,
+            checkInterruption: () => this.checkInterruption(),
+            setAbortController: (ctrl) => {
+              this.abortController = ctrl;
+            },
+          },
           updatedMessages,
           stateRound,
           stateGlobal,


### PR DESCRIPTION
## Summary
- extract `processResponseCycle` logic to `src/agent/core/ResponseCycle.ts`
- export helper via `agent/core` index
- call `runResponseCycle` from `BaseReflectionAgent.process` and `.reflect`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884844a64c88324a6b47879dfc9363c