### PR TITLE
fix: unescape underscores in ref commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Generalize output handling and packaging scripts to work with any round count
 - Track total executed rounds in agent statistics
 - Consolidate API key setup alerts into banner to avoid multiple popups
+- Unescape underscores in LaTeX references to remove unnecessary escape characters
 
 ## [0.33.3] - 2025-08-29
 

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -228,13 +228,20 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
     '([Aa]ppendix|[Pp]roblem|[Ss]olution|[Cc]hapter|[Aa]lgorithm|[Ff]igure|[Tt]able|[Ss]ection|[Ee]quation|[Ll]emma|[Cc]orollary|[Pp]roposition|[Tt]heorem|[Ee]qns\\.|[Ee]q\\.)~?\\s*\\ref':
       '$1~\\ref',
 
-    // Unescape underscores in reference commands - first pass
+    // Unescape underscores in reference commands
     // LaTeX references (label names) don't require escaped underscores
+    // We use multiple unique patterns (with subtle regex variations) to handle multiple underscores
+    // Each pattern is applied sequentially, allowing iterative replacement
+    // Pass 1: Using non-greedy match
     '(\\\\(?:cref|ref|eqref)\\{[^{}]*?)\\\\(_)': '$1$2',
-    // Second pass to handle multiple underscores
-    '(\\\\(?:cref|ref|eqref)\\{[^{}]*?)\\\\(_)': '$1$2',
-    // Third pass for edge cases with many underscores
-    '(\\\\(?:cref|ref|eqref)\\{[^{}]*?)\\\\(_)': '$1$2',
+    // Pass 2: Using character class for 'r'
+    '(\\\\(?:c[r]ef|ref|eq[r]ef)\\{[^{}]*?)\\\\(_)': '$1$2',
+    // Pass 3: Using character class for 'e'
+    '(\\\\(?:cr[e]f|r[e]f|eqr[e]f)\\{[^{}]*?)\\\\(_)': '$1$2',
+    // Pass 4: Using character class for 'f'
+    '(\\\\(?:cre[f]|re[f]|eqre[f])\\{[^{}]*?)\\\\(_)': '$1$2',
+    // Pass 5: Using redundant grouping
+    '(\\\\(?:(?:cref)|(?:ref)|(?:eqref))\\{[^{}]*?)\\\\(_)': '$1$2',
 
     // Fix inconsistent blank lines after environments (universally preferred)
     '(\\\\end\\{(equation|align|figure|table|itemize|enumerate|description)\\})([A-Za-z])':

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -228,8 +228,13 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
     '([Aa]ppendix|[Pp]roblem|[Ss]olution|[Cc]hapter|[Aa]lgorithm|[Ff]igure|[Tt]able|[Ss]ection|[Ee]quation|[Ll]emma|[Cc]orollary|[Pp]roposition|[Tt]heorem|[Ee]qns\\.|[Ee]q\\.)~?\\s*\\ref':
       '$1~\\ref',
 
-    // Unescape underscores in reference commands
-    '(?<=\\(?:cref|ref|eqref)\\{[^{}]*)\\_': '_',
+    // Unescape underscores in reference commands - first pass
+    // LaTeX references (label names) don't require escaped underscores
+    '(\\\\(?:cref|ref|eqref)\\{[^{}]*?)\\\\(_)': '$1$2',
+    // Second pass to handle multiple underscores
+    '(\\\\(?:cref|ref|eqref)\\{[^{}]*?)\\\\(_)': '$1$2',
+    // Third pass for edge cases with many underscores
+    '(\\\\(?:cref|ref|eqref)\\{[^{}]*?)\\\\(_)': '$1$2',
 
     // Fix inconsistent blank lines after environments (universally preferred)
     '(\\\\end\\{(equation|align|figure|table|itemize|enumerate|description)\\})([A-Za-z])':

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -228,6 +228,9 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
     '([Aa]ppendix|[Pp]roblem|[Ss]olution|[Cc]hapter|[Aa]lgorithm|[Ff]igure|[Tt]able|[Ss]ection|[Ee]quation|[Ll]emma|[Cc]orollary|[Pp]roposition|[Tt]heorem|[Ee]qns\\.|[Ee]q\\.)~?\\s*\\ref':
       '$1~\\ref',
 
+    // Unescape underscores in reference commands
+    '(?<=\\(?:cref|ref|eqref)\\{[^{}]*)\\_': '_',
+
     // Fix inconsistent blank lines after environments (universally preferred)
     '(\\\\end\\{(equation|align|figure|table|itemize|enumerate|description)\\})([A-Za-z])':
       '$1\n\n$3',

--- a/src/test/replacement/referenceUnderscore.test.ts
+++ b/src/test/replacement/referenceUnderscore.test.ts
@@ -4,9 +4,9 @@ import { applyReplacements } from '@replacement/engine';
 import { EQUATION_STYLE_REPLACEMENTS } from '@replacement/rulesRegex';
 
 describe('reference underscore replacements', () => {
-  it('removes escapes in \\ref', () => {
-    const input = '\\ref{ch:THREE\\_FLUCT\\_THM}';
-    const expected = '\\ref{ch:THREE_FLUCT_THM}';
+  it('handles multiple underscores in one reference', () => {
+    const input = '\\ref{sec\\_one\\_two\\_three}';
+    const expected = '\\ref{sec_one_two_three}';
     const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
       processMathUnicode: false,
     });
@@ -16,6 +16,33 @@ describe('reference underscore replacements', () => {
   it('removes escapes in \\cref and \\eqref', () => {
     const input = '\\cref{sec\\_one} and \\eqref{eq\\_1}';
     const expected = '\\cref{sec_one} and \\eqref{eq_1}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('leaves unescaped underscores unchanged', () => {
+    const input = '\\ref{sec_one\\_two}';
+    const expected = '\\ref{sec_one_two}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('handles multiple references on same line', () => {
+    const input = 'See \\ref{fig\\_1} and \\cref{tab\\_2}';
+    const expected = 'See \\ref{fig_1} and \\cref{tab_2}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('does not affect underscores outside reference commands', () => {
+    const input = '\\textit{some\\_text} \\ref{valid\\_ref}';
+    const expected = '\\textit{some\\_text} \\ref{valid_ref}';
     const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
       processMathUnicode: false,
     });

--- a/src/test/replacement/referenceUnderscore.test.ts
+++ b/src/test/replacement/referenceUnderscore.test.ts
@@ -1,0 +1,24 @@
+import { strict as assert } from 'assert';
+
+import { applyReplacements } from '@replacement/engine';
+import { EQUATION_STYLE_REPLACEMENTS } from '@replacement/rulesRegex';
+
+describe('reference underscore replacements', () => {
+  it('removes escapes in \\ref', () => {
+    const input = '\\ref{ch:THREE\\_FLUCT\\_THM}';
+    const expected = '\\ref{ch:THREE_FLUCT_THM}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('removes escapes in \\cref and \\eqref', () => {
+    const input = '\\cref{sec\\_one} and \\eqref{eq\\_1}';
+    const expected = '\\cref{sec_one} and \\eqref{eq_1}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+});


### PR DESCRIPTION
## Summary
- unescape escaped underscores inside `\cref{}`, `\ref{}`, and `\eqref{}`
- add tests covering reference underscore handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b80d78eaa48324b29cff2d5329fb18