### PR TITLE
fix: restrict gpt-oss models to OpenRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.3] - 2025-08-26
+
+### Bug Fixes
+
+- Restrict GPT OSS models to OpenRouter only
+
 ## [0.33.2] - 2025-08-25
 
 ### Features

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -41,24 +41,24 @@ To experiment with Anthropic's 1M-token context window for Sonnet 4, enable `"t
 
 Known for strong reasoning and creative capabilities.
 
-| Model ID  | Key Strength / Use Case               | Relative Cost | Relative Speed | Notes                   |
-| :-------- | :------------------------------------ | :------------ | :------------- | :---------------------- |
-| `o1`      | Advanced reasoning, math, figures     | $$$$          | Slow           | Explicit reasoning      |
-| `gpt45`   | High quality, vision (Preview)        | $$$$          | Medium         |                         |
-| `gpt5`    | Flagship reasoning & coding           | $$$           | Medium         | 400k context            |
-| `gpt5-`   | Flagship mini, fast                   | $$            | Fast           | 400k context, mini      |
-| `gpt5--`  | Flagship nano, fastest                | $             | Very Fast      | 400k context, nano      |
-| `gpt41`   | Long-context vision, powerful         | $$$           | Medium         | 1M tokens context       |
-| `gpt41-`  | Long-context vision, cost-effective   | $$            | Medium         | 1M tokens context, mini |
-| `gpt41--` | Long-context vision, cheapest         | $             | Medium         | 1M tokens context, nano |
-| `gpt4o`   | Strong all-rounder, vision            | $$$           | Medium         | Good default choice     |
-| `gpt4ol`  | Latest `gpt4o`, potentially better    | $$$           | Medium         |                         |
-| `o3`      | Coding, tool calling                  | $$$           | Medium         |                         |
-| `o3pro`   | Reliable answers, heavy compute       | $$$$          | Slow           | `o3-pro`                |
-| `o3-`     | Fast reasoning                        | $$$           | Fast           | `o3-mini`               |
-| `o1-`     | Fast reasoning (smaller `o1`)         | $$$           | Fast           | `o1-mini`               |
-| `gptoss`  | Open-weight reasoning, large context  | $$            | Medium         | `gpt-oss-120b`          |
-| `gptoss-` | Open-weight reasoning, cost-effective | $             | Fast           | `gpt-oss-20b`           |
+| Model ID  | Key Strength / Use Case               | Relative Cost | Relative Speed | Notes                            |
+| :-------- | :------------------------------------ | :------------ | :------------- | :------------------------------- |
+| `o1`      | Advanced reasoning, math, figures     | $$$$          | Slow           | Explicit reasoning               |
+| `gpt45`   | High quality, vision (Preview)        | $$$$          | Medium         |                                  |
+| `gpt5`    | Flagship reasoning & coding           | $$$           | Medium         | 400k context                     |
+| `gpt5-`   | Flagship mini, fast                   | $$            | Fast           | 400k context, mini               |
+| `gpt5--`  | Flagship nano, fastest                | $             | Very Fast      | 400k context, nano               |
+| `gpt41`   | Long-context vision, powerful         | $$$           | Medium         | 1M tokens context                |
+| `gpt41-`  | Long-context vision, cost-effective   | $$            | Medium         | 1M tokens context, mini          |
+| `gpt41--` | Long-context vision, cheapest         | $             | Medium         | 1M tokens context, nano          |
+| `gpt4o`   | Strong all-rounder, vision            | $$$           | Medium         | Good default choice              |
+| `gpt4ol`  | Latest `gpt4o`, potentially better    | $$$           | Medium         |                                  |
+| `o3`      | Coding, tool calling                  | $$$           | Medium         |                                  |
+| `o3pro`   | Reliable answers, heavy compute       | $$$$          | Slow           | `o3-pro`                         |
+| `o3-`     | Fast reasoning                        | $$$           | Fast           | `o3-mini`                        |
+| `o1-`     | Fast reasoning (smaller `o1`)         | $$$           | Fast           | `o1-mini`                        |
+| `gptoss`  | Open-weight reasoning, large context  | $$            | Medium         | `gpt-oss-120b` (OpenRouter only) |
+| `gptoss-` | Open-weight reasoning, cost-effective | $             | Fast           | `gpt-oss-20b` (OpenRouter only)  |
 
 ### Google Models
 

--- a/docs/guide/openai-responses-api.md
+++ b/docs/guide/openai-responses-api.md
@@ -22,5 +22,6 @@ When `"texra.model.useOpenAIResponsesAPI"` is enabled, the extension automatical
 
 This keeps requests small and simplifies conversation management.
 
-The open-weight models `gpt-oss-120b` and `gpt-oss-20b` also use the
-Responses API automatically, even if the setting isn't enabled.
+The open-weight models `gpt-oss-120b` and `gpt-oss-20b` (available only via
+OpenRouter) also use the Responses API automatically, even if the setting isn't
+enabled.

--- a/src/model/providers/openaiReasoningModels.ts
+++ b/src/model/providers/openaiReasoningModels.ts
@@ -173,7 +173,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
       supportsVision: false,
     } satisfies ModelCapabilities,
-    openRouterOnly: false,
+    openRouterOnly: true,
   },
   'gptoss-': {
     name: 'gptoss-',
@@ -188,7 +188,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
       supportsVision: false,
     } satisfies ModelCapabilities,
-    openRouterOnly: false,
+    openRouterOnly: true,
   },
   gpt5: {
     name: 'gpt5',


### PR DESCRIPTION
## Summary
- mark gpt-oss model configs as OpenRouter-only
- document gpt-oss availability via OpenRouter
- record change in changelog

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aecb6409a883248420b9eadff70f24