### PR TITLE
Fix markdown spacing for model responses

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -209,7 +209,7 @@ export class LogEntryFormatter {
       .replace(/\n(\s*)\n(\s*)\n(\s*)- /g, '\n$3- ')
       .replace(/\n(\s*)\n(\s*)- /g, '\n$2- ')
       .replace(/\n{4,}/g, '\n\n')
-      .replace(/ {4}/gm, '  ');
+      // .replace(/ {4}/gm, '  ');
   }
 
   /**

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -151,6 +151,10 @@ export class LogEntryFormatter {
       content = decodeHtml(content);
     }
 
+    // Normalize line breaks and spacing similar to xmlUtils.formatContent
+    // to avoid excessive whitespace in rendered output
+    content = this._normalizeLineBreaks(content);
+
     // Pre-process LaTeX references to protect them from markdown parsing
     content = content.replace(/\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
     content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
@@ -191,6 +195,21 @@ export class LogEntryFormatter {
       .replace(/@@LATEX-EQREF:([^@]+)@@/g, (_, label) =>
         this._createLatexReferenceHtml('eqref', label),
       );
+  }
+
+  /**
+   * Collapse excessive blank lines and normalize spacing. This mirrors
+   * cleanup applied by xmlUtils.formatContent for special contents so that
+   * model responses render consistently.
+   * @param {string} text - Raw markdown text
+   * @returns {string} Normalized text
+   */
+  _normalizeLineBreaks(text) {
+    return text
+      .replace(/\n(\s*)\n(\s*)\n(\s*)- /g, '\n$3- ')
+      .replace(/\n(\s*)\n(\s*)- /g, '\n$2- ')
+      .replace(/\n{4,}/g, '\n\n')
+      .replace(/ {4}/gm, '  ');
   }
 
   /**


### PR DESCRIPTION
## Summary
- normalize line breaks in `LogEntryFormatter` to remove excess whitespace
- apply the same cleanup when processing markdown so model responses render consistently

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68895012d5f883249abc2c4b93f771c0