### PR TITLE
fix: add file management doc link

### DIFF
--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -24,7 +24,14 @@ export class ExecutionManager {
 
   async handleExecute(message: any): Promise<void> {
     if (!message.inputFile) {
-      vscode.window.showErrorMessage('Please select an input file.');
+      const openDocs = 'File Management Guide';
+      const choice = await vscode.window.showErrorMessage(
+        'Please select an input file.',
+        openDocs,
+      );
+      if (choice === openDocs) {
+        vscode.commands.executeCommand('texra.openDoc', 'file-management');
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- show File Management Guide when no input file selected

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689b8e8cba448324b5c3c7713d39df16