### PR TITLE
fix: update anthropic opus model alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Detect MSYS2 Perl directories on Windows so `latexdiff` can find `perl`.
 - Prevent first task from being marked as error when progress view loads.
 - Recover TeX from named `document` tags when standard extraction fails.
+- Rename OpenRouter alias `anthropic/claude-opus-4.1:thinking` to `anthropic/claude-opus-4.1`.
 
 ### Improvements
 

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -29,7 +29,7 @@ export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
   opus41T: {
     name: 'opus41T',
     fullName: 'claude-opus-4-1-20250805',
-    openrouterFullName: 'anthropic/claude-opus-4.1:thinking',
+    openrouterFullName: 'anthropic/claude-opus-4.1',
     provider: ModelProvider.ANTHROPIC,
     maxOutputTokens: 32000, // Official Claude Opus 4.1 limit - streaming recommended for large outputs
     contextWindow: 200000,


### PR DESCRIPTION
## Summary
- rename OpenRouter alias for Claude Opus 4.1 thinking model to `anthropic/claude-opus-4.1`
- document model rename in changelog

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack build hangs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a478715e648324a772b5bd299662f9