### PR TITLE
Use VS Code Diagnostic type

### DIFF
--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utils
-import { getLinterMessages } from '@frontend/latex/linter';
+import { getLinterMessages, getSeverityString } from '@frontend/latex/linter';
 import { WorkspaceFS } from '@utils/files';
 
 // Local imports - core
@@ -49,10 +49,13 @@ export async function handleShowLinterMessages(): Promise<void> {
     }
 
     // Format messages for display
-    const formattedMessages = messages.map(
-      (msg) =>
-        `${msg.severity.toUpperCase()} [${msg.source}]: Line ${msg.line}, Col ${msg.column} - ${msg.message}`,
-    );
+    const formattedMessages = messages.map((msg) => {
+      const severity = getSeverityString(msg.severity).toUpperCase();
+      const line = msg.range.start.line + 1;
+      const col = msg.range.start.character + 1;
+      const source = msg.source ?? 'unknown';
+      return `${severity} [${source}]: Line ${line}, Col ${col} - ${msg.message}`;
+    });
 
     // Use logger instead of output channel
     logger.info(CHANNEL, `Linter messages for: ${relativePath}`);
@@ -102,16 +105,16 @@ export async function handleCountLinterMessages(): Promise<void> {
 
     messages.forEach((msg) => {
       switch (msg.severity) {
-        case 'error':
+        case vscode.DiagnosticSeverity.Error:
           counts.errors++;
           break;
-        case 'warning':
+        case vscode.DiagnosticSeverity.Warning:
           counts.warnings++;
           break;
-        case 'info':
+        case vscode.DiagnosticSeverity.Information:
           counts.info++;
           break;
-        case 'hint':
+        case vscode.DiagnosticSeverity.Hint:
           counts.hints++;
           break;
       }

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -5,7 +5,11 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utils
-import { getLinterMessages, getSeverityString } from '@frontend/latex/linter';
+import {
+  getLinterMessages,
+  getSeverityString,
+  countDiagnosticsBySeverity,
+} from '@frontend/latex/linter';
 import { WorkspaceFS } from '@utils/files';
 
 // Local imports - core
@@ -96,29 +100,7 @@ export async function handleCountLinterMessages(): Promise<void> {
     const messages = await getLinterMessages(relativePath);
 
     // Count by severity
-    const counts = {
-      errors: 0,
-      warnings: 0,
-      info: 0,
-      hints: 0,
-    };
-
-    messages.forEach((msg) => {
-      switch (msg.severity) {
-        case vscode.DiagnosticSeverity.Error:
-          counts.errors++;
-          break;
-        case vscode.DiagnosticSeverity.Warning:
-          counts.warnings++;
-          break;
-        case vscode.DiagnosticSeverity.Information:
-          counts.info++;
-          break;
-        case vscode.DiagnosticSeverity.Hint:
-          counts.hints++;
-          break;
-      }
-    });
+    const counts = countDiagnosticsBySeverity(messages);
 
     const total = counts.errors + counts.warnings + counts.info + counts.hints;
 

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -9,15 +9,6 @@ import { sleep } from '@utils/helpers';
 const CHANNEL = 'LinterUtils';
 logger.initialize(CHANNEL);
 
-// Define a type for the linter message
-export type LinterMessage = {
-  message: string;
-  line: number;
-  column: number;
-  severity: string;
-  source: string;
-};
-
 /**
  * Trigger a LaTeX build for a specific file
  * @param filePath Path to the file (relative to workspace)
@@ -124,13 +115,13 @@ export function getDiagnostics(filePath: string): vscode.Diagnostic[] {
 }
 
 /**
- * Get formatted linter messages for a file
+ * Retrieve linter diagnostics for a file
  * @param filePath Path to the file
- * @returns Array of formatted error/warning messages
+ * @returns Array of VS Code diagnostic objects
  */
 export async function getLinterMessages(
   filePath: string,
-): Promise<LinterMessage[]> {
+): Promise<vscode.Diagnostic[]> {
   try {
     // First trigger LaTeX build for TeX files to refresh diagnostics
     if (filePath.toLowerCase().endsWith('.tex')) {
@@ -139,16 +130,7 @@ export async function getLinterMessages(
 
     const diagnostics = getDiagnostics(filePath);
 
-    return diagnostics.map((diagnostic) => {
-      const severity = getSeverityString(diagnostic.severity);
-      return {
-        message: diagnostic.message,
-        line: diagnostic.range.start.line + 1, // Convert to 1-based line numbers
-        column: diagnostic.range.start.character + 1, // Convert to 1-based column numbers
-        severity,
-        source: diagnostic.source || 'unknown',
-      };
-    });
+    return diagnostics;
   } catch (err) {
     logger.error(
       CHANNEL,
@@ -161,7 +143,7 @@ export async function getLinterMessages(
 /**
  * Convert diagnostic severity to a readable string
  */
-function getSeverityString(severity: vscode.DiagnosticSeverity): string {
+export function getSeverityString(severity: vscode.DiagnosticSeverity): string {
   switch (severity) {
     case vscode.DiagnosticSeverity.Error:
       return 'error';

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -161,45 +161,35 @@ export function getSeverityString(severity: vscode.DiagnosticSeverity): string {
 /**
  * Count diagnostics by severity for a file
  */
-export function countDiagnosticsBySeverity(filePath: string): {
+export function countDiagnosticsBySeverity(diagnostics: vscode.Diagnostic[]): {
   errors: number;
   warnings: number;
   info: number;
   hints: number;
 } {
-  try {
-    const diagnostics = getDiagnostics(filePath);
+  const counts = {
+    errors: 0,
+    warnings: 0,
+    info: 0,
+    hints: 0,
+  };
 
-    const counts = {
-      errors: 0,
-      warnings: 0,
-      info: 0,
-      hints: 0,
-    };
+  diagnostics.forEach((diagnostic) => {
+    switch (diagnostic.severity) {
+      case vscode.DiagnosticSeverity.Error:
+        counts.errors++;
+        break;
+      case vscode.DiagnosticSeverity.Warning:
+        counts.warnings++;
+        break;
+      case vscode.DiagnosticSeverity.Information:
+        counts.info++;
+        break;
+      case vscode.DiagnosticSeverity.Hint:
+        counts.hints++;
+        break;
+    }
+  });
 
-    diagnostics.forEach((diagnostic) => {
-      switch (diagnostic.severity) {
-        case vscode.DiagnosticSeverity.Error:
-          counts.errors++;
-          break;
-        case vscode.DiagnosticSeverity.Warning:
-          counts.warnings++;
-          break;
-        case vscode.DiagnosticSeverity.Information:
-          counts.info++;
-          break;
-        case vscode.DiagnosticSeverity.Hint:
-          counts.hints++;
-          break;
-      }
-    });
-
-    return counts;
-  } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error counting diagnostics for ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return { errors: 0, warnings: 0, info: 0, hints: 0 };
-  }
+  return counts;
 }

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
-import { getLinterMessages } from '@frontend/latex/linter';
-import * as vscode from 'vscode';
+import {
+  getLinterMessages,
+  countDiagnosticsBySeverity,
+} from '@frontend/latex/linter';
 import * as logger from '@logger/logUtils';
 import { BaseTool } from './core/base';
 import { ToolResult, ToolError } from './result';
@@ -38,23 +40,7 @@ export class DiagnosticsTool extends BaseTool<DiagnosticsInput> {
         }
         case 'count': {
           const messages = await getLinterMessages(path);
-          const counts = { errors: 0, warnings: 0, info: 0, hints: 0 };
-          messages.forEach((m) => {
-            switch (m.severity) {
-              case vscode.DiagnosticSeverity.Error:
-                counts.errors++;
-                break;
-              case vscode.DiagnosticSeverity.Warning:
-                counts.warnings++;
-                break;
-              case vscode.DiagnosticSeverity.Information:
-                counts.info++;
-                break;
-              case vscode.DiagnosticSeverity.Hint:
-                counts.hints++;
-                break;
-            }
-          });
+          const counts = countDiagnosticsBySeverity(messages);
           return new ToolResult({ output: JSON.stringify(counts) });
         }
         default:

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { getLinterMessages } from '@frontend/latex/linter';
+import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 import { BaseTool } from './core/base';
 import { ToolResult, ToolError } from './result';
@@ -40,16 +41,16 @@ export class DiagnosticsTool extends BaseTool<DiagnosticsInput> {
           const counts = { errors: 0, warnings: 0, info: 0, hints: 0 };
           messages.forEach((m) => {
             switch (m.severity) {
-              case 'error':
+              case vscode.DiagnosticSeverity.Error:
                 counts.errors++;
                 break;
-              case 'warning':
+              case vscode.DiagnosticSeverity.Warning:
                 counts.warnings++;
                 break;
-              case 'info':
+              case vscode.DiagnosticSeverity.Information:
                 counts.info++;
                 break;
-              case 'hint':
+              case vscode.DiagnosticSeverity.Hint:
                 counts.hints++;
                 break;
             }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -76,10 +76,6 @@ export interface XMLValidationError extends BaseError {
 }
 
 /**
- * Import the LinterMessage type from linterUtils
- */
-
-/**
  * Standard validation result interface for all agents
  */
 export interface ValidationResult<T extends BaseError | BaseError[]> {


### PR DESCRIPTION
## Summary
- remove custom `LinterMessage` interface
- return native `vscode.Diagnostic` objects from `getLinterMessages`
- update linter commands and tools to work with diagnostics

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889ec6f98e08324936dc534f6fe8b82