### PR TITLE
feat: add empty-state placeholder to progress view

### DIFF
--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -54,6 +54,10 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
         webview,
         'modules/uiManagers/EventsManager.js',
       ),
+      placeholderUri: this.getWebviewUri(
+        webview,
+        'modules/uiManagers/Placeholder.js',
+      ),
     };
   }
 }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -41,6 +41,7 @@
           "./modules/uiManagers/Status.js": "${statusUri}",
           "./modules/uiManagers/FileList.js": "${fileListUri}",
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
+          "./modules/uiManagers/Placeholder.js": "${placeholderUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -10,6 +10,7 @@ export const STATUS = {
 // DOM element IDs used across the progress view
 export const ELEMENT_IDS = {
   LOG_CONTENT: 'logContent',
+  LOG_PLACEHOLDER: 'logPlaceholder',
   GENERATED_FILES: 'generatedFiles',
   STREAM_TABS: 'streamTabs',
   ACTIVE_STREAM_NAME: 'activeStreamName',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -7,6 +7,7 @@ import { EventsManager } from './uiManagers/EventsManager.js';
 import { FileList } from './uiManagers/FileList.js';
 import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
+import { Placeholder } from './uiManagers/Placeholder.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 
@@ -25,6 +26,7 @@ export class ProgressViewDomHandler {
     this.taskGroups = new TaskGroupManager();
     this.logEntries = new LogEntryManager();
     this.events = new EventsManager();
+    this.placeholder = new Placeholder();
   }
 }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -64,6 +64,12 @@ export class ProgressViewMessageHandler {
     });
     dom.streamTabs.update(message.streams, message.activeStream);
 
+    if (message.streams.length === 0) {
+      dom.placeholder.show();
+    } else {
+      dom.placeholder.hide();
+    }
+
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
       const active = message.streams.find(

--- a/src/progressView/modules/uiManagers/Placeholder.js
+++ b/src/progressView/modules/uiManagers/Placeholder.js
@@ -1,0 +1,43 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+
+/**
+ * Manages the empty state placeholder in the log view.
+ */
+export class Placeholder {
+  constructor() {
+    /** @type {HTMLElement|null} */
+    this._element = null;
+  }
+
+  /**
+   * Show the placeholder inside the log content container.
+   */
+  show() {
+    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    if (!container) return;
+
+    if (!this._element) {
+      this._element = document.createElement('div');
+      this._element.id = ELEMENT_IDS.LOG_PLACEHOLDER;
+      this._element.className = 'log-placeholder';
+      const sampleLink =
+        '<a href="command:texra.createSampleProject">create a sample project</a>';
+      const guideArgs = encodeURIComponent(JSON.stringify(['quick-start']));
+      const guideLink = `<a href="command:texra.openDoc?${guideArgs}">user guide</a>`;
+      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${sampleLink} or read the ${guideLink}.`;
+    }
+
+    container.innerHTML = '';
+    container.appendChild(this._element);
+  }
+
+  /**
+   * Hide the placeholder if it is currently shown.
+   */
+  hide() {
+    if (this._element && this._element.parentElement) {
+      this._element.parentElement.removeChild(this._element);
+    }
+  }
+}

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ]);
   initializeIconButtons();
   progressViewDomHandler.toolbar.render();
+  progressViewDomHandler.placeholder.show();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();
 

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -13,6 +13,7 @@
 @import './tabs.css';
 @import './buttons.css';
 @import './logs.css';
+@import './placeholder.css';
 @import './groups.css';
 @import './markdown.css';
 @import './scratchpad.css';

--- a/src/progressView/styles/placeholder.css
+++ b/src/progressView/styles/placeholder.css
@@ -1,0 +1,15 @@
+/**
+ * Placeholder styles for ProgressView
+ * Displayed when no streams are available
+ */
+
+.log-placeholder {
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+  padding: var(--spacing-large) var(--spacing-medium);
+}
+
+.log-placeholder a {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- show 'No runs yet' placeholder in progress view with helpful links
- hide placeholder once streams begin
- style placeholder and wire up resources in import map

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e371de0832494e82021bedb9a62