### PR TITLE
feat: show API key banner when no keys configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Include `.bbl` files when searching for reference files
+- Show Set API Key banner in main view when no API keys are configured
 
 ### Bug Fixes
 

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -162,6 +162,13 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
 
     // Check if any API keys are set and display notification if needed
     SecretManager.checkAndNotifyMissingApiKeys();
+    SecretManager.anyApiKeyExists().then((exists) => {
+      if (!exists) {
+        webviewView.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+        });
+      }
+    });
   }
 
   private async setupInitialState(webviewView: vscode.WebviewView) {

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -71,6 +71,7 @@ export const MAIN_VIEW_COMMANDS = {
   SHOW_AGENT_HISTORY: 'showAgentHistory',
   OPEN_AGENT_SETTINGS: 'openAgentSettings',
   OPEN_MODEL_SETTINGS: 'openModelSettings',
+  SET_API_KEY: 'setApiKey',
   CLIPBOARD_IMAGE: 'clipboardImage',
 
   // Extension response events
@@ -91,6 +92,8 @@ export const MAIN_VIEW_COMMANDS = {
   SET_CURRENT_FILE: 'setCurrentFile',
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
+  SHOW_API_KEY_BANNER: 'showApiKeyBanner',
+  HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
 
   // File refresh and update operations
   REFRESH_ALL_FILES: 'refreshAllFiles',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -71,6 +71,7 @@ export const MAIN_VIEW_COMMANDS = {
   SHOW_AGENT_HISTORY: 'showAgentHistory',
   OPEN_AGENT_SETTINGS: 'openAgentSettings',
   OPEN_MODEL_SETTINGS: 'openModelSettings',
+  SET_API_KEY: 'setApiKey',
   CLIPBOARD_IMAGE: 'clipboardImage',
 
   // Extension response events
@@ -91,6 +92,8 @@ export const MAIN_VIEW_COMMANDS = {
   SET_CURRENT_FILE: 'setCurrentFile',
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
+  SHOW_API_KEY_BANNER: 'showApiKeyBanner',
+  HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
 
   // File refresh and update operations
   REFRESH_ALL_FILES: 'refreshAllFiles',

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -93,6 +93,10 @@ export class MainViewContentProvider extends BaseViewContentProvider {
         webview,
         'modules/uiManagers/LatexdiffManager.js',
       ),
+      apiKeyBannerManagerUri: this.getWebviewUri(
+        webview,
+        'modules/uiManagers/ApiKeyBannerManager.js',
+      ),
     };
   }
 

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -20,6 +20,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { getConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+import { SecretManager } from '@frontend/secretManager';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly settingsManager: SettingsManager;
@@ -132,6 +133,14 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.settingsManager.openAgentSettings(),
       [MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS]: async () =>
         this.settingsManager.openModelSettings(),
+      [MAIN_VIEW_COMMANDS.SET_API_KEY]: async (_m, w) => {
+        await vscode.commands.executeCommand('texra.setApiKey');
+        if (await SecretManager.anyApiKeyExists()) {
+          w.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
+          });
+        }
+      },
 
       // Instruction commands
       [MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT]: async (m, w) =>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -25,6 +25,7 @@
           "./modules/uiManagers/InstructionManager.js": "${instructionManagerUri}",
           "./modules/uiManagers/OutputFilesManager.js": "${outputFilesManagerUri}",
           "./modules/uiManagers/LatexdiffManager.js": "${latexdiffManagerUri}",
+          "./modules/uiManagers/ApiKeyBannerManager.js": "${apiKeyBannerManagerUri}",
           "./modules/domHandlers.js": "${domHandlersUri}",
           "./modules/eventBus.js": "${eventBusUri}",
           "./modules/constants.js": "${constantsUri}",
@@ -50,6 +51,11 @@
 
   <body>
     <div class="content-wrapper">
+      <div id="apiKeyBanner" class="api-key-banner">
+        <span>TeXRA requires an API key.</span>
+        <button id="setApiKeyButton" class="vscode-button">Set API Key</button>
+        <span id="dismissApiKeyBanner" class="codicon codicon-close"></span>
+      </div>
       <div class="main-content">
         <div class="file-selection-group">
           <div class="file-select">

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -96,4 +96,7 @@ export const ELEMENT_IDS = {
   OUTPUT_FILES_CONTAINER: 'outputFilesContainer',
   TOGGLE_OUTPUT_FILES: 'toggleOutputFiles',
   INSTRUCTION: 'instruction',
+  API_KEY_BANNER: 'apiKeyBanner',
+  SET_API_KEY_BUTTON: 'setApiKeyButton',
+  DISMISS_API_KEY_BANNER: 'dismissApiKeyBanner',
 };

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -13,6 +13,7 @@ import { RecordingManager } from './uiManagers/RecordingManager.js';
 import { SettingsButtonManager } from './uiManagers/SettingsButtonManager.js';
 import { ToggleManager } from './uiManagers/ToggleManager.js';
 import { vscode } from '@common/webviewContext.js';
+import { ApiKeyBannerManager } from './uiManagers/ApiKeyBannerManager.js';
 
 export const instructionManager = new InstructionManager(
   'instruction',
@@ -21,6 +22,7 @@ export const instructionManager = new InstructionManager(
 );
 export const toggleManager = new ToggleManager();
 export const recordingManager = new RecordingManager(vscode, webviewEventBus);
+export const apiKeyBannerManager = new ApiKeyBannerManager(vscode);
 
 /**
  * Coordinates UI managers for the main webview.
@@ -30,6 +32,7 @@ export class MainViewDomHandler {
     this.fileInputManager = null;
     this.actionButtonManager = null;
     this.settingsButtonManager = null;
+    this.apiKeyBannerManager = null;
     this.debugMode = false;
   }
 
@@ -70,11 +73,13 @@ export class MainViewDomHandler {
       latexdiffManager,
       mainViewState,
     );
+    this.apiKeyBannerManager = apiKeyBannerManager;
 
     this.fileInputManager.setup();
     this.actionButtonManager.setup();
     this.settingsButtonManager.setup();
     recordingManager.setupRecordButton();
+    this.apiKeyBannerManager.setup();
   }
 
   cleanupUI() {
@@ -89,6 +94,10 @@ export class MainViewDomHandler {
     if (this.settingsButtonManager) {
       this.settingsButtonManager.cleanup();
       this.settingsButtonManager = null;
+    }
+    if (this.apiKeyBannerManager) {
+      this.apiKeyBannerManager.cleanup();
+      this.apiKeyBannerManager = null;
     }
   }
 }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -9,7 +9,7 @@ import {
   BASE_FILE,
   ELEMENT_IDS,
 } from './constants.js';
-import { mainViewDomHandler } from './domHandlers.js';
+import { mainViewDomHandler, apiKeyBannerManager } from './domHandlers.js';
 import { webviewEventBus } from './eventBus.js';
 import { createFileHandlers } from './handlers/fileHandlers.js';
 import { createRecordingHandlers } from './handlers/recordingHandlers.js';
@@ -61,6 +61,7 @@ export class MainViewMessageHandler {
       ...this._createInstructionHandlers(),
       ...createRecordingHandlers({ postHandle: ctx.postHandle }),
       ...createFileHandlers(ctx),
+      ...this._createApiKeyHandlers(),
     };
   }
 
@@ -69,6 +70,15 @@ export class MainViewMessageHandler {
       [MAIN_VIEW_COMMANDS.STATE_RESTORE]: (m) => this.handleRestoreState(m),
       [MAIN_VIEW_COMMANDS.CHECK_RESTORED_BASE_FILE]: () =>
         this.handleCheckRestoredBaseFile(),
+    };
+  }
+
+  _createApiKeyHandlers() {
+    return {
+      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: () =>
+        apiKeyBannerManager.show(),
+      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () =>
+        apiKeyBannerManager.hide(),
     };
   }
 

--- a/src/webview/modules/uiManagers/ApiKeyBannerManager.js
+++ b/src/webview/modules/uiManagers/ApiKeyBannerManager.js
@@ -1,0 +1,36 @@
+// Local imports - webview
+import { BaseUIManager } from './BaseUIManager.js';
+import { ELEMENT_IDS } from '../constants.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { vscode } from '@common/webviewContext.js';
+import { safeGetElementById } from '@common/domUtils.js';
+
+export class ApiKeyBannerManager extends BaseUIManager {
+  constructor(vscodeInstance = vscode) {
+    super();
+    this.vscode = vscodeInstance;
+    this.bannerEl = null;
+  }
+
+  setup() {
+    this.bannerEl = safeGetElementById(ELEMENT_IDS.API_KEY_BANNER);
+    this.addListener(ELEMENT_IDS.SET_API_KEY_BUTTON, 'click', () => {
+      this.vscode.postMessage({ command: MAIN_VIEW_COMMANDS.SET_API_KEY });
+    });
+    this.addListener(ELEMENT_IDS.DISMISS_API_KEY_BANNER, 'click', () =>
+      this.hide(),
+    );
+  }
+
+  show() {
+    if (this.bannerEl) {
+      this.bannerEl.style.display = 'flex';
+    }
+  }
+
+  hide() {
+    if (this.bannerEl) {
+      this.bannerEl.style.display = 'none';
+    }
+  }
+}

--- a/src/webview/styles/api-key-banner.css
+++ b/src/webview/styles/api-key-banner.css
@@ -1,0 +1,18 @@
+#apiKeyBanner {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background-color: var(--vscode-notificationsWarningBackground);
+  color: var(--vscode-notificationsWarningForeground);
+  border-bottom: 1px solid var(--vscode-notificationsWarningBorder);
+}
+
+#dismissApiKeyBanner {
+  margin-left: auto;
+  cursor: pointer;
+}
+
+#setApiKeyButton {
+  margin-left: 0.5rem;
+}

--- a/src/webview/styles/index.css
+++ b/src/webview/styles/index.css
@@ -15,3 +15,4 @@
 @import './instruction-box.css';
 @import './footer.css';
 @import './dropdown.css';
+@import './api-key-banner.css';


### PR DESCRIPTION
## Summary
- prompt webview to show Set API Key banner when no keys are stored
- add dismissible API key banner and handler that runs `texra.setApiKey`
- hide banner automatically after an API key is configured

## Testing
- `npm run lint`
- `npm test` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b1253545048324979af39fa7d10c2b