### PR TITLE
fix: add docs action for latexdiff errors

### DIFF
--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -31,6 +31,18 @@ logger.initialize(CHANNEL);
 
 const service = new LaTeXdiffService(CHANNEL);
 
+/**
+ * Show an error message and optionally open Latexdiff documentation.
+ * @param message The error message to display.
+ */
+async function showLatexdiffError(message: string) {
+  const docsAction = 'Latexdiff Docs';
+  const selection = await vscode.window.showErrorMessage(message, docsAction);
+  if (selection === docsAction) {
+    await vscode.commands.executeCommand('texra.openDoc', 'latex-diff');
+  }
+}
+
 export function registerLatexdiffCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.latexdiff', handleLatexdiff),
@@ -61,11 +73,11 @@ async function handleLatexdiff(
   editedFile: string,
 ) {
   if (!(baseFile || inputFile)) {
-    vscode.window.showErrorMessage('No base file specified for latexdiff');
+    await showLatexdiffError('No base file specified for latexdiff');
     return;
   }
   if (!editedFile) {
-    vscode.window.showErrorMessage('No revised file specified for latexdiff');
+    await showLatexdiffError('No revised file specified for latexdiff');
     return;
   }
 


### PR DESCRIPTION
## Summary
- add reusable error helper with Latexdiff Docs action
- open `texra.openDoc` for missing base or revised file errors

## Testing
- `npm run format -- src/commands/latex/latexdiffCommands.ts`
- `npm run lint -- src/commands/latex/latexdiffCommands.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897aa08b0dc8324bd0869f4248d9b3c