### PR TITLE
Refine OpenAI Response pricing types

### DIFF
--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -3,6 +3,7 @@
 
 // Third-party imports
 import OpenAI from 'openai';
+import type { CompletionUsage } from 'openai/resources/completions';
 
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
@@ -12,6 +13,10 @@ import type { ToolDefinition } from '@model';
 // Local imports - utilities
 import { convertContentToString } from '@agent/utils/text/messageUtils';
 import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
+import {
+  OpenAIAPIResponseUsage,
+  type ExtendedCompletionUsage,
+} from '../core/ResponseUsage';
 
 // TODO: prompt_cache_hit_tokens can also be used here to correct the price and response usage computation in the base class (just overwrite the computePrice and computeResponseUsage methods with a revalues responseUsage.prompt_tokens_details?.cached_tokens and then call the super methods)
 // DEEPSEEK RESPONSE USAGE FORMAT:
@@ -55,6 +60,66 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     const baseURL = this.getBaseUrl();
     this.logger.debug(`Using DeepSeek API key. Base URL: ${baseURL}`);
     return new OpenAI({ apiKey, baseURL });
+  }
+
+  /**
+   * Compute price using DeepSeek's usage object by mapping it to the
+   * extended OpenAI format and delegating to the parent implementation.
+   */
+  computePrice(responseUsage: CompletionUsage | null): number {
+    if (!responseUsage) {
+      return super.computePrice(null);
+    }
+
+    const mapped: ExtendedCompletionUsage = {
+      prompt_tokens: responseUsage.prompt_tokens,
+      completion_tokens: responseUsage.completion_tokens,
+      total_tokens: responseUsage.total_tokens,
+      prompt_cache_hit_tokens: (responseUsage as any).prompt_cache_hit_tokens,
+      prompt_tokens_details: {
+        cached_tokens: (responseUsage as any).prompt_cache_hit_tokens ?? 0,
+      },
+      completion_tokens_details: {
+        reasoning_tokens:
+          (responseUsage as any).completion_tokens_details?.reasoning_tokens ??
+          0,
+        accepted_prediction_tokens: undefined,
+        rejected_prediction_tokens: undefined,
+      },
+    };
+
+    return super.computePrice(mapped);
+  }
+
+  /**
+   * Map DeepSeek usage to the extended OpenAI format and compute detailed usage.
+   */
+  computeResponseUsage(
+    responseUsage: CompletionUsage | null,
+    responseTime: number,
+  ): OpenAIAPIResponseUsage {
+    if (!responseUsage) {
+      return super.computeResponseUsage(null, responseTime);
+    }
+
+    const mapped: ExtendedCompletionUsage = {
+      prompt_tokens: responseUsage.prompt_tokens,
+      completion_tokens: responseUsage.completion_tokens,
+      total_tokens: responseUsage.total_tokens,
+      prompt_cache_hit_tokens: (responseUsage as any).prompt_cache_hit_tokens,
+      prompt_tokens_details: {
+        cached_tokens: (responseUsage as any).prompt_cache_hit_tokens ?? 0,
+      },
+      completion_tokens_details: {
+        reasoning_tokens:
+          (responseUsage as any).completion_tokens_details?.reasoning_tokens ??
+          0,
+        accepted_prediction_tokens: undefined,
+        rejected_prediction_tokens: undefined,
+      },
+    };
+
+    return super.computeResponseUsage(mapped, responseTime);
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -5,6 +5,15 @@
 import OpenAI from 'openai';
 import type { CompletionUsage } from 'openai/resources/completions';
 
+/** DeepSeek-specific response usage interface */
+interface DeepSeekResponseUsage extends CompletionUsage {
+  prompt_cache_hit_tokens?: number;
+  prompt_cache_miss_tokens?: number;
+  completion_tokens_details?: {
+    reasoning_tokens?: number;
+  };
+}
+
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { ToolState } from '../core/ToolState';
@@ -54,6 +63,29 @@ import {
  * Handler for DeepSeek models using OpenAI-compatible API.
  */
 export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
+  /**
+   * Maps DeepSeek-specific usage format to ExtendedCompletionUsage.
+   * Centralizes the conversion logic to avoid duplication.
+   */
+  private mapDeepSeekUsageToExtended(
+    responseUsage: DeepSeekResponseUsage,
+  ): ExtendedCompletionUsage {
+    return {
+      prompt_tokens: responseUsage.prompt_tokens,
+      completion_tokens: responseUsage.completion_tokens,
+      total_tokens: responseUsage.total_tokens,
+      prompt_cache_hit_tokens: responseUsage.prompt_cache_hit_tokens,
+      prompt_tokens_details: {
+        cached_tokens: responseUsage.prompt_cache_hit_tokens ?? 0,
+      },
+      completion_tokens_details: {
+        reasoning_tokens:
+          responseUsage.completion_tokens_details?.reasoning_tokens ?? 0,
+        accepted_prediction_tokens: undefined,
+        rejected_prediction_tokens: undefined,
+      },
+    };
+  }
   /** Returns OpenAI client configured with DeepSeek's base URL. */
   async getClient(): Promise<OpenAI> {
     const apiKey = await this.getApiKey();
@@ -71,23 +103,9 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
       return super.computePrice(null);
     }
 
-    const mapped: ExtendedCompletionUsage = {
-      prompt_tokens: responseUsage.prompt_tokens,
-      completion_tokens: responseUsage.completion_tokens,
-      total_tokens: responseUsage.total_tokens,
-      prompt_cache_hit_tokens: (responseUsage as any).prompt_cache_hit_tokens,
-      prompt_tokens_details: {
-        cached_tokens: (responseUsage as any).prompt_cache_hit_tokens ?? 0,
-      },
-      completion_tokens_details: {
-        reasoning_tokens:
-          (responseUsage as any).completion_tokens_details?.reasoning_tokens ??
-          0,
-        accepted_prediction_tokens: undefined,
-        rejected_prediction_tokens: undefined,
-      },
-    };
-
+    const mapped = this.mapDeepSeekUsageToExtended(
+      responseUsage as DeepSeekResponseUsage,
+    );
     return super.computePrice(mapped);
   }
 
@@ -102,23 +120,9 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
       return super.computeResponseUsage(null, responseTime);
     }
 
-    const mapped: ExtendedCompletionUsage = {
-      prompt_tokens: responseUsage.prompt_tokens,
-      completion_tokens: responseUsage.completion_tokens,
-      total_tokens: responseUsage.total_tokens,
-      prompt_cache_hit_tokens: (responseUsage as any).prompt_cache_hit_tokens,
-      prompt_tokens_details: {
-        cached_tokens: (responseUsage as any).prompt_cache_hit_tokens ?? 0,
-      },
-      completion_tokens_details: {
-        reasoning_tokens:
-          (responseUsage as any).completion_tokens_details?.reasoning_tokens ??
-          0,
-        accepted_prediction_tokens: undefined,
-        rejected_prediction_tokens: undefined,
-      },
-    };
-
+    const mapped = this.mapDeepSeekUsageToExtended(
+      responseUsage as DeepSeekResponseUsage,
+    );
     return super.computeResponseUsage(mapped, responseTime);
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -29,6 +29,7 @@ import {
   ResponseUsageFactory,
   ExtendedCompletionUsage,
 } from '../core/ResponseUsage';
+import type { ResponseUsage } from 'openai/resources/responses/responses';
 import { ToolState } from '../core/ToolState';
 import { K_SLICE } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
@@ -40,7 +41,7 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
  * OpenAI-specific handlers.
  */
 export class ModelHandlerOpenAI extends ModelHandler<
-  ExtendedCompletionUsage | null,
+  ExtendedCompletionUsage | ResponseUsage | null | undefined,
   OpenAIAPIResponseUsage
 > {
   /** Returns OpenAI client with configured API key. */
@@ -652,16 +653,39 @@ export class ModelHandlerOpenAI extends ModelHandler<
   }
 
   /** Computes cost based on token usage and model pricing. */
-  computePrice(responseUsage: ExtendedCompletionUsage | null): number {
+  computePrice(
+    responseUsage: ExtendedCompletionUsage | ResponseUsage | null | undefined,
+  ): number {
     // Handle models that return None for usage
     if (!responseUsage) {
       return 0.0;
     }
 
+    // Normalize ResponseUsage to ExtendedCompletionUsage if needed
+    const usage: ExtendedCompletionUsage =
+      'input_tokens' in responseUsage
+        ? {
+            prompt_tokens: responseUsage.input_tokens,
+            completion_tokens: responseUsage.output_tokens,
+            total_tokens: responseUsage.total_tokens,
+            prompt_cache_hit_tokens: (responseUsage as any)
+              .prompt_cache_hit_tokens,
+            prompt_tokens_details: {
+              cached_tokens:
+                responseUsage.input_tokens_details?.cached_tokens ?? 0,
+            },
+            completion_tokens_details: {
+              reasoning_tokens:
+                responseUsage.output_tokens_details?.reasoning_tokens ?? 0,
+              accepted_prediction_tokens: undefined,
+              rejected_prediction_tokens: undefined,
+            },
+          }
+        : responseUsage;
+
     // Get token counts
-    const promptTokens = responseUsage.prompt_tokens ?? 0;
-    const completionTokens = responseUsage.completion_tokens ?? 0;
-    // Note: OpenAI doesn't provide tool_use_tokens in their API response
+    const promptTokens = usage.prompt_tokens ?? 0;
+    const completionTokens = usage.completion_tokens ?? 0;
 
     let basePrice = calculateTokenPrice(
       promptTokens,
@@ -672,10 +696,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
 
     // Retrieve nested token details if present
     const reasoningTokens =
-      responseUsage.completion_tokens_details?.reasoning_tokens ?? 0;
+      usage.completion_tokens_details?.reasoning_tokens ?? 0;
     const cachedTokens =
-      responseUsage.prompt_tokens_details?.cached_tokens ??
-      responseUsage.prompt_cache_hit_tokens ?? // deepseek
+      usage.prompt_tokens_details?.cached_tokens ??
+      usage.prompt_cache_hit_tokens ?? // deepseek
       0;
 
     if (reasoningTokens) {
@@ -694,7 +718,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
 
   /** Creates usage statistics from OpenAI's response format. */
   computeResponseUsage(
-    responseUsage: ExtendedCompletionUsage | null,
+    responseUsage: ExtendedCompletionUsage | ResponseUsage | null | undefined,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
     // For Google models, create a minimal usage object with zeros
@@ -718,9 +742,30 @@ export class ModelHandlerOpenAI extends ModelHandler<
       );
     }
 
+    const usage: ExtendedCompletionUsage =
+      'input_tokens' in responseUsage
+        ? {
+            prompt_tokens: responseUsage.input_tokens,
+            completion_tokens: responseUsage.output_tokens,
+            total_tokens: responseUsage.total_tokens,
+            prompt_cache_hit_tokens: (responseUsage as any)
+              .prompt_cache_hit_tokens,
+            prompt_tokens_details: {
+              cached_tokens:
+                responseUsage.input_tokens_details?.cached_tokens ?? 0,
+            },
+            completion_tokens_details: {
+              reasoning_tokens:
+                responseUsage.output_tokens_details?.reasoning_tokens ?? 0,
+              accepted_prediction_tokens: undefined,
+              rejected_prediction_tokens: undefined,
+            },
+          }
+        : responseUsage;
+
     return ResponseUsageFactory.fromOpenAIResponse(
-      responseUsage,
-      this.computePrice(responseUsage),
+      usage,
+      this.computePrice(usage),
       responseTime,
     );
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -16,7 +16,11 @@ import type {
 
 // Local imports - base handler
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { ResponseUsageFactory } from '../core/ResponseUsage';
+import {
+  ResponseUsageFactory,
+  OpenAIAPIResponseUsage,
+  ExtendedCompletionUsage,
+} from '../core/ResponseUsage';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { ToolState } from '../core/ToolState';
 import { K_SLICE } from '@utils/config';
@@ -297,66 +301,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
   }
 
   /** Price computation adapted for Responses API token fields. */
-  computePrice(responseUsage: any): number {
+  computePrice(responseUsage: ResponseUsage | undefined): number {
     if (!responseUsage) {
       return 0.0;
     }
 
-    // Response API uses input_tokens/output_tokens
-    const promptTokens = responseUsage.input_tokens ?? 0;
-    const completionTokens = responseUsage.output_tokens ?? 0;
-
-    let basePrice = calculateTokenPrice(
-      promptTokens,
-      completionTokens,
-      this.config.inputPrice,
-      this.config.outputPrice,
-    );
-
-    // Response API uses output_tokens_details and input_tokens_details
-    const reasoningTokens =
-      responseUsage.output_tokens_details?.reasoning_tokens ?? 0;
-    const cachedTokens = responseUsage.input_tokens_details?.cached_tokens ?? 0;
-
-    if (reasoningTokens) {
-      basePrice += (reasoningTokens * this.config.outputPrice) / 1e6;
-    }
-    if (cachedTokens) {
-      basePrice -=
-        (cachedTokens *
-          this.config.inputPrice *
-          (1 - this.capabilities.cacheDiscountFactor)) /
-        1e6;
-    }
-
-    return basePrice;
-  }
-
-  /** Map usage fields and create usage statistics object. */
-  computeResponseUsage(responseUsage: any, responseTime: number): any {
-    if (!responseUsage) {
-      const emptyUsage = {
-        input_tokens: 0,
-        output_tokens: 0,
-        total_tokens: 0,
-        input_tokens_details: { cached_tokens: 0 },
-        output_tokens_details: { reasoning_tokens: 0 },
-      };
-      const mapped = {
-        prompt_tokens: 0,
-        completion_tokens: 0,
-        total_tokens: 0,
-        prompt_tokens_details: { cached_tokens: 0 },
-        completion_tokens_details: { reasoning_tokens: 0 },
-      };
-      return ResponseUsageFactory.fromOpenAIResponse(
-        mapped,
-        this.computePrice(emptyUsage),
-        responseTime,
-      );
-    }
-
-    const mapped = {
+    const mapped: ExtendedCompletionUsage = {
       prompt_tokens: responseUsage.input_tokens,
       completion_tokens: responseUsage.output_tokens,
       total_tokens: responseUsage.total_tokens,
@@ -371,9 +321,39 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       },
     };
 
+    return super.computePrice(mapped);
+  }
+
+  /** Map usage fields and create usage statistics object. */
+  computeResponseUsage(
+    responseUsage: ResponseUsage | undefined,
+    responseTime: number,
+  ): OpenAIAPIResponseUsage {
+    const usage: ResponseUsage = responseUsage ?? {
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    };
+
+    const mapped: ExtendedCompletionUsage = {
+      prompt_tokens: usage.input_tokens,
+      completion_tokens: usage.output_tokens,
+      total_tokens: usage.total_tokens,
+      prompt_tokens_details: {
+        cached_tokens: usage.input_tokens_details?.cached_tokens ?? 0,
+      },
+      completion_tokens_details: {
+        reasoning_tokens: usage.output_tokens_details?.reasoning_tokens ?? 0,
+        accepted_prediction_tokens: undefined,
+        rejected_prediction_tokens: undefined,
+      },
+    };
+
     return ResponseUsageFactory.fromOpenAIResponse(
       mapped,
-      this.computePrice(responseUsage),
+      this.computePrice(usage),
       responseTime,
     );
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -42,6 +42,29 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
   private sentMessages = 0;
 
   /**
+   * Maps ResponseUsage to ExtendedCompletionUsage format.
+   * Centralizes the conversion logic to avoid duplication.
+   */
+  private mapResponseUsageToExtended(
+    responseUsage: ResponseUsage,
+  ): ExtendedCompletionUsage {
+    return {
+      prompt_tokens: responseUsage.input_tokens,
+      completion_tokens: responseUsage.output_tokens,
+      total_tokens: responseUsage.total_tokens,
+      prompt_tokens_details: {
+        cached_tokens: responseUsage.input_tokens_details?.cached_tokens ?? 0,
+      },
+      completion_tokens_details: {
+        reasoning_tokens:
+          responseUsage.output_tokens_details?.reasoning_tokens ?? 0,
+        accepted_prediction_tokens: undefined,
+        rejected_prediction_tokens: undefined,
+      },
+    };
+  }
+
+  /**
    * Manually set the previous response ID to resume a conversation.
    * Call with `null` to reset the stored ID.
    */
@@ -306,21 +329,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       return 0.0;
     }
 
-    const mapped: ExtendedCompletionUsage = {
-      prompt_tokens: responseUsage.input_tokens,
-      completion_tokens: responseUsage.output_tokens,
-      total_tokens: responseUsage.total_tokens,
-      prompt_tokens_details: {
-        cached_tokens: responseUsage.input_tokens_details?.cached_tokens ?? 0,
-      },
-      completion_tokens_details: {
-        reasoning_tokens:
-          responseUsage.output_tokens_details?.reasoning_tokens ?? 0,
-        accepted_prediction_tokens: undefined,
-        rejected_prediction_tokens: undefined,
-      },
-    };
-
+    const mapped = this.mapResponseUsageToExtended(responseUsage);
     return super.computePrice(mapped);
   }
 
@@ -337,20 +346,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       output_tokens_details: { reasoning_tokens: 0 },
     };
 
-    const mapped: ExtendedCompletionUsage = {
-      prompt_tokens: usage.input_tokens,
-      completion_tokens: usage.output_tokens,
-      total_tokens: usage.total_tokens,
-      prompt_tokens_details: {
-        cached_tokens: usage.input_tokens_details?.cached_tokens ?? 0,
-      },
-      completion_tokens_details: {
-        reasoning_tokens: usage.output_tokens_details?.reasoning_tokens ?? 0,
-        accepted_prediction_tokens: undefined,
-        rejected_prediction_tokens: undefined,
-      },
-    };
-
+    const mapped = this.mapResponseUsageToExtended(usage);
     return ResponseUsageFactory.fromOpenAIResponse(
       mapped,
       this.computePrice(usage),


### PR DESCRIPTION
## Summary
- narrow OpenAI Responses handler to `ResponseUsage`
- map Response API usage to OpenAI format before delegating pricing
- allow OpenAI base handler to normalize either usage shape

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(webpack warning, tests run via vscode-test)*

------
https://chatgpt.com/codex/tasks/task_e_6889d341e85083248ddd229d7ebb5e9f