### PR TITLE
Improve latexdiff log layout

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -418,7 +418,7 @@ export class LogEntryFormatter {
 
         items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
           baseName,
-        )}</span> &rarr; <span class="file-link clickable-link" data-file="${revisedEsc}">${encodeHtml(
+        )}</span> <span class="arrow">&rarr;</span> <span class="file-link clickable-link" data-file="${revisedEsc}">${encodeHtml(
           revisedName,
         )}</span> (<span class="file-link clickable-link" data-file="${outputEsc}">diff</span>)</li>`;
       });

--- a/src/progressView/styles/latexdiff.css
+++ b/src/progressView/styles/latexdiff.css
@@ -14,4 +14,13 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
+  flex-wrap: wrap;
+}
+
+.latexdiff-content .file-link {
+  overflow-wrap: anywhere;
+}
+
+.latexdiff-content .arrow {
+  flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- allow wrapping of long latexdiff entries
- add flex wrapping and overflow handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884adae16b48324ad61b01d9a4c1a0a