### PR TITLE
Use DOM templates in progress view formatters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@vscode/test-electron": "^2.5.2",
         "eslint": "^9.31.0",
         "globals": "^16.3.0",
+        "jsdom": "^26.1.0",
         "node-loader": "^2.1.0",
         "nunjucks": "^3.2.4",
         "path-browserify": "^1.0.1",
@@ -83,6 +84,27 @@
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -113,6 +135,121 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -2238,6 +2375,71 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2267,6 +2469,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3545,6 +3754,19 @@
       "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -3866,6 +4088,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4028,6 +4257,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/json-bigint": {
@@ -4817,6 +5123,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
+      "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5092,6 +5405,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -5620,6 +5959,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5678,6 +6024,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.3.2",
@@ -6186,6 +6545,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tapable": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
@@ -6341,6 +6707,26 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6361,6 +6747,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -6610,6 +7009,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -6802,6 +7214,29 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -7043,6 +7478,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -1185,6 +1185,7 @@
     "@vscode/test-electron": "^2.5.2",
     "eslint": "^9.31.0",
     "globals": "^16.3.0",
+    "jsdom": "^26.1.0",
     "node-loader": "^2.1.0",
     "nunjucks": "^3.2.4",
     "path-browserify": "^1.0.1",

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -148,9 +148,8 @@
         </template>
         <template id="logLineTemplate">
           <div class="log-line">
-            <span class="timestamp"></span>
-            <span class="level"></span>
-            <span class="message"></span>
+            <span class="timestamp"></span> <span class="level"></span
+            ><span class="message"></span>
           </div>
         </template>
         <template id="specialDetailsTemplate">
@@ -176,9 +175,9 @@
         <template id="modelResponseTemplate">
           <div class="log-line">
             <span class="timestamp"></span>
-            <span class="message-container">
-              <div class="model-response-content markdown-content"></div>
-            </span>
+            <span class="message-container"
+              ><div class="model-response-content markdown-content"></div
+            ></span>
           </div>
         </template>
         <template id="fileListDetailsTemplate">

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -146,6 +146,91 @@
             <div class="round-header"></div>
           </div>
         </template>
+        <template id="logLineTemplate">
+          <div class="log-line">
+            <span class="timestamp"></span>
+            <span class="level"></span>
+            <span class="message"></span>
+          </div>
+        </template>
+        <template id="specialDetailsTemplate">
+          <details class="special-details">
+            <summary class="details-summary">
+              <i class="toggle-icon"></i>
+              <i class="codicon icon"></i>
+              <span class="label"></span>
+            </summary>
+            <div class="special-content markdown-content"></div>
+          </details>
+        </template>
+        <template id="toolUseTemplate">
+          <details class="special-details">
+            <summary class="details-summary">
+              <i class="toggle-icon"></i>
+              <i class="codicon codicon-wrench"></i>
+              <span>Tool Use</span>
+            </summary>
+            <div class="special-content"></div>
+          </details>
+        </template>
+        <template id="modelResponseTemplate">
+          <div class="log-line">
+            <span class="timestamp"></span>
+            <span class="message-container">
+              <div class="model-response-content markdown-content"></div>
+            </span>
+          </div>
+        </template>
+        <template id="fileListDetailsTemplate">
+          <details class="file-list-details">
+            <summary class="details-summary">
+              <i class="toggle-icon"></i>
+              <i class="codicon codicon-list-tree"></i>
+              <span class="summary-text"></span>
+            </summary>
+            <ul class="file-list-content"></ul>
+          </details>
+        </template>
+        <template id="missingOutputsDetailsTemplate">
+          <details class="file-list-details">
+            <summary class="details-summary">
+              <i class="toggle-icon"></i>
+              <i class="codicon codicon-warning"></i>
+              <span class="summary-text"></span>
+            </summary>
+            <ul class="file-list-content"></ul>
+          </details>
+        </template>
+        <template id="latexdiffDetailsTemplate">
+          <details class="latexdiff-details" open>
+            <summary class="details-summary">
+              <i class="toggle-icon"></i>
+              <i class="codicon codicon-diff"></i>
+              <span class="summary-text"></span>
+            </summary>
+            <ul class="latexdiff-content"></ul>
+          </details>
+        </template>
+        <template id="statisticsDetailsTemplate">
+          <details class="statistics-details" open>
+            <summary class="details-summary">
+              <i class="toggle-icon"></i>
+              <i class="codicon codicon-dashboard"></i>
+              <span>Statistics</span>
+            </summary>
+            <div class="statistics-content"></div>
+          </details>
+        </template>
+        <template id="groupHeaderTemplate">
+          <summary class="log-group-header">
+            <span class="group-status-icon"></span>
+            <span class="group-title"></span>
+            <span class="group-time">
+              <span class="group-start-time"></span>
+              <span class="group-duration"></span>
+            </span>
+          </summary>
+        </template>
       </div>
       <div class="tabs split">
         <div id="streamTabs" class="tabs-content">

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -594,7 +594,12 @@ export class LogEntryFormatter {
     if (xmlLink && element) {
       const div = document.createElement('div');
       div.innerHTML = xmlLink;
-      element.appendChild(div.firstElementChild);
+      const xmlElement = div.firstElementChild;
+      if (xmlElement) {
+        element.appendChild(xmlElement);
+      } else {
+        console.error('Failed to create XML link element from HTML:', xmlLink);
+      }
     }
 
     return element;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -9,10 +9,9 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
 import { STATUS } from './constants.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 // Constants
-export const BULLET_MARKUP =
-  '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
 
 export const EMOJI_BY_LEVEL = {
   error: '🔴',
@@ -70,22 +69,23 @@ export function formatTokens(tokens) {
  */
 export class MessageTimestampExtractor {
   /**
-   * Extract timestamp from HTML message
-   * @param {string} message - HTML message containing timestamp
+   * Extract timestamp from a log line element
+   * @param {HTMLElement} element - Log line element
    * @returns {string} Extracted timestamp
    */
-  extract(message) {
-    // First try to extract the full timestamp from data-full-timestamp attribute
-    const div = document.createElement('div');
-    div.innerHTML = message;
-    const logLine = div.querySelector('.log-line');
+  extract(element) {
+    const logLine = element.classList.contains('log-line')
+      ? element
+      : element.querySelector('.log-line');
     if (logLine && logLine.dataset.fullTimestamp) {
-      return logLine.dataset.fullTimestamp; // Return the full precise timestamp
+      return logLine.dataset.fullTimestamp;
     }
 
-    // Fallback: extract from the message content using regex
-    const match = message.match(/\[(.*?)\]/);
-    return match ? match[1] : ''; // Extract timestamp or empty string
+    const text = logLine
+      ? logLine.textContent || ''
+      : element.textContent || '';
+    const match = text.match(/\[(.*?)\]/);
+    return match ? match[1] : '';
   }
 }
 
@@ -191,12 +191,33 @@ export class LogEntryFormatter {
     const date = new Date(timestamp);
     const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
 
-    const prefix = `<div class="log-line" data-log-id="${id}" ${
-      groupId ? `data-group-id="${groupId}"` : ''
-    } data-full-timestamp="${fullTimestamp}">`;
-    const levelMarkup = verbose
-      ? `<span class="level-${level}">${level.toUpperCase().padEnd(8)}</span> `
-      : '';
+    const element = createFromTemplate('logLineTemplate');
+    if (!element) return document.createElement('div');
+    element.dataset.logId = id;
+    if (groupId) element.dataset.groupId = groupId;
+    element.dataset.fullTimestamp = fullTimestamp;
+
+    const timestampEl = element.querySelector('.timestamp');
+    if (timestampEl) {
+      timestampEl.title = fullTimestamp;
+      timestampEl.textContent = `${emoji}${verbose ? ` [${timeDisplay}]` : ''}`;
+    }
+
+    const levelEl = element.querySelector('.level');
+    if (levelEl) {
+      if (verbose) {
+        levelEl.className = `level-${level}`;
+        levelEl.textContent = level.toUpperCase().padEnd(8);
+      } else {
+        levelEl.remove();
+      }
+    }
+
+    const msgEl = element.querySelector('.message');
+    if (msgEl) {
+      msgEl.className = `message-${level}`;
+      msgEl.textContent = text;
+    }
 
     if (messageType === 'thinking' || messageType === 'scratchpad') {
       const label = messageType === 'thinking' ? 'Thinking' : 'Scratchpad';
@@ -255,37 +276,36 @@ export class LogEntryFormatter {
       }
     }
 
-    const htmlMessage =
-      prefix +
-      `<span class="timestamp" title="${fullTimestamp}">${emoji}${
-        verbose ? ` [${timeDisplay}]` : ''
-      }</span> ` +
-      levelMarkup +
-      `<span class="message-${level}">${text}</span>` +
-      `</div>`;
-
-    return htmlMessage;
+    return element;
   }
 
   _formatSpecialContent(content, contentType, logId) {
     try {
       const parsedMarkdown = this._processMarkdownContent(content);
+      let element = createFromTemplate('specialDetailsTemplate');
+      if (!element) element = document.createElement('div');
 
-      // Create enhanced content element with better formatting
-      const idAttr = logId ? ` data-log-id="${logId}"` : '';
-      // Determine label and icon based on content type
       const isThinking = contentType.includes('Thinking');
       const labelText = isThinking ? 'Thinking' : 'Scratchpad';
       const icon = isThinking ? 'codicon-lightbulb' : 'codicon-pencil';
 
-      return `<details class="special-details">
-        <summary class="details-summary">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon ${icon}"></i>
-          <span>${labelText}</span>
-        </summary>
-        <div class="special-content markdown-content"${idAttr}>${parsedMarkdown}</div>
-      </details>`;
+      const toggleIcon = element.querySelector('.toggle-icon');
+      if (toggleIcon)
+        toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+
+      const iconElem = element.querySelector('.icon');
+      if (iconElem) iconElem.classList.add(icon);
+
+      const labelElem = element.querySelector('.label');
+      if (labelElem) labelElem.textContent = labelText;
+
+      const contentElem = element.querySelector('.special-content');
+      if (contentElem) {
+        contentElem.innerHTML = parsedMarkdown;
+        if (logId) contentElem.dataset.logId = logId;
+      }
+
+      return element;
     } catch (e) {
       console.error('Error parsing markdown:', e);
       return null;
@@ -294,7 +314,8 @@ export class LogEntryFormatter {
 
   _formatToolUse(content, logId) {
     try {
-      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const element = createFromTemplate('toolUseTemplate');
+      if (!element) return null;
       let formattedContent;
       try {
         // Try to parse as JSON first - don't decode HTML entities
@@ -331,14 +352,18 @@ export class LogEntryFormatter {
         // This preserves any HTML entities in error messages
         formattedContent = `<pre>${content}</pre>`;
       }
-      return `<details class="special-details">
-        <summary class="details-summary">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon codicon-wrench"></i>
-          <span>Tool Use</span>
-        </summary>
-        <div class="special-content"${idAttr}>${formattedContent}</div>
-      </details>`;
+
+      const toggleIcon = element.querySelector('.toggle-icon');
+      if (toggleIcon)
+        toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+
+      const contentElem = element.querySelector('.special-content');
+      if (contentElem) {
+        contentElem.innerHTML = formattedContent;
+        if (logId) contentElem.dataset.logId = logId;
+      }
+
+      return element;
     } catch (e) {
       console.error('Error parsing tool use content:', e);
       return null;
@@ -349,16 +374,27 @@ export class LogEntryFormatter {
     try {
       const date = new Date(timestamp);
       const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
-      const groupAttr = groupId ? ` data-group-id="${groupId}"` : '';
-      const prefix = `<div class="log-line" data-log-id="${id}"${groupAttr} data-full-timestamp="${fullTimestamp}">`;
-      const timeMarkup = `<span class="timestamp" title="${fullTimestamp}">${
-        verbose ? `[${timeDisplay}]` : ''
-      }</span>`;
-      const parsedMarkdown = this._processMarkdownContent(content);
-      const html =
-        prefix +
-        `${timeMarkup} <span class="message-${level}"><div class="model-response-content markdown-content">${parsedMarkdown}</div></span></div>`;
-      return html;
+      const element = createFromTemplate('modelResponseTemplate');
+      if (!element) return null;
+
+      element.dataset.logId = id;
+      if (groupId) element.dataset.groupId = groupId;
+      element.dataset.fullTimestamp = fullTimestamp;
+
+      const timeEl = element.querySelector('.timestamp');
+      if (timeEl) {
+        timeEl.title = fullTimestamp;
+        timeEl.textContent = verbose ? `[${timeDisplay}]` : '';
+      }
+
+      const container = element.querySelector('.message-container');
+      if (container) container.classList.add(`message-${level}`);
+
+      const contentEl = element.querySelector('.model-response-content');
+      if (contentEl)
+        contentEl.innerHTML = this._processMarkdownContent(content);
+
+      return element;
     } catch (e) {
       console.error('Error parsing model response:', e);
       return null;
@@ -367,7 +403,14 @@ export class LogEntryFormatter {
 
   _formatFileList(content, data, logId) {
     try {
-      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const element = createFromTemplate('fileListDetailsTemplate');
+      if (!element) return null;
+      const contentElem = element.querySelector('.file-list-content');
+      const summaryElem = element.querySelector('.summary-text');
+      const toggleIcon = element.querySelector('.toggle-icon');
+      if (toggleIcon)
+        toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+
       const parsed = data ?? JSON.parse(decodeHtml(content));
 
       if (!Array.isArray(parsed)) {
@@ -428,14 +471,13 @@ export class LogEntryFormatter {
       }
       summary += ')';
 
-      return `<details class="file-list-details">
-        <summary class="details-summary">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon codicon-list-tree"></i>
-          <span>${summary}</span>
-        </summary>
-        <ul class="file-list-content"${idAttr}>${items}</ul>
-      </details>`;
+      if (summaryElem) summaryElem.textContent = summary;
+      if (contentElem) {
+        contentElem.innerHTML = items;
+        if (logId) contentElem.dataset.logId = logId;
+      }
+
+      return element;
     } catch (e) {
       console.error('Error parsing file list:', e);
       return null;
@@ -444,7 +486,14 @@ export class LogEntryFormatter {
 
   _formatMissingOutputs(content, data, logId) {
     try {
-      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const element = createFromTemplate('missingOutputsDetailsTemplate');
+      if (!element) return null;
+      const contentElem = element.querySelector('.file-list-content');
+      const summaryElem = element.querySelector('.summary-text');
+      const toggleIcon = element.querySelector('.toggle-icon');
+      if (toggleIcon)
+        toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+
       const parsed = data ?? JSON.parse(decodeHtml(content));
 
       // Handle both old format (array) and new format (object with missing, xmlFile, documentTag)
@@ -493,20 +542,25 @@ export class LogEntryFormatter {
       }
 
       if (missingFiles.length === 0 && xmlFile) {
-        return xmlLink;
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = xmlLink;
+        return wrapper.firstElementChild;
       }
 
       const summary = `Missing outputs (${missingFiles.length})`;
 
-      return `<details class="file-list-details">
-        <summary class="details-summary">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon codicon-warning"></i>
-          <span>${summary}</span>
-        </summary>
-        <ul class="file-list-content"${idAttr}>${items}</ul>
-        ${xmlLink}
-      </details>`;
+      if (summaryElem) summaryElem.textContent = summary;
+      if (contentElem) {
+        contentElem.innerHTML = items;
+        if (logId) contentElem.dataset.logId = logId;
+      }
+      if (xmlLink && element) {
+        const div = document.createElement('div');
+        div.innerHTML = xmlLink;
+        element.appendChild(div.firstElementChild);
+      }
+
+      return element;
     } catch (e) {
       console.error('Error parsing missing outputs:', e);
       return null;
@@ -515,7 +569,14 @@ export class LogEntryFormatter {
 
   _formatLatexdiff(content, data, logId) {
     try {
-      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const element = createFromTemplate('latexdiffDetailsTemplate');
+      if (!element) return null;
+      const contentElem = element.querySelector('.latexdiff-content');
+      const summaryElem = element.querySelector('.summary-text');
+      const toggleIcon = element.querySelector('.toggle-icon');
+      if (toggleIcon)
+        toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
+
       const parsed = data ?? JSON.parse(decodeHtml(content));
       const entries = Array.isArray(parsed)
         ? parsed
@@ -562,14 +623,13 @@ export class LogEntryFormatter {
           ? 'Latexdiff result'
           : `Latexdiff results (${entries.length})`;
 
-      return `<details class="latexdiff-details" open>
-        <summary class="details-summary">
-          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
-          <i class="codicon codicon-diff"></i>
-          <span>${summary}</span>
-        </summary>
-        <ul class="latexdiff-content"${idAttr}>${items}</ul>
-      </details>`;
+      if (summaryElem) summaryElem.textContent = summary;
+      if (contentElem) {
+        contentElem.innerHTML = items;
+        if (logId) contentElem.dataset.logId = logId;
+      }
+
+      return element;
     } catch (e) {
       console.error('Error parsing latexdiff entry:', e);
       return null;
@@ -578,7 +638,12 @@ export class LogEntryFormatter {
 
   _formatStatistics(content, data, logId) {
     try {
-      const idAttr = logId ? ` data-log-id="${logId}"` : '';
+      const element = createFromTemplate('statisticsDetailsTemplate');
+      if (!element) return null;
+      const contentElem = element.querySelector('.statistics-content');
+      const toggleIcon = element.querySelector('.toggle-icon');
+      if (toggleIcon)
+        toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
       const parsed = data;
       if (!parsed || typeof parsed !== 'object') {
         return null;
@@ -647,14 +712,12 @@ export class LogEntryFormatter {
         pushItem('codicon-rocket', 'Cost', `$${parsed.cost.toFixed(3)}`);
       }
 
-      return `<details class="statistics-details" open>
-        <summary class="details-summary">
-          <i class="${CHEVRON_DOWN_CLASS} toggle-icon"></i>
-          <i class="codicon codicon-dashboard"></i>
-          <span>Statistics</span>
-        </summary>
-        <div class="statistics-content"${idAttr}>${items.join('')}</div>
-      </details>`;
+      if (contentElem) {
+        contentElem.innerHTML = items.join('');
+        if (logId) contentElem.dataset.logId = logId;
+      }
+
+      return element;
     } catch (e) {
       console.error('Error parsing statistics:', e);
       return null;
@@ -667,61 +730,52 @@ export class LogEntryFormatter {
  */
 export class TaskGroupHeaderFormatter {
   /**
-   * Create a group header HTML
+   * Create a group header element
    * @param {Object} group - Task group data
-   * @returns {string} HTML for group header
+   * @returns {HTMLElement} Header element
    */
   create(group) {
     const startDate = new Date(group.startTime);
     const level = this._getGroupLevel(group);
     const formattedStartTime = level.formatTime(startDate);
 
-    let durationDisplay = '';
-    if (group.endTime) {
-      const durationMs = group.endTime - group.startTime;
-      durationDisplay = `<span class="group-duration">${this._formatDuration(durationMs)}</span>`;
+    const header = createFromTemplate('groupHeaderTemplate');
+    if (!header) return document.createElement('summary');
+
+    header.id = `group-header-${group.id}`;
+    header.className = this._getHeaderClass(group, level);
+
+    const statusIconElem = header.querySelector('.group-status-icon');
+    if (statusIconElem) {
+      statusIconElem.innerHTML = this._getStatusIcon(group.status);
     }
 
-    // Add indicator based on status
-    const statusIcon = this._getStatusIcon(group.status);
-
-    // Add usage information if available
-    let usageDisplay = '';
-    if (group.usage) {
-      const { inputTokens = 0, outputTokens = 0, cost = 0 } = group.usage;
-      usageDisplay =
-        `<span class="group-usage"><i class="codicon codicon-arrow-up"></i> ${formatTokens(inputTokens)}, ` +
-        `<i class="codicon codicon-arrow-down"></i> ${formatTokens(outputTokens)}, ` +
-        `$${cost.toFixed(3)}</span>`;
+    const titleElem = header.querySelector('.group-title');
+    if (titleElem) {
+      if (level.showTitle) {
+        titleElem.textContent = group.name;
+      } else {
+        titleElem.remove();
+      }
     }
 
-    const titleMarkup = level.showTitle
-      ? `<span class="group-title">${group.name}</span>`
-      : '';
-    const headerClass = this._getHeaderClass(group, level);
+    const startTimeElem = header.querySelector('.group-start-time');
+    if (startTimeElem) {
+      startTimeElem.dataset.start = String(group.startTime);
+      startTimeElem.innerHTML = `<i class="codicon codicon-clock"></i> ${formattedStartTime}`;
+    }
 
-    const timeMarkup = `
-        <span class="group-time">
-          <span class="group-start-time" data-start="${group.startTime}">
-            <i class="codicon codicon-clock"></i> ${formattedStartTime}
-          </span>
-          ${durationDisplay}
-        </span>`;
+    const durationElem = header.querySelector('.group-duration');
+    if (durationElem) {
+      if (group.endTime) {
+        const durationMs = group.endTime - group.startTime;
+        durationElem.textContent = this._formatDuration(durationMs);
+      } else {
+        durationElem.remove();
+      }
+    }
 
-    const bulletMarkup = BULLET_MARKUP;
-
-    const headerContents = this._formatHeaderElements(
-      level,
-      timeMarkup,
-      usageDisplay,
-      bulletMarkup,
-    );
-
-    return `
-      <summary id="group-header-${group.id}" class="${headerClass}">
-        <span class="group-status-icon">${statusIcon}</span>${titleMarkup}${headerContents}
-      </summary>
-    `;
+    return header;
   }
 
   _getGroupLevel(group) {
@@ -767,16 +821,6 @@ export class TaskGroupHeaderFormatter {
       return `${minutes}min`;
     } else {
       return `${minutes}min, ${seconds}sec`;
-    }
-  }
-
-  _formatHeaderElements(level, timeMarkup, usageDisplay, bulletMarkup) {
-    if (level.headerOrder === 'time-first') {
-      // For root level: time → bullet → usage
-      return `${timeMarkup}${usageDisplay ? `${bulletMarkup}${usageDisplay}` : ''}`;
-    } else {
-      // For nested level: usage → bullet → time
-      return `${usageDisplay ? `${usageDisplay}${bulletMarkup}` : ''}${timeMarkup}`;
     }
   }
 }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -334,8 +334,8 @@ export class LogEntryFormatter {
 
   _formatSpecialContent(content, contentType, logId) {
     const parsedMarkdown = this._processMarkdownContent(content);
-    let element = createFromTemplate('specialDetailsTemplate');
-    if (!element) element = document.createElement('div');
+    const element = createFromTemplate('specialDetailsTemplate');
+    if (!element) return null;
 
     const isThinking = contentType.includes('Thinking');
     const labelText = isThinking ? 'Thinking' : 'Scratchpad';
@@ -576,7 +576,12 @@ export class LogEntryFormatter {
     if (missingFiles.length === 0 && xmlFile) {
       const wrapper = document.createElement('div');
       wrapper.innerHTML = xmlLink;
-      return wrapper.firstElementChild;
+      const element = wrapper.firstElementChild;
+      if (!element) {
+        console.error('Failed to create XML link element from HTML:', xmlLink);
+        return null;
+      }
+      return element;
     }
 
     const summary = `Missing outputs (${missingFiles.length})`;
@@ -749,7 +754,7 @@ export class TaskGroupHeaderFormatter {
   /**
    * Create a group header element
    * @param {Object} group - Task group data
-   * @returns {HTMLElement} Header element
+   * @returns {HTMLElement|null} Header element or null if template creation fails
    */
   create(group) {
     const startDate = new Date(group.startTime);
@@ -757,7 +762,7 @@ export class TaskGroupHeaderFormatter {
     const formattedStartTime = level.formatTime(startDate);
 
     const header = createFromTemplate('groupHeaderTemplate');
-    if (!header) return document.createElement('summary');
+    if (!header) return null;
 
     header.id = `group-header-${group.id}`;
     header.className = this._getHeaderClass(group, level);

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1,3 +1,16 @@
+/**
+ * Formatters for log entries in the progress view.
+ *
+ * WHITESPACE HANDLING NOTE:
+ * This module uses a hybrid approach for HTML generation:
+ * - String-based HTML for format() and _formatModelResponse() to maintain precise whitespace control
+ * - Template-based HTML for other methods where whitespace is less critical
+ *
+ * This is necessary because Prettier reformats HTML templates, introducing line breaks
+ * that cause excessive whitespace in the rendered output. The two critical methods
+ * that display plain text messages must use string concatenation to avoid this issue.
+ */
+
 // Third-party imports
 import MarkdownIt from 'markdown-it';
 import markdownItKatex from '@vscode/markdown-it-katex';
@@ -12,6 +25,8 @@ import { STATUS } from './constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 // Constants
+export const BULLET_MARKUP =
+  '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
 
 export const EMOJI_BY_LEVEL = {
   error: '🔴',
@@ -179,9 +194,79 @@ export class LogEntryFormatter {
   }
 
   /**
+   * Get the formatter for a specific message type
+   * @private
+   * @returns {Object} Map of message types to their formatters with error handling
+   */
+  _getFormatters() {
+    return {
+      thinking: (text, id) =>
+        this._safeFormat(
+          () => this._formatSpecialContent(text, 'Thinking', id),
+          'thinking',
+        ),
+      scratchpad: (text, id) =>
+        this._safeFormat(
+          () => this._formatSpecialContent(text, 'Scratchpad', id),
+          'scratchpad',
+        ),
+      toolUse: (text, id) =>
+        this._safeFormat(() => this._formatToolUse(text, id), 'tool use'),
+      modelResponse: (params) =>
+        this._safeFormat(
+          () => this._formatModelResponse(params),
+          'model response',
+        ),
+      fileList: (text, data, id) =>
+        this._safeFormat(
+          () => this._formatFileList(text, data, id),
+          'file list',
+        ),
+      missingOutputs: (text, data, id) =>
+        this._safeFormat(
+          () => this._formatMissingOutputs(text, data, id),
+          'missing outputs',
+        ),
+      latexdiff: (text, data, id) =>
+        this._safeFormat(
+          () => this._formatLatexdiff(text, data, id),
+          'latexdiff',
+        ),
+      statistics: (text, data, id) =>
+        this._safeFormat(
+          () => this._formatStatistics(text, data, id),
+          'statistics',
+        ),
+    };
+  }
+
+  /**
+   * Safely execute a formatting function with error handling
+   * @private
+   * @param {Function} formatter - The formatting function to execute
+   * @param {string} errorContext - Context for error message (e.g., 'special content', 'tool use')
+   * @returns {*} Result of formatter or null if error
+   */
+  _safeFormat(formatter, errorContext) {
+    try {
+      return formatter();
+    } catch (e) {
+      console.error(`Error parsing ${errorContext}:`, e);
+      return null;
+    }
+  }
+
+  /**
    * Format a log entry with Markdown rendering for special content
    * @param {Object} logMessage - The log message to format
-   * @returns {string} Formatted HTML for the log message
+   * @returns {HTMLElement} DOM element for the log message
+   *
+   * IMPORTANT: This method uses string-based HTML generation instead of templates
+   * for the default log messages to maintain precise control over whitespace.
+   * Prettier and other formatters will reformat HTML templates, introducing unwanted
+   * line breaks and spaces that create visual issues in the output.
+   * DO NOT convert this to use templates unless you have a solution for the
+   * whitespace formatting issue.
    */
   format(logMessage) {
     const { id, text, level, timestamp, groupId, messageType, verbose, data } =
@@ -191,537 +276,469 @@ export class LogEntryFormatter {
     const date = new Date(timestamp);
     const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
 
-    const element = createFromTemplate('logLineTemplate');
-    if (!element) return document.createElement('div');
-    element.dataset.logId = id;
-    if (groupId) element.dataset.groupId = groupId;
-    element.dataset.fullTimestamp = fullTimestamp;
+    // Check if we have a special formatter for this message type
+    const formatters = this._getFormatters();
+    const formatter = formatters[messageType];
 
-    const timestampEl = element.querySelector('.timestamp');
-    if (timestampEl) {
-      timestampEl.title = fullTimestamp;
-      timestampEl.textContent = `${emoji}${verbose ? ` [${timeDisplay}]` : ''}`;
-    }
-
-    const levelEl = element.querySelector('.level');
-    if (levelEl) {
-      if (verbose) {
-        levelEl.className = `level-${level}`;
-        levelEl.textContent = level.toUpperCase().padEnd(8);
+    if (formatter) {
+      let result;
+      if (messageType === 'modelResponse') {
+        // modelResponse needs the full parameter object
+        result = formatter({
+          id,
+          groupId,
+          timestamp,
+          verbose,
+          content: text,
+          level,
+        });
+      } else if (
+        messageType === 'thinking' ||
+        messageType === 'scratchpad' ||
+        messageType === 'toolUse'
+      ) {
+        // These only need text and id
+        result = formatter(text, id);
       } else {
-        levelEl.remove();
+        // File list, missing outputs, latexdiff, statistics need data
+        result = formatter(text, data, id);
+      }
+
+      if (result) {
+        return result;
       }
     }
 
-    const msgEl = element.querySelector('.message');
-    if (msgEl) {
-      msgEl.className = `message-${level}`;
-      msgEl.textContent = text;
-    }
+    // Default formatting for regular log messages
+    const prefix = `<div class="log-line" data-log-id="${id}" ${
+      groupId ? `data-group-id="${groupId}"` : ''
+    } data-full-timestamp="${fullTimestamp}">`;
+    const levelMarkup = verbose
+      ? `<span class="level-${level}">${level.toUpperCase().padEnd(8)}</span> `
+      : '';
 
-    if (messageType === 'thinking' || messageType === 'scratchpad') {
-      const label = messageType === 'thinking' ? 'Thinking' : 'Scratchpad';
-      const special = this._formatSpecialContent(text, label, id);
-      if (special) {
-        return special;
-      }
-    }
+    const htmlMessage =
+      prefix +
+      `<span class="timestamp" title="${fullTimestamp}">${emoji}${
+        verbose ? ` [${timeDisplay}]` : ''
+      }</span> ` +
+      levelMarkup +
+      `<span class="message-${level}">${text}</span>` +
+      `</div>`;
 
-    if (messageType === 'toolUse') {
-      const tool = this._formatToolUse(text, id);
-      if (tool) {
-        return tool;
-      }
-    }
+    // Convert HTML string to DOM element
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = htmlMessage;
+    return wrapper.firstElementChild;
+  }
 
-    if (messageType === 'modelResponse') {
-      const model = this._formatModelResponse({
-        id,
-        groupId,
-        timestamp,
-        verbose,
-        content: text,
-        level,
-      });
-      if (model) {
-        return model;
-      }
-    }
+  _formatSpecialContent(content, contentType, logId) {
+    const parsedMarkdown = this._processMarkdownContent(content);
+    let element = createFromTemplate('specialDetailsTemplate');
+    if (!element) element = document.createElement('div');
 
-    if (messageType === 'fileList') {
-      const list = this._formatFileList(text, data, id);
-      if (list) {
-        return list;
-      }
-    }
+    const isThinking = contentType.includes('Thinking');
+    const labelText = isThinking ? 'Thinking' : 'Scratchpad';
+    const icon = isThinking ? 'codicon-lightbulb' : 'codicon-pencil';
 
-    if (messageType === 'missingOutputs') {
-      const missing = this._formatMissingOutputs(text, data, id);
-      if (missing) {
-        return missing;
-      }
-    }
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
 
-    if (messageType === 'latexdiff') {
-      const diff = this._formatLatexdiff(text, data, id);
-      if (diff) {
-        return diff;
-      }
-    }
+    const iconElem = element.querySelector('.icon');
+    if (iconElem) iconElem.classList.add(icon);
 
-    if (messageType === 'statistics') {
-      const stats = this._formatStatistics(text, data, id);
-      if (stats) {
-        return stats;
-      }
+    const labelElem = element.querySelector('.label');
+    if (labelElem) labelElem.textContent = labelText;
+
+    const contentElem = element.querySelector('.special-content');
+    if (contentElem) {
+      contentElem.innerHTML = parsedMarkdown;
+      if (logId) contentElem.dataset.logId = logId;
     }
 
     return element;
   }
 
-  _formatSpecialContent(content, contentType, logId) {
-    try {
-      const parsedMarkdown = this._processMarkdownContent(content);
-      let element = createFromTemplate('specialDetailsTemplate');
-      if (!element) element = document.createElement('div');
-
-      const isThinking = contentType.includes('Thinking');
-      const labelText = isThinking ? 'Thinking' : 'Scratchpad';
-      const icon = isThinking ? 'codicon-lightbulb' : 'codicon-pencil';
-
-      const toggleIcon = element.querySelector('.toggle-icon');
-      if (toggleIcon)
-        toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
-
-      const iconElem = element.querySelector('.icon');
-      if (iconElem) iconElem.classList.add(icon);
-
-      const labelElem = element.querySelector('.label');
-      if (labelElem) labelElem.textContent = labelText;
-
-      const contentElem = element.querySelector('.special-content');
-      if (contentElem) {
-        contentElem.innerHTML = parsedMarkdown;
-        if (logId) contentElem.dataset.logId = logId;
-      }
-
-      return element;
-    } catch (e) {
-      console.error('Error parsing markdown:', e);
-      return null;
-    }
-  }
-
   _formatToolUse(content, logId) {
+    const element = createFromTemplate('toolUseTemplate');
+    if (!element) return null;
+    let formattedContent;
     try {
-      const element = createFromTemplate('toolUseTemplate');
-      if (!element) return null;
-      let formattedContent;
-      try {
-        // Try to parse as JSON first - don't decode HTML entities
-        const parsed = JSON.parse(content);
+      // Try to parse as JSON first - don't decode HTML entities
+      const parsed = JSON.parse(content);
 
-        // Check if this is the new combined format
-        if (parsed.tool && parsed.input && parsed.output) {
-          // Format combined tool input/output
-          const toolName = parsed.tool;
-          const inputJson = JSON.stringify(parsed.input, null, 2);
-          const outputJson = JSON.stringify(parsed.output, null, 2);
+      // Check if this is the new combined format
+      if (parsed.tool && parsed.input && parsed.output) {
+        // Format combined tool input/output
+        const toolName = parsed.tool;
+        const inputJson = JSON.stringify(parsed.input, null, 2);
+        const outputJson = JSON.stringify(parsed.output, null, 2);
 
-          formattedContent = `
-            <div class="tool-use-section">
-              <div class="tool-use-label">${toolName}</div>
-              <div class="tool-use-subsection">
-                <span class="tool-use-sublabel">Input:</span>
-                <pre>${inputJson}</pre>
-              </div>
+        formattedContent = `
+          <div class="tool-use-section">
+            <div class="tool-use-label">${toolName}</div>
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">Input:</span>
+              <pre>${inputJson}</pre>
             </div>
-            <hr class="tool-use-separator">
-            <div class="tool-use-section">
-              <div class="tool-use-subsection">
-                <span class="tool-use-sublabel">Output:</span>
-                <pre>${outputJson}</pre>
-              </div>
-            </div>`;
-        } else {
-          // Legacy format - just display as before
-          formattedContent = `<pre>${JSON.stringify(parsed, null, 2)}</pre>`;
-        }
-      } catch {
-        // If not valid JSON, just display as-is in a pre block
-        // This preserves any HTML entities in error messages
-        formattedContent = `<pre>${content}</pre>`;
+          </div>
+          <hr class="tool-use-separator">
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">Output:</span>
+              <pre>${outputJson}</pre>
+            </div>
+          </div>`;
+      } else {
+        // Legacy format - just display as before
+        formattedContent = `<pre>${JSON.stringify(parsed, null, 2)}</pre>`;
       }
-
-      const toggleIcon = element.querySelector('.toggle-icon');
-      if (toggleIcon)
-        toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
-
-      const contentElem = element.querySelector('.special-content');
-      if (contentElem) {
-        contentElem.innerHTML = formattedContent;
-        if (logId) contentElem.dataset.logId = logId;
-      }
-
-      return element;
-    } catch (e) {
-      console.error('Error parsing tool use content:', e);
-      return null;
+    } catch {
+      // If not valid JSON, just display as-is in a pre block
+      // This preserves any HTML entities in error messages
+      formattedContent = `<pre>${content}</pre>`;
     }
+
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+
+    const contentElem = element.querySelector('.special-content');
+    if (contentElem) {
+      contentElem.innerHTML = formattedContent;
+      if (logId) contentElem.dataset.logId = logId;
+    }
+
+    return element;
   }
 
+  /**
+   * Format a model response with markdown rendering
+   * @private
+   * @param {Object} params - Response parameters
+   * @returns {HTMLElement|null} DOM element for the model response
+   *
+   * IMPORTANT: Like the format() method, this uses string-based HTML generation
+   * to maintain precise whitespace control. Templates would be reformatted by
+   * Prettier, causing excessive line breaks in the output.
+   * DO NOT convert to templates without addressing the whitespace issue.
+   */
   _formatModelResponse({ id, groupId, timestamp, verbose, content, level }) {
-    try {
-      const date = new Date(timestamp);
-      const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
-      const element = createFromTemplate('modelResponseTemplate');
-      if (!element) return null;
+    const date = new Date(timestamp);
+    const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
+    const groupAttr = groupId ? ` data-group-id="${groupId}"` : '';
+    const prefix = `<div class="log-line" data-log-id="${id}"${groupAttr} data-full-timestamp="${fullTimestamp}">`;
+    const timeMarkup = `<span class="timestamp" title="${fullTimestamp}">${
+      verbose ? `[${timeDisplay}]` : ''
+    }</span>`;
+    const parsedMarkdown = this._processMarkdownContent(content);
+    const html =
+      prefix +
+      `${timeMarkup} <span class="message-${level}"><div class="model-response-content markdown-content">${parsedMarkdown}</div></span></div>`;
 
-      element.dataset.logId = id;
-      if (groupId) element.dataset.groupId = groupId;
-      element.dataset.fullTimestamp = fullTimestamp;
-
-      const timeEl = element.querySelector('.timestamp');
-      if (timeEl) {
-        timeEl.title = fullTimestamp;
-        timeEl.textContent = verbose ? `[${timeDisplay}]` : '';
-      }
-
-      const container = element.querySelector('.message-container');
-      if (container) container.classList.add(`message-${level}`);
-
-      const contentEl = element.querySelector('.model-response-content');
-      if (contentEl)
-        contentEl.innerHTML = this._processMarkdownContent(content);
-
-      return element;
-    } catch (e) {
-      console.error('Error parsing model response:', e);
-      return null;
-    }
+    // Convert HTML string to DOM element
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = html;
+    return wrapper.firstElementChild;
   }
 
   _formatFileList(content, data, logId) {
-    try {
-      const element = createFromTemplate('fileListDetailsTemplate');
-      if (!element) return null;
-      const contentElem = element.querySelector('.file-list-content');
-      const summaryElem = element.querySelector('.summary-text');
-      const toggleIcon = element.querySelector('.toggle-icon');
-      if (toggleIcon)
-        toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+    const element = createFromTemplate('fileListDetailsTemplate');
+    if (!element) return null;
+    const contentElem = element.querySelector('.file-list-content');
+    const summaryElem = element.querySelector('.summary-text');
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
 
-      const parsed = data ?? JSON.parse(decodeHtml(content));
+    const parsed = data ?? JSON.parse(decodeHtml(content));
 
-      if (!Array.isArray(parsed)) {
-        console.warn('Missing structured data for file list log entry');
-        return null;
-      }
-
-      // Group files by source for better organization
-      const filesBySource = {};
-      parsed.forEach((f) => {
-        const source = f.source || 'unknown';
-        if (!filesBySource[source]) {
-          filesBySource[source] = [];
-        }
-        filesBySource[source].push(f);
-      });
-
-      let items = '';
-      Object.entries(filesBySource).forEach(([source, files]) => {
-        files.forEach((f) => {
-          const icon = f.ok ? 'codicon-check' : 'codicon-warning';
-          const filePath = String(f.path ?? '');
-          const escaped = encodeHtml(filePath);
-
-          // Extract just the filename for display
-          const fileName = filePath.split('/').pop() || filePath;
-          const fileNameEscaped = encodeHtml(fileName);
-
-          // Build metadata string
-          let metadata = '';
-          if (f.varName) {
-            metadata += `<span class="file-var">[${f.varName}]</span>`;
-          }
-          if (source && source !== 'unknown') {
-            // Simplify source display
-            const sourceDisplay = source
-              .replace('requiredFiles', 'required')
-              .replace('Pattern ', '')
-              .replace(/'/g, '');
-            if (f.internal) {
-              metadata += ` <span class="file-source">(${sourceDisplay}, internal)</span>`;
-            } else {
-              metadata += ` <span class="file-source">(${sourceDisplay})</span>`;
-            }
-          }
-
-          items += `<li title="${escaped}"><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span> ${metadata}</li>`;
-        });
-      });
-
-      const totalFiles = parsed.length;
-      const loadedFiles = parsed.filter((f) => f.ok).length;
-      const failedFiles = totalFiles - loadedFiles;
-
-      let summary = `Files (${loadedFiles}/${totalFiles} loaded`;
-      if (failedFiles > 0) {
-        summary += `, ${failedFiles} not found`;
-      }
-      summary += ')';
-
-      if (summaryElem) summaryElem.textContent = summary;
-      if (contentElem) {
-        contentElem.innerHTML = items;
-        if (logId) contentElem.dataset.logId = logId;
-      }
-
-      return element;
-    } catch (e) {
-      console.error('Error parsing file list:', e);
+    if (!Array.isArray(parsed)) {
+      console.warn('Missing structured data for file list log entry');
       return null;
     }
+
+    // Group files by source for better organization
+    const filesBySource = {};
+    parsed.forEach((f) => {
+      const source = f.source || 'unknown';
+      if (!filesBySource[source]) {
+        filesBySource[source] = [];
+      }
+      filesBySource[source].push(f);
+    });
+
+    let items = '';
+    Object.entries(filesBySource).forEach(([source, files]) => {
+      files.forEach((f) => {
+        const icon = f.ok ? 'codicon-check' : 'codicon-warning';
+        const filePath = String(f.path ?? '');
+        const escaped = encodeHtml(filePath);
+
+        // Extract just the filename for display
+        const fileName = filePath.split('/').pop() || filePath;
+        const fileNameEscaped = encodeHtml(fileName);
+
+        // Build metadata string
+        let metadata = '';
+        if (f.varName) {
+          metadata += `<span class="file-var">[${f.varName}]</span>`;
+        }
+        if (source && source !== 'unknown') {
+          // Simplify source display
+          const sourceDisplay = source
+            .replace('requiredFiles', 'required')
+            .replace('Pattern ', '')
+            .replace(/'/g, '');
+          if (f.internal) {
+            metadata += ` <span class="file-source">(${sourceDisplay}, internal)</span>`;
+          } else {
+            metadata += ` <span class="file-source">(${sourceDisplay})</span>`;
+          }
+        }
+
+        items += `<li title="${escaped}"><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span> ${metadata}</li>`;
+      });
+    });
+
+    const totalFiles = parsed.length;
+    const loadedFiles = parsed.filter((f) => f.ok).length;
+    const failedFiles = totalFiles - loadedFiles;
+
+    let summary = `Files (${loadedFiles}/${totalFiles} loaded`;
+    if (failedFiles > 0) {
+      summary += `, ${failedFiles} not found`;
+    }
+    summary += ')';
+
+    if (summaryElem) summaryElem.textContent = summary;
+    if (contentElem) {
+      contentElem.innerHTML = items;
+      if (logId) contentElem.dataset.logId = logId;
+    }
+
+    return element;
   }
 
   _formatMissingOutputs(content, data, logId) {
-    try {
-      const element = createFromTemplate('missingOutputsDetailsTemplate');
-      if (!element) return null;
-      const contentElem = element.querySelector('.file-list-content');
-      const summaryElem = element.querySelector('.summary-text');
-      const toggleIcon = element.querySelector('.toggle-icon');
-      if (toggleIcon)
-        toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+    const element = createFromTemplate('missingOutputsDetailsTemplate');
+    if (!element) return null;
+    const contentElem = element.querySelector('.file-list-content');
+    const summaryElem = element.querySelector('.summary-text');
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
 
-      const parsed = data ?? JSON.parse(decodeHtml(content));
+    const parsed = data ?? JSON.parse(decodeHtml(content));
 
-      // Handle both old format (array) and new format (object with missing, xmlFile, documentTag)
-      let missingFiles = [];
-      let xmlFile = null;
-      let documentTag = null;
+    // Handle both old format (array) and new format (object with missing, xmlFile, documentTag)
+    let missingFiles = [];
+    let xmlFile = null;
+    let documentTag = null;
 
-      if (Array.isArray(parsed)) {
-        // Old format: just an array of missing files
-        missingFiles = parsed;
-      } else if (parsed && typeof parsed === 'object') {
-        // New format: object with missing files, XML file, and optional document tag
-        missingFiles = parsed.missing || [];
-        xmlFile = parsed.xmlFile;
-        documentTag = parsed.documentTag;
-      } else {
-        console.warn('Missing structured data for missing outputs log entry');
-        return null;
-      }
+    if (Array.isArray(parsed)) {
+      // Old format: just an array of missing files
+      missingFiles = parsed;
+    } else if (parsed && typeof parsed === 'object') {
+      // New format: object with missing files, XML file, and optional document tag
+      missingFiles = parsed.missing || [];
+      xmlFile = parsed.xmlFile;
+      documentTag = parsed.documentTag;
+    } else {
+      console.warn('Missing structured data for missing outputs log entry');
+      return null;
+    }
 
-      const items = missingFiles
-        .map((f) => {
-          const filePath = String(f);
-          const escaped = encodeHtml(filePath);
-          const fileName = filePath.split('/').pop() || filePath;
-          const fileNameEscaped = encodeHtml(fileName);
-          return `<li title="${escaped}"><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span></li>`;
-        })
-        .join('');
+    const items = missingFiles
+      .map((f) => {
+        const filePath = String(f);
+        const escaped = encodeHtml(filePath);
+        const fileName = filePath.split('/').pop() || filePath;
+        const fileNameEscaped = encodeHtml(fileName);
+        return `<li title="${escaped}"><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span></li>`;
+      })
+      .join('');
 
-      // Add XML file link if available
-      let xmlLink = '';
-      if (xmlFile) {
-        const xmlEscaped = encodeHtml(xmlFile);
-        const xmlFileName = xmlFile.split('/').pop() || xmlFile;
-        const xmlFileNameEscaped = encodeHtml(xmlFileName);
-        const tagInfo = documentTag
-          ? `<span class="document-tag">(Expected &lt;${encodeHtml(documentTag)}&gt; block)</span>`
-          : '';
-        xmlLink = `<div class="xml-link-container">
+    // Add XML file link if available
+    let xmlLink = '';
+    if (xmlFile) {
+      const xmlEscaped = encodeHtml(xmlFile);
+      const xmlFileName = xmlFile.split('/').pop() || xmlFile;
+      const xmlFileNameEscaped = encodeHtml(xmlFileName);
+      const tagInfo = documentTag
+        ? `<span class="document-tag">(Expected &lt;${encodeHtml(documentTag)}&gt; block)</span>`
+        : '';
+      xmlLink = `<div class="xml-link-container">
           <i class="codicon codicon-file-code"></i>
           <span>Open XML to check tag consistency:</span>
           <span class="file-link clickable-link" data-file="${xmlEscaped}">${xmlFileNameEscaped}</span>
           ${tagInfo}
         </div>`;
-      }
-
-      if (missingFiles.length === 0 && xmlFile) {
-        const wrapper = document.createElement('div');
-        wrapper.innerHTML = xmlLink;
-        return wrapper.firstElementChild;
-      }
-
-      const summary = `Missing outputs (${missingFiles.length})`;
-
-      if (summaryElem) summaryElem.textContent = summary;
-      if (contentElem) {
-        contentElem.innerHTML = items;
-        if (logId) contentElem.dataset.logId = logId;
-      }
-      if (xmlLink && element) {
-        const div = document.createElement('div');
-        div.innerHTML = xmlLink;
-        element.appendChild(div.firstElementChild);
-      }
-
-      return element;
-    } catch (e) {
-      console.error('Error parsing missing outputs:', e);
-      return null;
     }
+
+    if (missingFiles.length === 0 && xmlFile) {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = xmlLink;
+      return wrapper.firstElementChild;
+    }
+
+    const summary = `Missing outputs (${missingFiles.length})`;
+
+    if (summaryElem) summaryElem.textContent = summary;
+    if (contentElem) {
+      contentElem.innerHTML = items;
+      if (logId) contentElem.dataset.logId = logId;
+    }
+    if (xmlLink && element) {
+      const div = document.createElement('div');
+      div.innerHTML = xmlLink;
+      element.appendChild(div.firstElementChild);
+    }
+
+    return element;
   }
 
   _formatLatexdiff(content, data, logId) {
-    try {
-      const element = createFromTemplate('latexdiffDetailsTemplate');
-      if (!element) return null;
-      const contentElem = element.querySelector('.latexdiff-content');
-      const summaryElem = element.querySelector('.summary-text');
-      const toggleIcon = element.querySelector('.toggle-icon');
-      if (toggleIcon)
-        toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
+    const element = createFromTemplate('latexdiffDetailsTemplate');
+    if (!element) return null;
+    const contentElem = element.querySelector('.latexdiff-content');
+    const summaryElem = element.querySelector('.summary-text');
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
 
-      const parsed = data ?? JSON.parse(decodeHtml(content));
-      const entries = Array.isArray(parsed)
-        ? parsed
-        : parsed && typeof parsed === 'object'
-          ? [parsed]
-          : [];
+    const parsed = data ?? JSON.parse(decodeHtml(content));
+    const entries = Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === 'object'
+        ? [parsed]
+        : [];
 
-      if (entries.length === 0) {
-        return null;
-      }
-
-      let items = '';
-      entries.forEach((d) => {
-        const basePath = String(d.base ?? '');
-        const revisedPath = String(d.revised ?? '');
-        const outputPath = String(d.output ?? '');
-        const msg = d.message ? String(d.message) : '';
-
-        const baseEsc = encodeHtml(basePath);
-        const revisedEsc = encodeHtml(revisedPath);
-        const outputEsc = encodeHtml(outputPath);
-
-        const baseName = basePath.split('/').pop() || basePath;
-        const revisedName = revisedPath.split('/').pop() || revisedPath;
-
-        let icon = 'codicon-question';
-        if (d.status === 'success') {
-          icon = 'codicon-check';
-        } else if (d.status === 'error') {
-          icon = 'codicon-error';
-        }
-
-        const titleAttr = msg ? ` title="${encodeHtml(msg)}"` : '';
-
-        items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
-          baseName,
-        )}</span> <span class="arrow">&rarr;</span> <span class="file-link clickable-link" data-file="${revisedEsc}">${encodeHtml(
-          revisedName,
-        )}</span> (<span class="file-link clickable-link" data-file="${outputEsc}">diff</span>)</li>`;
-      });
-
-      const summary =
-        entries.length === 1
-          ? 'Latexdiff result'
-          : `Latexdiff results (${entries.length})`;
-
-      if (summaryElem) summaryElem.textContent = summary;
-      if (contentElem) {
-        contentElem.innerHTML = items;
-        if (logId) contentElem.dataset.logId = logId;
-      }
-
-      return element;
-    } catch (e) {
-      console.error('Error parsing latexdiff entry:', e);
+    if (entries.length === 0) {
       return null;
     }
+
+    let items = '';
+    entries.forEach((d) => {
+      const basePath = String(d.base ?? '');
+      const revisedPath = String(d.revised ?? '');
+      const outputPath = String(d.output ?? '');
+      const msg = d.message ? String(d.message) : '';
+
+      const baseEsc = encodeHtml(basePath);
+      const revisedEsc = encodeHtml(revisedPath);
+      const outputEsc = encodeHtml(outputPath);
+
+      const baseName = basePath.split('/').pop() || basePath;
+      const revisedName = revisedPath.split('/').pop() || revisedPath;
+
+      let icon = 'codicon-question';
+      if (d.status === 'success') {
+        icon = 'codicon-check';
+      } else if (d.status === 'error') {
+        icon = 'codicon-error';
+      }
+
+      const titleAttr = msg ? ` title="${encodeHtml(msg)}"` : '';
+
+      items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
+        baseName,
+      )}</span> <span class="arrow">&rarr;</span> <span class="file-link clickable-link" data-file="${revisedEsc}">${encodeHtml(
+        revisedName,
+      )}</span> (<span class="file-link clickable-link" data-file="${outputEsc}">diff</span>)</li>`;
+    });
+
+    const summary =
+      entries.length === 1
+        ? 'Latexdiff result'
+        : `Latexdiff results (${entries.length})`;
+
+    if (summaryElem) summaryElem.textContent = summary;
+    if (contentElem) {
+      contentElem.innerHTML = items;
+      if (logId) contentElem.dataset.logId = logId;
+    }
+
+    return element;
   }
 
   _formatStatistics(content, data, logId) {
-    try {
-      const element = createFromTemplate('statisticsDetailsTemplate');
-      if (!element) return null;
-      const contentElem = element.querySelector('.statistics-content');
-      const toggleIcon = element.querySelector('.toggle-icon');
-      if (toggleIcon)
-        toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
-      const parsed = data;
-      if (!parsed || typeof parsed !== 'object') {
-        return null;
-      }
-
-      const items = [];
-      const pushItem = (icon, label, value, suffix = '') => {
-        items.push(
-          `<span class="stat-item" title="${label}"><i class="codicon ${icon}"></i> ${value}${suffix}</span>`,
-        );
-      };
-
-      if (parsed.inputTokens !== undefined) {
-        pushItem(
-          'codicon-arrow-up',
-          'Input tokens',
-          formatTokens(parsed.inputTokens),
-        );
-      }
-      if (parsed.outputTokens !== undefined) {
-        pushItem(
-          'codicon-arrow-down',
-          'Output tokens',
-          formatTokens(parsed.outputTokens),
-        );
-      }
-      if (parsed.cacheReadInputTokens !== undefined) {
-        pushItem(
-          'codicon-history',
-          'Cache hits',
-          formatTokens(parsed.cacheReadInputTokens),
-        );
-      }
-      if (parsed.cacheCreationInputTokens !== undefined) {
-        pushItem(
-          'codicon-save',
-          'Cache writes',
-          formatTokens(parsed.cacheCreationInputTokens),
-        );
-      }
-      if (parsed.percentageCached !== undefined) {
-        pushItem(
-          'codicon-graph-line',
-          'Cached %',
-          `${parsed.percentageCached.toFixed(2)}%`,
-        );
-      }
-      if (parsed.reasoningTokens !== undefined) {
-        pushItem(
-          'codicon-comment-discussion',
-          'Reasoning tokens',
-          formatTokens(parsed.reasoningTokens),
-        );
-      }
-      if (parsed.toolUseTokens !== undefined) {
-        pushItem(
-          'codicon-tools',
-          'Tool tokens',
-          formatTokens(parsed.toolUseTokens),
-        );
-      }
-      if (parsed.elapsedTime !== undefined) {
-        pushItem('codicon-clock', 'Elapsed time', parsed.elapsedTime, 's');
-      }
-      if (parsed.cost !== undefined) {
-        pushItem('codicon-rocket', 'Cost', `$${parsed.cost.toFixed(3)}`);
-      }
-
-      if (contentElem) {
-        contentElem.innerHTML = items.join('');
-        if (logId) contentElem.dataset.logId = logId;
-      }
-
-      return element;
-    } catch (e) {
-      console.error('Error parsing statistics:', e);
+    // Note: content parameter kept for consistency with other formatters but not used
+    const element = createFromTemplate('statisticsDetailsTemplate');
+    if (!element) return null;
+    const contentElem = element.querySelector('.statistics-content');
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
+    const parsed = data;
+    if (!parsed || typeof parsed !== 'object') {
       return null;
     }
+
+    const items = [];
+    const pushItem = (icon, label, value, suffix = '') => {
+      items.push(
+        `<span class="stat-item" title="${label}"><i class="codicon ${icon}"></i> ${value}${suffix}</span>`,
+      );
+    };
+
+    if (parsed.inputTokens !== undefined) {
+      pushItem(
+        'codicon-arrow-up',
+        'Input tokens',
+        formatTokens(parsed.inputTokens),
+      );
+    }
+    if (parsed.outputTokens !== undefined) {
+      pushItem(
+        'codicon-arrow-down',
+        'Output tokens',
+        formatTokens(parsed.outputTokens),
+      );
+    }
+    if (parsed.cacheReadInputTokens !== undefined) {
+      pushItem(
+        'codicon-history',
+        'Cache hits',
+        formatTokens(parsed.cacheReadInputTokens),
+      );
+    }
+    if (parsed.cacheCreationInputTokens !== undefined) {
+      pushItem(
+        'codicon-save',
+        'Cache writes',
+        formatTokens(parsed.cacheCreationInputTokens),
+      );
+    }
+    if (parsed.percentageCached !== undefined) {
+      pushItem(
+        'codicon-graph-line',
+        'Cached %',
+        `${parsed.percentageCached.toFixed(2)}%`,
+      );
+    }
+    if (parsed.reasoningTokens !== undefined) {
+      pushItem(
+        'codicon-comment-discussion',
+        'Reasoning tokens',
+        formatTokens(parsed.reasoningTokens),
+      );
+    }
+    if (parsed.toolUseTokens !== undefined) {
+      pushItem(
+        'codicon-tools',
+        'Tool tokens',
+        formatTokens(parsed.toolUseTokens),
+      );
+    }
+    if (parsed.elapsedTime !== undefined) {
+      pushItem('codicon-clock', 'Elapsed time', parsed.elapsedTime, 's');
+    }
+    if (parsed.cost !== undefined) {
+      pushItem('codicon-rocket', 'Cost', `$${parsed.cost.toFixed(3)}`);
+    }
+
+    if (contentElem) {
+      contentElem.innerHTML = items.join('');
+      if (logId) contentElem.dataset.logId = logId;
+    }
+
+    return element;
   }
 }
 
@@ -772,6 +789,36 @@ export class TaskGroupHeaderFormatter {
         durationElem.textContent = this._formatDuration(durationMs);
       } else {
         durationElem.remove();
+      }
+    }
+
+    // Add usage information if available
+    if (group.usage) {
+      const { inputTokens = 0, outputTokens = 0, cost = 0 } = group.usage;
+      const usageDisplay =
+        `<span class="group-usage"><i class="codicon codicon-arrow-up"></i> ${formatTokens(inputTokens)}, ` +
+        `<i class="codicon codicon-arrow-down"></i> ${formatTokens(outputTokens)}, ` +
+        `$${cost.toFixed(3)}</span>`;
+
+      const bulletMarkup =
+        '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
+
+      // Add usage and bullet based on level
+      const timeSpan = header.querySelector('.group-time');
+      if (timeSpan) {
+        if (level.headerOrder === 'time-first') {
+          // For root level: time → bullet → usage
+          timeSpan.insertAdjacentHTML(
+            'afterend',
+            usageDisplay ? `${bulletMarkup}${usageDisplay}` : '',
+          );
+        } else {
+          // For nested level: usage → bullet → time
+          timeSpan.insertAdjacentHTML(
+            'beforebegin',
+            usageDisplay ? `${usageDisplay}${bulletMarkup}` : '',
+          );
+        }
       }
     }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -49,9 +49,7 @@ export class TaskGroupManager {
     detailsElem.id = `group-${group.id}`;
 
     // Create the header element as a <summary>
-    const headerTemplate = document.createElement('template');
-    headerTemplate.innerHTML = this.headerFormatter.create(group);
-    const headerElement = headerTemplate.content.firstElementChild;
+    const headerElement = this.headerFormatter.create(group);
 
     // Create a container for the group's messages
     const groupContainer = document.createElement('div');
@@ -310,9 +308,7 @@ export class LogEntryManager {
         `group-content-${logMessage.groupId}`,
       );
       if (groupContent) {
-        const messageElement = document.createElement('div');
-        messageElement.innerHTML = this.entryFormatter.format(logMessage);
-        const logLineElement = messageElement.firstElementChild;
+        const logLineElement = this.entryFormatter.format(logMessage);
 
         // Extract timestamp from the message for chronological ordering
         const msgDate = new Date(logMessage.timestamp);
@@ -376,9 +372,8 @@ export class LogEntryManager {
   update(logMessage) {
     const existing = document.querySelector(`[data-log-id="${logMessage.id}"]`);
     if (existing) {
-      const wrapper = document.createElement('div');
-      wrapper.innerHTML = this.entryFormatter.format(logMessage);
-      existing.replaceWith(wrapper.firstElementChild);
+      const newEl = this.entryFormatter.format(logMessage);
+      existing.replaceWith(newEl);
     }
   }
 }

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -1,6 +1,6 @@
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { formatTokens, BULLET_MARKUP, TaskGroupLevel } from './formatters.js';
+import { formatTokens, TaskGroupLevel } from './formatters.js';
 import { ELEMENT_IDS } from './constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -25,6 +25,15 @@ document.addEventListener('DOMContentLoaded', () => {
     'bulletTemplate',
     'streamTabTemplate',
     'roundHeaderTemplate',
+    'logLineTemplate',
+    'specialDetailsTemplate',
+    'toolUseTemplate',
+    'modelResponseTemplate',
+    'fileListDetailsTemplate',
+    'missingOutputsDetailsTemplate',
+    'latexdiffDetailsTemplate',
+    'statisticsDetailsTemplate',
+    'groupHeaderTemplate',
   ]);
   initializeIconButtons();
   progressViewDomHandler.toolbar.render();

--- a/src/test/progressView/Formatters.test.ts
+++ b/src/test/progressView/Formatters.test.ts
@@ -1,0 +1,31 @@
+import { strict as assert } from 'assert';
+// @ts-ignore: jsdom lacks ESM typings in this context
+import { JSDOM } from 'jsdom';
+// @ts-ignore: formatter is compiled JS module
+import { LogEntryFormatter } from '../../progressView/modules/formatters.js';
+
+describe('LogEntryFormatter DOM', () => {
+  it('creates basic log line element', () => {
+    const dom = new JSDOM(`<!doctype html><html><body>
+      <template id="logLineTemplate">
+        <div class="log-line"><span class="timestamp"></span><span class="level"></span><span class="message"></span></div>
+      </template>
+    </body></html>`);
+    global.document = dom.window.document as any;
+
+    const formatter = new LogEntryFormatter();
+    const el = formatter.format({
+      id: '1',
+      text: 'hello',
+      level: 'info',
+      timestamp: Date.now(),
+      groupId: null,
+      messageType: 'info',
+      verbose: false,
+      data: null,
+    } as any);
+
+    assert.ok(el instanceof dom.window.HTMLElement);
+    assert.equal(el.querySelector('.message')?.textContent, 'hello');
+  });
+});


### PR DESCRIPTION
## Summary
- add templates for log entries in progress view
- build log line elements using `createFromTemplate`
- use DOM nodes for task group headers
- ensure timestamp extractor works on elements
- add jsdom dependency for tests
- handle template fallbacks for `_formatSpecialContent` and `_formatMissingOutputs`

## Testing
- `npm run lint`
- `npm test` *(fails to complete due to webpack compile step)*

------
https://chatgpt.com/codex/tasks/task_e_68890df8f280832496eec3493743eb98