### PR TITLE
feat: add cross-platform basename helper

### DIFF
--- a/src/common/modules/pathUtils.js
+++ b/src/common/modules/pathUtils.js
@@ -1,0 +1,10 @@
+/**
+ * Get the base name of a path across platforms.
+ * @param {string} filePath - Path to evaluate
+ * @returns {string} Basename of the provided path
+ */
+export function getBasename(filePath) {
+  const normalized = filePath.replace(/\\/g, '/');
+  const parts = normalized.split('/');
+  return parts.pop() || '';
+}

--- a/src/common/modules/pathUtils.js
+++ b/src/common/modules/pathUtils.js
@@ -1,10 +1,28 @@
 /**
- * Get the base name of a path across platforms.
- * @param {string} filePath - Path to evaluate
- * @returns {string} Basename of the provided path
+ * Extract the base name (filename) from a file path.
+ * Handles platform-specific separators (\ on Windows, / on Unix).
+ * 
+ * @param {string} filePath - Path to evaluate (can be absolute or relative)
+ * @returns {string} Base name of the file/directory
+ * @example
+ * getBasename('/home/user/document.pdf') // returns 'document.pdf'
+ * getBasename('C:\\Users\\file.txt')     // returns 'file.txt'
+ * getBasename('/path/to/')               // returns 'to'
+ * getBasename('/')                       // returns ''
  */
 export function getBasename(filePath) {
+  if (!filePath) return '';
+  
+  // Normalize path separators to forward slashes
   const normalized = filePath.replace(/\\/g, '/');
-  const parts = normalized.split('/');
-  return parts.pop() || '';
+  
+  // Remove trailing slashes except for root
+  const cleaned = normalized.replace(/\/+$/, '') || '/';
+  
+  // Handle root path
+  if (cleaned === '/') return '';
+  
+  // Split and get last part
+  const parts = cleaned.split('/');
+  return parts[parts.length - 1] || '';
 }

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -158,6 +158,7 @@ export abstract class BaseViewContentProvider {
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
+      pathUtilsUri: this.getCommonUri(webview, 'modules/pathUtils.js'),
       codiconUri: this.getNodeModulesUri(
         webview,
         '@vscode/codicons/dist/codicon.css',

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -52,6 +52,7 @@
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/pathUtils.js": "${pathUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -28,6 +28,7 @@ import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,
 } from '@common/iconConstants.js';
+import { getBasename } from '@common/pathUtils.js';
 
 // Constants
 export const BULLET_MARKUP =
@@ -541,7 +542,7 @@ export class LogEntryFormatter {
         const escaped = encodeHtml(filePath);
 
         // Extract just the filename for display
-        const fileName = filePath.split('/').pop() || filePath;
+        const fileName = getBasename(filePath);
         const fileNameEscaped = encodeHtml(fileName);
 
         // Build metadata string
@@ -617,7 +618,7 @@ export class LogEntryFormatter {
       .map((f) => {
         const filePath = String(f);
         const escaped = encodeHtml(filePath);
-        const fileName = filePath.split('/').pop() || filePath;
+        const fileName = getBasename(filePath);
         const fileNameEscaped = encodeHtml(fileName);
         return `<li title="${escaped}"><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span></li>`;
       })
@@ -627,7 +628,7 @@ export class LogEntryFormatter {
     let xmlLink = '';
     if (xmlFile) {
       const xmlEscaped = encodeHtml(xmlFile);
-      const xmlFileName = xmlFile.split('/').pop() || xmlFile;
+      const xmlFileName = getBasename(xmlFile);
       const xmlFileNameEscaped = encodeHtml(xmlFileName);
       const tagInfo = documentTag
         ? `<span class="document-tag">(Expected &lt;${encodeHtml(documentTag)}&gt; block)</span>`
@@ -702,8 +703,8 @@ export class LogEntryFormatter {
       const revisedEsc = encodeHtml(revisedPath);
       const outputEsc = encodeHtml(outputPath);
 
-      const baseName = basePath.split('/').pop() || basePath;
-      const revisedName = revisedPath.split('/').pop() || revisedPath;
+      const baseName = getBasename(basePath);
+      const revisedName = getBasename(revisedPath);
 
       let icon = 'codicon-question';
       if (d.status === 'success') {

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -5,6 +5,7 @@ import { formatTokens } from '../formatters.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
+import { getBasename } from '@common/pathUtils.js';
 
 /**
  * Manages file list rendering.
@@ -108,9 +109,12 @@ export class FileList {
 
         // Use original name if available, otherwise use generated path
         const displayPath = file.original || file.path;
-        const parts = displayPath.split('/');
-        const basename = parts.pop() || '';
-        const dirPath = parts.length > 0 ? parts.join('/') + '/' : '';
+        const basename = getBasename(displayPath);
+        const idx = Math.max(
+          displayPath.lastIndexOf('/'),
+          displayPath.lastIndexOf('\\'),
+        );
+        const dirPath = idx >= 0 ? displayPath.slice(0, idx + 1) : '';
 
         // Set file data attributes
         if (fileItem) {

--- a/src/test/common/modules/pathUtils.test.js
+++ b/src/test/common/modules/pathUtils.test.js
@@ -1,0 +1,69 @@
+import * as assert from 'assert';
+import { getBasename } from '../../../common/modules/pathUtils.js';
+
+suite('pathUtils.js Test Suite', () => {
+  suite('getBasename', () => {
+    test('should extract basename from Unix paths', () => {
+      assert.strictEqual(getBasename('/home/user/file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('/usr/local/bin/node'), 'node');
+      assert.strictEqual(getBasename('/path/to/document.pdf'), 'document.pdf');
+    });
+
+    test('should extract basename from Windows paths', () => {
+      assert.strictEqual(getBasename('C:\\Users\\file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('C:\\Program Files\\app.exe'), 'app.exe');
+      assert.strictEqual(getBasename('D:\\Documents\\report.docx'), 'report.docx');
+    });
+
+    test('should handle mixed path separators', () => {
+      assert.strictEqual(getBasename('C:/Users\\Documents/file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('/home\\user/document.pdf'), 'document.pdf');
+    });
+
+    test('should handle paths with trailing slashes', () => {
+      assert.strictEqual(getBasename('/path/to/'), 'to');
+      assert.strictEqual(getBasename('/path/to/dir/'), 'dir');
+      assert.strictEqual(getBasename('C:\\Users\\'), 'Users');
+    });
+
+    test('should handle edge cases', () => {
+      assert.strictEqual(getBasename(''), '');
+      assert.strictEqual(getBasename('/'), '');
+      assert.strictEqual(getBasename('//'), '');
+      assert.strictEqual(getBasename('file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('./file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('../file.txt'), 'file.txt');
+    });
+
+    test('should handle files with multiple dots', () => {
+      assert.strictEqual(getBasename('/path/to/file.tar.gz'), 'file.tar.gz');
+      assert.strictEqual(getBasename('archive.backup.zip'), 'archive.backup.zip');
+      assert.strictEqual(getBasename('/home/user/.bashrc'), '.bashrc');
+    });
+
+    test('should handle special characters in filenames', () => {
+      assert.strictEqual(getBasename('/path/to/file with spaces.txt'), 'file with spaces.txt');
+      assert.strictEqual(getBasename('/path/to/file-with-dashes.txt'), 'file-with-dashes.txt');
+      assert.strictEqual(getBasename('/path/to/file_with_underscores.txt'), 'file_with_underscores.txt');
+    });
+
+    test('should handle relative paths', () => {
+      assert.strictEqual(getBasename('relative/path/to/file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('./relative/file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('../parent/file.txt'), 'file.txt');
+    });
+
+    test('should handle directory paths without extensions', () => {
+      assert.strictEqual(getBasename('/home/user/Documents'), 'Documents');
+      assert.strictEqual(getBasename('C:\\Program Files'), 'Program Files');
+      assert.strictEqual(getBasename('/usr/local/bin'), 'bin');
+    });
+
+    test('should not return empty string for valid directory names', () => {
+      // This was the bug reported by cursor - paths ending with separator would return empty
+      assert.strictEqual(getBasename('folder/'), 'folder');
+      assert.strictEqual(getBasename('/home/user/folder/'), 'folder');
+      assert.notStrictEqual(getBasename('folder/'), '');
+    });
+  });
+});

--- a/src/test/utils/files/pathUtils.test.ts
+++ b/src/test/utils/files/pathUtils.test.ts
@@ -1,0 +1,102 @@
+import * as assert from 'assert';
+import { getBasename, isTexFile, resolveFilePath } from '../../../utils/files/pathUtils';
+import * as path from 'path';
+
+suite('pathUtils Test Suite', () => {
+  suite('getBasename', () => {
+    test('should extract basename from Unix paths', () => {
+      assert.strictEqual(getBasename('/home/user/file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('/usr/local/bin/node'), 'node');
+      assert.strictEqual(getBasename('/path/to/document.pdf'), 'document.pdf');
+    });
+
+    test('should extract basename from Windows paths', () => {
+      assert.strictEqual(getBasename('C:\\Users\\file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('C:\\Program Files\\app.exe'), 'app.exe');
+      assert.strictEqual(getBasename('D:\\Documents\\report.docx'), 'report.docx');
+    });
+
+    test('should handle mixed path separators', () => {
+      assert.strictEqual(getBasename('C:/Users\\Documents/file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('/home\\user/document.pdf'), 'document.pdf');
+    });
+
+    test('should handle paths with trailing slashes', () => {
+      assert.strictEqual(getBasename('/path/to/'), 'to');
+      assert.strictEqual(getBasename('/path/to/dir/'), 'dir');
+      assert.strictEqual(getBasename('C:\\Users\\'), 'Users');
+    });
+
+    test('should handle edge cases', () => {
+      assert.strictEqual(getBasename(''), '');
+      assert.strictEqual(getBasename('/'), '');
+      assert.strictEqual(getBasename('//'), '');
+      assert.strictEqual(getBasename('file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('./file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('../file.txt'), 'file.txt');
+    });
+
+    test('should handle files with multiple dots', () => {
+      assert.strictEqual(getBasename('/path/to/file.tar.gz'), 'file.tar.gz');
+      assert.strictEqual(getBasename('archive.backup.zip'), 'archive.backup.zip');
+      assert.strictEqual(getBasename('/home/user/.bashrc'), '.bashrc');
+    });
+
+    test('should handle special characters in filenames', () => {
+      assert.strictEqual(getBasename('/path/to/file with spaces.txt'), 'file with spaces.txt');
+      assert.strictEqual(getBasename('/path/to/file-with-dashes.txt'), 'file-with-dashes.txt');
+      assert.strictEqual(getBasename('/path/to/file_with_underscores.txt'), 'file_with_underscores.txt');
+      assert.strictEqual(getBasename('/path/to/file(with)parens.txt'), 'file(with)parens.txt');
+    });
+
+    test('should handle relative paths', () => {
+      assert.strictEqual(getBasename('relative/path/to/file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('./relative/file.txt'), 'file.txt');
+      assert.strictEqual(getBasename('../parent/file.txt'), 'file.txt');
+    });
+
+    test('should handle directory paths without extensions', () => {
+      assert.strictEqual(getBasename('/home/user/Documents'), 'Documents');
+      assert.strictEqual(getBasename('C:\\Program Files'), 'Program Files');
+      assert.strictEqual(getBasename('/usr/local/bin'), 'bin');
+    });
+  });
+
+  suite('isTexFile', () => {
+    test('should identify TeX files correctly', () => {
+      assert.strictEqual(isTexFile('document.tex'), true);
+      assert.strictEqual(isTexFile('DOCUMENT.TEX'), true);
+      assert.strictEqual(isTexFile('path/to/file.tex'), true);
+      assert.strictEqual(isTexFile('file.TeX'), true);
+    });
+
+    test('should reject non-TeX files', () => {
+      assert.strictEqual(isTexFile('document.txt'), false);
+      assert.strictEqual(isTexFile('file.pdf'), false);
+      assert.strictEqual(isTexFile('image.png'), false);
+      assert.strictEqual(isTexFile('script.js'), false);
+      assert.strictEqual(isTexFile('noextension'), false);
+    });
+
+    test('should handle edge cases', () => {
+      assert.strictEqual(isTexFile(''), false);
+      assert.strictEqual(isTexFile('.tex'), true);
+      assert.strictEqual(isTexFile('tex'), false);
+      assert.strictEqual(isTexFile('file.texture'), false);
+    });
+  });
+
+  suite('resolveFilePath', () => {
+    test('should return absolute paths unchanged', () => {
+      const absolutePath = path.resolve('/absolute/path/file.txt');
+      assert.strictEqual(resolveFilePath(absolutePath), absolutePath);
+    });
+
+    test('should resolve relative paths to workspace', () => {
+      const relativePath = 'relative/path/file.txt';
+      const resolved = resolveFilePath(relativePath);
+      assert.strictEqual(path.isAbsolute(resolved), true);
+      assert.strictEqual(resolved.endsWith(relativePath), true);
+    });
+  });
+});

--- a/src/utils/files/pathUtils.ts
+++ b/src/utils/files/pathUtils.ts
@@ -15,10 +15,16 @@ export function isTexFile(file: string): boolean {
 }
 
 /**
- * Get the base name of a path.
- * Handles platform-specific separators.
- * @param filePath - Path to evaluate
- * @returns Basename of the provided path
+ * Extract the base name (filename) from a file path.
+ * Handles platform-specific separators (\ on Windows, / on Unix).
+ * 
+ * @param filePath - Path to evaluate (can be absolute or relative)
+ * @returns Base name of the file/directory
+ * @example
+ * getBasename('/home/user/document.pdf') // returns 'document.pdf'
+ * getBasename('C:\\Users\\file.txt')     // returns 'file.txt'
+ * getBasename('/path/to/')               // returns 'to'
+ * getBasename('/')                       // returns ''
  */
 export function getBasename(filePath: string): string {
   return path.basename(filePath);

--- a/src/utils/files/pathUtils.ts
+++ b/src/utils/files/pathUtils.ts
@@ -13,3 +13,13 @@ export function resolveFilePath(file: string): string {
 export function isTexFile(file: string): boolean {
   return file.toLowerCase().endsWith('.tex');
 }
+
+/**
+ * Get the base name of a path.
+ * Handles platform-specific separators.
+ * @param filePath - Path to evaluate
+ * @returns Basename of the provided path
+ */
+export function getBasename(filePath: string): string {
+  return path.basename(filePath);
+}


### PR DESCRIPTION
## Summary
- add `getBasename` utility for platform-agnostic path handling
- use `getBasename` in progress view file and log formatters
- expose new utility to webviews via import map

## Testing
- `npm run lint`
- `npm test` *(fails: /workspace/TeXRA/.vscode-test/.../code: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c17ada3bd48324a2230b53cf0cd2eb