### PR TITLE
refactor: centralize map persistence logic

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -318,7 +318,7 @@ export class ProgressEventHandler {
       return;
     }
 
-    this.state.streamTabs.add(stream, logMessage);
+    this.state.streamTabs.addMessage(stream, logMessage);
 
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.appendLogMessage(stream, logMessage);

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -1,13 +1,15 @@
 // Local imports - progress view
-// Local imports
+import { PersistentMapManager } from '../persistence/PersistentMapManager';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
+
+// Local imports
+import { WorkspaceStateKey } from '@common/state/stateManager';
+import { AgentLogger } from '@logger/AgentLogger';
+import { WorkspaceFS } from '@utils/files';
 
 // Types
 import type { DiffStats } from '@agent/types/DiffTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-import { WorkspaceStateKey } from '@common/state/stateManager';
-import { AgentLogger } from '@logger/AgentLogger';
-import { WorkspaceFS } from '@utils/files';
 
 interface OutputFileInfo extends DiffStats {
   path: string;
@@ -20,33 +22,32 @@ interface OutputFileInfo extends DiffStats {
  * Manages output files collection with persistence and file existence validation.
  * Handles adding, updating, and managing output files for different streams.
  */
-export class OutputFilesManager {
-  private _outputFiles: Map<StreamTabId, { [key: number]: OutputFileInfo[] }> =
-    new Map();
+export class OutputFilesManager extends PersistentMapManager<
+  StreamTabId,
+  { [key: number]: OutputFileInfo[] }
+> {
   private _missingOutputs: Map<StreamTabId, { [key: number]: string[] }> =
     new Map();
   private readonly logger: AgentLogger;
+  private totalFilesProcessed = 0;
+  private totalFilesRemoved = 0;
 
-  constructor(private persistence: StatePersistenceManager) {
+  constructor(persistence: StatePersistenceManager) {
+    super(persistence, WorkspaceStateKey.OUTPUT_FILES);
     this.logger = new AgentLogger('OutputFilesManager');
   }
 
-  /**
-   * Add output files for a stream and round
-   */
+  /** Add output files for a stream and round */
   addFiles(
     stream: StreamTabId,
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): void {
-    const existing = this._outputFiles.get(stream) || {};
+    const existing = this.get(stream) || {};
     const merged = { ...existing, ...filesByRound };
-    this._outputFiles.set(stream, merged);
-    this.save();
+    this.add(stream, merged);
   }
 
-  /**
-   * Update missing outputs for a stream
-   */
+  /** Update missing outputs for a stream */
   updateMissingOutputs(
     stream: StreamTabId,
     filesByRound: { [key: number]: string[] },
@@ -65,181 +66,83 @@ export class OutputFilesManager {
     this.saveMissingOutputs();
   }
 
-  /**
-   * Get output files for a stream
-   */
+  /** Get output files for a stream */
   getFiles(
     stream: StreamTabId,
   ): { [key: number]: OutputFileInfo[] } | undefined {
-    return this._outputFiles.get(stream);
+    return this.get(stream);
   }
 
-  /**
-   * Get missing outputs for a stream
-   */
+  /** Get missing outputs for a stream */
   getMissingOutputs(
     stream: StreamTabId,
   ): { [key: number]: string[] } | undefined {
     return this._missingOutputs.get(stream);
   }
 
-  /**
-   * Clear output files for a stream
-   */
+  /** Clear output files for a stream */
   clearFiles(stream: StreamTabId): void {
-    this._outputFiles.delete(stream);
-    this.save();
+    this.delete(stream);
   }
 
-  /**
-   * Clear missing outputs for a stream
-   */
+  /** Clear missing outputs for a stream */
   clearMissingOutputs(stream: StreamTabId): void {
     this._missingOutputs.delete(stream);
     this.saveMissingOutputs();
   }
 
-  /**
-   * Delete all files for a stream
-   */
+  /** Delete all files for a stream */
   deleteStream(stream: StreamTabId): void {
-    this._outputFiles.delete(stream);
+    super.delete(stream);
     this._missingOutputs.delete(stream);
-    this.save();
     this.saveMissingOutputs();
   }
 
-  /**
-   * Clear all output files
-   */
+  /** Clear all output files */
   clear(): void {
-    this._outputFiles.clear();
+    super.clear();
     this._missingOutputs.clear();
-    this.save();
     this.saveMissingOutputs();
   }
 
-  /**
-   * Get all output files
-   */
+  /** Get all output files */
   getAllFiles(): Map<StreamTabId, { [key: number]: OutputFileInfo[] }> {
-    return new Map(this._outputFiles);
+    return this.getAll();
   }
 
-  /**
-   * Get all missing outputs
-   */
+  /** Get all missing outputs */
   getAllMissingOutputs(): Map<StreamTabId, { [key: number]: string[] }> {
     return new Map(this._missingOutputs);
   }
 
-  /**
-   * Set all output files (used during loading)
-   */
+  /** Set all output files (used during loading) */
   setAllFiles(
     files: Map<StreamTabId, { [key: number]: OutputFileInfo[] }>,
   ): void {
-    this._outputFiles = new Map(files);
+    this.setAll(files);
   }
 
-  /**
-   * Set all missing outputs (used during loading)
-   */
+  /** Set all missing outputs (used during loading) */
   setAllMissingOutputs(
     missing: Map<StreamTabId, { [key: number]: string[] }>,
   ): void {
     this._missingOutputs = new Map(missing);
   }
 
-  /**
-   * Load output files from persistence and clean up missing files
-   */
+  /** Load output files from persistence and clean up missing files */
   async load(): Promise<void> {
-    await this.loadOutputFiles();
+    this.totalFilesProcessed = 0;
+    this.totalFilesRemoved = 0;
+    await super.load();
     await this.loadMissingOutputs();
-  }
-
-  /**
-   * Load output files and validate they still exist
-   */
-  private async loadOutputFiles(): Promise<void> {
-    const savedFiles = await this.persistence.load<{
-      [key: string]: { [key: number]: OutputFileInfo[] };
-    }>(WorkspaceStateKey.OUTPUT_FILES, {});
-
-    if (savedFiles && Object.keys(savedFiles).length > 0) {
-      const cleaned: [string, { [key: number]: OutputFileInfo[] }][] = [];
-      let totalFilesProcessed = 0;
-      let totalFilesRemoved = 0;
-
-      for (const [streamId, rounds] of Object.entries(savedFiles)) {
-        const roundMap: { [key: number]: OutputFileInfo[] } = {};
-        const streamFilesProcessed = Object.values(rounds).reduce(
-          (sum, files) => sum + files.length,
-          0,
-        );
-        totalFilesProcessed += streamFilesProcessed;
-
-        for (const [roundStr, infos] of Object.entries(rounds)) {
-          const roundNum = parseInt(roundStr, 10);
-          this.logger.debug(
-            `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
-          );
-
-          try {
-            const filtered = await WorkspaceFS.filterExistingFiles(infos);
-            const removedCount = infos.length - filtered.length;
-
-            if (removedCount > 0) {
-              this.logger.debug(
-                `Removed ${removedCount} missing file(s) from stream ${streamId}, round ${roundNum}`,
-              );
-              totalFilesRemoved += removedCount;
-
-              // Log which files were removed for debugging
-              const removedFiles = infos.filter(
-                (info) => !filtered.find((f) => f.path === info.path),
-              );
-              removedFiles.forEach((file) => {
-                this.logger.debug(`  - Removed missing file: ${file.path}`);
-              });
-            }
-
-            // Always preserve round structure, even if empty (for UI consistency)
-            // Only skip rounds that had no files to begin with
-            if (infos.length > 0) {
-              roundMap[roundNum] = filtered;
-            }
-          } catch (error) {
-            this.logger.warn(
-              `Error checking files in stream ${streamId}, round ${roundNum}: ${error instanceof Error ? error.message : String(error)}`,
-            );
-            // On error, preserve the original files to avoid data loss
-            roundMap[roundNum] = infos;
-          }
-        }
-
-        // Always preserve streams that had any rounds (even if they become empty)
-        if (Object.keys(rounds).length > 0) {
-          cleaned.push([streamId, roundMap]);
-        }
-      }
-
-      this._outputFiles = new Map(cleaned);
-
-      if (totalFilesRemoved > 0) {
-        this.logger.info(
-          `File cleanup completed: processed ${totalFilesProcessed} files, removed ${totalFilesRemoved} missing files`,
-        );
-      }
-    } else {
-      this._outputFiles.clear();
+    if (this.totalFilesRemoved > 0) {
+      this.logger.info(
+        `File cleanup completed: processed ${this.totalFilesProcessed} files, removed ${this.totalFilesRemoved} missing files`,
+      );
     }
   }
 
-  /**
-   * Load missing outputs from persistence
-   */
+  /** Load missing outputs from persistence */
   private async loadMissingOutputs(): Promise<void> {
     const saved = await this.persistence.load<{
       [key: string]: { [key: number]: string[] };
@@ -261,19 +164,61 @@ export class OutputFilesManager {
     }
   }
 
-  /**
-   * Save output files to persistence
-   */
-  save(): void {
-    const filesObj = Object.fromEntries(this._outputFiles.entries());
-    this.persistence.save(WorkspaceStateKey.OUTPUT_FILES, filesObj);
-  }
-
-  /**
-   * Save missing outputs to persistence
-   */
+  /** Save missing outputs to persistence */
   saveMissingOutputs(): void {
     const obj = Object.fromEntries(this._missingOutputs.entries());
     this.persistence.save(WorkspaceStateKey.MISSING_OUTPUTS, obj);
+  }
+
+  /** Validate and normalize loaded output files */
+  protected override async deserialize(
+    data: unknown,
+    streamId: StreamTabId,
+  ): Promise<{ [key: number]: OutputFileInfo[] }> {
+    const rounds = data as { [key: number]: OutputFileInfo[] };
+    const roundMap: { [key: number]: OutputFileInfo[] } = {};
+    const streamFilesProcessed = Object.values(rounds).reduce(
+      (sum, files) => sum + files.length,
+      0,
+    );
+    this.totalFilesProcessed += streamFilesProcessed;
+
+    for (const [roundStr, infos] of Object.entries(rounds)) {
+      const roundNum = parseInt(roundStr, 10);
+      this.logger.debug(
+        `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
+      );
+
+      try {
+        const filtered = await WorkspaceFS.filterExistingFiles(infos);
+        const removedCount = infos.length - filtered.length;
+
+        if (removedCount > 0) {
+          this.logger.debug(
+            `Removed ${removedCount} missing file(s) from stream ${streamId}, round ${roundNum}`,
+          );
+          this.totalFilesRemoved += removedCount;
+          const removedFiles = infos.filter(
+            (info) => !filtered.find((f) => f.path === info.path),
+          );
+          removedFiles.forEach((file) => {
+            this.logger.debug(`  - Removed missing file: ${file.path}`);
+          });
+        }
+
+        if (infos.length > 0) {
+          roundMap[roundNum] = filtered;
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Error checking files in stream ${streamId}, round ${roundNum}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        roundMap[roundNum] = infos;
+      }
+    }
+
+    return roundMap;
   }
 }

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -23,6 +23,7 @@ export class StreamTabsManager extends PersistentMapManager<
   StreamTabId,
   LogMessageData[]
 > {
+  private static readonly MAX_MESSAGE_HISTORY = 1000;
   private readonly logger: AgentLogger;
 
   constructor(persistence: StatePersistenceManager) {
@@ -48,8 +49,8 @@ export class StreamTabsManager extends PersistentMapManager<
     messages.push(message);
 
     // Limit message history to prevent memory issues
-    if (messages.length > 1000) {
-      messages.splice(0, messages.length - 1000);
+    if (messages.length > StreamTabsManager.MAX_MESSAGE_HISTORY) {
+      messages.splice(0, messages.length - StreamTabsManager.MAX_MESSAGE_HISTORY);
     }
 
     this.save();

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 // Local imports - progress view
 
 // Local imports
+import { PersistentMapManager } from '../persistence/PersistentMapManager';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
@@ -18,23 +19,26 @@ import { parseLegacyLogData } from '@logger/logUtils';
  * Manages stream tabs collection with persistence.
  * Handles adding, retrieving, and managing log messages for different streams.
  */
-export class StreamTabsManager {
-  private _tabs: Map<StreamTabId, LogMessageData[]> = new Map();
+export class StreamTabsManager extends PersistentMapManager<
+  StreamTabId,
+  LogMessageData[]
+> {
   private readonly logger: AgentLogger;
 
-  constructor(private persistence: StatePersistenceManager) {
+  constructor(persistence: StatePersistenceManager) {
+    super(persistence, WorkspaceStateKey.STREAM_TABS, 'texra.logStreams');
     this.logger = new AgentLogger('StreamTabsManager');
   }
 
   /**
    * Add a log message to a stream
    */
-  add(stream: StreamTabId, message: LogMessageData): void {
-    if (!this._tabs.has(stream)) {
-      this._tabs.set(stream, []);
+  addMessage(stream: StreamTabId, message: LogMessageData): void {
+    if (!this.has(stream)) {
+      this.items.set(stream, []);
     }
 
-    const messages = this._tabs.get(stream)!;
+    const messages = this.get(stream)!;
 
     // Ensure message has required fields
     if (!message.id) {
@@ -52,26 +56,11 @@ export class StreamTabsManager {
   }
 
   /**
-   * Get messages for a stream
-   */
-  get(stream: StreamTabId): LogMessageData[] | undefined {
-    return this._tabs.get(stream);
-  }
-
-  /**
-   * Check if stream exists
-   */
-  has(stream: StreamTabId): boolean {
-    return this._tabs.has(stream);
-  }
-
-  /**
    * Create an empty stream if it doesn't exist
    */
   ensureStream(stream: StreamTabId): void {
-    if (!this._tabs.has(stream)) {
-      this._tabs.set(stream, []);
-      this.save();
+    if (!this.has(stream)) {
+      super.add(stream, []);
     }
   }
 
@@ -79,105 +68,77 @@ export class StreamTabsManager {
    * Delete a stream and its messages
    */
   delete(stream: StreamTabId): void {
-    this._tabs.delete(stream);
-    this.save();
+    super.delete(stream);
   }
 
   /**
    * Clear all streams
    */
   clear(): void {
-    this._tabs.clear();
-    this.save();
+    super.clear();
   }
 
   /**
    * Clear content of a specific stream (but keep the stream)
    */
   clearContent(stream: StreamTabId): void {
-    if (this._tabs.has(stream)) {
-      this._tabs.get(stream)!.length = 0;
+    if (this.has(stream)) {
+      const arr = this.get(stream)!;
+      arr.length = 0;
       this.save();
     }
-  }
-
-  /**
-   * Get all stream IDs
-   */
-  keys(): StreamTabId[] {
-    return Array.from(this._tabs.keys());
-  }
-
-  /**
-   * Get all streams as Map
-   */
-  getAll(): Map<StreamTabId, LogMessageData[]> {
-    return new Map(this._tabs);
-  }
-
-  /**
-   * Set streams (used during loading)
-   */
-  setAll(streams: Map<StreamTabId, LogMessageData[]>): void {
-    this._tabs = new Map(streams);
   }
 
   /**
    * Load streams from persistence
    */
   async load(): Promise<void> {
-    const savedState = await this.persistence.loadWithMigration<{
-      [key: string]: LogMessageData[] | any[];
-    }>(WorkspaceStateKey.STREAM_TABS, 'texra.logStreams', {});
-
-    if (savedState && Object.keys(savedState).length > 0) {
-      const processedStreams = new Map<StreamTabId, LogMessageData[]>();
-
-      for (const [stream, messages] of Object.entries(savedState)) {
-        const processedMessages = messages.map((msg: any) => {
-          // Ensure message has required fields
-          if (!msg.id) {
-            msg.id = randomUUID();
-          }
-          if (msg.text === undefined && msg.message !== undefined) {
-            msg.text = msg.message;
-          }
-          if (msg.timestamp === undefined) {
-            const attrMatch =
-              typeof msg.text === 'string'
-                ? msg.text.match(/data-full-timestamp="([^"]+)"/)
-                : null;
-            const timeString =
-              attrMatch?.[1] ||
-              (typeof msg.text === 'string'
-                ? (msg.text.match(/\[(.*?)\]/)?.[1] ?? '')
-                : '');
-            const timestamp = new Date(timeString).getTime();
-            msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
-          }
-          const log = msg as LogMessageData;
-          parseLegacyLogData(log, this.logger);
-          if (!log.messageType) {
-            log.messageType = 'default';
-          }
-          return log;
-        });
-
-        processedStreams.set(stream, processedMessages);
-      }
-
-      this._tabs = processedStreams;
-      this.logger.debug(`Loaded ${this._tabs.size} streams from storage`);
-    } else {
-      this._tabs.clear();
+    await super.load();
+    if (this.items.size > 0) {
+      this.logger.debug(`Loaded ${this.items.size} streams from storage`);
     }
   }
 
-  /**
-   * Save streams to persistence
-   */
-  save(): void {
-    const stateObj = Object.fromEntries(this._tabs.entries());
-    this.persistence.save(WorkspaceStateKey.STREAM_TABS, stateObj);
+  /** Serialize messages before saving */
+  protected override serialize(
+    value: LogMessageData[],
+    _key: StreamTabId,
+  ): unknown {
+    return value;
+  }
+
+  /** Normalize loaded messages */
+  protected override async deserialize(
+    data: unknown,
+    _key: StreamTabId,
+  ): Promise<LogMessageData[]> {
+    const messages = Array.isArray(data) ? data : [];
+    return messages.map((msg: any) => {
+      if (!msg.id) {
+        msg.id = randomUUID();
+      }
+      if (msg.text === undefined && msg.message !== undefined) {
+        msg.text = msg.message;
+      }
+      if (msg.timestamp === undefined) {
+        const attrMatch =
+          typeof msg.text === 'string'
+            ? msg.text.match(/data-full-timestamp="([^"]+)"/)
+            : null;
+        const timeString =
+          attrMatch?.[1] ||
+          (typeof msg.text === 'string'
+            ? (msg.text.match(/\[(.*?)\]/)?.[1] ?? '')
+            : '');
+        const timestamp = new Date(timeString).getTime();
+        msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
+      }
+      const log = msg as LogMessageData;
+      parseLegacyLogData(log, this.logger);
+      if (!log.messageType) {
+        log.messageType = 'default';
+      }
+      return log;
+    });
   }
 }

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -1,5 +1,6 @@
 // Local imports - progress view
 // Local imports
+import { PersistentMapManager } from '../persistence/PersistentMapManager';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
@@ -12,11 +13,14 @@ import { TaskGroup } from '@logger/LogTypes';
  * Manages task groups collection with persistence.
  * Handles adding, updating, and managing task groups for different streams.
  */
-export class TaskGroupManager {
-  private _groups: Map<StreamTabId, Map<string, TaskGroup>> = new Map();
+export class TaskGroupManager extends PersistentMapManager<
+  StreamTabId,
+  Map<string, TaskGroup>
+> {
   private readonly logger: AgentLogger;
 
-  constructor(private persistence: StatePersistenceManager) {
+  constructor(persistence: StatePersistenceManager) {
+    super(persistence, WorkspaceStateKey.TASK_GROUPS, 'texra.logGroups');
     this.logger = new AgentLogger('TaskGroupManager');
   }
 
@@ -24,11 +28,11 @@ export class TaskGroupManager {
    * Add a task group to a stream
    */
   addGroup(stream: StreamTabId, groupId: string, group: TaskGroup): void {
-    if (!this._groups.has(stream)) {
-      this._groups.set(stream, new Map());
+    if (!this.has(stream)) {
+      this.items.set(stream, new Map());
     }
 
-    const streamGroups = this._groups.get(stream)!;
+    const streamGroups = this.get(stream)!;
     streamGroups.set(groupId, { ...group });
     this.save();
   }
@@ -41,7 +45,7 @@ export class TaskGroupManager {
     groupId: string,
     updates: Partial<TaskGroup>,
   ): void {
-    const streamGroups = this._groups.get(stream);
+    const streamGroups = this.get(stream);
     if (!streamGroups) {
       this.logger.warn(
         `Cannot update group ${groupId}: stream ${stream} not found`,
@@ -67,7 +71,7 @@ export class TaskGroupManager {
    * Get a specific task group
    */
   getGroup(stream: StreamTabId, groupId: string): TaskGroup | undefined {
-    const streamGroups = this._groups.get(stream);
+    const streamGroups = this.get(stream);
     return streamGroups?.get(groupId);
   }
 
@@ -75,97 +79,78 @@ export class TaskGroupManager {
    * Get all groups for a stream
    */
   getStreamGroups(stream: StreamTabId): Map<string, TaskGroup> {
-    return this._groups.get(stream) || new Map();
-  }
-
-  /**
-   * Get all groups across all streams
-   */
-  getAll(): Map<StreamTabId, Map<string, TaskGroup>> {
-    return new Map(this._groups);
+    return this.get(stream) || new Map();
   }
 
   /**
    * Check if a stream has groups
    */
   hasStream(stream: StreamTabId): boolean {
-    return this._groups.has(stream);
+    return this.has(stream);
   }
 
   /**
    * Delete all groups for a stream
    */
   deleteStream(stream: StreamTabId): void {
-    this._groups.delete(stream);
-    this.save();
+    this.delete(stream);
   }
 
   /**
    * Clear all groups
    */
   clear(): void {
-    this._groups.clear();
-    this.save();
+    super.clear();
   }
 
   /**
    * Set all groups (used during loading)
    */
   setAll(groups: Map<StreamTabId, Map<string, TaskGroup>>): void {
-    this._groups = new Map(groups);
+    super.setAll(groups);
   }
 
   /**
    * Load task groups from persistence
    */
   async load(): Promise<void> {
-    const savedGroups = await this.persistence.loadWithMigration<{
-      [key: string]: { [groupId: string]: TaskGroup };
-    }>(WorkspaceStateKey.TASK_GROUPS, 'texra.logGroups', {});
-
-    if (savedGroups && Object.keys(savedGroups).length > 0) {
-      const processedGroups = new Map<StreamTabId, Map<string, TaskGroup>>();
-
-      for (const [streamId, groups] of Object.entries(savedGroups)) {
-        const streamGroupsMap = new Map<string, TaskGroup>();
-
-        for (const [id, group] of Object.entries(groups)) {
-          // Normalize timestamp fields
-          const normalizedGroup: TaskGroup = {
-            ...group,
-            startTime:
-              typeof group.startTime === 'string'
-                ? new Date(group.startTime).getTime()
-                : group.startTime,
-            endTime:
-              group.endTime !== undefined
-                ? typeof group.endTime === 'string'
-                  ? new Date(group.endTime).getTime()
-                  : group.endTime
-                : undefined,
-          };
-
-          streamGroupsMap.set(id, normalizedGroup);
-        }
-
-        processedGroups.set(streamId, streamGroupsMap);
-      }
-
-      this._groups = processedGroups;
-      this.logger.debug(`Loaded task groups for ${this._groups.size} streams`);
-    } else {
-      this._groups.clear();
+    await super.load();
+    if (this.items.size > 0) {
+      this.logger.debug(`Loaded task groups for ${this.items.size} streams`);
     }
   }
 
-  /**
-   * Save task groups to persistence
-   */
-  save(): void {
-    const persistentGroups = Array.from(this._groups.entries()).map(
-      ([streamId, groups]) => [streamId, Object.fromEntries(groups.entries())],
-    );
-    const groupsObj = Object.fromEntries(persistentGroups);
-    this.persistence.save(WorkspaceStateKey.TASK_GROUPS, groupsObj);
+  /** Convert groups map to plain object */
+  protected override serialize(
+    value: Map<string, TaskGroup>,
+    _key: StreamTabId,
+  ): unknown {
+    return Object.fromEntries(value.entries());
+  }
+
+  /** Normalize loaded groups */
+  protected override async deserialize(
+    data: unknown,
+    _key: StreamTabId,
+  ): Promise<Map<string, TaskGroup>> {
+    const groups = data as Record<string, TaskGroup>;
+    const map = new Map<string, TaskGroup>();
+    for (const [id, group] of Object.entries(groups)) {
+      const normalized: TaskGroup = {
+        ...group,
+        startTime:
+          typeof group.startTime === 'string'
+            ? new Date(group.startTime).getTime()
+            : group.startTime,
+        endTime:
+          group.endTime !== undefined
+            ? typeof group.endTime === 'string'
+              ? new Date(group.endTime).getTime()
+              : group.endTime
+            : undefined,
+      };
+      map.set(id, normalized);
+    }
+    return map;
   }
 }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -1,5 +1,6 @@
 // Local imports - progress view
 // Local imports
+import { PersistentMapManager } from '../persistence/PersistentMapManager';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
@@ -12,11 +13,14 @@ import { AgentLogger } from '@logger/AgentLogger';
  * Manages usage statistics collection with persistence.
  * Handles tracking and updating token usage and costs for different streams.
  */
-export class UsageStatsManager {
-  private _usageStats: Map<StreamTabId, TokenUsageStats> = new Map();
+export class UsageStatsManager extends PersistentMapManager<
+  StreamTabId,
+  TokenUsageStats
+> {
   private readonly logger: AgentLogger;
 
-  constructor(private persistence: StatePersistenceManager) {
+  constructor(persistence: StatePersistenceManager) {
+    super(persistence, WorkspaceStateKey.USAGE_STATS);
     this.logger = new AgentLogger('UsageStatsManager');
   }
 
@@ -24,15 +28,14 @@ export class UsageStatsManager {
    * Update usage statistics for a stream
    */
   updateStreamUsage(stream: StreamTabId, usage: TokenUsageStats): void {
-    this._usageStats.set(stream, { ...usage });
-    this.save();
+    this.add(stream, { ...usage });
   }
 
   /**
    * Add usage to existing stream statistics
    */
   addToStreamUsage(stream: StreamTabId, usage: TokenUsageStats): void {
-    const existing = this._usageStats.get(stream) || {
+    const existing = this.get(stream) || {
       inputTokens: 0,
       outputTokens: 0,
       cost: 0,
@@ -44,45 +47,35 @@ export class UsageStatsManager {
       cost: existing.cost + (usage.cost || 0),
     };
 
-    this._usageStats.set(stream, updated);
-    this.save();
+    this.add(stream, updated);
   }
 
   /**
    * Get usage statistics for a stream
    */
   getStreamUsage(stream: StreamTabId): TokenUsageStats | undefined {
-    return this._usageStats.get(stream);
-  }
-
-  /**
-   * Get all usage statistics
-   */
-  getAll(): Map<StreamTabId, TokenUsageStats> {
-    return new Map(this._usageStats);
+    return this.get(stream);
   }
 
   /**
    * Delete usage statistics for a stream
    */
   deleteStream(stream: StreamTabId): void {
-    this._usageStats.delete(stream);
-    this.save();
+    this.delete(stream);
   }
 
   /**
    * Clear all usage statistics
    */
   clear(): void {
-    this._usageStats.clear();
-    this.save();
+    super.clear();
   }
 
   /**
    * Set all usage statistics (used during loading)
    */
   setAll(stats: Map<StreamTabId, TokenUsageStats>): void {
-    this._usageStats = new Map(stats);
+    super.setAll(stats);
   }
 
   /**
@@ -95,7 +88,7 @@ export class UsageStatsManager {
       cost: 0,
     };
 
-    for (const usage of this._usageStats.values()) {
+    for (const usage of this.items.values()) {
       total.inputTokens += usage.inputTokens || 0;
       total.outputTokens += usage.outputTokens || 0;
       total.cost += usage.cost || 0;
@@ -108,56 +101,42 @@ export class UsageStatsManager {
    * Get streams with usage statistics
    */
   getStreamsWithUsage(): StreamTabId[] {
-    return Array.from(this._usageStats.keys());
+    return this.keys();
   }
 
   /**
    * Check if stream has usage statistics
    */
   hasUsage(stream: StreamTabId): boolean {
-    return this._usageStats.has(stream);
+    return this.has(stream);
   }
 
   /**
    * Load usage statistics from persistence
    */
   async load(): Promise<void> {
-    const savedUsage = await this.persistence.load<{
-      [key: string]: {
-        inputTokens: number;
-        outputTokens: number;
-        cost: number;
-      };
-    }>(WorkspaceStateKey.USAGE_STATS, {});
-
-    if (savedUsage && Object.keys(savedUsage).length > 0) {
-      const processedUsage = new Map<StreamTabId, TokenUsageStats>();
-
-      for (const [stream, usage] of Object.entries(savedUsage)) {
-        // Ensure all required fields are present
-        const normalizedUsage: TokenUsageStats = {
-          inputTokens: usage.inputTokens || 0,
-          outputTokens: usage.outputTokens || 0,
-          cost: usage.cost || 0,
-        };
-
-        processedUsage.set(stream, normalizedUsage);
-      }
-
-      this._usageStats = processedUsage;
+    await super.load();
+    if (this.items.size > 0) {
       this.logger.debug(
-        `Loaded usage statistics for ${this._usageStats.size} streams`,
+        `Loaded usage statistics for ${this.items.size} streams`,
       );
-    } else {
-      this._usageStats.clear();
     }
   }
 
-  /**
-   * Save usage statistics to persistence
-   */
-  save(): void {
-    const usageObj = Object.fromEntries(this._usageStats.entries());
-    this.persistence.save(WorkspaceStateKey.USAGE_STATS, usageObj);
+  /** Normalize loaded usage records */
+  protected override async deserialize(
+    data: unknown,
+    _key: StreamTabId,
+  ): Promise<TokenUsageStats> {
+    const usage = (data as TokenUsageStats) || {
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+    };
+    return {
+      inputTokens: usage.inputTokens || 0,
+      outputTokens: usage.outputTokens || 0,
+      cost: usage.cost || 0,
+    };
   }
 }

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -1,0 +1,108 @@
+// Local imports - progress view
+import { StatePersistenceManager } from './StatePersistenceManager';
+// Local imports
+import { WorkspaceStateKey } from '@common/state/stateManager';
+
+/**
+ * Generic manager for map-based state with persistence support.
+ * Handles common map operations and storage serialization.
+ */
+export abstract class PersistentMapManager<K extends string, V> {
+  protected items: Map<K, V> = new Map();
+
+  constructor(
+    protected readonly persistence: StatePersistenceManager,
+    protected readonly storageKey: WorkspaceStateKey,
+    protected readonly legacyKey?: string,
+  ) {}
+
+  /** Add an entry to the map and persist it */
+  add(key: K, value: V): void {
+    this.items.set(key, value);
+    this.save();
+  }
+
+  /** Delete an entry and persist the change */
+  delete(key: K): void {
+    this.items.delete(key);
+    this.save();
+  }
+
+  /** Clear the map and persist the change */
+  clear(): void {
+    this.items.clear();
+    this.save();
+  }
+
+  /** Get a value for the key */
+  get(key: K): V | undefined {
+    return this.items.get(key);
+  }
+
+  /** Get a shallow copy of all entries */
+  getAll(): Map<K, V> {
+    return new Map(this.items);
+  }
+
+  /** Check if key exists */
+  has(key: K): boolean {
+    return this.items.has(key);
+  }
+
+  /** Get all keys */
+  keys(): K[] {
+    return Array.from(this.items.keys());
+  }
+
+  /** Replace all entries (used during loading) */
+  setAll(entries: Map<K, V>): void {
+    this.items = new Map(entries);
+  }
+
+  /** Serialize a value before saving */
+  protected serialize(value: V, _key: K): unknown {
+    return value as unknown;
+  }
+
+  /**
+   * Deserialize a persisted value. Can perform async operations like cleanup.
+   */
+  protected async deserialize(data: unknown, _key: K): Promise<V> {
+    return data as V;
+  }
+
+  /** Load state from persistence */
+  async load(): Promise<void> {
+    const saved = this.legacyKey
+      ? await this.persistence.loadWithMigration<Record<string, unknown>>(
+          this.storageKey,
+          this.legacyKey,
+          {},
+        )
+      : await this.persistence.load<Record<string, unknown>>(
+          this.storageKey,
+          {},
+        );
+
+    if (saved && Object.keys(saved).length > 0) {
+      const entries: [K, V][] = [];
+      for (const [key, value] of Object.entries(saved)) {
+        const deserialized = await this.deserialize(value, key as K);
+        entries.push([key as K, deserialized]);
+      }
+      this.items = new Map(entries);
+    } else {
+      this.items.clear();
+    }
+  }
+
+  /** Save current state to persistence */
+  save(): void {
+    const serialized = Array.from(this.items.entries()).map(([key, value]) => [
+      key,
+      this.serialize(value, key),
+    ]);
+    const obj = Object.fromEntries(serialized);
+    this.persistence.save(this.storageKey, obj as any);
+  }
+}

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -103,6 +103,6 @@ export abstract class PersistentMapManager<K extends string, V> {
       this.serialize(value, key),
     ]);
     const obj = Object.fromEntries(serialized);
-    this.persistence.save(this.storageKey, obj as any);
+    this.persistence.save(this.storageKey, obj);
   }
 }


### PR DESCRIPTION
## Summary
- create generic PersistentMapManager to handle persisted map operations
- refactor stream, usage, task group, and output file managers to extend the base
- update log event handler for new stream tab API

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1485b92188324ad38fb4bad0bfdfe