### PR TITLE
fix: recover TeX from named document tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Stabilize status bar command registration and task cancellation handling.
 - Detect MSYS2 Perl directories on Windows so `latexdiff` can find `perl`.
 - Prevent first task from being marked as error when progress view loads.
+- Recover TeX from named `document` tags when standard extraction fails.
 
 ### Improvements
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -66,6 +66,19 @@ export class XmlOutputManager {
         );
         return markdownFallback;
       }
+      const documents = xmlUtils.extractMultipleTextFromTag(outputContent);
+      if (documents && documents.length > 0) {
+        const filename = path.basename(this.agentConfig.inputFile);
+        const match = documents.find((doc) => doc.name === filename);
+        if (match && match.content) {
+          this.logger.info(
+            `Recovered ${documentTag} from named document tag`,
+            undefined,
+            MESSAGE_TYPES.INTERNAL,
+          );
+          return match.content;
+        }
+      }
       this.logger.debug(
         `No ${documentTag} found in output file using fallback method`,
         undefined,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -70,4 +70,26 @@ describe('XmlOutputManager markdown fallback', () => {
     await WorkspaceFS.delete(outputXml);
     await WorkspaceFS.delete(texPath);
   });
+
+  it('writes tex file from named document tag', async () => {
+    const logger = new AgentLogger('TestXmlOutput');
+    const manager = new XmlOutputManager(setting, config, logger);
+    const outputXml = 'named_document.xml';
+    const xmlContent =
+      '<document name="input.tex"><![CDATA[\\begin{document}\nhello\n\\end{document}]]></document>';
+
+    await WorkspaceFS.writeFile(outputXml, xmlContent);
+
+    const texPath = await manager.splitScratchpadOutputXml(
+      outputXml,
+      setting.documentTag,
+    );
+
+    const written = await WorkspaceFS.readFile('named_document.tex');
+    assert.ok(written.includes('hello'));
+    assert.ok(!written.includes('CDATA'));
+
+    await WorkspaceFS.delete(outputXml);
+    await WorkspaceFS.delete(texPath);
+  });
 });


### PR DESCRIPTION
## Summary
- extend XML fallback to locate `<document>` elements by input filename
- test named `<document>` extraction and CDATA stripping
- note fallback in changelog

## Testing
- `npm run lint`
- `CI=1 npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a40d826a188324b2f35e42d572459b