### PR TITLE
Add model name to debug message files

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -94,6 +94,7 @@ export async function runResponseCycle(
       logger,
       continuationCount: stateRound.continuationCount,
       outputFile,
+      modelName: agentConfig.model,
       executionId,
       groupId: taskGroupId,
     });

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -40,6 +40,8 @@ export interface ToolUseCycleOptions {
   setAbortController: (ctrl: AbortController | null) => void;
   /** Runtime state tracking for tools */
   toolState?: ToolState;
+  /** Name of the model used for this run */
+  modelName?: string;
 }
 
 /**
@@ -60,6 +62,7 @@ export async function runToolUseCycle(
     checkInterruption,
     setAbortController,
     toolState,
+    modelName,
   } = options;
 
   let iteration = 0;
@@ -74,6 +77,7 @@ export async function runToolUseCycle(
       logger,
       continuationCount: iteration,
       baseName: 'tooluse',
+      modelName,
       groupId,
     });
 

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -99,6 +99,7 @@ export class BaseToolUseAgent extends BaseAgent {
             this.abortController = ctrl;
           },
           toolState,
+          modelName: this.agentConfig.model,
         },
         messages,
         this.runGroupId,

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -17,6 +17,8 @@ export interface SaveMessagesParams {
   continuationCount?: number;
   outputFile?: string;
   baseName?: string;
+  /** Name of the model used for this conversation */
+  modelName?: string;
   executionId?: ExecutionId;
   groupId?: string;
 }
@@ -31,6 +33,7 @@ export async function maybeSaveMessages({
   continuationCount,
   outputFile,
   baseName = 'messages',
+  modelName,
   executionId,
   groupId,
 }: SaveMessagesParams): Promise<void> {
@@ -45,7 +48,8 @@ export async function maybeSaveMessages({
       : baseName;
   const cont =
     continuationCount !== undefined ? `_cont${continuationCount}` : '';
-  const debugFileName = `${fileBase}${cont}.json`;
+  const modelPart = modelName ? `_${modelName.replace(/[\\/]/g, '_')}` : '';
+  const debugFileName = `${fileBase}${modelPart}${cont}.json`;
 
   const debugFilePath = executionId
     ? path.join(getRunDir(executionId), debugFileName)

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -121,6 +121,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       checkInterruption: () => false,
       setAbortController: () => {},
       toolState,
+      modelName: 'test',
     };
     const events: any[] = [];
     const dispose = bus.on('addLogMessage', (e) => events.push(e));


### PR DESCRIPTION
## Summary
- include optional `modelName` in message-saving params
- propagate model name from agents and tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a38c2b72483248972a95bfcd85aae