### PR TITLE
fix: prioritize named document extraction

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -48,6 +48,19 @@ export class XmlOutputManager {
     documentTag: string,
   ): string | null {
     try {
+      const documents = xmlUtils.extractMultipleTextFromTag(outputContent);
+      if (documents && documents.length > 0) {
+        const filename = path.basename(this.agentConfig.inputFile);
+        const match = documents.find((doc) => doc.name === filename);
+        if (match && match.content) {
+          this.logger.info(
+            `Recovered ${documentTag} from named document tag`,
+            undefined,
+            MESSAGE_TYPES.INTERNAL,
+          );
+          return match.content;
+        }
+      }
       const fallbackContent = xmlUtils.extractTextFromTag(
         outputContent,
         documentTag,
@@ -68,19 +81,6 @@ export class XmlOutputManager {
           MESSAGE_TYPES.INTERNAL,
         );
         return markdownFallback;
-      }
-      const documents = xmlUtils.extractMultipleTextFromTag(outputContent);
-      if (documents && documents.length > 0) {
-        const filename = path.basename(this.agentConfig.inputFile);
-        const match = documents.find((doc) => doc.name === filename);
-        if (match && match.content) {
-          this.logger.info(
-            `Recovered ${documentTag} from named document tag`,
-            undefined,
-            MESSAGE_TYPES.INTERNAL,
-          );
-          return match.content;
-        }
       }
       const latexFallback =
         xmlUtils.extractLatexBetweenDocumentClass(outputContent);

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -96,6 +96,29 @@ describe('XmlOutputManager markdown fallback', () => {
     await WorkspaceFS.delete(texPath);
   });
 
+  it('prefers named document over latex_document when both present', async () => {
+    const logger = new AgentLogger('TestXmlOutput');
+    const manager = new XmlOutputManager(setting, config, logger);
+    const outputXml = 'both_tags.xml';
+    const xmlContent =
+      '<latex_document><![CDATA[\\begin{document}wrong\\end{document}]]></latex_document>' +
+      '<document name="input.tex"><![CDATA[\\begin{document}right\\end{document}]]></document><';
+
+    await WorkspaceFS.writeFile(outputXml, xmlContent);
+
+    const texPath = await manager.splitScratchpadOutputXml(
+      outputXml,
+      setting.documentTag,
+    );
+
+    const written = await WorkspaceFS.readFile('both_tags.tex');
+    assert.ok(written.includes('right'));
+    assert.ok(!written.includes('wrong'));
+
+    await WorkspaceFS.delete(outputXml);
+    await WorkspaceFS.delete(texPath);
+  });
+
   it('writes tex file from plain LaTeX document block', async () => {
     const logger = new AgentLogger('TestXmlOutput');
     const manager = new XmlOutputManager(setting, config, logger);


### PR DESCRIPTION
## Summary
- prioritize named document tags when extracting document content
- add regression test for named document fallback over `<latex_document>`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87c8a3044832482ed7386c2ef0393