### PR TITLE
fix: preserve usage and finish reason in streaming handlers

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -321,13 +321,18 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         const stream = await chat.sendMessageStream(streamParams);
 
         const fullParts: Part[] = [];
+        let lastCandidate: any;
+        let finalUsage: GenerateContentResponseUsageMetadata | undefined;
         const finalResponse = new GenerateContentResponse();
         for await (const chunk of stream) {
-          if (chunk.candidates?.[0]?.content?.parts) {
-            fullParts.push(...chunk.candidates[0].content.parts);
+          if (chunk.candidates?.[0]) {
+            lastCandidate = chunk.candidates[0];
+            if (chunk.candidates[0].content?.parts) {
+              fullParts.push(...chunk.candidates[0].content.parts);
+            }
           }
           if (chunk.usageMetadata) {
-            finalResponse.usageMetadata = chunk.usageMetadata;
+            finalUsage = chunk.usageMetadata;
           }
           if (chunk.responseId) finalResponse.responseId = chunk.responseId;
           if (chunk.createTime) finalResponse.createTime = chunk.createTime;
@@ -342,10 +347,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           throw new Error('Stream yielded no chunks');
         }
 
+        finalResponse.usageMetadata = finalUsage;
         finalResponse.candidates = [
           {
             content: { role: 'model', parts: fullParts },
-            finishReason: FinishReason.STOP, // there is no good choice, could be length, but let us just put this.
+            finishReason:
+              lastCandidate?.finishReason ??
+              FinishReason.FINISH_REASON_UNSPECIFIED,
+            finishMessage: lastCandidate?.finishMessage,
+            safetyRatings: lastCandidate?.safetyRatings,
           },
         ];
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -156,44 +156,34 @@ export class ModelHandlerOpenAI extends ModelHandler<
         });
 
         if (this.config.fullName.includes('deepseek')) {
-          // This wait for finalMessage method do not support deepseek models, so we need to aggreatate the results manually like this:
-          let reasoning_content = '';
-          let content = '';
+          // DeepSeek models do not support the wait for final message helper, so aggregate chunks manually
+          let fullContent = '';
+          let reasoning = '';
+          let lastChunk: any;
           for await (const chunk of stream) {
-            if ((chunk.choices[0].delta as any).reasoning_content) {
-              reasoning_content += (chunk.choices[0].delta as any)
-                .reasoning_content;
-            } else {
-              content += (chunk.choices[0].delta as any).content;
-            }
+            lastChunk = chunk;
+            fullContent += chunk.choices[0]?.delta?.content ?? '';
+            reasoning +=
+              (chunk.choices[0]?.delta as any)?.reasoning_content ?? '';
           }
-          response = {
-            role: 'assistant',
-            // there is no good choice it seems unless deepseek models support it
-            finish_reason: OPENAI_CHAT_FINISH.STOP,
-            // In the future maybe we can count the output tokens to see if it is at the limit approximatelly..
+          return {
+            id: lastChunk?.id,
+            object: 'chat.completion',
+            created: lastChunk?.created,
+            model: lastChunk?.model,
+            system_fingerprint: lastChunk?.system_fingerprint,
+            usage: lastChunk?.usage,
             choices: [
               {
+                index: 0,
                 message: {
-                  content: content,
-                  reasoning_content: reasoning_content,
+                  content: fullContent,
+                  reasoning_content: reasoning,
                 },
-                finish_reason: OPENAI_CHAT_FINISH.STOP,
+                finish_reason: lastChunk?.choices?.[0]?.finish_reason,
               },
             ],
           };
-          const tokenCount = countTokens(content + reasoning_content);
-          this.logger.debug(
-            `Token count output of deepseek model: ${tokenCount}`,
-          );
-
-          if (Math.abs(tokenCount - this.config.maxOutputTokens) < 1000) {
-            this.logger.warn(
-              `Token count output of deepseek model is close to the max output tokens: ${tokenCount} - ${this.config.maxOutputTokens}. Setting finish_reason to length`,
-            );
-            response.finish_reason = OPENAI_CHAT_FINISH.LENGTH;
-          }
-          return response;
         }
 
         response = await stream.finalChatCompletion();

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -180,7 +180,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
                   content: fullContent,
                   reasoning_content: reasoning,
                 },
-                finish_reason: lastChunk?.choices?.[0]?.finish_reason,
+                finish_reason: lastChunk?.choices?.[0]?.finish_reason ?? OPENAI_CHAT_FINISH.STOP,
               },
             ],
           };


### PR DESCRIPTION
## Summary
- capture final usage and finish reason for DeepSeek streaming responses
- retain final candidate info and usage metadata for Google GenAI streams

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack build hangs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a44224a9d483248fad379b37a80d3a