### PR TITLE
refactor: use safe DOM helpers in webviews

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -13,20 +13,14 @@ export function addEventListenerSafely(elementOrId, event, handler, options) {
 }
 
 export function safeSetElementValue(id, value) {
-  const element = document.getElementById(id);
-  if (!element) {
-    console.warn(`Element with id '${id}' not found`);
-    return;
-  }
+  const element = safeGetElementById(id);
+  if (!element) return;
   element.value = value;
 }
 
 export function safeSetElementChecked(id, checked) {
-  const element = document.getElementById(id);
-  if (!element) {
-    console.warn(`Element with id '${id}' not found`);
-    return;
-  }
+  const element = safeGetElementById(id);
+  if (!element) return;
   element.checked = checked;
 }
 
@@ -39,21 +33,13 @@ export function safeGetElementById(id) {
 }
 
 export function safeGetElementValue(id) {
-  const element = document.getElementById(id);
-  if (!element) {
-    console.warn(`Element with id '${id}' not found`);
-    return '';
-  }
-  return element.value;
+  const element = safeGetElementById(id);
+  return element ? element.value : '';
 }
 
 export function safeGetElementChecked(id) {
-  const element = document.getElementById(id);
-  if (!element) {
-    console.warn(`Element with id '${id}' not found`);
-    return false;
-  }
-  return element.checked;
+  const element = safeGetElementById(id);
+  return element ? element.checked : false;
 }
 
 /**

--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -1,9 +1,8 @@
+import { safeGetElementById } from './domUtils.js';
+
 export function renderTemplate(templateId) {
-  const template = document.getElementById(templateId);
-  if (!template) {
-    console.warn(`Template ${templateId} not found`);
-    return null;
-  }
+  const template = safeGetElementById(templateId);
+  if (!template) return null;
   return template.content.firstElementChild.cloneNode(true);
 }
 
@@ -43,14 +42,7 @@ export function createFromTemplate(templateId, replacements = {}) {
 }
 
 export function validateTemplates(templateIds) {
-  return templateIds.every((id) => {
-    const template = document.getElementById(id);
-    if (!template) {
-      console.error(`Template ${id} not found`);
-      return false;
-    }
-    return true;
-  });
+  return templateIds.every((id) => !!safeGetElementById(id));
 }
 
 export function createIconButton({

--- a/src/historyView/modules/uiManagers/HistoryEventsManager.js
+++ b/src/historyView/modules/uiManagers/HistoryEventsManager.js
@@ -1,6 +1,9 @@
 // Local imports - history view
 import { ELEMENT_IDS } from '../constants.js';
-import { addEventListenerSafely } from '@common/domUtils.js';
+import {
+  addEventListenerSafely,
+  safeGetElementById,
+} from '@common/domUtils.js';
 
 /**
  * Registers global event listeners for the history view.
@@ -20,7 +23,7 @@ export class HistoryEventsManager {
   }
 
   setupEventListeners() {
-    const searchInput = document.getElementById(ELEMENT_IDS.SEARCH_INPUT);
+    const searchInput = safeGetElementById(ELEMENT_IDS.SEARCH_INPUT);
     const searchHandler = this._debounce((e) => {
       const term = e.target.value.trim();
       this.searchManager.search(term);
@@ -36,7 +39,7 @@ export class HistoryEventsManager {
 
     const prevHandler = () => this.searchManager.navigatePrev();
     addEventListenerSafely(ELEMENT_IDS.PREV_MATCH, 'click', prevHandler);
-    const prevEl = document.getElementById(ELEMENT_IDS.PREV_MATCH);
+    const prevEl = safeGetElementById(ELEMENT_IDS.PREV_MATCH);
     if (prevEl)
       this.handlers.push({
         element: prevEl,
@@ -46,7 +49,7 @@ export class HistoryEventsManager {
 
     const nextHandler = () => this.searchManager.navigateNext();
     addEventListenerSafely(ELEMENT_IDS.NEXT_MATCH, 'click', nextHandler);
-    const nextEl = document.getElementById(ELEMENT_IDS.NEXT_MATCH);
+    const nextEl = safeGetElementById(ELEMENT_IDS.NEXT_MATCH);
     if (nextEl)
       this.handlers.push({
         element: nextEl,

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -228,7 +228,7 @@ export class HistoryRenderer {
   applyToggleStates() {
     const entries = historyViewState.toggleStates.entries();
     for (const [id, expanded] of entries) {
-      const content = document.getElementById(`content-${id}`);
+      const content = safeGetElementById(`content-${id}`);
       const toggle = document.querySelector(
         `.${CLASS_NAMES.TOGGLE_BUTTON}[data-id="${id}"]`,
       );

--- a/src/progressView/modules/handlers/themeHandlers.js
+++ b/src/progressView/modules/handlers/themeHandlers.js
@@ -1,6 +1,7 @@
 // Local imports - progress view
 // Handler for theme-related messages in the progress view
 import { COMMON_COMMANDS } from '@common/webview/commands.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Create handlers for theme and debug mode updates.
@@ -8,7 +9,7 @@ import { COMMON_COMMANDS } from '@common/webview/commands.js';
  * @param {Function} ctx.postHandle Callback after handling a message.
  */
 export function createThemeHandlers({ postHandle } = {}) {
-  const link = document.getElementById('hljs-theme');
+  const link = safeGetElementById('hljs-theme');
   const updateHighlightTheme = (theme) => {
     if (!link) return;
     link.href = `https://cdn.jsdelivr.net/npm/highlight.js@11.11.1/styles/${theme === 'dark' ? 'github-dark' : 'github'}.css`;

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -6,6 +6,7 @@ import { appendFormatted } from './utils.js';
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
 import { registerMessageHandlers } from '@common/webviewContext.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 // Create shorter aliases for internal use
 const state = progressViewState;
@@ -27,7 +28,8 @@ export class ProgressViewMessageHandler {
    * Toggle the placeholder based on active stream and log content
    */
   _updatePlaceholderVisibility() {
-    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const logContent = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
+    if (!logContent) return;
     if (!state.activeStream && logContent.children.length === 0) {
       dom.placeholder.show();
     } else {
@@ -79,7 +81,7 @@ export class ProgressViewMessageHandler {
 
     this._updatePlaceholderVisibility();
 
-    const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
+    const container = safeGetElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
       const active = message.streams.find(
         (s) => s.name === message.activeStream,
@@ -98,7 +100,7 @@ export class ProgressViewMessageHandler {
   }
 
   handleUpdateLogs(message) {
-    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const logContent = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
     if (message.stream === state.activeStream) {
       logContent.innerHTML = '';
       state.taskGroups.clear();
@@ -136,7 +138,7 @@ export class ProgressViewMessageHandler {
   }
 
   handleClearLogs() {
-    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const logContent = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
     logContent.innerHTML = '';
     const groupIds = [];
     const headers = Array.from(document.querySelectorAll('.log-group-header'));
@@ -151,7 +153,7 @@ export class ProgressViewMessageHandler {
 
   handleAppendLog(message) {
     if (message.stream === state.activeStream) {
-      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      const logContent = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
         const formatted = this._entryFormatter.format(message.logMessage);
@@ -174,7 +176,7 @@ export class ProgressViewMessageHandler {
 
   handleUpdateLog(message) {
     if (message.stream === state.activeStream) {
-      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      const logContent = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
       const updated = dom.logEntries.update(message.logMessage);
       if (!updated) {
         // Fallback: append as new log with proper group placement
@@ -188,7 +190,8 @@ export class ProgressViewMessageHandler {
               formatted.setAttribute('open', '');
               const toggleIcon = formatted.querySelector('.toggle-icon');
               if (toggleIcon) {
-                toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
+                toggleIcon.className =
+                  'codicon codicon-chevron-down toggle-icon';
               }
             }
           }
@@ -201,7 +204,7 @@ export class ProgressViewMessageHandler {
 
   handleAddTaskGroup(message) {
     if (message.stream === state.activeStream) {
-      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      const logContent = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
       dom.taskGroups.add(message.group);
       logContent.scrollTop = logContent.scrollHeight;
     }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -4,6 +4,7 @@ import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { insertChronologically } from './utils.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Manages task group DOM operations.
@@ -21,7 +22,7 @@ export class TaskGroupManager {
   add(group) {
     // Check if this specific group (by ID) already exists in the DOM
     // This prevents duplicate groups from race conditions between UPDATE_LOGS and ADD_TASK_GROUP
-    const existingGroup = document.getElementById(`group-${group.id}`);
+    const existingGroup = safeGetElementById(`group-${group.id}`);
     if (existingGroup) {
       // Verify the group also exists in memory state
       if (!progressViewState.taskGroups.get(group.id)) {
@@ -71,11 +72,11 @@ export class TaskGroupManager {
     });
 
     // Insert the group at the right position in the parent
-    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const container = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
 
     if (group.parentGroupId) {
       // Find the parent group and append to its content container
-      const parentGroupContent = document.getElementById(
+      const parentGroupContent = safeGetElementById(
         `group-content-${group.parentGroupId}`,
       );
       if (parentGroupContent) {
@@ -110,7 +111,7 @@ export class TaskGroupManager {
     }
 
     // Update the header in the UI if it exists
-    const header = document.getElementById(`group-header-${groupId}`);
+    const header = safeGetElementById(`group-header-${groupId}`);
     if (header) {
       const level = this.headerFormatter._getGroupLevel(group);
       header.className = this.headerFormatter._getHeaderClass(group, level);
@@ -163,7 +164,7 @@ export class TaskGroupManager {
     }
 
     // Collapse this group
-    const detailsElem = document.getElementById(`group-${groupId}`);
+    const detailsElem = safeGetElementById(`group-${groupId}`);
     if (detailsElem) {
       detailsElem.open = false;
       progressViewState.toggleStates.set(groupId, true);
@@ -185,7 +186,7 @@ export class TaskGroupManager {
     let latestTime = 0;
 
     for (const [id, group] of progressViewState.taskGroups.getAll()) {
-      const detailsElem = document.getElementById(`group-${id}`);
+      const detailsElem = safeGetElementById(`group-${id}`);
       if (detailsElem && detailsElem.open && group.startTime > latestTime) {
         latestGroup = id;
         latestTime = group.startTime;
@@ -253,7 +254,7 @@ export class LogEntryManager {
   append(logMessage) {
     // If the message has a group ID, append it to the right group
     if (logMessage.groupId) {
-      const groupContent = document.getElementById(
+      const groupContent = safeGetElementById(
         `group-content-${logMessage.groupId}`,
       );
       if (groupContent) {

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -7,7 +7,10 @@ import { COMMANDS, SPLIT_SIZES, ELEMENT_IDS } from '../constants.js';
 
 // Local imports
 import { progressViewState } from '../progressViewState.js';
-import { addEventListenerSafely } from '@common/domUtils.js';
+import {
+  addEventListenerSafely,
+  safeGetElementById,
+} from '@common/domUtils.js';
 import { vscode } from '@common/webviewContext.js';
 import {
   CHEVRON_RIGHT_CLASS,
@@ -25,7 +28,7 @@ export class EventsManager {
     const taskGroups = progressViewState.taskGroups.getAll();
     for (const [groupId, _] of taskGroups) {
       const isCollapsed = progressViewState.toggleStates.get(groupId);
-      const detailsElem = document.getElementById(`group-${groupId}`);
+      const detailsElem = safeGetElementById(`group-${groupId}`);
 
       if (detailsElem && isCollapsed !== undefined) {
         detailsElem.open = !isCollapsed;
@@ -105,7 +108,7 @@ export class EventsManager {
 
     // Follow-up input handler
     const sendFollowUp = () => {
-      const followInput = document.getElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
+      const followInput = safeGetElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
       if (!followInput) return;
       const text = followInput.value.trim();
       if (!text) return;

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -5,6 +5,7 @@ import { formatTokens } from '../formatters.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Manages file list rendering.
@@ -39,16 +40,13 @@ export class FileList {
    * @param {Object} filesByRound - Files organized by round
    */
   update(filesByRound) {
-    const container = document.getElementById(ELEMENT_IDS.GENERATED_FILES);
+    const container = safeGetElementById(ELEMENT_IDS.GENERATED_FILES);
     if (!container) return;
 
     container.innerHTML = '';
 
-    const template = document.getElementById(ELEMENT_IDS.FILE_ITEM_TEMPLATE);
-    if (!template) {
-      console.error('File item template not found');
-      return;
-    }
+    const template = safeGetElementById(ELEMENT_IDS.FILE_ITEM_TEMPLATE);
+    if (!template) return;
 
     if (!filesByRound || Object.keys(filesByRound).length === 0) {
       container.textContent = 'No generated files';

--- a/src/progressView/modules/uiManagers/Placeholder.js
+++ b/src/progressView/modules/uiManagers/Placeholder.js
@@ -1,5 +1,6 @@
 // Local imports - progress view
 import { ELEMENT_IDS } from '../constants.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Manages the empty state placeholder in the log view.
@@ -14,7 +15,7 @@ export class Placeholder {
    * Show the placeholder inside the log content container.
    */
   show() {
-    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const container = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
     if (!container) return;
 
     if (!this._element) {

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -2,6 +2,7 @@
 import { STATUS, TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
 // Local imports
 import { progressViewState } from '../progressViewState.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Manages status display and button states.
@@ -54,16 +55,11 @@ export class Status {
    * @param {string} status - The status to set
    */
   update(status) {
-    const statusIndicator = document.getElementById(
-      ELEMENT_IDS.STATUS_INDICATOR,
-    );
-    if (!statusIndicator) {
-      console.error('Status.update: statusIndicator element not found');
-      return;
-    }
+    const statusIndicator = safeGetElementById(ELEMENT_IDS.STATUS_INDICATOR);
+    if (!statusIndicator) return;
 
     const buttons = (this._buttonElements ||= this.BUTTON_IDS.map((id) =>
-      document.getElementById(id),
+      safeGetElementById(id),
     ).filter(Boolean));
 
     buttons.forEach((b) => {
@@ -71,7 +67,7 @@ export class Status {
     });
 
     // Always enable the erase button regardless of status
-    const eraseBtn = document.getElementById(ELEMENT_IDS.ERASE_STREAM_BTN);
+    const eraseBtn = safeGetElementById(ELEMENT_IDS.ERASE_STREAM_BTN);
     if (eraseBtn) eraseBtn.disabled = false;
 
     statusIndicator.className = 'status-indicator';
@@ -95,7 +91,7 @@ export class Status {
       statusIndicator.dataset.status = cfg.label;
 
       cfg.enable.forEach((id) => {
-        const el = document.getElementById(id);
+        const el = safeGetElementById(id);
         if (el) el.disabled = false;
       });
 

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -3,6 +3,7 @@
 import { ELEMENT_IDS } from '../constants.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { createFromTemplate } from '@common/templateUtils.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 const AGENT_ICONS = {
   CoT: 'terminal',
@@ -25,11 +26,8 @@ export class StreamTabs {
       console.error('StreamTabs.update: streams must be an array');
       return;
     }
-    const tabsContainer = document.getElementById(ELEMENT_IDS.STREAM_TABS);
-    if (!tabsContainer) {
-      console.error('StreamTabs.update: streamTabs container not found');
-      return;
-    }
+    const tabsContainer = safeGetElementById(ELEMENT_IDS.STREAM_TABS);
+    if (!tabsContainer) return;
     tabsContainer.innerHTML = '';
     streams.forEach((info) => {
       if (!info || typeof info !== 'object') {
@@ -82,9 +80,7 @@ export class StreamTabs {
     });
 
     // Update active stream name
-    const streamNameElem = document.getElementById(
-      ELEMENT_IDS.ACTIVE_STREAM_NAME,
-    );
+    const streamNameElem = safeGetElementById(ELEMENT_IDS.ACTIVE_STREAM_NAME);
     if (streamNameElem) {
       streamNameElem.textContent = activeStream || '';
     }

--- a/src/progressView/modules/uiManagers/Toolbar.js
+++ b/src/progressView/modules/uiManagers/Toolbar.js
@@ -2,17 +2,15 @@
 // Local imports
 import { TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
 import { createIconButton } from '@common/templateUtils.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Manages toolbar rendering.
  */
 export class Toolbar {
   render() {
-    const container = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
-    if (!container) {
-      console.error('Toolbar.render: toolbarContainer not found');
-      return;
-    }
+    const container = safeGetElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
+    if (!container) return;
     container.innerHTML = '';
     TOOLBAR_BUTTONS.forEach((def) => {
       try {

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -4,6 +4,7 @@ import { formatTokens, TaskGroupLevel } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { createFromTemplate } from '@common/templateUtils.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Manages usage summary display.
@@ -21,7 +22,7 @@ export class UsageSummary {
   update(usage) {
     // Cache the summary element
     if (!this._summaryElem) {
-      this._summaryElem = document.getElementById(ELEMENT_IDS.RUN_SUMMARY);
+      this._summaryElem = safeGetElementById(ELEMENT_IDS.RUN_SUMMARY);
     }
     if (!this._summaryElem) return;
     // If usage is not provided, compute it from existing log groups
@@ -68,13 +69,8 @@ export class UsageGroup {
       return;
     }
 
-    const groupHeader = document.getElementById(`group-header-${groupId}`);
-    if (!groupHeader) {
-      console.warn(
-        `UsageGroup.update: Group header not found for ID: ${groupId}`,
-      );
-      return;
-    }
+    const groupHeader = safeGetElementById(`group-header-${groupId}`);
+    if (!groupHeader) return;
 
     // Find or create usage display element in the group header
     let usageElem = groupHeader.querySelector('.group-usage');

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -15,6 +15,7 @@ import { ToggleManager } from './uiManagers/ToggleManager.js';
 import { BaseUIManager } from './uiManagers/BaseUIManager.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 export const instructionManager = new InstructionManager(
   'instruction',
@@ -37,8 +38,8 @@ export class MainViewDomHandler extends BaseUIManager {
   }
 
   _updateDebugButtonVisibility() {
-    const packBtn = document.getElementById(ELEMENT_IDS.PACK_BUTTON);
-    const cleanBtn = document.getElementById(ELEMENT_IDS.CLEAN_BUTTON);
+    const packBtn = safeGetElementById(ELEMENT_IDS.PACK_BUTTON);
+    const cleanBtn = safeGetElementById(ELEMENT_IDS.CLEAN_BUTTON);
     [packBtn, cleanBtn].forEach((btn) => {
       if (btn) {
         btn.style.display = this.debugMode ? '' : 'none';
@@ -82,7 +83,7 @@ export class MainViewDomHandler extends BaseUIManager {
 
     this.addListener(ELEMENT_IDS.API_KEY_BANNER_BUTTON, 'click', () => {
       // Get provider from banner element to determine which setup to open
-      const banner = document.getElementById(ELEMENT_IDS.API_KEY_BANNER);
+      const banner = safeGetElementById(ELEMENT_IDS.API_KEY_BANNER);
       const provider = banner?.dataset?.provider;
 
       if (provider) {
@@ -101,7 +102,7 @@ export class MainViewDomHandler extends BaseUIManager {
 
     this.addListener(ELEMENT_IDS.API_KEY_GUIDE_BUTTON, 'click', () => {
       // Get provider from banner element to determine which action to take
-      const banner = document.getElementById(ELEMENT_IDS.API_KEY_BANNER);
+      const banner = safeGetElementById(ELEMENT_IDS.API_KEY_BANNER);
       const provider = banner?.dataset?.provider;
 
       if (provider) {
@@ -125,7 +126,7 @@ export class MainViewDomHandler extends BaseUIManager {
     });
 
     this.addListener(ELEMENT_IDS.AGENT_CONFIG_DIR_BUTTON, 'click', () => {
-      const banner = document.getElementById(ELEMENT_IDS.AGENT_CONFIG_BANNER);
+      const banner = safeGetElementById(ELEMENT_IDS.AGENT_CONFIG_BANNER);
       const customDirSet = banner?.dataset?.customDirSet === 'true';
       vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY,

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -156,7 +156,7 @@ export class MainViewMessageHandler {
         };
 
         // Don't cache if element doesn't exist yet
-        const select = document.getElementById('model');
+        const select = safeGetElementById('model');
         if (!select) {
           // Prevent concurrent retry attempts
           if (this._modelOptionsRetryInProgress) {
@@ -171,7 +171,7 @@ export class MainViewMessageHandler {
           const retryDelay = [100, 200, 400, 800, 1600];
 
           const tryApplyOptions = () => {
-            const retrySelect = document.getElementById('model');
+            const retrySelect = safeGetElementById('model');
             if (retrySelect) {
               applyOptions(retrySelect);
               this._modelOptionsRetryInProgress = false;
@@ -198,11 +198,8 @@ export class MainViewMessageHandler {
           console.warn('SET_AGENT_OPTIONS: No options provided');
           return;
         }
-        const select = document.getElementById('agent');
-        if (!select) {
-          console.warn('SET_AGENT_OPTIONS: Agent select element not found');
-          return;
-        }
+        const select = safeGetElementById('agent');
+        if (!select) return;
         const previous = select.value;
         select.innerHTML = m.options;
         if (previous) {

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -24,11 +24,8 @@ export class FileSelect {
   }
 
   update(id, files) {
-    const selectDiv = document.getElementById(id);
-    if (!selectDiv) {
-      console.warn(`[FileSelect] Element with id '${id}' not found`);
-      return;
-    }
+    const selectDiv = safeGetElementById(id);
+    if (!selectDiv) return;
     selectDiv.innerHTML = '';
     this.addOption(selectDiv, '', 'None');
     files.forEach((f) => this.addOption(selectDiv, f, f));
@@ -60,7 +57,7 @@ export class FileSelect {
   setElementsDisabled(elements, disabled) {
     elements.forEach((el) => {
       if (typeof el === 'string') {
-        const elem = document.getElementById(el);
+        const elem = safeGetElementById(el);
         if (elem) elem.disabled = disabled;
       } else {
         el.disabled = disabled;
@@ -74,7 +71,8 @@ export class FileSelect {
       ELEMENT_IDS.CLEAN_LATEXDIFF_VC_BUTTON,
       ELEMENT_IDS.LATEXDIFF_VC_BUTTON,
     ];
-    const commitDiv = document.getElementById(ELEMENT_IDS.COMMIT_SELECT);
+    const commitDiv = safeGetElementById(ELEMENT_IDS.COMMIT_SELECT);
+    if (!commitDiv) return;
     commitDiv.innerHTML = '';
 
     if (message.isGitRepo === false) {
@@ -92,11 +90,8 @@ export class FileSelect {
 
   handleSetCurrentFile({ fileType, filePath }) {
     const fileId = `${uncapitalize(fileType)}File`;
-    const fileDiv = document.getElementById(fileId);
-    if (!fileDiv) {
-      console.warn(`Element with id '${fileId}' not found`);
-      return;
-    }
+    const fileDiv = safeGetElementById(fileId);
+    if (!fileDiv) return;
 
     const options = Array.from(fileDiv.options);
     if (options.some((o) => o.value === filePath)) {


### PR DESCRIPTION
## Summary
- replace document.getElementById usages with safeGetElementById and related helpers
- drop redundant element existence warnings and checks
- standardize DOM access across webview modules

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a4ddeebc83248b6b5854e506f579