### PR TITLE
style: centralize details summary styling

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -226,3 +226,28 @@ select:focus {
   color: var(--vscode-textLink-activeForeground);
   text-decoration: underline;
 }
+
+/* Shared styling for expandable summary blocks */
+.details-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) 0;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  opacity: var(--opacity-normal);
+}
+
+.details-summary:hover {
+  opacity: 1;
+}
+
+.details-summary::-webkit-details-marker {
+  display: none;
+}
+
+.details-summary .toggle-icon {
+  opacity: var(--opacity-subtle);
+  font-size: var(--font-size-sm);
+}

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -217,7 +217,7 @@ export class LogEntryFormatter {
       const icon = isThinking ? 'codicon-lightbulb' : 'codicon-pencil';
 
       return `<details class="special-details">
-        <summary>
+        <summary class="details-summary">
           <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon ${icon}"></i>
           <span>${labelText}</span>
@@ -295,7 +295,7 @@ export class LogEntryFormatter {
       summary += ')';
 
       return `<details class="file-list-details">
-        <summary>
+        <summary class="details-summary">
           <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon codicon-list-tree"></i>
           <span>${summary}</span>
@@ -365,7 +365,7 @@ export class LogEntryFormatter {
       const summary = `Missing outputs (${missingFiles.length})`;
 
       return `<details class="file-list-details">
-        <summary>
+        <summary class="details-summary">
           <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon codicon-warning"></i>
           <span>${summary}</span>
@@ -429,7 +429,7 @@ export class LogEntryFormatter {
           : `Latexdiff results (${entries.length})`;
 
       return `<details class="latexdiff-details" open>
-        <summary>
+        <summary class="details-summary">
           <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
           <i class="codicon codicon-diff"></i>
           <span>${summary}</span>
@@ -514,7 +514,7 @@ export class LogEntryFormatter {
       }
 
       return `<details class="statistics-details" open>
-        <summary>
+        <summary class="details-summary">
           <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
           <i class="codicon codicon-dashboard"></i>
           <span>Statistics</span>

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -7,26 +7,6 @@
 .file-list-details {
   margin: var(--spacing-small) 0;
 }
-
-.file-list-details summary {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  padding: var(--spacing-tiny) 0;
-  cursor: pointer;
-  list-style: none;
-  user-select: none;
-  opacity: var(--opacity-normal);
-}
-
-.file-list-details summary:hover {
-  opacity: 1;
-}
-
-.file-list-details summary::-webkit-details-marker {
-  display: none;
-}
-
 .file-list-content {
   padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
   list-style: none;
@@ -36,12 +16,6 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-}
-
-/* Toggle icon styling for file lists */
-.file-list-details summary .toggle-icon {
-  opacity: var(--opacity-subtle);
-  font-size: var(--font-size-sm);
 }
 
 /* File metadata styling */

--- a/src/progressView/styles/latexdiff.css
+++ b/src/progressView/styles/latexdiff.css
@@ -5,26 +5,6 @@
 .latexdiff-details {
   margin: var(--spacing-small) 0;
 }
-
-.latexdiff-details summary {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  padding: var(--spacing-tiny) 0;
-  cursor: pointer;
-  list-style: none;
-  user-select: none;
-  opacity: var(--opacity-normal);
-}
-
-.latexdiff-details summary:hover {
-  opacity: 1;
-}
-
-.latexdiff-details summary::-webkit-details-marker {
-  display: none;
-}
-
 .latexdiff-content {
   padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
   list-style: none;
@@ -34,9 +14,4 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-}
-
-.latexdiff-details summary .toggle-icon {
-  opacity: var(--opacity-subtle);
-  font-size: var(--font-size-sm);
 }

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -7,36 +7,10 @@
 .special-details {
   margin: var(--spacing-small) 0;
 }
-
-.special-details summary {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  padding: var(--spacing-tiny) 0;
-  cursor: pointer;
-  list-style: none;
-  user-select: none;
-  opacity: var(--opacity-normal);
-}
-
-.special-details summary:hover {
-  opacity: 1;
-}
-
-.special-details summary::-webkit-details-marker {
-  display: none;
-}
-
 .special-details .special-content {
   padding: var(--spacing-small) 0 var(--spacing-medium) var(--spacing-large);
   /* Remove max-height to prevent nested scrollbars */
   overflow: visible;
-}
-
-/* Toggle icon styling */
-.special-details summary .toggle-icon {
-  opacity: var(--opacity-subtle);
-  font-size: var(--font-size-sm);
 }
 
 /* Style markdown elements in special content */

--- a/src/progressView/styles/statistics.css
+++ b/src/progressView/styles/statistics.css
@@ -6,25 +6,6 @@
   margin: var(--spacing-small) 0;
 }
 
-.statistics-details summary {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  padding: var(--spacing-tiny) 0;
-  cursor: pointer;
-  list-style: none;
-  user-select: none;
-  opacity: var(--opacity-normal);
-}
-
-.statistics-details summary:hover {
-  opacity: 1;
-}
-
-.statistics-details summary::-webkit-details-marker {
-  display: none;
-}
-
 .statistics-content {
   padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
   display: flex;
@@ -37,9 +18,4 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-}
-
-.statistics-details summary .toggle-icon {
-  opacity: var(--opacity-subtle);
-  font-size: var(--font-size-sm);
 }


### PR DESCRIPTION
## Summary
- move shared details summary styles to `common.css`
- remove duplicate summary rules from various ProgressView stylesheets
- reference the new `.details-summary` class in generated markup

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68848d5f90ec8324ac7211961ad6f272