### PR TITLE
feat: link docs from YAML load errors

### DIFF
--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -46,9 +46,17 @@ export async function loadYaml(absolutePath: string): Promise<object> {
     console.log(`Successfully loaded YAML from: ${absolutePath}`);
     return parsedYaml;
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error loading YAML file ${absolutePath}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    const moreInfo = 'More Info';
+    vscode.window
+      .showErrorMessage(
+        `Error loading YAML file ${absolutePath}: ${err instanceof Error ? err.message : String(err)}`,
+        moreInfo,
+      )
+      .then((selection) => {
+        if (selection === moreInfo) {
+          void vscode.commands.executeCommand('texra.openDoc', 'custom-agents');
+        }
+      });
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- add **More Info** action to `loadYaml` error handling
- open custom agents guide when action selected

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689b8e52e24c8324b4c180e6c9fb7a14