### PR TITLE
Add text support for follow-up messages

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -263,6 +263,7 @@ export async function runToolUseCycle(
       parsed,
       resultObj,
       toolState,
+      text,
     );
     messages.push(callMsg, resultMsg);
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -738,6 +738,7 @@ export abstract class ModelHandler<
     call: any,
     result: Record<string, unknown>,
     toolState?: ToolState,
+    text?: string,
   ): [any, any];
 
   /**

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -982,8 +982,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
     call: any,
     result: Record<string, unknown>,
     toolState?: ToolState,
+    text?: string,
   ): [any, any] {
     const content: any[] = [];
+    if (text) {
+      content.push({ type: 'text', text });
+    }
     if (toolState?.thinkingBlocks && toolState.thinkingBlocks.length > 0) {
       content.push(...toolState.thinkingBlocks);
     }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -962,6 +962,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
+    _text?: string,
   ): [any, any] {
     const callPart = createPartFromFunctionCall(
       name,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -892,6 +892,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
+    _text?: string,
   ): [any, any] {
     const callMsg: ChatCompletionAssistantMessageParam = {
       role: 'assistant',

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -503,6 +503,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
+    _text?: string,
   ): [any, any] {
     const callMsg: ResponseFunctionToolCall = {
       type: 'function_call',

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -188,5 +188,6 @@ export interface IModelHandler<
     call: any,
     result: Record<string, unknown>,
     toolState?: ToolState,
+    text?: string,
   ): [M, M];
 }


### PR DESCRIPTION
## Summary
- allow tool follow-up message creation to accept optional text
- pass the extracted text to `createFollowUpMessage`
- support Anthropic text blocks before thinking and tool-use blocks

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a2fc8b0808324a3c599464ab0c189