### PR TITLE
feat: improve API key onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project will be documented in this file.
 - Restrict GPT OSS models to OpenRouter only
 - Consider environment variables when checking for API keys to prevent false missing-key alerts
 
+## [Unreleased]
+
+### Features
+
+- Guide new users through API key setup with links to provider pages
+- Show persistent “Set API Key” banner and status bar warning until a key is configured
+
 ## [0.33.2] - 2025-08-25
 
 ### Features

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -179,6 +179,12 @@ TeXRA also loads environment variables from a `.env` file in your workspace. Def
 - **OpenAI API Key**: Available from [OpenAI API](https://platform.openai.com/api-keys)
 - **Anthropic API Key**: Available from [Anthropic Console](https://console.anthropic.com/)
 - **Google API Key**: Available from [Google AI Studio](https://aistudio.google.com/app/apikey)
+- **OpenRouter API Key**: Available from [OpenRouter Dashboard](https://openrouter.ai/keys)
+- **xAI API Key**: Available from [xAI Console](https://console.x.ai/)
+- **DeepSeek API Key**: Available from [DeepSeek Platform](https://platform.deepseek.com/api_keys)
+- **Moonshot API Key**: Available from [Moonshot Console](https://platform.moonshot.cn/console)
+- **DashScope API Key**: Available from [DashScope Console](https://dashscope.aliyun.com/api-console/)
+- **Wolfram LLM API Key**: Available from [Wolfram LLM App](https://llm-api.wolframalpha.com/)
   :::
 
 ## Verifying Installation

--- a/package.json
+++ b/package.json
@@ -116,6 +116,17 @@
         }
       },
       {
+        "title": "User Interface",
+        "properties": {
+          "texra.ui.showApiKeyReminders": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show API key reminders in the status bar and main view when no API keys are configured",
+            "scope": "resource"
+          }
+        }
+      },
+      {
         "title": "Model Settings",
         "properties": {
           "texra.model.useOpenRouter": {

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -162,6 +162,13 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
 
     // Check if any API keys are set and display notification if needed
     SecretManager.checkAndNotifyMissingApiKeys();
+    SecretManager.anyApiKeyExists().then((exists) => {
+      if (!exists) {
+        webviewView.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+        });
+      }
+    });
   }
 
   private async setupInitialState(webviewView: vscode.WebviewView) {

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -161,14 +161,19 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     this.setupInitialState(webviewView);
 
     // Check if any API keys are set and display notification if needed
-    SecretManager.checkAndNotifyMissingApiKeys();
-    SecretManager.anyApiKeyExists().then((exists) => {
-      if (!exists) {
-        webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
-        });
-      }
-    });
+    const config = vscode.workspace.getConfiguration('texra');
+    const showReminders = config.get<boolean>('ui.showApiKeyReminders', true);
+    
+    if (showReminders) {
+      SecretManager.checkAndNotifyMissingApiKeys();
+      SecretManager.anyApiKeyExists().then((exists) => {
+        if (!exists) {
+          webviewView.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+          });
+        }
+      });
+    }
   }
 
   private async setupInitialState(webviewView: vscode.WebviewView) {

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -55,6 +55,8 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
         await vscode.env.openExternal(
           vscode.Uri.parse(PROVIDER_URLS[provider]),
         );
+        // User selected "Get API Key" - don't prompt for input
+        return;
       }
 
       const apiKey = await vscode.window.showInputBox({

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -3,6 +3,19 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+const PROVIDER_URLS: Record<ApiProvider, string> = {
+  openai: 'https://platform.openai.com/api-keys',
+  anthropic: 'https://console.anthropic.com/',
+  openRouter: 'https://openrouter.ai/keys',
+  google: 'https://aistudio.google.com/app/apikey',
+  xai: 'https://console.x.ai/',
+  deepseek: 'https://platform.deepseek.com/api_keys',
+  moonshot: 'https://platform.moonshot.cn/console',
+  dashscope: 'https://dashscope.aliyun.com/api-console/',
+  wolframllmapp: 'https://llm-api.wolframalpha.com/',
+};
 
 export const apiKeyCommands = {
   setApiKey: 'texra.setApiKey',
@@ -26,7 +39,24 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
         return;
       }
 
-      // Then get the API key
+      const enterKey = 'Enter Key';
+      const getApiKey = 'Get API Key';
+      const action = await vscode.window.showInformationMessage(
+        `Set your ${provider} API key`,
+        enterKey,
+        getApiKey,
+      );
+
+      if (!action) {
+        return;
+      }
+
+      if (action === getApiKey) {
+        await vscode.env.openExternal(
+          vscode.Uri.parse(PROVIDER_URLS[provider]),
+        );
+      }
+
       const apiKey = await vscode.window.showInputBox({
         prompt: `Enter ${provider} API key`,
         password: true,
@@ -45,6 +75,13 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage(
           `${provider} API key has been set`,
         );
+        await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
+        const view = await vscode.commands.executeCommand<vscode.WebviewView>(
+          'texra.getWebviewView',
+        );
+        view?.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
+        });
       } catch (err) {
         vscode.window.showErrorMessage(
           `Failed to set ${provider} API key: ${err}`,
@@ -75,6 +112,16 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage(
           `${provider} API key has been removed`,
         );
+        await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
+        const any = await SecretManager.anyApiKeyExists();
+        const view = await vscode.commands.executeCommand<vscode.WebviewView>(
+          'texra.getWebviewView',
+        );
+        view?.webview.postMessage({
+          command: any
+            ? MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER
+            : MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+        });
       } catch (err) {
         vscode.window.showErrorMessage(
           `Failed to remove ${provider} API key: ${err}`,

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -72,6 +72,9 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_AGENT_SETTINGS: 'openAgentSettings',
   OPEN_MODEL_SETTINGS: 'openModelSettings',
   CLIPBOARD_IMAGE: 'clipboardImage',
+  OPEN_SET_API_KEY: 'openSetApiKey',
+  SHOW_API_KEY_BANNER: 'showApiKeyBanner',
+  HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -72,6 +72,9 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_AGENT_SETTINGS: 'openAgentSettings',
   OPEN_MODEL_SETTINGS: 'openModelSettings',
   CLIPBOARD_IMAGE: 'clipboardImage',
+  OPEN_SET_API_KEY: 'openSetApiKey',
+  SHOW_API_KEY_BANNER: 'showApiKeyBanner',
+  HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,16 @@ async function refreshApiKeyStatus() {
   if (!apiKeyStatusBarItem) {
     return;
   }
+  
+  // Check if reminders are enabled
+  const config = vscode.workspace.getConfiguration('texra');
+  const showReminders = config.get<boolean>('ui.showApiKeyReminders', true);
+  
+  if (!showReminders) {
+    apiKeyStatusBarItem.hide();
+    return;
+  }
+  
   const exists = await SecretManager.anyApiKeyExists();
   if (!exists) {
     apiKeyStatusBarItem.text = '$(warning) TeXRA: API Key Required';
@@ -117,7 +127,8 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.StatusBarAlignment.Left,
   );
   context.subscriptions.push(apiKeyStatusBarItem);
-  await refreshApiKeyStatus();
+  // Non-blocking refresh to avoid delaying extension activation
+  refreshApiKeyStatus().catch(console.error);
 
   const runningStreams = new Set<string>();
   disposeStatusListener = bus.on(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,22 @@ import { WatcherManager } from './explorer/WatcherManager';
 import { registerCommands } from './commands';
 
 let statusBarItem: vscode.StatusBarItem | undefined;
+let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
+
+async function refreshApiKeyStatus() {
+  if (!apiKeyStatusBarItem) {
+    return;
+  }
+  const exists = await SecretManager.anyApiKeyExists();
+  if (!exists) {
+    apiKeyStatusBarItem.text = '$(warning) TeXRA: API Key Required';
+    apiKeyStatusBarItem.command = 'texra.setApiKey';
+    apiKeyStatusBarItem.show();
+  } else {
+    apiKeyStatusBarItem.hide();
+  }
+}
 
 export async function activate(context: vscode.ExtensionContext) {
   const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -98,6 +113,12 @@ export async function activate(context: vscode.ExtensionContext) {
   statusBarItem.text = 'TeXRA: Idle';
   statusBarItem.show();
 
+  apiKeyStatusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+  );
+  context.subscriptions.push(apiKeyStatusBarItem);
+  await refreshApiKeyStatus();
+
   const runningStreams = new Set<string>();
   disposeStatusListener = bus.on(
     'updateStreamStatus',
@@ -116,7 +137,14 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   );
 
-  context.subscriptions.push({ dispose: disposeStatusListener }, statusBarItem);
+  context.subscriptions.push(
+    { dispose: disposeStatusListener },
+    statusBarItem,
+    vscode.commands.registerCommand(
+      'texra.refreshApiKeyStatus',
+      refreshApiKeyStatus,
+    ),
+  );
 
   // Register the folder explorer with context
   const folderExplorer = new FolderExplorer(workspaceRoot, context);
@@ -175,6 +203,34 @@ export async function activate(context: vscode.ExtensionContext) {
       ],
     )
       .then(() => context.globalState.update(welcomeKey, true))
+      .catch(console.error);
+  }
+
+  const apiKeyIntroKey = 'texra.apiKeyIntroShown';
+  if (!context.globalState.get<boolean>(apiKeyIntroKey)) {
+    void showInstructionWithSuppress(
+      'apiKeyIntro',
+      'TeXRA uses API keys to access language models. Learn how to obtain a key and set it here.',
+      [
+        {
+          title: 'Open API-Key Guide',
+          callback: async () => {
+            await vscode.env.openExternal(
+              vscode.Uri.parse(
+                'https://texra.ai/guide/installation#setting-up-api-keys',
+              ),
+            );
+          },
+        },
+        {
+          title: 'Set API Key',
+          callback: async () => {
+            await vscode.commands.executeCommand('texra.setApiKey');
+          },
+        },
+      ],
+    )
+      .then(() => context.globalState.update(apiKeyIntroKey, true))
       .catch(console.error);
   }
 }

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -99,14 +99,22 @@ export class SecretManager {
       const exists = await this.anyApiKeyExists();
       if (!exists) {
         const setKey = 'Set API Key';
+        const learnMore = 'Learn More';
         const result = await vscode.window.showErrorMessage(
           'No API keys found. TeXRA requires an API key to function properly.',
           { modal: true },
           setKey,
+          learnMore,
         );
 
         if (result === setKey) {
           vscode.commands.executeCommand('texra.setApiKey');
+        } else if (result === learnMore) {
+          void vscode.env.openExternal(
+            vscode.Uri.parse(
+              'https://texra.ai/guide/installation#setting-up-api-keys',
+            ),
+          );
         }
 
         this.apiKeyNotificationShown = true;

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -140,6 +140,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.instructionManager.handleTranscribeInstruction(w),
       [MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE]: async (m, w) =>
         this.instructionManager.handleClipboardImage(m, w),
+      [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: async () =>
+        safeExecuteCommand('texra.setApiKey'),
 
       // Recording commands
       [MAIN_VIEW_COMMANDS.START_RECORDING]: async (_m, w) =>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -50,6 +50,12 @@
 
   <body>
     <div class="content-wrapper">
+      <div id="apiKeyBanner" class="api-key-banner" style="display: none">
+        <span>TeXRA requires an API key to run.</span>
+        <button id="apiKeyBannerButton" class="vscode-button" data-icon="key">
+          Set API Key
+        </button>
+      </div>
       <div class="main-content">
         <div class="file-selection-group">
           <div class="file-select">

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -96,4 +96,6 @@ export const ELEMENT_IDS = {
   OUTPUT_FILES_CONTAINER: 'outputFilesContainer',
   TOGGLE_OUTPUT_FILES: 'toggleOutputFiles',
   INSTRUCTION: 'instruction',
+  API_KEY_BANNER: 'apiKeyBanner',
+  API_KEY_BANNER_BUTTON: 'apiKeyBannerButton',
 };

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -12,6 +12,7 @@ import { outputFilesManager } from './uiManagers/OutputFilesManager.js';
 import { RecordingManager } from './uiManagers/RecordingManager.js';
 import { SettingsButtonManager } from './uiManagers/SettingsButtonManager.js';
 import { ToggleManager } from './uiManagers/ToggleManager.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 
 export const instructionManager = new InstructionManager(
@@ -31,6 +32,7 @@ export class MainViewDomHandler {
     this.actionButtonManager = null;
     this.settingsButtonManager = null;
     this.debugMode = false;
+    this.apiKeyButtonHandler = null;
   }
 
   _updateDebugButtonVisibility() {
@@ -75,6 +77,18 @@ export class MainViewDomHandler {
     this.actionButtonManager.setup();
     this.settingsButtonManager.setup();
     recordingManager.setupRecordButton();
+
+    const apiKeyButton = document.getElementById(
+      ELEMENT_IDS.API_KEY_BANNER_BUTTON,
+    );
+    if (apiKeyButton) {
+      this.apiKeyButtonHandler = () => {
+        vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY,
+        });
+      };
+      apiKeyButton.addEventListener('click', this.apiKeyButtonHandler);
+    }
   }
 
   cleanupUI() {
@@ -89,6 +103,13 @@ export class MainViewDomHandler {
     if (this.settingsButtonManager) {
       this.settingsButtonManager.cleanup();
       this.settingsButtonManager = null;
+    }
+    const apiKeyButton = document.getElementById(
+      ELEMENT_IDS.API_KEY_BANNER_BUTTON,
+    );
+    if (apiKeyButton && this.apiKeyButtonHandler) {
+      apiKeyButton.removeEventListener('click', this.apiKeyButtonHandler);
+      this.apiKeyButtonHandler = null;
     }
   }
 }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -61,6 +61,16 @@ export class MainViewMessageHandler {
       ...this._createInstructionHandlers(),
       ...createRecordingHandlers({ postHandle: ctx.postHandle }),
       ...createFileHandlers(ctx),
+      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: () =>
+        this._getElement(ELEMENT_IDS.API_KEY_BANNER)?.style.setProperty(
+          'display',
+          'flex',
+        ),
+      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () =>
+        this._getElement(ELEMENT_IDS.API_KEY_BANNER)?.style.setProperty(
+          'display',
+          'none',
+        ),
     };
   }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -61,16 +61,18 @@ export class MainViewMessageHandler {
       ...this._createInstructionHandlers(),
       ...createRecordingHandlers({ postHandle: ctx.postHandle }),
       ...createFileHandlers(ctx),
-      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: () =>
-        this._getElement(ELEMENT_IDS.API_KEY_BANNER)?.style.setProperty(
-          'display',
-          'flex',
-        ),
-      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () =>
-        this._getElement(ELEMENT_IDS.API_KEY_BANNER)?.style.setProperty(
-          'display',
-          'none',
-        ),
+      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: () => {
+        const element = this._getElement(ELEMENT_IDS.API_KEY_BANNER);
+        if (element) {
+          element.style.setProperty('display', 'flex');
+        }
+      },
+      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () => {
+        const element = this._getElement(ELEMENT_IDS.API_KEY_BANNER);
+        if (element) {
+          element.style.setProperty('display', 'none');
+        }
+      },
     };
   }
 

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -78,3 +78,16 @@
   color: var(--vscode-errorForeground);
   cursor: pointer;
 }
+
+/* API key reminder banner */
+.api-key-banner {
+  background-color: var(--vscode-inputValidation-warningBackground);
+  color: var(--vscode-inputValidation-warningForeground);
+  border: 1px solid var(--vscode-inputValidation-warningBorder);
+  border-radius: var(--border-radius);
+  padding: var(--spacing-small) var(--spacing-medium);
+  margin-bottom: var(--spacing-large);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- add in-product API key guide with provider links
- show persistent banner and status bar reminder until a key is set
- document how to obtain API keys for all providers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b123e4d960832489f6401fcf6c28d9