### PR TITLE
fix: clarify tool call handling

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -464,6 +464,17 @@ export class ModelHandlerOpenAI extends ModelHandler<
     let newResponse = '';
     if (choice.message.content) {
       newResponse = choice.message.content.trim();
+    } else if (
+      stopReason === 'tool_calls' ||
+      stopReason === 'tool_use' ||
+      stopReason === 'function_call' ||
+      Array.isArray(choice.message.tool_calls) ||
+      choice.message.function_call
+    ) {
+      // Other provider SDKs (Anthropic, Google, etc.) keep a placeholder
+      // message when a tool is invoked. OpenAI omits `content` entirely,
+      // so lack of content is not an error in this case.
+      this.logger.debug('Received tool call without message content');
     } else {
       newResponse = '';
       this.logger.error(


### PR DESCRIPTION
## Summary
- log a debug message when OpenAI omits message content for tool calls
- explain via comment that other providers keep placeholder content

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888f473efd083248135138e74936f29