### PR TITLE
feat: add merge docs action to error message

### DIFF
--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -26,7 +26,14 @@ async function handleMerge(
   if (!editedFile || (!baseFile && !inputFile)) {
     const errorMsg =
       'Both input file and edited file must be specified for merge operation';
-    vscode.window.showErrorMessage(errorMsg);
+    const docsAction = 'View Merge Docs';
+    const selection = await vscode.window.showErrorMessage(
+      errorMsg,
+      docsAction,
+    );
+    if (selection === docsAction) {
+      vscode.commands.executeCommand('texra.openDoc', 'intelligent-merge');
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- show error message with a "View Merge Docs" action when merge files are missing
- open the intelligent merge guide when user picks the action

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a1e931648324977e78040501de96