### PR TITLE
fix: reduce extra whitespace in model responses

### DIFF
--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -8,6 +8,13 @@
 
 .model-response-content {
   padding: var(--spacing-small) 0;
+  /* Override log-line whitespace preservation for model responses */
+  white-space: normal;
+}
+
+/* Preserve formatting for code blocks within model responses */
+.model-response-content pre {
+  white-space: pre-wrap;
 }
 
 .markdown-content h1,


### PR DESCRIPTION
## Summary
- override `log-line` whitespace in model response CSS
- keep code block formatting intact

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a697546a48324b7f61eccee2b7449