### PR TITLE
fix: skip thinking blocks without reasoning

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -984,7 +984,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
     toolState?: ToolState,
   ): [any, any] {
     const content: any[] = [];
-    if (toolState?.thinkingBlocks && toolState.thinkingBlocks.length > 0) {
+    if (
+      this.capabilities.supportsReasoning &&
+      toolState?.thinkingBlocks &&
+      toolState.thinkingBlocks.length > 0
+    ) {
       content.push(...toolState.thinkingBlocks);
     }
     content.push({


### PR DESCRIPTION
## Summary
- avoid adding thinking blocks when the model lacks reasoning support

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: cannot find module 'vscode' and others)*

------
https://chatgpt.com/codex/tasks/task_e_688a2af0dcd08324809f1968909d9309