### PR TITLE
refactor: centralize recent commit retrieval

### DIFF
--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -42,39 +42,37 @@ export class DiffManager {
     );
   }
 
-  async handleRequestRecentCommits(
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async _fetchRecentCommits(): Promise<{
+    commits: string[];
+    isGitRepo: boolean;
+  }> {
     const isGitRepo = await vscode.commands.executeCommand<boolean>(
       'texra.isGitRepository',
     );
-    const commits = isGitRepo
-      ? await vscode.commands.executeCommand<string[]>('texra.getRecentCommits')
-      : [];
+    if (!isGitRepo) {
+      return { commits: [], isGitRepo: false };
+    }
+    const commits = await vscode.commands.executeCommand<string[]>(
+      'texra.getRecentCommits',
+    );
+    return { commits, isGitRepo: true };
+  }
+
+  async handleRequestRecentCommits(
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const result = await this._fetchRecentCommits();
     webviewView.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-      commits,
-      isGitRepo,
+      ...result,
     });
   }
 
   async handleRefreshCommits(webviewView: vscode.WebviewView): Promise<void> {
-    const isGitRepoRefresh = await vscode.commands.executeCommand<boolean>(
-      'texra.isGitRepository',
-    );
-    if (isGitRepoRefresh) {
-      const commitsRefresh = await vscode.commands.executeCommand<string[]>(
-        'texra.getRecentCommits',
-      );
-      webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-        commits: commitsRefresh,
-      });
-    } else {
-      webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-        isGitRepo: false,
-      });
-    }
+    const result = await this._fetchRecentCommits();
+    webviewView.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+      ...result,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add `_fetchRecentCommits` helper to DiffManager
- reuse helper in recent commit handlers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1177c80bc832481cd68f9e17d396b