### PR TITLE
Add type field for Anthropic tools

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -27,11 +27,20 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 
 /** Convert generic ToolDefinition objects to Anthropic Tool format. */
 export function toAnthropicTools(defs: ToolDefinition[]): ToolUnion[] {
-  return defs.map<ToolUnion>((d) => ({
-    name: d.name,
-    description: d.description,
-    input_schema: (d.parameters ?? {}) as AnthropicTool['input_schema'],
-  }));
+  return defs.map<ToolUnion>((d) => {
+    const base: ToolUnion = {
+      name: d.name,
+      description: d.description,
+      ...(d.type ? { type: d.type } : {}),
+    } as ToolUnion;
+
+    if (d.parameters) {
+      (base as AnthropicTool).input_schema =
+        d.parameters as AnthropicTool['input_schema'];
+    }
+
+    return base;
+  });
 }
 
 /** Convert generic ToolDefinition objects to Google Gemini Tool format. */

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -12,6 +12,8 @@ export const ToolDefinitionSchema = z
     name: z.string(),
     /** Optional description for the model */
     description: z.string().optional(),
+    /** Optional provider-specific tool type */
+    type: z.string().optional(),
     /** Parameter schema or provider specific metadata */
     parameters: z.record(z.unknown()).optional(),
   })


### PR DESCRIPTION
## Summary
- support `type` in `ToolDefinition` to specify provider tool type
- include `type` and optional parameters when converting to Anthropic tool format

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688913ecf3348324be3409d575cf02da