### PR TITLE
Add assistant text handling for tool responses

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -257,7 +257,7 @@ export async function runToolUseCycle(
       resultObj.base64Image = result.base64Image;
     if (result.system !== undefined) resultObj.system = result.system;
 
-    const [callMsg, resultMsg] = modelHandler.createFollowUpMessage(
+    const followUpMsgs = modelHandler.createFollowUpMessage(
       id,
       name,
       parsed,
@@ -265,7 +265,7 @@ export async function runToolUseCycle(
       toolState,
       text,
     );
-    messages.push(callMsg, resultMsg);
+    messages.push(...followUpMsgs);
 
     iteration++;
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -739,7 +739,7 @@ export abstract class ModelHandler<
     result: Record<string, unknown>,
     toolState?: ToolState,
     text?: string,
-  ): [any, any];
+  ): any[];
 
   /**
    * Creates a log group for model operations with the given name.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -983,7 +983,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     result: Record<string, unknown>,
     toolState?: ToolState,
     text?: string,
-  ): [any, any] {
+  ): any[] {
     const content: any[] = [];
     if (text) {
       content.push({ type: 'text', text });

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -975,8 +975,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
-    _text?: string,
-  ): [any, any] {
+    text?: string,
+  ): any[] {
+    const messages: Content[] = [];
+    if (text) {
+      messages.push({ role: 'assistant', parts: [{ text }] });
+    }
     const callPart = createPartFromFunctionCall(
       name,
       typeof call?.args === 'object' ? call.args : (call?.input ?? {}),
@@ -985,10 +989,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       callPart.functionCall.id = id;
     }
     const resultPart = createPartFromFunctionResponse(id, name, result);
-    return [
+    messages.push(
       { role: 'assistant', parts: [callPart] },
       { role: 'user', parts: [resultPart] },
-    ];
+    );
+    return messages;
   }
 
   // Assuming containCutOffMessage is available from base class ModelHandler

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -977,10 +977,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     _toolState?: ToolState,
     text?: string,
   ): any[] {
-    const messages: Content[] = [];
-    if (text) {
-      messages.push({ role: 'assistant', parts: [{ text }] });
-    }
     const callPart = createPartFromFunctionCall(
       name,
       typeof call?.args === 'object' ? call.args : (call?.input ?? {}),
@@ -989,11 +985,14 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       callPart.functionCall.id = id;
     }
     const resultPart = createPartFromFunctionResponse(id, name, result);
-    messages.push(
-      { role: 'assistant', parts: [callPart] },
-      { role: 'user', parts: [resultPart] },
-    );
-    return messages;
+    const callParts: Part[] = [];
+    if (text) {
+      callParts.push({ text });
+    }
+    callParts.push(callPart);
+    const callMsg: Content = { role: 'assistant', parts: callParts };
+    const resultMsg: Content = { role: 'user', parts: [resultPart] };
+    return [callMsg, resultMsg];
   }
 
   // Assuming containCutOffMessage is available from base class ModelHandler

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -894,10 +894,6 @@ export class ModelHandlerOpenAI extends ModelHandler<
     _toolState?: ToolState,
     text?: string,
   ): any[] {
-    const messages: ChatCompletionMessageParam[] = [];
-    if (text) {
-      messages.push({ role: 'assistant', content: [{ type: 'text', text }] });
-    }
     const callMsg: ChatCompletionAssistantMessageParam = {
       role: 'assistant',
       tool_calls: [
@@ -914,13 +910,15 @@ export class ModelHandlerOpenAI extends ModelHandler<
         },
       ],
     };
+    if (text) {
+      callMsg.content = [{ type: 'text', text }];
+    }
     const resultMsg: ChatCompletionToolMessageParam = {
       role: 'tool',
       tool_call_id: id,
       content: JSON.stringify(result),
     };
-    messages.push(callMsg, resultMsg);
-    return messages;
+    return [callMsg, resultMsg];
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -892,8 +892,12 @@ export class ModelHandlerOpenAI extends ModelHandler<
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
-    _text?: string,
-  ): [any, any] {
+    text?: string,
+  ): any[] {
+    const messages: ChatCompletionMessageParam[] = [];
+    if (text) {
+      messages.push({ role: 'assistant', content: [{ type: 'text', text }] });
+    }
     const callMsg: ChatCompletionAssistantMessageParam = {
       role: 'assistant',
       tool_calls: [
@@ -915,7 +919,8 @@ export class ModelHandlerOpenAI extends ModelHandler<
       tool_call_id: id,
       content: JSON.stringify(result),
     };
-    return [callMsg, resultMsg];
+    messages.push(callMsg, resultMsg);
+    return messages;
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -503,8 +503,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     call: any,
     result: Record<string, unknown>,
     _toolState?: ToolState,
-    _text?: string,
-  ): [any, any] {
+    text?: string,
+  ): any[] {
+    const messages: (ResponseInputItem | ChatCompletionMessageParam)[] = [];
+    if (text) {
+      messages.push({ role: 'assistant', content: [{ type: 'text', text }] });
+    }
     const callMsg: ResponseFunctionToolCall = {
       type: 'function_call',
       call_id: id,
@@ -519,6 +523,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       call_id: id,
       output: JSON.stringify(result),
     };
-    return [callMsg, resultMsg];
+    messages.push(callMsg, resultMsg);
+    return messages;
   }
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -189,5 +189,5 @@ export interface IModelHandler<
     result: Record<string, unknown>,
     toolState?: ToolState,
     text?: string,
-  ): [M, M];
+  ): M[];
 }

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -44,6 +44,11 @@ class MockHandler extends ModelHandlerOpenAIResponse {
         status: 'completed',
         output: [
           {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'intro', annotations: [] }],
+          },
+          {
             type: 'function_call',
             id: 'c1',
             name: 'echo',
@@ -61,13 +66,19 @@ class MockHandler extends ModelHandlerOpenAIResponse {
           type: 'message',
           role: 'assistant',
           status: 'completed',
-          content: [{ type: 'output_text', text: 'done' }],
+          content: [{ type: 'output_text', text: 'done', annotations: [] }],
         },
       ],
       usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
     };
   }
   override extractResponse(resp: any): [string, any, any] {
+    if (resp.id === 'r1') {
+      return ['intro', resp.usage, 'stop'];
+    }
+    if (resp.id === 'r2') {
+      return ['done', resp.usage, 'stop'];
+    }
     return ['', resp.usage, 'stop'];
   }
 }
@@ -134,12 +145,16 @@ describe('runToolUseCycle OpenAIResponse', () => {
     );
     assert.equal(toolEvents.length, 2);
     assert.deepEqual(messages[0], {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'intro' }],
+    });
+    assert.deepEqual(messages[1], {
       type: 'function_call',
       call_id: 'c1',
       name: 'echo',
       arguments: '{"value":"hello"}',
     });
-    assert.deepEqual(messages[1], {
+    assert.deepEqual(messages[2], {
       type: 'function_call_output',
       call_id: 'c1',
       output: JSON.stringify({ output: 'hello' }),


### PR DESCRIPTION
## Summary
- return arrays from `createFollowUpMessage` so providers can insert text
- include assistant text when creating follow-up messages for all model handlers
- push all follow-up messages in the tool use cycle
- update OpenAI Response tool use test for new text message

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a354828e08324be1446a36fe44f10