### PR TITLE
fix: add settings guide for missing API key

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -360,6 +360,7 @@ async function executeAgentWithLogging<T extends IAgent>(
       errorMsg.includes('API key not found')
     ) {
       const setKey = 'Set API Key';
+      const openGuide = 'Open Settings Guide';
       await showInstructionWithSuppress(
         'missingApiKey',
         'API key not found. Set your API key in the extension settings and run again.',
@@ -367,6 +368,11 @@ async function executeAgentWithLogging<T extends IAgent>(
           {
             title: setKey,
             callback: () => vscode.commands.executeCommand('texra.setApiKey'),
+          },
+          {
+            title: openGuide,
+            callback: () =>
+              vscode.commands.executeCommand('texra.openDoc', 'configuration'),
           },
         ],
         false,


### PR DESCRIPTION
## Summary
- add "Open Settings Guide" action to missing API key instruction

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8e7f4bc08324a3fae5dd70816f68