### PR TITLE
refactor: add shared three-day duration constant

### DIFF
--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -13,6 +13,7 @@ import * as logger from '@logger/logUtils';
 import { AbsoluteFS, StorageFS } from '@utils/files';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { getConfig } from '@utils/config/configUtils';
+import { THREE_DAYS_MS } from '@utils/config';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import {
   extendEnvPath,
@@ -202,7 +203,7 @@ export async function stopRecordingAndTranscribe(
     // Clean up old recordings
     // Initialize StorageFS with context if not already done
     StorageFS.initialize(context);
-    await StorageFS.cleanupOldFiles(RECORDINGS_DIR, 3 * 24 * 60 * 60 * 1000);
+    await StorageFS.cleanupOldFiles(RECORDINGS_DIR, THREE_DAYS_MS);
 
     return { success: true, text: result.text };
   } catch (err) {

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -44,3 +44,4 @@ export const WORD_WRAP_INIT_DELAY_MS = 200;
 export const DIFF_REGISTRATION_DELAY_MS = 300;
 export const LATEX_VIEWER_OPEN_DELAY_MS = 5000;
 export const LATEX_VIEWER_REFRESH_DELAY_MS = 5000;
+export const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -9,8 +9,11 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+
+// Local imports - utils
 import { StorageFS } from '@utils/files';
 import { PASTED_DIR } from '@utils/files/pastedImageUtils';
+import { THREE_DAYS_MS } from '@utils/config';
 import { sleep } from '@utils/helpers';
 import {
   polishTextWithAI,
@@ -24,9 +27,7 @@ export class InstructionManager {
   constructor(private readonly _context: vscode.ExtensionContext) {
     setTimeout(() => {
       StorageFS.ensureDir(PASTED_DIR)
-        .then(() =>
-          StorageFS.cleanupOldFiles(PASTED_DIR, 3 * 24 * 60 * 60 * 1000),
-        )
+        .then(() => StorageFS.cleanupOldFiles(PASTED_DIR, THREE_DAYS_MS))
         .catch((e) =>
           logger.warn(
             CHANNEL,
@@ -180,7 +181,7 @@ export class InstructionManager {
       await StorageFS.ensureDir(PASTED_DIR);
       const relativePath = path.join(PASTED_DIR, fileName);
       await StorageFS.write(relativePath, Buffer.from(base64, 'base64'));
-      await StorageFS.cleanupOldFiles(PASTED_DIR, 3 * 24 * 60 * 60 * 1000);
+      await StorageFS.cleanupOldFiles(PASTED_DIR, THREE_DAYS_MS);
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE,
         file: fileName,


### PR DESCRIPTION
## Summary
- add `THREE_DAYS_MS` time constant
- use constant for cleanup thresholds in InstructionManager and audio utils

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c16cc6276883248fbd91cbfebbeb12