### PR TITLE
fix: restore file list button handlers

### DIFF
--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -142,11 +142,11 @@ export class FileList {
           file.path,
         );
 
-        // Update existing buttons based on file state
-        this.updateFileButtons(clone, file, effectiveBase);
-
-        // Replace any icon placeholders inside the clone
+        // Replace any icon placeholders before attaching handlers
         initializeIconButtons(clone);
+
+        // Update buttons with click handlers
+        this.updateFileButtons(clone, file, effectiveBase);
 
         roundGroup.appendChild(clone);
       });


### PR DESCRIPTION
## Summary
- initialize icon buttons before attaching event handlers

## Testing
- `npm run lint`
- `npm test` *(fails: BaseAgent.ts(182,7): error TS2322)*

------
https://chatgpt.com/codex/tasks/task_e_68875ff4f6788324a68c8ee70becc21c