### PR TITLE
feat: recover latex between documentclass markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Allow disabling LaTeX formatting and silencing missing `latexindent` warnings
 - Added configurable `texra.maxImageDimension` setting to control the maximum image size threshold
 - Add "New" button in main view to reset all fields.
+- Recover LaTeX from plain output between `\documentclass` and `\end{document}` when other markers are missing.
 
 ### Bug Fixes
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -79,6 +79,16 @@ export class XmlOutputManager {
           return match.content;
         }
       }
+      const latexFallback =
+        xmlUtils.extractLatexBetweenDocumentClass(outputContent);
+      if (latexFallback) {
+        this.logger.info(
+          `Recovered ${documentTag} from \\documentclass block`,
+          undefined,
+          MESSAGE_TYPES.INTERNAL,
+        );
+        return latexFallback;
+      }
       this.logger.debug(
         `No ${documentTag} found in output file using fallback method`,
         undefined,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -92,4 +92,27 @@ describe('XmlOutputManager markdown fallback', () => {
     await WorkspaceFS.delete(outputXml);
     await WorkspaceFS.delete(texPath);
   });
+
+  it('writes tex file from plain LaTeX document block', async () => {
+    const logger = new AgentLogger('TestXmlOutput');
+    const manager = new XmlOutputManager(setting, config, logger);
+    const outputXml = 'plain_latex.xml';
+    const content =
+      'some explanation\n\\documentclass{article}\n\\begin{document}\nhello\n\\end{document}\nmore text';
+
+    await WorkspaceFS.writeFile(outputXml, content);
+
+    const texPath = await manager.splitScratchpadOutputXml(
+      outputXml,
+      setting.documentTag,
+    );
+
+    const written = await WorkspaceFS.readFile('plain_latex.tex');
+    assert.ok(written.includes('\\documentclass'));
+    assert.ok(written.includes('\\end{document}'));
+    assert.ok(!written.includes('some explanation'));
+
+    await WorkspaceFS.delete(outputXml);
+    await WorkspaceFS.delete(texPath);
+  });
 });

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -169,6 +169,19 @@ export function extractLatexFromMarkdown(content: string): string | null {
 }
 
 /**
+ * Extract LaTeX document starting at \documentclass and ending at \end{document}
+ */
+export function extractLatexBetweenDocumentClass(
+  content: string,
+): string | null {
+  const match = content.match(/\\documentclass[\s\S]*?\\end{document}/);
+  if (!match) {
+    return null;
+  }
+  return match[0].replace(/<!\[CDATA\[(.*?)\]\]>/gs, '$1');
+}
+
+/**
  * Extract multiple document elements from an XML container tag
  * Used as a fallback for extracting documents when XML parsing fails
  */
@@ -413,6 +426,7 @@ export const xmlUtils = {
   addCdataToTagsMultiple,
   extractTextFromTag,
   extractLatexFromMarkdown,
+  extractLatexBetweenDocumentClass,
   extractMultipleTextFromTag,
   filterTagsFromText,
   extractContentFromXMLbyTag,


### PR DESCRIPTION
## Summary
- add regex utility to grab LaTeX from `\documentclass` to `\end{document}`
- use new fallback when extracting documents from agent output
- test LaTeX-only output and update changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a44d0ff5b48324890bf9ed0d9fe9da