### PR TITLE
feat: warn when agent config is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Disable agents with missing YAML in the picker and allow refreshing options
+
+### Bug Fixes
+
+- Warn instead of throwing when agent configuration is missing
+
 ## [0.33.5] - 2025-09-05
 
 ### Features

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -1,0 +1,66 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import { globSync } from 'glob';
+
+// Local imports - utilities
+import { getConfig } from '@utils/config';
+import { GlobalStorageFS, AbsoluteFS } from '@utils/files';
+
+/**
+ * Compute agent <option> tags, disabling entries whose YAML definition
+ * cannot be found in any configured directory.
+ */
+export function computeAgentOptions(): string {
+  const agents = getConfig<string[]>('agents', []);
+  const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
+  const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
+  let extraAgents: string[] = [];
+  if (includeToolUse) {
+    try {
+      extraAgents = AbsoluteFS.readDirSync(toolUseDir)
+        .filter((f) => f.endsWith('.yaml'))
+        .map((f) => path.basename(f, '.yaml'));
+    } catch {
+      extraAgents = [];
+    }
+  }
+  const allAgents = Array.from(new Set([...agents, ...extraAgents]));
+
+  const customDir = getConfig<string>('explorer.agentsDirectory', '');
+  const builtInDir = GlobalStorageFS.fullPath('agents');
+  const builtInToolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
+
+  const optionTags = allAgents.map((agent) => {
+    const fileName = `${agent}.yaml`;
+    let exists = false;
+    if (customDir && path.isAbsolute(customDir)) {
+      const matches = globSync(`**/${fileName}`, {
+        cwd: customDir,
+        nodir: true,
+        dot: false,
+      });
+      exists = matches.length > 0;
+    }
+    if (!exists) {
+      const builtInMatch = globSync(`**/${fileName}`, {
+        cwd: builtInDir,
+        nodir: true,
+        dot: false,
+      });
+      const toolUseMatch = globSync(`**/${fileName}`, {
+        cwd: builtInToolUseDir,
+        nodir: true,
+        dot: false,
+      });
+      exists = builtInMatch.length > 0 || toolUseMatch.length > 0;
+    }
+    const missingAttr = exists
+      ? ''
+      : ' class="disabled-agent" title="Agent configuration not found"';
+    return `<option value="${agent}"${missingAttr}>${agent}</option>`;
+  });
+
+  return optionTags.join('\n');
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -60,7 +60,7 @@ type AgentConstructor = {
 export async function getAgentPath(
   agentName: string,
   context: vscode.ExtensionContext,
-): Promise<string> {
+): Promise<string | undefined> {
   try {
     // First check custom agents directory
     const customDir = await agentDirectories.custom();
@@ -98,25 +98,22 @@ export async function getAgentPath(
     const allMatches = [...builtInMatches, ...toolUseMatches];
 
     if (allMatches.length === 0) {
+      logger.warn(`Could not find yaml file for agent: ${agentName}`);
       const configureButton = 'Open Settings';
-      await showInstructionWithSuppress(
-        'agentNotFound',
-        'Agent configuration is missing. Configure your custom agents directory and ensure the YAML file exists.',
-        [
-          {
-            title: configureButton,
-            callback: () =>
-              vscode.commands.executeCommand(
-                'workbench.action.openSettings',
-                '@ext:texra-ai.texra explorer.agentsDirectory',
-              ),
-          },
-        ],
-        false,
-      );
-
-      const errorMsg = `Could not find yaml file for agent: ${agentName}`;
-      throw new Error(errorMsg);
+      vscode.window
+        .showWarningMessage(
+          'Agent configuration is missing. Configure your custom agents directory and ensure the YAML file exists.',
+          configureButton,
+        )
+        .then((selection) => {
+          if (selection === configureButton) {
+            vscode.commands.executeCommand(
+              'workbench.action.openSettings',
+              '@ext:texra-ai.texra explorer.agentsDirectory',
+            );
+          }
+        });
+      return undefined;
     }
 
     // Return the directory containing the yaml file
@@ -126,8 +123,9 @@ export async function getAgentPath(
     return path.join(builtInToolUseDir, path.dirname(toolUseMatches[0]));
   } catch (err) {
     const errorMsg = `Error finding agent path: ${err instanceof Error ? err.message : String(err)}`;
-    vscode.window.showErrorMessage(errorMsg);
-    throw new Error(errorMsg);
+    logger.warn(errorMsg);
+    vscode.window.showWarningMessage(errorMsg);
+    return undefined;
   }
 }
 
@@ -398,40 +396,43 @@ export async function executeAgent(
 
   const agentName = getAgentName(agentConfig.agent, agentConfig.outputFiles);
 
+  // Create full agent config
+  const fullConfig = AgentConfigSchema.parse(agentConfig);
+
+  // Get model configuration
+  const modelName = fullConfig.model;
+  if (!(modelName in MODEL_CONFIGS)) {
+    const openDocs = 'Model Documentation';
+    await showInstructionWithSuppress(
+      'modelNotRecognized',
+      `Model "${modelName}" is not recognized. Review the documentation for supported models.`,
+      [
+        {
+          title: openDocs,
+          callback: () =>
+            vscode.commands.executeCommand('texra.openDoc', 'models'),
+        },
+      ],
+      false,
+    );
+    throw new Error(`Model ${modelName} not found in MODEL_CONFIGS`);
+  }
+
+  const modelConfig = MODEL_CONFIGS[modelName];
+  modelConfig.toolConfig = fullConfig.toolConfig;
+
+  const agentPath = await getAgentPath(fullConfig.agent, context);
+  if (!agentPath) {
+    vscode.window.showWarningMessage(
+      `Agent "${fullConfig.agent}" is unavailable. Configure the agent and try again.`,
+    );
+    return;
+  }
+
   await executeAgentWithLogging(
     agentName,
     async () => {
-      // Create full agent config
-      const fullConfig = AgentConfigSchema.parse(agentConfig);
-
-      // Get model configuration
-      const modelName = fullConfig.model;
-      if (!(modelName in MODEL_CONFIGS)) {
-        const openDocs = 'Model Documentation';
-        await showInstructionWithSuppress(
-          'modelNotRecognized',
-          `Model "${modelName}" is not recognized. Review the documentation for supported models.`,
-          [
-            {
-              title: openDocs,
-              callback: () =>
-                vscode.commands.executeCommand('texra.openDoc', 'models'),
-            },
-          ],
-          false,
-        );
-        throw new Error(`Model ${modelName} not found in MODEL_CONFIGS`);
-      }
-
-      const modelConfig = MODEL_CONFIGS[modelName];
-      // Only set toolConfig reference - no need to override openRouterOnly
-      modelConfig.toolConfig = fullConfig.toolConfig;
-
-      // Create model handler
       const modelHandler = ModelFactory.createHandler(modelConfig);
-
-      // Get agent path
-      const agentPath = await getAgentPath(fullConfig.agent, context);
 
       // Load settings and prompts
       const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
@@ -465,11 +466,17 @@ export async function executeMergeAgent(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   const agentName = 'merge';
+  const agentPath = await getAgentPath('merge', context);
+  if (!agentPath) {
+    vscode.window.showWarningMessage(
+      'Merge agent configuration is missing. Configure the agent and try again.',
+    );
+    return;
+  }
 
   await executeAgentWithLogging(
     agentName,
     async () => {
-      // Create agent config for merge operation
       const agentConfig = AgentConfigSchema.parse({
         agent: 'merge',
         model,
@@ -477,7 +484,6 @@ export async function executeMergeAgent(
         editedFile,
       });
 
-      // Get model configuration
       if (!(model in MODEL_CONFIGS)) {
         const openDocs = 'Model Documentation';
         const choice = await vscode.window.showErrorMessage(
@@ -492,9 +498,6 @@ export async function executeMergeAgent(
 
       const modelConfig = MODEL_CONFIGS[model];
       const modelHandler = ModelFactory.createHandler(modelConfig);
-
-      // Get agent path and load settings/prompts
-      const agentPath = await getAgentPath('merge', context);
       const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
         agentPath,
         'merge',

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -6,10 +6,12 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 // Local imports - utilities
 import { safeExecuteCommand } from '@utils/system';
 import { computeModelOptions } from '@model/computeModelOptions';
+import { computeAgentOptions } from '@agent/computeAgentOptions';
 
 export const mainViewCommands = {
   reset: 'texra.mainView.reset',
   refreshModelOptions: 'texra.refreshModelOptions',
+  refreshAgentOptions: 'texra.refreshAgentOptions',
 };
 
 /**
@@ -66,7 +68,40 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
     },
   );
 
-  context.subscriptions.push(resetCommand, refreshModelOptionsCommand);
+  const refreshAgentOptionsCommand = vscode.commands.registerCommand(
+    mainViewCommands.refreshAgentOptions,
+    async () => {
+      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
+        'texra.getWebviewView',
+        [],
+        'mainViewCommands',
+      );
+      if (webviewView) {
+        try {
+          const options = computeAgentOptions();
+          webviewView.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+            options,
+          });
+        } catch (error) {
+          console.error('Failed to refresh agent options:', error);
+          vscode.window.showErrorMessage(
+            'Failed to refresh agent options. Please check the output console for details.',
+          );
+        }
+      }
+    },
+  );
 
-  return { resetCommand, refreshModelOptionsCommand };
+  context.subscriptions.push(
+    resetCommand,
+    refreshModelOptionsCommand,
+    refreshAgentOptionsCommand,
+  );
+
+  return {
+    resetCommand,
+    refreshModelOptionsCommand,
+    refreshAgentOptionsCommand,
+  };
 }

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -164,6 +164,12 @@ export async function handleLoadSpecificAgent(
 
     // Use getAgentPath to find the agent's directory
     const agentPath = await getAgentPath(agentName, context);
+    if (!agentPath) {
+      vscode.window.showWarningMessage(
+        `Agent "${agentName}" configuration not found. Configure the agent and try again.`,
+      );
+      return;
+    }
     logger.info(CHANNEL, `Loading from path: ${agentPath}`);
 
     // Load and display the agent configuration

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -98,6 +98,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
   SET_MODEL_OPTIONS: 'setModelOptions',
+  SET_AGENT_OPTIONS: 'setAgentOptions',
 
   // File refresh and update operations
   REFRESH_ALL_FILES: 'refreshAllFiles',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -98,6 +98,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
   SET_MODEL_OPTIONS: 'setModelOptions',
+  SET_AGENT_OPTIONS: 'setAgentOptions',
 
   // File refresh and update operations
   REFRESH_ALL_FILES: 'refreshAllFiles',

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-import * as path from 'path';
 
 // Third-party imports
 import * as vscode from 'vscode';
@@ -7,7 +6,7 @@ import * as vscode from 'vscode';
 // Local imports - webview
 import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
 import { getConfig } from '@utils/config';
-import { GlobalStorageFS, AbsoluteFS } from '@utils/files';
+import { computeAgentOptions } from '@agent/computeAgentOptions';
 
 export class MainViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
@@ -97,25 +96,7 @@ export class MainViewContentProvider extends BaseViewContentProvider {
   }
 
   protected getTemplateVariables(): Record<string, any> {
-    const agents = getConfig<string[]>('agents', []);
-    const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
-    const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
-    let extraAgents: string[] = [];
-    if (includeToolUse) {
-      try {
-        const files = AbsoluteFS.readDirSync(toolUseDir);
-        extraAgents = files
-          .filter((f) => f.endsWith('.yaml'))
-          .map((f) => path.basename(f, '.yaml'));
-      } catch {
-        extraAgents = [];
-      }
-    }
-    const allAgents = Array.from(new Set([...agents, ...extraAgents]));
-    const agentOptions = allAgents
-      .map((agent) => `<option value="${agent}">${agent}</option>`)
-      .join('\n');
-
+    const agentOptions = computeAgentOptions();
     const models = getConfig<string[]>('models', []);
     const modelOptions = models
       .map((model) => `<option value="${model}">${model}</option>`)

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -21,6 +21,7 @@ import { getConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { computeModelOptions } from '@model/computeModelOptions';
+import { computeAgentOptions } from '@agent/computeAgentOptions';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
@@ -290,15 +291,20 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   ): Promise<void> {
     await super.handleWebviewReady(_message, webviewView);
     try {
-      const options = await computeModelOptions();
+      const modelOptions = await computeModelOptions();
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-        options,
+        options: modelOptions,
+      });
+      const agentOptions = computeAgentOptions();
+      webviewView.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+        options: agentOptions,
       });
     } catch (error) {
       this.logger.error(
         this.channel,
-        `Failed to compute model options: ${
+        `Failed to compute dropdown options: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -144,6 +144,13 @@ export class FileManager {
 
     try {
       const agentPath = await getAgentPath(agent, this.context);
+      if (!agentPath) {
+        webviewView.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES,
+          files: [],
+        });
+        return;
+      }
       const [settings] = await loadAgentSettingAndPrompts(agentPath, agent);
       const files = Array.isArray(settings?.defaultOutputFiles)
         ? settings.defaultOutputFiles

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -47,6 +47,8 @@ export class MainViewMessageHandler {
     this._fileListHandlers = {};
     // Flag to prevent concurrent retry attempts for model options
     this._modelOptionsRetryInProgress = false;
+    // Flag to prevent concurrent retry attempts for agent options
+    this._agentOptionsRetryInProgress = false;
 
     const ctx = {
       postHandle: this._postHandle.bind(this),
@@ -154,6 +156,54 @@ export class MainViewMessageHandler {
           };
 
           setTimeout(tryApplyOptions, retryDelay[0]);
+          retryCount = 1;
+          return;
+        }
+
+        applyOptions(select);
+      },
+      [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: (m) => {
+        if (!m.options) {
+          console.warn('SET_AGENT_OPTIONS: No options provided');
+          return;
+        }
+
+        const applyOptions = (selectElement) => {
+          const previous = selectElement.value;
+          selectElement.innerHTML = m.options;
+          if (previous) {
+            selectElement.value = previous;
+          }
+        };
+
+        const select = document.getElementById('agent');
+        if (!select) {
+          if (this._agentOptionsRetryInProgress) {
+            console.warn('SET_AGENT_OPTIONS: Retry already in progress');
+            return;
+          }
+          this._agentOptionsRetryInProgress = true;
+          let retryCount = 0;
+          const maxRetries = 5;
+          const retryDelay = [100, 200, 400, 800, 1600];
+
+          const tryApply = () => {
+            const retrySelect = document.getElementById('agent');
+            if (retrySelect) {
+              applyOptions(retrySelect);
+              this._agentOptionsRetryInProgress = false;
+            } else if (retryCount < maxRetries) {
+              setTimeout(tryApply, retryDelay[retryCount]);
+              retryCount++;
+            } else {
+              console.warn(
+                'SET_AGENT_OPTIONS: Agent select element not found after retries',
+              );
+              this._agentOptionsRetryInProgress = false;
+            }
+          };
+
+          setTimeout(tryApply, retryDelay[0]);
           retryCount = 1;
           return;
         }

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -93,6 +93,7 @@
 
 /* Disabled model option styling */
 option.disabled-model,
+option.disabled-agent,
 option[data-requires-key='true'] {
   color: var(--vscode-descriptionForeground);
   opacity: 0.6;


### PR DESCRIPTION
## Summary
- disable agents without YAML definitions in dropdown and refresh options on demand
- warn instead of error when an agent's configuration is missing

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc937c61548324bf1424515d895ee8