### PR TITLE
refactor: centralize button config logic

### DIFF
--- a/src/common/modules/buttonUtils.js
+++ b/src/common/modules/buttonUtils.js
@@ -1,0 +1,71 @@
+/**
+ * Apply button configuration objects to DOM elements.
+ * Each configuration may specify an `id` or `selector` to locate the element.
+ * When `condition` is falsy, the element is hidden.
+ * When `dataset` is provided, its key/value pairs are applied to the element's dataset.
+ * When `handler` is provided, it is attached as an event listener (default event: "click").
+ * A `configure` callback can perform additional custom logic on the element.
+ *
+ * @param {Document|ParentNode} root - Root node for element resolution.
+ * @param {Array} configs - Array of button configuration objects.
+ * @returns {Map<string, Function>} Map of element keys to handlers for later cleanup.
+ */
+export function applyButtonConfigs(root, configs) {
+  const handlersMap = new Map();
+  if (!configs) return handlersMap;
+
+  configs.forEach((config) => {
+    const {
+      id,
+      selector,
+      element: explicitElement,
+      condition = true,
+      dataset,
+      handler,
+      event = 'click',
+      configure,
+    } = config;
+
+    let el = explicitElement;
+    if (!el) {
+      if (id && root.getElementById) {
+        el = root.getElementById(id);
+      }
+      if (!el && selector && root.querySelector) {
+        el = root.querySelector(selector);
+      }
+    }
+
+    if (!el) {
+      return;
+    }
+
+    if (!condition) {
+      el.style.display = 'none';
+      return;
+    }
+
+    if (dataset) {
+      Object.entries(dataset).forEach(([key, value]) => {
+        if (value !== undefined) {
+          el.dataset[key] = value;
+        }
+      });
+    }
+
+    if (handler) {
+      el.addEventListener(event, handler);
+      if (id) {
+        handlersMap.set(id, handler);
+      } else if (selector) {
+        handlersMap.set(selector, handler);
+      }
+    }
+
+    if (configure) {
+      configure(el);
+    }
+  });
+
+  return handlersMap;
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -158,6 +158,7 @@ export abstract class BaseViewContentProvider {
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
+      buttonUtilsUri: this.getCommonUri(webview, 'modules/buttonUtils.js'),
       codiconUri: this.getNodeModulesUri(
         webview,
         '@vscode/codicons/dist/codicon.css',

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -30,7 +30,8 @@
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
-          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}"
+          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/buttonUtils.js": "${buttonUtilsUri}"
         }
       }
     </script>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -52,6 +52,7 @@
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/buttonUtils.js": "${buttonUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -5,6 +5,7 @@ import { formatTokens } from '../formatters.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
+import { applyButtonConfigs } from '@common/buttonUtils.js';
 
 /**
  * Manages file list rendering.
@@ -165,51 +166,52 @@ export class FileList {
     const buttonConfigs = [
       {
         selector: '.compare-btn',
-        command: COMMANDS.COMPARE_ORIGINAL,
         condition: effectiveBase,
+        dataset: {
+          command: COMMANDS.COMPARE_ORIGINAL,
+          file: file.path,
+          base: effectiveBase,
+        },
       },
       {
         selector: '.accept-btn',
-        command: COMMANDS.ACCEPT_FILE,
         condition: effectiveBase,
+        dataset: {
+          command: COMMANDS.ACCEPT_FILE,
+          file: file.path,
+          base: effectiveBase,
+        },
       },
       {
         selector: '.merge-btn',
-        command: COMMANDS.MERGE_FILE,
         condition: effectiveBase,
+        dataset: {
+          command: COMMANDS.MERGE_FILE,
+          file: file.path,
+          base: effectiveBase,
+        },
       },
       {
         selector: '.diff-btn',
-        command: COMMANDS.LATEXDIFF_FILE,
         condition: effectiveBase,
+        dataset: {
+          command: COMMANDS.LATEXDIFF_FILE,
+          file: file.path,
+          base: effectiveBase,
+        },
       },
       {
         selector: '.prev-btn',
-        command: COMMANDS.COMPARE_PREVIOUS,
         condition: file.prev,
-        configure: (btn) => {
-          btn.dataset.prev = file.prev;
+        dataset: {
+          command: COMMANDS.COMPARE_PREVIOUS,
+          file: file.path,
+          prev: file.prev,
         },
       },
     ];
 
-    buttonConfigs.forEach(({ selector, command, condition, configure }) => {
-      const button = clone.querySelector(selector);
-      if (!button) {
-        return;
-      }
-      if (condition) {
-        button.dataset.command = command;
-        button.dataset.file = file.path;
-        if (configure) {
-          configure(button);
-        } else {
-          button.dataset.base = effectiveBase;
-        }
-      } else {
-        button.style.display = 'none';
-      }
-    });
+    applyButtonConfigs(clone, buttonConfigs);
 
     // Add dataset for the file path link
     const filePathSpan = clone.querySelector('.file-path');

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -39,6 +39,7 @@
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/buttonUtils.js": "${buttonUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",
           "nanoid": "https://cdn.skypack.dev/nanoid"

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -14,6 +14,7 @@ import { SettingsButtonManager } from './uiManagers/SettingsButtonManager.js';
 import { ToggleManager } from './uiManagers/ToggleManager.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
+import { applyButtonConfigs } from '@common/buttonUtils.js';
 
 export const instructionManager = new InstructionManager(
   'instruction',
@@ -153,14 +154,7 @@ export class MainViewDomHandler {
         },
       },
     ];
-
-    this.buttonConfigs.forEach(({ id, handler }) => {
-      const element = document.getElementById(id);
-      if (element) {
-        element.addEventListener('click', handler);
-        this.buttonHandlers.set(id, handler);
-      }
-    });
+    this.buttonHandlers = applyButtonConfigs(document, this.buttonConfigs);
   }
 
   cleanupUI() {


### PR DESCRIPTION
## Summary
- add reusable `applyButtonConfigs` helper for dataset and visibility handling
- streamline `FileList` and `MainViewDomHandler` by using the shared helper
- expose the helper to all webviews via updated import maps

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17abc40c08324832eaec06c61ea7c