### PR TITLE
refactor: use getConfig for configuration access

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';
 import { MainViewContentProvider } from './webview/MainViewContentProvider';
 import { SecretManager } from '@frontend/secretManager';
-import { watchConfig } from '@utils/config';
+import { watchConfig, getConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 export class MainViewProvider implements vscode.WebviewViewProvider {
@@ -161,8 +161,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     this.setupInitialState(webviewView);
 
     // Check if any API keys are set and display banner if needed
-    const config = vscode.workspace.getConfiguration('texra');
-    const showReminders = config.get<boolean>('ui.showApiKeyReminders', true);
+    const showReminders = getConfig<boolean>('ui.showApiKeyReminders', true);
 
     if (showReminders) {
       SecretManager.anyApiKeyExists().then((exists) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import dotenv from 'dotenv';
 
 // Local imports - core
 import * as logger from '@logger/logUtils';
-import { watchConfig } from '@utils/config';
+import { watchConfig, getConfig } from '@utils/config';
 import { SecretManager } from '@frontend/secretManager';
 import { copyDefaultAgents, configureLatexSettings } from '@frontend/setup';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
@@ -36,8 +36,7 @@ async function refreshApiKeyStatus() {
   }
 
   // Check if reminders are enabled
-  const config = vscode.workspace.getConfiguration('texra');
-  const showReminders = config.get<boolean>('ui.showApiKeyReminders', true);
+  const showReminders = getConfig<boolean>('ui.showApiKeyReminders', true);
 
   if (!showReminders) {
     apiKeyStatusBarItem.hide();

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -20,8 +20,7 @@ export async function promptToAddAgentToConfig(
   agentName: string,
   autoAdd = false,
 ): Promise<void> {
-  const config = vscode.workspace.getConfiguration();
-  const current = config.get<string[]>('texra.agents', []);
+  const current = getConfig<string[]>('agents', []);
 
   const baseName = agentName.endsWith('_multiple')
     ? agentName.replace(/_multiple$/, '')
@@ -59,11 +58,9 @@ export async function promptToAddAgentToConfig(
 
   if (autoAdd) {
     current.push(agentName);
-    await config.update(
-      'texra.agents',
-      current,
-      vscode.ConfigurationTarget.Workspace,
-    );
+    await vscode.workspace
+      .getConfiguration()
+      .update('texra.agents', current, vscode.ConfigurationTarget.Workspace);
     vscode.window.showInformationMessage(
       `Added "${agentName}" to texra.agents`,
     );
@@ -79,11 +76,9 @@ export async function promptToAddAgentToConfig(
 
   if (choice === addButton) {
     current.push(agentName);
-    await config.update(
-      'texra.agents',
-      current,
-      vscode.ConfigurationTarget.Workspace,
-    );
+    await vscode.workspace
+      .getConfiguration()
+      .update('texra.agents', current, vscode.ConfigurationTarget.Workspace);
     vscode.window.showInformationMessage(
       `Added "${agentName}" to texra.agents`,
     );
@@ -123,7 +118,7 @@ export async function validateYamlAndPromptAdd(
     return;
   }
 
-  const configuredAgents = getConfig<string[]>('texra.agents', []);
+  const configuredAgents = getConfig<string[]>('agents', []);
   if (!configuredAgents.includes(filenameBase)) {
     await promptToAddAgentToConfig(filenameBase, !prompt);
   }

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as logger from '@logger/logUtils';
 import { isValidAgentYaml } from '@agent/runtime/agentLoad';
-import { getConfig } from '@utils/config';
+import { getConfig, setConfig } from '@utils/config';
 
 const CHANNEL = 'AgentRegister';
 logger.initialize(CHANNEL);
@@ -58,9 +58,7 @@ export async function promptToAddAgentToConfig(
 
   if (autoAdd) {
     current.push(agentName);
-    await vscode.workspace
-      .getConfiguration()
-      .update('texra.agents', current, vscode.ConfigurationTarget.Workspace);
+    await setConfig('agents', current, vscode.ConfigurationTarget.Workspace);
     vscode.window.showInformationMessage(
       `Added "${agentName}" to texra.agents`,
     );
@@ -76,9 +74,7 @@ export async function promptToAddAgentToConfig(
 
   if (choice === addButton) {
     current.push(agentName);
-    await vscode.workspace
-      .getConfiguration()
-      .update('texra.agents', current, vscode.ConfigurationTarget.Workspace);
+    await setConfig('agents', current, vscode.ConfigurationTarget.Workspace);
     vscode.window.showInformationMessage(
       `Added "${agentName}" to texra.agents`,
     );

--- a/src/frontend/media/img.ts
+++ b/src/frontend/media/img.ts
@@ -4,7 +4,6 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Third-party imports
-import * as vscode from 'vscode';
 import { PDFDocument } from '@cantoo/pdf-lib';
 import { fromPath } from 'pdf2pic';
 
@@ -12,6 +11,7 @@ import { fromPath } from 'pdf2pic';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
+import { getConfig } from '@utils/config';
 import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { executeCommand } from '@utils/system/execUtils';
@@ -24,8 +24,7 @@ logger.initialize(CHANNEL);
  * @returns Maximum image dimension (defaults to 2000)
  */
 function getMaxImageDimension(): number {
-  const config = vscode.workspace.getConfiguration('texra');
-  return config.get<number>('maxImageDimension', 2000);
+  return getConfig<number>('maxImageDimension', 2000);
 }
 
 // Define the temporary directory path

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -1,6 +1,20 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+/**
+ * Gets a configuration value from VS Code settings.
+ * 
+ * Path conventions:
+ * - Use dot notation without the 'texra' prefix (e.g., 'agents', 'api.engine')
+ * - The function will automatically try multiple namespaces:
+ *   1. The path as given (for non-texra configs like 'latex.latexindentConfig')
+ *   2. Under the 'texra' namespace
+ *   3. With explicit 'texra.' prefix
+ * 
+ * @param path Configuration path (e.g., 'agents' or 'api.engine')
+ * @param defaultValue Optional default value if configuration is not found
+ * @returns The configuration value or default value
+ */
 export function getConfig<T>(path: string, defaultValue?: T): T {
   const parts = path.split('.');
 
@@ -21,6 +35,28 @@ export function getConfig<T>(path: string, defaultValue?: T): T {
 
   // Return default value if still undefined
   return result !== undefined ? result : (defaultValue as T);
+}
+
+/**
+ * Sets a configuration value in VS Code settings.
+ * 
+ * Path conventions:
+ * - Use dot notation without the 'texra' prefix (e.g., 'agents', 'api.engine')
+ * - The function will automatically add the 'texra.' prefix
+ * 
+ * @param path Configuration path without 'texra' prefix (e.g., 'agents')
+ * @param value The value to set
+ * @param target Configuration target (defaults to Workspace)
+ * @returns Promise that resolves when configuration is updated
+ */
+export async function setConfig<T>(
+  path: string,
+  value: T,
+  target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Workspace,
+): Promise<void> {
+  await vscode.workspace
+    .getConfiguration()
+    .update(`texra.${path}`, value, target);
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace direct workspace configuration calls with getConfig helper
- streamline agent registration config updates
- remove redundant config variables and imports

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: output truncated, tests not executed)*

------
https://chatgpt.com/codex/tasks/task_e_68c115b01bb8832496f812c9d5de11a1