### PR TITLE
feat: add welcome instruction on activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { watchConfig } from '@utils/config';
 import { SecretManager } from '@frontend/secretManager';
 import { copyDefaultAgents, configureLatexSettings } from '@frontend/setup';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
+import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { StorageFS } from '@utils/files';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { initializeStateManagers } from '@common/state/stateManager';
@@ -98,6 +99,17 @@ export async function activate(context: vscode.ExtensionContext) {
     watcherManager.setup();
     folderExplorer.refresh();
   });
+
+  await showInstructionWithSuppress('welcome', 'Welcome to TeXRA…', [
+    {
+      title: 'Open Guide',
+      callback: async () => {
+        await vscode.env.openExternal(
+          vscode.Uri.parse('https://texra.ai/guide/'),
+        );
+      },
+    },
+  ]);
 }
 
 export function deactivate() {


### PR DESCRIPTION
## Summary
- greet users with a one-time welcome message on first activation
- link to the TeXRA guide from the welcome notification

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: process hung during webpack build)*

------
https://chatgpt.com/codex/tasks/task_e_689bfc506570832488e08401a6d564ea