### PR TITLE
refactor: centralize webview provider setup

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -4,22 +4,28 @@ import * as vscode from 'vscode';
 // Local imports - webview
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';
 import { MainViewContentProvider } from './webview/MainViewContentProvider';
-import { SecretManager } from '@frontend/secretManager';
-import { watchConfig } from '@utils/config';
+
+// Local imports - common
+import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
-export class MainViewProvider implements vscode.WebviewViewProvider {
-  private messageHandler: MainViewMessageHandler;
-  private contentProvider: MainViewContentProvider;
+// Local imports - utilities
+import { SecretManager } from '@frontend/secretManager';
+import { watchConfig } from '@utils/config';
+
+export class MainViewProvider
+  extends BaseWebviewProvider<vscode.WebviewView>
+  implements vscode.WebviewViewProvider
+{
   private fileWatcher: vscode.FileSystemWatcher | undefined;
-  private webviewView: vscode.WebviewView | undefined;
 
   // Static flag to track if commands have been registered
   private static commandsRegistered = false;
 
-  constructor(private readonly context: vscode.ExtensionContext) {
-    this.messageHandler = new MainViewMessageHandler(context);
+  constructor(context: vscode.ExtensionContext) {
+    super(context);
     this.contentProvider = new MainViewContentProvider(context);
+    this.messageHandler = new MainViewMessageHandler(context);
     this.setupFileWatcher();
     this.setupConfigurationWatcher();
     this.registerCommandHandlers();
@@ -35,7 +41,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
           if (!commands.includes('texra.getWebviewView')) {
             this.context.subscriptions.push(
               vscode.commands.registerCommand('texra.getWebviewView', () => {
-                return this.webviewView;
+                return this.view;
               }),
             );
             MainViewProvider.commandsRegistered = true;
@@ -60,13 +66,13 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     // Always set up notifier for this instance, regardless of command registration
     this.context.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor(() => {
-        if (this.webviewView) {
+        if (this.view) {
           // Notify the webview that the active editor has changed
           // TODO: This command is sent but not handled in the webview (no handler in messageHandlers.js)
           // This appears to be an incomplete implementation from commit bb28ecbf
           const activeEditor = vscode.window.activeTextEditor;
           if (activeEditor && activeEditor.document) {
-            this.webviewView.webview.postMessage({
+            this.view.webview.postMessage({
               command: MAIN_VIEW_COMMANDS.ACTIVE_EDITOR_CHANGED,
               file: activeEditor.document.fileName,
             });
@@ -86,9 +92,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async refreshOptionsAndView() {
-    if (this.webviewView) {
-      this.webviewView.webview.html = this.contentProvider.getHtmlContent(
-        this.webviewView.webview,
+    if (this.view) {
+      this.view.webview.html = this.contentProvider.getHtmlContent(
+        this.view.webview,
       );
     }
   }
@@ -108,16 +114,15 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async refreshFiles() {
-    if (this.webviewView) {
+    if (this.view) {
       await this.messageHandler.handleMessage(
         { command: MAIN_VIEW_COMMANDS.REFRESH_ALL_FILES },
-        this.webviewView,
+        this.view,
       );
     }
   }
 
   resolveWebviewView(webviewView: vscode.WebviewView) {
-    this.webviewView = webviewView;
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [
@@ -150,14 +155,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       ],
     };
 
-    webviewView.webview.html = this.contentProvider.getHtmlContent(
-      webviewView.webview,
-    );
-
-    webviewView.webview.onDidReceiveMessage(async (message) => {
-      await this.messageHandler.handleMessage(message, webviewView);
-    });
-
+    super.resolveWebviewView(webviewView);
     this.setupInitialState(webviewView);
 
     // Check if any API keys are set and display banner if needed

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -1,0 +1,45 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Base class for webview providers handling common setup and disposal
+export abstract class BaseWebviewProvider<
+  V extends { webview: vscode.Webview; onDidDispose: vscode.Event<void> },
+> implements vscode.Disposable
+{
+  protected view?: V;
+  private viewDisposables: vscode.Disposable[] = [];
+  protected contentProvider!: {
+    getHtmlContent(webview: vscode.Webview): string;
+  };
+  protected messageHandler!: {
+    handleMessage(message: any, view: V): Promise<void> | void;
+  };
+
+  constructor(protected readonly context: vscode.ExtensionContext) {}
+
+  public dispose(): void {
+    this.cleanupView();
+  }
+
+  protected registerViewDisposable(disposable: vscode.Disposable): void {
+    this.viewDisposables.push(disposable);
+  }
+
+  protected cleanupView(): void {
+    this.viewDisposables.forEach((d) => d.dispose());
+    this.viewDisposables = [];
+    this.view = undefined;
+  }
+
+  public resolveWebviewView(view: V): void {
+    this.cleanupView();
+    this.view = view;
+    view.webview.html = this.contentProvider.getHtmlContent(view.webview);
+    this.registerViewDisposable(
+      view.webview.onDidReceiveMessage((message) =>
+        this.messageHandler.handleMessage(message, view),
+      ),
+    );
+    this.registerViewDisposable(view.onDidDispose(() => this.cleanupView()));
+  }
+}

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -1,5 +1,4 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports - history view
@@ -8,23 +7,19 @@ import * as vscode from 'vscode';
 import { HistoryViewContentProvider } from './HistoryViewContentProvider';
 import { HistoryViewMessageHandler } from './HistoryViewMessageHandler';
 
-export class HistoryViewProvider implements vscode.WebviewViewProvider {
+// Local imports - common
+import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
+
+export class HistoryViewProvider extends BaseWebviewProvider<vscode.WebviewPanel> {
   public static readonly viewType = 'texra.historyView';
-  private _view?: vscode.WebviewPanel;
-  private readonly contentProvider: HistoryViewContentProvider;
-  private readonly messageHandler: HistoryViewMessageHandler;
 
-  constructor(private readonly context: vscode.ExtensionContext) {
+  private historyMessageHandler: HistoryViewMessageHandler;
+
+  constructor(context: vscode.ExtensionContext) {
+    super(context);
     this.contentProvider = new HistoryViewContentProvider(context);
-    this.messageHandler = new HistoryViewMessageHandler(context);
-  }
-
-  /**
-   * This is required for the WebviewViewProvider interface but we won't use it
-   * as we're removing the sidebar integration
-   */
-  public resolveWebviewView(webviewView: vscode.WebviewView): void {
-    // We no longer use webview in the sidebar, but we need this method for the interface
+    this.historyMessageHandler = new HistoryViewMessageHandler(context);
+    this.messageHandler = this.historyMessageHandler as any;
   }
 
   /**
@@ -32,13 +27,13 @@ export class HistoryViewProvider implements vscode.WebviewViewProvider {
    */
   public async showHistoryView() {
     // If we already have a panel, show it
-    if (this._view) {
-      this._view.reveal(vscode.ViewColumn.One);
+    if (this.view) {
+      this.view.reveal(vscode.ViewColumn.One);
       return;
     }
 
     // Otherwise, create a new panel
-    this._view = vscode.window.createWebviewPanel(
+    const panel = vscode.window.createWebviewPanel(
       HistoryViewProvider.viewType,
       'TeXRA History',
       vscode.ViewColumn.One,
@@ -76,40 +71,12 @@ export class HistoryViewProvider implements vscode.WebviewViewProvider {
       },
     );
 
-    // Handle webview disposal
-    this._view.onDidDispose(() => {
-      this._view = undefined;
-    });
+    super.resolveWebviewView(panel);
 
-    // Handle messages from the webview
-    this._view.webview.onDidReceiveMessage(async (message) => {
-      await this.messageHandler.handleMessage(
-        message,
-        this._view as unknown as vscode.WebviewView,
-      );
-    });
-
-    // Set initial HTML content
-    await this.updateWebviewContent();
-  }
-
-  // No additional logic needed here; all message handling is delegated
-  // to HistoryViewMessageHandler
-
-  /**
-   * Update the content of the webview
-   */
-  private async updateWebviewContent() {
-    if (this._view) {
-      this._view.webview.html = this.contentProvider.getHtmlContent(
-        this._view.webview,
-      );
-
-      // Send history data after a short delay to ensure the webview is ready
-      setTimeout(
-        () => this.messageHandler.sendHistoryData(this._view!.webview),
-        100,
-      );
-    }
+    // Send history data after a short delay to ensure the webview is ready
+    setTimeout(
+      () => this.historyMessageHandler.sendHistoryData(panel.webview),
+      100,
+    );
   }
 }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 
 // Local imports - progress view
 import type { ProgressViewProvider } from './ProgressViewProvider';
+
+// Local imports - common
 import {
   BaseViewMessageHandler,
   MessageHandler,
@@ -61,6 +63,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   // Handler implementations
+  protected async handleWebviewReady(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    this.provider.onWebviewReady();
+  }
+
   private async handleSwitchStream(
     message: any,
     webviewView: vscode.WebviewView,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -1,5 +1,4 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports - progress view
@@ -7,21 +6,22 @@ import { ProgressEventHandler } from './events/ProgressEventHandler';
 import { WebviewUpdater } from './managers';
 
 // @ts-ignore - Import JavaScript module
-import { STATUS, COMMANDS } from './modules/constants.js';
+import { STATUS } from './modules/constants.js';
 
 // Local imports - new architecture
 import { StatePersistenceManager } from './persistence/StatePersistenceManager';
+import { ProgressViewState } from './state/ProgressViewState';
 
 // Local imports - existing components
 import { ProgressViewContentProvider } from './ProgressViewContentProvider';
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
-import { ProgressViewState } from './state/ProgressViewState';
+
+// Local imports - common
+import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
 
 // Types
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { AgentLogger } from '@logger/AgentLogger';
-import { LogMessageData } from '@logger/LogTypes';
 import { TaskState } from '@logger/TaskState';
 
 // Type aliases for status values
@@ -35,22 +35,19 @@ type StreamStatusType =
  * This class now focuses on orchestration and delegation to focused managers,
  * following the design principles from AGENTS.md.
  */
-export class ProgressViewProvider implements vscode.WebviewViewProvider {
+export class ProgressViewProvider
+  extends BaseWebviewProvider<vscode.WebviewView>
+  implements vscode.WebviewViewProvider
+{
   private static _instance: ProgressViewProvider | undefined;
-  private _view?: vscode.WebviewView;
 
   // New modular architecture components
   public readonly state: ProgressViewState;
   public readonly eventHandler: ProgressEventHandler;
   public readonly webviewUpdater: WebviewUpdater;
 
-  // Existing components (will be gradually updated)
-  private readonly contentProvider: ProgressViewContentProvider;
-  private readonly messageHandler: ProgressViewMessageHandler;
-
   // Infrastructure
   private _disposables: vscode.Disposable[] = [];
-  private _viewDisposables: vscode.Disposable[] = [];
   private readonly _extensionUri: vscode.Uri;
   private readonly _viewTitle: string;
   private _webviewReady = false;
@@ -58,10 +55,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private _hasResolved = false;
   private readonly logger: AgentLogger;
 
-  constructor(
-    private readonly context: vscode.ExtensionContext,
-    title: string = 'Tasks',
-  ) {
+  constructor(context: vscode.ExtensionContext, title: string = 'Tasks') {
+    super(context);
     this._extensionUri = context.extensionUri;
     this._viewTitle = title;
     this.logger = new AgentLogger('ProgressViewProviderNew');
@@ -71,7 +66,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
       context.workspaceState,
     );
     this.state = new ProgressViewState(persistenceManager);
-    this.webviewUpdater = new WebviewUpdater(() => this._view?.webview);
+    this.webviewUpdater = new WebviewUpdater(() => this.view?.webview);
     this.eventHandler = new ProgressEventHandler(
       this.state,
       this.webviewUpdater,
@@ -116,10 +111,8 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this.cleanupView();
   }
 
-  private cleanupView(): void {
-    this._viewDisposables.forEach((d) => d.dispose());
-    this._viewDisposables = [];
-    this._view = undefined;
+  protected cleanupView(): void {
+    super.cleanupView();
     this._webviewReady = false;
     this._pendingUpdate = false;
   }
@@ -135,7 +128,6 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     this._webviewReady = false;
     this._pendingUpdate = false;
-    this._view = webviewView;
 
     this.setupWebview(webviewView);
     this.updateWebview();
@@ -166,34 +158,21 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     webviewView.title = this._viewTitle;
 
-    // Set initial HTML content
-    webviewView.webview.html = this.contentProvider.getHtmlContent(
-      webviewView.webview,
-    );
+    super.resolveWebviewView(webviewView);
 
     // Setup event handlers
-    this._viewDisposables.push(
+    this.registerViewDisposable(
       webviewView.onDidChangeVisibility(() => {
         if (webviewView.visible) {
           this.updateWebview();
         }
       }),
+    );
+    this.registerViewDisposable(
       vscode.window.onDidChangeActiveColorTheme(() => {
         if (webviewView.visible) {
           this.updateWebview();
         }
-      }),
-      webviewView.webview.onDidReceiveMessage(async (message) => {
-        if (message.command === COMMANDS.WEBVIEW_READY) {
-          this._webviewReady = true;
-          // Always update webview when it becomes ready to ensure all streams are shown
-          this.updateWebview();
-          return;
-        }
-        await this.messageHandler.handleMessage(message, webviewView);
-      }),
-      webviewView.onDidDispose(() => {
-        this.cleanupView();
       }),
     );
   }
@@ -202,7 +181,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
    * Update webview content using the new architecture
    */
   public updateWebview(): void {
-    if (!this._view) return;
+    if (!this.view) return;
 
     if (!this._webviewReady) {
       this._pendingUpdate = true;
@@ -240,6 +219,11 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     this._pendingUpdate = false;
   }
 
+  public onWebviewReady(): void {
+    this._webviewReady = true;
+    this.updateWebview();
+  }
+
   // Public API methods - these delegate to the new architecture
 
   /**
@@ -270,7 +254,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
    * Check if view is visible (legacy compatibility)
    */
   public isViewVisible(): boolean {
-    return this._view?.visible ?? false;
+    return this.view?.visible ?? false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `BaseWebviewProvider` with shared HTML and message setup for webviews
- refactor Main, Progress, and History providers to extend the base and remove duplicate wiring
- handle webview ready signal within ProgressViewMessageHandler

## Testing
- `npm run format`
- `npm run lint`
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c115e05d1c8324b0b8e78dfc6f711c