### PR TITLE
Add helper methods for agent run groups

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -170,7 +170,7 @@ export abstract class BaseAgent implements IAgent {
   protected endRunGroup(status: 'stopped' | 'error' = 'stopped'): void {
     if (this.runGroupId) {
       this.logger.endGroup(this.runGroupId, status);
-      this.runGroupId = undefined;
+      this.runGroupId = null;
     }
   }
 

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -149,6 +149,31 @@ export abstract class BaseAgent implements IAgent {
     await this.usageMonitor.recordUsage(stateGlobal, groupId);
   }
 
+  /**
+   * Start a log group for this agent's run and store its ID.
+   * @param parentGroupId Optional parent group
+   * @returns The created group ID
+   */
+  protected async startRunGroup(parentGroupId?: string): Promise<string> {
+    this.runGroupId = await this.logger.startGroup(
+      `Run: ${this.agentConfig.agent}@${this.agentConfig.model}`,
+      undefined,
+      parentGroupId,
+    );
+    return this.runGroupId;
+  }
+
+  /**
+   * End the current run group.
+   * @param status Status to mark for the group
+   */
+  protected endRunGroup(status: 'stopped' | 'error' = 'stopped'): void {
+    if (this.runGroupId) {
+      this.logger.endGroup(this.runGroupId, status);
+      this.runGroupId = undefined;
+    }
+  }
+
   public static getRunningAgent(
     streamTabId: StreamTabId,
   ): BaseAgent | undefined {

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -48,7 +48,7 @@ import { K_SLICE } from '@utils/config';
 
 /**
  * Options for handling round output.
- * 
+ *
  * @property outputFile - The path to the file where the round's output will be saved.
  * @property endTurn - A flag indicating whether the current turn should be ended after processing.
  * @property processGroupId - (Optional) An identifier for grouping related processes, useful for tracking or managing outputs.
@@ -557,9 +557,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    */
   public async run(): Promise<void> {
     // Create a dedicated run group for this agent execution
-    this.runGroupId = await this.logger.startGroup(
-      `Run: ${this.agentConfig.agent}@${this.agentConfig.model}`,
-    );
+    await this.startRunGroup();
 
     try {
       // Initialize agent variables within the run group
@@ -584,12 +582,10 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       }
 
       // End the run group with success status
-      this.logger.endGroup(this.runGroupId, 'stopped');
+      this.endRunGroup('stopped');
     } catch (error) {
       // End the run group with error status
-      if (this.runGroupId) {
-        this.logger.endGroup(this.runGroupId, 'error');
-      }
+      this.endRunGroup('error');
       throw error;
     } finally {
       // Always clean up, whether execution completed or was interrupted


### PR DESCRIPTION
## Summary
- add `startRunGroup` and `endRunGroup` helpers in `BaseAgent`
- refactor `BaseReflectionAgent.run` to use new helpers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688555516ef083248f813d0ab4e3ca2b