### PR TITLE
feat: add named document fallback for xml extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Automatically resize large images (> 2000px) before base64 encoding to optimize memory usage and performance
 - Added configurable `texra.maxImageDimension` setting to control the maximum image size threshold
 - Add "New" button in main view to reset all fields.
+- Recover single-output files from `<document name="…">` tags when other fallbacks fail.
 
 ### Bug Fixes
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -66,6 +66,19 @@ export class XmlOutputManager {
         );
         return markdownFallback;
       }
+      const byName = xmlUtils.extractNamedTextFromTag(
+        outputContent,
+        documentTag,
+        path.basename(this.agentConfig.inputFile),
+      );
+      if (byName) {
+        this.logger.info(
+          `Recovered ${documentTag} from named document tag`,
+          undefined,
+          MESSAGE_TYPES.INTERNAL,
+        );
+        return byName;
+      }
       this.logger.debug(
         `No ${documentTag} found in output file using fallback method`,
         undefined,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -7,49 +7,49 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { WorkspaceFS } from '@utils/files';
 import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 
+const setting: AgentSetting = {
+  agentType: AgentType.CoT,
+  documentTag: 'latex_document',
+  temperature: 0,
+  isRewrite: true,
+  rounds: 1,
+  prefills: [],
+  outputExt: 'tex',
+  endTag: '</latex_document>',
+  requiredFiles: {},
+  requiredFilesInternal: {},
+  defaultOutputFiles: [],
+  filePatternsContain: [],
+  tools: [],
+};
+
+const config: AgentConfig = {
+  model: 'test',
+  agent: 'a',
+  instruction: '',
+  inputFile: 'input.tex',
+  inputFiles: null,
+  referenceFile: null,
+  referenceFiles: null,
+  auxiliaryFile: null,
+  auxiliaryFiles: null,
+  mediaFile: null,
+  mediaFiles: null,
+  outputFiles: null,
+  editedFile: null,
+  toolConfig: {
+    reflect: false,
+    usePrefillFromInput: false,
+    autoExtractFigure: false,
+    autoExtractTikzFigure: false,
+    attachTeXCount: false,
+    attachDiagnostics: false,
+    printInputPrompt: false,
+    autoCompileInputPdf: false,
+  },
+};
+
 describe('XmlOutputManager markdown fallback', () => {
-  const setting: AgentSetting = {
-    agentType: AgentType.CoT,
-    documentTag: 'latex_document',
-    temperature: 0,
-    isRewrite: true,
-    rounds: 1,
-    prefills: [],
-    outputExt: 'tex',
-    endTag: '</latex_document>',
-    requiredFiles: {},
-    requiredFilesInternal: {},
-    defaultOutputFiles: [],
-    filePatternsContain: [],
-    tools: [],
-  };
-
-  const config: AgentConfig = {
-    model: 'test',
-    agent: 'a',
-    instruction: '',
-    inputFile: 'input.tex',
-    inputFiles: null,
-    referenceFile: null,
-    referenceFiles: null,
-    auxiliaryFile: null,
-    auxiliaryFiles: null,
-    mediaFile: null,
-    mediaFiles: null,
-    outputFiles: null,
-    editedFile: null,
-    toolConfig: {
-      reflect: false,
-      usePrefillFromInput: false,
-      autoExtractFigure: false,
-      autoExtractTikzFigure: false,
-      attachTeXCount: false,
-      attachDiagnostics: false,
-      printInputPrompt: false,
-      autoCompileInputPdf: false,
-    },
-  };
-
   it('writes tex file from markdown fenced latex block', async () => {
     const logger = new AgentLogger('TestXmlOutput');
     const manager = new XmlOutputManager(setting, config, logger);
@@ -65,6 +65,29 @@ describe('XmlOutputManager markdown fallback', () => {
     );
 
     const written = await WorkspaceFS.readFile('markdown_only.tex');
+    assert.ok(written.includes('hello'));
+
+    await WorkspaceFS.delete(outputXml);
+    await WorkspaceFS.delete(texPath);
+  });
+});
+
+describe('XmlOutputManager named-document fallback', () => {
+  it('writes tex file when latex_document uses name attribute', async () => {
+    const logger = new AgentLogger('TestXmlOutput');
+    const manager = new XmlOutputManager(setting, config, logger);
+    const outputXml = 'named_document.xml';
+    const namedContent =
+      '<latex_document name="input.tex"><![CDATA[\\begin{document}\nhello\n\\end{document}]]></latex_document>';
+
+    await WorkspaceFS.writeFile(outputXml, namedContent);
+
+    const texPath = await manager.splitScratchpadOutputXml(
+      outputXml,
+      setting.documentTag,
+    );
+
+    const written = await WorkspaceFS.readFile('named_document.tex');
     assert.ok(written.includes('hello'));
 
     await WorkspaceFS.delete(outputXml);

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -169,6 +169,26 @@ export function extractLatexFromMarkdown(content: string): string | null {
 }
 
 /**
+ * Extract content from a tag with a specific name attribute
+ */
+export function extractNamedTextFromTag(
+  inputContent: string,
+  documentTag: string,
+  name: string,
+): string | null {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(
+    `<${documentTag}\\b[^>]*\\bname="${escapedName}"[^>]*>([\\s\\S]*?)<\\/${documentTag}>`,
+  );
+  const match = regex.exec(inputContent);
+  if (!match) {
+    return null;
+  }
+  const content = match[1].replace(/<!\\[CDATA\\[(.*?)\\]\\]>/gs, '$1');
+  return content;
+}
+
+/**
  * Extract multiple document elements from an XML container tag
  * Used as a fallback for extracting documents when XML parsing fails
  */
@@ -413,6 +433,7 @@ export const xmlUtils = {
   addCdataToTagsMultiple,
   extractTextFromTag,
   extractLatexFromMarkdown,
+  extractNamedTextFromTag,
   extractMultipleTextFromTag,
   filterTagsFromText,
   extractContentFromXMLbyTag,


### PR DESCRIPTION
## Summary
- add utility to capture `<document name="…">` sections
- fallback to named document tags when parsing single XML outputs
- test extraction of named document content

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a40a3e2df483249fa20f4d28dc8b95