### PR TITLE
fix: log error data for model handlers

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -17,6 +17,7 @@ import {
 } from '@frontend/media/img';
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import {
   ANTHROPIC_STOP,
@@ -519,7 +520,12 @@ export abstract class ModelHandler<
           mediaFileResults.push({ path: mediaFile, ok: true });
         }
       } catch (err) {
-        this.logger.error(`Failed to process media ${mediaFile}: ${err}`);
+        this.logger.error(
+          `Failed to process media ${mediaFile}: ${getSdkErrorMessage(err)}`,
+          undefined,
+          undefined,
+          err,
+        );
         mediaFileResults.push({ path: mediaFile, ok: false });
         continue;
       }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -201,7 +201,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
         response = await client.beta.messages.create(options, { signal });
       }
     } catch (err) {
-      this.logger.error(`Error creating response: ${getSdkErrorMessage(err)}`);
+      this.logger.error(
+        `Error creating response: ${getSdkErrorMessage(err)}`,
+        undefined,
+        undefined,
+        err,
+      );
       throw err;
     }
 
@@ -294,7 +299,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         );
       } catch (err) {
         this.logger.error(
-          `Error processing media files for follow-up round: ${err}`,
+          `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
+          undefined,
+          undefined,
+          err,
         );
       }
     }
@@ -956,7 +964,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
         }
       }
     } catch (e) {
-      this.logger.error(`Error extracting thinking blocks: ${e}`, groupId);
+      this.logger.error(
+        `Error extracting thinking blocks: ${getSdkErrorMessage(e)}`,
+        groupId,
+        undefined,
+        e,
+      );
       return null;
     }
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -290,6 +290,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       } catch (err) {
         this.logger.error(
           `Token counting failed, proceeding without token adjustment: ${getSdkErrorMessage(err)}`,
+          undefined,
+          undefined,
+          err,
         );
       }
     }
@@ -359,6 +362,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     } catch (error) {
       this.logger.error(
         `Error during Google GenAI Chat API call: ${getSdkErrorMessage(error)}`,
+        undefined,
+        undefined,
+        error,
       );
       if (
         error instanceof Error &&
@@ -447,6 +453,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         } catch (error) {
           this.logger.error(
             `Failed to upload media file ${mediaFile} via native SDK: ${getSdkErrorMessage(error)}`,
+            undefined,
+            undefined,
+            error,
           );
           mediaFileResults.push({ path: mediaFile, ok: false });
         }
@@ -560,6 +569,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         } catch (error) {
           this.logger.error(
             `Failed to upload media file ${mediaFile} for follow-up round: ${getSdkErrorMessage(error)}`,
+            undefined,
+            undefined,
+            error,
           );
           mediaFileResults.push({ path: mediaFile, ok: false });
         }

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -13,6 +13,7 @@ import type { ToolDefinition } from '@model';
 // Local imports - utilities
 import { convertContentToString } from '@agent/utils/text/messageUtils';
 import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
@@ -192,7 +193,10 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         return response;
       } catch (err) {
         this.logger.error(
-          `Error in createResponse for Kimi thinking model: ${err}`,
+          `Error in createResponse for Kimi thinking model: ${getSdkErrorMessage(err)}`,
+          undefined,
+          undefined,
+          err,
         );
         throw err;
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -139,7 +139,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
       }
     } catch (err) {
       this.logger.error(
-        `Token counting failed: ${err instanceof Error ? err.message : String(err)}. Proceeding without token adjustment.`,
+        `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
+        undefined,
+        undefined,
+        err,
       );
       // Decide if you want to throw here or let the API call potentially fail
     }
@@ -201,6 +204,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
       } catch (err) {
         this.logger.error(
           `Error in createResponse(streaming): ${getSdkErrorMessage(err)}`,
+          undefined,
+          undefined,
+          err,
         );
         throw err;
       }
@@ -214,6 +220,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
       } catch (err) {
         this.logger.error(
           `Error in createResponse: ${getSdkErrorMessage(err)}`,
+          undefined,
+          undefined,
+          err,
         );
         throw err;
       }
@@ -338,7 +347,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
         roundContent.push(...formattedMediaContent);
       } catch (err) {
         this.logger.error(
-          `Error processing media files for follow-up round: ${err}`,
+          `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
+          undefined,
+          undefined,
+          err,
         );
       }
     }
@@ -984,7 +996,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
     } catch (err) {
       // Log the error and re-throw to indicate failure
       this.logger.error(
-        `Error counting tokens: ${err instanceof Error ? err.message : String(err)}`,
+        `Error counting tokens: ${getSdkErrorMessage(err)}`,
+        undefined,
+        undefined,
+        err,
       );
       throw err;
     }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -42,6 +42,13 @@ export function getColorForLevel(level: string): string {
   return EMOJI_BY_LEVEL[level.toLowerCase()] ?? '•';
 }
 
+function serializeLogData(data: unknown): unknown {
+  if (data instanceof Error) {
+    return { name: data.name, message: data.message, stack: data.stack };
+  }
+  return data;
+}
+
 // Group State
 
 // Main TeXRA output channel for non-agent logs
@@ -77,6 +84,7 @@ class VSCodeTransport extends Transport {
 
   log(info: any, callback: () => void) {
     const { level, message, timestamp, messageType } = info;
+    const structuredData = serializeLogData(info.data);
     // Use the provided groupId or fall back to the activeGroupId if available
     const groupId = info.groupId || this.activeGroupId;
 
@@ -102,6 +110,16 @@ class VSCodeTransport extends Transport {
     //   this.channel.appendLine(formattedMessage);
     // }
     this.channel.appendLine(formattedMessage);
+    if (
+      structuredData !== undefined &&
+      getConfig<boolean>('logger.debugMode', false)
+    ) {
+      const dataString =
+        typeof structuredData === 'string'
+          ? structuredData
+          : JSON.stringify(structuredData, null, 2);
+      this.channel.appendLine(dataString);
+    }
 
     // Skip debug messages in ProgressView if debug mode is disabled
     if (level === 'debug' && !getConfig<boolean>('logger.debugMode', false)) {
@@ -139,7 +157,7 @@ class VSCodeTransport extends Transport {
       groupId,
       messageType: msgType,
       verbose: isVerbose,
-      data: info.data,
+      data: structuredData,
     } satisfies import('./LogTypes').LogMessageData;
 
     bus.emit('addLogMessage', {

--- a/src/test/logger/errorData.test.ts
+++ b/src/test/logger/errorData.test.ts
@@ -1,0 +1,21 @@
+import { strict as assert } from 'assert';
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
+
+describe('AgentLogger error data', () => {
+  it('emits error data with stack', () => {
+    const logger = new AgentLogger('TestErrorLogger');
+    const err = new Error('test failure');
+    let captured: any;
+    const off = bus.on('addLogMessage', (payload) => {
+      if (payload.stream === 'TestErrorLogger') {
+        captured = payload.logMessage;
+      }
+    });
+    logger.error(`Error occurred: ${err.message}`, undefined, undefined, err);
+    off();
+    assert.ok(captured);
+    assert.strictEqual(captured.data.message, 'test failure');
+    assert.ok(captured.data.stack);
+  });
+});


### PR DESCRIPTION
## Summary
- attach error objects to logger calls in model handlers
- serialize error data in logger utility so stack traces appear in debug mode
- test that error objects propagate through logging

## Testing
- `npm run lint`
- `CI=1 npm test` *(fails: command did not complete in container)*

------
https://chatgpt.com/codex/tasks/task_e_6897a245ca9c83248c3abc5f856faa16