### PR TITLE
Fix tool alias expansion for Anthropic tool use

### DIFF
--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -124,10 +124,13 @@ export async function loadAgentSettingAndPrompts(
             output.push(...resolveSets(ToolSets[item], visited));
             visited.delete(item);
           } else if (typeof item === 'string') {
-            if (!DEFAULT_TOOL_REGISTRY[item]) {
+            const tool = DEFAULT_TOOL_REGISTRY[item];
+            if (!tool) {
               logger.warn(CHANNEL, `Tool "${item}" not found in registry`);
+              output.push({ name: item });
+            } else {
+              output.push(tool.definition);
             }
-            output.push({ name: item });
           } else {
             if (!DEFAULT_TOOL_REGISTRY[item.name]) {
               logger.warn(CHANNEL, `Tool "${item.name}" not found in registry`);


### PR DESCRIPTION
## Summary
- resolve tool aliases via DEFAULT_TOOL_REGISTRY when loading agent settings

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '@anthropic-ai/sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68894ba5a2e0832485ad1a3111c92958