### PR TITLE
feat: add shared relative time formatter

### DIFF
--- a/src/common/modules/stringUtils.js
+++ b/src/common/modules/stringUtils.js
@@ -5,3 +5,23 @@ export function capitalize(str) {
 export function uncapitalize(str) {
   return str.charAt(0).toLowerCase() + str.slice(1);
 }
+
+/**
+ * Formats a timestamp as a relative time string (e.g., "2 mins ago").
+ * @param {number} timestamp - Unix epoch time in milliseconds
+ * @returns {string} Human-readable relative time
+ */
+export function formatRelativeTime(timestamp) {
+  if (!timestamp) return '';
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes === 1) return '1 min ago';
+  if (minutes < 60) return `${minutes} mins ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return '1 hr ago';
+  if (hours < 24) return `${hours} hrs ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -3,6 +3,7 @@
 import { ELEMENT_IDS } from '../constants.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { createFromTemplate } from '@common/templateUtils.js';
+import { formatRelativeTime } from '@common/stringUtils.js';
 
 const AGENT_ICONS = {
   CoT: 'terminal',
@@ -40,7 +41,7 @@ export class StreamTabs {
         text: {
           '.tab-title': info.label || info.name,
           '.model': info.model || '',
-          '.last-active': this.formatRelativeTime(info.lastTimestamp),
+          '.last-active': formatRelativeTime(info.lastTimestamp),
         },
         attributes: {
           '.tab': { title: info.name },
@@ -88,20 +89,5 @@ export class StreamTabs {
     if (streamNameElem) {
       streamNameElem.textContent = activeStream || '';
     }
-  }
-
-  formatRelativeTime(timestamp) {
-    if (!timestamp) return '';
-    const diff = Date.now() - timestamp;
-    const minutes = Math.floor(diff / 60000);
-    if (minutes < 1) return 'just now';
-    if (minutes === 1) return '1 min ago';
-    if (minutes < 60) return `${minutes} mins ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours === 1) return '1 hr ago';
-    if (hours < 24) return `${hours} hrs ago`;
-    const days = Math.floor(hours / 24);
-    if (days === 1) return '1 day ago';
-    return `${days} days ago`;
   }
 }

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -16,3 +16,22 @@ export function objectToLogString(obj: any, maxLength: number = 1000): string {
     return String(obj);
   }
 }
+
+/**
+ * Formats a timestamp as a relative time string (e.g., "2 mins ago").
+ * @param timestamp Unix epoch time in milliseconds
+ */
+export function formatRelativeTime(timestamp?: number): string {
+  if (!timestamp) return '';
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes === 1) return '1 min ago';
+  if (minutes < 60) return `${minutes} mins ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return '1 hr ago';
+  if (hours < 24) return `${hours} hrs ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}


### PR DESCRIPTION
## Summary
- Add formatRelativeTime helper to common string utils
- Use shared helper in StreamTabs UI
- Expose relative time formatting for other modules

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ac48b7dc8324b4b35c6fce66a463