### PR TITLE
Add tool-use agent integration

### DIFF
--- a/resources/tool_use_agents/file_edit.yaml
+++ b/resources/tool_use_agents/file_edit.yaml
@@ -7,6 +7,6 @@ prompts:
   systemPrompt: |
     You edit files using the provided text_editor tool.
   userPrefix: |
-    The target file is {{FILE}}.
+    The target file is {{ INPUT_FILE }}.
   userRequest: |
-    {{INSTRUCTION}}
+    {{ INSTRUCTION }}

--- a/resources/tool_use_agents/file_edit.yaml
+++ b/resources/tool_use_agents/file_edit.yaml
@@ -1,0 +1,12 @@
+name: file_edit
+settings:
+  agentType: toolUse
+  tools:
+    - text_editor
+prompts:
+  systemPrompt: |
+    You edit files using the provided text_editor tool.
+  userPrefix: |
+    The target file is {{FILE}}.
+  userRequest: |
+    {{INSTRUCTION}}

--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -67,10 +67,20 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
 
       const items: FileItem[] = [];
       const builtInPath = await agentDirectories.builtIn(this.context);
+      const builtInToolUsePath = await agentDirectories.builtInToolUse(
+        this.context,
+      );
       items.push(
         new FileItem(
           'Built-in Agents',
           vscode.Uri.file(builtInPath),
+          vscode.TreeItemCollapsibleState.Collapsed,
+        ),
+      );
+      items.push(
+        new FileItem(
+          'Tool Use Agents',
+          vscode.Uri.file(builtInToolUsePath),
           vscode.TreeItemCollapsibleState.Collapsed,
         ),
       );

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -13,6 +13,7 @@ export const ToolConfigSchema = z
     autoExtractFigure: z.boolean().default(false),
     autoExtractTikzFigure: z.boolean().default(false),
     attachTeXCount: z.boolean().default(false),
+    attachDiagnostics: z.boolean().default(false),
     printInputPrompt: z.boolean().default(false),
     autoCompileInputPdf: z.boolean().default(false),
   })

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -170,7 +170,7 @@ export abstract class BaseAgent implements IAgent {
   protected endRunGroup(status: 'stopped' | 'error' = 'stopped'): void {
     if (this.runGroupId) {
       this.logger.endGroup(this.runGroupId, status);
-      this.runGroupId = null;
+      this.runGroupId = undefined;
     }
   }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -711,6 +711,13 @@ export abstract class ModelHandler<U = any, R = any>
   ): string | null;
 
   /**
+   * Extracts tool-use information from provider responses.
+   * @param responseObject The raw response object from the model
+   * @returns JSON string with tool call details or null if not present
+   */
+  abstract extractToolUse(responseObject: any): string | null;
+
+  /**
    * Creates a log group for model operations with the given name.
    * @param name Name of the operation group
    * @param parentGroupId Optional parent group ID

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -76,6 +76,7 @@ export abstract class ModelHandler<U = any, R = any>
         autoExtractTikzFigure: false,
         reflect: false,
         attachTeXCount: false,
+        attachDiagnostics: false,
         printInputPrompt: false,
         autoCompileInputPdf: false,
       },

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -953,4 +953,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Return content of the first regular thinking block for logging
     return regularThinkingContent;
   }
+
+  extractToolUse(responseObject: BetaMessage): string | null {
+    const content = responseObject?.content;
+    if (Array.isArray(content)) {
+      const tu = content.find((c: any) => c.type === 'tool_use');
+      if (tu) {
+        return JSON.stringify(tu, null, 2);
+      }
+    }
+    return null;
+  }
 }

--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -42,6 +42,10 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     return null;
   }
 
+  extractToolUse(_responseObject: any): string | null {
+    return null;
+  }
+
   /**
    * Preprocess messages array for DashScope Qwen models
    * Ensures compatibility with Qwen API format requirements

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -124,6 +124,10 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     return reasoningContent;
   }
 
+  extractToolUse(_responseObject: any): string | null {
+    return null;
+  }
+
   /**
    * Preprocess messages array to ensure there are no consecutive user or assistant messages
    * and that content is in string format for DeepSeek models

--- a/src/agent/modelHandlers/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogle.ts
@@ -94,4 +94,8 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
   ): boolean {
     return !hasEndTag(agentSetting, newResponse);
   }
+
+  extractToolUse(_responseObject: any): string | null {
+    return null;
+  }
 }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -937,5 +937,17 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return thoughtContent || null;
   }
 
+  extractToolUse(responseObject: GenerateContentResponse): string | null {
+    const candidate = responseObject?.candidates?.[0];
+    const parts = candidate?.content?.parts;
+    if (Array.isArray(parts)) {
+      const funcPart = parts.find((p: any) => p.functionCall);
+      if (funcPart) {
+        return JSON.stringify(funcPart.functionCall, null, 2);
+      }
+    }
+    return null;
+  }
+
   // Assuming containCutOffMessage is available from base class ModelHandler
 }

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -96,6 +96,10 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     return reasoningContent;
   }
 
+  extractToolUse(_responseObject: any): string | null {
+    return null;
+  }
+
   /**
    * Preprocess messages array for Moonshot Kimi models
    * Ensures compatibility with Kimi API format requirements

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -843,6 +843,18 @@ export class ModelHandlerOpenAI extends ModelHandler<
     return null;
   }
 
+  extractToolUse(responseObject: any): string | null {
+    const toolCalls = responseObject?.choices?.[0]?.message?.tool_calls;
+    if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+      return JSON.stringify(toolCalls[0], null, 2);
+    }
+    const func = responseObject?.choices?.[0]?.message?.function_call;
+    if (func) {
+      return JSON.stringify(func, null, 2);
+    }
+    return null;
+  }
+
   /**
    * Calculates the approximate number of tokens for a given set of messages and system prompt
    * using gpt-tokenizer. This is an estimation and might not perfectly match OpenAI's

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -447,4 +447,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
 
     return thoughtContent || null;
   }
+
+  extractToolUse(_response: Response): string | null {
+    return null;
+  }
 }

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -88,6 +88,10 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
     return reasoningContent;
   }
 
+  extractToolUse(_responseObject: any): string | null {
+    return null;
+  }
+
   /** Extracts response text and usage statistics from API response. */
   extractResponse(
     responseObject: any,

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -157,4 +157,7 @@ export interface IModelHandler<U = any, R = any> {
     groupId?: string,
     toolState?: ToolState,
   ): string | null;
+
+  /** Extract tool-use details from a provider response. */
+  extractToolUse(responseObject: any): string | null;
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -23,6 +23,7 @@ import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ModelFactory } from '@agent/runtime/ModelFactory';
 
 import { DirectAgent, CoTAgent, MergeAgent } from '@agent/implementations';
+import { ToolUseAgent } from '@agent/toolUse';
 
 import { AgentLogger } from '@logger/AgentLogger';
 
@@ -122,6 +123,7 @@ function getAgentClass(settings: AgentSetting): AgentConstructor {
   const agentTypeMapping: Record<string, AgentConstructor> = {
     direct: DirectAgent,
     CoT: CoTAgent,
+    toolUse: ToolUseAgent,
   };
   return agentTypeMapping[settings.agentType] || DirectAgent;
 }

--- a/src/agent/toolUse/ToolUseAgent.ts
+++ b/src/agent/toolUse/ToolUseAgent.ts
@@ -1,0 +1,129 @@
+// Agent implementation for one-shot tool use conversations
+
+// Standard library imports
+import { encode as encodeHtml } from 'he';
+
+// Local imports - core
+import { BaseAgent } from '../implementations/BaseAgent';
+import type { AgentConfig } from '../core/AgentConfig';
+import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
+import { getSystemPromptWithRules } from '../utils/promptHelpers';
+import { renderPrompt } from '../utils/promptUtils';
+import type { IModelHandler } from '../modelHandlers';
+import type { ToolDefinition } from '@model';
+import { WorkspaceFS } from '@utils/files';
+import xmlUtils from '@utils/text/xmlUtils';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+export class ToolUseAgent extends BaseAgent {
+  constructor(
+    modelHandler: IModelHandler,
+    agentConfig: AgentConfig,
+    agentSetting: AgentSetting,
+    agentPrompt: AgentPrompt,
+    agentPath: string,
+  ) {
+    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
+  }
+
+  private getTools(): ToolDefinition[] {
+    let tools: ToolDefinition[] = [];
+    const cfg = this.agentSetting.tools;
+    if (Array.isArray(cfg) && cfg.length > 0) {
+      if (typeof cfg[0] === 'string') {
+        tools = (cfg as unknown as string[]).map((n) => ({ name: n }));
+      } else {
+        tools = cfg as ToolDefinition[];
+      }
+    }
+    if (this.agentConfig.toolConfig.attachDiagnostics) {
+      if (!tools.some((t) => t.name === 'diagnostics')) {
+        tools.push({ name: 'diagnostics' });
+      }
+    }
+    return tools;
+  }
+
+  private extractToolUse(response: any): string | null {
+    if (response?.content && Array.isArray(response.content)) {
+      const tu = response.content.find((c: any) => c.type === 'tool_use');
+      if (tu) {
+        return encodeHtml(JSON.stringify(tu, null, 2));
+      }
+    }
+    const openai = response?.choices?.[0]?.message?.tool_calls?.[0];
+    if (openai) {
+      return encodeHtml(JSON.stringify(openai, null, 2));
+    }
+    return null;
+  }
+
+  public async run(): Promise<void> {
+    await this.startRunGroup();
+    try {
+      await this.init(this.runGroupId);
+      await this.initializeClient();
+
+      const [systemPrompt, userRequest, userPrefix] = await Promise.all([
+        getSystemPromptWithRules(this.agentPrompt.systemPrompt, this.userVars),
+        renderPrompt(this.agentPrompt.userRequest, this.userVars),
+        renderPrompt(this.agentPrompt.userPrefix, this.userVars),
+      ]);
+
+      const messages = await this.modelHandler.initializeMessages(
+        userPrefix,
+        userRequest,
+        undefined,
+        systemPrompt,
+      );
+
+      const response = await this.modelHandler.createResponse(
+        this.client,
+        messages,
+        this.agentSetting.temperature ?? 0,
+        undefined,
+        this.agentSetting.endTag,
+        undefined,
+        this.getTools(),
+      );
+
+      const thinking = this.modelHandler.processThinkingBlock(
+        response,
+        this.runGroupId,
+      );
+      if (thinking) {
+        const formatted = await xmlUtils.formatContent(thinking);
+        this.logger.info(formatted, this.runGroupId, MESSAGE_TYPES.THINKING);
+      }
+
+      const toolInfo = this.extractToolUse(response);
+      if (toolInfo) {
+        this.logger.info(toolInfo, this.runGroupId, MESSAGE_TYPES.TOOL_USE);
+      }
+
+      const [text, usage] = this.modelHandler.extractResponse(
+        response,
+        this.agentSetting.endTag,
+      );
+      if (text) {
+        this.logger.debug(
+          `Model response: ${text.slice(0, 100)}`,
+          this.runGroupId,
+        );
+        await WorkspaceFS.writeFile(
+          this.agentConfig.inputFile + '.tool.txt',
+          text,
+        );
+      }
+      if (usage) {
+        this.logger.statistics(usage, this.runGroupId);
+      }
+      this.endRunGroup('stopped');
+    } catch (err) {
+      this.endRunGroup('error');
+      throw err;
+    } finally {
+      this.cleanup();
+    }
+  }
+}

--- a/src/agent/toolUse/ToolUseAgent.ts
+++ b/src/agent/toolUse/ToolUseAgent.ts
@@ -2,7 +2,6 @@
 
 // Standard library imports
 import { encode as encodeHtml } from 'he';
-
 // Local imports - core
 import { BaseAgent } from '../implementations/BaseAgent';
 import type { AgentConfig } from '../core/AgentConfig';
@@ -11,7 +10,6 @@ import { getSystemPromptWithRules } from '../utils/promptHelpers';
 import { renderPrompt } from '../utils/promptUtils';
 import type { IModelHandler } from '../modelHandlers';
 import type { ToolDefinition } from '@model';
-import { WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
@@ -27,35 +25,25 @@ export class ToolUseAgent extends BaseAgent {
   }
 
   private getTools(): ToolDefinition[] {
-    let tools: ToolDefinition[] = [];
     const cfg = this.agentSetting.tools;
+    let tools: ToolDefinition[] = [];
+
     if (Array.isArray(cfg) && cfg.length > 0) {
-      if (typeof cfg[0] === 'string') {
-        tools = (cfg as unknown as string[]).map((n) => ({ name: n }));
+      if (cfg.every((t) => typeof t === 'string')) {
+        tools = (cfg as string[]).map((name) => ({ name }));
       } else {
         tools = cfg as ToolDefinition[];
       }
     }
-    if (this.agentConfig.toolConfig.attachDiagnostics) {
-      if (!tools.some((t) => t.name === 'diagnostics')) {
-        tools.push({ name: 'diagnostics' });
-      }
-    }
-    return tools;
-  }
 
-  private extractToolUse(response: any): string | null {
-    if (response?.content && Array.isArray(response.content)) {
-      const tu = response.content.find((c: any) => c.type === 'tool_use');
-      if (tu) {
-        return encodeHtml(JSON.stringify(tu, null, 2));
-      }
+    if (
+      this.agentConfig.toolConfig.attachDiagnostics &&
+      !tools.some((t) => t.name === 'diagnostics')
+    ) {
+      tools.push({ name: 'diagnostics' });
     }
-    const openai = response?.choices?.[0]?.message?.tool_calls?.[0];
-    if (openai) {
-      return encodeHtml(JSON.stringify(openai, null, 2));
-    }
-    return null;
+
+    return tools;
   }
 
   public async run(): Promise<void> {
@@ -96,9 +84,13 @@ export class ToolUseAgent extends BaseAgent {
         this.logger.info(formatted, this.runGroupId, MESSAGE_TYPES.THINKING);
       }
 
-      const toolInfo = this.extractToolUse(response);
+      const toolInfo = this.modelHandler.extractToolUse(response);
       if (toolInfo) {
-        this.logger.info(toolInfo, this.runGroupId, MESSAGE_TYPES.TOOL_USE);
+        this.logger.info(
+          encodeHtml(toolInfo),
+          this.runGroupId,
+          MESSAGE_TYPES.TOOL_USE,
+        );
       }
 
       const [text, usage] = this.modelHandler.extractResponse(
@@ -109,10 +101,6 @@ export class ToolUseAgent extends BaseAgent {
         this.logger.debug(
           `Model response: ${text.slice(0, 100)}`,
           this.runGroupId,
-        );
-        await WorkspaceFS.writeFile(
-          this.agentConfig.inputFile + '.tool.txt',
-          text,
         );
       }
       if (usage) {

--- a/src/agent/toolUse/index.ts
+++ b/src/agent/toolUse/index.ts
@@ -8,10 +8,11 @@
 // Local imports - agents
 import { ValidationFixAgent } from './ValidationFixAgent';
 import { BaseToolUseAgent } from './BaseToolUseAgent';
+import { ToolUseAgent } from './ToolUseAgent';
 import type { IToolUseAgent } from './IToolUseAgent';
 
 // Export individual classes
-export { ValidationFixAgent, BaseToolUseAgent };
+export { ValidationFixAgent, BaseToolUseAgent, ToolUseAgent };
 export type { IToolUseAgent };
 
 // Export shared tool implementations and types

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -47,6 +47,7 @@ logger.initialize(CHANNEL);
 
 export class ExplorerOperations {
   private builtInAgentsPath = '';
+  private builtInToolUsePath = '';
   private editingItem: FileItem | undefined;
 
   constructor(
@@ -58,13 +59,19 @@ export class ExplorerOperations {
       agentDirectories.builtIn(this.context).then((p) => {
         this.builtInAgentsPath = p;
       });
+      agentDirectories.builtInToolUse(this.context).then((p) => {
+        this.builtInToolUsePath = p;
+      });
     }
   }
 
   async open(uri: vscode.Uri) {
     try {
       const isBuiltIn =
-        this.builtInAgentsPath && uri.fsPath.startsWith(this.builtInAgentsPath);
+        (this.builtInAgentsPath &&
+          uri.fsPath.startsWith(this.builtInAgentsPath)) ||
+        (this.builtInToolUsePath &&
+          uri.fsPath.startsWith(this.builtInToolUsePath));
 
       const document = await vscode.workspace.openTextDocument(uri);
       await vscode.window.showTextDocument(document);
@@ -96,7 +103,10 @@ export class ExplorerOperations {
         return;
       }
 
-      const relativePath = path.relative(this.builtInAgentsPath, uri.fsPath);
+      const base = uri.fsPath.startsWith(this.builtInToolUsePath)
+        ? this.builtInToolUsePath
+        : this.builtInAgentsPath;
+      const relativePath = path.relative(base, uri.fsPath);
       const targetPath = path.join(customPath, relativePath);
 
       const targetDir = path.dirname(targetPath);
@@ -126,8 +136,14 @@ export class ExplorerOperations {
 
       let parentPath = node?.resourceUri.fsPath || customBase;
 
-      if (parentPath.startsWith(this.builtInAgentsPath)) {
-        const relative = path.relative(this.builtInAgentsPath, parentPath);
+      if (
+        parentPath.startsWith(this.builtInAgentsPath) ||
+        parentPath.startsWith(this.builtInToolUsePath)
+      ) {
+        const base = parentPath.startsWith(this.builtInToolUsePath)
+          ? this.builtInToolUsePath
+          : this.builtInAgentsPath;
+        const relative = path.relative(base, parentPath);
         parentPath = path.join(customBase, relative);
       }
 

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -42,9 +42,12 @@ export class WatcherManager {
       this.dispose();
 
       const builtInAgentsPath = await agentDirectories.builtIn(this.context);
+      const builtInToolUsePath = await agentDirectories.builtInToolUse(
+        this.context,
+      );
       const customAgentsPath = await agentDirectories.custom();
 
-      const pathsToWatch = [builtInAgentsPath];
+      const pathsToWatch = [builtInAgentsPath, builtInToolUsePath];
       if (customAgentsPath) {
         pathsToWatch.push(customAgentsPath);
       }

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -25,6 +25,20 @@ export class AgentDirectoryManager {
     return basePath;
   }
 
+  async builtInToolUse(context: vscode.ExtensionContext): Promise<string> {
+    if (!context) {
+      throw new Error('Extension context required for built-in agents');
+    }
+
+    StorageFS.initialize(context);
+    await GlobalStorageFS.ensureDir('tool_use_agents');
+
+    const basePath = GlobalStorageFS.fullPath('tool_use_agents');
+    logger.debug(CHANNEL, `Using built-in tool-use directory: ${basePath}`);
+
+    return basePath;
+  }
+
   async custom(): Promise<string> {
     const customPath = getConfig<string>('explorer.agentsDirectory', '');
 

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -35,6 +35,11 @@ export async function copyDefaultAgents(context: vscode.ExtensionContext) {
   );
 
   const resourcesPath = path.join(context.extensionPath, 'resources', 'agents');
+  const resourcesToolUse = path.join(
+    context.extensionPath,
+    'resources',
+    'tool_use_agents',
+  );
   const globalStoragePath = GlobalStorageFS.fullPath('agents');
 
   console.log('Resources path:', resourcesPath);
@@ -43,6 +48,7 @@ export async function copyDefaultAgents(context: vscode.ExtensionContext) {
   try {
     // Ensure the global storage agents directory exists
     await GlobalStorageFS.ensureDir('agents');
+    await GlobalStorageFS.ensureDir('tool_use_agents');
     console.log('Created or verified global storage directory');
 
     // Recursive function to copy files and directories
@@ -69,6 +75,7 @@ export async function copyDefaultAgents(context: vscode.ExtensionContext) {
 
     // Start recursive copy from root
     await copyRecursively(resourcesPath, 'agents');
+    await copyRecursively(resourcesToolUse, 'tool_use_agents');
 
     // Update the stored version after successful copy
     await globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, currentVersion);

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -43,6 +43,7 @@ export interface LogMessageData {
     | 'missingOutputs'
     | 'latexdiff'
     | 'statistics'
+    | 'toolUse'
     | 'internal';
   /** Whether verbose details should be displayed */
   verbose?: boolean;

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -5,6 +5,7 @@ export const MESSAGE_TYPES = {
   MISSING_OUTPUTS: 'missingOutputs',
   LATEXDIFF: 'latexdiff',
   STATISTICS: 'statistics',
+  TOOL_USE: 'toolUse',
   /** Messages that should be hidden from the progress view */
   INTERNAL: 'internal',
   DEFAULT: 'default',

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -174,6 +174,10 @@ export class LogEntryFormatter {
       return this._formatSpecialContent(htmlMessage, text, label, id);
     }
 
+    if (messageType === 'toolUse') {
+      return this._formatToolUse(htmlMessage, text, id);
+    }
+
     if (messageType === 'fileList') {
       return this._formatFileList(htmlMessage, text, data, id);
     }
@@ -227,6 +231,25 @@ export class LogEntryFormatter {
     } catch (e) {
       console.error('Error parsing markdown:', e);
       // Fallback to original content
+      return message;
+    }
+  }
+
+  _formatToolUse(message, content, logId) {
+    try {
+      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      content = decodeHtml(content);
+      const parsedMarkdown = this.md.render(content);
+      return `<details class="special-details">
+        <summary class="details-summary">
+          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
+          <i class="codicon codicon-wrench"></i>
+          <span>Tool Use</span>
+        </summary>
+        <div class="special-content"${idAttr}>${parsedMarkdown}</div>
+      </details>`;
+    } catch (e) {
+      console.error('Error parsing tool use content:', e);
       return message;
     }
   }

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -73,6 +73,7 @@ describe('OutputHandler.finalizeRound', () => {
       autoExtractFigure: false,
       autoExtractTikzFigure: false,
       attachTeXCount: false,
+      attachDiagnostics: false,
       printInputPrompt: false,
       autoCompileInputPdf: false,
     },

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { getConfig } from '@utils/config';
+import { GlobalStorageFS, AbsoluteFS } from '@utils/files';
+import * as path from 'path';
 import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
 
 export class MainViewContentProvider extends BaseViewContentProvider {
@@ -91,7 +93,18 @@ export class MainViewContentProvider extends BaseViewContentProvider {
 
   protected getTemplateVariables(): Record<string, any> {
     const agents = getConfig<string[]>('agents', []);
-    const agentOptions = agents
+    const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
+    let extraAgents: string[] = [];
+    try {
+      const files = AbsoluteFS.readDirSync(toolUseDir);
+      extraAgents = files
+        .filter((f) => f.endsWith('.yaml'))
+        .map((f) => path.basename(f, '.yaml'));
+    } catch {
+      extraAgents = [];
+    }
+    const allAgents = [...agents, ...extraAgents];
+    const agentOptions = allAgents
       .map((agent) => `<option value="${agent}">${agent}</option>`)
       .join('\n');
 

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -384,6 +384,11 @@
                     Count</label
                   >
                   <label class="vscode-checkbox"
+                    ><input type="checkbox" id="attachDiagnostics" />
+                    <i class="codicon codicon-tools"></i> Attach
+                    Diagnostics</label
+                  >
+                  <label class="vscode-checkbox"
                     ><input type="checkbox" id="usePrefillFromInput" />
                     <i class="codicon codicon-edit"></i> Use Prefill from
                     Input</label

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -33,6 +33,7 @@ export class ExecutionManager {
       autoExtractTikzFigure: message.autoExtractTikzFigure,
       reflect: message.reflect,
       attachTeXCount: message.attachTeXCount,
+      attachDiagnostics: message.attachDiagnostics,
       usePrefillFromInput: message.usePrefillFromInput,
       printInputPrompt: message.printInputPrompt,
       autoCompileInputPdf: message.autoCompileInputPdf,

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -38,6 +38,7 @@ export const CHECK_BOXES_AUTO_EXTRACT = [
 // Tool configuration checkboxes
 export const CHECK_BOXES_TOOL_USE = [
   'attachTeXCount',
+  'attachDiagnostics',
   'usePrefillFromInput',
   'printInputPrompt',
   'reflect',

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -251,6 +251,8 @@ export class MainViewMessageHandler {
         false,
       attachTeXCount:
         state.attachTeXCount ?? toolConfig.attachTeXCount ?? false,
+      attachDiagnostics:
+        state.attachDiagnostics ?? toolConfig.attachDiagnostics ?? false,
       usePrefillFromInput:
         state.usePrefillFromInput ?? toolConfig.usePrefillFromInput ?? false,
       printInputPrompt:


### PR DESCRIPTION
## Summary
- add `toolUse` message type
- render tool-use logs in progress view
- include attachDiagnostics flag in ToolConfig
- implement `ToolUseAgent` for one-shot tool usage
- export new agent and wire into execution runtime
- copy and watch tool use agents
- expose attachDiagnostics option in the webview
- add sample `file_edit` tool-use agent

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68855f01cd548324863d57c393f2a9e9