### PR TITLE
Fix missing icons in progress view file panel

### DIFF
--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -3,6 +3,7 @@ import { formatTokens } from '../formatters.js';
 import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 import { vscode } from '@common/webviewContext.js';
 import { createFromTemplate } from '@common/templateUtils.js';
+import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 
 /**
  * Manages file list rendering.
@@ -149,6 +150,7 @@ export class FileList {
 
       // Append the round group to the container
       container.appendChild(roundGroup);
+      initializeIconButtons(roundGroup);
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure icon button initializer runs for new file items in ProgressView

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884baee1ae883249ed140f4dc2454b0