### PR TITLE
Fix tool call data for streaming

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -193,7 +193,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
           return response;
         }
 
-        response = await stream.finalMessage();
+        response = await stream.finalChatCompletion();
 
         // in the future we can add: stream_options: {"include_usage": true} to get usage statistics
         // in the future if we pass stream to outside (signal: controller.signal)), calling stream.controller.abort() will abort the stream; which will be very useful for our stop button (controller.abort();)

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -75,7 +75,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     if (useStreaming) {
       kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
       const stream = client.chat.completions.stream(kwargs, { signal });
-      return await stream.finalMessage();
+      return await stream.finalChatCompletion();
     } else {
       return await client.chat.completions.create(kwargs, { signal });
     }


### PR DESCRIPTION
## Summary
- return the full chat completion when streaming

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack warning only)*

------
https://chatgpt.com/codex/tasks/task_e_688a4d8939348324b3a904e17b42e4b8