### PR TITLE
feat: collect math macros from LaTeX sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Parse LaTeX source and aux files to collect math macros for latexdiff.
+
 ## [0.33.0] - 2025-08-18
 
 ### Features

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -19,6 +19,8 @@ export { getTeXCountStats } from './texcount';
 
 // Export latexdiff service
 export { LaTeXdiffService } from './latexdiff';
+// Export latexdiff helpers
+export { collectMathMacros } from './latexdiff/mathMacroDetector';
 
 export { ArxivSourceProcessor, arxivProcessor } from './arxivProcessor';
 

--- a/src/latex/latexdiff/mathMacroDetector.ts
+++ b/src/latex/latexdiff/mathMacroDetector.ts
@@ -1,0 +1,87 @@
+// Standard library imports
+
+// Local imports - utilities
+import { WorkspaceFS } from '@utils/files';
+
+/**
+ * Collects user-defined macros that are used inside math mode.
+ *
+ * The function scans the provided LaTeX source file for math segments
+ * (inline `$...$`, `\(...\)`, `\[...\]`, and common math environments)
+ * and gathers macro names that both appear in these segments and are
+ * defined via `\newcommand`, `\renewcommand`, `\providecommand`, `\def`,
+ * or `\DeclareMathOperator`. Definitions can be located in the main
+ * `.tex` file or the accompanying `.aux` file.
+ *
+ * The returned list is sorted and de-duplicated.
+ */
+export async function collectMathMacros(
+  texPath: string,
+  auxPath?: string,
+): Promise<string[]> {
+  const definedMacros = new Set<string>();
+
+  const addDefinitions = (content: string): void => {
+    const defPatterns = [
+      /\\(?:newcommand|renewcommand|providecommand)\s*{\\([A-Za-z@]+)}/g,
+      /\\def\\([A-Za-z@]+)\b/g,
+      /\\DeclareMathOperator\s*{\\([A-Za-z@]+)}/g,
+    ];
+    for (const pattern of defPatterns) {
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(content)) !== null) {
+        definedMacros.add(match[1]);
+      }
+    }
+  };
+
+  const texContent = await WorkspaceFS.readFile(texPath);
+  addDefinitions(texContent);
+
+  if (auxPath && (await WorkspaceFS.exists(auxPath))) {
+    const auxContent = await WorkspaceFS.readFile(auxPath);
+    addDefinitions(auxContent);
+  }
+
+  const mathSegments: string[] = [];
+  const inlinePatterns = [
+    /\$(?:[^$\\]|\\.)*?\$/gs,
+    /\\\((?:[^\\]|\\.)*?\\\)/gs,
+    /\\\[(?:[^\\]|\\.)*?\\\]/gs,
+  ];
+  for (const pattern of inlinePatterns) {
+    mathSegments.push(...(texContent.match(pattern) ?? []));
+  }
+
+  const envNames = [
+    'equation',
+    'align',
+    'align\*',
+    'gather',
+    'multline',
+    'flalign',
+    'alignat',
+  ];
+  const envRegex = new RegExp(
+    `\\\begin\\{(${envNames.join('|')})\\}([\\s\\S]*?)\\\end\\{\\1\\}`,
+    'g',
+  );
+  let envMatch: RegExpExecArray | null;
+  while ((envMatch = envRegex.exec(texContent)) !== null) {
+    mathSegments.push(envMatch[2]);
+  }
+
+  const usedMacros = new Set<string>();
+  const macroRegex = /\\([A-Za-z@]+)/g;
+  for (const segment of mathSegments) {
+    let match: RegExpExecArray | null;
+    while ((match = macroRegex.exec(segment)) !== null) {
+      const name = match[1];
+      if (definedMacros.has(name)) {
+        usedMacros.add(name);
+      }
+    }
+  }
+
+  return Array.from(usedMacros).sort();
+}


### PR DESCRIPTION
## Summary
- add utility to collect user-defined math macros from LaTeX and aux files
- export `collectMathMacros` and document feature in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a44bdb637c83249533cb1b00e63614