### PR TITLE
feat: show task status in status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Show TeXRA task status in the VS Code status bar.
+
 ## [0.32.9] - 2025-08-09
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Show TeXRA task status in the VS Code status bar.
 
+### Bug Fixes
+
+- Stabilize status bar command registration and task cancellation handling.
+
 ## [0.32.9] - 2025-08-09
 
 ### Bug Fixes

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { WatcherManager } from './explorer/WatcherManager';
 import { registerCommands } from './commands';
 
 let statusBarItem: vscode.StatusBarItem | undefined;
+let disposeStatusListener: (() => void) | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
@@ -49,30 +50,6 @@ export async function activate(context: vscode.ExtensionContext) {
   initializeStateManagers(context);
   FileLister.initialize(context);
 
-  // Create a status bar item to show TeXRA progress
-  statusBarItem = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Left,
-  );
-  statusBarItem.command = 'texra.showProgressView';
-  statusBarItem.text = 'TeXRA: Idle';
-  statusBarItem.show();
-  context.subscriptions.push(statusBarItem);
-
-  const runningStreams = new Set<string>();
-  const disposeStatusListener = bus.on(
-    'updateStreamStatus',
-    ({ stream, status }: { stream: string; status: string }) => {
-      if (status === 'running') {
-        runningStreams.add(stream);
-      } else if (status === 'stopped' || status === 'error') {
-        runningStreams.delete(stream);
-      }
-      statusBarItem!.text =
-        runningStreams.size > 0 ? 'TeXRA: Running' : 'TeXRA: Idle';
-    },
-  );
-  context.subscriptions.push({ dispose: disposeStatusListener });
-
   // Create the log view provider
   const progressViewProvider = new ProgressViewProvider(context);
   await progressViewProvider.initialize();
@@ -91,6 +68,34 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register commands first - this will create and store the MainViewProvider
   registerCommands(context);
+
+  // Create a status bar item to show TeXRA progress
+  statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+  );
+  statusBarItem.command = 'texra.showProgressView';
+  statusBarItem.text = 'TeXRA: Idle';
+  statusBarItem.show();
+
+  const runningStreams = new Set<string>();
+  disposeStatusListener = bus.on(
+    'updateStreamStatus',
+    ({ stream, status }: { stream: string; status: string }) => {
+      if (status === 'running') {
+        runningStreams.add(stream);
+      } else if (
+        status === 'stopped' ||
+        status === 'error' ||
+        status === 'cancelled'
+      ) {
+        runningStreams.delete(stream);
+      }
+      statusBarItem!.text =
+        runningStreams.size > 0 ? 'TeXRA: Running' : 'TeXRA: Idle';
+    },
+  );
+
+  context.subscriptions.push({ dispose: disposeStatusListener }, statusBarItem);
 
   // Register the folder explorer with context
   const folderExplorer = new FolderExplorer(workspaceRoot, context);
@@ -128,6 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
+  disposeStatusListener?.();
   // Get the ProgressViewProvider instance
   const progressViewProvider = ProgressViewProvider.getInstance();
   if (progressViewProvider) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { StorageFS } from '@utils/files';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { initializeStateManagers } from '@common/state/stateManager';
 import { FileLister } from '@frontend/files/fileLister';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -23,6 +24,8 @@ import { ExplorerOperations } from './explorer/ExplorerOperations';
 import { ExplorerCommands } from './explorer/ExplorerCommands';
 import { WatcherManager } from './explorer/WatcherManager';
 import { registerCommands } from './commands';
+
+let statusBarItem: vscode.StatusBarItem | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
@@ -45,6 +48,30 @@ export async function activate(context: vscode.ExtensionContext) {
   await StorageFS.ensureDir(TASK_RUNS_DIR);
   initializeStateManagers(context);
   FileLister.initialize(context);
+
+  // Create a status bar item to show TeXRA progress
+  statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+  );
+  statusBarItem.command = 'texra.showProgressView';
+  statusBarItem.text = 'TeXRA: Idle';
+  statusBarItem.show();
+  context.subscriptions.push(statusBarItem);
+
+  const runningStreams = new Set<string>();
+  const disposeStatusListener = bus.on(
+    'updateStreamStatus',
+    ({ stream, status }: { stream: string; status: string }) => {
+      if (status === 'running') {
+        runningStreams.add(stream);
+      } else if (status === 'stopped' || status === 'error') {
+        runningStreams.delete(stream);
+      }
+      statusBarItem!.text =
+        runningStreams.size > 0 ? 'TeXRA: Running' : 'TeXRA: Idle';
+    },
+  );
+  context.subscriptions.push({ dispose: disposeStatusListener });
 
   // Create the log view provider
   const progressViewProvider = new ProgressViewProvider(context);
@@ -107,5 +134,6 @@ export function deactivate() {
     // Mark all running tasks as cancelled when extension deactivates
     progressViewProvider.eventHandler.markAllRunningTasksAsCancelled();
   }
+  statusBarItem?.dispose();
   disposeDiffRefresh();
 }


### PR DESCRIPTION
## Summary
- display TeXRA run state in the status bar
- track running streams via ProgressEventBus
- note status bar indicator in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfd16c75c8324b3643ab4ec3b4942