### PR TITLE
fix: strip Gemini thought tokens from final response

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -660,7 +660,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     let responseText = '';
     if (candidate?.content?.parts) {
       responseText = candidate.content.parts
-        .filter((part) => !!part.text)
+        // Exclude reasoning/thought blocks from the returned text
+        .filter((part) => !!part.text && !part.thought)
         .map((part: Part) => part.text ?? '')
         .join('')
         .trim();


### PR DESCRIPTION
## Summary
- ignore Google GenAI `thought` parts when assembling final response text
- keep `processThinkingBlock` logging separate `thought` segments

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `node test/api-streaming/test-genai-stream.js` *(fails: fetch failed sending request)*

------
https://chatgpt.com/codex/tasks/task_e_68a49c32f7148324a6e946726e1316a9