### PR TITLE
feat: enhance sox detection on windows

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -84,6 +84,16 @@ Configure how TeXRA connects to AI model providers:
 
 **Note:** Only the providers marked with ✅ are supported by the proxy. Other providers will use their direct API endpoints even when proxy is enabled.
 
+### Audio Settings
+
+Specify a custom path to the [SoX](http://sox.sourceforge.net/) binary when automatic detection fails:
+
+```json
+"texra.audio.soxPath": "C:\\Users\\thinking\\scoop\\apps\\sox\\current\\sox.exe"
+```
+
+If unset, TeXRA searches common install locations and your `PATH`.
+
 ## File Management Configuration
 
 ### File Extensions

--- a/package.json
+++ b/package.json
@@ -726,6 +726,17 @@
         }
       },
       {
+        "title": "Audio",
+        "properties": {
+          "texra.audio.soxPath": {
+            "type": "string",
+            "default": "",
+            "description": "Path to the SoX executable. Overrides automatic detection.",
+            "scope": "resource"
+          }
+        }
+      },
+      {
         "title": "API Keys",
         "properties": {
           "texra.apiKeys.set": {

--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -13,6 +13,7 @@ import * as logger from '@logger/logUtils';
 import { SecretManager } from '@frontend/secretManager';
 import { AbsoluteFS, StorageFS } from '@utils/files';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import { getConfig } from '@utils/config/configUtils';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import {
   extendEnvPath,
@@ -45,8 +46,12 @@ export async function startRecording(
       };
     }
 
-    // Check if sox is installed (don't show error dialog)
-    const soxPath = findToolInCommonPaths('sox');
+    // Determine sox path from configuration or auto-detection
+    const configuredPath = getConfig<string>('audio.soxPath', '');
+    const soxPath =
+      configuredPath && AbsoluteFS.existsSync(configuredPath)
+        ? configuredPath
+        : findToolInCommonPaths('sox');
     logger.info(CHANNEL, `Sox path found: ${soxPath}`);
 
     const soxInstalled = await checkToolInstalled('sox', false);

--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -55,19 +55,14 @@ export async function startRecording(
     logger.info(CHANNEL, `Sox path found: ${soxPath}`);
 
     const soxInstalled = await checkToolInstalled('sox', false);
-    if (!soxInstalled) {
-      logger.error(
-        CHANNEL,
-        'Sox check failed - but we found it at: ' + soxPath,
-      );
-      // If we found sox path, proceed anyway
-      if (!soxPath) {
-        return {
-          success: false,
-          error:
-            'Sox is required for audio recording. Please install it first.',
-        };
-      }
+    if (!soxInstalled && !soxPath) {
+      return {
+        success: false,
+        error: 'Sox is required for audio recording. Please install it first.',
+      };
+    }
+    if (!soxInstalled && soxPath) {
+      logger.warn(CHANNEL, `Sox check failed but found at: ${soxPath}`);
     }
     // Initialize StorageFS with context if not already done
     StorageFS.initialize(context);

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -48,6 +48,26 @@ export function getExtraDirs(): string[] {
         `${localAppData.replace(/\\/g, '/')}/Programs/MiKTeX/miktex/bin/x64`,
       );
     }
+
+    const scoopDir =
+      process.env.SCOOP ||
+      process.env.SCOOP_HOME ||
+      (process.env.USERPROFILE
+        ? path.join(process.env.USERPROFILE, 'scoop')
+        : null);
+    if (scoopDir && AbsoluteFS.existsSync(scoopDir)) {
+      const normalizedScoop = scoopDir.replace(/\\/g, '/');
+      dirs.push(`${normalizedScoop}/shims`);
+      try {
+        const matches = glob
+          .sync(`${normalizedScoop}/apps/*/current`)
+          .sort()
+          .reverse();
+        dirs.push(...matches);
+      } catch {
+        // ignore glob errors
+      }
+    }
   } else {
     dirs.push(
       '/usr/local/bin',
@@ -198,6 +218,19 @@ export function findToolInCommonPaths(tool: string): string | null {
       }
     } catch {
       // ignore kpsewhich errors
+    }
+  }
+  if (process.platform === 'win32') {
+    for (const name of candidates) {
+      try {
+        const result = execaSync('where', [name], execOptions);
+        const found = result.stdout.split(/\r?\n/)[0]?.trim();
+        if (result.exitCode === 0 && found) {
+          return found;
+        }
+      } catch {
+        // ignore where errors
+      }
     }
   }
   return null;

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -45,7 +45,7 @@ export function getExtraDirs(): string[] {
     const localAppData = process.env.LOCALAPPDATA;
     if (localAppData) {
       dirs.push(
-        `${localAppData.replace(/\\/g, '/')}/Programs/MiKTeX/miktex/bin/x64`,
+        path.join(localAppData, 'Programs', 'MiKTeX', 'miktex', 'bin', 'x64'),
       );
     }
 
@@ -56,11 +56,10 @@ export function getExtraDirs(): string[] {
         ? path.join(process.env.USERPROFILE, 'scoop')
         : null);
     if (scoopDir && AbsoluteFS.existsSync(scoopDir)) {
-      const normalizedScoop = scoopDir.replace(/\\/g, '/');
-      dirs.push(`${normalizedScoop}/shims`);
+      dirs.push(path.join(scoopDir, 'shims'));
       try {
         const matches = glob
-          .sync(`${normalizedScoop}/apps/*/current`)
+          .sync(path.join(scoopDir, 'apps', '*', 'current'))
           .sort()
           .reverse();
         dirs.push(...matches);


### PR DESCRIPTION
## Summary
- include Scoop directories and `where.exe` fallback for tool lookup on Windows
- allow configurable SoX path via `texra.audio.soxPath`
- document new SoX path setting in configuration guide

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(terminates early in container; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a19576cbdc832483dd1bae2e247ba1