### PR TITLE
feat: add typed diagnostics for ToolResult

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -14,6 +14,8 @@ import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
 import { maybeSaveMessages } from '@agent/utils/debugMessageSaver';
+import type { LinterMessage } from '@frontend/latex/linter';
+import type { BaseError } from '@tools/types';
 
 export interface ToolUseCycleOptions {
   /** Model handler for API interactions */
@@ -184,25 +186,17 @@ export async function runToolUseCycle(
       } catch (err) {
         // Prepare both user-friendly error and detailed diagnostics
         let errorMessage: string;
-        let diagnostics: any;
+        let diagnostics: LinterMessage[] | BaseError | BaseError[] | undefined;
 
         if (err && typeof err === 'object' && 'issues' in err) {
           // This is a Zod validation error
           const zodError = err as any;
           // Simple message for the model/user
           errorMessage = `${name}: Invalid parameters provided`;
-          // Detailed diagnostics for debugging
-          diagnostics = {
-            type: 'validation_error',
-            issues: zodError.issues,
-            formatted: zodError.issues?.map((issue: any) => ({
-              path: issue.path.join('.'),
-              message: issue.message,
-              expected: issue.expected,
-              received: issue.received,
-              code: issue.code,
-            })),
-          };
+          // Convert issues to BaseError array for diagnostics
+          diagnostics = zodError.issues?.map((issue: any) => ({
+            message: issue.message,
+          }));
         } else {
           errorMessage =
             err instanceof Error

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -1,10 +1,14 @@
+// Local imports - types
+import type { LinterMessage } from '@frontend/latex/linter';
+import type { BaseError } from '@tools/types';
+
 export class ToolResult {
   output?: string;
   error?: string;
   base64Image?: string;
   system?: string;
   isError: boolean;
-  diagnostics?: any; // Additional error details like validation issues
+  diagnostics?: LinterMessage[] | BaseError | BaseError[]; // Additional error details like validation issues
 
   constructor({
     output,
@@ -19,7 +23,7 @@ export class ToolResult {
     base64Image?: string;
     system?: string;
     isError?: boolean;
-    diagnostics?: any;
+    diagnostics?: LinterMessage[] | BaseError | BaseError[];
   }) {
     this.output = output;
     this.error = error;


### PR DESCRIPTION
## Summary
- import `LinterMessage` and `BaseError` types
- type `ToolResult` diagnostics with these types
- convert validation diagnostics to `BaseError[]`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6889ccbbed5c83249058e53c1e02ec95