### PR TITLE
Add persistent bash session support

### DIFF
--- a/docs/guide/bash-tool.md
+++ b/docs/guide/bash-tool.md
@@ -1,0 +1,29 @@
+# Bash Tool
+
+TeXRA includes a `bash` tool that lets agents execute shell commands within your workspace. The
+session is persistent, meaning commands share the same environment and working directory.
+
+## Usage
+
+The tool accepts either a `command` to run or a `restart` flag:
+
+```json
+{ "command": "ls" }
+{ "restart": true }
+```
+
+Use `restart` to start a fresh shell session. A typical workflow might change directories and run
+subsequent commands that rely on that state. Restarting resets the working directory and clears
+any environment variables set during the session.
+
+Outputs longer than 100 lines are truncated to avoid flooding the log. Potentially dangerous
+commands like `rm -rf /` are blocked.
+
+## Example
+
+```json
+{ "command": "cd data && ls" }
+```
+
+Calling the tool again with `pwd` will show `data` because the session kept the directory change.
+Use `{ "restart": true }` if you need to reset the environment.

--- a/docs/guide/tool-integration.md
+++ b/docs/guide/tool-integration.md
@@ -34,6 +34,12 @@ Providing quantitative insights into your document structure.
 
 _(Note: These tools often rely on external programs that need to be installed separately. See the [Installation guide](./installation.md) for requirements.)_
 
+### 4. Shell Access
+
+For advanced workflows, TeXRA exposes a persistent shell via the [bash tool](./bash-tool.md). This
+allows agents to run simple commands, chain them together, and manipulate files within the
+workspace. Restart the session when needed using the `restart` flag.
+
 ## How Tools Enhance Agents
 
 Tool integration improves agent performance and reliability:

--- a/src/test/toolUse/BashTool.test.ts
+++ b/src/test/toolUse/BashTool.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from 'assert';
+
+// Local imports
+import { BashTool } from '@tools/bash';
+import { WorkspaceFS } from '@utils/files';
+
+const tool = new BashTool();
+
+describe('BashTool persistent session', () => {
+  it('maintains directory between calls and restarts', async () => {
+    const cwd = WorkspaceFS.getPath();
+    if (!cwd) {
+      throw new Error('No workspace path');
+    }
+    await tool.call({ restart: true });
+    const out1 = await tool.call({ command: 'pwd' });
+    assert.equal(out1.output?.trim(), cwd);
+
+    await tool.call({ command: 'mkdir -p tmp_test_dir && cd tmp_test_dir' });
+    const out2 = await tool.call({ command: 'pwd' });
+    assert.ok(out2.output?.endsWith('tmp_test_dir'));
+
+    await tool.call({ restart: true });
+    const out3 = await tool.call({ command: 'pwd' });
+    assert.equal(out3.output?.trim(), cwd);
+  });
+});

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -2,17 +2,23 @@
 
 // Local imports - core
 import { z } from 'zod';
-import { executeCommand } from '@utils/system/execUtils';
+import { BashSession } from '@utils/system/bashSession';
 import { BaseTool } from './core/base';
 import { ToolResult } from '@tools/result';
 import type { ToolDefinition } from '@model';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
-const BashInputSchema = z.object({
-  command: z.string(),
-});
+const BashInputSchema = z
+  .object({
+    command: z.string().optional(),
+    restart: z.boolean().optional(),
+  })
+  .refine((data) => data.command || data.restart, {
+    message: 'command or restart required',
+  });
 
 export type BashInput = z.infer<typeof BashInputSchema>;
+const bashSession = new BashSession();
 
 export class BashTool extends BaseTool<BashInput> {
   constructor() {
@@ -25,12 +31,20 @@ export class BashTool extends BaseTool<BashInput> {
   }
 
   protected async execute(input: BashInput): Promise<ToolResult> {
-    const result = await executeCommand(input.command, { truncate: true });
+    if (input.restart) {
+      bashSession.restart();
+      return new ToolResult({ output: 'Bash session restarted' });
+    }
+    const result = await bashSession.execute(input.command ?? '', {
+      truncate: true,
+    });
     if (result.success) {
       return new ToolResult({ output: result.stdout || '' });
     }
     return new ToolResult({
-      error: result.stderr || 'Command failed',
+      error: result.timedOut
+        ? 'Error: Command timed out'
+        : result.stderr || 'Command failed',
       isError: true,
     });
   }

--- a/src/utils/system/bashSession.ts
+++ b/src/utils/system/bashSession.ts
@@ -1,0 +1,139 @@
+// Third-party imports
+import { execa, type Subprocess } from 'execa';
+import { nanoid } from 'nanoid';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
+import { WorkspaceFS } from '@utils/files';
+import { extendEnvPath } from './platformPaths';
+import type { ExecResult } from '@agent/types/ResultTypes';
+
+const CHANNEL = 'bashSession';
+logger.initialize(CHANNEL);
+
+function truncateOutput(output: string, maxLines = 100): string {
+  const lines = output.split('\n');
+  if (lines.length > maxLines) {
+    return (
+      lines.slice(0, maxLines).join('\n') +
+      `\n\n... Output truncated (${lines.length} total lines) ...`
+    );
+  }
+  return output;
+}
+
+function validateCommand(command: string): [boolean, string?] {
+  const dangerousPatterns = ['rm -rf /', ':(){:|:&};:'];
+  for (const pattern of dangerousPatterns) {
+    if (command.includes(pattern)) {
+      return [false, pattern];
+    }
+  }
+  return [true];
+}
+
+export class BashSession {
+  private process: Subprocess | null = null;
+
+  constructor() {
+    this.start();
+  }
+
+  private start() {
+    const cwd = WorkspaceFS.getPath();
+    if (!cwd) {
+      throw new Error('No workspace path found');
+    }
+    const env = { ...process.env };
+    env.PATH = extendEnvPath(env.PATH);
+    this.process = execa('/bin/bash', [], {
+      cwd,
+      env,
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      reject: false,
+    });
+    if (this.process.stdout) {
+      this.process.stdout.setEncoding('utf8');
+    }
+    if (this.process.stderr) {
+      this.process.stderr.setEncoding('utf8');
+    }
+  }
+
+  public restart() {
+    if (this.process) {
+      this.process.kill();
+    }
+    this.start();
+  }
+
+  public async execute(
+    command: string,
+    options: { timeout?: number; truncate?: boolean } = {},
+  ): Promise<ExecResult> {
+    const [valid, reason] = validateCommand(command);
+    if (!valid) {
+      return {
+        success: false,
+        stdout: null,
+        stderr: `Command contains dangerous pattern: ${reason}`,
+        timedOut: false,
+      };
+    }
+    const session = this.process;
+    if (!session || !session.stdin || !session.stdout) {
+      return {
+        success: false,
+        stdout: null,
+        stderr: 'Bash session not initialized',
+        timedOut: false,
+      };
+    }
+
+    const marker = `__texra_end_${nanoid(6)}__`;
+    let stdout = '';
+    let stderr = '';
+
+    return new Promise<ExecResult>((resolve) => {
+      const timeoutMs = options.timeout ?? 30000;
+      const timeoutHandle = setTimeout(() => {
+        cleanup(true);
+      }, timeoutMs);
+
+      const onStdout = (data: Buffer) => {
+        stdout += data.toString();
+        if (stdout.includes(marker)) {
+          cleanup(false);
+        }
+      };
+      const onStderr = (data: Buffer) => {
+        stderr += data.toString();
+      };
+      const cleanup = (timedOut: boolean) => {
+        session.stdout?.off('data', onStdout);
+        session.stderr?.off('data', onStderr);
+        clearTimeout(timeoutHandle);
+        const trimmedOut = stdout.replace(marker, '').trim();
+        const resultOut = options.truncate
+          ? truncateOutput(trimmedOut)
+          : trimmedOut;
+        const trimmedErr = stderr.trim() || null;
+        resolve({
+          success: !timedOut,
+          stdout: resultOut || null,
+          stderr: trimmedErr,
+          timedOut,
+        });
+      };
+
+
+
+      session.stdout?.on('data', onStdout);
+      session.stderr?.on('data', onStderr);
+
+      session.stdin?.write(`${command}\necho ${marker}\n`);
+    });
+  }
+}

--- a/src/utils/system/index.ts
+++ b/src/utils/system/index.ts
@@ -2,3 +2,4 @@ export * from './execUtils';
 export * from './commandUtils';
 export * from './toolUtils';
 export * from './platformPaths';
+export * from './bashSession';


### PR DESCRIPTION
## Summary
- support persistent bash session in BashTool
- expose `BashSession` util and export from system utilities
- document bash session behaviour
- test persistence and restart logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test could not run in container)*

------
https://chatgpt.com/codex/tasks/task_e_68893646b4f883249ca8bc316a21be31