### PR TITLE
feat: add sample project command

### DIFF
--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -45,7 +45,7 @@ Let's go through an example to illustrate the basic workflow.
 3. Open or create a LaTeX document from the workspace you'd like to improve
 
 ::: tip Example
-You can download our [example document](/examples/draft.tex) to try TeXRA with a ready-made sample file.
+Run **TeXRA: Create Sample Project** from the Command Palette to add a ready-made example to your workspace. This creates a `draft.tex` file under `texra-sample/`. Open it, run **TeXRA: Set API Key** to add your credentials, then select an agent and model in the TeXRA panel. Finally, write your instruction and execute the agent to see results.
 :::
 
 ### Step 2: Select Files

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "onView:texra.mainView",
     "onView:texra.folderExplorer",
     "onView:texra.progressView",
-    "onColorTheme"
+    "onColorTheme",
+    "onCommand:texra.createSampleProject"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -749,6 +750,11 @@
       }
     ],
     "commands": [
+      {
+        "command": "texra.createSampleProject",
+        "title": "Create Sample Project",
+        "category": "TeXRA"
+      },
       {
         "command": "texra.cleanOutput",
         "title": "Clean All LLM Output Files",

--- a/resources/examples/draft.tex
+++ b/resources/examples/draft.tex
@@ -1,0 +1,91 @@
+\documentclass[12pt,a4paper]{article}
+\usepackage{amsmath,amssymb,amsthm}
+\usepackage{graphicx}
+\usepackage{tikz}
+\usepackage{algorithm}
+\usepackage{algpseudocode}
+\usepackage{mathtools}
+
+\newtheorem{theorem}{Theorem}
+\newtheorem{lemma}[theorem]{Lemma}
+\newtheorem{proposition}[theorem]{Proposition}
+\newtheorem{corollary}[theorem]{Corollary}
+\newtheorem{definition}{Definition}
+\newtheorem{remark}{Remark}
+
+\title{Notes on Spectral Propertys of Random Graphs}
+\author{Dr. John Doe}
+\date{\today}
+
+\begin{document}
+
+\maketitle
+
+\section{Introduction}
+In these notes, we study the spectral properties of random graphs, with particular emphasis on the eighenvalue distribution of their adjacency matrices. The study of random graphs was initiated by Erdős and Renyi \cite{erdos1960evolution}, and has since become a central topic in discrete mathematics and theoretical computer scince.
+
+\section{Preliminaries}
+\begin{definition}
+    An Erdős-Rényi random graph $G(n,p)$ is a graph on $n$ vertices where each posible edge is included with probability $p$ independent of all other edges.
+\end{definition}
+
+Let $A$ be the adjacency matrix of a graph $G$. The eigenvalues of $A$ are denoted $\lambda_1 \geq \lambda_2 \geq \cdots \geq \lambda_n$.
+
+\section{Spectral Gap in Random Regular Graphs}
+For a $d$-regular graph, it is well-known that $\lambda_1 = d$. The spectral gap, defined as $d - \lambda_2$, plays a crucial role in determining the expansion properties of the graph.
+
+\begin{theorem}[Alon-Bopanna]
+    For any $d$-regular graph on $n$ vertices, we have
+    \begin{equation}
+        \lambda_2 \geq 2\sqrt{d-1} - o(1)
+    \end{equation}
+    where $o(1)$ tends to zero as the diameter of the graph tends to infinity.
+\end{theorem}
+
+However, for random $d$-regular graphs, we can establish a stronger result
+
+\begin{theorem}[Friedman's Theorem]
+    For any $\epsilon > 0$, a random $d$-regular graph $G$ satisfies
+    \begin{equation}
+        \lambda_2(G) \leq 2\sqrt{d-1} + \epsilon
+    \end{equation}
+    with probability approaching 1 as $n \to \infty$.
+\end{theorem}
+
+The proof relies on the trace method and careful analysis of the moments of \dots
+
+\section{Concentration of Eigenvalues}
+For the Erdős-Rényi random graph $G(n,p)$ with $p = \frac{d}{n}$ for some constant $d > 0$, the eigenvalues of the adjacency matrix exhibit interesting concentration phenomena.
+
+\begin{proposition}
+    Let $A$ be the adjacency matrix of $G(n,p)$ with $p = \frac{d}{n}$. Then, as $n \to \infty$:
+    \begin{enumerate}
+        \item $\lambda_1 = (1+o(1))np = (1+o(1))d$ almost surely
+        \item For $i \ge 2$, $|\lambda_i| \leq (2+o(1))\sqrt{np(1-p)} = (2+o(1))\sqrt{d}$ almost surely
+    \end{enumerate}
+\end{proposition}
+
+This shows that the bulk of the spectrum is concentrated in a band of width $O(\sqrt{d})$ around the origin, while the largest eigenvalue is separated from this band.
+
+\bibliographystyle{plain}
+\begin{thebibliography}{9}
+    \bibitem{erdos1960evolution}
+    P. Erdős and A. Rényi,
+    \textit{On the evolution of random graphs},
+    Publ. Math. Inst. Hung. Acad. Sci, 5(1):17--60, 1960.
+
+    \bibitem{friedman2008proof}
+    J. Friedman,
+    \textit{A proof of Alon's second eigenvalue conjecture and related problems},
+    Memoirs of the American Mathematical Society, 195(910), 2008.
+
+    \bibitem{wigner1958distribution}
+    E. P. Wigner,
+    \textit{On the distribution of the roots of certain symmetric matrices},
+    Annals of Mathematics, 67(2):325--327, 1958.
+
+    % [TODO: Add more relevant citations, maybe something on Wigner's semicircle law?]
+
+\end{thebibliography}
+
+\end{document}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -32,6 +32,7 @@ import { registerProgressViewCommands } from '@commands/progress/progressViewCom
 import { registerOpenFileCommands } from '@commands/files/openFileCommands';
 import { registerSettingsCommands } from '@commands/system/settingsCommands';
 import { registerMainViewCommands } from '@commands/system/mainViewCommands';
+import { registerSampleProjectCommands } from '@commands/system/sampleProjectCommands';
 
 import * as logger from '@logger/logUtils';
 
@@ -75,6 +76,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     help: registerHelpCommands(context),
     mainView: registerMainViewCommands(context),
     settings: registerSettingsCommands(context),
+    sampleProject: registerSampleProjectCommands(context),
   };
 
   // Register webview provider
@@ -120,3 +122,4 @@ export { agentCreatorCommands } from '@commands/agent/agentCreatorCommands';
 export { registerOpenFileCommands as openFileCommands } from '@commands/files/openFileCommands';
 export { settingsCommands } from '@commands/system/settingsCommands';
 export { mainViewCommands } from '@commands/system/mainViewCommands';
+export { sampleProjectCommands } from '@commands/system/sampleProjectCommands';

--- a/src/commands/system/sampleProjectCommands.ts
+++ b/src/commands/system/sampleProjectCommands.ts
@@ -1,0 +1,66 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - fs
+import { WorkspaceFS, copyDirToFS } from '@utils/files';
+
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
+const CHANNEL = 'SampleProjectCommands';
+logger.initialize(CHANNEL);
+
+export const sampleProjectCommands = {
+  createSampleProject: 'texra.createSampleProject',
+};
+
+export function registerSampleProjectCommands(
+  context: vscode.ExtensionContext,
+) {
+  const createSampleProjectCommand = vscode.commands.registerCommand(
+    sampleProjectCommands.createSampleProject,
+    async () => {
+      try {
+        if (!WorkspaceFS.getPath()) {
+          void vscode.window.showErrorMessage(
+            'Open a workspace to create the sample project.',
+          );
+          return;
+        }
+
+        const destFolder = 'texra-sample';
+        if (await WorkspaceFS.exists(destFolder)) {
+          void vscode.window.showInformationMessage(
+            'Sample project already exists in workspace.',
+          );
+          return;
+        }
+
+        const sourcePath = path.join(
+          context.extensionPath,
+          'resources',
+          'examples',
+        );
+
+        await copyDirToFS(sourcePath, destFolder, WorkspaceFS);
+
+        void vscode.window.showInformationMessage(
+          'Created TeXRA sample project.',
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error(CHANNEL, `Failed to create sample project: ${message}`);
+        void vscode.window.showErrorMessage(
+          `Failed to create sample project: ${message}`,
+        );
+      }
+    },
+  );
+
+  context.subscriptions.push(createSampleProjectCommand);
+
+  return { createSampleProjectCommand };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,16 +138,26 @@ export async function activate(context: vscode.ExtensionContext) {
     folderExplorer.refresh();
   });
 
-  await showInstructionWithSuppress('welcome', 'Welcome to TeXRA…', [
-    {
-      title: 'Open Guide',
-      callback: async () => {
-        await vscode.env.openExternal(
-          vscode.Uri.parse('https://texra.ai/guide/'),
-        );
+  await showInstructionWithSuppress(
+    'welcome',
+    'Welcome to TeXRA! Run "TeXRA: Create Sample Project" to add a draft.tex example, set your API keys, choose an agent and model, then write instructions and execute.',
+    [
+      {
+        title: 'Open Guide',
+        callback: async () => {
+          await vscode.env.openExternal(
+            vscode.Uri.parse('https://texra.ai/guide/'),
+          );
+        },
       },
-    },
-  ]);
+      {
+        title: 'Create Sample Project',
+        callback: async () => {
+          await vscode.commands.executeCommand('texra.createSampleProject');
+        },
+      },
+    ],
+  );
 }
 
 export function deactivate() {

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import * as logger from '@logger/logUtils';
-import { AbsoluteFS, GlobalStorageFS, StorageFS } from '@utils/files';
+import { GlobalStorageFS, StorageFS, copyDirToFS } from '@utils/files';
 import { GlobalStateKey, globalSM } from '@common/state/stateManager';
 import { safeExecuteCommand } from '@utils/system';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
@@ -53,31 +53,9 @@ export async function copyDefaultAgents(context: vscode.ExtensionContext) {
     await GlobalStorageFS.ensureDir('tool_use_agents');
     console.log('Created or verified global storage directory');
 
-    // Recursive function to copy files and directories
-    // Consider the native recursive copy available in Node 16+?
-    const copyRecursively = async (
-      sourcePath: string,
-      targetRelativePath: string,
-    ) => {
-      const stats = AbsoluteFS.statSync(sourcePath);
-
-      if (stats.isDirectory()) {
-        await GlobalStorageFS.createDir(targetRelativePath);
-        const files = AbsoluteFS.readDirSync(sourcePath);
-        for (const file of files) {
-          const sourceFilePath = path.join(sourcePath, file);
-          const targetFileRelativePath = path.join(targetRelativePath, file);
-          await copyRecursively(sourceFilePath, targetFileRelativePath);
-        }
-      } else {
-        const content = AbsoluteFS.readBytesSync(sourcePath);
-        await GlobalStorageFS.write(targetRelativePath, content);
-      }
-    };
-
     // Start recursive copy from root
-    await copyRecursively(resourcesPath, 'agents');
-    await copyRecursively(resourcesToolUse, 'tool_use_agents');
+    await copyDirToFS(resourcesPath, 'agents', GlobalStorageFS);
+    await copyDirToFS(resourcesToolUse, 'tool_use_agents', GlobalStorageFS);
 
     // Update the stored version after successful copy
     await globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, currentVersion);

--- a/src/utils/files/copyUtils.ts
+++ b/src/utils/files/copyUtils.ts
@@ -1,0 +1,40 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - fs
+import { AbsoluteFS } from './absoluteFS';
+
+type FileSystem = {
+  createDir(relativePath: string): Promise<void>;
+  write(relativePath: string, content: Uint8Array): Promise<void>;
+};
+
+/**
+ * Recursively copy a directory from an absolute source path to a relative
+ * destination using the provided filesystem implementation.
+ *
+ * @param sourcePath Absolute path to the directory to copy
+ * @param destRelativePath Destination path relative to the filesystem base
+ * @param destFS Filesystem class (e.g., WorkspaceFS, GlobalStorageFS)
+ */
+export async function copyDirToFS(
+  sourcePath: string,
+  destRelativePath: string,
+  destFS: FileSystem,
+): Promise<void> {
+  await destFS.createDir(destRelativePath);
+  const entries = AbsoluteFS.readDirSync(sourcePath);
+  for (const entry of entries) {
+    const srcEntry = path.join(sourcePath, entry);
+    const destEntryRel = path.join(destRelativePath, entry);
+    const stats = AbsoluteFS.statSync(srcEntry);
+    if (stats.isDirectory()) {
+      await copyDirToFS(srcEntry, destEntryRel, destFS);
+    } else {
+      const data = AbsoluteFS.readBytesSync(srcEntry);
+      await destFS.write(destEntryRel, data);
+    }
+  }
+}
+
+export default copyDirToFS;

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -8,3 +8,4 @@ export * from './fileMappingUtils';
 export * from './pathUtils';
 export * from './mimeUtils';
 export * from './taskRunStorage';
+export * from './copyUtils';


### PR DESCRIPTION
## Summary
- add minimal example project and agent configuration
- introduce texra.createSampleProject command to copy the example into the workspace
- advertise the sample command in quick start guide and welcome message
- expand sample project with detailed LaTeX draft and shareable copy utility

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c8cefed4832489f59278e5dfcac6