### PR TITLE
feat: add Sonnet 4 1M context opt-in

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -33,6 +33,10 @@ Known for strong instruction following and context handling.
 | `sonnet37`  | Strong all-rounder, good context            | $$$           | Medium         |                               |
 | `sonnet35`  | Good balance of quality/cost (older Sonnet) | $$$           | Medium         |                               |
 
+#### Sonnet 4 1M Context (Beta)
+
+To experiment with Anthropic's 1M-token context window for Sonnet 4, enable `"texra.model.useAnthropic1MBeta": true` in VS Code settings. The extension attaches the `context-1m-2025-08-07` beta header for these requests. Only Sonnet 4 supports this beta, and TeXRA still enforces the tier‑4 limit of 200 K tokens.
+
 ### OpenAI Models
 
 Known for strong reasoning and creative capabilities.

--- a/package.json
+++ b/package.json
@@ -181,6 +181,12 @@
             "description": "Use the native @google/genai SDK for Google models instead of the OpenAI-compatible API. This feature is experimental and may not work as expected.",
             "scope": "resource"
           },
+          "texra.model.useAnthropic1MBeta": {
+            "type": "boolean",
+            "default": false,
+            "description": "Attach the `context-1m-2025-08-07` beta header for Claude Sonnet 4 requests to enable the 1M-token context window (usage capped at 200 K by extension).",
+            "scope": "resource"
+          },
           "texra.model.useCopilot": {
             "type": "boolean",
             "default": false,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -34,7 +34,7 @@ import {
 import { ToolState } from '@agent/core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { AgentStateRound } from '@agent/core/AgentState';
-import { K_SLICE } from '@utils/config';
+import { K_SLICE, getConfig } from '@utils/config';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -72,6 +72,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
   ): Promise<BetaMessage> {
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
+    const useAnthropic1MBeta = getConfig<boolean>(
+      'model.useAnthropic1MBeta',
+      false,
+    );
 
     // Prepare options for the API call
     const options: MessageCreateParams & { betas?: string[] } = {
@@ -129,6 +133,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // The thinking configuration is now handled above for all reasoning models
     }
 
+    // Opt-in beta for 1M context window on Claude Sonnet 4
+    if (
+      useAnthropic1MBeta &&
+      this.config.fullName.includes('claude-sonnet-4')
+    ) {
+      options.betas = [...(options.betas ?? []), 'context-1m-2025-08-07'];
+    }
+
     if (this.capabilities.supportsTokenCounting) {
       const countTokensParams: any = {
         model: this.config.fullName,
@@ -141,6 +153,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Without this, the API returns an error when messages contain thinking blocks.
       if (options.thinking) {
         countTokensParams.thinking = options.thinking;
+      }
+
+      if (
+        useAnthropic1MBeta &&
+        this.config.fullName.includes('claude-sonnet-4')
+      ) {
+        countTokensParams.betas = ['context-1m-2025-08-07'];
       }
 
       const responseTokenCount =

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -136,7 +136,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Opt-in beta for 1M context window on Claude Sonnet 4
     if (
       useAnthropic1MBeta &&
-      this.config.fullName.includes('claude-sonnet-4')
+      this.config.fullName === 'claude-sonnet-4-20250514'
     ) {
       options.betas = [...(options.betas ?? []), 'context-1m-2025-08-07'];
     }
@@ -157,7 +157,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
       if (
         useAnthropic1MBeta &&
-        this.config.fullName.includes('claude-sonnet-4')
+        this.config.fullName === 'claude-sonnet-4-20250514'
       ) {
         countTokensParams.betas = ['context-1m-2025-08-07'];
       }


### PR DESCRIPTION
## Summary
- expose `texra.model.useAnthropic1MBeta` setting to opt into Claude Sonnet 4's 1M-token context window
- read the setting in the Anthropic model handler and attach the `context-1m-2025-08-07` beta header for message creation and token counting
- document the opt-in in the model guide

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bf72d2b888324ba5d085e0a461ada