### PR TITLE
fix: show initial model options

### DIFF
--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -116,9 +116,13 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       .map((agent) => `<option value="${agent}">${agent}</option>`)
       .join('\n');
 
-    // Model options are provided asynchronously after the webview loads
-    // to reflect current API key availability.
-    const modelOptions = '';
+    // Provide initial model options from configuration; detailed availability
+    // (e.g. disabled states based on API keys) is refreshed after the webview
+    // loads to avoid showing an empty selector.
+    const models = getConfig<string[]>('models', []);
+    const modelOptions = models
+      .map((model) => `<option value="${model}">${model}</option>`)
+      .join('\n');
 
     return {
       agentOptions,


### PR DESCRIPTION
## Summary
- pre-populate model dropdown from configured models and refresh after load

## Testing
- `npm run format`
- `npm run lint`
- `CI=1 npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a8a96ba4832485424e8388516dbc