### PR TITLE
Fix parsing of provider tool calls

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -168,7 +168,7 @@ export async function runToolUseCycle(
       );
       break;
     }
-    let input = parsed.input;
+    let input = parsed.input ?? parsed.args;
     if (!input && parsed.function?.arguments) {
       try {
         input = JSON.parse(parsed.function.arguments);


### PR DESCRIPTION
## Summary
- support `args` property when executing tool calls

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack build shows warnings, but `vscode-test` ran)*

------
https://chatgpt.com/codex/tasks/task_e_688a1678153083249d166635df376d77