### PR TITLE
feat: route helpers through proxy-aware clients

### DIFF
--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -10,7 +10,6 @@ import { execa, type Subprocess } from 'execa';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utils
-import { SecretManager } from '@frontend/secretManager';
 import { AbsoluteFS, StorageFS } from '@utils/files';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { getConfig } from '@utils/config/configUtils';
@@ -19,6 +18,12 @@ import {
   extendEnvPath,
   findToolInCommonPaths,
 } from '@utils/system/platformPaths';
+
+// Local imports - agent handlers
+import { ModelHandlerOpenAI } from '@agent/modelHandlers/modelHandlerOpenAI';
+
+// Local imports - model configs
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
 
 const CHANNEL = 'AudioUtils';
 logger.initialize(CHANNEL);
@@ -185,9 +190,9 @@ export async function stopRecordingAndTranscribe(
       };
     }
 
-    // Transcribe the audio
-    const apiKey = await SecretManager.getApiKey('openai');
-    const client = new OpenAI({ apiKey });
+    // Transcribe the audio using model handler for proxy support
+    const handler = new ModelHandlerOpenAI(MODEL_CONFIGS['gpt4o']);
+    const client = await handler.getClient();
     const result = await client.audio.transcriptions.create({
       file: AbsoluteFS.createReadStream(recordingPath),
       model: 'gpt-4o-transcribe',

--- a/src/latex/textConnection.ts
+++ b/src/latex/textConnection.ts
@@ -7,7 +7,13 @@ import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
-import { SecretManager, ApiProvider } from '@frontend/secretManager';
+
+// Local imports - agent handlers
+import { ModelHandlerOpenAI } from '@agent/modelHandlers/modelHandlerOpenAI';
+import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+
+// Local imports - model configs
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -88,22 +94,6 @@ function processMajorityChoice(choices: string[]): ConnectionResult {
 }
 
 /**
- * Gets API key from VS Code settings
- */
-
-// it should also be possible to fallback to openrouter for this maybe
-// Use Vercel ai sdk for this for convenience?
-async function getApiKey(provider: 'openai' | 'anthropic'): Promise<string> {
-  try {
-    return await SecretManager.getApiKey(provider as ApiProvider);
-  } catch (err) {
-    throw new Error(
-      `Missing API key from ${provider.toUpperCase()}. Please set it using the "Set API Key" command.`,
-    );
-  }
-}
-
-/**
  * Determines the best way to connect two strings in a LaTeX context using GPT-4
  */
 export async function bestConnectionMethod(
@@ -113,9 +103,12 @@ export async function bestConnectionMethod(
   n: number = 10,
 ): Promise<ConnectionResult> {
   try {
-    const apiKey = openaiApiKey || (await getApiKey('openai'));
     const { prompt } = preparePrompt(str1, str2);
-    const client = new OpenAI({ apiKey });
+    const handler = new ModelHandlerOpenAI(MODEL_CONFIGS['gpt41']);
+    const baseURL = handler.getBaseUrl() || undefined;
+    const client = openaiApiKey
+      ? new OpenAI({ apiKey: openaiApiKey, baseURL })
+      : await handler.getClient();
 
     const completion = await client.chat.completions.create({
       model: 'gpt-4.1', //'gpt-4-turbo',
@@ -161,9 +154,12 @@ export async function bestConnectionMethodAnthropic(
   n: number = 10,
 ): Promise<ConnectionResult> {
   try {
-    const apiKey = anthropicApiKey || (await getApiKey('anthropic'));
     const { prompt } = preparePrompt(str1, str2);
-    const client = new Anthropic({ apiKey });
+    const handler = new ModelHandlerAnthropic(MODEL_CONFIGS['sonnet37']);
+    const baseURL = handler.getBaseUrl() || undefined;
+    const client = anthropicApiKey
+      ? new Anthropic({ apiKey: anthropicApiKey, baseURL })
+      : await handler.getClient();
 
     // Make multiple API calls since Anthropic doesn't support n parameter
     const choices = await Promise.all(

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -13,9 +13,14 @@ import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { SecretManager } from '@frontend/secretManager';
 import xmlUtils from './xmlUtils';
 import { getConfig } from '../config';
+
+// Local imports - agent handlers
+import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+
+// Local imports - model configs
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
 
 const CHANNEL = 'TextEnhancement';
 
@@ -63,18 +68,6 @@ export async function polishTextWithAI(
 ): Promise<{ success: boolean; text: string; error?: string }> {
   try {
     const useCopilot = getConfig<boolean>('model.useCopilot', false);
-
-    // Get the API key from secrets when not using Copilot
-    const apiKey = useCopilot
-      ? undefined
-      : await SecretManager.getApiKey('anthropic');
-    if (!useCopilot && !apiKey) {
-      return {
-        success: false,
-        text: text,
-        error: 'No Anthropic API key found. Please set your API key first.',
-      };
-    }
 
     // Build file context string if available
     let fileContextString = '';
@@ -167,8 +160,18 @@ ${text}`;
         responseText += chunk;
       }
     } else {
-      // Use the Anthropic SDK
-      const anthropic = new Anthropic({ apiKey: apiKey! });
+      // Use the Anthropic SDK via model handler for proxy support
+      let anthropic: Anthropic;
+      try {
+        const handler = new ModelHandlerAnthropic(MODEL_CONFIGS['sonnet37']);
+        anthropic = await handler.getClient();
+      } catch {
+        return {
+          success: false,
+          text,
+          error: 'No Anthropic API key found. Please set your API key first.',
+        };
+      }
       const params: MessageCreateParams = {
         model: 'claude-3-7-sonnet-20250219',
         messages: [{ role: 'user', content: prompt }],


### PR DESCRIPTION
## Summary
- use proxy-aware OpenAI client in `bestConnectionMethod`
- enable proxy routing for `bestConnectionMethodAnthropic` and `polishTextWithAI`
- send audio transcription through proxy-aware OpenAI client

## Testing
- `npm run format`
- `npm run lint`
- `CI=1 npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a42639cb00832491030a117298bafe