### PR TITLE
Fix: Pass thinking parameter to countTokens API for tool use

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -74,11 +74,16 @@ export async function runToolUseCycle(
 
     await maybeSaveDebugObject({
       object: messages,
-      logger,
-      continuationCount: iteration,
-      baseName: 'tooluse',
-      modelName,
-      groupId,
+      objectType: 'messages',
+      context: {
+        logger,
+        modelName,
+        groupId,
+      },
+      fileOptions: {
+        continuationCount: iteration,
+        baseName: 'tooluse',
+      },
     });
 
     const abortController = new AbortController();
@@ -100,11 +105,16 @@ export async function runToolUseCycle(
     }
     await maybeSaveDebugObject({
       object: response,
-      logger,
-      continuationCount: iteration,
-      baseName: 'tooluse_response',
-      modelName,
-      groupId,
+      objectType: 'response',
+      context: {
+        logger,
+        modelName,
+        groupId,
+      },
+      fileOptions: {
+        continuationCount: iteration,
+        baseName: 'tooluse_response',
+      },
     });
     const responseTime = (Date.now() - startTime) / 1000;
     if (!response) {

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -15,11 +15,7 @@ import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
-import {
-  maybeSaveDebugObject,
-  maybeSaveMessages,
-  maybeSaveResponse,
-} from '@agent/utils/debugMessageSaver';
+import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import { ANTHROPIC_STOP } from '../modelHandlers/types/StopReasonTypes';
 import { ToolState } from './ToolState';
 
@@ -76,8 +72,8 @@ export async function runToolUseCycle(
       break;
     }
 
-    await maybeSaveMessages({
-      messages,
+    await maybeSaveDebugObject({
+      object: messages,
       logger,
       continuationCount: iteration,
       baseName: 'tooluse',
@@ -102,8 +98,8 @@ export async function runToolUseCycle(
     } finally {
       setAbortController(null);
     }
-    await maybeSaveResponse({
-      responseObject: response,
+    await maybeSaveDebugObject({
+      object: response,
       logger,
       continuationCount: iteration,
       baseName: 'tooluse_response',

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -128,11 +128,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     if (this.capabilities.supportsTokenCounting) {
-      const responseTokenCount = await client.beta.messages.countTokens({
+      const countTokensParams: any = {
         model: this.config.fullName,
         system: systemPrompt,
         messages: messages,
-      });
+      };
+
+      // If thinking is enabled, we need to pass it to countTokens as well
+      if (options.thinking) {
+        countTokensParams.thinking = options.thinking;
+      }
+
+      const responseTokenCount =
+        await client.beta.messages.countTokens(countTokensParams);
       this.logger.debug(
         `Token count of message: ${responseTokenCount.input_tokens}`,
       );

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -135,6 +135,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
       };
 
       // If thinking is enabled, we need to pass it to countTokens as well
+      // to ensure consistency with the actual message creation.
+      // Without this, the API returns an error when messages contain thinking blocks.
       if (options.thinking) {
         countTokensParams.thinking = options.thinking;
       }


### PR DESCRIPTION
## Summary
- Fixes 400 error when using tool use with thinking models (e.g., sonnet4T)
- Updates deprecated function calls to use maybeSaveDebugObject

## Problem
When using tool use with Anthropic thinking models, the second API call (after tool execution) was failing with:
```
400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: When thinking is disabled, an `assistant` message in the final position cannot contain `thinking`. To use thinking blocks, enable `thinking` in your request."}}
```

The error was misleading - thinking was actually enabled, but the `countTokens` API call wasn't receiving the thinking configuration.

## Solution
- Pass the `thinking` parameter to the `countTokens` API call when thinking is enabled
- This ensures consistency between token counting and message creation

## Test plan
- [x] Test tool use with sonnet4T model
- [x] Verify tool use still works with non-thinking models
- [x] Confirm no regression in regular (non-tool-use) flows

🤖 Generated with [Claude Code](https://claude.ai/code)