### PR TITLE
fix: include type in Anthropic tool schema

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -27,11 +27,17 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 
 /** Convert generic ToolDefinition objects to Anthropic Tool format. */
 export function toAnthropicTools(defs: ToolDefinition[]): ToolUnion[] {
-  return defs.map<ToolUnion>((d) => ({
-    name: d.name,
-    description: d.description,
-    input_schema: (d.parameters ?? {}) as AnthropicTool['input_schema'],
-  }));
+  return defs.map<ToolUnion>(
+    (d) =>
+      ({
+        name: d.name,
+        description: d.description,
+        // Include the provider specific type when present to support
+        // Anthropic's built-in tools like the text editor.
+        ...(d.type ? { type: d.type } : { type: 'custom' }),
+        input_schema: (d.parameters ?? {}) as AnthropicTool['input_schema'],
+      }) as unknown as ToolUnion,
+  );
 }
 
 /** Convert generic ToolDefinition objects to Google Gemini Tool format. */

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -12,6 +12,8 @@ export const ToolDefinitionSchema = z
     name: z.string(),
     /** Optional description for the model */
     description: z.string().optional(),
+    /** Optional provider specific type (e.g. Anthropic built-in tool id) */
+    type: z.string().optional(),
     /** Parameter schema or provider specific metadata */
     parameters: z.record(z.unknown()).optional(),
   })

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -65,6 +65,8 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
       name,
       description:
         'Edit files using search and replace or insertion operations',
+      // Provide the built-in tool type so Anthropic can recognize it
+      type: apiType,
       parameters: zodToJsonSchema(TextEditorInputSchema),
     };
     super(definition, TextEditorInputSchema);


### PR DESCRIPTION
## Summary
- add optional `type` field to generic `ToolDefinition`
- include tool type when converting to Anthropic format
- set `type` when constructing `TextEditorTool`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6888e386cc008324918a9b54b823b543