### PR TITLE
fix: unify text editor tool name

### DIFF
--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -166,7 +166,7 @@ when the agent configuration is loaded. The `wolframExec` set enables the
 `wolfram` tool for running small Wolfram Language snippets during a run.
 
 The built-in `ToolSetRegistry` maps aliases to lists of tool definitions. For
-instance, the `file_edit` set expands to `{ name: 'text_editor' }`. Nested sets
+instance, the `file_edit` set expands to `{ name: 'str_replace_editor' }`. Nested sets
 are resolved recursively, and any unknown names trigger a warning during agent
 loading.
 
@@ -176,7 +176,7 @@ Example:
 settings:
   agentType: toolUse
   tools:
-    - file_edit # expands to the text_editor tool
+    - file_edit # expands to the str_replace_editor tool
     - wolframExec # execute Wolfram Language code
     - bash # single tool by name
     - basic_io # adds bash and file_op tools

--- a/resources/tool_use_agents/file_edit.yaml
+++ b/resources/tool_use_agents/file_edit.yaml
@@ -2,10 +2,10 @@ name: file_edit
 settings:
   agentType: toolUse
   tools:
-    - text_editor
+    - str_replace_editor
 prompts:
   systemPrompt: |
-    You edit files using the provided text_editor tool.
+    You edit files using the provided str_replace_editor tool.
   userPrefix: |
     The target file is {{ INPUT_FILE }}.
   userRequest: |

--- a/resources/tool_use_agents/tex_linter_fix.yaml
+++ b/resources/tool_use_agents/tex_linter_fix.yaml
@@ -2,11 +2,11 @@ name: tex_linter_fix
 settings:
   agentType: toolUse
   tools:
-    - text_editor
+    - str_replace_editor
     - diagnostics
 prompts:
   systemPrompt: |
-    You fix LaTeX linter issues. Use the diagnostics tool to list current problems and the text_editor tool to apply minimal edits.
+    You fix LaTeX linter issues. Use the diagnostics tool to list current problems and the str_replace_editor tool to apply minimal edits.
   userPrefix: |
     Fix linter issues in {{FILE}}. The first problem context is:
     {{ERROR_CONTEXT}}

--- a/resources/tool_use_agents/xml_validator.yaml
+++ b/resources/tool_use_agents/xml_validator.yaml
@@ -2,10 +2,10 @@ name: xml_validator
 settings:
   agentType: toolUse
   tools:
-    - text_editor
+    - str_replace_editor
 prompts:
   systemPrompt: |
-    You validate XML files. Review errors and apply fixes with the text_editor tool.
+    You validate XML files. Review errors and apply fixes with the str_replace_editor tool.
   userPrefix: |
     The file {{FILE}} contains an XML error:
     {{ERROR_CONTEXT}}

--- a/src/agent/toolUse/ToolSetRegistry.ts
+++ b/src/agent/toolUse/ToolSetRegistry.ts
@@ -1,7 +1,7 @@
 import type { ToolDefinition } from '@model';
 
 export const ToolSets: Record<string, ToolDefinition[]> = {
-  file_edit: [{ name: 'text_editor' }],
+  file_edit: [{ name: 'str_replace_editor' }],
   diagnostics_only: [{ name: 'diagnostics' }],
   basic_io: [{ name: 'bash' }, { name: 'file_op' }],
   wolframExec: [{ name: 'wolfram' }],

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -6,7 +6,7 @@ import { WolframTool } from './wolfram';
 
 import { BaseTool } from './core/base';
 export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
-  text_editor: new TextEditorTool(),
+  str_replace_editor: new TextEditorTool(),
   diagnostics: new DiagnosticsTool(),
   bash: new BashTool(),
   file_op: new FileOpTool(),


### PR DESCRIPTION
## Summary
- rename text_editor tool key to str_replace_editor
- update tool set aliases
- adjust tool use agent YAMLs to reference new name
- document new file_edit expansion

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68895e3fd1288324952f8638a7aebc6c