### PR TITLE
refactor: centralize chevron constants

### DIFF
--- a/src/common/modules/webviewContext.js
+++ b/src/common/modules/webviewContext.js
@@ -11,7 +11,3 @@ export function registerMessageHandlers(handlers) {
   window.addEventListener('message', listener);
   return () => window.removeEventListener('message', listener);
 }
-
-export const CHEVRON_UP_CLASS = 'codicon codicon-chevron-up';
-export const CHEVRON_DOWN_CLASS = 'codicon codicon-chevron-down';
-export const CHEVRON_RIGHT_CLASS = 'codicon codicon-chevron-right';

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -155,6 +155,7 @@ export abstract class BaseViewContentProvider {
         webview,
         'modules/iconButtonInitializer.js',
       ),
+      iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
       codiconUri: this.getNodeModulesUri(

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -52,6 +52,7 @@
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/iconConstants.js": "${iconConstantsUri}",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",
           "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0"

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -27,7 +27,7 @@ import { createFromTemplate } from '@common/templateUtils.js';
 import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,
-} from '@common/webviewContext.js';
+} from '@common/iconConstants.js';
 
 // Constants
 export const BULLET_MARKUP =

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -7,11 +7,11 @@ import { COMMANDS, SPLIT_SIZES, ELEMENT_IDS } from '../constants.js';
 
 // Local imports
 import { progressViewState } from '../progressViewState.js';
+import { vscode } from '@common/webviewContext.js';
 import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,
-  vscode,
-} from '@common/webviewContext.js';
+} from '@common/iconConstants.js';
 
 /**
  * Manages event handling and state application.

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -39,6 +39,7 @@
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/iconConstants.js": "${iconConstantsUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",
           "nanoid": "https://cdn.skypack.dev/nanoid"
         }

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -17,7 +17,7 @@ import {
   setChevronIcon,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
-import { CHEVRON_DOWN_CLASS } from '@common/webviewContext.js';
+import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { WebviewStateManager } from '@common/webviewState.js';
 
 /**


### PR DESCRIPTION
## Summary
- remove chevron exports from webviewContext and import from iconConstants
- map iconConstants in webview providers and update import paths

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c16e6c224883249a25bf60e253fdf8