### PR TITLE
refactor: centralize config access

### DIFF
--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { getConfig } from '@utils/config';
+import { getConfig, updateConfig } from '@utils/config';
 import { GlobalStorageFS, StorageFS, AbsoluteFS } from '@utils/files';
 import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
 
@@ -83,12 +83,7 @@ export class AgentDirectoryManager {
     const selectedPath = folder[0].fsPath;
     await AbsoluteFS.ensureDir(selectedPath);
 
-    const config = vscode.workspace.getConfiguration();
-    await config.update(
-      'texra.explorer.agentsDirectory',
-      selectedPath,
-      vscode.ConfigurationTarget.Workspace,
-    );
+    await updateConfig('explorer.agentsDirectory', selectedPath);
 
     return selectedPath;
   }

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as logger from '@logger/logUtils';
 import { isValidAgentYaml } from '@agent/runtime/agentLoad';
-import { getConfig, setConfig } from '@utils/config';
+import { getConfig, updateConfig } from '@utils/config';
 
 const CHANNEL = 'AgentRegister';
 logger.initialize(CHANNEL);
@@ -58,7 +58,7 @@ export async function promptToAddAgentToConfig(
 
   if (autoAdd) {
     current.push(agentName);
-    await setConfig('agents', current, vscode.ConfigurationTarget.Workspace);
+    await updateConfig('agents', current);
     vscode.window.showInformationMessage(
       `Added "${agentName}" to texra.agents`,
     );
@@ -74,7 +74,7 @@ export async function promptToAddAgentToConfig(
 
   if (choice === addButton) {
     current.push(agentName);
-    await setConfig('agents', current, vscode.ConfigurationTarget.Workspace);
+    await updateConfig('agents', current);
     vscode.window.showInformationMessage(
       `Added "${agentName}" to texra.agents`,
     );

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -10,6 +10,7 @@ import { GlobalStorageFS, StorageFS, copyDirToFS } from '@utils/files';
 import { GlobalStateKey, globalSM } from '@common/state/stateManager';
 import { safeExecuteCommand } from '@utils/system';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+import { updateConfig } from '@utils/config';
 
 /**
  * Copies default agent files from the extension resources to the global storage directory
@@ -80,65 +81,93 @@ export async function configureLatexSettings() {
         'extension',
         'LaTeX Workshop extension detected, configuring settings',
       );
-      const config = vscode.workspace.getConfiguration();
-
-      // Helper to update LaTeX Workshop settings only when unset
-      const updateIfUnset = async <T>(key: string, value: T) => {
-        const setting = config.inspect<T>(key);
-        if (
-          setting &&
-          setting.globalValue === undefined &&
-          setting.workspaceValue === undefined &&
-          setting.workspaceFolderValue === undefined
-        ) {
-          await config.update(key, value, vscode.ConfigurationTarget.Global);
-        }
-      };
-
       // Update LaTeX Workshop build settings
-      await updateIfUnset<string[]>(
+      await updateConfig(
         'latex-workshop.latex.external.build.args',
         ['--output-directory=build', '-f', '-pdf'],
+        {
+          target: vscode.ConfigurationTarget.Global,
+          prefix: false,
+          ifUnset: true,
+        },
       );
 
-      await updateIfUnset<string>(
-        'latex-workshop.latex.outDir',
-        '%DIR%/build/',
-      );
+      await updateConfig('latex-workshop.latex.outDir', '%DIR%/build/', {
+        target: vscode.ConfigurationTarget.Global,
+        prefix: false,
+        ifUnset: true,
+      });
 
       // Add nonstopmode magic arguments for LaTeX Workshop
-      await updateIfUnset<string[]>('latex-workshop.latex.magic.args', [
-        '-synctex=1',
-        '-interaction=nonstopmode',
-        '-file-line-error',
-        '%DOC%',
-        '-pdf',
-        '-f',
-      ]);
-
-      // Configure LaTeX formatting
-      await updateIfUnset<string>(
-        'latex-workshop.formatting.latex',
-        'latexindent',
+      await updateConfig(
+        'latex-workshop.latex.magic.args',
+        [
+          '-synctex=1',
+          '-interaction=nonstopmode',
+          '-file-line-error',
+          '%DOC%',
+          '-pdf',
+          '-f',
+        ],
+        {
+          target: vscode.ConfigurationTarget.Global,
+          prefix: false,
+          ifUnset: true,
+        },
       );
 
-      // Configure word wrap for LaTeX files
-      await updateIfUnset('[latex]', {
-        'editor.wordWrap': 'on',
-        'files.autoSave': 'afterDelay',
+      // Configure LaTeX formatting
+      await updateConfig('latex-workshop.formatting.latex', 'latexindent', {
+        target: vscode.ConfigurationTarget.Global,
+        prefix: false,
+        ifUnset: true,
       });
+
+      // Configure word wrap for LaTeX files
+      await updateConfig(
+        '[latex]',
+        {
+          'editor.wordWrap': 'on',
+          'files.autoSave': 'afterDelay',
+        },
+        {
+          target: vscode.ConfigurationTarget.Global,
+          prefix: false,
+          ifUnset: true,
+        },
+      );
 
       // Also add word wrap for yaml files
-      await updateIfUnset('[yaml]', {
-        'editor.wordWrap': 'on',
-        'files.autoSave': 'afterDelay',
-      });
+      await updateConfig(
+        '[yaml]',
+        {
+          'editor.wordWrap': 'on',
+          'files.autoSave': 'afterDelay',
+        },
+        {
+          target: vscode.ConfigurationTarget.Global,
+          prefix: false,
+          ifUnset: true,
+        },
+      );
 
       // Configure explorer settings to not automatically reveal build directory
-      await updateIfUnset('explorer.autoRevealExclude', { 'build/': true });
+      await updateConfig(
+        'explorer.autoRevealExclude',
+        { 'build/': true },
+        {
+          target: vscode.ConfigurationTarget.Global,
+          prefix: false,
+          ifUnset: true,
+        },
+      );
 
       // Disable automatic revealing of files in explorer
-      await updateIfUnset('explorer.autoReveal', false);
+      await updateConfig('explorer.autoReveal', false, {
+        target: vscode.ConfigurationTarget.Global,
+        prefix: false,
+        ifUnset: true,
+      });
 
       const isWindsurf = vscode.env.appName?.toLowerCase().includes('windsurf');
 
@@ -146,7 +175,11 @@ export async function configureLatexSettings() {
         const activityBarKey = 'workbench.activityBar.location';
 
         // Update activity bar location only if unset
-        await updateIfUnset(activityBarKey, 'default');
+        await updateConfig(activityBarKey, 'default', {
+          target: vscode.ConfigurationTarget.Global,
+          prefix: false,
+          ifUnset: true,
+        });
         logger.info('extension', 'Activity bar location set to default');
       }
 

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -3,14 +3,14 @@ import * as vscode from 'vscode';
 
 /**
  * Gets a configuration value from VS Code settings.
- * 
+ *
  * Path conventions:
  * - Use dot notation without the 'texra' prefix (e.g., 'agents', 'api.engine')
  * - The function will automatically try multiple namespaces:
  *   1. The path as given (for non-texra configs like 'latex.latexindentConfig')
  *   2. Under the 'texra' namespace
  *   3. With explicit 'texra.' prefix
- * 
+ *
  * @param path Configuration path (e.g., 'agents' or 'api.engine')
  * @param defaultValue Optional default value if configuration is not found
  * @returns The configuration value or default value
@@ -38,26 +38,52 @@ export function getConfig<T>(path: string, defaultValue?: T): T {
 }
 
 /**
- * Sets a configuration value in VS Code settings.
- * 
+ * Updates a configuration value in VS Code settings.
+ *
  * Path conventions:
- * - Use dot notation without the 'texra' prefix (e.g., 'agents', 'api.engine')
- * - The function will automatically add the 'texra.' prefix
- * 
- * @param path Configuration path without 'texra' prefix (e.g., 'agents')
+ * - Use dot notation without the 'texra' prefix for extension settings
+ *   (e.g., 'agents', 'api.engine')
+ * - Non-extension settings should set `prefix` to false and pass the full key
+ *
+ * @param path Configuration path
  * @param value The value to set
- * @param target Configuration target (defaults to Workspace)
+ * @param options Additional options for the update
  * @returns Promise that resolves when configuration is updated
  */
-export async function setConfig<T>(
+export async function updateConfig<T>(
   path: string,
   value: T,
-  target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Workspace,
+  options: {
+    target?: vscode.ConfigurationTarget;
+    prefix?: boolean;
+    ifUnset?: boolean;
+  } = {},
 ): Promise<void> {
-  await vscode.workspace
-    .getConfiguration()
-    .update(`texra.${path}`, value, target);
+  const {
+    target = vscode.ConfigurationTarget.Workspace,
+    prefix = true,
+    ifUnset = false,
+  } = options;
+
+  const key = prefix && !path.startsWith('texra.') ? `texra.${path}` : path;
+
+  if (ifUnset) {
+    const setting = vscode.workspace.getConfiguration().inspect(key);
+    if (
+      setting &&
+      setting.globalValue === undefined &&
+      setting.workspaceValue === undefined &&
+      setting.workspaceFolderValue === undefined
+    ) {
+      await vscode.workspace.getConfiguration().update(key, value, target);
+    }
+  } else {
+    await vscode.workspace.getConfiguration().update(key, value, target);
+  }
 }
+
+// Backwards-compatible alias
+export const setConfig = updateConfig;
 
 /**
  * Register a listener for configuration changes on the given keys.


### PR DESCRIPTION
## Summary
- add `updateConfig` helper with optional prefix and if-unset support
- switch LaTeX setup and agent directory manager to `updateConfig`
- use config helper for agent registration

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c14815fef483249e30189c9717c84d