### PR TITLE
feat: refresh model options based on api keys

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -226,10 +226,14 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async sendModelOptions(webviewView: vscode.WebviewView) {
-    const options = await computeModelOptions();
-    webviewView.webview.postMessage({
-      command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-      options,
-    });
+    try {
+      const options = await computeModelOptions();
+      webviewView.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+        options,
+      });
+    } catch (error) {
+      console.error('Failed to send model options:', error);
+    }
   }
 }

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -7,6 +7,7 @@ import { MainViewContentProvider } from './webview/MainViewContentProvider';
 import { SecretManager } from '@frontend/secretManager';
 import { watchConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { computeModelOptions } from '@model/computeModelOptions';
 
 export class MainViewProvider implements vscode.WebviewViewProvider {
   private messageHandler: MainViewMessageHandler;
@@ -85,11 +86,12 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     );
   }
 
-  private refreshOptionsAndView() {
+  private async refreshOptionsAndView() {
     if (this.webviewView) {
       this.webviewView.webview.html = this.contentProvider.getHtmlContent(
         this.webviewView.webview,
       );
+      await this.sendModelOptions(this.webviewView);
     }
   }
 
@@ -159,6 +161,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     });
 
     this.setupInitialState(webviewView);
+    void this.sendModelOptions(webviewView);
 
     // Check if any API keys are set and display banner if needed
     const config = vscode.workspace.getConfiguration('texra');
@@ -220,5 +223,13 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
         console.error('Error restoring state from context:', error);
       }
     }
+  }
+
+  private async sendModelOptions(webviewView: vscode.WebviewView) {
+    const options = await computeModelOptions();
+    webviewView.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+      options,
+    });
   }
 }

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -78,6 +78,7 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
           `${provider} API key has been set`,
         );
         await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
+        void vscode.commands.executeCommand('texra.refreshModelOptions');
         const view = await vscode.commands.executeCommand<vscode.WebviewView>(
           'texra.getWebviewView',
         );
@@ -115,6 +116,7 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
           `${provider} API key has been removed`,
         );
         await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
+        void vscode.commands.executeCommand('texra.refreshModelOptions');
         const any = await SecretManager.anyApiKeyExists();
         const view = await vscode.commands.executeCommand<vscode.WebviewView>(
           'texra.getWebviewView',

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -5,9 +5,11 @@ import * as vscode from 'vscode';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 // Local imports - utilities
 import { safeExecuteCommand } from '@utils/system';
+import { computeModelOptions } from '@model/computeModelOptions';
 
 export const mainViewCommands = {
   reset: 'texra.mainView.reset',
+  refreshModelOptions: 'texra.refreshModelOptions',
 };
 
 /**
@@ -39,7 +41,25 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
     },
   );
 
-  context.subscriptions.push(resetCommand);
+  const refreshModelOptionsCommand = vscode.commands.registerCommand(
+    mainViewCommands.refreshModelOptions,
+    async () => {
+      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
+        'texra.getWebviewView',
+        [],
+        'mainViewCommands',
+      );
+      if (webviewView) {
+        const options = await computeModelOptions();
+        webviewView.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          options,
+        });
+      }
+    },
+  );
 
-  return { resetCommand };
+  context.subscriptions.push(resetCommand, refreshModelOptionsCommand);
+
+  return { resetCommand, refreshModelOptionsCommand };
 }

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -50,11 +50,18 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
         'mainViewCommands',
       );
       if (webviewView) {
-        const options = await computeModelOptions();
-        webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-          options,
-        });
+        try {
+          const options = await computeModelOptions();
+          webviewView.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+            options,
+          });
+        } catch (error) {
+          console.error('Failed to refresh model options:', error);
+          vscode.window.showErrorMessage(
+            'Failed to refresh model options. Please check the output console for details.',
+          );
+        }
       }
     },
   );

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -95,6 +95,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_CURRENT_FILE: 'setCurrentFile',
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
+  SET_MODEL_OPTIONS: 'setModelOptions',
 
   // File refresh and update operations
   REFRESH_ALL_FILES: 'refreshAllFiles',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -95,6 +95,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_CURRENT_FILE: 'setCurrentFile',
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
+  SET_MODEL_OPTIONS: 'setModelOptions',
 
   // File refresh and update operations
   REFRESH_ALL_FILES: 'refreshAllFiles',

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -1,0 +1,42 @@
+// Third-party imports
+// (none)
+
+// Local imports - model utilities
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
+import { SecretManager, ApiProvider } from '@frontend/secretManager';
+import { getConfig } from '@utils/config';
+
+/**
+ * Compute model <option> tags based on available API keys.
+ * Models without a required key are marked as disabled with a "(no key)" label.
+ */
+export async function computeModelOptions(): Promise<string> {
+  const models = getConfig<string[]>('models', []);
+  const hasOpenRouter = await SecretManager.apiKeyExists('openRouter');
+
+  const optionTags = await Promise.all(
+    models.map(async (model) => {
+      const config = MODEL_CONFIGS[model];
+      if (!config) {
+        return `<option value="${model}">${model}</option>`;
+      }
+
+      const provider = config.provider.toLowerCase();
+      let available = false;
+
+      if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
+        available = await SecretManager.apiKeyExists(provider as ApiProvider);
+      }
+
+      if (!available && config.openrouterFullName && hasOpenRouter) {
+        available = true;
+      }
+
+      const label = available ? model : `${model} (no key)`;
+      const disabledAttr = available ? '' : ' disabled';
+      return `<option value="${model}"${disabledAttr}>${label}</option>`;
+    }),
+  );
+
+  return optionTags.join('\n');
+}

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -21,13 +21,23 @@ export async function computeModelOptions(): Promise<string> {
         return `<option value="${model}">${model}</option>`;
       }
 
-      const provider = config.provider.toLowerCase();
+      const provider = config.provider;
       let available = false;
 
+      // Check if the provider requires an API key
       if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
-        available = await SecretManager.apiKeyExists(provider as ApiProvider);
+        try {
+          available = await SecretManager.apiKeyExists(provider as ApiProvider);
+        } catch (error) {
+          console.warn(`Failed to check API key for ${provider}:`, error);
+          available = false;
+        }
+      } else {
+        // Models from providers that don't require API keys (like copilot) are always available
+        available = true;
       }
 
+      // Check OpenRouter availability only if not already available and model supports it
       if (!available && config.openrouterFullName && hasOpenRouter) {
         available = true;
       }

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -116,10 +116,9 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       .map((agent) => `<option value="${agent}">${agent}</option>`)
       .join('\n');
 
-    const models = getConfig<string[]>('models', []);
-    const modelOptions = models
-      .map((model) => `<option value="${model}">${model}</option>`)
-      .join('\n');
+    // Model options are provided asynchronously after the webview loads
+    // to reflect current API key availability.
+    const modelOptions = '';
 
     return {
       agentOptions,

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -74,42 +74,54 @@ export class MainViewMessageHandler {
         }
       },
       [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (m) => {
+        // Validate that options are provided
+        if (!m.options) {
+          console.warn('SET_MODEL_OPTIONS: No options provided');
+          return;
+        }
+
+        // Helper function to apply options to select element
+        const applyOptions = (selectElement) => {
+          const previous = selectElement.value;
+          selectElement.innerHTML = m.options;
+          if (previous) {
+            selectElement.value = previous;
+          }
+          Array.from(selectElement.options).forEach((opt) => {
+            if (opt.disabled) {
+              opt.classList.add('disabled-model');
+            } else {
+              opt.classList.remove('disabled-model');
+            }
+          });
+        };
+
         // Don't cache if element doesn't exist yet
         const select = document.getElementById('model');
         if (!select) {
-          // Queue for later when DOM is ready
-          setTimeout(() => {
+          // Use a more robust retry mechanism with exponential backoff
+          let retryCount = 0;
+          const maxRetries = 5;
+          const retryDelay = [100, 200, 400, 800, 1600];
+          
+          const tryApplyOptions = () => {
             const retrySelect = document.getElementById('model');
             if (retrySelect) {
-              const previous = retrySelect.value;
-              retrySelect.innerHTML = m.options;
-              if (previous) {
-                retrySelect.value = previous;
-              }
-              Array.from(retrySelect.options).forEach((opt) => {
-                if (opt.disabled) {
-                  opt.classList.add('disabled-model');
-                } else {
-                  opt.classList.remove('disabled-model');
-                }
-              });
+              applyOptions(retrySelect);
+            } else if (retryCount < maxRetries) {
+              setTimeout(tryApplyOptions, retryDelay[retryCount]);
+              retryCount++;
+            } else {
+              console.warn('SET_MODEL_OPTIONS: Model select element not found after retries');
             }
-          }, 100);
+          };
+          
+          setTimeout(tryApplyOptions, retryDelay[0]);
+          retryCount = 1;
           return;
         }
         
-        const previous = select.value;
-        select.innerHTML = m.options;
-        if (previous) {
-          select.value = previous;
-        }
-        Array.from(select.options).forEach((opt) => {
-          if (opt.disabled) {
-            opt.classList.add('disabled-model');
-          } else {
-            opt.classList.remove('disabled-model');
-          }
-        });
+        applyOptions(select);
       },
     };
   }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -73,6 +73,23 @@ export class MainViewMessageHandler {
           element.style.setProperty('display', 'none');
         }
       },
+      [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (m) => {
+        const select = this._getElement('model');
+        if (select) {
+          const previous = select.value;
+          select.innerHTML = m.options;
+          if (previous) {
+            select.value = previous;
+          }
+          Array.from(select.options).forEach((opt) => {
+            if (opt.disabled) {
+              opt.style.color = 'var(--vscode-descriptionForeground)';
+            } else {
+              opt.style.removeProperty('color');
+            }
+          });
+        }
+      },
     };
   }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -74,21 +74,42 @@ export class MainViewMessageHandler {
         }
       },
       [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (m) => {
-        const select = this._getElement('model');
-        if (select) {
-          const previous = select.value;
-          select.innerHTML = m.options;
-          if (previous) {
-            select.value = previous;
-          }
-          Array.from(select.options).forEach((opt) => {
-            if (opt.disabled) {
-              opt.style.color = 'var(--vscode-descriptionForeground)';
-            } else {
-              opt.style.removeProperty('color');
+        // Don't cache if element doesn't exist yet
+        const select = document.getElementById('model');
+        if (!select) {
+          // Queue for later when DOM is ready
+          setTimeout(() => {
+            const retrySelect = document.getElementById('model');
+            if (retrySelect) {
+              const previous = retrySelect.value;
+              retrySelect.innerHTML = m.options;
+              if (previous) {
+                retrySelect.value = previous;
+              }
+              Array.from(retrySelect.options).forEach((opt) => {
+                if (opt.disabled) {
+                  opt.classList.add('disabled-model');
+                } else {
+                  opt.classList.remove('disabled-model');
+                }
+              });
             }
-          });
+          }, 100);
+          return;
         }
+        
+        const previous = select.value;
+        select.innerHTML = m.options;
+        if (previous) {
+          select.value = previous;
+        }
+        Array.from(select.options).forEach((opt) => {
+          if (opt.disabled) {
+            opt.classList.add('disabled-model');
+          } else {
+            opt.classList.remove('disabled-model');
+          }
+        });
       },
     };
   }

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -90,3 +90,8 @@
   opacity: var(--opacity-subtle);
   font-size: calc(var(--vscode-editor-font-size) * 0.9);
 }
+
+/* Disabled model option styling */
+.disabled-model {
+  color: var(--vscode-descriptionForeground);
+}


### PR DESCRIPTION
## Summary
- add computeModelOptions helper to render model dropdown based on available API keys
- send dynamic model options to webview and refresh after API key changes
- update webview handler to apply disabled styling for unavailable models

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack compile hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b4649def108324b411b4da69b599bb