### PR TITLE
Convert codicon buttons to templates

### DIFF
--- a/src/common/modules/iconButtonInitializer.js
+++ b/src/common/modules/iconButtonInitializer.js
@@ -1,0 +1,36 @@
+// Local imports
+import { createIconButton } from '@common/templateUtils.js';
+
+/**
+ * Replace buttons with a `data-icon` attribute using icon button templates.
+ * The original button's id, title, class, disabled state, and dataset
+ * (excluding the `icon` value) are preserved. Any text inside the button is
+ * appended after the generated icon element.
+ *
+ * @param {Document|HTMLElement} scope - Element to search within.
+ */
+export function initializeIconButtons(scope = document) {
+  const buttons = scope.querySelectorAll('button[data-icon]');
+  buttons.forEach((btn) => {
+    const icon = btn.dataset.icon;
+    if (!icon) return;
+
+    const { id, title, className, disabled } = btn;
+    const dataset = { ...btn.dataset };
+    delete dataset.icon;
+
+    const newBtn = createIconButton({
+      id,
+      icon,
+      title: title || '',
+      className: className || '',
+      disabled: disabled || false,
+      dataset,
+    });
+    if (!newBtn) return;
+
+    const text = btn.textContent.trim();
+    btn.replaceWith(newBtn);
+    if (text) newBtn.append(' ', text);
+  });
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -113,6 +113,10 @@ export abstract class BaseViewContentProvider {
       ),
       commandsUri: this.getCommonUri(webview, 'webview/commands.js'),
       templateUtilsUri: this.getCommonUri(webview, 'modules/templateUtils.js'),
+      iconButtonInitializerUri: this.getCommonUri(
+        webview,
+        'modules/iconButtonInitializer.js',
+      ),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
       codiconUri: this.getNodeModulesUri(

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -29,7 +29,8 @@
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
-          "@common/templateUtils.js": "${templateUtilsUri}"
+          "@common/templateUtils.js": "${templateUtilsUri}",
+          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}"
         }
       }
     </script>
@@ -52,16 +53,14 @@
             id="prevMatch"
             class="vscode-button search-nav-btn"
             title="Previous match"
-          >
-            <i class="codicon codicon-chevron-up"></i>
-          </button>
+            data-icon="chevron-up"
+          ></button>
           <button
             id="nextMatch"
             class="vscode-button search-nav-btn"
             title="Next match"
-          >
-            <i class="codicon codicon-chevron-down"></i>
-          </button>
+            data-icon="chevron-down"
+          ></button>
           <span id="matchCount" class="match-count"></span>
         </div>
       </div>
@@ -79,15 +78,21 @@
         <div class="history-item-header">
           <div class="history-timestamp"></div>
           <div class="history-actions button-group">
-            <button class="vscode-button delete-btn" title="">
-              <i class="codicon codicon-trash"></i>
-            </button>
-            <button class="vscode-button restore-btn" title="">
-              <i class="codicon codicon-reply"></i>
-            </button>
-            <button class="vscode-button rerun-btn" title="">
-              <i class="codicon codicon-debug-rerun"></i>
-            </button>
+            <button
+              class="vscode-button delete-btn"
+              title=""
+              data-icon="trash"
+            ></button>
+            <button
+              class="vscode-button restore-btn"
+              title=""
+              data-icon="reply"
+            ></button>
+            <button
+              class="vscode-button rerun-btn"
+              title=""
+              data-icon="debug-rerun"
+            ></button>
           </div>
         </div>
         <div class="history-details basic-details"></div>
@@ -96,6 +101,11 @@
         </div>
         <button class="toggle-button"></button>
       </div>
+    </template>
+    <template id="iconButtonTemplate">
+      <button class="vscode-button">
+        <i class="codicon"></i>
+      </button>
     </template>
     <template id="codiconTemplate">
       <i class="codicon"></i>

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -3,6 +3,7 @@ import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
 import { messageHandler } from './modules/messageHandlers.js';
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 
 historyViewState.initialize();
 
@@ -10,6 +11,7 @@ historyViewState.initialize();
 messageHandler.setup();
 
 document.addEventListener('DOMContentLoaded', () => {
+  initializeIconButtons();
   historyViewDomHandler.events.setupEventListeners();
   vscode.postMessage({ command: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA });
 });

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -41,6 +41,7 @@
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
+          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "he": "https://esm.sh/he@1.2.0"
@@ -83,24 +84,28 @@
               <button
                 class="vscode-button compare-btn"
                 title="Compare with base"
-              >
-                <i class="codicon codicon-diff"></i>
-              </button>
-              <button class="vscode-button accept-btn" title="Accept edits">
-                <i class="codicon codicon-check"></i>
-              </button>
-              <button class="vscode-button merge-btn" title="Merge edits">
-                <i class="codicon codicon-git-merge"></i>
-              </button>
-              <button class="vscode-button diff-btn" title="LaTeXdiff">
-                <i class="codicon codicon-diff-single"></i>
-              </button>
+                data-icon="diff"
+              ></button>
+              <button
+                class="vscode-button accept-btn"
+                title="Accept edits"
+                data-icon="check"
+              ></button>
+              <button
+                class="vscode-button merge-btn"
+                title="Merge edits"
+                data-icon="git-merge"
+              ></button>
+              <button
+                class="vscode-button diff-btn"
+                title="LaTeXdiff"
+                data-icon="diff-single"
+              ></button>
               <button
                 class="vscode-button prev-btn"
                 title="Compare with previous round"
-              >
-                <i class="codicon codicon-diff-added"></i>
-              </button>
+                data-icon="diff-added"
+              ></button>
             </span>
           </div>
         </template>
@@ -128,9 +133,12 @@
                 <i class="multi-file"></i>
               </div>
             </button>
-            <button class="tab-delete" data-stream="" title="Delete stream">
-              <i class="codicon codicon-close"></i>
-            </button>
+            <button
+              class="tab-delete"
+              data-stream=""
+              title="Delete stream"
+              data-icon="close"
+            ></button>
           </div>
         </template>
         <template id="roundHeaderTemplate">
@@ -144,8 +152,8 @@
           <!-- Stream tabs will be dynamically inserted here -->
         </div>
         <div class="clear-all-container">
-          <button class="clear-button" id="deleteAllBtn">
-            <i class="codicon codicon-close-all"></i> Delete All
+          <button class="clear-button" id="deleteAllBtn" data-icon="close-all">
+            Delete All
           </button>
         </div>
       </div>

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -4,6 +4,7 @@ import { progressViewDomHandler } from './modules/domHandlers.js';
 import { vscode } from '@common/webviewContext.js';
 import { COMMANDS } from './modules/constants.js';
 import { validateTemplates } from '@common/templateUtils.js';
+import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 
 // Initialize the state when the window loads
 progressViewState.initialize();
@@ -25,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'streamTabTemplate',
     'roundHeaderTemplate',
   ]);
+  initializeIconButtons();
   progressViewDomHandler.toolbar.render();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -34,6 +34,7 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webview/commands.js": "${commandsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
+          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",
@@ -65,16 +66,14 @@
                   id="currentInputFileButton"
                   class="vscode-button"
                   title="Set current file as input"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
+                  data-icon="file-code"
+                ></button>
                 <button
                   id="emptyInputFileButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
+                  data-icon="close"
+                ></button>
                 <span id="toggleInputFiles" class="toggle-icon" title="Multiple"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
@@ -82,23 +81,20 @@
                   id="addOpenedInputFilesButton"
                   class="vscode-button"
                   title="Add opened files as input"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
+                  data-icon="folder-opened"
+                ></button>
                 <button
                   id="emptyInputFilesButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
+                  data-icon="trash"
+                ></button>
                 <button
                   id="selectInputFilesButton"
                   class="vscode-button"
                   title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
+                  data-icon="add"
+                ></button>
               </div>
             </div>
             <select id="inputFile">
@@ -128,16 +124,14 @@
                   id="currentReferenceFileButton"
                   class="vscode-button"
                   title="Set current file as reference"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
+                  data-icon="file-code"
+                ></button>
                 <button
                   id="emptyReferenceFileButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
+                  data-icon="close"
+                ></button>
                 <span
                   id="toggleReferenceFiles"
                   class="toggle-icon"
@@ -148,23 +142,20 @@
                   id="addOpenedReferenceFilesButton"
                   class="vscode-button"
                   title="Add opened files as reference"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
+                  data-icon="folder-opened"
+                ></button>
                 <button
                   id="emptyReferenceFilesButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
+                  data-icon="trash"
+                ></button>
                 <button
                   id="selectReferenceFilesButton"
                   class="vscode-button"
                   title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
+                  data-icon="add"
+                ></button>
               </div>
             </div>
             <select id="referenceFile">
@@ -194,16 +185,14 @@
                   id="currentAuxiliaryFileButton"
                   class="vscode-button"
                   title="Set current file as auxiliary"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
+                  data-icon="file-code"
+                ></button>
                 <button
                   id="emptyAuxiliaryFileButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
+                  data-icon="close"
+                ></button>
                 <span
                   id="toggleAuxiliaryFiles"
                   class="toggle-icon"
@@ -214,23 +203,20 @@
                   id="addOpenedAuxiliaryFilesButton"
                   class="vscode-button"
                   title="Add opened files as auxiliary"
-                >
-                  <i class="codicon codicon-folder-opened"></i>
-                </button>
+                  data-icon="folder-opened"
+                ></button>
                 <button
                   id="emptyAuxiliaryFilesButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
+                  data-icon="trash"
+                ></button>
                 <button
                   id="selectAuxiliaryFilesButton"
                   class="vscode-button"
                   title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
+                  data-icon="add"
+                ></button>
               </div>
             </div>
             <select id="auxiliaryFile">
@@ -296,9 +282,8 @@
                   id="emptyMediaFileButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
+                  data-icon="close"
+                ></button>
                 <span id="toggleMediaFiles" class="toggle-icon" title="Multiple"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
@@ -306,16 +291,14 @@
                   id="emptyMediaFilesButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
+                  data-icon="trash"
+                ></button>
                 <button
                   id="selectMediaFilesButton"
                   class="vscode-button"
                   title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
+                  data-icon="add"
+                ></button>
               </div>
             </div>
             <select id="mediaFile">
@@ -347,16 +330,14 @@
                   id="emptyOutputFilesButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
+                  data-icon="trash"
+                ></button>
                 <button
                   id="selectOutputFilesButton"
                   class="vscode-button"
                   title="Add"
-                >
-                  <i class="codicon codicon-add"></i>
-                </button>
+                  data-icon="add"
+                ></button>
               </div>
             </div>
             <div
@@ -419,38 +400,33 @@
                 class="vscode-button"
                 title="Pack the output for this agent into the History folder"
                 style="display: none"
-              >
-                <i class="codicon codicon-archive"></i>
-              </button>
+                data-icon="archive"
+              ></button>
               <button
                 id="cleanButton"
                 class="vscode-button"
                 title="Clean the output for this agent"
                 style="display: none"
-              >
-                <i class="codicon codicon-trash"></i>
-              </button>
+                data-icon="trash"
+              ></button>
               <button
                 id="magicPolishButton"
                 class="vscode-button"
                 title="Polish instruction text with AI"
-              >
-                <i class="codicon codicon-sparkle"></i>
-              </button>
+                data-icon="sparkle"
+              ></button>
               <button
                 id="recordInstructionButton"
                 class="vscode-button"
                 title="Record instruction with microphone"
-              >
-                <i class="codicon codicon-mic"></i>
-              </button>
+                data-icon="mic"
+              ></button>
               <button
                 id="eraseInstructionButton"
                 class="vscode-button"
                 title="Erase Instruction"
-              >
-                <i class="codicon codicon-clear-all"></i>
-              </button>
+                data-icon="clear-all"
+              ></button>
             </div>
           </div>
           <textarea
@@ -480,9 +456,12 @@
               </select>
             </div>
           </div>
-          <button id="executeButton" class="vscode-button" title="Execute">
-            <i class="codicon codicon-play"></i>
-          </button>
+          <button
+            id="executeButton"
+            class="vscode-button"
+            title="Execute"
+            data-icon="play"
+          ></button>
         </div>
       </div>
       <div class="latexdiffs-section">
@@ -509,16 +488,14 @@
                   id="currentBaseFileButton"
                   class="vscode-button"
                   title="Set current file as base"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
+                  data-icon="file-code"
+                ></button>
                 <button
                   id="emptyBaseFileButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
+                  data-icon="close"
+                ></button>
               </div>
             </div>
             <select id="baseFile">
@@ -541,44 +518,38 @@
                   id="acceptButton"
                   class="vscode-button"
                   title="Accept changes from edited file and overwrite base file"
-                >
-                  <i class="codicon codicon-check"></i>
-                </button>
+                  data-icon="check"
+                ></button>
                 <button
                   id="compareButton"
                   class="vscode-button"
                   title="Compare the selected edited file with the selected base file"
-                >
-                  <i class="codicon codicon-diff"></i>
-                </button>
+                  data-icon="diff"
+                ></button>
                 <button
                   id="mergeButton"
                   class="vscode-button"
                   title="Create a new verion of the base file by merging the edits suggested by the edited file"
-                >
-                  <i class="codicon codicon-merge"></i>
-                </button>
+                  data-icon="merge"
+                ></button>
                 <button
                   id="latexdiffButton"
                   class="vscode-button"
                   title="LaTeXdiff the selected edited file with the selected base file"
-                >
-                  <i class="codicon codicon-diff-single"></i>
-                </button>
+                  data-icon="diff-single"
+                ></button>
                 <button
                   id="currentEditedFileButton"
                   class="vscode-button"
                   title="Set current file as edited"
-                >
-                  <i class="codicon codicon-file-code"></i>
-                </button>
+                  data-icon="file-code"
+                ></button>
                 <button
                   id="emptyEditedFileButton"
                   class="vscode-button"
                   title="Empty"
-                >
-                  <i class="codicon codicon-close"></i>
-                </button>
+                  data-icon="close"
+                ></button>
               </div>
             </div>
             <select id="editedFile">
@@ -601,23 +572,20 @@
                   id="latexdiffvcButton"
                   class="vscode-button"
                   title="LaTeXdiff the selected base file with another git commit"
-                >
-                  <i class="codicon codicon-diff-single"></i>
-                </button>
+                  data-icon="diff-single"
+                ></button>
                 <button
                   id="packLatexdiffvcButton"
                   class="vscode-button"
                   title="Pack the latexdiff-vc output into the History folder"
-                >
-                  <i class="codicon codicon-archive"></i>
-                </button>
+                  data-icon="archive"
+                ></button>
                 <button
                   id="cleanLatexdiffvcButton"
                   class="vscode-button"
                   title="Clean the latexdiff-vc output"
-                >
-                  <i class="codicon codicon-trash"></i>
-                </button>
+                  data-icon="trash"
+                ></button>
               </div>
             </div>
             <select id="commit">

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -5,6 +5,7 @@ import {
   instructionManager,
   toggleManager,
 } from './modules/domHandlers.js';
+import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 
 // Register handlers immediately so early messages aren't missed
 messageHandler.setup({ requestData: false });
@@ -16,6 +17,7 @@ window.addEventListener('beforeunload', () => {
 
 // Setup UI when DOM is loaded
 document.addEventListener('DOMContentLoaded', function () {
+  initializeIconButtons();
   mainViewState.restore();
   instructionManager.setup();
   mainViewDomHandler.initializeUI();


### PR DESCRIPTION
## Summary
- use `initializeIconButtons` to convert buttons with Codicons dynamically
- expose new `iconButtonInitializer.js` in webview content providers
- drop inline `<i>` markup in the webview, progress view and history view

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884a161c91c8324b0445118cec4db44