### PR TITLE
refactor: centralize wolframscript execution

### DIFF
--- a/src/test/tools/wolframScriptUtils.test.ts
+++ b/src/test/tools/wolframScriptUtils.test.ts
@@ -1,0 +1,67 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - tools
+import {
+  executeWolframCode,
+  executeWolframScriptFile,
+} from '@tools/wolfram/wolframScriptUtils';
+import * as toolUtils from '@utils/system/toolUtils';
+import * as execUtils from '@utils/system/execUtils';
+
+describe('wolframScriptUtils', () => {
+  let originalCheckToolInstalled: typeof toolUtils.checkToolInstalled;
+  let originalExecuteCommand: typeof execUtils.executeCommand;
+
+  beforeEach(() => {
+    originalCheckToolInstalled = toolUtils.checkToolInstalled;
+    originalExecuteCommand = execUtils.executeCommand;
+  });
+
+  afterEach(() => {
+    (toolUtils as any).checkToolInstalled = originalCheckToolInstalled;
+    (execUtils as any).executeCommand = originalExecuteCommand;
+  });
+
+  it('executeWolframCode delegates to runWolfram with code args', async () => {
+    const calls: any[] = [];
+    (toolUtils as any).checkToolInstalled = async () => true;
+    (execUtils as any).executeCommand = async (
+      command: string[],
+      opts: any,
+    ) => {
+      calls.push(command, opts);
+      return { success: true, stdout: '2', stderr: '' } as any;
+    };
+
+    const result = await executeWolframCode('1+1');
+
+    assert.deepStrictEqual(calls[0], ['wolframscript', '-code', '1+1']);
+    assert.strictEqual(calls[1].timeout, 30000);
+    assert.ok(result.success);
+    assert.strictEqual(result.output, '2');
+  });
+
+  it('executeWolframScriptFile delegates to runWolfram with file args', async () => {
+    const calls: any[] = [];
+    (toolUtils as any).checkToolInstalled = async () => true;
+    (execUtils as any).executeCommand = async (
+      command: string[],
+      opts: any,
+    ) => {
+      calls.push(command, opts);
+      return { success: true, stdout: 'done', stderr: '' } as any;
+    };
+
+    const result = await executeWolframScriptFile('/tmp/test.wls');
+
+    assert.deepStrictEqual(calls[0], [
+      'wolframscript',
+      '-file',
+      '/tmp/test.wls',
+    ]);
+    assert.strictEqual(calls[1].timeout, 60000);
+    assert.ok(result.success);
+    assert.strictEqual(result.output, 'done');
+  });
+});

--- a/src/tools/wolfram/wolframScriptUtils.ts
+++ b/src/tools/wolfram/wolframScriptUtils.ts
@@ -17,6 +17,55 @@ export interface WolframScriptResult {
 }
 
 /**
+ * Internal helper to run wolframscript commands with installation check.
+ */
+async function runWolfram(
+  commandArgs: string[],
+  opts: { timeout?: number; showErrorsToUser?: boolean } = {},
+): Promise<WolframScriptResult> {
+  const isInstalled = await checkToolInstalled(
+    'wolframscript',
+    opts.showErrorsToUser,
+  );
+  if (!isInstalled) {
+    return {
+      success: false,
+      output: null,
+      error: 'Mathematica/wolframscript is not installed or not in your PATH.',
+    };
+  }
+
+  try {
+    const command = ['wolframscript', ...commandArgs];
+    const result = await executeCommand(command, {
+      truncate: false,
+      timeout: opts.timeout,
+      channel: 'WolframTool',
+    });
+
+    return {
+      success: result.success,
+      output: result.stdout,
+      error: result.stderr,
+    };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+
+    if (opts.showErrorsToUser) {
+      vscode.window.showErrorMessage(
+        `Error executing Wolfram command: ${errorMessage}`,
+      );
+    }
+
+    return {
+      success: false,
+      output: null,
+      error: errorMessage,
+    };
+  }
+}
+
+/**
  * Execute Wolfram Language code through wolframscript
  * @param code The Wolfram Language code to execute
  * @param options Additional options for execution
@@ -29,48 +78,10 @@ export async function executeWolframCode(
     showErrorsToUser?: boolean;
   } = {},
 ): Promise<WolframScriptResult> {
-  // Check if wolframscript is installed before attempting to run code
-  const isInstalled = await checkToolInstalled(
-    'wolframscript',
-    options.showErrorsToUser,
-  );
-  if (!isInstalled) {
-    return {
-      success: false,
-      output: null,
-      error: 'Mathematica/wolframscript is not installed or not in your PATH.',
-    };
-  }
-
-  try {
-    const command = ['wolframscript', '-code', code];
-
-    const result = await executeCommand(command, {
-      truncate: false,
-      timeout: options.timeout || 30000, // Default 30 second timeout
-      channel: 'WolframTool',
-    });
-
-    return {
-      success: result.success,
-      output: result.stdout,
-      error: result.stderr,
-    };
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
-
-    if (options.showErrorsToUser) {
-      vscode.window.showErrorMessage(
-        `Error executing Wolfram code: ${errorMessage}`,
-      );
-    }
-
-    return {
-      success: false,
-      output: null,
-      error: errorMessage,
-    };
-  }
+  return runWolfram(['-code', code], {
+    timeout: options.timeout ?? 30000,
+    showErrorsToUser: options.showErrorsToUser,
+  });
 }
 
 /**
@@ -86,48 +97,10 @@ export async function executeWolframScriptFile(
     showErrorsToUser?: boolean;
   } = {},
 ): Promise<WolframScriptResult> {
-  // Check if wolframscript is installed before attempting to run the script
-  const isInstalled = await checkToolInstalled(
-    'wolframscript',
-    options.showErrorsToUser,
-  );
-  if (!isInstalled) {
-    return {
-      success: false,
-      output: null,
-      error: 'Mathematica/wolframscript is not installed or not in your PATH.',
-    };
-  }
-
-  try {
-    const command = ['wolframscript', '-file', filePath];
-
-    const result = await executeCommand(command, {
-      truncate: false,
-      timeout: options.timeout || 60000, // Default 1 minute timeout for script files
-      channel: 'WolframTool',
-    });
-
-    return {
-      success: result.success,
-      output: result.stdout,
-      error: result.stderr,
-    };
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
-
-    if (options.showErrorsToUser) {
-      vscode.window.showErrorMessage(
-        `Error executing Wolfram script file: ${errorMessage}`,
-      );
-    }
-
-    return {
-      success: false,
-      output: null,
-      error: errorMessage,
-    };
-  }
+  return runWolfram(['-file', filePath], {
+    timeout: options.timeout ?? 60000,
+    showErrorsToUser: options.showErrorsToUser,
+  });
 }
 
 // The verifyMathematicalExpression helper has been removed. It previously

--- a/src/tools/wolfram/wolframScriptUtils.ts
+++ b/src/tools/wolfram/wolframScriptUtils.ts
@@ -9,6 +9,13 @@ import { executeCommand, checkToolInstalled } from '@utils/system';
 
 // Wolfram configuration is now in toolUtils.ts
 
+// Constants
+const DEFAULT_CODE_TIMEOUT = 30000; // 30 seconds
+const DEFAULT_FILE_TIMEOUT = 60000; // 60 seconds
+const WOLFRAM_NOT_INSTALLED_ERROR =
+  'Mathematica/wolframscript is not installed or not in your PATH.';
+const WOLFRAM_CHANNEL = 'WolframTool';
+
 // Interface for execution result
 export interface WolframScriptResult {
   success: boolean;
@@ -18,6 +25,9 @@ export interface WolframScriptResult {
 
 /**
  * Internal helper to run wolframscript commands with installation check.
+ * @param commandArgs Array of command-line arguments to pass to wolframscript (e.g., ['-code', 'expr'] or ['-file', 'path'])
+ * @param opts Execution options including timeout and error display settings
+ * @returns Promise resolving to execution result with success status, output, and error information
  */
 async function runWolfram(
   commandArgs: string[],
@@ -31,7 +41,7 @@ async function runWolfram(
     return {
       success: false,
       output: null,
-      error: 'Mathematica/wolframscript is not installed or not in your PATH.',
+      error: WOLFRAM_NOT_INSTALLED_ERROR,
     };
   }
 
@@ -40,7 +50,7 @@ async function runWolfram(
     const result = await executeCommand(command, {
       truncate: false,
       timeout: opts.timeout,
-      channel: 'WolframTool',
+      channel: WOLFRAM_CHANNEL,
     });
 
     return {
@@ -79,7 +89,7 @@ export async function executeWolframCode(
   } = {},
 ): Promise<WolframScriptResult> {
   return runWolfram(['-code', code], {
-    timeout: options.timeout ?? 30000,
+    timeout: options.timeout ?? DEFAULT_CODE_TIMEOUT,
     showErrorsToUser: options.showErrorsToUser,
   });
 }
@@ -98,7 +108,7 @@ export async function executeWolframScriptFile(
   } = {},
 ): Promise<WolframScriptResult> {
   return runWolfram(['-file', filePath], {
-    timeout: options.timeout ?? 60000,
+    timeout: options.timeout ?? DEFAULT_FILE_TIMEOUT,
     showErrorsToUser: options.showErrorsToUser,
   });
 }


### PR DESCRIPTION
## Summary
- add internal runWolfram helper for wolframscript calls
- delegate executeWolframCode and executeWolframScriptFile to runWolfram
- add tests for wolframScriptUtils

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1169cbf3883248d4ae50eccc5e0d5