### PR TITLE
fix: improve latexdiff handling of mathematical subscripts and superscripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ All notable changes to this project will be documented in this file.
 - Detect arXiv source file type and handle plain `.tex` downloads without extraction
 - Add descriptive tooltips for Input, Reference, Auxiliary and Media file selectors in the main webview
 
-
 ## [0.33.0] - 2025-08-19 🎂 Birthday Edition
 
 ### Features

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -109,38 +109,54 @@ export const LATEXDIFF_MARKUP_REPLACEMENTS: ReplacementCategory = {
     // TODO: Consider multi-pass processing or more sophisticated parsing for complex cases
     // with multiple math fragments within a single \DIFdel block
 
-    // Pattern 1: Subscript with braces and arithmetic
+    // Pattern 1: Numeric subscripts
+    // Example: \DIFdel{_1|}%DIFDELCMD → \DIFdel{$_1$}%DIFDELCMD
+    // Example: \DIFdel{_0)}%DIFDELCMD → \DIFdel{$_0$}%DIFDELCMD
+    '\\\\DIFdel\\{_(\\d+)[\\)\\|]?\\}%DIFDELCMD': '\\DIFdel{$_$1$}%DIFDELCMD',
+
+    // Pattern 2: Prime symbols (derivatives)
+    // Example: \DIFdel{'_0)}%DIFDELCMD → \DIFdel{$'_0$}%DIFDELCMD
+    // Example: \DIFdel{''_t}%DIFDELCMD → \DIFdel{$''_t$}%DIFDELCMD
+    "\\\\DIFdel\\{('+)_([a-zA-Z\\d]+)[\\)\\|]?\\}%DIFDELCMD":
+      '\\DIFdel{$$1_$2$}%DIFDELCMD',
+
+    // Pattern 3: Subscript with braces and arithmetic
     // Example: \DIFdel{_{t-1})}%DIFDELCMD → \DIFdel{$_{t-1}$}%DIFDELCMD
     // Example: \DIFdel{_{n+2}}%DIFDELCMD → \DIFdel{$_{n+2}$}%DIFDELCMD
     '\\\\DIFdel\\{_\\{([a-zA-Z][+-]?\\d*)\\}[\\)\\|]?\\}%DIFDELCMD':
       '\\DIFdel{$_{$1}$}%DIFDELCMD',
 
-    // Pattern 2: Simple subscript with optional arithmetic
+    // Pattern 4: Simple subscript with optional arithmetic
     // Example: \DIFdel{_{t}|}%DIFDELCMD → \DIFdel{$_t$}%DIFDELCMD
     // Example: \DIFdel{_{k-1})}%DIFDELCMD → \DIFdel{$_{k-1}$}%DIFDELCMD
     '\\\\DIFdel\\{_([a-zA-Z](?:[+-]\\d+)?)[\\)\\|]?\\}%DIFDELCMD':
       '\\DIFdel{$_$1$}%DIFDELCMD',
 
-    // Pattern 3: Superscript with braces and arithmetic
+    // Pattern 5: Numeric superscripts
+    // Example: \DIFdel{^2}%DIFDELCMD → \DIFdel{$^2$}%DIFDELCMD
+    // Example: \DIFdel{^{10}}%DIFDELCMD → \DIFdel{$^{10}$}%DIFDELCMD
+    '\\\\DIFdel\\{\\^(\\d+)[\\)\\|]?\\}%DIFDELCMD': '\\DIFdel{$^$1$}%DIFDELCMD',
+
+    // Pattern 6: Superscript with braces and arithmetic
     // Example: \DIFdel{^{t-1}}%DIFDELCMD → \DIFdel{$^{t-1}$}%DIFDELCMD
     // Example: \DIFdel{^{n+2})}%DIFDELCMD → \DIFdel{$^{n+2}$}%DIFDELCMD
     '\\\\DIFdel\\{\\^\\{([a-zA-Z][+-]?\\d*)\\}[\\)\\|]?\\}%DIFDELCMD':
       '\\DIFdel{$^{$1}$}%DIFDELCMD',
 
-    // Pattern 4: Simple superscript with optional arithmetic
+    // Pattern 7: Simple superscript with optional arithmetic
     // Example: \DIFdel{^t|}%DIFDELCMD → \DIFdel{$^t$}%DIFDELCMD
     // Example: \DIFdel{^{k-1}}%DIFDELCMD → \DIFdel{$^{k-1}$}%DIFDELCMD
     '\\\\DIFdel\\{\\^([a-zA-Z](?:[+-]\\d+)?)[\\)\\|]?\\}%DIFDELCMD':
       '\\DIFdel{$^$1$}%DIFDELCMD',
 
-    // Pattern 5: Special cases for LaTeX commands as subscripts
+    // Pattern 8: Special cases for LaTeX commands as subscripts
     // Example: \DIFdel{_\tf}%DIFDELCMD → \DIFdel{$_\tf$}%DIFDELCMD
     // Example: \DIFdel{_\tauf}%DIFDELCMD → \DIFdel{$_\tauf$}%DIFDELCMD
     // Example: \DIFdel{_{\tf-1}}%DIFDELCMD → \DIFdel{$_{\tf-1}$}%DIFDELCMD
     '\\\\DIFdel\\{_\\{?(\\\\(?:tf|tauf)(?:[+-]\\d+)?)[\\}\\)\\|]?\\}%DIFDELCMD':
       '\\DIFdel{$_$1$}%DIFDELCMD',
 
-    // Pattern 6: Fallback for simple single-letter subscripts
+    // Pattern 9: Fallback for simple single-letter subscripts
     // Example: \DIFdel{_I()}%DIFDELCMD → \DIFdel{$_I$}%DIFDELCMD
     // Example: \DIFdel{_x|}%DIFDELCMD → \DIFdel{$_x$}%DIFDELCMD
     '\\\\DIFdel\\{_([a-zA-Z])[\\(\\)\\|]?\\}%DIFDELCMD':
@@ -149,6 +165,15 @@ export const LATEXDIFF_MARKUP_REPLACEMENTS: ReplacementCategory = {
     // === Fix broken math fragments with \DIFadd commands ===
     // Similar conservative patterns for \DIFadd commands
 
+    // Numeric subscripts in \DIFadd
+    // Example: \DIFadd{_1|}%DIFADDCMD → \DIFadd{$_1$}%DIFADDCMD
+    '\\\\DIFadd\\{_(\\d+)[\\)\\|]?\\}%DIFADDCMD': '\\DIFadd{$_$1$}%DIFADDCMD',
+
+    // Prime symbols in \DIFadd
+    // Example: \DIFadd{'_0)}%DIFADDCMD → \DIFadd{$'_0$}%DIFADDCMD
+    "\\\\DIFadd\\{('+)_([a-zA-Z\\d]+)[\\)\\|]?\\}%DIFADDCMD":
+      '\\DIFadd{$$1_$2$}%DIFADDCMD',
+
     // Example: \DIFadd{_{t-1}}%DIFADDCMD → \DIFadd{$_{t-1}$}%DIFADDCMD
     '\\\\DIFadd\\{_\\{([a-zA-Z][+-]?\\d*)\\}[\\)\\|]?\\}%DIFADDCMD':
       '\\DIFadd{$_{$1}$}%DIFADDCMD',
@@ -156,6 +181,10 @@ export const LATEXDIFF_MARKUP_REPLACEMENTS: ReplacementCategory = {
     // Example: \DIFadd{_{k})}%DIFADDCMD → \DIFadd{$_k$}%DIFADDCMD
     '\\\\DIFadd\\{_([a-zA-Z](?:[+-]\\d+)?)[\\)\\|]?\\}%DIFADDCMD':
       '\\DIFadd{$_$1$}%DIFADDCMD',
+
+    // Numeric superscripts in \DIFadd
+    // Example: \DIFadd{^2}%DIFADDCMD → \DIFadd{$^2$}%DIFADDCMD
+    '\\\\DIFadd\\{\\^(\\d+)[\\)\\|]?\\}%DIFADDCMD': '\\DIFadd{$^$1$}%DIFADDCMD',
 
     // Special cases for LaTeX commands as subscripts in \DIFadd
     // Example: \DIFadd{_\tf}%DIFADDCMD → \DIFadd{$_\tf$}%DIFADDCMD

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -70,6 +70,23 @@ export const INLINE_MATH_REPLACEMENTS: ReplacementCategory = {
   },
 };
 
+/**
+ * LATEXDIFF USAGE NOTE:
+ *
+ * For commands that should not have their arguments split by latexdiff,
+ * use the --append-safecmd option:
+ *
+ * latexdiff --append-safecmd="bze,hbze,mycommand" old.tex new.tex
+ *
+ * This tells latexdiff to treat these commands and their arguments as
+ * atomic units that should not be split across \DIFdel/\DIFadd blocks.
+ *
+ * Common commands to add as safecmd:
+ * - Custom macros with mathematical arguments
+ * - Commands with complex subscripts/superscripts
+ * - Commands whose arguments must remain intact for compilation
+ */
+
 // Latexdiff markup fixes using regex
 export const LATEXDIFF_MARKUP_REPLACEMENTS: ReplacementCategory = {
   name: 'latexdiff_markup',
@@ -82,15 +99,73 @@ export const LATEXDIFF_MARKUP_REPLACEMENTS: ReplacementCategory = {
     '\n[ \t]*\n[ \t]*\\}\\\\end\\{(align|aligned)(\\*?)\\}%DIFAUXCMD':
       '\n}\\end{$1$2}%DIFAUXCMD',
 
-    // fix \DIFdel{_I()}%DIFDELCMD
-    // '\\\\DIFdel\\{^([a-zA-Z])[^\\n\\}]*\\}%DIFDELCMD':
-    // '\\DIFdel{$^$1($}%DIFDELCMD',
-    '\\\\DIFdel\\{_([a-zA-Z])[^\\n\\}]{0,10}\\}%DIFDELCMD':
-      '\\DIFdel{$^$1($}%DIFDELCMD',
-    // There are more edge cases like:
-    // \DIFdel{_{t-1})D_{t-1}(}%DIFDELCMD < \bze%%%
-    // \DIFdel{_{t}|}%DIFDELCMD < \bze%%%
-    // \DIFdel{_{t-1})
+    // === Fix broken subscripts/superscripts in \DIFdel commands ===
+    // These patterns wrap math fragments in dollar signs to preserve math mode
+    //
+    // LIMITATION: These patterns only fix isolated subscript/superscript fragments.
+    // If there's additional content after (like in \DIFdel{_{t-1})F_{t-1|t}(}),
+    // the additional content is NOT processed to avoid overly aggressive replacements.
+    //
+    // TODO: Consider multi-pass processing or more sophisticated parsing for complex cases
+    // with multiple math fragments within a single \DIFdel block
+
+    // Pattern 1: Subscript with braces and arithmetic
+    // Example: \DIFdel{_{t-1})}%DIFDELCMD → \DIFdel{$_{t-1}$}%DIFDELCMD
+    // Example: \DIFdel{_{n+2}}%DIFDELCMD → \DIFdel{$_{n+2}$}%DIFDELCMD
+    '\\\\DIFdel\\{_\\{([a-zA-Z][+-]?\\d*)\\}[\\)\\|]?\\}%DIFDELCMD':
+      '\\DIFdel{$_{$1}$}%DIFDELCMD',
+
+    // Pattern 2: Simple subscript with optional arithmetic
+    // Example: \DIFdel{_{t}|}%DIFDELCMD → \DIFdel{$_t$}%DIFDELCMD
+    // Example: \DIFdel{_{k-1})}%DIFDELCMD → \DIFdel{$_{k-1}$}%DIFDELCMD
+    '\\\\DIFdel\\{_([a-zA-Z](?:[+-]\\d+)?)[\\)\\|]?\\}%DIFDELCMD':
+      '\\DIFdel{$_$1$}%DIFDELCMD',
+
+    // Pattern 3: Superscript with braces and arithmetic
+    // Example: \DIFdel{^{t-1}}%DIFDELCMD → \DIFdel{$^{t-1}$}%DIFDELCMD
+    // Example: \DIFdel{^{n+2})}%DIFDELCMD → \DIFdel{$^{n+2}$}%DIFDELCMD
+    '\\\\DIFdel\\{\\^\\{([a-zA-Z][+-]?\\d*)\\}[\\)\\|]?\\}%DIFDELCMD':
+      '\\DIFdel{$^{$1}$}%DIFDELCMD',
+
+    // Pattern 4: Simple superscript with optional arithmetic
+    // Example: \DIFdel{^t|}%DIFDELCMD → \DIFdel{$^t$}%DIFDELCMD
+    // Example: \DIFdel{^{k-1}}%DIFDELCMD → \DIFdel{$^{k-1}$}%DIFDELCMD
+    '\\\\DIFdel\\{\\^([a-zA-Z](?:[+-]\\d+)?)[\\)\\|]?\\}%DIFDELCMD':
+      '\\DIFdel{$^$1$}%DIFDELCMD',
+
+    // Pattern 5: Special cases for LaTeX commands as subscripts
+    // Example: \DIFdel{_\tf}%DIFDELCMD → \DIFdel{$_\tf$}%DIFDELCMD
+    // Example: \DIFdel{_\tauf}%DIFDELCMD → \DIFdel{$_\tauf$}%DIFDELCMD
+    // Example: \DIFdel{_{\tf-1}}%DIFDELCMD → \DIFdel{$_{\tf-1}$}%DIFDELCMD
+    '\\\\DIFdel\\{_\\{?(\\\\(?:tf|tauf)(?:[+-]\\d+)?)[\\}\\)\\|]?\\}%DIFDELCMD':
+      '\\DIFdel{$_$1$}%DIFDELCMD',
+
+    // Pattern 6: Fallback for simple single-letter subscripts
+    // Example: \DIFdel{_I()}%DIFDELCMD → \DIFdel{$_I$}%DIFDELCMD
+    // Example: \DIFdel{_x|}%DIFDELCMD → \DIFdel{$_x$}%DIFDELCMD
+    '\\\\DIFdel\\{_([a-zA-Z])[\\(\\)\\|]?\\}%DIFDELCMD':
+      '\\DIFdel{$_$1$}%DIFDELCMD',
+
+    // === Fix broken math fragments with \DIFadd commands ===
+    // Similar conservative patterns for \DIFadd commands
+
+    // Example: \DIFadd{_{t-1}}%DIFADDCMD → \DIFadd{$_{t-1}$}%DIFADDCMD
+    '\\\\DIFadd\\{_\\{([a-zA-Z][+-]?\\d*)\\}[\\)\\|]?\\}%DIFADDCMD':
+      '\\DIFadd{$_{$1}$}%DIFADDCMD',
+
+    // Example: \DIFadd{_{k})}%DIFADDCMD → \DIFadd{$_k$}%DIFADDCMD
+    '\\\\DIFadd\\{_([a-zA-Z](?:[+-]\\d+)?)[\\)\\|]?\\}%DIFADDCMD':
+      '\\DIFadd{$_$1$}%DIFADDCMD',
+
+    // Special cases for LaTeX commands as subscripts in \DIFadd
+    // Example: \DIFadd{_\tf}%DIFADDCMD → \DIFadd{$_\tf$}%DIFADDCMD
+    // Example: \DIFadd{_{\tauf-1}}%DIFADDCMD → \DIFadd{$_{\tauf-1}$}%DIFADDCMD
+    '\\\\DIFadd\\{_\\{?(\\\\(?:tf|tauf)(?:[+-]\\d+)?)[\\}\\)\\|]?\\}%DIFADDCMD':
+      '\\DIFadd{$_$1$}%DIFADDCMD',
+
+    // Note: For commands like \bze that should not be split, use:
+    // latexdiff --append-safecmd="bze,hbze" old.tex new.tex
+    // This prevents latexdiff from splitting the command and its arguments
   },
 };
 


### PR DESCRIPTION
## Summary

This PR fixes LaTeX compilation errors that occur when latexdiff splits mathematical subscripts and superscripts across `\DIFdel`/`\DIFadd` blocks, breaking math mode.

### Problem

Latexdiff sometimes splits mathematical expressions incorrectly, creating fragments like:
- `\DIFdel{_{t-1})}%DIFDELCMD` - broken subscript with closing parenthesis
- `\DIFdel{^{n+2}}%DIFDELCMD` - isolated superscript
- `\DIFdel{_\tf}%DIFDELCMD` - subscript with LaTeX command

These fragments cause LaTeX compilation to fail because they're not in proper math mode.

### Solution

Added comprehensive regex patterns to wrap these mathematical fragments in dollar signs:
- **Subscripts with arithmetic**: `_{t-1}`, `_{n+2}`, `_{k-1}` → `$_{t-1}$`, `$_{n+2}$`, `$_{k-1}$`
- **Superscripts with arithmetic**: `^{t-1}`, `^{n+2}` → `$^{t-1}$`, `$^{n+2}$`
- **LaTeX commands as subscripts**: `_\tf`, `_{\tauf-1}` → `$_\tf$`, `$_{\tauf-1}$`
- **Simple subscripts/superscripts**: `_I`, `^t` → `$_I$`, `$^t$`

### Features

- **Conservative approach**: Only processes isolated math fragments to avoid overly aggressive replacements
- **Comprehensive coverage**: Handles both `\DIFdel` and `\DIFadd` commands
- **Special LaTeX commands**: Supports common commands like `\tf` and `\tauf` in subscripts
- **Documentation**: Added usage notes about the `--append-safecmd` option for preventing command splits

### Test Cases Handled

- `\DIFdel{_{t-1})}%DIFDELCMD` → `\DIFdel{$_{t-1}$}%DIFDELCMD`
- `\DIFdel{^{n+2}}%DIFDELCMD` → `\DIFdel{$^{n+2}$}%DIFDELCMD`
- `\DIFdel{_\tf}%DIFDELCMD` → `\DIFdel{$_\tf$}%DIFDELCMD`
- `\DIFdel{_{k}|}%DIFDELCMD` → `\DIFdel{$_k$}%DIFDELCMD`

### Documentation

Added comprehensive documentation about using `latexdiff --append-safecmd="command1,command2"` to prevent splitting of custom commands and their arguments.

🤖 Generated with [Claude Code](https://claude.ai/code)