### PR TITLE
feat: prompt LaTeX Workshop installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Allow disabling LaTeX formatting and silencing missing `latexindent` warnings
 - Added configurable `texra.maxImageDimension` setting to control the maximum image size threshold
 - Add "New" button in main view to reset all fields.
+- Prompt to install LaTeX Workshop when the extension is missing.
 
 ### Bug Fixes
 

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -18,6 +18,7 @@ export enum WorkspaceStateKey {
 
 export enum GlobalStateKey {
   LAST_KNOWN_VERSION = 'lastKnownVersion',
+  LATEX_WORKSHOP_PROMPTED = 'latexWorkshopPrompted',
 }
 
 // Prefix used for per-instruction suppression flags

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -143,28 +143,22 @@ export async function configureLatexSettings() {
       );
 
       // Configure word wrap for LaTeX files
-      await updateIfUnset(
-        '[latex]',
-        { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' },
-      );
+      await updateIfUnset('[latex]', {
+        'editor.wordWrap': 'on',
+        'files.autoSave': 'afterDelay',
+      });
 
       // Also add word wrap for yaml files
-      await updateIfUnset(
-        '[yaml]',
-        { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' },
-      );
+      await updateIfUnset('[yaml]', {
+        'editor.wordWrap': 'on',
+        'files.autoSave': 'afterDelay',
+      });
 
       // Configure explorer settings to not automatically reveal build directory
-      await updateIfUnset(
-        'explorer.autoRevealExclude',
-        { 'build/': true },
-      );
+      await updateIfUnset('explorer.autoRevealExclude', { 'build/': true });
 
       // Disable automatic revealing of files in explorer
-      await updateIfUnset(
-        'explorer.autoReveal',
-        false,
-      );
+      await updateIfUnset('explorer.autoReveal', false);
 
       const isWindsurf = vscode.env.appName?.toLowerCase().includes('windsurf');
 
@@ -185,6 +179,24 @@ export async function configureLatexSettings() {
         'extension',
         'LaTeX Workshop extension not found, skipping configuration',
       );
+      const prompted = globalSM.get<boolean>(
+        GlobalStateKey.LATEX_WORKSHOP_PROMPTED,
+      );
+      if (!prompted) {
+        const install = 'Install';
+        const choice = await vscode.window.showInformationMessage(
+          'LaTeX Workshop is recommended for LaTeX compilation and preview. Install now?',
+          install,
+          'Dismiss',
+        );
+        if (choice === install) {
+          await vscode.commands.executeCommand(
+            'workbench.extensions.installExtension',
+            'James-Yu.latex-workshop',
+          );
+        }
+        await globalSM.update(GlobalStateKey.LATEX_WORKSHOP_PROMPTED, true);
+      }
     }
   } catch (err) {
     logger.error('extension', `Error configuring LaTeX settings: ${err}`);


### PR DESCRIPTION
## Summary
- prompt to install LaTeX Workshop if not detected
- persist prompt state to avoid repeated notifications
- document LaTeX Workshop installation prompt in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4541acfb48324b768b84470a7237f