### PR TITLE
refactor: base WorkspaceFS on RelativeFS

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -234,7 +234,7 @@ export async function runResponseCycle(
 
     if (!exists) {
       logger.debug(`Creating new file: ${outputFile}`, taskGroupId);
-      await WorkspaceFS.writeFile(outputFile, processedResponse);
+      await WorkspaceFS.write(outputFile, processedResponse);
     } else {
       logger.debug(`Appending to existing file: ${outputFile}`, taskGroupId);
       await WorkspaceFS.appendFile(

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -568,9 +568,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
           toolState.accumulatedOutput.includes('<scratchpad>') &&
           prefill === '<scratchpad>' // this is not so neat
         ) {
-          await WorkspaceFS.writeFile(outputFile, prefill);
+          await WorkspaceFS.write(outputFile, prefill);
         } else if (agentSetting.outputExt === 'xml') {
-          await WorkspaceFS.writeFile(outputFile, prefill + '\n');
+          await WorkspaceFS.write(outputFile, prefill + '\n');
         }
         messages.push({
           role: 'assistant',
@@ -596,7 +596,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Get prefill from existing and non-trivial file
-    let fileContent = await WorkspaceFS.readFile(outputFile);
+    let fileContent = await WorkspaceFS.read(outputFile);
     fileContent = cleanFileContent(fileContent);
 
     // Extract any existing scratchpad content
@@ -608,7 +608,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
-    await WorkspaceFS.writeFile(outputFile, fileContent);
+    await WorkspaceFS.write(outputFile, fileContent);
 
     // Update the toolState with the actual file content
     toolState.updateAccumulatedOutput(fileContent);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -904,7 +904,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     this.logger.debug(
       `Output file ${outputFile} exists and is non-trivial. Reading content.`,
     );
-    let fileContent = await WorkspaceFS.readFile(outputFile);
+    let fileContent = await WorkspaceFS.read(outputFile);
     fileContent = cleanFileContent(fileContent);
 
     // Extract any existing scratchpad content
@@ -916,7 +916,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
-    await WorkspaceFS.writeFile(outputFile, fileContent);
+    await WorkspaceFS.write(outputFile, fileContent);
     this.logger.debug(`Cleaned and saved existing content to ${outputFile}.`);
     messages.push({
       role: 'assistant',

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -640,7 +640,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     }
 
     // Get prefill from existing and non-trivial file
-    let fileContent = await WorkspaceFS.readFile(outputFile);
+    let fileContent = await WorkspaceFS.read(outputFile);
     fileContent = cleanFileContent(fileContent);
 
     // Extract any existing scratchpad content
@@ -653,7 +653,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     }
 
     // Write file content to output file
-    await WorkspaceFS.writeFile(outputFile, fileContent);
+    await WorkspaceFS.write(outputFile, fileContent);
 
     messages.push({
       role: 'assistant',
@@ -693,7 +693,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
       toolState.updateAccumulatedOutput(fileContent);
     } else {
       toolState.updateAccumulatedOutput(prefill + fileContent);
-      await WorkspaceFS.writeFile(outputFile, toolState.accumulatedOutput);
+      await WorkspaceFS.write(outputFile, toolState.accumulatedOutput);
     }
     const state = new AgentStateRound(0);
     toolState.lastResponse = toolState.accumulatedOutput;

--- a/src/agent/output/DiffStatsManager.ts
+++ b/src/agent/output/DiffStatsManager.ts
@@ -20,14 +20,14 @@ export class DiffStatsManager {
   ): Promise<DiffStats> {
     try {
       if (!baseFile) {
-        const outContent = await WorkspaceFS.readFile(outputFile);
+        const outContent = await WorkspaceFS.read(outputFile);
         const added = this.countLines(outContent);
         return { added };
       }
 
       const [baseContent, outContent] = await Promise.all([
-        WorkspaceFS.readFile(baseFile),
-        WorkspaceFS.readFile(outputFile),
+        WorkspaceFS.read(baseFile),
+        WorkspaceFS.read(outputFile),
       ]);
 
       const dmp = new diff_match_patch();

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -149,7 +149,7 @@ export class XmlOutputManager {
     const { dir, name } = path.parse(outputFile);
     const texFile = path.join(dir, `${name}.tex`);
 
-    let outputContent = await WorkspaceFS.readFile(outputFile);
+    let outputContent = await WorkspaceFS.read(outputFile);
     const tagsToWrap = [documentTag, thinkingTag];
     outputContent = xmlUtils.addCdataToTags(outputContent, tagsToWrap);
 
@@ -169,7 +169,7 @@ export class XmlOutputManager {
         documentTag,
       );
       if (latexDocument) {
-        await WorkspaceFS.writeFile(texFile, latexDocument);
+        await WorkspaceFS.write(texFile, latexDocument);
         return texFile;
       }
       this.logger.debug(
@@ -182,7 +182,7 @@ export class XmlOutputManager {
         documentTag,
       );
       if (fallbackContent) {
-        await WorkspaceFS.writeFile(texFile, fallbackContent);
+        await WorkspaceFS.write(texFile, fallbackContent);
         return texFile;
       }
       throw new Error(
@@ -199,7 +199,7 @@ export class XmlOutputManager {
         documentTag,
       );
       if (fallbackContent) {
-        await WorkspaceFS.writeFile(texFile, fallbackContent);
+        await WorkspaceFS.write(texFile, fallbackContent);
         return texFile;
       }
       throw err;
@@ -211,7 +211,7 @@ export class XmlOutputManager {
     documentTag: string,
     thinkingTag: string = 'scratchpad',
   ): Promise<NamedOutputFile[]> {
-    let outputContent = await WorkspaceFS.readFile(outputFile);
+    let outputContent = await WorkspaceFS.read(outputFile);
 
     const tagsToWrap = [thinkingTag, 'document'];
     outputContent = xmlUtils.addCdataToTagsMultiple(outputContent, tagsToWrap);
@@ -305,7 +305,7 @@ export class XmlOutputManager {
         extension,
         currRound,
       );
-      await WorkspaceFS.writeFile(texFile, doc.content.trim());
+      await WorkspaceFS.write(texFile, doc.content.trim());
       outputFiles.push({ source, path: texFile });
       this.logger.debug(
         `XML Source: ${source} -> TeX file written: ${texFile}`,
@@ -323,7 +323,7 @@ export class XmlOutputManager {
       this.agentSetting.documentTag,
     );
 
-    const xmlContent = await WorkspaceFS.readFile(outputFile);
+    const xmlContent = await WorkspaceFS.read(outputFile);
     let original = '';
     const nameMatch = xmlContent.match(/<document[^>]*name="(.*?)"[^>]*>/);
     if (nameMatch && nameMatch[1]) {
@@ -354,7 +354,7 @@ export class XmlOutputManager {
     documentTag: string,
   ): Promise<void> {
     this.logger.debug(`Ensuring correct XML structure: ${filePath}`);
-    let content = await WorkspaceFS.readFile(filePath);
+    let content = await WorkspaceFS.read(filePath);
 
     content = await this.processXmlContent(content);
 
@@ -371,6 +371,6 @@ export class XmlOutputManager {
         }
       }
     }
-    await WorkspaceFS.writeFile(filePath, content);
+    await WorkspaceFS.write(filePath, content);
   }
 }

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -95,10 +95,7 @@ export async function maybeSaveDebugObject({
     if (executionId) {
       await StorageFS.write(debugFilePath, content);
     } else {
-      await WorkspaceFS.writeFile(
-        WorkspaceFS.relativePath(debugFilePath),
-        content,
-      );
+      await WorkspaceFS.write(WorkspaceFS.relativePath(debugFilePath), content);
     }
     logger.info(`Saved ${objectType} object to ${debugFilePath}`, groupId);
   } catch (error) {

--- a/src/agent/utils/promptUtils.ts
+++ b/src/agent/utils/promptUtils.ts
@@ -23,7 +23,7 @@ logger.initialize(CHANNEL);
  */
 export async function getXmlFormatFromFile(file: string): Promise<string> {
   try {
-    const content = await WorkspaceFS.readFile(file);
+    const content = await WorkspaceFS.read(file);
     return `<document name="${file}">\n${content}\n</document>`;
   } catch (err) {
     logger.error(
@@ -142,7 +142,7 @@ export async function getFirstKCharsFromDocument(
   k: number,
 ): Promise<string | null> {
   try {
-    const content = await WorkspaceFS.readFile(inputFile);
+    const content = await WorkspaceFS.read(inputFile);
     return content ? content.slice(0, k).trim() : null;
   } catch (err) {
     logger.error(
@@ -177,7 +177,7 @@ export async function writePromptToXml(
     logger.debug(CHANNEL, `Writing input prompt to ${outputFile}`);
 
     const fullPrompt = `\n<system>${systemPrompt}</system>\n\n${userPrefix}\n${userRequest}\n`;
-    await WorkspaceFS.writeFile(outputFile, fullPrompt);
+    await WorkspaceFS.write(outputFile, fullPrompt);
 
     return outputFile;
   } catch (err) {

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -103,7 +103,7 @@ async function getFileVars(
   for (const [prefix, filePath] of Object.entries(singleFileMappings)) {
     userVars[`${prefix}_FILE`] = filePath;
     userVars[`${prefix}_CONTENT`] = filePath
-      ? await WorkspaceFS.readFile(filePath)
+      ? await WorkspaceFS.read(filePath)
       : null;
   }
 

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -19,7 +19,7 @@ export async function openLabel(label: string): Promise<void> {
 
   for (const file of candidates) {
     try {
-      const content = await WorkspaceFS.readFile(file);
+      const content = await WorkspaceFS.read(file);
       const match = content.match(pattern);
       if (match && match.index !== undefined) {
         const doc = await vscode.workspace.openTextDocument(

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -140,7 +140,7 @@ async function handleAcceptEdited(
     }
 
     // Read content from edited file using workspace utilities
-    const editedContent = await WorkspaceFS.readFile(editedFile);
+    const editedContent = await WorkspaceFS.read(editedFile);
 
     // Confirm with user
     const baseFileName = path.basename(fileToUse);
@@ -158,7 +158,7 @@ async function handleAcceptEdited(
     }
 
     // Write content to base file using workspace utilities
-    await WorkspaceFS.writeFile(fileToUse, editedContent);
+    await WorkspaceFS.write(fileToUse, editedContent);
 
     vscode.window.showInformationMessage(
       `Successfully replaced '${baseFileName}' with content from '${editedFileName}'`,

--- a/src/frontend/files/rules.ts
+++ b/src/frontend/files/rules.ts
@@ -21,7 +21,7 @@ export async function loadTexraRules(): Promise<string> {
     const rulesFile = '.texrarules';
 
     if (workspacePath && (await WorkspaceFS.exists(rulesFile))) {
-      const content = await WorkspaceFS.readFile(rulesFile);
+      const content = await WorkspaceFS.read(rulesFile);
       if (content.trim()) {
         logger.debug(CHANNEL, `Loaded workspace ${rulesFile}`);
         return content.trim();

--- a/src/frontend/files/vars.ts
+++ b/src/frontend/files/vars.ts
@@ -27,7 +27,7 @@ export async function setVarFromFile(
   try {
     const fileContent = absolute
       ? await AbsoluteFS.read(filePath)
-      : await WorkspaceFS.readFile(filePath);
+      : await WorkspaceFS.read(filePath);
     userVars[`${varName}_FILE`] = filePath;
     userVars[`${varName}_CONTENT`] = fileContent;
     // No logging here - will be aggregated in buildUserVars

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -89,7 +89,7 @@ export async function runPackLatexdiffvc(
             logger.debug(CHANNEL, `Created output directory: ${outputFolder}`);
             anyFilesPacked = true;
           }
-          await WorkspaceFS.move(
+          await WorkspaceFS.rename(
             file,
             path.join(outputFolder, path.basename(file)),
           );

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -118,7 +118,7 @@ export async function runPackSingle(
       for (const file of movedFiles) {
         const destination = path.join(outputFolder, path.basename(file));
         operations.push(`Moving: ${file} -> ${destination}`);
-        await WorkspaceFS.move(file, destination);
+        await WorkspaceFS.rename(file, destination);
       }
       for (const file of copiedFiles) {
         const destination = path.join(outputFolder, path.basename(file));
@@ -230,7 +230,7 @@ export async function runPackMultiple(
           await WorkspaceFS.createDir(commonOutputFolder);
         }
         logger.debug(CHANNEL, `Found additional XML file: ${filePath}`);
-        await WorkspaceFS.move(
+        await WorkspaceFS.rename(
           filePath,
           path.join(commonOutputFolder, pattern),
         );

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -58,7 +58,7 @@ export class TikzPictureManager {
     channel: string = this.channel,
   ): Promise<[string, string[]][]> {
     try {
-      const content = await WorkspaceFS.readFile(latexFile);
+      const content = await WorkspaceFS.read(latexFile);
 
       // Regular expressions to match figure environments and tikzpictures
       const figurePattern =
@@ -117,7 +117,7 @@ export class TikzPictureManager {
       const filename = suffix ? `${label}_${suffix}.tex` : `${label}.tex`;
       const filePath = path.join(buildDir, filename);
 
-      await WorkspaceFS.writeFile(filePath, standaloneContent);
+      await WorkspaceFS.write(filePath, standaloneContent);
       logger.debug(channel, `Created standalone LaTeX file: ${filePath}`);
 
       return filePath;

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -215,7 +215,7 @@ export class ArxivSourceProcessor {
       const downloadedRel = WorkspaceFS.relativePath(downloadedPath);
       const targetRel = path.join(paperDirRelative, 'main.tex');
       if (path.basename(downloadedPath) !== 'main.tex') {
-        await WorkspaceFS.move(downloadedRel, targetRel);
+        await WorkspaceFS.rename(downloadedRel, targetRel);
       }
     }
 

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -62,7 +62,7 @@ export async function extractFigurePathsFromLatex(
     ];
 
     // Read file content
-    const content = await WorkspaceFS.readFile(latexFile);
+    const content = await WorkspaceFS.read(latexFile);
 
     // Parse graphicspaths
     const paths = parseGraphicspath(content);

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -124,7 +124,7 @@ export class LaTeXdiffService {
       }
 
       // Write and process output
-      await WorkspaceFS.writeFile(outputPath, result.stdout);
+      await WorkspaceFS.write(outputPath, result.stdout);
       await this.fileProcessor.processDiffFile(outputPath);
 
       logger.debug(
@@ -308,7 +308,7 @@ export class LaTeXdiffService {
     ...files: string[]
   ): Promise<boolean> {
     for (const file of files) {
-      const content = await WorkspaceFS.readFile(file);
+      const content = await WorkspaceFS.read(file);
       if (
         !content.includes('\\begin{document}') ||
         !content.includes('\\end{document}')

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -12,11 +12,11 @@ export class DiffFileProcessor {
 
   async processDiffFile(diffFileName: string): Promise<void> {
     try {
-      const content = await WorkspaceFS.readFile(diffFileName);
+      const content = await WorkspaceFS.read(diffFileName);
       let processedContent = this.processStarEnvironments(content);
       processedContent = this.processLineByLine(processedContent);
       processedContent = replacementEngine.applyAll(processedContent);
-      await WorkspaceFS.writeFile(diffFileName, processedContent);
+      await WorkspaceFS.write(diffFileName, processedContent);
       await this.processTikzPictureEndings(diffFileName);
     } catch (err) {
       logger.error(
@@ -106,7 +106,7 @@ export class DiffFileProcessor {
   }
 
   private async processTikzPictureEndings(filePath: string): Promise<void> {
-    const content = await WorkspaceFS.readFile(filePath);
+    const content = await WorkspaceFS.read(filePath);
     let newContent = content;
 
     const patterns = [
@@ -118,6 +118,6 @@ export class DiffFileProcessor {
       newContent = newContent.replace(pattern, replacement as string);
     }
 
-    await WorkspaceFS.writeFile(filePath, newContent);
+    await WorkspaceFS.write(filePath, newContent);
   }
 }

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -15,7 +15,7 @@ logger.initialize(CHANNEL);
  */
 async function hasChinesePackages(filePath: string): Promise<boolean> {
   try {
-    const content = await WorkspaceFS.readFile(filePath);
+    const content = await WorkspaceFS.read(filePath);
     const chinesePackages = [
       'xeCJK',
       'ctexart',

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -60,14 +60,14 @@ describe('XmlOutputManager markdown fallback', () => {
     const markdownContent =
       '```latex\n\\begin{document}\nhello\n\\end{document}\n```';
 
-    await WorkspaceFS.writeFile(outputXml, markdownContent);
+    await WorkspaceFS.write(outputXml, markdownContent);
 
     const texPath = await manager.splitScratchpadOutputXml(
       outputXml,
       setting.documentTag,
     );
 
-    const written = await WorkspaceFS.readFile('markdown_only.tex');
+    const written = await WorkspaceFS.read('markdown_only.tex');
     assert.ok(written.includes('hello'));
 
     await WorkspaceFS.delete(outputXml);
@@ -81,14 +81,14 @@ describe('XmlOutputManager markdown fallback', () => {
     const xmlContent =
       '<document name="input.tex"><![CDATA[\\begin{document}\nhello\n\\end{document}]]></document>';
 
-    await WorkspaceFS.writeFile(outputXml, xmlContent);
+    await WorkspaceFS.write(outputXml, xmlContent);
 
     const texPath = await manager.splitScratchpadOutputXml(
       outputXml,
       setting.documentTag,
     );
 
-    const written = await WorkspaceFS.readFile('named_document.tex');
+    const written = await WorkspaceFS.read('named_document.tex');
     assert.ok(written.includes('hello'));
     assert.ok(!written.includes('CDATA'));
 
@@ -104,14 +104,14 @@ describe('XmlOutputManager markdown fallback', () => {
       '<latex_document><![CDATA[\\begin{document}wrong\\end{document}]]></latex_document>' +
       '<document name="input.tex"><![CDATA[\\begin{document}right\\end{document}]]></document><';
 
-    await WorkspaceFS.writeFile(outputXml, xmlContent);
+    await WorkspaceFS.write(outputXml, xmlContent);
 
     const texPath = await manager.splitScratchpadOutputXml(
       outputXml,
       setting.documentTag,
     );
 
-    const written = await WorkspaceFS.readFile('both_tags.tex');
+    const written = await WorkspaceFS.read('both_tags.tex');
     assert.ok(written.includes('right'));
     assert.ok(!written.includes('wrong'));
 
@@ -126,14 +126,14 @@ describe('XmlOutputManager markdown fallback', () => {
     const content =
       'some explanation\n\\documentclass{article}\n\\begin{document}\nhello\n\\end{document}\nmore text';
 
-    await WorkspaceFS.writeFile(outputXml, content);
+    await WorkspaceFS.write(outputXml, content);
 
     const texPath = await manager.splitScratchpadOutputXml(
       outputXml,
       setting.documentTag,
     );
 
-    const written = await WorkspaceFS.readFile('plain_latex.tex');
+    const written = await WorkspaceFS.read('plain_latex.tex');
     assert.ok(written.includes('\\documentclass'));
     assert.ok(written.includes('\\end{document}'));
     assert.ok(!written.includes('some explanation'));

--- a/src/test/utils/files/WorkspaceFS.test.ts
+++ b/src/test/utils/files/WorkspaceFS.test.ts
@@ -1,0 +1,15 @@
+import * as assert from 'assert';
+import { WorkspaceFS } from '../../../utils/files/workspaceFS';
+
+suite('WorkspaceFS Test Suite', () => {
+  test('delete should be idempotent - not throw when file does not exist', async () => {
+    // Test that deleting a non-existent file doesn't throw
+    const nonExistentPath = 'this-file-definitely-does-not-exist-12345.txt';
+    
+    // This should not throw an error
+    await assert.doesNotReject(
+      async () => await WorkspaceFS.delete(nonExistentPath),
+      'delete() should not throw when file does not exist',
+    );
+  });
+});

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -241,7 +241,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
       }
 
       // Read file contents
-      let fileContent = await WorkspaceFS.readFile(filePath);
+      let fileContent = await WorkspaceFS.read(filePath);
       let initLine = 1;
 
       // Handle view range if provided
@@ -312,7 +312,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
       }
 
       // Write file content
-      await WorkspaceFS.writeFile(filePath, content);
+      await WorkspaceFS.write(filePath, content);
 
       return new ToolResult({
         output: `File created successfully at: ${filePath}`,
@@ -336,7 +336,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
   ): Promise<ToolResult> {
     try {
       // Read file content
-      const fileContent = await WorkspaceFS.readFile(filePath);
+      const fileContent = await WorkspaceFS.read(filePath);
 
       // Expand tabs in content and search string
       const expandedFileContent = fileContent.replace(/\t/g, '    ');
@@ -374,7 +374,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
         expandedOldStr,
         expandedNewStr,
       );
-      await WorkspaceFS.writeFile(filePath, newFileContent);
+      await WorkspaceFS.write(filePath, newFileContent);
 
       // Create a snippet of the edited section
       const textBeforeReplacement =
@@ -422,7 +422,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
   ): Promise<ToolResult> {
     try {
       // Read file content
-      const fileContent = await WorkspaceFS.readFile(filePath);
+      const fileContent = await WorkspaceFS.read(filePath);
 
       // Expand tabs in content and new string
       const expandedFileContent = fileContent.replace(/\t/g, '    ');
@@ -459,7 +459,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
 
       // Write new content to file
       const newFileContent = newFileLines.join('\n');
-      await WorkspaceFS.writeFile(filePath, newFileContent);
+      await WorkspaceFS.write(filePath, newFileContent);
 
       // Prepare success message
       const snippetText = snippetLines.join('\n');
@@ -499,7 +499,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
 
       // Restore previous content
       const oldContent = history.pop()!;
-      await WorkspaceFS.writeFile(filePath, oldContent);
+      await WorkspaceFS.write(filePath, oldContent);
 
       // If the history is now empty, delete the entry
       if (history.length === 0) {

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -34,7 +34,7 @@ export class FileOpTool extends BaseTool<FileOpInput> {
     try {
       switch (command) {
         case 'read': {
-          const data = await WorkspaceFS.readFile(path);
+          const data = await WorkspaceFS.read(path);
           return new ToolResult({ output: data });
         }
         case 'write': {
@@ -44,7 +44,7 @@ export class FileOpTool extends BaseTool<FileOpInput> {
               isError: true,
             });
           }
-          await WorkspaceFS.writeFile(path, content);
+          await WorkspaceFS.write(path, content);
           return new ToolResult({ output: 'written' });
         }
         case 'append': {

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -48,7 +48,10 @@ export class FileOpTool extends BaseTool<FileOpInput> {
       }
       case 'append': {
         if (content === undefined) {
-          throw new ToolError('File operation error: Content parameter is required for append command');
+          return new ToolResult({
+            error: 'content parameter is required for append',
+            isError: true,
+          });
         }
         await WorkspaceFS.appendFile(path, content);
         return new ToolResult({ output: 'appended' });

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -124,13 +124,13 @@ export async function replaceInputCommands(
     }
 
     try {
-      const content = await WorkspaceFS.readFile(outputFile);
+      const content = await WorkspaceFS.read(outputFile);
       const newContent = content.replace(/\\input{([^}]+)}/g, (match, p1) =>
         baseToOutput.has(p1) ? `\\input{${baseToOutput.get(p1)}}` : match,
       );
 
       if (newContent !== content) {
-        await WorkspaceFS.writeFile(outputFile, newContent);
+        await WorkspaceFS.write(outputFile, newContent);
         logger?.debug(`Updated input commands in ${outputFile}`);
       }
     } catch (err) {

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -10,6 +10,7 @@ import {
   showLoggedErrorMessage,
   showLoggedMessage,
 } from '@common/errors/errorHandlingUtils';
+import { RelativeFS } from './relativeFS';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -17,53 +18,30 @@ import * as logger from '@logger/logUtils';
 const CHANNEL = 'workspaceFS';
 logger.initialize(CHANNEL);
 
-export class WorkspaceFS {
-  public static relativePath(filePath: string): string {
-    const workspacePath = this.getPath();
-    return workspacePath ? path.relative(workspacePath, filePath) : filePath;
-  }
-
-  public static getPath(): string | undefined {
+export class WorkspaceFS extends RelativeFS {
+  protected static override getBasePath(): string {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders || workspaceFolders.length === 0) {
-      return undefined;
+      throw new Error('No workspace path found');
     }
     return workspaceFolders[0].uri.fsPath;
   }
 
-  public static fullPath(filePath: string): string {
-    const workspacePath = this.getPath();
-    if (!workspacePath) {
-      throw new Error('No workspace path found');
+  protected static override getChannel(): string {
+    return CHANNEL;
+  }
+
+  public static getPath(): string | undefined {
+    try {
+      return this.getBasePath();
+    } catch {
+      return undefined;
     }
-    return path.join(workspacePath, filePath);
   }
 
-  public static async readFile(filePath: string): Promise<string> {
-    const fullPath = this.fullPath(filePath);
-    const uri = vscode.Uri.file(fullPath);
-    const content = await vscode.workspace.fs.readFile(uri);
-    return Buffer.from(content).toString('utf-8');
-  }
-
-  public static async writeFile(
-    filePath: string,
-    content: string,
-  ): Promise<void> {
-    const fullPath = this.fullPath(filePath);
-    const uri = vscode.Uri.file(fullPath);
-    await vscode.workspace.fs.writeFile(uri, Buffer.from(content, 'utf-8'));
-  }
-
-  public static async write(
-    filePath: string,
-    content: string | Uint8Array,
-  ): Promise<void> {
-    const fullPath = this.fullPath(filePath);
-    const uri = vscode.Uri.file(fullPath);
-    const buffer =
-      typeof content === 'string' ? Buffer.from(content, 'utf-8') : content;
-    await vscode.workspace.fs.writeFile(uri, buffer);
+  public static relativePath(filePath: string): string {
+    const workspacePath = this.getPath();
+    return workspacePath ? path.relative(workspacePath, filePath) : filePath;
   }
 
   public static async appendFile(
@@ -71,24 +49,10 @@ export class WorkspaceFS {
     content: string,
   ): Promise<void> {
     try {
-      const fullPath = this.fullPath(filePath);
-      const uri = vscode.Uri.file(fullPath);
-
-      // Read existing content
-      let existingContent = '';
-      try {
-        const fileContent = await vscode.workspace.fs.readFile(uri);
-        existingContent = Buffer.from(fileContent).toString('utf-8');
-      } catch (err) {
-        // File might not exist yet, which is fine
-      }
-
-      // Append new content
-      const newContent = existingContent + content;
-      await vscode.workspace.fs.writeFile(
-        uri,
-        Buffer.from(newContent, 'utf-8'),
-      );
+      const existing = (await this.exists(filePath))
+        ? await this.read(filePath)
+        : '';
+      await this.write(filePath, existing + content);
       logger.debug(CHANNEL, `Successfully appended to file: ${filePath}`);
     } catch (err) {
       logger.error(
@@ -99,160 +63,9 @@ export class WorkspaceFS {
     }
   }
 
-  public static async delete(filePath: string): Promise<void> {
-    try {
-      const fullPath = this.fullPath(filePath);
-      const uri = vscode.Uri.file(fullPath);
-      await vscode.workspace.fs.delete(uri, { useTrash: false });
-      logger.debug(CHANNEL, `Deleted: ${filePath}`);
-    } catch (err) {
-      if (err instanceof vscode.FileSystemError) {
-        if (err.code === 'FileNotFound') {
-          logger.debug(CHANNEL, `File not found when deleting: ${filePath}`);
-        } else {
-          logger.warn(
-            CHANNEL,
-            `Unable to delete ${filePath}. It may be in use.`,
-          );
-          vscode.window.showWarningMessage(
-            `Unable to delete ${filePath}. It may be in use.`,
-          );
-        }
-      } else {
-        await showLoggedErrorMessage(
-          CHANNEL,
-          `Error deleting ${filePath}`,
-          err,
-        );
-      }
-    }
-  }
-
-  public static async move(source: string, destination: string): Promise<void> {
-    logger.debug(CHANNEL, `Moving file from ${source} to ${destination}`);
-    try {
-      const fullSourcePath = this.fullPath(source);
-      const fullDestPath = this.fullPath(destination);
-
-      const sourceUri = vscode.Uri.file(fullSourcePath);
-      const destUri = vscode.Uri.file(fullDestPath);
-
-      // Check if source exists
-      const sourceExists = await AbsoluteFS.exists(fullSourcePath);
-      if (!sourceExists) {
-        logger.warn(CHANNEL, `Source file doesn't exist: ${source}`);
-        return;
-      }
-
-      await vscode.workspace.fs.rename(sourceUri, destUri, { overwrite: true });
-      logger.info(CHANNEL, `Successfully moved: ${source} to ${destination}`);
-    } catch (err) {
-      await showLoggedErrorMessage(
-        CHANNEL,
-        `Error moving file from ${source} to ${destination}`,
-        err,
-      );
-    }
-  }
-
-  public static async copy(source: string, destination: string): Promise<void> {
-    logger.debug(CHANNEL, `Copying file from ${source} to ${destination}`);
-    try {
-      const fullSourcePath = this.fullPath(source);
-      const fullDestPath = this.fullPath(destination);
-
-      const sourceUri = vscode.Uri.file(fullSourcePath);
-      const destUri = vscode.Uri.file(fullDestPath);
-
-      // Check if source exists
-      const sourceExists = await AbsoluteFS.exists(fullSourcePath);
-      if (!sourceExists) {
-        logger.warn(CHANNEL, `Source file doesn't exist: ${source}`);
-        return;
-      }
-
-      await vscode.workspace.fs.copy(sourceUri, destUri, { overwrite: true });
-      logger.info(
-        CHANNEL,
-        `Successfully copied: source=${source} to destination=${destination}`,
-      );
-    } catch (err) {
-      await showLoggedErrorMessage(
-        CHANNEL,
-        `Error copying file from source=${source} to destination=${destination}`,
-        err,
-      );
-    }
-  }
-
-  public static async createDir(relativePath: string): Promise<void> {
-    try {
-      const fullPath = this.fullPath(relativePath);
-      await vscode.workspace.fs.createDirectory(vscode.Uri.file(fullPath));
-      logger.debug(CHANNEL, `Created directory: ${relativePath}`);
-    } catch (err) {
-      if (err instanceof vscode.FileSystemError) {
-        await showLoggedMessage(
-          CHANNEL,
-          `Unable to create directory ${relativePath}. Permission denied.`,
-        );
-        throw new Error(
-          `Unable to create directory ${relativePath}. Permission denied.`,
-        );
-      } else {
-        await showLoggedErrorMessage(
-          CHANNEL,
-          `Error creating directory ${relativePath}`,
-          err,
-        );
-        throw err;
-      }
-    }
-  }
-
-  /**
-   * Ensure a directory exists, creating it if necessary
-   */
-  public static async ensureDir(relativePath: string): Promise<void> {
-    try {
-      const exists = await this.exists(relativePath);
-      if (!exists) {
-        await this.createDir(relativePath);
-      }
-    } catch (err) {
-      // If error is because directory already exists, ignore it
-      if (err instanceof vscode.FileSystemError && err.code === 'FileExists') {
-        return;
-      }
-      throw err;
-    }
-  }
-
-  public static async readDir(
-    dirPath: string,
-  ): Promise<[string, vscode.FileType][]> {
-    try {
-      const fullPath = this.fullPath(dirPath);
-      const dirUri = vscode.Uri.file(fullPath);
-      return await vscode.workspace.fs.readDirectory(dirUri);
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error reading directory ${dirPath}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      throw err;
-    }
-  }
-
-  public static async exists(filePath: string): Promise<boolean> {
-    const fullPath = this.fullPath(filePath);
-    return await AbsoluteFS.exists(fullPath);
-  }
-
   public static async existsAndNonTrivial(filePath: string): Promise<boolean> {
     return (
-      (await this.exists(filePath)) &&
-      (await this.readFile(filePath)).length > 15
+      (await this.exists(filePath)) && (await this.read(filePath)).length > 15
     );
   }
 

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -44,6 +44,34 @@ export class WorkspaceFS extends RelativeFS {
     return workspacePath ? path.relative(workspacePath, filePath) : filePath;
   }
 
+  /**
+   * Delete a file or directory. Tolerant of missing files (idempotent).
+   * @param relativePath The path to delete
+   * @param options Optional deletion options
+   */
+  public static async delete(
+    relativePath: string,
+    options?: { recursive?: boolean; useTrash?: boolean },
+  ): Promise<void> {
+    try {
+      await super.delete(relativePath, options);
+    } catch (err) {
+      // Make delete idempotent - if file doesn't exist, that's fine
+      if (
+        err instanceof vscode.FileSystemError &&
+        err.code === 'FileNotFound'
+      ) {
+        logger.debug(
+          CHANNEL,
+          `Skipping deletion of non-existent file: ${relativePath}`,
+        );
+        return;
+      }
+      // Re-throw other errors
+      throw err;
+    }
+  }
+
   public static async appendFile(
     filePath: string,
     content: string,


### PR DESCRIPTION
## Summary
- derive WorkspaceFS from RelativeFS with workspace-root override
- remove duplicate file utilities and update call sites to use RelativeFS methods

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c147f499008324ae71f68ef79de0ba