### PR TITLE
refactor: centralize webview theme handlers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,6 +83,7 @@ export default tseslint.config(
       'src/webview/modules/**/*.js',
       'src/common/*.js',
       'src/common/modules/*.js',
+      'src/common/webview/*.js',
       'src/historyView/script.js',
       'src/progressView/script.js',
       'src/webview/script.js',

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -150,6 +150,10 @@ export abstract class BaseViewContentProvider {
         'modules/webviewContext.js',
       ),
       commandsUri: this.getCommonUri(webview, 'webview/commands.js'),
+      webviewThemeHandlersUri: this.getCommonUri(
+        webview,
+        'webview/themeHandlers.js',
+      ),
       templateUtilsUri: this.getCommonUri(webview, 'modules/templateUtils.js'),
       iconButtonInitializerUri: this.getCommonUri(
         webview,

--- a/src/common/webview/themeHandlers.js
+++ b/src/common/webview/themeHandlers.js
@@ -1,0 +1,34 @@
+// Local imports - webview
+// (none)
+
+/**
+ * Create handlers for theme and debug mode updates.
+ * @param {Object} params
+ * @param {Object} params.commands Command constants providing THEME_SET and DEBUG_MODE_SET.
+ * @param {Function} [params.postHandle] Callback after handling a message.
+ * @param {(theme: string) => void} [params.onThemeChange] Optional theme change callback.
+ * @param {(debugMode: boolean) => void} [params.onDebugModeChange] Optional debug mode callback.
+ * @returns {Object} Message handlers keyed by command.
+ */
+export function createThemeHandlers({
+  commands,
+  postHandle,
+  onThemeChange,
+  onDebugModeChange,
+} = {}) {
+  return {
+    [commands.THEME_SET]: (message) => {
+      if (!message || typeof message.theme !== 'string') {
+        console.warn('Invalid theme message:', message);
+        return;
+      }
+      document.body.className = message.theme;
+      if (onThemeChange) onThemeChange(message.theme);
+      if (postHandle) postHandle();
+    },
+    [commands.DEBUG_MODE_SET]: (message) => {
+      if (onDebugModeChange) onDebugModeChange(message.debugMode);
+      if (postHandle) postHandle();
+    },
+  };
+}

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -47,6 +47,7 @@
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/webview/commands.js": "${commandsUri}",
+          "@common/webview/themeHandlers.js": "${webviewThemeHandlersUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",

--- a/src/progressView/modules/handlers/themeHandlers.js
+++ b/src/progressView/modules/handlers/themeHandlers.js
@@ -1,6 +1,6 @@
 // Local imports - progress view
-// Handler for theme-related messages in the progress view
 import { COMMON_COMMANDS } from '@common/webview/commands.js';
+import { createThemeHandlers as createCommonThemeHandlers } from '@common/webview/themeHandlers.js';
 
 /**
  * Create handlers for theme and debug mode updates.
@@ -11,21 +11,14 @@ export function createThemeHandlers({ postHandle } = {}) {
   const link = document.getElementById('hljs-theme');
   const updateHighlightTheme = (theme) => {
     if (!link) return;
-    link.href = `https://cdn.jsdelivr.net/npm/highlight.js@11.11.1/styles/${theme === 'dark' ? 'github-dark' : 'github'}.css`;
+    link.href = `https://cdn.jsdelivr.net/npm/highlight.js@11.11.1/styles/${
+      theme === 'dark' ? 'github-dark' : 'github'
+    }.css`;
   };
 
-  return {
-    [COMMON_COMMANDS.THEME_SET]: (message) => {
-      if (!message || typeof message.theme !== 'string') {
-        console.warn('Invalid theme message:', message);
-        return;
-      }
-      document.body.className = message.theme;
-      updateHighlightTheme(message.theme);
-      if (postHandle) postHandle();
-    },
-    [COMMON_COMMANDS.DEBUG_MODE_SET]: (message) => {
-      if (postHandle) postHandle();
-    },
-  };
+  return createCommonThemeHandlers({
+    commands: COMMON_COMMANDS,
+    postHandle,
+    onThemeChange: updateHighlightTheme,
+  });
 }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -35,6 +35,7 @@
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webview/commands.js": "${commandsUri}",
+          "@common/webview/themeHandlers.js": "${webviewThemeHandlersUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",

--- a/src/webview/modules/handlers/themeHandlers.js
+++ b/src/webview/modules/handlers/themeHandlers.js
@@ -3,6 +3,7 @@ import { mainViewDomHandler } from '../domHandlers.js';
 // Local imports - DOM utilities
 import { safeSetElementValue } from '@common/domUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { createThemeHandlers as createCommonThemeHandlers } from '@common/webview/themeHandlers.js';
 
 /**
  * Create handlers related to theme and model configuration.
@@ -10,19 +11,15 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
  * @param {Function} ctx.postHandle Function to call after handling a message.
  */
 export function createThemeHandlers({ postHandle }) {
+  const baseHandlers = createCommonThemeHandlers({
+    commands: MAIN_VIEW_COMMANDS,
+    postHandle,
+    onDebugModeChange: (debugMode) =>
+      mainViewDomHandler.setDebugMode(debugMode),
+  });
+
   return {
-    [MAIN_VIEW_COMMANDS.THEME_SET]: (message) => {
-      if (!message || typeof message.theme !== 'string') {
-        console.warn('Invalid theme message:', message);
-        return;
-      }
-      document.body.className = message.theme;
-      postHandle();
-    },
-    [MAIN_VIEW_COMMANDS.DEBUG_MODE_SET]: (message) => {
-      mainViewDomHandler.setDebugMode(message.debugMode);
-      postHandle();
-    },
+    ...baseHandlers,
     [MAIN_VIEW_COMMANDS.MODEL_SELECTED]: (message) => {
       safeSetElementValue('model', message.model);
       postHandle();


### PR DESCRIPTION
## Summary
- share theme/debug message handling via new common webview helper
- wrap progress and main view handlers around shared implementation
- expose common theme handler in import maps and content provider

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ac6dbcb883249face1261327e2ac