### PR TITLE
fix: render model responses via template

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -173,11 +173,9 @@
           </details>
         </template>
         <template id="modelResponseTemplate">
-          <div class="log-line">
+          <div class="model-response-line">
             <span class="timestamp"></span>
-            <span class="message-container"
-              ><div class="model-response-content markdown-content"></div
-            ></span>
+            <div class="model-response-content markdown-content"></div>
           </div>
         </template>
         <template id="fileListDetailsTemplate">

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -435,29 +435,31 @@ export class LogEntryFormatter {
    * @private
    * @param {Object} params - Response parameters
    * @returns {HTMLElement|null} DOM element for the model response
-   *
-   * IMPORTANT: Like the format() method, this uses string-based HTML generation
-   * to maintain precise whitespace control. Templates would be reformatted by
-   * Prettier, causing excessive line breaks in the output.
-   * DO NOT convert to templates without addressing the whitespace issue.
    */
   _formatModelResponse({ id, groupId, timestamp, verbose, content, level }) {
+    const element = createFromTemplate('modelResponseTemplate');
+    if (!element) return null;
+
     const date = new Date(timestamp);
     const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
-    const groupAttr = groupId ? ` data-group-id="${groupId}"` : '';
-    const prefix = `<div class="log-line" data-log-id="${id}"${groupAttr} data-full-timestamp="${fullTimestamp}">`;
-    const timeMarkup = `<span class="timestamp" title="${fullTimestamp}">${
-      verbose ? `[${timeDisplay}]` : ''
-    }</span>`;
-    const parsedMarkdown = this._processMarkdownContent(content);
-    const html =
-      prefix +
-      `${timeMarkup} <span class="message-${level}"><div class="model-response-content markdown-content">${parsedMarkdown}</div></span></div>`;
 
-    // Convert HTML string to DOM element
-    const wrapper = document.createElement('div');
-    wrapper.innerHTML = html;
-    return wrapper.firstElementChild;
+    element.dataset.logId = id;
+    element.dataset.fullTimestamp = fullTimestamp;
+    if (groupId) element.dataset.groupId = groupId;
+
+    const ts = element.querySelector('.timestamp');
+    if (ts) {
+      ts.title = fullTimestamp;
+      if (verbose) ts.textContent = `[${timeDisplay}]`;
+    }
+
+    const contentElem = element.querySelector('.model-response-content');
+    if (contentElem) {
+      contentElem.classList.add(`message-${level}`);
+      contentElem.innerHTML = this._processMarkdownContent(content);
+    }
+
+    return element;
   }
 
   _formatFileList(content, data, logId) {

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -93,7 +93,10 @@ export class TaskGroupManager {
             }
           }
           // If sibling is a log message, check if group should come before it
-          else if (sibling.classList.contains('log-line')) {
+          else if (
+            sibling.classList.contains('log-line') ||
+            sibling.classList.contains('model-response-line')
+          ) {
             // Extract full timestamp from data attribute if available
             const msgFullTimestamp = sibling.dataset.fullTimestamp;
             const msgTime = msgFullTimestamp
@@ -338,7 +341,10 @@ export class LogEntryManager {
             }
           }
           // If this is a log message, extract its timestamp
-          else if (child.classList.contains('log-line')) {
+          else if (
+            child.classList.contains('log-line') ||
+            child.classList.contains('model-response-line')
+          ) {
             // Try to get the full timestamp from data attribute
             const childFullTimestamp = child.dataset.fullTimestamp;
             if (childFullTimestamp) {

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -74,7 +74,8 @@
 }
 
 /* Make sure log lines in groups are associated */
-.log-line[data-group-id] {
+.log-line[data-group-id],
+.model-response-line[data-group-id] {
   border-left: var(--border-medium) solid transparent;
 }
 
@@ -92,12 +93,14 @@
 }
 
 /* Log lines within a group */
-.log-group-content > .log-line {
+.log-group-content > .log-line,
+.log-group-content > .model-response-line {
   margin-left: var(--spacing-small);
 }
 
 /* Log lines within a nested group */
-.log-group-content .log-group-content .log-line {
+.log-group-content .log-group-content .log-line,
+.log-group-content .log-group-content .model-response-line {
   margin-left: 0; /* No extra indent for nested log lines */
 }
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -15,14 +15,22 @@
   position: relative;
 }
 
-.log-line {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  word-break: break-all;
+.log-line,
+.model-response-line {
   line-height: 1.4;
   margin: 0;
   padding: calc(var(--spacing-tiny) / 2) 0;
   display: block;
+}
+
+.log-line {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-all;
+}
+
+.model-response-line {
+  white-space: normal;
 }
 
 /* Timestamp color */

--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -7,8 +7,8 @@
 }
 
 .model-response-content {
-  padding: var(--spacing-small) 0;
-  /* Override log-line whitespace preservation for model responses */
+  padding: 0;
+  /* Model responses use normal whitespace handling */
   white-space: normal;
 }
 
@@ -184,6 +184,14 @@
 /* Additional enhancements for scratchpad content */
 .markdown-content p:first-child {
   margin-top: 0;
+}
+
+.markdown-content pre:first-child {
+  margin-top: 0;
+}
+
+.markdown-content pre:last-child {
+  margin-bottom: 0;
 }
 
 .markdown-content p:last-child {


### PR DESCRIPTION
## Summary
- generate model responses using `modelResponseTemplate`
- trim whitespace in model responses
- remove top/bottom margins from first and last code blocks

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(webpack compiled but VS Code tests did not run)*

------
https://chatgpt.com/codex/tasks/task_e_688b0f54cd10832498e6a566e48513bc