### PR TITLE
Add DeepSeek tool-call support

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -63,7 +63,8 @@ Known for large context windows, multimodality, and speed/cost efficiency.
 
 ### DeepSeek Models
 
-Strong technical and coding performance, cost-effective.
+Strong technical and coding performance, cost-effective. DeepSeek's API now
+supports function calling so agents can use external tools during a run.
 
 | Model ID | Key Strength / Use Case     | Relative Cost | Relative Speed | Notes            |
 | :------- | :-------------------------- | :------------ | :------------- | :--------------- |

--- a/docs/reference/tool-format.md
+++ b/docs/reference/tool-format.md
@@ -19,3 +19,11 @@ const tools: ToolDefinition[] = [
 ```
 
 See your provider's documentation for the exact schema.
+
+DeepSeek uses the same structure as OpenAI. Tool calls are returned in
+`choices[0].message.tool_calls` and results should be sent back using:
+
+```ts
+{ role: 'assistant', tool_calls: [/* ... */] }
+{ role: 'tool', tool_call_id: id, content: JSON.stringify(result) }
+```

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -124,8 +124,51 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     return reasoningContent;
   }
 
-  extractToolUse(_responseObject: any): string | null {
+  extractToolUse(responseObject: any): string | null {
+    const toolCalls = responseObject?.choices?.[0]?.message?.tool_calls;
+    if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+      return JSON.stringify(toolCalls[0], null, 2);
+    }
+    const func = responseObject?.choices?.[0]?.message?.function_call;
+    if (func) {
+      return JSON.stringify(func, null, 2);
+    }
     return null;
+  }
+
+  createFollowUpMessage(
+    id: string,
+    name: string,
+    call: any,
+    result: Record<string, unknown>,
+    _toolState?: ToolState,
+    text?: string,
+  ): any[] {
+    const callMsg: any = {
+      role: 'assistant',
+      tool_calls: [
+        {
+          id,
+          type: 'function',
+          function: {
+            name,
+            arguments:
+              typeof call?.arguments === 'string'
+                ? call.arguments
+                : JSON.stringify(call?.input ?? call?.arguments ?? {}),
+          },
+        },
+      ],
+    };
+    if (text) {
+      callMsg.content = text;
+    }
+    const resultMsg = {
+      role: 'tool',
+      tool_call_id: id,
+      content: JSON.stringify(result),
+    };
+    return [callMsg, resultMsg];
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -144,6 +144,15 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     _toolState?: ToolState,
     text?: string,
   ): any[] {
+    const argString =
+      typeof call?.function?.arguments === 'string'
+        ? call.function.arguments
+        : typeof call?.arguments === 'string'
+          ? call.arguments
+          : JSON.stringify(
+              call?.input ?? call?.function?.arguments ?? call?.arguments ?? {},
+            );
+
     const callMsg: any = {
       role: 'assistant',
       tool_calls: [
@@ -152,10 +161,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
           type: 'function',
           function: {
             name,
-            arguments:
-              typeof call?.arguments === 'string'
-                ? call.arguments
-                : JSON.stringify(call?.input ?? call?.arguments ?? {}),
+            arguments: argString,
           },
         },
       ],

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -1,0 +1,156 @@
+import { strict as assert } from 'assert';
+import { z } from 'zod';
+
+import { bus } from '@eventBus/ProgressEventBus';
+import { runToolUseCycle } from '@agent/core/ToolUseCycle';
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { BaseTool } from '@tools/core/base';
+import { ToolResult } from '@tools/result';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { ToolState } from '@agent/core/ToolState';
+import {
+  AgentSetting,
+  AgentType,
+  AgentPrompt,
+} from '@agent/core/AgentDataclass';
+import { ModelHandlerDeepSeek } from '@agent/modelHandlers/modelHandlerDeepSeek';
+import {
+  ModelConfig,
+  ModelProvider,
+  DEFAULT_MODEL_CAPABILITIES,
+} from '@model/ModelConfig';
+
+class EchoTool extends BaseTool<{ value: string }> {
+  constructor() {
+    super({ name: 'echo' }, z.object({ value: z.string() }));
+  }
+  protected async execute(input: { value: string }): Promise<ToolResult> {
+    return new ToolResult({ output: input.value });
+  }
+}
+
+class MockHandler extends ModelHandlerDeepSeek {
+  private call = 0;
+  async getClient() {
+    return {} as any;
+  }
+  override async createResponse(): Promise<any> {
+    this.call++;
+    if (this.call === 1) {
+      return {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'intro',
+              tool_calls: [
+                {
+                  id: 'c1',
+                  type: 'function',
+                  function: { name: 'echo', arguments: '{"value":"hello"}' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      };
+    }
+    return {
+      choices: [
+        {
+          message: { role: 'assistant', content: 'done' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+  }
+  override extractResponse(resp: any): [string, any, any] {
+    const text = resp.choices[0].message.content;
+    return [text, resp.usage, resp.choices[0].finish_reason];
+  }
+}
+
+describe('runToolUseCycle DeepSeek', () => {
+  it('logs tool calls and creates follow-up message', async () => {
+    const config: ModelConfig = {
+      name: 'ds',
+      fullName: 'ds',
+      provider: ModelProvider.DEEPSEEK,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    };
+    const handler = new MockHandler(config);
+    const logger = new AgentLogger('TestHandler', true);
+    const toolRegistry = { echo: new EchoTool() };
+    const setting: AgentSetting = {
+      agentType: AgentType.ToolUse,
+      documentTag: 'doc',
+      temperature: 0,
+      isRewrite: true,
+      rounds: 1,
+      prefills: [],
+      outputExt: 'txt',
+      endTag: '</doc>',
+      requiredFiles: {},
+      requiredFilesInternal: {},
+      defaultOutputFiles: [],
+      filePatternsContain: [],
+      tools: [{ name: 'echo' }],
+    };
+    const prompt: AgentPrompt = {
+      systemPrompt: '',
+      userPrefix: '',
+      userRequest: '',
+      userReflect: '',
+    };
+    const toolState = new ToolState();
+    const options = {
+      modelHandler: handler,
+      agentSetting: setting,
+      agentPrompt: prompt,
+      userVars: {},
+      logger,
+      client: {},
+      toolRegistry,
+      checkInterruption: () => false,
+      setAbortController: () => {},
+      toolState,
+      modelName: 'ds',
+    };
+    const events: any[] = [];
+    const dispose = bus.on('addLogMessage', (e) => events.push(e));
+    const messages: ProviderMessage[] = [];
+
+    await runToolUseCycle(options, messages);
+    dispose();
+
+    const toolEvents = events.filter(
+      (e) => e.logMessage.messageType === MESSAGE_TYPES.TOOL_USE,
+    );
+    assert.equal(toolEvents.length, 2);
+    assert.deepEqual(messages[0], {
+      role: 'assistant',
+      tool_calls: [
+        {
+          id: 'c1',
+          type: 'function',
+          function: { name: 'echo', arguments: '{"value":"hello"}' },
+        },
+      ],
+      content: 'intro',
+    });
+    assert.deepEqual(messages[1], {
+      role: 'tool',
+      tool_call_id: 'c1',
+      content: JSON.stringify({ output: 'hello' }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement function calling helpers for DeepSeek
- document DeepSeek tool use
- add DeepSeek tool-use cycle test

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_688a4e29f1b88324bd2a83dce1c3ac2d