### PR TITLE
Fix Anthropic tool definitions

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -27,11 +27,21 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 
 /** Convert generic ToolDefinition objects to Anthropic Tool format. */
 export function toAnthropicTools(defs: ToolDefinition[]): ToolUnion[] {
-  return defs.map<ToolUnion>((d) => ({
-    name: d.name,
-    description: d.description,
-    input_schema: (d.parameters ?? {}) as AnthropicTool['input_schema'],
-  }));
+  return defs.map<ToolUnion>((d) => {
+    if (d.type) {
+      const def: Record<string, any> = { name: d.name, type: d.type };
+      if (d.max_characters) {
+        def.max_characters = d.max_characters;
+      }
+      return def as ToolUnion;
+    }
+    return {
+      name: d.name,
+      description: d.description,
+      input_schema: (d.parameters ?? {}) as AnthropicTool['input_schema'],
+      type: 'custom',
+    } as ToolUnion;
+  });
 }
 
 /** Convert generic ToolDefinition objects to Google Gemini Tool format. */

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -14,6 +14,10 @@ export const ToolDefinitionSchema = z
     description: z.string().optional(),
     /** Parameter schema or provider specific metadata */
     parameters: z.record(z.unknown()).optional(),
+    /** Optional provider specific type, e.g. Anthropic built-in tools */
+    type: z.string().optional(),
+    /** Additional provider specific metadata */
+    max_characters: z.number().optional(),
   })
   .strict();
 

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -66,6 +66,8 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
       description:
         'Edit files using search and replace or insertion operations',
       parameters: zodToJsonSchema(TextEditorInputSchema),
+      type: apiType,
+      max_characters: 10000,
     };
     super(definition, TextEditorInputSchema);
     this.apiType = apiType;


### PR DESCRIPTION
## Summary
- support provider-specific type metadata in `ToolDefinition`
- include tool type when defining `TextEditorTool`
- generate native Anthropic tool objects when converting tools

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888e386cc008324918a9b54b823b543