### PR TITLE
fix: restrict to single workspace folder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,8 +30,8 @@ let statusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-  if (!workspaceRoot) {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders || workspaceFolders.length === 0) {
     const openAction = 'Open Folder';
     vscode.window
       .showInformationMessage(
@@ -44,7 +44,21 @@ export async function activate(context: vscode.ExtensionContext) {
         }
       });
     return; // Exit before further initialization
+  } else if (workspaceFolders.length > 1) {
+    const openAction = 'Open Folder';
+    vscode.window
+      .showInformationMessage(
+        'TeXRA supports only a single-folder workspace. Please open one folder to enable the extension.',
+        openAction,
+      )
+      .then((choice) => {
+        if (choice === openAction) {
+          vscode.commands.executeCommand('workbench.action.files.openFolder');
+        }
+      });
+    return;
   }
+  const workspaceRoot = workspaceFolders[0].uri.fsPath;
 
   dotenv.config({
     path: path.join(workspaceRoot, '.env'),


### PR DESCRIPTION
## Summary
- guard activation when workspace has zero or multiple folders

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b8f4cd088324b548e0636a85c819