### PR TITLE
feat: add main view reset button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Show TeXRA task status in the VS Code status bar.
-- - Automatically resize large images (> 2000px) before base64 encoding to optimize memory usage and performance
+- Automatically resize large images (> 2000px) before base64 encoding to optimize memory usage and performance
 - Added configurable `texra.maxImageDimension` setting to control the maximum image size threshold
-- Add “New” button in main view to reset all fields.
+- Add "New" button in main view to reset all fields.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Show TeXRA task status in the VS Code status bar.
 - - Automatically resize large images (> 2000px) before base64 encoding to optimize memory usage and performance
 - Added configurable `texra.maxImageDimension` setting to control the maximum image size threshold
+- Add “New” button in main view to reset all fields.
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1047,6 +1047,12 @@
         "category": "TeXRA"
       },
       {
+        "command": "texra.mainView.reset",
+        "title": "New",
+        "category": "TeXRA",
+        "icon": "$(new-file)"
+      },
+      {
         "command": "texra.showAgentHistory",
         "title": "Show Agent Execution History",
         "category": "TeXRA",
@@ -1163,6 +1169,11 @@
           "command": "texra.createAgentWithAI",
           "when": "view == texra.folderExplorer",
           "group": "navigation"
+        },
+        {
+          "command": "texra.mainView.reset",
+          "when": "view == texra.mainView",
+          "group": "navigation@0"
         },
         {
           "command": "texra.openSettings",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -31,6 +31,7 @@ import { registerHelpCommands } from '@commands/system/helpCommands';
 import { registerProgressViewCommands } from '@commands/progress/progressViewCommands';
 import { registerOpenFileCommands } from '@commands/files/openFileCommands';
 import { registerSettingsCommands } from '@commands/system/settingsCommands';
+import { registerMainViewCommands } from '@commands/system/mainViewCommands';
 
 import * as logger from '@logger/logUtils';
 
@@ -72,6 +73,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     followUp: registerFollowUpCommand(context),
     openFile: registerOpenFileCommands(context),
     help: registerHelpCommands(context),
+    mainView: registerMainViewCommands(context),
     settings: registerSettingsCommands(context),
   };
 
@@ -117,3 +119,4 @@ export { helpCommands } from '@commands/system/helpCommands';
 export { agentCreatorCommands } from '@commands/agent/agentCreatorCommands';
 export { registerOpenFileCommands as openFileCommands } from '@commands/files/openFileCommands';
 export { settingsCommands } from '@commands/system/settingsCommands';
+export { mainViewCommands } from '@commands/system/mainViewCommands';

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -1,0 +1,33 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - webview commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+// Local imports - utilities
+import { safeExecuteCommand } from '@utils/system';
+
+export const mainViewCommands = {
+  reset: 'texra.mainView.reset',
+};
+
+export function registerMainViewCommands(context: vscode.ExtensionContext) {
+  const resetCommand = vscode.commands.registerCommand(
+    mainViewCommands.reset,
+    async () => {
+      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
+        'texra.getWebviewView',
+        [],
+        'mainViewCommands',
+      );
+
+      webviewView?.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+        state: {},
+      });
+    },
+  );
+
+  context.subscriptions.push(resetCommand);
+
+  return { resetCommand };
+}

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -10,6 +10,11 @@ export const mainViewCommands = {
   reset: 'texra.mainView.reset',
 };
 
+/**
+ * Registers main view commands for the extension
+ * @param context - The VS Code extension context
+ * @returns Object containing the registered commands
+ */
 export function registerMainViewCommands(context: vscode.ExtensionContext) {
   const resetCommand = vscode.commands.registerCommand(
     mainViewCommands.reset,
@@ -20,10 +25,17 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
         'mainViewCommands',
       );
 
-      webviewView?.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-        state: {},
-      });
+      if (webviewView) {
+        webviewView.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+          state: {},
+        });
+      } else {
+        // Log warning when webview is not available
+        vscode.window.showWarningMessage(
+          'Main view is not available. Please ensure the TeXRA view is open.',
+        );
+      }
     },
   );
 

--- a/src/test/commands/system/mainViewCommands.test.ts
+++ b/src/test/commands/system/mainViewCommands.test.ts
@@ -1,0 +1,129 @@
+import { strict as assert } from 'assert';
+import * as vscode from 'vscode';
+import { registerMainViewCommands, mainViewCommands } from '@commands/system/mainViewCommands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+describe('Main View Commands', () => {
+  let context: vscode.ExtensionContext;
+  let registeredCommands: Map<string, Function>;
+  let warningMessages: string[];
+  let executeCommandResults: Map<string, any>;
+
+  // Mock VS Code API
+  const originalRegisterCommand = vscode.commands.registerCommand;
+  const originalExecuteCommand = vscode.commands.executeCommand;
+  const originalShowWarningMessage = vscode.window.showWarningMessage;
+
+  beforeEach(() => {
+    context = {
+      subscriptions: [],
+    } as any;
+
+    registeredCommands = new Map();
+    warningMessages = [];
+    executeCommandResults = new Map();
+
+    // Mock registerCommand
+    (vscode.commands as any).registerCommand = (command: string, callback: Function) => {
+      registeredCommands.set(command, callback);
+      const disposable = { dispose: () => {} };
+      return disposable;
+    };
+
+    // Mock executeCommand
+    (vscode.commands as any).executeCommand = async (command: string, ...args: any[]) => {
+      if (executeCommandResults.has(command)) {
+        const result = executeCommandResults.get(command);
+        if (result instanceof Error) {
+          throw result;
+        }
+        return result;
+      }
+      return undefined;
+    };
+
+    // Mock showWarningMessage
+    (vscode.window as any).showWarningMessage = (message: string) => {
+      warningMessages.push(message);
+      return Promise.resolve();
+    };
+  });
+
+  afterEach(() => {
+    // Restore original functions
+    (vscode.commands as any).registerCommand = originalRegisterCommand;
+    (vscode.commands as any).executeCommand = originalExecuteCommand;
+    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+  });
+
+  describe('registerMainViewCommands', () => {
+    it('should register reset command and add to subscriptions', () => {
+      const result = registerMainViewCommands(context);
+
+      assert.ok(registeredCommands.has(mainViewCommands.reset));
+      assert.strictEqual(context.subscriptions.length, 1);
+      assert.ok(result.resetCommand);
+    });
+  });
+
+  describe('reset command', () => {
+    let resetHandler: Function;
+    let mockWebviewView: vscode.WebviewView;
+    let postMessageCalls: any[];
+
+    beforeEach(() => {
+      postMessageCalls = [];
+      mockWebviewView = {
+        webview: {
+          postMessage: (message: any) => {
+            postMessageCalls.push(message);
+            return Promise.resolve(true);
+          },
+        },
+      } as any;
+
+      registerMainViewCommands(context);
+      resetHandler = registeredCommands.get(mainViewCommands.reset)!;
+    });
+
+    it('should send STATE_RESTORE message when webview is available', async () => {
+      executeCommandResults.set('texra.getWebviewView', mockWebviewView);
+
+      await resetHandler();
+
+      assert.strictEqual(postMessageCalls.length, 1);
+      assert.deepStrictEqual(postMessageCalls[0], {
+        command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+        state: {},
+      });
+      assert.strictEqual(warningMessages.length, 0);
+    });
+
+    it('should show warning message when webview is undefined', async () => {
+      executeCommandResults.set('texra.getWebviewView', undefined);
+
+      await resetHandler();
+
+      assert.strictEqual(warningMessages.length, 1);
+      assert.strictEqual(
+        warningMessages[0],
+        'Main view is not available. Please ensure the TeXRA view is open.'
+      );
+      assert.strictEqual(postMessageCalls.length, 0);
+    });
+
+    it('should handle errors gracefully when executeCommand fails', async () => {
+      executeCommandResults.set('texra.getWebviewView', new Error('Command failed'));
+
+      // The safeExecuteCommand should catch the error and return undefined
+      await resetHandler();
+
+      assert.strictEqual(warningMessages.length, 1);
+      assert.strictEqual(
+        warningMessages[0],
+        'Main view is not available. Please ensure the TeXRA view is open.'
+      );
+      assert.strictEqual(postMessageCalls.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `texra.mainView.reset` command to clear main view inputs
- register reset command in command registry and package contributions
- document new "New" toolbar button in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a34d02e2388324afa33788207a6f7b