### PR TITLE
fix: derive round count from reflection prompts

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -89,6 +89,7 @@ export abstract class BaseAgent implements IAgent {
     return buildUserVars(
       this.agentConfig,
       this.agentSetting,
+      this.agentPrompt,
       this.agentPath,
       this.modelHandler,
       this.logger,

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -130,7 +130,11 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    * Returns the configured number of conversation rounds.
    */
   protected getNumberOfRounds(): number {
-    return this.agentSetting.rounds ?? 2;
+    const configuredRounds = this.agentSetting.rounds ?? 2;
+    const reflectRounds = Array.isArray(this.agentPrompt.userReflect)
+      ? this.agentPrompt.userReflect.length + 1
+      : 0;
+    return Math.max(configuredRounds, reflectRounds);
   }
 
   /**

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -44,6 +44,7 @@ import { getConfig } from '@utils/config';
 import { K_SLICE } from '@utils/config';
 
 // Local imports - utilities
+import { calculateTotalRounds } from '@agent/utils/roundUtils';
 import { WorkspaceFS } from '@utils/files';
 
 /**
@@ -130,11 +131,10 @@ export abstract class BaseReflectionAgent extends BaseAgent {
    * Returns the configured number of conversation rounds.
    */
   protected getNumberOfRounds(): number {
-    const configuredRounds = this.agentSetting.rounds ?? 2;
-    const reflectRounds = Array.isArray(this.agentPrompt.userReflect)
-      ? this.agentPrompt.userReflect.length + 1
-      : 0;
-    return Math.max(configuredRounds, reflectRounds);
+    return calculateTotalRounds(
+      this.agentSetting.rounds,
+      this.agentPrompt.userReflect,
+    );
   }
 
   /**

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -8,3 +8,4 @@ export * from './priceUtils';
 export * from './text';
 export * from './UsageMonitor';
 export * from './debugMessageSaver';
+export * from './roundUtils';

--- a/src/agent/utils/roundUtils.ts
+++ b/src/agent/utils/roundUtils.ts
@@ -1,0 +1,23 @@
+// Local imports - utilities
+
+/**
+ * Calculate the total number of conversation rounds.
+ *
+ * The configured round count provides a baseline (defaulting to 2).
+ * When user reflection prompts are supplied, each prompt represents
+ * an additional round and we add one more round for the final output
+ * after all reflections. This function returns whichever count is
+ * greater to ensure arrays sized by rounds are correctly allocated.
+ *
+ * @param configuredRounds Number of rounds specified in the agent settings
+ * @param userReflect User-provided reflection prompts
+ * @returns Total number of conversation rounds to execute
+ */
+export function calculateTotalRounds(
+  configuredRounds: number | undefined,
+  userReflect: string | string[] | undefined,
+): number {
+  const rounds = configuredRounds ?? 2;
+  const reflectRounds = Array.isArray(userReflect) ? userReflect.length + 1 : 0;
+  return Math.max(rounds, reflectRounds);
+}

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 // Local imports - agent
 import type { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting } from '../core/AgentDataclass';
+import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
 import type { IModelHandler } from '@agent/modelHandlers';
 import {
   getXmlFormatFromFiles,
@@ -23,6 +23,7 @@ import { WorkspaceFS } from '@utils/files';
 export async function buildUserVars(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
+  agentPrompt: AgentPrompt,
   agentPath: string,
   modelHandler: IModelHandler,
   logger: AgentLogger,
@@ -50,7 +51,7 @@ export async function buildUserVars(
   allLoadedFiles.push(...patternFiles);
 
   Object.assign(userVars, getOutputFilesOrder(agentConfig, agentSetting));
-  Object.assign(userVars, getToolFlags(agentConfig, agentSetting));
+  Object.assign(userVars, getToolFlags(agentConfig, agentSetting, agentPrompt));
 
   // Emit aggregated file list if any files were loaded
   if (allLoadedFiles.length > 0) {
@@ -306,9 +307,14 @@ function getOutputFilesOrder(
 function getToolFlags(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
+  agentPrompt: AgentPrompt,
 ): Record<string, any> {
+  const configuredRounds = agentSetting.rounds ?? 2;
+  const reflectRounds = Array.isArray(agentPrompt.userReflect)
+    ? agentPrompt.userReflect.length + 1
+    : 0;
   return {
-    ROUNDS: agentSetting.rounds ?? 2,
+    ROUNDS: Math.max(configuredRounds, reflectRounds),
     AUTO_EXTRACT_FIGURE: agentConfig.toolConfig.autoExtractFigure,
     AUTO_EXTRACT_TIKZ_FIGURE: agentConfig.toolConfig.autoExtractTikzFigure,
     INCLUDE_TEX_COUNT: agentConfig.toolConfig.attachTeXCount,

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -10,6 +10,7 @@ import {
   getXmlFormatFromFiles,
   getListOfFiles,
 } from '@agent/utils/promptUtils';
+import { calculateTotalRounds } from '@agent/utils/roundUtils';
 import { setVarFromFile } from '@frontend/files/vars';
 
 // Local imports
@@ -309,12 +310,8 @@ function getToolFlags(
   agentSetting: AgentSetting,
   agentPrompt: AgentPrompt,
 ): Record<string, any> {
-  const configuredRounds = agentSetting.rounds ?? 2;
-  const reflectRounds = Array.isArray(agentPrompt.userReflect)
-    ? agentPrompt.userReflect.length + 1
-    : 0;
   return {
-    ROUNDS: Math.max(configuredRounds, reflectRounds),
+    ROUNDS: calculateTotalRounds(agentSetting.rounds, agentPrompt.userReflect),
     AUTO_EXTRACT_FIGURE: agentConfig.toolConfig.autoExtractFigure,
     AUTO_EXTRACT_TIKZ_FIGURE: agentConfig.toolConfig.autoExtractTikzFigure,
     INCLUDE_TEX_COUNT: agentConfig.toolConfig.attachTeXCount,


### PR DESCRIPTION
## Summary
- compute total rounds from reflection prompts and configured rounds
- pass reflection prompts to user variable builder so templates see true round count

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b89c02e65c8324a128d0c062bf7fd1