### PR TITLE
Fix statistics logging for tool use agents

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -99,7 +99,13 @@ export async function runToolUseCycle(
     }
     if (usage) {
       const normalized = modelHandler.computeResponseUsage(usage, responseTime);
-      logger.statistics(normalized, groupId);
+      const stats = {
+        inputTokens: normalized.totalInputTokens,
+        outputTokens: normalized.totalOutputTokens,
+        cost: normalized.cost,
+        elapsedTime: normalized.responseTime,
+      };
+      logger.statistics(stats, groupId);
     }
 
     if (!toolInfo || stopReason === 'end_turn') {

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -63,6 +63,7 @@ export async function runToolUseCycle(
     const abortController = new AbortController();
     setAbortController(abortController);
     let response: any;
+    const startTime = Date.now();
     try {
       response = await modelHandler.createResponse(
         client,
@@ -76,6 +77,7 @@ export async function runToolUseCycle(
     } finally {
       setAbortController(null);
     }
+    const responseTime = (Date.now() - startTime) / 1000;
     if (!response) {
       break;
     }
@@ -96,7 +98,8 @@ export async function runToolUseCycle(
       logger.info(encodeHtml(text), groupId);
     }
     if (usage) {
-      logger.statistics(usage, groupId);
+      const normalized = modelHandler.computeResponseUsage(usage, responseTime);
+      logger.statistics(normalized, groupId);
     }
 
     if (!toolInfo || stopReason === 'end_turn') {


### PR DESCRIPTION
## Summary
- normalize usage data in tool use cycle

## Testing
- `npm run lint`
- `npm test` *(fails: webpack emitted warnings, no results)*

------
https://chatgpt.com/codex/tasks/task_e_6888d5c531c88324bfcadc713e83f9f4