### PR TITLE
feat: clarify output files controls in webview

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -330,10 +330,14 @@
                 <span
                   id="toggleOutputFiles"
                   class="toggle-icon"
-                  title="Multiple"
+                  title="Show or hide additional files for the agent’s output"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
-                <span class="optional-label">Multiple Outputs</span>
+                <span
+                  class="optional-label"
+                  title="List the files that should receive the agent’s output"
+                  >Multiple Outputs</span
+                >
               </div>
               <div class="file-select-actions button-group">
                 <button

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -78,7 +78,10 @@
                   title="Empty"
                   data-icon="close"
                 ></button>
-                <span id="toggleInputFiles" class="toggle-icon" title="Multiple"
+                <span
+                  id="toggleInputFiles"
+                  class="toggle-icon"
+                  title="Show or hide additional input files"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
                 <button
@@ -141,7 +144,7 @@
                 <span
                   id="toggleReferenceFiles"
                   class="toggle-icon"
-                  title="Multiple"
+                  title="Show or hide additional reference files"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
                 <button
@@ -204,7 +207,7 @@
                 <span
                   id="toggleAuxiliaryFiles"
                   class="toggle-icon"
-                  title="Multiple"
+                  title="Show or hide additional auxiliary files"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
                 <button
@@ -294,7 +297,10 @@
                   title="Empty"
                   data-icon="close"
                 ></button>
-                <span id="toggleMediaFiles" class="toggle-icon" title="Multiple"
+                <span
+                  id="toggleMediaFiles"
+                  class="toggle-icon"
+                  title="Show or hide additional media files"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
                 <button
@@ -546,7 +552,9 @@
           <div class="file-select">
             <div class="file-select-header">
               <div class="file-select-label-group">
-                <label for="editedFile"
+                <label
+                  for="editedFile"
+                  title="File containing edits to merge into the base file"
                   ><i
                     class="codicon codicon-edit clickable"
                     title="Edited (Click to refresh)"

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -29,6 +29,11 @@ export class FileList {
     const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
     if (!container || !toggleIcon) return;
 
+    const placeholder = container.querySelector('.file-list-placeholder');
+    if (placeholder) {
+      container.removeChild(placeholder);
+    }
+
     const fileElement = createFromTemplate('fileListEntryTemplate', {
       text: { '.file-name': file },
       dataset: { '': { path: file } },

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -63,7 +63,7 @@ export class OutputFilesManager {
       const placeholder = document.createElement('div');
       placeholder.className = 'file-list-placeholder';
       placeholder.textContent =
-        'No extra outputs selected. Click ‘Add’ to choose files.';
+        'No extra outputs selected. Click "Add" to choose files.';
       outputFilesDiv.appendChild(placeholder);
     }
 

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -59,6 +59,14 @@ export class OutputFilesManager {
       this.fileList.add(OUTPUT_FILES_ID, file);
     });
 
+    if (outputFilesDiv.children.length === 0) {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'file-list-placeholder';
+      placeholder.textContent =
+        'No extra outputs selected. Click ‘Add’ to choose files.';
+      outputFilesDiv.appendChild(placeholder);
+    }
+
     this.state.save();
   }
 


### PR DESCRIPTION
## Summary
- clarify toggle for additional output files with descriptive tooltip
- explain "Multiple Outputs" label and handle empty state with placeholder text
- remove placeholder when output files are added

## Testing
- `npm run lint`
- `npm test` *(webpack warning, outputs truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf224721c8324980f2afef76c6765