### PR TITLE
fix: respect existing LaTeX Workshop config

### DIFF
--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -215,7 +215,7 @@ TeXRA automatically detects appropriate input files based on:
 
 ### LaTeX Workshop Integration
 
-If you use the popular [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) extension, TeXRA attempts to automatically configure some settings upon its first activation to ensure smoother integration and cleaner project structures:
+If you use the popular [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) extension, TeXRA attempts to automatically configure some settings upon its first activation to ensure smoother integration and cleaner project structures. These defaults are applied only if the corresponding settings are not already defined:
 
 - **Output Directory**: Sets `latex-workshop.latex.outDir` to `%DIR%/build/`. This directs LaTeX compilation output (like `.aux`, `.log`, `.pdf` files) into a `build` subdirectory within your project, keeping your main directory tidy.
 

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -137,38 +137,33 @@ export async function configureLatexSettings() {
       ]);
 
       // Configure LaTeX formatting
-      await config.update(
+      await updateIfUnset<string>(
         'latex-workshop.formatting.latex',
         'latexindent',
-        vscode.ConfigurationTarget.Global,
       );
 
       // Configure word wrap for LaTeX files
-      await config.update(
+      await updateIfUnset(
         '[latex]',
         { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' },
-        vscode.ConfigurationTarget.Global,
       );
 
       // Also add word wrap for yaml files
-      await config.update(
+      await updateIfUnset(
         '[yaml]',
         { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' },
-        vscode.ConfigurationTarget.Global,
       );
 
       // Configure explorer settings to not automatically reveal build directory
-      await config.update(
+      await updateIfUnset(
         'explorer.autoRevealExclude',
         { 'build/': true },
-        vscode.ConfigurationTarget.Global,
       );
 
       // Disable automatic revealing of files in explorer
-      await config.update(
+      await updateIfUnset(
         'explorer.autoReveal',
         false,
-        vscode.ConfigurationTarget.Global,
       );
 
       const isWindsurf = vscode.env.appName?.toLowerCase().includes('windsurf');
@@ -176,17 +171,9 @@ export async function configureLatexSettings() {
       if (!isWindsurf) {
         const activityBarKey = 'workbench.activityBar.location';
 
-        // Check if the activity bar location setting exists
-        const activityBarSetting = config.inspect(activityBarKey);
-        if (activityBarSetting) {
-          // Setting exists, update it
-          await config.update(
-            activityBarKey,
-            'default',
-            vscode.ConfigurationTarget.Global,
-          );
-          logger.info('extension', 'Activity bar location set to default');
-        }
+        // Update activity bar location only if unset
+        await updateIfUnset(activityBarKey, 'default');
+        logger.info('extension', 'Activity bar location set to default');
       }
 
       logger.info(

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -102,32 +102,39 @@ export async function configureLatexSettings() {
       );
       const config = vscode.workspace.getConfiguration();
 
+      // Helper to update LaTeX Workshop settings only when unset
+      const updateIfUnset = async <T>(key: string, value: T) => {
+        const setting = config.inspect<T>(key);
+        if (
+          setting &&
+          setting.globalValue === undefined &&
+          setting.workspaceValue === undefined &&
+          setting.workspaceFolderValue === undefined
+        ) {
+          await config.update(key, value, vscode.ConfigurationTarget.Global);
+        }
+      };
+
       // Update LaTeX Workshop build settings
-      await config.update(
+      await updateIfUnset<string[]>(
         'latex-workshop.latex.external.build.args',
         ['--output-directory=build', '-f', '-pdf'],
-        vscode.ConfigurationTarget.Global,
       );
 
-      await config.update(
+      await updateIfUnset<string>(
         'latex-workshop.latex.outDir',
         '%DIR%/build/',
-        vscode.ConfigurationTarget.Global,
       );
 
       // Add nonstopmode magic arguments for LaTeX Workshop
-      await config.update(
-        'latex-workshop.latex.magic.args',
-        [
-          '-synctex=1',
-          '-interaction=nonstopmode',
-          '-file-line-error',
-          '%DOC%',
-          '-pdf',
-          '-f',
-        ],
-        vscode.ConfigurationTarget.Global,
-      );
+      await updateIfUnset<string[]>('latex-workshop.latex.magic.args', [
+        '-synctex=1',
+        '-interaction=nonstopmode',
+        '-file-line-error',
+        '%DOC%',
+        '-pdf',
+        '-f',
+      ]);
 
       // Configure LaTeX formatting
       await config.update(


### PR DESCRIPTION
## Summary
- avoid overriding `latex-workshop.latex` settings if user already configured them
- document that LaTeX Workshop defaults apply only when unset

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a43c76b8f08324b9b8942a3b21b3ea