### PR TITLE
feat: adapt code highlight to theme

### DIFF
--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -31,6 +31,10 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
       usageManagersUri: this.getWebviewUri(webview, 'modules/usageManagers.js'),
       constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
       katexMacrosUri: this.getWebviewUri(webview, 'modules/katexMacros.js'),
+      themeHandlersUri: this.getWebviewUri(
+        webview,
+        'modules/handlers/themeHandlers.js',
+      ),
 
       // UI managers
       streamTabsUri: this.getWebviewUri(

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -19,6 +19,7 @@
       href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/copy-tex.min.css"
     />
     <link
+      id="hljs-theme"
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github-dark.css"
     />
@@ -40,6 +41,7 @@
           "./modules/uiManagers/Status.js": "${statusUri}",
           "./modules/uiManagers/FileList.js": "${fileListUri}",
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
+          "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/webview/commands.js": "${commandsUri}",

--- a/src/progressView/modules/handlers/themeHandlers.js
+++ b/src/progressView/modules/handlers/themeHandlers.js
@@ -1,0 +1,31 @@
+// Handler for theme-related messages in the progress view
+import { COMMON_COMMANDS } from '@common/webview/commands.js';
+
+/**
+ * Create handlers for theme and debug mode updates.
+ * @param {Object} ctx Context utilities.
+ * @param {Function} ctx.postHandle Callback after handling a message.
+ */
+export function createThemeHandlers({ postHandle } = {}) {
+  const updateHighlightTheme = (theme) => {
+    const link = document.getElementById('hljs-theme');
+    if (!link) return;
+    const base = 'https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/';
+    link.href = `${base}${theme === 'dark' ? 'github-dark' : 'github'}.css`;
+  };
+
+  return {
+    [COMMON_COMMANDS.THEME_SET]: (message) => {
+      if (!message || typeof message.theme !== 'string') {
+        console.warn('Invalid theme message:', message);
+        return;
+      }
+      document.body.className = message.theme;
+      updateHighlightTheme(message.theme);
+      if (postHandle) postHandle();
+    },
+    [COMMON_COMMANDS.DEBUG_MODE_SET]: (message) => {
+      if (postHandle) postHandle();
+    },
+  };
+}

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -3,6 +3,7 @@ import { progressViewState } from './progressViewState.js';
 import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
 import { COMMANDS, STATUS, ELEMENT_IDS } from './constants.js';
 import { registerMessageHandlers } from '@common/webviewContext.js';
+import { createThemeHandlers } from './handlers/themeHandlers.js';
 
 // Create shorter aliases for internal use
 const state = progressViewState;
@@ -14,7 +15,10 @@ export class ProgressViewMessageHandler {
   constructor() {
     this._cleanupFn = null;
     this._entryFormatter = new LogEntryFormatter();
-    this._handlers = this._createHandlers();
+    this._handlers = {
+      ...createThemeHandlers(),
+      ...this._createHandlers(),
+    };
   }
 
   _createHandlers() {


### PR DESCRIPTION
## Summary
- update progress view to set code highlight theme based on VS Code theme
- expose theme handlers module to progress webview
- switch highlight stylesheet dynamically

## Testing
- `npm run lint`
- `npm test` *(fails: webpack built with a warning but tests did not run)*

------
https://chatgpt.com/codex/tasks/task_e_688b2e842984832493ea87464d9e301a