### PR TITLE
feat: add tool runner with installation checks

### DIFF
--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -10,9 +10,8 @@ import * as logger from '@logger/logUtils';
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
-import { executeCommand } from '@utils/system';
 import { sleep } from '@utils/helpers';
-import { checkToolInstalled } from '@utils/system';
+import { runToolWithCheck } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -24,9 +23,6 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
       'latex.showLatexindentWarning',
       true,
     );
-    if (!(await checkToolInstalled('latexindent', showWarning))) {
-      return false;
-    }
 
     const workspacePath = WorkspaceFS.getPath();
     if (!workspacePath) {
@@ -38,14 +34,17 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     const latexindentConfig = getConfig<string>('latex.latexindentConfig');
 
     // Build command array - note we're using -w (overwrite) and -s (silent)
-    const command = ['latexindent', '-w', '-s'];
+    const args = ['-w', '-s'];
     if (latexindentConfig) {
-      command.push(`-l=${latexindentConfig}`);
+      args.push(`-l=${latexindentConfig}`);
     }
-    command.push(filePath);
+    args.push(filePath);
 
-    const result = await executeCommand(command, { channel: CHANNEL });
-    if (!result.success) {
+    const result = await runToolWithCheck('latexindent', args, {
+      channel: CHANNEL,
+      showError: showWarning,
+    });
+    if (!result || !result.success) {
       return false;
     }
 

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -3,29 +3,27 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { getConfig } from '@utils/config';
-import { executeCommand, checkToolInstalled } from '@utils/system';
+import { runToolWithCheck } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
 
 export async function runTexFmt(filePath: string): Promise<boolean> {
   try {
-    if (!(await checkToolInstalled('tex-fmt'))) {
-      return false;
-    }
-
     const texfmtConfig = getConfig<string>('latex.texfmtConfig');
 
-    const command = ['tex-fmt'];
+    const args: string[] = [];
     if (texfmtConfig) {
-      command.push('--config', texfmtConfig);
+      args.push('--config', texfmtConfig);
     } else {
-      command.push('--nowrap');
+      args.push('--nowrap');
     }
-    command.push(filePath);
+    args.push(filePath);
 
-    const result = await executeCommand(command, { channel: CHANNEL });
-    if (!result.success) {
+    const result = await runToolWithCheck('tex-fmt', args, {
+      channel: CHANNEL,
+    });
+    if (!result || !result.success) {
       return false;
     }
 

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -22,6 +22,7 @@ export async function runTexFmt(filePath: string): Promise<boolean> {
 
     const result = await runToolWithCheck('tex-fmt', args, {
       channel: CHANNEL,
+      showError: true, // Consistent with default behavior
     });
     if (!result || !result.success) {
       return false;

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -93,18 +93,20 @@ export async function compileLatex2Pdf(
       result = await runToolWithCheck('latexmk', latexmkArgs, {
         channel,
         env,
-        showError: false,
+        showError: false, // Suppress error for latexmk to try pdflatex as fallback
       });
       if (!result) {
         result = await runToolWithCheck('pdflatex', pdflatexArgs, {
           channel,
           env,
+          showError: true, // Show error if pdflatex also fails
         });
       }
     } else {
       result = await runToolWithCheck('pdflatex', pdflatexArgs, {
         channel,
         env,
+        showError: true, // Show error for missing pdflatex
       });
     }
 

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { executeCommand, checkToolInstalled } from '@utils/system';
+import { runToolWithCheck } from '@utils/system';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 // No additional imports needed
@@ -28,13 +28,6 @@ export async function compileLatex2Pdf(
   outputDirectory?: string,
   useLatexmk: boolean = false,
 ): Promise<boolean> {
-  const useLatexmkInstalled = useLatexmk
-    ? await checkToolInstalled('latexmk', false)
-    : false;
-  if (!useLatexmkInstalled && !(await checkToolInstalled('pdflatex'))) {
-    return false;
-  }
-
   try {
     const outDir = outputDirectory || path.dirname(latexFile);
     await WorkspaceFS.createDir(outDir);
@@ -81,24 +74,41 @@ export async function compileLatex2Pdf(
       logger.debug(channel, `Setting TEXINPUTS to: ${texInputs}`);
     }
 
-    const command = useLatexmkInstalled
-      ? [
-          'latexmk',
-          '-pdf',
-          '-f',
-          '-interaction=nonstopmode',
-          `-output-directory=${outDir}`,
-          latexFile,
-        ]
-      : [
-          'pdflatex',
-          '-interaction=nonstopmode',
-          `-output-directory=${outDir}`,
-          latexFile,
-        ];
+    const latexmkArgs = [
+      '-pdf',
+      '-f',
+      '-interaction=nonstopmode',
+      `-output-directory=${outDir}`,
+      latexFile,
+    ];
 
-    const result = await executeCommand(command, { channel, env });
-    if (result.success) {
+    const pdflatexArgs = [
+      '-interaction=nonstopmode',
+      `-output-directory=${outDir}`,
+      latexFile,
+    ];
+
+    let result: Awaited<ReturnType<typeof runToolWithCheck>>;
+    if (useLatexmk) {
+      result = await runToolWithCheck('latexmk', latexmkArgs, {
+        channel,
+        env,
+        showError: false,
+      });
+      if (!result) {
+        result = await runToolWithCheck('pdflatex', pdflatexArgs, {
+          channel,
+          env,
+        });
+      }
+    } else {
+      result = await runToolWithCheck('pdflatex', pdflatexArgs, {
+        channel,
+        env,
+      });
+    }
+
+    if (result && result.success) {
       logger.debug(channel, `Successfully compiled ${latexFile}`);
       return true;
     }

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -89,6 +89,7 @@ export async function getTeXCount(
       const result = await runToolWithCheck('texcount', args, {
         channel,
         truncate: false, // Don't truncate texcount output as we need the full statistics
+        showError: true, // Show error for missing texcount
       });
       if (!result) {
         return null;

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -3,7 +3,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
-import { executeCommand, checkToolInstalled } from '@utils/system';
+import { runToolWithCheck } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -52,11 +52,6 @@ export async function getTeXCount(
   channel: string = CHANNEL,
 ): Promise<string | null> {
   try {
-    // Check if texcount is installed
-    if (!(await checkToolInstalled('texcount'))) {
-      return null;
-    }
-
     // Convert single path to array
     const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
     const allOutputs: string[] = [];
@@ -75,26 +70,29 @@ export async function getTeXCount(
         continue;
       }
 
-      const command = ['texcount'];
+      const args: string[] = [];
       if (merge) {
-        command.push('-merge');
+        args.push('-merge');
       }
 
       // Add Chinese counting support if Chinese packages are detected
       if (await hasChinesePackages(filePath)) {
-        command.push('-ch-only'); // Use Chinese-only mode for accurate character counting
+        args.push('-ch-only'); // Use Chinese-only mode for accurate character counting
         logger.debug(
           channel,
           `Chinese packages detected in ${filePath}, enabling Chinese character counting`,
         );
       }
 
-      command.push(filePath);
+      args.push(filePath);
 
-      const result = await executeCommand(command, {
+      const result = await runToolWithCheck('texcount', args, {
         channel,
         truncate: false, // Don't truncate texcount output as we need the full statistics
       });
+      if (!result) {
+        return null;
+      }
       if (result.success && result.stdout) {
         allOutputs.push(`TeX Count Results for ${filePath}:\n${result.stdout}`);
         logger.debug(channel, `Successfully counted ${filePath}`);

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -8,8 +8,8 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { extendEnvPath, findToolInCommonPaths } from './platformPaths';
-
-// No local imports needed
+import { executeCommand } from './execUtils';
+import type { ExecResult } from '@agent/types/ResultTypes';
 
 // Interface for tool configuration
 export interface ToolConfig {
@@ -305,6 +305,25 @@ export async function checkToolInstalled(
 }
 
 /**
+ * Run a tool after verifying it is installed.
+ * @param toolName Name of the tool to execute
+ * @param args Arguments to pass to the tool (without the tool name)
+ * @param options Execution options and installation check settings
+ * @returns ExecResult if the tool ran, or false if the tool is missing
+ */
+export async function runToolWithCheck(
+  toolName: string,
+  args: string[],
+  options: { showError?: boolean } & Parameters<typeof executeCommand>[1] = {},
+): Promise<ExecResult | false> {
+  const { showError, ...execOptions } = options;
+  if (!(await checkToolInstalled(toolName, showError))) {
+    return false;
+  }
+  return executeCommand([toolName, ...args], execOptions);
+}
+
+/**
  * Check if multiple tools are installed
  * @param configs Array of tool configurations
  * @param showError Whether to show error messages for missing tools
@@ -332,26 +351,33 @@ export async function checkCoreDependencies(
   try {
     // Check basic tools
     const basicTools = ['latexindent', 'perl', 'gs'];
-    const basicResults = await checkMultipleToolsInstalled(basicTools, showError);
+    const basicResults = await checkMultipleToolsInstalled(
+      basicTools,
+      showError,
+    );
     const missingBasicTools = basicTools.filter((_, i) => !basicResults[i]);
-    
+
     // Check for either GraphicsMagick or ImageMagick
     const [hasMagick, hasGm] = await checkMultipleToolsInstalled(
       ['magick', 'gm'],
       false, // Don't show errors since we're checking alternatives
     );
-    
+
     // Add image tool to missing list only if neither is installed
     const missingTools = [...missingBasicTools];
     if (!hasMagick && !hasGm) {
       missingTools.push('gm/magick');
       if (showError) {
-        const errorMsg = 'Neither GraphicsMagick nor ImageMagick is installed. Please install either tool for image processing.\n' +
-          'GraphicsMagick:\n' + GM_INSTRUCTIONS + '\n\nOR\n\nImageMagick:\n' + MAGICK_INSTRUCTIONS;
+        const errorMsg =
+          'Neither GraphicsMagick nor ImageMagick is installed. Please install either tool for image processing.\n' +
+          'GraphicsMagick:\n' +
+          GM_INSTRUCTIONS +
+          '\n\nOR\n\nImageMagick:\n' +
+          MAGICK_INSTRUCTIONS;
         throw new Error(errorMsg);
       }
     }
-    
+
     return missingTools;
   } catch (error) {
     // If checking fails, assume all tools are missing to prompt user to check

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -305,18 +305,26 @@ export async function checkToolInstalled(
 }
 
 /**
+ * Options for runToolWithCheck function
+ */
+export type RunToolOptions = {
+  /** Whether to show error messages for missing tools */
+  showError?: boolean;
+} & Parameters<typeof executeCommand>[1];
+
+/**
  * Run a tool after verifying it is installed.
  * @param toolName Name of the tool to execute
  * @param args Arguments to pass to the tool (without the tool name)
  * @param options Execution options and installation check settings
- * @returns ExecResult if the tool ran, or false if the tool is missing
+ * @returns Promise<ExecResult | false> if the tool ran, or false if the tool is missing
  */
 export async function runToolWithCheck(
   toolName: string,
   args: string[],
-  options: { showError?: boolean } & Parameters<typeof executeCommand>[1] = {},
+  options: RunToolOptions = {},
 ): Promise<ExecResult | false> {
-  const { showError, ...execOptions } = options;
+  const { showError = true, ...execOptions } = options;
   if (!(await checkToolInstalled(toolName, showError))) {
     return false;
   }


### PR DESCRIPTION
## Summary
- add `runToolWithCheck` helper for executing tools after ensuring installation
- use new helper across LaTeX utilities for texcount, formatting, and compilation

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17b94db0c8324aa63fd0cffe78b83