### PR TITLE
refactor: centralize webview module URIs

### DIFF
--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -5,6 +5,12 @@ import * as vscode from 'vscode';
 import { buildWebviewHtml } from '@frontend/webview/html';
 import * as logger from '@logger/logUtils';
 
+/** Descriptor for a webview module resource. */
+export interface ModuleDescriptor {
+  key: string;
+  path: string;
+}
+
 /**
  * Base class for all webview content providers.
  * Eliminates code duplication and provides consistent patterns.
@@ -41,6 +47,15 @@ export abstract class BaseViewContentProvider {
     return {};
   }
 
+  /** Shared module descriptors available to all views */
+  private readonly sharedModuleDescriptors: ModuleDescriptor[] = [
+    { key: 'styleUri', path: 'styles/index.css' },
+    { key: 'scriptUri', path: 'script.js' },
+    { key: 'domHandlersUri', path: 'modules/domHandlers.js' },
+    { key: 'constantsUri', path: 'modules/constants.js' },
+    { key: 'messageHandlersUri', path: 'modules/messageHandlers.js' },
+  ];
+
   /**
    * Common method to get webview paths
    */
@@ -72,6 +87,24 @@ export abstract class BaseViewContentProvider {
     );
   }
 
+  /** Convert an array of descriptors into a URI record */
+  protected buildUriRecord(
+    webview: vscode.Webview,
+    descriptors: ModuleDescriptor[],
+  ): Record<string, vscode.Uri> {
+    return descriptors.reduce<Record<string, vscode.Uri>>((acc, d) => {
+      acc[d.key] = this.getWebviewUri(webview, d.path);
+      return acc;
+    }, {});
+  }
+
+  /** URIs shared by all views */
+  private getSharedModuleUris(
+    webview: vscode.Webview,
+  ): Record<string, vscode.Uri> {
+    return this.buildUriRecord(webview, this.sharedModuleDescriptors);
+  }
+
   /**
    * Standard implementation that subclasses can override if needed
    */
@@ -79,6 +112,7 @@ export abstract class BaseViewContentProvider {
     try {
       const htmlPath = this.getWebviewPath('index.html');
       const commonUris = this.getCommonModuleUris(webview);
+      const sharedUris = this.getSharedModuleUris(webview);
       const specificUris = this.getModuleUris(webview);
       const templateVariables = this.getTemplateVariables();
 
@@ -89,6 +123,7 @@ export abstract class BaseViewContentProvider {
 
       return buildWebviewHtml(webview, htmlPath, {
         ...commonUris,
+        ...sharedUris,
         ...specificUris,
         ...templateVariables,
       });

--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -2,7 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - history view
-import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
+import {
+  BaseViewContentProvider,
+  ModuleDescriptor,
+} from '@common/webview/BaseViewContentProvider';
 
 export class HistoryViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
@@ -13,34 +16,17 @@ export class HistoryViewContentProvider extends BaseViewContentProvider {
     return 'historyView';
   }
 
-  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return {
-      styleUri: this.getWebviewUri(webview, 'styles/index.css'),
-      scriptUri: this.getWebviewUri(webview, 'script.js'),
+  private readonly moduleDescriptors: ModuleDescriptor[] = [
+    { key: 'eventsUri', path: 'modules/uiManagers/HistoryEventsManager.js' },
+    {
+      key: 'historyRendererUri',
+      path: 'modules/uiManagers/HistoryRenderer.js',
+    },
+    { key: 'historyViewStateUri', path: 'modules/historyViewState.js' },
+    { key: 'searchManagerUri', path: 'modules/uiManagers/SearchManager.js' },
+  ];
 
-      // History view specific modules
-      domHandlersUri: this.getWebviewUri(webview, 'modules/domHandlers.js'),
-      constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
-      eventsUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/HistoryEventsManager.js',
-      ),
-      historyRendererUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/HistoryRenderer.js',
-      ),
-      historyViewStateUri: this.getWebviewUri(
-        webview,
-        'modules/historyViewState.js',
-      ),
-      searchManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/SearchManager.js',
-      ),
-      messageHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/messageHandlers.js',
-      ),
-    };
+  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
+    return this.buildUriRecord(webview, this.moduleDescriptors);
   }
 }

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -2,7 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
+import {
+  BaseViewContentProvider,
+  ModuleDescriptor,
+} from '@common/webview/BaseViewContentProvider';
 
 export class ProgressViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
@@ -13,52 +16,28 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
     return 'progressView';
   }
 
+  private readonly moduleDescriptors: ModuleDescriptor[] = [
+    { key: 'progressViewStateUri', path: 'modules/progressViewState.js' },
+    { key: 'formattersUri', path: 'modules/formatters.js' },
+    { key: 'taskManagersUri', path: 'modules/taskManagers.js' },
+    { key: 'utilsUri', path: 'modules/utils.js' },
+    { key: 'usageManagersUri', path: 'modules/usageManagers.js' },
+    { key: 'katexMacrosUri', path: 'modules/katexMacros.js' },
+    { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
+
+    // UI managers
+    { key: 'streamTabsUri', path: 'modules/uiManagers/StreamTabs.js' },
+    { key: 'toolbarUri', path: 'modules/uiManagers/Toolbar.js' },
+    { key: 'statusUri', path: 'modules/uiManagers/Status.js' },
+    { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
+    { key: 'eventsUri', path: 'modules/uiManagers/EventsManager.js' },
+    { key: 'placeholderUri', path: 'modules/uiManagers/Placeholder.js' },
+  ];
+
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
     return {
-      styleUri: this.getWebviewUri(webview, 'styles/index.css'),
-      scriptUri: this.getWebviewUri(webview, 'script.js'),
+      ...this.buildUriRecord(webview, this.moduleDescriptors),
       splitJsUri: this.getNodeModulesUri(webview, 'split.js/dist/split.es.js'),
-
-      // Progress view specific modules
-      progressViewStateUri: this.getWebviewUri(
-        webview,
-        'modules/progressViewState.js',
-      ),
-      messageHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/messageHandlers.js',
-      ),
-      domHandlersUri: this.getWebviewUri(webview, 'modules/domHandlers.js'),
-      formattersUri: this.getWebviewUri(webview, 'modules/formatters.js'),
-      taskManagersUri: this.getWebviewUri(webview, 'modules/taskManagers.js'),
-      utilsUri: this.getWebviewUri(webview, 'modules/utils.js'),
-      usageManagersUri: this.getWebviewUri(webview, 'modules/usageManagers.js'),
-      constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
-      katexMacrosUri: this.getWebviewUri(webview, 'modules/katexMacros.js'),
-      themeHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/handlers/themeHandlers.js',
-      ),
-
-      // UI managers
-      streamTabsUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/StreamTabs.js',
-      ),
-      toolbarUri: this.getWebviewUri(webview, 'modules/uiManagers/Toolbar.js'),
-      statusUri: this.getWebviewUri(webview, 'modules/uiManagers/Status.js'),
-      fileListUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/FileList.js',
-      ),
-      eventsUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/EventsManager.js',
-      ),
-      placeholderUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/Placeholder.js',
-      ),
     };
   }
 }

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -5,7 +5,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - webview
-import { BaseViewContentProvider } from '@common/webview/BaseViewContentProvider';
+import {
+  BaseViewContentProvider,
+  ModuleDescriptor,
+} from '@common/webview/BaseViewContentProvider';
 import { getConfig } from '@utils/config';
 import { GlobalStorageFS, AbsoluteFS } from '@utils/files';
 
@@ -18,82 +21,51 @@ export class MainViewContentProvider extends BaseViewContentProvider {
     return 'webview';
   }
 
+  private readonly moduleDescriptors: ModuleDescriptor[] = [
+    { key: 'webviewStateModuleUri', path: 'modules/mainViewState.js' },
+    { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
+    { key: 'fileMessageHandlersUri', path: 'modules/handlers/fileHandlers.js' },
+    {
+      key: 'recordingHandlersUri',
+      path: 'modules/handlers/recordingHandlers.js',
+    },
+    { key: 'eventBusUri', path: 'modules/eventBus.js' },
+    { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
+    { key: 'fileSelectUri', path: 'modules/uiManagers/FileSelect.js' },
+    { key: 'toggleManagerUri', path: 'modules/uiManagers/ToggleManager.js' },
+    { key: 'baseUIManagerUri', path: 'modules/uiManagers/BaseUIManager.js' },
+    {
+      key: 'fileInputManagerUri',
+      path: 'modules/uiManagers/FileInputManager.js',
+    },
+    {
+      key: 'actionButtonManagerUri',
+      path: 'modules/uiManagers/ActionButtonManager.js',
+    },
+    {
+      key: 'settingsButtonManagerUri',
+      path: 'modules/uiManagers/SettingsButtonManager.js',
+    },
+    {
+      key: 'recordingManagerUri',
+      path: 'modules/uiManagers/RecordingManager.js',
+    },
+    {
+      key: 'instructionManagerUri',
+      path: 'modules/uiManagers/InstructionManager.js',
+    },
+    {
+      key: 'outputFilesManagerUri',
+      path: 'modules/uiManagers/OutputFilesManager.js',
+    },
+    {
+      key: 'latexdiffManagerUri',
+      path: 'modules/uiManagers/LatexdiffManager.js',
+    },
+  ];
+
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return {
-      styleUri: this.getWebviewUri(webview, 'styles/index.css'),
-      scriptUri: this.getWebviewUri(webview, 'script.js'),
-
-      // Main view specific modules
-      webviewStateModuleUri: this.getWebviewUri(
-        webview,
-        'modules/mainViewState.js',
-      ),
-      messageHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/messageHandlers.js',
-      ),
-      themeHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/handlers/themeHandlers.js',
-      ),
-      fileMessageHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/handlers/fileHandlers.js',
-      ),
-      recordingHandlersUri: this.getWebviewUri(
-        webview,
-        'modules/handlers/recordingHandlers.js',
-      ),
-      domHandlersUri: this.getWebviewUri(webview, 'modules/domHandlers.js'),
-      constantsUri: this.getWebviewUri(webview, 'modules/constants.js'),
-      eventBusUri: this.getWebviewUri(webview, 'modules/eventBus.js'),
-
-      // UI managers
-      fileListUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/FileList.js',
-      ),
-      fileSelectUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/FileSelect.js',
-      ),
-      toggleManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/ToggleManager.js',
-      ),
-      baseUIManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/BaseUIManager.js',
-      ),
-      fileInputManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/FileInputManager.js',
-      ),
-      actionButtonManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/ActionButtonManager.js',
-      ),
-      settingsButtonManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/SettingsButtonManager.js',
-      ),
-      recordingManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/RecordingManager.js',
-      ),
-      instructionManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/InstructionManager.js',
-      ),
-      outputFilesManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/OutputFilesManager.js',
-      ),
-      latexdiffManagerUri: this.getWebviewUri(
-        webview,
-        'modules/uiManagers/LatexdiffManager.js',
-      ),
-    };
+    return this.buildUriRecord(webview, this.moduleDescriptors);
   }
 
   protected getTemplateVariables(): Record<string, any> {


### PR DESCRIPTION
## Summary
- centralize common webview module URIs in BaseViewContentProvider
- iterate descriptor arrays for view-specific module URIs
- refactor view content providers to define concise module descriptor lists

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1353a1760832491ce83771406f3cd