### PR TITLE
refactor: centralize API key message logic

### DIFF
--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -30,6 +30,7 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       path: 'modules/handlers/recordingHandlers.js',
     },
     { key: 'eventBusUri', path: 'modules/eventBus.js' },
+    { key: 'apiKeyHelpersUri', path: 'modules/helpers/apiKeyHelpers.js' },
     { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
     { key: 'fileSelectUri', path: 'modules/uiManagers/FileSelect.js' },
     { key: 'toggleManagerUri', path: 'modules/uiManagers/ToggleManager.js' },

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -27,6 +27,7 @@
           "./modules/uiManagers/LatexdiffManager.js": "${latexdiffManagerUri}",
           "./modules/domHandlers.js": "${domHandlersUri}",
           "./modules/eventBus.js": "${eventBusUri}",
+          "./modules/helpers/apiKeyHelpers.js": "${apiKeyHelpersUri}",
           "./modules/constants.js": "${constantsUri}",
           "./modules/messageHandlers.js": "${messageHandlersUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -12,6 +12,7 @@ import { outputFilesManager } from './uiManagers/OutputFilesManager.js';
 import { RecordingManager } from './uiManagers/RecordingManager.js';
 import { SettingsButtonManager } from './uiManagers/SettingsButtonManager.js';
 import { ToggleManager } from './uiManagers/ToggleManager.js';
+import { sendApiKeyMessage } from './helpers/apiKeyHelpers.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -84,43 +85,17 @@ export class MainViewDomHandler {
       {
         id: ELEMENT_IDS.API_KEY_BANNER_BUTTON,
         handler: () => {
-          // Get provider from banner element to determine which setup to open
           const banner = document.getElementById(ELEMENT_IDS.API_KEY_BANNER);
           const provider = banner?.dataset?.provider;
-
-          if (provider) {
-            // Provider-specific context - use provider-specific API key setup
-            vscode.postMessage({
-              command: MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY,
-              provider,
-            });
-          } else {
-            // General context - use generic API key setup
-            vscode.postMessage({
-              command: MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY,
-            });
-          }
+          sendApiKeyMessage(provider, MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY);
         },
       },
       {
         id: ELEMENT_IDS.API_KEY_GUIDE_BUTTON,
         handler: () => {
-          // Get provider from banner element to determine which action to take
           const banner = document.getElementById(ELEMENT_IDS.API_KEY_BANNER);
           const provider = banner?.dataset?.provider;
-
-          if (provider) {
-            // Provider-specific context - open provider's API key page
-            vscode.postMessage({
-              command: MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL,
-              provider,
-            });
-          } else {
-            // General context - open TeXRA's API key guide
-            vscode.postMessage({
-              command: MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE,
-            });
-          }
+          sendApiKeyMessage(provider, MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE);
         },
       },
       {

--- a/src/webview/modules/helpers/apiKeyHelpers.js
+++ b/src/webview/modules/helpers/apiKeyHelpers.js
@@ -1,0 +1,26 @@
+// Local imports - webview
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { vscode } from '@common/webviewContext.js';
+
+const providerCommandMap = {
+  [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]:
+    MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY,
+  [MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE]:
+    MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL,
+};
+
+/**
+ * Send an API key-related message, adjusting for provider-specific context.
+ * @param {string | undefined} provider Provider identifier.
+ * @param {string} commandWhenNone Command to send when no provider is specified.
+ */
+export function sendApiKeyMessage(provider, commandWhenNone) {
+  const command = provider
+    ? providerCommandMap[commandWhenNone]
+    : commandWhenNone;
+  if (!command) {
+    return;
+  }
+  const message = provider ? { command, provider } : { command };
+  vscode.postMessage(message);
+}


### PR DESCRIPTION
## Summary
- factor out API key banner messaging into a helper
- use helper for banner and guide button handlers
- wire helper into import map for main view

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17ae309308324a3c05512b3ec9d6b