### PR TITLE
fix: bundle progress view assets for offline use

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -33,6 +33,12 @@ CLAUDE.md
 
 !node_modules/@vscode/codicons/dist/**
 !node_modules/split.js/**
+!node_modules/katex/**
+!node_modules/@vscode/markdown-it-katex/**
+!node_modules/markdown-it/**
+!node_modules/markdown-it-highlightjs/**
+!node_modules/highlight.js/**
+!node_modules/he/**
 
 
 !resources/**

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -15,6 +15,30 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
       styleUri: this.getWebviewUri(webview, 'styles/index.css'),
       scriptUri: this.getWebviewUri(webview, 'script.js'),
       splitJsUri: this.getNodeModulesUri(webview, 'split.js/dist/split.es.js'),
+      katexCssUri: this.getNodeModulesUri(webview, 'katex/dist/katex.min.css'),
+      copyTexUri: this.getNodeModulesUri(
+        webview,
+        'katex/dist/contrib/copy-tex.mjs',
+      ),
+      markdownItUri: this.getNodeModulesUri(webview, 'markdown-it/index.mjs'),
+      markdownItKatexUri: this.getNodeModulesUri(
+        webview,
+        '@vscode/markdown-it-katex/dist/index.js',
+      ),
+      highlightJsUri: this.getNodeModulesUri(
+        webview,
+        'highlight.js/es/index.js',
+      ),
+      markdownItHighlightJsUri: this.getNodeModulesUri(
+        webview,
+        'markdown-it-highlightjs/dist/index.js',
+      ),
+      heUri: this.getNodeModulesUri(webview, 'he/he.js'),
+      highlightCssUri: this.getNodeModulesUri(
+        webview,
+        'highlight.js/styles/github-dark.css',
+      ),
+      highlightBaseUri: this.getNodeModulesUri(webview, 'highlight.js/styles'),
 
       // Progress view specific modules
       progressViewStateUri: this.getWebviewUri(

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -5,30 +5,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'nonce-${nonce}' https://esm.sh; font-src ${cspSource} vscode-resource: https://cdn.jsdelivr.net; img-src ${cspSource} data: https:;"
+      content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${cspSource} vscode-resource:; img-src ${cspSource} data: https:;"
     />
     <link rel="stylesheet" href="${commonStyleUri}" />
     <link rel="stylesheet" href="${styleUri}" />
     <link rel="stylesheet" href="${codiconUri}" />
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"
-    />
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/copy-tex.min.css"
-    />
+    <link rel="stylesheet" href="${katexCssUri}" />
     <link
       id="hljs-theme"
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/highlight.js@11.11.1/styles/github-dark.css"
+      href="${highlightCssUri}"
+      data-base="${highlightBaseUri}/"
     />
     <script type="importmap" nonce="${nonce}">
       {
         "imports": {
           "split.js": "${splitJsUri}",
-          "markdown-it": "https://esm.sh/markdown-it@14.1.0",
-          "@vscode/markdown-it-katex": "https://esm.sh/@vscode/markdown-it-katex@1.1.1",
+          "markdown-it": "${markdownItUri}",
+          "@vscode/markdown-it-katex": "${markdownItKatexUri}",
           "./modules/progressViewState.js": "${progressViewStateUri}",
           "./modules/messageHandlers.js": "${messageHandlersUri}",
           "./modules/domHandlers.js": "${domHandlersUri}",
@@ -50,15 +44,13 @@
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
-          "he": "https://esm.sh/he@1.2.0",
-          "highlight.js": "https://esm.sh/highlight.js@11.11.1",
-          "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0"
+          "he": "${heUri}",
+          "highlight.js": "${highlightJsUri}",
+          "markdown-it-highlightjs": "${markdownItHighlightJsUri}"
         }
       }
     </script>
-    <script type="module" nonce="${nonce}">
-      import 'https://esm.sh/katex@0.16.22/dist/contrib/copy-tex';
-    </script>
+    <script type="module" nonce="${nonce}" src="${copyTexUri}"></script>
     <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
   </head>
 

--- a/src/progressView/modules/handlers/themeHandlers.js
+++ b/src/progressView/modules/handlers/themeHandlers.js
@@ -7,10 +7,10 @@ import { COMMON_COMMANDS } from '@common/webview/commands.js';
  * @param {Function} ctx.postHandle Callback after handling a message.
  */
 export function createThemeHandlers({ postHandle } = {}) {
+  const link = document.getElementById('hljs-theme');
+  const base = link?.dataset.base || '';
   const updateHighlightTheme = (theme) => {
-    const link = document.getElementById('hljs-theme');
     if (!link) return;
-    const base = 'https://cdn.jsdelivr.net/npm/highlight.js@11.11.1/styles/';
     link.href = `${base}${theme === 'dark' ? 'github-dark' : 'github'}.css`;
   };
 


### PR DESCRIPTION
## Summary
- include KaTeX/markdown-it/highlight.js packages in VSIX and load them locally
- serve progress view resources from bundled URIs rather than external CDNs
- allow theme handler to switch highlight.js themes from local styles

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c17c92cac83248e8b931493f794ef