### PR TITLE
refactor: use TokenUsageStats for logging

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -14,6 +14,7 @@ import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
 import { maybeSaveMessages } from '@agent/utils/debugMessageSaver';
+import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 
 export interface ToolUseCycleOptions {
   /** Model handler for API interactions */
@@ -113,7 +114,7 @@ export async function runToolUseCycle(
     }
     if (usage) {
       const normalized = modelHandler.computeResponseUsage(usage, responseTime);
-      const stats = {
+      const stats: ExtendedTokenUsageStats = {
         inputTokens: normalized.totalInputTokens,
         outputTokens: normalized.totalOutputTokens,
         cost: normalized.cost,

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -15,6 +15,24 @@ export const TokenUsageStatsSchema = z.object({
 export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 
 /**
+ * Extended usage statistics for detailed logging.
+ */
+export interface ExtendedTokenUsageStats extends TokenUsageStats {
+  /** Total response time in seconds */
+  elapsedTime?: number;
+  /** Number of tokens retrieved from cache */
+  cacheReadInputTokens?: number;
+  /** Number of tokens stored in cache */
+  cacheCreationInputTokens?: number;
+  /** Percentage of cache hits */
+  percentageCached?: number;
+  /** Number of reasoning tokens generated */
+  reasoningTokens?: number;
+  /** Number of tokens used for tool calls */
+  toolUseTokens?: number;
+}
+
+/**
  * Message interface for updating usage stats in the progress view.
  */
 export const StreamUsageMessageSchema = z.object({

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -10,6 +10,10 @@ import {
 } from '@agent/core/ResponseUsage';
 import { ResponseUsage } from 'openai/resources/responses/responses';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+import type {
+  TokenUsageStats,
+  ExtendedTokenUsageStats,
+} from '@agent/types/UsageTypes';
 
 /**
  * Handles recording usage statistics to the log and progress view.
@@ -107,46 +111,46 @@ export class UsageMonitor {
         });
       }
 
-      const payload: Record<string, number> = {
+      const cachingStats =
+        this.modelHandler.capabilities.supportsPromptCaching ||
+        this.modelHandler.capabilities.supportsAutoPromptCaching;
+
+      const totalCacheableTokens = cachingStats
+        ? this.modelHandler.capabilities.supportsPromptCaching
+          ? stateGlobal.totalCacheCreationInputTokens +
+            stateGlobal.totalCacheReadInputTokens
+          : stateGlobal.totalInputTokens
+        : 0;
+
+      const percentageCached = cachingStats
+        ? totalCacheableTokens > 0
+          ? (stateGlobal.totalCacheReadInputTokens / totalCacheableTokens) * 100
+          : 0
+        : undefined;
+
+      const baseStats: TokenUsageStats = {
         inputTokens: stateGlobal.totalInputTokens,
         outputTokens: stateGlobal.totalOutputTokens,
-        elapsedTime: Number(stateGlobal.totalResponseTime.toFixed(1)),
         cost: Number(cost.toFixed(3)),
       };
 
-      if (
-        this.modelHandler.capabilities.supportsPromptCaching ||
-        this.modelHandler.capabilities.supportsAutoPromptCaching
-      ) {
-        payload.cacheReadInputTokens = stateGlobal.totalCacheReadInputTokens;
-
-        if (this.modelHandler.capabilities.supportsPromptCaching) {
-          payload.cacheCreationInputTokens =
-            stateGlobal.totalCacheCreationInputTokens;
-        }
-
-        const totalCacheableTokens = this.modelHandler.capabilities
-          .supportsPromptCaching
-          ? stateGlobal.totalCacheCreationInputTokens +
-            stateGlobal.totalCacheReadInputTokens
-          : stateGlobal.totalInputTokens;
-
-        const percentageCached =
-          totalCacheableTokens > 0
-            ? (stateGlobal.totalCacheReadInputTokens / totalCacheableTokens) *
-              100
-            : 0;
-
-        payload.percentageCached = Number(percentageCached.toFixed(2));
-      }
-
-      if (this.modelHandler.capabilities.supportsReasoning) {
-        payload.reasoningTokens = stateGlobal.totalReasoningTokens;
-      }
-
-      if (stateGlobal.totalToolUseTokens > 0) {
-        payload.toolUseTokens = stateGlobal.totalToolUseTokens;
-      }
+      const payload: ExtendedTokenUsageStats = {
+        ...baseStats,
+        elapsedTime: Number(stateGlobal.totalResponseTime.toFixed(1)),
+        ...(cachingStats && {
+          cacheReadInputTokens: stateGlobal.totalCacheReadInputTokens,
+          ...(this.modelHandler.capabilities.supportsPromptCaching && {
+            cacheCreationInputTokens: stateGlobal.totalCacheCreationInputTokens,
+          }),
+          percentageCached: Number((percentageCached ?? 0).toFixed(2)),
+        }),
+        ...(this.modelHandler.capabilities.supportsReasoning && {
+          reasoningTokens: stateGlobal.totalReasoningTokens,
+        }),
+        ...(stateGlobal.totalToolUseTokens > 0 && {
+          toolUseTokens: stateGlobal.totalToolUseTokens,
+        }),
+      };
 
       this.logger.statistics(payload, statsGroupId);
     } catch (error) {

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -5,6 +5,7 @@
 import * as logger from './logUtils';
 import type { MessageType } from './messageTypes';
 import { MESSAGE_TYPES } from './messageTypes';
+import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 import { sleep } from '@utils/helpers';
 import { SHORT_SLEEP_MS } from '@utils/config';
 
@@ -117,7 +118,7 @@ export class AgentLogger {
   /**
    * Log statistics information.
    */
-  statistics(stats: Record<string, number>, groupId?: string): void {
+  statistics(stats: ExtendedTokenUsageStats, groupId?: string): void {
     const summary = `Usage - input: ${stats.inputTokens ?? 0}, output: ${stats.outputTokens ?? 0}`;
     this.info(summary, groupId, MESSAGE_TYPES.STATISTICS, stats);
   }


### PR DESCRIPTION
## Summary
- import TokenUsageStats in `AgentLogger`
- update `AgentLogger.statistics` signature
- build stats payloads using TokenUsageStats in `UsageMonitor`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889cd4a4c9083248cd2ca42f8aa7e8b