### PR TITLE
fix: add markdown fallback for latex extraction

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -57,6 +57,15 @@ export class XmlOutputManager {
         );
         return fallbackContent;
       }
+      const markdownFallback = xmlUtils.extractLatexFromMarkdown(outputContent);
+      if (markdownFallback) {
+        this.logger.info(
+          `Recovered ${documentTag} from markdown code block`,
+          undefined,
+          MESSAGE_TYPES.INTERNAL,
+        );
+        return markdownFallback;
+      }
       this.logger.debug(
         `No ${documentTag} found in output file using fallback method`,
         undefined,

--- a/src/replacement/rules/latexDocument.ts
+++ b/src/replacement/rules/latexDocument.ts
@@ -18,8 +18,8 @@ export const LATEX_DOCUMENT_REPLACEMENTS: ReplacementCategory = {
     '<scratchpad>\n<scratchpad>\n': '<scratchpad>\n',
     '<scratchpad>\n```latex\n': '<scratchpad>\n<latex_document>\n',
     '<scratchpad>```latex': '<scratchpad>\n<latex_document>',
-    '```\n</scratchpad>\n</latex_document>': '</latex_document>',
-    '</latex_document>\n```\n</latex_document>': '</latex_document>\n',
+    // '```\n</scratchpad>\n</latex_document>': '</latex_document>',
+    // '</latex_document>\n```\n</latex_document>': '</latex_document>\n',
     '</latex_document>\n</latex_document>': '</latex_document>\n',
     '</latex_document>\n\n</latex_document>': '</latex_document>\n',
 

--- a/src/replacement/rules/scratchpadXml.ts
+++ b/src/replacement/rules/scratchpadXml.ts
@@ -29,7 +29,7 @@ export const SCRATCHPAD_XML_REPLACEMENTS: ReplacementCategory = {
     '</scratchpad>\n```latex': '</scratchpad>\n<latex_document>',
     '</scratchpad>\n\n```latex': '</scratchpad>\n\n<latex_document>',
     '</scratchpad>\n    \n```latex': '</scratchpad>\n\n<latex_document>',
-    '```\n</latex_document>': '</latex_document>',
+    // '```\n</latex_document>': '</latex_document>',
     // Special LaTeX content handling
     '</scratchpad>\n\\section{':
       '</scratchpad>\n\\<latex_document>\n\\section{',

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -1,0 +1,73 @@
+import { strict as assert } from 'assert';
+
+// Local imports
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentLogger } from '@logger/AgentLogger';
+import { WorkspaceFS } from '@utils/files';
+import { XmlOutputManager } from '@agent/output/XmlOutputManager';
+
+describe('XmlOutputManager markdown fallback', () => {
+  const setting: AgentSetting = {
+    agentType: AgentType.CoT,
+    documentTag: 'latex_document',
+    temperature: 0,
+    isRewrite: true,
+    rounds: 1,
+    prefills: [],
+    outputExt: 'tex',
+    endTag: '</latex_document>',
+    requiredFiles: {},
+    requiredFilesInternal: {},
+    defaultOutputFiles: [],
+    filePatternsContain: [],
+    tools: [],
+  };
+
+  const config: AgentConfig = {
+    model: 'test',
+    agent: 'a',
+    instruction: '',
+    inputFile: 'input.tex',
+    inputFiles: null,
+    referenceFile: null,
+    referenceFiles: null,
+    auxiliaryFile: null,
+    auxiliaryFiles: null,
+    mediaFile: null,
+    mediaFiles: null,
+    outputFiles: null,
+    editedFile: null,
+    toolConfig: {
+      reflect: false,
+      usePrefillFromInput: false,
+      autoExtractFigure: false,
+      autoExtractTikzFigure: false,
+      attachTeXCount: false,
+      attachDiagnostics: false,
+      printInputPrompt: false,
+      autoCompileInputPdf: false,
+    },
+  };
+
+  it('writes tex file from markdown fenced latex block', async () => {
+    const logger = new AgentLogger('TestXmlOutput');
+    const manager = new XmlOutputManager(setting, config, logger);
+    const outputXml = 'markdown_only.xml';
+    const markdownContent =
+      '```latex\n\\begin{document}\nhello\n\\end{document}\n```';
+
+    await WorkspaceFS.writeFile(outputXml, markdownContent);
+
+    const texPath = await manager.splitScratchpadOutputXml(
+      outputXml,
+      setting.documentTag,
+    );
+
+    const written = await WorkspaceFS.readFile('markdown_only.tex');
+    assert.ok(written.includes('hello'));
+
+    await WorkspaceFS.delete(outputXml);
+    await WorkspaceFS.delete(texPath);
+  });
+});

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -161,6 +161,14 @@ export function extractTextFromTag(
 }
 
 /**
+ * Extract LaTeX content from a markdown fenced code block
+ */
+export function extractLatexFromMarkdown(content: string): string | null {
+  const match = content.match(/```(?:latex|tex)\n([\s\S]*?)\n```/i);
+  return match ? match[1] : null;
+}
+
+/**
  * Extract multiple document elements from an XML container tag
  * Used as a fallback for extracting documents when XML parsing fails
  */
@@ -404,6 +412,7 @@ export const xmlUtils = {
   addCdataToTags,
   addCdataToTagsMultiple,
   extractTextFromTag,
+  extractLatexFromMarkdown,
   extractMultipleTextFromTag,
   filterTagsFromText,
   extractContentFromXMLbyTag,


### PR DESCRIPTION
## Summary
- fall back to parsing markdown `latex` fences when XML tags are missing
- comment out replacement rules that stripped closing ``` fences
- add regression test for markdown-only latex extraction

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: environment lacks VS Code test support)*

------
https://chatgpt.com/codex/tasks/task_e_68a3617e63c083249a470547b32b1cc7