### PR TITLE
feat: guide API key setup from model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.5] - 2025-09-02
+
+### Features
+
+- Highlight missing API keys for models with provider-specific banner and setup links
+
 ## [0.33.4] - 2025-08-31
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.33.5] - 2025-09-02
-
-### Features
-
-- Highlight missing API keys for models with provider-specific banner and setup links
-
 ## [0.33.4] - 2025-08-31
 
 ### Features
 
 - Support round-specific reflection prompts and iteration across multiple rounds
 - Record per-round agent and tool state for future analysis
+- Highlight missing API keys for models with provider-specific banner and setup links
 
 ### Bug Fixes
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -44,7 +44,8 @@ export async function computeModelOptions(): Promise<string> {
 
       const label = available ? model : `${model} (no key)`;
       const disabledAttr = available ? '' : ' disabled';
-      return `<option value="${model}"${disabledAttr}>${label}</option>`;
+      const providerAttr = ` data-provider="${provider}"`;
+      return `<option value="${model}"${providerAttr}${disabledAttr}>${label}</option>`;
     }),
   );
 

--- a/src/test/model/computeModelOptions.test.ts
+++ b/src/test/model/computeModelOptions.test.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { computeModelOptions } from '../../model/computeModelOptions';
+import { SecretManager } from '../../frontend/secretManager';
+import * as config from '../../utils/config';
+
+suite('computeModelOptions', () => {
+  let getConfigStub: sinon.SinonStub;
+  let apiKeyExistsStub: sinon.SinonStub;
+
+  setup(() => {
+    getConfigStub = sinon.stub(config, 'getConfig');
+    apiKeyExistsStub = sinon.stub(SecretManager, 'apiKeyExists');
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('should add provider metadata to option elements', async () => {
+    getConfigStub.withArgs('models').returns(['claude-3-opus']);
+    apiKeyExistsStub.withArgs('anthropic').resolves(true);
+    apiKeyExistsStub.withArgs('openRouter').resolves(false);
+
+    const result = await computeModelOptions();
+    
+    assert.ok(result.includes('data-provider="anthropic"'));
+    assert.ok(!result.includes('disabled'));
+  });
+
+  test('should disable models without API keys', async () => {
+    getConfigStub.withArgs('models').returns(['claude-3-opus']);
+    apiKeyExistsStub.resolves(false);
+
+    const result = await computeModelOptions();
+    
+    assert.ok(result.includes('disabled'));
+    assert.ok(result.includes('(no key)'));
+  });
+
+  test('should handle provider check failures gracefully', async () => {
+    getConfigStub.withArgs('models').returns(['claude-3-opus']);
+    apiKeyExistsStub.rejects(new Error('API check failed'));
+
+    const result = await computeModelOptions();
+    
+    assert.ok(result.includes('disabled'));
+    assert.ok(result.includes('(no key)'));
+  });
+});

--- a/src/test/webview/SettingsButtonManager.test.ts
+++ b/src/test/webview/SettingsButtonManager.test.ts
@@ -1,0 +1,125 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { SettingsButtonManager } from '../../webview/modules/uiManagers/SettingsButtonManager';
+import { MAIN_VIEW_COMMANDS } from '../../common/webview/commands';
+
+suite('SettingsButtonManager', () => {
+  let manager: SettingsButtonManager;
+  let vscodeStub: any;
+  let addListenerStub: sinon.SinonStub;
+  
+  setup(() => {
+    vscodeStub = {
+      postMessage: sinon.stub()
+    };
+    
+    manager = new SettingsButtonManager(vscodeStub, null, null, null);
+    addListenerStub = sinon.stub(manager, 'addListener');
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('should handle disabled option selection correctly', () => {
+    // Setup mock event handlers
+    let focusHandler: Function;
+    let changeHandler: Function;
+    
+    addListenerStub.callsFake((id, event, handler) => {
+      if (id === 'model' && event === 'focus') focusHandler = handler;
+      if (id === 'model' && event === 'change') changeHandler = handler;
+    });
+    
+    manager._setupDropdowns();
+    
+    // Simulate focus event to store previous value
+    const focusEvent = { target: { value: 'claude-3-opus' } };
+    focusHandler(focusEvent);
+    
+    // Simulate change event with disabled option
+    const changeEvent = {
+      target: {
+        value: 'gpt-4',
+        selectedIndex: 1,
+        options: [{}, {
+          disabled: true,
+          dataset: { provider: 'openai' }
+        }]
+      }
+    };
+    
+    changeHandler(changeEvent);
+    
+    // Verify that value was reverted
+    assert.strictEqual(changeEvent.target.value, 'claude-3-opus');
+    
+    // Verify that API key setup was triggered
+    assert.ok(vscodeStub.postMessage.calledWith({
+      command: MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY
+    }));
+    
+    // Verify that banner was shown with provider
+    assert.ok(vscodeStub.postMessage.calledWith({
+      command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+      provider: 'openai'
+    }));
+  });
+
+  test('should handle OpenRouter provider specially', () => {
+    let changeHandler: Function;
+    
+    addListenerStub.callsFake((id, event, handler) => {
+      if (id === 'model' && event === 'change') changeHandler = handler;
+    });
+    
+    manager._setupDropdowns();
+    
+    const changeEvent = {
+      target: {
+        value: 'gpt-4',
+        selectedIndex: 0,
+        options: [{
+          disabled: true,
+          dataset: { provider: 'openrouter' }
+        }]
+      }
+    };
+    
+    changeHandler(changeEvent);
+    
+    // Verify OpenRouter uses the guide command
+    assert.ok(vscodeStub.postMessage.calledWith({
+      command: MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE
+    }));
+  });
+
+  test('should handle valid model selection normally', () => {
+    let changeHandler: Function;
+    
+    addListenerStub.callsFake((id, event, handler) => {
+      if (id === 'model' && event === 'change') changeHandler = handler;
+    });
+    
+    manager._setupDropdowns();
+    
+    const changeEvent = {
+      target: {
+        value: 'claude-3-opus',
+        selectedIndex: 0,
+        options: [{
+          disabled: false,
+          dataset: { provider: 'anthropic' }
+        }]
+      }
+    };
+    
+    changeHandler(changeEvent);
+    
+    // Verify normal model selection flow
+    assert.ok(vscodeStub.postMessage.calledWith({
+      command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
+      model: 'claude-3-opus'
+    }));
+  });
+});

--- a/src/test/webview/messageHandlers.test.ts
+++ b/src/test/webview/messageHandlers.test.ts
@@ -1,0 +1,71 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { MainViewMessageHandler } from '../../webview/modules/messageHandlers';
+import { MAIN_VIEW_COMMANDS } from '../../common/webview/commands';
+
+suite('MainViewMessageHandler', () => {
+  let handler: MainViewMessageHandler;
+  let getElementStub: sinon.SinonStub;
+  let clock: sinon.SinonFakeTimers;
+
+  setup(() => {
+    handler = new MainViewMessageHandler();
+    getElementStub = sinon.stub(handler as any, '_getElement');
+    clock = sinon.useFakeTimers();
+  });
+
+  teardown(() => {
+    sinon.restore();
+    clock.restore();
+  });
+
+  test('should capitalize provider name in API key banner', () => {
+    const mockElement = {
+      querySelector: sinon.stub().returns({
+        textContent: ''
+      }),
+      style: {
+        setProperty: sinon.stub()
+      }
+    };
+    
+    getElementStub.returns(mockElement);
+    
+    const handlers = (handler as any)._handlers;
+    handlers[MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]({ provider: 'anthropic' });
+    
+    const textSpan = mockElement.querySelector.returnValues[0];
+    assert.strictEqual(textSpan.textContent, 'Missing Anthropic API key.');
+  });
+
+  test('should prevent concurrent retry attempts for model options', () => {
+    const consoleWarnStub = sinon.stub(console, 'warn');
+    const handlers = (handler as any)._handlers;
+    
+    // First call - starts retry
+    handlers[MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]({ options: '<option>Test</option>' });
+    
+    // Second call - should be blocked
+    handlers[MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]({ options: '<option>Test2</option>' });
+    
+    assert.ok(consoleWarnStub.calledWith('SET_MODEL_OPTIONS: Retry already in progress'));
+  });
+
+  test('should reset retry flag after successful model options update', () => {
+    const mockSelect = {
+      innerHTML: '',
+      value: 'previous',
+      options: []
+    };
+    
+    sinon.stub(document, 'getElementById').returns(null).onSecondCall().returns(mockSelect as any);
+    
+    const handlers = (handler as any)._handlers;
+    handlers[MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]({ options: '<option>Test</option>' });
+    
+    // Advance time to trigger first retry
+    clock.tick(100);
+    
+    assert.strictEqual((handler as any)._modelOptionsRetryInProgress, false);
+  });
+});

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -61,9 +61,13 @@ export class MainViewMessageHandler {
       ...this._createInstructionHandlers(),
       ...createRecordingHandlers({ postHandle: ctx.postHandle }),
       ...createFileHandlers(ctx),
-      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: () => {
+      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: (m) => {
         const element = this._getElement(ELEMENT_IDS.API_KEY_BANNER);
         if (element) {
+          const textSpan = element.querySelector('span');
+          if (textSpan && m?.provider) {
+            textSpan.textContent = `Missing ${m.provider} API key.`;
+          }
           element.style.setProperty('display', 'flex');
         }
       },

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -47,6 +47,8 @@ export class MainViewMessageHandler {
     this._elementCache = new Map();
     // Track file list event handlers for cleanup
     this._fileListHandlers = {};
+    // Flag to prevent concurrent retry attempts for model options
+    this._modelOptionsRetryInProgress = false;
 
     const ctx = {
       postHandle: this._postHandle.bind(this),
@@ -66,7 +68,9 @@ export class MainViewMessageHandler {
         if (element) {
           const textSpan = element.querySelector('span');
           if (textSpan && m?.provider) {
-            textSpan.textContent = `Missing ${m.provider} API key.`;
+            // Capitalize provider name for better UX
+            const providerName = m.provider.charAt(0).toUpperCase() + m.provider.slice(1);
+            textSpan.textContent = `Missing ${providerName} API key.`;
           }
           element.style.setProperty('display', 'flex');
         }
@@ -103,7 +107,14 @@ export class MainViewMessageHandler {
         // Don't cache if element doesn't exist yet
         const select = document.getElementById('model');
         if (!select) {
+          // Prevent concurrent retry attempts
+          if (this._modelOptionsRetryInProgress) {
+            console.warn('SET_MODEL_OPTIONS: Retry already in progress');
+            return;
+          }
+          
           // Use a more robust retry mechanism with exponential backoff
+          this._modelOptionsRetryInProgress = true;
           let retryCount = 0;
           const maxRetries = 5;
           const retryDelay = [100, 200, 400, 800, 1600];
@@ -112,6 +123,7 @@ export class MainViewMessageHandler {
             const retrySelect = document.getElementById('model');
             if (retrySelect) {
               applyOptions(retrySelect);
+              this._modelOptionsRetryInProgress = false;
             } else if (retryCount < maxRetries) {
               setTimeout(tryApplyOptions, retryDelay[retryCount]);
               retryCount++;
@@ -119,6 +131,7 @@ export class MainViewMessageHandler {
               console.warn(
                 'SET_MODEL_OPTIONS: Model select element not found after retries',
               );
+              this._modelOptionsRetryInProgress = false;
             }
           };
 

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -117,28 +117,48 @@ export class SettingsButtonManager extends BaseUIManager {
       });
     });
 
-    this.addListener('model', 'change', (e) => {
-      this.vscode.postMessage({
-        command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
-        model: e.target.value,
-      });
-      this.state.save();
+    // Track the previous valid selection
+    let previousModelValue = null;
+    
+    this.addListener('model', 'focus', (e) => {
+      // Store the current value when focus is gained
+      previousModelValue = e.target.value;
     });
 
-    // Listen for clicks on disabled model options to guide API key setup
-    this.addListener('model', 'click', (e) => {
-      const option = e.target;
-      if (option.tagName === 'OPTION' && option.disabled) {
-        const provider = option.dataset.provider;
+    this.addListener('model', 'change', (e) => {
+      const selectElement = e.target;
+      const selectedOption = selectElement.options[selectElement.selectedIndex];
+      
+      // Check if the selected option is disabled
+      if (selectedOption && selectedOption.disabled) {
+        // Revert to previous value
+        if (previousModelValue !== null) {
+          selectElement.value = previousModelValue;
+        }
+        
+        // Get provider from the disabled option
+        const provider = selectedOption.dataset?.provider || 'Unknown';
+        
+        // Open appropriate API key setup
         const command =
-          provider && provider.toLowerCase() === 'openrouter'
+          provider.toLowerCase() === 'openrouter'
             ? MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE
             : MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY;
         this.vscode.postMessage({ command });
+        
+        // Show banner with provider info
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
           provider,
         });
+      } else {
+        // Valid selection - update the previous value and proceed normally
+        previousModelValue = selectElement.value;
+        this.vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
+          model: selectElement.value,
+        });
+        this.state.save();
       }
     });
   }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -124,6 +124,23 @@ export class SettingsButtonManager extends BaseUIManager {
       });
       this.state.save();
     });
+
+    // Listen for clicks on disabled model options to guide API key setup
+    this.addListener('model', 'click', (e) => {
+      const option = e.target;
+      if (option.tagName === 'OPTION' && option.disabled) {
+        const provider = option.dataset.provider;
+        const command =
+          provider && provider.toLowerCase() === 'openrouter'
+            ? MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE
+            : MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY;
+        this.vscode.postMessage({ command });
+        this.vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+          provider,
+        });
+      }
+    });
   }
 
   setup() {


### PR DESCRIPTION
## Summary
- add provider metadata to model options to identify missing API keys
- open API key setup or guide when clicking disabled model entries and show contextual banner

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b699b205bc8324bf25d591c61d6d08