### PR TITLE
Add run storage utilities

### DIFF
--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -52,6 +52,8 @@ The header provides a summary and actions for the selected stream:
   - <i class="codicon codicon-trash"></i> **Clean**: Deletes the output files associated with this stream.
   - <i class="codicon codicon-clear-all"></i> **Erase**: Removes this stream and its log content entirely from the ProgressBoard.
 
+Every time you run a task, TeXRA also creates a folder under the extension's workspace storage: `taskRuns/<executionId>`. This directory stores intermediate artifacts like debug message JSON files. You can inspect these files if you enable the `debug.saveMessageObjects` setting.
+
 ### Log Content
 
 This scrollable area displays the detailed, timestamped logs for the selected agent run.

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -10,6 +10,7 @@ import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { IAgent } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';
 import { buildUserVars } from '../utils/userVars';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
@@ -27,6 +28,7 @@ export abstract class BaseAgent implements IAgent {
   protected agentPath: string;
   protected logger: AgentLogger;
   protected runGroupId?: string;
+  public executionId?: ExecutionId;
   protected userVars: Record<string, any> = {};
   protected client: any;
   protected isInterrupted = false;

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-// (none needed)
+import * as path from 'path';
 
 // Third-party imports
 // (none needed)
@@ -12,7 +12,7 @@ import { bestConnectionMethod, LatexMediaManager } from '@latex';
 import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
+import { WorkspaceFS, StorageFS, getRunDir } from '@utils/files';
 import {
   renderPrompt,
   getFirstKCharsFromDocument,
@@ -173,10 +173,15 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           false,
         );
         if (shouldSaveMessageObjects) {
-          const outputFileBaseName = outputFile.replace('.xml', '');
-          const debugFilePath = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
+          const outputFileBaseName = path
+            .basename(outputFile)
+            .replace('.xml', '');
+          const debugFileName = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
+          const debugFilePath = this.executionId
+            ? path.join(getRunDir(this.executionId), debugFileName)
+            : debugFileName;
           try {
-            await WorkspaceFS.writeFile(
+            await StorageFS.write(
               debugFilePath,
               JSON.stringify(messages, null, 2),
             );

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -22,7 +22,12 @@ import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ModelFactory } from '@agent/runtime/ModelFactory';
 
-import { DirectAgent, CoTAgent, MergeAgent } from '@agent/implementations';
+import {
+  DirectAgent,
+  CoTAgent,
+  MergeAgent,
+  BaseAgent,
+} from '@agent/implementations';
 
 import { AgentLogger } from '@logger/AgentLogger';
 
@@ -35,6 +40,7 @@ import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { getStreamTabId } from '@/logger/streamUtils';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { IAgent } from '@agent/core/IAgent';
+import { ensureRunDir } from '@utils/files';
 
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
@@ -152,6 +158,11 @@ async function executeAgentWithLogging<T extends IAgent>(
   try {
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
+
+    if (executionId) {
+      await ensureRunDir(executionId);
+      (agent as unknown as BaseAgent).executionId = executionId;
+    }
 
     // Get the full stream tab ID
     const config = agent.config;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { watchConfig } from '@utils/config';
 import { SecretManager } from '@frontend/secretManager';
 import { copyDefaultAgents, configureLatexSettings } from '@frontend/setup';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
-import { StorageFS } from '@utils/files';
+import { StorageFS, TASK_RUNS_DIR } from '@utils/files';
 import { initializeStateManagers } from '@common/state/stateManager';
 import { FileLister } from '@frontend/files/fileLister';
 
@@ -41,6 +41,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize storage systems
   SecretManager.initialize(context);
   StorageFS.initialize(context);
+  await StorageFS.ensureDir(TASK_RUNS_DIR);
   initializeStateManagers(context);
   FileLister.initialize(context);
 

--- a/src/test/taskRunStorage.test.ts
+++ b/src/test/taskRunStorage.test.ts
@@ -1,0 +1,33 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as os from 'os';
+
+import {
+  StorageFS,
+  TASK_RUNS_DIR,
+  ensureRunDir,
+  getRunDir,
+} from '../utils/files';
+
+suite('taskRunStorage', () => {
+  const tmpBase = path.join(os.tmpdir(), `texra-${Date.now()}`);
+  const context = {
+    storageUri: vscode.Uri.file(tmpBase),
+    globalStorageUri: vscode.Uri.file(tmpBase),
+  } as unknown as vscode.ExtensionContext;
+
+  suiteSetup(() => {
+    StorageFS.initialize(context);
+  });
+
+  test('ensureRunDir creates directory', async () => {
+    const id = `run-${Date.now()}`;
+    await ensureRunDir(id);
+    const exists = await StorageFS.exists(path.join(TASK_RUNS_DIR, id));
+    assert.strictEqual(exists, true);
+    assert.strictEqual(getRunDir(id), path.join(tmpBase, TASK_RUNS_DIR, id));
+
+    await StorageFS.delete(path.join(TASK_RUNS_DIR, id), { recursive: true });
+  });
+});

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -2,6 +2,7 @@ export { WorkspaceFS } from './workspaceFS';
 export { AbsoluteFS } from './absoluteFS';
 export { StorageFS, GlobalStorageFS } from './storageFS';
 export { RelativeFS } from './relativeFS';
+export * from './taskRunStorage';
 export * from './pastedImageUtils';
 export * from './baseFileUtils';
 export * from './fileMappingUtils';

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -1,0 +1,26 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - file utils
+import { StorageFS } from './storageFS';
+
+// Local imports - types
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+
+/** Base directory under workspace storage for per-task data. */
+export const TASK_RUNS_DIR = 'taskRuns';
+
+/**
+ * Get the absolute path to the directory for a specific execution.
+ */
+export function getRunDir(id: ExecutionId): string {
+  return StorageFS.fullPath(path.join(TASK_RUNS_DIR, id));
+}
+
+/**
+ * Ensure the task run directory exists, along with the base directory.
+ */
+export async function ensureRunDir(id: ExecutionId): Promise<void> {
+  await StorageFS.ensureDir(TASK_RUNS_DIR);
+  await StorageFS.ensureDir(path.join(TASK_RUNS_DIR, id));
+}


### PR DESCRIPTION
## Summary
- manage task run folders in workspace storage
- create run directories when an execution begins
- store debug JSON under `taskRuns/<executionId>`
- document how task run folders store intermediate artifacts
- test run directory creation logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884a00ea0e483249e3fed5f15957363