### PR TITLE
feat: add chat tool-use agent

### DIFF
--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -8,6 +8,15 @@ The underlying prompts and specific behaviors of these built-in agents may chang
 
 For details on the underlying structure and execution flow common to all agents, see the [Agent Architecture & Execution Flow](./agent-architecture.md) guide.
 
+## Conversational Agents
+
+### `chat`
+
+The `chat` agent acts as a friendly scientist focused on careful reasoning during conversation.
+It can execute `bash` commands and manipulate files using the `file_op` tool.
+When derivations are required, it presents steps inside `\begin{aligned} ... \end{aligned}` blocks
+to keep mathematical discussions accurate.
+
 ## Correction & Polishing Agents
 
 ### `correct`

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
               "type": "string"
             },
             "default": [
+              "chat",
               "correct",
               "polish",
               "draw",

--- a/resources/tool_use_agents/chat.yaml
+++ b/resources/tool_use_agents/chat.yaml
@@ -1,0 +1,10 @@
+name: chat
+settings:
+  agentType: toolUse
+  tools: [bash, file_op]
+prompts:
+  systemPrompt: |
+    You are a scientist. Reason deeply.
+    Use \begin{aligned} … \end{aligned} for derivations.
+    Converse with the user and ensure mathematical accuracy.
+  userRequest: '{{INSTRUCTION}}'

--- a/resources/tool_use_agents/chat.yaml
+++ b/resources/tool_use_agents/chat.yaml
@@ -7,4 +7,12 @@ prompts:
     You are a scientist. Reason deeply.
     Use \begin{aligned} … \end{aligned} for derivations.
     Converse with the user and ensure mathematical accuracy.
+    
+    Safety Guidelines:
+    - When editing files, always ask for user confirmation before making changes
+    - For bash operations, distinguish between safe and potentially risky commands:
+      * Safe commands (execute without confirmation): ls, pwd, cat, echo, grep, find, which, date, whoami
+      * Potentially complicated operations: Ask for confirmation before executing (e.g., rm, mv, cp with wildcards, curl/wget, npm/pip install, git operations beyond status/log)
+    - Clearly explain what any command will do before executing it
+    - Prefer reading files over modifying them unless explicitly requested
   userRequest: '{{INSTRUCTION}}'


### PR DESCRIPTION
## Summary
- add chat tool-use agent configuration
- register chat agent in default configuration and document scientist-style behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5634e6f88324af33472d9b491fc2