### PR TITLE
feat: route gpt-oss models through responses api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.8] - 2025-08-07
+
+### Features
+
+- Route GPT OSS models through OpenAI Responses API by default
+
 ## [0.32.7] - 2025-08-05
 
 ### Features

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -37,21 +37,21 @@ Known for strong instruction following and context handling.
 
 Known for strong reasoning and creative capabilities.
 
-| Model ID  | Key Strength / Use Case               | Relative Cost | Relative Speed | Notes                   |
-| :-------- | :------------------------------------ | :------------ | :------------- | :---------------------- |
-| `o1`      | Advanced reasoning, math, figures     | $$$$          | Slow           | Explicit reasoning      |
-| `gpt45`   | High quality, vision (Preview)        | $$$$          | Medium         |                         |
-| `gpt41`   | Long-context vision, powerful         | $$$           | Medium         | 1M tokens context       |
-| `gpt41-`  | Long-context vision, cost-effective   | $$            | Medium         | 1M tokens context, mini |
-| `gpt41--` | Long-context vision, cheapest         | $             | Medium         | 1M tokens context, nano |
-| `gpt4o`   | Strong all-rounder, vision            | $$$           | Medium         | Good default choice     |
-| `gpt4ol`  | Latest `gpt4o`, potentially better    | $$$           | Medium         |                         |
-| `o3`      | Coding, tool calling                  | $$$           | Medium         |                         |
-| `o3pro`   | Reliable answers, heavy compute       | $$$$          | Slow           | `o3-pro`                |
-| `o3-`     | Fast reasoning                        | $$$           | Fast           | `o3-mini`               |
-| `o1-`     | Fast reasoning (smaller `o1`)         | $$$           | Fast           | `o1-mini`               |
-| `gptoss`  | Open-weight reasoning, large context  | $$            | Medium         | `gpt-oss-120b`          |
-| `gptoss-` | Open-weight reasoning, cost-effective | $             | Fast           | `gpt-oss-20b`           |
+| Model ID  | Key Strength / Use Case               | Relative Cost | Relative Speed | Notes                          |
+| :-------- | :------------------------------------ | :------------ | :------------- | :----------------------------- |
+| `o1`      | Advanced reasoning, math, figures     | $$$$          | Slow           | Explicit reasoning             |
+| `gpt45`   | High quality, vision (Preview)        | $$$$          | Medium         |                                |
+| `gpt41`   | Long-context vision, powerful         | $$$           | Medium         | 1M tokens context              |
+| `gpt41-`  | Long-context vision, cost-effective   | $$            | Medium         | 1M tokens context, mini        |
+| `gpt41--` | Long-context vision, cheapest         | $             | Medium         | 1M tokens context, nano        |
+| `gpt4o`   | Strong all-rounder, vision            | $$$           | Medium         | Good default choice            |
+| `gpt4ol`  | Latest `gpt4o`, potentially better    | $$$           | Medium         |                                |
+| `o3`      | Coding, tool calling                  | $$$           | Medium         |                                |
+| `o3pro`   | Reliable answers, heavy compute       | $$$$          | Slow           | `o3-pro`                       |
+| `o3-`     | Fast reasoning                        | $$$           | Fast           | `o3-mini`                      |
+| `o1-`     | Fast reasoning (smaller `o1`)         | $$$           | Fast           | `o1-mini`                      |
+| `gptoss`  | Open-weight reasoning, large context  | $$            | Medium         | `gpt-oss-120b` (Responses API) |
+| `gptoss-` | Open-weight reasoning, cost-effective | $             | Fast           | `gpt-oss-20b` (Responses API)  |
 
 ### Google Models
 

--- a/docs/guide/openai-responses-api.md
+++ b/docs/guide/openai-responses-api.md
@@ -21,3 +21,6 @@ When `"texra.model.useOpenAIResponsesAPI"` is enabled, the extension automatical
 3. Reads the returned text from `output_text` or the `output` array.
 
 This keeps requests small and simplifies conversation management.
+
+The open-weight models `gpt-oss-120b` and `gpt-oss-20b` also use the
+Responses API automatically, even if the setting isn't enabled.

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -70,7 +70,10 @@ export class ModelFactory {
       'model.useOpenAIResponsesAPI',
       false,
     );
-    if (config.provider === ModelProvider.OPENAI && useOpenAIResponsesAPI) {
+    if (
+      config.provider === ModelProvider.OPENAI &&
+      (useOpenAIResponsesAPI || config.fullName.startsWith('gpt-oss'))
+    ) {
       logger.debug(
         CHANNEL,
         'Using OpenAI Responses API Handler (ModelHandlerOpenAIResponse)',

--- a/src/model/providers/openaiReasoningModels.ts
+++ b/src/model/providers/openaiReasoningModels.ts
@@ -173,7 +173,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
       supportsVision: false,
     } satisfies ModelCapabilities,
-    openRouterOnly: true,
+    openRouterOnly: false,
   },
   'gptoss-': {
     name: 'gptoss-',
@@ -188,6 +188,6 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
       supportsVision: false,
     } satisfies ModelCapabilities,
-    openRouterOnly: true,
+    openRouterOnly: false,
   },
 };


### PR DESCRIPTION
## Summary
- Route GPT OSS models through OpenAI Responses API automatically
- Document Responses API usage for gpt-oss models
- Update changelog for gpt-oss Responses API support

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6894e1f68a908324a84f5e77c5ac76f7