### PR TITLE
feat: stream model responses separately

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -162,11 +162,10 @@ export async function runResponseCycle(
       toolState,
     );
     const useStreaming = modelHandler.getStreamingConfig();
-    const streamOutput = modelHandler.isOutputStreamingEnabled();
 
     if (newResponse) {
       logger.debug(`Model response: ${newResponse.slice(0, 100)}`, taskGroupId);
-      if (!streamOutput) {
+      if (!useStreaming) {
         const formattedResponse = await xmlUtils.formatContent(newResponse);
         logger.info(
           formattedResponse,

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -110,6 +110,7 @@ export async function runResponseCycle(
 
     const abortController = new AbortController();
     setAbortController(abortController);
+    modelHandler.setOutputStreaming(false);
     let responseObject;
     try {
       responseObject = await modelHandler.createResponse(
@@ -161,6 +162,19 @@ export async function runResponseCycle(
       toolState,
     );
     const useStreaming = modelHandler.getStreamingConfig();
+    const streamOutput = modelHandler.isOutputStreamingEnabled();
+
+    if (newResponse) {
+      logger.debug(`Model response: ${newResponse.slice(0, 100)}`, taskGroupId);
+      if (!streamOutput) {
+        const formattedResponse = await xmlUtils.formatContent(newResponse);
+        logger.info(
+          formattedResponse,
+          taskGroupId,
+          MESSAGE_TYPES.MODEL_RESPONSE,
+        );
+      }
+    }
 
     // Only log thinking content for non-streaming responses
     // Streaming responses display thinking content progressively via createThinkingStream()

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -91,6 +91,7 @@ export async function runToolUseCycle(
     let response: any;
     const startTime = Date.now();
     try {
+      modelHandler.setOutputStreaming(true);
       response = await modelHandler.createResponse(
         client,
         messages,
@@ -127,6 +128,7 @@ export async function runToolUseCycle(
       toolState,
     );
     const useStreaming = modelHandler.getStreamingConfig();
+    const streamOutput = modelHandler.isOutputStreamingEnabled();
     if (thinking && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinking);
       logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
@@ -142,8 +144,10 @@ export async function runToolUseCycle(
     );
     if (text) {
       logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
-      const formatted = await xmlUtils.formatContent(text);
-      logger.info(formatted, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
+      if (!streamOutput) {
+        const formatted = await xmlUtils.formatContent(text);
+        logger.info(formatted, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
+      }
     }
     if (usage) {
       const normalized = modelHandler.computeResponseUsage(usage, responseTime);

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -128,7 +128,6 @@ export async function runToolUseCycle(
       toolState,
     );
     const useStreaming = modelHandler.getStreamingConfig();
-    const streamOutput = modelHandler.isOutputStreamingEnabled();
     if (thinking && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinking);
       logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
@@ -144,7 +143,7 @@ export async function runToolUseCycle(
     );
     if (text) {
       logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
-      if (!streamOutput) {
+      if (!useStreaming) {
         const formatted = await xmlUtils.formatContent(text);
         logger.info(formatted, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
       }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -33,7 +33,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { MESSAGE_TYPES, MessageType } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
 import {
   ModelConfig,
@@ -82,6 +82,7 @@ export abstract class ModelHandler<
   public inputTokenLimit: number;
   public maxOutputTokensFactor: number;
   protected logger: AgentLogger;
+  protected outputStreaming = false;
 
   constructor(config: ModelConfig) {
     this.config = {
@@ -113,13 +114,27 @@ export abstract class ModelHandler<
   }
 
   /**
-   * Creates a thinking stream that aggregates reasoning chunks and streams them
-   * to the Progress view.
+   * Enables or disables streaming of model output text.
+   */
+  public setOutputStreaming(enabled: boolean): void {
+    this.outputStreaming = enabled;
+  }
+
+  /**
+   * Indicates whether model output streaming is enabled.
+   */
+  public isOutputStreamingEnabled(): boolean {
+    return this.outputStreaming;
+  }
+
+  /**
+   * Creates a log stream for progressive updates to the Progress view.
    *
+   * @param type Message type for the stream.
    * @param groupId Optional log group identifier.
    * @returns Object with `append` and `finalize` helpers.
    */
-  protected createThinkingStream(groupId?: string) {
+  protected createLogStream(type: MessageType, groupId?: string) {
     const streamId = this.logger.channelId;
     const id = randomUUID();
     let buffer = '';
@@ -140,7 +155,7 @@ export abstract class ModelHandler<
               level: 'info',
               timestamp: Date.now(),
               groupId,
-              messageType: MESSAGE_TYPES.THINKING,
+              messageType: type,
             },
           });
           isFirstUpdate = false;
@@ -151,7 +166,7 @@ export abstract class ModelHandler<
               id,
               text: encodeHtml(buffer),
               groupId,
-              messageType: MESSAGE_TYPES.THINKING,
+              messageType: type,
             },
           });
         }
@@ -171,7 +186,7 @@ export abstract class ModelHandler<
               level: 'info',
               timestamp: Date.now(),
               groupId,
-              messageType: MESSAGE_TYPES.THINKING,
+              messageType: type,
             },
           });
         } else {
@@ -181,15 +196,29 @@ export abstract class ModelHandler<
               id,
               text: encodeHtml(buffer),
               groupId,
-              messageType: MESSAGE_TYPES.THINKING,
+              messageType: type,
             },
           });
         }
 
-        this.logger.debug(`Final reasoning length: ${buffer.length}`, groupId);
+        this.logger.debug(`Final ${type} length: ${buffer.length}`, groupId);
         return buffer;
       },
     };
+  }
+
+  /**
+   * Convenience wrapper for thinking streams.
+   */
+  protected createThinkingStream(groupId?: string) {
+    return this.createLogStream(MESSAGE_TYPES.THINKING, groupId);
+  }
+
+  /**
+   * Convenience wrapper for output streams.
+   */
+  protected createOutputStream(groupId?: string) {
+    return this.createLogStream(MESSAGE_TYPES.MODEL_RESPONSE, groupId);
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -217,17 +217,28 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
         // we should also make sure partial results can be returned in the presence of errors!
         const stream = client.beta.messages.stream(options, { signal });
-        const thinking = this.createThinkingStream(
-          this.logger.getActiveGroupId(),
-        );
+        const groupId = this.logger.getActiveGroupId();
+        const thinking = this.createThinkingStream(groupId);
+        const output = this.isOutputStreamingEnabled()
+          ? this.createOutputStream(groupId)
+          : undefined;
         stream.on('thinking', (delta: string) => {
           thinking.append(delta);
+        });
+        stream.on('text', (delta: string) => {
+          output?.append(delta);
         });
 
         // Note that there is no second consumption problem as per anthropic sdk examples
         response = await stream.finalMessage();
         const finalReasoning = this.processThinkingBlock(response);
         thinking.finalize(finalReasoning ?? undefined);
+        const finalOutput =
+          response.content
+            ?.filter((c: any) => c.type === 'text')
+            ?.map((c: any) => c.text)
+            .join('') ?? '';
+        if (output) output.finalize(finalOutput);
       } else {
         response = await client.beta.messages.create(options, { signal });
       }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -322,9 +322,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         };
         const stream = await chat.sendMessageStream(streamParams);
 
-        const thinking = this.createThinkingStream(
-          this.logger.getActiveGroupId(),
-        );
+        const groupId = this.logger.getActiveGroupId();
+        const thinking = this.createThinkingStream(groupId);
+        const output = this.isOutputStreamingEnabled()
+          ? this.createOutputStream(groupId)
+          : undefined;
         const fullParts: Part[] = [];
         let lastCandidate: Candidate | undefined;
         let finalUsage: GenerateContentResponseUsageMetadata | undefined;
@@ -338,6 +340,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
               for (const part of parts) {
                 if ((part as any).thought && typeof part.text === 'string') {
                   thinking.append(part.text);
+                } else if (typeof (part as any).text === 'string') {
+                  output?.append((part as any).text);
                 }
               }
             }
@@ -372,6 +376,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
         const finalReasoning = this.processThinkingBlock(finalResponse);
         thinking.finalize(finalReasoning ?? undefined);
+        const finalOutput = fullParts
+          .filter((p: any) => typeof p.text === 'string' && !(p as any).thought)
+          .map((p: any) => p.text)
+          .join('');
+        if (output) output.finalize(finalOutput);
         return finalResponse;
       }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -157,9 +157,11 @@ export class ModelHandlerOpenAI extends ModelHandler<
         const stream = client.chat.completions.stream(kwargs as any, {
           signal,
         });
-        const thinking = this.createThinkingStream(
-          this.logger.getActiveGroupId(),
-        );
+        const groupId = this.logger.getActiveGroupId();
+        const thinking = this.createThinkingStream(groupId);
+        const output = this.isOutputStreamingEnabled()
+          ? this.createOutputStream(groupId)
+          : undefined;
 
         if (this.config.fullName.includes('deepseek')) {
           // Aggregate stream chunks manually for DeepSeek models
@@ -170,8 +172,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
             lastChunk = chunk;
             const delta: any = chunk.choices[0]?.delta;
             const reasoningDelta = delta?.reasoning_content ?? '';
+            const contentDelta = delta?.content ?? '';
             if (reasoningDelta) thinking.append(reasoningDelta);
-            fullContent += delta?.content ?? '';
+            if (contentDelta) output?.append(contentDelta);
+            fullContent += contentDelta;
             reasoning += reasoningDelta;
           }
           const finalResponse = {
@@ -197,19 +201,24 @@ export class ModelHandlerOpenAI extends ModelHandler<
           };
           const finalReasoning = this.processThinkingBlock(finalResponse);
           thinking.finalize(finalReasoning ?? undefined);
+          if (output) output.finalize(fullContent);
           return finalResponse;
         }
 
         for await (const chunk of stream) {
           const reasoningDelta =
             (chunk.choices[0]?.delta as any)?.reasoning_content ?? '';
+          const contentDelta = chunk.choices[0]?.delta?.content ?? '';
           if (reasoningDelta) thinking.append(reasoningDelta);
+          if (contentDelta) output?.append(contentDelta);
         }
 
         // Note that there is no second consumption problem as per openai sdk examples
         response = await stream.finalChatCompletion();
         const finalReasoning = this.processThinkingBlock(response);
         thinking.finalize(finalReasoning ?? undefined);
+        const finalOutput = response.choices?.[0]?.message?.content ?? '';
+        if (output) output.finalize(finalOutput);
 
         // in the future we can add: stream_options: {"include_usage": true} to get usage statistics
         // in the future if we pass stream to outside (signal: controller.signal)), calling stream.controller.abort() will abort the stream; which will be very useful for our stop button (controller.abort();)

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -231,9 +231,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       const stream = client.responses.stream(params, {
         signal,
       });
-      const thinking = this.createThinkingStream(
-        this.logger.getActiveGroupId(),
-      );
+      const groupId = this.logger.getActiveGroupId();
+      const thinking = this.createThinkingStream(groupId);
+      const output = this.isOutputStreamingEnabled()
+        ? this.createOutputStream(groupId)
+        : undefined;
       for await (const event of stream) {
         if (
           event.type === 'response.reasoning_text.delta' ||
@@ -241,12 +243,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
         ) {
           thinking.append((event as any).delta);
         }
+        if (event.type === 'response.output_text.delta') {
+          output?.append((event as any).delta);
+        }
       }
 
       // Note that there is no second consumption problem as per openai sdk examples
       const response = await stream.finalResponse();
       const finalReasoning = this.processThinkingBlock(response);
       thinking.finalize(finalReasoning ?? undefined);
+      const [finalText] = this.extractResponse(response, '');
+      if (output) output.finalize(finalText);
       // this.logger.debug(
       //   `OpenAI Responses final response: ${JSON.stringify(response)}`,
       // );

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -77,13 +77,17 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     if (useStreaming) {
       kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
       const stream = client.chat.completions.stream(kwargs, { signal });
-      const thinking = this.createThinkingStream(
-        this.logger.getActiveGroupId(),
-      );
+      const groupId = this.logger.getActiveGroupId();
+      const thinking = this.createThinkingStream(groupId);
+      const output = this.isOutputStreamingEnabled()
+        ? this.createOutputStream(groupId)
+        : undefined;
       for await (const chunk of stream) {
         const reasoningDelta =
           (chunk.choices[0]?.delta as any)?.reasoning_content ?? '';
+        const contentDelta = chunk.choices[0]?.delta?.content ?? '';
         if (reasoningDelta) thinking.append(reasoningDelta);
+        if (contentDelta) output?.append(contentDelta);
       }
 
       // Note that there is no second consumption problem
@@ -91,6 +95,8 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       const response = await stream.finalChatCompletion();
       const finalReasoning = this.processThinkingBlock(response);
       thinking.finalize(finalReasoning ?? undefined);
+      const finalOutput = response.choices?.[0]?.message?.content ?? '';
+      if (output) output.finalize(finalOutput);
       return response;
     } else {
       return await client.chat.completions.create(kwargs, { signal });

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -42,6 +42,12 @@ export interface IModelHandler<
   /** Determine if streaming should be used for the current model. */
   getStreamingConfig(): boolean;
 
+  /** Enable or disable streaming of model output text. */
+  setOutputStreaming(enabled: boolean): void;
+
+  /** Check if output streaming is enabled. */
+  isOutputStreamingEnabled(): boolean;
+
   /** Indicates if the model is served by Google. */
   readonly isGoogle: boolean;
 


### PR DESCRIPTION
## Summary
- create generic log stream helper with wrappers for thinking and model output
- stream model responses alongside reasoning for supported handlers
- add toggle to stream model output only for tool-use cycles

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c7384e8c8324b3cb070934266074