### PR TITLE
Enable iterative tool use

### DIFF
--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -164,6 +164,11 @@ Tools live under `src/tools/` and each one defines its input schema with Zod.
 Your YAML can reference individual tools or predefined sets. Sets are expanded
 when the agent configuration is loaded.
 
+The built-in `ToolSetRegistry` maps aliases to lists of tool definitions. For
+instance, the `file_edit` set expands to `{ name: 'text_editor' }`. Nested sets
+are resolved recursively, and any unknown names trigger a warning during agent
+loading.
+
 Example:
 
 ```yaml
@@ -172,6 +177,7 @@ settings:
   tools:
     - file_edit # expands to the text_editor tool
     - bash # single tool by name
+    - basic_io # adds bash and file_op tools
 ```
 
 The ProgressBoard shows the JSON passed to each tool along with the tool's

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -118,7 +118,10 @@ export async function runToolUseCycle(
     const id = parsed.id || parsed.tool_use_id || parsed.tool_call_id;
     const name = parsed.name || parsed.function?.name;
     if (!id || !name) {
-      logger.error('Tool JSON missing id or name', groupId);
+      logger.error(
+        `Tool JSON missing id or name: id=${String(id)} name=${String(name)}`,
+        groupId,
+      );
       break;
     }
     let input = parsed.input;
@@ -139,7 +142,10 @@ export async function runToolUseCycle(
         result = await tool.call(input);
       } catch (err) {
         result = new ToolResult({
-          error: err instanceof Error ? err.message : String(err),
+          error:
+            err instanceof Error
+              ? `${name}: ${err.message}`
+              : `${name}: ${String(err)}`,
           isError: true,
         });
       }

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -2,7 +2,6 @@
 
 // Third-party imports
 import { encode as encodeHtml } from 'he';
-import { createPartFromFunctionResponse } from '@google/genai';
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
@@ -17,14 +16,23 @@ import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
 
 export interface ToolUseCycleOptions {
+  /** Model handler for API interactions */
   modelHandler: IModelHandler;
+  /** Agent settings with tool configuration */
   agentSetting: AgentSetting;
+  /** Prompt configuration for the agent */
   agentPrompt: AgentPrompt;
+  /** User variables resolved from YAML */
   userVars: Record<string, any>;
+  /** Logger instance for progress output */
   logger: AgentLogger;
+  /** Provider client object */
   client: any;
+  /** Registry mapping tool names to implementations */
   toolRegistry: Record<string, BaseTool<any>>;
+  /** Check if the agent run has been interrupted */
   checkInterruption: () => Promise<boolean> | boolean;
+  /** Pass abort controllers back to the agent */
   setAbortController: (ctrl: AbortController | null) => void;
 }
 
@@ -109,6 +117,10 @@ export async function runToolUseCycle(
 
     const id = parsed.id || parsed.tool_use_id || parsed.tool_call_id;
     const name = parsed.name || parsed.function?.name;
+    if (!id || !name) {
+      logger.error('Tool JSON missing id or name', groupId);
+      break;
+    }
     let input = parsed.input;
     if (!input && parsed.function?.arguments) {
       try {
@@ -147,28 +159,7 @@ export async function runToolUseCycle(
       resultObj.base64Image = result.base64Image;
     if (result.system !== undefined) resultObj.system = result.system;
 
-    if (modelHandler.isAnthropic) {
-      messages.push({
-        role: 'user',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: id,
-            content: JSON.stringify(resultObj),
-          },
-        ],
-      });
-    } else if (modelHandler.isOpenaiCompatible) {
-      messages.push({
-        role: 'tool',
-        tool_call_id: id,
-        content: JSON.stringify(resultObj),
-      });
-    } else if (modelHandler.isGoogle) {
-      const part = createPartFromFunctionResponse(id, name, resultObj);
-      messages.push({ role: 'user', parts: [part] });
-    } else {
-      messages.push({ role: 'user', content: JSON.stringify(resultObj) });
-    }
+    const followUp = modelHandler.createFollowUpMessage(id, name, resultObj);
+    messages.push(followUp);
   }
 }

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -1,0 +1,174 @@
+// Utility to run iterative tool-use cycles
+
+// Third-party imports
+import { encode as encodeHtml } from 'he';
+import { createPartFromFunctionResponse } from '@google/genai';
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+// Local imports - agent components
+import type { AgentSetting, AgentPrompt } from './AgentDataclass';
+import type { ToolDefinition } from '@model';
+import type { IModelHandler } from '../modelHandlers';
+import { BaseTool } from '@tools/core/base';
+import { ToolResult } from '@tools/result';
+import xmlUtils from '@utils/text/xmlUtils';
+
+export interface ToolUseCycleOptions {
+  modelHandler: IModelHandler;
+  agentSetting: AgentSetting;
+  agentPrompt: AgentPrompt;
+  userVars: Record<string, any>;
+  logger: AgentLogger;
+  client: any;
+  toolRegistry: Record<string, BaseTool<any>>;
+  checkInterruption: () => Promise<boolean> | boolean;
+  setAbortController: (ctrl: AbortController | null) => void;
+}
+
+/**
+ * Execute a tool-use interaction loop until the model returns no tool calls or
+ * signals end of turn.
+ */
+export async function runToolUseCycle(
+  options: ToolUseCycleOptions,
+  messages: any[],
+  groupId?: string,
+): Promise<void> {
+  const {
+    modelHandler,
+    agentSetting,
+    logger,
+    client,
+    toolRegistry,
+    checkInterruption,
+    setAbortController,
+  } = options;
+
+  while (true) {
+    if (await checkInterruption()) {
+      break;
+    }
+
+    const abortController = new AbortController();
+    setAbortController(abortController);
+    let response: any;
+    try {
+      response = await modelHandler.createResponse(
+        client,
+        messages,
+        agentSetting.temperature ?? 0,
+        undefined,
+        agentSetting.endTag,
+        abortController.signal,
+        agentSetting.tools as ToolDefinition[],
+      );
+    } finally {
+      setAbortController(null);
+    }
+    if (!response) {
+      break;
+    }
+
+    const thinking = modelHandler.processThinkingBlock(response, groupId);
+    if (thinking) {
+      const formatted = await xmlUtils.formatContent(thinking);
+      logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
+    }
+
+    const toolInfo = modelHandler.extractToolUse(response);
+    const [text, usage, stopReason] = modelHandler.extractResponse(
+      response,
+      agentSetting.endTag,
+    );
+    if (text) {
+      logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
+    }
+    if (usage) {
+      logger.statistics(usage, groupId);
+    }
+
+    if (!toolInfo || stopReason === 'end_turn') {
+      break;
+    }
+
+    logger.info(encodeHtml(toolInfo), groupId, MESSAGE_TYPES.TOOL_USE);
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(toolInfo);
+    } catch (err) {
+      logger.error(
+        `Malformed tool JSON: ${err instanceof Error ? err.message : String(err)}`,
+        groupId,
+      );
+      break;
+    }
+
+    const id = parsed.id || parsed.tool_use_id || parsed.tool_call_id;
+    const name = parsed.name || parsed.function?.name;
+    let input = parsed.input;
+    if (!input && parsed.function?.arguments) {
+      try {
+        input = JSON.parse(parsed.function.arguments);
+      } catch {
+        input = parsed.function.arguments;
+      }
+    }
+
+    const tool = toolRegistry[name];
+    let result: ToolResult;
+    if (!tool) {
+      result = new ToolResult({ error: `Unknown tool ${name}`, isError: true });
+    } else {
+      try {
+        result = await tool.call(input);
+      } catch (err) {
+        result = new ToolResult({
+          error: err instanceof Error ? err.message : String(err),
+          isError: true,
+        });
+      }
+    }
+
+    logger.info(
+      encodeHtml(JSON.stringify(result, null, 2)),
+      groupId,
+      MESSAGE_TYPES.TOOL_USE,
+    );
+
+    // Build provider-specific message containing the tool result
+    const resultObj: Record<string, unknown> = {};
+    if (result.output !== undefined) resultObj.output = result.output;
+    if (result.error !== undefined) resultObj.error = result.error;
+    if (result.base64Image !== undefined)
+      resultObj.base64Image = result.base64Image;
+    if (result.system !== undefined) resultObj.system = result.system;
+
+    if (modelHandler.isAnthropic) {
+      messages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: id,
+            content: JSON.stringify(resultObj),
+          },
+        ],
+      });
+    } else if (modelHandler.isOpenaiCompatible) {
+      messages.push({
+        role: 'tool',
+        tool_call_id: id,
+        content: JSON.stringify(resultObj),
+      });
+    } else if (modelHandler.isGoogle) {
+      const part = createPartFromFunctionResponse(id, name, resultObj);
+      messages.push({ role: 'user', parts: [part] });
+    } else {
+      messages.push({ role: 'user', content: JSON.stringify(resultObj) });
+    }
+  }
+}

--- a/src/agent/core/index.ts
+++ b/src/agent/core/index.ts
@@ -6,3 +6,4 @@ export * from './ToolState';
 export * from './ResponseUsage';
 export * from './IAgent';
 export * from './ResponseCycle';
+export * from './ToolUseCycle';

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -1,7 +1,6 @@
 // Base class for tool-use agents
 
 // Standard library imports
-import { encode as encodeHtml } from 'he';
 
 // Local imports - core
 import { BaseAgent } from './BaseAgent';
@@ -11,11 +10,11 @@ import { getSystemPromptWithRules } from '../utils/promptHelpers';
 import { renderPrompt } from '../utils/promptUtils';
 import type { IModelHandler } from '../modelHandlers';
 import type { ToolDefinition } from '@model';
-import xmlUtils from '@utils/text/xmlUtils';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
+
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
+import { runToolUseCycle } from '../core/ToolUseCycle';
 import { TOOL_USE_INSTRUCTIONS } from '../utils/toolUsePrompt';
 
 export class BaseToolUseAgent extends BaseAgent {
@@ -86,72 +85,23 @@ export class BaseToolUseAgent extends BaseAgent {
         systemPrompt,
       );
 
-      const response = await this.modelHandler.createResponse(
-        this.client,
+      await runToolUseCycle(
+        {
+          modelHandler: this.modelHandler,
+          agentSetting: this.agentSetting,
+          agentPrompt: this.agentPrompt,
+          userVars: this.userVars,
+          logger: this.logger,
+          client: this.client,
+          toolRegistry: this.toolRegistry,
+          checkInterruption: () => this.checkInterruption(),
+          setAbortController: (ctrl) => {
+            this.abortController = ctrl;
+          },
+        },
         messages,
-        this.agentSetting.temperature ?? 0,
-        undefined,
-        this.agentSetting.endTag,
-        undefined,
-        this.getTools(),
-      );
-
-      const thinking = this.modelHandler.processThinkingBlock(
-        response,
         this.runGroupId,
       );
-      if (thinking) {
-        const formatted = await xmlUtils.formatContent(thinking);
-        this.logger.info(formatted, this.runGroupId, MESSAGE_TYPES.THINKING);
-      }
-
-      const toolInfo = this.modelHandler.extractToolUse(response);
-      if (toolInfo) {
-        this.logger.info(
-          encodeHtml(toolInfo),
-          this.runGroupId,
-          MESSAGE_TYPES.TOOL_USE,
-        );
-        let parsed: { name: string; input: unknown } | undefined;
-        try {
-          parsed = JSON.parse(toolInfo);
-        } catch (jsonErr) {
-          this.logger.error(
-            `Malformed tool JSON: ${jsonErr instanceof Error ? jsonErr.message : String(jsonErr)}`,
-            this.runGroupId,
-          );
-          parsed = undefined;
-        }
-        if (parsed && parsed.name) {
-          try {
-            const result = await this.runTool(parsed.name, parsed.input);
-            this.logger.info(
-              encodeHtml(JSON.stringify(result, null, 2)),
-              this.runGroupId,
-              MESSAGE_TYPES.TOOL_USE,
-            );
-          } catch (err) {
-            this.logger.error(
-              `Failed to execute tool: ${err instanceof Error ? err.message : String(err)}`,
-              this.runGroupId,
-            );
-          }
-        }
-      }
-
-      const [text, usage] = this.modelHandler.extractResponse(
-        response,
-        this.agentSetting.endTag,
-      );
-      if (text) {
-        this.logger.debug(
-          `Model response: ${text.slice(0, 100)}`,
-          this.runGroupId,
-        );
-      }
-      if (usage) {
-        this.logger.statistics(usage, this.runGroupId);
-      }
       this.endRunGroup('stopped');
     } catch (err) {
       this.endRunGroup('error');

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -13,7 +13,6 @@ import type { ToolDefinition } from '@model';
 
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
 import { BaseTool } from '@tools/core/base';
-import { ToolResult } from '@tools/result';
 import { runToolUseCycle } from '../core/ToolUseCycle';
 import { TOOL_USE_INSTRUCTIONS } from '../utils/toolUsePrompt';
 
@@ -43,6 +42,7 @@ export class BaseToolUseAgent extends BaseAgent {
           `Tool "${def.name}" not found in registry`,
           this.runGroupId,
         );
+        continue;
       }
       tools.push(def);
     }
@@ -53,14 +53,6 @@ export class BaseToolUseAgent extends BaseAgent {
       tools.push({ name: 'diagnostics' });
     }
     return tools;
-  }
-
-  private async runTool(name: string, input: any): Promise<ToolResult> {
-    const tool = this.toolRegistry[name];
-    if (!tool) {
-      return new ToolResult({ error: `Unknown tool ${name}`, isError: true });
-    }
-    return tool.call(input);
   }
 
   public async run(): Promise<void> {
@@ -85,10 +77,15 @@ export class BaseToolUseAgent extends BaseAgent {
         systemPrompt,
       );
 
+      const resolvedSetting = {
+        ...this.agentSetting,
+        tools: this.getTools(),
+      };
+
       await runToolUseCycle(
         {
           modelHandler: this.modelHandler,
-          agentSetting: this.agentSetting,
+          agentSetting: resolvedSetting,
           agentPrompt: this.agentPrompt,
           userVars: this.userVars,
           logger: this.logger,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -718,6 +718,15 @@ export abstract class ModelHandler<U = any, R = any>
   abstract extractToolUse(responseObject: any): string | null;
 
   /**
+   * Build a provider-specific follow-up message containing a tool result.
+   */
+  abstract createFollowUpMessage(
+    id: string,
+    name: string,
+    result: Record<string, unknown>,
+  ): any;
+
+  /**
    * Creates a log group for model operations with the given name.
    * @param name Name of the operation group
    * @param parentGroupId Optional parent group ID

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -964,4 +964,21 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
     return null;
   }
+
+  createFollowUpMessage(
+    id: string,
+    _name: string,
+    result: Record<string, unknown>,
+  ): any {
+    return {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: id,
+          content: JSON.stringify(result),
+        },
+      ],
+    };
+  }
 }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -10,6 +10,7 @@ import {
   FinishReason,
   File,
   createPartFromUri,
+  createPartFromFunctionResponse,
   GenerateContentConfig,
   type CreateChatParameters,
   type SendMessageParameters,
@@ -947,6 +948,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       }
     }
     return null;
+  }
+
+  createFollowUpMessage(
+    id: string,
+    name: string,
+    result: Record<string, unknown>,
+  ): any {
+    const part = createPartFromFunctionResponse(id, name, result);
+    return { role: 'user', parts: [part] };
   }
 
   // Assuming containCutOffMessage is available from base class ModelHandler

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -855,6 +855,18 @@ export class ModelHandlerOpenAI extends ModelHandler<
     return null;
   }
 
+  createFollowUpMessage(
+    id: string,
+    _name: string,
+    result: Record<string, unknown>,
+  ): any {
+    return {
+      role: 'tool',
+      tool_call_id: id,
+      content: JSON.stringify(result),
+    };
+  }
+
   /**
    * Calculates the approximate number of tokens for a given set of messages and system prompt
    * using gpt-tokenizer. This is an estimation and might not perfectly match OpenAI's

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -160,4 +160,18 @@ export interface IModelHandler<U = any, R = any> {
 
   /** Extract tool-use details from a provider response. */
   extractToolUse(responseObject: any): string | null;
+
+  /**
+   * Create a provider-specific follow-up message containing the tool result.
+   *
+   * @param id - Tool call identifier from the model response
+   * @param name - Tool name
+   * @param result - Object with output/error fields
+   * @returns Message formatted for the provider API
+   */
+  createFollowUpMessage(
+    id: string,
+    name: string,
+    result: Record<string, unknown>,
+  ): any;
 }

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -9,6 +9,7 @@ export type OpenAIFinishReason =
   | 'stop'
   | 'length'
   | 'tool_calls'
+  | 'tool_use'
   | 'content_filter'
   | 'function_call'
   | null;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -239,14 +239,21 @@ export class LogEntryFormatter {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
       content = decodeHtml(content);
-      const parsedMarkdown = this.md.render(content);
+      let parsed;
+      try {
+        parsed = JSON.parse(content);
+        content = `<pre>${encodeHtml(JSON.stringify(parsed, null, 2))}</pre>`;
+      } catch {
+        const md = this.md.render(content);
+        content = md;
+      }
       return `<details class="special-details">
         <summary class="details-summary">
           <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon codicon-wrench"></i>
           <span>Tool Use</span>
         </summary>
-        <div class="special-content"${idAttr}>${parsedMarkdown}</div>
+        <div class="special-content"${idAttr}>${content}</div>
       </details>`;
     } catch (e) {
       console.error('Error parsing tool use content:', e);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,7 +2,8 @@ import { TextEditorTool } from './TextEditorTool';
 import { DiagnosticsTool } from './DiagnosticsTool';
 import { BashTool } from './bash';
 import { FileOpTool } from './fileOp';
-export const DEFAULT_TOOL_REGISTRY: Record<string, any> = {
+import { BaseTool } from './core/base';
+export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   text_editor: new TextEditorTool(),
   diagnostics: new DiagnosticsTool(),
   bash: new BashTool(),


### PR DESCRIPTION
## Summary
- add `runToolUseCycle` helper for multi-step tool execution
- refactor `BaseToolUseAgent` to use the new cycle
- display tool-use JSON in progress view
- tighten tool registry typing
- document how tool set aliases expand

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(webpack warns, tests run)*

------
https://chatgpt.com/codex/tasks/task_e_6887d8a7165083248e0a44fe5071cd3c