### PR TITLE
fix: order thinking blocks before text

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -985,15 +985,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
     text?: string,
   ): [any, any] {
     const content: any[] = [];
-    if (text) {
-      content.push({ type: 'text', text });
-    }
     if (
       this.capabilities.supportsReasoning &&
       toolState?.thinkingBlocks &&
       toolState.thinkingBlocks.length > 0
     ) {
+      // Anthropic models expect thinking blocks before text
       content.push(...toolState.thinkingBlocks);
+    }
+    if (text) {
+      content.push({ type: 'text', text });
     }
     content.push({
       type: 'tool_use',


### PR DESCRIPTION
## Summary
- put thinking blocks before text when sending tool results with the Anthropic handler

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a388c03e083249269b0865ee81b5d