### PR TITLE
fix: aggregate DeepSeek streaming responses

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -156,44 +156,35 @@ export class ModelHandlerOpenAI extends ModelHandler<
         });
 
         if (this.config.fullName.includes('deepseek')) {
-          // This wait for finalMessage method do not support deepseek models, so we need to aggreatate the results manually like this:
-          let reasoning_content = '';
-          let content = '';
+          // Aggregate stream chunks manually for DeepSeek models
+          let fullContent = '';
+          let reasoning = '';
+          let lastChunk: any;
           for await (const chunk of stream) {
-            if ((chunk.choices[0].delta as any).reasoning_content) {
-              reasoning_content += (chunk.choices[0].delta as any)
-                .reasoning_content;
-            } else {
-              content += (chunk.choices[0].delta as any).content;
-            }
+            lastChunk = chunk;
+            fullContent += (chunk.choices[0]?.delta as any)?.content ?? '';
+            reasoning +=
+              (chunk.choices[0]?.delta as any)?.reasoning_content ?? '';
           }
-          response = {
-            role: 'assistant',
-            // there is no good choice it seems unless deepseek models support it
-            finish_reason: OPENAI_CHAT_FINISH.STOP,
-            // In the future maybe we can count the output tokens to see if it is at the limit approximatelly..
+          return {
+            id: lastChunk?.id,
+            object: 'chat.completion',
+            created: lastChunk?.created,
+            model: lastChunk?.model,
+            system_fingerprint: lastChunk?.system_fingerprint,
+            usage: lastChunk?.usage,
             choices: [
               {
+                index: 0,
                 message: {
-                  content: content,
-                  reasoning_content: reasoning_content,
+                  content: fullContent,
+                  reasoning_content: reasoning,
                 },
-                finish_reason: OPENAI_CHAT_FINISH.STOP,
+                finish_reason: lastChunk?.choices?.[0]?.finish_reason,
+                stop_reason: (lastChunk?.choices?.[0] as any)?.stop_reason,
               },
             ],
           };
-          const tokenCount = countTokens(content + reasoning_content);
-          this.logger.debug(
-            `Token count output of deepseek model: ${tokenCount}`,
-          );
-
-          if (Math.abs(tokenCount - this.config.maxOutputTokens) < 1000) {
-            this.logger.warn(
-              `Token count output of deepseek model is close to the max output tokens: ${tokenCount} - ${this.config.maxOutputTokens}. Setting finish_reason to length`,
-            );
-            response.finish_reason = OPENAI_CHAT_FINISH.LENGTH;
-          }
-          return response;
         }
 
         response = await stream.finalChatCompletion();
@@ -456,12 +447,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
         // Since we don't have a stop reason in this format, assume stop
         let stopReason = OPENAI_CHAT_FINISH.STOP;
         // let stopReason = OPENAI_CHAT_FINISH.LENGTH;
-        if (responseObject.finish_reason) {
-          stopReason = responseObject.finish_reason;
+        if (responseObject.choices?.[0]?.finish_reason) {
+          stopReason = responseObject.choices[0].finish_reason;
         }
-        // if (responseObject.choices[0].finish_reason) {
-        //   stopReason = responseObject.choices[0].finish_reason;
-        // }
 
         // For usage, we'll use empty values since they're not provided; TODO needs to test at some points
         const usage = responseObject.usage || {


### PR DESCRIPTION
## Summary
- aggregate DeepSeek stream chunks and return metadata from final chunk
- drop manual finish_reason heuristics and token counting
- read finish reasons from `choices[0].finish_reason` when parsing responses

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4482c78308324aaf7db7a5159f8da