### PR TITLE
fix: remove redundant await in recursive file listing

### DIFF
--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -95,7 +95,7 @@ export async function getFilesRecursively(
         !name.startsWith('.') &&
         !normalizedExcludeDirs.has(nameLower)
       ) {
-        return await getFilesRecursively(
+        return getFilesRecursively(
           fullPath,
           root,
           includeExtensions,


### PR DESCRIPTION
## Summary
- remove redundant await in recursive file search

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b467f4cea08324bf756e7acd9620fa