### PR TITLE
fix: detect MSYS2 Perl directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.11] - 2025-08-18
+
+### Bug Fixes
+
+- Detect MSYS2 Perl directories on Windows so `latexdiff` can find `perl`.
+
 ## [0.32.10] - 2025-08-13
 
 ### Bug Fixes

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -16,6 +16,9 @@ logger.initialize(CHANNEL);
 // Cache for extra directories to avoid repeated glob operations
 let cachedExtraDirs: string[] | null = null;
 
+const DEFAULT_MSYS_ROOTS = ['C:\\msys64', 'C:\\msys32'];
+const MSYS_SUBDIRS = ['usr\\bin', 'mingw64\\bin', 'mingw32\\bin'];
+
 /**
  * Return common tool directories based on the current platform.
  * Results are cached for the session to improve performance.
@@ -68,21 +71,18 @@ export function getExtraDirs(): string[] {
       }
     }
 
-    const msysRoots = new Set<string>();
+    const msysRoots = new Set<string>(DEFAULT_MSYS_ROOTS);
     if (process.env.MSYS2_HOME) {
       msysRoots.add(process.env.MSYS2_HOME);
     }
-    msysRoots.add('C:\\msys64');
-    msysRoots.add('C:\\msys32');
 
     for (const root of msysRoots) {
-      const candidates = [
-        path.join(root, 'usr', 'bin'),
-        path.join(root, 'mingw64', 'bin'),
-        path.join(root, 'mingw32', 'bin'),
-      ];
-      for (const dir of candidates) {
-        if (AbsoluteFS.existsSync(path.join(dir, 'perl.exe'))) {
+      for (const sub of MSYS_SUBDIRS) {
+        const dir = path.join(root, sub);
+        if (
+          AbsoluteFS.existsSync(path.join(dir, 'perl.exe')) &&
+          !dirs.includes(dir)
+        ) {
           dirs.push(dir);
         }
       }

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -67,6 +67,26 @@ export function getExtraDirs(): string[] {
         // ignore glob errors
       }
     }
+
+    const msysRoots = new Set<string>();
+    if (process.env.MSYS2_HOME) {
+      msysRoots.add(process.env.MSYS2_HOME);
+    }
+    msysRoots.add('C:\\msys64');
+    msysRoots.add('C:\\msys32');
+
+    for (const root of msysRoots) {
+      const candidates = [
+        path.join(root, 'usr', 'bin'),
+        path.join(root, 'mingw64', 'bin'),
+        path.join(root, 'mingw32', 'bin'),
+      ];
+      for (const dir of candidates) {
+        if (AbsoluteFS.existsSync(path.join(dir, 'perl.exe'))) {
+          dirs.push(dir);
+        }
+      }
+    }
   } else {
     dirs.push(
       '/usr/local/bin',


### PR DESCRIPTION
## Summary
- detect common MSYS2 installation paths and append those containing perl.exe
- document Windows MSYS2 Perl detection in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: required VS Code download not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c78f879883248a27e306c117c5d5