### PR TITLE
fix: upload PDF files in OpenAI Responses handler

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -104,54 +104,75 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
   ): Promise<Response> {
     const useStreaming = this.getStreamingConfig();
 
-    const newMessages = messages.slice(this.sentMessages).map((msg) => {
-      if ('role' in msg) {
-        return {
-          role: msg.role,
-          content:
+    const newMessages = await Promise.all(
+      messages.slice(this.sentMessages).map(async (msg) => {
+        if ('role' in msg) {
+          const content =
             typeof msg.content === 'string'
               ? [{ type: 'input_text', text: msg.content }]
               : Array.isArray(msg.content)
-                ? msg.content.map((part: any) => {
-                    if (part.type === 'text') {
-                      if (msg.role === 'user') {
-                        return { type: 'input_text', text: part.text };
-                      } else if (msg.role === 'assistant') {
-                        return { type: 'output_text', text: part.text };
-                      } else {
-                        return { type: 'input_text', text: part.text };
+                ? await Promise.all(
+                    msg.content.map(async (part: any) => {
+                      if (part.type === 'text') {
+                        if (msg.role === 'user') {
+                          return { type: 'input_text', text: part.text };
+                        } else if (msg.role === 'assistant') {
+                          return { type: 'output_text', text: part.text };
+                        } else {
+                          return { type: 'input_text', text: part.text };
+                        }
                       }
-                    }
-                    if (part.type === 'image_url') {
-                      const url =
-                        typeof part.image_url === 'string'
-                          ? part.image_url
-                          : part.image_url.url;
+                      if (part.type === 'image_url') {
+                        const url =
+                          typeof part.image_url === 'string'
+                            ? part.image_url
+                            : part.image_url.url;
 
-                      if (url.startsWith('data:application/pdf;base64,')) {
-                        const base64Data = url.replace(
-                          'data:application/pdf;base64,',
-                          '',
-                        );
-                        return {
-                          type: 'input_file',
-                          input_file: {
-                            data: base64Data,
-                            mime_type: 'application/pdf',
-                          },
-                        };
+                        if (url.startsWith('data:application/pdf;base64,')) {
+                          const base64Data = url.replace(
+                            'data:application/pdf;base64,',
+                            '',
+                          );
+                          let buffer: Buffer | undefined;
+                          try {
+                            buffer = Buffer.from(base64Data, 'base64');
+                            const uploadedFile = await client.files.create({
+                              file: buffer as any,
+                              purpose: 'assistants',
+                            });
+                            return {
+                              type: 'input_file',
+                              file_id: uploadedFile.id,
+                            };
+                          } catch (error) {
+                            this.logger.error(
+                              'Failed to upload PDF',
+                              undefined,
+                              undefined,
+                              error,
+                            );
+                            throw error;
+                          } finally {
+                            buffer?.fill(0);
+                            buffer = undefined;
+                          }
+                        }
+
+                        const detail = part.image_url?.detail ?? 'auto';
+                        return { type: 'input_image', image_url: url, detail };
                       }
-
-                      const detail = part.image_url?.detail ?? 'auto';
-                      return { type: 'input_image', image_url: url, detail };
-                    }
-                    return part;
-                  })
-                : [],
-        };
-      }
-      return msg;
-    });
+                      return part;
+                    }),
+                  )
+                : [];
+          return {
+            role: msg.role,
+            content,
+          };
+        }
+        return msg;
+      }),
+    );
 
     const params: any = {
       model: this.config.fullName,


### PR DESCRIPTION
## Summary
- upload PDF messages via OpenAI Files API instead of embedding base64 data
- handle upload errors and clear temporary buffers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e70dae1c8324998bcc53bce0c0b7