### PR TITLE
Refactor output processing logic

### DIFF
--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,6 +1,7 @@
 // Local imports - types
 import { NamedOutputFile, OutputFileInfo } from './types';
 import { XmlOutputManager } from './XmlOutputManager';
+import { OutputProcessor } from './OutputProcessor';
 
 /** Interface describing OutputHandler behavior used by agents. */
 export interface IOutputHandler {
@@ -10,14 +11,11 @@ export interface IOutputHandler {
   /** Mapping of source to processed output files by round. */
   outputMappings: { [key: number]: NamedOutputFile[] };
 
+  /** Processor for splitting and formatting outputs. */
+  outputProcessor: OutputProcessor;
+
   /** XML manager for parsing and splitting outputs. */
   xmlManager: XmlOutputManager;
-
-  /** Indent a single LaTeX file for readability. */
-  indentLatexFile(filePath: string): Promise<void>;
-
-  /** Indent multiple LaTeX files for readability. */
-  indentLatexFiles(filePaths: string[]): Promise<void>;
 
   /** Run latexdiff comparisons for the current round. */
   handleLatexdiffofOutput(currRound: number, groupId?: string): Promise<void>;

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -2,24 +2,23 @@
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
 import * as path from 'path';
-import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { runLatexFormatter } from '@latex/texFormatter';
 import { XmlOutputManager } from './XmlOutputManager';
 import { LatexDiffManager } from './LatexDiffManager';
 import { DiffStatsManager } from './DiffStatsManager';
+import { OutputProcessor } from './OutputProcessor';
 import { NamedOutputFile } from './types';
 import type { IOutputHandler } from './IOutputHandler';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 
 // Local imports - utilities
-import { replaceInputCommands, createFileMapping } from '@utils/files';
+import { createFileMapping } from '@utils/files';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -39,6 +38,7 @@ export class OutputHandler implements IOutputHandler {
   public processGroupId?: string;
   protected logger: AgentLogger;
   protected channel: string;
+  public readonly outputProcessor: OutputProcessor;
   public readonly xmlManager: XmlOutputManager;
   private diffManager: LatexDiffManager;
   private diffStatsManager: DiffStatsManager;
@@ -59,11 +59,13 @@ export class OutputHandler implements IOutputHandler {
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
 
-    this.xmlManager = new XmlOutputManager(
+    this.outputProcessor = new OutputProcessor(
       this.agentSetting,
       this.agentConfig,
+      this.baseFiles,
       this.logger,
     );
+    this.xmlManager = this.outputProcessor.xmlManager;
     this.diffManager = new LatexDiffManager(
       this.agentSetting,
       this.outputFiles,
@@ -111,26 +113,6 @@ export class OutputHandler implements IOutputHandler {
       // this.logger.info(`Completed output processing`, this.processGroupId);
       this.logger.endGroup(this.processGroupId, status);
       this.processGroupId = undefined;
-    }
-  }
-
-  /**
-   * Indents a LaTeX file for better readability
-   */
-  public async indentLatexFile(filePath: string): Promise<void> {
-    if (!filePath.includes('.tex')) {
-      return;
-    }
-    this.logger.debug(`Formatting ${filePath}`);
-    await runLatexFormatter(filePath);
-  }
-
-  /**
-   * Indents multiple LaTeX files for better readability
-   */
-  public async indentLatexFiles(filePaths: string[]): Promise<void> {
-    for (const filePath of filePaths) {
-      await this.indentLatexFile(filePath);
     }
   }
 
@@ -317,109 +299,24 @@ export class OutputHandler implements IOutputHandler {
     groupId?: string,
   ): Promise<void> {
     const activeGroupId = groupId || this.logger.getActiveGroupId();
+    const { files, mappings } = await this.outputProcessor.processOutputFiles(
+      outputFile,
+      activeGroupId,
+    );
 
     if (
+      files.length === 0 &&
       Array.isArray(this.agentConfig.outputFiles) &&
       this.agentConfig.outputFiles.length > 0
     ) {
-      // Multiple output files case
-      this.logger.debug(
-        `Processing multiple outputs for ${outputFile}; outputFiles: ${this.agentConfig.outputFiles}`,
-        activeGroupId,
-      );
-
-      try {
-        const processedPairs =
-          await this.xmlManager.processMultipleXmlOutputs(outputFile);
-
-        if (processedPairs && processedPairs.length > 0) {
-          const processedFiles = processedPairs.map((p) => p.path);
-          await this.indentLatexFiles(processedFiles);
-          this.logger.debug(
-            `Indented multiple output files: ${processedFiles.join(',')}`,
-            activeGroupId,
-          );
-
-          this.outputFiles[currRound] = processedFiles;
-          this.outputMappings[currRound] = processedPairs;
-
-          if (this.baseFiles && this.baseFiles.length > 0) {
-            await replaceInputCommands(
-              this.baseFiles,
-              processedFiles,
-              this.logger,
-            );
-          }
-        } else {
-          this.logger.debug(
-            `No processed files were generated from ${outputFile}`,
-            activeGroupId,
-          );
-          this.outputFiles[currRound] = [];
-          this.outputMappings[currRound] = [];
-        }
-      } catch (err) {
-        this.logger.debug(
-          `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
-          activeGroupId,
-          MESSAGE_TYPES.INTERNAL,
-        );
-        this.outputFiles[currRound] = [];
-        this.outputMappings[currRound] = [];
-      }
-    } else {
-      // Single output file case
-      this.logger.debug(
-        `Processing single output for ${outputFile}`,
-        activeGroupId,
-      );
-
-      try {
-        let processed: NamedOutputFile = {
-          source: outputFile,
-          path: outputFile,
-        };
-        if (this.agentSetting.agentType === AgentType.CoT) {
-          processed = await this.xmlManager.processSingleXmlOutput(outputFile);
-        }
-
-        if (processed && processed.path) {
-          await this.indentLatexFile(processed.path);
-          this.logger.debug(
-            `Indented single output file: ${processed.path}`,
-            activeGroupId,
-          );
-
-          this.outputFiles[currRound] = [processed.path];
-          this.outputMappings[currRound] = [processed];
-        } else {
-          this.logger.debug(
-            `No processed file was generated from ${outputFile}`,
-            activeGroupId,
-          );
-          this.outputFiles[currRound] = [];
-          this.outputMappings[currRound] = [];
-        }
-      } catch (err) {
-        this.logger.debug(
-          `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
-          activeGroupId,
-          MESSAGE_TYPES.INTERNAL,
-        );
-        const missingOutputsData = {
-          missing: [],
-          xmlFile: outputFile,
-          documentTag: this.agentSetting.documentTag,
-        };
-        this.logger.missingOutputs(missingOutputsData, activeGroupId);
-        bus.emit('updateMissingOutputs', {
-          stream: this.channel,
-          filesByRound: { [currRound]: [] },
-        });
-        this.outputFiles[currRound] = [];
-        this.outputMappings[currRound] = [];
-      }
+      bus.emit('updateMissingOutputs', {
+        stream: this.channel,
+        filesByRound: { [currRound]: [] },
+      });
     }
+
+    this.outputFiles[currRound] = files;
+    this.outputMappings[currRound] = mappings;
   }
   /** Processes output files for current round. */
   protected async handleOutput(

--- a/src/agent/output/OutputProcessor.ts
+++ b/src/agent/output/OutputProcessor.ts
@@ -1,0 +1,134 @@
+// Standard library imports
+
+// Local imports - utilities
+import { runLatexFormatter } from '@latex/texFormatter';
+import { replaceInputCommands } from '@utils/files';
+
+// Local imports - agent components
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { AgentLogger } from '@logger/AgentLogger';
+
+import { XmlOutputManager } from './XmlOutputManager';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import type { NamedOutputFile } from './types';
+
+/**
+ * Handles splitting and formatting of agent output files.
+ */
+export class OutputProcessor {
+  public readonly xmlManager: XmlOutputManager;
+
+  constructor(
+    private readonly agentSetting: AgentSetting,
+    private readonly agentConfig: AgentConfig,
+    private readonly baseFiles: string[],
+    private readonly logger: AgentLogger,
+  ) {
+    this.xmlManager = new XmlOutputManager(
+      this.agentSetting,
+      this.agentConfig,
+      this.logger,
+    );
+  }
+
+  private async indentLatexFile(filePath: string): Promise<void> {
+    if (!filePath.includes('.tex')) {
+      return;
+    }
+    this.logger.debug(`Formatting ${filePath}`);
+    await runLatexFormatter(filePath);
+  }
+
+  private async indentLatexFiles(filePaths: string[]): Promise<void> {
+    for (const filePath of filePaths) {
+      await this.indentLatexFile(filePath);
+    }
+  }
+
+  /**
+   * Split XML outputs and indent generated TeX files.
+   * Returns processed paths and mappings.
+   */
+  public async processOutputFiles(
+    outputFile: string,
+    groupId?: string,
+  ): Promise<{ files: string[]; mappings: NamedOutputFile[] }> {
+    if (
+      Array.isArray(this.agentConfig.outputFiles) &&
+      this.agentConfig.outputFiles.length > 0
+    ) {
+      // Multiple output files case
+      this.logger.debug(
+        `Processing multiple outputs for ${outputFile}; outputFiles: ${this.agentConfig.outputFiles}`,
+        groupId,
+      );
+
+      try {
+        const processedPairs =
+          await this.xmlManager.processMultipleXmlOutputs(outputFile);
+
+        if (processedPairs && processedPairs.length > 0) {
+          const processedFiles = processedPairs.map((p) => p.path);
+          await this.indentLatexFiles(processedFiles);
+
+          if (this.baseFiles && this.baseFiles.length > 0) {
+            await replaceInputCommands(
+              this.baseFiles,
+              processedFiles,
+              this.logger,
+            );
+          }
+
+          return { files: processedFiles, mappings: processedPairs };
+        }
+
+        this.logger.debug(
+          `No processed files were generated from ${outputFile}`,
+          groupId,
+        );
+        return { files: [], mappings: [] };
+      } catch (err) {
+        this.logger.debug(
+          `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
+          groupId,
+          MESSAGE_TYPES.INTERNAL,
+        );
+        return { files: [], mappings: [] };
+      }
+    } else {
+      // Single output file case
+      this.logger.debug(`Processing single output for ${outputFile}`, groupId);
+
+      try {
+        let processed: NamedOutputFile = {
+          source: outputFile,
+          path: outputFile,
+        };
+        if (this.agentSetting.agentType === AgentType.CoT) {
+          processed = await this.xmlManager.processSingleXmlOutput(outputFile);
+        }
+
+        if (processed && processed.path) {
+          await this.indentLatexFile(processed.path);
+          return { files: [processed.path], mappings: [processed] };
+        }
+
+        this.logger.debug(
+          `No processed file was generated from ${outputFile}`,
+          groupId,
+        );
+        return { files: [], mappings: [] };
+      } catch (err) {
+        this.logger.debug(
+          `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
+          groupId,
+          MESSAGE_TYPES.INTERNAL,
+        );
+        return { files: [], mappings: [] };
+      }
+    }
+  }
+}
+
+export type { NamedOutputFile } from './types';

--- a/src/agent/output/index.ts
+++ b/src/agent/output/index.ts
@@ -1,4 +1,5 @@
 export * from './OutputHandler';
 export * from './IOutputHandler';
+export * from './OutputProcessor';
 export { NamedOutputFile } from './types';
 export { getOutputFileName } from '@agent/utils/outputFileUtils';


### PR DESCRIPTION
## Summary
- add new `OutputProcessor` class to split XML and format TeX outputs
- use `OutputProcessor` from `OutputHandler`
- expose processor through `IOutputHandler` interface
- update exports for output module

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack compiled with a warning but tests couldn't run)*

------
https://chatgpt.com/codex/tasks/task_e_68855473f43c83249cce91f52b42b258