### PR TITLE
feat: add claude opus 4.1 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.32.7] - 2025-08-05
 
+### Features
+
+- Added Claude Opus 4.1 (regular and thinking) models (`opus41` and `opus41T`)
+
 ### Bug Fixes
 
 - Updated OpenAI, Anthropic, and Gemini SDKs to their latest releases

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -23,8 +23,10 @@ Known for strong instruction following and context handling.
 
 | Model ID    | Key Strength / Use Case                     | Relative Cost | Relative Speed | Notes                         |
 | :---------- | :------------------------------------------ | :------------ | :------------- | :---------------------------- |
-| `opus4T`    | Latest Opus with explicit reasoning steps   | $$$$          | Slow           | Claude 4 Opus with thinking   |
-| `opus4`     | Latest high quality, complex tasks          | $$$$          | Slow           | Claude 4 Opus                 |
+| `opus41T`   | Latest Opus with explicit reasoning steps   | $$$$          | Slow           | Claude 4.1 Opus with thinking |
+| `opus41`    | Latest high quality, complex tasks          | $$$$          | Slow           | Claude 4.1 Opus               |
+| `opus4T`    | Opus 4 with explicit reasoning steps        | $$$$          | Slow           | Claude 4 Opus with thinking   |
+| `opus4`     | Opus 4 high quality, complex tasks          | $$$$          | Slow           | Claude 4 Opus                 |
 | `sonnet4T`  | Latest Sonnet with explicit reasoning steps | $$$           | Medium         | Claude 4 Sonnet with thinking |
 | `sonnet4`   | Latest strong all-rounder                   | $$$           | Medium         | Claude 4 Sonnet               |
 | `sonnet37T` | `sonnet37` with explicit reasoning steps    | $$$           | Medium         | Good for math, complex logic  |

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -234,7 +234,7 @@ Here are some common tasks you can try with TeXRA:
 ### Improving Writing Style
 
 - **Agent**: `polish`
-- **Model**: `opus` or `sonnet37T`
+- **Model**: `opus41` or `sonnet37T`
 - **Instruction**: "Improve the writing style to make it more engaging and clear. Enhance the flow between paragraphs while preserving all technical content."
 
 ## Understanding the Output

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
             "items": {
               "type": "string",
               "enum": [
+                "opus41T",
+                "opus41",
                 "opus4T",
                 "opus4",
                 "sonnet4T",
@@ -80,7 +82,7 @@
               ]
             },
             "default": [
-              "opus4T",
+              "opus41T",
               "sonnet4T",
               "dsr1",
               "o3",
@@ -92,7 +94,7 @@
               "gemini25f",
               "grok4"
             ],
-            "description": "List of available models. Model codes: opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1 (OpenAI reasoning models), gpt41/gpt4o (GPT-4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), dsv3/dsr1 (DeepSeek V3.1/R1), grok4 (Grok 4), grok3 (Grok 3), qwenplus (Qwen Plus), kimit/kimiv/kimi2 (Kimi Thinking/Vision/K2)",
+            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1 (OpenAI reasoning models), gpt41/gpt4o (GPT-4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), dsv3/dsr1 (DeepSeek V3.1/R1), grok4 (Grok 4), grok3 (Grok 3), qwenplus (Qwen Plus), kimit/kimiv/kimi2 (Kimi Thinking/Vision/K2)",
             "scope": "resource"
           }
         }

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -258,7 +258,7 @@ async function handleCreateAgentWithAI(context: vscode.ExtensionContext) {
       let prompt = basePrompt;
       for (let attempt = 0; attempt < 2; attempt++) {
         const params: MessageCreateParams = {
-          model: ANTHROPIC_MODELS.opus4.fullName,
+          model: ANTHROPIC_MODELS.opus41.fullName,
           messages: [{ role: 'user', content: prompt }],
           max_tokens: 2048,
         };

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -26,6 +26,43 @@ const ANTHROPIC_DEFAULT_CAPABILITIES: ModelCapabilities = {
 };
 
 export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
+  opus41T: {
+    name: 'opus41T',
+    fullName: 'claude-opus-4-1-20250805',
+    openrouterFullName: 'anthropic/claude-opus-4.1:thinking',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 32000, // Official Claude Opus 4.1 limit - streaming recommended for large outputs
+    contextWindow: 200000,
+    inputPrice: 15.0,
+    outputPrice: 75.0,
+    capabilities: {
+      ...ANTHROPIC_DEFAULT_CAPABILITIES,
+      supportsNativeMCPServer: true,
+      supportsNativeWebSearch: true,
+      supportsNativeCodeExecution: true,
+      supportsAssistantPrefill: false,
+      supportsReasoning: true,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
+  opus41: {
+    name: 'opus41',
+    fullName: 'claude-opus-4-1-20250805',
+    openrouterFullName: 'anthropic/claude-opus-4.1',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 32000, // Official Claude Opus 4.1 limit - streaming recommended for large outputs
+    contextWindow: 200000,
+    inputPrice: 15.0,
+    outputPrice: 75.0,
+    capabilities: {
+      ...ANTHROPIC_DEFAULT_CAPABILITIES,
+      supportsNativeWebSearch: true,
+      supportsNativeCodeExecution: true,
+      supportsAssistantPrefill: true,
+      supportsReasoning: false,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
   opus4T: {
     name: 'opus4T',
     fullName: 'claude-opus-4-20250514',


### PR DESCRIPTION
## Summary
- add `opus41` and `opus41T` Anthropic models
- use `opus41` in agent creator and surface models in docs & config
- keep package version and changelog at `0.32.7`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892456593fc8324b0df1fe4ad535a09