### PR TITLE
fix: use zod-to-json-schema package for tool schemas

### DIFF
--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -4,7 +4,7 @@ import * as logger from '@logger/logUtils';
 import { BaseTool } from './core/base';
 import { ToolResult, ToolError } from './result';
 import type { ToolDefinition } from '@model';
-import { zodToJsonSchema } from 'openai/_vendor/zod-to-json-schema/index.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 const CHANNEL = 'DiagnosticsTool';
 logger.initialize(CHANNEL);

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -9,7 +9,7 @@ import { BaseTool } from './core/base';
 import { ToolCallInput, EditorCommand, FileHistoryEntry } from './types';
 import { ToolResult, CLIResult, ToolError } from './result';
 import type { ToolDefinition } from '@model';
-import { zodToJsonSchema } from 'openai/_vendor/zod-to-json-schema/index.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 // Local imports - utilities
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -6,7 +6,7 @@ import { executeCommand } from '@utils/system/execUtils';
 import { BaseTool } from './core/base';
 import { ToolResult } from '@tools/result';
 import type { ToolDefinition } from '@model';
-import { zodToJsonSchema } from 'openai/_vendor/zod-to-json-schema/index.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 const BashInputSchema = z.object({
   command: z.string(),

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -6,7 +6,7 @@ import { WorkspaceFS } from '@utils/files';
 import { BaseTool } from './core/base';
 import { ToolResult } from '@tools/result';
 import type { ToolDefinition } from '@model';
-import { zodToJsonSchema } from 'openai/_vendor/zod-to-json-schema/index.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 const FileOpInputSchema = z.object({
   command: z.enum(['read', 'write', 'append']),


### PR DESCRIPTION
## Summary
- update imports in BashTool, DiagnosticsTool, TextEditorTool, and FileOpTool to
  use the `zod-to-json-schema` package

## Testing
- `npm run lint`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888a2c387ac8324a5cb31f55f5e2eb0