### PR TITLE
feat: include .bbl reference files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.33.3] - 2025-08-26
 
+### Features
+
+- Include `.bbl` files when searching for reference files
+
 ### Bug Fixes
 
 - Restrict GPT OSS models to OpenRouter only

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -108,6 +108,12 @@ Control which file types TeXRA includes:
   ".tex",
   ".md"
 ],
+"texra.files.included.referenceExtensions": [
+  ".txt",
+  ".tex",
+  ".md",
+  ".bbl"
+],
 "texra.files.included.mediaExtensions": [
   ".png",
   ".pdf",

--- a/package.json
+++ b/package.json
@@ -261,7 +261,8 @@
             "default": [
               ".txt",
               ".tex",
-              ".md"
+              ".md",
+              ".bbl"
             ],
             "description": "File extensions to include when searching for reference files",
             "editPresentation": "multilineText",


### PR DESCRIPTION
## Summary
- include `.bbl` in default reference file extensions
- document reference extensions in configuration guide
- note new reference file support in changelog

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b02719d0e4832487c49d1f00bc0dc5