### PR TITLE
refactor: unify settings open method

### DIFF
--- a/src/commands/system/settingsCommands.ts
+++ b/src/commands/system/settingsCommands.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - utils
+import { SETTINGS_QUERY } from '@utils/settingsQueries';
+
 export const settingsCommands = {
   openSettings: 'texra.openSettings',
 };
@@ -12,7 +15,7 @@ export function registerSettingsCommands(context: vscode.ExtensionContext) {
       // Open VS Code settings with TeXRA filter
       await vscode.commands.executeCommand(
         'workbench.action.openSettings',
-        '@ext:texra-ai.texra',
+        SETTINGS_QUERY.EXTENSION,
       );
     },
   );

--- a/src/utils/settingsQueries.ts
+++ b/src/utils/settingsQueries.ts
@@ -1,0 +1,5 @@
+export const SETTINGS_QUERY = {
+  EXTENSION: '@ext:texra-ai.texra',
+  AGENTS: '@ext:texra-ai.texra agents',
+  MODELS: '@ext:texra-ai.texra models',
+} as const;

--- a/src/utils/settingsQueries.ts
+++ b/src/utils/settingsQueries.ts
@@ -2,4 +2,5 @@ export const SETTINGS_QUERY = {
   EXTENSION: '@ext:texra-ai.texra',
   AGENTS: '@ext:texra-ai.texra agents',
   MODELS: '@ext:texra-ai.texra models',
+  AGENT_DIRECTORY: '@ext:texra-ai.texra explorer.agentsDirectory',
 } as const;

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -19,6 +19,7 @@ import {
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { getConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system';
+import { SETTINGS_QUERY } from '@utils/settingsQueries';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { computeModelOptions } from '@model/computeModelOptions';
 import { computeAgentOptions } from '@agent/computeAgentOptions';
@@ -133,9 +134,9 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.SETTINGS_OPEN]: async () =>
         this.settingsManager.openSettings(),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS]: async () =>
-        this.settingsManager.openAgentSettings(),
+        this.settingsManager.openSettings(SETTINGS_QUERY.AGENTS),
       [MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS]: async () =>
-        this.settingsManager.openModelSettings(),
+        this.settingsManager.openSettings(SETTINGS_QUERY.MODELS),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {
         if (m?.customDirSet) {
           const dir = await agentDirectories.custom();

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -149,7 +149,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         } else {
           await safeExecuteCommand(
             'workbench.action.openSettings',
-            ['@ext:texra-ai.texra explorer.agentsDirectory'],
+            [SETTINGS_QUERY.AGENT_DIRECTORY],
             this.viewName,
           );
         }

--- a/src/webview/managers/SettingsManager.ts
+++ b/src/webview/managers/SettingsManager.ts
@@ -1,30 +1,11 @@
-// Local imports - webview
+// Local imports - utils
 import { safeExecuteCommand } from '@utils/system';
+import { SETTINGS_QUERY } from '@utils/settingsQueries';
 
 const CHANNEL = 'SettingsManager';
 
 export class SettingsManager {
-  async openSettings(): Promise<void> {
-    await safeExecuteCommand(
-      'workbench.action.openSettings',
-      ['@ext:texra-ai.texra'],
-      CHANNEL,
-    );
-  }
-
-  async openAgentSettings(): Promise<void> {
-    await safeExecuteCommand(
-      'workbench.action.openSettings',
-      ['@ext:texra-ai.texra agents'],
-      CHANNEL,
-    );
-  }
-
-  async openModelSettings(): Promise<void> {
-    await safeExecuteCommand(
-      'workbench.action.openSettings',
-      ['@ext:texra-ai.texra models'],
-      CHANNEL,
-    );
+  async openSettings(query: string = SETTINGS_QUERY.EXTENSION): Promise<void> {
+    await safeExecuteCommand('workbench.action.openSettings', [query], CHANNEL);
   }
 }


### PR DESCRIPTION
## Summary
- centralize settings query strings
- replace multiple settings open functions with single query-based method
- use shared query constants across commands

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: webpack compile hangs, no test output)*

------
https://chatgpt.com/codex/tasks/task_e_68c16e34cd688324b05a1490120e7ca1