### PR TITLE
fix: log follow-up errors

### DIFF
--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -1,8 +1,11 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - commands
+// Local imports - agent
 import { BaseAgent } from '@agent/implementations/BaseAgent';
+
+// Local imports - utilities
+import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 
 const CHANNEL = 'followUpCommand';
 console.log(`[${CHANNEL}] command registered`);
@@ -17,7 +20,11 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
           try {
             (agent as any).appendFollowUp(payload.text);
           } catch (err) {
-            console.error(`Failed to send follow-up: ${String(err)}`);
+            await showLoggedErrorMessage(
+              CHANNEL,
+              'Failed to send follow-up',
+              err,
+            );
           }
         }
       },


### PR DESCRIPTION
## Summary
- use showLoggedErrorMessage for follow-up send errors

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0545cbf348324a98d3b3d5a698667