### PR TITLE
Fix formatting of model responses

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -97,7 +97,8 @@ export async function runToolUseCycle(
     );
     if (text) {
       logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
-      logger.info(text, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
+      const formatted = await xmlUtils.formatContent(text);
+      logger.info(formatted, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
     }
     if (usage) {
       const normalized = modelHandler.computeResponseUsage(usage, responseTime);


### PR DESCRIPTION
## Summary
- preprocess model responses with `formatContent` before logging

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: could not run vscode-test in container)*

------
https://chatgpt.com/codex/tasks/task_e_68895012d5f883249abc2c4b93f771c0