### PR TITLE
Remove redundant provider error helper

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -12,7 +12,7 @@ import {
 import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 
 // Local imports - error utils
-import { formatProviderError } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
@@ -184,7 +184,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         response = await client.beta.messages.create(options, { signal });
       }
     } catch (err) {
-      this.logger.error(formatProviderError('Error creating response', err));
+      this.logger.error(`Error creating response: ${getSdkErrorMessage(err)}`);
       throw err;
     }
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -35,7 +35,7 @@ import { toGoogleTools } from './toolConversion';
 
 // Local imports - utilities
 import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
-import { formatProviderError } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import xmlUtils from '@utils/text/xmlUtils';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -272,10 +272,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         }
       } catch (err) {
         this.logger.error(
-          formatProviderError(
-            'Token counting failed, proceeding without token adjustment',
-            err,
-          ),
+          `Token counting failed, proceeding without token adjustment: ${getSdkErrorMessage(err)}`,
         );
       }
     }
@@ -340,7 +337,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       return result;
     } catch (error) {
       this.logger.error(
-        formatProviderError('Error during Google GenAI Chat API call', error),
+        `Error during Google GenAI Chat API call: ${getSdkErrorMessage(error)}`,
       );
       if (
         error instanceof Error &&
@@ -428,10 +425,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           mediaFileResults.push({ path: mediaFile, ok: true });
         } catch (error) {
           this.logger.error(
-            formatProviderError(
-              `Failed to upload media file ${mediaFile} via native SDK`,
-              error,
-            ),
+            `Failed to upload media file ${mediaFile} via native SDK: ${getSdkErrorMessage(error)}`,
           );
           mediaFileResults.push({ path: mediaFile, ok: false });
         }
@@ -544,10 +538,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           mediaFileResults.push({ path: mediaFile, ok: true });
         } catch (error) {
           this.logger.error(
-            formatProviderError(
-              `Failed to upload media file ${mediaFile} for follow-up round`,
-              error,
-            ),
+            `Failed to upload media file ${mediaFile} for follow-up round: ${getSdkErrorMessage(error)}`,
           );
           mediaFileResults.push({ path: mediaFile, ok: false });
         }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -10,7 +10,7 @@ import { countTokens } from 'gpt-tokenizer';
 import { WorkspaceFS } from '@utils/files';
 import { cleanFileContent } from '@replacement/engine';
 import xmlUtils from '@utils/text/xmlUtils';
-import { formatProviderError } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Local imports - agent components
 import type { AgentConfig } from '../core/AgentConfig';
@@ -192,7 +192,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
         // we should also make sure partial results can be returned in the presence of errors!
       } catch (err) {
         this.logger.error(
-          formatProviderError('Error in createResponse(streaming)', err),
+          `Error in createResponse(streaming): ${getSdkErrorMessage(err)}`,
         );
         throw err;
       }
@@ -204,7 +204,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
         });
         return response;
       } catch (err) {
-        this.logger.error(formatProviderError('Error in createResponse', err));
+        this.logger.error(
+          `Error in createResponse: ${getSdkErrorMessage(err)}`,
+        );
         throw err;
       }
     }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -113,10 +113,3 @@ export function getSdkErrorMessage(err: unknown): string {
 
   return 'An unexpected error occurred.';
 }
-
-/**
- * Formats a provider error with a custom prefix.
- */
-export function formatProviderError(prefix: string, err: unknown): string {
-  return `${prefix}: ${getSdkErrorMessage(err)}`;
-}

--- a/src/latex/textConnection.ts
+++ b/src/latex/textConnection.ts
@@ -3,7 +3,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
 
 // Local imports - error utils
-import { formatProviderError } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -142,7 +142,7 @@ export async function bestConnectionMethod(
   } catch (err) {
     logger.error(
       CHANNEL,
-      formatProviderError('Error in bestConnectionMethod', err),
+      `Error in bestConnectionMethod: ${getSdkErrorMessage(err)}`,
     );
     return {
       connector: ' ',
@@ -195,7 +195,7 @@ export async function bestConnectionMethodAnthropic(
   } catch (err) {
     logger.error(
       CHANNEL,
-      formatProviderError('Error in bestConnectionMethodAnthropic', err),
+      `Error in bestConnectionMethodAnthropic: ${getSdkErrorMessage(err)}`,
     );
     return {
       connector: ' ',

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -7,7 +7,7 @@ import type { MessageCreateParams } from '@anthropic-ai/sdk/resources/messages';
 import * as vscode from 'vscode';
 
 // Local imports - error utils
-import { formatProviderError } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -204,7 +204,7 @@ ${text}`;
       text: trimmedText,
     };
   } catch (error) {
-    logger.error(CHANNEL, formatProviderError('Error polishing text', error));
+    logger.error(CHANNEL, `Error polishing text: ${getSdkErrorMessage(error)}`);
     return {
       success: false,
       text: text,


### PR DESCRIPTION
## Summary
- inline provider error strings and drop `formatProviderError`
- update callers to construct the message with `getSdkErrorMessage`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68848ccef60c8324b8367b35cce1e381