### PR TITLE
feat: add tooltips for file selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Add descriptive tooltips for Input, Reference, Auxiliary and Media file selectors in the main webview
+
 ## [0.33.0] - 2025-08-19 🎂 Birthday Edition
 
 ### Features

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -55,10 +55,12 @@
           <div class="file-select">
             <div class="file-select-header">
               <div class="file-select-label-group">
-                <label for="inputFile"
+                <label
+                  for="inputFile"
+                  title="Primary files the agent processes, such as .tex, .txt, or .md"
                   ><i
                     class="codicon codicon-file-code clickable"
-                    title="Input (Click to refresh)"
+                    title="Refresh input files"
                   ></i>
                   Input</label
                 >
@@ -114,10 +116,12 @@
           </div>
           <div class="file-select">
             <div class="file-select-header">
-              <label for="referenceFile"
+              <label
+                for="referenceFile"
+                title="Example or context files that guide the agent's output"
                 ><i
                   class="codicon codicon-book clickable"
-                  title="Reference (Click to refresh)"
+                  title="Refresh reference files"
                 ></i>
                 Reference</label
               >
@@ -175,10 +179,12 @@
           </div>
           <div class="file-select">
             <div class="file-select-header">
-              <label for="auxiliaryFile"
+              <label
+                for="auxiliaryFile"
+                title="Supporting files required for correct processing, including .cls, .sty, .bib"
                 ><i
                   class="codicon codicon-file-add clickable"
-                  title="Auxiliary (Click to refresh)"
+                  title="Refresh auxiliary files"
                 ></i>
                 Auxiliary</label
               >
@@ -237,10 +243,12 @@
           <div class="file-select">
             <div class="file-select-header">
               <div class="file-select-label-group">
-                <label for="mediaFile"
+                <label
+                  for="mediaFile"
+                  title="Visual or audio assets such as images or PDFs"
                   ><i
                     class="codicon codicon-file-media clickable"
-                    title="Media (Click to refresh)"
+                    title="Refresh media files"
                   ></i>
                   Media</label
                 >


### PR DESCRIPTION
## Summary
- add descriptive hover text to Input, Reference, Auxiliary and Media file selectors in the main webview
- document the new tooltips in the changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(no output, possibly due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a57dd667a88324b1972c056bf6ed27