### PR TITLE
refactor: unify file handler creation

### DIFF
--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -1,10 +1,6 @@
 // Local imports - webview
 import {
   FILE_TYPES,
-  INPUT_FILE,
-  REFERENCE_FILE,
-  AUXILIARY_FILE,
-  MEDIA_FILE,
   EDITED_FILE,
   BASE_FILE,
   ELEMENT_IDS,
@@ -16,7 +12,6 @@ import { safeSetElementValue } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - utilities
-import { vscode } from '@common/webviewContext.js';
 
 /**
  * Create file related handlers.
@@ -28,97 +23,55 @@ import { vscode } from '@common/webviewContext.js';
  */
 export function createFileHandlers(ctx) {
   const { postHandle, getElement, setToggleIcon, setupFileListHandler } = ctx;
-
-  function handleSetInputFile(message) {
-    fileSelect.update(INPUT_FILE, message.files);
+  const createSetFileHandler = (fileType, domId) => (message) => {
+    fileSelect.update(domId, message.files);
     postHandle();
-  }
+  };
 
-  function handleSetReferenceFile(message) {
-    fileSelect.update(REFERENCE_FILE, message.files);
+  const createFileSelectedHandler = (fileType, domId) => (message) => {
+    safeSetElementValue(domId, message.filePath);
     postHandle();
-  }
+  };
 
-  function handleSetAuxiliaryFile(message) {
-    fileSelect.update(AUXILIARY_FILE, message.files);
-    postHandle();
-  }
-
-  function handleSetMediaFile(message) {
-    fileSelect.update(MEDIA_FILE, message.files);
-    postHandle();
-  }
-
-  function handleSetEditedFile(message) {
-    fileSelect.update(EDITED_FILE, message.files);
-    postHandle();
-  }
-
-  function handleInputFileSelected(message) {
-    safeSetElementValue(INPUT_FILE, message.filePath);
-    postHandle();
-  }
-
-  function handleReferenceFileSelected(message) {
-    safeSetElementValue(REFERENCE_FILE, message.filePath);
-    postHandle();
-  }
-
-  function handleAuxiliaryFileSelected(message) {
-    safeSetElementValue(AUXILIARY_FILE, message.filePath);
-    postHandle();
-  }
-
-  function handleMediaFileSelected(message) {
-    safeSetElementValue(MEDIA_FILE, message.filePath);
-    postHandle();
-  }
-
-  function handleEditedFileSelected(message) {
-    safeSetElementValue(EDITED_FILE, message.filePath);
-    postHandle();
-  }
-
-  function handleSetDefaultOutputFiles(message) {
-    fileSelect.setAgentDefaultOutputFiles(message.files || []);
-    postHandle();
-  }
-
-  function handleSetInputFiles(message) {
-    fileList.update('inputFiles', 'toggleInputFiles', message.files);
-    const listEl = getElement('inputFiles');
+  const createSetFilesHandler = (fileType, listId, toggleId) => (message) => {
+    fileList.update(listId, toggleId, message.files);
+    const listEl = getElement(listId);
     if (listEl) {
-      setupFileListHandler('input', listEl);
+      setupFileListHandler(fileType, listEl);
     }
     postHandle();
+  };
+
+  const handlers = {};
+
+  for (const fileType of FILE_TYPES) {
+    const listId =
+      fileType === 'output' ? ELEMENT_IDS.OUTPUT_FILES : `${fileType}Files`;
+    const toggleId =
+      fileType === 'output'
+        ? ELEMENT_IDS.TOGGLE_OUTPUT_FILES
+        : `toggle${capitalize(fileType)}Files`;
+
+    handlers[MAIN_VIEW_COMMANDS[`SET_${fileType.toUpperCase()}_FILES`]] =
+      createSetFilesHandler(fileType, listId, toggleId);
+
+    if (fileType !== 'output') {
+      const domId = `${fileType}File`;
+      handlers[MAIN_VIEW_COMMANDS[`SET_${fileType.toUpperCase()}_FILE`]] =
+        createSetFileHandler(fileType, domId);
+      handlers[MAIN_VIEW_COMMANDS[`${fileType.toUpperCase()}_FILE_SELECTED`]] =
+        createFileSelectedHandler(fileType, domId);
+    }
   }
 
-  function handleSetReferenceFiles(message) {
-    fileList.update('referenceFiles', 'toggleReferenceFiles', message.files);
-    const listEl = getElement('referenceFiles');
-    if (listEl) {
-      setupFileListHandler('reference', listEl);
-    }
-    postHandle();
-  }
-
-  function handleSetAuxiliaryFiles(message) {
-    fileList.update('auxiliaryFiles', 'toggleAuxiliaryFiles', message.files);
-    const listEl = getElement('auxiliaryFiles');
-    if (listEl) {
-      setupFileListHandler('auxiliary', listEl);
-    }
-    postHandle();
-  }
-
-  function handleSetMediaFiles(message) {
-    fileList.update('mediaFiles', 'toggleMediaFiles', message.files);
-    const listEl = getElement('mediaFiles');
-    if (listEl) {
-      setupFileListHandler('media', listEl);
-    }
-    postHandle();
-  }
+  handlers[MAIN_VIEW_COMMANDS.SET_EDITED_FILE] = createSetFileHandler(
+    'edited',
+    EDITED_FILE,
+  );
+  handlers[MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED] = createFileSelectedHandler(
+    'edited',
+    EDITED_FILE,
+  );
 
   function handleAddMediaFile(message) {
     const listDiv = getElement('mediaFiles');
@@ -141,16 +94,8 @@ export function createFileHandlers(ctx) {
     postHandle();
   }
 
-  function handleSetOutputFiles(message) {
-    fileList.update(
-      ELEMENT_IDS.OUTPUT_FILES,
-      ELEMENT_IDS.TOGGLE_OUTPUT_FILES,
-      message.files,
-    );
-    const outputEl = getElement(ELEMENT_IDS.OUTPUT_FILES);
-    if (outputEl) {
-      setupFileListHandler('output', outputEl);
-    }
+  function handleSetDefaultOutputFiles(message) {
+    fileSelect.setAgentDefaultOutputFiles(message.files || []);
     postHandle();
   }
 
@@ -211,30 +156,13 @@ export function createFileHandlers(ctx) {
     postHandle();
   }
 
-  return {
-    // single file
-    [MAIN_VIEW_COMMANDS.SET_INPUT_FILE]: handleSetInputFile,
-    [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILE]: handleSetReferenceFile,
-    [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILE]: handleSetAuxiliaryFile,
-    [MAIN_VIEW_COMMANDS.SET_MEDIA_FILE]: handleSetMediaFile,
-    [MAIN_VIEW_COMMANDS.SET_EDITED_FILE]: handleSetEditedFile,
-    [MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED]: handleInputFileSelected,
-    [MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED]: handleReferenceFileSelected,
-    [MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED]: handleAuxiliaryFileSelected,
-    [MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED]: handleMediaFileSelected,
-    [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: handleEditedFileSelected,
-    [MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES]: handleSetDefaultOutputFiles,
-    // multi file
-    [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: handleSetInputFiles,
-    [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES]: handleSetReferenceFiles,
-    [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES]: handleSetAuxiliaryFiles,
-    [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: handleSetMediaFiles,
-    [MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE]: handleAddMediaFile,
-    [MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES]: handleSetOutputFiles,
-    // misc
-    [MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS]: handleSetRecentCommits,
-    [MAIN_VIEW_COMMANDS.SET_CURRENT_FILE]: handleSetCurrentFile,
-    [MAIN_VIEW_COMMANDS.SET_OPENED_FILES]: handleSetOpenedFiles,
-    [MAIN_VIEW_COMMANDS.SET_BASE_FILE]: handleSetBaseFile,
-  };
+  handlers[MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES] =
+    handleSetDefaultOutputFiles;
+  handlers[MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE] = handleAddMediaFile;
+  handlers[MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS] = handleSetRecentCommits;
+  handlers[MAIN_VIEW_COMMANDS.SET_CURRENT_FILE] = handleSetCurrentFile;
+  handlers[MAIN_VIEW_COMMANDS.SET_OPENED_FILES] = handleSetOpenedFiles;
+  handlers[MAIN_VIEW_COMMANDS.SET_BASE_FILE] = handleSetBaseFile;
+
+  return handlers;
 }


### PR DESCRIPTION
## Summary
- replace per-file message handlers with a generic factory
- build handler map dynamically by iterating over FILE_TYPES
- drop duplicated function blocks

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17b0ff8fc832489d48779710cf40b