### PR TITLE
fix: show welcome instruction asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Restrict extension to single workspace folder to prevent initialization issues
+- Set welcome dialog flag only after the dialog displays to avoid missing messages
 
 ## [0.33.0] - 2025-08-19 🎂 Birthday Edition
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,7 +154,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const welcomeKey = 'texra.welcomeShown';
   if (!context.globalState.get<boolean>(welcomeKey)) {
-    showInstructionWithSuppress(
+    void showInstructionWithSuppress(
       'welcome',
       'Welcome to TeXRA! Run "TeXRA: Create Sample Project" to add a draft.tex example, set your API keys, choose an agent and model, then write instructions and execute.',
       [
@@ -173,8 +173,9 @@ export async function activate(context: vscode.ExtensionContext) {
           },
         },
       ],
-    ).catch(console.error);
-    void context.globalState.update(welcomeKey, true);
+    )
+      .then(() => context.globalState.update(welcomeKey, true))
+      .catch(console.error);
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,26 +152,30 @@ export async function activate(context: vscode.ExtensionContext) {
     folderExplorer.refresh();
   });
 
-  await showInstructionWithSuppress(
-    'welcome',
-    'Welcome to TeXRA! Run "TeXRA: Create Sample Project" to add a draft.tex example, set your API keys, choose an agent and model, then write instructions and execute.',
-    [
-      {
-        title: 'Open Guide',
-        callback: async () => {
-          await vscode.env.openExternal(
-            vscode.Uri.parse('https://texra.ai/guide/'),
-          );
+  const welcomeKey = 'texra.welcomeShown';
+  if (!context.globalState.get<boolean>(welcomeKey)) {
+    showInstructionWithSuppress(
+      'welcome',
+      'Welcome to TeXRA! Run "TeXRA: Create Sample Project" to add a draft.tex example, set your API keys, choose an agent and model, then write instructions and execute.',
+      [
+        {
+          title: 'Open Guide',
+          callback: async () => {
+            await vscode.env.openExternal(
+              vscode.Uri.parse('https://texra.ai/guide/'),
+            );
+          },
         },
-      },
-      {
-        title: 'Create Sample Project',
-        callback: async () => {
-          await vscode.commands.executeCommand('texra.createSampleProject');
+        {
+          title: 'Create Sample Project',
+          callback: async () => {
+            await vscode.commands.executeCommand('texra.createSampleProject');
+          },
         },
-      },
-    ],
-  );
+      ],
+    ).catch(console.error);
+    void context.globalState.update(welcomeKey, true);
+  }
 }
 
 export function deactivate() {


### PR DESCRIPTION
## Summary
- show welcome instructions without blocking activation
- track a global flag so the welcome dialog appears once

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68acd917e6b883249a3ae6bccbbccfcc