### PR TITLE
chore: upgrade zod to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.33.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@alcyone-labs/zod-to-json-schema": "^4.0.10",
         "@anthropic-ai/sdk": "^0.61.0",
         "@cantoo/pdf-lib": "^2.4.3",
         "@google/genai": "^1.17.0",
@@ -41,8 +42,7 @@
         "tar": "^7.4.3",
         "winston": "^3.17.0",
         "yaml": "^2.8.1",
-        "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.24.6"
+        "zod": "^4.1.5"
       },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^5.3.1",
@@ -76,6 +76,15 @@
       },
       "engines": {
         "vscode": "^1.99.3"
+      }
+    },
+    "node_modules/@alcyone-labs/zod-to-json-schema": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@alcyone-labs/zod-to-json-schema/-/zod-to-json-schema-4.0.10.tgz",
+      "integrity": "sha512-TFsSpAPToqmqmT85SGHXuxoCwEeK9zUDvn512O9aBVvWRhSuy+VvAXZkifzsdllD3ncF0ZjUrf4MpBwIEixdWQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^4.0.5"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -705,6 +714,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7687,9 +7705,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1270,6 +1270,7 @@
   },
   "homepage": "https://texra.ai",
   "dependencies": {
+    "@alcyone-labs/zod-to-json-schema": "^4.0.10",
     "@anthropic-ai/sdk": "^0.61.0",
     "@cantoo/pdf-lib": "^2.4.3",
     "@google/genai": "^1.17.0",
@@ -1302,7 +1303,6 @@
     "tar": "^7.4.3",
     "winston": "^3.17.0",
     "yaml": "^2.8.1",
-    "zod": "^3.25.76",
-    "zod-to-json-schema": "^3.24.6"
+    "zod": "^4.1.5"
   }
 }

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -35,7 +35,7 @@ export const AgentConfigSchema = z
     outputFiles: z.array(z.string()).nullable().default(null),
     editedFile: z.string().nullable().default(null),
 
-    toolConfig: ToolConfigSchema.default({}),
+    toolConfig: ToolConfigSchema,
   })
   .strict()
   .refine(validateOutputFiles, {

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -37,8 +37,12 @@ export const AgentSettingSchema = z
     outputExt: z.string().default('txt'),
     endTag: z.string().default('</latex_document>'),
 
-    requiredFiles: z.record(z.string()).default({}),
-    requiredFilesInternal: z.record(z.string()).default({}),
+    requiredFiles: z
+      .record(z.string(), z.string())
+      .default({} as Record<string, string>),
+    requiredFilesInternal: z
+      .record(z.string(), z.string())
+      .default({} as Record<string, string>),
     defaultOutputFiles: z.array(z.string()).default([]),
     filePatternsContain: z
       .array(
@@ -99,8 +103,8 @@ export const AgentDefinitionSchema = z
   .object({
     name: z.string().trim().min(1),
     inherits: z.string().optional(),
-    settings: z.record(z.unknown()).optional(),
-    prompts: z.record(z.unknown()).optional(),
+    settings: z.record(z.string(), z.unknown()).optional(),
+    prompts: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -19,6 +19,15 @@ export const ToolConfigSchema = z
     autoCompileInputPdf: z.boolean().default(false),
   })
   .strict()
-  .default({});
+  .default({
+    reflect: false,
+    usePrefillFromInput: false,
+    autoExtractFigure: false,
+    autoExtractTikzFigure: false,
+    attachTeXCount: false,
+    attachDiagnostics: false,
+    printInputPrompt: false,
+    autoCompileInputPdf: false,
+  });
 
 export type ToolConfig = z.infer<typeof ToolConfigSchema>;

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -13,7 +13,7 @@ export const ToolDefinitionSchema = z
     /** Optional description for the model */
     description: z.string().optional(),
     /** Parameter schema or provider specific metadata */
-    parameters: z.record(z.unknown()).optional(),
+    parameters: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { zodToJsonSchema } from '@alcyone-labs/zod-to-json-schema';
 
 // Local imports - tools
 import { BaseTool } from './core/base';

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { zodToJsonSchema } from '@alcyone-labs/zod-to-json-schema';
 
 // Local imports - tools
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -3,7 +3,7 @@
 
 // Local imports - core
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { zodToJsonSchema } from '@alcyone-labs/zod-to-json-schema';
 
 // Local imports - tools
 import { BaseTool } from './core/base';

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -3,7 +3,7 @@
 
 // Local imports - core
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { zodToJsonSchema } from '@alcyone-labs/zod-to-json-schema';
 
 // Local imports - tools
 import { BaseTool } from './core/base';

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 // Local imports - core
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { zodToJsonSchema } from '@alcyone-labs/zod-to-json-schema';
 
 // Local imports - tools
 import { BaseTool } from '../core/base';

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -3,7 +3,7 @@
 
 // Local imports - core
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { zodToJsonSchema } from '@alcyone-labs/zod-to-json-schema';
 
 // Local imports - tools
 import { BaseTool } from '../core/base';


### PR DESCRIPTION
## Summary
- upgrade to zod v4.1.5 and replace `zod-to-json-schema` with `@alcyone-labs/zod-to-json-schema`
- adjust schemas for new `z.record` signature and default handling
- update all tool modules to use the new json-schema converter

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: build process did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfb6c36848324804c5ab3dad04633