### PR TITLE
Add ModelClient union

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -26,7 +26,7 @@ import type { AgentConfig } from './AgentConfig';
 import type { AgentSetting, AgentPrompt } from './AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from './AgentState';
 import { ToolState } from './ToolState';
-import type { IModelHandler } from '@agent/modelHandlers';
+import type { IModelHandler, ModelClient } from '@agent/modelHandlers';
 
 // Shared constants
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
@@ -42,7 +42,7 @@ export interface ResponseCycleOptions {
   agentPrompt: AgentPrompt;
   userVars: Record<string, any>;
   logger: AgentLogger;
-  client: any;
+  client: ModelClient;
   checkInterruption: () => Promise<boolean> | boolean;
   setAbortController: (ctrl: AbortController | null) => void;
 }

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -9,7 +9,7 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 // Local imports - agent components
 import type { AgentSetting, AgentPrompt } from './AgentDataclass';
 import type { ToolDefinition } from '@model';
-import type { IModelHandler } from '../modelHandlers';
+import type { IModelHandler, ModelClient } from '../modelHandlers';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
@@ -27,7 +27,7 @@ export interface ToolUseCycleOptions {
   /** Logger instance for progress output */
   logger: AgentLogger;
   /** Provider client object */
-  client: any;
+  client: ModelClient;
   /** Registry mapping tool names to implementations */
   toolRegistry: Record<string, BaseTool<any>>;
   /** Check if the agent run has been interrupted */

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -8,7 +8,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import type { AgentConfig } from '../core/AgentConfig';
 import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { IAgent } from '../core/IAgent';
-import type { IModelHandler } from '../modelHandlers';
+import type { IModelHandler, ModelClient } from '../modelHandlers';
 import { buildUserVars } from '../utils/userVars';
 import { UsageMonitor } from '../utils/UsageMonitor';
 import { AgentStateGlobal } from '../core/AgentState';
@@ -31,7 +31,7 @@ export abstract class BaseAgent implements IAgent {
   protected usageMonitor: UsageMonitor;
   protected runGroupId?: string;
   protected userVars: Record<string, any> = {};
-  protected client: any;
+  protected client!: ModelClient;
   protected isInterrupted = false;
   protected abortController: AbortController | null = null;
   protected executionId?: ExecutionId;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -19,6 +19,7 @@ import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type { IModelHandler } from './types/IModelHandler';
+import type { ModelClient } from './types/ModelClient';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 // Local imports - agent components
@@ -561,14 +562,14 @@ export abstract class ModelHandler<U = any, R = any>
   }
 
   /** Creates and configures a client instance for the specific model provider. */
-  abstract getClient(): Promise<any>;
+  abstract getClient(): Promise<ModelClient>;
 
   /**
    * Generates a model response using the provider's API.
    * @returns Promise resolving to provider-specific response object
    */
   abstract createResponse(
-    client: any,
+    client: ModelClient,
     messages: any[],
     temperature: number,
     systemPrompt?: string,

--- a/src/agent/modelHandlers/index.ts
+++ b/src/agent/modelHandlers/index.ts
@@ -3,6 +3,7 @@
 // Base class
 export { ModelHandler } from './ModelHandler';
 export type { IModelHandler } from './types/IModelHandler';
+export type { ModelClient } from './types/ModelClient';
 
 // Specific model handler implementations
 export { ModelHandlerAnthropic } from './modelHandlerAnthropic';

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -9,6 +9,7 @@ import { ToolState } from '../../core/ToolState';
 import type { MediaEntry } from '../../utils/mediaTypes';
 import type { ModelConfig, ModelCapabilities, ToolDefinition } from '@model';
 import type { ProviderStopReason } from './StopReasonTypes';
+import type { ModelClient } from './ModelClient';
 
 /**
  * Common interface implemented by all model handlers.
@@ -36,7 +37,7 @@ export interface IModelHandler<U = any, R = any> {
   setLogger(logger: AgentLogger): void;
 
   /** Retrieve an authenticated client instance. */
-  getClient(): Promise<any>;
+  getClient(): Promise<ModelClient>;
 
   /**
    * Generate a response from the model.
@@ -48,7 +49,7 @@ export interface IModelHandler<U = any, R = any> {
    * @param signal Optional abort signal
    */
   createResponse(
-    client: any,
+    client: ModelClient,
     messages: any[],
     temperature: number,
     systemPrompt?: string,

--- a/src/agent/modelHandlers/types/ModelClient.ts
+++ b/src/agent/modelHandlers/types/ModelClient.ts
@@ -1,0 +1,4 @@
+export type ModelClient =
+  | import('openai').default
+  | import('@anthropic-ai/sdk').Anthropic
+  | import('@google/genai').GoogleGenAI;

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -14,6 +14,7 @@ import {
   AgentPrompt,
 } from '@agent/core/AgentDataclass';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+import OpenAI from 'openai';
 import {
   ModelConfig,
   ModelProvider,
@@ -32,7 +33,7 @@ class EchoTool extends BaseTool<{ value: string }> {
 class MockHandler extends ModelHandlerOpenAIResponse {
   private call = 0;
   async getClient() {
-    return {} as any;
+    return {} as unknown as OpenAI;
   }
   override async createResponse(): Promise<any> {
     this.call++;
@@ -113,7 +114,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       agentPrompt: prompt,
       userVars: {},
       logger,
-      client: {},
+      client: {} as unknown as OpenAI,
       toolRegistry,
       checkInterruption: () => false,
       setAbortController: () => {},


### PR DESCRIPTION
## Summary
- define `ModelClient` union type
- type clients in ResponseCycle and ToolUseCycle
- return concrete client types in model handlers
- update agent and tests for new typing

## Testing
- `npm run compile-tests`
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack warnings but test runner executed)*

------
https://chatgpt.com/codex/tasks/task_e_6889c89e1b04832492debe6ba2486eee