### PR TITLE
refactor: centralize webview message setup

### DIFF
--- a/src/common/modules/BaseWebviewMessageHandler.js
+++ b/src/common/modules/BaseWebviewMessageHandler.js
@@ -1,0 +1,35 @@
+// Local imports - common
+import { registerMessageHandlers } from './webviewContext.js';
+
+/**
+ * Base class for webview message handlers.
+ * Provides default setup and cleanup logic for registering
+ * message handlers with the VS Code webview context.
+ */
+export class BaseWebviewMessageHandler {
+  constructor() {
+    this._cleanupFn = null;
+    this._handlers = {};
+  }
+
+  /**
+   * Register message handlers with the webview and store the cleanup function.
+   */
+  setup() {
+    if (!this._cleanupFn) {
+      this._cleanupFn = registerMessageHandlers(this._handlers);
+    }
+  }
+
+  /**
+   * Remove previously registered message handlers.
+   */
+  cleanup() {
+    if (this._cleanupFn) {
+      this._cleanupFn();
+      this._cleanupFn = null;
+    }
+  }
+}
+
+export default BaseWebviewMessageHandler;

--- a/src/common/modules/BaseWebviewMessageHandler.js
+++ b/src/common/modules/BaseWebviewMessageHandler.js
@@ -5,24 +5,63 @@ import { registerMessageHandlers } from './webviewContext.js';
  * Base class for webview message handlers.
  * Provides default setup and cleanup logic for registering
  * message handlers with the VS Code webview context.
+ *
+ * @abstract
+ * @example
+ * class MyHandler extends BaseWebviewMessageHandler {
+ *   constructor() {
+ *     super();
+ *     // Populate handlers before calling setup()
+ *     this._handlers = {
+ *       'MY_COMMAND': (message) => { ... }
+ *     };
+ *   }
+ * }
  */
 export class BaseWebviewMessageHandler {
   constructor() {
+    /**
+     * Cleanup function returned from registerMessageHandlers.
+     * Used to unregister handlers when cleanup() is called.
+     * @type {Function|null}
+     * @protected
+     */
     this._cleanupFn = null;
+
+    /**
+     * Map of command names to handler functions.
+     * Derived classes must populate this before calling setup().
+     * @type {Object.<string, Function>}
+     * @protected
+     */
     this._handlers = {};
   }
 
   /**
    * Register message handlers with the webview and store the cleanup function.
+   * Validates that handlers are defined before registration.
+   * @throws {Error} If handlers are not properly defined
    */
   setup() {
     if (!this._cleanupFn) {
+      // Validate handlers are defined
+      if (!this._handlers || typeof this._handlers !== 'object') {
+        throw new Error('BaseWebviewMessageHandler: handlers must be an object');
+      }
+
+      // Warn if no handlers are defined (but don't throw - could be intentional)
+      if (Object.keys(this._handlers).length === 0) {
+        console.warn('BaseWebviewMessageHandler: No handlers defined for registration');
+      }
+
       this._cleanupFn = registerMessageHandlers(this._handlers);
     }
   }
 
   /**
    * Remove previously registered message handlers.
+   * Calls the stored cleanup function and resets internal state.
+   * Safe to call multiple times.
    */
   cleanup() {
     if (this._cleanupFn) {

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -156,6 +156,10 @@ export abstract class BaseViewContentProvider {
         'modules/iconButtonInitializer.js',
       ),
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
+      baseWebviewMessageHandlerUri: this.getCommonUri(
+        webview,
+        'modules/BaseWebviewMessageHandler.js',
+      ),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
       codiconUri: this.getNodeModulesUri(

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -30,7 +30,8 @@
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
-          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}"
+          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}"
         }
       }
     </script>

--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -1,32 +1,20 @@
 // Local imports - history view
 import { historyViewDomHandler } from './domHandlers.js';
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
-// Local imports
-import { registerMessageHandlers } from '@common/webviewContext.js';
+import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
 
 /**
  * Handles messages from the extension for the history view.
  */
-export class HistoryViewMessageHandler {
+export class HistoryViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
-    this._cleanupFn = null;
+    super();
     this._handlers = {
       [HISTORY_VIEW_COMMANDS.UPDATE_HISTORY]: (m) =>
         this.handleUpdateHistory(m),
       [HISTORY_VIEW_COMMANDS.HISTORY_CLEARED]: () =>
         this.handleHistoryCleared(),
     };
-  }
-
-  setup() {
-    this._cleanupFn = registerMessageHandlers(this._handlers);
-  }
-
-  cleanup() {
-    if (this._cleanupFn) {
-      this._cleanupFn();
-      this._cleanupFn = null;
-    }
   }
 
   handleUpdateHistory(message) {

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -53,6 +53,7 @@
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
+          "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",
           "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0"

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -5,7 +5,7 @@ import { createThemeHandlers } from './handlers/themeHandlers.js';
 import { appendFormatted } from './utils.js';
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
-import { registerMessageHandlers } from '@common/webviewContext.js';
+import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
 
 // Create shorter aliases for internal use
 const state = progressViewState;
@@ -13,9 +13,9 @@ const dom = progressViewDomHandler;
 
 // Create formatter instances
 
-export class ProgressViewMessageHandler {
+export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
-    this._cleanupFn = null;
+    super();
     this._entryFormatter = new LogEntryFormatter();
     this._handlers = {
       ...createThemeHandlers(),
@@ -53,17 +53,6 @@ export class ProgressViewMessageHandler {
       [COMMANDS.DELETE_STREAM]: (m) => this.handleDeleteStream(m),
       [COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
     };
-  }
-
-  setup() {
-    this._cleanupFn = registerMessageHandlers(this._handlers);
-  }
-
-  cleanup() {
-    if (this._cleanupFn) {
-      this._cleanupFn();
-      this._cleanupFn = null;
-    }
   }
 
   handleUpdateStreams(message) {
@@ -188,7 +177,8 @@ export class ProgressViewMessageHandler {
               formatted.setAttribute('open', '');
               const toggleIcon = formatted.querySelector('.toggle-icon');
               if (toggleIcon) {
-                toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
+                toggleIcon.className =
+                  'codicon codicon-chevron-down toggle-icon';
               }
             }
           }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -40,6 +40,7 @@
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
+          "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",
           "nanoid": "https://cdn.skypack.dev/nanoid"
         }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -30,15 +30,16 @@ import { createFromTemplate } from '@common/templateUtils.js';
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - webview context
-import { vscode, registerMessageHandlers } from '@common/webviewContext.js';
+import { vscode } from '@common/webviewContext.js';
+import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
 
 /**
  * Handles messages from the extension and syncs the webview state.
  */
-export class MainViewMessageHandler {
+export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
+    super();
     this._skipNextRestoreState = false;
-    this._cleanupFn = null;
 
     // Cached DOM elements
     this._instructionEl = null;
@@ -238,19 +239,14 @@ export class MainViewMessageHandler {
   /** Register handlers and optionally request initial data. */
   setup(options = {}) {
     const { requestData = true } = options;
-    if (!this._cleanupFn) {
-      this._cleanupFn = registerMessageHandlers(this._handlers);
-    }
+    super.setup();
     if (requestData) {
       this._initializeDataRequests();
     }
   }
 
   cleanup() {
-    if (this._cleanupFn) {
-      this._cleanupFn();
-      this._cleanupFn = null;
-    }
+    super.cleanup();
     Object.values(this._fileListHandlers).forEach(({ container, handler }) => {
       container.removeEventListener('click', handler);
     });


### PR DESCRIPTION
## Summary
- add BaseWebviewMessageHandler with shared setup/cleanup
- use BaseWebviewMessageHandler across main, progress, and history views
- expose new base handler in webview import maps

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: incomplete output?)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a504446c8324a62d4a66fe655ed3