### PR TITLE
feat: persist tool-use agent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Harden persistent tool-use agent sessions with state validation and optional session expiry
+- Ensure resumed tool-use agents process initial requests and only save state when uninterrupted
+- Prompt before resuming saved sessions on startup to avoid unexpected costs
 
 ## [0.33.1] - 2025-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.2] - 2025-08-23
+
+### Bug Fixes
+
+- Harden persistent tool-use agent sessions with state validation and optional session expiry
+
 ## [0.33.1] - 2025-08-22
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Ensure resumed tool-use agents process initial requests and only save state when uninterrupted
 - Prompt before resuming saved sessions on startup to avoid unexpected costs
 - Prevent empty or partial saves during tool-use agent follow-ups
+- Support resuming multiple tool-use sessions and continue follow-ups after restart
+- Fix false "Task already running" errors when resuming sessions
 
 ## [0.33.1] - 2025-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Harden persistent tool-use agent sessions with state validation and optional session expiry
 - Ensure resumed tool-use agents process initial requests and only save state when uninterrupted
 - Prompt before resuming saved sessions on startup to avoid unexpected costs
+- Prevent empty or partial saves during tool-use agent follow-ups
 
 ## [0.33.1] - 2025-08-22
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,18 @@
             "description": "Include built-in tool-use agents (e.g., xml_validator, tex_linter_fix) in the agent list",
             "scope": "resource"
           },
+          "texra.agent.persistSessions": {
+            "type": "boolean",
+            "default": true,
+            "description": "Persist active ToolUse agent sessions across reloads",
+            "scope": "window"
+          },
+          "texra.agent.sessionTtlHours": {
+            "type": "number",
+            "default": 24,
+            "description": "Hours before a persisted agent session expires",
+            "scope": "window"
+          },
           "texra.models": {
             "type": "array",
             "items": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "onView:texra.folderExplorer",
     "onView:texra.progressView",
     "onColorTheme",
-    "onCommand:texra.createSampleProject"
+    "onCommand:texra.createSampleProject",
+    "onCommand:texra.resumeAgent"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -884,6 +885,11 @@
       {
         "command": "texra.stopAgent",
         "title": "Stop Agent",
+        "category": "TeXRA"
+      },
+      {
+        "command": "texra.resumeAgent",
+        "title": "Resume Agent",
         "category": "TeXRA"
       },
       {

--- a/src/agent/core/ToolState.ts
+++ b/src/agent/core/ToolState.ts
@@ -67,9 +67,18 @@ export class ToolState implements IToolState {
     state.firstKCharsFromInput = data.firstKCharsFromInput ?? null;
     state.lastResponse = data.lastResponse ?? '';
     state.accumulatedOutput = data.accumulatedOutput ?? '';
-    state.mediaFiles = Array.isArray(data.mediaFiles) ? data.mediaFiles : [];
+    state.mediaFiles = Array.isArray(data.mediaFiles)
+      ? data.mediaFiles.filter(
+          (f: unknown): f is string => typeof f === 'string',
+        )
+      : [];
     state.thinkingBlocks = Array.isArray(data.thinkingBlocks)
       ? data.thinkingBlocks
+          .filter(
+            (b: unknown): b is Record<string, unknown> =>
+              !!b && typeof b === 'object',
+          )
+          .map((b: Record<string, unknown>) => JSON.parse(JSON.stringify(b)))
       : [];
     state.thinkingAdded = data.thinkingAdded ?? false;
     return state;

--- a/src/agent/core/ToolState.ts
+++ b/src/agent/core/ToolState.ts
@@ -55,6 +55,27 @@ export class ToolState implements IToolState {
   }
 
   /**
+   * Reconstruct a ToolState instance from a plain object.
+   * @param data Serialized tool state
+   */
+  static deserialize(data: any): ToolState {
+    const state = new ToolState();
+    if (!data || typeof data !== 'object') {
+      return state;
+    }
+    state.texcountStats = data.texcountStats ?? null;
+    state.firstKCharsFromInput = data.firstKCharsFromInput ?? null;
+    state.lastResponse = data.lastResponse ?? '';
+    state.accumulatedOutput = data.accumulatedOutput ?? '';
+    state.mediaFiles = Array.isArray(data.mediaFiles) ? data.mediaFiles : [];
+    state.thinkingBlocks = Array.isArray(data.thinkingBlocks)
+      ? data.thinkingBlocks
+      : [];
+    state.thinkingAdded = data.thinkingAdded ?? false;
+    return state;
+  }
+
+  /**
    * Updates the most recent model response.
    * @param response New response text from the model
    */

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -196,5 +196,14 @@ export abstract class BaseAgent implements IAgent {
     BaseAgent.runningAgents.delete(streamTabId);
   }
 
+  // Serialization hooks for subclasses
+  public serializeState(): any {
+    return {};
+  }
+
+  public restoreState(_state: any): void {
+    // Default no-op
+  }
+
   abstract run(): Promise<void>;
 }

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -129,7 +129,7 @@ export class BaseToolUseAgent extends BaseAgent {
       }
     } finally {
       this.followUpResolver = null;
-      await ActiveAgentManager.clear();
+      await ActiveAgentManager.clear(this.agentConfig);
     }
   }
 
@@ -198,7 +198,7 @@ export class BaseToolUseAgent extends BaseAgent {
       if (needsInitialCycle) {
         await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
         if (this.checkInterruption()) {
-          await ActiveAgentManager.clear();
+          await ActiveAgentManager.clear(this.agentConfig);
           this.endRunGroup('stopped');
           return;
         }

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -100,7 +100,7 @@ export class BaseToolUseAgent extends BaseAgent {
   public override restoreState(state: any): void {
     this.messages = state.messages || [];
     this.toolState = state.toolState
-      ? Object.assign(new ToolState(), state.toolState)
+      ? ToolState.deserialize(state.toolState)
       : null;
     if (state.executionId) {
       this.executionId = state.executionId;
@@ -108,19 +108,23 @@ export class BaseToolUseAgent extends BaseAgent {
   }
 
   private async followUpLoop(cycleOptions: any): Promise<void> {
-    while (true) {
-      const followUp = await this.waitForFollowUp();
-      if (!followUp || this.checkInterruption()) break;
-      this.logger.userMessage(followUp, this.runGroupId);
-      this.messages = await this.modelHandler.createUserFollowUpMessages(
-        this.messages,
-        followUp,
-      );
-      await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
-      if (this.checkInterruption()) break;
-      await ActiveAgentManager.save(this.serialize());
+    try {
+      while (true) {
+        const followUp = await this.waitForFollowUp();
+        if (!followUp || this.checkInterruption()) break;
+        this.logger.userMessage(followUp, this.runGroupId);
+        this.messages = await this.modelHandler.createUserFollowUpMessages(
+          this.messages,
+          followUp,
+        );
+        await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
+        if (this.checkInterruption()) break;
+        await ActiveAgentManager.save(this.serialize());
+      }
+    } finally {
+      this.followUpResolver = null;
+      await ActiveAgentManager.clear();
     }
-    await ActiveAgentManager.clear();
   }
 
   public serialize(): any {
@@ -141,7 +145,8 @@ export class BaseToolUseAgent extends BaseAgent {
     try {
       await this.init(this.runGroupId);
       await this.initializeClient();
-      if (this.messages.length === 0) {
+      const isResuming = this.messages.length > 0;
+      if (!isResuming) {
         const [systemPrompt, userRequest, userPrefix] = await Promise.all([
           getSystemPromptWithRules(
             `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
@@ -183,7 +188,7 @@ export class BaseToolUseAgent extends BaseAgent {
         modelName: this.agentConfig.model,
       } as const;
 
-      if (this.messages.length === 0) {
+      if (!isResuming) {
         await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
         if (this.checkInterruption()) {
           await ActiveAgentManager.clear();
@@ -192,7 +197,9 @@ export class BaseToolUseAgent extends BaseAgent {
         }
       }
 
-      await ActiveAgentManager.save(this.serialize());
+      if (this.messages.length > 0) {
+        await ActiveAgentManager.save(this.serialize());
+      }
       await this.followUpLoop(cycleOptions);
 
       this.endRunGroup('stopped');

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -36,6 +36,7 @@ export class BaseToolUseAgent extends BaseAgent {
   ) {
     super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
     this.toolRegistry = DEFAULT_TOOL_REGISTRY;
+    this.initialCycleCompleted = false;
   }
 
   private getTools(): ToolDefinition[] {
@@ -122,7 +123,7 @@ export class BaseToolUseAgent extends BaseAgent {
         );
         await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
         if (this.checkInterruption()) break;
-        if (!this.checkInterruption()) {
+        if (!this.checkInterruption() && this.messages.length > 0) {
           await ActiveAgentManager.save(this.serialize());
         }
       }

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -25,6 +25,7 @@ export class BaseToolUseAgent extends BaseAgent {
   private followUpResolver: ((v: string | null) => void) | null = null;
   private messages: ProviderMessage[] = [];
   private toolState: ToolState | null = null;
+  private initialCycleCompleted = false;
 
   constructor(
     modelHandler: IModelHandler,
@@ -94,6 +95,7 @@ export class BaseToolUseAgent extends BaseAgent {
       messages: this.messages,
       toolState: this.toolState,
       executionId: this.executionId,
+      initialCycleCompleted: this.initialCycleCompleted,
     };
   }
 
@@ -105,6 +107,7 @@ export class BaseToolUseAgent extends BaseAgent {
     if (state.executionId) {
       this.executionId = state.executionId;
     }
+    this.initialCycleCompleted = state.initialCycleCompleted || false;
   }
 
   private async followUpLoop(cycleOptions: any): Promise<void> {
@@ -119,7 +122,9 @@ export class BaseToolUseAgent extends BaseAgent {
         );
         await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
         if (this.checkInterruption()) break;
-        await ActiveAgentManager.save(this.serialize());
+        if (!this.checkInterruption()) {
+          await ActiveAgentManager.save(this.serialize());
+        }
       }
     } finally {
       this.followUpResolver = null;
@@ -137,6 +142,7 @@ export class BaseToolUseAgent extends BaseAgent {
       messages: this.messages,
       toolState: this.toolState,
       executionId: this.executionId,
+      initialCycleCompleted: this.initialCycleCompleted,
     };
   }
 
@@ -187,19 +193,20 @@ export class BaseToolUseAgent extends BaseAgent {
         toolState: this.toolState,
         modelName: this.agentConfig.model,
       } as const;
-
-      if (!isResuming) {
+      const needsInitialCycle = !this.initialCycleCompleted;
+      if (needsInitialCycle) {
         await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
         if (this.checkInterruption()) {
           await ActiveAgentManager.clear();
           this.endRunGroup('stopped');
           return;
         }
+        this.initialCycleCompleted = true;
+        if (this.messages.length > 0) {
+          await ActiveAgentManager.save(this.serialize());
+        }
       }
 
-      if (this.messages.length > 0) {
-        await ActiveAgentManager.save(this.serialize());
-      }
       await this.followUpLoop(cycleOptions);
 
       this.endRunGroup('stopped');

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -3,6 +3,7 @@ import type { AgentConfig } from '../core/AgentConfig';
 import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { ToolState } from '../core/ToolState';
 import { runToolUseCycle } from '../core/ToolUseCycle';
+import { ActiveAgentManager } from '@agent/runtime/ActiveAgentManager';
 import type { IModelHandler } from '../modelHandlers';
 import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
 import { getSystemPromptWithRules } from '../utils/promptHelpers';
@@ -88,29 +89,78 @@ export class BaseToolUseAgent extends BaseAgent {
     }
   }
 
+  public override serializeState(): any {
+    return {
+      messages: this.messages,
+      toolState: this.toolState,
+      executionId: this.executionId,
+    };
+  }
+
+  public override restoreState(state: any): void {
+    this.messages = state.messages || [];
+    this.toolState = state.toolState
+      ? Object.assign(new ToolState(), state.toolState)
+      : null;
+    if (state.executionId) {
+      this.executionId = state.executionId;
+    }
+  }
+
+  private async followUpLoop(cycleOptions: any): Promise<void> {
+    while (true) {
+      const followUp = await this.waitForFollowUp();
+      if (!followUp || this.checkInterruption()) break;
+      this.logger.userMessage(followUp, this.runGroupId);
+      this.messages = await this.modelHandler.createUserFollowUpMessages(
+        this.messages,
+        followUp,
+      );
+      await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
+      if (this.checkInterruption()) break;
+      await ActiveAgentManager.save(this.serialize());
+    }
+    await ActiveAgentManager.clear();
+  }
+
+  public serialize(): any {
+    return {
+      type: 'toolUse',
+      agentConfig: this.agentConfig,
+      agentSetting: this.agentSetting,
+      agentPrompt: this.agentPrompt,
+      agentPath: this.agentPath,
+      messages: this.messages,
+      toolState: this.toolState,
+      executionId: this.executionId,
+    };
+  }
+
   public async run(): Promise<void> {
     await this.startRunGroup();
     try {
       await this.init(this.runGroupId);
       await this.initializeClient();
+      if (this.messages.length === 0) {
+        const [systemPrompt, userRequest, userPrefix] = await Promise.all([
+          getSystemPromptWithRules(
+            `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
+            this.userVars,
+          ),
+          renderPrompt(this.agentPrompt.userRequest, this.userVars),
+          renderPrompt(this.agentPrompt.userPrefix, this.userVars),
+        ]);
 
-      const [systemPrompt, userRequest, userPrefix] = await Promise.all([
-        getSystemPromptWithRules(
-          `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
-          this.userVars,
-        ),
-        renderPrompt(this.agentPrompt.userRequest, this.userVars),
-        renderPrompt(this.agentPrompt.userPrefix, this.userVars),
-      ]);
+        this.messages = await this.modelHandler.initializeMessages(
+          userPrefix,
+          userRequest,
+          undefined,
+          systemPrompt,
+        );
+        this.toolState = new ToolState();
+      }
 
-      this.messages = await this.modelHandler.initializeMessages(
-        userPrefix,
-        userRequest,
-        undefined,
-        systemPrompt,
-      );
-
-      this.toolState = new ToolState();
+      this.toolState = this.toolState ?? new ToolState();
 
       const resolvedSetting = {
         ...this.agentSetting,
@@ -133,17 +183,17 @@ export class BaseToolUseAgent extends BaseAgent {
         modelName: this.agentConfig.model,
       } as const;
 
-      while (true) {
+      if (this.messages.length === 0) {
         await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
-        if (this.checkInterruption()) break;
-        const followUp = await this.waitForFollowUp();
-        if (!followUp || this.checkInterruption()) break;
-        this.logger.userMessage(followUp, this.runGroupId);
-        this.messages = await this.modelHandler.createUserFollowUpMessages(
-          this.messages,
-          followUp,
-        );
+        if (this.checkInterruption()) {
+          await ActiveAgentManager.clear();
+          this.endRunGroup('stopped');
+          return;
+        }
       }
+
+      await ActiveAgentManager.save(this.serialize());
+      await this.followUpLoop(cycleOptions);
 
       this.endRunGroup('stopped');
     } catch (err) {

--- a/src/agent/runtime/ActiveAgentManager.ts
+++ b/src/agent/runtime/ActiveAgentManager.ts
@@ -3,6 +3,7 @@ import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
 
 // Local imports - utils
 import { getConfig } from '@utils/config';
+import { getStreamTabId } from '@/logger/streamUtils';
 
 // Third-party imports
 import { z } from 'zod';
@@ -43,36 +44,84 @@ const PersistedToolUseAgentStateSchema = z.object({
   timestamp: z.number(),
 });
 
+type PersistedStateMap = Record<string, PersistedToolUseAgentState>;
+
 export class ActiveAgentManager {
-  public static async save(state: SaveableToolUseAgentState): Promise<void> {
-    if (!getConfig<boolean>('agent.persistSessions', true)) return;
-    const toSave = { ...state, timestamp: Date.now() };
-    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, toSave);
+  private static computeStreamId(config: AgentConfig): string {
+    return getStreamTabId(config.agent, config.model, config.inputFile);
   }
 
-  public static async getState(): Promise<
-    PersistedToolUseAgentState | undefined
-  > {
+  private static async getAllStates(): Promise<PersistedStateMap> {
+    return (
+      workspaceSM.get<PersistedStateMap>(
+        WorkspaceStateKey.ACTIVE_AGENT_STATE,
+        {},
+      ) || {}
+    );
+  }
+
+  public static async save(state: SaveableToolUseAgentState): Promise<void> {
+    if (!getConfig<boolean>('agent.persistSessions', true)) return;
+    const streamId = this.computeStreamId(state.agentConfig);
+    const all = await this.getAllStates();
+    all[streamId] = { ...state, timestamp: Date.now() };
+    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, all);
+  }
+
+  public static async getState(
+    streamId: string,
+  ): Promise<PersistedToolUseAgentState | undefined> {
     if (!getConfig<boolean>('agent.persistSessions', true)) return undefined;
-    const raw = workspaceSM.get<any>(WorkspaceStateKey.ACTIVE_AGENT_STATE);
-    if (!raw) return undefined;
-    let parsed: PersistedToolUseAgentState;
+    const all = await this.getAllStates();
+    const state = all[streamId];
+    if (!state) return undefined;
     try {
-      parsed = PersistedToolUseAgentStateSchema.parse(
-        raw,
-      ) as PersistedToolUseAgentState;
+      PersistedToolUseAgentStateSchema.parse(state);
     } catch {
+      await this.clear(streamId);
       return undefined;
     }
     const ttl = getConfig<number>('agent.sessionTtlHours', 24) * 3600000;
-    if (Date.now() - parsed.timestamp > ttl) {
-      await this.clear();
+    if (Date.now() - state.timestamp > ttl) {
+      await this.clear(streamId);
       return undefined;
     }
-    return parsed;
+    return state;
   }
 
-  public static async clear(): Promise<void> {
-    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, undefined);
+  public static async getStates(): Promise<PersistedStateMap> {
+    if (!getConfig<boolean>('agent.persistSessions', true)) return {};
+    const all = await this.getAllStates();
+    const ttl = getConfig<number>('agent.sessionTtlHours', 24) * 3600000;
+    const now = Date.now();
+    let changed = false;
+    for (const [id, state] of Object.entries(all)) {
+      if (now - state.timestamp > ttl) {
+        delete all[id];
+        changed = true;
+      } else {
+        try {
+          PersistedToolUseAgentStateSchema.parse(state);
+        } catch {
+          delete all[id];
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, all);
+    }
+    return all;
+  }
+
+  public static async clear(arg?: string | AgentConfig): Promise<void> {
+    const all = await this.getAllStates();
+    if (!arg) {
+      await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, {});
+      return;
+    }
+    const streamId = typeof arg === 'string' ? arg : this.computeStreamId(arg);
+    delete all[streamId];
+    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, all);
   }
 }

--- a/src/agent/runtime/ActiveAgentManager.ts
+++ b/src/agent/runtime/ActiveAgentManager.ts
@@ -1,6 +1,12 @@
 // Local imports - state
 import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
 
+// Local imports - utils
+import { getConfig } from '@utils/config';
+
+// Third-party imports
+import { z } from 'zod';
+
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
@@ -17,19 +23,53 @@ export interface PersistedToolUseAgentState {
   messages: ProviderMessage[];
   toolState: ToolState | null;
   executionId?: ExecutionId;
+  timestamp: number;
 }
 
+export type SaveableToolUseAgentState = Omit<
+  PersistedToolUseAgentState,
+  'timestamp'
+>;
+
+const PersistedToolUseAgentStateSchema = z.object({
+  type: z.literal('toolUse'),
+  agentConfig: z.any(),
+  agentSetting: z.any(),
+  agentPrompt: z.any(),
+  agentPath: z.string(),
+  messages: z.array(z.any()),
+  toolState: z.any().nullable(),
+  executionId: z.any().optional(),
+  timestamp: z.number(),
+});
+
 export class ActiveAgentManager {
-  public static async save(state: PersistedToolUseAgentState): Promise<void> {
-    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, state);
+  public static async save(state: SaveableToolUseAgentState): Promise<void> {
+    if (!getConfig<boolean>('agent.persistSessions', true)) return;
+    const toSave = { ...state, timestamp: Date.now() };
+    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, toSave);
   }
 
   public static async getState(): Promise<
     PersistedToolUseAgentState | undefined
   > {
-    return workspaceSM.get<PersistedToolUseAgentState>(
-      WorkspaceStateKey.ACTIVE_AGENT_STATE,
-    );
+    if (!getConfig<boolean>('agent.persistSessions', true)) return undefined;
+    const raw = workspaceSM.get<any>(WorkspaceStateKey.ACTIVE_AGENT_STATE);
+    if (!raw) return undefined;
+    let parsed: PersistedToolUseAgentState;
+    try {
+      parsed = PersistedToolUseAgentStateSchema.parse(
+        raw,
+      ) as PersistedToolUseAgentState;
+    } catch {
+      return undefined;
+    }
+    const ttl = getConfig<number>('agent.sessionTtlHours', 24) * 3600000;
+    if (Date.now() - parsed.timestamp > ttl) {
+      await this.clear();
+      return undefined;
+    }
+    return parsed;
   }
 
   public static async clear(): Promise<void> {

--- a/src/agent/runtime/ActiveAgentManager.ts
+++ b/src/agent/runtime/ActiveAgentManager.ts
@@ -1,0 +1,38 @@
+// Local imports - state
+import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
+
+// Local imports - agent components
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { ToolState } from '@agent/core/ToolState';
+
+export interface PersistedToolUseAgentState {
+  type: 'toolUse';
+  agentConfig: AgentConfig;
+  agentSetting: AgentSetting;
+  agentPrompt: AgentPrompt;
+  agentPath: string;
+  messages: ProviderMessage[];
+  toolState: ToolState | null;
+  executionId?: ExecutionId;
+}
+
+export class ActiveAgentManager {
+  public static async save(state: PersistedToolUseAgentState): Promise<void> {
+    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, state);
+  }
+
+  public static async getState(): Promise<
+    PersistedToolUseAgentState | undefined
+  > {
+    return workspaceSM.get<PersistedToolUseAgentState>(
+      WorkspaceStateKey.ACTIVE_AGENT_STATE,
+    );
+  }
+
+  public static async clear(): Promise<void> {
+    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, undefined);
+  }
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -160,7 +160,7 @@ function getAgentName(
 /**
  * Common function to execute any agent with proper logging and status handling
  */
-async function executeAgentWithLogging<T extends IAgent>(
+export async function executeAgentWithLogging<T extends IAgent>(
   agentName: string,
   createAgentFn: () => Promise<{ agent: T; agentType?: AgentType }>,
   context: vscode.ExtensionContext,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1,3 +1,4 @@
 export * from './executeAgent';
 export * from './agentLoad';
 export * from './ModelFactory';
+export * from './ActiveAgentManager';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,6 +20,7 @@ import { registerAgentCreatorCommands } from '@commands/agent/agentCreatorComman
 import { registerApiKeyCommands } from '@commands/api/apiKeyCommands';
 import { registerStateRestoreCommand } from '@commands/history/stateRestoreCommand';
 import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
+import { registerResumeCommand } from '@commands/agent/resumeCommand';
 import { registerTextEditorCommands } from '@commands/system/textEditorCommands';
 import { registerLinterCommands } from '@commands/latex/linterCommands';
 import { registerWolframScriptCommands } from '@commands/wolfram/wolframScriptCommands';
@@ -72,6 +73,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     compare: registerCompareCommands(context),
     progressView: registerProgressViewCommands(context),
     followUp: registerFollowUpCommand(context),
+    resume: registerResumeCommand(context),
     openFile: registerOpenFileCommands(context),
     help: registerHelpCommands(context),
     mainView: registerMainViewCommands(context),

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -1,0 +1,66 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent runtime
+import { ActiveAgentManager, executeAgentWithLogging } from '@agent/runtime';
+import { ModelFactory } from '@agent/runtime/ModelFactory';
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
+import { BaseToolUseAgent } from '@agent/implementations';
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import { agentConfigToTaskState } from '@utils/config';
+import { bus } from '@eventBus/ProgressEventBus';
+import { getStreamTabId } from '@/logger/streamUtils';
+
+const CHANNEL = 'resumeCommand';
+console.log(`[${CHANNEL}] command registered`);
+
+export function registerResumeCommand(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('texra.resumeAgent', async () => {
+      const state = await ActiveAgentManager.getState();
+      if (!state) {
+        vscode.window.showInformationMessage('No agent state to resume');
+        return;
+      }
+      const agentConfig = AgentConfigSchema.parse(state.agentConfig);
+      const modelName = agentConfig.model;
+      const modelConfig = MODEL_CONFIGS[modelName];
+      modelConfig.toolConfig = agentConfig.toolConfig;
+      const modelHandler = ModelFactory.createHandler(modelConfig);
+      const agentPath = state.agentPath;
+      const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
+        agentPath,
+        agentConfig.agent,
+      );
+      const agent = new BaseToolUseAgent(
+        modelHandler,
+        agentConfig,
+        agentSetting,
+        agentPrompt,
+        agentPath,
+      );
+      agent.restoreState(state);
+      const streamTabId = getStreamTabId(
+        agentConfig.agent,
+        agentConfig.model,
+        agentConfig.inputFile,
+      );
+      bus.emit('updateStreamStatus', {
+        stream: streamTabId,
+        status: 'running',
+      });
+      bus.emit('setTaskState', {
+        streamTabId,
+        executionId: state.executionId,
+        taskState: agentConfigToTaskState(agentConfig, agentSetting.agentType),
+      });
+      await executeAgentWithLogging(
+        agentConfig.agent,
+        async () => ({ agent, agentType: agentSetting.agentType }),
+        context,
+        state.executionId,
+      );
+    }),
+  );
+}

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -26,6 +26,13 @@ export function registerResumeCommand(context: vscode.ExtensionContext) {
       const agentConfig = AgentConfigSchema.parse(state.agentConfig);
       const modelName = agentConfig.model;
       const modelConfig = MODEL_CONFIGS[modelName];
+      if (!modelConfig) {
+        vscode.window.showErrorMessage(
+          `Model configuration for ${modelName} not found`,
+        );
+        await ActiveAgentManager.clear();
+        return;
+      }
       modelConfig.toolConfig = agentConfig.toolConfig;
       const modelHandler = ModelFactory.createHandler(modelConfig);
       const agentPath = state.agentPath;
@@ -40,7 +47,15 @@ export function registerResumeCommand(context: vscode.ExtensionContext) {
         agentPrompt,
         agentPath,
       );
-      agent.restoreState(state);
+      try {
+        agent.restoreState(state);
+      } catch (error: any) {
+        vscode.window.showErrorMessage(
+          `Failed to restore agent state: ${error.message}`,
+        );
+        await ActiveAgentManager.clear();
+        return;
+      }
       const streamTabId = getStreamTabId(
         agentConfig.agent,
         agentConfig.model,

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -17,65 +17,67 @@ console.log(`[${CHANNEL}] command registered`);
 
 export function registerResumeCommand(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand('texra.resumeAgent', async () => {
-      const state = await ActiveAgentManager.getState();
-      if (!state) {
-        vscode.window.showInformationMessage('No agent state to resume');
-        return;
-      }
-      const agentConfig = AgentConfigSchema.parse(state.agentConfig);
-      const modelName = agentConfig.model;
-      const modelConfig = MODEL_CONFIGS[modelName];
-      if (!modelConfig) {
-        vscode.window.showErrorMessage(
-          `Model configuration for ${modelName} not found`,
+    vscode.commands.registerCommand(
+      'texra.resumeAgent',
+      async (streamId: string) => {
+        const state = await ActiveAgentManager.getState(streamId);
+        if (!state) {
+          vscode.window.showInformationMessage('No agent state to resume');
+          return;
+        }
+        const agentConfig = AgentConfigSchema.parse(state.agentConfig);
+        const modelName = agentConfig.model;
+        const modelConfig = MODEL_CONFIGS[modelName];
+        if (!modelConfig) {
+          vscode.window.showErrorMessage(
+            `Model configuration for ${modelName} not found`,
+          );
+          await ActiveAgentManager.clear(streamId);
+          return;
+        }
+        modelConfig.toolConfig = agentConfig.toolConfig;
+        const modelHandler = ModelFactory.createHandler(modelConfig);
+        const agentPath = state.agentPath;
+        const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
+          agentPath,
+          agentConfig.agent,
         );
-        await ActiveAgentManager.clear();
-        return;
-      }
-      modelConfig.toolConfig = agentConfig.toolConfig;
-      const modelHandler = ModelFactory.createHandler(modelConfig);
-      const agentPath = state.agentPath;
-      const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
-        agentPath,
-        agentConfig.agent,
-      );
-      const agent = new BaseToolUseAgent(
-        modelHandler,
-        agentConfig,
-        agentSetting,
-        agentPrompt,
-        agentPath,
-      );
-      try {
-        agent.restoreState(state);
-      } catch (error: any) {
-        vscode.window.showErrorMessage(
-          `Failed to restore agent state: ${error.message}`,
+        const agent = new BaseToolUseAgent(
+          modelHandler,
+          agentConfig,
+          agentSetting,
+          agentPrompt,
+          agentPath,
         );
-        await ActiveAgentManager.clear();
-        return;
-      }
-      const streamTabId = getStreamTabId(
-        agentConfig.agent,
-        agentConfig.model,
-        agentConfig.inputFile,
-      );
-      bus.emit('updateStreamStatus', {
-        stream: streamTabId,
-        status: 'running',
-      });
-      bus.emit('setTaskState', {
-        streamTabId,
-        executionId: state.executionId,
-        taskState: agentConfigToTaskState(agentConfig, agentSetting.agentType),
-      });
-      await executeAgentWithLogging(
-        agentConfig.agent,
-        async () => ({ agent, agentType: agentSetting.agentType }),
-        context,
-        state.executionId,
-      );
-    }),
+        try {
+          agent.restoreState(state);
+        } catch (error: any) {
+          vscode.window.showErrorMessage(
+            `Failed to restore agent state: ${error.message}`,
+          );
+          await ActiveAgentManager.clear(streamId);
+          return;
+        }
+        const streamTabId = getStreamTabId(
+          agentConfig.agent,
+          agentConfig.model,
+          agentConfig.inputFile,
+        );
+        bus.emit('setTaskState', {
+          streamTabId,
+          executionId: state.executionId,
+          taskState: agentConfigToTaskState(
+            agentConfig,
+            agentSetting.agentType,
+          ),
+        });
+        await executeAgentWithLogging(
+          agentConfig.agent,
+          async () => ({ agent, agentType: agentSetting.agentType }),
+          context,
+          state.executionId,
+        );
+      },
+    ),
   );
 }

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -14,6 +14,7 @@ export enum WorkspaceStateKey {
   TASK_IDS = 'texra.taskIds', // Legacy key for migration
   EXECUTION_IDS = 'texra.executionIds',
   USAGE_STATS = 'texra.usageStats',
+  ACTIVE_AGENT_STATE = 'texra.activeAgentState',
   STREAM_SORT_ORDER = 'texra.streamSortOrder',
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,18 +91,18 @@ export async function activate(context: vscode.ExtensionContext) {
   // Register commands first - this will create and store the MainViewProvider
   registerCommands(context);
 
-  const savedState = await ActiveAgentManager.getState();
-  if (savedState) {
+  const savedStates = await ActiveAgentManager.getStates();
+  for (const [streamId, state] of Object.entries(savedStates)) {
     const resume = 'Resume session';
     const dismiss = 'Dismiss';
     const choice = await vscode.window.showInformationMessage(
-      'An agent session was interrupted. Resume it?',
+      `An agent session (${state.agentConfig.agent}@${state.agentConfig.model}) was interrupted. Resume it?`,
       resume,
       dismiss,
     );
     if (choice === resume) {
       try {
-        await vscode.commands.executeCommand('texra.resumeAgent');
+        await vscode.commands.executeCommand('texra.resumeAgent', streamId);
       } catch (err) {
         logger.error(
           'extension',
@@ -112,10 +112,10 @@ export async function activate(context: vscode.ExtensionContext) {
           false,
           err,
         );
-        await ActiveAgentManager.clear();
+        await ActiveAgentManager.clear(streamId);
       }
     } else {
-      await ActiveAgentManager.clear();
+      await ActiveAgentManager.clear(streamId);
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,30 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const savedState = await ActiveAgentManager.getState();
   if (savedState) {
-    await vscode.commands.executeCommand('texra.resumeAgent');
+    const resume = 'Resume session';
+    const dismiss = 'Dismiss';
+    const choice = await vscode.window.showInformationMessage(
+      'An agent session was interrupted. Resume it?',
+      resume,
+      dismiss,
+    );
+    if (choice === resume) {
+      try {
+        await vscode.commands.executeCommand('texra.resumeAgent');
+      } catch (err) {
+        logger.error(
+          'extension',
+          'Failed to resume agent',
+          undefined,
+          undefined,
+          false,
+          err,
+        );
+        await ActiveAgentManager.clear();
+      }
+    } else {
+      await ActiveAgentManager.clear();
+    }
   }
 
   // Create a status bar item to show TeXRA progress

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { ExplorerOperations } from './explorer/ExplorerOperations';
 import { ExplorerCommands } from './explorer/ExplorerCommands';
 import { WatcherManager } from './explorer/WatcherManager';
 import { registerCommands } from './commands';
+import { ActiveAgentManager } from '@agent/runtime/ActiveAgentManager';
 
 let statusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
@@ -89,6 +90,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register commands first - this will create and store the MainViewProvider
   registerCommands(context);
+
+  const savedState = await ActiveAgentManager.getState();
+  if (savedState) {
+    await vscode.commands.executeCommand('texra.resumeAgent');
+  }
 
   // Create a status bar item to show TeXRA progress
   statusBarItem = vscode.window.createStatusBarItem(


### PR DESCRIPTION
## Summary
- add workspace storage and manager for active tool-use agent state
- enable BaseToolUseAgent to serialize and resume conversations
- automatically restore saved sessions via new `texra.resumeAgent` command

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2dbcf5588324aa63d000d765b447