### PR TITLE
refactor: centralize file operations

### DIFF
--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -83,31 +83,25 @@ export class ExecutionManager {
     await vscode.commands.executeCommand('texra.execute', agentConfig);
   }
 
-  handleMerge(message: any): void {
+  private handleFileOperation(message: any): void {
     vscode.commands.executeCommand(
       `texra.${message.command}`,
       message.inputFile,
       message.baseFile,
       message.editedFile,
     );
+  }
+
+  handleMerge(message: any): void {
+    this.handleFileOperation(message);
   }
 
   handleCompare(message: any): void {
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.baseFile,
-      message.editedFile,
-    );
+    this.handleFileOperation(message);
   }
 
   handleAcceptEdited(message: any): void {
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.baseFile,
-      message.editedFile,
-    );
+    this.handleFileOperation(message);
   }
 
   handleHousekeeping(message: any): void {


### PR DESCRIPTION
## Summary
- consolidate repetitive merge/compare/accept logic into a single `handleFileOperation`
- route merge, compare, and accept edited actions through the new helper

## Testing
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1170a5de88324b43315ad9d274d27