### PR TITLE
Implement tool use for OpenAI Responses

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -9,7 +9,8 @@ import type {
   ResponseOutputMessage,
   ResponseOutputText,
   ResponseReasoningItem,
-  EasyInputMessage,
+  ResponseFunctionToolCallItem,
+  ResponseInputItem,
 } from 'openai/resources/responses/responses';
 
 // Local imports - base handler
@@ -55,7 +56,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     userRequest: string,
     mediaFiles?: string[],
     systemPrompt?: string,
-  ): Promise<EasyInputMessage[]> {
+  ): Promise<ResponseInputItem[]> {
     this.previousResponseId = null;
     this.sentMessages = 0;
     return super.initializeMessages(
@@ -69,7 +70,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
   /** Create a response using the Responses API. */
   async createResponse(
     client: OpenAI,
-    messages: EasyInputMessage[],
+    messages: ResponseInputItem[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
@@ -78,50 +79,52 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
   ): Promise<Response> {
     const useStreaming = this.getStreamingConfig();
 
-    const newMessages = messages.slice(this.sentMessages).map((msg) => ({
-      role: msg.role,
-      content:
-        typeof msg.content === 'string'
-          ? [{ type: 'input_text', text: msg.content }]
-          : msg.content.map((part: any) => {
-              if (part.type === 'text') {
-                if (msg.role === 'user') {
-                  return { type: 'input_text', text: part.text };
-                } else if (msg.role === 'assistant') {
-                  return { type: 'output_text', text: part.text };
-                } else {
-                  return { type: 'input_text', text: part.text };
-                }
-              }
-              if (part.type === 'image_url') {
-                const url =
-                  typeof part.image_url === 'string'
-                    ? part.image_url
-                    : part.image_url.url;
+    const newMessages = messages.slice(this.sentMessages).map((msg) => {
+      if ('role' in msg) {
+        return {
+          role: msg.role,
+          content:
+            typeof msg.content === 'string'
+              ? [{ type: 'input_text', text: msg.content }]
+              : msg.content.map((part: any) => {
+                  if (part.type === 'text') {
+                    if (msg.role === 'user') {
+                      return { type: 'input_text', text: part.text };
+                    } else if (msg.role === 'assistant') {
+                      return { type: 'output_text', text: part.text };
+                    } else {
+                      return { type: 'input_text', text: part.text };
+                    }
+                  }
+                  if (part.type === 'image_url') {
+                    const url =
+                      typeof part.image_url === 'string'
+                        ? part.image_url
+                        : part.image_url.url;
 
-                // Check if this is a PDF by examining the data URL
-                if (url.startsWith('data:application/pdf;base64,')) {
-                  // Extract the base64 data from the data URL
-                  const base64Data = url.replace(
-                    'data:application/pdf;base64,',
-                    '',
-                  );
-                  return {
-                    type: 'input_file',
-                    input_file: {
-                      data: base64Data,
-                      mime_type: 'application/pdf',
-                    },
-                  };
-                }
+                    if (url.startsWith('data:application/pdf;base64,')) {
+                      const base64Data = url.replace(
+                        'data:application/pdf;base64,',
+                        '',
+                      );
+                      return {
+                        type: 'input_file',
+                        input_file: {
+                          data: base64Data,
+                          mime_type: 'application/pdf',
+                        },
+                      };
+                    }
 
-                // For regular images, use input_image format
-                const detail = part.image_url?.detail ?? 'auto';
-                return { type: 'input_image', image_url: url, detail };
-              }
-              return part;
-            }),
-    }));
+                    const detail = part.image_url?.detail ?? 'auto';
+                    return { type: 'input_image', image_url: url, detail };
+                  }
+                  return part;
+                }),
+        };
+      }
+      return msg;
+    });
 
     const params: any = {
       model: this.config.fullName,
@@ -448,7 +451,25 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     return thoughtContent || null;
   }
 
-  extractToolUse(_response: Response): string | null {
-    return null;
+  extractToolUse(response: Response): string | null {
+    const items = response?.output;
+    if (!Array.isArray(items)) return null;
+
+    const call = items.find(
+      (it): it is ResponseFunctionToolCallItem => it?.type === 'function_call',
+    );
+    return call ? JSON.stringify(call, null, 2) : null;
+  }
+
+  createFollowUpMessage(
+    id: string,
+    _name: string,
+    result: Record<string, unknown>,
+  ): ResponseInputItem.FunctionCallOutput {
+    return {
+      type: 'function_call_output',
+      call_id: id,
+      output: JSON.stringify(result),
+    };
   }
 }

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -1,0 +1,138 @@
+import { strict as assert } from 'assert';
+import { z } from 'zod';
+
+// Local imports
+import { bus } from '@eventBus/ProgressEventBus';
+import { runToolUseCycle } from '@agent/core/ToolUseCycle';
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { BaseTool } from '@tools/core/base';
+import { ToolResult } from '@tools/result';
+import {
+  AgentSetting,
+  AgentType,
+  AgentPrompt,
+} from '@agent/core/AgentDataclass';
+import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+import {
+  ModelConfig,
+  ModelProvider,
+  DEFAULT_MODEL_CAPABILITIES,
+} from '@model/ModelConfig';
+
+class EchoTool extends BaseTool<{ value: string }> {
+  constructor() {
+    super({ name: 'echo' }, z.object({ value: z.string() }));
+  }
+  protected async execute(input: { value: string }): Promise<ToolResult> {
+    return new ToolResult({ output: input.value });
+  }
+}
+
+class MockHandler extends ModelHandlerOpenAIResponse {
+  private call = 0;
+  async getClient() {
+    return {} as any;
+  }
+  override async createResponse(): Promise<any> {
+    this.call++;
+    if (this.call === 1) {
+      return {
+        id: 'r1',
+        status: 'completed',
+        output: [
+          {
+            type: 'function_call',
+            id: 'c1',
+            name: 'echo',
+            arguments: '{"value":"hello"}',
+          },
+        ],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      };
+    }
+    return {
+      id: 'r2',
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'done' }],
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    };
+  }
+  override extractResponse(resp: any): [string, any, any] {
+    return ['', resp.usage, 'stop'];
+  }
+}
+
+describe('runToolUseCycle OpenAIResponse', () => {
+  it('logs tool calls and creates follow-up message', async () => {
+    const config: ModelConfig = {
+      name: 'test',
+      fullName: 'test',
+      provider: ModelProvider.OPENAI,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    };
+    const handler = new MockHandler(config);
+    const logger = new AgentLogger('TestHandler', true);
+    const toolRegistry = { echo: new EchoTool() };
+    const setting: AgentSetting = {
+      agentType: AgentType.ToolUse,
+      documentTag: 'doc',
+      temperature: 0,
+      isRewrite: true,
+      rounds: 1,
+      prefills: [],
+      outputExt: 'txt',
+      endTag: '</doc>',
+      requiredFiles: {},
+      requiredFilesInternal: {},
+      defaultOutputFiles: [],
+      filePatternsContain: [],
+      tools: [{ name: 'echo' }],
+    };
+    const prompt: AgentPrompt = {
+      systemPrompt: '',
+      userPrefix: '',
+      userRequest: '',
+      userReflect: '',
+    };
+    const options = {
+      modelHandler: handler,
+      agentSetting: setting,
+      agentPrompt: prompt,
+      userVars: {},
+      logger,
+      client: {},
+      toolRegistry,
+      checkInterruption: () => false,
+      setAbortController: () => {},
+    };
+    const events: any[] = [];
+    const dispose = bus.on('addLogMessage', (e) => events.push(e));
+    const messages: any[] = [];
+
+    await runToolUseCycle(options, messages);
+    dispose();
+
+    const toolEvents = events.filter(
+      (e) => e.logMessage.messageType === MESSAGE_TYPES.TOOL_USE,
+    );
+    assert.equal(toolEvents.length, 2);
+    assert.deepEqual(messages[0], {
+      type: 'function_call_output',
+      call_id: 'c1',
+      output: JSON.stringify({ output: 'hello' }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- parse tool calls from the OpenAI Responses API
- build tool follow-up messages for Responses handler
- add unit test covering tool use cycle with Responses handler

## Testing
- `npm run lint`
- `npm test` *(fails: vscode-test not supported in container)*

------
https://chatgpt.com/codex/tasks/task_e_6888a2acb6bc8324be5c990ebe6bd860