### PR TITLE
fix: flag models requiring keys in dropdown

### DIFF
--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -19,7 +19,7 @@ function formatContext(context: number): string {
  * Format cost values for display
  */
 function formatCost(inputPrice?: number, outputPrice?: number): string {
-  if (inputPrice == null || outputPrice == null) return '';
+  if (inputPrice === undefined || outputPrice === undefined) return '';
   return `$${inputPrice.toFixed(3)}/$${outputPrice.toFixed(3)}`;
 }
 
@@ -60,7 +60,9 @@ export async function computeModelOptions(): Promise<string> {
       }
 
       const label = available ? model : `${model} (no key)`;
-      const disabledAttr = available ? '' : ' disabled';
+      const requiresKeyAttr = available
+        ? ''
+        : ' data-requires-key="true" class="disabled-model"';
 
       // Build data attributes, only including them if values are defined
       const providerAttr = provider ? ` data-provider="${provider}"` : '';
@@ -72,7 +74,7 @@ export async function computeModelOptions(): Promise<string> {
         ? ` data-cost="${formatCost(config.inputPrice, config.outputPrice)}"`
         : '';
 
-      return `<option value="${model}"${disabledAttr}${providerAttr}${contextAttr}${costAttr}>${label}</option>`;
+      return `<option value="${model}"${requiresKeyAttr}${providerAttr}${contextAttr}${costAttr}>${label}</option>`;
     }),
   );
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -19,13 +19,14 @@ function formatContext(context: number): string {
  * Format cost values for display
  */
 function formatCost(inputPrice?: number, outputPrice?: number): string {
-  if (inputPrice === undefined || outputPrice === undefined) return '';
+  if (inputPrice == null || outputPrice == null) return '';
   return `$${inputPrice.toFixed(3)}/$${outputPrice.toFixed(3)}`;
 }
 
 /**
  * Compute model <option> tags based on available API keys.
- * Models without a required key are marked as disabled with a "(no key)" label.
+ * Models without a required key are marked as disabled with a "(no key)" label
+ * and include both disabled and data-requires-key attributes for proper handling.
  */
 export async function computeModelOptions(): Promise<string> {
   const models = getConfig<string[]>('models', []);
@@ -62,7 +63,7 @@ export async function computeModelOptions(): Promise<string> {
       const label = available ? model : `${model} (no key)`;
       const requiresKeyAttr = available
         ? ''
-        : ' data-requires-key="true" class="disabled-model"';
+        : ' disabled data-requires-key="true" class="disabled-model"';
 
       // Build data attributes, only including them if values are defined
       const providerAttr = provider ? ` data-provider="${provider}"` : '';

--- a/src/progressView/modules/katexMacros.js
+++ b/src/progressView/modules/katexMacros.js
@@ -206,7 +206,6 @@ export const katexMacros = {
   '\\tp': '\\tilde{p}',
   '\\tv': '\\tilde{v}',
   '\\trho': '\\tilde{\\rho}',
-  '\\tphi': '\\tilde{\\phi}',
 
   // More special symbols
   '\\bksl': '\\backslash',

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -97,7 +97,7 @@ export class MainViewMessageHandler {
             selectElement.value = previous;
           }
           Array.from(selectElement.options).forEach((opt) => {
-            if (opt.disabled) {
+            if (opt.dataset.requiresKey) {
               opt.classList.add('disabled-model');
             } else {
               opt.classList.remove('disabled-model');

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -97,11 +97,8 @@ export class MainViewMessageHandler {
             selectElement.value = previous;
           }
           Array.from(selectElement.options).forEach((opt) => {
-            if (opt.dataset.requiresKey) {
-              opt.classList.add('disabled-model');
-            } else {
-              opt.classList.remove('disabled-model');
-            }
+            // Note: disabled-model class is already set server-side in computeModelOptions
+            // We only need to add tooltips here
             const { provider, context, cost } = opt.dataset;
             if (provider || context || cost) {
               opt.title = `Provider: ${provider ?? 'N/A'}, Context: ${context ?? 'N/A'}, Cost: ${cost ?? 'N/A'}`;

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -129,7 +129,8 @@ export class SettingsButtonManager extends BaseUIManager {
       const selectElement = e.target;
       const selectedOption = selectElement.options[selectElement.selectedIndex];
 
-      // Check if the selected option requires an API key
+      // Check if the selected option requires an API key (using data attribute)
+      // The disabled attribute prevents selection in most browsers, but this is a fallback
       if (selectedOption?.dataset?.requiresKey) {
         // Revert to previous value
         if (previousModelValue !== null) {
@@ -137,7 +138,7 @@ export class SettingsButtonManager extends BaseUIManager {
         }
 
         // Get provider from the option
-        const provider = selectedOption.dataset?.provider || 'Unknown';
+        const provider = selectedOption?.dataset?.provider || 'Unknown';
 
         // Open appropriate API key setup
         const command =

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -129,14 +129,14 @@ export class SettingsButtonManager extends BaseUIManager {
       const selectElement = e.target;
       const selectedOption = selectElement.options[selectElement.selectedIndex];
 
-      // Check if the selected option is disabled
-      if (selectedOption && selectedOption.disabled) {
+      // Check if the selected option requires an API key
+      if (selectedOption?.dataset?.requiresKey) {
         // Revert to previous value
         if (previousModelValue !== null) {
           selectElement.value = previousModelValue;
         }
 
-        // Get provider from the disabled option
+        // Get provider from the option
         const provider = selectedOption.dataset?.provider || 'Unknown';
 
         // Open appropriate API key setup

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -92,6 +92,7 @@
 }
 
 /* Disabled model option styling */
-.disabled-model {
+option.disabled-model,
+option[data-requires-key='true'] {
   color: var(--vscode-descriptionForeground);
 }

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -93,6 +93,7 @@
 
 /* Disabled model option styling */
 option.disabled-model,
-option[data-requires-key='true'] {
+option[data-requires-key='true'],
+option[disabled] {
   color: var(--vscode-descriptionForeground);
 }


### PR DESCRIPTION
## Summary
- mark models without API keys using `data-requires-key` and `.disabled-model`
- block selection of keyless models and prompt for key setup
- remove duplicate KaTeX macro causing lint failure

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: process did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b6beefbc348324bdc3ea4a8bab8217