### PR TITLE
fix: avoid false error state on first progress view load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.11] - 2025-08-14
+
+### Bug Fixes
+
+- Prevent first task from being marked as error when progress view loads.
+
 ## [0.32.10] - 2025-08-13
 
 ### Bug Fixes

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -52,6 +52,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private readonly _viewTitle: string;
   private _webviewReady = false;
   private _pendingUpdate = false;
+  private _hasResolved = false;
   private readonly logger: AgentLogger;
 
   constructor(
@@ -123,8 +124,11 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
     this.cleanupView();
 
-    // Mark all running tasks as cancelled since they will lose contact when webview reloads
-    this.resetRunningStreamStatuses();
+    // Mark running tasks as cancelled on subsequent webview resolves
+    if (this._hasResolved) {
+      this.resetRunningStreamStatuses();
+    }
+    this._hasResolved = true;
 
     this._webviewReady = false;
     this._pendingUpdate = false;


### PR DESCRIPTION
## Summary
- skip resetting running streams on first progress view resolve
- document fix in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3187852788324a3b8a1d8d6cc65cb