### PR TITLE
Fix stream tab delete icon

### DIFF
--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -1,6 +1,7 @@
 // Local imports
 import { ELEMENT_IDS } from '../constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
+import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 
 const AGENT_ICONS = {
   CoT: 'terminal',
@@ -50,6 +51,7 @@ export class StreamTabs {
         },
       });
       if (!tabEl) return;
+      initializeIconButtons(tabEl);
       const agentIcon = tabEl.querySelector('.agent-type');
       if (agentIcon) {
         const key = info.agentType || info.agent || 'unknown';


### PR DESCRIPTION
## Summary
- initialize delete button icons for stream tabs

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: attempts to run VS Code tests without downloaded editor)*

------
https://chatgpt.com/codex/tasks/task_e_68879b5de6cc832487096d2ab01c2767