### PR TITLE
fix: avoid erroneous log when content missing for tool calls

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -464,6 +464,14 @@ export class ModelHandlerOpenAI extends ModelHandler<
     let newResponse = '';
     if (choice.message.content) {
       newResponse = choice.message.content.trim();
+    } else if (
+      stopReason === 'tool_calls' ||
+      stopReason === 'tool_use' ||
+      stopReason === 'function_call' ||
+      Array.isArray(choice.message.tool_calls) ||
+      choice.message.function_call
+    ) {
+      this.logger.debug('Received tool call without message content');
     } else {
       newResponse = '';
       this.logger.error(


### PR DESCRIPTION
## Summary
- avoid error log in OpenAI handler when content is missing due to tool calls

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f473efd083248135138e74936f29