### PR TITLE
feat: link custom agent path error to docs

### DIFF
--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -1,11 +1,16 @@
 // Standard library imports
 import * as path from 'path';
+
+// Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+
+// Local imports - utilities
 import { getConfig } from '@utils/config';
 import { GlobalStorageFS, StorageFS, AbsoluteFS } from '@utils/files';
+import { safeExecuteCommand } from '@utils/system';
 
 const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
@@ -51,9 +56,14 @@ export class AgentDirectoryManager {
         CHANNEL,
         `Custom agents directory must be an absolute path: ${customPath}`,
       );
-      vscode.window.showErrorMessage(
+      const docsAction = 'View Docs';
+      const selection = await vscode.window.showErrorMessage(
         'Custom agents directory must be an absolute path',
+        docsAction,
       );
+      if (selection === docsAction) {
+        await safeExecuteCommand('texra.openDoc', ['custom-agents'], CHANNEL);
+      }
       return '';
     }
 


### PR DESCRIPTION
## Summary
- show documentation option when custom agents path isn't absolute
- open `custom-agents` guide via `texra.openDoc`

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8dd79644832492330846d1963523