### PR TITLE
feat: add usage monitor and round hooks

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -10,11 +10,14 @@ import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { IAgent } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';
 import { buildUserVars } from '../utils/userVars';
+import { UsageMonitor } from '../utils';
+import type { RoundResult } from '../types/RoundResult';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
 import { sleep } from '@utils/helpers';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { AgentStateGlobal } from '../core/AgentState';
 
 /**
  * Minimal abstract base class providing shared setup and interruption logic.
@@ -31,6 +34,7 @@ export abstract class BaseAgent implements IAgent {
   protected client: any;
   protected isInterrupted = false;
   protected abortController: AbortController | null = null;
+  protected usageMonitor: UsageMonitor;
 
   private static runningAgents: Map<string, BaseAgent> = new Map();
 
@@ -54,6 +58,11 @@ export abstract class BaseAgent implements IAgent {
     const streamTabId = this.getStreamTabId();
     this.logger = new AgentLogger(streamTabId, true);
     this.modelHandler.setLogger(this.logger);
+    this.usageMonitor = new UsageMonitor(
+      this.modelHandler,
+      this.logger.channelId,
+      this.logger,
+    );
   }
 
   /** Initialize the API client. */
@@ -144,6 +153,20 @@ export abstract class BaseAgent implements IAgent {
     const streamTabId = this.getStreamTabId();
     BaseAgent.runningAgents.delete(streamTabId);
   }
+
+  protected async trackRoundUsage(
+    state: AgentStateGlobal,
+    options?: { groupId?: string },
+  ): Promise<void> {
+    await this.usageMonitor.recordUsage(state, options?.groupId);
+  }
+
+  protected async onRoundStart(_round: number): Promise<void> {}
+
+  protected abstract onRoundComplete(
+    round: number,
+    result: RoundResult,
+  ): Promise<void>;
 
   abstract run(): Promise<void>;
 }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -39,7 +39,7 @@ import type { ToolDefinition } from '@model';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { UsageStatsManager } from '@agent/utils';
+import { UsageMonitor } from '@agent/utils';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -62,7 +62,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /** Handler for output file processing and validation. */
   protected outputHandler: IOutputHandler;
   protected latexMediaManager: LatexMediaManager;
-  protected usageStats: UsageStatsManager;
 
   constructor(
     modelHandler: IModelHandler,
@@ -106,11 +105,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     );
 
     this.latexMediaManager = new LatexMediaManager(this.logger);
-    this.usageStats = new UsageStatsManager(
-      this.modelHandler,
-      this.logger.channelId,
-      this.logger,
-    );
   }
 
   /**
@@ -168,7 +162,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /**
    * Processes output files for current round.
    * This method orchestrates the overall output processing flow with clear separation of concerns:
-   * 1. Statistics handling via UsageStatsManager
+   * 1. Statistics handling via UsageMonitor
    * 2. LaTeX diff operations via handleLatexdiffofOutput (only when endTurn is true)
    *
    * The actual file processing is handled separately in processOutputFiles.
@@ -183,8 +177,8 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     currRound: number = 0,
     processGroupId?: string,
   ): Promise<string[]> {
-    // Print statistics at the end of each round
-    await this.usageStats.printStatistics(stateGlobal, processGroupId);
+    // Record usage at the end of each round
+    await this.trackRoundUsage(stateGlobal, { groupId: processGroupId });
 
     // If this is the end of a turn, handle latexdiff operations as a separate step
     if (

--- a/src/agent/types/RoundResult.ts
+++ b/src/agent/types/RoundResult.ts
@@ -1,0 +1,1 @@
+export type RoundResult = Record<string, unknown>;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -14,14 +14,14 @@ import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpe
 /**
  * Handles printing usage statistics to the log and progress view.
  */
-export class UsageStatsManager {
+export class UsageMonitor {
   constructor(
     private readonly modelHandler: IModelHandler,
     private readonly channel: string,
     private readonly logger: AgentLogger,
   ) {}
 
-  async printStatistics(
+  async recordUsage(
     stateGlobal: AgentStateGlobal,
     groupId?: string,
   ): Promise<void> {

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -6,4 +6,4 @@ export * from './promptHelpers';
 export * from './outputFileUtils';
 export * from './priceUtils';
 export * from './text';
-export * from './UsageStatsManager';
+export * from './UsageMonitor';


### PR DESCRIPTION
## Summary
- rename `UsageStatsManager` to `UsageMonitor`
- initialize the usage monitor in `BaseAgent`
- expose `trackRoundUsage` and lifecycle hooks on `BaseAgent`
- update `BaseReflectionAgent` to use `trackRoundUsage`
- add placeholder `RoundResult` type

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68854583aea483248b742c449c3f23b8