### PR TITLE
feat: add finalizeRound to OutputHandler

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -157,33 +157,12 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       throw error;
     }
 
-    const fileInfos = await this.outputHandler.gatherOutputFileInfo(currRound);
-
-    // Validate expected outputs if this is the end of the turn
-    if (endTurn) {
-      try {
-        await this.outputHandler.validateExpectedOutputs(
-          outputFile,
-          currRound,
-          roundGroupId,
-        );
-        this.logger.debug(
-          `Expected outputs validated for round ${currRound}`,
-          roundGroupId,
-        );
-      } catch (error) {
-        this.logger.error(
-          `Expected output validation failed after round ${currRound}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-          roundGroupId,
-        );
-      }
-    }
-    bus.emit('addOutputFiles', {
-      stream: this.logger.channelId,
-      filesByRound: { [currRound]: fileInfos },
-    });
+    await this.outputHandler.finalizeRound(
+      outputFile,
+      currRound,
+      endTurn,
+      roundGroupId,
+    );
   }
 
   /**

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -38,4 +38,12 @@ export interface IOutputHandler {
     currRound: number,
     groupId?: string,
   ): Promise<void>;
+
+  /** Finalize processing for a round. */
+  finalizeRound(
+    outputFile: string,
+    currRound: number,
+    endTurn: boolean,
+    groupId?: string,
+  ): Promise<void>;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -273,6 +273,42 @@ export class OutputHandler implements IOutputHandler {
   }
 
   /**
+   * Finalize processing for a conversation round.
+   * Gathers file info, validates expected outputs and
+   * emits an event with the collected files.
+   */
+  public async finalizeRound(
+    outputFile: string,
+    currRound: number,
+    endTurn: boolean,
+    groupId?: string,
+  ): Promise<void> {
+    const fileInfos = await this.gatherOutputFileInfo(currRound);
+
+    if (endTurn) {
+      try {
+        await this.validateExpectedOutputs(outputFile, currRound, groupId);
+        this.logger.debug(
+          `Expected outputs validated for round ${currRound}`,
+          groupId,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Expected output validation failed after round ${currRound}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          groupId,
+        );
+      }
+    }
+
+    bus.emit('addOutputFiles', {
+      stream: this.channel,
+      filesByRound: { [currRound]: fileInfos },
+    });
+  }
+
+  /**
    * Processes output files from XML or direct input.
    */
   public async processOutputFiles(

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -1,0 +1,109 @@
+import { strict as assert } from 'assert';
+
+// Local imports
+import { bus } from '@eventBus/ProgressEventBus';
+import { OutputHandler } from '@agent/output';
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentLogger } from '@logger/AgentLogger';
+
+class MockOutputHandler extends OutputHandler {
+  public gatherCalled = false;
+  public validateCalled = false;
+
+  constructor(setting: AgentSetting, config: AgentConfig) {
+    super(setting, config, 0, [], new AgentLogger('TestOutputHandler'));
+  }
+
+  public override async gatherOutputFileInfo(round: number) {
+    this.gatherCalled = true;
+    return [
+      {
+        path: `out${round}.tex`,
+        base: null,
+        prev: null,
+        original: null,
+      } as any,
+    ];
+  }
+
+  public override async validateExpectedOutputs(
+    outputFile: string,
+    currRound: number,
+    groupId?: string,
+  ): Promise<void> {
+    this.validateCalled = true;
+  }
+}
+
+describe('OutputHandler.finalizeRound', () => {
+  const setting: AgentSetting = {
+    agentType: AgentType.CoT,
+    documentTag: 'document',
+    temperature: 0,
+    isRewrite: true,
+    rounds: 1,
+    prefills: [],
+    outputExt: 'tex',
+    endTag: '</latex_document>',
+    requiredFiles: {},
+    requiredFilesInternal: {},
+    defaultOutputFiles: [],
+    filePatternsContain: [],
+    tools: [],
+  };
+
+  const config: AgentConfig = {
+    model: 'test',
+    agent: 'a',
+    instruction: '',
+    inputFile: 'input.tex',
+    inputFiles: null,
+    referenceFile: null,
+    referenceFiles: null,
+    auxiliaryFile: null,
+    auxiliaryFiles: null,
+    mediaFile: null,
+    mediaFiles: null,
+    outputFiles: null,
+    editedFile: null,
+    toolConfig: {
+      reflect: false,
+      usePrefillFromInput: false,
+      autoExtractFigure: false,
+      autoExtractTikzFigure: false,
+      attachTeXCount: false,
+      printInputPrompt: false,
+      autoCompileInputPdf: false,
+    },
+  };
+
+  it('emits addOutputFiles and validates when endTurn', async () => {
+    const handler = new MockOutputHandler(setting, config);
+    const events: any[] = [];
+    const dispose = bus.on('addOutputFiles', (data) => events.push(data));
+
+    await handler.finalizeRound('out.xml', 0, true);
+
+    assert.ok(handler.gatherCalled);
+    assert.ok(handler.validateCalled);
+    assert.equal(events.length, 1);
+    assert.deepEqual(events[0].filesByRound[0], [
+      { path: 'out0.tex', base: null, prev: null, original: null },
+    ]);
+    dispose();
+  });
+
+  it('skips validation when not endTurn', async () => {
+    const handler = new MockOutputHandler(setting, config);
+    const events: any[] = [];
+    const dispose = bus.on('addOutputFiles', (data) => events.push(data));
+
+    await handler.finalizeRound('out.xml', 0, false);
+
+    assert.ok(handler.gatherCalled);
+    assert.strictEqual(handler.validateCalled, false);
+    assert.equal(events.length, 1);
+    dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `finalizeRound` in `OutputHandler` to validate and emit results
- call `finalizeRound` from `BaseReflectionAgent`
- expose new method via `IOutputHandler`
- add unit tests for `finalizeRound`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68852b692b6c83248cfdb2c5a459153c