### PR TITLE
feat: add flag for tool-use agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Add `texra.includeToolUseAgents` setting to optionally show built-in tool-use agents in the agent dropdown.
+
 ## [0.33.0] - 2025-08-18
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
             "description": "List of available agents",
             "scope": "resource"
           },
+          "texra.includeToolUseAgents": {
+            "type": "boolean",
+            "default": false,
+            "description": "Include built-in tool-use agents (e.g., xml_validator, tex_linter_fix) in the agent list",
+            "scope": "resource"
+          },
           "texra.models": {
             "type": "array",
             "items": {

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -93,15 +93,18 @@ export class MainViewContentProvider extends BaseViewContentProvider {
 
   protected getTemplateVariables(): Record<string, any> {
     const agents = getConfig<string[]>('agents', []);
+    const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
     const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
     let extraAgents: string[] = [];
-    try {
-      const files = AbsoluteFS.readDirSync(toolUseDir);
-      extraAgents = files
-        .filter((f) => f.endsWith('.yaml'))
-        .map((f) => path.basename(f, '.yaml'));
-    } catch {
-      extraAgents = [];
+    if (includeToolUse) {
+      try {
+        const files = AbsoluteFS.readDirSync(toolUseDir);
+        extraAgents = files
+          .filter((f) => f.endsWith('.yaml'))
+          .map((f) => path.basename(f, '.yaml'));
+      } catch {
+        extraAgents = [];
+      }
     }
     const allAgents = Array.from(new Set([...agents, ...extraAgents]));
     const agentOptions = allAgents


### PR DESCRIPTION
## Summary
- add `texra.includeToolUseAgents` setting to optionally show tool-use agents in dropdown
- hide tool-use agents unless explicitly enabled

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a481efbe388324a9286e25fceb4c1f