### PR TITLE
feat: organize API streaming test scripts

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -28,6 +28,7 @@ tsconfig.json
 venv/**
 docs/**
 prototypes/**
+test/**
 AGENTS.md
 CLAUDE.md
 

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -66,4 +66,5 @@ CLAUDE.md
 !src/progressView/*.html
 !src/progressView/*.css
 
+.env
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.60.0",
-        "@cantoo/pdf-lib": "^2.4.2",
-        "@google/genai": "^1.14.0",
+        "@cantoo/pdf-lib": "^2.4.3",
+        "@google/genai": "^1.15.0",
         "@modelcontextprotocol/sdk": "^1.17.3",
         "@vscode/codicons": "^0.0.39",
         "@vscode/markdown-it-katex": "^1.1.2",
@@ -116,9 +116,9 @@
       "license": "MIT"
     },
     "node_modules/@cantoo/pdf-lib": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@cantoo/pdf-lib/-/pdf-lib-2.4.2.tgz",
-      "integrity": "sha512-ZqMiY8XEyM6Rc3WjpsQnrZYwCdyf/Emg2J3RbmSxoIKN1Kpa/93uIaO9cx/14dJoC6vkcAtMhrYsO7YLB8i8Lg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@cantoo/pdf-lib/-/pdf-lib-2.4.3.tgz",
+      "integrity": "sha512-RmGblYllpDf0yVwkZTyrqtSLBGm30Bz02ihXNmS9T3fT4oBcpRnOMQU37G0McdseXyhYmOJrP537AE2Xf6a3nQ==",
       "license": "MIT",
       "dependencies": {
         "@pdf-lib/standard-fonts": "^1.0.0",
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.14.0.tgz",
-      "integrity": "sha512-jirYprAAJU1svjwSDVCzyVq+FrJpJd5CSxR/g2Ga/gZ0ZYZpcWjMS75KJl9y71K1mDN+tcx6s21CzCbB2R840g==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.15.0.tgz",
+      "integrity": "sha512-4CSW+hRTESWl3xVtde7pkQ3E+dDFhDq+m4ztmccRctZfx1gKy3v0M9STIMGk6Nq0s6O2uKMXupOZQ1JGorXVwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",

--- a/package.json
+++ b/package.json
@@ -1307,8 +1307,8 @@
   "homepage": "https://texra.ai",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.60.0",
-    "@cantoo/pdf-lib": "^2.4.2",
-    "@google/genai": "^1.14.0",
+    "@cantoo/pdf-lib": "^2.4.3",
+    "@google/genai": "^1.15.0",
     "@modelcontextprotocol/sdk": "^1.17.3",
     "@vscode/codicons": "^0.0.39",
     "@vscode/markdown-it-katex": "^1.1.2",

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -230,9 +230,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
         signal,
       });
       const response = await stream.finalResponse();
-      this.logger.debug(
-        `OpenAI Responses final response: ${JSON.stringify(response)}`,
-      );
+      // this.logger.debug(
+      //   `OpenAI Responses final response: ${JSON.stringify(response)}`,
+      // );
       this.previousResponseId = response.id;
       this.sentMessages = messages.length;
       return response;

--- a/test/api-streaming/test-deepseek-stream.js
+++ b/test/api-streaming/test-deepseek-stream.js
@@ -1,0 +1,69 @@
+import OpenAI from 'openai';
+
+// DeepSeek uses OpenAI-compatible API
+const client = new OpenAI({
+  apiKey: process.env.DEEPSEEK_API_KEY,
+  baseURL: 'https://api.deepseek.com/v1',
+});
+
+async function run() {
+  try {
+    console.log('Starting DeepSeek stream...\n');
+    
+    const stream = await client.chat.completions.create({
+      model: 'deepseek-chat',
+      messages: [
+        { role: 'user', content: 'Count from 1 to 5. Each number on a new line.' }
+      ],
+      stream: true,
+      stream_options: { include_usage: true }, // Request usage info in stream
+    });
+
+    let lastChunk;
+    let fullContent = '';
+    
+    // Process the stream
+    for await (const chunk of stream) {
+      lastChunk = chunk;
+      const content = chunk.choices[0]?.delta?.content || '';
+      fullContent += content;
+      process.stdout.write(content);
+      
+      // Check if this is the final chunk with usage data
+      if (chunk.usage) {
+        console.log('\n\n--- Usage data received in chunk ---');
+        console.log('Usage:', JSON.stringify(chunk.usage, null, 2));
+      }
+    }
+
+    console.log('\n\n--- Last Chunk Structure ---');
+    console.log('Last chunk keys:', Object.keys(lastChunk || {}));
+    console.log('Last chunk:', JSON.stringify(lastChunk, null, 2));
+    
+    // Check finish reason from last chunk
+    if (lastChunk?.choices?.[0]) {
+      const choice = lastChunk.choices[0];
+      console.log('\n--- Finish Information ---');
+      console.log('Finish reason:', choice.finish_reason);
+      console.log('Stop reason:', choice.stop_reason);
+    }
+    
+    // Try the non-streaming approach for comparison
+    console.log('\n\n--- Non-streaming comparison ---');
+    const nonStreamResponse = await client.chat.completions.create({
+      model: 'deepseek-chat',
+      messages: [
+        { role: 'user', content: 'Count from 1 to 5. Each number on a new line.' }
+      ],
+      stream: false,
+    });
+    
+    console.log('Non-stream usage:', JSON.stringify(nonStreamResponse.usage, null, 2));
+    console.log('Non-stream finish_reason:', nonStreamResponse.choices[0]?.finish_reason);
+    
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+run();

--- a/test/api-streaming/test-deepseek-stream.js
+++ b/test/api-streaming/test-deepseek-stream.js
@@ -9,11 +9,14 @@ const client = new OpenAI({
 async function run() {
   try {
     console.log('Starting DeepSeek stream...\n');
-    
+
     const stream = await client.chat.completions.create({
       model: 'deepseek-chat',
       messages: [
-        { role: 'user', content: 'Count from 1 to 5. Each number on a new line.' }
+        {
+          role: 'user',
+          content: 'Count from 1 to 5. Each number on a new line.',
+        },
       ],
       stream: true,
       stream_options: { include_usage: true }, // Request usage info in stream
@@ -21,14 +24,14 @@ async function run() {
 
     let lastChunk;
     let fullContent = '';
-    
+
     // Process the stream
     for await (const chunk of stream) {
       lastChunk = chunk;
       const content = chunk.choices[0]?.delta?.content || '';
       fullContent += content;
       process.stdout.write(content);
-      
+
       // Check if this is the final chunk with usage data
       if (chunk.usage) {
         console.log('\n\n--- Usage data received in chunk ---');
@@ -39,7 +42,7 @@ async function run() {
     console.log('\n\n--- Last Chunk Structure ---');
     console.log('Last chunk keys:', Object.keys(lastChunk || {}));
     console.log('Last chunk:', JSON.stringify(lastChunk, null, 2));
-    
+
     // Check finish reason from last chunk
     if (lastChunk?.choices?.[0]) {
       const choice = lastChunk.choices[0];
@@ -47,20 +50,28 @@ async function run() {
       console.log('Finish reason:', choice.finish_reason);
       console.log('Stop reason:', choice.stop_reason);
     }
-    
+
     // Try the non-streaming approach for comparison
     console.log('\n\n--- Non-streaming comparison ---');
     const nonStreamResponse = await client.chat.completions.create({
       model: 'deepseek-chat',
       messages: [
-        { role: 'user', content: 'Count from 1 to 5. Each number on a new line.' }
+        {
+          role: 'user',
+          content: 'Count from 1 to 5. Each number on a new line.',
+        },
       ],
       stream: false,
     });
-    
-    console.log('Non-stream usage:', JSON.stringify(nonStreamResponse.usage, null, 2));
-    console.log('Non-stream finish_reason:', nonStreamResponse.choices[0]?.finish_reason);
-    
+
+    console.log(
+      'Non-stream usage:',
+      JSON.stringify(nonStreamResponse.usage, null, 2),
+    );
+    console.log(
+      'Non-stream finish_reason:',
+      nonStreamResponse.choices[0]?.finish_reason,
+    );
   } catch (error) {
     console.error('Error:', error);
   }

--- a/test/api-streaming/test-genai-stream.js
+++ b/test/api-streaming/test-genai-stream.js
@@ -1,0 +1,62 @@
+import { GoogleGenAI } from '@google/genai';
+
+// Set the API key directly or via environment variable
+const apiKey = process.env.GEMINI_API_KEY || 'YOUR_API_KEY_HERE';
+const ai = new GoogleGenAI({ apiKey });
+
+async function run() {
+  try {
+    console.log('Starting stream...\n');
+    
+    const stream = await ai.models.generateContentStream({
+      model: 'gemini-2.5-flash',
+      contents: 'Count from 1 to 5. Each number on a new line.',
+    });
+
+    // Process the stream
+    let lastChunk;
+    for await (const chunk of stream) {
+      lastChunk = chunk;
+      // Check if chunk has text method or is text directly
+      const text = typeof chunk.text === 'function' ? chunk.text() : chunk.text;
+      process.stdout.write(text ?? chunk.toString());
+    }
+
+    console.log('\n\n--- Last Chunk Structure ---');
+    console.log('Last chunk keys:', Object.keys(lastChunk || {}));
+    console.log('Last chunk:', JSON.stringify(lastChunk, null, 2));
+    
+    // Check stream object properties
+    console.log('\n--- Stream Object Properties ---');
+    console.log('Stream keys:', Object.keys(stream));
+    console.log('Stream.response exists?', 'response' in stream);
+    
+    // Try to get the final response after streaming
+    const finalResponse = stream.response;
+    
+    console.log('\n\n--- Final Response Metadata ---');
+    console.log('Final response exists?', finalResponse !== undefined);
+    console.log('Usage Metadata:', JSON.stringify(finalResponse?.usageMetadata, null, 2));
+    
+    // Check for candidates and finish reason
+    if (finalResponse?.candidates && finalResponse.candidates.length > 0) {
+      const candidate = finalResponse.candidates[0];
+      console.log('Finish Reason:', candidate.finishReason);
+      console.log('Finish Message:', candidate.finishMessage);
+      console.log('Safety Ratings:', JSON.stringify(candidate.safetyRatings, null, 2));
+    }
+    
+    // Check for end turn reason or similar properties
+    console.log('Model Version:', finalResponse?.modelVersion);
+    console.log('Prompt Feedback:', JSON.stringify(finalResponse?.promptFeedback, null, 2));
+    
+    // Log the entire response structure for inspection
+    console.log('\n--- Full Response Structure ---');
+    console.log(JSON.stringify(finalResponse, null, 2));
+    
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+run();

--- a/test/api-streaming/test-genai-stream.js
+++ b/test/api-streaming/test-genai-stream.js
@@ -7,7 +7,7 @@ const ai = new GoogleGenAI({ apiKey });
 async function run() {
   try {
     console.log('Starting stream...\n');
-    
+
     const stream = await ai.models.generateContentStream({
       model: 'gemini-2.5-flash',
       contents: 'Count from 1 to 5. Each number on a new line.',
@@ -25,35 +25,43 @@ async function run() {
     console.log('\n\n--- Last Chunk Structure ---');
     console.log('Last chunk keys:', Object.keys(lastChunk || {}));
     console.log('Last chunk:', JSON.stringify(lastChunk, null, 2));
-    
+
     // Check stream object properties
     console.log('\n--- Stream Object Properties ---');
     console.log('Stream keys:', Object.keys(stream));
     console.log('Stream.response exists?', 'response' in stream);
-    
+
     // Try to get the final response after streaming
     const finalResponse = stream.response;
-    
+
     console.log('\n\n--- Final Response Metadata ---');
     console.log('Final response exists?', finalResponse !== undefined);
-    console.log('Usage Metadata:', JSON.stringify(finalResponse?.usageMetadata, null, 2));
-    
+    console.log(
+      'Usage Metadata:',
+      JSON.stringify(finalResponse?.usageMetadata, null, 2),
+    );
+
     // Check for candidates and finish reason
     if (finalResponse?.candidates && finalResponse.candidates.length > 0) {
       const candidate = finalResponse.candidates[0];
       console.log('Finish Reason:', candidate.finishReason);
       console.log('Finish Message:', candidate.finishMessage);
-      console.log('Safety Ratings:', JSON.stringify(candidate.safetyRatings, null, 2));
+      console.log(
+        'Safety Ratings:',
+        JSON.stringify(candidate.safetyRatings, null, 2),
+      );
     }
-    
+
     // Check for end turn reason or similar properties
     console.log('Model Version:', finalResponse?.modelVersion);
-    console.log('Prompt Feedback:', JSON.stringify(finalResponse?.promptFeedback, null, 2));
-    
+    console.log(
+      'Prompt Feedback:',
+      JSON.stringify(finalResponse?.promptFeedback, null, 2),
+    );
+
     // Log the entire response structure for inspection
     console.log('\n--- Full Response Structure ---');
     console.log(JSON.stringify(finalResponse, null, 2));
-    
   } catch (error) {
     console.error('Error:', error);
   }


### PR DESCRIPTION
## Summary
- Organized API streaming test scripts into a dedicated test directory
- Added test utilities for verifying streaming metadata from Google GenAI and DeepSeek APIs
- Reduced verbose debug logging in OpenAI response handler

## Changes
- Created `test/api-streaming/` directory with test scripts for:
  - Google GenAI streaming metadata verification
  - DeepSeek streaming metadata and usage tracking
- Updated `.vscodeignore` to exclude test directory from VSIX package
- Commented out verbose debug logging in OpenAI response handler to reduce console noise

## Test Scripts
The test scripts verify that we can properly retrieve:
- Usage metadata (token counts) in streaming mode
- Finish reasons and completion status
- Model version and response metadata

These scripts are useful for debugging API integration issues and verifying streaming behavior across different providers.

🤖 Generated with [Claude Code](https://claude.ai/code)