### PR TITLE
Update Anthropic tool mapping

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -13,6 +13,14 @@ import type {
   Schema,
 } from '@google/genai/dist/genai';
 
+// Map local tool names to Anthropic remote tool types
+const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
+  bash: 'bash_20250124',
+  str_replace_editor: 'text_editor_20250124',
+  str_replace_based_edit_tool: 'text_editor_20250429',
+  web_search: 'web_search_20250305',
+} as const;
+
 /** Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format. */
 export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
   return defs.map((d) => ({
@@ -27,20 +35,12 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 
 /** Convert generic ToolDefinition objects to Anthropic Tool format. */
 export function toAnthropicTools(defs: ToolDefinition[]): ToolUnion[] {
-  const typeMap: Record<string, string> = {
-    bash: 'bash_20250124',
-    str_replace_editor: 'text_editor_20250124',
-    str_replace_based_edit_tool: 'text_editor_20250429',
-    web_search: 'web_search_20250305',
-  };
-
   return defs.map<ToolUnion>((d) => {
-    const remoteType = typeMap[d.name];
+    const remoteType = ANTHROPIC_TOOL_TYPE_MAP[d.name];
     if (remoteType) {
       return {
         name: d.name,
         type: remoteType,
-        ...(d.parameters ?? {}),
       } as ToolUnion;
     }
 

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -27,11 +27,30 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 
 /** Convert generic ToolDefinition objects to Anthropic Tool format. */
 export function toAnthropicTools(defs: ToolDefinition[]): ToolUnion[] {
-  return defs.map<ToolUnion>((d) => ({
-    name: d.name,
-    description: d.description,
-    input_schema: (d.parameters ?? {}) as AnthropicTool['input_schema'],
-  }));
+  const typeMap: Record<string, string> = {
+    bash: 'bash_20250124',
+    str_replace_editor: 'text_editor_20250124',
+    str_replace_based_edit_tool: 'text_editor_20250429',
+    web_search: 'web_search_20250305',
+  };
+
+  return defs.map<ToolUnion>((d) => {
+    const remoteType = typeMap[d.name];
+    if (remoteType) {
+      return {
+        name: d.name,
+        type: remoteType,
+        ...(d.parameters ?? {}),
+      } as ToolUnion;
+    }
+
+    const params = d.parameters as AnthropicTool['input_schema'] | undefined;
+    return {
+      name: d.name,
+      description: d.description,
+      ...(params ? { input_schema: params } : {}),
+    } as ToolUnion;
+  });
 }
 
 /** Convert generic ToolDefinition objects to Google Gemini Tool format. */


### PR DESCRIPTION
## Summary
- support built‑in Anthropic tools by mapping names to remote types

## Testing
- `npm run lint`
- `npm test` *(fails: webpack warnings and `vscode-test` run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_688911ebabb08324a6750f349e8222a0