### PR TITLE
refactor: centralize webview module uri mapping

### DIFF
--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -5,6 +5,12 @@ import * as vscode from 'vscode';
 import { buildWebviewHtml } from '@frontend/webview/html';
 import * as logger from '@logger/logUtils';
 
+/** Descriptor mapping a template key to its module path */
+export interface ModuleDescriptor {
+  key: string;
+  path: string;
+}
+
 /**
  * Base class for all webview content providers.
  * Eliminates code duplication and provides consistent patterns.
@@ -12,6 +18,15 @@ import * as logger from '@logger/logUtils';
 export abstract class BaseViewContentProvider {
   protected readonly logger: any;
   protected readonly channel: string;
+
+  /** Modules shared by all view providers */
+  protected readonly sharedModuleDescriptors: ModuleDescriptor[] = [
+    { key: 'styleUri', path: 'styles/index.css' },
+    { key: 'scriptUri', path: 'script.js' },
+    { key: 'domHandlersUri', path: 'modules/domHandlers.js' },
+    { key: 'constantsUri', path: 'modules/constants.js' },
+    { key: 'messageHandlersUri', path: 'modules/messageHandlers.js' },
+  ];
 
   constructor(
     protected readonly context: vscode.ExtensionContext,

--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -2,9 +2,21 @@
 import * as vscode from 'vscode';
 
 // Local imports - history view
-import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
+import {
+  BaseViewContentProvider,
+  ModuleDescriptor,
+} from '@common/webview/BaseViewContentProvider';
 
 export class HistoryViewContentProvider extends BaseViewContentProvider {
+  private readonly moduleDescriptors: ModuleDescriptor[] = [
+    { key: 'eventsUri', path: 'modules/uiManagers/HistoryEventsManager.js' },
+    {
+      key: 'historyRendererUri',
+      path: 'modules/uiManagers/HistoryRenderer.js',
+    },
+    { key: 'historyViewStateUri', path: 'modules/historyViewState.js' },
+    { key: 'searchManagerUri', path: 'modules/uiManagers/SearchManager.js' },
+  ];
   constructor(context: vscode.ExtensionContext) {
     super(context, 'HistoryView');
   }
@@ -14,33 +26,14 @@ export class HistoryViewContentProvider extends BaseViewContentProvider {
   }
 
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return {
-      styleUri: this.getWebviewUri(webview, 'styles/index.css'),
-      scriptUri: this.getWebviewUri(webview, 'script.js'),
-
-      // History view specific modules
-      domHandlersUri: this.getWebviewUri(webview, 'modules/domHandlers.js'),
-      constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
-      eventsUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/HistoryEventsManager.js',
-      ),
-      historyRendererUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/HistoryRenderer.js',
-      ),
-      historyViewStateUri: this.getWebviewUri(
-        webview,
-        'modules/historyViewState.js',
-      ),
-      searchManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/SearchManager.js',
-      ),
-      messageHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/messageHandlers.js',
-      ),
-    };
+    const modules = [
+      ...this.sharedModuleDescriptors,
+      ...this.moduleDescriptors,
+    ];
+    const uris: Record<string, vscode.Uri> = {};
+    for (const { key, path } of modules) {
+      uris[key] = this.getWebviewUri(webview, path);
+    }
+    return uris;
   }
 }

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -2,9 +2,26 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
+import {
+  BaseViewContentProvider,
+  ModuleDescriptor,
+} from '@common/webview/BaseViewContentProvider';
 
 export class ProgressViewContentProvider extends BaseViewContentProvider {
+  private readonly moduleDescriptors: ModuleDescriptor[] = [
+    { key: 'progressViewStateUri', path: 'modules/progressViewState.js' },
+    { key: 'formattersUri', path: 'modules/formatters.js' },
+    { key: 'taskManagersUri', path: 'modules/taskManagers.js' },
+    { key: 'usageManagersUri', path: 'modules/usageManagers.js' },
+    { key: 'katexMacrosUri', path: 'modules/katexMacros.js' },
+    { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
+    { key: 'streamTabsUri', path: 'modules/uiManagers/StreamTabs.js' },
+    { key: 'toolbarUri', path: 'modules/uiManagers/Toolbar.js' },
+    { key: 'statusUri', path: 'modules/uiManagers/Status.js' },
+    { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
+    { key: 'eventsUri', path: 'modules/uiManagers/EventsManager.js' },
+    { key: 'placeholderUri', path: 'modules/uiManagers/Placeholder.js' },
+  ];
   constructor(context: vscode.ExtensionContext) {
     super(context, 'ProgressView');
   }
@@ -14,50 +31,16 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
   }
 
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return {
-      styleUri: this.getWebviewUri(webview, 'styles/index.css'),
-      scriptUri: this.getWebviewUri(webview, 'script.js'),
+    const modules = [
+      ...this.sharedModuleDescriptors,
+      ...this.moduleDescriptors,
+    ];
+    const uris: Record<string, vscode.Uri> = {
       splitJsUri: this.getNodeModulesUri(webview, 'split.js/dist/split.es.js'),
-
-      // Progress view specific modules
-      progressViewStateUri: this.getWebviewUri(
-        webview,
-        'modules/progressViewState.js',
-      ),
-      messageHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/messageHandlers.js',
-      ),
-      domHandlersUri: this.getWebviewUri(webview, 'modules/domHandlers.js'),
-      formattersUri: this.getWebviewUri(webview, 'modules/formatters.js'),
-      taskManagersUri: this.getWebviewUri(webview, 'modules/taskManagers.js'),
-      usageManagersUri: this.getWebviewUri(webview, 'modules/usageManagers.js'),
-      constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
-      katexMacrosUri: this.getWebviewUri(webview, 'modules/katexMacros.js'),
-      themeHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/handlers/themeHandlers.js',
-      ),
-
-      // UI managers
-      streamTabsUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/StreamTabs.js',
-      ),
-      toolbarUri: this.getWebviewUri(webview, 'modules/uiManagers/Toolbar.js'),
-      statusUri: this.getWebviewUri(webview, 'modules/uiManagers/Status.js'),
-      fileListUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/FileList.js',
-      ),
-      eventsUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/EventsManager.js',
-      ),
-      placeholderUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/Placeholder.js',
-      ),
     };
+    for (const { key, path } of modules) {
+      uris[key] = this.getWebviewUri(webview, path);
+    }
+    return uris;
   }
 }

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -5,11 +5,56 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - webview
-import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
+import {
+  BaseViewContentProvider,
+  ModuleDescriptor,
+} from '@common/webview/BaseViewContentProvider';
 import { getConfig } from '@utils/config';
 import { GlobalStorageFS, AbsoluteFS } from '@utils/files';
 
 export class MainViewContentProvider extends BaseViewContentProvider {
+  private readonly moduleDescriptors: ModuleDescriptor[] = [
+    { key: 'webviewStateModuleUri', path: 'modules/mainViewState.js' },
+    { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
+    { key: 'fileMessageHandlersUri', path: 'modules/handlers/fileHandlers.js' },
+    {
+      key: 'recordingHandlersUri',
+      path: 'modules/handlers/recordingHandlers.js',
+    },
+    { key: 'eventBusUri', path: 'modules/eventBus.js' },
+    { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
+    { key: 'fileSelectUri', path: 'modules/uiManagers/FileSelect.js' },
+    { key: 'toggleManagerUri', path: 'modules/uiManagers/ToggleManager.js' },
+    { key: 'baseUIManagerUri', path: 'modules/uiManagers/BaseUIManager.js' },
+    {
+      key: 'fileInputManagerUri',
+      path: 'modules/uiManagers/FileInputManager.js',
+    },
+    {
+      key: 'actionButtonManagerUri',
+      path: 'modules/uiManagers/ActionButtonManager.js',
+    },
+    {
+      key: 'settingsButtonManagerUri',
+      path: 'modules/uiManagers/SettingsButtonManager.js',
+    },
+    {
+      key: 'recordingManagerUri',
+      path: 'modules/uiManagers/RecordingManager.js',
+    },
+    {
+      key: 'instructionManagerUri',
+      path: 'modules/uiManagers/InstructionManager.js',
+    },
+    {
+      key: 'outputFilesManagerUri',
+      path: 'modules/uiManagers/OutputFilesManager.js',
+    },
+    {
+      key: 'latexdiffManagerUri',
+      path: 'modules/uiManagers/LatexdiffManager.js',
+    },
+  ];
   constructor(context: vscode.ExtensionContext) {
     super(context, 'MainView');
   }
@@ -19,81 +64,15 @@ export class MainViewContentProvider extends BaseViewContentProvider {
   }
 
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return {
-      styleUri: this.getWebviewUri(webview, 'styles/index.css'),
-      scriptUri: this.getWebviewUri(webview, 'script.js'),
-
-      // Main view specific modules
-      webviewStateModuleUri: this.getWebviewUri(
-        webview,
-        'modules/mainViewState.js',
-      ),
-      messageHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/messageHandlers.js',
-      ),
-      themeHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/handlers/themeHandlers.js',
-      ),
-      fileMessageHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/handlers/fileHandlers.js',
-      ),
-      recordingHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/handlers/recordingHandlers.js',
-      ),
-      domHandlersUri: this.getWebviewUri(webview, 'modules/domHandlers.js'),
-      constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
-      eventBusUri: this.getWebviewUri(webview, 'modules/eventBus.js'),
-
-      // UI managers
-      fileListUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/FileList.js',
-      ),
-      fileSelectUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/FileSelect.js',
-      ),
-      toggleManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/ToggleManager.js',
-      ),
-      baseUIManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/BaseUIManager.js',
-      ),
-      fileInputManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/FileInputManager.js',
-      ),
-      actionButtonManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/ActionButtonManager.js',
-      ),
-      settingsButtonManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/SettingsButtonManager.js',
-      ),
-      recordingManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/RecordingManager.js',
-      ),
-      instructionManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/InstructionManager.js',
-      ),
-      outputFilesManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/OutputFilesManager.js',
-      ),
-      latexdiffManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/LatexdiffManager.js',
-      ),
-    };
+    const modules = [
+      ...this.sharedModuleDescriptors,
+      ...this.moduleDescriptors,
+    ];
+    const uris: Record<string, vscode.Uri> = {};
+    for (const { key, path } of modules) {
+      uris[key] = this.getWebviewUri(webview, path);
+    }
+    return uris;
   }
 
   protected getTemplateVariables(): Record<string, any> {


### PR DESCRIPTION
## Summary
- share common webview module descriptors in BaseViewContentProvider
- load view-specific modules via descriptor arrays in content providers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c116085e80832480fc6f58097ace21