### PR TITLE
feat: add dependency check banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,12 @@
             "default": true,
             "description": "Show API key reminders in the status bar and main view when no API keys are configured",
             "scope": "resource"
+          },
+          "texra.ui.showDependencyReminders": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show dependency check reminders in the main view when core dependencies are missing",
+            "scope": "resource"
           }
         }
       },

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -175,14 +175,17 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     }
 
     // Check for missing core dependencies and display banner if needed
-    checkCoreDependencies(false).then((missingTools) => {
-      if (missingTools.length > 0) {
-        webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
-          missingTools: missingTools,
-        });
-      }
-    });
+    const showDependencyReminders = getConfig<boolean>('ui.showDependencyReminders', true);
+    if (showDependencyReminders) {
+      checkCoreDependencies(false).then((missingTools) => {
+        if (missingTools.length > 0) {
+          webviewView.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
+            missingTools: missingTools,
+          });
+        }
+      });
+    }
   }
 
   private async setupInitialState(webviewView: vscode.WebviewView) {

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -7,6 +7,7 @@ import { MainViewContentProvider } from './webview/MainViewContentProvider';
 import { SecretManager } from '@frontend/secretManager';
 import { watchConfig, getConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { checkCoreDependencies } from '@utils/system/toolUtils';
 
 export class MainViewProvider implements vscode.WebviewViewProvider {
   private messageHandler: MainViewMessageHandler;
@@ -172,6 +173,16 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
         }
       });
     }
+
+    // Check for missing core dependencies and display banner if needed
+    checkCoreDependencies(false).then((missingTools) => {
+      if (missingTools.length > 0) {
+        webviewView.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
+          missingTools: missingTools,
+        });
+      }
+    });
   }
 
   private async setupInitialState(webviewView: vscode.WebviewView) {

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -85,6 +85,7 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
   SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',
   HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
+  UPDATE_DEPENDENCY_REMINDER_SETTING: 'updateDependencyReminderSetting',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -80,8 +80,11 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
   OPEN_AGENT_DIRECTORY: 'openAgentDirectory',
   OPEN_AGENT_DOCS: 'openAgentDocs',
+  OPEN_INSTALLATION_DOCS: 'openInstallationDocs',
   SHOW_AGENT_CONFIG_BANNER: 'showAgentConfigBanner',
   HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
+  SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',
+  HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -85,6 +85,7 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
   SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',
   HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
+  UPDATE_DEPENDENCY_REMINDER_SETTING: 'updateDependencyReminderSetting',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -80,8 +80,11 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
   OPEN_AGENT_DIRECTORY: 'openAgentDirectory',
   OPEN_AGENT_DOCS: 'openAgentDocs',
+  OPEN_INSTALLATION_DOCS: 'openInstallationDocs',
   SHOW_AGENT_CONFIG_BANNER: 'showAgentConfigBanner',
   HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
+  SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',
+  HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -44,6 +44,12 @@ export function getExtraDirs(): string[] {
       'C:\\Program Files\\MiKTeX\\miktex\\bin',
       'C:\\Program Files (x86)\\MiKTeX\\miktex\\bin',
       'C:\\Program Files (x86)\\MiKTeX 2.9\\miktex\\bin',
+      'C:\\Program Files\\gs\\gs9.56.1\\bin',
+      'C:\\Program Files\\gs\\gs9.55.0\\bin',
+      'C:\\Program Files\\gs\\gs9.54.0\\bin',
+      'C:\\Program Files (x86)\\gs\\gs9.56.1\\bin',
+      'C:\\Program Files (x86)\\gs\\gs9.55.0\\bin',
+      'C:\\Program Files (x86)\\gs\\gs9.54.0\\bin',
     );
     const localAppData = process.env.LOCALAPPDATA;
     if (localAppData) {
@@ -211,8 +217,14 @@ export function findToolInCommonPaths(tool: string): string | null {
   if (!tool.toLowerCase().endsWith('.pl')) {
     candidates.push(`${tool}.pl`);
   }
-  if (process.platform === 'win32' && !tool.toLowerCase().endsWith('.exe')) {
-    candidates.unshift(`${tool}.exe`);
+  if (process.platform === 'win32') {
+    // Special handling for Ghostscript on Windows
+    if (tool === 'gs') {
+      candidates.push('gswin64c', 'gswin32c');
+      candidates.push('gswin64c.exe', 'gswin32c.exe');
+    } else if (!tool.toLowerCase().endsWith('.exe')) {
+      candidates.unshift(`${tool}.exe`);
+    }
   }
 
   for (const dir of getExtraDirs()) {

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -43,6 +43,18 @@ const TEXCOUNT_INSTRUCTIONS =
   '- Ubuntu: sudo apt-get install texlive-extra-utils\n' +
   '- Windows: Install through MiKTeX or TeX Live package manager';
 
+const PERL_INSTRUCTIONS =
+  'Installation instructions:\n' +
+  '- Mac: brew install perl\n' +
+  '- Ubuntu: sudo apt-get install perl\n' +
+  '- Windows: Download from https://strawberryperl.com/';
+
+const GHOSTSCRIPT_INSTRUCTIONS =
+  'Installation instructions:\n' +
+  '- Mac: brew install ghostscript\n' +
+  '- Ubuntu: sudo apt-get install ghostscript\n' +
+  '- Windows: Download from https://ghostscript.com/releases/gsdnld.html';
+
 const GM_INSTRUCTIONS =
   'Installation instructions:\n' +
   '- Mac: brew install graphicsmagick\n' +
@@ -94,6 +106,21 @@ const TOOL_CONFIGS: Record<string, ToolConfig> = {
     errorMessage:
       'GraphicsMagick is not installed. Please install GraphicsMagick to use PDF to PNG conversion.\n' +
       GM_INSTRUCTIONS,
+  },
+
+  // System dependencies
+  perl: {
+    command: 'perl --version',
+    errorMessage:
+      'Perl is not installed. latexindent requires Perl.\n' + PERL_INSTRUCTIONS,
+    openDocsCommand: 'texra.openDoc,installation',
+  },
+  gs: {
+    command: 'gs --version',
+    errorMessage:
+      'Ghostscript is not installed. Please install Ghostscript to use PDF to PNG conversion.\n' +
+      GHOSTSCRIPT_INSTRUCTIONS,
+    openDocsCommand: 'texra.openDoc,installation',
   },
 
   // Wolfram tools
@@ -288,4 +315,18 @@ export async function checkMultipleToolsInstalled(
     configs.map((config) => checkToolInstalled(config, showError)),
   );
   return results;
+}
+
+/**
+ * Check core dependencies required by TeXRA features
+ * (latexindent, Perl, Ghostscript, GraphicsMagick).
+ * @param showError Whether to show error messages for missing tools
+ * @returns Promise<string[]> Array of missing tool names
+ */
+export async function checkCoreDependencies(
+  showError: boolean = true,
+): Promise<string[]> {
+  const tools = ['latexindent', 'perl', 'gs', 'gm'];
+  const results = await checkMultipleToolsInstalled(tools, showError);
+  return tools.filter((_, i) => !results[i]);
 }

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -322,21 +322,41 @@ export async function checkMultipleToolsInstalled(
 
 /**
  * Check core dependencies required by TeXRA features
- * (latexindent, Perl, Ghostscript, GraphicsMagick).
+ * (latexindent, Perl, Ghostscript, GraphicsMagick/ImageMagick).
  * @param showError Whether to show error messages for missing tools
  * @returns Promise<string[]> Array of missing tool names
  */
 export async function checkCoreDependencies(
   showError: boolean = true,
 ): Promise<string[]> {
-  const tools = ['latexindent', 'perl', 'gs', 'gm'];
   try {
-    const results = await checkMultipleToolsInstalled(tools, showError);
-    return tools.filter((_, i) => !results[i]);
+    // Check basic tools
+    const basicTools = ['latexindent', 'perl', 'gs'];
+    const basicResults = await checkMultipleToolsInstalled(basicTools, showError);
+    const missingBasicTools = basicTools.filter((_, i) => !basicResults[i]);
+    
+    // Check for either GraphicsMagick or ImageMagick
+    const [hasMagick, hasGm] = await checkMultipleToolsInstalled(
+      ['magick', 'gm'],
+      false, // Don't show errors since we're checking alternatives
+    );
+    
+    // Add image tool to missing list only if neither is installed
+    const missingTools = [...missingBasicTools];
+    if (!hasMagick && !hasGm) {
+      missingTools.push('gm/magick');
+      if (showError) {
+        const errorMsg = 'Neither GraphicsMagick nor ImageMagick is installed. Please install either tool for image processing.\n' +
+          'GraphicsMagick:\n' + GM_INSTRUCTIONS + '\n\nOR\n\nImageMagick:\n' + MAGICK_INSTRUCTIONS;
+        throw new Error(errorMsg);
+      }
+    }
+    
+    return missingTools;
   } catch (error) {
     // If checking fails, assume all tools are missing to prompt user to check
     // This is safer than silently ignoring the error
     console.error('Failed to check core dependencies:', error);
-    return tools;
+    return ['latexindent', 'perl', 'gs', 'gm/magick'];
   }
 }

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -327,6 +327,13 @@ export async function checkCoreDependencies(
   showError: boolean = true,
 ): Promise<string[]> {
   const tools = ['latexindent', 'perl', 'gs', 'gm'];
-  const results = await checkMultipleToolsInstalled(tools, showError);
-  return tools.filter((_, i) => !results[i]);
+  try {
+    const results = await checkMultipleToolsInstalled(tools, showError);
+    return tools.filter((_, i) => !results[i]);
+  } catch (error) {
+    // If checking fails, assume all tools are missing to prompt user to check
+    // This is safer than silently ignoring the error
+    console.error('Failed to check core dependencies:', error);
+    return tools;
+  }
 }

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -116,7 +116,10 @@ const TOOL_CONFIGS: Record<string, ToolConfig> = {
     openDocsCommand: 'texra.openDoc,installation',
   },
   gs: {
-    command: 'gs --version',
+    command:
+      process.platform === 'win32'
+        ? ['gswin64c --version', 'gswin32c --version', 'gs --version']
+        : 'gs --version',
     errorMessage:
       'Ghostscript is not installed. Please install Ghostscript to use PDF to PNG conversion.\n' +
       GHOSTSCRIPT_INSTRUCTIONS,

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -155,6 +155,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       },
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS]: async () =>
         safeExecuteCommand('texra.openDoc', ['agent-explorer'], this.viewName),
+      [MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS]: async () =>
+        safeExecuteCommand('texra.openDoc', ['installation'], this.viewName),
 
       // Instruction commands
       [MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT]: async (m, w) =>
@@ -200,6 +202,14 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         w.webview.postMessage(m);
       },
       [MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER]: async (m, w) => {
+        /* Banner handled client-side */
+        w.webview.postMessage(m);
+      },
+      [MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER]: async (m, w) => {
+        /* Banner handled client-side */
+        w.webview.postMessage(m);
+      },
+      [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: async (m, w) => {
         /* Banner handled client-side */
         w.webview.postMessage(m);
       },

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -17,7 +17,7 @@ import {
 
 // @ts-ignore - Import JavaScript module
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
-import { getConfig } from '@utils/config';
+import { getConfig, setConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { computeModelOptions } from '@model/computeModelOptions';
@@ -212,6 +212,9 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: async (m, w) => {
         /* Banner handled client-side */
         w.webview.postMessage(m);
+      },
+      [MAIN_VIEW_COMMANDS.UPDATE_DEPENDENCY_REMINDER_SETTING]: async (m) => {
+        await setConfig('ui.showDependencyReminders', m.value);
       },
 
       // Recording commands

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -541,6 +541,24 @@
             </button>
           </div>
         </div>
+
+        <!-- Dependency Banner -->
+        <div
+          id="dependencyBanner"
+          class="dependency-banner"
+          style="display: none"
+        >
+          <span>Required dependencies are missing.</span>
+          <div class="actions">
+            <button
+              id="dependencyDocsButton"
+              class="vscode-button"
+              data-icon="book"
+            >
+              Installation Guide
+            </button>
+          </div>
+        </div>
       </div>
 
       <div class="latexdiffs-section">

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -557,6 +557,14 @@
             >
               Installation Guide
             </button>
+            <button
+              id="dependencyDismissButton"
+              class="vscode-button secondary"
+              data-icon="close"
+              title="Dismiss (can be re-enabled in settings)"
+            >
+              Dismiss
+            </button>
           </div>
         </div>
       </div>

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -103,4 +103,6 @@ export const ELEMENT_IDS = {
   AGENT_CONFIG_EDIT_BUTTON: 'agentConfigEditButton',
   AGENT_CONFIG_DIR_BUTTON: 'agentConfigDirButton',
   AGENT_CONFIG_DOC_BUTTON: 'agentConfigDocButton',
+  DEPENDENCY_BANNER: 'dependencyBanner',
+  DEPENDENCY_DOCS_BUTTON: 'dependencyDocsButton',
 };

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -105,4 +105,5 @@ export const ELEMENT_IDS = {
   AGENT_CONFIG_DOC_BUTTON: 'agentConfigDocButton',
   DEPENDENCY_BANNER: 'dependencyBanner',
   DEPENDENCY_DOCS_BUTTON: 'dependencyDocsButton',
+  DEPENDENCY_DISMISS_BUTTON: 'dependencyDismissButton',
 };

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -72,6 +72,7 @@ export class MainViewDomHandler {
       toggleManager,
       latexdiffManager,
       mainViewState,
+      webviewEventBus,
     );
 
     this.fileInputManager.setup();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -123,6 +123,14 @@ export class MainViewMessageHandler {
           element.style.setProperty('display', 'none');
         }
       },
+      [MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER]: (m) => {
+        webviewEventBus.dispatchEvent(
+          new CustomEvent('showDependencyBanner', { detail: m }),
+        );
+      },
+      [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: () => {
+        webviewEventBus.dispatchEvent(new CustomEvent('hideDependencyBanner'));
+      },
       [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (m) => {
         // Validate that options are provided
         if (!m.options) {

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -92,8 +92,21 @@ export class SettingsButtonManager extends BaseUIManager {
       });
     });
 
+    this.addListener(ELEMENT_IDS.DEPENDENCY_DISMISS_BUTTON, 'click', () => {
+      // Hide the banner
+      const element = safeGetElementById(ELEMENT_IDS.DEPENDENCY_BANNER);
+      if (element) {
+        element.style.setProperty('display', 'none');
+      }
+      // Update the setting to disable future reminders
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.UPDATE_DEPENDENCY_REMINDER_SETTING,
+        value: false,
+      });
+    });
+
     this.eventBus.addEventListener('showDependencyBanner', (e) => {
-      const missing = e.detail?.missing || [];
+      const missing = e.detail?.missingTools || [];
       const element = safeGetElementById(ELEMENT_IDS.DEPENDENCY_BANNER);
       if (element) {
         const textSpan = element.querySelector('span');

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -111,7 +111,14 @@ export class SettingsButtonManager extends BaseUIManager {
       if (element) {
         const textSpan = element.querySelector('span');
         if (textSpan) {
-          textSpan.textContent = `Missing dependencies: ${missing.join(', ')}`;
+          // Format the display of missing tools more nicely
+          const formattedTools = missing.map(tool => {
+            if (tool === 'gm/magick') {
+              return 'GraphicsMagick or ImageMagick';
+            }
+            return tool;
+          });
+          textSpan.textContent = `Missing dependencies: ${formattedTools.join(', ')}`;
         }
         element.style.setProperty('display', 'flex');
       }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -8,6 +8,7 @@ import { ELEMENT_IDS } from '../constants.js';
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
 import { BaseUIManager } from './BaseUIManager.js';
+import { webviewEventBus } from '../eventBus.js';
 import { safeGetElementById } from '@common/domUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -18,12 +19,14 @@ export class SettingsButtonManager extends BaseUIManager {
     toggleManager,
     latexdiffManager,
     state = mainViewState,
+    eventBus = webviewEventBus,
   ) {
     super();
     this.vscode = vscodeInstance;
     this.toggleManager = toggleManager;
     this.latexdiffManager = latexdiffManager;
     this.state = state;
+    this.eventBus = eventBus;
   }
 
   _setupToggles() {
@@ -79,6 +82,33 @@ export class SettingsButtonManager extends BaseUIManager {
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS,
       });
+    });
+  }
+
+  _setupDependencyBanner() {
+    this.addListener(ELEMENT_IDS.DEPENDENCY_DOCS_BUTTON, 'click', () => {
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS,
+      });
+    });
+
+    this.eventBus.addEventListener('showDependencyBanner', (e) => {
+      const missing = e.detail?.missing || [];
+      const element = safeGetElementById(ELEMENT_IDS.DEPENDENCY_BANNER);
+      if (element) {
+        const textSpan = element.querySelector('span');
+        if (textSpan) {
+          textSpan.textContent = `Missing dependencies: ${missing.join(', ')}`;
+        }
+        element.style.setProperty('display', 'flex');
+      }
+    });
+
+    this.eventBus.addEventListener('hideDependencyBanner', () => {
+      const element = safeGetElementById(ELEMENT_IDS.DEPENDENCY_BANNER);
+      if (element) {
+        element.style.setProperty('display', 'none');
+      }
     });
   }
 
@@ -164,5 +194,6 @@ export class SettingsButtonManager extends BaseUIManager {
     this._setupToggles();
     this._setupSettingsButtons();
     this._setupDropdowns();
+    this._setupDependencyBanner();
   }
 }

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -70,7 +70,8 @@
 }
 
 .api-key-banner .actions,
-.agent-config-banner .actions {
+.agent-config-banner .actions,
+.dependency-banner .actions {
   display: flex;
   gap: var(--spacing-small);
 }
@@ -87,7 +88,8 @@
 
 /* Banners */
 .api-key-banner,
-.agent-config-banner {
+.agent-config-banner,
+.dependency-banner {
   background-color: var(--vscode-inputValidation-warningBackground);
   color: var(--vscode-inputValidation-warningForeground);
   border: 1px solid var(--vscode-inputValidation-warningBorder);


### PR DESCRIPTION
## Summary
- check for core dependencies like latexindent, Perl, Ghostscript, and GraphicsMagick
- show a dependency banner in the main view with quick doc links
- wire up commands and styles for new dependency banner

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c135d060308324be5d2a0e610a3637