### PR TITLE
Fix tool call follow-up flow

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -234,7 +234,12 @@ export async function runToolUseCycle(
       resultObj.base64Image = result.base64Image;
     if (result.system !== undefined) resultObj.system = result.system;
 
-    const followUp = modelHandler.createFollowUpMessage(id, name, resultObj);
-    messages.push(followUp);
+    const [callMsg, resultMsg] = modelHandler.createFollowUpMessage(
+      id,
+      name,
+      parsed,
+      resultObj,
+    );
+    messages.push(callMsg, resultMsg);
   }
 }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -723,8 +723,9 @@ export abstract class ModelHandler<U = any, R = any>
   abstract createFollowUpMessage(
     id: string,
     name: string,
+    call: any,
     result: Record<string, unknown>,
-  ): any;
+  ): [any, any];
 
   /**
    * Creates a log group for model operations with the given name.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -967,10 +967,22 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   createFollowUpMessage(
     id: string,
-    _name: string,
+    name: string,
+    call: any,
     result: Record<string, unknown>,
-  ): any {
-    return {
+  ): [any, any] {
+    const callMsg = {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id,
+          name,
+          input: call?.input ?? call?.arguments ?? {},
+        },
+      ],
+    };
+    const resultMsg = {
       role: 'user',
       content: [
         {
@@ -980,5 +992,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         },
       ],
     };
+    return [callMsg, resultMsg];
   }
 }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -10,6 +10,7 @@ import {
   FinishReason,
   File,
   createPartFromUri,
+  createPartFromFunctionCall,
   createPartFromFunctionResponse,
   GenerateContentConfig,
   type CreateChatParameters,
@@ -953,10 +954,21 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   createFollowUpMessage(
     id: string,
     name: string,
+    call: any,
     result: Record<string, unknown>,
-  ): any {
-    const part = createPartFromFunctionResponse(id, name, result);
-    return { role: 'user', parts: [part] };
+  ): [any, any] {
+    const callPart = createPartFromFunctionCall(
+      name,
+      typeof call?.args === 'object' ? call.args : (call?.input ?? {}),
+    );
+    if (callPart.functionCall) {
+      callPart.functionCall.id = id;
+    }
+    const resultPart = createPartFromFunctionResponse(id, name, result);
+    return [
+      { role: 'assistant', parts: [callPart] },
+      { role: 'user', parts: [resultPart] },
+    ];
   }
 
   // Assuming containCutOffMessage is available from base class ModelHandler

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -3,7 +3,11 @@
 
 // Third-party imports
 import OpenAI from 'openai';
-import { ChatCompletionContentPart } from 'openai/resources/chat/completions';
+import {
+  ChatCompletionContentPart,
+  ChatCompletionAssistantMessageParam,
+  ChatCompletionToolMessageParam,
+} from 'openai/resources/chat/completions';
 import { countTokens } from 'gpt-tokenizer';
 
 // Local imports - utilities
@@ -865,14 +869,32 @@ export class ModelHandlerOpenAI extends ModelHandler<
 
   createFollowUpMessage(
     id: string,
-    _name: string,
+    name: string,
+    call: any,
     result: Record<string, unknown>,
-  ): any {
-    return {
+  ): [any, any] {
+    const callMsg: ChatCompletionAssistantMessageParam = {
+      role: 'assistant',
+      tool_calls: [
+        {
+          id,
+          type: 'function',
+          function: {
+            name,
+            arguments:
+              typeof call?.arguments === 'string'
+                ? call.arguments
+                : JSON.stringify(call?.input ?? call?.arguments ?? {}),
+          },
+        },
+      ],
+    };
+    const resultMsg: ChatCompletionToolMessageParam = {
       role: 'tool',
       tool_call_id: id,
       content: JSON.stringify(result),
     };
+    return [callMsg, resultMsg];
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -10,6 +10,7 @@ import type {
   ResponseOutputText,
   ResponseReasoningItem,
   ResponseFunctionToolCallItem,
+  ResponseFunctionToolCall,
   ResponseInputItem,
 } from 'openai/resources/responses/responses';
 
@@ -463,13 +464,24 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
 
   createFollowUpMessage(
     id: string,
-    _name: string,
+    name: string,
+    call: any,
     result: Record<string, unknown>,
-  ): ResponseInputItem.FunctionCallOutput {
-    return {
+  ): [any, any] {
+    const callMsg: ResponseFunctionToolCall = {
+      type: 'function_call',
+      call_id: id,
+      name,
+      arguments:
+        typeof call?.arguments === 'string'
+          ? call.arguments
+          : JSON.stringify(call?.input ?? call?.arguments ?? {}),
+    };
+    const resultMsg: ResponseInputItem.FunctionCallOutput = {
       type: 'function_call_output',
       call_id: id,
       output: JSON.stringify(result),
     };
+    return [callMsg, resultMsg];
   }
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -162,16 +162,18 @@ export interface IModelHandler<U = any, R = any> {
   extractToolUse(responseObject: any): string | null;
 
   /**
-   * Create a provider-specific follow-up message containing the tool result.
+   * Create provider-specific messages capturing the tool call and result.
    *
    * @param id - Tool call identifier from the model response
    * @param name - Tool name
+   * @param call - Parsed tool call object or input payload
    * @param result - Object with output/error fields
-   * @returns Message formatted for the provider API
+   * @returns Tuple of [call message, result message]
    */
   createFollowUpMessage(
     id: string,
     name: string,
+    call: any,
     result: Record<string, unknown>,
-  ): any;
+  ): [any, any];
 }

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -130,6 +130,12 @@ describe('runToolUseCycle OpenAIResponse', () => {
     );
     assert.equal(toolEvents.length, 2);
     assert.deepEqual(messages[0], {
+      type: 'function_call',
+      call_id: 'c1',
+      name: 'echo',
+      arguments: '{"value":"hello"}',
+    });
+    assert.deepEqual(messages[1], {
       type: 'function_call_output',
       call_id: 'c1',
       output: JSON.stringify({ output: 'hello' }),


### PR DESCRIPTION
## Summary
- track tool call info in conversation history
- return call and result messages for tool follow-ups
- adjust provider handlers
- update OpenAIResponse tool cycle test

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890e80c47c8324957f071e0ba45a07