### PR TITLE
Add Wolfram execution tool

### DIFF
--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -162,7 +162,8 @@ userPrefix: |
 
 Tools live under `src/tools/` and each one defines its input schema with Zod.
 Your YAML can reference individual tools or predefined sets. Sets are expanded
-when the agent configuration is loaded.
+when the agent configuration is loaded. The `wolfram_exec` set enables the
+`wolfram` tool for running small Wolfram Language snippets during a run.
 
 Example:
 
@@ -171,6 +172,7 @@ settings:
   agentType: toolUse
   tools:
     - file_edit # expands to the text_editor tool
+    - wolfram_exec # execute Wolfram Language code
     - bash # single tool by name
 ```
 

--- a/docs/guide/tool-integration.md
+++ b/docs/guide/tool-integration.md
@@ -30,6 +30,7 @@ Processing visual elements for analysis and inclusion.
 Providing quantitative insights into your document structure.
 
 - **Statistics:** `texcount` analyzes your document to provide statistics like word counts, heading counts, and math element counts. This information can optionally be included in prompts to give the LLM better context about the document's scale and complexity. See the "Attach TeX Count" option in the UI ([File Management guide](./file-management.md#tool-config-dropdown)) and the `texra.getTeXCount` command.
+- **Symbolic Math:** The `wolfram` tool runs Wolfram Language code through `wolframscript`, letting agents verify calculations or perform algebra before responding.
 
 _(Note: These tools often rely on external programs that need to be installed separately. See the [Installation guide](./installation.md) for requirements.)_
 

--- a/package.json
+++ b/package.json
@@ -975,6 +975,11 @@
         "category": "TeXRA"
       },
       {
+        "command": "texra.testWolframTool",
+        "title": "Test Wolfram Tool",
+        "category": "TeXRA"
+      },
+      {
         "command": "texra.wolframScriptExecute",
         "title": "Execute Wolfram Language Code",
         "category": "TeXRA"

--- a/src/agent/toolUse/ToolSetRegistry.ts
+++ b/src/agent/toolUse/ToolSetRegistry.ts
@@ -4,4 +4,5 @@ export const ToolSets: Record<string, ToolDefinition[]> = {
   file_edit: [{ name: 'text_editor' }],
   diagnostics_only: [{ name: 'diagnostics' }],
   basic_io: [{ name: 'bash' }, { name: 'file_op' }],
+  wolfram_exec: [{ name: 'wolfram' }],
 };

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,6 +22,7 @@ import { registerStateRestoreCommand } from '@commands/history/stateRestoreComma
 import { registerTextEditorCommands } from '@commands/system/textEditorCommands';
 import { registerLinterCommands } from '@commands/latex/linterCommands';
 import { registerWolframScriptCommands } from '@commands/wolfram/wolframScriptCommands';
+import { registerWolframToolCommands } from '@commands/wolfram/wolframToolCommands';
 import { registerHistoryCommands } from '@commands/history/historyCommands';
 import { registerArXivCommands } from '@commands/latex/arXivCommands';
 import { registerCompareCommands } from '@commands/latex/compareCommands';
@@ -61,6 +62,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     stateRestore: registerStateRestoreCommand(context),
     textEditor: registerTextEditorCommands(context),
     linter: registerLinterCommands(context),
+    wolframTool: registerWolframToolCommands(context),
     wolframScript: registerWolframScriptCommands(context),
     history: registerHistoryCommands(context),
     arXiv: registerArXivCommands(context),
@@ -104,6 +106,7 @@ export { apiKeyCommands } from '@commands/api/apiKeyCommands';
 export { stateRestoreCommand } from '@commands/history/stateRestoreCommand';
 export { textEditorCommands } from '@commands/system/textEditorCommands';
 export { linterCommands } from '@commands/latex/linterCommands';
+export { wolframToolCommands } from '@commands/wolfram/wolframToolCommands';
 export { wolframScriptCommands } from '@commands/wolfram/wolframScriptCommands';
 export { historyCommands } from '@commands/history/historyCommands';
 export { arXivCommands } from '@commands/latex/arXivCommands';

--- a/src/commands/wolfram/wolframToolCommands.ts
+++ b/src/commands/wolfram/wolframToolCommands.ts
@@ -1,0 +1,50 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { WolframTool } from '@tools/wolfram';
+import * as logger from '@logger/logUtils';
+import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+
+const CHANNEL = 'WolframToolCommands';
+logger.initialize(CHANNEL);
+
+export const wolframToolCommands = {
+  testWolframTool: 'texra.testWolframTool',
+};
+
+export function registerWolframToolCommands(context: vscode.ExtensionContext) {
+  const testCommand = vscode.commands.registerCommand(
+    wolframToolCommands.testWolframTool,
+    async () => {
+      try {
+        const code = await vscode.window.showInputBox({
+          prompt: 'Enter Wolfram Language code to run with the tool',
+          placeHolder: 'N[Pi,20]',
+        });
+        if (!code) {
+          return;
+        }
+        const tool = new WolframTool();
+        const result = await tool.call({ code });
+        if (result.isError) {
+          await showLoggedErrorMessage(
+            CHANNEL,
+            'Wolfram tool error',
+            result.error,
+          );
+        } else {
+          vscode.window.showInformationMessage(result.output ?? 'No output');
+        }
+      } catch (err) {
+        await showLoggedErrorMessage(
+          CHANNEL,
+          'Error running Wolfram tool',
+          err,
+        );
+      }
+    },
+  );
+  context.subscriptions.push(testCommand);
+  return { testCommand };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,3 +5,4 @@ export * from './bash';
 export * from './fileOp';
 export * from './core/base';
 export * from './registry';
+export * from './wolfram';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,9 +2,11 @@ import { TextEditorTool } from './TextEditorTool';
 import { DiagnosticsTool } from './DiagnosticsTool';
 import { BashTool } from './bash';
 import { FileOpTool } from './fileOp';
+import { WolframTool } from './wolfram';
 export const DEFAULT_TOOL_REGISTRY: Record<string, any> = {
   text_editor: new TextEditorTool(),
   diagnostics: new DiagnosticsTool(),
   bash: new BashTool(),
   file_op: new FileOpTool(),
+  wolfram: new WolframTool(),
 };

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import type { ToolDefinition } from '@model';
+import { BaseTool } from '../core/base';
+import { ToolResult } from '../result';
+import { executeWolframCode } from './wolframScriptUtils';
+import { zodToJsonSchema } from 'openai/_vendor/zod-to-json-schema/index.js';
+
+const WolframInputSchema = z.object({
+  code: z.string(),
+  timeout: z.number().optional(),
+});
+
+export type WolframInput = z.infer<typeof WolframInputSchema>;
+
+export class WolframTool extends BaseTool<WolframInput> {
+  constructor() {
+    const definition: ToolDefinition = {
+      name: 'wolfram',
+      description: 'Execute Wolfram Language code',
+      parameters: zodToJsonSchema(WolframInputSchema, { name: 'wolframInput' }),
+    };
+    super(definition, WolframInputSchema);
+  }
+
+  protected async execute(input: WolframInput): Promise<ToolResult> {
+    const result = await executeWolframCode(input.code, {
+      timeout: input.timeout,
+      showErrorsToUser: false,
+    });
+    if (result.success) {
+      return new ToolResult({ output: result.output ?? '' });
+    }
+    return new ToolResult({
+      error: result.error ?? 'Execution failed',
+      isError: true,
+    });
+  }
+}

--- a/src/tools/wolfram/index.ts
+++ b/src/tools/wolfram/index.ts
@@ -1,3 +1,4 @@
 // Export wolframscript utilities
 export { default as WolframScript } from './wolframScriptUtils';
 export * from './wolframScriptUtils';
+export * from './WolframTool';


### PR DESCRIPTION
## Summary
- implement `WolframTool` for running wolframscript code
- expose the new tool and register it in the default registry
- add a `wolfram_exec` tool set
- provide a test command for manual verification
- document the new tool in the guide

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887dd0ac72c83249d49df206f4c5ea3