### PR TITLE
fix: decouple welcome dialog from activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,27 +151,31 @@ export async function activate(context: vscode.ExtensionContext) {
     watcherManager.setup();
     folderExplorer.refresh();
   });
-
-  await showInstructionWithSuppress(
-    'welcome',
-    'Welcome to TeXRA! Run "TeXRA: Create Sample Project" to add a draft.tex example, set your API keys, choose an agent and model, then write instructions and execute.',
-    [
-      {
-        title: 'Open Guide',
-        callback: async () => {
-          await vscode.env.openExternal(
-            vscode.Uri.parse('https://texra.ai/guide/'),
-          );
-        },
-      },
-      {
-        title: 'Create Sample Project',
-        callback: async () => {
-          await vscode.commands.executeCommand('texra.createSampleProject');
-        },
-      },
-    ],
-  );
+  if (!context.globalState.get('texra.welcomeShown')) {
+    setTimeout(() => {
+      showInstructionWithSuppress(
+        'welcome',
+        'Welcome to TeXRA! Run "TeXRA: Create Sample Project" to add a draft.tex example, set your API keys, choose an agent and model, then write instructions and execute.',
+        [
+          {
+            title: 'Open Guide',
+            callback: async () => {
+              await vscode.env.openExternal(
+                vscode.Uri.parse('https://texra.ai/guide/'),
+              );
+            },
+          },
+          {
+            title: 'Create Sample Project',
+            callback: async () => {
+              await vscode.commands.executeCommand('texra.createSampleProject');
+            },
+          },
+        ],
+      ).catch(console.error);
+    }, 0);
+    await context.globalState.update('texra.welcomeShown', true);
+  }
 }
 
 export function deactivate() {


### PR DESCRIPTION
## Summary
- show the welcome dialog asynchronously without blocking activation
- persist a global flag so the welcome dialog appears only once

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68acd917e6b883249a3ae6bccbbccfcc