### PR TITLE
fix: consolidate API key prompts into banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.4] - 2025-09-01
+
+### Bug Fixes
+
+- Consolidate API key setup alerts into banner to avoid multiple popups
+
 ## [0.33.3] - 2025-08-29
 
 ### Features
@@ -14,7 +20,6 @@ All notable changes to this project will be documented in this file.
 
 - Restrict GPT OSS models to OpenRouter only
 - Improve API key detection to check environment variables and only show intro message when no keys are configured
-
 
 ## [0.33.2] - 2025-08-25
 

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -160,12 +160,11 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
 
     this.setupInitialState(webviewView);
 
-    // Check if any API keys are set and display notification if needed
+    // Check if any API keys are set and display banner if needed
     const config = vscode.workspace.getConfiguration('texra');
     const showReminders = config.get<boolean>('ui.showApiKeyReminders', true);
 
     if (showReminders) {
-      SecretManager.checkAndNotifyMissingApiKeys();
       SecretManager.anyApiKeyExists().then((exists) => {
         if (!exists) {
           webviewView.webview.postMessage({

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -73,6 +73,7 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_MODEL_SETTINGS: 'openModelSettings',
   CLIPBOARD_IMAGE: 'clipboardImage',
   OPEN_SET_API_KEY: 'openSetApiKey',
+  OPEN_API_KEY_GUIDE: 'openApiKeyGuide',
   SHOW_API_KEY_BANNER: 'showApiKeyBanner',
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
 

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -73,6 +73,7 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_MODEL_SETTINGS: 'openModelSettings',
   CLIPBOARD_IMAGE: 'clipboardImage',
   OPEN_SET_API_KEY: 'openSetApiKey',
+  OPEN_API_KEY_GUIDE: 'openApiKeyGuide',
   SHOW_API_KEY_BANNER: 'showApiKeyBanner',
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,44 +216,6 @@ export async function activate(context: vscode.ExtensionContext) {
       .then(() => context.globalState.update(welcomeKey, true))
       .catch(console.error);
   }
-
-  const apiKeyIntroKey = 'texra.apiKeyIntroShown';
-  // Only show API key intro if not shown before AND no API keys are set
-  if (!context.globalState.get<boolean>(apiKeyIntroKey)) {
-    SecretManager.anyApiKeyExists()
-      .then((hasKeys) => {
-        if (!hasKeys) {
-          void showInstructionWithSuppress(
-            'apiKeyIntro',
-            'TeXRA uses API keys to access language models. Learn how to obtain a key and set it here.',
-            [
-              {
-                title: 'Open API-Key Guide',
-                callback: async () => {
-                  await vscode.env.openExternal(
-                    vscode.Uri.parse(
-                      'https://texra.ai/guide/installation#setting-up-api-keys',
-                    ),
-                  );
-                },
-              },
-              {
-                title: 'Set API Key',
-                callback: async () => {
-                  await vscode.commands.executeCommand('texra.setApiKey');
-                },
-              },
-            ],
-          )
-            .then(() => context.globalState.update(apiKeyIntroKey, true))
-            .catch(console.error);
-        } else {
-          // Mark as shown if keys already exist
-          void context.globalState.update(apiKeyIntroKey, true);
-        }
-      })
-      .catch(console.error);
-  }
 }
 
 export function deactivate() {

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -9,7 +9,6 @@ export interface ApiProviderQuickPickItem extends vscode.QuickPickItem {
 
 export class SecretManager {
   private static secretStorage: vscode.SecretStorage | undefined;
-  private static apiKeyNotificationShown = false;
 
   public static initialize(context: vscode.ExtensionContext): void {
     this.secretStorage = context.secrets;
@@ -84,44 +83,6 @@ export class SecretManager {
 
     const envKey = `${provider.toUpperCase()}_API_KEY`;
     return Boolean(process.env[envKey]);
-  }
-
-  /**
-   * Check if any API keys exist and show a notification if none do
-   */
-  public static async checkAndNotifyMissingApiKeys(): Promise<void> {
-    // Only show the notification once per session
-    if (this.apiKeyNotificationShown) {
-      return;
-    }
-
-    try {
-      const exists = await this.anyApiKeyExists();
-      if (!exists) {
-        const setKey = 'Set API Key';
-        const learnMore = 'Learn More';
-        const result = await vscode.window.showErrorMessage(
-          'No API keys found. TeXRA requires an API key to function properly.',
-          { modal: true },
-          setKey,
-          learnMore,
-        );
-
-        if (result === setKey) {
-          vscode.commands.executeCommand('texra.setApiKey');
-        } else if (result === learnMore) {
-          void vscode.env.openExternal(
-            vscode.Uri.parse(
-              'https://texra.ai/guide/installation#setting-up-api-keys',
-            ),
-          );
-        }
-
-        this.apiKeyNotificationShown = true;
-      }
-    } catch (error) {
-      console.error('Error checking API keys:', error);
-    }
   }
 
   public static async getApiProviderQuickPickItems(): Promise<

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -142,6 +142,13 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.instructionManager.handleClipboardImage(m, w),
       [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: async () =>
         safeExecuteCommand('texra.setApiKey'),
+      [MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE]: async () => {
+        await vscode.env.openExternal(
+          vscode.Uri.parse(
+            'https://texra.ai/guide/installation#setting-up-api-keys',
+          ),
+        );
+      },
 
       // Recording commands
       [MAIN_VIEW_COMMANDS.START_RECORDING]: async (_m, w) =>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -52,9 +52,14 @@
     <div class="content-wrapper">
       <div id="apiKeyBanner" class="api-key-banner" style="display: none">
         <span>TeXRA requires an API key to run.</span>
-        <button id="apiKeyBannerButton" class="vscode-button" data-icon="key">
-          Set API Key
-        </button>
+        <div class="actions">
+          <button id="apiKeyBannerButton" class="vscode-button" data-icon="key">
+            Set API Key
+          </button>
+          <button id="apiKeyGuideButton" class="vscode-button" data-icon="book">
+            API Key Guide
+          </button>
+        </div>
       </div>
       <div class="main-content">
         <div class="file-selection-group">

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -98,4 +98,5 @@ export const ELEMENT_IDS = {
   INSTRUCTION: 'instruction',
   API_KEY_BANNER: 'apiKeyBanner',
   API_KEY_BANNER_BUTTON: 'apiKeyBannerButton',
+  API_KEY_GUIDE_BUTTON: 'apiKeyGuideButton',
 };

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -33,6 +33,7 @@ export class MainViewDomHandler {
     this.settingsButtonManager = null;
     this.debugMode = false;
     this.apiKeyButtonHandler = null;
+    this.apiKeyGuideButtonHandler = null;
   }
 
   _updateDebugButtonVisibility() {
@@ -89,6 +90,21 @@ export class MainViewDomHandler {
       };
       apiKeyButton.addEventListener('click', this.apiKeyButtonHandler);
     }
+
+    const apiKeyGuideButton = document.getElementById(
+      ELEMENT_IDS.API_KEY_GUIDE_BUTTON,
+    );
+    if (apiKeyGuideButton) {
+      this.apiKeyGuideButtonHandler = () => {
+        vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE,
+        });
+      };
+      apiKeyGuideButton.addEventListener(
+        'click',
+        this.apiKeyGuideButtonHandler,
+      );
+    }
   }
 
   cleanupUI() {
@@ -110,6 +126,16 @@ export class MainViewDomHandler {
     if (apiKeyButton && this.apiKeyButtonHandler) {
       apiKeyButton.removeEventListener('click', this.apiKeyButtonHandler);
       this.apiKeyButtonHandler = null;
+    }
+    const apiKeyGuideButton = document.getElementById(
+      ELEMENT_IDS.API_KEY_GUIDE_BUTTON,
+    );
+    if (apiKeyGuideButton && this.apiKeyGuideButtonHandler) {
+      apiKeyGuideButton.removeEventListener(
+        'click',
+        this.apiKeyGuideButtonHandler,
+      );
+      this.apiKeyGuideButtonHandler = null;
     }
   }
 }

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -69,6 +69,11 @@
   align-items: center;
 }
 
+.api-key-banner .actions {
+  display: flex;
+  gap: var(--spacing-small);
+}
+
 .output-filename-override {
   border-top: 1px solid var(--dropdown-border);
   padding-top: var(--spacing-medium);


### PR DESCRIPTION
## Summary
- show missing API key warnings only in the main view banner
- add API Key Guide button to banner
- remove unused API key notification logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b15a9a1ba48324afe62dbdd6b049f9