### PR TITLE
refactor: consolidate DOM property helpers

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -21,23 +21,48 @@ export function safeGetElementById(id) {
 }
 
 const DEFAULTS = { value: '', checked: false };
+const SUPPORTED_PROPERTIES = ['value', 'checked'];
 
+/**
+ * Get or set a DOM element property safely.
+ * @param {string|HTMLElement} elementOrId - Element ID or the element itself
+ * @param {string} key - Property name ('value', 'checked', etc.)
+ * @param {*} [value] - Value to set (omit to get current value)
+ * @param {*} [defaultValue] - Default value for getter mode
+ * @returns {*|boolean} Property value when getting, true on successful set, false on failure
+ */
 export function safeElementProperty(
-  id,
+  elementOrId,
   key,
   value,
   defaultValue = DEFAULTS[key],
 ) {
-  const element = document.getElementById(id);
+  // Support both element references and IDs for better performance
+  const element =
+    typeof elementOrId === 'string'
+      ? document.getElementById(elementOrId)
+      : elementOrId;
+  
   if (!element) {
+    const id = typeof elementOrId === 'string' ? elementOrId : 'provided element';
     console.warn(`Element with id '${id}' not found`);
     if (value === undefined) return defaultValue;
-    return;
+    return false;
   }
+  
+  // Warn about potentially unsupported properties
+  if (!SUPPORTED_PROPERTIES.includes(key) && defaultValue === undefined) {
+    console.warn(`Property '${key}' may not have a default value. Consider providing one.`);
+  }
+  
+  // Getter mode
   if (value === undefined) {
     return element[key] ?? defaultValue;
   }
+  
+  // Setter mode
   element[key] = value;
+  return true;
 }
 
 /**

--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -12,24 +12,6 @@ export function addEventListenerSafely(elementOrId, event, handler) {
   }
 }
 
-export function safeSetElementValue(id, value) {
-  const element = document.getElementById(id);
-  if (!element) {
-    console.warn(`Element with id '${id}' not found`);
-    return;
-  }
-  element.value = value;
-}
-
-export function safeSetElementChecked(id, checked) {
-  const element = document.getElementById(id);
-  if (!element) {
-    console.warn(`Element with id '${id}' not found`);
-    return;
-  }
-  element.checked = checked;
-}
-
 export function safeGetElementById(id) {
   const element = document.getElementById(id);
   if (!element) {
@@ -38,22 +20,24 @@ export function safeGetElementById(id) {
   return element;
 }
 
-export function safeGetElementValue(id) {
-  const element = document.getElementById(id);
-  if (!element) {
-    console.warn(`Element with id '${id}' not found`);
-    return '';
-  }
-  return element.value;
-}
+const DEFAULTS = { value: '', checked: false };
 
-export function safeGetElementChecked(id) {
+export function safeElementProperty(
+  id,
+  key,
+  value,
+  defaultValue = DEFAULTS[key],
+) {
   const element = document.getElementById(id);
   if (!element) {
     console.warn(`Element with id '${id}' not found`);
-    return false;
+    if (value === undefined) return defaultValue;
+    return;
   }
-  return element.checked;
+  if (value === undefined) {
+    return element[key] ?? defaultValue;
+  }
+  element[key] = value;
 }
 
 /**

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -12,7 +12,7 @@ import {
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from '../uiManagers/FileList.js';
 import { fileSelect } from '../uiManagers/FileSelect.js';
-import { safeSetElementValue } from '@common/domUtils.js';
+import { safeElementProperty } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - utilities
@@ -55,27 +55,27 @@ export function createFileHandlers(ctx) {
   }
 
   function handleInputFileSelected(message) {
-    safeSetElementValue(INPUT_FILE, message.filePath);
+    safeElementProperty(INPUT_FILE, 'value', message.filePath);
     postHandle();
   }
 
   function handleReferenceFileSelected(message) {
-    safeSetElementValue(REFERENCE_FILE, message.filePath);
+    safeElementProperty(REFERENCE_FILE, 'value', message.filePath);
     postHandle();
   }
 
   function handleAuxiliaryFileSelected(message) {
-    safeSetElementValue(AUXILIARY_FILE, message.filePath);
+    safeElementProperty(AUXILIARY_FILE, 'value', message.filePath);
     postHandle();
   }
 
   function handleMediaFileSelected(message) {
-    safeSetElementValue(MEDIA_FILE, message.filePath);
+    safeElementProperty(MEDIA_FILE, 'value', message.filePath);
     postHandle();
   }
 
   function handleEditedFileSelected(message) {
-    safeSetElementValue(EDITED_FILE, message.filePath);
+    safeElementProperty(EDITED_FILE, 'value', message.filePath);
     postHandle();
   }
 

--- a/src/webview/modules/handlers/themeHandlers.js
+++ b/src/webview/modules/handlers/themeHandlers.js
@@ -1,7 +1,7 @@
 // Local imports - webview
 import { mainViewDomHandler } from '../domHandlers.js';
 // Local imports - DOM utilities
-import { safeSetElementValue } from '@common/domUtils.js';
+import { safeElementProperty } from '@common/domUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 /**
@@ -24,7 +24,7 @@ export function createThemeHandlers({ postHandle }) {
       postHandle();
     },
     [MAIN_VIEW_COMMANDS.MODEL_SELECTED]: (message) => {
-      safeSetElementValue('model', message.model);
+      safeElementProperty('model', 'value', message.model);
       postHandle();
     },
   };

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -9,11 +9,8 @@ import {
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
-  safeGetElementValue,
+  safeElementProperty,
   safeGetElementById,
-  safeGetElementChecked,
-  safeSetElementValue,
-  safeSetElementChecked,
   setChevronIcon,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
@@ -82,11 +79,15 @@ export class MainViewState {
       const defaults = { agent: 'correct', model: 'gemini25p', commit: 'HEAD' };
 
       VALUE_ELEMENTS.forEach((id) => {
-        safeSetElementValue(id, previousState[id] ?? defaults[id] ?? '');
+        safeElementProperty(
+          id,
+          'value',
+          previousState[id] ?? defaults[id] ?? '',
+        );
       });
 
       CHECK_BOXES.forEach((id) => {
-        safeSetElementChecked(id, previousState[id] ?? false);
+        safeElementProperty(id, 'checked', previousState[id] ?? false);
       });
 
       const autoExtractToggle = safeGetElementById(
@@ -96,7 +97,7 @@ export class MainViewState {
         ELEMENT_IDS.AUTO_EXTRACT_OPTIONS,
       );
       const hasAutoExtractChecked = CHECK_BOXES_AUTO_EXTRACT.some((id) =>
-        safeGetElementChecked(id),
+        safeElementProperty(id, 'checked'),
       );
       if (autoExtractToggle && autoExtractOptions) {
         autoExtractToggle.classList.toggle('active', hasAutoExtractChecked);
@@ -111,7 +112,7 @@ export class MainViewState {
         ELEMENT_IDS.TOOL_CONFIG_OPTIONS,
       );
       const hasToolConfigChecked = CHECK_BOXES_TOOL_USE.some((id) =>
-        safeGetElementChecked(id),
+        safeElementProperty(id, 'checked'),
       );
       if (toggleToolConfig && toolConfigOptions) {
         toggleToolConfig.classList.toggle('active', hasToolConfigChecked);
@@ -172,14 +173,14 @@ export class MainViewState {
     };
 
     VALUE_ELEMENTS.forEach((id) => {
-      const value = safeGetElementValue(id);
+      const value = safeElementProperty(id, 'value');
       if (value !== undefined) {
         state[id] = value;
       }
     });
 
     CHECK_BOXES.forEach((id) => {
-      state[id] = safeGetElementChecked(id);
+      state[id] = safeElementProperty(id, 'checked');
     });
 
     MULTIPLE_SELECTIONS.forEach((id) => {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -20,7 +20,7 @@ import { mainViewState } from './mainViewState.js';
 // Local imports - UI managers
 import { fileSelect } from './uiManagers/FileSelect.js';
 import {
-  safeSetElementValue,
+  safeElementProperty,
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
@@ -361,8 +361,8 @@ export class MainViewMessageHandler {
   }
 
   _restoreFormFields(state, savedState) {
-    if (state.agent) safeSetElementValue('agent', state.agent);
-    if (state.model) safeSetElementValue('model', state.model);
+    if (state.agent) safeElementProperty('agent', 'value', state.agent);
+    if (state.model) safeElementProperty('model', 'value', state.model);
 
     const instructionContent = state.instruction || '';
     const instruction =
@@ -373,12 +373,14 @@ export class MainViewMessageHandler {
       instruction.dispatchEvent(new Event('input'));
     }
 
-    if (state.inputFile) safeSetElementValue(INPUT_FILE, state.inputFile);
+    if (state.inputFile)
+      safeElementProperty(INPUT_FILE, 'value', state.inputFile);
     if (state.referenceFile)
-      safeSetElementValue(REFERENCE_FILE, state.referenceFile);
+      safeElementProperty(REFERENCE_FILE, 'value', state.referenceFile);
     if (state.auxiliaryFile)
-      safeSetElementValue(AUXILIARY_FILE, state.auxiliaryFile);
-    if (state.mediaFile) safeSetElementValue(MEDIA_FILE, state.mediaFile);
+      safeElementProperty(AUXILIARY_FILE, 'value', state.auxiliaryFile);
+    if (state.mediaFile)
+      safeElementProperty(MEDIA_FILE, 'value', state.mediaFile);
 
     const toolConfig = state.toolConfig || {};
     Object.assign(savedState, {

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -7,11 +7,7 @@ import {
   EDITED_FILE,
 } from '../constants.js';
 import { BaseUIManager } from './BaseUIManager.js';
-import {
-  safeGetElementById,
-  safeGetElementValue,
-  safeGetElementChecked,
-} from '@common/domUtils.js';
+import { safeElementProperty, safeGetElementById } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -28,7 +24,7 @@ export class ActionButtonManager extends BaseUIManager {
   _getSingleFileData(fileTypes = ['input', 'reference', 'auxiliary', 'media']) {
     const data = {};
     fileTypes.forEach((type) => {
-      data[`${type}File`] = safeGetElementValue(`${type}File`);
+      data[`${type}File`] = safeElementProperty(`${type}File`, 'value');
     });
     return data;
   }
@@ -68,8 +64,8 @@ export class ActionButtonManager extends BaseUIManager {
     this.addListener(ELEMENT_IDS.MAGIC_POLISH_BUTTON, 'click', () => {
       const instruction = safeGetElementById(ELEMENT_IDS.INSTRUCTION);
       if (instruction && instruction.value.trim()) {
-        const agent = safeGetElementValue('agent');
-        const model = safeGetElementValue('model');
+        const agent = safeElementProperty('agent', 'value');
+        const model = safeElementProperty('model', 'value');
         const singleFiles = this._getSingleFileData();
         const multipleFilesData = this._getMultipleFileData(singleFiles);
 
@@ -87,15 +83,15 @@ export class ActionButtonManager extends BaseUIManager {
 
   _setupExecuteButtons() {
     this.addListener(ELEMENT_IDS.EXECUTE_BUTTON, 'click', () => {
-      const agent = safeGetElementValue('agent');
-      const model = safeGetElementValue('model');
-      const instruction = safeGetElementValue(ELEMENT_IDS.INSTRUCTION);
+      const agent = safeElementProperty('agent', 'value');
+      const model = safeElementProperty('model', 'value');
+      const instruction = safeElementProperty(ELEMENT_IDS.INSTRUCTION, 'value');
       const singleFiles = this._getSingleFileData();
       const multipleFilesData = this._getMultipleFileData(singleFiles);
 
       const checkboxValues = {};
       CHECK_BOXES.forEach((id) => {
-        checkboxValues[id] = safeGetElementChecked(id);
+        checkboxValues[id] = safeElementProperty(id, 'checked');
       });
 
       this.vscode.postMessage({
@@ -111,7 +107,7 @@ export class ActionButtonManager extends BaseUIManager {
 
     this.addListener(ELEMENT_IDS.MERGE_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
-      const editedFile = safeGetElementValue(EDITED_FILE);
+      const editedFile = safeElementProperty(EDITED_FILE, 'value');
 
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.MERGE,
@@ -131,8 +127,8 @@ export class ActionButtonManager extends BaseUIManager {
     ].forEach(({ id, action }) => {
       this.addListener(id, 'click', () => {
         const { inputFile } = this._getSingleFileData(['input']);
-        const agent = safeGetElementValue('agent');
-        const model = safeGetElementValue('model');
+        const agent = safeElementProperty('agent', 'value');
+        const model = safeElementProperty('model', 'value');
 
         const outputFiles = this.fileList.getSelected(
           safeGetElementById(ELEMENT_IDS.OUTPUT_FILES),
@@ -194,8 +190,8 @@ export class ActionButtonManager extends BaseUIManager {
   _setupLatexdiffButtons() {
     this.addListener(ELEMENT_IDS.LATEXDIFF_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
-      const baseFile = safeGetElementValue(BASE_FILE);
-      const editedFile = safeGetElementValue(EDITED_FILE);
+      const baseFile = safeElementProperty(BASE_FILE, 'value');
+      const editedFile = safeElementProperty(EDITED_FILE, 'value');
 
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.LATEXDIFF,
@@ -212,8 +208,11 @@ export class ActionButtonManager extends BaseUIManager {
 
     this.addListener(ELEMENT_IDS.LATEXDIFF_VC_BUTTON, 'click', () => {
       const { inputFile } = this._getSingleFileData(['input']);
-      const baseFile = safeGetElementValue(BASE_FILE);
-      const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
+      const baseFile = safeElementProperty(BASE_FILE, 'value');
+      const commitHash = safeElementProperty(
+        ELEMENT_IDS.COMMIT_SELECT,
+        'value',
+      );
 
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.LATEXDIFFVC,
@@ -234,8 +233,11 @@ export class ActionButtonManager extends BaseUIManager {
     ].forEach(({ id, action }) => {
       this.addListener(id, 'click', () => {
         const { inputFile } = this._getSingleFileData(['input']);
-        const baseFile = safeGetElementValue(BASE_FILE);
-        const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
+        const baseFile = safeElementProperty(BASE_FILE, 'value');
+        const commitHash = safeElementProperty(
+          ELEMENT_IDS.COMMIT_SELECT,
+          'value',
+        );
 
         const command =
           action === 'pack'
@@ -259,8 +261,8 @@ export class ActionButtonManager extends BaseUIManager {
 
   _setupCompareButtons() {
     this.addListener(ELEMENT_IDS.COMPARE_BUTTON, 'click', () => {
-      const baseFile = safeGetElementValue(BASE_FILE);
-      const editedFile = safeGetElementValue(EDITED_FILE);
+      const baseFile = safeElementProperty(BASE_FILE, 'value');
+      const editedFile = safeElementProperty(EDITED_FILE, 'value');
       if (baseFile && editedFile) {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.COMPARE,
@@ -276,8 +278,8 @@ export class ActionButtonManager extends BaseUIManager {
     });
 
     this.addListener(ELEMENT_IDS.ACCEPT_BUTTON, 'click', () => {
-      const baseFile = safeGetElementValue(BASE_FILE);
-      const editedFile = safeGetElementValue(EDITED_FILE);
+      const baseFile = safeElementProperty(BASE_FILE, 'value');
+      const editedFile = safeElementProperty(EDITED_FILE, 'value');
       if (baseFile && editedFile) {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.ACCEPT_EDITED,

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -18,7 +18,7 @@ import { BaseUIManager } from './BaseUIManager.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
-import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
+import { safeElementProperty, safeGetElementById } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -80,7 +80,7 @@ export class FileInputManager extends BaseUIManager {
     });
 
     this.addListener(BASE_FILE, 'change', () => {
-      const baseFile = safeGetElementValue(BASE_FILE);
+      const baseFile = safeElementProperty(BASE_FILE, 'value');
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE,
         baseFile,
@@ -105,7 +105,7 @@ export class FileInputManager extends BaseUIManager {
     selectors.forEach(({ id, selectId }) => {
       const buttonId = `select${id}Button`;
       this.addListener(buttonId, 'click', () => {
-        const currentFile = safeGetElementValue(selectId);
+        const currentFile = safeElementProperty(selectId, 'value');
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES,
           fileType: id,
@@ -135,7 +135,7 @@ export class FileInputManager extends BaseUIManager {
 
     ['base', 'edited'].forEach((type) => {
       this.addListener(`current${capitalize(type)}FileButton`, 'click', () => {
-        const baseFile = safeGetElementValue(BASE_FILE);
+        const baseFile = safeElementProperty(BASE_FILE, 'value');
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
           fileType: type,

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,6 +1,6 @@
 // Local imports - webview
 import { ELEMENT_IDS, EDITED_FILE } from '../constants.js';
-import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
+import { safeElementProperty, safeGetElementById } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -100,7 +100,7 @@ export class FileSelect {
 
     const options = Array.from(fileDiv.options);
     if (options.some((o) => o.value === filePath)) {
-      safeSetElementValue(fileId, filePath);
+      safeElementProperty(fileId, 'value', filePath);
       fileDiv.dispatchEvent(new Event('change'));
     } else {
       vscode.postMessage({

--- a/src/webview/modules/uiManagers/ToggleManager.js
+++ b/src/webview/modules/uiManagers/ToggleManager.js
@@ -5,8 +5,8 @@ import {
   ELEMENT_IDS,
 } from '../constants.js';
 import {
+  safeElementProperty,
   safeGetElementById,
-  safeGetElementChecked,
   setChevronIcon,
 } from '@common/domUtils.js';
 import { createCodicon } from '@common/templateUtils.js';
@@ -17,7 +17,7 @@ export class ToggleManager {
   }
 
   hasAnyChecked(checkboxIds) {
-    return checkboxIds.some((id) => safeGetElementChecked(id));
+    return checkboxIds.some((id) => safeElementProperty(id, 'checked'));
   }
 
   setToggleIcon(toggle, icon, visible, active) {


### PR DESCRIPTION
## Summary
- add generic `safeElementProperty` for DOM value/checked access
- update UI modules to use the new helper

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c16d9b76888324bbeb8ae881dfbc39