### PR TITLE
feat: display tool output as markdown

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -69,7 +69,7 @@ export async function runToolUseCycle(
         messages,
         agentSetting.temperature ?? 0,
         undefined,
-        agentSetting.endTag,
+        undefined,
         abortController.signal,
         agentSetting.tools as ToolDefinition[],
       );
@@ -89,11 +89,11 @@ export async function runToolUseCycle(
     const toolInfo = modelHandler.extractToolUse(response);
     const [text, usage, stopReason] = modelHandler.extractResponse(
       response,
-      agentSetting.endTag,
+      '',
     );
     if (text) {
       logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
-      logger.info(encodeHtml(text), groupId);
+      logger.info(encodeHtml(text), groupId, MESSAGE_TYPES.TOOL_OUTPUT);
     }
     if (usage) {
       logger.statistics(usage, groupId);

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -43,6 +43,7 @@ export interface LogMessageData {
     | 'missingOutputs'
     | 'latexdiff'
     | 'statistics'
+    | 'toolOutput'
     | 'toolUse'
     | 'internal';
   /** Whether verbose details should be displayed */

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -6,6 +6,7 @@ export const MESSAGE_TYPES = {
   LATEXDIFF: 'latexdiff',
   STATISTICS: 'statistics',
   TOOL_USE: 'toolUse',
+  TOOL_OUTPUT: 'toolOutput',
   /** Messages that should be hidden from the progress view */
   INTERNAL: 'internal',
   DEFAULT: 'default',

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -178,6 +178,10 @@ export class LogEntryFormatter {
       return this._formatToolUse(htmlMessage, text, id);
     }
 
+    if (messageType === 'toolOutput') {
+      return this._formatToolOutput(text, id);
+    }
+
     if (messageType === 'fileList') {
       return this._formatFileList(htmlMessage, text, data, id);
     }
@@ -258,6 +262,22 @@ export class LogEntryFormatter {
     } catch (e) {
       console.error('Error parsing tool use content:', e);
       return message;
+    }
+  }
+
+  _formatToolOutput(content, logId) {
+    try {
+      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      content = decodeHtml(content);
+      content = content.replace(/\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
+      content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
+      content = content.replace(/\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
+      let parsedMarkdown = this.md.render(content);
+      parsedMarkdown = this._restoreLatexReferences(parsedMarkdown);
+      return `<div class="tool-output-content"${idAttr}>${parsedMarkdown}</div>`;
+    } catch (e) {
+      console.error('Error parsing tool output:', e);
+      return content;
     }
   }
 

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -179,7 +179,7 @@ export class LogEntryFormatter {
     }
 
     if (messageType === 'toolOutput') {
-      return this._formatToolOutput(text, id);
+      return this._formatToolOutput(text, timestamp, id);
     }
 
     if (messageType === 'fileList') {
@@ -265,16 +265,19 @@ export class LogEntryFormatter {
     }
   }
 
-  _formatToolOutput(content, logId) {
+  _formatToolOutput(content, timestamp, logId) {
     try {
       const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const timeAttr = timestamp
+        ? ` data-full-timestamp="${new Date(timestamp).toISOString()}"`
+        : '';
       content = decodeHtml(content);
       content = content.replace(/\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
       content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
       content = content.replace(/\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
       let parsedMarkdown = this.md.render(content);
       parsedMarkdown = this._restoreLatexReferences(parsedMarkdown);
-      return `<div class="tool-output-content"${idAttr}>${parsedMarkdown}</div>`;
+      return `<div class="tool-output-content"${idAttr}${timeAttr}>${parsedMarkdown}</div>`;
     } catch (e) {
       console.error('Error parsing tool output:', e);
       return content;

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -13,6 +13,12 @@
   overflow: visible;
 }
 
+.tool-output-content {
+  padding: var(--spacing-small) 0 var(--spacing-medium) var(--spacing-large);
+  margin: var(--spacing-small) 0;
+  overflow: visible;
+}
+
 /* Style markdown elements in special content */
 .special-content h1,
 .special-content h2,


### PR DESCRIPTION
## Summary
- support `toolOutput` log type
- render tool output with markdown without bullet
- disable end tag for tool-use text responses

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888cd68b1a08324bb42801908a30b5b