### PR TITLE
Fix optional tool schema for OpenAI Responses

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -43,7 +43,10 @@ export function toOpenAIResponseTools(defs: ToolDefinition[]): FunctionTool[] {
       name: d.name,
       description: d.description,
       parameters: params,
-      strict: true,
+      // Setting strict=true requires an explicit `required` array covering all
+      // parameters. The Wolfram tool uses optional fields, so disable strict
+      // validation to avoid schema errors from the OpenAI Responses API.
+      strict: false,
     };
   });
 }


### PR DESCRIPTION
## Summary
- disable strict schema validation for Responses API tools to support optional parameters

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a37c7d744832489ed0b20f55c5d23