### PR TITLE
Fix duplicate agents in dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Agent configuration improvements with better file type handling and validation.
 - Fixed restoration of agent states when reopening TeXRA sessions.
 - Improved agent metadata handling for better performance tracking.
+- Duplicate agents removed from main view dropdown.
 
 ## 0.32.3 - 2025-07-20
 

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -103,7 +103,7 @@ export class MainViewContentProvider extends BaseViewContentProvider {
     } catch {
       extraAgents = [];
     }
-    const allAgents = [...agents, ...extraAgents];
+    const allAgents = Array.from(new Set([...agents, ...extraAgents]));
     const agentOptions = allAgents
       .map((agent) => `<option value="${agent}">${agent}</option>`)
       .join('\n');


### PR DESCRIPTION
## Summary
- dedupe agent names in MainView dropdown
- document dropdown change in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68889361f738832485a66de24887a6df