### PR TITLE
feat: support provider parameter types in ToolDefinition

### DIFF
--- a/docs/reference/tool-format.md
+++ b/docs/reference/tool-format.md
@@ -12,10 +12,16 @@ const tools: ToolDefinition[] = [
     name: 'searchWeb',
     description: 'Perform a web search',
     parameters: {
-      /* JSON schema */
+      type: 'object',
+      /* JSON schema properties */
     },
   },
 ];
 ```
 
-See your provider's documentation for the exact schema.
+`parameters` should contain a valid JSON Schema object describing the tool
+inputs. Include `type: 'object'` at the root to satisfy providers like
+Anthropic. The definition is compatible with OpenAI
+(`ChatCompletionTool['function']['parameters']`), Anthropic
+(`Tool['input_schema']`), and Google Gemini (`FunctionDeclaration.parameters`).
+Refer to your provider's documentation for the full schema details.

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -20,7 +20,7 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
     function: {
       name: d.name,
       description: d.description,
-      parameters: d.parameters,
+      parameters: d.parameters as ChatCompletionTool['function']['parameters'],
     },
   }));
 }

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -1,8 +1,21 @@
 // Third-party imports
 import { z } from 'zod';
+import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { Schema } from '@google/genai/dist/genai';
+
+export type ParameterSchema =
+  | ChatCompletionTool['function']['parameters']
+  | AnthropicTool['input_schema']
+  | Schema
+  | Record<string, unknown>;
 
 /** Zod schema describing a tool/function that a provider can execute. */
-export const ToolDefinitionSchema = z
+export const ToolDefinitionSchema: z.ZodType<{
+  name: string;
+  description?: string;
+  parameters?: ParameterSchema;
+}> = z
   .object({
     /** Name of the tool or function */
     name: z.string(),


### PR DESCRIPTION
## Summary
- extend `ToolDefinition` parameter typing to match OpenAI, Anthropic, and Gemini SDKs
- document that `parameters` must include `type: 'object'`
- ensure OpenAI conversion casts parameters correctly

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888d5978bac8324a005d67d5f9ee6e6