### PR TITLE
fix: support call_id in Response tool use

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -162,7 +162,8 @@ export async function runToolUseCycle(
       break;
     }
 
-    const id = parsed.id || parsed.tool_use_id || parsed.tool_call_id;
+    const id =
+      parsed.call_id || parsed.id || parsed.tool_use_id || parsed.tool_call_id;
     const name = parsed.name || parsed.function?.name;
     if (!name) {
       const errorMsg = `Tool JSON missing name: ${JSON.stringify(parsed)}`;

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -50,7 +50,7 @@ class MockHandler extends ModelHandlerOpenAIResponse {
           },
           {
             type: 'function_call',
-            id: 'c1',
+            call_id: 'c1',
             name: 'echo',
             arguments: '{"value":"hello"}',
           },


### PR DESCRIPTION
## Summary
- recognize `call_id` when processing tool output
- adjust Response API test data

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack build warning)*

------
https://chatgpt.com/codex/tasks/task_e_688a4f5e406c8324a628b90c19315791