### PR TITLE
Fix highlight.js theme switching

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -202,6 +202,12 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    const theme =
+      vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
+        ? 'dark'
+        : 'light';
+    this.webviewUpdater.updateTheme(theme);
+
     // Validate and update active stream if necessary
     const streams = this.state.streamTabs.keys();
     if (!streams.includes(this.state.activeStream)) {

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -136,6 +136,19 @@ export class WebviewUpdater {
   }
 
   /**
+   * Update the code highlight theme
+   */
+  updateTheme(theme: 'dark' | 'light'): void {
+    const webview = this.getWebview();
+    if (!webview) return;
+
+    webview.postMessage({
+      command: COMMANDS.THEME_SET,
+      theme,
+    });
+  }
+
+  /**
    * Update stream status
    */
   updateStatus(status: StatusType): void {


### PR DESCRIPTION
## Summary
- update highlight theme through WebviewUpdater
- send theme updates from ProgressViewProvider

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b3941eb4883248381ac4d798dafb6