### PR TITLE
Refactor reflection agent handlers

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -122,12 +122,14 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    * Processes completion of conversation round.
    */
   private async handleRoundCompletion(
+    currRound: number,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number,
-    roundGroupId?: string,
+    options: {
+      outputFile: string;
+      endTurn: boolean;
+      processGroupId?: string;
+    },
   ): Promise<void> {
     try {
       // Instead of creating a new group, use the round group directly
@@ -136,25 +138,22 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       //   roundGroupId,
       // );
 
-      await this.handleOutput(
-        stateRound,
-        stateGlobal,
-        outputFile,
-        endTurn,
-        currRound,
-        roundGroupId,
-      );
+      await this.handleOutput(currRound, stateRound, stateGlobal, {
+        outputFile: options.outputFile,
+        endTurn: options.endTurn,
+        processGroupId: options.processGroupId,
+      });
 
-      this.logger.debug(`Completed round ${currRound}`, roundGroupId);
+      this.logger.debug(`Completed round ${currRound}`, options.processGroupId);
     } catch (error) {
       throw error;
     }
 
     await this.outputHandler.finalizeRound(
-      outputFile,
+      options.outputFile,
       currRound,
-      endTurn,
-      roundGroupId,
+      options.endTurn,
+      options.processGroupId,
     );
   }
 
@@ -169,19 +168,21 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    * @returns Array of processed output file paths
    */
   protected async handleOutput(
+    currRound: number = 0,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    processGroupId?: string,
+    options: {
+      outputFile: string;
+      endTurn: boolean;
+      processGroupId?: string;
+    },
   ): Promise<string[]> {
     // Record usage statistics at the end of each round
-    await this.trackRoundUsage(stateGlobal, processGroupId);
+    await this.trackRoundUsage(stateGlobal, options.processGroupId);
 
     // If this is the end of a turn, handle latexdiff operations as a separate step
     if (
-      endTurn &&
+      options.endTurn &&
       this.outputHandler.outputFiles[currRound] &&
       this.outputHandler.outputFiles[currRound].length > 0
     ) {
@@ -193,12 +194,12 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         // Pass the process group ID to maintain proper nesting in the log hierarchy
         await this.outputHandler.handleLatexdiffofOutput(
           currRound,
-          processGroupId,
+          options.processGroupId,
         );
       } else {
         this.logger.debug(
           `Skipping latexdiff for round ${currRound} - base files missing`,
-          processGroupId,
+          options.processGroupId,
         );
       }
     }
@@ -348,12 +349,14 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
         // Handle output and logging
         await this.handleRoundCompletion(
+          currRound,
           updatedStateRound,
           updatedStateGlobal,
-          this.outputFile[currRound],
-          finalEndTurn,
-          currRound,
-          round0GroupId, // Pass the round group ID
+          {
+            outputFile: this.outputFile[currRound],
+            endTurn: finalEndTurn,
+            processGroupId: round0GroupId,
+          },
         );
 
         this.logger.debug(
@@ -374,14 +377,11 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       }
 
       // Handle output and logging for early termination
-      await this.handleRoundCompletion(
-        stateRound,
-        stateGlobal,
-        this.outputFile[currRound],
-        finalEndTurn,
-        currRound,
-        round0GroupId, // Pass the round group ID
-      );
+      await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
+        outputFile: this.outputFile[currRound],
+        endTurn: finalEndTurn,
+        processGroupId: round0GroupId,
+      });
 
       // End the round group
       this.logger.endGroup(round0GroupId, 'stopped');
@@ -516,12 +516,14 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
         // Handle output and logging
         await this.handleRoundCompletion(
+          currRound,
           updatedStateRound,
           updatedStateGlobal,
-          this.outputFile[currRound],
-          newEndTurn,
-          currRound,
-          round1GroupId,
+          {
+            outputFile: this.outputFile[currRound],
+            endTurn: newEndTurn,
+            processGroupId: round1GroupId,
+          },
         );
 
         this.logger.endGroup(round1GroupId, 'stopped');
@@ -534,14 +536,11 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       }
 
       // Handle output and logging for early termination
-      await this.handleRoundCompletion(
-        stateRound,
-        stateGlobal,
-        this.outputFile[currRound],
-        endTurn,
-        currRound,
-        round1GroupId,
-      );
+      await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
+        outputFile: this.outputFile[currRound],
+        endTurn: endTurn,
+        processGroupId: round1GroupId,
+      });
 
       this.logger.endGroup(round1GroupId, 'stopped');
       return [stateRound, stateGlobal, updatedMessages, endTurn];

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -34,20 +34,22 @@ export class CoTAgent extends BaseReflectionAgent {
    * @returns Array of processed output file paths
    */
   protected async handleOutput(
+    currRound: number = 0,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    processGroupId?: string,
+    options: {
+      outputFile: string;
+      endTurn: boolean;
+      processGroupId?: string;
+    },
   ): Promise<string[]> {
     // Declare the process group ID at the function scope level
-    // Initialize with processGroupId if provided, otherwise it will be set in the try block
-    let outputProcessGroupId: string = processGroupId || '';
+    // Initialize with options.processGroupId if provided, otherwise it will be set in the try block
+    let outputProcessGroupId: string = options.processGroupId || '';
 
     try {
       // Start a main output processing group if none provided
-      if (!processGroupId) {
+      if (!options.processGroupId) {
         outputProcessGroupId = await this.logger.startGroup(
           `OutputProcessing-Round${currRound}`,
           undefined,
@@ -59,7 +61,7 @@ export class CoTAgent extends BaseReflectionAgent {
       this.outputHandler.outputFiles[currRound] =
         this.outputHandler.outputFiles[currRound] || [];
 
-      if (endTurn) {
+      if (options.endTurn) {
         this.logger.debug(
           `Processing output for round ${currRound}`,
           outputProcessGroupId,
@@ -67,13 +69,13 @@ export class CoTAgent extends BaseReflectionAgent {
 
         // First fix XML structure
         await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-          outputFile,
+          options.outputFile,
           this.agentSetting.documentTag,
         );
 
         // Then process output files using the output handler
         await this.outputHandler.processOutputFiles(
-          outputFile,
+          options.outputFile,
           currRound,
           outputProcessGroupId,
         );
@@ -83,16 +85,18 @@ export class CoTAgent extends BaseReflectionAgent {
 
       // Finally handle statistics in base class (but pass our group ID)
       const result = await super.handleOutput(
+        currRound,
         stateRound,
         stateGlobal,
-        outputFile,
-        endTurn,
-        currRound,
-        outputProcessGroupId, // The statistics will be a subgroup of our output processing group
+        {
+          outputFile: options.outputFile,
+          endTurn: options.endTurn,
+          processGroupId: outputProcessGroupId,
+        },
       );
 
       // Only end the processing group if we created it
-      if (!processGroupId) {
+      if (!options.processGroupId) {
         this.logger.endGroup(outputProcessGroupId, 'stopped');
       }
 
@@ -100,11 +104,11 @@ export class CoTAgent extends BaseReflectionAgent {
     } catch (err) {
       this.logger.error(
         `Error in handleOutput for round ${currRound}: ${err}`,
-        processGroupId,
+        options.processGroupId,
       );
 
       // Only end the processing group if we created it and we have a valid outputProcessGroupId
-      if (!processGroupId && outputProcessGroupId) {
+      if (!options.processGroupId && outputProcessGroupId) {
         this.logger.endGroup(outputProcessGroupId, 'error');
       }
 

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -30,21 +30,23 @@ export class DirectAgent extends BaseReflectionAgent {
    * @returns Array of processed output file paths
    */
   protected async handleOutput(
+    currRound: number = 0,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    processGroupId?: string,
+    options: {
+      outputFile: string;
+      endTurn: boolean;
+      processGroupId?: string;
+    },
   ): Promise<string[]> {
     // Declare the process group ID at the function scope level
-    // Initialize with processGroupId if provided, otherwise it will be set in the try block
-    let outputProcessGroupId: string = processGroupId || '';
+    // Initialize with options.processGroupId if provided, otherwise it will be set in the try block
+    let outputProcessGroupId: string = options.processGroupId || '';
 
     // These groups needs to be made consistent with the @BaseReflectionAgent.handleOutput method
     try {
       // Start a main output processing group if none provided
-      if (!processGroupId) {
+      if (!options.processGroupId) {
         outputProcessGroupId = await this.logger.startGroup(
           `OutputProcessing-Round${currRound}`,
           undefined,
@@ -56,7 +58,7 @@ export class DirectAgent extends BaseReflectionAgent {
       this.outputHandler.outputFiles[currRound] =
         this.outputHandler.outputFiles[currRound] || [];
 
-      if (endTurn) {
+      if (options.endTurn) {
         this.logger.debug(
           `Processing output for round ${currRound}`,
           outputProcessGroupId,
@@ -64,7 +66,7 @@ export class DirectAgent extends BaseReflectionAgent {
 
         // Process output files using the output handler
         await this.outputHandler.processOutputFiles(
-          outputFile,
+          options.outputFile,
           currRound,
           outputProcessGroupId,
         );
@@ -78,16 +80,18 @@ export class DirectAgent extends BaseReflectionAgent {
 
       // Finally handle statistics in base class (but pass our group ID)
       const result = await super.handleOutput(
+        currRound,
         stateRound,
         stateGlobal,
-        outputFile,
-        endTurn,
-        currRound,
-        outputProcessGroupId, // The statistics will be a subgroup of our output processing group
+        {
+          outputFile: options.outputFile,
+          endTurn: options.endTurn,
+          processGroupId: outputProcessGroupId,
+        },
       );
 
       // Only end the processing group if we created it
-      if (!processGroupId) {
+      if (!options.processGroupId) {
         this.logger.endGroup(outputProcessGroupId, 'stopped');
       }
 
@@ -95,11 +99,11 @@ export class DirectAgent extends BaseReflectionAgent {
     } catch (error) {
       this.logger.error(
         `Error in DirectAgent.handleOutput: ${error}`,
-        processGroupId,
+        options.processGroupId,
       );
 
       // Only end the processing group if we created it and we have a valid outputProcessGroupId
-      if (!processGroupId && outputProcessGroupId) {
+      if (!options.processGroupId && outputProcessGroupId) {
         this.logger.endGroup(outputProcessGroupId, 'error');
       }
 

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -128,27 +128,34 @@ export class MergeAgent extends DirectAgent {
    * @returns Array of processed output file paths
    */
   protected async handleOutput(
+    currRound: number = 0,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    processGroupId?: string,
+    options: {
+      outputFile: string;
+      endTurn: boolean;
+      processGroupId?: string;
+    },
   ): Promise<string[]> {
-    if (endTurn) {
+    if (options.endTurn) {
       this.logger.debug(
         `Processing merge output for round ${currRound}`,
-        processGroupId,
+        options.processGroupId,
       );
       const files = await super.handleOutput(
+        currRound,
         stateRound,
         stateGlobal,
-        outputFile,
-        endTurn,
-        currRound,
-        processGroupId,
+        {
+          outputFile: options.outputFile,
+          endTurn: options.endTurn,
+          processGroupId: options.processGroupId,
+        },
       );
-      this.logger.info(`Merge output file: ${outputFile}`, processGroupId);
+      this.logger.info(
+        `Merge output file: ${options.outputFile}`,
+        options.processGroupId,
+      );
       return files;
     }
     return [];


### PR DESCRIPTION
## Summary
- update `handleRoundCompletion` and `handleOutput` signatures in `BaseReflectionAgent`
- adapt implementations in `DirectAgent`, `CoTAgent`, and `MergeAgent`
- pass round number first and consolidate options

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack/vscode-test error)*

------
https://chatgpt.com/codex/tasks/task_e_68854a640c58832496e49f55a12b983e