### PR TITLE
chore: group imports with comments

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -1,7 +1,9 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - agent
 // Local imports - agent components
 import { ToolConfigSchema } from './ToolConfig';
-
-import { z } from 'zod';
 
 /**
  * Checks that the number of output files does not exceed the number of input files.

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -1,6 +1,9 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - agent
 // Local imports - model types
 import { ToolDefinitionSchema } from '@model';
-import { z } from 'zod';
 
 /** Temperature bounds for agent generation. */
 export const MIN_TEMPERATURE = 0;

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -1,3 +1,10 @@
+// Local imports - agent
+
+// Local imports - agent components
+import {
+  OpenAIAPIResponseUsage,
+  AnthropicAPIResponseUsage,
+} from './ResponseUsage';
 // Standard library imports
 // (none needed)
 
@@ -6,12 +13,6 @@
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
-
-// Local imports - agent components
-import {
-  OpenAIAPIResponseUsage,
-  AnthropicAPIResponseUsage,
-} from './ResponseUsage';
 
 const CHANNEL = 'Agent';
 logger.initialize(CHANNEL);

--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -1,3 +1,4 @@
+// Local imports - agent
 // Local imports - agent components
 import type { AgentConfig } from './AgentConfig';
 

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -1,25 +1,4 @@
-// Standard library imports
-
-// Third-party imports
-// (none needed)
-
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-
-// Local imports - latex utils
-import { bestConnectionMethod } from '@latex';
-
-// Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
-import { getRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
-import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
-import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
-import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
-import replacementEngine from '@replacement/engine';
-import xmlUtils from '@utils/text/xmlUtils';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
-import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+// Local imports - agent
 
 // Local imports - agent components
 import type { AgentConfig } from './AgentConfig';
@@ -28,9 +7,31 @@ import { AgentStateRound, AgentStateGlobal } from './AgentState';
 import { ToolState } from './ToolState';
 import type { IModelHandler } from '@agent/modelHandlers';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
+import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
+import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
+
+// Local imports - latex utils
+import { bestConnectionMethod } from '@latex';
+// Standard library imports
+
+// Third-party imports
+// (none needed)
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import replacementEngine from '@replacement/engine';
 
 // Shared constants
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
+
+// Local imports - utilities
+import { WorkspaceFS } from '@utils/files';
+import { getRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
+import xmlUtils from '@utils/text/xmlUtils';
 
 /**
  * Options required to run a single response cycle.

--- a/src/agent/core/ResponseUsage.ts
+++ b/src/agent/core/ResponseUsage.ts
@@ -1,10 +1,12 @@
+// Third-party imports
+import type { Usage as AnthropicUsage } from '@anthropic-ai/sdk/resources/messages';
+
+// import type { UsageMetadata as GenerateContentResponseUsageMetadata } from '@google/genai';
+import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 /** Types and utilities for tracking and analyzing model API response usage metrics. */
 
 // Third-party imports
 import type { CompletionUsage } from 'openai/resources/completions';
-import type { Usage as AnthropicUsage } from '@anthropic-ai/sdk/resources/messages';
-// import type { UsageMetadata as GenerateContentResponseUsageMetadata } from '@google/genai';
-import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 
 /**
  * Extended OpenAI usage type with additional fields used by various providers.

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 import { z } from 'zod';
 
 /**

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -1,3 +1,12 @@
+// Local imports - agent
+import type { IModelHandler } from '../modelHandlers';
+import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
+
+// Local imports - agent components
+import type { AgentSetting, AgentPrompt } from './AgentDataclass';
+import { ToolState } from './ToolState';
+import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
+import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 // Utility to run iterative tool-use cycles
 
 // Third-party imports
@@ -5,18 +14,10 @@
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
-
-// Local imports - agent components
-import type { AgentSetting, AgentPrompt } from './AgentDataclass';
 import type { ToolDefinition } from '@model';
-import type { IModelHandler } from '../modelHandlers';
-import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
 import { BaseTool } from '@tools/core/base';
 import { ToolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
-import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
-import { ToolState } from './ToolState';
 
 export interface ToolUseCycleOptions {
   /** Model handler for API interactions */

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
 
 // Local imports - agent

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -1,22 +1,25 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
 
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
+// Local imports - agent
 
 // Local imports - agent components
 import type { AgentConfig } from '../core/AgentConfig';
 import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
+import { AgentStateGlobal } from '../core/AgentState';
 import { IAgent } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';
-import { buildUserVars } from '../utils/userVars';
 import { UsageMonitor } from '../utils/UsageMonitor';
-import { AgentStateGlobal } from '../core/AgentState';
+import { buildUserVars } from '../utils/userVars';
+import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
 import { sleep } from '@utils/helpers';
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 
 /**
  * Minimal abstract base class providing shared setup and interruption logic.

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -1,3 +1,28 @@
+// Local imports - agent
+
+// Local imports - agent components
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import {
+  AgentSetting,
+  AgentPrompt,
+  AgentType,
+} from '@agent/core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
+import { runResponseCycle } from '@agent/core/ResponseCycle';
+import { ToolState } from '@agent/core/ToolState';
+import { BaseAgent } from '@agent/implementations/BaseAgent';
+import type { IModelHandler } from '@agent/modelHandlers';
+import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import {
+  getSystemPromptWithRules,
+  getPrefillForRound,
+} from '@agent/utils/promptHelpers';
+import {
+  renderPrompt,
+  getFirstKCharsFromDocument,
+  writePromptToXml,
+} from '@agent/utils/promptUtils';
+import { bus } from '@eventBus/ProgressEventBus';
 // Standard library imports
 // (none needed)
 
@@ -8,43 +33,17 @@
 
 // Local imports - latex utils
 import { LatexMediaManager } from '@latex';
-
-import { bus } from '@eventBus/ProgressEventBus';
-
-// Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
-import {
-  renderPrompt,
-  getFirstKCharsFromDocument,
-  writePromptToXml,
-} from '@agent/utils/promptUtils';
-
-import {
-  getSystemPromptWithRules,
-  getPrefillForRound,
-} from '@agent/utils/promptHelpers';
-
-// Local imports - agent components
-import type { AgentConfig } from '@agent/core/AgentConfig';
-import {
-  AgentSetting,
-  AgentPrompt,
-  AgentType,
-} from '@agent/core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
-import { ToolState } from '@agent/core/ToolState';
-import { runResponseCycle } from '@agent/core/ResponseCycle';
-import type { IModelHandler } from '@agent/modelHandlers';
-import type { ToolDefinition } from '@model';
-import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
-import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import type { ToolDefinition } from '@model';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
 
 // Shared constants
 import { K_SLICE } from '@utils/config';
+
+// Local imports - utilities
+import { WorkspaceFS } from '@utils/files';
 
 /**
  * Options for handling round output.

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -1,22 +1,22 @@
+// Local imports - agent
+import type { AgentConfig } from '../core/AgentConfig';
+import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
+import { ToolState } from '../core/ToolState';
+import { runToolUseCycle } from '../core/ToolUseCycle';
+import type { IModelHandler } from '../modelHandlers';
+import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
+import { getSystemPromptWithRules } from '../utils/promptHelpers';
+import { renderPrompt } from '../utils/promptUtils';
+import { TOOL_USE_INSTRUCTIONS } from '../utils/toolUsePrompt';
 // Base class for tool-use agents
 
 // Standard library imports
 
 // Local imports - core
 import { BaseAgent } from './BaseAgent';
-import type { AgentConfig } from '../core/AgentConfig';
-import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
-import { getSystemPromptWithRules } from '../utils/promptHelpers';
-import { renderPrompt } from '../utils/promptUtils';
-import type { IModelHandler } from '../modelHandlers';
 import type { ToolDefinition } from '@model';
-
-import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
 import { BaseTool } from '@tools/core/base';
-import { runToolUseCycle } from '../core/ToolUseCycle';
-import { ToolState } from '../core/ToolState';
-import { TOOL_USE_INSTRUCTIONS } from '../utils/toolUsePrompt';
-import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
+import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
 
 export class BaseToolUseAgent extends BaseAgent {
   private toolRegistry: Record<string, BaseTool<any>>;

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -1,7 +1,8 @@
+// Local imports - agent
 // Local imports - agent components
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
-import { getOutputFileName } from '@agent/output';
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
+import { getOutputFileName } from '@agent/output';
 
 /**
  * Chain of Thought (CoT) agent implementation that extends BaseReflectionAgent.

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -1,6 +1,7 @@
+// Local imports - agent
+import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 // Local imports - agent components
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { getOutputFileName } from '@agent/output';
 
 /**

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
 
 // Local imports - agent

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -1,13 +1,16 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
+
+// Local imports - agent
+import type { AgentConfig } from '../core/AgentConfig';
+import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
+import { RoundOutputOptions } from './BaseReflectionAgent';
 
 // Local imports - agent components
 import { DirectAgent } from './DirectAgent';
-import { RoundOutputOptions } from './BaseReflectionAgent';
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import type { IModelHandler } from '@agent/modelHandlers';
-import type { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
 
 /**
  * Specialized agent for merging multiple edited files into a consolidated output.

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1,47 +1,52 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
-// (none needed)
+import { FinishReason } from '@google/genai';
 
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
+// Local imports - agent
 
-// Local imports - utilities
-import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import {
-  getBase64EncodedMedia,
-  countPdfPages,
-  processPdf2Png,
-} from '@frontend/media/img';
-import { checkMultipleToolsInstalled } from '@utils/system';
-import { getConfig } from '@utils/config';
-import { normalizeUrl } from '@utils/urlUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+// Local imports - agent components
+import type { AgentConfig } from '../core/AgentConfig';
+import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
+import { ToolState } from '../core/ToolState';
+import type { IModelHandler } from './types/IModelHandler';
+import type { ProviderMessage } from './types/ProviderMessage';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import {
   ANTHROPIC_STOP,
   OPENAI_CHAT_FINISH,
   MCP_STOP,
 } from './types/StopReasonTypes';
-import { FinishReason } from '@google/genai';
-import type { IModelHandler } from './types/IModelHandler';
-import type { ProviderMessage } from './types/ProviderMessage';
+import { MediaEntry } from '@agent/utils/mediaTypes';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  getBase64EncodedMedia,
+  countPdfPages,
+  processPdf2Png,
+} from '@frontend/media/img';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
-// Local imports - agent components
-import type { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
+// Third-party imports
+// (none needed)
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import type { ToolDefinition } from '@model';
 import {
   ModelConfig,
   ModelProvider,
   ModelCapabilities,
 } from '@model/ModelConfig';
-import type { ToolDefinition } from '@model';
-import { ToolState } from '../core/ToolState';
-import { MediaEntry } from '@agent/utils/mediaTypes';
+import { getConfig } from '@utils/config';
+
+// Local imports - utilities
+import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
+import { checkMultipleToolsInstalled } from '@utils/system';
+import { normalizeUrl } from '@utils/urlUtils';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1,11 +1,8 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
 import { FinishReason } from '@google/genai';
-
-// Local imports - agent
 
 // Local imports - agent components
 import type { AgentConfig } from '../core/AgentConfig';
@@ -29,8 +26,6 @@ import {
 } from '@frontend/media/img';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
-// Third-party imports
-// (none needed)
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -26,7 +26,6 @@ import {
 } from '@frontend/media/img';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
-
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1,4 +1,3 @@
-// Third-party imports
 // Standard library imports
 // (none needed)
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1,45 +1,48 @@
+// Third-party imports
 // Standard library imports
 // (none needed)
 
 // Third-party imports
 import { Anthropic } from '@anthropic-ai/sdk';
+import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 import {
   MessageParam,
   ContentBlock,
   ContentBlockParam,
   MessageCreateParams,
 } from '@anthropic-ai/sdk/resources/messages';
-import type { BetaMessage } from '@anthropic-ai/sdk/resources/beta/messages';
 
-// Local imports - error utils
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
-
-// Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
-import { cleanFileContent } from '@replacement/engine';
-import replacementEngine from '@replacement/engine';
+// Local imports - agent
+import { toAnthropicTools } from './toolConversion';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import { ANTHROPIC_STOP } from './types/StopReasonTypes';
-import xmlUtils from '@utils/text/xmlUtils';
 
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
-import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import { AgentStateRound } from '@agent/core/AgentState';
 import {
   AnthropicAPIResponseUsage,
   ResponseUsageFactory,
   AnthropicUsage,
 } from '@agent/core/ResponseUsage';
 import { ToolState } from '@agent/core/ToolState';
+import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { AgentStateRound } from '@agent/core/AgentState';
-import { K_SLICE, getConfig } from '@utils/config';
-import { objectToLogString } from '@utils/text/stringUtils';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
+
+// Local imports - error utils
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
-import { toAnthropicTools } from './toolConversion';
+import { cleanFileContent } from '@replacement/engine';
+import replacementEngine from '@replacement/engine';
+import { K_SLICE, getConfig } from '@utils/config';
+
+// Local imports - utilities
+import { WorkspaceFS } from '@utils/files';
+import { objectToLogString } from '@utils/text/stringUtils';
+import xmlUtils from '@utils/text/xmlUtils';
 
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.

--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -1,4 +1,3 @@
-// Third-party imports
 // Standard library imports
 // (none needed)
 

--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -1,17 +1,20 @@
+// Third-party imports
 // Standard library imports
 // (none needed)
 
 // Third-party imports
 import OpenAI from 'openai';
 
+// Local imports - agent
+import { ToolState } from '../core/ToolState';
+
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { ToolState } from '../core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import type { ToolDefinition } from '@model';
 
 // Local imports - utilities
 import { convertContentToString } from '@agent/utils/text/messageUtils';
+import type { ToolDefinition } from '@model';
 import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 /**

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -1,4 +1,3 @@
-// Third-party imports
 // Standard library imports
 // (none needed)
 

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -1,16 +1,19 @@
+// Third-party imports
 // Standard library imports
 // (none needed)
 
 // Third-party imports
 import OpenAI from 'openai';
 
+// Local imports - agent
+import { ToolState } from '../core/ToolState';
+
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { ToolState } from '../core/ToolState';
-import type { ToolDefinition } from '@model';
 
 // Local imports - utilities
 import { convertContentToString } from '@agent/utils/text/messageUtils';
+import type { ToolDefinition } from '@model';
 import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 // TODO: prompt_cache_hit_tokens can also be used here to correct the price and response usage computation in the base class (just overwrite the computePrice and computeResponseUsage methods with a revalues responseUsage.prompt_tokens_details?.cached_tokens and then call the super methods)

--- a/src/agent/modelHandlers/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogle.ts
@@ -1,17 +1,20 @@
+// Third-party imports
 // Standard library imports
 // (none needed)
 
 // Third-party imports
 import OpenAI from 'openai';
+import type { CompletionUsage } from 'openai/resources/completions';
 
-// Local imports - agent components
-import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+// Local imports - agent
 import { hasEndTag } from '../core/AgentDataclass';
 import {
   OpenAIAPIResponseUsage,
   GenerateContentResponseUsageMetadata,
 } from '../core/ResponseUsage';
-import type { CompletionUsage } from 'openai/resources/completions';
+
+// Local imports - agent components
+import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 
 /**

--- a/src/agent/modelHandlers/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogle.ts
@@ -1,4 +1,3 @@
-// Third-party imports
 // Standard library imports
 // (none needed)
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1,5 +1,8 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
+
+// Third-party imports
 
 // Third-party imports
 import {
@@ -19,38 +22,39 @@ import {
   type UploadFileParameters,
 } from '@google/genai';
 
-// Local imports - agent components
-import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+// Local imports - agent
+import { toGoogleTools } from './toolConversion';
+import type { ProviderStopReason } from './types/StopReasonTypes';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
-import { ToolState } from '@agent/core/ToolState';
 import {
   OpenAIAPIResponseUsage,
   ResponseUsageFactory,
   GenerateContentResponseUsageMetadata,
   ExtendedCompletionUsage,
 } from '@agent/core/ResponseUsage';
+import { ToolState } from '@agent/core/ToolState';
+
+// Local imports - agent components
+import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { AgentLogger } from '@logger/AgentLogger';
-import type { ToolDefinition } from '@model';
-import { toGoogleTools } from './toolConversion';
-
-// Local imports - utilities
-import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
-import xmlUtils from '@utils/text/xmlUtils';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-
+import type { ToolDefinition } from '@model';
 import { cleanFileContent } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
 
-import type { ProviderStopReason } from './types/StopReasonTypes';
 // Google finish reasons are re-exported from the SDK
 
 // Local constant
 import { K_SLICE } from '@utils/config';
+
+// Local imports - utilities
+import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
+import xmlUtils from '@utils/text/xmlUtils';
 
 // Internal type definition
 type InternalMessagePart = {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
-
-// Third-party imports
 
 // Third-party imports
 import {

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -1,19 +1,22 @@
+// Third-party imports
 // Standard library imports
 // (none needed)
 
 // Third-party imports
 import OpenAI from 'openai';
 
+// Local imports - agent
+import { ToolState } from '../core/ToolState';
+
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { ToolState } from '../core/ToolState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import type { ToolDefinition } from '@model';
 
 // Local imports - utilities
 import { convertContentToString } from '@agent/utils/text/messageUtils';
-import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import type { ToolDefinition } from '@model';
+import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -1,4 +1,3 @@
-// Third-party imports
 // Standard library imports
 // (none needed)
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1,3 +1,5 @@
+// Third-party imports
+import { countTokens } from 'gpt-tokenizer';
 // Standard library imports
 // (none needed)
 
@@ -9,34 +11,35 @@ import {
   ChatCompletionToolMessageParam,
   ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
-import { countTokens } from 'gpt-tokenizer';
 
-// Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
-import { cleanFileContent } from '@replacement/engine';
-import xmlUtils from '@utils/text/xmlUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+// Local imports - agent
 
 // Local imports - agent components
 import type { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
 import { AgentStateRound } from '../core/AgentState';
-import { ModelHandler } from './ModelHandler';
-import type { ProviderStopReason } from './types/StopReasonTypes';
-import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
-import { toOpenAITools } from './toolConversion';
-import type { ToolDefinition } from '@model';
 import {
   OpenAIAPIResponseUsage,
   ResponseUsageFactory,
   ExtendedCompletionUsage,
 } from '../core/ResponseUsage';
 import { ToolState } from '../core/ToolState';
-import { K_SLICE } from '@utils/config';
-import { objectToLogString } from '@utils/text/stringUtils';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
+import { ModelHandler } from './ModelHandler';
+import { toOpenAITools } from './toolConversion';
+import type { ProviderStopReason } from './types/StopReasonTypes';
+import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { MediaEntry } from '@agent/utils/mediaTypes';
+import { calculateTokenPrice } from '@agent/utils/priceUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import type { ToolDefinition } from '@model';
+import { cleanFileContent } from '@replacement/engine';
+import { K_SLICE } from '@utils/config';
+
+// Local imports - utilities
+import { WorkspaceFS } from '@utils/files';
+import { objectToLogString } from '@utils/text/stringUtils';
+import xmlUtils from '@utils/text/xmlUtils';
 
 /**
  * OpenAI-specific handlers.

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1,8 +1,12 @@
 // Standard library imports
+// Standard library imports
 import { Buffer } from 'node:buffer';
 
 // Third-party imports
+
+// Third-party imports
 import OpenAI, { toFile } from 'openai';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import type {
   Response,
   ResponseUsage,
@@ -13,19 +17,20 @@ import type {
   ResponseFunctionToolCall,
   ResponseInputItem,
 } from 'openai/resources/responses/responses';
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+
+// Local imports - agent
+import { ResponseUsageFactory } from '../core/ResponseUsage';
+import { ToolState } from '../core/ToolState';
 
 // Local imports - base handler
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { ResponseUsageFactory } from '../core/ResponseUsage';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import { ToolState } from '../core/ToolState';
-import { K_SLICE } from '@utils/config';
+import { toOpenAIResponseTools } from './toolConversion';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
-import type { ToolDefinition } from '@model';
-import { toOpenAIResponseTools } from './toolConversion';
+import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { logErrorMessage } from '@common/errors/errorHandlingUtils';
+import type { ToolDefinition } from '@model';
+import { K_SLICE } from '@utils/config';
 
 // import { ResponseCreateParams } from 'openai/src/resources/responses/response';
 // this is incorrect now, but would be nice to use

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import { Buffer } from 'node:buffer';
-
-// Third-party imports
 
 // Third-party imports
 import OpenAI, { toFile } from 'openai';

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -1,4 +1,3 @@
-// Third-party imports
 // Standard library imports
 // (none needed)
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -1,15 +1,18 @@
+// Third-party imports
 // Standard library imports
 // (none needed)
 
 // Third-party imports
 import OpenAI from 'openai';
 
+// Local imports - agent
+import { ToolState } from '../core/ToolState';
+
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { ToolState } from '../core/ToolState';
-import { K_SLICE } from '@utils/config';
-import type { ToolDefinition } from '@model';
 import { toOpenAITools } from './toolConversion';
+import type { ToolDefinition } from '@model';
+import { K_SLICE } from '@utils/config';
 
 /**
  * Handler for models accessed through OpenRouter.

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -1,14 +1,17 @@
+// Third-party imports
 // Standard library imports
 // (none needed)
 
 // Third-party imports
 import OpenAI from 'openai';
 
+// Local imports - agent
+import { ToolState } from '../core/ToolState';
+
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { ToolState } from '../core/ToolState';
-import { K_SLICE } from '@utils/config';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import { K_SLICE } from '@utils/config';
 
 /**
  * Handler for xAI models using OpenAI-compatible API.

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -1,4 +1,3 @@
-// Third-party imports
 // Standard library imports
 // (none needed)
 

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -1,10 +1,15 @@
 // Standard library imports
+// Standard library imports
 import { randomUUID } from 'crypto';
+
+// Third-party imports
+import { encode as encodeHtml } from 'he';
+
+// Local imports - agent
 
 // Local imports
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import { encode as encodeHtml } from 'he';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 /**

--- a/src/agent/modelHandlers/streamUtils.ts
+++ b/src/agent/modelHandlers/streamUtils.ts
@@ -1,11 +1,8 @@
 // Standard library imports
-// Standard library imports
 import { randomUUID } from 'crypto';
 
 // Third-party imports
 import { encode as encodeHtml } from 'he';
-
-// Local imports - agent
 
 // Local imports
 import { bus } from '@eventBus/ProgressEventBus';

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -1,9 +1,4 @@
-// Local imports - types
-import type { ToolDefinition } from '@model';
-
 // Third-party imports
-import type { ChatCompletionTool } from 'openai/resources/chat/completions';
-import type { FunctionTool } from 'openai/resources/responses/responses';
 import type {
   Tool as AnthropicTool,
   ToolUnion,
@@ -13,6 +8,14 @@ import type {
   FunctionDeclaration,
   Schema,
 } from '@google/genai/dist/genai';
+
+// Third-party imports
+import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import type { FunctionTool } from 'openai/resources/responses/responses';
+
+// Local imports - agent
+// Local imports - types
+import type { ToolDefinition } from '@model';
 
 // Map local tool names to Anthropic remote tool types
 const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -1,5 +1,4 @@
-// Local imports - log
-import type { AgentLogger } from '@logger/AgentLogger';
+// Local imports - agent
 
 // Local imports - agent components
 import type { AgentConfig } from '../../core/AgentConfig';
@@ -7,9 +6,11 @@ import { AgentSetting } from '../../core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '../../core/AgentState';
 import { ToolState } from '../../core/ToolState';
 import type { MediaEntry } from '../../utils/mediaTypes';
-import type { ModelConfig, ModelCapabilities, ToolDefinition } from '@model';
-import type { ProviderStopReason } from './StopReasonTypes';
 import type { ProviderMessage } from './ProviderMessage';
+import type { ProviderStopReason } from './StopReasonTypes';
+// Local imports - log
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ModelConfig, ModelCapabilities, ToolDefinition } from '@model';
 
 /**
  * Common interface implemented by all model handlers.

--- a/src/agent/modelHandlers/types/ProviderMessage.ts
+++ b/src/agent/modelHandlers/types/ProviderMessage.ts
@@ -1,10 +1,11 @@
+// Third-party imports
+import type { MessageParam } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { Content } from '@google/genai';
 // Union type for message objects used across model providers
 
 // Third-party imports
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import type { ResponseInputItem } from 'openai/resources/responses/responses';
-import type { MessageParam } from '@anthropic-ai/sdk/resources/messages/messages';
-import type { Content } from '@google/genai';
 
 /**
  * Message formats supported by the various model providers.

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+// Third-party imports
 import { FinishReason } from '@google/genai';
 
 // Local imports - none

--- a/src/agent/output/DiffStatsManager.ts
+++ b/src/agent/output/DiffStatsManager.ts
@@ -1,7 +1,10 @@
+// Third-party imports
+import { diff_match_patch } from 'diff-match-patch';
+
+// Local imports - agent
+import type { DiffStats } from '@agent/types/DiffTypes';
 // Local imports
 import { WorkspaceFS } from '@utils/files';
-import { diff_match_patch } from 'diff-match-patch';
-import type { DiffStats } from '@agent/types/DiffTypes';
 
 export class DiffStatsManager {
   private countLines(text: string): number {

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,3 +1,4 @@
+// Local imports - agent
 // Local imports - types
 import { NamedOutputFile, OutputFileInfo } from './types';
 import { XmlOutputManager } from './XmlOutputManager';

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -1,13 +1,15 @@
+// Standard library imports
 import * as path from 'path';
 
+// Local imports - agent
 import { AgentSetting } from '@agent/core/AgentDataclass';
+import { LaTeXdiffService, LaTeXdiffResult } from '@latex/latexdiff';
+import { compileLatex2Pdf } from '@latex/texTools';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { objectToLogString } from '@utils/text/stringUtils';
 import { createFileMapping } from '@utils/files';
-import { compileLatex2Pdf } from '@latex/texTools';
 import { checkToolInstalled } from '@utils/system';
-import { LaTeXdiffService, LaTeXdiffResult } from '@latex/latexdiff';
+import { objectToLogString } from '@utils/text/stringUtils';
 
 export class LatexDiffManager {
   private readonly latexdiffService: LaTeXdiffService;

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -21,7 +21,7 @@ import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 
 // Local imports - utilities
 import { runLatexFormatter } from '@latex/texFormatter';
-// Standard library imports
+
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -1,30 +1,35 @@
 // Standard library imports
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
 import * as path from 'path';
+
+// Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - utilities
-import { runLatexFormatter } from '@latex/texFormatter';
-import { XmlOutputManager } from './XmlOutputManager';
-import { LatexDiffManager } from './LatexDiffManager';
+// Local imports - agent
 import { DiffStatsManager } from './DiffStatsManager';
-import type { NamedOutputFile, OutputFileInfo } from './types';
 import type { IOutputHandler } from './IOutputHandler';
-import { getOutputFileName } from '@agent/utils/outputFileUtils';
+import { LatexDiffManager } from './LatexDiffManager';
+import type { NamedOutputFile, OutputFileInfo } from './types';
+import { XmlOutputManager } from './XmlOutputManager';
 
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
+import { getOutputFileName } from '@agent/utils/outputFileUtils';
+import { bus } from '@eventBus/ProgressEventBus';
+import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+
+// Local imports - utilities
+import { runLatexFormatter } from '@latex/texFormatter';
+// Standard library imports
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - utilities
 import { replaceInputCommands, createFileMapping } from '@utils/files';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
-import { bus } from '@eventBus/ProgressEventBus';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 
 // Local imports - types
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -1,20 +1,23 @@
+// Standard library imports
 import * as path from 'path';
+
+// Third-party imports
 import { XMLParser } from 'fast-xml-parser';
 
-import { AgentSetting } from '@agent/core/AgentDataclass';
+// Local imports - agent
+import { NamedOutputFile } from './types';
 import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentSetting } from '@agent/core/AgentDataclass';
+import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { WorkspaceFS } from '@utils/files';
-import xmlUtils from '@utils/text/xmlUtils';
-import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import {
   applyReplacements,
   getReplacementsByCategory,
 } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
-
-import { NamedOutputFile } from './types';
+import { WorkspaceFS } from '@utils/files';
+import xmlUtils from '@utils/text/xmlUtils';
 
 export class XmlOutputManager {
   constructor(

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -1,3 +1,4 @@
+// Local imports - agent
 import type { DiffStats } from '@agent/types/DiffTypes';
 
 export interface NamedOutputFile {

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -1,5 +1,4 @@
-// Local imports - agent components
-import { ModelConfig, ModelProvider } from '@model';
+// Local imports - agent
 
 // Local imports - model handlers
 import {
@@ -17,10 +16,12 @@ import {
   ModelHandlerOpenAIResponse,
 } from '@agent/modelHandlers';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import * as logger from '@logger/logUtils';
+// Local imports - agent components
+import { ModelConfig, ModelProvider } from '@model';
 
 // Local imports - utils
 import { getConfig } from '@utils/config';
-import * as logger from '@logger/logUtils';
 
 // Initialize logger
 const CHANNEL = 'ModelFactory';

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -1,11 +1,16 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
+
+// Third-party imports
+import deepmerge from 'deepmerge';
 
 // Third-party imports
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
-import deepmerge from 'deepmerge';
 import { z } from 'zod';
+
+// Local imports - agent
 
 // Local imports - agent components
 import {
@@ -15,10 +20,10 @@ import {
   AgentPromptSchema,
   AgentDefinitionSchema,
 } from '@agent/core/AgentDataclass';
-import type { ToolDefinition } from '@model';
 
 // Local imports - utils
 import * as logger from '@logger/logUtils';
+import type { ToolDefinition } from '@model';
 import { AbsoluteFS } from '@utils/files';
 
 const CHANNEL = 'agentLoad';

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -1,16 +1,11 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
 import deepmerge from 'deepmerge';
-
-// Third-party imports
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
 import { z } from 'zod';
-
-// Local imports - agent
 
 // Local imports - agent components
 import {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -1,13 +1,15 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
-import * as vscode from 'vscode';
+
+// Third-party imports
 
 // Third-party imports
 import { glob } from 'glob';
+import * as vscode from 'vscode';
 
-// Local imports - utilities
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { agentConfigToTaskState } from '@utils/config';
+// Local imports - agent
+import { getStreamTabId } from '@/logger/streamUtils';
 
 // Local imports - agent components
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
@@ -17,30 +19,27 @@ import {
   AgentPrompt,
   AgentType,
 } from '@agent/core/AgentDataclass';
-import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
-
-import { MODEL_CONFIGS } from '@model/ModelRegistry';
-import { ModelFactory } from '@agent/runtime/ModelFactory';
-
+import { IAgent } from '@agent/core/IAgent';
 import {
   DirectAgent,
   CoTAgent,
   MergeAgent,
   BaseToolUseAgent,
 } from '@agent/implementations';
-
-import { AgentLogger } from '@logger/AgentLogger';
-
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
+import { ModelFactory } from '@agent/runtime/ModelFactory';
+import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { bus } from '@eventBus/ProgressEventBus';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
+// Local imports - utilities
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
-
-import { getStreamTabId } from '@/logger/streamUtils';
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import { AgentLogger } from '@logger/AgentLogger';
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { agentConfigToTaskState } from '@utils/config';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
-import { IAgent } from '@agent/core/IAgent';
 
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
-
-// Third-party imports
 
 // Third-party imports
 import { glob } from 'glob';

--- a/src/agent/types/DiffTypes.ts
+++ b/src/agent/types/DiffTypes.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 /**
  * Diff statistic schema used for file comparisons.
  */

--- a/src/agent/types/ResultTypes.ts
+++ b/src/agent/types/ResultTypes.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 /**
  * Common result schemas used across utilities.
  */

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 /**
  * Token usage statistics for tracking model usage and costs.
  */

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -1,19 +1,22 @@
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
-import { bus } from '@eventBus/ProgressEventBus';
+// Third-party imports
+import { ResponseUsage } from 'openai/resources/responses/responses';
+
+// Local imports - agent
 import { AgentStateGlobal } from '@agent/core/AgentState';
-import type { IModelHandler } from '@agent/modelHandlers';
 import {
   ExtendedCompletionUsage,
   AnthropicUsage,
   GenerateContentResponseUsageMetadata,
 } from '@agent/core/ResponseUsage';
-import { ResponseUsage } from 'openai/resources/responses/responses';
+import type { IModelHandler } from '@agent/modelHandlers';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
 import type {
   TokenUsageStats,
   ExtendedTokenUsageStats,
 } from '@agent/types/UsageTypes';
+import { bus } from '@eventBus/ProgressEventBus';
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
 
 /**
  * Handles recording usage statistics to the log and progress view.

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,15 +1,18 @@
+// Standard library imports
 // Utility for saving debug objects (messages/responses) during debugging
 
 // Standard library imports
 import * as path from 'path';
 
+// Local imports - agent
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { AgentLogger } from '@logger/AgentLogger';
+import { getConfig } from '@utils/config';
+
 // Local imports
 import { WorkspaceFS, StorageFS } from '@utils/files';
 import { getRunDir } from '@utils/files/taskRunStorage';
-import { getConfig } from '@utils/config';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
-import { AgentLogger } from '@logger/AgentLogger';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 /**
  * Context information for the debug save operation

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,7 +1,5 @@
 // Standard library imports
 // Utility for saving debug objects (messages/responses) during debugging
-
-// Standard library imports
 import * as path from 'path';
 
 // Local imports - agent

--- a/src/agent/utils/messageSkeletonUtils.ts
+++ b/src/agent/utils/messageSkeletonUtils.ts
@@ -1,10 +1,11 @@
+// Local imports - agent
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 /**
  * Utility functions for working with message objects in agent conversations.
  */
 
 // Local imports
 import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 /**
  * Creates a skeleton representation of a message object for debugging.

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -1,3 +1,4 @@
+// Standard library imports
 import * as path from 'path';
 
 /**

--- a/src/agent/utils/promptHelpers.ts
+++ b/src/agent/utils/promptHelpers.ts
@@ -1,3 +1,4 @@
+// Local imports - agent
 // Utility helpers for constructing prompts
 
 // Local imports

--- a/src/agent/utils/promptUtils.ts
+++ b/src/agent/utils/promptUtils.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
-
-// Third-party imports
 
 // Third-party imports
 import * as nunjucks from 'nunjucks';

--- a/src/agent/utils/promptUtils.ts
+++ b/src/agent/utils/promptUtils.ts
@@ -1,15 +1,20 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
+
+// Third-party imports
 import * as nunjucks from 'nunjucks';
+
+// Local imports - agent
+import { getAgentFirstNameChunk } from '@housekeeping/utils';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
-import { getAgentFirstNameChunk } from '@housekeeping/utils';
 
 const CHANNEL = 'promptUtils';
 logger.initialize(CHANNEL);

--- a/src/agent/utils/text/repetitionUtils.ts
+++ b/src/agent/utils/text/repetitionUtils.ts
@@ -1,4 +1,3 @@
-// Third-party imports
 // Standard library imports
 // (none needed)
 

--- a/src/agent/utils/text/repetitionUtils.ts
+++ b/src/agent/utils/text/repetitionUtils.ts
@@ -1,9 +1,12 @@
+// Third-party imports
 // Standard library imports
 // (none needed)
 
 // Third-party imports
 import { diff_match_patch } from 'diff-match-patch';
 import * as difflib from 'difflib';
+
+// Local imports - agent
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -1,20 +1,23 @@
+// Standard library imports
 // Utility functions for building user variables for prompts
 
 // Standard library imports
 import * as path from 'path';
 
-// Local imports
-import { AgentLogger } from '@logger/AgentLogger';
-import { WorkspaceFS } from '@utils/files';
-import { setVarFromFile } from '@frontend/files/vars';
+// Local imports - agent
+import type { AgentConfig } from '../core/AgentConfig';
+import { AgentSetting } from '../core/AgentDataclass';
+import type { IModelHandler } from '@agent/modelHandlers';
 import {
   getXmlFormatFromFiles,
   getListOfFiles,
 } from '@agent/utils/promptUtils';
+import { setVarFromFile } from '@frontend/files/vars';
+
+// Local imports
+import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import type { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting } from '../core/AgentDataclass';
-import type { IModelHandler } from '@agent/modelHandlers';
+import { WorkspaceFS } from '@utils/files';
 
 /**
  * Build all user variables needed for prompt rendering.

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -1,7 +1,5 @@
 // Standard library imports
 // Utility functions for building user variables for prompts
-
-// Standard library imports
 import * as path from 'path';
 
 // Local imports - agent

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -1,8 +1,5 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
-
-// Local imports - commands
 
 // Local imports - agent
 import { BaseAgent } from '@agent/implementations/BaseAgent';

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -1,12 +1,15 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
+// Local imports - commands
 
 // Local imports - agent
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import { bus } from '@eventBus/ProgressEventBus';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'AgentCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -1,19 +1,21 @@
 // Third-party imports
-import * as vscode from 'vscode';
 import Anthropic from '@anthropic-ai/sdk';
 import type { MessageCreateParams } from '@anthropic-ai/sdk/resources/messages';
+// Third-party imports
+import * as vscode from 'vscode';
 import * as yaml from 'yaml';
 
+// Local imports - commands
 import {
   AgentDefinitionSchema,
   AgentPromptSchema,
   AgentSettingSchema,
 } from '@agent/core/AgentDataclass';
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
+import { promptToAddAgentToConfig } from '@frontend/agents/register';
 
 // Local imports - utils
 import { SecretManager } from '@frontend/secretManager';
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { promptToAddAgentToConfig } from '@frontend/agents/register';
 import * as logger from '@logger/logUtils';
 import { ANTHROPIC_MODELS } from '@model/providers/anthropicModels';
 import { AbsoluteFS } from '@utils/files';

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -1,7 +1,6 @@
 // Third-party imports
 import Anthropic from '@anthropic-ai/sdk';
 import type { MessageCreateParams } from '@anthropic-ai/sdk/resources/messages';
-// Third-party imports
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
 

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -1,13 +1,16 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - commands
 
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - history
 import { AgentHistoryManager } from '@historyView/managers';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Add the registration function
 export function registerExecuteCommand(context: vscode.ExtensionContext) {

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -1,8 +1,5 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
-
-// Local imports - commands
 
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -1,4 +1,7 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - commands
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 
 const CHANNEL = 'followUpCommand';

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -1,8 +1,5 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
-
-// Local imports - commands
 
 // Local imports - agent
 import { executeMergeAgent } from '@agent/runtime/executeAgent';

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -1,11 +1,14 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - utilities
-import { getConfig } from '@utils/config';
+// Local imports - commands
 
 // Local imports - agent
 import { executeMergeAgent } from '@agent/runtime/executeAgent';
+
+// Local imports - utilities
+import { getConfig } from '@utils/config';
 
 export function registerMergeCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 /**
  * Utility functions for consistent error logging and formatting across the TeXRA extension.
  *
@@ -13,6 +14,8 @@
 
 // Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - common
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,19 +1,5 @@
 // Third-party imports
 import {
-  APIConnectionError as OpenAIConnectionError,
-  APIConnectionTimeoutError as OpenAIConnectionTimeoutError,
-  APIError as OpenAIAPIError,
-  AuthenticationError as OpenAIAuthenticationError,
-  PermissionDeniedError as OpenAIPermissionDeniedError,
-  RateLimitError as OpenAIRateLimitError,
-  BadRequestError as OpenAIBadRequestError,
-  NotFoundError as OpenAINotFoundError,
-  ConflictError as OpenAIConflictError,
-  UnprocessableEntityError as OpenAIUnprocessableEntityError,
-  InternalServerError as OpenAIInternalServerError,
-  APIUserAbortError as OpenAIUserAbortError,
-} from 'openai';
-import {
   APIConnectionError as AnthropicConnectionError,
   APIConnectionTimeoutError as AnthropicConnectionTimeoutError,
   APIError as AnthropicAPIError,
@@ -27,6 +13,23 @@ import {
   InternalServerError as AnthropicInternalServerError,
   APIUserAbortError as AnthropicUserAbortError,
 } from '@anthropic-ai/sdk';
+// Third-party imports
+import {
+  APIConnectionError as OpenAIConnectionError,
+  APIConnectionTimeoutError as OpenAIConnectionTimeoutError,
+  APIError as OpenAIAPIError,
+  AuthenticationError as OpenAIAuthenticationError,
+  PermissionDeniedError as OpenAIPermissionDeniedError,
+  RateLimitError as OpenAIRateLimitError,
+  BadRequestError as OpenAIBadRequestError,
+  NotFoundError as OpenAINotFoundError,
+  ConflictError as OpenAIConflictError,
+  UnprocessableEntityError as OpenAIUnprocessableEntityError,
+  InternalServerError as OpenAIInternalServerError,
+  APIUserAbortError as OpenAIUserAbortError,
+} from 'openai';
+
+// Local imports - common
 
 // Local imports
 import { getConfig } from '@utils/config';

--- a/src/common/files/fileTypeUtils.ts
+++ b/src/common/files/fileTypeUtils.ts
@@ -1,3 +1,4 @@
+// Local imports - common
 // Local imports
 import { getConfig } from '@utils/config';
 

--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -1,3 +1,4 @@
+// Local imports - common
 import { CHEVRON_UP_CLASS, CHEVRON_DOWN_CLASS } from './iconConstants.js';
 
 export function addEventListenerSafely(elementOrId, event, handler) {

--- a/src/common/modules/iconButtonInitializer.js
+++ b/src/common/modules/iconButtonInitializer.js
@@ -1,3 +1,4 @@
+// Local imports - common
 // Local imports
 import { createIconButton } from '@common/templateUtils.js';
 

--- a/src/common/modules/webviewState.js
+++ b/src/common/modules/webviewState.js
@@ -1,3 +1,4 @@
+// Local imports - common
 import { vscode } from '@common/webviewContext.js';
 
 /**

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
 
 // Simple enums for commonly used state keys

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -1,6 +1,9 @@
+// Third-party imports
 import * as vscode from 'vscode';
-import * as logger from '@logger/logUtils';
+
+// Local imports - common
 import { buildWebviewHtml } from '@frontend/webview/html';
+import * as logger from '@logger/logUtils';
 
 /**
  * Base class for all webview content providers.

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -1,6 +1,9 @@
+// Third-party imports
 import * as vscode from 'vscode';
-import * as logger from '@logger/logUtils';
+
+// Local imports - common
 import { COMMON_COMMANDS } from './commands';
+import * as logger from '@logger/logUtils';
 
 export type MessageHandler = (
   message: any,

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -1,3 +1,4 @@
+// Standard library imports
 import { EventEmitter } from 'events';
 
 // Maximum number of events to buffer when no listeners are registered

--- a/src/explorer/ExplorerCommands.ts
+++ b/src/explorer/ExplorerCommands.ts
@@ -1,10 +1,7 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports - explorer
-
-// Local imports
 import { ExplorerOperations } from './ExplorerOperations';
 import { FileItem } from './FileItem';
 

--- a/src/explorer/ExplorerCommands.ts
+++ b/src/explorer/ExplorerCommands.ts
@@ -1,5 +1,8 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - explorer
 
 // Local imports
 import { ExplorerOperations } from './ExplorerOperations';

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -1,18 +1,21 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
-import * as vscode from 'vscode';
-import * as logger from '@logger/logUtils';
 
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - explorer
+import { FileItem } from './FileItem';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 
 // Local imports
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { AbsoluteFS } from '@utils/files';
-
-import { FileItem } from './FileItem';
 import { validateYamlAndPromptAdd } from '@frontend/agents/register';
+import * as logger from '@logger/logUtils';
+import { AbsoluteFS } from '@utils/files';
 
 const NEW_AGENT_TEMPLATE = `# --- Agent Inheritance (Optional) ---
 # inherits: base

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
-
-// Third-party imports
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/src/explorer/FileItem.ts
+++ b/src/explorer/FileItem.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 import * as vscode from 'vscode';
 
 export class FileItem extends vscode.TreeItem {

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -1,13 +1,8 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
-
-// Third-party imports
 import * as vscode from 'vscode';
-
-// Local imports - explorer
 
 // Local imports
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -1,12 +1,18 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
+
+// Third-party imports
+
 // Third-party imports
 import * as vscode from 'vscode';
-import * as logger from '@logger/logUtils';
+
+// Local imports - explorer
 
 // Local imports
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { validateYamlAndPromptAdd } from '@frontend/agents/register';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);

--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -1,4 +1,7 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - history view
 import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
 
 export class HistoryViewContentProvider extends BaseViewContentProvider {

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -1,17 +1,21 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - history view
+import { executeCommand } from '@commands/agent/executeCommand';
+import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 
 // Local imports - common
 import {
   BaseViewMessageHandler,
   type MessageHandler,
 } from '@common/webview/BaseViewMessageHandler';
+
 // @ts-ignore - Import JavaScript module
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands';
 import { AgentHistoryManager } from '@historyView/managers';
-import { executeCommand } from '@commands/agent/executeCommand';
 import { agentConfigToTaskState } from '@utils/config';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 
 export class HistoryViewMessageHandler extends BaseViewMessageHandler {
   constructor(private readonly context: vscode.ExtensionContext) {

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -1,5 +1,8 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - history view
 
 // Local imports - components
 import { HistoryViewContentProvider } from './HistoryViewContentProvider';

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -1,13 +1,18 @@
-// Third-party imports
-import * as vscode from 'vscode';
+// Standard library imports
 
 // Standard library imports
 import { randomUUID } from 'crypto';
 
+// Third-party imports
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - history view
+
 // Local imports
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import { workspaceSM } from '@common/state/stateManager';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { workspaceSM } from '@common/state/stateManager';
 
 /**
  * Represents a historical agent execution

--- a/src/historyView/modules/constants.js
+++ b/src/historyView/modules/constants.js
@@ -1,3 +1,4 @@
+// Local imports - history view
 // Constants for History View
 
 // Import standardized commands

--- a/src/historyView/modules/domHandlers.js
+++ b/src/historyView/modules/domHandlers.js
@@ -1,8 +1,9 @@
+// Local imports - history view
+import { historyViewState } from './historyViewState.js';
+import { HistoryEventsManager } from './uiManagers/HistoryEventsManager.js';
 // Local imports
 import { HistoryRenderer } from './uiManagers/HistoryRenderer.js';
 import { SearchManager } from './uiManagers/SearchManager.js';
-import { HistoryEventsManager } from './uiManagers/HistoryEventsManager.js';
-import { historyViewState } from './historyViewState.js';
 
 /**
  * Coordinates the history view DOM managers.

--- a/src/historyView/modules/historyViewState.js
+++ b/src/historyView/modules/historyViewState.js
@@ -1,3 +1,4 @@
+// Local imports - history view
 import { WebviewStateManager } from '@common/webviewState.js';
 
 class ToggleStates {

--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -1,7 +1,8 @@
-// Local imports
-import { registerMessageHandlers } from '@common/webviewContext.js';
+// Local imports - history view
 import { historyViewDomHandler } from './domHandlers.js';
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
+// Local imports
+import { registerMessageHandlers } from '@common/webviewContext.js';
 
 /**
  * Handles messages from the extension for the history view.

--- a/src/historyView/modules/uiManagers/HistoryEventsManager.js
+++ b/src/historyView/modules/uiManagers/HistoryEventsManager.js
@@ -1,5 +1,6 @@
-import { addEventListenerSafely } from '@common/domUtils.js';
+// Local imports - history view
 import { ELEMENT_IDS } from '../constants.js';
+import { addEventListenerSafely } from '@common/domUtils.js';
 
 /**
  * Registers global event listeners for the history view.

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -1,13 +1,14 @@
-// Local imports
-import { vscode } from '@common/webviewContext.js';
+// Local imports - history view
+import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
+import { historyViewState } from '../historyViewState.js';
 import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
-import { historyViewState } from '../historyViewState.js';
-import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
-import { createFromTemplate, createCodicon } from '@common/templateUtils.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
+import { createFromTemplate, createCodicon } from '@common/templateUtils.js';
+// Local imports
+import { vscode } from '@common/webviewContext.js';
 
 /**
  * Renders history items and manages per-item events.

--- a/src/historyView/modules/uiManagers/SearchManager.js
+++ b/src/historyView/modules/uiManagers/SearchManager.js
@@ -1,7 +1,8 @@
+// Local imports - history view
+import { CLASS_NAMES, ELEMENT_IDS, LABELS } from '../constants.js';
+import { historyViewState } from '../historyViewState.js';
 /* global Mark */
 import { safeGetElementById } from '@common/domUtils.js';
-import { historyViewState } from '../historyViewState.js';
-import { CLASS_NAMES, ELEMENT_IDS, LABELS } from '../constants.js';
 
 /**
  * Handles search functionality using mark.js.

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -1,9 +1,10 @@
-import { vscode } from '@common/webviewContext.js';
+// Local imports - history view
 import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
 import { messageHandler } from './modules/messageHandlers.js';
-import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
+import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { vscode } from '@common/webviewContext.js';
 
 historyViewState.initialize();
 

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -1,4 +1,7 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - progress view
 import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
 
 export class ProgressViewContentProvider extends BaseViewContentProvider {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -1,9 +1,13 @@
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - progress view
+import type { ProgressViewProvider } from './ProgressViewProvider';
 import {
   BaseViewMessageHandler,
   MessageHandler,
 } from '@common/webview/BaseViewMessageHandler';
-import type { ProgressViewProvider } from './ProgressViewProvider';
+
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -1,25 +1,28 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - progress view
+import { ProgressEventHandler } from './events/ProgressEventHandler';
+import { WebviewUpdater } from './managers';
+
+// @ts-ignore - Import JavaScript module
+import { STATUS, COMMANDS } from './modules/constants.js';
 
 // Local imports - new architecture
 import { StatePersistenceManager } from './persistence/StatePersistenceManager';
-import { ProgressViewState } from './state/ProgressViewState';
-import { ProgressEventHandler } from './events/ProgressEventHandler';
-import { WebviewUpdater } from './managers';
 
 // Local imports - existing components
 import { ProgressViewContentProvider } from './ProgressViewContentProvider';
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
-import { AgentLogger } from '@logger/AgentLogger';
+import { ProgressViewState } from './state/ProgressViewState';
 
 // Types
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
-import { TaskState } from '@logger/TaskState';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
-
-// @ts-ignore - Import JavaScript module
-import { STATUS, COMMANDS } from './modules/constants.js';
+import { TaskState } from '@logger/TaskState';
 
 // Type aliases for status values
 type StreamStatusType =

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -1,23 +1,27 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
-// Local imports
-import { ProgressViewState } from '../state/ProgressViewState';
-import { WebviewUpdater } from '../managers';
-import { AgentLogger } from '@logger/AgentLogger';
-import { getConfig } from '@utils/config';
-import { bus } from '@eventBus/ProgressEventBus';
-import { buildStreamInfos } from '../streamInfoUtils';
 
-// Types
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
-import { TaskState } from '@logger/TaskState';
-import { LogMessageData, TaskGroup } from '@logger/LogTypes';
-import { parseLegacyLogData } from '@logger/logUtils';
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
-import type { StreamTabInfo } from '../types';
+// Local imports - progress view
+import { WebviewUpdater } from '../managers';
 
 // @ts-ignore - Import JavaScript module
 import { STATUS } from '../modules/constants.js';
+
+// Local imports
+import { ProgressViewState } from '../state/ProgressViewState';
+import { buildStreamInfos } from '../streamInfoUtils';
+import type { StreamTabInfo } from '../types';
+import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+
+// Types
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
+import { LogMessageData, TaskGroup } from '@logger/LogTypes';
+import { parseLegacyLogData } from '@logger/logUtils';
+import { TaskState } from '@logger/TaskState';
+import { getConfig } from '@utils/config';
 
 // Type aliases for status values
 type StatusType =

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -1,12 +1,13 @@
+// Local imports - progress view
 // Local imports
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
-import { WorkspaceStateKey } from '@common/state/stateManager';
-import { WorkspaceFS } from '@utils/files';
-import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
 import type { DiffStats } from '@agent/types/DiffTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { WorkspaceStateKey } from '@common/state/stateManager';
+import { AgentLogger } from '@logger/AgentLogger';
+import { WorkspaceFS } from '@utils/files';
 
 interface OutputFileInfo extends DiffStats {
   path: string;

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -1,15 +1,18 @@
+// Standard library imports
 // Third-party imports
 import { randomUUID } from 'crypto';
 
+// Local imports - progress view
+
 // Local imports
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
-import { parseLegacyLogData } from '@logger/logUtils';
 
 // Types
 import { LogMessageData } from '@logger/LogTypes';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { parseLegacyLogData } from '@logger/logUtils';
 
 /**
  * Manages stream tabs collection with persistence.

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -1,11 +1,12 @@
+// Local imports - progress view
 // Local imports
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
 import { TaskGroup } from '@logger/LogTypes';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 /**
  * Manages task groups collection with persistence.

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -1,11 +1,12 @@
+// Local imports - progress view
 // Local imports
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
-import { WorkspaceStateKey } from '@common/state/stateManager';
-import { AgentLogger } from '@logger/AgentLogger';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { WorkspaceStateKey } from '@common/state/stateManager';
+import { AgentLogger } from '@logger/AgentLogger';
 
 /**
  * Manages usage statistics collection with persistence.

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -1,19 +1,22 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports
-import { ProgressViewState } from '../state/ProgressViewState';
-import { AgentLogger } from '@logger/AgentLogger';
-import { buildStreamInfos } from '../streamInfoUtils';
-
-// Types
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
-import { LogMessageData } from '@logger/LogTypes';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
-import type { StreamTabInfo } from '../types';
+// Local imports - progress view
 
 // @ts-ignore - Import JavaScript module
 import { COMMANDS } from '../modules/constants.js';
+
+// Local imports
+import { ProgressViewState } from '../state/ProgressViewState';
+import { buildStreamInfos } from '../streamInfoUtils';
+import type { StreamTabInfo } from '../types';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+
+// Types
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import { AgentLogger } from '@logger/AgentLogger';
+import { LogMessageData } from '@logger/LogTypes';
 
 // Type aliases for status values
 type StatusType = 'running' | 'error' | 'stopped' | 'ready';

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,13 +1,14 @@
+// Local imports - progress view
+import { LogEntryFormatter } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { LogEntryFormatter } from './formatters.js';
 import { TaskGroupManager, LogEntryManager } from './taskManagers.js';
-import { UsageSummary, UsageGroup } from './usageManagers.js';
+import { EventsManager } from './uiManagers/EventsManager.js';
+import { FileList } from './uiManagers/FileList.js';
+import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
-import { Status } from './uiManagers/Status.js';
-import { FileList } from './uiManagers/FileList.js';
-import { EventsManager } from './uiManagers/EventsManager.js';
+import { UsageSummary, UsageGroup } from './usageManagers.js';
 
 /**
  * Manages all DOM operations for the progress view.

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1,3 +1,6 @@
+// Third-party imports
+import markdownItKatex from '@vscode/markdown-it-katex';
+import { encode as encodeHtml, decode as decodeHtml } from 'he';
 /**
  * Formatters for log entries in the progress view.
  *
@@ -13,17 +16,18 @@
 
 // Third-party imports
 import MarkdownIt from 'markdown-it';
-import markdownItKatex from '@vscode/markdown-it-katex';
 import highlight from 'markdown-it-highlightjs';
-import { encode as encodeHtml, decode as decodeHtml } from 'he';
+
+// Local imports - progress view
+import { STATUS } from './constants.js';
+
 // Local imports
 import { katexMacros } from './katexMacros.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,
 } from '@common/webviewContext.js';
-import { STATUS } from './constants.js';
-import { createFromTemplate } from '@common/templateUtils.js';
 
 // Constants
 export const BULLET_MARKUP =

--- a/src/progressView/modules/handlers/themeHandlers.js
+++ b/src/progressView/modules/handlers/themeHandlers.js
@@ -1,3 +1,4 @@
+// Local imports - progress view
 // Handler for theme-related messages in the progress view
 import { COMMON_COMMANDS } from '@common/webview/commands.js';
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,9 +1,10 @@
+// Local imports - progress view
+import { COMMANDS, STATUS, ELEMENT_IDS } from './constants.js';
+import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
+import { createThemeHandlers } from './handlers/themeHandlers.js';
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
-import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
-import { COMMANDS, STATUS, ELEMENT_IDS } from './constants.js';
 import { registerMessageHandlers } from '@common/webviewContext.js';
-import { createThemeHandlers } from './handlers/themeHandlers.js';
 
 // Create shorter aliases for internal use
 const state = progressViewState;

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -1,3 +1,4 @@
+// Local imports - progress view
 // Local imports - state management helper
 import { WebviewStateManager } from '@common/webviewState.js';
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,7 +1,8 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from './constants.js';
+import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
-import { ELEMENT_IDS } from './constants.js';
 
 /**
  * Manages task group DOM operations.

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -1,8 +1,12 @@
 // Third-party imports
+// Third-party imports
 import Split from 'split.js';
+
+// Local imports - progress view
+import { COMMANDS, SPLIT_SIZES, ELEMENT_IDS } from '../constants.js';
+
 // Local imports
 import { progressViewState } from '../progressViewState.js';
-import { COMMANDS, SPLIT_SIZES, ELEMENT_IDS } from '../constants.js';
 import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -1,9 +1,10 @@
+// Local imports - progress view
+import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 // Local imports
 import { formatTokens } from '../formatters.js';
-import { COMMANDS, ELEMENT_IDS } from '../constants.js';
-import { vscode } from '@common/webviewContext.js';
-import { createFromTemplate } from '@common/templateUtils.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
+import { createFromTemplate } from '@common/templateUtils.js';
+import { vscode } from '@common/webviewContext.js';
 
 /**
  * Manages file list rendering.

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -1,6 +1,7 @@
+// Local imports - progress view
+import { STATUS, TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
 // Local imports
 import { progressViewState } from '../progressViewState.js';
-import { STATUS, TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
 
 /**
  * Manages status display and button states.

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -1,7 +1,8 @@
+// Local imports - progress view
 // Local imports
 import { ELEMENT_IDS } from '../constants.js';
-import { createFromTemplate } from '@common/templateUtils.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 const AGENT_ICONS = {
   CoT: 'terminal',

--- a/src/progressView/modules/uiManagers/Toolbar.js
+++ b/src/progressView/modules/uiManagers/Toolbar.js
@@ -1,3 +1,4 @@
+// Local imports - progress view
 // Local imports
 import { TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
 import { createIconButton } from '@common/templateUtils.js';

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -1,7 +1,8 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from './constants.js';
+import { formatTokens, TaskGroupLevel } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { formatTokens, TaskGroupLevel } from './formatters.js';
-import { ELEMENT_IDS } from './constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 /**

--- a/src/progressView/persistence/StatePersistenceManager.ts
+++ b/src/progressView/persistence/StatePersistenceManager.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
 
 /**

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -1,10 +1,11 @@
-import { progressViewState } from './modules/progressViewState.js';
-import { messageHandler } from './modules/messageHandlers.js';
-import { progressViewDomHandler } from './modules/domHandlers.js';
-import { vscode } from '@common/webviewContext.js';
+// Local imports - progress view
 import { COMMANDS } from './modules/constants.js';
-import { validateTemplates } from '@common/templateUtils.js';
+import { progressViewDomHandler } from './modules/domHandlers.js';
+import { messageHandler } from './modules/messageHandlers.js';
+import { progressViewState } from './modules/progressViewState.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
+import { validateTemplates } from '@common/templateUtils.js';
+import { vscode } from '@common/webviewContext.js';
 
 // Initialize the state when the window loads
 progressViewState.initialize();

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -1,18 +1,19 @@
-// Local imports
-import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
+// Local imports - progress view
 import {
   StreamTabsManager,
   TaskGroupManager,
   OutputFilesManager,
   UsageStatsManager,
 } from '../managers';
+// Local imports
+import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
+import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
-import { objectToTaskState, getConfig } from '@utils/config';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Types
 import { TaskState } from '@logger/TaskState';
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import { objectToTaskState, getConfig } from '@utils/config';
 
 /**
  * Core state management for the progress view.

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -1,4 +1,7 @@
+// Standard library imports
 import * as path from 'path';
+
+// Local imports - progress view
 import type { ProgressViewState } from './state/ProgressViewState';
 import type { StreamTabInfo } from './types';
 

--- a/src/replacement/rules/characters.ts
+++ b/src/replacement/rules/characters.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 export const CHARACTER_REPLACEMENTS: ReplacementCategory = {
   name: 'characters',
   description: 'Fixes for special characters and diacritics',

--- a/src/replacement/rules/equations.ts
+++ b/src/replacement/rules/equations.ts
@@ -1,4 +1,4 @@
-import { ReplacementCategory } from '../types';
+// Local imports - replacement
 import {
   generateGroupedBackslashFixes,
   generateReferenceSpacing,
@@ -7,6 +7,8 @@ import {
   GREEK_LETTERS,
   MATH_OPERATORS,
 } from '../helpers';
+import { ReplacementCategory } from '../types';
+
 // Common LaTeX equation spacing fixes
 export const EQUATION_REPLACEMENTS: ReplacementCategory = {
   name: 'equations',

--- a/src/replacement/rules/fontCommands.ts
+++ b/src/replacement/rules/fontCommands.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 export const FONT_COMMAND_REPLACEMENTS: ReplacementCategory = {
   name: 'font_commands',
   description: 'Normalize deprecated font commands to modern equivalents',

--- a/src/replacement/rules/gptness.ts
+++ b/src/replacement/rules/gptness.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 export const GPTNESS_REPLACEMENTS: ReplacementCategory = {
   name: 'gptness',
   description: 'GPTness improvements',

--- a/src/replacement/rules/latexDocument.ts
+++ b/src/replacement/rules/latexDocument.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 export const LATEX_DOCUMENT_REPLACEMENTS: ReplacementCategory = {
   name: 'latex_document',
   description: 'Fixes for LaTeX document structure, code blocks, and cleanup',

--- a/src/replacement/rules/latexXml.ts
+++ b/src/replacement/rules/latexXml.ts
@@ -1,9 +1,11 @@
-import { ReplacementCategory } from '../types';
+// Local imports - replacement
 import {
   generateXmlLatexConversions,
   generateLatexToXmlConversions,
   LATEX_ENVIRONMENTS,
 } from '../helpers';
+import { ReplacementCategory } from '../types';
+
 export const LATEX_XML_REPLACEMENTS: ReplacementCategory = {
   name: 'latex_xml',
   description: 'Fixes specific to XML output processing',

--- a/src/replacement/rules/latexdiff.ts
+++ b/src/replacement/rules/latexdiff.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 export const LATEXDIFF_REPLACEMENTS: ReplacementCategory = {
   name: 'latexdiff',
   description: 'Fixes for LaTeXdiff markup and compatibility issues',

--- a/src/replacement/rules/personalStyle.ts
+++ b/src/replacement/rules/personalStyle.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 export const PERSONAL_STYLE_REPLACEMENTS: ReplacementCategory = {
   name: 'personal_style',
   description:

--- a/src/replacement/rules/scratchpadXml.ts
+++ b/src/replacement/rules/scratchpadXml.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 export const SCRATCHPAD_XML_REPLACEMENTS: ReplacementCategory = {
   name: 'scratchpad_xml',
   description: 'Fixes for scratchpad XML processing',

--- a/src/replacement/rules/sections.ts
+++ b/src/replacement/rules/sections.ts
@@ -1,5 +1,7 @@
-import { ReplacementCategory } from '../types';
+// Local imports - replacement
 import { generateSectionSpacingFixes, SECTION_TYPES } from '../helpers';
+import { ReplacementCategory } from '../types';
+
 export const SECTION_REPLACEMENTS: ReplacementCategory = {
   name: 'sections',
   description: 'Fixes for section spacing in LaTeX documents',

--- a/src/replacement/rules/spacing.ts
+++ b/src/replacement/rules/spacing.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 // LaTeX spacing and punctuation fixes
 export const LATEX_SPACING_REPLACEMENTS: ReplacementCategory = {
   name: 'latex_spacing',

--- a/src/replacement/rules/unicode.ts
+++ b/src/replacement/rules/unicode.ts
@@ -1,4 +1,6 @@
+// Local imports - replacement
 import { ReplacementCategory } from '../types';
+
 export const UNICODE_REPLACEMENTS: ReplacementCategory = {
   name: 'unicode',
   description:

--- a/src/test/commands/system/mainViewCommands.test.ts
+++ b/src/test/commands/system/mainViewCommands.test.ts
@@ -1,5 +1,10 @@
+// Standard library imports
 import { strict as assert } from 'assert';
+
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - test
 import {
   registerMainViewCommands,
   mainViewCommands,

--- a/src/test/logger/errorData.test.ts
+++ b/src/test/logger/errorData.test.ts
@@ -1,4 +1,7 @@
+// Standard library imports
 import { strict as assert } from 'assert';
+
+// Local imports - test
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -1,5 +1,7 @@
+// Standard library imports
 import { strict as assert } from 'assert';
 
+// Local imports - test
 import { toOpenAIResponseTools } from '@agent/modelHandlers/toolConversion';
 import type { ToolDefinition } from '@model';
 

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -1,10 +1,13 @@
+// Standard library imports
 import { strict as assert } from 'assert';
+
+// Local imports - test
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { OutputHandler } from '@agent/output';
 
 // Local imports
 import { bus } from '@eventBus/ProgressEventBus';
-import { OutputHandler } from '@agent/output';
-import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
-import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentLogger } from '@logger/AgentLogger';
 
 class MockOutputHandler extends OutputHandler {

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -1,11 +1,14 @@
+// Standard library imports
 import { strict as assert } from 'assert';
+
+// Local imports - test
+import type { AgentConfig } from '@agent/core/AgentConfig';
 
 // Local imports
 import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
-import type { AgentConfig } from '@agent/core/AgentConfig';
+import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import { AgentLogger } from '@logger/AgentLogger';
 import { WorkspaceFS } from '@utils/files';
-import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 
 describe('XmlOutputManager markdown fallback', () => {
   const setting: AgentSetting = {

--- a/src/test/progressView/Formatters.test.ts
+++ b/src/test/progressView/Formatters.test.ts
@@ -1,6 +1,13 @@
+// Standard library imports
 import { strict as assert } from 'assert';
+
+// Third-party imports
+
 // @ts-ignore: jsdom lacks ESM typings in this context
 import { JSDOM } from 'jsdom';
+
+// Local imports - test
+
 // @ts-ignore: formatter is compiled JS module
 import { LogEntryFormatter } from '../../progressView/modules/formatters.js';
 

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -1,15 +1,18 @@
+// Standard library imports
 import { strict as assert } from 'assert';
-import { bus } from '@eventBus/ProgressEventBus';
-import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
-import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+
+// Local imports - test
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import {
   AgentSetting,
   AgentPrompt,
   AgentType,
 } from '@agent/core/AgentDataclass';
-import { ModelProvider, DEFAULT_MODEL_CAPABILITIES } from '@model/ModelConfig';
-import type { AgentConfig } from '@agent/core/AgentConfig';
+import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { bus } from '@eventBus/ProgressEventBus';
+import { ModelProvider, DEFAULT_MODEL_CAPABILITIES } from '@model/ModelConfig';
 
 class DummyHandler extends ModelHandler {
   calls = 0;

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -1,25 +1,29 @@
+// Standard library imports
 import { strict as assert } from 'assert';
+
+// Third-party imports
 import { z } from 'zod';
 
-import { bus } from '@eventBus/ProgressEventBus';
-import { runToolUseCycle } from '@agent/core/ToolUseCycle';
-import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { BaseTool } from '@tools/core/base';
-import { ToolResult } from '@tools/result';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import { ToolState } from '@agent/core/ToolState';
+// Local imports - test
 import {
   AgentSetting,
   AgentType,
   AgentPrompt,
 } from '@agent/core/AgentDataclass';
+import { ToolState } from '@agent/core/ToolState';
+import { runToolUseCycle } from '@agent/core/ToolUseCycle';
 import { ModelHandlerDeepSeek } from '@agent/modelHandlers/modelHandlerDeepSeek';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   ModelConfig,
   ModelProvider,
   DEFAULT_MODEL_CAPABILITIES,
 } from '@model/ModelConfig';
+import { BaseTool } from '@tools/core/base';
+import { ToolResult } from '@tools/result';
 
 class EchoTool extends BaseTool<{ value: string }> {
   constructor() {

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -1,26 +1,31 @@
+// Standard library imports
 import { strict as assert } from 'assert';
+
+// Third-party imports
 import { z } from 'zod';
 
-// Local imports
-import { bus } from '@eventBus/ProgressEventBus';
-import { runToolUseCycle } from '@agent/core/ToolUseCycle';
-import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { BaseTool } from '@tools/core/base';
-import { ToolResult } from '@tools/result';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import { ToolState } from '@agent/core/ToolState';
+// Local imports - test
 import {
   AgentSetting,
   AgentType,
   AgentPrompt,
 } from '@agent/core/AgentDataclass';
+import { ToolState } from '@agent/core/ToolState';
+import { runToolUseCycle } from '@agent/core/ToolUseCycle';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+// Local imports
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   ModelConfig,
   ModelProvider,
   DEFAULT_MODEL_CAPABILITIES,
 } from '@model/ModelConfig';
+import { BaseTool } from '@tools/core/base';
+import { ToolResult } from '@tools/result';
 
 class EchoTool extends BaseTool<{ value: string }> {
   constructor() {

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -1,13 +1,16 @@
+// Third-party imports
 import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+// Local imports - tools
+import { BaseTool } from './core/base';
+import { ToolResult, ToolError } from './result';
 import {
   getLinterMessages,
   countDiagnosticsBySeverity,
 } from '@frontend/latex/linter';
 import * as logger from '@logger/logUtils';
-import { BaseTool } from './core/base';
-import { ToolResult, ToolError } from './result';
 import type { ToolDefinition } from '@model';
-import { zodToJsonSchema } from 'zod-to-json-schema';
 
 const CHANNEL = 'DiagnosticsTool';
 logger.initialize(CHANNEL);

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-// Standard library imports
 
 import * as path from 'path';
 

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -1,21 +1,26 @@
 // Standard library imports
+// Standard library imports
 
 import * as path from 'path';
+
+// Third-party imports
 import * as vscode from 'vscode';
 import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+// Local imports - tools
 
 // Local imports - core
 import { BaseTool } from './core/base';
-import { ToolCallInput, EditorCommand, FileHistoryEntry } from './types';
 import { ToolResult, CLIResult, ToolError } from './result';
-import type { ToolDefinition } from '@model';
-import { zodToJsonSchema } from 'zod-to-json-schema';
-
-// Local imports - utilities
-import { WorkspaceFS, AbsoluteFS } from '@utils/files';
+import { ToolCallInput, EditorCommand, FileHistoryEntry } from './types';
 
 // Local imports - Log
 import * as logger from '@logger/logUtils';
+import type { ToolDefinition } from '@model';
+
+// Local imports - utilities
+import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 
 // Constants
 const CHANNEL = 'TextEditorTool';

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,12 +1,15 @@
+// Third-party imports
 // Standard library imports
 
 // Local imports - core
 import { z } from 'zod';
-import { executeCommand } from '@utils/system/execUtils';
-import { BaseTool } from './core/base';
-import { ToolResult } from '@tools/result';
-import type { ToolDefinition } from '@model';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+
+// Local imports - tools
+import { BaseTool } from './core/base';
+import type { ToolDefinition } from '@model';
+import { ToolResult } from '@tools/result';
+import { executeCommand } from '@utils/system/execUtils';
 
 const BashInputSchema = z.object({
   command: z.string(),

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -1,4 +1,7 @@
+// Third-party imports
 import { z } from 'zod';
+
+// Local imports - tools
 import type { ToolDefinition } from '@model';
 import { ToolResult } from '@tools/result';
 

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -1,12 +1,15 @@
+// Third-party imports
 // Standard library imports
 
 // Local imports - core
 import { z } from 'zod';
-import { WorkspaceFS } from '@utils/files';
-import { BaseTool } from './core/base';
-import { ToolResult } from '@tools/result';
-import type { ToolDefinition } from '@model';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+
+// Local imports - tools
+import { BaseTool } from './core/base';
+import type { ToolDefinition } from '@model';
+import { ToolResult } from '@tools/result';
+import { WorkspaceFS } from '@utils/files';
 
 const FileOpInputSchema = z.object({
   command: z.enum(['read', 'write', 'append']),

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,11 +1,12 @@
-import { TextEditorTool } from './TextEditorTool';
-import { DiagnosticsTool } from './DiagnosticsTool';
+// Local imports - tools
 import { BashTool } from './bash';
-import { FileOpTool } from './fileOp';
-import { WolframTool } from './wolfram';
-import { WebSearchTool } from './web/WebSearchTool';
-
 import { BaseTool } from './core/base';
+import { DiagnosticsTool } from './DiagnosticsTool';
+import { FileOpTool } from './fileOp';
+import { TextEditorTool } from './TextEditorTool';
+import { WebSearchTool } from './web/WebSearchTool';
+import { WolframTool } from './wolfram';
+
 export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   str_replace_editor: new TextEditorTool(),
   diagnostics: new DiagnosticsTool(),

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -1,12 +1,15 @@
+// Third-party imports
+import axios from 'axios';
 // Standard library imports
 
 // Local imports - core
 import { z } from 'zod';
-import axios from 'axios';
-import type { ToolDefinition } from '@model';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+// Local imports - tools
 import { BaseTool } from '../core/base';
 import { ToolResult } from '../result';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { ToolDefinition } from '@model';
 
 const WebSearchInputSchema = z.object({
   query: z.string(),

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -1,12 +1,15 @@
+// Third-party imports
 // Standard library imports
 
 // Local imports - core
 import { z } from 'zod';
-import type { ToolDefinition } from '@model';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+// Local imports - tools
 import { BaseTool } from '../core/base';
 import { ToolResult } from '../result';
 import { executeWolframCode } from './wolframScriptUtils';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { ToolDefinition } from '@model';
 
 const WolframInputSchema = z.object({
   code: z.string(),

--- a/src/tools/wolfram/wolframScriptUtils.ts
+++ b/src/tools/wolfram/wolframScriptUtils.ts
@@ -1,5 +1,8 @@
+// Third-party imports
 // Standard library imports
 import * as vscode from 'vscode';
+
+// Local imports - tools
 
 // Local imports
 import { executeCommand, checkToolInstalled } from '@utils/system';

--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -1,9 +1,14 @@
 // Standard library imports
+// Standard library imports
 import * as fs from 'fs';
 import * as path from 'path';
 
 // Third-party imports
+
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - utils
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -1,14 +1,9 @@
 // Standard library imports
-// Standard library imports
 import * as fs from 'fs';
 import * as path from 'path';
 
 // Third-party imports
-
-// Third-party imports
 import * as vscode from 'vscode';
-
-// Local imports - utils
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -1,5 +1,8 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
+
+// Local imports - utils
 
 // Local imports
 import { WorkspaceFS } from './workspaceFS';

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
-
-// Local imports - utils
 
 // Local imports
 import { WorkspaceFS } from './workspaceFS';

--- a/src/utils/files/mimeUtils.ts
+++ b/src/utils/files/mimeUtils.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+// Third-party imports
 import mime from 'mime-types';
 
 /**

--- a/src/utils/files/mimeUtils.ts
+++ b/src/utils/files/mimeUtils.ts
@@ -1,5 +1,4 @@
 // Third-party imports
-// Third-party imports
 import mime from 'mime-types';
 
 /**

--- a/src/utils/files/pastedImageUtils.ts
+++ b/src/utils/files/pastedImageUtils.ts
@@ -1,13 +1,8 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
-
-// Third-party imports
 import { nanoid } from 'nanoid';
-
-// Local imports - utils
 
 // Local imports
 import { StorageFS } from './storageFS';

--- a/src/utils/files/pastedImageUtils.ts
+++ b/src/utils/files/pastedImageUtils.ts
@@ -1,8 +1,13 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
+
+// Third-party imports
 import { nanoid } from 'nanoid';
+
+// Local imports - utils
 
 // Local imports
 import { StorageFS } from './storageFS';

--- a/src/utils/files/pathUtils.ts
+++ b/src/utils/files/pathUtils.ts
@@ -1,4 +1,7 @@
+// Standard library imports
 import * as path from 'path';
+
+// Local imports - utils
 import { WorkspaceFS } from './workspaceFS';
 
 /** Resolve a file path relative to the workspace if not already absolute. */

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -1,13 +1,8 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
-
-// Third-party imports
 import * as vscode from 'vscode';
-
-// Local imports - utils
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -1,8 +1,13 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
 
 // Third-party imports
+
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - utils
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/utils/files/storageFS.ts
+++ b/src/utils/files/storageFS.ts
@@ -1,8 +1,5 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
-
-// Local imports - utils
 
 // Local imports - fs
 import { RelativeFS } from './relativeFS';

--- a/src/utils/files/storageFS.ts
+++ b/src/utils/files/storageFS.ts
@@ -1,5 +1,8 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - utils
 
 // Local imports - fs
 import { RelativeFS } from './relativeFS';

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
-
-// Local imports - utils
 
 // Local imports - storage
 import { StorageFS } from './storageFS';

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -1,5 +1,8 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
+
+// Local imports - utils
 
 // Local imports - storage
 import { StorageFS } from './storageFS';

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -1,16 +1,21 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
+
+// Third-party imports
 
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
+// Local imports - utils
 import { AbsoluteFS } from './absoluteFS';
 import {
   showLoggedErrorMessage,
   showLoggedMessage,
 } from '@common/errors/errorHandlingUtils';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'workspaceFS';
 logger.initialize(CHANNEL);

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
-
-// Third-party imports
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -1,8 +1,13 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - webview
+import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
 import { getConfig } from '@utils/config';
 import { GlobalStorageFS, AbsoluteFS } from '@utils/files';
-import * as path from 'path';
-import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
 
 export class MainViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -1,12 +1,7 @@
+// Third-party imports
 import * as vscode from 'vscode';
-import { safeExecuteCommand } from '@utils/system';
-import { getConfig } from '@utils/config';
-import {
-  BaseViewMessageHandler,
-  MessageHandler,
-} from '@common/webview/BaseViewMessageHandler';
-// @ts-ignore - Import JavaScript module
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - webview
 import {
   SettingsManager,
   RecordingManager,
@@ -15,6 +10,15 @@ import {
   DiffManager,
   InstructionManager,
 } from './managers';
+import {
+  BaseViewMessageHandler,
+  MessageHandler,
+} from '@common/webview/BaseViewMessageHandler';
+
+// @ts-ignore - Import JavaScript module
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { getConfig } from '@utils/config';
+import { safeExecuteCommand } from '@utils/system';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly settingsManager: SettingsManager;

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -1,10 +1,14 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - webview
+
+// Local imports - commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
-// Local imports - commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 const CHANNEL = 'DiffManager';
 logger.initialize(CHANNEL);

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -1,20 +1,23 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
+// Local imports - webview
+import type { AgentConfig } from '@agent/core/AgentConfig';
+
+// Local imports - agent
+import { ToolConfig } from '@agent/core/ToolConfig';
+import { getFilesIfNotEmpty } from '@frontend/files/listing';
 
 // Local imports - utils
 import { capitalize } from '@frontend/ui/messageUtils';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
 import {
   isPastedImage,
   getPastedImageFullPath,
 } from '@utils/files/pastedImageUtils';
-import { getFilesIfNotEmpty } from '@frontend/files/listing';
-
-// Local imports - agent
-import { ToolConfig } from '@agent/core/ToolConfig';
-import type { AgentConfig } from '@agent/core/AgentConfig';
 
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -1,26 +1,31 @@
 // Standard library imports
+// Standard library imports
 import * as path from 'path';
+
+// Third-party imports
 
 // Third-party imports
 import * as vscode from 'vscode';
 import { workspace } from 'vscode';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
-import { uncapitalize } from '@frontend/ui/messageUtils';
-import { showLoggedMessage } from '@common/errors/errorHandlingUtils';
-
-// Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
-import { getConfig } from '@utils/config';
-import { fileLister } from '@frontend/files/fileLister';
-
-// Local imports - commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+// Local imports - webview
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 
 // Local imports - agent
 import { getAgentPath } from '@agent/runtime/executeAgent';
-import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
+import { showLoggedMessage } from '@common/errors/errorHandlingUtils';
+
+// Local imports - commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { fileLister } from '@frontend/files/fileLister';
+import { uncapitalize } from '@frontend/ui/messageUtils';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
+import { getConfig } from '@utils/config';
+
+// Local imports - utilities
+import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'FileManager';
 logger.initialize(CHANNEL);

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -1,8 +1,5 @@
 // Standard library imports
-// Standard library imports
 import * as path from 'path';
-
-// Third-party imports
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -1,13 +1,8 @@
 // Standard library imports
-
-// Local imports - utilities
 import * as path from 'path';
 
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
-
-// Local imports - webview
 
 // Local imports - commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -1,21 +1,26 @@
-// Third-party imports
-import * as vscode from 'vscode';
-
-// Local imports - log
-import * as logger from '@logger/logUtils';
+// Standard library imports
 
 // Local imports - utilities
 import * as path from 'path';
 
+// Third-party imports
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - webview
+
+// Local imports - commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
 import { StorageFS } from '@utils/files';
 import { PASTED_DIR } from '@utils/files/pastedImageUtils';
+import { sleep } from '@utils/helpers';
 import {
   polishTextWithAI,
   FileContext,
 } from '@utils/text/textEnhancementUtils';
-import { sleep } from '@utils/helpers';
-// Local imports - commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 const CHANNEL = 'InstructionManager';
 logger.initialize(CHANNEL);

--- a/src/webview/managers/RecordingManager.ts
+++ b/src/webview/managers/RecordingManager.ts
@@ -1,16 +1,20 @@
 // Third-party imports
+// Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
+// Local imports - webview
+
+// Local imports - commands
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - utilities
 import {
   startRecording,
   stopRecordingAndTranscribe,
 } from '@frontend/media/audio';
-// Local imports - commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'RecordingManager';
 logger.initialize(CHANNEL);

--- a/src/webview/managers/SettingsManager.ts
+++ b/src/webview/managers/SettingsManager.ts
@@ -1,5 +1,4 @@
 // Local imports - webview
-// Local imports
 import { safeExecuteCommand } from '@utils/system';
 
 const CHANNEL = 'SettingsManager';

--- a/src/webview/managers/SettingsManager.ts
+++ b/src/webview/managers/SettingsManager.ts
@@ -1,3 +1,4 @@
+// Local imports - webview
 // Local imports
 import { safeExecuteCommand } from '@utils/system';
 

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -1,4 +1,6 @@
+// Local imports - webview
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+
 // Basic file types
 export const FILE_TYPES = [
   'input',

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -1,17 +1,18 @@
-import { vscode } from '@common/webviewContext.js';
+// Local imports - webview
+import { ELEMENT_IDS } from './constants.js';
+import { webviewEventBus } from './eventBus.js';
 import { mainViewState } from './mainViewState.js';
+import { ActionButtonManager } from './uiManagers/ActionButtonManager.js';
+import { FileInputManager } from './uiManagers/FileInputManager.js';
 import { fileList } from './uiManagers/FileList.js';
 import { fileSelect } from './uiManagers/FileSelect.js';
-import { outputFilesManager } from './uiManagers/OutputFilesManager.js';
-import { latexdiffManager } from './uiManagers/LatexdiffManager.js';
 import { InstructionManager } from './uiManagers/InstructionManager.js';
-import { ToggleManager } from './uiManagers/ToggleManager.js';
+import { latexdiffManager } from './uiManagers/LatexdiffManager.js';
+import { outputFilesManager } from './uiManagers/OutputFilesManager.js';
 import { RecordingManager } from './uiManagers/RecordingManager.js';
-import { FileInputManager } from './uiManagers/FileInputManager.js';
-import { ActionButtonManager } from './uiManagers/ActionButtonManager.js';
 import { SettingsButtonManager } from './uiManagers/SettingsButtonManager.js';
-import { webviewEventBus } from './eventBus.js';
-import { ELEMENT_IDS } from './constants.js';
+import { ToggleManager } from './uiManagers/ToggleManager.js';
+import { vscode } from '@common/webviewContext.js';
 
 export const instructionManager = new InstructionManager(
   'instruction',

--- a/src/webview/modules/fileHandlers.js
+++ b/src/webview/modules/fileHandlers.js
@@ -1,3 +1,4 @@
+// Local imports - webview
 import { mainViewState } from './mainViewState.js';
 
 export function handleCheckboxChange(event) {

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -1,7 +1,4 @@
-// Local imports - utilities
-import { vscode } from '@common/webviewContext.js';
-import { safeSetElementValue } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+// Local imports - webview
 import {
   FILE_TYPES,
   INPUT_FILE,
@@ -12,10 +9,14 @@ import {
   BASE_FILE,
   ELEMENT_IDS,
 } from '../constants.js';
+import { mainViewState } from '../mainViewState.js';
 import { fileList } from '../uiManagers/FileList.js';
 import { fileSelect } from '../uiManagers/FileSelect.js';
-import { mainViewState } from '../mainViewState.js';
+import { safeSetElementValue } from '@common/domUtils.js';
+import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+// Local imports - utilities
+import { vscode } from '@common/webviewContext.js';
 
 /**
  * Create file related handlers.

--- a/src/webview/modules/handlers/recordingHandlers.js
+++ b/src/webview/modules/handlers/recordingHandlers.js
@@ -1,5 +1,6 @@
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+// Local imports - webview
 import { webviewEventBus } from '../eventBus.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 /**
  * Handlers related to recording state.

--- a/src/webview/modules/handlers/themeHandlers.js
+++ b/src/webview/modules/handlers/themeHandlers.js
@@ -1,7 +1,8 @@
+// Local imports - webview
+import { mainViewDomHandler } from '../domHandlers.js';
 // Local imports - DOM utilities
 import { safeSetElementValue } from '@common/domUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-import { mainViewDomHandler } from '../domHandlers.js';
 
 /**
  * Create handlers related to theme and model configuration.

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -1,4 +1,4 @@
-import { WebviewStateManager } from '@common/webviewState.js';
+// Local imports - webview
 import {
   MULTIPLE_SELECTIONS,
   CHECK_BOXES,
@@ -8,7 +8,6 @@ import {
   ELEMENT_IDS,
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
-import { CHEVRON_DOWN_CLASS } from '@common/webviewContext.js';
 import {
   safeGetElementValue,
   safeGetElementById,
@@ -18,6 +17,8 @@ import {
   setChevronIcon,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
+import { CHEVRON_DOWN_CLASS } from '@common/webviewContext.js';
+import { WebviewStateManager } from '@common/webviewState.js';
 
 /**
  * Manages persistent state for the main webview.

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1,24 +1,4 @@
-// Local imports - webview context
-import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
-import {
-  safeSetElementValue,
-  safeGetElementById,
-  setChevronIcon,
-} from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { createFromTemplate } from '@common/templateUtils.js';
-import { mainViewState } from './mainViewState.js';
-import { mainViewDomHandler } from './domHandlers.js';
-
-// Local imports - UI managers
-import { fileList } from './uiManagers/FileList.js';
-import { fileSelect } from './uiManagers/FileSelect.js';
-import { webviewEventBus } from './eventBus.js';
-// Handler submodules
-import { createThemeHandlers } from './handlers/themeHandlers.js';
-import { createRecordingHandlers } from './handlers/recordingHandlers.js';
-import { createFileHandlers } from './handlers/fileHandlers.js';
-
+// Local imports - webview
 import {
   FILE_TYPES,
   INPUT_FILE,
@@ -29,9 +9,30 @@ import {
   BASE_FILE,
   ELEMENT_IDS,
 } from './constants.js';
+import { mainViewDomHandler } from './domHandlers.js';
+import { webviewEventBus } from './eventBus.js';
+import { createFileHandlers } from './handlers/fileHandlers.js';
+import { createRecordingHandlers } from './handlers/recordingHandlers.js';
+
+// Handler submodules
+import { createThemeHandlers } from './handlers/themeHandlers.js';
+import { mainViewState } from './mainViewState.js';
+
+// Local imports - UI managers
+import { fileList } from './uiManagers/FileList.js';
+import { fileSelect } from './uiManagers/FileSelect.js';
+import {
+  safeSetElementValue,
+  safeGetElementById,
+  setChevronIcon,
+} from '@common/domUtils.js';
+import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { createFromTemplate } from '@common/templateUtils.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+// Local imports - webview context
+import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
 
 /**
  * Handles messages from the extension and syncs the webview state.

--- a/src/webview/modules/pasteHandler.js
+++ b/src/webview/modules/pasteHandler.js
@@ -1,6 +1,9 @@
+// Third-party imports
+import { nanoid } from 'nanoid';
+
+// Local imports - webview
 // Image paste handling utilities
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-import { nanoid } from 'nanoid';
 
 // Comprehensive MIME type to extension mapping
 export const IMAGE_MIME_TYPES = {

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -14,7 +14,6 @@ import {
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-// Local imports
 import { vscode } from '@common/webviewContext.js';
 
 export class ActionButtonManager extends BaseUIManager {

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -1,11 +1,4 @@
-// Local imports
-import { vscode } from '@common/webviewContext.js';
-import {
-  safeGetElementById,
-  safeGetElementValue,
-  safeGetElementChecked,
-} from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+// Local imports - webview
 import {
   CHECK_BOXES,
   MULTIPLE_SELECTIONS,
@@ -13,8 +6,16 @@ import {
   BASE_FILE,
   EDITED_FILE,
 } from '../constants.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { BaseUIManager } from './BaseUIManager.js';
+import {
+  safeGetElementById,
+  safeGetElementValue,
+  safeGetElementChecked,
+} from '@common/domUtils.js';
+import { capitalize } from '@common/stringUtils.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+// Local imports
+import { vscode } from '@common/webviewContext.js';
 
 export class ActionButtonManager extends BaseUIManager {
   constructor(vscodeInstance = vscode, fileList, state, instructionMgr) {

--- a/src/webview/modules/uiManagers/BaseUIManager.js
+++ b/src/webview/modules/uiManagers/BaseUIManager.js
@@ -1,4 +1,6 @@
+// Local imports - webview
 import { safeGetElementById } from '@common/domUtils.js';
+
 export class BaseUIManager {
   constructor() {
     this._listeners = [];

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -21,7 +21,6 @@ import { outputFilesManager } from './OutputFilesManager.js';
 import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-// Local imports
 import { vscode } from '@common/webviewContext.js';
 
 export class FileInputManager extends BaseUIManager {

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -1,8 +1,7 @@
-// Local imports
-import { vscode } from '@common/webviewContext.js';
+// Third-party imports
 import Sortable from 'sortablejs';
-import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+
+// Local imports - webview
 import {
   MULTIPLE_SELECTIONS,
   FILE_TYPES,
@@ -14,12 +13,16 @@ import {
   EDITED_FILE,
   BASE_FILE,
 } from '../constants.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { mainViewState } from '../mainViewState.js';
+import { BaseUIManager } from './BaseUIManager.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
-import { mainViewState } from '../mainViewState.js';
-import { BaseUIManager } from './BaseUIManager.js';
+import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
+import { capitalize } from '@common/stringUtils.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+// Local imports
+import { vscode } from '@common/webviewContext.js';
 
 export class FileInputManager extends BaseUIManager {
   constructor(

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -1,5 +1,4 @@
 // Local imports - webview
-// Local imports
 import {
   addEventListenerSafely,
   safeGetElementById,

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -1,3 +1,4 @@
+// Local imports - webview
 // Local imports
 import {
   addEventListenerSafely,

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,10 +1,11 @@
+// Local imports - webview
+import { ELEMENT_IDS, EDITED_FILE } from '../constants.js';
+import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
+import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { createFromTemplate } from '@common/templateUtils.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports
 import { vscode } from '@common/webviewContext.js';
-import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
-import { createFromTemplate } from '@common/templateUtils.js';
-import { ELEMENT_IDS, EDITED_FILE } from '../constants.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 /**
  * Handles single-file dropdown updates and commit list logic.

--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -1,3 +1,4 @@
+// Local imports - webview
 import { setupPasteListener } from '../pasteHandler.js';
 import { safeGetElementById } from '@common/domUtils.js';
 

--- a/src/webview/modules/uiManagers/LatexdiffManager.js
+++ b/src/webview/modules/uiManagers/LatexdiffManager.js
@@ -1,7 +1,8 @@
+// Local imports - webview
+import { ELEMENT_IDS } from '../constants.js';
+import { mainViewState } from '../mainViewState.js';
 // Local imports
 import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
-import { mainViewState } from '../mainViewState.js';
-import { ELEMENT_IDS } from '../constants.js';
 
 const LATEXDIFF_CONTENT_ID = ELEMENT_IDS.LATEXDIFFS_CONTENT;
 const TOGGLE_LATEXDIFFS_ID = ELEMENT_IDS.TOGGLE_LATEXDIFFS;

--- a/src/webview/modules/uiManagers/LatexdiffManager.js
+++ b/src/webview/modules/uiManagers/LatexdiffManager.js
@@ -1,7 +1,6 @@
 // Local imports - webview
 import { ELEMENT_IDS } from '../constants.js';
 import { mainViewState } from '../mainViewState.js';
-// Local imports
 import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
 
 const LATEXDIFF_CONTENT_ID = ELEMENT_IDS.LATEXDIFFS_CONTENT;

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -3,7 +3,6 @@ import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
-// Local imports
 import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
 
 const INPUT_FILE_ID = INPUT_FILE;

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -1,10 +1,10 @@
-// Local imports
-import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
-
+// Local imports - webview
+import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
-import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
+// Local imports
+import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
 
 const INPUT_FILE_ID = INPUT_FILE;
 const OUTPUT_FILES_ID = ELEMENT_IDS.OUTPUT_FILES;

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -1,9 +1,10 @@
+// Local imports - webview
+import { ELEMENT_IDS } from '../constants.js';
+import { webviewEventBus } from '../eventBus.js';
 import {
   addEventListenerSafely,
   safeGetElementById,
 } from '@common/domUtils.js';
-import { ELEMENT_IDS } from '../constants.js';
-import { webviewEventBus } from '../eventBus.js';
 import { createCodicon } from '@common/templateUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -1,16 +1,17 @@
-// Local imports
-import { vscode } from '@common/webviewContext.js';
-import { safeGetElementById } from '@common/domUtils.js';
+// Local imports - webview
 import {
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
   CHECK_BOXES,
 } from '../constants.js';
+import { ELEMENT_IDS } from '../constants.js';
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-import { ELEMENT_IDS } from '../constants.js';
 import { BaseUIManager } from './BaseUIManager.js';
+import { safeGetElementById } from '@common/domUtils.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+// Local imports
+import { vscode } from '@common/webviewContext.js';
 
 export class SettingsButtonManager extends BaseUIManager {
   constructor(

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -10,7 +10,6 @@ import { mainViewState } from '../mainViewState.js';
 import { BaseUIManager } from './BaseUIManager.js';
 import { safeGetElementById } from '@common/domUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-// Local imports
 import { vscode } from '@common/webviewContext.js';
 
 export class SettingsButtonManager extends BaseUIManager {

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -1,13 +1,14 @@
-import {
-  safeGetElementById,
-  safeGetElementChecked,
-  setChevronIcon,
-} from '@common/domUtils.js';
+// Local imports - webview
 import {
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
   ELEMENT_IDS,
 } from '../constants.js';
+import {
+  safeGetElementById,
+  safeGetElementChecked,
+  setChevronIcon,
+} from '@common/domUtils.js';
 import { createCodicon } from '@common/templateUtils.js';
 
 export class ToggleManager {

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -1,13 +1,14 @@
-import { mainViewState } from './modules/mainViewState.js';
-import {
-  setup as setupHandlers,
-  cleanup as cleanupHandlers,
-} from './modules/messageHandlers.js';
+// Local imports - webview
 import {
   mainViewDomHandler,
   instructionManager,
   toggleManager,
 } from './modules/domHandlers.js';
+import { mainViewState } from './modules/mainViewState.js';
+import {
+  setup as setupHandlers,
+  cleanup as cleanupHandlers,
+} from './modules/messageHandlers.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 
 // Register handlers immediately so early messages aren't missed

--- a/test/api-streaming/test-deepseek-stream.js
+++ b/test/api-streaming/test-deepseek-stream.js
@@ -1,3 +1,4 @@
+// Third-party imports
 import OpenAI from 'openai';
 
 // DeepSeek uses OpenAI-compatible API

--- a/test/api-streaming/test-genai-stream.js
+++ b/test/api-streaming/test-genai-stream.js
@@ -1,3 +1,4 @@
+// Third-party imports
 import { GoogleGenAI } from '@google/genai';
 
 // Set the API key directly or via environment variable


### PR DESCRIPTION
## Summary
- group standard, third-party, and local imports across modules
- alphabetize and label import groups for webview, history, progress, and agent components

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ef1ae6d88324b8a129229fda2366