### PR TITLE
Remove obsolete checkbox commands

### DIFF
--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -116,15 +116,6 @@ export const MAIN_VIEW_COMMANDS = {
   PACK_MULTIPLE: 'packMultiple',
   CLEAN_MULTIPLE: 'cleanMultiple',
 
-  // Checkbox update operations
-  UPDATE_REFLECT: 'updateReflect',
-  UPDATE_ATTACH_TEX_COUNT: 'updateAttachTeXCount',
-  UPDATE_AUTO_EXTRACT_FIGURE: 'updateAutoExtractFigure',
-  UPDATE_AUTO_EXTRACT_TIKZ_FIGURE: 'updateAutoExtractTikzFigure',
-  UPDATE_AUTO_COMPILE_INPUT_PDF: 'updateAutoCompileInputPdf',
-  UPDATE_USE_PREFILL_FROM_INPUT: 'updateUsePrefillFromInput',
-  UPDATE_PRINT_INPUT_PROMPT: 'updatePrintInputPrompt',
-
   // Other operations
   ACCEPT_EDITED: 'acceptEdited',
 

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -116,15 +116,6 @@ export const MAIN_VIEW_COMMANDS = {
   PACK_MULTIPLE: 'packMultiple',
   CLEAN_MULTIPLE: 'cleanMultiple',
 
-  // Checkbox update operations
-  UPDATE_REFLECT: 'updateReflect',
-  UPDATE_ATTACH_TEX_COUNT: 'updateAttachTeXCount',
-  UPDATE_AUTO_EXTRACT_FIGURE: 'updateAutoExtractFigure',
-  UPDATE_AUTO_EXTRACT_TIKZ_FIGURE: 'updateAutoExtractTikzFigure',
-  UPDATE_AUTO_COMPILE_INPUT_PDF: 'updateAutoCompileInputPdf',
-  UPDATE_USE_PREFILL_FROM_INPUT: 'updateUsePrefillFromInput',
-  UPDATE_PRINT_INPUT_PROMPT: 'updatePrintInputPrompt',
-
   // Other operations
   ACCEPT_EDITED: 'acceptEdited',
 

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -187,29 +187,6 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       // Other operations
       [MAIN_VIEW_COMMANDS.ACCEPT_EDITED]: async (m) =>
         this.executionManager.handleAcceptEdited(m),
-
-      // Checkbox update operations - handled client-side, empty handlers to prevent warnings
-      [MAIN_VIEW_COMMANDS.UPDATE_REFLECT]: async () => {
-        /* State saved client-side */
-      },
-      [MAIN_VIEW_COMMANDS.UPDATE_ATTACH_TEX_COUNT]: async () => {
-        /* State saved client-side */
-      },
-      [MAIN_VIEW_COMMANDS.UPDATE_AUTO_EXTRACT_FIGURE]: async () => {
-        /* State saved client-side */
-      },
-      [MAIN_VIEW_COMMANDS.UPDATE_AUTO_EXTRACT_TIKZ_FIGURE]: async () => {
-        /* State saved client-side */
-      },
-      [MAIN_VIEW_COMMANDS.UPDATE_AUTO_COMPILE_INPUT_PDF]: async () => {
-        /* State saved client-side */
-      },
-      [MAIN_VIEW_COMMANDS.UPDATE_USE_PREFILL_FROM_INPUT]: async () => {
-        /* State saved client-side */
-      },
-      [MAIN_VIEW_COMMANDS.UPDATE_PRINT_INPUT_PROMPT]: async () => {
-        /* State saved client-side */
-      },
     };
   }
 

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -49,17 +49,6 @@ export const CHECK_BOXES = [
   ...CHECK_BOXES_TOOL_USE,
 ];
 
-// Map checkbox IDs to their corresponding update commands
-export const CHECKBOX_UPDATE_COMMANDS = {
-  autoExtractFigure: MAIN_VIEW_COMMANDS.UPDATE_AUTO_EXTRACT_FIGURE,
-  autoExtractTikzFigure: MAIN_VIEW_COMMANDS.UPDATE_AUTO_EXTRACT_TIKZ_FIGURE,
-  autoCompileInputPdf: MAIN_VIEW_COMMANDS.UPDATE_AUTO_COMPILE_INPUT_PDF,
-  attachTeXCount: MAIN_VIEW_COMMANDS.UPDATE_ATTACH_TEX_COUNT,
-  usePrefillFromInput: MAIN_VIEW_COMMANDS.UPDATE_USE_PREFILL_FROM_INPUT,
-  printInputPrompt: MAIN_VIEW_COMMANDS.UPDATE_PRINT_INPUT_PROMPT,
-  reflect: MAIN_VIEW_COMMANDS.UPDATE_REFLECT,
-};
-
 // Form elements with values to save
 export const VALUE_ELEMENTS = [
   // parameters

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -1,18 +1,10 @@
-import { vscode } from '@common/webviewContext.js';
-import { CHECKBOX_UPDATE_COMMANDS } from './constants.js';
+import { mainViewState } from './mainViewState.js';
 
 export function handleCheckboxChange(event) {
   const checkbox = event?.target || this;
   const checkboxId = checkbox.id;
   const isChecked = checkbox.checked;
 
-  const command = CHECKBOX_UPDATE_COMMANDS[checkboxId];
-  if (!command) {
-    return;
-  }
-
-  vscode.postMessage({
-    command,
-    value: isChecked,
-  });
+  mainViewState.update({ [checkboxId]: isChecked });
+  mainViewState.save();
 }


### PR DESCRIPTION
## Summary
- clean up MainViewMessageHandler command map
- handle checkbox state only in the webview
- drop unused checkbox command constants

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack warning then exits)*

------
https://chatgpt.com/codex/tasks/task_e_68848cf63e188324abebef6f8568f7b8