### PR TITLE
refactor: centralize webview provider setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,7 @@ When creating a new release:
    ```
 
 5. Publish to Open VSX Marketplace
+
    ```bash
    ovsx publish
    ```

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - common
+import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
+
 // Local imports - webview
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';
 import { MainViewContentProvider } from './webview/MainViewContentProvider';
@@ -8,16 +11,16 @@ import { SecretManager } from '@frontend/secretManager';
 import { watchConfig, getConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
-export class MainViewProvider implements vscode.WebviewViewProvider {
-  private messageHandler: MainViewMessageHandler;
-  private contentProvider: MainViewContentProvider;
+export class MainViewProvider extends BaseWebviewProvider {
+  protected messageHandler: MainViewMessageHandler;
+  protected contentProvider: MainViewContentProvider;
   private fileWatcher: vscode.FileSystemWatcher | undefined;
-  private webviewView: vscode.WebviewView | undefined;
 
   // Static flag to track if commands have been registered
   private static commandsRegistered = false;
 
-  constructor(private readonly context: vscode.ExtensionContext) {
+  constructor(protected readonly context: vscode.ExtensionContext) {
+    super(context);
     this.messageHandler = new MainViewMessageHandler(context);
     this.contentProvider = new MainViewContentProvider(context);
     this.setupFileWatcher();
@@ -35,7 +38,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
           if (!commands.includes('texra.getWebviewView')) {
             this.context.subscriptions.push(
               vscode.commands.registerCommand('texra.getWebviewView', () => {
-                return this.webviewView;
+                return this._view as vscode.WebviewView;
               }),
             );
             MainViewProvider.commandsRegistered = true;
@@ -60,13 +63,13 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     // Always set up notifier for this instance, regardless of command registration
     this.context.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor(() => {
-        if (this.webviewView) {
+        if (this._view) {
           // Notify the webview that the active editor has changed
           // TODO: This command is sent but not handled in the webview (no handler in messageHandlers.js)
           // This appears to be an incomplete implementation from commit bb28ecbf
           const activeEditor = vscode.window.activeTextEditor;
           if (activeEditor && activeEditor.document) {
-            this.webviewView.webview.postMessage({
+            this._view.webview.postMessage({
               command: MAIN_VIEW_COMMANDS.ACTIVE_EDITOR_CHANGED,
               file: activeEditor.document.fileName,
             });
@@ -86,9 +89,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async refreshOptionsAndView() {
-    if (this.webviewView) {
-      this.webviewView.webview.html = this.contentProvider.getHtmlContent(
-        this.webviewView.webview,
+    if (this._view) {
+      this._view.webview.html = this.contentProvider.getHtmlContent(
+        this._view.webview,
       );
     }
   }
@@ -108,16 +111,15 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async refreshFiles() {
-    if (this.webviewView) {
+    if (this._view) {
       await this.messageHandler.handleMessage(
         { command: MAIN_VIEW_COMMANDS.REFRESH_ALL_FILES },
-        this.webviewView,
+        this._view as vscode.WebviewView,
       );
     }
   }
 
   resolveWebviewView(webviewView: vscode.WebviewView) {
-    this.webviewView = webviewView;
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [
@@ -150,13 +152,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       ],
     };
 
-    webviewView.webview.html = this.contentProvider.getHtmlContent(
-      webviewView.webview,
-    );
-
-    webviewView.webview.onDidReceiveMessage(async (message) => {
-      await this.messageHandler.handleMessage(message, webviewView);
-    });
+    super.resolveWebviewView(webviewView);
 
     this.setupInitialState(webviewView);
 

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -11,7 +11,10 @@ import { SecretManager } from '@frontend/secretManager';
 import { watchConfig, getConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
-export class MainViewProvider extends BaseWebviewProvider {
+export class MainViewProvider
+  extends BaseWebviewProvider
+  implements vscode.WebviewViewProvider
+{
   protected messageHandler: MainViewMessageHandler;
   protected contentProvider: MainViewContentProvider;
   private fileWatcher: vscode.FileSystemWatcher | undefined;

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -152,7 +152,7 @@ export class MainViewProvider extends BaseWebviewProvider {
       ],
     };
 
-    super.resolveWebviewView(webviewView);
+    super.resolveWebviewViewInternal(webviewView);
 
     this.setupInitialState(webviewView);
 

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -5,9 +5,9 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - errors
-import { 
-  showLoggedMessageWithDocs, 
-  showLoggedErrorMessage 
+import {
+  showLoggedMessageWithDocs,
+  showLoggedErrorMessage,
 } from '@common/errors/errorHandlingUtils';
 
 // Local imports - agent
@@ -52,7 +52,11 @@ async function handleMerge(
     await executeMergeAgent(model, fileToUse, editedFile, context);
   } catch (err) {
     // Log the error before re-throwing
-    await showLoggedErrorMessage('MergeCommands', 'Merge operation failed', err);
+    await showLoggedErrorMessage(
+      'MergeCommands',
+      'Merge operation failed',
+      err,
+    );
     throw err;
   }
 }

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -24,10 +24,10 @@ import * as logger from '@logger/logUtils';
  * Valid documentation identifiers for error messages.
  * This ensures type safety when referencing documentation sections.
  */
-export type DocId = 
-  | 'intelligent-merge' 
-  | 'custom-agents' 
-  | 'tool-integration' 
+export type DocId =
+  | 'intelligent-merge'
+  | 'custom-agents'
+  | 'tool-integration'
   | 'latex-diff';
 
 /** Maximum length for error details before truncation */
@@ -59,12 +59,12 @@ const MAX_ERROR_LENGTH = 500;
  */
 export function formatError(prefix: string, err: unknown): string {
   let detail = err instanceof Error ? err.message : String(err);
-  
+
   // Truncate overly long error details for better readability
   if (detail.length > MAX_ERROR_LENGTH) {
     detail = detail.substring(0, MAX_ERROR_LENGTH) + '...';
   }
-  
+
   return `${prefix}: ${detail}`;
 }
 

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -5,19 +5,23 @@ import * as vscode from 'vscode';
 import { COMMON_COMMANDS } from './commands';
 import * as logger from '@logger/logUtils';
 
-export type MessageHandler = (
-  message: any,
-  webviewView: vscode.WebviewView,
-) => Promise<void>;
+export type MessageHandler<T extends vscode.WebviewView | vscode.WebviewPanel> =
+  (
+    message: any,
+    webviewView: T,
+  ) => Promise<void>;
 
 /**
  * Base class for all webview message handlers.
  * Provides consistent error handling, logging, and common patterns.
+ * @template T - The webview type (WebviewView or WebviewPanel)
  */
-export abstract class BaseViewMessageHandler {
+export abstract class BaseViewMessageHandler<
+  T extends vscode.WebviewView | vscode.WebviewPanel = vscode.WebviewView,
+> {
   protected readonly logger: any;
   protected readonly channel: string;
-  protected readonly handlers: Record<string, MessageHandler>;
+  protected readonly handlers: Record<string, MessageHandler<T>>;
 
   constructor(protected readonly viewName: string) {
     this.logger = logger;
@@ -29,14 +33,14 @@ export abstract class BaseViewMessageHandler {
   /**
    * Subclasses must implement this to provide their specific handlers
    */
-  protected abstract createHandlers(): Record<string, MessageHandler>;
+  protected abstract createHandlers(): Record<string, MessageHandler<T>>;
 
   /**
    * Standard message handling with consistent error handling and logging
    */
   public async handleMessage(
     message: any,
-    webviewView: vscode.WebviewView,
+    webviewView: T,
   ): Promise<void> {
     if (!message?.command) {
       this.logger.warn(
@@ -77,7 +81,7 @@ export abstract class BaseViewMessageHandler {
    */
   protected async handleTheme(
     message: any,
-    webviewView: vscode.WebviewView,
+    webviewView: T,
   ): Promise<void> {
     if (!message?.theme) {
       this.logger.warn('Invalid theme message:', message);
@@ -95,7 +99,7 @@ export abstract class BaseViewMessageHandler {
    */
   protected async handleDebugMode(
     message: any,
-    webviewView: vscode.WebviewView,
+    webviewView: T,
   ): Promise<void> {
     webviewView.webview.postMessage({
       command: COMMON_COMMANDS.DEBUG_MODE_SET,
@@ -104,11 +108,13 @@ export abstract class BaseViewMessageHandler {
   }
 
   /**
-   * Helper method for webview ready state
+   * Helper method for webview ready state.
+   * Subclasses can override this method to perform custom initialization
+   * when the webview signals it is ready.
    */
   protected async handleWebviewReady(
     message: any,
-    webviewView: vscode.WebviewView,
+    webviewView: T,
   ): Promise<void> {
     this.logger.debug('Webview ready signal received');
     // Subclasses can override for custom ready handling

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -7,7 +7,7 @@ import * as logger from '@logger/logUtils';
 
 export type MessageHandler<
   T extends vscode.WebviewView | vscode.WebviewPanel = vscode.WebviewView,
-> = (message: any, webviewView: T) => Promise<void>;
+> = (message: any, webviewView: T) => Promise<void> | void;
 
 /**
  * Base class for all webview message handlers.

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -5,11 +5,9 @@ import * as vscode from 'vscode';
 import { COMMON_COMMANDS } from './commands';
 import * as logger from '@logger/logUtils';
 
-export type MessageHandler<T extends vscode.WebviewView | vscode.WebviewPanel> =
-  (
-    message: any,
-    webviewView: T,
-  ) => Promise<void>;
+export type MessageHandler<
+  T extends vscode.WebviewView | vscode.WebviewPanel = vscode.WebviewView,
+> = (message: any, webviewView: T) => Promise<void>;
 
 /**
  * Base class for all webview message handlers.

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -36,10 +36,7 @@ export abstract class BaseViewMessageHandler<
   /**
    * Standard message handling with consistent error handling and logging
    */
-  public async handleMessage(
-    message: any,
-    webviewView: T,
-  ): Promise<void> {
+  public async handleMessage(message: any, webviewView: T): Promise<void> {
     if (!message?.command) {
       this.logger.warn(
         this.channel,
@@ -77,10 +74,7 @@ export abstract class BaseViewMessageHandler<
   /**
    * Helper method for common theme handling
    */
-  protected async handleTheme(
-    message: any,
-    webviewView: T,
-  ): Promise<void> {
+  protected async handleTheme(message: any, webviewView: T): Promise<void> {
     if (!message?.theme) {
       this.logger.warn('Invalid theme message:', message);
       return;
@@ -95,10 +89,7 @@ export abstract class BaseViewMessageHandler<
   /**
    * Helper method for common debug mode handling
    */
-  protected async handleDebugMode(
-    message: any,
-    webviewView: T,
-  ): Promise<void> {
+  protected async handleDebugMode(message: any, webviewView: T): Promise<void> {
     webviewView.webview.postMessage({
       command: COMMON_COMMANDS.DEBUG_MODE_SET,
       debugMode: message.debugMode,

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -4,13 +4,9 @@ import * as vscode from 'vscode';
 /**
  * Base class for webview providers.
  * Handles HTML assignment, message routing, and disposable management.
- * @template T - The webview type (WebviewView or WebviewPanel)
  */
-export abstract class BaseWebviewProvider<
-  T extends vscode.WebviewView | vscode.WebviewPanel = vscode.WebviewView,
-> implements vscode.WebviewViewProvider
-{
-  protected _view?: T;
+export abstract class BaseWebviewProvider {
+  protected _view?: vscode.WebviewView | vscode.WebviewPanel;
   protected readonly _disposables: vscode.Disposable[] = [];
   protected _viewDisposables: vscode.Disposable[] = [];
 
@@ -20,7 +16,7 @@ export abstract class BaseWebviewProvider<
   protected abstract messageHandler: {
     handleMessage(
       message: any,
-      webviewView: T,
+      webviewView: vscode.WebviewView | vscode.WebviewPanel,
     ): Promise<void> | void;
   };
 
@@ -31,10 +27,12 @@ export abstract class BaseWebviewProvider<
     context: vscode.WebviewViewResolveContext,
     token: vscode.CancellationToken,
   ): void {
-    this.resolveWebviewViewInternal(webviewView as T);
+    this.resolveWebviewViewInternal(webviewView);
   }
 
-  protected resolveWebviewViewInternal(webviewView: T): void {
+  protected resolveWebviewViewInternal(
+    webviewView: vscode.WebviewView | vscode.WebviewPanel,
+  ): void {
     this.cleanupView();
     this._view = webviewView;
 

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -4,11 +4,13 @@ import * as vscode from 'vscode';
 /**
  * Base class for webview providers.
  * Handles HTML assignment, message routing, and disposable management.
+ * @template T - The webview type (WebviewView or WebviewPanel)
  */
-export abstract class BaseWebviewProvider
-  implements vscode.WebviewViewProvider
+export abstract class BaseWebviewProvider<
+  T extends vscode.WebviewView | vscode.WebviewPanel = vscode.WebviewView,
+> implements vscode.WebviewViewProvider
 {
-  protected _view?: vscode.WebviewView | vscode.WebviewPanel;
+  protected _view?: T;
   protected readonly _disposables: vscode.Disposable[] = [];
   protected _viewDisposables: vscode.Disposable[] = [];
 
@@ -18,15 +20,13 @@ export abstract class BaseWebviewProvider
   protected abstract messageHandler: {
     handleMessage(
       message: any,
-      webviewView: vscode.WebviewView,
+      webviewView: T,
     ): Promise<void> | void;
   };
 
   constructor(protected readonly context: vscode.ExtensionContext) {}
 
-  public resolveWebviewView(
-    webviewView: vscode.WebviewView | vscode.WebviewPanel,
-  ): void {
+  public resolveWebviewView(webviewView: T): void {
     this.cleanupView();
     this._view = webviewView;
 
@@ -36,10 +36,7 @@ export abstract class BaseWebviewProvider
 
     this._viewDisposables.push(
       webviewView.webview.onDidReceiveMessage((message) =>
-        this.messageHandler.handleMessage(
-          message,
-          webviewView as vscode.WebviewView,
-        ),
+        this.messageHandler.handleMessage(message, webviewView),
       ),
       webviewView.onDidDispose(() => this.cleanupView()),
     );

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -1,0 +1,63 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+/**
+ * Base class for webview providers.
+ * Handles HTML assignment, message routing, and disposable management.
+ */
+export abstract class BaseWebviewProvider
+  implements vscode.WebviewViewProvider
+{
+  protected _view?: vscode.WebviewView | vscode.WebviewPanel;
+  protected readonly _disposables: vscode.Disposable[] = [];
+  protected _viewDisposables: vscode.Disposable[] = [];
+
+  protected abstract contentProvider: {
+    getHtmlContent(webview: vscode.Webview): string;
+  };
+  protected abstract messageHandler: {
+    handleMessage(
+      message: any,
+      webviewView: vscode.WebviewView,
+    ): Promise<void> | void;
+  };
+
+  constructor(protected readonly context: vscode.ExtensionContext) {}
+
+  public resolveWebviewView(
+    webviewView: vscode.WebviewView | vscode.WebviewPanel,
+  ): void {
+    this.cleanupView();
+    this._view = webviewView;
+
+    webviewView.webview.html = this.contentProvider.getHtmlContent(
+      webviewView.webview,
+    );
+
+    this._viewDisposables.push(
+      webviewView.webview.onDidReceiveMessage((message) =>
+        this.messageHandler.handleMessage(
+          message,
+          webviewView as vscode.WebviewView,
+        ),
+      ),
+      webviewView.onDidDispose(() => this.cleanupView()),
+    );
+  }
+
+  protected addViewDisposables(...disposables: vscode.Disposable[]): void {
+    this._viewDisposables.push(...disposables);
+  }
+
+  protected cleanupView(): void {
+    this._viewDisposables.forEach((d) => d.dispose());
+    this._viewDisposables = [];
+    this._view = undefined;
+  }
+
+  public dispose(): void {
+    this.cleanupView();
+    this._disposables.forEach((d) => d.dispose());
+    this._disposables.length = 0;
+  }
+}

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -26,7 +26,15 @@ export abstract class BaseWebviewProvider<
 
   constructor(protected readonly context: vscode.ExtensionContext) {}
 
-  public resolveWebviewView(webviewView: T): void {
+  public resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    context: vscode.WebviewViewResolveContext,
+    token: vscode.CancellationToken,
+  ): void {
+    this.resolveWebviewViewInternal(webviewView as T);
+  }
+
+  protected resolveWebviewViewInternal(webviewView: T): void {
     this.cleanupView();
     this._view = webviewView;
 

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -24,8 +24,8 @@ export abstract class BaseWebviewProvider {
 
   public resolveWebviewView(
     webviewView: vscode.WebviewView,
-    context: vscode.WebviewViewResolveContext,
-    token: vscode.CancellationToken,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken,
   ): void {
     this.resolveWebviewViewInternal(webviewView);
   }

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -17,12 +17,17 @@ import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands';
 import { AgentHistoryManager } from '@historyView/managers';
 import { agentConfigToTaskState } from '@utils/config';
 
-export class HistoryViewMessageHandler extends BaseViewMessageHandler {
+export class HistoryViewMessageHandler extends BaseViewMessageHandler<
+  vscode.WebviewView | vscode.WebviewPanel
+> {
   constructor(private readonly context: vscode.ExtensionContext) {
     super('HistoryView');
   }
 
-  protected createHandlers(): Record<string, MessageHandler> {
+  protected createHandlers(): Record<
+    string,
+    MessageHandler<vscode.WebviewView | vscode.WebviewPanel>
+  > {
     return {
       [HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA]:
         this.handleGetHistoryData.bind(this),
@@ -43,14 +48,14 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleGetHistoryData(
     _message: any,
-    view: vscode.WebviewView,
+    view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     await this.sendHistoryData(view.webview);
   }
 
   private async handleRerunAgent(
     message: any,
-    _view: vscode.WebviewView,
+    _view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     const historyId: string | undefined = message.historyId;
     if (!historyId) return;
@@ -73,7 +78,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleRestoreAgent(
     message: any,
-    _view: vscode.WebviewView,
+    _view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     const historyId: string | undefined = message.historyId;
     if (!historyId) return;
@@ -97,7 +102,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleDeleteAgent(
     message: any,
-    view: vscode.WebviewView,
+    view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     const historyId: string | undefined = message.historyId;
     if (!historyId) return;
@@ -122,7 +127,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleClearHistory(
     _message: any,
-    view: vscode.WebviewView,
+    view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     try {
       await AgentHistoryManager.clearHistory();

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -9,9 +9,10 @@ import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
 import { HistoryViewContentProvider } from './HistoryViewContentProvider';
 import { HistoryViewMessageHandler } from './HistoryViewMessageHandler';
 
-export class HistoryViewProvider extends BaseWebviewProvider<
-  vscode.WebviewView | vscode.WebviewPanel
-> {
+export class HistoryViewProvider
+  extends BaseWebviewProvider
+  implements vscode.WebviewViewProvider
+{
   public static readonly viewType = 'texra.historyView';
   protected contentProvider: HistoryViewContentProvider;
   protected messageHandler: HistoryViewMessageHandler;

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -122,10 +122,16 @@ export class HistoryViewProvider extends BaseWebviewProvider<
    */
   private async updateWebviewContent() {
     if (this._view) {
-      setTimeout(
-        () => this.messageHandler.sendHistoryData(this._view!.webview),
-        100,
+      // Set the HTML content first
+      this._view.webview.html = this.contentProvider.getHtmlContent(
+        this._view.webview,
       );
+      // Then send the history data after a short delay
+      setTimeout(() => {
+        if (this._view) {
+          this.messageHandler.sendHistoryData(this._view.webview);
+        }
+      }, 100);
     }
   }
 }

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -58,7 +58,7 @@ export class HistoryViewProvider extends BaseWebviewProvider<
       ],
     };
 
-    super.resolveWebviewView(webviewView);
+    super.resolveWebviewViewInternal(webviewView);
   }
 
   /**
@@ -110,7 +110,7 @@ export class HistoryViewProvider extends BaseWebviewProvider<
       },
     );
 
-    super.resolveWebviewView(this._view);
+    super.resolveWebviewViewInternal(this._view);
     await this.updateWebviewContent();
   }
 

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -2,29 +2,61 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - history view
+// Local imports - common
+import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
 
 // Local imports - components
 import { HistoryViewContentProvider } from './HistoryViewContentProvider';
 import { HistoryViewMessageHandler } from './HistoryViewMessageHandler';
 
-export class HistoryViewProvider implements vscode.WebviewViewProvider {
+export class HistoryViewProvider extends BaseWebviewProvider {
   public static readonly viewType = 'texra.historyView';
-  private _view?: vscode.WebviewPanel;
-  private readonly contentProvider: HistoryViewContentProvider;
-  private readonly messageHandler: HistoryViewMessageHandler;
+  protected contentProvider: HistoryViewContentProvider;
+  protected messageHandler: HistoryViewMessageHandler;
 
-  constructor(private readonly context: vscode.ExtensionContext) {
+  constructor(protected readonly context: vscode.ExtensionContext) {
+    super(context);
     this.contentProvider = new HistoryViewContentProvider(context);
     this.messageHandler = new HistoryViewMessageHandler(context);
   }
 
   /**
-   * This is required for the WebviewViewProvider interface but we won't use it
-   * as we're removing the sidebar integration
+   * Resolve webview for potential sidebar integration.
    */
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
-    // We no longer use webview in the sidebar, but we need this method for the interface
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [
+        vscode.Uri.joinPath(this.context.extensionUri, 'src', 'historyView'),
+        vscode.Uri.joinPath(
+          this.context.extensionUri,
+          'src',
+          'common',
+          'styles',
+        ),
+        vscode.Uri.joinPath(
+          this.context.extensionUri,
+          'src',
+          'common',
+          'modules',
+        ),
+        vscode.Uri.joinPath(
+          this.context.extensionUri,
+          'src',
+          'common',
+          'webview',
+        ),
+        vscode.Uri.joinPath(
+          this.context.extensionUri,
+          'node_modules',
+          '@vscode',
+          'codicons',
+          'dist',
+        ),
+      ],
+    };
+
+    super.resolveWebviewView(webviewView);
   }
 
   /**
@@ -33,7 +65,7 @@ export class HistoryViewProvider implements vscode.WebviewViewProvider {
   public async showHistoryView() {
     // If we already have a panel, show it
     if (this._view) {
-      this._view.reveal(vscode.ViewColumn.One);
+      (this._view as vscode.WebviewPanel).reveal(vscode.ViewColumn.One);
       return;
     }
 
@@ -76,20 +108,7 @@ export class HistoryViewProvider implements vscode.WebviewViewProvider {
       },
     );
 
-    // Handle webview disposal
-    this._view.onDidDispose(() => {
-      this._view = undefined;
-    });
-
-    // Handle messages from the webview
-    this._view.webview.onDidReceiveMessage(async (message) => {
-      await this.messageHandler.handleMessage(
-        message,
-        this._view as unknown as vscode.WebviewView,
-      );
-    });
-
-    // Set initial HTML content
+    super.resolveWebviewView(this._view);
     await this.updateWebviewContent();
   }
 
@@ -101,11 +120,6 @@ export class HistoryViewProvider implements vscode.WebviewViewProvider {
    */
   private async updateWebviewContent() {
     if (this._view) {
-      this._view.webview.html = this.contentProvider.getHtmlContent(
-        this._view.webview,
-      );
-
-      // Send history data after a short delay to ensure the webview is ready
       setTimeout(
         () => this.messageHandler.sendHistoryData(this._view!.webview),
         100,

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -9,7 +9,9 @@ import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
 import { HistoryViewContentProvider } from './HistoryViewContentProvider';
 import { HistoryViewMessageHandler } from './HistoryViewMessageHandler';
 
-export class HistoryViewProvider extends BaseWebviewProvider {
+export class HistoryViewProvider extends BaseWebviewProvider<
+  vscode.WebviewView | vscode.WebviewPanel
+> {
   public static readonly viewType = 'texra.historyView';
   protected contentProvider: HistoryViewContentProvider;
   protected messageHandler: HistoryViewMessageHandler;
@@ -64,8 +66,8 @@ export class HistoryViewProvider extends BaseWebviewProvider {
    */
   public async showHistoryView() {
     // If we already have a panel, show it
-    if (this._view) {
-      (this._view as vscode.WebviewPanel).reveal(vscode.ViewColumn.One);
+    if (this._view && 'reveal' in this._view) {
+      this._view.reveal(vscode.ViewColumn.One);
       return;
     }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -16,7 +16,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     super('ProgressView');
   }
 
-  protected createHandlers(): Record<string, MessageHandler> {
+  protected createHandlers(): Record<
+    string,
+    MessageHandler<vscode.WebviewView>
+  > {
     return {
       // Common handlers
       [PROGRESS_VIEW_COMMANDS.THEME_SET]: this.handleTheme.bind(this),

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -61,6 +61,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   // Handler implementations
+  protected override async handleWebviewReady(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    this.provider.markWebviewReady();
+  }
+
   private async handleSwitchStream(
     message: any,
     webviewView: vscode.WebviewView,

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -61,6 +61,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   // Handler implementations
+  /**
+   * Override to notify the provider when webview is ready.
+   * This allows the provider to process any pending updates that
+   * were queued while the webview was initializing.
+   */
   protected override async handleWebviewReady(
     message: any,
     webviewView: vscode.WebviewView,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -37,7 +37,10 @@ type StreamStatusType =
  * This class now focuses on orchestration and delegation to focused managers,
  * following the design principles from AGENTS.md.
  */
-export class ProgressViewProvider extends BaseWebviewProvider {
+export class ProgressViewProvider
+  extends BaseWebviewProvider
+  implements vscode.WebviewViewProvider
+{
   private static _instance: ProgressViewProvider | undefined;
 
   // New modular architecture components

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -148,7 +148,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     webviewView.title = this._viewTitle;
 
     // Call super first to set up base functionality and clean up old disposables
-    super.resolveWebviewView(webviewView);
+    super.resolveWebviewViewInternal(webviewView);
 
     // Add visibility and theme listeners after super.resolveWebviewView
     // This ensures they aren't cleared by the base class's cleanupView()

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -1,13 +1,15 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
+
+// Local imports - common
+import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
 
 // Local imports - progress view
 import { ProgressEventHandler } from './events/ProgressEventHandler';
 import { WebviewUpdater } from './managers';
 
 // @ts-ignore - Import JavaScript module
-import { STATUS, COMMANDS } from './modules/constants.js';
+import { STATUS } from './modules/constants.js';
 
 // Local imports - new architecture
 import { StatePersistenceManager } from './persistence/StatePersistenceManager';
@@ -35,9 +37,8 @@ type StreamStatusType =
  * This class now focuses on orchestration and delegation to focused managers,
  * following the design principles from AGENTS.md.
  */
-export class ProgressViewProvider implements vscode.WebviewViewProvider {
+export class ProgressViewProvider extends BaseWebviewProvider {
   private static _instance: ProgressViewProvider | undefined;
-  private _view?: vscode.WebviewView;
 
   // New modular architecture components
   public readonly state: ProgressViewState;
@@ -45,12 +46,10 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   public readonly webviewUpdater: WebviewUpdater;
 
   // Existing components (will be gradually updated)
-  private readonly contentProvider: ProgressViewContentProvider;
-  private readonly messageHandler: ProgressViewMessageHandler;
+  protected readonly contentProvider: ProgressViewContentProvider;
+  protected readonly messageHandler: ProgressViewMessageHandler;
 
   // Infrastructure
-  private _disposables: vscode.Disposable[] = [];
-  private _viewDisposables: vscode.Disposable[] = [];
   private readonly _extensionUri: vscode.Uri;
   private readonly _viewTitle: string;
   private _webviewReady = false;
@@ -59,9 +58,10 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
   private readonly logger: AgentLogger;
 
   constructor(
-    private readonly context: vscode.ExtensionContext,
+    protected readonly context: vscode.ExtensionContext,
     title: string = 'Tasks',
   ) {
+    super(context);
     this._extensionUri = context.extensionUri;
     this._viewTitle = title;
     this.logger = new AgentLogger('ProgressViewProviderNew');
@@ -111,22 +111,13 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     return this._instance;
   }
 
-  public dispose(): void {
-    this._disposables.forEach((d) => d.dispose());
-    this.cleanupView();
-  }
-
-  private cleanupView(): void {
-    this._viewDisposables.forEach((d) => d.dispose());
-    this._viewDisposables = [];
-    this._view = undefined;
+  protected override cleanupView(): void {
+    super.cleanupView();
     this._webviewReady = false;
     this._pendingUpdate = false;
   }
 
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
-    this.cleanupView();
-
     // Mark running tasks as cancelled on subsequent webview resolves
     if (this._hasResolved) {
       this.resetRunningStreamStatuses();
@@ -135,16 +126,6 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     this._webviewReady = false;
     this._pendingUpdate = false;
-    this._view = webviewView;
-
-    this.setupWebview(webviewView);
-    this.updateWebview();
-  }
-
-  /**
-   * Setup webview configuration and event handlers
-   */
-  private setupWebview(webviewView: vscode.WebviewView): void {
     webviewView.webview.options = {
       enableScripts: true,
       enableCommandUris: true,
@@ -166,13 +147,7 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
 
     webviewView.title = this._viewTitle;
 
-    // Set initial HTML content
-    webviewView.webview.html = this.contentProvider.getHtmlContent(
-      webviewView.webview,
-    );
-
-    // Setup event handlers
-    this._viewDisposables.push(
+    this.addViewDisposables(
       webviewView.onDidChangeVisibility(() => {
         if (webviewView.visible) {
           this.updateWebview();
@@ -183,19 +158,10 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
           this.updateWebview();
         }
       }),
-      webviewView.webview.onDidReceiveMessage(async (message) => {
-        if (message.command === COMMANDS.WEBVIEW_READY) {
-          this._webviewReady = true;
-          // Always update webview when it becomes ready to ensure all streams are shown
-          this.updateWebview();
-          return;
-        }
-        await this.messageHandler.handleMessage(message, webviewView);
-      }),
-      webviewView.onDidDispose(() => {
-        this.cleanupView();
-      }),
     );
+
+    super.resolveWebviewView(webviewView);
+    this.updateWebview();
   }
 
   /**
@@ -238,6 +204,14 @@ export class ProgressViewProvider implements vscode.WebviewViewProvider {
     }
 
     this._pendingUpdate = false;
+  }
+
+  /**
+   * Mark the webview as ready and process any pending updates.
+   */
+  public markWebviewReady(): void {
+    this._webviewReady = true;
+    this.updateWebview();
   }
 
   // Public API methods - these delegate to the new architecture

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -147,6 +147,11 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
     webviewView.title = this._viewTitle;
 
+    // Call super first to set up base functionality and clean up old disposables
+    super.resolveWebviewView(webviewView);
+
+    // Add visibility and theme listeners after super.resolveWebviewView
+    // This ensures they aren't cleared by the base class's cleanupView()
     this.addViewDisposables(
       webviewView.onDidChangeVisibility(() => {
         if (webviewView.visible) {
@@ -160,7 +165,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       }),
     );
 
-    super.resolveWebviewView(webviewView);
     this.updateWebview();
   }
 

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -3,14 +3,14 @@ import * as vscode from 'vscode';
 
 /**
  * Gets a configuration value from VS Code settings.
- * 
+ *
  * Path conventions:
  * - Use dot notation without the 'texra' prefix (e.g., 'agents', 'api.engine')
  * - The function will automatically try multiple namespaces:
  *   1. The path as given (for non-texra configs like 'latex.latexindentConfig')
  *   2. Under the 'texra' namespace
  *   3. With explicit 'texra.' prefix
- * 
+ *
  * @param path Configuration path (e.g., 'agents' or 'api.engine')
  * @param defaultValue Optional default value if configuration is not found
  * @returns The configuration value or default value
@@ -39,11 +39,11 @@ export function getConfig<T>(path: string, defaultValue?: T): T {
 
 /**
  * Sets a configuration value in VS Code settings.
- * 
+ *
  * Path conventions:
  * - Use dot notation without the 'texra' prefix (e.g., 'agents', 'api.engine')
  * - The function will automatically add the 'texra.' prefix
- * 
+ *
  * @param path Configuration path without 'texra' prefix (e.g., 'agents')
  * @param value The value to set
  * @param target Configuration target (defaults to Workspace)

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -43,7 +43,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     this.instructionManager = new InstructionManager(context);
   }
 
-  protected createHandlers(): Record<string, MessageHandler> {
+  protected createHandlers(): Record<
+    string,
+    MessageHandler<vscode.WebviewView>
+  > {
     return {
       // Common handlers
       [MAIN_VIEW_COMMANDS.THEME_SET]: this.handleTheme.bind(this),


### PR DESCRIPTION
## Summary
- add BaseWebviewProvider to standardize webview initialization and cleanup
- refactor main, progress, and history view providers to extend base and delegate setup
- route progress view ready handling through provider and message handler

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c142d5f1cc8324b908ab6a5c0d36fa