### PR TITLE
feat: support multi-round reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.4] - 2025-08-31
+
+### Features
+
+- Support round-specific reflection prompts and iteration across multiple rounds
+- Record per-round agent and tool state for future analysis
+
+### Bug Fixes
+
+- Generalize output handling and packaging scripts to work with any round count
+- Track total executed rounds in agent statistics
+
 ## [0.33.3] - 2025-08-29
 
 ### Features
@@ -14,7 +26,6 @@ All notable changes to this project will be documented in this file.
 
 - Restrict GPT OSS models to OpenRouter only
 - Improve API key detection to check environment variables and only show intro message when no keys are configured
-
 
 ## [0.33.2] - 2025-08-25
 

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -84,7 +84,7 @@ export const AgentPromptSchema = z
     systemPrompt: z.string().default(''),
     userPrefix: z.string().default(''),
     userRequest: z.string().default(''),
-    userReflect: z.string().default(''),
+    userReflect: z.union([z.string(), z.array(z.string())]).default(''),
   })
   .strict();
 

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -168,6 +168,10 @@ export class AgentStateGlobal implements IAgentStateGlobal {
     this.totalResponseTime += stateRound.responseTime;
   }
 
+  incrementRounds(): void {
+    this.totalRounds += 1;
+  }
+
   // are the following two methods needed?
   /** Converts global state to a serializable object for persistence. */
   toObject(): Record<string, any> {

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -16,6 +16,7 @@ import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import {
   getSystemPromptWithRules,
   getPrefillForRound,
+  getReflectPromptForRound,
 } from '@agent/utils/promptHelpers';
 import {
   renderPrompt,
@@ -73,6 +74,8 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /** Handler for output file processing and validation. */
   protected outputHandler: IOutputHandler;
   protected latexMediaManager: LatexMediaManager;
+  public roundStates: AgentStateRound[] = [];
+  public toolStates: ToolState[] = [];
 
   constructor(
     modelHandler: IModelHandler,
@@ -410,7 +413,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     messages: any[],
     toolState: ToolState,
     currRound: number = 1,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean]> {
+  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
     this.logger.debug(`Processing round ${currRound}`);
 
     // Create a dedicated group for round 1, as a child of the main run group
@@ -451,8 +454,12 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       const stateRound = new AgentStateRound(currRound);
 
       // Prepare round message
+      const reflectTemplate = getReflectPromptForRound(
+        this.agentPrompt,
+        currRound,
+      );
       const userRequestReflect = await renderPrompt(
-        this.agentPrompt.userReflect,
+        reflectTemplate,
         this.userVars,
       );
       let userMessage = userRequestReflect ? `${userRequestReflect}\n` : '';
@@ -463,7 +470,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       // Only proceed if there's actual content
       if (!userMessage.trim()) {
         this.logger.endGroup(round1GroupId, 'stopped');
-        return [stateRound, stateGlobal, messages, true];
+        return [stateRound, stateGlobal, messages, true, toolState];
       }
 
       const roundMessages = await this.modelHandler.createRoundMessages(
@@ -534,6 +541,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           updatedStateGlobal,
           updatedMessages,
           newEndTurn,
+          updatedToolState,
         ];
       }
 
@@ -545,7 +553,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       });
 
       this.logger.endGroup(round1GroupId, 'stopped');
-      return [stateRound, stateGlobal, updatedMessages, endTurn];
+      return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
     } catch (error) {
       // End the round group with error status in case of exceptions
       this.logger.endGroup(round1GroupId, 'error');
@@ -553,43 +561,60 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     }
   }
 
+  private async runRound(
+    currRound: number,
+    stateGlobal: AgentStateGlobal,
+    messages: any[],
+    toolState: ToolState,
+  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
+    if (currRound === 0) {
+      return await this.process();
+    }
+    return await this.reflect(stateGlobal, messages, toolState, currRound);
+  }
+
   /**
    * Main execution method that processes inputs and generates outputs.
    */
   public async run(): Promise<void> {
-    // Create a dedicated run group for this agent execution
     await this.startRunGroup();
 
     try {
-      // Initialize agent variables within the run group
       await this.init(this.runGroupId);
-
-      // Initialize client before starting
       await this.initializeClient();
 
-      const [stateRound, stateGlobal, messages, endTurn, toolState] =
-        await this.process();
-      this.logger.debug(`Round 0 completed\n`, this.runGroupId);
+      let stateGlobal = new AgentStateGlobal();
+      let messages: any[] = [];
+      let continueRounds = true;
 
-      // Check for interruption before next round
-      if (
-        !this.isInterrupted &&
-        this.agentConfig.toolConfig.reflect &&
-        endTurn
-      ) {
-        const toolStateReflection = new ToolState();
-        await this.reflect(stateGlobal, messages, toolStateReflection);
-        this.logger.debug(`Round 1 completed\n`, this.runGroupId);
+      const totalRounds = this.getNumberOfRounds();
+      for (let currRound = 0; currRound < totalRounds; currRound++) {
+        if (
+          currRound > 0 &&
+          (!this.agentConfig.toolConfig.reflect ||
+            !continueRounds ||
+            this.isInterrupted)
+        ) {
+          break;
+        }
+
+        this.userVars.CURRENT_ROUND = currRound;
+        const toolState = new ToolState();
+        const [stateRound, updatedGlobal, newMessages, endTurn, usedToolState] =
+          await this.runRound(currRound, stateGlobal, messages, toolState);
+        this.roundStates.push(stateRound);
+        this.toolStates.push(usedToolState);
+        stateGlobal = updatedGlobal;
+        messages = newMessages;
+        continueRounds = endTurn;
+        stateGlobal.incrementRounds();
       }
 
-      // End the run group with success status
       this.endRunGroup('stopped');
     } catch (error) {
-      // End the run group with error status
       this.endRunGroup('error');
       throw error;
     } finally {
-      // Always clean up, whether execution completed or was interrupted
       this.cleanup();
     }
   }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -58,8 +58,8 @@ export class OutputHandler implements IOutputHandler {
     this.agentSetting = agentSetting;
     this.agentConfig = agentConfig;
     this.logId = logId;
-    this.outputFiles = { 0: [], 1: [] };
-    this.outputMappings = { 0: [], 1: [] };
+    this.outputFiles = {};
+    this.outputMappings = {};
     this.baseFiles = baseFiles;
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
@@ -77,6 +77,15 @@ export class OutputHandler implements IOutputHandler {
       this.channel,
     );
     this.diffStatsManager = new DiffStatsManager();
+  }
+
+  private ensureRound(round: number): void {
+    if (!this.outputFiles[round]) {
+      this.outputFiles[round] = [];
+    }
+    if (!this.outputMappings[round]) {
+      this.outputMappings[round] = [];
+    }
   }
 
   /**
@@ -159,6 +168,7 @@ export class OutputHandler implements IOutputHandler {
     currRound: number,
     groupId?: string,
   ): Promise<void> {
+    this.ensureRound(currRound);
     await this.diffManager.handleLatexdiffofOutput(currRound, groupId);
   }
 
@@ -168,7 +178,8 @@ export class OutputHandler implements IOutputHandler {
   public async gatherOutputFileInfo(
     currRound: number,
   ): Promise<OutputFileInfo[]> {
-    const roundOutputs = this.outputFiles[currRound] || [];
+    this.ensureRound(currRound);
+    const roundOutputs = this.outputFiles[currRound];
     const baseMap = createFileMapping(this.baseFiles, roundOutputs, 'contains');
     const prevMap =
       currRound > 0
@@ -281,6 +292,7 @@ export class OutputHandler implements IOutputHandler {
     options: { endTurn: boolean; groupId?: string },
   ): Promise<void> {
     const { endTurn, groupId } = options;
+    this.ensureRound(currRound);
     const fileInfos = await this.gatherOutputFileInfo(currRound);
 
     if (endTurn) {
@@ -315,6 +327,7 @@ export class OutputHandler implements IOutputHandler {
     groupId?: string,
   ): Promise<void> {
     const activeGroupId = groupId || this.logger.getActiveGroupId();
+    this.ensureRound(currRound);
 
     if (
       Array.isArray(this.agentConfig.outputFiles) &&
@@ -428,7 +441,8 @@ export class OutputHandler implements IOutputHandler {
     currRound: number = 0,
     roundGroupId?: string,
   ): Promise<string[]> {
-    return this.outputFiles[currRound] || [];
+    this.ensureRound(currRound);
+    return this.outputFiles[currRound];
   }
 }
 

--- a/src/agent/utils/promptHelpers.ts
+++ b/src/agent/utils/promptHelpers.ts
@@ -4,6 +4,7 @@
 // Local imports
 import { renderPrompt } from './promptUtils';
 import { loadTexraRules } from '@frontend/files/rules';
+import type { AgentPrompt } from '@agent/core/AgentDataclass';
 
 /**
  * Combine the base system prompt with optional rules from `.texrarules`.
@@ -36,4 +37,24 @@ export function getPrefillForRound(
     return '';
   }
   return currRound < prefills.length ? prefills[currRound] : prefills[0];
+}
+
+/**
+ * Retrieve the reflection prompt template for a given round.
+ *
+ * @param agentPrompt The agent prompt configuration
+ * @param currRound Current conversation round index
+ * @returns Reflection prompt template string
+ */
+export function getReflectPromptForRound(
+  agentPrompt: AgentPrompt,
+  currRound: number,
+): string {
+  const { userReflect } = agentPrompt;
+  if (Array.isArray(userReflect)) {
+    return currRound < userReflect.length
+      ? userReflect[currRound]
+      : userReflect[0] || '';
+  }
+  return userReflect || '';
 }

--- a/src/agent/utils/promptHelpers.ts
+++ b/src/agent/utils/promptHelpers.ts
@@ -40,10 +40,23 @@ export function getPrefillForRound(
 }
 
 /**
+ * Convert reflection round number to array index.
+ * Reflection rounds start at 1, arrays start at 0.
+ *
+ * @param reflectionRound The reflection round number (1-based)
+ * @returns Array index (0-based)
+ */
+export function reflectionRoundToIndex(reflectionRound: number): number {
+  // Round 0 is the initial process, reflection starts at round 1
+  // So round 1 should map to index 0, round 2 to index 1, etc.
+  return Math.max(0, reflectionRound - 1);
+}
+
+/**
  * Retrieve the reflection prompt template for a given round.
  *
  * @param agentPrompt The agent prompt configuration
- * @param currRound Current conversation round index
+ * @param currRound Current conversation round index (1-based for reflections)
  * @returns Reflection prompt template string
  */
 export function getReflectPromptForRound(
@@ -52,8 +65,10 @@ export function getReflectPromptForRound(
 ): string {
   const { userReflect } = agentPrompt;
   if (Array.isArray(userReflect)) {
-    return currRound < userReflect.length
-      ? userReflect[currRound]
+    const index = reflectionRoundToIndex(currRound);
+    // Use the specific round template if available, otherwise fall back to first
+    return index < userReflect.length
+      ? userReflect[index]
       : userReflect[0] || '';
   }
   return userReflect || '';

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -20,12 +20,14 @@ import {
   TEMP_EXTENSIONS,
   PACK_EXTENSIONS,
   MODELS,
+  DEFAULT_MAX_ROUNDS,
 } from './constants';
 import {
   getAgentFirstNameChunk,
   getFilePatterns,
   findFilesFromPatterns,
 } from './utils';
+import { getConfig } from '@utils/config';
 
 const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
@@ -56,7 +58,8 @@ export async function runCleanSingle(
   );
 
   const agentFirstNameChunk = getAgentFirstNameChunk(agent);
-  const filePatterns = getFilePatterns(baseName, model, agentFirstNameChunk);
+  const maxRounds = getConfig<number>('agent.rounds', DEFAULT_MAX_ROUNDS);
+  const filePatterns = getFilePatterns(baseName, model, agentFirstNameChunk, maxRounds);
   logger.debug(CHANNEL, `Generated patterns: ${filePatterns}`);
 
   const extensions = [...TEMP_EXTENSIONS, ...PACK_EXTENSIONS];

--- a/src/housekeeping/constants.ts
+++ b/src/housekeeping/constants.ts
@@ -40,3 +40,6 @@ export const TEMP_EXTENSIONS = [
 export const MODELS = Object.keys(MODEL_CONFIGS);
 
 export const HISTORY_DIR = 'History';
+
+// Default maximum number of reflection rounds for housekeeping operations
+export const DEFAULT_MAX_ROUNDS = 5;

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -20,6 +20,7 @@ import {
   getFilePatterns,
   findFilesFromPatterns,
 } from './utils';
+import { getConfig } from '@utils/config';
 
 const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
@@ -208,10 +209,13 @@ export async function runPackMultiple(
 
     // Pack additional XML files
     const agentFirstNameChunk = getAgentFirstNameChunk(agent);
-    const additionalPatterns = [
-      `${baseName}_${agentFirstNameChunk}_r0_${model}.xml`,
-      `${baseName}_${agentFirstNameChunk}_r1_${model}.xml`,
-    ];
+    const maxRounds = getConfig<number>('agent.rounds', 2);
+    const additionalPatterns: string[] = [];
+    for (let i = 0; i < maxRounds; i++) {
+      additionalPatterns.push(
+        `${baseName}_${agentFirstNameChunk}_r${i}_${model}.xml`,
+      );
+    }
 
     for (const pattern of additionalPatterns) {
       const filePath = path.join(outputDir, pattern);

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -14,7 +14,7 @@ import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
 // Local imports - housekeeping
-import { PACK_EXTENSIONS, TEMP_EXTENSIONS, HISTORY_DIR } from './constants';
+import { PACK_EXTENSIONS, TEMP_EXTENSIONS, HISTORY_DIR, DEFAULT_MAX_ROUNDS } from './constants';
 import {
   getAgentFirstNameChunk,
   getFilePatterns,
@@ -52,8 +52,9 @@ export async function runPackSingle(
   );
 
   const agentFirstNameChunk = getAgentFirstNameChunk(agent);
+  const maxRounds = getConfig<number>('agent.rounds', DEFAULT_MAX_ROUNDS);
   const filePatterns = [
-    ...getFilePatterns(baseName, model, agentFirstNameChunk),
+    ...getFilePatterns(baseName, model, agentFirstNameChunk, maxRounds),
     baseName,
   ];
   logger.debug(CHANNEL, `Generated patterns: ${filePatterns}`);
@@ -209,7 +210,7 @@ export async function runPackMultiple(
 
     // Pack additional XML files
     const agentFirstNameChunk = getAgentFirstNameChunk(agent);
-    const maxRounds = getConfig<number>('agent.rounds', 2);
+    const maxRounds = getConfig<number>('agent.rounds', DEFAULT_MAX_ROUNDS);
     const additionalPatterns: string[] = [];
     for (let i = 0; i < maxRounds; i++) {
       additionalPatterns.push(

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -35,12 +35,18 @@ export function getFilePatterns(
     patterns.push(
       `${base}_${agentFirstNameChunk}_r${round}_${model}`,
       `${base}_${agentFirstNameChunk}_r${round}_${model}_diff`,
-      `${base}_${agentFirstNameChunk}_r${round}_${model}_diffr${round}r${round - 1}`,
       `${base}_${agentFirstNameChunk}_r${round}_full_${model}`,
       `${base}_${agentFirstNameChunk}_r${round}_full_${model}_diff`,
-      `${base}_${agentFirstNameChunk}_r${round}_full_${model}_diffr${round}r${round - 1}`,
       `${base}_${agentFirstNameChunk}_r${round}_${model}_thinking`,
     );
+
+    // Only add diff patterns for rounds > 0 to avoid negative references
+    if (round > 0) {
+      patterns.push(
+        `${base}_${agentFirstNameChunk}_r${round}_${model}_diffr${round}r${round - 1}`,
+        `${base}_${agentFirstNameChunk}_r${round}_full_${model}_diffr${round}r${round - 1}`,
+      );
+    }
   }
   return patterns;
 }


### PR DESCRIPTION
## Summary
- allow prompts to specify multiple reflection templates and select them per round
- consolidate round execution to iterate through an arbitrary number of rounds while tracking per-round state
- generalize output handling and packaging for configurable round counts

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4392954148324ba3ce3353e237739