### PR TITLE
Add shared BaseUIManager

### DIFF
--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -43,6 +43,10 @@ export class MainViewContentProvider extends BaseViewContentProvider {
         webview,
         'modules/uiManagers/ToggleManager.js',
       ),
+      baseUIManagerUri: this.getWebviewUri(
+        webview,
+        'modules/uiManagers/BaseUIManager.js',
+      ),
       fileInputManagerUri: this.getWebviewUri(
         webview,
         'modules/uiManagers/FileInputManager.js',

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -18,6 +18,7 @@
           "./modules/uiManagers/FileList.js": "${fileListUri}",
           "./modules/uiManagers/FileSelect.js": "${fileSelectUri}",
           "./modules/uiManagers/ToggleManager.js": "${toggleManagerUri}",
+          "./modules/uiManagers/BaseUIManager.js": "${baseUIManagerUri}",
           "./modules/uiManagers/FileInputManager.js": "${fileInputManagerUri}",
           "./modules/uiManagers/ActionButtonManager.js": "${actionButtonManagerUri}",
           "./modules/uiManagers/SettingsButtonManager.js": "${settingsButtonManagerUri}",

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -14,25 +14,15 @@ import {
   EDITED_FILE,
 } from '../constants.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { BaseUIManager } from './BaseUIManager.js';
 
-export class ActionButtonManager {
+export class ActionButtonManager extends BaseUIManager {
   constructor(vscodeInstance = vscode, fileList, state, instructionMgr) {
+    super();
     this.vscode = vscodeInstance;
     this.fileList = fileList;
     this.state = state;
     this.instructionManager = instructionMgr;
-    this._listeners = [];
-  }
-
-  _addListener(elementOrId, event, handler) {
-    const element =
-      typeof elementOrId === 'string'
-        ? safeGetElementById(elementOrId)
-        : elementOrId;
-    if (element) {
-      element.addEventListener(event, handler);
-      this._listeners.push({ element, event, handler });
-    }
   }
 
   _getSingleFileData(fileTypes = ['input', 'reference', 'auxiliary', 'media']) {
@@ -66,7 +56,7 @@ export class ActionButtonManager {
   }
 
   _setupInstructionButtons() {
-    this._addListener(ELEMENT_IDS.ERASE_INSTRUCTION_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.ERASE_INSTRUCTION_BUTTON, 'click', () => {
       const instruction = safeGetElementById(ELEMENT_IDS.INSTRUCTION);
       if (instruction) {
         instruction.value = '';
@@ -75,7 +65,7 @@ export class ActionButtonManager {
       }
     });
 
-    this._addListener(ELEMENT_IDS.MAGIC_POLISH_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.MAGIC_POLISH_BUTTON, 'click', () => {
       const instruction = safeGetElementById(ELEMENT_IDS.INSTRUCTION);
       if (instruction && instruction.value.trim()) {
         const agent = safeGetElementValue('agent');
@@ -96,7 +86,7 @@ export class ActionButtonManager {
   }
 
   _setupExecuteButtons() {
-    this._addListener(ELEMENT_IDS.EXECUTE_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.EXECUTE_BUTTON, 'click', () => {
       const agent = safeGetElementValue('agent');
       const model = safeGetElementValue('model');
       const instruction = safeGetElementValue(ELEMENT_IDS.INSTRUCTION);
@@ -119,7 +109,7 @@ export class ActionButtonManager {
       });
     });
 
-    this._addListener(ELEMENT_IDS.MERGE_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.MERGE_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
       const editedFile = safeGetElementValue(EDITED_FILE);
 
@@ -139,7 +129,7 @@ export class ActionButtonManager {
       { id: ELEMENT_IDS.PACK_BUTTON, action: 'pack' },
       { id: ELEMENT_IDS.CLEAN_BUTTON, action: 'clean' },
     ].forEach(({ id, action }) => {
-      this._addListener(id, 'click', () => {
+      this.addListener(id, 'click', () => {
         const { inputFile } = this._getSingleFileData(['input']);
         const agent = safeGetElementValue('agent');
         const model = safeGetElementValue('model');
@@ -202,7 +192,7 @@ export class ActionButtonManager {
   }
 
   _setupLatexdiffButtons() {
-    this._addListener(ELEMENT_IDS.LATEXDIFF_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.LATEXDIFF_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
       const baseFile = safeGetElementValue(BASE_FILE);
       const editedFile = safeGetElementValue(EDITED_FILE);
@@ -220,7 +210,7 @@ export class ActionButtonManager {
       });
     });
 
-    this._addListener(ELEMENT_IDS.LATEXDIFF_VC_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.LATEXDIFF_VC_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
       const baseFile = safeGetElementValue(BASE_FILE);
       const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
@@ -242,7 +232,7 @@ export class ActionButtonManager {
       { id: ELEMENT_IDS.PACK_LATEXDIFF_VC_BUTTON, action: 'pack' },
       { id: ELEMENT_IDS.CLEAN_LATEXDIFF_VC_BUTTON, action: 'clean' },
     ].forEach(({ id, action }) => {
-      this._addListener(id, 'click', () => {
+      this.addListener(id, 'click', () => {
         const { inputFile } = this._getSingleFileData(['input']);
         const baseFile = safeGetElementValue(BASE_FILE);
         const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
@@ -268,7 +258,7 @@ export class ActionButtonManager {
   }
 
   _setupCompareButtons() {
-    this._addListener(ELEMENT_IDS.COMPARE_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.COMPARE_BUTTON, 'click', () => {
       const baseFile = safeGetElementValue(BASE_FILE);
       const editedFile = safeGetElementValue(EDITED_FILE);
       if (baseFile && editedFile) {
@@ -285,7 +275,7 @@ export class ActionButtonManager {
       }
     });
 
-    this._addListener(ELEMENT_IDS.ACCEPT_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.ACCEPT_BUTTON, 'click', () => {
       const baseFile = safeGetElementValue(BASE_FILE);
       const editedFile = safeGetElementValue(EDITED_FILE);
       if (baseFile && editedFile) {
@@ -308,12 +298,5 @@ export class ActionButtonManager {
     this._setupExecuteButtons();
     this._setupLatexdiffButtons();
     this._setupCompareButtons();
-  }
-
-  cleanup() {
-    this._listeners.forEach(({ element, event, handler }) => {
-      element.removeEventListener(event, handler);
-    });
-    this._listeners = [];
   }
 }

--- a/src/webview/modules/uiManagers/BaseUIManager.js
+++ b/src/webview/modules/uiManagers/BaseUIManager.js
@@ -1,0 +1,33 @@
+import { safeGetElementById } from '@common/domUtils.js';
+export class BaseUIManager {
+  constructor() {
+    this._listeners = [];
+  }
+
+  /**
+   * Register an event handler and store the listener for cleanup.
+   * @param {HTMLElement|string} elementOrId - element or its ID
+   * @param {string} event - event type
+   * @param {EventListenerOrEventListenerObject} handler - handler function
+   */
+  addListener(elementOrId, event, handler) {
+    const element =
+      typeof elementOrId === 'string'
+        ? safeGetElementById(elementOrId)
+        : elementOrId;
+    if (element) {
+      element.addEventListener(event, handler);
+      this._listeners.push({ element, event, handler });
+    }
+  }
+
+  /**
+   * Remove all registered event listeners.
+   */
+  cleanup() {
+    this._listeners.forEach(({ element, event, handler }) => {
+      element.removeEventListener(event, handler);
+    });
+    this._listeners = [];
+  }
+}

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -19,8 +19,9 @@ import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
 import { mainViewState } from '../mainViewState.js';
+import { BaseUIManager } from './BaseUIManager.js';
 
-export class FileInputManager {
+export class FileInputManager extends BaseUIManager {
   constructor(
     vscodeInstance = vscode,
     state = mainViewState,
@@ -28,24 +29,13 @@ export class FileInputManager {
     select = fileSelect,
     outputMgr = outputFilesManager,
   ) {
+    super();
     this.vscode = vscodeInstance;
     this.state = state;
     this.fileList = list;
     this.fileSelect = select;
     this.outputFilesManager = outputMgr;
-    this._listeners = [];
     this._sortables = [];
-  }
-
-  _addListener(elementOrId, event, handler) {
-    const element =
-      typeof elementOrId === 'string'
-        ? safeGetElementById(elementOrId)
-        : elementOrId;
-    if (element) {
-      element.addEventListener(event, handler);
-      this._listeners.push({ element, event, handler });
-    }
   }
 
   _setupSortable() {
@@ -62,7 +52,7 @@ export class FileInputManager {
   }
 
   _setupSingleFileSelectors() {
-    this._addListener(INPUT_FILE, 'change', (e) => {
+    this.addListener(INPUT_FILE, 'change', (e) => {
       const inputFile = e.target.value;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
@@ -70,7 +60,7 @@ export class FileInputManager {
       });
     });
 
-    this._addListener(REFERENCE_FILE, 'change', (e) => {
+    this.addListener(REFERENCE_FILE, 'change', (e) => {
       const referenceFile = e.target.value;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED,
@@ -78,7 +68,7 @@ export class FileInputManager {
       });
     });
 
-    this._addListener(BASE_FILE, 'change', () => {
+    this.addListener(BASE_FILE, 'change', () => {
       const baseFile = safeGetElementValue(BASE_FILE);
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE,
@@ -103,7 +93,7 @@ export class FileInputManager {
 
     selectors.forEach(({ id, selectId }) => {
       const buttonId = `select${id}Button`;
-      this._addListener(buttonId, 'click', () => {
+      this.addListener(buttonId, 'click', () => {
         const currentFile = safeGetElementValue(selectId);
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES,
@@ -118,13 +108,13 @@ export class FileInputManager {
     const fileTypes = ['input', 'reference', 'auxiliary'];
     fileTypes.forEach((type) => {
       const cap = capitalize(type);
-      this._addListener(`addOpened${cap}FilesButton`, 'click', () => {
+      this.addListener(`addOpened${cap}FilesButton`, 'click', () => {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.ADD_OPENED_FILES,
           fileType: type,
         });
       });
-      this._addListener(`current${cap}FileButton`, 'click', () => {
+      this.addListener(`current${cap}FileButton`, 'click', () => {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
           fileType: type,
@@ -133,7 +123,7 @@ export class FileInputManager {
     });
 
     ['base', 'edited'].forEach((type) => {
-      this._addListener(`current${capitalize(type)}FileButton`, 'click', () => {
+      this.addListener(`current${capitalize(type)}FileButton`, 'click', () => {
         const baseFile = safeGetElementValue(BASE_FILE);
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
@@ -148,10 +138,10 @@ export class FileInputManager {
     MULTIPLE_SELECTIONS.forEach((id) => {
       const toggleId = `toggle${capitalize(id)}`;
       const emptyButtonId = `empty${capitalize(id)}Button`;
-      this._addListener(emptyButtonId, 'click', () =>
+      this.addListener(emptyButtonId, 'click', () =>
         this.fileList.empty(id, toggleId),
       );
-      this._addListener(toggleId, 'click', () => {
+      this.addListener(toggleId, 'click', () => {
         if (id === 'outputFiles') {
           this.outputFilesManager.toggleOutputFiles();
         } else {
@@ -172,8 +162,7 @@ export class FileInputManager {
             command: MAIN_VIEW_COMMANDS.REFRESH_COMMITS,
           });
         };
-        icon.addEventListener('click', handler);
-        this._listeners.push({ element: icon, event: 'click', handler });
+        this.addListener(icon, 'click', handler);
       }
     });
   }
@@ -188,7 +177,7 @@ export class FileInputManager {
       'edited',
     ];
     types.forEach((type) => {
-      this._addListener(`empty${capitalize(type)}FileButton`, 'click', () => {
+      this.addListener(`empty${capitalize(type)}FileButton`, 'click', () => {
         const selectEl = safeGetElementById(`${type}File`);
         if (selectEl) {
           selectEl.value = '';
@@ -204,10 +193,10 @@ export class FileInputManager {
         return; // handled by SettingsButtonManager
       }
       if (id !== 'instruction') {
-        this._addListener(id, 'change', () => this.state.save());
+        this.addListener(id, 'change', () => this.state.save());
       }
     });
-    this._addListener('instruction', 'input', () => this.state.save());
+    this.addListener('instruction', 'input', () => this.state.save());
   }
 
   setup() {
@@ -219,10 +208,7 @@ export class FileInputManager {
   }
 
   cleanup() {
-    this._listeners.forEach(({ element, event, handler }) => {
-      element.removeEventListener(event, handler);
-    });
-    this._listeners = [];
+    super.cleanup();
     this._sortables.forEach((s) => s.destroy());
     this._sortables = [];
   }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -10,34 +10,24 @@ import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { ELEMENT_IDS } from '../constants.js';
+import { BaseUIManager } from './BaseUIManager.js';
 
-export class SettingsButtonManager {
+export class SettingsButtonManager extends BaseUIManager {
   constructor(
     vscodeInstance = vscode,
     toggleManager,
     latexdiffManager,
     state = mainViewState,
   ) {
+    super();
     this.vscode = vscodeInstance;
     this.toggleManager = toggleManager;
     this.latexdiffManager = latexdiffManager;
     this.state = state;
-    this._listeners = [];
-  }
-
-  _addListener(elementOrId, event, handler) {
-    const element =
-      typeof elementOrId === 'string'
-        ? safeGetElementById(elementOrId)
-        : elementOrId;
-    if (element) {
-      element.addEventListener(event, handler);
-      this._listeners.push({ element, event, handler });
-    }
   }
 
   _setupToggles() {
-    this._addListener(ELEMENT_IDS.TOGGLE_AUTO_EXTRACT, 'click', (e) => {
+    this.addListener(ELEMENT_IDS.TOGGLE_AUTO_EXTRACT, 'click', (e) => {
       e.stopPropagation();
       const options = safeGetElementById(ELEMENT_IDS.AUTO_EXTRACT_OPTIONS);
       if (options) {
@@ -47,7 +37,7 @@ export class SettingsButtonManager {
       this.toggleManager.updateAutoToggleState();
     });
 
-    this._addListener(ELEMENT_IDS.TOGGLE_TOOL_CONFIG, 'click', (e) => {
+    this.addListener(ELEMENT_IDS.TOGGLE_TOOL_CONFIG, 'click', (e) => {
       e.stopPropagation();
       const options = safeGetElementById(ELEMENT_IDS.TOOL_CONFIG_OPTIONS);
       if (options) {
@@ -58,34 +48,34 @@ export class SettingsButtonManager {
     });
 
     CHECK_BOXES_AUTO_EXTRACT.forEach((id) => {
-      this._addListener(id, 'change', () => {
+      this.addListener(id, 'change', () => {
         this.toggleManager.updateAutoToggleState();
       });
     });
 
     CHECK_BOXES_TOOL_USE.forEach((id) => {
-      this._addListener(id, 'change', () => {
+      this.addListener(id, 'change', () => {
         this.toggleManager.updateToolConfigToggleState();
       });
     });
 
     CHECK_BOXES.forEach((id) => {
-      this._addListener(id, 'change', handleCheckboxChange);
+      this.addListener(id, 'change', handleCheckboxChange);
     });
 
-    this._addListener(ELEMENT_IDS.TOGGLE_LATEXDIFFS, 'click', () => {
+    this.addListener(ELEMENT_IDS.TOGGLE_LATEXDIFFS, 'click', () => {
       this.latexdiffManager.toggleLatexdiffs();
     });
   }
 
   _setupSettingsButtons() {
-    this._addListener(ELEMENT_IDS.AGENT_SETTINGS_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.AGENT_SETTINGS_BUTTON, 'click', () => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
       });
     });
 
-    this._addListener(ELEMENT_IDS.MODEL_SETTINGS_BUTTON, 'click', () => {
+    this.addListener(ELEMENT_IDS.MODEL_SETTINGS_BUTTON, 'click', () => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS,
       });
@@ -93,7 +83,7 @@ export class SettingsButtonManager {
   }
 
   _setupDropdowns() {
-    this._addListener('agent', 'change', (e) => {
+    this.addListener('agent', 'change', (e) => {
       const selectedAgent = e.target.value;
       const reflectCheckbox = safeGetElementById('reflect');
       if (reflectCheckbox) {
@@ -109,7 +99,7 @@ export class SettingsButtonManager {
       this.state.save();
     });
 
-    this._addListener('model', 'change', (e) => {
+    this.addListener('model', 'change', (e) => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
         model: e.target.value,
@@ -122,12 +112,5 @@ export class SettingsButtonManager {
     this._setupToggles();
     this._setupSettingsButtons();
     this._setupDropdowns();
-  }
-
-  cleanup() {
-    this._listeners.forEach(({ element, event, handler }) => {
-      element.removeEventListener(event, handler);
-    });
-    this._listeners = [];
   }
 }


### PR DESCRIPTION
## Summary
- add `BaseUIManager` with listener tracking
- refactor ActionButtonManager, FileInputManager and SettingsButtonManager to extend it
- expose new module to the webview import map

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68848d426e208324b92342a9d293738e