### PR TITLE
fix: prevent duplicate intertext wrapping

### DIFF
--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -386,7 +386,7 @@ export function wrapCritiqueInAlign(text: string): string {
     // For each command, wrap bare instances not already inside \intertext
     for (const cmd of ['critique', 'comment']) {
       const regex = new RegExp(
-        `(?<!\\\\intertext\\\\{)\\\\${cmd}{((?:[^{}]|{[^{}]*})*)}`,
+        `(?<!\\\\intertext{)\\\\${cmd}{((?:[^{}]|{[^{}]*})*)}`,
         'g',
       );
       block = block.replace(regex, `\\intertext{\\${cmd}{$1}}`);

--- a/src/test/replacement/wrapCritiqueInAlign.test.ts
+++ b/src/test/replacement/wrapCritiqueInAlign.test.ts
@@ -15,6 +15,12 @@ describe('wrapCritiqueInAlign', () => {
     assert.strictEqual(wrapCritiqueInAlign(input), expected);
   });
 
+  it('wraps bare comment inside align', () => {
+    const input = `\\begin{align}\n\\comment{note}\n\\end{align}`;
+    const expected = `\\begin{align}\n\\intertext{\\comment{note}}\n\\end{align}`;
+    assert.strictEqual(wrapCritiqueInAlign(input), expected);
+  });
+
   it('wraps multiple critiques in same align block', () => {
     const input = `\\begin{align}\na &= b \\\\n\\critique{first}\nc &= d \\\\n\\critique{second}\n\\end{align}`;
     const expected = `\\begin{align}\na &= b \\\\n\\intertext{\\critique{first}}\nc &= d \\\\n\\intertext{\\critique{second}}\n\\end{align}`;
@@ -30,6 +36,12 @@ describe('wrapCritiqueInAlign', () => {
   it('leaves existing intertext wrapping unchanged', () => {
     const input = `\\begin{align}\n\\intertext{\\critique{note}}\n\\end{align}`;
     assert.strictEqual(wrapCritiqueInAlign(input), input);
+  });
+
+  it('is idempotent for comment', () => {
+    const input = `\\begin{align}\n\\comment{note}\n\\end{align}`;
+    const once = wrapCritiqueInAlign(input);
+    assert.strictEqual(wrapCritiqueInAlign(once), once);
   });
 
   it('does not touch critique outside align', () => {


### PR DESCRIPTION
## Summary
- avoid repeatedly wrapping `\comment` and `\critique` in `\intertext`
- add tests to cover comment wrapping and idempotence

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68b6f8b4c7fc83249d13bb7593ec13db