### PR TITLE
Add chevron icon helper

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -52,3 +52,28 @@ export function safeGetElementChecked(id) {
   }
   return element.checked;
 }
+
+/**
+ * Update or insert a chevron icon inside the given toggle element.
+ *
+ * @param {HTMLElement} toggleElement - The element containing the chevron.
+ * @param {boolean} expanded - True if the section is expanded.
+ */
+export function updateChevronIcon(toggleElement, expanded) {
+  if (!toggleElement) {
+    console.warn('[domUtils] Missing toggleElement for updateChevronIcon');
+    return;
+  }
+
+  const icon = toggleElement.querySelector(
+    '.codicon-chevron-up, .codicon-chevron-down',
+  );
+  if (icon) {
+    icon.classList.toggle('codicon-chevron-up', expanded);
+    icon.classList.toggle('codicon-chevron-down', !expanded);
+  } else {
+    const newIcon = document.createElement('i');
+    newIcon.className = `codicon ${expanded ? 'codicon-chevron-up' : 'codicon-chevron-down'}`;
+    toggleElement.appendChild(newIcon);
+  }
+}

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -9,15 +9,12 @@ import {
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
-import {
   safeGetElementValue,
   safeGetElementById,
   safeGetElementChecked,
   safeSetElementValue,
   safeSetElementChecked,
+  updateChevronIcon,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 
@@ -51,8 +48,10 @@ export class MainViewState {
     );
     if (autoExtractToggle && autoExtractOptions) {
       autoExtractToggle.classList.remove('active');
-      autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+      autoExtractToggle.innerHTML =
+        '<i class="codicon codicon-wand"></i><i class="codicon codicon-chevron-down"></i>';
       autoExtractOptions.style.display = 'none';
+      updateChevronIcon(autoExtractToggle, false);
     }
 
     MULTIPLE_SELECTIONS.forEach((id) => {
@@ -70,7 +69,9 @@ export class MainViewState {
     const toggleLatexdiffs = safeGetElementById(ELEMENT_IDS.TOGGLE_LATEXDIFFS);
     if (latexdiffsContent && toggleLatexdiffs) {
       latexdiffsContent.style.display = 'none';
-      toggleLatexdiffs.innerHTML = `<i class="${CHEVRON_DOWN_CLASS}"></i>`;
+      toggleLatexdiffs.innerHTML =
+        '<i class="codicon codicon-chevron-down"></i>';
+      updateChevronIcon(toggleLatexdiffs, false);
     }
 
     this.save();
@@ -101,8 +102,10 @@ export class MainViewState {
       );
       if (autoExtractToggle && autoExtractOptions) {
         autoExtractToggle.classList.toggle('active', hasAutoExtractChecked);
-        autoExtractToggle.innerHTML = `<i class="codicon codicon-wand"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+        autoExtractToggle.innerHTML =
+          '<i class="codicon codicon-wand"></i><i class="codicon codicon-chevron-down"></i>';
         autoExtractOptions.style.display = 'none';
+        updateChevronIcon(autoExtractToggle, false);
       }
 
       const toggleToolConfig = safeGetElementById(
@@ -116,8 +119,10 @@ export class MainViewState {
       );
       if (toggleToolConfig && toolConfigOptions) {
         toggleToolConfig.classList.toggle('active', hasToolConfigChecked);
-        toggleToolConfig.innerHTML = `<i class="codicon codicon-tools"></i><i class="${CHEVRON_DOWN_CLASS}"></i>`;
+        toggleToolConfig.innerHTML =
+          '<i class="codicon codicon-tools"></i><i class="codicon codicon-chevron-down"></i>';
         toolConfigOptions.style.display = 'none';
+        updateChevronIcon(toggleToolConfig, false);
       }
 
       MULTIPLE_SELECTIONS.forEach((id) => {
@@ -155,9 +160,9 @@ export class MainViewState {
       if (latexdiffsContent && toggleLatexdiffs) {
         const visible = previousState.latexdiffsVisible ?? false;
         latexdiffsContent.style.display = visible ? 'block' : 'none';
-        toggleLatexdiffs.innerHTML = `<i class="${
-          visible ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS
-        }"></i>`;
+        toggleLatexdiffs.innerHTML =
+          '<i class="codicon codicon-chevron-down"></i>';
+        updateChevronIcon(toggleLatexdiffs, visible);
       }
     } else {
       this.setDefaults();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1,8 +1,12 @@
 // Local imports - webview context
 import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
-import { safeSetElementValue, safeGetElementById } from '@common/domUtils.js';
+import {
+  safeSetElementValue,
+  safeGetElementById,
+  updateChevronIcon,
+} from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { createCodicon, createFromTemplate } from '@common/templateUtils.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 import { mainViewState } from './mainViewState.js';
 import { mainViewDomHandler } from './domHandlers.js';
 
@@ -162,9 +166,7 @@ export class MainViewMessageHandler {
   /* ---------- Private helpers ---------- */
   _setToggleIcon(element, isVisible) {
     if (!element) return;
-    element.innerHTML = '';
-    const icon = createCodicon(isVisible ? 'chevron-up' : 'chevron-down');
-    if (icon) element.appendChild(icon);
+    updateChevronIcon(element, isVisible);
   }
 
   _createFileItem(file) {

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -2,9 +2,10 @@
 import {
   addEventListenerSafely,
   safeGetElementById,
+  updateChevronIcon,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
-import { createCodicon, createFromTemplate } from '@common/templateUtils.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Handles multi-file list DOM updates.
@@ -62,9 +63,7 @@ export class FileList {
     if (newFiles.length > 0) {
       newFiles.forEach((file) => this.add(listId, file));
       listDiv.style.display = 'block';
-      toggleIcon.innerHTML = '';
-      const icon = createCodicon('chevron-up');
-      if (icon) toggleIcon.appendChild(icon);
+      updateChevronIcon(toggleIcon, true);
 
       const container = safeGetElementById(`${listId}Container`);
       if (container) {
@@ -86,9 +85,7 @@ export class FileList {
     const toggleIcon = safeGetElementById(toggleId);
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
-    toggleIcon.innerHTML = '';
-    const icon = createCodicon(isVisible ? 'chevron-up' : 'chevron-down');
-    if (icon) toggleIcon.appendChild(icon);
+    updateChevronIcon(toggleIcon, isVisible);
   }
 
   /** Toggle visibility of a file list container */
@@ -110,9 +107,7 @@ export class FileList {
     container.style.display = 'none';
     const toggleIconDiv = safeGetElementById(toggleId);
     if (toggleIconDiv) {
-      toggleIconDiv.innerHTML = '';
-      const icon = createCodicon('chevron-down');
-      if (icon) toggleIconDiv.appendChild(icon);
+      updateChevronIcon(toggleIconDiv, false);
     }
     this._saveFn();
   }

--- a/src/webview/modules/uiManagers/LatexdiffManager.js
+++ b/src/webview/modules/uiManagers/LatexdiffManager.js
@@ -1,15 +1,10 @@
 // Local imports
-import { safeGetElementById } from '@common/domUtils.js';
-import {
-  CHEVRON_UP_CLASS,
-  CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
+import { safeGetElementById, updateChevronIcon } from '@common/domUtils.js';
 import { mainViewState } from '../mainViewState.js';
 import { ELEMENT_IDS } from '../constants.js';
 
 const LATEXDIFF_CONTENT_ID = ELEMENT_IDS.LATEXDIFFS_CONTENT;
 const TOGGLE_LATEXDIFFS_ID = ELEMENT_IDS.TOGGLE_LATEXDIFFS;
-const ICON_SELECTOR = 'i';
 
 /**
  * Handles LaTeX diff section visibility.
@@ -29,13 +24,7 @@ export class LatexdiffManager {
       const shouldShow = state && state.latexdiffsVisible;
 
       container.style.display = shouldShow ? 'block' : 'none';
-
-      const iconElement = toggleIcon.querySelector(ICON_SELECTOR);
-      if (iconElement) {
-        iconElement.className = shouldShow
-          ? CHEVRON_UP_CLASS
-          : CHEVRON_DOWN_CLASS;
-      }
+      updateChevronIcon(toggleIcon, shouldShow);
     }
   }
 
@@ -48,10 +37,7 @@ export class LatexdiffManager {
     const isVisible = container.style.display !== 'none';
     container.style.display = isVisible ? 'none' : 'block';
 
-    const iconElement = toggleIcon.querySelector(ICON_SELECTOR);
-    if (iconElement) {
-      iconElement.className = isVisible ? CHEVRON_DOWN_CLASS : CHEVRON_UP_CLASS;
-    }
+    updateChevronIcon(toggleIcon, !isVisible);
 
     this.state.update({ latexdiffsVisible: !isVisible });
     this.state.save();

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -1,10 +1,9 @@
 // Local imports
-import { safeGetElementById } from '@common/domUtils.js';
+import { safeGetElementById, updateChevronIcon } from '@common/domUtils.js';
 
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
-import { createCodicon } from '@common/templateUtils.js';
 import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 
 const INPUT_FILE_ID = INPUT_FILE;
@@ -88,9 +87,7 @@ export class OutputFilesManager {
       const shouldShow = state && state.outputFilesActive;
 
       container.style.display = shouldShow ? 'block' : 'none';
-      toggleIcon.innerHTML = '';
-      const icon = createCodicon(shouldShow ? 'chevron-up' : 'chevron-down');
-      if (icon) toggleIcon.appendChild(icon);
+      updateChevronIcon(toggleIcon, shouldShow);
     }
   }
 }

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -1,4 +1,8 @@
-import { safeGetElementById, safeGetElementChecked } from '@common/domUtils.js';
+import {
+  safeGetElementById,
+  safeGetElementChecked,
+  updateChevronIcon,
+} from '@common/domUtils.js';
 import {
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
@@ -19,9 +23,8 @@ export class ToggleManager {
     toggle.classList.toggle('active', active);
     toggle.innerHTML = '';
     const iconEl = createCodicon(icon);
-    const chevron = createCodicon(visible ? 'chevron-up' : 'chevron-down');
     if (iconEl) toggle.appendChild(iconEl);
-    if (chevron) toggle.appendChild(chevron);
+    updateChevronIcon(toggle, visible);
   }
 
   updateDropdownToggleState(toggleId, optionsId, checkboxIds, icon) {


### PR DESCRIPTION
## Summary
- add `updateChevronIcon` helper to toggle codicon classes
- refactor toggle and diff managers and other modules to use the helper

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884a176ed7483249c8f62a6005c359d