### PR TITLE
feat: add open folder option after packing

### DIFF
--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -25,9 +25,20 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {
     case 'success':
       if (result.outputFolder) {
-        vscode.window.showInformationMessage(
-          `Files packed into ${result.outputFolder}`,
-        );
+        const openFolder = 'Open Folder';
+        vscode.window
+          .showInformationMessage(
+            `Files packed into ${result.outputFolder}`,
+            openFolder,
+          )
+          .then((selection) => {
+            if (selection === openFolder) {
+              void vscode.commands.executeCommand(
+                'revealFileInOS',
+                vscode.Uri.file(result.outputFolder!),
+              );
+            }
+          });
       }
       break;
     case 'noFiles':


### PR DESCRIPTION
## Summary
- allow opening packed output folder directly from success message

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: process hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a42fe8000483249df3dcf3b9e2bb4b