### PR TITLE
fix: expose markdown resources in progress view

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -158,6 +158,22 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           'codicons',
           'dist',
         ),
+        vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'katex'),
+        vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'highlight.js'),
+        vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'markdown-it'),
+        vscode.Uri.joinPath(
+          this._extensionUri,
+          'node_modules',
+          'markdown-it-highlightjs',
+        ),
+        vscode.Uri.joinPath(
+          this._extensionUri,
+          'node_modules',
+          '@vscode',
+          'markdown-it-katex',
+          'dist',
+        ),
+        vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'he'),
       ],
     };
 

--- a/src/test/commands/system/mainViewCommands.test.ts
+++ b/src/test/commands/system/mainViewCommands.test.ts
@@ -1,11 +1,14 @@
 import { strict as assert } from 'assert';
 import * as vscode from 'vscode';
-import { registerMainViewCommands, mainViewCommands } from '@commands/system/mainViewCommands';
+import {
+  registerMainViewCommands,
+  mainViewCommands,
+} from '@commands/system/mainViewCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 describe('Main View Commands', () => {
   let context: vscode.ExtensionContext;
-  let registeredCommands: Map<string, Function>;
+  let registeredCommands: Map<string, (...args: unknown[]) => unknown>;
   let warningMessages: string[];
   let executeCommandResults: Map<string, any>;
 
@@ -24,14 +27,20 @@ describe('Main View Commands', () => {
     executeCommandResults = new Map();
 
     // Mock registerCommand
-    (vscode.commands as any).registerCommand = (command: string, callback: Function) => {
+    (vscode.commands as any).registerCommand = (
+      command: string,
+      callback: (...args: unknown[]) => unknown,
+    ) => {
       registeredCommands.set(command, callback);
       const disposable = { dispose: () => {} };
       return disposable;
     };
 
     // Mock executeCommand
-    (vscode.commands as any).executeCommand = async (command: string, ...args: any[]) => {
+    (vscode.commands as any).executeCommand = async (
+      command: string,
+      ...args: any[]
+    ) => {
       if (executeCommandResults.has(command)) {
         const result = executeCommandResults.get(command);
         if (result instanceof Error) {
@@ -67,7 +76,7 @@ describe('Main View Commands', () => {
   });
 
   describe('reset command', () => {
-    let resetHandler: Function;
+    let resetHandler: (...args: unknown[]) => unknown;
     let mockWebviewView: vscode.WebviewView;
     let postMessageCalls: any[];
 
@@ -107,13 +116,16 @@ describe('Main View Commands', () => {
       assert.strictEqual(warningMessages.length, 1);
       assert.strictEqual(
         warningMessages[0],
-        'Main view is not available. Please ensure the TeXRA view is open.'
+        'Main view is not available. Please ensure the TeXRA view is open.',
       );
       assert.strictEqual(postMessageCalls.length, 0);
     });
 
     it('should handle errors gracefully when executeCommand fails', async () => {
-      executeCommandResults.set('texra.getWebviewView', new Error('Command failed'));
+      executeCommandResults.set(
+        'texra.getWebviewView',
+        new Error('Command failed'),
+      );
 
       // The safeExecuteCommand should catch the error and return undefined
       await resetHandler();
@@ -121,7 +133,7 @@ describe('Main View Commands', () => {
       assert.strictEqual(warningMessages.length, 1);
       assert.strictEqual(
         warningMessages[0],
-        'Main view is not available. Please ensure the TeXRA view is open.'
+        'Main view is not available. Please ensure the TeXRA view is open.',
       );
       assert.strictEqual(postMessageCalls.length, 0);
     });


### PR DESCRIPTION
## Summary
- allow ProgressView webview to load markdown rendering dependencies
- use explicit function types in main view commands test to satisfy lint

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a387c90f0c8324a14dd9409e52aab3