### PR TITLE
fix: use active task output selection for pack and clean

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -272,14 +272,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     }
 
     const outputFilesArray = Array.from(allFiles);
+    const outputActive = taskState.activeFiles.output;
     await vscode.commands.executeCommand(command, {
       streamId: stream,
       agent: taskState.agentConfig.agent,
       model: taskState.agentConfig.model,
       inputFile: taskState.agentConfig.inputFile,
-      outputFiles: outputFilesArray,
+      outputFiles: outputActive ? outputFilesArray : [],
       activeFiles: {
-        output: outputFilesArray.length > 0,
+        output: outputActive,
       },
     });
   }


### PR DESCRIPTION
## Summary
- respect stored output selection when running file operations
- avoid passing output files when none are active

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab521cfd48832488d293c253f2492e