### PR TITLE
refactor: centralize tool error handling

### DIFF
--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -46,7 +46,7 @@ export class DiagnosticsTool extends BaseTool<DiagnosticsInput> {
         return new ToolResult({ output: JSON.stringify(counts) });
       }
       default:
-        throw new ToolError(`Unrecognized command: ${command}`);
+        throw new ToolError(`Diagnostics tool error: Unrecognized command '${command}'. Expected 'list' or 'count'.`);
     }
   }
 }

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -34,26 +34,19 @@ export class DiagnosticsTool extends BaseTool<DiagnosticsInput> {
   }
 
   protected async execute(input: DiagnosticsInput): Promise<ToolResult> {
-    try {
-      const { command, path } = input;
-      switch (command) {
-        case 'list': {
-          const messages = await getLinterMessages(path);
-          return new ToolResult({ output: JSON.stringify(messages) });
-        }
-        case 'count': {
-          const messages = await getLinterMessages(path);
-          const counts = countDiagnosticsBySeverity(messages);
-          return new ToolResult({ output: JSON.stringify(counts) });
-        }
-        default:
-          throw new ToolError(`Unrecognized command: ${command}`);
+    const { command, path } = input;
+    switch (command) {
+      case 'list': {
+        const messages = await getLinterMessages(path);
+        return new ToolResult({ output: JSON.stringify(messages) });
       }
-    } catch (err) {
-      if (err instanceof ToolError) {
-        return new ToolResult({ error: err.message, isError: true });
+      case 'count': {
+        const messages = await getLinterMessages(path);
+        const counts = countDiagnosticsBySeverity(messages);
+        return new ToolResult({ output: JSON.stringify(counts) });
       }
-      return new ToolResult({ error: String(err), isError: true });
+      default:
+        throw new ToolError(`Unrecognized command: ${command}`);
     }
   }
 }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -81,82 +81,72 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
    * @param input - Tool call input parameters
    */
   protected async execute(input: TextEditorInput): Promise<ToolResult> {
-    try {
-      const { command, path: filePath } = input;
+    const { command, path: filePath } = input;
 
-      // Validate the path and command
-      await this.validatePath(command, filePath);
+    // Validate the path and command
+    await this.validatePath(command, filePath);
 
-      // Execute the appropriate command
-      switch (command) {
-        case 'view':
-          return await this.view(filePath, input.view_range);
-        case 'create':
-          if (!input.file_text) {
-            throw new ToolError(
-              'Parameter `file_text` is required for command: create',
-            );
-          }
-          logger.info(CHANNEL, `create: ${filePath}`);
-          return await this.create(filePath, input.file_text);
-        case 'str_replace':
-          if (!input.old_str) {
-            throw new ToolError(
-              'Parameter `old_str` is required for command: str_replace',
-            );
-          }
-          logger.info(
-            CHANNEL,
-            `str_replace: ${input.old_str} -> ${input.new_str}`,
-          );
-          return await this.strReplace(
-            filePath,
-            input.old_str,
-            input.new_str ?? '',
-          );
-
-        case 'insert':
-          if (input.insert_line === undefined) {
-            throw new ToolError(
-              'Parameter `insert_line` is required for command: insert',
-            );
-          }
-          if (!input.new_str) {
-            throw new ToolError(
-              'Parameter `new_str` is required for command: insert',
-            );
-          }
-          logger.info(
-            CHANNEL,
-            `insert: ${input.insert_line} -> ${input.new_str}`,
-          );
-          return await this.insert(filePath, input.insert_line, input.new_str);
-        case 'undo_edit':
-          // Claude 4 models don't support undo_edit command
-          if (this.apiType === 'text_editor_20250429') {
-            throw new ToolError(
-              `The 'undo_edit' command is not supported in Claude 4 models. Use the str_replace_based_edit_tool with explicit content instead.`,
-            );
-          }
-          logger.info(CHANNEL, `undo_edit: ${filePath}`);
-          return await this.undoEdit(filePath);
-        default:
-          const allowedCommands =
-            this.apiType === 'text_editor_20250429'
-              ? 'view, create, str_replace, insert'
-              : 'view, create, str_replace, insert, undo_edit';
+    // Execute the appropriate command
+    switch (command) {
+      case 'view':
+        return await this.view(filePath, input.view_range);
+      case 'create':
+        if (!input.file_text) {
           throw new ToolError(
-            `Unrecognized command ${command}. The allowed commands for the ${this.name} tool are: ${allowedCommands}`,
+            'Parameter `file_text` is required for command: create',
           );
-      }
-    } catch (error) {
-      if (error instanceof ToolError) {
-        return new ToolResult({ error: error.message, isError: true });
-      }
-      return new ToolResult({
-        error: `Unexpected error: ${String(error)}`,
-        isError: true,
-      });
+        }
+        logger.info(CHANNEL, `create: ${filePath}`);
+        return await this.create(filePath, input.file_text);
+      case 'str_replace':
+        if (!input.old_str) {
+          throw new ToolError(
+            'Parameter `old_str` is required for command: str_replace',
+          );
+        }
+        logger.info(
+          CHANNEL,
+          `str_replace: ${input.old_str} -> ${input.new_str}`,
+        );
+        return await this.strReplace(
+          filePath,
+          input.old_str,
+          input.new_str ?? '',
+        );
+
+      case 'insert':
+        if (input.insert_line === undefined) {
+          throw new ToolError(
+            'Parameter `insert_line` is required for command: insert',
+          );
+        }
+        if (!input.new_str) {
+          throw new ToolError(
+            'Parameter `new_str` is required for command: insert',
+          );
+        }
+        logger.info(
+          CHANNEL,
+          `insert: ${input.insert_line} -> ${input.new_str}`,
+        );
+        return await this.insert(filePath, input.insert_line, input.new_str);
+      case 'undo_edit':
+        // Claude 4 models don't support undo_edit command
+        if (this.apiType === 'text_editor_20250429') {
+          throw new ToolError(
+            `The 'undo_edit' command is not supported in Claude 4 models. Use the str_replace_based_edit_tool with explicit content instead.`,
+          );
+        }
+        logger.info(CHANNEL, `undo_edit: ${filePath}`);
+        return await this.undoEdit(filePath);
+      default:
+        const allowedCommands =
+          this.apiType === 'text_editor_20250429'
+            ? 'view, create, str_replace, insert'
+            : 'view, create, str_replace, insert, undo_edit';
+        throw new ToolError(
+          `Unrecognized command ${command}. The allowed commands for the ${this.name} tool are: ${allowedCommands}`,
+        );
     }
   }
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -8,7 +8,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 // Local imports - tools
 import { BaseTool } from './core/base';
 import type { ToolDefinition } from '@model';
-import { ToolResult } from '@tools/result';
+import { ToolResult, ToolError } from '@tools/result';
 import { executeCommand } from '@utils/system/execUtils';
 
 const BashInputSchema = z.object({
@@ -32,9 +32,6 @@ export class BashTool extends BaseTool<BashInput> {
     if (result.success) {
       return new ToolResult({ output: result.stdout || '' });
     }
-    return new ToolResult({
-      error: result.stderr || 'Command failed',
-      isError: true,
-    });
+    throw new ToolError(result.stderr || 'Command failed');
   }
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -32,6 +32,6 @@ export class BashTool extends BaseTool<BashInput> {
     if (result.success) {
       return new ToolResult({ output: result.stdout || '' });
     }
-    throw new ToolError(result.stderr || 'Command failed');
+    throw new ToolError(`Bash command failed: ${result.stderr || 'No error output available'}`);
   }
 }

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -18,6 +18,21 @@ export abstract class BaseTool<T> {
     return this.schema.parse(input);
   }
 
+  /**
+   * Execute the tool with centralized error handling.
+   * 
+   * This method validates the input using Zod schema, executes the tool's
+   * implementation, and wraps any errors in a ToolResult with diagnostic
+   * information.
+   * 
+   * @param rawInput - The raw input to validate and pass to the tool
+   * @returns A ToolResult containing either the output or error information
+   * 
+   * Error handling behavior:
+   * - ZodError: Returns error result with validation issues in diagnostics
+   * - ToolError or other Error: Returns error result with name and stack trace
+   * - Other thrown values: Returns error result with string representation
+   */
   async call(rawInput: unknown): Promise<ToolResult> {
     try {
       const input = this.validate(rawInput);

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { z } from 'zod';
+import { z, ZodError } from 'zod';
 
 // Local imports - tools
 import type { ToolDefinition } from '@model';
@@ -19,8 +19,26 @@ export abstract class BaseTool<T> {
   }
 
   async call(rawInput: unknown): Promise<ToolResult> {
-    const input = this.validate(rawInput);
-    return this.execute(input);
+    try {
+      const input = this.validate(rawInput);
+      return await this.execute(input);
+    } catch (err) {
+      if (err instanceof ZodError) {
+        return new ToolResult({
+          error: 'Invalid input',
+          isError: true,
+          diagnostics: err.issues,
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      const diagnostics =
+        err instanceof Error ? { name: err.name, stack: err.stack } : undefined;
+      return new ToolResult({
+        error: message,
+        isError: true,
+        diagnostics,
+      });
+    }
   }
 
   protected abstract execute(input: T): Promise<ToolResult>;

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -8,7 +8,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 // Local imports - tools
 import { BaseTool } from './core/base';
 import type { ToolDefinition } from '@model';
-import { ToolResult } from '@tools/result';
+import { ToolResult, ToolError } from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
 
 const FileOpInputSchema = z.object({
@@ -31,40 +31,27 @@ export class FileOpTool extends BaseTool<FileOpInput> {
 
   protected async execute(input: FileOpInput): Promise<ToolResult> {
     const { command, path, content } = input;
-    try {
-      switch (command) {
-        case 'read': {
-          const data = await WorkspaceFS.readFile(path);
-          return new ToolResult({ output: data });
-        }
-        case 'write': {
-          if (content === undefined) {
-            return new ToolResult({
-              error: 'content parameter is required for write',
-              isError: true,
-            });
-          }
-          await WorkspaceFS.writeFile(path, content);
-          return new ToolResult({ output: 'written' });
-        }
-        case 'append': {
-          if (content === undefined) {
-            return new ToolResult({
-              error: 'content parameter is required for append',
-              isError: true,
-            });
-          }
-          await WorkspaceFS.appendFile(path, content);
-          return new ToolResult({ output: 'appended' });
-        }
-        default:
-          return new ToolResult({ error: 'unknown command', isError: true });
+    switch (command) {
+      case 'read': {
+        const data = await WorkspaceFS.readFile(path);
+        return new ToolResult({ output: data });
       }
-    } catch (err) {
-      return new ToolResult({
-        error: err instanceof Error ? err.message : String(err),
-        isError: true,
-      });
+      case 'write': {
+        if (content === undefined) {
+          throw new ToolError('content parameter is required for write');
+        }
+        await WorkspaceFS.writeFile(path, content);
+        return new ToolResult({ output: 'written' });
+      }
+      case 'append': {
+        if (content === undefined) {
+          throw new ToolError('content parameter is required for append');
+        }
+        await WorkspaceFS.appendFile(path, content);
+        return new ToolResult({ output: 'appended' });
+      }
+      default:
+        throw new ToolError(`unknown command: ${command}`);
     }
   }
 }

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -38,20 +38,20 @@ export class FileOpTool extends BaseTool<FileOpInput> {
       }
       case 'write': {
         if (content === undefined) {
-          throw new ToolError('content parameter is required for write');
+          throw new ToolError('File operation error: Content parameter is required for write command');
         }
         await WorkspaceFS.writeFile(path, content);
         return new ToolResult({ output: 'written' });
       }
       case 'append': {
         if (content === undefined) {
-          throw new ToolError('content parameter is required for append');
+          throw new ToolError('File operation error: Content parameter is required for append command');
         }
         await WorkspaceFS.appendFile(path, content);
         return new ToolResult({ output: 'appended' });
       }
       default:
-        throw new ToolError(`unknown command: ${command}`);
+        throw new ToolError(`File operation error: Unknown command '${command}'. Expected 'read', 'write', or 'append'.`);
     }
   }
 }

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -1,10 +1,18 @@
+import type { ZodIssue } from 'zod';
+
+// Define proper type for diagnostic information
+export type ErrorDiagnostics = 
+  | ZodIssue[]  // For validation errors
+  | { name: string; stack?: string }  // For regular errors
+  | unknown;  // For other types of diagnostics
+
 export class ToolResult {
   output?: string;
   error?: string;
   base64Image?: string;
   system?: string;
   isError: boolean;
-  diagnostics?: any; // Additional error details like validation issues
+  diagnostics?: ErrorDiagnostics; // Additional error details like validation issues
 
   constructor({
     output,
@@ -19,7 +27,7 @@ export class ToolResult {
     base64Image?: string;
     system?: string;
     isError?: boolean;
-    diagnostics?: any;
+    diagnostics?: ErrorDiagnostics;
   }) {
     this.output = output;
     this.error = error;

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -8,7 +8,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 
 // Local imports - tools
 import { BaseTool } from '../core/base';
-import { ToolResult } from '../result';
+import { ToolResult, ToolError } from '../result';
 import type { ToolDefinition } from '@model';
 
 const WebSearchInputSchema = z.object({
@@ -30,9 +30,15 @@ export class WebSearchTool extends BaseTool<WebSearchInput> {
 
   protected async execute(input: WebSearchInput): Promise<ToolResult> {
     const { query, max_results = 3 } = input;
-    const response = await axios.get('https://api.duckduckgo.com/', {
-      params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
-    });
+    let response;
+    try {
+      response = await axios.get('https://api.duckduckgo.com/', {
+        params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ToolError(`Web search failed: ${message}`);
+    }
     const data = response.data;
     const results: string[] = [];
     if (Array.isArray(data.RelatedTopics)) {

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -30,31 +30,24 @@ export class WebSearchTool extends BaseTool<WebSearchInput> {
 
   protected async execute(input: WebSearchInput): Promise<ToolResult> {
     const { query, max_results = 3 } = input;
-    try {
-      const response = await axios.get('https://api.duckduckgo.com/', {
-        params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
-      });
-      const data = response.data;
-      const results: string[] = [];
-      if (Array.isArray(data.RelatedTopics)) {
-        for (const item of data.RelatedTopics.slice(0, max_results)) {
-          if (
-            typeof item.Text === 'string' &&
-            typeof item.FirstURL === 'string'
-          ) {
-            results.push(`${item.Text} (${item.FirstURL})`);
-          }
+    const response = await axios.get('https://api.duckduckgo.com/', {
+      params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
+    });
+    const data = response.data;
+    const results: string[] = [];
+    if (Array.isArray(data.RelatedTopics)) {
+      for (const item of data.RelatedTopics.slice(0, max_results)) {
+        if (
+          typeof item.Text === 'string' &&
+          typeof item.FirstURL === 'string'
+        ) {
+          results.push(`${item.Text} (${item.FirstURL})`);
         }
       }
-      if (results.length === 0) {
-        return new ToolResult({ output: 'No results found.' });
-      }
-      return new ToolResult({ output: results.join('\n') });
-    } catch (err) {
-      return new ToolResult({
-        error: err instanceof Error ? err.message : String(err),
-        isError: true,
-      });
     }
+    if (results.length === 0) {
+      return new ToolResult({ output: 'No results found.' });
+    }
+    return new ToolResult({ output: results.join('\n') });
   }
 }

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 
 // Local imports - tools
 import { BaseTool } from '../core/base';
-import { ToolResult } from '../result';
+import { ToolResult, ToolError } from '../result';
 import { executeWolframCode } from './wolframScriptUtils';
 import type { ToolDefinition } from '@model';
 
@@ -36,9 +36,6 @@ export class WolframTool extends BaseTool<WolframInput> {
     if (result.success) {
       return new ToolResult({ output: result.output ?? '' });
     }
-    return new ToolResult({
-      error: result.error ?? 'Unknown error executing Wolfram code',
-      isError: true,
-    });
+    throw new ToolError(result.error ?? 'Unknown error executing Wolfram code');
   }
 }

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -36,6 +36,6 @@ export class WolframTool extends BaseTool<WolframInput> {
     if (result.success) {
       return new ToolResult({ output: result.output ?? '' });
     }
-    throw new ToolError(result.error ?? 'Unknown error executing Wolfram code');
+    throw new ToolError(`Wolfram execution failed: ${result.error ?? 'No error details available'}`);
   }
 }


### PR DESCRIPTION
## Summary
- convert BaseTool.call to wrap execute errors into ToolResult with diagnostics
- let DiagnosticsTool, WebSearchTool, TextEditorTool, BashTool, FileOpTool and WolframTool throw ToolError on failure

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1486b0fc483248d2acaf0e8930208