### PR TITLE
Fix: Improve model API key banner UX and functionality

### DIFF
--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
-const PROVIDER_URLS: Record<ApiProvider, string> = {
+export const PROVIDER_URLS: Record<ApiProvider, string> = {
   openai: 'https://platform.openai.com/api-keys',
   anthropic: 'https://console.anthropic.com/',
   openRouter: 'https://openrouter.ai/keys',
@@ -22,74 +22,82 @@ export const apiKeyCommands = {
   removeApiKey: 'texra.removeApiKey',
 };
 
+// Helper function to set API key for a specific provider
+async function setApiKeyForProvider(
+  provider: ApiProvider,
+  skipDialog = false,
+): Promise<void> {
+  if (!skipDialog) {
+    const enterKey = 'Enter Key';
+    const getApiKey = 'Get API Key';
+    const action = await vscode.window.showInformationMessage(
+      `Set your ${provider} API key`,
+      enterKey,
+      getApiKey,
+    );
+
+    if (!action) {
+      return;
+    }
+
+    if (action === getApiKey) {
+      await vscode.env.openExternal(vscode.Uri.parse(PROVIDER_URLS[provider]));
+      return;
+    }
+  }
+
+  const apiKey = await vscode.window.showInputBox({
+    prompt: `Enter ${provider} API key`,
+    password: true,
+    placeHolder: '************************************',
+  });
+
+  if (!apiKey) {
+    return;
+  }
+
+  try {
+    await SecretManager.set(
+      SecretManager.getApiKeySecretName(provider),
+      apiKey,
+    );
+    vscode.window.showInformationMessage(`${provider} API key has been set`);
+    await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
+    void vscode.commands.executeCommand('texra.refreshModelOptions');
+    const view = await vscode.commands.executeCommand<vscode.WebviewView>(
+      'texra.getWebviewView',
+    );
+    view?.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
+    });
+  } catch (err) {
+    vscode.window.showErrorMessage(`Failed to set ${provider} API key: ${err}`);
+  }
+}
+
 export function registerApiKeyCommands(context: vscode.ExtensionContext) {
-  // Command to set API key
+  // Command to set API key (accepts optional provider parameter)
   const setApiKeyCommand = vscode.commands.registerCommand(
     apiKeyCommands.setApiKey,
-    async () => {
-      // First select the provider
-      const providerItems = await SecretManager.getApiProviderQuickPickItems();
-      const providerPick = await vscode.window.showQuickPick(providerItems, {
-        placeHolder: 'Select API provider',
-      });
+    async (provider?: ApiProvider) => {
+      let selectedProvider = provider;
+      const skipDialog = !!provider; // Skip dialog if provider was passed
 
-      const provider = providerPick?.provider;
-
-      if (!provider) {
-        return;
-      }
-
-      const enterKey = 'Enter Key';
-      const getApiKey = 'Get API Key';
-      const action = await vscode.window.showInformationMessage(
-        `Set your ${provider} API key`,
-        enterKey,
-        getApiKey,
-      );
-
-      if (!action) {
-        return;
-      }
-
-      if (action === getApiKey) {
-        await vscode.env.openExternal(
-          vscode.Uri.parse(PROVIDER_URLS[provider]),
-        );
-        // User selected "Get API Key" - don't prompt for input
-        return;
-      }
-
-      const apiKey = await vscode.window.showInputBox({
-        prompt: `Enter ${provider} API key`,
-        password: true,
-        placeHolder: '************************************',
-      });
-
-      if (!apiKey) {
-        return;
-      }
-
-      try {
-        await SecretManager.set(
-          SecretManager.getApiKeySecretName(provider as ApiProvider),
-          apiKey,
-        );
-        vscode.window.showInformationMessage(
-          `${provider} API key has been set`,
-        );
-        await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
-        void vscode.commands.executeCommand('texra.refreshModelOptions');
-        const view = await vscode.commands.executeCommand<vscode.WebviewView>(
-          'texra.getWebviewView',
-        );
-        view?.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
+      if (!selectedProvider) {
+        // Show provider selection if no provider specified
+        const providerItems =
+          await SecretManager.getApiProviderQuickPickItems();
+        const providerPick = await vscode.window.showQuickPick(providerItems, {
+          placeHolder: 'Select API provider',
         });
-      } catch (err) {
-        vscode.window.showErrorMessage(
-          `Failed to set ${provider} API key: ${err}`,
-        );
+        selectedProvider = providerPick?.provider;
       }
+
+      if (!selectedProvider) {
+        return;
+      }
+
+      await setApiKeyForProvider(selectedProvider, skipDialog);
     },
   );
 

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -73,6 +73,8 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_MODEL_SETTINGS: 'openModelSettings',
   CLIPBOARD_IMAGE: 'clipboardImage',
   OPEN_SET_API_KEY: 'openSetApiKey',
+  OPEN_SET_PROVIDER_API_KEY: 'openSetProviderApiKey',
+  OPEN_PROVIDER_API_KEY_URL: 'openProviderApiKeyUrl',
   OPEN_API_KEY_GUIDE: 'openApiKeyGuide',
   SHOW_API_KEY_BANNER: 'showApiKeyBanner',
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -73,6 +73,8 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_MODEL_SETTINGS: 'openModelSettings',
   CLIPBOARD_IMAGE: 'clipboardImage',
   OPEN_SET_API_KEY: 'openSetApiKey',
+  OPEN_SET_PROVIDER_API_KEY: 'openSetProviderApiKey',
+  OPEN_PROVIDER_API_KEY_URL: 'openProviderApiKeyUrl',
   OPEN_API_KEY_GUIDE: 'openApiKeyGuide',
   SHOW_API_KEY_BANNER: 'showApiKeyBanner',
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -25,8 +25,8 @@ function formatCost(inputPrice?: number, outputPrice?: number): string {
 
 /**
  * Compute model <option> tags based on available API keys.
- * Models without a required key are marked as disabled with a "(no key)" label
- * and include both disabled and data-requires-key attributes for proper handling.
+ * Models missing a required key receive a "(no key)" label and attributes so the
+ * webview can handle API key setup prompts.
  */
 export async function computeModelOptions(): Promise<string> {
   const models = getConfig<string[]>('models', []);
@@ -63,7 +63,7 @@ export async function computeModelOptions(): Promise<string> {
       const label = available ? model : `${model} (no key)`;
       const requiresKeyAttr = available
         ? ''
-        : ' disabled data-requires-key="true" class="disabled-model"';
+        : ' data-requires-key="true" class="disabled-model"';
 
       // Build data attributes, only including them if values are defined
       const providerAttr = provider ? ` data-provider="${provider}"` : '';

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -21,6 +21,7 @@ import { getConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { computeModelOptions } from '@model/computeModelOptions';
+import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly settingsManager: SettingsManager;
@@ -143,12 +144,35 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.instructionManager.handleClipboardImage(m, w),
       [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: async () =>
         safeExecuteCommand('texra.setApiKey'),
+      [MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY]: async (m) => {
+        // Reuse existing setApiKey command with provider parameter
+        if (m?.provider) {
+          await safeExecuteCommand('texra.setApiKey', m.provider);
+        }
+      },
+      [MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL]: async (m) => {
+        // Open provider-specific API key page
+        if (m?.provider) {
+          const url = PROVIDER_URLS[m.provider as keyof typeof PROVIDER_URLS];
+          if (url) {
+            await vscode.env.openExternal(vscode.Uri.parse(url));
+          }
+        }
+      },
       [MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE]: async () => {
         await vscode.env.openExternal(
           vscode.Uri.parse(
             'https://texra.ai/guide/installation#setting-up-api-keys',
           ),
         );
+      },
+      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: async (m, w) => {
+        /* Banner handled client-side */
+        w.webview.postMessage(m);
+      },
+      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: async (m, w) => {
+        /* Banner handled client-side */
+        w.webview.postMessage(m);
       },
 
       // Recording commands

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -50,17 +50,6 @@
 
   <body>
     <div class="content-wrapper">
-      <div id="apiKeyBanner" class="api-key-banner" style="display: none">
-        <span>TeXRA requires an API key to run.</span>
-        <div class="actions">
-          <button id="apiKeyBannerButton" class="vscode-button" data-icon="key">
-            Set API Key
-          </button>
-          <button id="apiKeyGuideButton" class="vscode-button" data-icon="book">
-            API Key Guide
-          </button>
-        </div>
-      </div>
       <div class="main-content">
         <div class="file-selection-group">
           <div class="file-select">
@@ -489,7 +478,29 @@
             data-icon="play"
           ></button>
         </div>
+
+        <!-- API Key Banner -->
+        <div id="apiKeyBanner" class="api-key-banner" style="display: none">
+          <span>TeXRA requires an API key to run.</span>
+          <div class="actions">
+            <button
+              id="apiKeyBannerButton"
+              class="vscode-button"
+              data-icon="key"
+            >
+              Set API Key
+            </button>
+            <button
+              id="apiKeyGuideButton"
+              class="vscode-button"
+              data-icon="book"
+            >
+              API Key Guide
+            </button>
+          </div>
+        </div>
       </div>
+
       <div class="latexdiffs-section">
         <div class="file-select-header">
           <div class="file-select-label-group">

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -84,9 +84,22 @@ export class MainViewDomHandler {
     );
     if (apiKeyButton) {
       this.apiKeyButtonHandler = () => {
-        vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY,
-        });
+        // Get provider from banner element to determine which setup to open
+        const banner = document.getElementById(ELEMENT_IDS.API_KEY_BANNER);
+        const provider = banner?.dataset?.provider;
+
+        if (provider) {
+          // Provider-specific context - use provider-specific API key setup
+          vscode.postMessage({
+            command: MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY,
+            provider,
+          });
+        } else {
+          // General context - use generic API key setup
+          vscode.postMessage({
+            command: MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY,
+          });
+        }
       };
       apiKeyButton.addEventListener('click', this.apiKeyButtonHandler);
     }
@@ -96,9 +109,22 @@ export class MainViewDomHandler {
     );
     if (apiKeyGuideButton) {
       this.apiKeyGuideButtonHandler = () => {
-        vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE,
-        });
+        // Get provider from banner element to determine which action to take
+        const banner = document.getElementById(ELEMENT_IDS.API_KEY_BANNER);
+        const provider = banner?.dataset?.provider;
+
+        if (provider) {
+          // Provider-specific context - open provider's API key page
+          vscode.postMessage({
+            command: MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL,
+            provider,
+          });
+        } else {
+          // General context - open TeXRA's API key guide
+          vscode.postMessage({
+            command: MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE,
+          });
+        }
       };
       apiKeyGuideButton.addEventListener(
         'click',

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -9,7 +9,6 @@ import {
   BASE_FILE,
   ELEMENT_IDS,
 } from './constants.js';
-import { mainViewDomHandler } from './domHandlers.js';
 import { webviewEventBus } from './eventBus.js';
 import { createFileHandlers } from './handlers/fileHandlers.js';
 import { createRecordingHandlers } from './handlers/recordingHandlers.js';
@@ -19,7 +18,6 @@ import { createThemeHandlers } from './handlers/themeHandlers.js';
 import { mainViewState } from './mainViewState.js';
 
 // Local imports - UI managers
-import { fileList } from './uiManagers/FileList.js';
 import { fileSelect } from './uiManagers/FileSelect.js';
 import {
   safeSetElementValue,
@@ -67,11 +65,29 @@ export class MainViewMessageHandler {
         const element = this._getElement(ELEMENT_IDS.API_KEY_BANNER);
         if (element) {
           const textSpan = element.querySelector('span');
-          if (textSpan && m?.provider) {
-            // Capitalize provider name for better UX
-            const providerName =
-              m.provider.charAt(0).toUpperCase() + m.provider.slice(1);
-            textSpan.textContent = `Missing ${providerName} API key.`;
+          const setButton = element.querySelector('#apiKeyBannerButton');
+          const getButton = element.querySelector('#apiKeyGuideButton');
+
+          if (textSpan && setButton && getButton) {
+            if (m?.provider) {
+              // Provider-specific context
+              const providerName =
+                m.provider.charAt(0).toUpperCase() + m.provider.slice(1);
+              textSpan.innerHTML = `<strong>${providerName}</strong> API key missing.`;
+              setButton.textContent = `Set Key`;
+              getButton.textContent = `Get Key`;
+
+              // Store provider info for click handlers
+              element.dataset.provider = m.provider;
+            } else {
+              // General context (no specific provider)
+              textSpan.textContent = `TeXRA requires an API key to run.`;
+              setButton.textContent = `Set API Key`;
+              getButton.textContent = `API Key Guide`;
+
+              // Clear provider info
+              delete element.dataset.provider;
+            }
           }
           element.style.setProperty('display', 'flex');
         }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -117,49 +117,33 @@ export class SettingsButtonManager extends BaseUIManager {
       });
     });
 
-    // Track the previous valid selection
-    let previousModelValue = null;
-
-    this.addListener('model', 'focus', (e) => {
-      // Store the current value when focus is gained
-      previousModelValue = e.target.value;
-    });
-
     this.addListener('model', 'change', (e) => {
       const selectElement = e.target;
       const selectedOption = selectElement.options[selectElement.selectedIndex];
 
-      // Check if the selected option requires an API key (using data attribute)
-      // The disabled attribute prevents selection in most browsers, but this is a fallback
-      if (selectedOption?.dataset?.requiresKey) {
-        // Revert to previous value
-        if (previousModelValue !== null) {
-          selectElement.value = previousModelValue;
-        }
+      // Always notify about model selection
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
+        model: selectElement.value,
+      });
+      this.state.save();
 
+      // Check if the selected option requires an API key (using data attribute)
+      // Show banner to guide API key setup if needed
+      if (selectedOption?.dataset?.requiresKey === 'true') {
         // Get provider from the option
         const provider = selectedOption?.dataset?.provider || 'Unknown';
 
-        // Open appropriate API key setup
-        const command =
-          provider.toLowerCase() === 'openrouter'
-            ? MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE
-            : MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY;
-        this.vscode.postMessage({ command });
-
-        // Show banner with provider info
+        // Show banner with provider info - user can click banner button to access setup
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
           provider,
         });
       } else {
-        // Valid selection - update the previous value and proceed normally
-        previousModelValue = selectElement.value;
+        // Hide banner for models that don't require API keys
         this.vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
-          model: selectElement.value,
+          command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
         });
-        this.state.save();
       }
     });
   }

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -93,7 +93,9 @@
 
 /* Disabled model option styling */
 option.disabled-model,
-option[data-requires-key='true'],
-option[disabled] {
+option[data-requires-key='true'] {
   color: var(--vscode-descriptionForeground);
+  opacity: 0.6;
+  font-style: italic;
+  background-color: var(--vscode-input-background);
 }


### PR DESCRIPTION
## Summary

- Fix disabled model selection to show provider-specific banner
- Enable selection of models without API keys (no reversion) 
- Add provider-specific banner with direct actions
- Improve visual styling and reduce repetitive text
- Follow DRY principle with existing API key logic

## Changes Made

### 🎯 **Core Functionality Fixes**
- **Fixed data attribute check**: Models without API keys now trigger banner correctly (`data-requires-key="true"` → `dataset.requiresKey`)
- **Removed selection reversion**: Users can now select models without keys and get guidance via banner
- **Added provider-specific actions**: Banner shows contextual buttons based on selected model's provider

### 🎨 **UI/UX Improvements**
- **Enhanced visual styling**: Disabled models now appear grayed out (60% opacity, italic, muted colors)
- **Repositioned banner**: Moved below model/agent/instruction section for better visual flow
- **Reduced repetitive text**: 
  - Before: "Missing Xai API key" + "Set Xai API Key" + "Get Xai API Key"  
  - After: "**Xai** API key missing." + "Set Key" + "Get Key"

### 🔧 **Technical Implementation**  
- **Provider-specific banner logic**: Shows appropriate message and actions per provider
- **Context-aware button behavior**:
  - **Set Key**: Direct input dialog (skips provider selection when called from banner)
  - **Get Key**: Opens provider's API page OR TeXRA guide (context-dependent)
- **DRY principle**: Enhanced existing `setApiKey` command to accept provider parameter instead of duplicating code

## Test Plan

- [x] Select model without API key → Banner appears with provider name
- [x] Click "Set Key" → Direct input dialog for that provider (no intermediate steps)  
- [x] Click "Get Key" → Opens provider's API key page directly
- [x] Select model with API key → Banner hides
- [x] Models without keys appear visually disabled but remain selectable
- [x] Banner positioned correctly below instruction section

## Expected Behavior

**Before**: Models without keys → General popup → Provider selection → Another dialog  
**After**: Models without keys → Provider-specific banner → Direct action

This creates a smooth, intuitive user experience with minimal clicks and clear visual feedback.

🤖 Generated with [Claude Code](https://claude.ai/code)