### PR TITLE
feat: allow disabling latex formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Show TeXRA task status in the VS Code status bar.
 - Automatically resize large images (> 2000px) before base64 encoding to optimize memory usage and performance
+- Allow disabling LaTeX formatting and silencing missing `latexindent` warnings
 - Added configurable `texra.maxImageDimension` setting to control the maximum image size threshold
 - Add "New" button in main view to reset all fields.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -168,12 +168,14 @@ Control which directories TeXRA ignores:
 Configure LaTeX formatting behavior:
 
 ```json
-"texra.latex.formatter": "latexindent",
+"texra.latex.formatter": "none",
+"texra.latex.showLatexindentWarning": false,
 "texra.latex.latexindentConfig": "/path/to/latexindent.yaml",
 "texra.latex.texfmtConfig": "/path/to/tex-fmt.toml"
 ```
 
-- `formatter`: Choose between `latexindent` and `tex-fmt`.
+- `formatter`: Choose between `latexindent`, `tex-fmt`, or `none` to disable formatting.
+- `showLatexindentWarning`: Set to `false` to suppress missing `latexindent` warnings.
 - `latexindentConfig`: Path to a `latexindent` configuration file.
 - `texfmtConfig`: Path to a `tex-fmt` configuration file.
 

--- a/package.json
+++ b/package.json
@@ -454,25 +454,32 @@
             "type": "string",
             "enum": [
               "latexindent",
-              "tex-fmt"
+              "tex-fmt",
+              "none"
             ],
             "default": "latexindent",
-            "description": "LaTeX formatter to use when formatting files",
+            "description": "LaTeX formatter to use when formatting files ('none' to disable)",
             "order": 1
+          },
+          "texra.latex.showLatexindentWarning": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show warning when latexindent is not installed",
+            "order": 2
           },
           "texra.latex.latexindentConfig": {
             "type": "string",
             "default": "",
             "description": "Path to latexindent configuration file",
             "editPresentation": "singlelineText",
-            "order": 2
+            "order": 3
           },
           "texra.latex.texfmtConfig": {
             "type": "string",
             "default": "",
             "description": "Path to tex-fmt configuration file",
             "editPresentation": "singlelineText",
-            "order": 3
+            "order": 4
           }
         }
       },

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -35,6 +35,10 @@ export async function indentLatexFilesInDirectory(
   );
 
   const formatter = getConfig<string>('latex.formatter', 'latexindent');
+  if (formatter === 'none') {
+    logger.debug(CHANNEL, 'LaTeX formatter disabled; skipping indentation');
+    return 0;
+  }
   const configKey =
     formatter === 'tex-fmt' ? 'latex.texfmtConfig' : 'latex.latexindentConfig';
   const config = getConfig<string>(configKey, '');

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -20,7 +20,11 @@ logger.initialize(CHANNEL);
 export async function runLatexIndent(filePath: string): Promise<boolean> {
   try {
     // Check if latexindent is installed
-    if (!(await checkToolInstalled('latexindent'))) {
+    const showWarning = getConfig<boolean>(
+      'latex.showLatexindentWarning',
+      true,
+    );
+    if (!(await checkToolInstalled('latexindent', showWarning))) {
       return false;
     }
 

--- a/src/latex/texFormatter.ts
+++ b/src/latex/texFormatter.ts
@@ -7,6 +7,9 @@ import { getConfig } from '@utils/config';
 
 export async function runLatexFormatter(filePath: string): Promise<boolean> {
   const formatter = getConfig<string>('latex.formatter', 'latexindent');
+  if (formatter === 'none') {
+    return true;
+  }
   if (formatter === 'tex-fmt') {
     return runTexFmt(filePath);
   }


### PR DESCRIPTION
## Summary
- allow disabling LaTeX formatting and silencing missing latexindent warnings
- document optional formatter and warning suppression settings

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a409f041008324897a5d6f53a2c95a