### PR TITLE
Fix final response logging

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -99,6 +99,9 @@ export async function runToolUseCycle(
     }
 
     if (!toolInfo || stopReason === 'end_turn') {
+      if (text) {
+        logger.info(encodeHtml(text), groupId);
+      }
       break;
     }
 

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -93,15 +93,13 @@ export async function runToolUseCycle(
     );
     if (text) {
       logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
+      logger.info(encodeHtml(text), groupId);
     }
     if (usage) {
       logger.statistics(usage, groupId);
     }
 
     if (!toolInfo || stopReason === 'end_turn') {
-      if (text) {
-        logger.info(encodeHtml(text), groupId);
-      }
       break;
     }
 


### PR DESCRIPTION
## Summary
- log final text before terminating the tool cycle

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888a2e993bc8324a781995d7610e0d1