### PR TITLE
feat: show onboarding tips for key controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Detect arXiv source file type and handle plain `.tex` downloads without extraction
 - Add descriptive tooltips for Input, Reference, Auxiliary and Media file selectors in the main webview
+- Show onboarding tooltips on first use of the input file selector or model picker, with a "Never remind again" option
 - Add real-time streaming display for model reasoning/thinking processes (Claude, DeepSeek, o1)
 
 ## [0.33.0] - 2025-08-19 🎂 Birthday Edition

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -53,6 +53,11 @@ You can download our [example document](/examples/draft.tex) to try TeXRA with a
 1. In the TeXRA panel, click the "Current" button next to "Input" to set your active document as the input file
 2. (Optional) Add reference, auxiliary, or figure files if needed for your task
 
+::: tip Onboarding Prompt
+The first time you choose an input file, TeXRA shows a tooltip explaining the selector.
+Select **Never remind again** to hide it permanently.
+:::
+
 ::: info Multiple Files
 For complex documents with multiple input files, use the "Multiple" dropdown to select additional files.
 :::
@@ -64,6 +69,11 @@ For complex documents with multiple input files, use the "Multiple" dropdown to 
 1. In the dropdown menus at the bottom of the instruction box, select:
    - **Agent**: `polish` (for improving writing)
    - **Model**: `sonnet37` (Claude 3.7 Sonnet) or another available model
+
+::: tip Onboarding Prompt
+When you first open the agent or model dropdown, a tooltip explains its role.
+You can dismiss these prompts with **Never remind again**.
+:::
 
 ![Agent and Model Selection](/images/agent-model-selection.png)
 

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -59,6 +59,7 @@ export const MAIN_VIEW_COMMANDS = {
 
   // Other operations
   SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
+  SHOW_INSTRUCTION: 'showInstruction',
   GET_THEME: 'getTheme',
   GET_DEBUG_MODE: 'getDebugMode',
   GET_CURRENT_FILE: 'getCurrentFile',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -59,6 +59,7 @@ export const MAIN_VIEW_COMMANDS = {
 
   // Other operations
   SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
+  SHOW_INSTRUCTION: 'showInstruction',
   GET_THEME: 'getTheme',
   GET_DEBUG_MODE: 'getDebugMode',
   GET_CURRENT_FILE: 'getCurrentFile',

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -19,6 +19,7 @@ import {
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { getConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system';
+import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly settingsManager: SettingsManager;
@@ -48,6 +49,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       // Core functionality
       [MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]:
         this.handleInfoMessage.bind(this),
+      [MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION]: async (m) =>
+        showInstructionWithSuppress(m.key, m.text),
       [MAIN_VIEW_COMMANDS.GET_THEME]: this.handleThemeRequest.bind(this),
       [MAIN_VIEW_COMMANDS.GET_DEBUG_MODE]:
         this.handleDebugModeRequest.bind(this),

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -38,7 +38,6 @@ export class FileInputManager extends BaseUIManager {
     this.fileSelect = select;
     this.outputFilesManager = outputMgr;
     this._sortables = [];
-    this._inputTipShown = false;
   }
 
   _setupSortable() {
@@ -57,14 +56,11 @@ export class FileInputManager extends BaseUIManager {
   _setupSingleFileSelectors() {
     this.addListener(INPUT_FILE, 'change', (e) => {
       const inputFile = e.target.value;
-      if (!this._inputTipShown) {
-        this._inputTipShown = true;
-        this.vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
-          key: 'inputFileSelect',
-          text: 'Choose the main LaTeX file to process. Use the Current button to pick the active editor.',
-        });
-      }
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
+        key: 'inputFileSelect',
+        text: 'Choose the main LaTeX file to process. Use the Current button to pick the active editor.',
+      });
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
         filePath: inputFile,

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -54,13 +54,17 @@ export class FileInputManager extends BaseUIManager {
   }
 
   _setupSingleFileSelectors() {
-    this.addListener(INPUT_FILE, 'change', (e) => {
-      const inputFile = e.target.value;
+    // Show instruction on focus, before user makes selection
+    this.addListener(INPUT_FILE, 'focus', () => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
         key: 'inputFileSelect',
         text: 'Choose the main LaTeX file to process. Use the Current button to pick the active editor.',
       });
+    });
+
+    this.addListener(INPUT_FILE, 'change', (e) => {
+      const inputFile = e.target.value;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
         filePath: inputFile,

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -38,6 +38,7 @@ export class FileInputManager extends BaseUIManager {
     this.fileSelect = select;
     this.outputFilesManager = outputMgr;
     this._sortables = [];
+    this._inputTipShown = false;
   }
 
   _setupSortable() {
@@ -56,6 +57,14 @@ export class FileInputManager extends BaseUIManager {
   _setupSingleFileSelectors() {
     this.addListener(INPUT_FILE, 'change', (e) => {
       const inputFile = e.target.value;
+      if (!this._inputTipShown) {
+        this._inputTipShown = true;
+        this.vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
+          key: 'inputFileSelect',
+          text: 'Choose the main LaTeX file to process. Use the Current button to pick the active editor.',
+        });
+      }
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
         filePath: inputFile,

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -83,13 +83,17 @@ export class SettingsButtonManager extends BaseUIManager {
   }
 
   _setupDropdowns() {
-    this.addListener('agent', 'change', (e) => {
-      const selectedAgent = e.target.value;
+    // Show instruction on focus, before user makes selection
+    this.addListener('agent', 'focus', () => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
         key: 'agentPicker',
         text: 'Select which agent will handle your request.',
       });
+    });
+
+    this.addListener('agent', 'change', (e) => {
+      const selectedAgent = e.target.value;
       const reflectCheckbox = safeGetElementById('reflect');
       if (reflectCheckbox) {
         reflectCheckbox.checked = !selectedAgent.startsWith('correct');
@@ -104,12 +108,16 @@ export class SettingsButtonManager extends BaseUIManager {
       this.state.save();
     });
 
-    this.addListener('model', 'change', (e) => {
+    // Show instruction on focus, before user makes selection
+    this.addListener('model', 'focus', () => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
         key: 'modelPicker',
         text: 'Choose the AI model used by the selected agent.',
       });
+    });
+
+    this.addListener('model', 'change', (e) => {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
         model: e.target.value,

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -24,6 +24,8 @@ export class SettingsButtonManager extends BaseUIManager {
     this.toggleManager = toggleManager;
     this.latexdiffManager = latexdiffManager;
     this.state = state;
+    this._agentTipShown = false;
+    this._modelTipShown = false;
   }
 
   _setupToggles() {
@@ -85,6 +87,14 @@ export class SettingsButtonManager extends BaseUIManager {
   _setupDropdowns() {
     this.addListener('agent', 'change', (e) => {
       const selectedAgent = e.target.value;
+      if (!this._agentTipShown) {
+        this._agentTipShown = true;
+        this.vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
+          key: 'agentPicker',
+          text: 'Select which agent will handle your request.',
+        });
+      }
       const reflectCheckbox = safeGetElementById('reflect');
       if (reflectCheckbox) {
         reflectCheckbox.checked = !selectedAgent.startsWith('correct');
@@ -100,6 +110,14 @@ export class SettingsButtonManager extends BaseUIManager {
     });
 
     this.addListener('model', 'change', (e) => {
+      if (!this._modelTipShown) {
+        this._modelTipShown = true;
+        this.vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
+          key: 'modelPicker',
+          text: 'Choose the AI model used by the selected agent.',
+        });
+      }
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
         model: e.target.value,

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -24,8 +24,6 @@ export class SettingsButtonManager extends BaseUIManager {
     this.toggleManager = toggleManager;
     this.latexdiffManager = latexdiffManager;
     this.state = state;
-    this._agentTipShown = false;
-    this._modelTipShown = false;
   }
 
   _setupToggles() {
@@ -87,14 +85,11 @@ export class SettingsButtonManager extends BaseUIManager {
   _setupDropdowns() {
     this.addListener('agent', 'change', (e) => {
       const selectedAgent = e.target.value;
-      if (!this._agentTipShown) {
-        this._agentTipShown = true;
-        this.vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
-          key: 'agentPicker',
-          text: 'Select which agent will handle your request.',
-        });
-      }
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
+        key: 'agentPicker',
+        text: 'Select which agent will handle your request.',
+      });
       const reflectCheckbox = safeGetElementById('reflect');
       if (reflectCheckbox) {
         reflectCheckbox.checked = !selectedAgent.startsWith('correct');
@@ -110,14 +105,11 @@ export class SettingsButtonManager extends BaseUIManager {
     });
 
     this.addListener('model', 'change', (e) => {
-      if (!this._modelTipShown) {
-        this._modelTipShown = true;
-        this.vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
-          key: 'modelPicker',
-          text: 'Choose the AI model used by the selected agent.',
-        });
-      }
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
+        key: 'modelPicker',
+        text: 'Choose the AI model used by the selected agent.',
+      });
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
         model: e.target.value,


### PR DESCRIPTION
## Summary
- show onboarding instructions when selecting input files
- show onboarding instructions for agent and model pickers
- document onboarding prompts in quick start guide

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c8b6db78832494aa6c39ea97b1dd