### PR TITLE
Add task run storage

### DIFF
--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -171,6 +171,19 @@ open using VS Code's default viewer, so PDFs and images display correctly while
 `.tex` documents open in the editor. Absolute paths are also handled
 properly.
 
+### Task Run Storage
+
+Every time you run an agent, TeXRA creates a folder under its workspace storage
+directory:
+
+```text
+.vscode/texra/taskRuns/<executionId>/
+```
+
+This folder stores intermediate artifacts such as the optional message JSON
+files written when `texra.debug.saveMessageObjects` is enabled. These directories
+are safe to delete if you need to reclaim space.
+
 ## Working with LaTeX Projects
 
 For complex LaTeX projects with many files and dependencies:

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -101,12 +101,12 @@ export async function runResponseCycle(
         : WorkspaceFS.fullPath(debugFileName);
       try {
         if (executionId) {
-          const runDirPath = path.join(TASK_RUNS_DIR, executionId, debugFileName);
+          const runDirPath = path.join(getRunDir(executionId), debugFileName);
           await StorageFS.write(
             runDirPath,
             JSON.stringify(messages, null, 2),
           );
-          logger.info(`Saved message object to ${path.join(getRunDir(executionId), debugFileName)}`, taskGroupId);
+          logger.info(`Saved message object to ${runDirPath}`, taskGroupId);
         } else {
           await WorkspaceFS.writeFile(
             WorkspaceFS.relativePath(debugFilePath),

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -101,12 +101,11 @@ export async function runResponseCycle(
         : WorkspaceFS.fullPath(debugFileName);
       try {
         if (executionId) {
-          const runDirPath = path.join(getRunDir(executionId), debugFileName);
           await StorageFS.write(
-            runDirPath,
+            debugFilePath,
             JSON.stringify(messages, null, 2),
           );
-          logger.info(`Saved message object to ${runDirPath}`, taskGroupId);
+          logger.info(`Saved message object to ${debugFilePath}`, taskGroupId);
         } else {
           await WorkspaceFS.writeFile(
             WorkspaceFS.relativePath(debugFilePath),

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -94,24 +94,26 @@ export async function runResponseCycle(
       false,
     );
     if (shouldSaveMessageObjects) {
-      const outputFileBaseName = outputFile.replace('.xml', '');
+      const outputFileBaseName = path.basename(outputFile, '.xml');
       const debugFileName = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
       const debugFilePath = executionId
         ? path.join(getRunDir(executionId), debugFileName)
         : WorkspaceFS.fullPath(debugFileName);
       try {
         if (executionId) {
+          const runDirPath = path.join(TASK_RUNS_DIR, executionId, debugFileName);
           await StorageFS.write(
-            path.join(TASK_RUNS_DIR, executionId, debugFileName),
+            runDirPath,
             JSON.stringify(messages, null, 2),
           );
+          logger.info(`Saved message object to ${path.join(getRunDir(executionId), debugFileName)}`, taskGroupId);
         } else {
           await WorkspaceFS.writeFile(
             WorkspaceFS.relativePath(debugFilePath),
             JSON.stringify(messages, null, 2),
           );
+          logger.info(`Saved message object to ${debugFilePath}`, taskGroupId);
         }
-        logger.info(`Saved message object to ${debugFilePath}`, taskGroupId);
       } catch (error) {
         logger.error(`Failed to save message object: ${error}`, taskGroupId);
       }

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-// (none needed)
+import * as path from 'path';
 
 // Third-party imports
 // (none needed)
@@ -13,11 +13,14 @@ import { bestConnectionMethod } from '@latex';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
+import { StorageFS } from '@utils/files';
+import { getRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 import replacementEngine from '@replacement/engine';
 import xmlUtils from '@utils/text/xmlUtils';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - agent components
 import type { AgentConfig } from './AgentConfig';
@@ -57,6 +60,7 @@ export async function runResponseCycle(
   toolState: ToolState,
   outputFile: string,
   roundGroupId?: string,
+  executionId?: ExecutionId,
 ): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
   const {
     modelHandler,
@@ -91,12 +95,22 @@ export async function runResponseCycle(
     );
     if (shouldSaveMessageObjects) {
       const outputFileBaseName = outputFile.replace('.xml', '');
-      const debugFilePath = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
+      const debugFileName = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
+      const debugFilePath = executionId
+        ? path.join(getRunDir(executionId), debugFileName)
+        : WorkspaceFS.fullPath(debugFileName);
       try {
-        await WorkspaceFS.writeFile(
-          debugFilePath,
-          JSON.stringify(messages, null, 2),
-        );
+        if (executionId) {
+          await StorageFS.write(
+            path.join(TASK_RUNS_DIR, executionId, debugFileName),
+            JSON.stringify(messages, null, 2),
+          );
+        } else {
+          await WorkspaceFS.writeFile(
+            WorkspaceFS.relativePath(debugFilePath),
+            JSON.stringify(messages, null, 2),
+          );
+        }
         logger.info(`Saved message object to ${debugFilePath}`, taskGroupId);
       } catch (error) {
         logger.error(`Failed to save message object: ${error}`, taskGroupId);

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -14,7 +14,7 @@ import { buildUserVars } from '../utils/userVars';
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
 import { sleep } from '@utils/helpers';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 
 /**
  * Minimal abstract base class providing shared setup and interruption logic.
@@ -31,6 +31,7 @@ export abstract class BaseAgent implements IAgent {
   protected client: any;
   protected isInterrupted = false;
   protected abortController: AbortController | null = null;
+  protected executionId?: ExecutionId;
 
   private static runningAgents: Map<string, BaseAgent> = new Map();
 
@@ -132,6 +133,14 @@ export abstract class BaseAgent implements IAgent {
       return true;
     }
     return false;
+  }
+
+  public setExecutionId(id: ExecutionId): void {
+    this.executionId = id;
+  }
+
+  public getExecutionId(): ExecutionId | undefined {
+    return this.executionId;
   }
 
   public static getRunningAgent(

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -149,6 +149,7 @@ export abstract class BaseAgent implements IAgent {
 
   public getExecutionId(): ExecutionId | undefined {
     return this.executionId;
+  }
 
   protected async trackRoundUsage(
     stateGlobal: AgentStateGlobal,

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -371,6 +371,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           toolState,
           this.outputFile[currRound],
           round0GroupId,
+          this.executionId,
         );
         finalEndTurn = newEndTurn;
 
@@ -540,6 +541,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           toolState,
           this.outputFile[currRound],
           round1GroupId,
+          this.executionId,
         );
 
         // Handle output and logging

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -34,6 +34,7 @@ import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 
 import { getStreamTabId } from '@/logger/streamUtils';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { IAgent } from '@agent/core/IAgent';
 
 const CHANNEL = 'executeAgent';
@@ -152,6 +153,11 @@ async function executeAgentWithLogging<T extends IAgent>(
   try {
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
+
+    if (executionId && 'setExecutionId' in agent) {
+      (agent as any).setExecutionId(executionId);
+      await ensureRunDir(executionId);
+    }
 
     // Get the full stream tab ID
     const config = agent.config;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -41,21 +41,6 @@ const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
 
 /**
- * Interface for agents that support execution ID tracking.
- */
-interface IExecutionIdTrackingAgent extends IAgent {
-  setExecutionId(id: ExecutionId): void;
-  getExecutionId(): ExecutionId | undefined;
-}
-
-/**
- * Type guard to check if an agent supports execution ID tracking.
- */
-function isExecutionIdTrackingAgent(agent: IAgent): agent is IExecutionIdTrackingAgent {
-  return 'setExecutionId' in agent && 'getExecutionId' in agent;
-}
-
-/**
  * Constructor signature for any agent implementation.
  */
 type AgentConstructor = {
@@ -169,8 +154,8 @@ async function executeAgentWithLogging<T extends IAgent>(
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
 
-    if (executionId && isExecutionIdTrackingAgent(agent)) {
-      agent.setExecutionId(executionId);
+    if (executionId && 'setExecutionId' in agent) {
+      (agent as any).setExecutionId(executionId);
       await ensureRunDir(executionId);
     }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -41,6 +41,21 @@ const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
 
 /**
+ * Interface for agents that support execution ID tracking.
+ */
+interface IExecutionIdTrackingAgent extends IAgent {
+  setExecutionId(id: ExecutionId): void;
+  getExecutionId(): ExecutionId | undefined;
+}
+
+/**
+ * Type guard to check if an agent supports execution ID tracking.
+ */
+function isExecutionIdTrackingAgent(agent: IAgent): agent is IExecutionIdTrackingAgent {
+  return 'setExecutionId' in agent && 'getExecutionId' in agent;
+}
+
+/**
  * Constructor signature for any agent implementation.
  */
 type AgentConstructor = {
@@ -154,8 +169,8 @@ async function executeAgentWithLogging<T extends IAgent>(
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
 
-    if (executionId && 'setExecutionId' in agent) {
-      (agent as any).setExecutionId(executionId);
+    if (executionId && isExecutionIdTrackingAgent(agent)) {
+      agent.setExecutionId(executionId);
       await ensureRunDir(executionId);
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { SecretManager } from '@frontend/secretManager';
 import { copyDefaultAgents, configureLatexSettings } from '@frontend/setup';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { StorageFS } from '@utils/files';
+import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { initializeStateManagers } from '@common/state/stateManager';
 import { FileLister } from '@frontend/files/fileLister';
 
@@ -41,6 +42,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize storage systems
   SecretManager.initialize(context);
   StorageFS.initialize(context);
+  await StorageFS.ensureDir(TASK_RUNS_DIR);
   initializeStateManagers(context);
   FileLister.initialize(context);
 

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -7,3 +7,4 @@ export * from './baseFileUtils';
 export * from './fileMappingUtils';
 export * from './pathUtils';
 export * from './mimeUtils';
+export * from './taskRunStorage';

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -5,13 +5,47 @@ import * as path from 'path';
 import { StorageFS } from './storageFS';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
+/**
+ * Directory name for storing task run artifacts.
+ * All task execution files (debug JSONs, logs, etc.) are organized
+ * in subdirectories under this parent directory.
+ */
 export const TASK_RUNS_DIR = 'taskRuns';
 
+/**
+ * Validate an execution ID to ensure it's safe for use in file paths.
+ * @param id - The execution ID to validate
+ * @returns True if the ID is valid, false otherwise
+ */
+function isValidExecutionId(id: ExecutionId): boolean {
+  // Ensure ID doesn't contain path traversal characters or other unsafe patterns
+  const invalidPatterns = ['..', '/', '\\', '\0'];
+  return !invalidPatterns.some(pattern => id.includes(pattern));
+}
+
+/**
+ * Get the full path to a specific task run directory.
+ * @param id - The execution ID for the task run
+ * @returns The full path to the task run directory
+ * @throws Error if the execution ID is invalid
+ */
 export function getRunDir(id: ExecutionId): string {
+  if (!isValidExecutionId(id)) {
+    throw new Error(`Invalid execution ID: ${id}`);
+  }
   return StorageFS.fullPath(path.join(TASK_RUNS_DIR, id));
 }
 
+/**
+ * Ensure a task run directory exists, creating it if necessary.
+ * Also ensures the parent taskRuns directory exists.
+ * @param id - The execution ID for the task run
+ * @throws Error if the execution ID is invalid
+ */
 export async function ensureRunDir(id: ExecutionId): Promise<void> {
+  if (!isValidExecutionId(id)) {
+    throw new Error(`Invalid execution ID: ${id}`);
+  }
   await StorageFS.ensureDir(TASK_RUNS_DIR);
   await StorageFS.ensureDir(path.join(TASK_RUNS_DIR, id));
 }

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -1,0 +1,17 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - storage
+import { StorageFS } from './storageFS';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+
+export const TASK_RUNS_DIR = 'taskRuns';
+
+export function getRunDir(id: ExecutionId): string {
+  return StorageFS.fullPath(path.join(TASK_RUNS_DIR, id));
+}
+
+export async function ensureRunDir(id: ExecutionId): Promise<void> {
+  await StorageFS.ensureDir(TASK_RUNS_DIR);
+  await StorageFS.ensureDir(path.join(TASK_RUNS_DIR, id));
+}


### PR DESCRIPTION
## Summary
- add `taskRunStorage` module for storing task run files
- create run folder on activation and when agents start
- save debug message JSONs inside run folder
- document taskRuns folder in file management guide

## Testing
- `npm run format`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688517082d5483249dcb0a5e9305813b