### PR TITLE
fix: require workspace to initialize extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.32.10] - 2025-08-09
+## [0.32.10] - 2025-08-13
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.10] - 2025-08-09
+
+### Bug Fixes
+
+- Prompt users to open a workspace folder when none is active to avoid initialization.
+
 ## [0.32.9] - 2025-08-09
 
 ### Bug Fixes

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,18 +26,24 @@ import { registerCommands } from './commands';
 
 export async function activate(context: vscode.ExtensionContext) {
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-
-  // Load .env file only if a workspace is open
-  if (workspaceRoot) {
-    dotenv.config({
-      path: path.join(workspaceRoot, '.env'),
-    });
-  } else {
-    logger.warn(
-      'extension',
-      'No workspace folder is open. Skipping .env loading.',
-    );
+  if (!workspaceRoot) {
+    const openAction = 'Open Folder';
+    vscode.window
+      .showInformationMessage(
+        'TeXRA requires an open workspace. Please open a folder to enable the extension.',
+        openAction,
+      )
+      .then((choice) => {
+        if (choice === openAction) {
+          vscode.commands.executeCommand('workbench.action.files.openFolder');
+        }
+      });
+    return; // Exit before further initialization
   }
+
+  dotenv.config({
+    path: path.join(workspaceRoot, '.env'),
+  });
 
   // Initialize storage systems
   SecretManager.initialize(context);


### PR DESCRIPTION
## Summary
- exit extension early when no workspace is open and prompt user to open a folder
- document workspace requirement in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(warning: test run produced limited output, possibly due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_689b8816fa548324b283bfbcf324c383