### PR TITLE
feat: save debug messages in tool use cycle

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -198,7 +198,7 @@ Control logging behavior:
 ```
 
 - `debugMode`: Show detailed debug messages in the logger view
-- `saveMessageObjects`: Save message JSON objects to files before API calls (for debugging)
+- `saveMessageObjects`: Save message JSON objects to files before API calls (for debugging, including tool use cycles)
 
 ## Environment-Specific Configuration
 

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -181,7 +181,8 @@ directory:
 ```
 
 This folder stores intermediate artifacts such as the optional message JSON
-files written when `texra.debug.saveMessageObjects` is enabled. These directories
+files written when `texra.debug.saveMessageObjects` is enabled (for both
+response and tool use cycles). These directories
 are safe to delete if you need to reclaim space.
 
 ## Working with LaTeX Projects

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-import * as path from 'path';
 
 // Third-party imports
 // (none needed)
@@ -13,7 +12,6 @@ import { bestConnectionMethod } from '@latex';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
-import { StorageFS } from '@utils/files';
 import { getRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
@@ -21,6 +19,7 @@ import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 import replacementEngine from '@replacement/engine';
 import xmlUtils from '@utils/text/xmlUtils';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { maybeSaveMessages } from '@agent/utils/debugMessageSaver';
 
 // Local imports - agent components
 import type { AgentConfig } from './AgentConfig';
@@ -89,34 +88,14 @@ export async function runResponseCycle(
       userVars,
     );
 
-    const shouldSaveMessageObjects = getConfig(
-      'debug.saveMessageObjects',
-      false,
-    );
-    if (shouldSaveMessageObjects) {
-      const outputFileBaseName = path.basename(outputFile, '.xml');
-      const debugFileName = `${outputFileBaseName}_cont${stateRound.continuationCount}.json`;
-      const debugFilePath = executionId
-        ? path.join(getRunDir(executionId), debugFileName)
-        : WorkspaceFS.fullPath(debugFileName);
-      try {
-        if (executionId) {
-          await StorageFS.write(
-            debugFilePath,
-            JSON.stringify(messages, null, 2),
-          );
-          logger.info(`Saved message object to ${debugFilePath}`, taskGroupId);
-        } else {
-          await WorkspaceFS.writeFile(
-            WorkspaceFS.relativePath(debugFilePath),
-            JSON.stringify(messages, null, 2),
-          );
-          logger.info(`Saved message object to ${debugFilePath}`, taskGroupId);
-        }
-      } catch (error) {
-        logger.error(`Failed to save message object: ${error}`, taskGroupId);
-      }
-    }
+    await maybeSaveMessages({
+      messages,
+      logger,
+      continuationCount: stateRound.continuationCount,
+      outputFile,
+      executionId,
+      groupId: taskGroupId,
+    });
 
     const abortController = new AbortController();
     setAbortController(abortController);

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -13,6 +13,7 @@ import type { IModelHandler } from '../modelHandlers';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
+import { maybeSaveMessages } from '@agent/utils/debugMessageSaver';
 
 export interface ToolUseCycleOptions {
   /** Model handler for API interactions */
@@ -54,10 +55,20 @@ export async function runToolUseCycle(
     setAbortController,
   } = options;
 
+  let iteration = 0;
+
   while (true) {
     if (await checkInterruption()) {
       break;
     }
+
+    await maybeSaveMessages({
+      messages,
+      logger,
+      continuationCount: iteration,
+      baseName: 'tooluse',
+      groupId,
+    });
 
     const abortController = new AbortController();
     setAbortController(abortController);
@@ -241,5 +252,7 @@ export async function runToolUseCycle(
       resultObj,
     );
     messages.push(callMsg, resultMsg);
+
+    iteration++;
   }
 }

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,0 +1,67 @@
+// Utility for saving message objects during debugging
+
+// Standard library imports
+import * as path from 'path';
+
+// Local imports
+import { WorkspaceFS, StorageFS } from '@utils/files';
+import { getRunDir } from '@utils/files/taskRunStorage';
+import { getConfig } from '@utils/config';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { AgentLogger } from '@logger/AgentLogger';
+
+export interface SaveMessagesParams {
+  messages: any[];
+  logger: AgentLogger;
+  continuationCount?: number;
+  outputFile?: string;
+  baseName?: string;
+  executionId?: ExecutionId;
+  groupId?: string;
+}
+
+/**
+ * Save conversation message objects to a JSON file when
+ * `texra.debug.saveMessageObjects` is enabled.
+ */
+export async function maybeSaveMessages({
+  messages,
+  logger,
+  continuationCount,
+  outputFile,
+  baseName = 'messages',
+  executionId,
+  groupId,
+}: SaveMessagesParams): Promise<void> {
+  const shouldSave = getConfig<boolean>('debug.saveMessageObjects', false);
+  if (!shouldSave) {
+    return;
+  }
+
+  const fileBase =
+    outputFile !== undefined
+      ? path.basename(outputFile, path.extname(outputFile))
+      : baseName;
+  const cont =
+    continuationCount !== undefined ? `_cont${continuationCount}` : '';
+  const debugFileName = `${fileBase}${cont}.json`;
+
+  const debugFilePath = executionId
+    ? path.join(getRunDir(executionId), debugFileName)
+    : WorkspaceFS.fullPath(debugFileName);
+
+  try {
+    const content = JSON.stringify(messages, null, 2);
+    if (executionId) {
+      await StorageFS.write(debugFilePath, content);
+    } else {
+      await WorkspaceFS.writeFile(
+        WorkspaceFS.relativePath(debugFilePath),
+        content,
+      );
+    }
+    logger.info(`Saved message object to ${debugFilePath}`, groupId);
+  } catch (error) {
+    logger.error(`Failed to save message object: ${error}`, groupId);
+  }
+}

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -7,3 +7,4 @@ export * from './outputFileUtils';
 export * from './priceUtils';
 export * from './text';
 export * from './UsageMonitor';
+export * from './debugMessageSaver';


### PR DESCRIPTION
## Summary
- add `maybeSaveMessages` helper to capture messages when debugging
- use the helper in `runResponseCycle` and `runToolUseCycle`
- document that debug messages are saved for tool use cycles as well

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: VS Code download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6889508b51f483248932798316498396