### PR TITLE
Add usage tracking to BaseAgent

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -10,6 +10,8 @@ import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { IAgent } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';
 import { buildUserVars } from '../utils/userVars';
+import { UsageMonitor } from '../utils/UsageMonitor';
+import { AgentStateGlobal } from '../core/AgentState';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
@@ -26,6 +28,7 @@ export abstract class BaseAgent implements IAgent {
   protected agentPrompt: AgentPrompt;
   protected agentPath: string;
   protected logger: AgentLogger;
+  protected usageMonitor: UsageMonitor;
   protected runGroupId?: string;
   protected userVars: Record<string, any> = {};
   protected client: any;
@@ -54,6 +57,11 @@ export abstract class BaseAgent implements IAgent {
     const streamTabId = this.getStreamTabId();
     this.logger = new AgentLogger(streamTabId, true);
     this.modelHandler.setLogger(this.logger);
+    this.usageMonitor = new UsageMonitor(
+      this.modelHandler,
+      this.logger.channelId,
+      this.logger,
+    );
   }
 
   /** Initialize the API client. */
@@ -132,6 +140,13 @@ export abstract class BaseAgent implements IAgent {
       return true;
     }
     return false;
+  }
+
+  protected async trackRoundUsage(
+    stateGlobal: AgentStateGlobal,
+    groupId?: string,
+  ): Promise<void> {
+    await this.usageMonitor.recordUsage(stateGlobal, groupId);
   }
 
   public static getRunningAgent(

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -39,7 +39,6 @@ import type { ToolDefinition } from '@model';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { UsageStatsManager } from '@agent/utils';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -62,7 +61,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /** Handler for output file processing and validation. */
   protected outputHandler: IOutputHandler;
   protected latexMediaManager: LatexMediaManager;
-  protected usageStats: UsageStatsManager;
 
   constructor(
     modelHandler: IModelHandler,
@@ -106,11 +104,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     );
 
     this.latexMediaManager = new LatexMediaManager(this.logger);
-    this.usageStats = new UsageStatsManager(
-      this.modelHandler,
-      this.logger.channelId,
-      this.logger,
-    );
   }
 
   /**
@@ -168,7 +161,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /**
    * Processes output files for current round.
    * This method orchestrates the overall output processing flow with clear separation of concerns:
-   * 1. Statistics handling via UsageStatsManager
+   * 1. Usage tracking via trackRoundUsage
    * 2. LaTeX diff operations via handleLatexdiffofOutput (only when endTurn is true)
    *
    * The actual file processing is handled separately in processOutputFiles.
@@ -183,8 +176,8 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     currRound: number = 0,
     processGroupId?: string,
   ): Promise<string[]> {
-    // Print statistics at the end of each round
-    await this.usageStats.printStatistics(stateGlobal, processGroupId);
+    // Record usage statistics at the end of each round
+    await this.trackRoundUsage(stateGlobal, processGroupId);
 
     // If this is the end of a turn, handle latexdiff operations as a separate step
     if (

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -12,16 +12,16 @@ import { ResponseUsage } from 'openai/resources/responses/responses';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
 
 /**
- * Handles printing usage statistics to the log and progress view.
+ * Handles recording usage statistics to the log and progress view.
  */
-export class UsageStatsManager {
+export class UsageMonitor {
   constructor(
     private readonly modelHandler: IModelHandler,
     private readonly channel: string,
     private readonly logger: AgentLogger,
   ) {}
 
-  async printStatistics(
+  async recordUsage(
     stateGlobal: AgentStateGlobal,
     groupId?: string,
   ): Promise<void> {

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -6,4 +6,4 @@ export * from './promptHelpers';
 export * from './outputFileUtils';
 export * from './priceUtils';
 export * from './text';
-export * from './UsageStatsManager';
+export * from './UsageMonitor';


### PR DESCRIPTION
## Summary
- move usage tracking logic up to `BaseAgent`
- remove `UsageStatsManager` from `BaseReflectionAgent`
- rename stats helper to `UsageMonitor`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: unable to download VS Code)*

------
https://chatgpt.com/codex/tasks/task_e_68854258b4948324a696846efd10b74c