### PR TITLE
feat: reveal agents directory in OS

### DIFF
--- a/docs/guide/agent-explorer.md
+++ b/docs/guide/agent-explorer.md
@@ -9,7 +9,7 @@ The TeXRA extension includes a dedicated **Agent Explorer** view within the VS C
 The Agent Explorer is organized into two main sections:
 
 1.  **Built-in Agents**: This section displays the standard agents that come bundled with the TeXRA extension. These files (`.yaml`) define the core functionalities like `correct`, `polish`, `draw`, etc.
-2.  **Custom Agents**: This section displays agents that you have created or added yourself. This directory's location can be customized in the VS Code settings via `texra.explorer.agentsDirectory`. If this setting is not configured, or the directory doesn't exist, this section might not appear.
+2.  **Custom Agents**: This section displays agents that you have created or added yourself. This directory's location can be customized in the VS Code settings via `texra.explorer.agentsDirectory` and must be an absolute path. If this setting is not configured, or the directory doesn't exist, this section might not appear.
 
 ## Browsing and Viewing Agents
 
@@ -34,6 +34,9 @@ Available actions for **Custom Agents** include:
 - **Delete** <i class="codicon codicon-trash"></i>: Deletes the selected custom file or folder (with confirmation).
 - **Add Agent to Config** <i class="codicon codicon-diff-added"></i>: Validates a YAML file and adds its agent name to `texra.agents`.
 - **Create AI Agent** <i class="codicon codicon-sparkle"></i>: Launches a wizard that collects a short description and output style (single vs. multiple files) then generates a starter YAML using Claude. See [Strict XML Extraction](./custom-agents.md#strict-xml-extraction) for why the YAML must be precise.
+- **Reveal in OS** <i class="codicon codicon-folder-opened"></i>: Opens the selected
+  folder in your operating system's file explorer so you can paste or manage files
+  directly.
 
 **Important**: These management actions (New File, New Folder, Rename, Delete) are **not available** for items within the "Built-in Agents" section.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -221,7 +221,7 @@ Configure the folder explorer view:
 "texra.explorer.agentsDirectory": "/path/to/custom/agents"
 ```
 
-This setting specifies a custom root path for the TeXRA file explorer view, which can be absolute or relative to the workspace root.
+This setting specifies a custom root path for the TeXRA file explorer view and must be an absolute path.
 
 ## Logger Configuration
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -19,7 +19,7 @@ Follow these steps to create a new custom agent:
 Custom agents reside in a specific directory.
 
 1.  **Find Existing**: Look for the "Custom Agents" folder within the [Agent Explorer](./agent-explorer.md).
-2.  **Configure (Optional)**: If the folder doesn't exist or you want to use a different location, set the path in VS Code Settings (`Ctrl+,`) under `texra.explorer.agentsDirectory`.
+2.  **Configure (Optional)**: If the folder doesn't exist or you want to use a different location, set the absolute path in VS Code Settings (`Ctrl+,`) under `texra.explorer.agentsDirectory`.
 
 ### Automatic Creation
 

--- a/package.json
+++ b/package.json
@@ -673,7 +673,7 @@
           "texra.explorer.agentsDirectory": {
             "type": "string",
             "default": "",
-            "description": "Root path for the TeXRA file explorer view. Can be absolute or relative to workspace root.",
+            "description": "Root path for the TeXRA file explorer view. Must be an absolute path.",
             "scope": "resource"
           }
         }
@@ -923,6 +923,12 @@
         "icon": "$(diff-added)"
       },
       {
+        "command": "texra.folderExplorer.revealInOS",
+        "title": "Reveal in OS",
+        "category": "TeXRA",
+        "icon": "$(folder-opened)"
+      },
+      {
         "command": "texra.createAgentWithAI",
         "title": "Create AI Agent",
         "category": "TeXRA",
@@ -1150,6 +1156,11 @@
           "command": "texra.folderExplorer.addToList",
           "when": "view == texra.folderExplorer && viewItem == file",
           "group": "4_modification"
+        },
+        {
+          "command": "texra.folderExplorer.revealInOS",
+          "when": "view == texra.folderExplorer && viewItem == folder",
+          "group": "5_modification"
         }
       ]
     },

--- a/src/explorer/ExplorerCommands.ts
+++ b/src/explorer/ExplorerCommands.ts
@@ -37,6 +37,10 @@ export class ExplorerCommands {
         'texra.folderExplorer.addToList',
         (node: FileItem) => this.operations.addToList(node),
       ),
+      vscode.commands.registerCommand(
+        'texra.folderExplorer.revealInOS',
+        (node: FileItem) => this.operations.reveal(node.resourceUri),
+      ),
     );
   }
 }

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -10,6 +10,7 @@ import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 // Local imports
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { AbsoluteFS } from '@utils/files';
+import { safeExecuteCommand } from '@utils/system/commandUtils';
 
 import { FileItem } from './FileItem';
 import { validateYamlAndPromptAdd } from '@frontend/agents/register';
@@ -94,6 +95,10 @@ export class ExplorerOperations {
     } catch (err) {
       await showLoggedErrorMessage(CHANNEL, 'Error opening file', err);
     }
+  }
+
+  async reveal(uri: vscode.Uri) {
+    await safeExecuteCommand('revealFileInOS', [uri], CHANNEL);
   }
 
   private async createCustomCopy(uri: vscode.Uri) {

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -14,9 +14,8 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { AbsoluteFS } from '@utils/files';
 import { safeExecuteCommand } from '@utils/system/commandUtils';
 import { validateYamlAndPromptAdd } from '@frontend/agents/register';
-import * as logger from '@logger/logUtils';
 
-import { FileItem } from './FileItem';
+import * as logger from '@logger/logUtils';
 
 const NEW_AGENT_TEMPLATE = `# --- Agent Inheritance (Optional) ---
 # inherits: base


### PR DESCRIPTION
## Summary
- add `texra.folderExplorer.revealInOS` command to open agent folders in the OS file explorer
- document absolute path requirement for `texra.explorer.agentsDirectory`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a569eababc8324aaef8132d11bc752