### PR TITLE
feat: persist tool-use agent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Automatically resume saved sessions on startup with error handling
 - Fix false "Task is already running" error when resuming sessions
 - Prevent empty or partial saves during tool-use agent follow-ups
+- Load persisted tool-use sessions after reload by resuming only after the progress view registers
 
 ## [0.33.1] - 2025-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.2] - 2025-08-23
+
+### Bug Fixes
+
+- Harden persistent tool-use agent sessions with state validation and optional session expiry
+- Ensure resumed tool-use agents process initial requests and only save state when uninterrupted
+- Automatically resume saved sessions on startup with error handling
+- Fix false "Task is already running" error when resuming sessions
+- Prevent empty or partial saves during tool-use agent follow-ups
+
 ## [0.33.1] - 2025-08-22
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Harden persistent tool-use agent sessions with state validation and optional session expiry
 - Ensure resumed tool-use agents process initial requests and only save state when uninterrupted
-- Automatically resume saved sessions on startup with error handling
+- Resume saved sessions only when sending a follow-up, preventing duplicate initial prompts after reload
 - Fix false "Task is already running" error when resuming sessions
 - Prevent empty or partial saves during tool-use agent follow-ups
 - Load persisted tool-use sessions after reload by resuming only after the progress view registers

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "onView:texra.folderExplorer",
     "onView:texra.progressView",
     "onColorTheme",
-    "onCommand:texra.createSampleProject"
+    "onCommand:texra.createSampleProject",
+    "onCommand:texra.resumeAgent"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -53,6 +54,18 @@
             "default": false,
             "description": "Include built-in tool-use agents (e.g., xml_validator, tex_linter_fix) in the agent list",
             "scope": "resource"
+          },
+          "texra.agent.persistSessions": {
+            "type": "boolean",
+            "default": true,
+            "description": "Persist active ToolUse agent sessions across reloads",
+            "scope": "window"
+          },
+          "texra.agent.sessionTtlHours": {
+            "type": "number",
+            "default": 24,
+            "description": "Hours before a persisted agent session expires",
+            "scope": "window"
           },
           "texra.models": {
             "type": "array",
@@ -884,6 +897,11 @@
       {
         "command": "texra.stopAgent",
         "title": "Stop Agent",
+        "category": "TeXRA"
+      },
+      {
+        "command": "texra.resumeAgent",
+        "title": "Resume Agent",
         "category": "TeXRA"
       },
       {

--- a/src/agent/core/ToolState.ts
+++ b/src/agent/core/ToolState.ts
@@ -55,6 +55,36 @@ export class ToolState implements IToolState {
   }
 
   /**
+   * Reconstruct a ToolState instance from a plain object.
+   * @param data Serialized tool state
+   */
+  static deserialize(data: any): ToolState {
+    const state = new ToolState();
+    if (!data || typeof data !== 'object') {
+      return state;
+    }
+    state.texcountStats = data.texcountStats ?? null;
+    state.firstKCharsFromInput = data.firstKCharsFromInput ?? null;
+    state.lastResponse = data.lastResponse ?? '';
+    state.accumulatedOutput = data.accumulatedOutput ?? '';
+    state.mediaFiles = Array.isArray(data.mediaFiles)
+      ? data.mediaFiles.filter(
+          (f: unknown): f is string => typeof f === 'string',
+        )
+      : [];
+    state.thinkingBlocks = Array.isArray(data.thinkingBlocks)
+      ? data.thinkingBlocks
+          .filter(
+            (b: unknown): b is Record<string, unknown> =>
+              !!b && typeof b === 'object',
+          )
+          .map((b: Record<string, unknown>) => JSON.parse(JSON.stringify(b)))
+      : [];
+    state.thinkingAdded = data.thinkingAdded ?? false;
+    return state;
+  }
+
+  /**
    * Updates the most recent model response.
    * @param response New response text from the model
    */

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -196,5 +196,14 @@ export abstract class BaseAgent implements IAgent {
     BaseAgent.runningAgents.delete(streamTabId);
   }
 
+  // Serialization hooks for subclasses
+  public serializeState(): any {
+    return {};
+  }
+
+  public restoreState(_state: any): void {
+    // Default no-op
+  }
+
   abstract run(): Promise<void>;
 }

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -3,6 +3,7 @@ import type { AgentConfig } from '../core/AgentConfig';
 import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { ToolState } from '../core/ToolState';
 import { runToolUseCycle } from '../core/ToolUseCycle';
+import { ActiveAgentManager } from '@agent/runtime/ActiveAgentManager';
 import type { IModelHandler } from '../modelHandlers';
 import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
 import { getSystemPromptWithRules } from '../utils/promptHelpers';
@@ -24,6 +25,7 @@ export class BaseToolUseAgent extends BaseAgent {
   private followUpResolver: ((v: string | null) => void) | null = null;
   private messages: ProviderMessage[] = [];
   private toolState: ToolState | null = null;
+  private initialCycleCompleted = false;
 
   constructor(
     modelHandler: IModelHandler,
@@ -34,6 +36,7 @@ export class BaseToolUseAgent extends BaseAgent {
   ) {
     super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
     this.toolRegistry = DEFAULT_TOOL_REGISTRY;
+    this.initialCycleCompleted = false;
   }
 
   private getTools(): ToolDefinition[] {
@@ -88,29 +91,88 @@ export class BaseToolUseAgent extends BaseAgent {
     }
   }
 
+  public override serializeState(): any {
+    return {
+      messages: this.messages,
+      toolState: this.toolState,
+      executionId: this.executionId,
+      initialCycleCompleted: this.initialCycleCompleted,
+    };
+  }
+
+  public override restoreState(state: any): void {
+    this.messages = state.messages || [];
+    this.toolState = state.toolState
+      ? ToolState.deserialize(state.toolState)
+      : null;
+    if (state.executionId) {
+      this.executionId = state.executionId;
+    }
+    this.initialCycleCompleted = state.initialCycleCompleted || false;
+  }
+
+  private async followUpLoop(cycleOptions: any): Promise<void> {
+    try {
+      while (true) {
+        const followUp = await this.waitForFollowUp();
+        if (!followUp || this.checkInterruption()) break;
+        this.logger.userMessage(followUp, this.runGroupId);
+        this.messages = await this.modelHandler.createUserFollowUpMessages(
+          this.messages,
+          followUp,
+        );
+        await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
+        if (this.checkInterruption()) break;
+        if (!this.checkInterruption() && this.messages.length > 0) {
+          await ActiveAgentManager.save(this.serialize());
+        }
+      }
+    } finally {
+      this.followUpResolver = null;
+      await ActiveAgentManager.clear();
+    }
+  }
+
+  public serialize(): any {
+    return {
+      type: 'toolUse',
+      agentConfig: this.agentConfig,
+      agentSetting: this.agentSetting,
+      agentPrompt: this.agentPrompt,
+      agentPath: this.agentPath,
+      messages: this.messages,
+      toolState: this.toolState,
+      executionId: this.executionId,
+      initialCycleCompleted: this.initialCycleCompleted,
+    };
+  }
+
   public async run(): Promise<void> {
     await this.startRunGroup();
     try {
       await this.init(this.runGroupId);
       await this.initializeClient();
+      const isResuming = this.messages.length > 0;
+      if (!isResuming) {
+        const [systemPrompt, userRequest, userPrefix] = await Promise.all([
+          getSystemPromptWithRules(
+            `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
+            this.userVars,
+          ),
+          renderPrompt(this.agentPrompt.userRequest, this.userVars),
+          renderPrompt(this.agentPrompt.userPrefix, this.userVars),
+        ]);
 
-      const [systemPrompt, userRequest, userPrefix] = await Promise.all([
-        getSystemPromptWithRules(
-          `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
-          this.userVars,
-        ),
-        renderPrompt(this.agentPrompt.userRequest, this.userVars),
-        renderPrompt(this.agentPrompt.userPrefix, this.userVars),
-      ]);
+        this.messages = await this.modelHandler.initializeMessages(
+          userPrefix,
+          userRequest,
+          undefined,
+          systemPrompt,
+        );
+        this.toolState = new ToolState();
+      }
 
-      this.messages = await this.modelHandler.initializeMessages(
-        userPrefix,
-        userRequest,
-        undefined,
-        systemPrompt,
-      );
-
-      this.toolState = new ToolState();
+      this.toolState = this.toolState ?? new ToolState();
 
       const resolvedSetting = {
         ...this.agentSetting,
@@ -132,18 +194,21 @@ export class BaseToolUseAgent extends BaseAgent {
         toolState: this.toolState,
         modelName: this.agentConfig.model,
       } as const;
-
-      while (true) {
+      const needsInitialCycle = !this.initialCycleCompleted;
+      if (needsInitialCycle) {
         await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
-        if (this.checkInterruption()) break;
-        const followUp = await this.waitForFollowUp();
-        if (!followUp || this.checkInterruption()) break;
-        this.logger.userMessage(followUp, this.runGroupId);
-        this.messages = await this.modelHandler.createUserFollowUpMessages(
-          this.messages,
-          followUp,
-        );
+        if (this.checkInterruption()) {
+          await ActiveAgentManager.clear();
+          this.endRunGroup('stopped');
+          return;
+        }
+        this.initialCycleCompleted = true;
+        if (this.messages.length > 0) {
+          await ActiveAgentManager.save(this.serialize());
+        }
       }
+
+      await this.followUpLoop(cycleOptions);
 
       this.endRunGroup('stopped');
     } catch (err) {

--- a/src/agent/runtime/ActiveAgentManager.ts
+++ b/src/agent/runtime/ActiveAgentManager.ts
@@ -1,0 +1,78 @@
+// Local imports - state
+import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
+
+// Local imports - utils
+import { getConfig } from '@utils/config';
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - agent components
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { ToolState } from '@agent/core/ToolState';
+
+export interface PersistedToolUseAgentState {
+  type: 'toolUse';
+  agentConfig: AgentConfig;
+  agentSetting: AgentSetting;
+  agentPrompt: AgentPrompt;
+  agentPath: string;
+  messages: ProviderMessage[];
+  toolState: ToolState | null;
+  executionId?: ExecutionId;
+  timestamp: number;
+}
+
+export type SaveableToolUseAgentState = Omit<
+  PersistedToolUseAgentState,
+  'timestamp'
+>;
+
+const PersistedToolUseAgentStateSchema = z.object({
+  type: z.literal('toolUse'),
+  agentConfig: z.any(),
+  agentSetting: z.any(),
+  agentPrompt: z.any(),
+  agentPath: z.string(),
+  messages: z.array(z.any()),
+  toolState: z.any().nullable(),
+  executionId: z.any().optional(),
+  timestamp: z.number(),
+});
+
+export class ActiveAgentManager {
+  public static async save(state: SaveableToolUseAgentState): Promise<void> {
+    if (!getConfig<boolean>('agent.persistSessions', true)) return;
+    const toSave = { ...state, timestamp: Date.now() };
+    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, toSave);
+  }
+
+  public static async getState(): Promise<
+    PersistedToolUseAgentState | undefined
+  > {
+    if (!getConfig<boolean>('agent.persistSessions', true)) return undefined;
+    const raw = workspaceSM.get<any>(WorkspaceStateKey.ACTIVE_AGENT_STATE);
+    if (!raw) return undefined;
+    let parsed: PersistedToolUseAgentState;
+    try {
+      parsed = PersistedToolUseAgentStateSchema.parse(
+        raw,
+      ) as PersistedToolUseAgentState;
+    } catch {
+      return undefined;
+    }
+    const ttl = getConfig<number>('agent.sessionTtlHours', 24) * 3600000;
+    if (Date.now() - parsed.timestamp > ttl) {
+      await this.clear();
+      return undefined;
+    }
+    return parsed;
+  }
+
+  public static async clear(): Promise<void> {
+    await workspaceSM.update(WorkspaceStateKey.ACTIVE_AGENT_STATE, undefined);
+  }
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -160,7 +160,7 @@ function getAgentName(
 /**
  * Common function to execute any agent with proper logging and status handling
  */
-async function executeAgentWithLogging<T extends IAgent>(
+export async function executeAgentWithLogging<T extends IAgent>(
   agentName: string,
   createAgentFn: () => Promise<{ agent: T; agentType?: AgentType }>,
   context: vscode.ExtensionContext,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1,3 +1,4 @@
 export * from './executeAgent';
 export * from './agentLoad';
 export * from './ModelFactory';
+export * from './ActiveAgentManager';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,6 +20,7 @@ import { registerAgentCreatorCommands } from '@commands/agent/agentCreatorComman
 import { registerApiKeyCommands } from '@commands/api/apiKeyCommands';
 import { registerStateRestoreCommand } from '@commands/history/stateRestoreCommand';
 import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
+import { registerResumeCommand } from '@commands/agent/resumeCommand';
 import { registerTextEditorCommands } from '@commands/system/textEditorCommands';
 import { registerLinterCommands } from '@commands/latex/linterCommands';
 import { registerWolframScriptCommands } from '@commands/wolfram/wolframScriptCommands';
@@ -72,6 +73,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     compare: registerCompareCommands(context),
     progressView: registerProgressViewCommands(context),
     followUp: registerFollowUpCommand(context),
+    resume: registerResumeCommand(context),
     openFile: registerOpenFileCommands(context),
     help: registerHelpCommands(context),
     mainView: registerMainViewCommands(context),

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -3,13 +3,21 @@ import * as vscode from 'vscode';
 
 // Local imports - commands
 import { BaseAgent } from '@agent/implementations/BaseAgent';
+import { ActiveAgentManager } from '@agent/runtime/ActiveAgentManager';
 
 export function registerFollowUpCommand(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'texra.sendFollowUp',
       async (payload: { stream: string; text: string }) => {
-        const agent = BaseAgent.getRunningAgent(payload.stream);
+        let agent = BaseAgent.getRunningAgent(payload.stream);
+        if (!agent) {
+          const state = await ActiveAgentManager.getState();
+          if (state) {
+            await vscode.commands.executeCommand('texra.resumeAgent');
+            agent = BaseAgent.getRunningAgent(payload.stream);
+          }
+        }
         if (agent && typeof (agent as any).appendFollowUp === 'function') {
           try {
             (agent as any).appendFollowUp(payload.text);

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -4,9 +4,6 @@ import * as vscode from 'vscode';
 // Local imports - commands
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 
-const CHANNEL = 'followUpCommand';
-console.log(`[${CHANNEL}] command registered`);
-
 export function registerFollowUpCommand(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -50,12 +50,14 @@ export function registerResumeCommand(context: vscode.ExtensionContext) {
         await ActiveAgentManager.clear();
         return;
       }
-      await executeAgentWithLogging(
+      executeAgentWithLogging(
         agentConfig.agent,
         async () => ({ agent, agentType: agentSetting.agentType }),
         context,
         state.executionId,
-      );
+      ).catch((err) => {
+        console.error(`Failed to run agent: ${String(err)}`);
+      });
     }),
   );
 }

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -1,0 +1,61 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent runtime
+import { ActiveAgentManager, executeAgentWithLogging } from '@agent/runtime';
+import { ModelFactory } from '@agent/runtime/ModelFactory';
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
+import { BaseToolUseAgent } from '@agent/implementations';
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+
+export function registerResumeCommand(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('texra.resumeAgent', async () => {
+      const state = await ActiveAgentManager.getState();
+      if (!state) {
+        vscode.window.showInformationMessage('No agent state to resume');
+        return;
+      }
+      const agentConfig = AgentConfigSchema.parse(state.agentConfig);
+      const modelName = agentConfig.model;
+      const modelConfig = MODEL_CONFIGS[modelName];
+      if (!modelConfig) {
+        vscode.window.showErrorMessage(
+          `Model configuration for ${modelName} not found`,
+        );
+        await ActiveAgentManager.clear();
+        return;
+      }
+      modelConfig.toolConfig = agentConfig.toolConfig;
+      const modelHandler = ModelFactory.createHandler(modelConfig);
+      const agentPath = state.agentPath;
+      const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
+        agentPath,
+        agentConfig.agent,
+      );
+      const agent = new BaseToolUseAgent(
+        modelHandler,
+        agentConfig,
+        agentSetting,
+        agentPrompt,
+        agentPath,
+      );
+      try {
+        agent.restoreState(state);
+      } catch (error: any) {
+        vscode.window.showErrorMessage(
+          `Failed to restore agent state: ${error.message}`,
+        );
+        await ActiveAgentManager.clear();
+        return;
+      }
+      await executeAgentWithLogging(
+        agentConfig.agent,
+        async () => ({ agent, agentType: agentSetting.agentType }),
+        context,
+        state.executionId,
+      );
+    }),
+  );
+}

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -14,6 +14,7 @@ export enum WorkspaceStateKey {
   TASK_IDS = 'texra.taskIds', // Legacy key for migration
   EXECUTION_IDS = 'texra.executionIds',
   USAGE_STATS = 'texra.usageStats',
+  ACTIVE_AGENT_STATE = 'texra.activeAgentState',
   STREAM_SORT_ORDER = 'texra.streamSortOrder',
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,23 +91,6 @@ export async function activate(context: vscode.ExtensionContext) {
   // Register commands first - this will create and store the MainViewProvider
   registerCommands(context);
 
-  const savedState = await ActiveAgentManager.getState();
-  if (savedState) {
-    try {
-      await vscode.commands.executeCommand('texra.resumeAgent');
-    } catch (err) {
-      logger.error(
-        'extension',
-        'Failed to resume agent',
-        undefined,
-        undefined,
-        false,
-        err,
-      );
-      await ActiveAgentManager.clear();
-    }
-  }
-
   // Create a status bar item to show TeXRA progress
   statusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
@@ -163,6 +146,24 @@ export async function activate(context: vscode.ExtensionContext) {
     // Add disposable for cleanup
     { dispose: () => watcherManager.dispose() },
   );
+
+  const savedState = await ActiveAgentManager.getState();
+  if (savedState) {
+    try {
+      await vscode.commands.executeCommand('texra.resumeAgent');
+      await vscode.commands.executeCommand('texra.showProgressView');
+    } catch (err) {
+      logger.error(
+        'extension',
+        'Failed to resume agent',
+        undefined,
+        undefined,
+        false,
+        err,
+      );
+      await ActiveAgentManager.clear();
+    }
+  }
 
   // Watch for agents directory changes
   watchConfig(context, 'texra.explorer.agentsDirectory', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,6 @@ import { ExplorerOperations } from './explorer/ExplorerOperations';
 import { ExplorerCommands } from './explorer/ExplorerCommands';
 import { WatcherManager } from './explorer/WatcherManager';
 import { registerCommands } from './commands';
-import { ActiveAgentManager } from '@agent/runtime/ActiveAgentManager';
 
 let statusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
@@ -146,24 +145,6 @@ export async function activate(context: vscode.ExtensionContext) {
     // Add disposable for cleanup
     { dispose: () => watcherManager.dispose() },
   );
-
-  const savedState = await ActiveAgentManager.getState();
-  if (savedState) {
-    try {
-      await vscode.commands.executeCommand('texra.resumeAgent');
-      await vscode.commands.executeCommand('texra.showProgressView');
-    } catch (err) {
-      logger.error(
-        'extension',
-        'Failed to resume agent',
-        undefined,
-        undefined,
-        false,
-        err,
-      );
-      await ActiveAgentManager.clear();
-    }
-  }
 
   // Watch for agents directory changes
   watchConfig(context, 'texra.explorer.agentsDirectory', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { ExplorerOperations } from './explorer/ExplorerOperations';
 import { ExplorerCommands } from './explorer/ExplorerCommands';
 import { WatcherManager } from './explorer/WatcherManager';
 import { registerCommands } from './commands';
+import { ActiveAgentManager } from '@agent/runtime/ActiveAgentManager';
 
 let statusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
@@ -89,6 +90,23 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register commands first - this will create and store the MainViewProvider
   registerCommands(context);
+
+  const savedState = await ActiveAgentManager.getState();
+  if (savedState) {
+    try {
+      await vscode.commands.executeCommand('texra.resumeAgent');
+    } catch (err) {
+      logger.error(
+        'extension',
+        'Failed to resume agent',
+        undefined,
+        undefined,
+        false,
+        err,
+      );
+      await ActiveAgentManager.clear();
+    }
+  }
 
   // Create a status bar item to show TeXRA progress
   statusBarItem = vscode.window.createStatusBarItem(


### PR DESCRIPTION
## Summary
- add workspace storage and manager for active tool-use agent state
- enable BaseToolUseAgent to serialize and resume conversations
- automatically restore saved sessions via new `texra.resumeAgent` command
- validate and secure persisted state with config toggle and TTL
- ensure resumed agents run an initial cycle before follow-ups and only persist when uninterrupted
- resume saved sessions on startup without prompting and fix bogus "already running" errors
- prevent empty or partial saves during tool-use agent follow-ups

## Testing
- `npm run format`
- `npm run lint`
- `CI=1 npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*


------
https://chatgpt.com/codex/tasks/task_e_68ac2dbcf5588324aa63d000d765b447