### PR TITLE
feat: show placeholder when progress view has no runs

### DIFF
--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -54,6 +54,10 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
         webview,
         'modules/uiManagers/EventsManager.js',
       ),
+      emptyStateUri: this.getWebviewUri(
+        webview,
+        'modules/uiManagers/EmptyState.js',
+      ),
     };
   }
 }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -41,6 +41,7 @@
           "./modules/uiManagers/Status.js": "${statusUri}",
           "./modules/uiManagers/FileList.js": "${fileListUri}",
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
+          "./modules/uiManagers/EmptyState.js": "${emptyStateUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -18,6 +18,7 @@ export const ELEMENT_IDS = {
   TOOLBAR_CONTAINER: 'toolbarContainer',
   FILE_ITEM_TEMPLATE: 'fileItemTemplate',
   DELETE_ALL_BTN: 'deleteAllBtn',
+  LOG_PLACEHOLDER: 'logPlaceholder',
   SORT_TIME_BTN: 'sortTimeBtn',
   SORT_FILE_BTN: 'sortFileBtn',
   SORT_AGENT_BTN: 'sortAgentBtn',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -8,6 +8,7 @@ import { FileList } from './uiManagers/FileList.js';
 import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
+import { EmptyState } from './uiManagers/EmptyState.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 
 /**
@@ -25,6 +26,7 @@ export class ProgressViewDomHandler {
     this.taskGroups = new TaskGroupManager();
     this.logEntries = new LogEntryManager();
     this.events = new EventsManager();
+    this.emptyState = new EmptyState();
   }
 }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -64,6 +64,12 @@ export class ProgressViewMessageHandler {
     });
     dom.streamTabs.update(message.streams, message.activeStream);
 
+    if (!message.streams || message.streams.length === 0) {
+      dom.emptyState.show();
+    } else {
+      dom.emptyState.hide();
+    }
+
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
       const active = message.streams.find(
@@ -84,35 +90,29 @@ export class ProgressViewMessageHandler {
 
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    if (message.stream === state.activeStream) {
-      logContent.innerHTML = '';
-      state.taskGroups.clear();
-      if (message.groups && message.groups.length > 0) {
-        const parentGroups = message.groups.filter((g) => !g.parentGroupId);
-        const childGroups = message.groups.filter((g) => g.parentGroupId);
-        parentGroups
-          .sort((a, b) => a.startTime - b.startTime)
-          .forEach((g) => dom.taskGroups.add(g));
-        childGroups
-          .sort((a, b) => a.startTime - b.startTime)
-          .forEach((g) => dom.taskGroups.add(g));
-      }
-      const sortedMessages = [...message.messages].sort(
-        (a, b) => a.timestamp - b.timestamp,
-      );
-      sortedMessages.forEach((msg) => {
-        if (msg.groupId) {
-          if (!dom.logEntries.append(msg)) {
-            const formatted = this._entryFormatter.format(msg);
-            if (formatted instanceof HTMLElement) {
-              logContent.appendChild(formatted);
-            } else {
-              const el = document.createElement('div');
-              el.innerHTML = formatted;
-              logContent.appendChild(el.firstElementChild);
-            }
-          }
-        } else {
+    if (!message.stream || message.stream !== state.activeStream) {
+      return;
+    }
+
+    dom.emptyState.hide();
+    logContent.innerHTML = '';
+    state.taskGroups.clear();
+    if (message.groups && message.groups.length > 0) {
+      const parentGroups = message.groups.filter((g) => !g.parentGroupId);
+      const childGroups = message.groups.filter((g) => g.parentGroupId);
+      parentGroups
+        .sort((a, b) => a.startTime - b.startTime)
+        .forEach((g) => dom.taskGroups.add(g));
+      childGroups
+        .sort((a, b) => a.startTime - b.startTime)
+        .forEach((g) => dom.taskGroups.add(g));
+    }
+    const sortedMessages = [...message.messages].sort(
+      (a, b) => a.timestamp - b.timestamp,
+    );
+    sortedMessages.forEach((msg) => {
+      if (msg.groupId) {
+        if (!dom.logEntries.append(msg)) {
           const formatted = this._entryFormatter.format(msg);
           if (formatted instanceof HTMLElement) {
             logContent.appendChild(formatted);
@@ -122,12 +122,21 @@ export class ProgressViewMessageHandler {
             logContent.appendChild(el.firstElementChild);
           }
         }
-      });
-      logContent.scrollTop = logContent.scrollHeight;
+      } else {
+        const formatted = this._entryFormatter.format(msg);
+        if (formatted instanceof HTMLElement) {
+          logContent.appendChild(formatted);
+        } else {
+          const el = document.createElement('div');
+          el.innerHTML = formatted;
+          logContent.appendChild(el.firstElementChild);
+        }
+      }
+    });
+    logContent.scrollTop = logContent.scrollHeight;
 
-      // Recalculate cumulative usage after loading groups
-      dom.usageSummary.update();
-    }
+    // Recalculate cumulative usage after loading groups
+    dom.usageSummary.update();
   }
 
   handleClearLogs() {
@@ -140,11 +149,15 @@ export class ProgressViewMessageHandler {
     }
     state.taskGroups.clear();
     state.toggleStates.clear(groupIds);
+    if (!state.activeStream) {
+      dom.emptyState.show();
+    }
   }
 
   handleAppendLog(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      dom.emptyState.hide();
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
         const formatted = this._entryFormatter.format(message.logMessage);
@@ -178,6 +191,7 @@ export class ProgressViewMessageHandler {
   handleAddTaskGroup(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      dom.emptyState.hide();
       dom.taskGroups.add(message.group);
       logContent.scrollTop = logContent.scrollHeight;
     }

--- a/src/progressView/modules/uiManagers/EmptyState.js
+++ b/src/progressView/modules/uiManagers/EmptyState.js
@@ -1,0 +1,36 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+
+/**
+ * Manages the empty state placeholder for the log area.
+ */
+export class EmptyState {
+  constructor() {
+    this.id = 'logPlaceholder';
+  }
+
+  show() {
+    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    if (!logContent) return;
+    logContent.innerHTML = '';
+    let placeholder = document.getElementById(this.id);
+    if (!placeholder) {
+      placeholder = document.createElement('div');
+      placeholder.id = this.id;
+      placeholder.className = 'log-placeholder';
+      placeholder.innerHTML =
+        'No runs yet—use TeXRA commands to start. <a href="command:texra.createSampleProject">Create sample project</a> or <a href="https://texra.ai/guide/" target="_blank">read the user guide</a>.';
+      logContent.appendChild(placeholder);
+    } else {
+      placeholder.style.display = 'block';
+      logContent.appendChild(placeholder);
+    }
+  }
+
+  hide() {
+    const placeholder = document.getElementById(this.id);
+    if (placeholder) {
+      placeholder.style.display = 'none';
+    }
+  }
+}

--- a/src/progressView/styles/empty-state.css
+++ b/src/progressView/styles/empty-state.css
@@ -1,0 +1,14 @@
+.log-placeholder {
+  padding: 1rem;
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+}
+
+.log-placeholder a {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: none;
+}
+
+.log-placeholder a:hover {
+  text-decoration: underline;
+}

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -21,3 +21,4 @@
 @import './statistics.css';
 @import './user-message.css';
 @import './follow-up-input.css';
+@import './empty-state.css';


### PR DESCRIPTION
## Summary
- display placeholder message with links when no streams exist
- hide the placeholder once a stream starts
- style placeholder with minimal CSS
- ensure placeholder remains visible until a stream runs

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e371de0832494e82021bedb9a62