### PR TITLE
Fix tool calling for OpenAI Responses

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -24,6 +24,7 @@ import { K_SLICE } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import type { ToolDefinition } from '@model';
+import { toOpenAIResponseTools } from './toolConversion';
 
 // import { ResponseCreateParams } from 'openai/src/resources/responses/response';
 // this is incorrect now, but would be nice to use
@@ -99,7 +100,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     systemPrompt?: string,
     endTag?: string,
     signal?: AbortSignal,
-    _tools?: ToolDefinition[],
+    tools?: ToolDefinition[],
   ): Promise<Response> {
     const useStreaming = this.getStreamingConfig();
 
@@ -171,6 +172,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     }
     if (systemPrompt) {
       params.instructions = systemPrompt;
+    }
+
+    if (tools && tools.length > 0) {
+      params.tools = toOpenAIResponseTools(tools);
+      params.tool_choice = 'auto';
     }
 
     if (this.capabilities.supportsReasoning) {

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -3,6 +3,7 @@ import type { ToolDefinition } from '@model';
 
 // Third-party imports
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import type { FunctionTool } from 'openai/resources/responses/responses';
 import type {
   Tool as AnthropicTool,
   ToolUnion,
@@ -30,6 +31,17 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
       description: d.description,
       parameters: d.parameters,
     },
+  }));
+}
+
+/** Convert generic ToolDefinition objects to OpenAI Responses FunctionTool format. */
+export function toOpenAIResponseTools(defs: ToolDefinition[]): FunctionTool[] {
+  return defs.map((d) => ({
+    type: 'function',
+    name: d.name,
+    description: d.description,
+    parameters: d.parameters as Record<string, unknown> | null,
+    strict: true,
   }));
 }
 

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -36,13 +36,16 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 
 /** Convert generic ToolDefinition objects to OpenAI Responses FunctionTool format. */
 export function toOpenAIResponseTools(defs: ToolDefinition[]): FunctionTool[] {
-  return defs.map((d) => ({
-    type: 'function',
-    name: d.name,
-    description: d.description,
-    parameters: d.parameters as Record<string, unknown> | null,
-    strict: true,
-  }));
+  return defs.map((d) => {
+    const params = (d.parameters ?? null) as Record<string, unknown> | null;
+    return {
+      type: 'function',
+      name: d.name,
+      description: d.description,
+      parameters: params,
+      strict: true,
+    };
+  });
 }
 
 /** Convert generic ToolDefinition objects to Anthropic Tool format. */

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -24,4 +24,16 @@ describe('toOpenAIResponseTools', () => {
     assert.equal(tools[0].name, 'echo');
     assert.deepEqual(tools[0].parameters, defs[0].parameters);
   });
+
+  it('sets parameters to null when omitted', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'noop',
+        description: 'no params',
+      },
+    ];
+
+    const tools = toOpenAIResponseTools(defs);
+    assert.equal(tools[0].parameters, null);
+  });
 });

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from 'assert';
+
+import { toOpenAIResponseTools } from '@agent/modelHandlers/toolConversion';
+import type { ToolDefinition } from '@model';
+
+describe('toOpenAIResponseTools', () => {
+  it('converts tool definitions to Response API format', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'echo',
+        description: 'Echo value',
+        parameters: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+        },
+      },
+    ];
+
+    const tools = toOpenAIResponseTools(defs);
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].type, 'function');
+    assert.equal(tools[0].name, 'echo');
+    assert.deepEqual(tools[0].parameters, defs[0].parameters);
+  });
+});


### PR DESCRIPTION
## Summary
- add tool conversion helper for OpenAI Responses API
- include tool definitions when creating a response
- add unit test for `toOpenAIResponseTools`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack compiled with a warning)*

------
https://chatgpt.com/codex/tasks/task_e_688a1a7e7c70832491ba98e9157e562b