### PR TITLE
Fix icon initialization for dynamic elements

### DIFF
--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -7,6 +7,7 @@ import {
 import { historyViewState } from '../historyViewState.js';
 import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
 import { createFromTemplate, createCodicon } from '@common/templateUtils.js';
+import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 
 /**
  * Renders history items and manages per-item events.
@@ -167,6 +168,9 @@ export class HistoryRenderer {
       collapsible.remove();
       toggleButton.remove();
     }
+
+    // Convert any icon placeholders within this item
+    initializeIconButtons(container);
 
     return container;
   }

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -3,6 +3,7 @@ import { formatTokens } from '../formatters.js';
 import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 import { vscode } from '@common/webviewContext.js';
 import { createFromTemplate } from '@common/templateUtils.js';
+import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 
 /**
  * Manages file list rendering.
@@ -143,6 +144,9 @@ export class FileList {
 
         // Update existing buttons based on file state
         this.updateFileButtons(clone, file, effectiveBase);
+
+        // Replace any icon placeholders inside the clone
+        initializeIconButtons(clone);
 
         roundGroup.appendChild(clone);
       });


### PR DESCRIPTION
## Summary
- ensure icon buttons created at runtime get initialized
- initialize icons for progress view file list items
- initialize icons for history view records

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6884baee1ae883249ed140f4dc2454b0