### PR TITLE
refactor: centralize webview bootstrap logic

### DIFF
--- a/docs/reference/webview-bootstrap.md
+++ b/docs/reference/webview-bootstrap.md
@@ -1,0 +1,41 @@
+# Webview Bootstrap Helper
+
+The `bootstrap` function centralizes common setup logic for webview scripts.
+It initializes state objects, registers message handlers and wires up lifecycle
+callbacks so each view follows the same pattern.
+
+## Usage
+
+```js
+import { bootstrap } from '@common/webview/bootstrap.js';
+
+bootstrap({
+  state: [viewState],
+  messageHandler: {
+    setup() {
+      // register message listeners
+    },
+    cleanup() {
+      // remove listeners
+    },
+  },
+  onDomContentLoaded() {
+    // initialize UI after the DOM is ready
+  },
+  onBeforeUnload() {
+    // dispose resources before the view is unloaded
+  },
+});
+```
+
+## Options
+
+| Option               | Description                                                                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `state`              | Array of objects with optional `initialize()` and `restore()` methods. `initialize` runs immediately; `restore` runs after `DOMContentLoaded`. |
+| `messageHandler`     | Object containing `setup()` and `cleanup()` methods for wiring VS Code message listeners.                                                      |
+| `onDomContentLoaded` | Callback executed once the DOM is ready and state has been restored.                                                                           |
+| `onBeforeUnload`     | Callback executed before the webview unloads.                                                                                                  |
+
+Using this helper keeps webview entry scripts minimal and consistent across
+views.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,6 +83,7 @@ export default tseslint.config(
       'src/webview/modules/**/*.js',
       'src/common/*.js',
       'src/common/modules/*.js',
+      'src/common/webview/*.js',
       'src/historyView/script.js',
       'src/progressView/script.js',
       'src/webview/script.js',

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -157,6 +157,7 @@ export abstract class BaseViewContentProvider {
       ),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
+      bootstrapUri: this.getCommonUri(webview, 'webview/bootstrap.js'),
       codiconUri: this.getNodeModulesUri(
         webview,
         '@vscode/codicons/dist/codicon.css',

--- a/src/common/webview/bootstrap.js
+++ b/src/common/webview/bootstrap.js
@@ -1,0 +1,54 @@
+/* eslint-env browser */
+
+/**
+ * Bootstraps a webview by initializing state objects, wiring up message
+ * handlers and registering lifecycle callbacks.
+ *
+ * @param {Object} options configuration options
+ * @param {Array<Object>} [options.state=[]] objects with optional `initialize`
+ * and `restore` methods
+ * @param {{setup: Function, cleanup: Function}} options.messageHandler message
+ * handler with setup/cleanup methods
+ * @param {Function} [options.onDomContentLoaded] callback after DOM is ready
+ * @param {Function} [options.onBeforeUnload] callback before the view unloads
+ */
+export function bootstrap({
+  state = [],
+  messageHandler,
+  onDomContentLoaded,
+  onBeforeUnload,
+} = {}) {
+  // Initialize state objects immediately if they provide an initialize method
+  state.forEach((s) => {
+    if (typeof s.initialize === 'function') {
+      s.initialize();
+    }
+  });
+
+  // Set up message handler early so initial messages are not missed
+  if (messageHandler && typeof messageHandler.setup === 'function') {
+    messageHandler.setup();
+  }
+
+  window.addEventListener('beforeunload', () => {
+    if (messageHandler && typeof messageHandler.cleanup === 'function') {
+      messageHandler.cleanup();
+    }
+    if (typeof onBeforeUnload === 'function') {
+      onBeforeUnload();
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    // Restore state once DOM is ready
+    state.forEach((s) => {
+      if (typeof s.restore === 'function') {
+        s.restore();
+      }
+    });
+
+    if (typeof onDomContentLoaded === 'function') {
+      onDomContentLoaded();
+    }
+  });
+}

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -30,7 +30,8 @@
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
-          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}"
+          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/webview/bootstrap.js": "${bootstrapUri}"
         }
       }
     </script>

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -4,21 +4,19 @@ import { historyViewState } from './modules/historyViewState.js';
 import { messageHandler } from './modules/messageHandlers.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { bootstrap } from '@common/webview/bootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
-historyViewState.initialize();
-
-// Register handlers early so messages aren't missed
-messageHandler.setup();
-
-document.addEventListener('DOMContentLoaded', () => {
-  initializeIconButtons();
-  historyViewDomHandler.events.setupEventListeners();
-  vscode.postMessage({ command: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA });
-});
-
-window.addEventListener('beforeunload', () => {
-  historyViewDomHandler.events.dispose();
-  historyViewDomHandler.searchManager.dispose();
-  messageHandler.cleanup();
+bootstrap({
+  state: [historyViewState],
+  messageHandler,
+  onDomContentLoaded: () => {
+    initializeIconButtons();
+    historyViewDomHandler.events.setupEventListeners();
+    vscode.postMessage({ command: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA });
+  },
+  onBeforeUnload: () => {
+    historyViewDomHandler.events.dispose();
+    historyViewDomHandler.searchManager.dispose();
+  },
 });

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -52,6 +52,7 @@
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/webview/bootstrap.js": "${bootstrapUri}",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",
           "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0"

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -5,46 +5,35 @@ import { messageHandler } from './modules/messageHandlers.js';
 import { progressViewState } from './modules/progressViewState.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { validateTemplates } from '@common/templateUtils.js';
+import { bootstrap } from '@common/webview/bootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
-// Initialize the state when the window loads
-progressViewState.initialize();
-
-// Register handlers for VSCode messages
-messageHandler.setup();
-
-window.addEventListener('beforeunload', () => {
-  messageHandler.cleanup();
-});
-
-// Initialize event listeners and state when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
-  validateTemplates([
-    'fileItemTemplate',
-    'iconButtonTemplate',
-    'usageTemplate',
-    'bulletTemplate',
-    'streamTabTemplate',
-    'roundHeaderTemplate',
-    'logLineTemplate',
-    'specialDetailsTemplate',
-    'toolUseTemplate',
-    'modelResponseTemplate',
-    'fileListDetailsTemplate',
-    'missingOutputsDetailsTemplate',
-    'latexdiffDetailsTemplate',
-    'statisticsDetailsTemplate',
-    'groupHeaderTemplate',
-  ]);
-  initializeIconButtons();
-  progressViewDomHandler.toolbar.render();
-  progressViewDomHandler.placeholder.show();
-  // Setup UI event listeners
-  progressViewDomHandler.events.setupEventListeners();
-
-  // Apply saved group toggle states to any groups already in the DOM
-  progressViewDomHandler.events.applyToggleStates();
-
-  // Notify extension that the webview is ready to receive messages
-  vscode.postMessage({ command: COMMANDS.WEBVIEW_READY });
+bootstrap({
+  state: [progressViewState],
+  messageHandler,
+  onDomContentLoaded: () => {
+    validateTemplates([
+      'fileItemTemplate',
+      'iconButtonTemplate',
+      'usageTemplate',
+      'bulletTemplate',
+      'streamTabTemplate',
+      'roundHeaderTemplate',
+      'logLineTemplate',
+      'specialDetailsTemplate',
+      'toolUseTemplate',
+      'modelResponseTemplate',
+      'fileListDetailsTemplate',
+      'missingOutputsDetailsTemplate',
+      'latexdiffDetailsTemplate',
+      'statisticsDetailsTemplate',
+      'groupHeaderTemplate',
+    ]);
+    initializeIconButtons();
+    progressViewDomHandler.toolbar.render();
+    progressViewDomHandler.placeholder.show();
+    progressViewDomHandler.events.setupEventListeners();
+    progressViewDomHandler.events.applyToggleStates();
+    vscode.postMessage({ command: COMMANDS.WEBVIEW_READY });
+  },
 });

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -39,6 +39,7 @@
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/webview/bootstrap.js": "${bootstrapUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",
           "nanoid": "https://cdn.skypack.dev/nanoid"
         }

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -11,25 +11,26 @@ import {
 } from './modules/messageHandlers.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { bootstrap } from '@common/webview/bootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
-// Register handlers immediately so early messages aren't missed
-setupHandlers({ requestData: false });
-
-window.addEventListener('beforeunload', () => {
-  cleanupHandlers();
-  mainViewDomHandler.cleanupUI();
-});
-
-// Setup UI when DOM is loaded
-document.addEventListener('DOMContentLoaded', function () {
-  initializeIconButtons();
-  mainViewState.restore();
-  instructionManager.setup();
-  mainViewDomHandler.initializeUI();
-  toggleManager.updateToolConfigToggleState();
-  toggleManager.updateAutoToggleState();
-  toggleManager.setupDocumentListeners();
-  setupHandlers({ requestData: true });
-  vscode.postMessage({ command: MAIN_VIEW_COMMANDS.WEBVIEW_READY });
+bootstrap({
+  state: [mainViewState],
+  messageHandler: {
+    setup: () => setupHandlers({ requestData: false }),
+    cleanup: cleanupHandlers,
+  },
+  onDomContentLoaded: () => {
+    initializeIconButtons();
+    instructionManager.setup();
+    mainViewDomHandler.initializeUI();
+    toggleManager.updateToolConfigToggleState();
+    toggleManager.updateAutoToggleState();
+    toggleManager.setupDocumentListeners();
+    setupHandlers({ requestData: true });
+    vscode.postMessage({ command: MAIN_VIEW_COMMANDS.WEBVIEW_READY });
+  },
+  onBeforeUnload: () => {
+    mainViewDomHandler.cleanupUI();
+  },
 });


### PR DESCRIPTION
## Summary
- add reusable webview bootstrap helper
- wire webview scripts to use bootstrap
- document bootstrap API for consistent future views

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c16b10403483248d2eef3944a10113