### PR TITLE
Add assistant text support for tool follow-ups

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -257,14 +257,15 @@ export async function runToolUseCycle(
       resultObj.base64Image = result.base64Image;
     if (result.system !== undefined) resultObj.system = result.system;
 
-    const [callMsg, resultMsg] = modelHandler.createFollowUpMessage(
+    const followUps = modelHandler.createFollowUpMessage(
       id,
       name,
       parsed,
       resultObj,
       toolState,
+      text,
     );
-    messages.push(callMsg, resultMsg);
+    messages.push(...followUps);
 
     iteration++;
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -738,7 +738,8 @@ export abstract class ModelHandler<
     call: any,
     result: Record<string, unknown>,
     toolState?: ToolState,
-  ): [any, any];
+    text?: string,
+  ): any[];
 
   /**
    * Creates a log group for model operations with the given name.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -982,10 +982,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
     call: any,
     result: Record<string, unknown>,
     toolState?: ToolState,
-  ): [any, any] {
+    text?: string,
+  ): any[] {
     const content: any[] = [];
     if (toolState?.thinkingBlocks && toolState.thinkingBlocks.length > 0) {
       content.push(...toolState.thinkingBlocks);
+    }
+    if (text) {
+      content.push({ type: 'text', text });
     }
     content.push({
       type: 'tool_use',

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -962,7 +962,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
-  ): [any, any] {
+    text?: string,
+  ): any[] {
     const callPart = createPartFromFunctionCall(
       name,
       typeof call?.args === 'object' ? call.args : (call?.input ?? {}),
@@ -971,8 +972,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       callPart.functionCall.id = id;
     }
     const resultPart = createPartFromFunctionResponse(id, name, result);
+    const parts = [] as any[];
+    if (text) parts.push({ text });
+    parts.push(callPart);
     return [
-      { role: 'assistant', parts: [callPart] },
+      { role: 'assistant', parts },
       { role: 'user', parts: [resultPart] },
     ];
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -892,7 +892,12 @@ export class ModelHandlerOpenAI extends ModelHandler<
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
-  ): [any, any] {
+    text?: string,
+  ): any[] {
+    const messages: ChatCompletionMessageParam[] = [];
+    if (text) {
+      messages.push({ role: 'assistant', content: text });
+    }
     const callMsg: ChatCompletionAssistantMessageParam = {
       role: 'assistant',
       tool_calls: [
@@ -914,7 +919,8 @@ export class ModelHandlerOpenAI extends ModelHandler<
       tool_call_id: id,
       content: JSON.stringify(result),
     };
-    return [callMsg, resultMsg];
+    messages.push(callMsg, resultMsg);
+    return messages;
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -13,7 +13,11 @@ import type {
   ResponseFunctionToolCall,
   ResponseInputItem,
 } from 'openai/resources/responses/responses';
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionAssistantMessageParam,
+} from 'openai/resources/chat/completions';
+import type { ProviderMessage } from './types/ProviderMessage';
 
 // Local imports - base handler
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
@@ -503,7 +507,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
-  ): [any, any] {
+    text?: string,
+  ): any[] {
+    const messages: ProviderMessage[] = [];
+    if (text) {
+      const textMsg: ChatCompletionAssistantMessageParam = {
+        role: 'assistant',
+        content: text,
+      };
+      messages.push(textMsg);
+    }
     const callMsg: ResponseFunctionToolCall = {
       type: 'function_call',
       call_id: id,
@@ -518,6 +531,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       call_id: id,
       output: JSON.stringify(result),
     };
-    return [callMsg, resultMsg];
+    messages.push(callMsg, resultMsg);
+    return messages;
   }
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -180,7 +180,8 @@ export interface IModelHandler<
    * @param name - Tool name
    * @param call - Parsed tool call object or input payload
    * @param result - Object with output/error fields
-   * @returns Tuple of [call message, result message]
+   * @param text - Optional assistant text preceding the tool call
+   * @returns Array of provider messages representing the tool call and result
    */
   createFollowUpMessage(
     id: string,
@@ -188,5 +189,6 @@ export interface IModelHandler<
     call: any,
     result: Record<string, unknown>,
     toolState?: ToolState,
-  ): [M, M];
+    text?: string,
+  ): M[];
 }

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -68,6 +68,9 @@ class MockHandler extends ModelHandlerOpenAIResponse {
     };
   }
   override extractResponse(resp: any): [string, any, any] {
+    if (this.call === 1) {
+      return ['intro', resp.usage, 'stop'];
+    }
     return ['', resp.usage, 'stop'];
   }
 }
@@ -134,12 +137,16 @@ describe('runToolUseCycle OpenAIResponse', () => {
     );
     assert.equal(toolEvents.length, 2);
     assert.deepEqual(messages[0], {
+      role: 'assistant',
+      content: 'intro',
+    });
+    assert.deepEqual(messages[1], {
       type: 'function_call',
       call_id: 'c1',
       name: 'echo',
       arguments: '{"value":"hello"}',
     });
-    assert.deepEqual(messages[1], {
+    assert.deepEqual(messages[2], {
       type: 'function_call_output',
       call_id: 'c1',
       output: JSON.stringify({ output: 'hello' }),


### PR DESCRIPTION
## Summary
- allow model handlers to send intro text before tool calls
- implement text injection for Anthropic, Google GenAI, OpenAI and Responses APIs
- propagate optional text through `runToolUseCycle`
- update OpenAI Responses tool cycle test

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a2fa5f6a883248b6c6c795554b2e0