### PR TITLE
feat: prompt LaTeX Workshop installation when missing

### DIFF
--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -215,7 +215,9 @@ TeXRA automatically detects appropriate input files based on:
 
 ### LaTeX Workshop Integration
 
-If you use the popular [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) extension, TeXRA attempts to automatically configure some settings upon its first activation to ensure smoother integration and cleaner project structures. These defaults are applied only if the corresponding settings are not already defined:
+If you use the popular [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) extension, TeXRA attempts to automatically configure some settings upon its first activation to ensure smoother integration and cleaner project structures.
+If the extension isn't installed, TeXRA will offer to install it for a smoother experience.
+These defaults are applied only if the corresponding settings are not already defined:
 
 - **Output Directory**: Sets `latex-workshop.latex.outDir` to `%DIR%/build/`. This directs LaTeX compilation output (like `.aux`, `.log`, `.pdf` files) into a `build` subdirectory within your project, keeping your main directory tidy.
 

--- a/docs/guide/latex-compilation.md
+++ b/docs/guide/latex-compilation.md
@@ -19,6 +19,7 @@ See the main [Installation Guide](./installation.md) for more details on install
 ## Integration with LaTeX Workshop
 
 TeXRA is designed to work smoothly alongside the popular [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) extension, which provides excellent compilation, previewing, and IntelliSense features.
+If the extension isn't detected, TeXRA will prompt you to install it so you can take advantage of these capabilities.
 
 **Workflow Interaction:**
 

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS, GlobalStorageFS, StorageFS } from '@utils/files';
 import { GlobalStateKey, globalSM } from '@common/state/stateManager';
+import { safeExecuteCommand } from '@utils/system';
 
 /**
  * Copies default agent files from the extension resources to the global storage directory
@@ -143,28 +144,22 @@ export async function configureLatexSettings() {
       );
 
       // Configure word wrap for LaTeX files
-      await updateIfUnset(
-        '[latex]',
-        { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' },
-      );
+      await updateIfUnset('[latex]', {
+        'editor.wordWrap': 'on',
+        'files.autoSave': 'afterDelay',
+      });
 
       // Also add word wrap for yaml files
-      await updateIfUnset(
-        '[yaml]',
-        { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' },
-      );
+      await updateIfUnset('[yaml]', {
+        'editor.wordWrap': 'on',
+        'files.autoSave': 'afterDelay',
+      });
 
       // Configure explorer settings to not automatically reveal build directory
-      await updateIfUnset(
-        'explorer.autoRevealExclude',
-        { 'build/': true },
-      );
+      await updateIfUnset('explorer.autoRevealExclude', { 'build/': true });
 
       // Disable automatic revealing of files in explorer
-      await updateIfUnset(
-        'explorer.autoReveal',
-        false,
-      );
+      await updateIfUnset('explorer.autoReveal', false);
 
       const isWindsurf = vscode.env.appName?.toLowerCase().includes('windsurf');
 
@@ -183,8 +178,19 @@ export async function configureLatexSettings() {
     } else {
       logger.info(
         'extension',
-        'LaTeX Workshop extension not found, skipping configuration',
+        'LaTeX Workshop extension not found, prompting installation',
       );
+      const selection = await vscode.window.showInformationMessage(
+        'LaTeX Workshop extension is recommended for full TeXRA functionality. Install now?',
+        'Install',
+      );
+      if (selection === 'Install') {
+        await safeExecuteCommand(
+          'workbench.extensions.installExtension',
+          ['James-Yu.latex-workshop'],
+          'extension',
+        );
+      }
     }
   } catch (err) {
     logger.error('extension', `Error configuring LaTeX settings: ${err}`);

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -9,6 +9,7 @@ import * as logger from '@logger/logUtils';
 import { AbsoluteFS, GlobalStorageFS, StorageFS } from '@utils/files';
 import { GlobalStateKey, globalSM } from '@common/state/stateManager';
 import { safeExecuteCommand } from '@utils/system';
+import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 
 /**
  * Copies default agent files from the extension resources to the global storage directory
@@ -180,17 +181,22 @@ export async function configureLatexSettings() {
         'extension',
         'LaTeX Workshop extension not found, prompting installation',
       );
-      const selection = await vscode.window.showInformationMessage(
-        'LaTeX Workshop extension is recommended for full TeXRA functionality. Install now?',
-        'Install',
+      await showInstructionWithSuppress(
+        'latex-workshop-install',
+        'LaTeX Workshop extension is recommended for full TeXRA functionality (LaTeX compilation, PDF preview, and IntelliSense). Install now?',
+        [
+          {
+            title: 'Install',
+            callback: async () => {
+              await safeExecuteCommand(
+                'workbench.extensions.installExtension',
+                ['James-Yu.latex-workshop'],
+                'extension',
+              );
+            },
+          },
+        ],
       );
-      if (selection === 'Install') {
-        await safeExecuteCommand(
-          'workbench.extensions.installExtension',
-          ['James-Yu.latex-workshop'],
-          'extension',
-        );
-      }
     }
   } catch (err) {
     logger.error('extension', `Error configuring LaTeX settings: ${err}`);


### PR DESCRIPTION
## Summary
- prompt users to install LaTeX Workshop when the extension is absent
- document that TeXRA offers to install LaTeX Workshop for smoother integration

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4541acfb48324b768b84470a7237f