### PR TITLE
feat: allow custom DeepSeek base URL

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -54,6 +54,7 @@ Configure how TeXRA connects to AI model providers:
 "texra.model.useOpenRouter": false,
 "texra.model.useImprovedConnection": false,
 "texra.model.improvedConnectionDomain": "proxy.texra.ai",
+"texra.model.baseUrlDeepSeek": "",
 "texra.model.useStreaming": false,
 "texra.model.useStreamingAnthropicReasoning": false,
 "texra.model.useStreamingOpenAIReasoning": false
@@ -63,6 +64,7 @@ Configure how TeXRA connects to AI model providers:
 - `useImprovedConnection`: Route all API requests through a proxy server
 - `improvedConnectionDomain`: Custom proxy domain when `useImprovedConnection` is enabled (default `proxy.texra.ai`)
   - ⚠️ **Security Warning:** When using a proxy, ensure you trust the proxy server as it will receive your API keys. Only use proxies from trusted sources.
+- `baseUrlDeepSeek`: Custom base URL for DeepSeek models; overrides the default `https://api.deepseek.com` endpoint
 - `useStreaming`: Enable streaming responses for better handling of long outputs
 - `useStreamingAnthropicReasoning`: Enable streaming specifically for Anthropic reasoning models
 - `useStreamingOpenAIReasoning`: Enable streaming specifically for OpenAI reasoning models

--- a/package.json
+++ b/package.json
@@ -163,6 +163,12 @@
             "description": "Enable streaming for DeepSeek models via OpenAI-compatible API. Overrides the global useStreaming setting.",
             "scope": "resource"
           },
+          "texra.model.baseUrlDeepSeek": {
+            "type": "string",
+            "default": "",
+            "description": "Custom base URL for DeepSeek models; leave blank to use `https://api.deepseek.com`.",
+            "scope": "resource"
+          },
           "texra.model.useStreamingOpenrouter": {
             "type": "boolean",
             "default": false,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -17,6 +17,7 @@ import {
 } from '@frontend/media/img';
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { getConfig } from '@utils/config';
+import { normalizeUrl } from '@utils/urlUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import {
@@ -156,10 +157,8 @@ export abstract class ModelHandler<
     );
 
     if (useImprovedConnection && improvedConnectionDomain) {
-      // Normalize proxy domain: remove protocol and trailing slashes
-      improvedConnectionDomain = improvedConnectionDomain
-        .replace(/^https?:\/\//, '') // Remove http:// or https://
-        .replace(/\/+$/, ''); // Remove trailing slashes
+      // Normalize proxy domain
+      improvedConnectionDomain = normalizeUrl(improvedConnectionDomain);
 
       // Define supported proxy paths for specific providers
       // Only these providers are supported by the proxy
@@ -200,6 +199,12 @@ export abstract class ModelHandler<
 
     if (useOpenRouter) {
       return 'https://openrouter.ai/api/v1';
+    }
+
+    const customDeepSeekUrl = getConfig<string>('model.baseUrlDeepSeek', '');
+    if (customDeepSeekUrl && this.config.provider === ModelProvider.DEEPSEEK) {
+      const normalized = normalizeUrl(customDeepSeekUrl);
+      return `https://${normalized}`;
     }
 
     // Provider-specific base URLs

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -1,0 +1,20 @@
+// Utility functions for working with URLs
+
+/**
+ * Normalize a URL-like string by removing any protocol prefix and trailing slashes.
+ * Preserves any path component provided.
+ * @param input Raw URL or host string
+ * @returns Normalized string without protocol and trailing slashes
+ */
+export function normalizeUrl(input: string): string {
+  if (!input) {
+    return '';
+  }
+  try {
+    const url = new URL(input.includes('://') ? input : `https://${input}`);
+    const withoutProtocol = `${url.host}${url.pathname}`;
+    return withoutProtocol.replace(/\/+$/, '');
+  } catch {
+    return input.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  }
+}


### PR DESCRIPTION
## Summary
- allow custom DeepSeek base URL via new `texra.model.baseUrlDeepSeek` setting
- honor DeepSeek base URL override in model handler
- document `baseUrlDeepSeek` configuration option
- centralize URL normalization and reuse for proxy and DeepSeek endpoints

## Testing
- `npm run format`
- `npm run lint`
- `npx vscode-test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a2312f1a888324876025fb24b0ee9c