### PR TITLE
feat: centralize usage stats manager

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -10,6 +10,7 @@ import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { IAgent } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';
 import { buildUserVars } from '../utils/userVars';
+import { UsageStatsManager } from '@agent/utils';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
@@ -31,6 +32,7 @@ export abstract class BaseAgent implements IAgent {
   protected client: any;
   protected isInterrupted = false;
   protected abortController: AbortController | null = null;
+  protected usageStats: UsageStatsManager;
 
   private static runningAgents: Map<string, BaseAgent> = new Map();
 
@@ -54,6 +56,11 @@ export abstract class BaseAgent implements IAgent {
     const streamTabId = this.getStreamTabId();
     this.logger = new AgentLogger(streamTabId, true);
     this.modelHandler.setLogger(this.logger);
+    this.usageStats = new UsageStatsManager(
+      this.modelHandler,
+      this.logger.channelId,
+      this.logger,
+    );
   }
 
   /** Initialize the API client. */

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -39,7 +39,6 @@ import type { ToolDefinition } from '@model';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { UsageStatsManager } from '@agent/utils';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -62,7 +61,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /** Handler for output file processing and validation. */
   protected outputHandler: IOutputHandler;
   protected latexMediaManager: LatexMediaManager;
-  protected usageStats: UsageStatsManager;
 
   constructor(
     modelHandler: IModelHandler,
@@ -106,11 +104,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     );
 
     this.latexMediaManager = new LatexMediaManager(this.logger);
-    this.usageStats = new UsageStatsManager(
-      this.modelHandler,
-      this.logger.channelId,
-      this.logger,
-    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- create UsageStatsManager in `BaseAgent`
- remove redundant instantiation from `BaseReflectionAgent`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68852b7777048324857316c5398de16d