### PR TITLE
Handle tool thinking in Anthropic cycle

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -17,6 +17,7 @@ import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
 import { maybeSaveMessages } from '@agent/utils/debugMessageSaver';
 import { ANTHROPIC_STOP } from '../modelHandlers/types/StopReasonTypes';
+import { ToolState } from './ToolState';
 
 export interface ToolUseCycleOptions {
   /** Model handler for API interactions */
@@ -37,6 +38,8 @@ export interface ToolUseCycleOptions {
   checkInterruption: () => Promise<boolean> | boolean;
   /** Pass abort controllers back to the agent */
   setAbortController: (ctrl: AbortController | null) => void;
+  /** Runtime state tracking for tools */
+  toolState?: ToolState;
 }
 
 /**
@@ -56,6 +59,7 @@ export async function runToolUseCycle(
     toolRegistry,
     checkInterruption,
     setAbortController,
+    toolState,
   } = options;
 
   let iteration = 0;
@@ -95,7 +99,11 @@ export async function runToolUseCycle(
       break;
     }
 
-    const thinking = modelHandler.processThinkingBlock(response, groupId);
+    const thinking = modelHandler.processThinkingBlock(
+      response,
+      groupId,
+      toolState,
+    );
     if (thinking) {
       const formatted = await xmlUtils.formatContent(thinking);
       logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
@@ -254,6 +262,7 @@ export async function runToolUseCycle(
       name,
       parsed,
       resultObj,
+      toolState,
     );
     messages.push(callMsg, resultMsg);
 

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -14,6 +14,7 @@ import type { ToolDefinition } from '@model';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
 import { BaseTool } from '@tools/core/base';
 import { runToolUseCycle } from '../core/ToolUseCycle';
+import { ToolState } from '../core/ToolState';
 import { TOOL_USE_INSTRUCTIONS } from '../utils/toolUsePrompt';
 
 export class BaseToolUseAgent extends BaseAgent {
@@ -77,6 +78,8 @@ export class BaseToolUseAgent extends BaseAgent {
         systemPrompt,
       );
 
+      const toolState = new ToolState();
+
       const resolvedSetting = {
         ...this.agentSetting,
         tools: this.getTools(),
@@ -95,6 +98,7 @@ export class BaseToolUseAgent extends BaseAgent {
           setAbortController: (ctrl) => {
             this.abortController = ctrl;
           },
+          toolState,
         },
         messages,
         this.runGroupId,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -737,6 +737,7 @@ export abstract class ModelHandler<
     name: string,
     call: any,
     result: Record<string, unknown>,
+    toolState?: ToolState,
   ): [any, any];
 
   /**

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -981,17 +981,21 @@ export class ModelHandlerAnthropic extends ModelHandler<
     name: string,
     call: any,
     result: Record<string, unknown>,
+    toolState?: ToolState,
   ): [any, any] {
+    const content: any[] = [];
+    if (toolState?.thinkingBlocks && toolState.thinkingBlocks.length > 0) {
+      content.push(...toolState.thinkingBlocks);
+    }
+    content.push({
+      type: 'tool_use',
+      id,
+      name,
+      input: call?.input ?? call?.arguments ?? {},
+    });
     const callMsg = {
       role: 'assistant',
-      content: [
-        {
-          type: 'tool_use',
-          id,
-          name,
-          input: call?.input ?? call?.arguments ?? {},
-        },
-      ],
+      content,
     };
     const resultMsg = {
       role: 'user',

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -961,6 +961,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     name: string,
     call: any,
     result: Record<string, unknown>,
+    _toolState?: ToolState,
   ): [any, any] {
     const callPart = createPartFromFunctionCall(
       name,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -891,6 +891,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     name: string,
     call: any,
     result: Record<string, unknown>,
+    _toolState?: ToolState,
   ): [any, any] {
     const callMsg: ChatCompletionAssistantMessageParam = {
       role: 'assistant',

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -502,6 +502,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     name: string,
     call: any,
     result: Record<string, unknown>,
+    _toolState?: ToolState,
   ): [any, any] {
     const callMsg: ResponseFunctionToolCall = {
       type: 'function_call',

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -187,5 +187,6 @@ export interface IModelHandler<
     name: string,
     call: any,
     result: Record<string, unknown>,
+    toolState?: ToolState,
   ): [M, M];
 }

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -9,6 +9,7 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { ToolState } from '@agent/core/ToolState';
 import {
   AgentSetting,
   AgentType,
@@ -108,6 +109,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       userRequest: '',
       userReflect: '',
     };
+    const toolState = new ToolState();
     const options = {
       modelHandler: handler,
       agentSetting: setting,
@@ -118,6 +120,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       toolRegistry,
       checkInterruption: () => false,
       setAbortController: () => {},
+      toolState,
     };
     const events: any[] = [];
     const dispose = bus.on('addLogMessage', (e) => events.push(e));


### PR DESCRIPTION
## Summary
- add toolState option for tool-use cycles
- pass toolState from BaseToolUseAgent
- forward toolState to thinking blocks and follow-up messages
- support Anthropic thinking blocks when constructing tool-use messages
- update tests for new option

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a189f4b4c8324a89be3ee8e990f13