### PR TITLE
feat: tidy model response rendering

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -96,8 +96,9 @@ export async function runToolUseCycle(
       '',
     );
     if (text) {
-      logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
-      logger.info(text, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
+      const formatted = await xmlUtils.formatContent(text);
+      logger.debug(`Model response: ${formatted.slice(0, 100)}`, groupId);
+      logger.info(formatted, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
     }
     if (usage) {
       const normalized = modelHandler.computeResponseUsage(usage, responseTime);


### PR DESCRIPTION
## Summary
- reduce blank lines in model responses by reusing the markdown cleanup used for thinking/scratchpad

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68895012d5f883249abc2c4b93f771c0