### PR TITLE
fix: consider env vars when checking API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Restrict GPT OSS models to OpenRouter only
+- Consider environment variables when checking for API keys to prevent false missing-key alerts
 
 ## [0.33.2] - 2025-08-25
 

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -69,8 +69,7 @@ export class SecretManager {
 
   public static async anyApiKeyExists(): Promise<boolean> {
     for (const provider of this.API_PROVIDERS) {
-      const key = await this.get(this.getApiKeySecretName(provider));
-      if (key) {
+      if (await this.apiKeyExists(provider)) {
         return true;
       }
     }


### PR DESCRIPTION
## Summary
- account for environment variables when determining if API keys exist
- document API key lookup improvement

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af0274017c832485cf5371d976359a