### PR TITLE
Fix tool use argument handling

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -181,6 +181,13 @@ export async function runToolUseCycle(
       break;
     }
     let input = parsed.input ?? parsed.args;
+    if (!input && parsed.arguments) {
+      try {
+        input = JSON.parse(parsed.arguments);
+      } catch {
+        input = parsed.arguments;
+      }
+    }
     if (!input && parsed.function?.arguments) {
       try {
         input = JSON.parse(parsed.function.arguments);


### PR DESCRIPTION
## Summary
- handle `arguments` field from Responses API tool calls

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Critical dependency message and truncated output)*

------
https://chatgpt.com/codex/tasks/task_e_688a420e38248324bca9f27e2f4a2a6b