### PR TITLE
feat: add agent config banner and dropdown indicators

### DIFF
--- a/docs/guide/agent-explorer.md
+++ b/docs/guide/agent-explorer.md
@@ -43,3 +43,11 @@ Available actions for **Custom Agents** include:
 ## Relationship to Custom Agent Creation
 
 The Agent Explorer is where you manage the files you create following the steps in the [Custom Agents](./custom-agents.md) guide. Use the explorer to organize your agent `.yaml` files effectively.
+
+## Agent Configuration Alerts
+
+When an agent name is listed in `texra.agents` but its YAML file is missing, the
+agent appears disabled in the main view dropdown. Choosing such an entry shows a
+banner offering to edit the agent list, open or set the custom agents directory,
+or view documentation. Agents that include a companion `<agent>_multiple.yaml`
+are flagged with a codicon in the dropdown to indicate multi-output support.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -31,10 +31,16 @@ Control which agents are available in the dropdown menu. Below is the default li
   "paper2note",
   "polish_cover",
   "solve_qi",
-  "transcribe_audio"
+"transcribe_audio"
   // Additional custom agents can be added here
 ]
 ```
+
+If an agent listed here lacks a corresponding `.yaml` file, it appears disabled
+in the main view. A banner provides quick actions to edit the list, set or open
+the custom agents directory, or read the documentation. Agents with a matching
+`_multiple.yaml` file show a codicon next to their name to indicate multi-output
+support.
 
 ### Model Configuration
 

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
               "gptoss",
               "o3",
               "o4-",
-              "grok4"
+              "grok4",
+              "kimi2"
             ],
             "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen3 Max), qwenplus (Qwen3 Plus 2025-07-28), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
             "scope": "resource"

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -32,13 +32,32 @@ export async function computeAgentOptions(
   context: vscode.ExtensionContext,
 ): Promise<string> {
   const agents = getConfig<string[]>('agents', []);
+  const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
+
+  // Get tool-use agents if enabled
+  let allAgents = [...agents];
+  if (includeToolUse) {
+    const toolUseDir = await agentDirectories.builtInToolUse(context);
+    try {
+      const toolUseFiles = await glob('**/*.yaml', {
+        cwd: toolUseDir,
+        dot: false,
+        nodir: true,
+        absolute: false,
+      });
+      const toolUseAgents = toolUseFiles.map((f) => f.replace(/\.yaml$/, '').replace(/.*\//, ''));
+      allAgents = Array.from(new Set([...agents, ...toolUseAgents]));
+    } catch {
+      // If tool-use directory doesn't exist or can't be read, just use base agents
+    }
+  }
 
   const customDir = await agentDirectories.custom();
   const builtInDir = await agentDirectories.builtIn(context);
   const builtInToolUseDir = await agentDirectories.builtInToolUse(context);
 
   const optionTags = await Promise.all(
-    agents.map(async (agent) => {
+    allAgents.map(async (agent) => {
       const yamlExists =
         (await fileExists(customDir, `**/${agent}.yaml`)) ||
         (await fileExists(builtInDir, `**/${agent}.yaml`)) ||
@@ -49,7 +68,9 @@ export async function computeAgentOptions(
         (await fileExists(builtInDir, `**/${agent}_multiple.yaml`)) ||
         (await fileExists(builtInToolUseDir, `**/${agent}_multiple.yaml`));
 
-      const disabledAttr = yamlExists ? '' : ' class="disabled-option disabled-agent"';
+      const disabledAttr = yamlExists
+        ? ''
+        : ' class="disabled-option disabled-agent"';
       const multipleAttr = multipleExists ? ' data-multiple="true"' : '';
 
       return `<option value="${agent}"${disabledAttr}${multipleAttr}>${agent}</option>`;

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -49,7 +49,7 @@ export async function computeAgentOptions(
         (await fileExists(builtInDir, `**/${agent}_multiple.yaml`)) ||
         (await fileExists(builtInToolUseDir, `**/${agent}_multiple.yaml`));
 
-      const disabledAttr = yamlExists ? '' : ' class="disabled-agent" disabled';
+      const disabledAttr = yamlExists ? '' : ' class="disabled-agent"';
       const multipleAttr = multipleExists ? ' data-multiple="true"' : '';
 
       return `<option value="${agent}"${disabledAttr}${multipleAttr}>${agent}</option>`;

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -9,7 +9,9 @@ import { getConfig } from '@utils/config';
 /**
  * Get all available agents including tool-use agents if enabled.
  */
-export async function getAllAgents(context: vscode.ExtensionContext): Promise<string[]> {
+export async function getAllAgents(
+  context: vscode.ExtensionContext,
+): Promise<string[]> {
   const agents = getConfig<string[]>('agents', []);
   const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
 
@@ -26,7 +28,9 @@ export async function getAllAgents(context: vscode.ExtensionContext): Promise<st
       nodir: true,
       absolute: false,
     });
-    const toolUseAgents = toolUseFiles.map((f) => f.replace(/\.yaml$/, '').replace(/.*\//, ''));
+    const toolUseAgents = toolUseFiles.map((f) =>
+      f.replace(/\.yaml$/, '').replace(/.*\//, ''),
+    );
     return Array.from(new Set([...agents, ...toolUseAgents]));
   } catch {
     // If tool-use directory doesn't exist or can't be read, just use base agents

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -7,6 +7,34 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { getConfig } from '@utils/config';
 
 /**
+ * Get all available agents including tool-use agents if enabled.
+ */
+export async function getAllAgents(context: vscode.ExtensionContext): Promise<string[]> {
+  const agents = getConfig<string[]>('agents', []);
+  const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
+
+  if (!includeToolUse) {
+    return agents;
+  }
+
+  // Get tool-use agents
+  const toolUseDir = await agentDirectories.builtInToolUse(context);
+  try {
+    const toolUseFiles = await glob('**/*.yaml', {
+      cwd: toolUseDir,
+      dot: false,
+      nodir: true,
+      absolute: false,
+    });
+    const toolUseAgents = toolUseFiles.map((f) => f.replace(/\.yaml$/, '').replace(/.*\//, ''));
+    return Array.from(new Set([...agents, ...toolUseAgents]));
+  } catch {
+    // If tool-use directory doesn't exist or can't be read, just use base agents
+    return agents;
+  }
+}
+
+/**
  * Check if a YAML file exists for the given agent name under the provided directory.
  */
 async function fileExists(dir: string, pattern: string): Promise<boolean> {
@@ -23,6 +51,17 @@ async function fileExists(dir: string, pattern: string): Promise<boolean> {
 }
 
 /**
+ * Get all agent directories.
+ */
+async function getAgentDirectories(context: vscode.ExtensionContext) {
+  return {
+    custom: await agentDirectories.custom(),
+    builtIn: await agentDirectories.builtIn(context),
+    builtInToolUse: await agentDirectories.builtInToolUse(context),
+  };
+}
+
+/**
  * Compute agent <option> tags for the agent dropdown.
  * Agents missing a YAML definition are marked as disabled and cannot be selected.
  * A codicon indicator is added via data-multiple when a corresponding
@@ -31,42 +70,20 @@ async function fileExists(dir: string, pattern: string): Promise<boolean> {
 export async function computeAgentOptions(
   context: vscode.ExtensionContext,
 ): Promise<string> {
-  const agents = getConfig<string[]>('agents', []);
-  const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
-
-  // Get tool-use agents if enabled
-  let allAgents = [...agents];
-  if (includeToolUse) {
-    const toolUseDir = await agentDirectories.builtInToolUse(context);
-    try {
-      const toolUseFiles = await glob('**/*.yaml', {
-        cwd: toolUseDir,
-        dot: false,
-        nodir: true,
-        absolute: false,
-      });
-      const toolUseAgents = toolUseFiles.map((f) => f.replace(/\.yaml$/, '').replace(/.*\//, ''));
-      allAgents = Array.from(new Set([...agents, ...toolUseAgents]));
-    } catch {
-      // If tool-use directory doesn't exist or can't be read, just use base agents
-    }
-  }
-
-  const customDir = await agentDirectories.custom();
-  const builtInDir = await agentDirectories.builtIn(context);
-  const builtInToolUseDir = await agentDirectories.builtInToolUse(context);
+  const allAgents = await getAllAgents(context);
+  const dirs = await getAgentDirectories(context);
 
   const optionTags = await Promise.all(
     allAgents.map(async (agent) => {
       const yamlExists =
-        (await fileExists(customDir, `**/${agent}.yaml`)) ||
-        (await fileExists(builtInDir, `**/${agent}.yaml`)) ||
-        (await fileExists(builtInToolUseDir, `**/${agent}.yaml`));
+        (await fileExists(dirs.custom, `**/${agent}.yaml`)) ||
+        (await fileExists(dirs.builtIn, `**/${agent}.yaml`)) ||
+        (await fileExists(dirs.builtInToolUse, `**/${agent}.yaml`));
 
       const multipleExists =
-        (await fileExists(customDir, `**/${agent}_multiple.yaml`)) ||
-        (await fileExists(builtInDir, `**/${agent}_multiple.yaml`)) ||
-        (await fileExists(builtInToolUseDir, `**/${agent}_multiple.yaml`));
+        (await fileExists(dirs.custom, `**/${agent}_multiple.yaml`)) ||
+        (await fileExists(dirs.builtIn, `**/${agent}_multiple.yaml`)) ||
+        (await fileExists(dirs.builtInToolUse, `**/${agent}_multiple.yaml`));
 
       const disabledAttr = yamlExists
         ? ''

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -49,7 +49,7 @@ export async function computeAgentOptions(
         (await fileExists(builtInDir, `**/${agent}_multiple.yaml`)) ||
         (await fileExists(builtInToolUseDir, `**/${agent}_multiple.yaml`));
 
-      const disabledAttr = yamlExists ? '' : ' class="disabled-agent"';
+      const disabledAttr = yamlExists ? '' : ' class="disabled-option disabled-agent"';
       const multipleAttr = multipleExists ? ' data-multiple="true"' : '';
 
       return `<option value="${agent}"${disabledAttr}${multipleAttr}>${agent}</option>`;

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -1,0 +1,60 @@
+// Third-party imports
+import { glob } from 'glob';
+import * as vscode from 'vscode';
+
+// Local imports - agent utilities
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
+import { getConfig } from '@utils/config';
+
+/**
+ * Check if a YAML file exists for the given agent name under the provided directory.
+ */
+async function fileExists(dir: string, pattern: string): Promise<boolean> {
+  if (!dir) {
+    return false;
+  }
+  const matches = await glob(pattern, {
+    cwd: dir,
+    dot: false,
+    nodir: true,
+    absolute: false,
+  });
+  return matches.length > 0;
+}
+
+/**
+ * Compute agent <option> tags for the agent dropdown.
+ * Agents missing a YAML definition are marked as disabled and cannot be selected.
+ * A codicon indicator is added via data-multiple when a corresponding
+ * `_multiple.yaml` file exists.
+ */
+export async function computeAgentOptions(
+  context: vscode.ExtensionContext,
+): Promise<string> {
+  const agents = getConfig<string[]>('agents', []);
+
+  const customDir = await agentDirectories.custom();
+  const builtInDir = await agentDirectories.builtIn(context);
+  const builtInToolUseDir = await agentDirectories.builtInToolUse(context);
+
+  const optionTags = await Promise.all(
+    agents.map(async (agent) => {
+      const yamlExists =
+        (await fileExists(customDir, `**/${agent}.yaml`)) ||
+        (await fileExists(builtInDir, `**/${agent}.yaml`)) ||
+        (await fileExists(builtInToolUseDir, `**/${agent}.yaml`));
+
+      const multipleExists =
+        (await fileExists(customDir, `**/${agent}_multiple.yaml`)) ||
+        (await fileExists(builtInDir, `**/${agent}_multiple.yaml`)) ||
+        (await fileExists(builtInToolUseDir, `**/${agent}_multiple.yaml`));
+
+      const disabledAttr = yamlExists ? '' : ' class="disabled-agent" disabled';
+      const multipleAttr = multipleExists ? ' data-multiple="true"' : '';
+
+      return `<option value="${agent}"${disabledAttr}${multipleAttr}>${agent}</option>`;
+    }),
+  );
+
+  return optionTags.join('\n');
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -119,7 +119,10 @@ export async function getAgentPath(
     return path.join(builtInToolUseDir, path.dirname(toolUseMatches[0]));
   } catch (err) {
     const errorMsg = `Error finding agent path: ${err instanceof Error ? err.message : String(err)}`;
-    vscode.window.showErrorMessage(errorMsg);
+    // Don't show error notification for missing YAML files - we handle it with banner
+    if (!err?.toString().includes('Could not find yaml file for agent')) {
+      vscode.window.showErrorMessage(errorMsg);
+    }
     throw new Error(errorMsg);
   }
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -37,6 +37,7 @@ import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { agentConfigToTaskState } from '@utils/config';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
@@ -98,23 +99,15 @@ export async function getAgentPath(
     const allMatches = [...builtInMatches, ...toolUseMatches];
 
     if (allMatches.length === 0) {
-      const configureButton = 'Open Settings';
-      await showInstructionWithSuppress(
-        'agentNotFound',
-        'Agent configuration is missing. Configure your custom agents directory and ensure the YAML file exists.',
-        [
-          {
-            title: configureButton,
-            callback: () =>
-              vscode.commands.executeCommand(
-                'workbench.action.openSettings',
-                '@ext:texra-ai.texra explorer.agentsDirectory',
-              ),
-          },
-        ],
-        false,
+      const view = await vscode.commands.executeCommand<vscode.WebviewView>(
+        'texra.getWebviewView',
       );
-
+      const customDir = await agentDirectories.custom();
+      view?.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER,
+        agentName,
+        customDirSet: !!customDir,
+      });
       const errorMsg = `Could not find yaml file for agent: ${agentName}`;
       throw new Error(errorMsg);
     }

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -78,6 +78,10 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_API_KEY_GUIDE: 'openApiKeyGuide',
   SHOW_API_KEY_BANNER: 'showApiKeyBanner',
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
+  OPEN_AGENT_DIRECTORY: 'openAgentDirectory',
+  OPEN_AGENT_DOCS: 'openAgentDocs',
+  SHOW_AGENT_CONFIG_BANNER: 'showAgentConfigBanner',
+  HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',
@@ -98,6 +102,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
   SET_MODEL_OPTIONS: 'setModelOptions',
+  SET_AGENT_OPTIONS: 'setAgentOptions',
 
   // File refresh and update operations
   REFRESH_ALL_FILES: 'refreshAllFiles',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -78,6 +78,10 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_API_KEY_GUIDE: 'openApiKeyGuide',
   SHOW_API_KEY_BANNER: 'showApiKeyBanner',
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
+  OPEN_AGENT_DIRECTORY: 'openAgentDirectory',
+  OPEN_AGENT_DOCS: 'openAgentDocs',
+  SHOW_AGENT_CONFIG_BANNER: 'showAgentConfigBanner',
+  HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',
@@ -98,6 +102,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
   SET_MODEL_OPTIONS: 'setModelOptions',
+  SET_AGENT_OPTIONS: 'setAgentOptions',
 
   // File refresh and update operations
   REFRESH_ALL_FILES: 'refreshAllFiles',

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -25,7 +25,7 @@ function formatCost(inputPrice?: number, outputPrice?: number): string {
 
 /**
  * Compute model <option> tags based on available API keys.
- * Models missing a required key receive a "(no key)" label and attributes so the
+ * Models missing a required key receive a "✗" label and attributes so the
  * webview can handle API key setup prompts.
  */
 export async function computeModelOptions(): Promise<string> {
@@ -60,10 +60,10 @@ export async function computeModelOptions(): Promise<string> {
         available = true;
       }
 
-      const label = available ? model : `${model} (no key)`;
+      const label = available ? model : `${model} ✗`;
       const requiresKeyAttr = available
         ? ''
-        : ' data-requires-key="true" class="disabled-model"';
+        : ' data-requires-key="true" class="disabled-option disabled-model"';
 
       // Build data attributes, only including them if values are defined
       const providerAttr = provider ? ` data-provider="${provider}"` : '';

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -97,6 +97,8 @@ export class MainViewContentProvider extends BaseViewContentProvider {
   }
 
   protected getTemplateVariables(): Record<string, any> {
+    // Note: This uses synchronous approach for template generation
+    // Agent options with metadata are computed asynchronously via computeAgentOptions
     const agents = getConfig<string[]>('agents', []);
     const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
     const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -21,6 +21,8 @@ import { getConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { computeModelOptions } from '@model/computeModelOptions';
+import { computeAgentOptions } from '@agent/computeAgentOptions';
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
@@ -134,6 +136,25 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.settingsManager.openAgentSettings(),
       [MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS]: async () =>
         this.settingsManager.openModelSettings(),
+      [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {
+        if (m?.customDirSet) {
+          const dir = await agentDirectories.custom();
+          if (dir) {
+            await vscode.commands.executeCommand(
+              'revealFileInOS',
+              vscode.Uri.file(dir),
+            );
+          }
+        } else {
+          await safeExecuteCommand(
+            'workbench.action.openSettings',
+            ['@ext:texra-ai.texra explorer.agentsDirectory'],
+            this.viewName,
+          );
+        }
+      },
+      [MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS]: async () =>
+        safeExecuteCommand('texra.openDoc', ['agent-explorer'], this.viewName),
 
       // Instruction commands
       [MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT]: async (m, w) =>
@@ -290,15 +311,20 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   ): Promise<void> {
     await super.handleWebviewReady(_message, webviewView);
     try {
-      const options = await computeModelOptions();
+      const modelOptions = await computeModelOptions();
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-        options,
+        options: modelOptions,
+      });
+      const agentOptions = await computeAgentOptions(this.context);
+      webviewView.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+        options: agentOptions,
       });
     } catch (error) {
       this.logger.error(
         this.channel,
-        `Failed to compute model options: ${
+        `Failed to compute options: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -195,6 +195,14 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         /* Banner handled client-side */
         w.webview.postMessage(m);
       },
+      [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: async (m, w) => {
+        /* Banner handled client-side */
+        w.webview.postMessage(m);
+      },
+      [MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER]: async (m, w) => {
+        /* Banner handled client-side */
+        w.webview.postMessage(m);
+      },
 
       // Recording commands
       [MAIN_VIEW_COMMANDS.START_RECORDING]: async (_m, w) =>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -479,6 +479,38 @@
           ></button>
         </div>
 
+        <!-- Agent Config Banner -->
+        <div
+          id="agentConfigBanner"
+          class="agent-config-banner"
+          style="display: none"
+        >
+          <span>Agent configuration is missing.</span>
+          <div class="actions">
+            <button
+              id="agentConfigEditButton"
+              class="vscode-button"
+              data-icon="list-selection"
+            >
+              Edit Agents
+            </button>
+            <button
+              id="agentConfigDirButton"
+              class="vscode-button"
+              data-icon="folder-opened"
+            >
+              Set Directory
+            </button>
+            <button
+              id="agentConfigDocButton"
+              class="vscode-button"
+              data-icon="book"
+            >
+              Docs
+            </button>
+          </div>
+        </div>
+
         <!-- API Key Banner -->
         <div id="apiKeyBanner" class="api-key-banner" style="display: none">
           <span>TeXRA requires an API key to run.</span>

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -99,4 +99,8 @@ export const ELEMENT_IDS = {
   API_KEY_BANNER: 'apiKeyBanner',
   API_KEY_BANNER_BUTTON: 'apiKeyBannerButton',
   API_KEY_GUIDE_BUTTON: 'apiKeyGuideButton',
+  AGENT_CONFIG_BANNER: 'agentConfigBanner',
+  AGENT_CONFIG_EDIT_BUTTON: 'agentConfigEditButton',
+  AGENT_CONFIG_DIR_BUTTON: 'agentConfigDirButton',
+  AGENT_CONFIG_DOC_BUTTON: 'agentConfigDocButton',
 };

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -34,6 +34,9 @@ export class MainViewDomHandler {
     this.debugMode = false;
     this.apiKeyButtonHandler = null;
     this.apiKeyGuideButtonHandler = null;
+    this.agentEditButtonHandler = null;
+    this.agentDirButtonHandler = null;
+    this.agentDocButtonHandler = null;
   }
 
   _updateDebugButtonVisibility() {
@@ -131,6 +134,45 @@ export class MainViewDomHandler {
         this.apiKeyGuideButtonHandler,
       );
     }
+
+    const agentEditButton = document.getElementById(
+      ELEMENT_IDS.AGENT_CONFIG_EDIT_BUTTON,
+    );
+    if (agentEditButton) {
+      this.agentEditButtonHandler = () => {
+        vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
+        });
+      };
+      agentEditButton.addEventListener('click', this.agentEditButtonHandler);
+    }
+
+    const agentDirButton = document.getElementById(
+      ELEMENT_IDS.AGENT_CONFIG_DIR_BUTTON,
+    );
+    if (agentDirButton) {
+      this.agentDirButtonHandler = () => {
+        const banner = document.getElementById(ELEMENT_IDS.AGENT_CONFIG_BANNER);
+        const customDirSet = banner?.dataset?.customDirSet === 'true';
+        vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY,
+          customDirSet,
+        });
+      };
+      agentDirButton.addEventListener('click', this.agentDirButtonHandler);
+    }
+
+    const agentDocButton = document.getElementById(
+      ELEMENT_IDS.AGENT_CONFIG_DOC_BUTTON,
+    );
+    if (agentDocButton) {
+      this.agentDocButtonHandler = () => {
+        vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS,
+        });
+      };
+      agentDocButton.addEventListener('click', this.agentDocButtonHandler);
+    }
   }
 
   cleanupUI() {
@@ -162,6 +204,27 @@ export class MainViewDomHandler {
         this.apiKeyGuideButtonHandler,
       );
       this.apiKeyGuideButtonHandler = null;
+    }
+    const agentEditButton = document.getElementById(
+      ELEMENT_IDS.AGENT_CONFIG_EDIT_BUTTON,
+    );
+    if (agentEditButton && this.agentEditButtonHandler) {
+      agentEditButton.removeEventListener('click', this.agentEditButtonHandler);
+      this.agentEditButtonHandler = null;
+    }
+    const agentDirButton = document.getElementById(
+      ELEMENT_IDS.AGENT_CONFIG_DIR_BUTTON,
+    );
+    if (agentDirButton && this.agentDirButtonHandler) {
+      agentDirButton.removeEventListener('click', this.agentDirButtonHandler);
+      this.agentDirButtonHandler = null;
+    }
+    const agentDocButton = document.getElementById(
+      ELEMENT_IDS.AGENT_CONFIG_DOC_BUTTON,
+    );
+    if (agentDocButton && this.agentDocButtonHandler) {
+      agentDocButton.removeEventListener('click', this.agentDocButtonHandler);
+      this.agentDocButtonHandler = null;
     }
   }
 }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -105,7 +105,7 @@ export class MainViewMessageHandler {
           const dirButton = element.querySelector('#agentConfigDirButton');
           if (textSpan) {
             textSpan.textContent = m?.agentName
-              ? `Configuration for "${m.agentName}" is missing.`
+              ? `Agent file for "${m.agentName}" is missing.`
               : 'Agent configuration is missing.';
           }
           if (dirButton) {
@@ -202,8 +202,8 @@ export class MainViewMessageHandler {
         }
         Array.from(select.options).forEach((opt) => {
           if (opt.dataset.multiple === 'true') {
-            opt.textContent = `${String.fromCharCode(0xeb36)} ${opt.textContent}`;
-            opt.style.fontFamily = 'codicon, var(--vscode-font-family)';
+            opt.textContent = `${opt.textContent} ∶∶`;
+            opt.style.opacity = '0.9';
           }
         });
       },

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -98,6 +98,31 @@ export class MainViewMessageHandler {
           element.style.setProperty('display', 'none');
         }
       },
+      [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: (m) => {
+        const element = this._getElement(ELEMENT_IDS.AGENT_CONFIG_BANNER);
+        if (element) {
+          const textSpan = element.querySelector('span');
+          const dirButton = element.querySelector('#agentConfigDirButton');
+          if (textSpan) {
+            textSpan.textContent = m?.agentName
+              ? `Configuration for "${m.agentName}" is missing.`
+              : 'Agent configuration is missing.';
+          }
+          if (dirButton) {
+            dirButton.textContent = m?.customDirSet
+              ? 'Open Directory'
+              : 'Set Directory';
+          }
+          element.dataset.customDirSet = m?.customDirSet ? 'true' : 'false';
+          element.style.setProperty('display', 'flex');
+        }
+      },
+      [MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER]: () => {
+        const element = this._getElement(ELEMENT_IDS.AGENT_CONFIG_BANNER);
+        if (element) {
+          element.style.setProperty('display', 'none');
+        }
+      },
       [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (m) => {
         // Validate that options are provided
         if (!m.options) {
@@ -159,6 +184,28 @@ export class MainViewMessageHandler {
         }
 
         applyOptions(select);
+      },
+      [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: (m) => {
+        if (!m.options) {
+          console.warn('SET_AGENT_OPTIONS: No options provided');
+          return;
+        }
+        const select = document.getElementById('agent');
+        if (!select) {
+          console.warn('SET_AGENT_OPTIONS: Agent select element not found');
+          return;
+        }
+        const previous = select.value;
+        select.innerHTML = m.options;
+        if (previous) {
+          select.value = previous;
+        }
+        Array.from(select.options).forEach((opt) => {
+          if (opt.dataset.multiple === 'true') {
+            opt.textContent = `${String.fromCharCode(0xeb36)} ${opt.textContent}`;
+            opt.style.fontFamily = 'codicon, var(--vscode-font-family)';
+          }
+        });
       },
     };
   }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -94,6 +94,18 @@ export class SettingsButtonManager extends BaseUIManager {
 
     this.addListener('agent', 'change', (e) => {
       const selectedAgent = e.target.value;
+      const selectedOption = e.target.options[e.target.selectedIndex];
+
+      // Hide agent config banner if a valid (non-disabled) agent is selected
+      if (
+        selectedOption &&
+        !selectedOption.classList.contains('disabled-agent')
+      ) {
+        this.vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER,
+        });
+      }
+
       const reflectCheckbox = safeGetElementById('reflect');
       if (reflectCheckbox) {
         reflectCheckbox.checked = !selectedAgent.startsWith('correct');

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -99,7 +99,7 @@ export class SettingsButtonManager extends BaseUIManager {
       // Hide agent config banner if a valid (non-disabled) agent is selected
       if (
         selectedOption &&
-        !selectedOption.classList.contains('disabled-agent')
+        !selectedOption.classList.contains('disabled-option')
       ) {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER,

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -69,7 +69,8 @@
   align-items: center;
 }
 
-.api-key-banner .actions {
+.api-key-banner .actions,
+.agent-config-banner .actions {
   display: flex;
   gap: var(--spacing-small);
 }
@@ -84,8 +85,9 @@
   cursor: pointer;
 }
 
-/* API key reminder banner */
-.api-key-banner {
+/* Banners */
+.api-key-banner,
+.agent-config-banner {
   background-color: var(--vscode-inputValidation-warningBackground);
   color: var(--vscode-inputValidation-warningForeground);
   border: 1px solid var(--vscode-inputValidation-warningBorder);

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -93,9 +93,14 @@
 
 /* Disabled model option styling */
 option.disabled-model,
+option.disabled-agent,
 option[data-requires-key='true'] {
   color: var(--vscode-descriptionForeground);
   opacity: 0.6;
   font-style: italic;
   background-color: var(--vscode-input-background);
+}
+
+option[data-multiple='true'] {
+  font-family: codicon, var(--vscode-font-family);
 }

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -91,7 +91,8 @@
   font-size: calc(var(--vscode-editor-font-size) * 0.9);
 }
 
-/* Disabled model option styling */
+/* Disabled option styling - shared across dropdowns */
+option.disabled-option,
 option.disabled-model,
 option.disabled-agent,
 option[data-requires-key='true'] {


### PR DESCRIPTION
## Summary
- add computeAgentOptions to disable missing agents and flag multiple variants
- show agent configuration banner with edit, directory, and docs actions
- display codicon marker for agents with _multiple YAML files

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc0b923f88324b75aa0808131485d