### PR TITLE
Refactor output callbacks

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -46,7 +46,13 @@ import { getConfig } from '@utils/config';
 // Shared constants
 import { K_SLICE } from '@utils/config';
 
-/** Options for handling round output */
+/**
+ * Options for handling round output.
+ * 
+ * @property outputFile - The path to the file where the round's output will be saved.
+ * @property endTurn - A flag indicating whether the current turn should be ended after processing.
+ * @property processGroupId - (Optional) An identifier for grouping related processes, useful for tracking or managing outputs.
+ */
 export interface RoundOutputOptions {
   outputFile: string;
   endTurn: boolean;

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -46,6 +46,13 @@ import { getConfig } from '@utils/config';
 // Shared constants
 import { K_SLICE } from '@utils/config';
 
+/** Options for handling round output */
+export interface RoundOutputOptions {
+  outputFile: string;
+  endTurn: boolean;
+  processGroupId?: string;
+}
+
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.
  * Provides core functionality for processing inputs, managing state, and handling outputs
@@ -122,40 +129,30 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    * Processes completion of conversation round.
    */
   private async handleRoundCompletion(
+    currRound: number,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number,
-    roundGroupId?: string,
+    options: RoundOutputOptions,
   ): Promise<void> {
+    const { outputFile, endTurn, processGroupId } = options;
     try {
       // Instead of creating a new group, use the round group directly
       // this.logger.debug(
       //   `State global: ${JSON.stringify(stateGlobal)}`,
-      //   roundGroupId,
+      //   processGroupId,
       // );
 
-      await this.handleOutput(
-        stateRound,
-        stateGlobal,
-        outputFile,
-        endTurn,
-        currRound,
-        roundGroupId,
-      );
+      await this.handleOutput(currRound, stateRound, stateGlobal, options);
 
-      this.logger.debug(`Completed round ${currRound}`, roundGroupId);
+      this.logger.debug(`Completed round ${currRound}`, processGroupId);
     } catch (error) {
       throw error;
     }
 
-    await this.outputHandler.finalizeRound(
-      outputFile,
-      currRound,
+    await this.outputHandler.finalizeRound(outputFile, currRound, {
       endTurn,
-      roundGroupId,
-    );
+      groupId: processGroupId,
+    });
   }
 
   /**
@@ -169,13 +166,12 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    * @returns Array of processed output file paths
    */
   protected async handleOutput(
+    currRound: number,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    processGroupId?: string,
+    options: RoundOutputOptions,
   ): Promise<string[]> {
+    const { outputFile, endTurn, processGroupId } = options;
     // Record usage statistics at the end of each round
     await this.trackRoundUsage(stateGlobal, processGroupId);
 
@@ -348,12 +344,14 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
         // Handle output and logging
         await this.handleRoundCompletion(
+          currRound,
           updatedStateRound,
           updatedStateGlobal,
-          this.outputFile[currRound],
-          finalEndTurn,
-          currRound,
-          round0GroupId, // Pass the round group ID
+          {
+            outputFile: this.outputFile[currRound],
+            endTurn: finalEndTurn,
+            processGroupId: round0GroupId,
+          },
         );
 
         this.logger.debug(
@@ -374,14 +372,11 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       }
 
       // Handle output and logging for early termination
-      await this.handleRoundCompletion(
-        stateRound,
-        stateGlobal,
-        this.outputFile[currRound],
-        finalEndTurn,
-        currRound,
-        round0GroupId, // Pass the round group ID
-      );
+      await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
+        outputFile: this.outputFile[currRound],
+        endTurn: finalEndTurn,
+        processGroupId: round0GroupId,
+      });
 
       // End the round group
       this.logger.endGroup(round0GroupId, 'stopped');
@@ -516,12 +511,14 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
         // Handle output and logging
         await this.handleRoundCompletion(
+          currRound,
           updatedStateRound,
           updatedStateGlobal,
-          this.outputFile[currRound],
-          newEndTurn,
-          currRound,
-          round1GroupId,
+          {
+            outputFile: this.outputFile[currRound],
+            endTurn: newEndTurn,
+            processGroupId: round1GroupId,
+          },
         );
 
         this.logger.endGroup(round1GroupId, 'stopped');
@@ -534,14 +531,11 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       }
 
       // Handle output and logging for early termination
-      await this.handleRoundCompletion(
-        stateRound,
-        stateGlobal,
-        this.outputFile[currRound],
+      await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
+        outputFile: this.outputFile[currRound],
         endTurn,
-        currRound,
-        round1GroupId,
-      );
+        processGroupId: round1GroupId,
+      });
 
       this.logger.endGroup(round1GroupId, 'stopped');
       return [stateRound, stateGlobal, updatedMessages, endTurn];

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -1,7 +1,7 @@
 // Local imports - agent components
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { getOutputFileName } from '@agent/output';
-import { BaseReflectionAgent } from './BaseReflectionAgent';
+import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 
 /**
  * Chain of Thought (CoT) agent implementation that extends BaseReflectionAgent.
@@ -34,13 +34,12 @@ export class CoTAgent extends BaseReflectionAgent {
    * @returns Array of processed output file paths
    */
   protected async handleOutput(
+    currRound: number,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    processGroupId?: string,
+    options: RoundOutputOptions,
   ): Promise<string[]> {
+    const { outputFile, endTurn, processGroupId } = options;
     // Declare the process group ID at the function scope level
     // Initialize with processGroupId if provided, otherwise it will be set in the try block
     let outputProcessGroupId: string = processGroupId || '';
@@ -83,12 +82,14 @@ export class CoTAgent extends BaseReflectionAgent {
 
       // Finally handle statistics in base class (but pass our group ID)
       const result = await super.handleOutput(
+        currRound,
         stateRound,
         stateGlobal,
-        outputFile,
-        endTurn,
-        currRound,
-        outputProcessGroupId, // The statistics will be a subgroup of our output processing group
+        {
+          outputFile,
+          endTurn,
+          processGroupId: outputProcessGroupId,
+        },
       );
 
       // Only end the processing group if we created it

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -1,5 +1,5 @@
 // Local imports - agent components
-import { BaseReflectionAgent } from './BaseReflectionAgent';
+import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { getOutputFileName } from '@agent/output';
 
@@ -30,13 +30,12 @@ export class DirectAgent extends BaseReflectionAgent {
    * @returns Array of processed output file paths
    */
   protected async handleOutput(
+    currRound: number,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    processGroupId?: string,
+    options: RoundOutputOptions,
   ): Promise<string[]> {
+    const { outputFile, endTurn, processGroupId } = options;
     // Declare the process group ID at the function scope level
     // Initialize with processGroupId if provided, otherwise it will be set in the try block
     let outputProcessGroupId: string = processGroupId || '';
@@ -78,12 +77,14 @@ export class DirectAgent extends BaseReflectionAgent {
 
       // Finally handle statistics in base class (but pass our group ID)
       const result = await super.handleOutput(
+        currRound,
         stateRound,
         stateGlobal,
-        outputFile,
-        endTurn,
-        currRound,
-        outputProcessGroupId, // The statistics will be a subgroup of our output processing group
+        {
+          outputFile,
+          endTurn,
+          processGroupId: outputProcessGroupId,
+        },
       );
 
       // Only end the processing group if we created it

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 // Local imports - agent components
 import { DirectAgent } from './DirectAgent';
+import { RoundOutputOptions } from './BaseReflectionAgent';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
 import type { AgentConfig } from '../core/AgentConfig';
@@ -119,34 +120,33 @@ export class MergeAgent extends DirectAgent {
 
   /**
    * Processes output files for merge operation.
+   * @param currRound Current round number (defaults to 0)
    * @param stateRound Current round state
    * @param stateGlobal Global conversation state
-   * @param outputFile Path to the output file
-   * @param endTurn Whether this is the end of the current turn
-   * @param currRound Current round number (defaults to 0)
-   * @param processGroupId Optional processing group ID for logging
+   * @param options Output processing options
    * @returns Array of processed output file paths
    */
   protected async handleOutput(
+    currRound: number,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    processGroupId?: string,
+    options: RoundOutputOptions,
   ): Promise<string[]> {
+    const { outputFile, endTurn, processGroupId } = options;
     if (endTurn) {
       this.logger.debug(
         `Processing merge output for round ${currRound}`,
         processGroupId,
       );
       const files = await super.handleOutput(
+        currRound,
         stateRound,
         stateGlobal,
-        outputFile,
-        endTurn,
-        currRound,
-        processGroupId,
+        {
+          outputFile,
+          endTurn,
+          processGroupId,
+        },
       );
       this.logger.info(`Merge output file: ${outputFile}`, processGroupId);
       return files;

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -43,7 +43,9 @@ export interface IOutputHandler {
   finalizeRound(
     outputFile: string,
     currRound: number,
-    endTurn: boolean,
-    groupId?: string,
+    options: {
+      endTurn: boolean;
+      groupId?: string;
+    },
   ): Promise<void>;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -280,9 +280,9 @@ export class OutputHandler implements IOutputHandler {
   public async finalizeRound(
     outputFile: string,
     currRound: number,
-    endTurn: boolean,
-    groupId?: string,
+    options: { endTurn: boolean; groupId?: string },
   ): Promise<void> {
+    const { endTurn, groupId } = options;
     const fileInfos = await this.gatherOutputFileInfo(currRound);
 
     if (endTurn) {

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -83,7 +83,7 @@ describe('OutputHandler.finalizeRound', () => {
     const events: any[] = [];
     const dispose = bus.on('addOutputFiles', (data) => events.push(data));
 
-    await handler.finalizeRound('out.xml', 0, true);
+    await handler.finalizeRound('out.xml', 0, { endTurn: true });
 
     assert.ok(handler.gatherCalled);
     assert.ok(handler.validateCalled);
@@ -99,7 +99,7 @@ describe('OutputHandler.finalizeRound', () => {
     const events: any[] = [];
     const dispose = bus.on('addOutputFiles', (data) => events.push(data));
 
-    await handler.finalizeRound('out.xml', 0, false);
+    await handler.finalizeRound('out.xml', 0, { endTurn: false });
 
     assert.ok(handler.gatherCalled);
     assert.strictEqual(handler.validateCalled, false);


### PR DESCRIPTION
## Summary
- refactor `BaseReflectionAgent` output APIs to take round first then options object
- switch `OutputHandler.finalizeRound` to use an options object for consistency
- update tests for new finalize signature

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68854a640c58832496e49f55a12b983e