### PR TITLE
refactor: centralize element disabling helper

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -56,6 +56,20 @@ export function safeGetElementChecked(id) {
   return element.checked;
 }
 
+export function setElementsDisabled(idsOrElements, disabled) {
+  const elements = Array.isArray(idsOrElements)
+    ? idsOrElements
+    : [idsOrElements];
+  elements.forEach((el) => {
+    if (typeof el === 'string') {
+      const elem = document.getElementById(el);
+      if (elem) elem.disabled = disabled;
+    } else if (el) {
+      el.disabled = disabled;
+    }
+  });
+}
+
 /**
  * Set a chevron icon to indicate expanded/collapsed state.
  * @param {HTMLElement} element - The icon container or <i> element.

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -2,6 +2,7 @@
 import { STATUS, TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
 // Local imports
 import { progressViewState } from '../progressViewState.js';
+import { setElementsDisabled } from '@common/domUtils.js';
 
 /**
  * Manages status display and button states.
@@ -66,13 +67,9 @@ export class Status {
       document.getElementById(id),
     ).filter(Boolean));
 
-    buttons.forEach((b) => {
-      if (b) b.disabled = true;
-    });
-
+    setElementsDisabled(buttons, true);
     // Always enable the erase button regardless of status
-    const eraseBtn = document.getElementById(ELEMENT_IDS.ERASE_STREAM_BTN);
-    if (eraseBtn) eraseBtn.disabled = false;
+    setElementsDisabled(ELEMENT_IDS.ERASE_STREAM_BTN, false);
 
     statusIndicator.className = 'status-indicator';
     statusIndicator.dataset.status = 'Ready';
@@ -94,10 +91,7 @@ export class Status {
       statusIndicator.classList.add(cfg.className);
       statusIndicator.dataset.status = cfg.label;
 
-      cfg.enable.forEach((id) => {
-        const el = document.getElementById(id);
-        if (el) el.disabled = false;
-      });
+      setElementsDisabled(cfg.enable, false);
 
       const activeStream = progressViewState.activeStream;
       if (activeStream && status !== STATUS.READY) {

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,6 +1,10 @@
 // Local imports - webview
 import { ELEMENT_IDS, EDITED_FILE } from '../constants.js';
-import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
+import {
+  safeGetElementById,
+  safeSetElementValue,
+  setElementsDisabled,
+} from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -57,17 +61,6 @@ export class FileSelect {
     if (option) select.appendChild(option);
   }
 
-  setElementsDisabled(elements, disabled) {
-    elements.forEach((el) => {
-      if (typeof el === 'string') {
-        const elem = document.getElementById(el);
-        if (elem) elem.disabled = disabled;
-      } else {
-        el.disabled = disabled;
-      }
-    });
-  }
-
   handleRecentCommits(message) {
     const commitButtons = [
       ELEMENT_IDS.PACK_LATEXDIFF_VC_BUTTON,
@@ -79,14 +72,14 @@ export class FileSelect {
 
     if (message.isGitRepo === false) {
       this.addOption(commitDiv, '', 'Not a Git repository');
-      this.setElementsDisabled([commitDiv, ...commitButtons], true);
+      setElementsDisabled([commitDiv, ...commitButtons], true);
     } else {
       this.addOption(commitDiv, 'HEAD', 'HEAD');
       message.commits.forEach((commit) => {
         const [commitHash] = commit.split(': ');
         this.addOption(commitDiv, commitHash, commit);
       });
-      this.setElementsDisabled([commitDiv, ...commitButtons], false);
+      setElementsDisabled([commitDiv, ...commitButtons], false);
     }
   }
 


### PR DESCRIPTION
## Summary
- share setElementsDisabled helper in domUtils
- use shared helper in FileSelect and Status managers
- replace ad-hoc button toggling with common function

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1abe8a49c832482e88baf8805f470