### PR TITLE
Introduce typed provider messages

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -27,6 +27,7 @@ import type { AgentSetting, AgentPrompt } from './AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from './AgentState';
 import { ToolState } from './ToolState';
 import type { IModelHandler } from '@agent/modelHandlers';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 // Shared constants
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
@@ -53,7 +54,7 @@ export interface ResponseCycleOptions {
  */
 export async function runResponseCycle(
   options: ResponseCycleOptions,
-  messages: any[],
+  messages: ProviderMessage[],
   stateRound: AgentStateRound,
   stateGlobal: AgentStateGlobal,
   toolState: ToolState,

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -10,6 +10,7 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { AgentSetting, AgentPrompt } from './AgentDataclass';
 import type { ToolDefinition } from '@model';
 import type { IModelHandler } from '../modelHandlers';
+import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
@@ -42,7 +43,7 @@ export interface ToolUseCycleOptions {
  */
 export async function runToolUseCycle(
   options: ToolUseCycleOptions,
-  messages: any[],
+  messages: ProviderMessage[],
   groupId?: string,
 ): Promise<void> {
   const {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -19,6 +19,7 @@ import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type { IModelHandler } from './types/IModelHandler';
+import type { ProviderMessage } from './types/ProviderMessage';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 // Local imports - agent components
@@ -57,8 +58,11 @@ interface MarkerFlags {
 /**
  * Abstract base class for model-specific handlers that manage API interactions, message processing, and response handling.
  */
-export abstract class ModelHandler<U = any, R = any>
-  implements IModelHandler<U, R>
+export abstract class ModelHandler<
+  M extends ProviderMessage = ProviderMessage,
+  U = any,
+  R = any,
+> implements IModelHandler<M, U, R>
 {
   public config: ModelConfig;
   public capabilities: ModelCapabilities;
@@ -569,7 +573,7 @@ export abstract class ModelHandler<U = any, R = any>
    */
   abstract createResponse(
     client: any,
-    messages: any[],
+    messages: M[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
@@ -586,17 +590,17 @@ export abstract class ModelHandler<U = any, R = any>
     userRequest: string,
     mediaFiles?: string[],
     systemPrompt?: string,
-  ): Promise<any[]>;
+  ): Promise<M[]>;
 
   /**
    * Creates messages for follow-up conversation rounds with optional images.
    * @returns Provider-specific message array with new round content
    */
   abstract createRoundMessages(
-    messages: any[],
+    messages: M[],
     userMessage: string,
     mediaFiles?: string[],
-  ): Promise<any[]>;
+  ): Promise<M[]>;
 
   /**
    * Formats image content into provider-specific message format.
@@ -620,7 +624,7 @@ export abstract class ModelHandler<U = any, R = any>
    * Updates messages array and tool state for next turn.
    */
   abstract addContinueMessageWithPrefill(
-    messages: any[],
+    messages: M[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -632,7 +636,7 @@ export abstract class ModelHandler<U = any, R = any>
    * Updates messages array and tool state for next turn.
    */
   abstract addContinueMessageWithoutPrefill(
-    messages: any[],
+    messages: M[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -646,12 +650,12 @@ export abstract class ModelHandler<U = any, R = any>
   abstract initializeOutputAndPrefill(
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
-    messages: any[],
+    messages: M[],
     toolState: ToolState,
     outputFile: string,
     prefill: string,
     groupId?: string,
-  ): Promise<[boolean, any[]]>;
+  ): Promise<[boolean, M[]]>;
 
   /**
    * Calculates API usage cost based on token counts and provider pricing.
@@ -670,7 +674,7 @@ export abstract class ModelHandler<U = any, R = any>
    * Handles cache control and content formatting.
    */
   abstract updateMessageContentWithPrefill(
-    messages: any[],
+    messages: M[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,
@@ -681,7 +685,7 @@ export abstract class ModelHandler<U = any, R = any>
    * Handles cache control and content formatting.
    */
   abstract updateMessageContentWithoutPrefill(
-    messages: any[],
+    messages: M[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -46,10 +46,10 @@ import { toAnthropicTools } from './toolConversion';
 
 // The new implicit prompt caching is worth checking out (can eliminate many controls of previous caching)
 export class ModelHandlerAnthropic extends ModelHandler<
+  MessageParam,
   AnthropicUsage,
   AnthropicAPIResponseUsage
 > {
-  /** Initializes an Anthropic API client using the configured API key. */
   async getClient(): Promise<Anthropic> {
     const apiKey = await this.getApiKey();
     this.logger.debug('Using Anthropic API.');

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -151,11 +151,11 @@ function convertMessagesToGoogleContentHistory(
  * Handler for Google models using the native @google/genai SDK and Chat API.
  */
 export class ModelHandlerGoogleGenAI extends ModelHandler<
+  Content,
   GenerateContentResponseUsageMetadata | null,
   OpenAIAPIResponseUsage
 > {
   private googleClient: GoogleGenAI | null = null;
-
   async getClient(): Promise<GoogleGenAI> {
     if (!this.googleClient) {
       const apiKey = await this.getApiKey();

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -7,6 +7,7 @@ import {
   ChatCompletionContentPart,
   ChatCompletionAssistantMessageParam,
   ChatCompletionToolMessageParam,
+  ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
 import { countTokens } from 'gpt-tokenizer';
 
@@ -40,6 +41,7 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
  * OpenAI-specific handlers.
  */
 export class ModelHandlerOpenAI extends ModelHandler<
+  ChatCompletionMessageParam,
   ExtendedCompletionUsage | null,
   OpenAIAPIResponseUsage
 > {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -9,7 +9,6 @@ import {
   ChatCompletionToolMessageParam,
   ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
-import type { ResponseInputItem } from 'openai/resources/responses/responses';
 import { countTokens } from 'gpt-tokenizer';
 
 // Local imports - utilities
@@ -60,7 +59,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /** Creates a chat completion with model-specific parameters. */
   async createResponse(
     client: OpenAI,
-    messages: ChatCompletionMessageParam[] | ResponseInputItem[],
+    messages: ChatCompletionMessageParam[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -58,7 +58,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /** Creates a chat completion with model-specific parameters. */
   async createResponse(
     client: OpenAI,
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -9,6 +9,7 @@ import {
   ChatCompletionToolMessageParam,
   ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
+import type { ResponseInputItem } from 'openai/resources/responses/responses';
 import { countTokens } from 'gpt-tokenizer';
 
 // Local imports - utilities
@@ -59,7 +60,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /** Creates a chat completion with model-specific parameters. */
   async createResponse(
     client: OpenAI,
-    messages: ChatCompletionMessageParam[],
+    messages: ChatCompletionMessageParam[] | ResponseInputItem[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -79,9 +79,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
   /**
    * Create a response using the Responses API.
    *
-   * Note: This method accepts ChatCompletionMessageParam[] (from the base class)
-   * but internally converts them to ResponseInputItem[] format required by the
-   * OpenAI Responses API. The conversion handles:
+   * IMPORTANT: This method maintains the base class signature for compatibility,
+   * accepting ChatCompletionMessageParam[] even though the Responses API requires
+   * ResponseInputItem[]. The conversion is handled internally to preserve the
+   * inheritance hierarchy and allow seamless integration with the existing infrastructure.
+   *
+   * The conversion handles:
    * - Text content: 'text' -> 'input_text' or 'output_text' based on role
    * - Images: 'image_url' -> 'input_image'
    * - PDFs: Special handling to convert from image_url to input_file format
@@ -105,7 +108,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
         return {
           role: msg.role,
           content:
-            msg.content && typeof msg.content === 'string'
+            typeof msg.content === 'string'
               ? [{ type: 'input_text', text: msg.content }]
               : Array.isArray(msg.content)
                 ? msg.content.map((part: any) => {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -32,6 +32,12 @@ import type { ToolDefinition } from '@model';
  * Handler for OpenAI's new Responses API. Uses `previous_response_id` to
  * manage conversation state between calls.
  *
+ * This class extends ModelHandlerOpenAI to maintain compatibility with the
+ * existing message handling infrastructure while adapting to the Responses API's
+ * different message format. The base class works with ChatCompletionMessageParam[],
+ * but the Responses API requires ResponseInputItem[]. All conversion happens
+ * internally in the createResponse method.
+ *
  * Note: PDFs are handled specially - they are converted from image_url format
  * to input_file format with mime_type 'application/pdf' for proper processing.
  */
@@ -70,7 +76,19 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     );
   }
 
-  /** Create a response using the Responses API. */
+  /**
+   * Create a response using the Responses API.
+   *
+   * Note: This method accepts ChatCompletionMessageParam[] (from the base class)
+   * but internally converts them to ResponseInputItem[] format required by the
+   * OpenAI Responses API. The conversion handles:
+   * - Text content: 'text' -> 'input_text' or 'output_text' based on role
+   * - Images: 'image_url' -> 'input_image'
+   * - PDFs: Special handling to convert from image_url to input_file format
+   *
+   * @param messages ChatCompletionMessageParam[] from base class methods
+   * @returns Response object from the Responses API
+   */
   async createResponse(
     client: OpenAI,
     messages: ChatCompletionMessageParam[],
@@ -91,40 +109,40 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
               ? [{ type: 'input_text', text: msg.content }]
               : Array.isArray(msg.content)
                 ? msg.content.map((part: any) => {
-                  if (part.type === 'text') {
-                    if (msg.role === 'user') {
-                      return { type: 'input_text', text: part.text };
-                    } else if (msg.role === 'assistant') {
-                      return { type: 'output_text', text: part.text };
-                    } else {
-                      return { type: 'input_text', text: part.text };
+                    if (part.type === 'text') {
+                      if (msg.role === 'user') {
+                        return { type: 'input_text', text: part.text };
+                      } else if (msg.role === 'assistant') {
+                        return { type: 'output_text', text: part.text };
+                      } else {
+                        return { type: 'input_text', text: part.text };
+                      }
                     }
-                  }
-                  if (part.type === 'image_url') {
-                    const url =
-                      typeof part.image_url === 'string'
-                        ? part.image_url
-                        : part.image_url.url;
+                    if (part.type === 'image_url') {
+                      const url =
+                        typeof part.image_url === 'string'
+                          ? part.image_url
+                          : part.image_url.url;
 
-                    if (url.startsWith('data:application/pdf;base64,')) {
-                      const base64Data = url.replace(
-                        'data:application/pdf;base64,',
-                        '',
-                      );
-                      return {
-                        type: 'input_file',
-                        input_file: {
-                          data: base64Data,
-                          mime_type: 'application/pdf',
-                        },
-                      };
+                      if (url.startsWith('data:application/pdf;base64,')) {
+                        const base64Data = url.replace(
+                          'data:application/pdf;base64,',
+                          '',
+                        );
+                        return {
+                          type: 'input_file',
+                          input_file: {
+                            data: base64Data,
+                            mime_type: 'application/pdf',
+                          },
+                        };
+                      }
+
+                      const detail = part.image_url?.detail ?? 'auto';
+                      return { type: 'input_image', image_url: url, detail };
                     }
-
-                    const detail = part.image_url?.detail ?? 'auto';
-                    return { type: 'input_image', image_url: url, detail };
-                  }
-                  return part;
-                })
+                    return part;
+                  })
                 : [],
         };
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -13,6 +13,7 @@ import type {
   ResponseFunctionToolCall,
   ResponseInputItem,
 } from 'openai/resources/responses/responses';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
 // Local imports - base handler
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
@@ -71,7 +72,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
   /** Create a response using the Responses API. */
   async createResponse(
     client: OpenAI,
-    messages: ResponseInputItem[],
+    messages: ChatCompletionMessageParam[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
@@ -85,9 +86,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
         return {
           role: msg.role,
           content:
-            typeof msg.content === 'string'
+            msg.content && typeof msg.content === 'string'
               ? [{ type: 'input_text', text: msg.content }]
-              : msg.content.map((part: any) => {
+              : Array.isArray(msg.content)
+                ? msg.content.map((part: any) => {
                   if (part.type === 'text') {
                     if (msg.role === 'user') {
                       return { type: 'input_text', text: part.text };
@@ -121,7 +123,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
                     return { type: 'input_image', image_url: url, detail };
                   }
                   return part;
-                }),
+                })
+                : [],
         };
       }
       return msg;

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -9,11 +9,16 @@ import { ToolState } from '../../core/ToolState';
 import type { MediaEntry } from '../../utils/mediaTypes';
 import type { ModelConfig, ModelCapabilities, ToolDefinition } from '@model';
 import type { ProviderStopReason } from './StopReasonTypes';
+import type { ProviderMessage } from './ProviderMessage';
 
 /**
  * Common interface implemented by all model handlers.
  */
-export interface IModelHandler<U = any, R = any> {
+export interface IModelHandler<
+  M extends ProviderMessage = ProviderMessage,
+  U = any,
+  R = any,
+> {
   /** Model configuration used by the handler. */
   config: ModelConfig;
 
@@ -49,7 +54,7 @@ export interface IModelHandler<U = any, R = any> {
    */
   createResponse(
     client: any,
-    messages: any[],
+    messages: M[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
@@ -63,14 +68,14 @@ export interface IModelHandler<U = any, R = any> {
     userRequest: string,
     mediaFiles?: string[],
     systemPrompt?: string,
-  ): Promise<any[]>;
+  ): Promise<M[]>;
 
   /** Create messages for a follow-up round. */
   createRoundMessages(
-    messages: any[],
+    messages: M[],
     userMessage: string,
     mediaFiles?: string[],
-  ): Promise<any[]>;
+  ): Promise<M[]>;
 
   /** Format media content for provider APIs. */
   createMediaContent(mediaMessage: MediaEntry[]): any[];
@@ -83,7 +88,7 @@ export interface IModelHandler<U = any, R = any> {
 
   /** Handle continuation for models supporting prefill. */
   addContinueMessageWithPrefill(
-    messages: any[],
+    messages: M[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -92,7 +97,7 @@ export interface IModelHandler<U = any, R = any> {
 
   /** Handle continuation for models without prefill. */
   addContinueMessageWithoutPrefill(
-    messages: any[],
+    messages: M[],
     stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -103,12 +108,12 @@ export interface IModelHandler<U = any, R = any> {
   initializeOutputAndPrefill(
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
-    messages: any[],
+    messages: M[],
     toolState: ToolState,
     outputFile: string,
     prefill: string,
     groupId?: string,
-  ): Promise<[boolean, any[]]>;
+  ): Promise<[boolean, M[]]>;
 
   /** Compute the cost for a response. */
   computePrice(responseUsage: U): number;
@@ -118,7 +123,7 @@ export interface IModelHandler<U = any, R = any> {
 
   /** Update messages when prefill is supported. */
   updateMessageContentWithPrefill(
-    messages: any[],
+    messages: M[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,
@@ -126,7 +131,7 @@ export interface IModelHandler<U = any, R = any> {
 
   /** Update messages when prefill is not supported. */
   updateMessageContentWithoutPrefill(
-    messages: any[],
+    messages: M[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,
@@ -175,5 +180,5 @@ export interface IModelHandler<U = any, R = any> {
     name: string,
     call: any,
     result: Record<string, unknown>,
-  ): [any, any];
+  ): [M, M];
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -13,6 +13,13 @@ import type { ProviderMessage } from './ProviderMessage';
 
 /**
  * Common interface implemented by all model handlers.
+ *
+ * @template M - Message type specific to the provider (e.g., MessageParam for Anthropic,
+ *               ChatCompletionMessageParam for OpenAI). Must extend ProviderMessage.
+ * @template U - Usage/statistics type returned by the provider's API response
+ *               (e.g., Usage for Anthropic, CompletionUsage for OpenAI)
+ * @template R - Processed response usage type for internal tracking
+ *               (e.g., AnthropicAPIResponseUsage, OpenAIAPIResponseUsage)
  */
 export interface IModelHandler<
   M extends ProviderMessage = ProviderMessage,

--- a/src/agent/modelHandlers/types/ProviderMessage.ts
+++ b/src/agent/modelHandlers/types/ProviderMessage.ts
@@ -1,0 +1,16 @@
+// Union type for message objects used across model providers
+
+// Third-party imports
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import type { ResponseInputItem } from 'openai/resources/responses/responses';
+import type { MessageParam } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { Content } from '@google/genai';
+
+/**
+ * Message formats supported by the various model providers.
+ */
+export type ProviderMessage =
+  | ChatCompletionMessageParam
+  | ResponseInputItem
+  | MessageParam
+  | Content;

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -16,6 +16,7 @@ import {
   ModelHandlerOpenAI,
   ModelHandlerOpenAIResponse,
 } from '@agent/modelHandlers';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 // Local imports - utils
 import { getConfig } from '@utils/config';
@@ -80,7 +81,7 @@ export class ModelFactory {
     // Map providers to their handler classes (excluding the native Google handler handled above)
     const handlerMap = new Map<
       ModelProvider,
-      new (config: ModelConfig) => ModelHandler
+      new (config: ModelConfig) => ModelHandler<ProviderMessage>
     >([
       [ModelProvider.ANTHROPIC, ModelHandlerAnthropic],
       [ModelProvider.OPENAI, ModelHandlerOpenAI],

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -9,9 +9,10 @@ import { getRunDir } from '@utils/files/taskRunStorage';
 import { getConfig } from '@utils/config';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { AgentLogger } from '@logger/AgentLogger';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 export interface SaveMessagesParams {
-  messages: any[];
+  messages: ProviderMessage[];
   logger: AgentLogger;
   continuationCount?: number;
   outputFile?: string;

--- a/src/agent/utils/messageSkeletonUtils.ts
+++ b/src/agent/utils/messageSkeletonUtils.ts
@@ -4,6 +4,7 @@
 
 // Local imports
 import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 /**
  * Creates a skeleton representation of a message object for debugging.
@@ -13,9 +14,9 @@ import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
  * @returns A simplified message object with truncated content
  */
 export function messageToSkeleton(
-  message: any,
+  message: ProviderMessage | any,
   maxContentLength: number = MESSAGE_PREVIEW_LENGTH,
-): any {
+): ProviderMessage | any {
   if (!message) {
     return null;
   }

--- a/src/agent/utils/messageSkeletonUtils.ts
+++ b/src/agent/utils/messageSkeletonUtils.ts
@@ -14,15 +14,17 @@ import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage
  * @returns A simplified message object with truncated content
  */
 export function messageToSkeleton(
-  message: ProviderMessage | any,
+  message: ProviderMessage | ProviderMessage[],
   maxContentLength: number = MESSAGE_PREVIEW_LENGTH,
-): ProviderMessage | any {
+): any {
   if (!message) {
     return null;
   }
 
   if (Array.isArray(message)) {
-    return message.map((item) => messageToSkeleton(item, maxContentLength));
+    return message.map((item) =>
+      messageToSkeleton(item as ProviderMessage, maxContentLength),
+    );
   }
 
   if (typeof message !== 'object') {
@@ -92,7 +94,10 @@ export function messageToSkeleton(
       value !== undefined
     ) {
       // Recursively process nested objects
-      result[key] = messageToSkeleton(value, maxContentLength);
+      result[key] = messageToSkeleton(
+        value as ProviderMessage,
+        maxContentLength,
+      );
     } else {
       // Pass through primitive values
       result[key] = value;

--- a/src/agent/utils/messageSkeletonUtils.ts
+++ b/src/agent/utils/messageSkeletonUtils.ts
@@ -22,9 +22,7 @@ export function messageToSkeleton(
   }
 
   if (Array.isArray(message)) {
-    return message.map((item) =>
-      messageToSkeleton(item as ProviderMessage, maxContentLength),
-    );
+    return message.map((item) => messageToSkeleton(item, maxContentLength));
   }
 
   if (typeof message !== 'object') {
@@ -94,10 +92,9 @@ export function messageToSkeleton(
       value !== undefined
     ) {
       // Recursively process nested objects
-      result[key] = messageToSkeleton(
-        value as ProviderMessage,
-        maxContentLength,
-      );
+      // Note: We pass 'any' here since nested properties within a message
+      // are not necessarily ProviderMessage instances themselves
+      result[key] = messageToSkeleton(value as any, maxContentLength);
     } else {
       // Pass through primitive values
       result[key] = value;

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -8,6 +8,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import {
   AgentSetting,
   AgentType,
@@ -120,7 +121,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
     };
     const events: any[] = [];
     const dispose = bus.on('addLogMessage', (e) => events.push(e));
-    const messages: any[] = [];
+    const messages: ProviderMessage[] = [];
 
     await runToolUseCycle(options, messages);
     dispose();


### PR DESCRIPTION
## Summary
- add `ProviderMessage` union covering provider SDK message types
- make `IModelHandler` generic over message type
- update base and provider handlers
- type messages in cycle helpers and tests
- adjust model factory to new generic signature

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889c91e7aa48324b47759a97292f665