### PR TITLE
Fix tool schema compatibility

### DIFF
--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -1,5 +1,9 @@
 // Third-party imports
 import { z } from 'zod';
+// Third-party imports - provider tool definitions
+import type { FunctionDefinition } from 'openai/resources/shared';
+import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { Schema as GeminiSchema } from '@google/genai/dist/genai';
 
 /** Zod schema describing a tool/function that a provider can execute. */
 export const ToolDefinitionSchema = z
@@ -13,4 +17,13 @@ export const ToolDefinitionSchema = z
   })
   .strict();
 
-export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
+/**
+ * Generic tool definition used across model providers. The parameters field
+ * aligns with OpenAI, Anthropic and Google Gemini function schemas.
+ */
+export type ToolDefinition = z.infer<typeof ToolDefinitionSchema> & {
+  parameters?:
+    | FunctionDefinition['parameters']
+    | AnthropicTool['input_schema']
+    | GeminiSchema;
+};

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -22,9 +22,7 @@ export class DiagnosticsTool extends BaseTool<DiagnosticsInput> {
       name: 'diagnostics',
       description:
         'Retrieve linter diagnostics. Use "list" for full messages or "count" for a summary.',
-      parameters: zodToJsonSchema(DiagnosticsInputSchema, {
-        name: 'diagnosticsInput',
-      }),
+      parameters: zodToJsonSchema(DiagnosticsInputSchema),
     };
     super(definition, DiagnosticsInputSchema);
   }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -65,9 +65,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
       name,
       description:
         'Edit files using search and replace or insertion operations',
-      parameters: zodToJsonSchema(TextEditorInputSchema, {
-        name: 'textEditorInput',
-      }),
+      parameters: zodToJsonSchema(TextEditorInputSchema),
     };
     super(definition, TextEditorInputSchema);
     this.apiType = apiType;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -19,7 +19,7 @@ export class BashTool extends BaseTool<BashInput> {
     const definition: ToolDefinition = {
       name: 'bash',
       description: 'Execute a shell command within the workspace',
-      parameters: zodToJsonSchema(BashInputSchema, { name: 'bashInput' }),
+      parameters: zodToJsonSchema(BashInputSchema),
     };
     super(definition, BashInputSchema);
   }

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -21,7 +21,7 @@ export class FileOpTool extends BaseTool<FileOpInput> {
     const definition: ToolDefinition = {
       name: 'file_op',
       description: 'Perform basic file operations',
-      parameters: zodToJsonSchema(FileOpInputSchema, { name: 'fileOpInput' }),
+      parameters: zodToJsonSchema(FileOpInputSchema),
     };
     super(definition, FileOpInputSchema);
   }

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -20,7 +20,7 @@ export class WolframTool extends BaseTool<WolframInput> {
     const definition: ToolDefinition = {
       name: 'wolfram',
       description: 'Execute Wolfram Language code',
-      parameters: zodToJsonSchema(WolframInputSchema, { name: 'wolframInput' }),
+      parameters: zodToJsonSchema(WolframInputSchema),
     };
     super(definition, WolframInputSchema);
   }


### PR DESCRIPTION
## Summary
- generalize `ToolDefinition` to use provider function schema types
- remove `zodToJsonSchema` naming option to include `type` field

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888d5978bac8324a005d67d5f9ee6e6