### PR TITLE
refactor: centralize base UI manager

### DIFF
--- a/src/common/modules/BaseUIManager.js
+++ b/src/common/modules/BaseUIManager.js
@@ -1,4 +1,4 @@
-// Local imports - webview
+// Local imports
 import { safeGetElementById } from '@common/domUtils.js';
 
 export class BaseUIManager {
@@ -11,15 +11,16 @@ export class BaseUIManager {
    * @param {HTMLElement|string} elementOrId - element or its ID
    * @param {string} event - event type
    * @param {EventListenerOrEventListenerObject} handler - handler function
+   * @param {boolean|AddEventListenerOptions} [options] - optional listener options
    */
-  addListener(elementOrId, event, handler) {
+  addListener(elementOrId, event, handler, options) {
     const element =
       typeof elementOrId === 'string'
         ? safeGetElementById(elementOrId)
         : elementOrId;
     if (element) {
-      element.addEventListener(event, handler);
-      this._listeners.push({ element, event, handler });
+      element.addEventListener(event, handler, options);
+      this._listeners.push({ element, event, handler, options });
     }
   }
 
@@ -27,8 +28,8 @@ export class BaseUIManager {
    * Remove all registered event listeners.
    */
   cleanup() {
-    this._listeners.forEach(({ element, event, handler }) => {
-      element.removeEventListener(event, handler);
+    this._listeners.forEach(({ element, event, handler, options }) => {
+      element.removeEventListener(event, handler, options);
     });
     this._listeners = [];
   }

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -158,6 +158,7 @@ export abstract class BaseViewContentProvider {
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
+      baseUIManagerUri: this.getCommonUri(webview, 'modules/BaseUIManager.js'),
       codiconUri: this.getNodeModulesUri(
         webview,
         '@vscode/codicons/dist/codicon.css',

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -30,7 +30,8 @@
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
-          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}"
+          "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/BaseUIManager.js": "${baseUIManagerUri}"
         }
       }
     </script>

--- a/src/historyView/modules/uiManagers/HistoryEventsManager.js
+++ b/src/historyView/modules/uiManagers/HistoryEventsManager.js
@@ -1,14 +1,15 @@
 // Local imports - history view
 import { ELEMENT_IDS } from '../constants.js';
-import { addEventListenerSafely } from '@common/domUtils.js';
+// Local imports - common
+import { BaseUIManager } from '@common/BaseUIManager.js';
 
 /**
  * Registers global event listeners for the history view.
  */
-export class HistoryEventsManager {
+export class HistoryEventsManager extends BaseUIManager {
   constructor(searchManager) {
+    super();
     this.searchManager = searchManager;
-    this.handlers = [];
   }
 
   _debounce(fn, delay) {
@@ -20,39 +21,17 @@ export class HistoryEventsManager {
   }
 
   setupEventListeners() {
-    const searchInput = document.getElementById(ELEMENT_IDS.SEARCH_INPUT);
     const searchHandler = this._debounce((e) => {
       const term = e.target.value.trim();
       this.searchManager.search(term);
     }, 300);
-    addEventListenerSafely(ELEMENT_IDS.SEARCH_INPUT, 'input', searchHandler);
-    if (searchInput) {
-      this.handlers.push({
-        element: searchInput,
-        type: 'input',
-        handler: searchHandler,
-      });
-    }
+    this.addListener(ELEMENT_IDS.SEARCH_INPUT, 'input', searchHandler);
 
     const prevHandler = () => this.searchManager.navigatePrev();
-    addEventListenerSafely(ELEMENT_IDS.PREV_MATCH, 'click', prevHandler);
-    const prevEl = document.getElementById(ELEMENT_IDS.PREV_MATCH);
-    if (prevEl)
-      this.handlers.push({
-        element: prevEl,
-        type: 'click',
-        handler: prevHandler,
-      });
+    this.addListener(ELEMENT_IDS.PREV_MATCH, 'click', prevHandler);
 
     const nextHandler = () => this.searchManager.navigateNext();
-    addEventListenerSafely(ELEMENT_IDS.NEXT_MATCH, 'click', nextHandler);
-    const nextEl = document.getElementById(ELEMENT_IDS.NEXT_MATCH);
-    if (nextEl)
-      this.handlers.push({
-        element: nextEl,
-        type: 'click',
-        handler: nextHandler,
-      });
+    this.addListener(ELEMENT_IDS.NEXT_MATCH, 'click', nextHandler);
 
     const keyHandler = (e) => {
       if (e.key === 'Enter') {
@@ -64,20 +43,10 @@ export class HistoryEventsManager {
         }
       }
     };
-    addEventListenerSafely(ELEMENT_IDS.SEARCH_INPUT, 'keydown', keyHandler);
-    if (searchInput) {
-      this.handlers.push({
-        element: searchInput,
-        type: 'keydown',
-        handler: keyHandler,
-      });
-    }
+    this.addListener(ELEMENT_IDS.SEARCH_INPUT, 'keydown', keyHandler);
   }
 
   dispose() {
-    this.handlers.forEach(({ element, type, handler }) => {
-      element.removeEventListener(type, handler);
-    });
-    this.handlers = [];
+    this.cleanup();
   }
 }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -53,6 +53,7 @@
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
+          "@common/BaseUIManager.js": "${baseUIManagerUri}",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",
           "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0"

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -1,13 +1,11 @@
 // Third-party imports
-// Third-party imports
 import Split from 'split.js';
 
 // Local imports - progress view
 import { COMMANDS, SPLIT_SIZES, ELEMENT_IDS } from '../constants.js';
-
-// Local imports
 import { progressViewState } from '../progressViewState.js';
-import { addEventListenerSafely } from '@common/domUtils.js';
+// Local imports - common
+import { BaseUIManager } from '@common/BaseUIManager.js';
 import { vscode } from '@common/webviewContext.js';
 import {
   CHEVRON_RIGHT_CLASS,
@@ -17,7 +15,11 @@ import {
 /**
  * Manages event handling and state application.
  */
-export class EventsManager {
+export class EventsManager extends BaseUIManager {
+  constructor() {
+    super();
+  }
+
   /**
    * Apply saved toggle states to any groups already in the DOM
    */
@@ -38,7 +40,7 @@ export class EventsManager {
    */
   setupEventListeners() {
     // Stream tab click handler
-    addEventListenerSafely(ELEMENT_IDS.STREAM_TABS, 'click', (e) => {
+    this.addListener(ELEMENT_IDS.STREAM_TABS, 'click', (e) => {
       const tabButton = e.target.closest('.tab');
       const deleteButton = e.target.closest('.tab-delete');
 
@@ -56,7 +58,7 @@ export class EventsManager {
     });
 
     // Toolbar click handler
-    addEventListenerSafely(ELEMENT_IDS.TOOLBAR_CONTAINER, 'click', (e) => {
+    this.addListener(ELEMENT_IDS.TOOLBAR_CONTAINER, 'click', (e) => {
       const button = e.target.closest('button[data-command]');
       if (!button || button.disabled) return;
 
@@ -72,7 +74,7 @@ export class EventsManager {
     // This appears to be orphaned code from a previous design
 
     // File list button handler
-    addEventListenerSafely(
+    this.addListener(
       ELEMENT_IDS.GENERATED_FILES,
       'click',
       (e) => {
@@ -89,11 +91,11 @@ export class EventsManager {
     );
 
     // Delete all button handler
-    addEventListenerSafely(ELEMENT_IDS.DELETE_ALL_BTN, 'click', () => {
+    this.addListener(ELEMENT_IDS.DELETE_ALL_BTN, 'click', () => {
       vscode.postMessage({ command: COMMANDS.DELETE_ALL });
     });
 
-    addEventListenerSafely('sortButtons', 'click', (e) => {
+    this.addListener('sortButtons', 'click', (e) => {
       const btn = e.target.closest('.sort-btn');
       if (btn && btn.dataset.sort) {
         vscode.postMessage({
@@ -116,12 +118,8 @@ export class EventsManager {
       });
       followInput.value = '';
     };
-    addEventListenerSafely(
-      ELEMENT_IDS.SEND_FOLLOW_UP_BTN,
-      'click',
-      sendFollowUp,
-    );
-    addEventListenerSafely(ELEMENT_IDS.FOLLOW_UP_INPUT, 'keydown', (e) => {
+    this.addListener(ELEMENT_IDS.SEND_FOLLOW_UP_BTN, 'click', sendFollowUp);
+    this.addListener(ELEMENT_IDS.FOLLOW_UP_INPUT, 'keydown', (e) => {
       // Enter sends, Shift+Enter adds new line
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
@@ -138,7 +136,8 @@ export class EventsManager {
     });
 
     // Handle special-details and file-list-details toggle events
-    document.addEventListener(
+    this.addListener(
+      document,
       'toggle',
       (e) => {
         if (
@@ -161,7 +160,7 @@ export class EventsManager {
     );
 
     // Handle clicks on file links inside file-list-details blocks
-    document.addEventListener('click', (e) => {
+    this.addListener(document, 'click', (e) => {
       const link = e.target.closest('.file-link');
       if (link && link.dataset.file) {
         vscode.postMessage({
@@ -172,7 +171,7 @@ export class EventsManager {
     });
 
     // Handle clicks on LaTeX references within logs
-    document.addEventListener('click', (e) => {
+    this.addListener(document, 'click', (e) => {
       const ref = e.target.closest('.latex-ref');
       if (ref && ref.dataset.label) {
         vscode.postMessage({

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -14,6 +14,7 @@ progressViewState.initialize();
 messageHandler.setup();
 
 window.addEventListener('beforeunload', () => {
+  progressViewDomHandler.events.cleanup();
   messageHandler.cleanup();
 });
 

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -33,7 +33,6 @@ export class MainViewContentProvider extends BaseViewContentProvider {
     { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
     { key: 'fileSelectUri', path: 'modules/uiManagers/FileSelect.js' },
     { key: 'toggleManagerUri', path: 'modules/uiManagers/ToggleManager.js' },
-    { key: 'baseUIManagerUri', path: 'modules/uiManagers/BaseUIManager.js' },
     {
       key: 'fileInputManagerUri',
       path: 'modules/uiManagers/FileInputManager.js',

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -17,7 +17,6 @@
           "./modules/uiManagers/FileList.js": "${fileListUri}",
           "./modules/uiManagers/FileSelect.js": "${fileSelectUri}",
           "./modules/uiManagers/ToggleManager.js": "${toggleManagerUri}",
-          "./modules/uiManagers/BaseUIManager.js": "${baseUIManagerUri}",
           "./modules/uiManagers/FileInputManager.js": "${fileInputManagerUri}",
           "./modules/uiManagers/ActionButtonManager.js": "${actionButtonManagerUri}",
           "./modules/uiManagers/SettingsButtonManager.js": "${settingsButtonManagerUri}",
@@ -40,6 +39,7 @@
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
+          "@common/BaseUIManager.js": "${baseUIManagerUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",
           "nanoid": "https://cdn.skypack.dev/nanoid"
         }

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -12,7 +12,8 @@ import { outputFilesManager } from './uiManagers/OutputFilesManager.js';
 import { RecordingManager } from './uiManagers/RecordingManager.js';
 import { SettingsButtonManager } from './uiManagers/SettingsButtonManager.js';
 import { ToggleManager } from './uiManagers/ToggleManager.js';
-import { BaseUIManager } from './uiManagers/BaseUIManager.js';
+// Local imports - common
+import { BaseUIManager } from '@common/BaseUIManager.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -6,7 +6,8 @@ import {
   BASE_FILE,
   EDITED_FILE,
 } from '../constants.js';
-import { BaseUIManager } from './BaseUIManager.js';
+// Local imports - common
+import { BaseUIManager } from '@common/BaseUIManager.js';
 import {
   safeGetElementById,
   safeGetElementValue,

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -14,10 +14,11 @@ import {
   BASE_FILE,
 } from '../constants.js';
 import { mainViewState } from '../mainViewState.js';
-import { BaseUIManager } from './BaseUIManager.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
+// Local imports - common
+import { BaseUIManager } from '@common/BaseUIManager.js';
 import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -7,8 +7,9 @@ import {
 import { ELEMENT_IDS } from '../constants.js';
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
-import { BaseUIManager } from './BaseUIManager.js';
 import { webviewEventBus } from '../eventBus.js';
+// Local imports - common
+import { BaseUIManager } from '@common/BaseUIManager.js';
 import { safeGetElementById } from '@common/domUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -112,7 +113,7 @@ export class SettingsButtonManager extends BaseUIManager {
         const textSpan = element.querySelector('span');
         if (textSpan) {
           // Format the display of missing tools more nicely
-          const formattedTools = missing.map(tool => {
+          const formattedTools = missing.map((tool) => {
             if (tool === 'gm/magick') {
               return 'GraphicsMagick or ImageMagick';
             }


### PR DESCRIPTION
## Summary
- move BaseUIManager into common modules with option support
- streamline EventsManager and HistoryEventsManager to extend base for listener cleanup
- update webview import maps to reference shared base manager

## Testing
- `npm run format`
- `npm run lint`
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1a3d43fd88324a8de315367142ecb