### PR TITLE
fix: reveal packed folder via WorkspaceFS

### DIFF
--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -9,6 +9,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { getStreamTabId } from '@/logger/streamUtils';
+import { WorkspaceFS } from '@utils/files';
 
 // Local imports - housekeeping
 import { runPack, runPackSingle, runPackMultiple } from '@housekeeping';
@@ -26,16 +27,17 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
     case 'success':
       if (result.outputFolder) {
         const openFolder = 'Open Folder';
+        const outputFolder = result.outputFolder;
         vscode.window
           .showInformationMessage(
-            `Files packed into ${result.outputFolder}`,
+            `Files packed into ${outputFolder}`,
             openFolder,
           )
           .then((selection) => {
             if (selection === openFolder) {
               void vscode.commands.executeCommand(
                 'revealFileInOS',
-                vscode.Uri.file(result.outputFolder!),
+                vscode.Uri.file(WorkspaceFS.fullPath(outputFolder)),
               );
             }
           });


### PR DESCRIPTION
## Summary
- use WorkspaceFS to normalize pack output path before revealing

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fc9689248324abddf08b174e5f10