### PR TITLE
refactor: centralize log appending helper

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -2,6 +2,7 @@
 import { COMMANDS, STATUS, ELEMENT_IDS } from './constants.js';
 import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
 import { createThemeHandlers } from './handlers/themeHandlers.js';
+import { appendFormatted } from './utils.js';
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
 import { registerMessageHandlers } from '@common/webviewContext.js';
@@ -118,23 +119,11 @@ export class ProgressViewMessageHandler {
         if (msg.groupId) {
           if (!dom.logEntries.append(msg)) {
             const formatted = this._entryFormatter.format(msg);
-            if (formatted instanceof HTMLElement) {
-              logContent.appendChild(formatted);
-            } else {
-              const el = document.createElement('div');
-              el.innerHTML = formatted;
-              logContent.appendChild(el.firstElementChild);
-            }
+            appendFormatted(logContent, formatted);
           }
         } else {
           const formatted = this._entryFormatter.format(msg);
-          if (formatted instanceof HTMLElement) {
-            logContent.appendChild(formatted);
-          } else {
-            const el = document.createElement('div');
-            el.innerHTML = formatted;
-            logContent.appendChild(el.firstElementChild);
-          }
+          appendFormatted(logContent, formatted);
         }
       });
       logContent.scrollTop = logContent.scrollHeight;
@@ -176,12 +165,8 @@ export class ProgressViewMessageHandler {
               toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
             }
           }
-          logContent.appendChild(formatted);
-        } else {
-          const el = document.createElement('div');
-          el.innerHTML = formatted;
-          logContent.appendChild(el.firstElementChild);
         }
+        appendFormatted(logContent, formatted);
       }
       logContent.scrollTop = logContent.scrollHeight;
     }
@@ -189,7 +174,13 @@ export class ProgressViewMessageHandler {
 
   handleUpdateLog(message) {
     if (message.stream === state.activeStream) {
-      dom.logEntries.update(message.logMessage);
+      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      const updated = dom.logEntries.update(message.logMessage);
+      if (!updated) {
+        const formatted = this._entryFormatter.format(message.logMessage);
+        appendFormatted(logContent, formatted);
+        logContent.scrollTop = logContent.scrollHeight;
+      }
     }
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -177,8 +177,23 @@ export class ProgressViewMessageHandler {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       const updated = dom.logEntries.update(message.logMessage);
       if (!updated) {
-        const formatted = this._entryFormatter.format(message.logMessage);
-        appendFormatted(logContent, formatted);
+        // Fallback: append as new log with proper group placement
+        const addedToGroup = dom.logEntries.append(message.logMessage);
+        if (!addedToGroup) {
+          const formatted = this._entryFormatter.format(message.logMessage);
+          if (formatted instanceof HTMLElement) {
+            // For thinking and scratchpad, auto-expand when live streaming
+            const messageType = message.logMessage.messageType;
+            if (messageType === 'thinking' || messageType === 'scratchpad') {
+              formatted.setAttribute('open', '');
+              const toggleIcon = formatted.querySelector('.toggle-icon');
+              if (toggleIcon) {
+                toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
+              }
+            }
+          }
+          appendFormatted(logContent, formatted);
+        }
         logContent.scrollTop = logContent.scrollHeight;
       }
     }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -274,6 +274,7 @@ export class LogEntryManager {
   /**
    * Update an existing log entry identified by ID
    * @param {Object} logMessage - The log message with updated content
+   * @returns {boolean} Whether the log entry was updated
    */
   update(logMessage) {
     const existing = document.querySelector(`[data-log-id="${logMessage.id}"]`);
@@ -296,6 +297,8 @@ export class LogEntryManager {
       }
 
       existing.replaceWith(newEl);
+      return true;
     }
+    return false;
   }
 }

--- a/src/progressView/modules/utils.js
+++ b/src/progressView/modules/utils.js
@@ -22,6 +22,27 @@ export function parseTimestamp(timestampStr) {
 }
 
 /**
+ * Append formatted content to a container. Supports both DOM elements and
+ * HTML strings.
+ * @param {HTMLElement} container - Element to append to
+ * @param {HTMLElement|string} formatted - Element or HTML string to append
+ */
+export function appendFormatted(container, formatted) {
+  if (formatted instanceof HTMLElement) {
+    container.appendChild(formatted);
+    return;
+  }
+
+  if (typeof formatted === 'string') {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = formatted;
+    if (wrapper.firstElementChild) {
+      container.appendChild(wrapper.firstElementChild);
+    }
+  }
+}
+
+/**
  * Insert an element into a container keeping children sorted chronologically.
  * Handles log groups and log entries by default, but a custom extractor can
  * be provided for specialized cases.


### PR DESCRIPTION
## Summary
- add appendFormatted helper for string or element log nodes
- use helper in ProgressViewMessageHandler to remove duplicate append logic
- return update status from LogEntryManager to support fallbacks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c147c305908324be8dbb260b382286