### PR TITLE
Add follow-up chat loop for tool-use agents

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -16,7 +16,6 @@ import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
-import { ANTHROPIC_STOP } from '../modelHandlers/types/StopReasonTypes';
 import { ToolState } from './ToolState';
 
 export interface ToolUseCycleOptions {
@@ -155,7 +154,13 @@ export async function runToolUseCycle(
       logger.statistics(stats, groupId);
     }
 
-    if (!toolInfo || stopReason === ANTHROPIC_STOP.END_TURN) {
+    const endTurn = modelHandler.isEndTurnStop(stopReason);
+    if (!toolInfo || endTurn) {
+      if (text) {
+        messages.push(modelHandler.createAssistantMessage(text));
+        toolState?.updateLastResponse(text);
+        toolState?.updateAccumulatedOutput(toolState.accumulatedOutput + text);
+      }
       break;
     }
 

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -159,7 +159,6 @@ export async function runToolUseCycle(
       if (text) {
         messages.push(modelHandler.createAssistantMessage(text));
         toolState?.updateLastResponse(text);
-        toolState?.updateAccumulatedOutput(toolState.accumulatedOutput + text);
       }
       break;
     }

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -138,7 +138,7 @@ export class BaseToolUseAgent extends BaseAgent {
         if (this.checkInterruption()) break;
         const followUp = await this.waitForFollowUp();
         if (!followUp || this.checkInterruption()) break;
-        this.logger.info(followUp, this.runGroupId);
+        this.logger.userMessage(followUp, this.runGroupId);
         this.messages = await this.modelHandler.createFollowUpMessages(
           this.messages,
           followUp,

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -16,9 +16,14 @@ import { BaseTool } from '@tools/core/base';
 import { runToolUseCycle } from '../core/ToolUseCycle';
 import { ToolState } from '../core/ToolState';
 import { TOOL_USE_INSTRUCTIONS } from '../utils/toolUsePrompt';
+import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
 
 export class BaseToolUseAgent extends BaseAgent {
   private toolRegistry: Record<string, BaseTool<any>>;
+  private followUpQueue: string[] = [];
+  private followUpResolver: ((v: string | null) => void) | null = null;
+  private messages: ProviderMessage[] = [];
+  private toolState: ToolState | null = null;
 
   constructor(
     modelHandler: IModelHandler,
@@ -56,6 +61,33 @@ export class BaseToolUseAgent extends BaseAgent {
     return tools;
   }
 
+  public appendFollowUp(text: string): void {
+    if (this.followUpResolver) {
+      this.followUpResolver(text);
+      this.followUpResolver = null;
+    } else {
+      this.followUpQueue.push(text);
+    }
+  }
+
+  private async waitForFollowUp(): Promise<string | null> {
+    if (this.followUpQueue.length > 0) {
+      return this.followUpQueue.shift()!;
+    }
+    if (this.isInterrupted) return null;
+    return new Promise<string | null>((resolve) => {
+      this.followUpResolver = resolve;
+    });
+  }
+
+  public override interrupt(): void {
+    super.interrupt();
+    if (this.followUpResolver) {
+      this.followUpResolver(null);
+      this.followUpResolver = null;
+    }
+  }
+
   public async run(): Promise<void> {
     await this.startRunGroup();
     try {
@@ -71,39 +103,48 @@ export class BaseToolUseAgent extends BaseAgent {
         renderPrompt(this.agentPrompt.userPrefix, this.userVars),
       ]);
 
-      const messages = await this.modelHandler.initializeMessages(
+      this.messages = await this.modelHandler.initializeMessages(
         userPrefix,
         userRequest,
         undefined,
         systemPrompt,
       );
 
-      const toolState = new ToolState();
+      this.toolState = new ToolState();
 
       const resolvedSetting = {
         ...this.agentSetting,
         tools: this.getTools(),
       };
 
-      await runToolUseCycle(
-        {
-          modelHandler: this.modelHandler,
-          agentSetting: resolvedSetting,
-          agentPrompt: this.agentPrompt,
-          userVars: this.userVars,
-          logger: this.logger,
-          client: this.client,
-          toolRegistry: this.toolRegistry,
-          checkInterruption: () => this.checkInterruption(),
-          setAbortController: (ctrl) => {
-            this.abortController = ctrl;
-          },
-          toolState,
-          modelName: this.agentConfig.model,
+      const cycleOptions = {
+        modelHandler: this.modelHandler,
+        agentSetting: resolvedSetting,
+        agentPrompt: this.agentPrompt,
+        userVars: this.userVars,
+        logger: this.logger,
+        client: this.client,
+        toolRegistry: this.toolRegistry,
+        checkInterruption: () => this.checkInterruption(),
+        setAbortController: (ctrl: AbortController | null) => {
+          this.abortController = ctrl;
         },
-        messages,
-        this.runGroupId,
-      );
+        toolState: this.toolState,
+        modelName: this.agentConfig.model,
+      } as const;
+
+      while (true) {
+        await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
+        if (this.checkInterruption()) break;
+        const followUp = await this.waitForFollowUp();
+        if (!followUp || this.checkInterruption()) break;
+        this.logger.info(followUp, this.runGroupId);
+        this.messages = await this.modelHandler.createFollowUpMessages(
+          this.messages,
+          followUp,
+        );
+      }
+
       this.endRunGroup('stopped');
     } catch (err) {
       this.endRunGroup('error');

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -139,7 +139,7 @@ export class BaseToolUseAgent extends BaseAgent {
         const followUp = await this.waitForFollowUp();
         if (!followUp || this.checkInterruption()) break;
         this.logger.userMessage(followUp, this.runGroupId);
-        this.messages = await this.modelHandler.createFollowUpMessages(
+        this.messages = await this.modelHandler.createUserFollowUpMessages(
           this.messages,
           followUp,
         );

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -748,7 +748,7 @@ export abstract class ModelHandler<
   /**
    * Append a simple text follow-up from the user.
    */
-  abstract createFollowUpMessages(
+  abstract createUserFollowUpMessages(
     messages: M[],
     userMessage: string,
   ): Promise<M[]>;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -742,6 +742,14 @@ export abstract class ModelHandler<
   ): any[];
 
   /**
+   * Append a simple text follow-up from the user.
+   */
+  abstract createFollowUpMessages(
+    messages: M[],
+    userMessage: string,
+  ): Promise<M[]>;
+
+  /**
    * Creates a log group for model operations with the given name.
    * @param name Name of the operation group
    * @param parentGroupId Optional parent group ID

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -18,7 +18,11 @@ import {
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
-import { ANTHROPIC_STOP, OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
+import {
+  ANTHROPIC_STOP,
+  OPENAI_CHAT_FINISH,
+  MCP_STOP,
+} from './types/StopReasonTypes';
 import { FinishReason } from '@google/genai';
 import type { IModelHandler } from './types/IModelHandler';
 import type { ProviderMessage } from './types/ProviderMessage';
@@ -748,6 +752,19 @@ export abstract class ModelHandler<
     messages: M[],
     userMessage: string,
   ): Promise<M[]>;
+
+  /** Build a simple assistant message from text. */
+  abstract createAssistantMessage(text: string): M;
+
+  /** Check if stop reason signals end-turn. */
+  public isEndTurnStop(reason: ProviderStopReason): boolean {
+    return (
+      reason === ANTHROPIC_STOP.END_TURN ||
+      reason === MCP_STOP.END_TURN ||
+      String(reason).toLowerCase() === 'end_turn' ||
+      String(reason).toLowerCase() === 'endturn'
+    );
+  }
 
   /**
    * Creates a log group for model operations with the given name.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -333,6 +333,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return messages;
   }
 
+  createAssistantMessage(text: string): MessageParam {
+    return {
+      role: 'assistant',
+      content: [{ type: 'text', text, citations: null }],
+    };
+  }
+
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */
   createMediaContent(mediaMessage: MediaEntry[]): ContentBlock[] {
     if (mediaMessage.length === 0) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -322,7 +322,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return messages;
   }
 
-  async createFollowUpMessages(
+  async createUserFollowUpMessages(
     messages: MessageParam[],
     userMessage: string,
   ): Promise<MessageParam[]> {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -322,6 +322,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return messages;
   }
 
+  async createFollowUpMessages(
+    messages: MessageParam[],
+    userMessage: string,
+  ): Promise<MessageParam[]> {
+    messages.push({
+      role: 'user',
+      content: [{ type: 'text', text: userMessage, citations: null }],
+    });
+    return messages;
+  }
+
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */
   createMediaContent(mediaMessage: MediaEntry[]): ContentBlock[] {
     if (mediaMessage.length === 0) {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -570,6 +570,14 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return messages;
   }
 
+  async createFollowUpMessages(
+    messages: Message[],
+    userMessage: string,
+  ): Promise<Message[]> {
+    messages.push({ role: 'user', parts: [{ text: userMessage }] });
+    return messages;
+  }
+
   createMediaContent(mediaMessage: MediaEntry[]): MediaEntry[] {
     this.logger.warn(
       'createMediaContent called on ModelHandlerGoogleGenAI - should be obsolete.',

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -570,7 +570,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return messages;
   }
 
-  async createFollowUpMessages(
+  async createUserFollowUpMessages(
     messages: Message[],
     userMessage: string,
   ): Promise<Message[]> {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -578,6 +578,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return messages;
   }
 
+  createAssistantMessage(text: string): Message {
+    return { role: 'model', parts: [{ text }] };
+  }
+
   createMediaContent(mediaMessage: MediaEntry[]): MediaEntry[] {
     this.logger.warn(
       'createMediaContent called on ModelHandlerGoogleGenAI - should be obsolete.',

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -348,7 +348,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     return messages;
   }
 
-  async createFollowUpMessages(
+  async createUserFollowUpMessages(
     messages: any[],
     userMessage: string,
   ): Promise<any[]> {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -359,6 +359,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
     return messages;
   }
 
+  createAssistantMessage(text: string): ChatCompletionMessageParam {
+    return { role: 'assistant', content: [{ type: 'text', text }] };
+  }
+
   /** Formats image/audio content for OpenAI/Google's vision/audio API. */
   createMediaContent(mediaMessage: MediaEntry[]): ChatCompletionContentPart[] {
     return mediaMessage.flatMap((media): ChatCompletionContentPart[] => {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -348,6 +348,17 @@ export class ModelHandlerOpenAI extends ModelHandler<
     return messages;
   }
 
+  async createFollowUpMessages(
+    messages: any[],
+    userMessage: string,
+  ): Promise<any[]> {
+    messages.push({
+      role: 'user',
+      content: [{ type: 'text', text: userMessage }],
+    });
+    return messages;
+  }
+
   /** Formats image/audio content for OpenAI/Google's vision/audio API. */
   createMediaContent(mediaMessage: MediaEntry[]): ChatCompletionContentPart[] {
     return mediaMessage.flatMap((media): ChatCompletionContentPart[] => {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -533,7 +533,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     return messages;
   }
 
-  async createFollowUpMessages(
+  async createUserFollowUpMessages(
     messages: ResponseInputItem[],
     userMessage: string,
   ): Promise<ResponseInputItem[]> {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -543,4 +543,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     });
     return messages;
   }
+
+  createAssistantMessage(text: string): ChatCompletionMessageParam {
+    return { role: 'assistant', content: [{ type: 'text', text }] };
+  }
 }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -532,4 +532,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
     messages.push(callMsg, resultMsg);
     return messages;
   }
+
+  async createFollowUpMessages(
+    messages: ResponseInputItem[],
+    userMessage: string,
+  ): Promise<ResponseInputItem[]> {
+    messages.push({
+      role: 'user',
+      content: [{ type: 'input_text', text: userMessage }],
+    });
+    return messages;
+  }
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -196,4 +196,14 @@ export interface IModelHandler<
    * Appends the user's message to the existing conversation array.
    */
   createFollowUpMessages(messages: M[], userMessage: string): Promise<M[]>;
+
+  /**
+   * Build a simple assistant message from plain text.
+   */
+  createAssistantMessage(text: string): M;
+
+  /**
+   * Determine if the stop reason represents an end-turn marker.
+   */
+  isEndTurnStop(reason: ProviderStopReason): boolean;
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -190,4 +190,10 @@ export interface IModelHandler<
     toolState?: ToolState,
     text?: string,
   ): M[];
+
+  /**
+   * Create provider-specific messages for a simple text follow-up.
+   * Appends the user's message to the existing conversation array.
+   */
+  createFollowUpMessages(messages: M[], userMessage: string): Promise<M[]>;
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -195,7 +195,7 @@ export interface IModelHandler<
    * Create provider-specific messages for a simple text follow-up.
    * Appends the user's message to the existing conversation array.
    */
-  createFollowUpMessages(messages: M[], userMessage: string): Promise<M[]>;
+  createUserFollowUpMessages(messages: M[], userMessage: string): Promise<M[]>;
 
   /**
    * Build a simple assistant message from plain text.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,6 +19,7 @@ import { registerAgentCommands } from '@commands/agent/agentCommands';
 import { registerAgentCreatorCommands } from '@commands/agent/agentCreatorCommands';
 import { registerApiKeyCommands } from '@commands/api/apiKeyCommands';
 import { registerStateRestoreCommand } from '@commands/history/stateRestoreCommand';
+import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
 import { registerTextEditorCommands } from '@commands/system/textEditorCommands';
 import { registerLinterCommands } from '@commands/latex/linterCommands';
 import { registerWolframScriptCommands } from '@commands/wolfram/wolframScriptCommands';
@@ -68,6 +69,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     arXiv: registerArXivCommands(context),
     compare: registerCompareCommands(context),
     progressView: registerProgressViewCommands(context),
+    followUp: registerFollowUpCommand(context),
     openFile: registerOpenFileCommands(context),
     help: registerHelpCommands(context),
     settings: registerSettingsCommands(context),

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+import { BaseAgent } from '@agent/implementations/BaseAgent';
+
+const CHANNEL = 'followUpCommand';
+console.log(`[${CHANNEL}] command registered`);
+
+export function registerFollowUpCommand(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'texra.sendFollowUp',
+      async (payload: { stream: string; text: string }) => {
+        const agent = BaseAgent.getRunningAgent(payload.stream);
+        if (agent && typeof (agent as any).appendFollowUp === 'function') {
+          try {
+            (agent as any).appendFollowUp(payload.text);
+          } catch (err) {
+            console.error(`Failed to send follow-up: ${String(err)}`);
+          }
+        }
+      },
+    ),
+  );
+}

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -36,7 +36,10 @@ export abstract class BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     if (!message?.command) {
-      this.logger.warn(this.channel, 'Received message without command');
+      this.logger.warn(
+        this.channel,
+        `Received message without command. Message: ${JSON.stringify(message)}`,
+      );
       return;
     }
 

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -160,6 +160,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   CLEAN_STREAM: 'cleanStream',
   SORT_STREAMS: 'sortStreams',
   RESTORE_STATE: 'restoreState',
+  SEND_FOLLOW_UP: 'sendFollowUp',
 
   // File operations
   OPEN_FILE: 'openFile',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -160,6 +160,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   CLEAN_STREAM: 'cleanStream',
   SORT_STREAMS: 'sortStreams',
   RESTORE_STATE: 'restoreState',
+  SEND_FOLLOW_UP: 'sendFollowUp',
 
   // File operations
   OPEN_FILE: 'openFile',

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -119,11 +119,18 @@ export class AgentLogger {
   }
 
   /**
-   * Log statistics information.
+   * Log statistics information (only shown in debug mode).
    */
   statistics(stats: ExtendedTokenUsageStats, groupId?: string): void {
     const summary = `Usage - input: ${stats.inputTokens ?? 0}, output: ${stats.outputTokens ?? 0}`;
-    this.info(summary, groupId, MESSAGE_TYPES.STATISTICS, stats);
+    this.debug(summary, groupId, MESSAGE_TYPES.STATISTICS, stats);
+  }
+
+  /**
+   * Log a user follow-up message.
+   */
+  userMessage(message: string, groupId?: string): void {
+    this.info(message, groupId, MESSAGE_TYPES.USER_MESSAGE);
   }
 
   /**

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -45,6 +45,7 @@ export interface LogMessageData {
     | 'statistics'
     | 'modelResponse'
     | 'toolUse'
+    | 'userMessage'
     | 'internal';
   /** Whether verbose details should be displayed */
   verbose?: boolean;

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -7,6 +7,7 @@ export const MESSAGE_TYPES = {
   STATISTICS: 'statistics',
   TOOL_USE: 'toolUse',
   MODEL_RESPONSE: 'modelResponse',
+  USER_MESSAGE: 'userMessage',
   /** Messages that should be hidden from the progress view */
   INTERNAL: 'internal',
   DEFAULT: 'default',

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -37,6 +37,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       [PROGRESS_VIEW_COMMANDS.SORT_STREAMS]: this.handleSortStreams.bind(this),
       [PROGRESS_VIEW_COMMANDS.RESTORE_STATE]:
         this.handleRestoreState.bind(this),
+      [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]:
+        this.handleSendFollowUp.bind(this),
 
       // File operations
       [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: this.handleOpenFile.bind(this),
@@ -152,6 +154,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     if (taskState) {
       await vscode.commands.executeCommand('texra.restoreState', taskState);
     }
+  }
+
+  private async handleSendFollowUp(
+    message: any,
+    _webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    await vscode.commands.executeCommand('texra.sendFollowUp', {
+      stream: message.stream,
+      text: message.text,
+    });
   }
 
   private async handleOpenFile(

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -79,6 +79,20 @@
         </div>
         <div id="logContent" class="log-container"></div>
         <div id="generatedFiles" class="files-container"></div>
+        <div id="followUpContainer" class="follow-up-container">
+          <input
+            id="followUpInput"
+            class="vscode-input"
+            type="text"
+            placeholder="Send follow-up message"
+          />
+          <button
+            id="sendFollowUpBtn"
+            class="vscode-button"
+            title="Send"
+            data-icon="send"
+          ></button>
+        </div>
         <template id="fileItemTemplate">
           <div class="file-item">
             <span class="file-name">

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -80,12 +80,11 @@
         <div id="logContent" class="log-container"></div>
         <div id="generatedFiles" class="files-container"></div>
         <div id="followUpContainer" class="follow-up-container">
-          <input
+          <textarea
             id="followUpInput"
-            class="vscode-input"
-            type="text"
+            class="vscode-textarea"
             placeholder="Send follow-up message"
-          />
+          ></textarea>
           <button
             id="sendFollowUpBtn"
             class="vscode-button"

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -200,6 +200,17 @@
             <div class="model-response-content markdown-content"></div>
           </div>
         </template>
+        <template id="userMessageTemplate">
+          <div class="user-message-container">
+            <div class="user-message">
+              <div class="user-message-header">
+                <i class="codicon codicon-account user-message-icon"></i>
+                <span class="user-message-timestamp"></span>
+              </div>
+              <div class="user-message-content"></div>
+            </div>
+          </div>
+        </template>
         <template id="fileListDetailsTemplate">
           <details class="file-list-details">
             <summary class="details-summary">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -4,6 +4,7 @@ export const STATUS = {
   ERROR: 'error',
   STOPPED: 'stopped',
   READY: 'ready',
+  WAITING: 'waiting',
 };
 
 // DOM element IDs used across the progress view

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -27,6 +27,9 @@ export const ELEMENT_IDS = {
   PACK_STREAM_BTN: 'packStreamBtn',
   CLEAN_STREAM_BTN: 'cleanStreamBtn',
   ERASE_STREAM_BTN: 'eraseStreamBtn',
+  FOLLOW_UP_CONTAINER: 'followUpContainer',
+  FOLLOW_UP_INPUT: 'followUpInput',
+  SEND_FOLLOW_UP_BTN: 'sendFollowUpBtn',
 };
 
 // Default sizes for split view

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -259,6 +259,11 @@ export class LogEntryFormatter {
           () => this._formatStatistics(text, data, id),
           'statistics',
         ),
+      userMessage: (text, id, timestamp) =>
+        this._safeFormat(
+          () => this._formatUserMessage(text, id, timestamp),
+          'user message',
+        ),
     };
   }
 
@@ -321,6 +326,9 @@ export class LogEntryFormatter {
       ) {
         // These only need text and id
         result = formatter(text, id);
+      } else if (messageType === 'userMessage') {
+        // User message needs text, id, and timestamp
+        result = formatter(text, id, timestamp);
       } else {
         // File list, missing outputs, latexdiff, statistics need data
         result = formatter(text, data, id);
@@ -698,7 +706,7 @@ export class LogEntryFormatter {
     if (!element) return null;
     const contentElem = element.querySelector('.statistics-content');
     const toggleIcon = element.querySelector('.toggle-icon');
-    if (toggleIcon) toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
     const parsed = data;
     if (!parsed || typeof parsed !== 'object') {
       return null;
@@ -769,6 +777,28 @@ export class LogEntryFormatter {
 
     if (contentElem) {
       contentElem.innerHTML = items.join('');
+      if (logId) contentElem.dataset.logId = logId;
+    }
+
+    return element;
+  }
+
+  _formatUserMessage(content, logId, timestamp) {
+    const element = createFromTemplate('userMessageTemplate');
+    if (!element) return null;
+
+    const date = new Date(timestamp);
+    const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
+
+    const timestampElem = element.querySelector('.user-message-timestamp');
+    if (timestampElem) {
+      timestampElem.textContent = timeDisplay;
+      timestampElem.title = fullTimestamp;
+    }
+
+    const contentElem = element.querySelector('.user-message-content');
+    if (contentElem) {
+      contentElem.textContent = content;
       if (logId) contentElem.dataset.logId = logId;
     }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -56,6 +56,15 @@ export class ProgressViewMessageHandler {
     state.activeStream = message.activeStream;
     dom.streamTabs.update(message.streams, message.activeStream);
 
+    const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
+    if (container) {
+      const active = message.streams.find(
+        (s) => s.name === message.activeStream,
+      );
+      container.style.display =
+        active && active.agentType === 'toolUse' ? 'flex' : 'none';
+    }
+
     // Update status based on whether there's an active stream
     if (!message.activeStream) {
       dom.status.update(STATUS.READY);

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -107,6 +107,29 @@ export class EventsManager {
       });
     }
 
+    // Follow-up input handler
+    const followInput = document.getElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
+    const followBtn = document.getElementById(ELEMENT_IDS.SEND_FOLLOW_UP_BTN);
+    if (followInput && followBtn) {
+      const send = () => {
+        const text = followInput.value.trim();
+        if (!text) return;
+        vscode.postMessage({
+          command: COMMANDS.SEND_FOLLOW_UP,
+          stream: progressViewState.activeStream,
+          text,
+        });
+        followInput.value = '';
+      };
+      followBtn.addEventListener('click', send);
+      followInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          send();
+        }
+      });
+    }
+
     // Initialize split view
     Split(['.content-area', '.tabs'], {
       sizes: [SPLIT_SIZES.CONTENT, SPLIT_SIZES.TABS],

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -123,7 +123,8 @@ export class EventsManager {
       };
       followBtn.addEventListener('click', send);
       followInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
+        // Enter sends, Shift+Enter adds new line
+        if (e.key === 'Enter' && !e.shiftKey) {
           e.preventDefault();
           send();
         }

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -1,0 +1,20 @@
+/**
+ * Follow-up input styles for ProgressView
+ * Minimal styling for the user input area
+ */
+
+/* Follow-up input container */
+.follow-up-container {
+  display: none;
+  padding: var(--spacing-medium);
+  border-top: 1px solid var(--vscode-panel-border);
+  gap: var(--spacing-small);
+}
+
+/* Style the textarea for multi-line input */
+#followUpInput {
+  min-height: 60px;
+  max-height: 120px;
+  resize: vertical;
+  flex: 1;
+}

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -6,6 +6,7 @@
 /* Follow-up input container */
 .follow-up-container {
   display: none;
+  align-items: flex-end;
   padding: var(--spacing-medium);
   border-top: 1px solid var(--vscode-panel-border);
   gap: var(--spacing-small);
@@ -13,8 +14,15 @@
 
 /* Style the textarea for multi-line input */
 #followUpInput {
-  min-height: 60px;
-  max-height: 120px;
-  resize: vertical;
+  min-height: 36px;
+  max-height: 200px;
+  resize: none;
   flex: 1;
+  overflow-y: auto;
+  line-height: 1.4;
+}
+
+/* Align send button to bottom */
+#sendFollowUpBtn {
+  margin-bottom: var(--spacing-tiny);
 }

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -19,3 +19,4 @@
 @import './file-list.css';
 @import './latexdiff.css';
 @import './statistics.css';
+@import './user-message.css';

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -20,3 +20,4 @@
 @import './latexdiff.css';
 @import './statistics.css';
 @import './user-message.css';
+@import './follow-up-input.css';

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -171,6 +171,12 @@
   box-shadow: 0 0 4px var(--vscode-testing-iconSkipped, #cca700);
 }
 
+.status-indicator.waiting {
+  background-color: var(--vscode-textLink-foreground, #3794ff);
+  box-shadow: 0 0 4px var(--vscode-textLink-foreground, #3794ff);
+  animation: pulse 3s infinite;
+}
+
 /* Generated files list */
 .files-container {
   padding: var(--spacing-small);

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -318,4 +318,15 @@
   .header-actions {
     margin-left: auto;
   }
+
+  .follow-up-container {
+    display: none;
+    padding: var(--spacing-small);
+    border-top: 1px solid var(--vscode-panel-border);
+    gap: var(--spacing-small);
+  }
+
+  .follow-up-container input {
+    flex: 1;
+  }
 }

--- a/src/progressView/styles/user-message.css
+++ b/src/progressView/styles/user-message.css
@@ -1,0 +1,53 @@
+/**
+ * User message styles for ProgressView
+ * Formatting for user follow-up messages in chat
+ */
+
+.user-message-container {
+  display: flex;
+  justify-content: flex-end;
+  margin: var(--spacing-medium) 0;
+  padding: 0 var(--spacing-medium);
+}
+
+.user-message {
+  background-color: var(--vscode-button-background);
+  border: 1px solid var(--vscode-button-border, var(--vscode-button-background));
+  border-radius: var(--border-radius-medium);
+  padding: var(--spacing-small) var(--spacing-medium);
+  max-width: 70%;
+  position: relative;
+  box-shadow: 0 1px 2px var(--vscode-widget-shadow);
+  margin-left: auto;
+}
+
+.user-message-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  margin-bottom: var(--spacing-tiny);
+  font-size: var(--font-size-sm);
+  color: var(--vscode-button-foreground);
+  opacity: 0.8;
+}
+
+.user-message-icon {
+  font-size: var(--font-size-sm);
+}
+
+.user-message-content {
+  color: var(--vscode-button-foreground);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  line-height: 1.4;
+}
+
+.user-message-timestamp {
+  font-size: var(--font-size-sm);
+  color: var(--vscode-descriptionForeground);
+}
+
+/* Hover effect */
+.user-message:hover {
+  background-color: var(--vscode-button-hoverBackground);
+}

--- a/src/progressView/styles/user-message.css
+++ b/src/progressView/styles/user-message.css
@@ -1,24 +1,21 @@
 /**
  * User message styles for ProgressView
- * Formatting for user follow-up messages in chat
+ * Minimal, VS Code native styling for user follow-up messages
  */
 
 .user-message-container {
   display: flex;
   justify-content: flex-end;
-  margin: var(--spacing-medium) 0;
-  padding: 0 var(--spacing-medium);
+  margin: var(--spacing-small) 0;
+  padding-right: var(--spacing-tiny);
 }
 
 .user-message {
-  background-color: var(--vscode-button-background);
-  border: 1px solid var(--vscode-button-border, var(--vscode-button-background));
-  border-radius: var(--border-radius-medium);
+  background-color: var(--vscode-editor-selectionBackground);
+  border-left: 3px solid var(--vscode-textLink-foreground);
   padding: var(--spacing-small) var(--spacing-medium);
-  max-width: 70%;
-  position: relative;
-  box-shadow: 0 1px 2px var(--vscode-widget-shadow);
-  margin-left: auto;
+  max-width: 85%;
+  margin-left: var(--spacing-xlarge);
 }
 
 .user-message-header {
@@ -27,16 +24,15 @@
   gap: var(--spacing-small);
   margin-bottom: var(--spacing-tiny);
   font-size: var(--font-size-sm);
-  color: var(--vscode-button-foreground);
-  opacity: 0.8;
 }
 
 .user-message-icon {
+  color: var(--vscode-textLink-foreground);
   font-size: var(--font-size-sm);
 }
 
 .user-message-content {
-  color: var(--vscode-button-foreground);
+  color: var(--vscode-foreground);
   white-space: pre-wrap;
   word-wrap: break-word;
   line-height: 1.4;
@@ -44,10 +40,6 @@
 
 .user-message-timestamp {
   font-size: var(--font-size-sm);
-  color: var(--vscode-descriptionForeground);
-}
-
-/* Hover effect */
-.user-message:hover {
-  background-color: var(--vscode-button-hoverBackground);
+  color: var(--vscode-foreground);
+  opacity: var(--opacity-subtle);
 }

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -49,6 +49,12 @@ class DummyHandler extends ModelHandler {
     m.push({ role: 'user', content: u });
     return m;
   }
+  createAssistantMessage(text: string) {
+    return { role: 'assistant', content: text } as any;
+  }
+  isEndTurnStop(_r: any): boolean {
+    return false;
+  }
   createMediaContent() {
     return [];
   }

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -1,0 +1,151 @@
+import { strict as assert } from 'assert';
+import { bus } from '@eventBus/ProgressEventBus';
+import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import {
+  AgentSetting,
+  AgentPrompt,
+  AgentType,
+} from '@agent/core/AgentDataclass';
+import { ModelProvider, DEFAULT_MODEL_CAPABILITIES } from '@model/ModelConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+class DummyHandler extends ModelHandler {
+  calls = 0;
+  constructor() {
+    super({
+      name: 'dummy',
+      fullName: 'dummy',
+      provider: ModelProvider.OPENAI,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    });
+  }
+  async getClient() {
+    return {};
+  }
+  async createResponse(): Promise<any> {
+    this.calls++;
+    return {};
+  }
+  async initializeMessages(
+    _: any,
+    __: any,
+    ___?: any,
+    ____?: any,
+  ): Promise<any[]> {
+    return [];
+  }
+  async createRoundMessages(m: any[], u: any): Promise<any[]> {
+    m.push({ role: 'user', content: u });
+    return m;
+  }
+  async createFollowUpMessages(m: any[], u: any): Promise<any[]> {
+    m.push({ role: 'user', content: u });
+    return m;
+  }
+  createMediaContent() {
+    return [];
+  }
+  extractResponse(): [string, any, any] {
+    return ['', null, 'stop'];
+  }
+  addContinueMessageWithPrefill() {}
+  addContinueMessageWithoutPrefill() {}
+  initializeOutputAndPrefill(): Promise<[boolean, any[]]> {
+    return Promise.resolve([true, []]);
+  }
+  computePrice() {
+    return 0;
+  }
+  computeResponseUsage() {
+    return {};
+  }
+  updateMessageContentWithPrefill() {}
+  updateMessageContentWithoutPrefill() {}
+  shouldContinue() {
+    return false;
+  }
+  checkStopConditions(): [boolean, boolean] {
+    return [true, true];
+  }
+  processThinkingBlock() {
+    return null;
+  }
+  extractToolUse() {
+    return null;
+  }
+  createToolUseFollowUpMessages() {
+    return [];
+  }
+}
+
+class TestAgent extends BaseToolUseAgent {}
+
+describe('BaseToolUseAgent follow-up loop', () => {
+  it('runs additional cycles for follow-ups', async () => {
+    const handler = new DummyHandler();
+    const setting: AgentSetting = {
+      agentType: AgentType.ToolUse,
+      documentTag: 'doc',
+      temperature: 0,
+      isRewrite: true,
+      rounds: 1,
+      prefills: [],
+      outputExt: 'txt',
+      endTag: '</doc>',
+      requiredFiles: {},
+      requiredFilesInternal: {},
+      defaultOutputFiles: [],
+      filePatternsContain: [],
+      tools: [],
+    } as any;
+    const prompt: AgentPrompt = {
+      systemPrompt: '',
+      userPrefix: '',
+      userRequest: '',
+      userReflect: '',
+    };
+    const config: AgentConfig = {
+      model: 'dummy',
+      agent: 'test',
+      instruction: '',
+      inputFile: '',
+      inputFiles: null,
+      referenceFile: null,
+      referenceFiles: null,
+      auxiliaryFile: null,
+      auxiliaryFiles: null,
+      mediaFile: null,
+      mediaFiles: null,
+      outputFiles: null,
+      editedFile: null,
+      toolConfig: {
+        reflect: false,
+        usePrefillFromInput: false,
+        autoExtractFigure: false,
+        autoExtractTikzFigure: false,
+        attachTeXCount: false,
+        attachDiagnostics: false,
+        printInputPrompt: false,
+        autoCompileInputPdf: false,
+      },
+    };
+    const agent = new TestAgent(handler, config, setting, prompt, '.');
+    const logs: any[] = [];
+    const dispose = bus.on('addLogMessage', (e) => logs.push(e));
+    const runPromise = agent.run();
+    agent.appendFollowUp('one');
+    agent.appendFollowUp('two');
+    setTimeout(() => agent.interrupt(), 10);
+    await runPromise;
+    dispose();
+    assert.equal(handler.calls, 3);
+    assert.ok(logs.length > 0);
+  });
+});

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -45,7 +45,7 @@ class DummyHandler extends ModelHandler {
     m.push({ role: 'user', content: u });
     return m;
   }
-  async createFollowUpMessages(m: any[], u: any): Promise<any[]> {
+  async createUserFollowUpMessages(m: any[], u: any): Promise<any[]> {
     m.push({ role: 'user', content: u });
     return m;
   }


### PR DESCRIPTION
## Summary
- implement multi-round follow-up in `BaseToolUseAgent`
- extend `IModelHandler` and handlers with `createFollowUpMessages`
- add progress view input box and command wiring
- expose `texra.sendFollowUp` command
- test follow-up loop behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc9e214688324a2182e783e3f7bfc