### PR TITLE
Rename follow-up message method

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -287,7 +287,7 @@ export async function runToolUseCycle(
       resultObj.base64Image = result.base64Image;
     if (result.system !== undefined) resultObj.system = result.system;
 
-    const followUpMsgs = modelHandler.createFollowUpMessage(
+    const followUpMsgs = modelHandler.createToolUseFollowUpMessages(
       id,
       name,
       parsed,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -732,7 +732,7 @@ export abstract class ModelHandler<
   /**
    * Build a provider-specific follow-up message containing a tool result.
    */
-  abstract createFollowUpMessage(
+  abstract createToolUseFollowUpMessages(
     id: string,
     name: string,
     call: any,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -986,7 +986,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return null;
   }
 
-  createFollowUpMessage(
+  createToolUseFollowUpMessages(
     id: string,
     name: string,
     call: any,

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -136,7 +136,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     return null;
   }
 
-  createFollowUpMessage(
+  createToolUseFollowUpMessages(
     id: string,
     name: string,
     call: any,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -969,7 +969,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return null;
   }
 
-  createFollowUpMessage(
+  createToolUseFollowUpMessages(
     id: string,
     name: string,
     call: any,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -886,7 +886,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     return null;
   }
 
-  createFollowUpMessage(
+  createToolUseFollowUpMessages(
     id: string,
     name: string,
     call: any,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -503,7 +503,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     return call ? JSON.stringify(call, null, 2) : null;
   }
 
-  createFollowUpMessage(
+  createToolUseFollowUpMessages(
     id: string,
     name: string,
     call: any,

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -182,7 +182,7 @@ export interface IModelHandler<
    * @param result - Object with output/error fields
    * @returns Tuple of [call message, result message]
    */
-  createFollowUpMessage(
+  createToolUseFollowUpMessages(
     id: string,
     name: string,
     call: any,


### PR DESCRIPTION
## Summary
- rename `createFollowUpMessage` to `createToolUseFollowUpMessages`
- update call sites and implementations

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: vscode-test can't run in container)*

------
https://chatgpt.com/codex/tasks/task_e_688bc3ac87408324a77c18194a09a2e3