### PR TITLE
fix: default to proxy.texra.ai when proxy domain unset

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -53,7 +53,7 @@ Configure how TeXRA connects to AI model providers:
 ```json
 "texra.model.useOpenRouter": false,
 "texra.model.useImprovedConnection": false,
-"texra.model.improvedConnectionDomain": "proxy.texra.ai",
+"texra.model.improvedConnectionDomain": "",
 "texra.model.baseUrlDeepSeek": "",
 "texra.model.useStreaming": false,
 "texra.model.useStreamingAnthropicReasoning": false,
@@ -62,7 +62,7 @@ Configure how TeXRA connects to AI model providers:
 
 - `useOpenRouter`: Access models through OpenRouter instead of direct APIs
 - `useImprovedConnection`: Route all API requests through a proxy server
-- `improvedConnectionDomain`: Custom proxy domain when `useImprovedConnection` is enabled (default `proxy.texra.ai`)
+- `improvedConnectionDomain`: Custom proxy domain when `useImprovedConnection` is enabled. Leave blank to use the built-in default.
   - ⚠️ **Security Warning:** When using a proxy, ensure you trust the proxy server as it will receive your API keys. Only use proxies from trusted sources.
 - `baseUrlDeepSeek`: Custom base URL for DeepSeek models; overrides the default `https://api.deepseek.com` endpoint
 - `useStreaming`: Enable streaming responses for better handling of long outputs

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -62,7 +62,7 @@ Configure how TeXRA connects to AI model providers:
 
 - `useOpenRouter`: Access models through OpenRouter instead of direct APIs
 - `useImprovedConnection`: Route all API requests through a proxy server
-- `improvedConnectionDomain`: Custom proxy domain when `useImprovedConnection` is enabled. Leave blank to use the built-in default.
+- `improvedConnectionDomain`: Custom proxy domain when `useImprovedConnection` is enabled. Defaults to the built-in proxy when unset.
   - ⚠️ **Security Warning:** When using a proxy, ensure you trust the proxy server as it will receive your API keys. Only use proxies from trusted sources.
 - `baseUrlDeepSeek`: Custom base URL for DeepSeek models; overrides the default `https://api.deepseek.com` endpoint
 - `useStreaming`: Enable streaming responses for better handling of long outputs

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
           "texra.model.improvedConnectionDomain": {
             "type": "string",
             "description": "Domain to use when using improved connection",
+            "default": "proxy.texra.ai",
             "scope": "resource"
           },
           "texra.model.useStreaming": {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -54,6 +54,9 @@ const DEFAULT_CONTINUE_LIMIT = 10;
 const DEFAULT_INPUT_TOKEN_LIMIT = 1500000;
 const DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
 
+// Default proxy domain
+const DEFAULT_PROXY_DOMAIN = 'proxy.texra.ai';
+
 /** Flags for token-based stop conditions. */
 interface TokenFlags {
   continuationLimit: boolean;
@@ -235,13 +238,17 @@ export abstract class ModelHandler<
       'model.useImprovedConnection',
       false,
     );
-    let improvedConnectionDomain = getConfig<string>(
+    const configValue = getConfig<string>(
       'model.improvedConnectionDomain',
-      '',
-    ).trim();
+      DEFAULT_PROXY_DOMAIN,
+    );
+    let improvedConnectionDomain = (configValue || '').trim();
 
     if (!improvedConnectionDomain) {
-      improvedConnectionDomain = 'proxy.texra.ai';
+      this.logger.debug(
+        `Using default proxy domain: ${DEFAULT_PROXY_DOMAIN}`,
+      );
+      improvedConnectionDomain = DEFAULT_PROXY_DOMAIN;
     }
 
     if (useImprovedConnection) {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -237,10 +237,14 @@ export abstract class ModelHandler<
     );
     let improvedConnectionDomain = getConfig<string>(
       'model.improvedConnectionDomain',
-      'proxy.texra.ai',
-    );
+      '',
+    ).trim();
 
-    if (useImprovedConnection && improvedConnectionDomain) {
+    if (!improvedConnectionDomain) {
+      improvedConnectionDomain = 'proxy.texra.ai';
+    }
+
+    if (useImprovedConnection) {
       // Normalize proxy domain
       improvedConnectionDomain = normalizeUrl(improvedConnectionDomain);
 


### PR DESCRIPTION
## Summary
- default to proxy.texra.ai if improved connection domain is empty
- document default proxy behavior without naming the domain
- expose default proxy domain in settings schema

## Testing
- `npm run format`
- `npm run lint`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c5a89bec8324be9689efcc164244