### PR TITLE
refactor: log error messages and centralize docs links

### DIFF
--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -1,6 +1,12 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
+// Local imports - errors
+import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
+
 // Local imports - agent
 import { executeMergeAgent } from '@agent/runtime/executeAgent';
 
@@ -17,6 +23,9 @@ export function registerMergeCommands(context: vscode.ExtensionContext) {
   );
 }
 
+const CHANNEL = 'MergeCommands';
+logger.initialize(CHANNEL);
+
 async function handleMerge(
   context: vscode.ExtensionContext,
   inputFile: string,
@@ -24,16 +33,12 @@ async function handleMerge(
   editedFile: string,
 ) {
   if (!editedFile || (!baseFile && !inputFile)) {
-    const errorMsg =
-      'Both input file and edited file must be specified for merge operation';
-    const docsAction = 'View Merge Docs';
-    const selection = await vscode.window.showErrorMessage(
-      errorMsg,
-      docsAction,
+    await showLoggedMessageWithDocs(
+      CHANNEL,
+      'Both input file and edited file must be specified for merge operation',
+      'intelligent-merge',
+      'View Merge Docs',
     );
-    if (selection === docsAction) {
-      vscode.commands.executeCommand('texra.openDoc', 'intelligent-merge');
-    }
     return;
   }
 

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -5,7 +5,10 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - errors
-import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
+import { 
+  showLoggedMessageWithDocs, 
+  showLoggedErrorMessage 
+} from '@common/errors/errorHandlingUtils';
 
 // Local imports - agent
 import { executeMergeAgent } from '@agent/runtime/executeAgent';
@@ -48,6 +51,8 @@ async function handleMerge(
   try {
     await executeMergeAgent(model, fileToUse, editedFile, context);
   } catch (err) {
+    // Log the error before re-throwing
+    await showLoggedErrorMessage('MergeCommands', 'Merge operation failed', err);
     throw err;
   }
 }

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -26,6 +26,13 @@ import {
 // Import agent utilities
 import { getAgentFirstNameChunk } from '@housekeeping/utils';
 
+// Local imports - errors
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+  showLoggedMessageWithDocs,
+} from '@common/errors/errorHandlingUtils';
+
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
 
@@ -36,11 +43,12 @@ const service = new LaTeXdiffService(CHANNEL);
  * @param message The error message to display.
  */
 async function showLatexdiffError(message: string) {
-  const docsAction = 'Latexdiff Docs';
-  const selection = await vscode.window.showErrorMessage(message, docsAction);
-  if (selection === docsAction) {
-    await vscode.commands.executeCommand('texra.openDoc', 'latex-diff');
-  }
+  await showLoggedMessageWithDocs(
+    CHANNEL,
+    message,
+    'latex-diff',
+    'Latexdiff Docs',
+  );
 }
 
 export function registerLatexdiffCommands(context: vscode.ExtensionContext) {
@@ -101,7 +109,8 @@ async function handleLatexdiff(
       result.diffFileName,
     );
     if (!(await WorkspaceFS.exists(filePathRelative))) {
-      vscode.window.showErrorMessage(
+      await showLoggedMessage(
+        CHANNEL,
         `Diff file could not be found. Expected path: ${filePathRelative}`,
       );
       return;
@@ -109,9 +118,7 @@ async function handleLatexdiff(
 
     await openBuildDisplayIfTex(filePathRelative, { preserveFocus: true });
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error creating LaTeX diff: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    await showLoggedErrorMessage(CHANNEL, 'Error creating LaTeX diff', err);
   }
 }
 
@@ -140,7 +147,8 @@ async function handleLatexdiffvc(
       result.diffFileName,
     );
     if (!(await WorkspaceFS.exists(filePathRelative))) {
-      vscode.window.showErrorMessage(
+      await showLoggedMessage(
+        CHANNEL,
         `Diff file could not be found. Expected path: ${filePathRelative}`,
       );
       return;
@@ -148,9 +156,7 @@ async function handleLatexdiffvc(
 
     await openBuildDisplayIfTex(filePathRelative, { preserveFocus: true });
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error creating LaTeX diff: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    await showLoggedErrorMessage(CHANNEL, 'Error creating LaTeX diff', err);
   }
 }
 
@@ -173,9 +179,7 @@ async function handlePackLatexdiffvc(
     const fileToUse = baseFile || inputFile;
     await runPackLatexdiffvc(fileToUse, commitHash, clean);
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error packing LaTeX diff: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    await showLoggedErrorMessage(CHANNEL, 'Error packing LaTeX diff', err);
   }
 }
 
@@ -197,9 +201,7 @@ async function handlePackLatexdiffvcMultiple(
     logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
     await runPackLatexdiffvcMultiple(inputFiles, commitHash, clean);
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error packing LaTeX diffs: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    await showLoggedErrorMessage(CHANNEL, 'Error packing LaTeX diffs', err);
   }
 }
 
@@ -221,9 +223,7 @@ async function handleCleanLatexdiffvc(
     const fileToUse = baseFile || inputFile;
     await runCleanLatexdiffvc(fileToUse, commitHash);
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error cleaning LaTeX diff: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    await showLoggedErrorMessage(CHANNEL, 'Error cleaning LaTeX diff', err);
   }
 }
 
@@ -241,9 +241,7 @@ async function handleCleanLatexdiffvcMultiple(
     logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
     await runCleanLatexdiffvcMultiple(inputFiles, commitHash);
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error cleaning LaTeX diffs: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    await showLoggedErrorMessage(CHANNEL, 'Error cleaning LaTeX diffs', err);
   }
 }
 
@@ -267,7 +265,8 @@ async function handleRunLatexdiff(config: any) {
     const { agent, model, inputFile, outputFiles } = config;
 
     if (!agent || !model || !inputFile) {
-      vscode.window.showErrorMessage(
+      await showLoggedMessage(
+        CHANNEL,
         'Missing required configuration parameters',
       );
       return;
@@ -487,7 +486,7 @@ async function handleRunLatexdiff(config: any) {
         const successCount = results.filter((r) => r.success).length;
 
         if (successCount === 0) {
-          vscode.window.showErrorMessage('All LaTeX diff operations failed');
+          await showLoggedMessage(CHANNEL, 'All LaTeX diff operations failed');
         } else if (successCount < totalOperations) {
           vscode.window.showWarningMessage(
             `${successCount} of ${totalOperations} LaTeX diff operations completed successfully`,
@@ -515,9 +514,7 @@ async function handleRunLatexdiff(config: any) {
       },
     );
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error running LaTeX diffs: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    await showLoggedErrorMessage(CHANNEL, 'Error running LaTeX diffs', err);
   }
 }
 

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -38,18 +38,7 @@ logger.initialize(CHANNEL);
 
 const service = new LaTeXdiffService(CHANNEL);
 
-/**
- * Show an error message and optionally open Latexdiff documentation.
- * @param message The error message to display.
- */
-async function showLatexdiffError(message: string) {
-  await showLoggedMessageWithDocs(
-    CHANNEL,
-    message,
-    'latex-diff',
-    'Latexdiff Docs',
-  );
-}
+// Removed showLatexdiffError wrapper - using showLoggedMessageWithDocs directly
 
 export function registerLatexdiffCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -81,11 +70,21 @@ async function handleLatexdiff(
   editedFile: string,
 ) {
   if (!(baseFile || inputFile)) {
-    await showLatexdiffError('No base file specified for latexdiff');
+    await showLoggedMessageWithDocs(
+      CHANNEL,
+      'No base file specified for latexdiff',
+      'latex-diff',
+      'Latexdiff Docs',
+    );
     return;
   }
   if (!editedFile) {
-    await showLatexdiffError('No revised file specified for latexdiff');
+    await showLoggedMessageWithDocs(
+      CHANNEL,
+      'No revised file specified for latexdiff',
+      'latex-diff',
+      'Latexdiff Docs',
+    );
     return;
   }
 

--- a/src/commands/wolfram/wolframScriptCommands.ts
+++ b/src/commands/wolfram/wolframScriptCommands.ts
@@ -34,14 +34,7 @@ logger.initialize(CHANNEL);
  * Show an error message with a link to Tool Integration docs.
  * @param message The error message to display.
  */
-async function showWolframError(message: string) {
-  await showLoggedMessageWithDocs(
-    CHANNEL,
-    `${message} See Tool Integration for setup instructions.`,
-    'tool-integration',
-    'Open Tool Integration Docs',
-  );
-}
+// Removed showWolframError wrapper - using showLoggedMessageWithDocs directly
 
 export function registerWolframScriptCommands(
   context: vscode.ExtensionContext,
@@ -68,17 +61,28 @@ export function registerWolframScriptCommands(
               `Wolframscript test successful: ${result.output}`,
             );
           } else {
-            await showWolframError(
-              `Wolframscript test failed: ${result.error}.`,
+            await showLoggedMessageWithDocs(
+              CHANNEL,
+              `Wolframscript test failed: ${result.error}. See Tool Integration for setup instructions.`,
+              'tool-integration',
+              'Open Tool Integration Docs',
             );
           }
         } else {
-          await showWolframError(
-            'Wolframscript is not properly installed or not available in PATH.',
+          await showLoggedMessageWithDocs(
+            CHANNEL,
+            'Wolframscript is not properly installed or not available in PATH. See Tool Integration for setup instructions.',
+            'tool-integration',
+            'Open Tool Integration Docs',
           );
         }
       } catch (err) {
-        await showWolframError(`Failed to test Wolframscript: ${err}`);
+        await showLoggedMessageWithDocs(
+          CHANNEL,
+          `Failed to test Wolframscript: ${err}. See Tool Integration for setup instructions.`,
+          'tool-integration',
+          'Open Tool Integration Docs',
+        );
       }
     },
   );
@@ -191,7 +195,12 @@ export function registerWolframScriptCommands(
           </html>
         `;
       } catch (err) {
-        await showWolframError(`Failed to execute Wolfram code: ${err}`);
+        await showLoggedMessageWithDocs(
+          CHANNEL,
+          `Failed to execute Wolfram code: ${err}. See Tool Integration for setup instructions.`,
+          'tool-integration',
+          'Open Tool Integration Docs',
+        );
       }
     },
   );
@@ -330,7 +339,12 @@ export function registerWolframScriptCommands(
           </html>
         `;
       } catch (err) {
-        await showWolframError(`Failed to execute Wolfram script file: ${err}`);
+        await showLoggedMessageWithDocs(
+          CHANNEL,
+          `Failed to execute Wolfram script file: ${err}. See Tool Integration for setup instructions.`,
+          'tool-integration',
+          'Open Tool Integration Docs',
+        );
       }
     },
   );

--- a/src/commands/wolfram/wolframScriptCommands.ts
+++ b/src/commands/wolfram/wolframScriptCommands.ts
@@ -1,6 +1,15 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
+// Local imports - errors
+import {
+  showLoggedMessage,
+  showLoggedMessageWithDocs,
+} from '@common/errors/errorHandlingUtils';
+
 // Standard library imports
 import * as path from 'path';
 
@@ -18,19 +27,20 @@ export const wolframScriptCommands = {
   wolframScriptRunFile: 'texra.wolframScriptRunFile',
 };
 
+const CHANNEL = 'WolframScriptCommands';
+logger.initialize(CHANNEL);
+
 /**
  * Show an error message with a link to Tool Integration docs.
  * @param message The error message to display.
  */
 async function showWolframError(message: string) {
-  const docsAction = 'Open Tool Integration Docs';
-  const selection = await vscode.window.showErrorMessage(
+  await showLoggedMessageWithDocs(
+    CHANNEL,
     `${message} See Tool Integration for setup instructions.`,
-    docsAction,
+    'tool-integration',
+    'Open Tool Integration Docs',
   );
-  if (selection === docsAction) {
-    await vscode.commands.executeCommand('texra.openDoc', 'tool-integration');
-  }
 }
 
 export function registerWolframScriptCommands(
@@ -192,7 +202,7 @@ export function registerWolframScriptCommands(
     async () => {
       const editor = vscode.window.activeTextEditor;
       if (!editor) {
-        vscode.window.showErrorMessage('No file is currently open');
+        await showLoggedMessage(CHANNEL, 'No file is currently open');
         return;
       }
 
@@ -201,7 +211,8 @@ export function registerWolframScriptCommands(
 
       // Check if the file is a Wolfram Language file
       if (fileExtension !== '.wl' && fileExtension !== '.m') {
-        vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          CHANNEL,
           'Current file is not a Wolfram Language file. Please open a .wl or .m file.',
         );
         return;

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -161,3 +161,27 @@ export async function showLoggedMessage(
   await vscode.window.showErrorMessage(message);
   return message;
 }
+
+/**
+ * Log an error message, display it with a docs action and open the docs if selected.
+ *
+ * This helper keeps messaging consistent when providing quick access to
+ * documentation for resolving the error.
+ *
+ * @param channel - The logging channel to use (e.g., "Configuration")
+ * @param message - The error message to log and display
+ * @param docId - Identifier for the documentation to open
+ * @param actionLabel - Label for the docs action button (defaults to 'View Docs')
+ */
+export async function showLoggedMessageWithDocs(
+  channel: string,
+  message: string,
+  docId: string,
+  actionLabel = 'View Docs',
+): Promise<void> {
+  logger.error(channel, message);
+  const selection = await vscode.window.showErrorMessage(message, actionLabel);
+  if (selection === actionLabel) {
+    await vscode.commands.executeCommand('texra.openDoc', docId);
+  }
+}

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -21,6 +21,19 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 /**
+ * Valid documentation identifiers for error messages.
+ * This ensures type safety when referencing documentation sections.
+ */
+export type DocId = 
+  | 'intelligent-merge' 
+  | 'custom-agents' 
+  | 'tool-integration' 
+  | 'latex-diff';
+
+/** Maximum length for error details before truncation */
+const MAX_ERROR_LENGTH = 500;
+
+/**
  * Format an error with a prefix for logging or user messages.
  *
  * This is the core formatting function used by all other error handling utilities.
@@ -45,7 +58,13 @@ import * as logger from '@logger/logUtils';
  * ```
  */
 export function formatError(prefix: string, err: unknown): string {
-  const detail = err instanceof Error ? err.message : String(err);
+  let detail = err instanceof Error ? err.message : String(err);
+  
+  // Truncate overly long error details for better readability
+  if (detail.length > MAX_ERROR_LENGTH) {
+    detail = detail.substring(0, MAX_ERROR_LENGTH) + '...';
+  }
+  
   return `${prefix}: ${detail}`;
 }
 
@@ -170,13 +189,13 @@ export async function showLoggedMessage(
  *
  * @param channel - The logging channel to use (e.g., "Configuration")
  * @param message - The error message to log and display
- * @param docId - Identifier for the documentation to open
+ * @param docId - Identifier for the documentation to open (must be a valid DocId)
  * @param actionLabel - Label for the docs action button (defaults to 'View Docs')
  */
 export async function showLoggedMessageWithDocs(
   channel: string,
   message: string,
-  docId: string,
+  docId: DocId,
   actionLabel = 'View Docs',
 ): Promise<void> {
   logger.error(channel, message);

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -201,6 +201,13 @@ export async function showLoggedMessageWithDocs(
   logger.error(channel, message);
   const selection = await vscode.window.showErrorMessage(message, actionLabel);
   if (selection === actionLabel) {
-    await vscode.commands.executeCommand('texra.openDoc', docId);
+    // Use try-catch to prevent uncaught errors if the command fails
+    // (e.g., during activation race conditions or if the command is not registered)
+    try {
+      await vscode.commands.executeCommand('texra.openDoc', docId);
+    } catch (err) {
+      // Log the error but don't show another error message to avoid error cascade
+      logger.error(channel, `Failed to open documentation: ${err}`);
+    }
   }
 }

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -10,7 +10,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { getConfig } from '@utils/config';
 import { GlobalStorageFS, StorageFS, AbsoluteFS } from '@utils/files';
-import { safeExecuteCommand } from '@utils/system';
+import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
 
 const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
@@ -56,14 +56,11 @@ export class AgentDirectoryManager {
         CHANNEL,
         `Custom agents directory must be an absolute path: ${customPath}`,
       );
-      const docsAction = 'View Docs';
-      const selection = await vscode.window.showErrorMessage(
+      await showLoggedMessageWithDocs(
+        CHANNEL,
         'Custom agents directory must be an absolute path',
-        docsAction,
+        'custom-agents',
       );
-      if (selection === docsAction) {
-        await safeExecuteCommand('texra.openDoc', ['custom-agents'], CHANNEL);
-      }
       return '';
     }
 


### PR DESCRIPTION
## Summary
- log errors with docs links via `showLoggedMessageWithDocs`
- replace direct `showErrorMessage` uses in merge, agent directory, wolfram, and latexdiff commands
- expose docs through consistent helper and supply log channels

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1173f86108324afc13bb36093a77c