### PR TITLE
refactor: centralize ensureDir logic

### DIFF
--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -8,6 +8,9 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
+// Local imports - utils
+import { ensureDirCommon } from './ensureDirCommon';
+
 const CHANNEL = 'absoluteFS';
 logger.initialize(CHANNEL);
 
@@ -92,18 +95,11 @@ export class AbsoluteFS {
    */
   public static async ensureDir(filePath: string): Promise<void> {
     this.validatePath(filePath, 'ensureDir');
-    try {
-      const exists = await this.exists(filePath);
-      if (!exists) {
-        await this.createDir(filePath);
-      }
-    } catch (err) {
-      // If error is because directory already exists, ignore it
-      if (err instanceof vscode.FileSystemError && err.code === 'FileExists') {
-        return;
-      }
-      throw err;
-    }
+    await ensureDirCommon(
+      filePath,
+      this.exists.bind(this),
+      this.createDir.bind(this),
+    );
   }
 
   /**

--- a/src/utils/files/ensureDirCommon.ts
+++ b/src/utils/files/ensureDirCommon.ts
@@ -1,0 +1,23 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+/**
+ * Ensure a directory exists by checking and creating as needed.
+ */
+export async function ensureDirCommon(
+  path: string,
+  exists: (p: string) => Promise<boolean>,
+  createDir: (p: string) => Promise<void>,
+): Promise<void> {
+  try {
+    const existsResult = await exists(path);
+    if (!existsResult) {
+      await createDir(path);
+    }
+  } catch (err) {
+    if (err instanceof vscode.FileSystemError && err.code === 'FileExists') {
+      return;
+    }
+    throw err;
+  }
+}

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -2,6 +2,7 @@ export { WorkspaceFS } from './workspaceFS';
 export { AbsoluteFS } from './absoluteFS';
 export { StorageFS, GlobalStorageFS } from './storageFS';
 export { RelativeFS } from './relativeFS';
+export { ensureDirCommon } from './ensureDirCommon';
 export * from './pastedImageUtils';
 export * from './baseFileUtils';
 export * from './fileMappingUtils';

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -7,6 +7,9 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
+// Local imports - utils
+import { ensureDirCommon } from './ensureDirCommon';
+
 const CHANNEL = 'relativeFS';
 logger.initialize(CHANNEL);
 
@@ -92,17 +95,11 @@ export abstract class RelativeFS {
    * Ensure a directory exists, creating it if necessary.
    */
   public static async ensureDir(relativePath: string): Promise<void> {
-    try {
-      const exists = await this.exists(relativePath);
-      if (!exists) {
-        await this.createDir(relativePath);
-      }
-    } catch (err) {
-      if (err instanceof vscode.FileSystemError && err.code === 'FileExists') {
-        return;
-      }
-      throw err;
-    }
+    await ensureDirCommon(
+      relativePath,
+      this.exists.bind(this),
+      this.createDir.bind(this),
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- extract shared `ensureDirCommon` helper for directory creation
- delegate `AbsoluteFS.ensureDir` and `RelativeFS.ensureDir` to new helper

## Testing
- `npm run lint`
- `npm test` *(fails: vscode-test produced no output in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c16d4af0208324883cbe7ad851df96