### PR TITLE
feat: centralize finish reason constants

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -14,6 +14,7 @@ import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
 import { maybeSaveMessages } from '@agent/utils/debugMessageSaver';
+import { ANTHROPIC_STOP } from '../modelHandlers/types/StopReasonTypes';
 
 export interface ToolUseCycleOptions {
   /** Model handler for API interactions */
@@ -122,7 +123,7 @@ export async function runToolUseCycle(
       logger.statistics(stats, groupId);
     }
 
-    if (!toolInfo || stopReason === 'end_turn') {
+    if (!toolInfo || stopReason === ANTHROPIC_STOP.END_TURN) {
       break;
     }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -18,6 +18,8 @@ import {
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import { ANTHROPIC_STOP, OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
+import { FinishReason } from '@google/genai';
 import type { IModelHandler } from './types/IModelHandler';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
@@ -502,10 +504,15 @@ export abstract class ModelHandler<U = any, R = any>
     response: string,
     setting: AgentSetting,
   ): MarkerFlags {
+    const endTurnReasons: ProviderStopReason[] = [
+      ANTHROPIC_STOP.END_TURN,
+      ANTHROPIC_STOP.STOP_SEQUENCE,
+      OPENAI_CHAT_FINISH.STOP,
+      FinishReason.STOP,
+    ];
+
     return {
-      endTurn: ['end_turn', 'stop_sequence', 'stop', 'STOP'].includes(
-        stopReason ?? '',
-      ),
+      endTurn: endTurnReasons.includes(stopReason ?? ''),
       encounterDocumentTag: response.includes(`</${setting.documentTag}>`),
     };
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -509,6 +509,7 @@ export abstract class ModelHandler<U = any, R = any>
       ANTHROPIC_STOP.STOP_SEQUENCE,
       OPENAI_CHAT_FINISH.STOP,
       FinishReason.STOP,
+      'STOP', // handle string form returned by some Google clients
     ];
 
     return {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -19,6 +19,7 @@ import { WorkspaceFS } from '@utils/files';
 import { cleanFileContent } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import { ANTHROPIC_STOP } from './types/StopReasonTypes';
 import xmlUtils from '@utils/text/xmlUtils';
 
 // Local imports - agent components
@@ -407,7 +408,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Add end tag if needed
-    if (stopReason === 'stop_sequence' && !newResponse.includes(endTag)) {
+    if (
+      stopReason === ANTHROPIC_STOP.STOP_SEQUENCE &&
+      !newResponse.includes(endTag)
+    ) {
       newResponse += `\n${endTag}`;
     }
 
@@ -857,7 +861,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     );
 
     // Handle Claude 4 refusal stop reason - never continue when model refuses
-    if (stopReason === 'refusal') {
+    if (stopReason === ANTHROPIC_STOP.REFUSAL) {
       this.logger.warn(
         'Model refused to generate content - stopping generation',
       );
@@ -867,10 +871,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // We should continue if:
     // 1. We hit the max tokens limit (stopReason === 'max_tokens')
     // 2. AND we don't have an end tag (meaning the response is incomplete)
-    if (stopReason === 'max_tokens' && !hasEndTag(agentSetting, newResponse)) {
+    if (
+      stopReason === ANTHROPIC_STOP.MAX_TOKENS &&
+      !hasEndTag(agentSetting, newResponse)
+    ) {
       return true;
     }
-    if (stopReason === 'stop_sequence') {
+    if (stopReason === ANTHROPIC_STOP.STOP_SEQUENCE) {
       if (!hasEndTag(agentSetting, newResponse)) {
         return true;
       } else {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -46,6 +46,7 @@ import { cleanFileContent } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
 
 import type { ProviderStopReason } from './types/StopReasonTypes';
+// Google finish reasons are re-exported from the SDK
 
 // Local constant
 import { K_SLICE } from '@utils/config';

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -877,8 +877,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean {
-    const hitTokenLimit =
-      stopReason === FinishReason.MAX_TOKENS || stopReason === 'MAX_TOKENS';
+    // Google SDK uses the FinishReason enum for stop reasons
+    const hitTokenLimit = stopReason === FinishReason.MAX_TOKENS;
     const containsEndTag = hasEndTag(agentSetting, newResponse);
 
     if (hitTokenLimit && !containsEndTag) {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -22,6 +22,7 @@ import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
 import { AgentStateRound } from '../core/AgentState';
 import { ModelHandler } from './ModelHandler';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { toOpenAITools } from './toolConversion';
 import type { ToolDefinition } from '@model';
 import {
@@ -439,7 +440,11 @@ export class ModelHandlerOpenAI extends ModelHandler<
         };
 
         // Add end tag if response was stopped and tag isn't present
-        if (stopReason === 'stop' && endTag && !newResponse.includes(endTag)) {
+        if (
+          stopReason === OPENAI_CHAT_FINISH.STOP &&
+          endTag &&
+          !newResponse.includes(endTag)
+        ) {
           this.logger.debug(`Adding end tag to response: ${endTag}`);
           newResponse = `${newResponse}\n${endTag}`;
         }
@@ -469,9 +474,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
     if (choice.message.content) {
       newResponse = choice.message.content.trim();
     } else if (
-      stopReason === 'tool_calls' ||
-      stopReason === 'tool_use' ||
-      stopReason === 'function_call' ||
+      stopReason === OPENAI_CHAT_FINISH.TOOL_CALLS ||
+      stopReason === OPENAI_CHAT_FINISH.TOOL_USE ||
+      stopReason === OPENAI_CHAT_FINISH.FUNCTION_CALL ||
       Array.isArray(choice.message.tool_calls) ||
       choice.message.function_call
     ) {
@@ -489,7 +494,11 @@ export class ModelHandlerOpenAI extends ModelHandler<
     }
 
     // Add end tag if response was stopped and tag isn't present
-    if (stopReason === 'stop' && endTag && !newResponse.includes(endTag)) {
+    if (
+      stopReason === OPENAI_CHAT_FINISH.STOP &&
+      endTag &&
+      !newResponse.includes(endTag)
+    ) {
       this.logger.debug(`Adding end tag to response: ${endTag}`);
       newResponse = `${newResponse}\n${endTag}`;
     }
@@ -841,7 +850,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean {
-    return stopReason === 'length' && !hasEndTag(agentSetting, newResponse);
+    return (
+      stopReason === OPENAI_CHAT_FINISH.LENGTH &&
+      !hasEndTag(agentSetting, newResponse)
+    );
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -164,7 +164,8 @@ export class ModelHandlerOpenAI extends ModelHandler<
           }
           response = {
             role: 'assistant',
-            finish_reason: 'stop', // there is no good choice it seems unless deepseek models support it;
+            // there is no good choice it seems unless deepseek models support it
+            finish_reason: OPENAI_CHAT_FINISH.STOP,
             // In the future maybe we can count the output tokens to see if it is at the limit approximatelly..
             choices: [
               {
@@ -172,7 +173,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
                   content: content,
                   reasoning_content: reasoning_content,
                 },
-                finish_reason: 'stop',
+                finish_reason: OPENAI_CHAT_FINISH.STOP,
               },
             ],
           };
@@ -185,7 +186,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
             this.logger.warn(
               `Token count output of deepseek model is close to the max output tokens: ${tokenCount} - ${this.config.maxOutputTokens}. Setting finish_reason to length`,
             );
-            response.finish_reason = 'length';
+            response.finish_reason = OPENAI_CHAT_FINISH.LENGTH;
           }
           return response;
         }
@@ -423,9 +424,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
           'Using direct response format (streaming style) as fallback',
         );
         let newResponse = responseObject.content.trim();
-        // Since we don't have a stop reason in this format, assume 'stop'
-        let stopReason = 'stop';
-        // let stopReason = 'length';
+        // Since we don't have a stop reason in this format, assume stop
+        let stopReason = OPENAI_CHAT_FINISH.STOP;
+        // let stopReason = OPENAI_CHAT_FINISH.LENGTH;
         if (responseObject.finish_reason) {
           stopReason = responseObject.finish_reason;
         }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -21,6 +21,7 @@ import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { ToolState } from '../core/ToolState';
 import { K_SLICE } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import type { ToolDefinition } from '@model';
 
 // import { ResponseCreateParams } from 'openai/src/resources/responses/response';
@@ -288,9 +289,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     }
 
     const stopReason =
-      responseObject.status === 'completed' ? 'stop' : 'length';
+      responseObject.status === 'completed'
+        ? OPENAI_CHAT_FINISH.STOP
+        : OPENAI_CHAT_FINISH.LENGTH;
 
-    if (stopReason === 'stop' && endTag && !newResponse.includes(endTag)) {
+    if (
+      stopReason === OPENAI_CHAT_FINISH.STOP &&
+      endTag &&
+      !newResponse.includes(endTag)
+    ) {
       return [`${newResponse}\n${endTag}`, usage, stopReason];
     }
     return [newResponse, usage, stopReason];

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -1,31 +1,97 @@
 // Third-party imports
-import type { StopReason as AnthropicStopReason } from '@anthropic-ai/sdk/resources/messages/messages';
-import type { FinishReason as GoogleFinishReason } from '@google/genai/dist/genai';
+import { FinishReason } from '@google/genai';
 
 // Local imports - none
 
-/** OpenAI finish reasons for chat completions. */
-export type OpenAIFinishReason =
-  | 'stop'
-  | 'length'
-  | 'tool_calls'
-  | 'tool_use'
-  | 'content_filter'
-  | 'function_call'
+/**
+ * Finish reasons returned by the OpenAI Chat Completion API.
+ * These are distinct from the Responses API status values.
+ */
+export const OPENAI_CHAT_FINISH = {
+  STOP: 'stop',
+  LENGTH: 'length',
+  TOOL_CALLS: 'tool_calls',
+  TOOL_USE: 'tool_use',
+  CONTENT_FILTER: 'content_filter',
+  FUNCTION_CALL: 'function_call',
+} as const;
+export const OPENAI_CHAT_FINISH_REASONS = Object.values(OPENAI_CHAT_FINISH);
+export type OpenAIChatFinishReason =
+  | (typeof OPENAI_CHAT_FINISH_REASONS)[number]
   | null;
 
-/** OpenAI finish reasons for text completions. */
-export type OpenAICompletionFinishReason = 'stop' | 'length' | 'content_filter';
+/**
+ * Finish reasons for the legacy OpenAI text completion API.
+ * The Responses API maps its status field to these values.
+ */
+export const OPENAI_COMPLETION_FINISH = {
+  STOP: 'stop',
+  LENGTH: 'length',
+  CONTENT_FILTER: 'content_filter',
+} as const;
+export const OPENAI_COMPLETION_FINISH_REASONS = Object.values(
+  OPENAI_COMPLETION_FINISH,
+);
+export type OpenAICompletionFinishReason =
+  (typeof OPENAI_COMPLETION_FINISH_REASONS)[number];
+
+/** Status values used by the OpenAI Responses API. */
+export const OPENAI_RESPONSE_STATUS = {
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  IN_PROGRESS: 'in_progress',
+  CANCELLED: 'cancelled',
+  QUEUED: 'queued',
+  INCOMPLETE: 'incomplete',
+} as const;
+export const OPENAI_RESPONSE_STATUSES = Object.values(OPENAI_RESPONSE_STATUS);
+export type OpenAIResponseStatus = (typeof OPENAI_RESPONSE_STATUSES)[number];
 
 /** Stop reasons defined in the Model Context Protocol SDK. */
-export type MCPStopReason = 'endTurn' | 'stopSequence' | 'maxTokens';
+export const MCP_STOP = {
+  END_TURN: 'endTurn',
+  STOP_SEQUENCE: 'stopSequence',
+  MAX_TOKENS: 'maxTokens',
+} as const;
+export const MCP_STOP_REASONS = Object.values(MCP_STOP);
+export type MCPStopReason = (typeof MCP_STOP_REASONS)[number];
+
+/** Stop reasons for Anthropic models. */
+export const ANTHROPIC_STOP = {
+  END_TURN: 'end_turn',
+  MAX_TOKENS: 'max_tokens',
+  STOP_SEQUENCE: 'stop_sequence',
+  TOOL_USE: 'tool_use',
+  PAUSE_TURN: 'pause_turn',
+  REFUSAL: 'refusal',
+} as const;
+export const ANTHROPIC_STOP_REASONS = Object.values(ANTHROPIC_STOP);
+export type AnthropicStopReason = (typeof ANTHROPIC_STOP_REASONS)[number];
+
+/** Finish reasons returned by Google's API. */
+export const GOOGLE_FINISH_REASONS = [
+  FinishReason.FINISH_REASON_UNSPECIFIED,
+  FinishReason.STOP,
+  FinishReason.MAX_TOKENS,
+  FinishReason.SAFETY,
+  FinishReason.RECITATION,
+  FinishReason.LANGUAGE,
+  FinishReason.OTHER,
+  FinishReason.BLOCKLIST,
+  FinishReason.PROHIBITED_CONTENT,
+  FinishReason.SPII,
+  FinishReason.MALFORMED_FUNCTION_CALL,
+  FinishReason.IMAGE_SAFETY,
+  FinishReason.UNEXPECTED_TOOL_CALL,
+] as const;
+export type GoogleFinishReason = (typeof GOOGLE_FINISH_REASONS)[number];
 
 /**
  * Union type covering all known provider stop reasons.
  * Additional string values are allowed for providers without explicit enums.
  */
 export type ProviderStopReason =
-  | OpenAIFinishReason
+  | OpenAIChatFinishReason
   | OpenAICompletionFinishReason
   | AnthropicStopReason
   | GoogleFinishReason


### PR DESCRIPTION
## Summary
- define provider stop reason constant objects
- replace string literals with named constants across handlers
- document Responses API status values

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889d323bd0083248d4a1109f7189e9d