### PR TITLE
fix: ensure model selector always populates

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -7,7 +7,6 @@ import { MainViewContentProvider } from './webview/MainViewContentProvider';
 import { SecretManager } from '@frontend/secretManager';
 import { watchConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
-import { computeModelOptions } from '@model/computeModelOptions';
 
 export class MainViewProvider implements vscode.WebviewViewProvider {
   private messageHandler: MainViewMessageHandler;
@@ -91,7 +90,6 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       this.webviewView.webview.html = this.contentProvider.getHtmlContent(
         this.webviewView.webview,
       );
-      await this.sendModelOptions(this.webviewView);
     }
   }
 
@@ -161,7 +159,6 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     });
 
     this.setupInitialState(webviewView);
-    void this.sendModelOptions(webviewView);
 
     // Check if any API keys are set and display banner if needed
     const config = vscode.workspace.getConfiguration('texra');
@@ -222,18 +219,6 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       } catch (error) {
         console.error('Error restoring state from context:', error);
       }
-    }
-  }
-
-  private async sendModelOptions(webviewView: vscode.WebviewView) {
-    try {
-      const options = await computeModelOptions();
-      webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-        options,
-      });
-    } catch (error) {
-      console.error('Failed to send model options:', error);
     }
   }
 }

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -116,9 +116,10 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       .map((agent) => `<option value="${agent}">${agent}</option>`)
       .join('\n');
 
-    // Model options are provided asynchronously after the webview loads
-    // to reflect current API key availability.
-    const modelOptions = '';
+    const models = getConfig<string[]>('models', []);
+    const modelOptions = models
+      .map((model) => `<option value="${model}">${model}</option>`)
+      .join('\n');
 
     return {
       agentOptions,

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -20,6 +20,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { getConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+import { computeModelOptions } from '@model/computeModelOptions';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly settingsManager: SettingsManager;
@@ -257,5 +258,26 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     await safeExecuteCommand('texra.showAgentHistory', [], this.viewName);
+  }
+
+  protected async handleWebviewReady(
+    _message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    await super.handleWebviewReady(_message, webviewView);
+    try {
+      const options = await computeModelOptions();
+      webviewView.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+        options,
+      });
+    } catch (error) {
+      this.logger.error(
+        this.channel,
+        `Failed to compute model options: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 }

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -10,6 +10,8 @@ import {
   cleanup as cleanupHandlers,
 } from './modules/messageHandlers.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { vscode } from '@common/webviewContext.js';
 
 // Register handlers immediately so early messages aren't missed
 setupHandlers({ requestData: false });
@@ -29,4 +31,5 @@ document.addEventListener('DOMContentLoaded', function () {
   toggleManager.updateAutoToggleState();
   toggleManager.setupDocumentListeners();
   setupHandlers({ requestData: true });
+  vscode.postMessage({ command: MAIN_VIEW_COMMANDS.WEBVIEW_READY });
 });


### PR DESCRIPTION
## Summary
- send WEBVIEW_READY after DOM load so extension can populate model dropdown
- compute model options in handler when webview signals readiness
- preload dropdown with configured models for placeholder options

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a8aea1c08324a67d98e1fd2fb2ea