### PR TITLE
refactor: centralize built-in agent directories

### DIFF
--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -16,32 +16,33 @@ const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
 
 export class AgentDirectoryManager {
-  async builtIn(context: vscode.ExtensionContext): Promise<string> {
+  /**
+   * Ensure a built-in agents directory exists and return its path.
+   */
+  private async ensureBuiltInDir(
+    context: vscode.ExtensionContext,
+    dirName: string,
+  ): Promise<string> {
     if (!context) {
       throw new Error('Extension context required for built-in agents');
     }
 
     StorageFS.initialize(context);
-    await GlobalStorageFS.ensureDir('agents');
+    await GlobalStorageFS.ensureDir(dirName);
 
-    const basePath = GlobalStorageFS.fullPath('agents');
-    logger.debug(CHANNEL, `Using built-in agents directory: ${basePath}`);
+    const basePath = GlobalStorageFS.fullPath(dirName);
+    const label = dirName === 'tool_use_agents' ? 'tool-use' : dirName;
+    logger.debug(CHANNEL, `Using built-in ${label} directory: ${basePath}`);
 
     return basePath;
   }
 
+  async builtIn(context: vscode.ExtensionContext): Promise<string> {
+    return this.ensureBuiltInDir(context, 'agents');
+  }
+
   async builtInToolUse(context: vscode.ExtensionContext): Promise<string> {
-    if (!context) {
-      throw new Error('Extension context required for built-in agents');
-    }
-
-    StorageFS.initialize(context);
-    await GlobalStorageFS.ensureDir('tool_use_agents');
-
-    const basePath = GlobalStorageFS.fullPath('tool_use_agents');
-    logger.debug(CHANNEL, `Using built-in tool-use directory: ${basePath}`);
-
-    return basePath;
+    return this.ensureBuiltInDir(context, 'tool_use_agents');
   }
 
   async custom(): Promise<string> {


### PR DESCRIPTION
## Summary
- extract ensureBuiltInDir helper to set up built-in agent directories
- use helper in builtIn and builtInToolUse to remove duplicated logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1172f921c832495a495de4a58b433