### PR TITLE
fix: parse markdown latex fallback

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -57,6 +57,15 @@ export class XmlOutputManager {
         );
         return fallbackContent;
       }
+      const markdownContent = xmlUtils.extractLatexFromMarkdown(outputContent);
+      if (markdownContent) {
+        this.logger.info(
+          `Recovered ${documentTag} from Markdown code block`,
+          undefined,
+          MESSAGE_TYPES.INTERNAL,
+        );
+        return markdownContent;
+      }
       this.logger.debug(
         `No ${documentTag} found in output file using fallback method`,
         undefined,

--- a/src/replacement/rules/latexDocument.ts
+++ b/src/replacement/rules/latexDocument.ts
@@ -18,8 +18,8 @@ export const LATEX_DOCUMENT_REPLACEMENTS: ReplacementCategory = {
     '<scratchpad>\n<scratchpad>\n': '<scratchpad>\n',
     '<scratchpad>\n```latex\n': '<scratchpad>\n<latex_document>\n',
     '<scratchpad>```latex': '<scratchpad>\n<latex_document>',
-    '```\n</scratchpad>\n</latex_document>': '</latex_document>',
-    '</latex_document>\n```\n</latex_document>': '</latex_document>\n',
+    // '```\n</scratchpad>\n</latex_document>': '</latex_document>', // Removed to keep closing code fences
+    // '</latex_document>\n```\n</latex_document>': '</latex_document>\n', // Removed to keep closing code fences
     '</latex_document>\n</latex_document>': '</latex_document>\n',
     '</latex_document>\n\n</latex_document>': '</latex_document>\n',
 

--- a/src/replacement/rules/scratchpadXml.ts
+++ b/src/replacement/rules/scratchpadXml.ts
@@ -29,7 +29,7 @@ export const SCRATCHPAD_XML_REPLACEMENTS: ReplacementCategory = {
     '</scratchpad>\n```latex': '</scratchpad>\n<latex_document>',
     '</scratchpad>\n\n```latex': '</scratchpad>\n\n<latex_document>',
     '</scratchpad>\n    \n```latex': '</scratchpad>\n\n<latex_document>',
-    '```\n</latex_document>': '</latex_document>',
+    // '```\n</latex_document>': '</latex_document>', // Removed to preserve closing code fences
     // Special LaTeX content handling
     '</scratchpad>\n\\section{':
       '</scratchpad>\n\\<latex_document>\n\\section{',

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -1,0 +1,74 @@
+import { strict as assert } from 'assert';
+
+// Local imports
+import { XmlOutputManager } from '@agent/output/XmlOutputManager';
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentLogger } from '@logger/AgentLogger';
+import { WorkspaceFS } from '@utils/files';
+
+describe('XmlOutputManager.splitScratchpadOutputXml', () => {
+  const setting: AgentSetting = {
+    agentType: AgentType.CoT,
+    documentTag: 'latex_document',
+    temperature: 0,
+    isRewrite: true,
+    rounds: 1,
+    prefills: [],
+    outputExt: 'tex',
+    endTag: '</latex_document>',
+    requiredFiles: {},
+    requiredFilesInternal: {},
+    defaultOutputFiles: [],
+    filePatternsContain: [],
+    tools: [],
+  };
+
+  const config: AgentConfig = {
+    model: 'test',
+    agent: 'a',
+    instruction: '',
+    inputFile: 'input.tex',
+    inputFiles: null,
+    referenceFile: null,
+    referenceFiles: null,
+    auxiliaryFile: null,
+    auxiliaryFiles: null,
+    mediaFile: null,
+    mediaFiles: null,
+    outputFiles: null,
+    editedFile: null,
+    toolConfig: {
+      reflect: false,
+      usePrefillFromInput: false,
+      autoExtractFigure: false,
+      autoExtractTikzFigure: false,
+      attachTeXCount: false,
+      attachDiagnostics: false,
+      printInputPrompt: false,
+      autoCompileInputPdf: false,
+    },
+  };
+
+  it('recovers LaTeX from Markdown code fence when XML tags missing', async () => {
+    const manager = new XmlOutputManager(
+      setting,
+      config,
+      new AgentLogger('XmlOutputTest'),
+    );
+    const xmlContent =
+      '<scratchpad>think</scratchpad>\n```latex\n\\begin{document}\nhello\\end{document}\n```';
+    const xmlFile = 'markdown-output.xml';
+    await WorkspaceFS.writeFile(xmlFile, xmlContent);
+
+    const texFile = await manager.splitScratchpadOutputXml(
+      xmlFile,
+      'latex_document',
+    );
+    const texContent = await WorkspaceFS.readFile(texFile);
+    assert.ok(texContent.includes('hello'));
+
+    await WorkspaceFS.delete(xmlFile);
+    await WorkspaceFS.delete('markdown-output.tex');
+  });
+});

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -161,6 +161,15 @@ export function extractTextFromTag(
 }
 
 /**
+ * Extract LaTeX content from a fenced Markdown code block.
+ */
+export function extractLatexFromMarkdown(content: string): string | null {
+  const regex = /```(?:latex|tex)\n([\s\S]*?)\n```/i;
+  const match = content.match(regex);
+  return match ? match[1] : null;
+}
+
+/**
  * Extract multiple document elements from an XML container tag
  * Used as a fallback for extracting documents when XML parsing fails
  */
@@ -404,6 +413,7 @@ export const xmlUtils = {
   addCdataToTags,
   addCdataToTagsMultiple,
   extractTextFromTag,
+  extractLatexFromMarkdown,
   extractMultipleTextFromTag,
   filterTagsFromText,
   extractContentFromXMLbyTag,


### PR DESCRIPTION
## Summary
- detect LaTeX from markdown fences when XML tags are missing
- preserve closing code fences in scratchpad and latex replacement rules
- test fallback extraction for markdown-only output

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3617e63c083249a470547b32b1cc7