### PR TITLE
fix: validate API key before agent tasks

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -429,6 +429,7 @@ export async function executeAgent(
 
       // Create model handler
       const modelHandler = ModelFactory.createHandler(modelConfig);
+      await modelHandler.getApiKey();
 
       // Get agent path
       const agentPath = await getAgentPath(fullConfig.agent, context);
@@ -492,6 +493,7 @@ export async function executeMergeAgent(
 
       const modelConfig = MODEL_CONFIGS[model];
       const modelHandler = ModelFactory.createHandler(modelConfig);
+      await modelHandler.getApiKey();
 
       // Get agent path and load settings/prompts
       const agentPath = await getAgentPath('merge', context);

--- a/src/test/agent/apiKeyValidation.test.ts
+++ b/src/test/agent/apiKeyValidation.test.ts
@@ -1,0 +1,56 @@
+import * as assert from 'assert';
+import { describe, it, before } from 'mocha';
+import * as vscode from 'vscode';
+import {
+  executeAgent,
+  executeMergeAgent,
+} from '../../agent/runtime/executeAgent';
+import { SecretManager } from '../../frontend/secretManager';
+import { bus } from '../../eventBus/ProgressEventBus';
+
+const stubContext: any = {
+  secrets: {
+    get: async () => undefined,
+    store: async () => {},
+    delete: async () => {},
+  },
+};
+
+function patchMessageApis() {
+  (vscode.window as any).showInformationMessage = async () => undefined;
+  (vscode.window as any).showErrorMessage = async () => undefined;
+}
+
+async function expectNoProgress(fn: () => Promise<unknown>) {
+  const events: string[] = [];
+  const originalEmit = (bus as any).emit.bind(bus);
+  (bus as any).emit = (event: string, payload: unknown) => {
+    events.push(event);
+    originalEmit(event, payload);
+  };
+  await assert.rejects(fn(), /Missing API key/);
+  assert.deepStrictEqual(events, []);
+  (bus as any).emit = originalEmit;
+}
+
+describe('API key validation', () => {
+  before(() => {
+    SecretManager.initialize(stubContext);
+    patchMessageApis();
+  });
+
+  it('executeAgent fails before progress events when key missing', async () => {
+    await expectNoProgress(() =>
+      executeAgent(
+        { agent: 'polish', model: 'gpt-4o-mini', inputFile: 'input.tex' },
+        {} as any,
+      ),
+    );
+  });
+
+  it('executeMergeAgent fails before progress events when key missing', async () => {
+    await expectNoProgress(() =>
+      executeMergeAgent('gpt-4o-mini', 'input.tex', 'edited.tex', {} as any),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- validate API key immediately after creating model handler for single and merge agents
- add tests confirming missing API key prevents progress events

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails to show full output in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bc9e88ec8324a41d3fba0540654d