### PR TITLE
Add web search tool and simplify tool config

### DIFF
--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -161,14 +161,9 @@ userPrefix: |
 ### Tool-Use Agents
 
 Tools live under `src/tools/` and each one defines its input schema with Zod.
-Your YAML can reference individual tools or predefined sets. Sets are expanded
-when the agent configuration is loaded. The `wolframExec` set enables the
-`wolfram` tool for running small Wolfram Language snippets during a run.
-
-The built-in `ToolSetRegistry` maps aliases to lists of tool definitions. For
-instance, the `file_edit` set expands to `{ name: 'str_replace_editor' }`. Nested sets
-are resolved recursively, and any unknown names trigger a warning during agent
-loading.
+List the desired tools by name in your agent YAML. The registry includes tools
+like `str_replace_editor`, `bash`, `file_op`, `wolfram`, and `web_search` for
+searching the web.
 
 Example:
 
@@ -176,10 +171,11 @@ Example:
 settings:
   agentType: toolUse
   tools:
-    - file_edit # expands to the str_replace_editor tool
-    - wolframExec # execute Wolfram Language code
-    - bash # single tool by name
-    - basic_io # adds bash and file_op tools
+    - str_replace_editor
+    - wolfram
+    - bash
+    - file_op
+    - web_search
 ```
 
 The ProgressBoard shows the JSON passed to each tool along with the tool's

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -16,7 +16,7 @@ import type {
 // Map local tool names to Anthropic remote tool types
 const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
   bash: 'bash_20250124',
-  str_replace_editor: 'text_editor_20250124',
+  str_replace_editor: 'text_editor_20250429',
   str_replace_based_edit_tool: 'text_editor_20250429',
   web_search: 'web_search_20250305',
 } as const;

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -106,41 +106,23 @@ export async function loadAgentSettingAndPrompts(
       });
     }
 
-    // Resolve tool set shortcuts before validation
+    // Resolve tool names to definitions
     if (Array.isArray(settings.tools)) {
-      const { ToolSets } = await import('@agent/toolUse/ToolSetRegistry');
       const { DEFAULT_TOOL_REGISTRY } = await import('@tools/registry');
-      const resolveSets = (
-        items: any[],
-        visited = new Set<string>(),
-      ): ToolDefinition[] => {
-        const output: ToolDefinition[] = [];
-        for (const item of items) {
-          if (typeof item === 'string' && ToolSets[item]) {
-            if (visited.has(item)) {
-              throw new Error(`Circular tool set reference: ${item}`);
-            }
-            visited.add(item);
-            output.push(...resolveSets(ToolSets[item], visited));
-            visited.delete(item);
-          } else if (typeof item === 'string') {
-            const tool = DEFAULT_TOOL_REGISTRY[item];
-            if (!tool) {
-              logger.warn(CHANNEL, `Tool "${item}" not found in registry`);
-              output.push({ name: item });
-            } else {
-              output.push(tool.definition);
-            }
-          } else {
-            if (!DEFAULT_TOOL_REGISTRY[item.name]) {
-              logger.warn(CHANNEL, `Tool "${item.name}" not found in registry`);
-            }
-            output.push(item as ToolDefinition);
+      settings.tools = (settings.tools as any[]).map((item) => {
+        if (typeof item === 'string') {
+          const tool = DEFAULT_TOOL_REGISTRY[item];
+          if (!tool) {
+            logger.warn(CHANNEL, `Tool "${item}" not found in registry`);
+            return { name: item } as ToolDefinition;
           }
+          return tool.definition;
         }
-        return output;
-      };
-      settings.tools = resolveSets(settings.tools as any[]);
+        if (!DEFAULT_TOOL_REGISTRY[item.name]) {
+          logger.warn(CHANNEL, `Tool "${item.name}" not found in registry`);
+        }
+        return item as ToolDefinition;
+      });
     }
 
     // Apply defaults and validate the final settings and prompts

--- a/src/agent/toolUse/ToolSetRegistry.ts
+++ b/src/agent/toolUse/ToolSetRegistry.ts
@@ -1,8 +1,0 @@
-import type { ToolDefinition } from '@model';
-
-export const ToolSets: Record<string, ToolDefinition[]> = {
-  file_edit: [{ name: 'str_replace_editor' }],
-  diagnostics_only: [{ name: 'diagnostics' }],
-  basic_io: [{ name: 'bash' }, { name: 'file_op' }],
-  wolframExec: [{ name: 'wolfram' }],
-};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,3 +6,4 @@ export * from './fileOp';
 export * from './core/base';
 export * from './registry';
 export * from './wolfram';
+export * from './web/WebSearchTool';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -3,6 +3,7 @@ import { DiagnosticsTool } from './DiagnosticsTool';
 import { BashTool } from './bash';
 import { FileOpTool } from './fileOp';
 import { WolframTool } from './wolfram';
+import { WebSearchTool } from './web/WebSearchTool';
 
 import { BaseTool } from './core/base';
 export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
@@ -11,4 +12,5 @@ export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   bash: new BashTool(),
   file_op: new FileOpTool(),
   wolfram: new WolframTool(),
+  web_search: new WebSearchTool(),
 };

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -1,0 +1,57 @@
+// Standard library imports
+
+// Local imports - core
+import { z } from 'zod';
+import axios from 'axios';
+import type { ToolDefinition } from '@model';
+import { BaseTool } from '../core/base';
+import { ToolResult } from '../result';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+const WebSearchInputSchema = z.object({
+  query: z.string(),
+  max_results: z.number().min(1).max(5).optional(),
+});
+
+export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;
+
+export class WebSearchTool extends BaseTool<WebSearchInput> {
+  constructor() {
+    const definition: ToolDefinition = {
+      name: 'web_search',
+      description: 'Search the web and return top results',
+      parameters: zodToJsonSchema(WebSearchInputSchema),
+    };
+    super(definition, WebSearchInputSchema);
+  }
+
+  protected async execute(input: WebSearchInput): Promise<ToolResult> {
+    const { query, max_results = 3 } = input;
+    try {
+      const response = await axios.get('https://api.duckduckgo.com/', {
+        params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
+      });
+      const data = response.data;
+      const results: string[] = [];
+      if (Array.isArray(data.RelatedTopics)) {
+        for (const item of data.RelatedTopics.slice(0, max_results)) {
+          if (
+            typeof item.Text === 'string' &&
+            typeof item.FirstURL === 'string'
+          ) {
+            results.push(`${item.Text} (${item.FirstURL})`);
+          }
+        }
+      }
+      if (results.length === 0) {
+        return new ToolResult({ output: 'No results found.' });
+      }
+      return new ToolResult({ output: results.join('\n') });
+    } catch (err) {
+      return new ToolResult({
+        error: err instanceof Error ? err.message : String(err),
+        isError: true,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove unused `ToolSetRegistry`
- resolve tool names directly in `agentLoad`
- map `str_replace_editor` to the new `text_editor` endpoint
- add a web search tool
- update docs to list available tools

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889c7f655f48324b1bd155b438231f0