### PR TITLE
Refactor output finalization

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -9,8 +9,6 @@
 // Local imports - latex utils
 import { LatexMediaManager } from '@latex';
 
-import { bus } from '@eventBus/ProgressEventBus';
-
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
 import {
@@ -152,38 +150,17 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         roundGroupId,
       );
 
+      await this.outputHandler.finalizeRound(
+        outputFile,
+        endTurn,
+        currRound,
+        roundGroupId,
+      );
+
       this.logger.debug(`Completed round ${currRound}`, roundGroupId);
     } catch (error) {
       throw error;
     }
-
-    const fileInfos = await this.outputHandler.gatherOutputFileInfo(currRound);
-
-    // Validate expected outputs if this is the end of the turn
-    if (endTurn) {
-      try {
-        await this.outputHandler.validateExpectedOutputs(
-          outputFile,
-          currRound,
-          roundGroupId,
-        );
-        this.logger.debug(
-          `Expected outputs validated for round ${currRound}`,
-          roundGroupId,
-        );
-      } catch (error) {
-        this.logger.error(
-          `Expected output validation failed after round ${currRound}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-          roundGroupId,
-        );
-      }
-    }
-    bus.emit('addOutputFiles', {
-      stream: this.logger.channelId,
-      filesByRound: { [currRound]: fileInfos },
-    });
   }
 
   /**
@@ -206,30 +183,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   ): Promise<string[]> {
     // Print statistics at the end of each round
     await this.usageStats.printStatistics(stateGlobal, processGroupId);
-
-    // If this is the end of a turn, handle latexdiff operations as a separate step
-    if (
-      endTurn &&
-      this.outputHandler.outputFiles[currRound] &&
-      this.outputHandler.outputFiles[currRound].length > 0
-    ) {
-      const existingBase = await Promise.all(
-        this.baseFiles.map(async (f) => await WorkspaceFS.exists(f)),
-      );
-
-      if (existingBase.some((e) => e)) {
-        // Pass the process group ID to maintain proper nesting in the log hierarchy
-        await this.outputHandler.handleLatexdiffofOutput(
-          currRound,
-          processGroupId,
-        );
-      } else {
-        this.logger.debug(
-          `Skipping latexdiff for round ${currRound} - base files missing`,
-          processGroupId,
-        );
-      }
-    }
 
     return this.outputHandler.outputFiles[currRound] || [];
   }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -151,9 +151,9 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       );
 
       await this.outputHandler.finalizeRound(
-        outputFile,
-        endTurn,
         currRound,
+        endTurn,
+        outputFile,
         roundGroupId,
       );
 

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -38,4 +38,15 @@ export interface IOutputHandler {
     currRound: number,
     groupId?: string,
   ): Promise<void>;
+
+  /**
+   * Finalize processing after a round completes by running diff operations,
+   * validating outputs and emitting update events.
+   */
+  finalizeRound(
+    outputFile: string,
+    endTurn: boolean,
+    currRound: number,
+    groupId?: string,
+  ): Promise<void>;
 }

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -44,9 +44,9 @@ export interface IOutputHandler {
    * validating outputs and emitting update events.
    */
   finalizeRound(
-    outputFile: string,
-    endTurn: boolean,
     currRound: number,
+    endTurn: boolean,
+    outputFile?: string,
     groupId?: string,
   ): Promise<void>;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -278,21 +278,20 @@ export class OutputHandler implements IOutputHandler {
    * events with gathered file info.
    */
   public async finalizeRound(
-    outputFile: string,
-    endTurn: boolean,
     currRound: number,
+    endTurn: boolean,
+    outputFile?: string,
     groupId?: string,
   ): Promise<void> {
-    if (
-      endTurn &&
-      this.outputFiles[currRound] &&
-      this.outputFiles[currRound].length > 0
-    ) {
+    const hasOutputs =
+      this.outputFiles[currRound] && this.outputFiles[currRound].length > 0;
+
+    if (endTurn && hasOutputs) {
       const existingBase = await Promise.all(
         this.baseFiles.map(async (f) => await WorkspaceFS.exists(f)),
       );
 
-      if (existingBase.some((e) => e)) {
+      if (existingBase.some(Boolean)) {
         await this.handleLatexdiffofOutput(currRound, groupId);
       } else {
         this.logger.debug(
@@ -300,13 +299,26 @@ export class OutputHandler implements IOutputHandler {
           groupId,
         );
       }
+
+      if (outputFile) {
+        try {
+          await this.validateExpectedOutputs(outputFile, currRound, groupId);
+          this.logger.debug(
+            `Expected outputs validated for round ${currRound}`,
+            groupId,
+          );
+        } catch (error) {
+          this.logger.error(
+            `Expected output validation failed after round ${currRound}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            groupId,
+          );
+        }
+      }
     }
 
     const fileInfos = await this.gatherOutputFileInfo(currRound);
-
-    if (endTurn) {
-      await this.validateExpectedOutputs(outputFile, currRound, groupId);
-    }
 
     bus.emit('addOutputFiles', {
       stream: this.channel,

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -273,6 +273,48 @@ export class OutputHandler implements IOutputHandler {
   }
 
   /**
+   * Finalize output processing for a round.
+   * Handles diff generation, expected output validation and emits progress
+   * events with gathered file info.
+   */
+  public async finalizeRound(
+    outputFile: string,
+    endTurn: boolean,
+    currRound: number,
+    groupId?: string,
+  ): Promise<void> {
+    if (
+      endTurn &&
+      this.outputFiles[currRound] &&
+      this.outputFiles[currRound].length > 0
+    ) {
+      const existingBase = await Promise.all(
+        this.baseFiles.map(async (f) => await WorkspaceFS.exists(f)),
+      );
+
+      if (existingBase.some((e) => e)) {
+        await this.handleLatexdiffofOutput(currRound, groupId);
+      } else {
+        this.logger.debug(
+          `Skipping latexdiff for round ${currRound} - base files missing`,
+          groupId,
+        );
+      }
+    }
+
+    const fileInfos = await this.gatherOutputFileInfo(currRound);
+
+    if (endTurn) {
+      await this.validateExpectedOutputs(outputFile, currRound, groupId);
+    }
+
+    bus.emit('addOutputFiles', {
+      stream: this.channel,
+      filesByRound: { [currRound]: fileInfos },
+    });
+  }
+
+  /**
    * Processes output files from XML or direct input.
    */
   public async processOutputFiles(


### PR DESCRIPTION
## Summary
- move diff, output validation and event emission logic into `OutputHandler.finalizeRound`
- simplify `BaseReflectionAgent` to call the new method
- extend `IOutputHandler` API

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: no output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68852c79f3e0832496e8a9205fdd7c3a