### PR TITLE
Add response saving for debugging

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -194,13 +194,11 @@ Control logging behavior:
 
 ```json
 "texra.logger.debugMode": false,
-"texra.debug.saveMessageObjects": false,
-"texra.debug.saveResponseObjects": false
+"texra.debug.saveDebugObjects": false
 ```
 
 - `debugMode`: Show detailed debug messages in the logger view
-- `saveMessageObjects`: Save message JSON objects to files before API calls (for debugging, including tool use cycles)
-- `saveResponseObjects`: Save raw model response objects to files after API calls
+- `saveDebugObjects`: Save message and response objects to JSON files for debugging purposes (includes both API messages and raw responses)
 
 ## Environment-Specific Configuration
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -194,11 +194,13 @@ Control logging behavior:
 
 ```json
 "texra.logger.debugMode": false,
-"texra.debug.saveMessageObjects": false
+"texra.debug.saveMessageObjects": false,
+"texra.debug.saveResponseObjects": false
 ```
 
 - `debugMode`: Show detailed debug messages in the logger view
 - `saveMessageObjects`: Save message JSON objects to files before API calls (for debugging, including tool use cycles)
+- `saveResponseObjects`: Save raw model response objects to files after API calls
 
 ## Environment-Specific Configuration
 

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -180,10 +180,9 @@ directory:
 .vscode/texra/taskRuns/<executionId>/
 ```
 
-This folder stores intermediate artifacts such as the optional message and
-response JSON files written when the `texra.debug.saveMessageObjects` and
-`texra.debug.saveResponseObjects` settings are enabled (for both response and
-tool use cycles). These directories
+This folder stores intermediate artifacts such as the optional debug JSON 
+files written when the `texra.debug.saveDebugObjects` setting is enabled 
+(saves both message and response objects for debugging). These directories
 are safe to delete if you need to reclaim space.
 
 ## Working with LaTeX Projects

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -180,9 +180,10 @@ directory:
 .vscode/texra/taskRuns/<executionId>/
 ```
 
-This folder stores intermediate artifacts such as the optional message JSON
-files written when `texra.debug.saveMessageObjects` is enabled (for both
-response and tool use cycles). These directories
+This folder stores intermediate artifacts such as the optional message and
+response JSON files written when the `texra.debug.saveMessageObjects` and
+`texra.debug.saveResponseObjects` settings are enabled (for both response and
+tool use cycles). These directories
 are safe to delete if you need to reclaim space.
 
 ## Working with LaTeX Projects

--- a/package.json
+++ b/package.json
@@ -724,16 +724,10 @@
             "description": "Whether to show verbose debug messages in the logger view",
             "scope": "resource"
           },
-          "texra.debug.saveMessageObjects": {
+          "texra.debug.saveDebugObjects": {
             "type": "boolean",
             "default": false,
-            "description": "Save message JSON objects to files before API calls for debugging purposes",
-            "scope": "resource"
-          },
-          "texra.debug.saveResponseObjects": {
-            "type": "boolean",
-            "default": false,
-            "description": "Save raw model response objects to files after API calls for debugging purposes",
+            "description": "Save message and response objects to JSON files for debugging purposes",
             "scope": "resource"
           }
         }

--- a/package.json
+++ b/package.json
@@ -729,6 +729,12 @@
             "default": false,
             "description": "Save message JSON objects to files before API calls for debugging purposes",
             "scope": "resource"
+          },
+          "texra.debug.saveResponseObjects": {
+            "type": "boolean",
+            "default": false,
+            "description": "Save raw model response objects to files after API calls for debugging purposes",
+            "scope": "resource"
           }
         }
       },

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -20,6 +20,7 @@ import replacementEngine from '@replacement/engine';
 import xmlUtils from '@utils/text/xmlUtils';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import {
+  maybeSaveDebugObject,
   maybeSaveMessages,
   maybeSaveResponse,
 } from '@agent/utils/debugMessageSaver';

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -19,7 +19,10 @@ import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 import replacementEngine from '@replacement/engine';
 import xmlUtils from '@utils/text/xmlUtils';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
-import { maybeSaveMessages } from '@agent/utils/debugMessageSaver';
+import {
+  maybeSaveMessages,
+  maybeSaveResponse,
+} from '@agent/utils/debugMessageSaver';
 
 // Local imports - agent components
 import type { AgentConfig } from './AgentConfig';
@@ -117,6 +120,15 @@ export async function runResponseCycle(
     } finally {
       setAbortController(null);
     }
+    await maybeSaveResponse({
+      responseObject,
+      logger,
+      continuationCount: stateRound.continuationCount,
+      outputFile,
+      modelName: agentConfig.model,
+      executionId,
+      groupId: taskGroupId,
+    });
     if (!responseObject) {
       logger.warn(
         'Model response was aborted or returned no data; output may be incomplete.',

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -15,7 +15,10 @@ import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
-import { maybeSaveMessages } from '@agent/utils/debugMessageSaver';
+import {
+  maybeSaveMessages,
+  maybeSaveResponse,
+} from '@agent/utils/debugMessageSaver';
 import { ANTHROPIC_STOP } from '../modelHandlers/types/StopReasonTypes';
 import { ToolState } from './ToolState';
 
@@ -98,6 +101,14 @@ export async function runToolUseCycle(
     } finally {
       setAbortController(null);
     }
+    await maybeSaveResponse({
+      responseObject: response,
+      logger,
+      continuationCount: iteration,
+      baseName: 'tooluse_response',
+      modelName,
+      groupId,
+    });
     const responseTime = (Date.now() - startTime) / 1000;
     if (!response) {
       break;

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -16,6 +16,7 @@ import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
 import {
+  maybeSaveDebugObject,
   maybeSaveMessages,
   maybeSaveResponse,
 } from '@agent/utils/debugMessageSaver';

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -11,58 +11,70 @@ import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
-export interface SaveDebugObjectParams {
-  object: unknown;
+/**
+ * Context information for the debug save operation
+ */
+export interface DebugContext {
+  /** Logger instance for the operation */
   logger: AgentLogger;
-  continuationCount?: number;
-  outputFile?: string;
-  baseName?: string;
+  /** Model name being used */
   modelName?: string;
+  /** Execution ID if part of a task run */
   executionId?: ExecutionId;
-  groupId?: string;
-  configKey: string;
-  label: string;
-}
-
-export interface SaveMessagesParams {
-  messages: ProviderMessage[];
-  logger: AgentLogger;
-  continuationCount?: number;
-  outputFile?: string;
-  baseName?: string;
-  /** Name of the model used for this conversation */
-  modelName?: string;
-  executionId?: ExecutionId;
+  /** Group ID for log correlation */
   groupId?: string;
 }
 
-export interface SaveResponseParams {
-  responseObject: any;
-  logger: AgentLogger;
-  continuationCount?: number;
+/**
+ * File naming and location options
+ */
+export interface FileOptions {
+  /** Output file path (if specific path needed) */
   outputFile?: string;
+  /** Base name for the file (e.g., 'messages', 'response') */
   baseName?: string;
-  modelName?: string;
-  executionId?: ExecutionId;
-  groupId?: string;
+  /** Continuation count for multi-part responses */
+  continuationCount?: number;
 }
 
-async function maybeSaveDebugObject({
+/**
+ * Type of object being saved (for file naming and logging)
+ */
+export type DebugObjectType = 'messages' | 'response';
+
+/**
+ * Parameters for saving debug objects
+ */
+export interface SaveDebugParams {
+  /** The object to save (messages array or response object) */
+  object: ProviderMessage[] | any;
+  /** Type of object for file naming */
+  objectType: DebugObjectType;
+  /** Execution context */
+  context: DebugContext;
+  /** File options */
+  fileOptions?: FileOptions;
+}
+
+/**
+ * Save debug objects (messages or responses) to a JSON file when
+ * `texra.debug.saveDebugObjects` is enabled.
+ * 
+ * @param params - Parameters for saving the debug object
+ */
+export async function maybeSaveDebugObject({
   object,
-  logger,
-  continuationCount,
-  outputFile,
-  baseName = 'debug',
-  modelName,
-  executionId,
-  groupId,
-  configKey,
-  label,
-}: SaveDebugObjectParams): Promise<void> {
-  const shouldSave = getConfig<boolean>(configKey, false);
+  objectType,
+  context,
+  fileOptions = {},
+}: SaveDebugParams): Promise<void> {
+  const shouldSave = getConfig<boolean>('debug.saveDebugObjects', false);
   if (!shouldSave) {
     return;
   }
+
+  const { logger, modelName, executionId, groupId } = context;
+  const { outputFile, baseName = objectType, continuationCount } = fileOptions;
 
   const fileBase =
     outputFile !== undefined
@@ -87,60 +99,61 @@ async function maybeSaveDebugObject({
         content,
       );
     }
-    logger.info(`Saved ${label} to ${debugFilePath}`, groupId);
+    logger.info(`Saved ${objectType} object to ${debugFilePath}`, groupId);
   } catch (error) {
-    logger.error(`Failed to save ${label}: ${error}`, groupId);
+    logger.error(`Failed to save ${objectType} object: ${error}`, groupId);
   }
 }
 
+// Legacy function signatures for backward compatibility
+// These will be removed in a future version
+
+export interface SaveMessagesParams {
+  messages: ProviderMessage[];
+  logger: AgentLogger;
+  continuationCount?: number;
+  outputFile?: string;
+  baseName?: string;
+  modelName?: string;
+  executionId?: ExecutionId;
+  groupId?: string;
+}
+
+export interface SaveResponseParams {
+  responseObject: any;
+  logger: AgentLogger;
+  continuationCount?: number;
+  outputFile?: string;
+  baseName?: string;
+  modelName?: string;
+  executionId?: ExecutionId;
+  groupId?: string;
+}
+
 /**
- * Save conversation message objects to a JSON file when
- * `texra.debug.saveMessageObjects` is enabled.
+ * @deprecated Use maybeSaveDebugObject instead
  */
-export async function maybeSaveMessages({
-  messages,
-  logger,
-  continuationCount,
-  outputFile,
-  baseName = 'messages',
-  modelName,
-  executionId,
-  groupId,
-}: SaveMessagesParams): Promise<void> {
+export async function maybeSaveMessages(params: SaveMessagesParams): Promise<void> {
+  const { messages, logger, modelName, executionId, groupId, ...fileOptions } = params;
+  
   await maybeSaveDebugObject({
     object: messages,
-    logger,
-    continuationCount,
-    outputFile,
-    baseName,
-    modelName,
-    executionId,
-    groupId,
-    configKey: 'debug.saveMessageObjects',
-    label: 'message object',
+    objectType: 'messages',
+    context: { logger, modelName, executionId, groupId },
+    fileOptions,
   });
 }
 
-export async function maybeSaveResponse({
-  responseObject,
-  logger,
-  continuationCount,
-  outputFile,
-  baseName = 'response',
-  modelName,
-  executionId,
-  groupId,
-}: SaveResponseParams): Promise<void> {
+/**
+ * @deprecated Use maybeSaveDebugObject instead
+ */
+export async function maybeSaveResponse(params: SaveResponseParams): Promise<void> {
+  const { responseObject, logger, modelName, executionId, groupId, ...fileOptions } = params;
+  
   await maybeSaveDebugObject({
     object: responseObject,
-    logger,
-    continuationCount,
-    outputFile,
-    baseName,
-    modelName,
-    executionId,
-    groupId,
-    configKey: 'debug.saveResponseObjects',
-    label: 'response object',
+    objectType: 'response',
+    context: { logger, modelName, executionId, groupId },
+    fileOptions,
   });
 }

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,4 +1,4 @@
-// Utility for saving message objects during debugging
+// Utility for saving debug objects (messages/responses) during debugging
 
 // Standard library imports
 import * as path from 'path';
@@ -10,6 +10,19 @@ import { getConfig } from '@utils/config';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+export interface SaveDebugObjectParams {
+  object: unknown;
+  logger: AgentLogger;
+  continuationCount?: number;
+  outputFile?: string;
+  baseName?: string;
+  modelName?: string;
+  executionId?: ExecutionId;
+  groupId?: string;
+  configKey: string;
+  label: string;
+}
 
 export interface SaveMessagesParams {
   messages: ProviderMessage[];
@@ -23,21 +36,30 @@ export interface SaveMessagesParams {
   groupId?: string;
 }
 
-/**
- * Save conversation message objects to a JSON file when
- * `texra.debug.saveMessageObjects` is enabled.
- */
-export async function maybeSaveMessages({
-  messages,
+export interface SaveResponseParams {
+  responseObject: any;
+  logger: AgentLogger;
+  continuationCount?: number;
+  outputFile?: string;
+  baseName?: string;
+  modelName?: string;
+  executionId?: ExecutionId;
+  groupId?: string;
+}
+
+async function maybeSaveDebugObject({
+  object,
   logger,
   continuationCount,
   outputFile,
-  baseName = 'messages',
+  baseName = 'debug',
   modelName,
   executionId,
   groupId,
-}: SaveMessagesParams): Promise<void> {
-  const shouldSave = getConfig<boolean>('debug.saveMessageObjects', false);
+  configKey,
+  label,
+}: SaveDebugObjectParams): Promise<void> {
+  const shouldSave = getConfig<boolean>(configKey, false);
   if (!shouldSave) {
     return;
   }
@@ -56,7 +78,7 @@ export async function maybeSaveMessages({
     : WorkspaceFS.fullPath(debugFileName);
 
   try {
-    const content = JSON.stringify(messages, null, 2);
+    const content = JSON.stringify(object, null, 2);
     if (executionId) {
       await StorageFS.write(debugFilePath, content);
     } else {
@@ -65,8 +87,60 @@ export async function maybeSaveMessages({
         content,
       );
     }
-    logger.info(`Saved message object to ${debugFilePath}`, groupId);
+    logger.info(`Saved ${label} to ${debugFilePath}`, groupId);
   } catch (error) {
-    logger.error(`Failed to save message object: ${error}`, groupId);
+    logger.error(`Failed to save ${label}: ${error}`, groupId);
   }
+}
+
+/**
+ * Save conversation message objects to a JSON file when
+ * `texra.debug.saveMessageObjects` is enabled.
+ */
+export async function maybeSaveMessages({
+  messages,
+  logger,
+  continuationCount,
+  outputFile,
+  baseName = 'messages',
+  modelName,
+  executionId,
+  groupId,
+}: SaveMessagesParams): Promise<void> {
+  await maybeSaveDebugObject({
+    object: messages,
+    logger,
+    continuationCount,
+    outputFile,
+    baseName,
+    modelName,
+    executionId,
+    groupId,
+    configKey: 'debug.saveMessageObjects',
+    label: 'message object',
+  });
+}
+
+export async function maybeSaveResponse({
+  responseObject,
+  logger,
+  continuationCount,
+  outputFile,
+  baseName = 'response',
+  modelName,
+  executionId,
+  groupId,
+}: SaveResponseParams): Promise<void> {
+  await maybeSaveDebugObject({
+    object: responseObject,
+    logger,
+    continuationCount,
+    outputFile,
+    baseName,
+    modelName,
+    executionId,
+    groupId,
+    configKey: 'debug.saveResponseObjects',
+    label: 'response object',
+  });
 }


### PR DESCRIPTION
## Summary
- extend debugMessageSaver utility to save arbitrary objects
- save raw model responses with new maybeSaveResponse
- log API responses in ToolUse and standard agent cycles
- document `texra.debug.saveResponseObjects` configuration

## Testing
- `npm run lint`
- `npm test` *(fails: Critical dependency warning with webpack)*

------
https://chatgpt.com/codex/tasks/task_e_688b0b11d30483249174d491eb073b84