### PR TITLE
fix: warn on multi-root workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - Add descriptive tooltips for Input, Reference, Auxiliary and Media file selectors in the main webview
 - Add real-time streaming display for model reasoning/thinking processes (Claude, DeepSeek, o1)
 
+### Bug Fixes
+
+- Warn and disable TeXRA in multi-root workspaces, requiring a single folder
+
 ## [0.33.0] - 2025-08-19 🎂 Birthday Edition
 
 ### Features

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,8 +30,8 @@ let statusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-  if (!workspaceRoot) {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders || workspaceFolders.length === 0) {
     const openAction = 'Open Folder';
     vscode.window
       .showInformationMessage(
@@ -45,6 +45,23 @@ export async function activate(context: vscode.ExtensionContext) {
       });
     return; // Exit before further initialization
   }
+
+  if (workspaceFolders.length > 1) {
+    const openAction = 'Open Folder';
+    vscode.window
+      .showInformationMessage(
+        'TeXRA does not support multi-root workspaces. Please open a single folder to enable the extension.',
+        openAction,
+      )
+      .then((choice) => {
+        if (choice === openAction) {
+          vscode.commands.executeCommand('workbench.action.files.openFolder');
+        }
+      });
+    return; // Exit before further initialization
+  }
+
+  const workspaceRoot = workspaceFolders[0].uri.fsPath;
 
   dotenv.config({
     path: path.join(workspaceRoot, '.env'),


### PR DESCRIPTION
## Summary
- warn and exit if VS Code workspace contains multiple folders
- note change in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: `vscode-test` hung, terminated after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_68a8acaf73dc8324aa13b36b5d00c9bc