### PR TITLE
refactor: centralize common webview handlers

### DIFF
--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -25,13 +25,27 @@ export abstract class BaseViewMessageHandler<
     this.logger = logger;
     this.channel = `${viewName}MessageHandler`;
     logger.initialize(this.channel);
-    this.handlers = this.createHandlers();
+    this.handlers = {
+      ...this.getBaseHandlers(),
+      ...this.createHandlers(),
+    };
   }
 
   /**
    * Subclasses must implement this to provide their specific handlers
    */
   protected abstract createHandlers(): Record<string, MessageHandler<T>>;
+
+  /**
+   * Base handlers shared across all webviews
+   */
+  protected getBaseHandlers(): Record<string, MessageHandler<T>> {
+    return {
+      [COMMON_COMMANDS.THEME_SET]: (m, w) => this.handleTheme(m, w),
+      [COMMON_COMMANDS.DEBUG_MODE_SET]: (m, w) => this.handleDebugMode(m, w),
+      [COMMON_COMMANDS.WEBVIEW_READY]: (m, w) => this.handleWebviewReady(m, w),
+    };
+  }
 
   /**
    * Standard message handling with consistent error handling and logging

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -21,12 +21,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     MessageHandler<vscode.WebviewView>
   > {
     return {
-      // Common handlers
-      [PROGRESS_VIEW_COMMANDS.THEME_SET]: this.handleTheme.bind(this),
-      [PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET]: this.handleDebugMode.bind(this),
-      [PROGRESS_VIEW_COMMANDS.WEBVIEW_READY]:
-        this.handleWebviewReady.bind(this),
-
       // Stream management
       [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]:
         this.handleSwitchStream.bind(this),

--- a/src/test/common/modules/pathUtils.test.js
+++ b/src/test/common/modules/pathUtils.test.js
@@ -1,4 +1,10 @@
+/* eslint-env mocha */
+
+// Third-party imports
 import * as assert from 'assert';
+import { suite, test } from 'mocha';
+
+// Local imports
 import { getBasename } from '../../../common/modules/pathUtils.js';
 
 suite('pathUtils.js Test Suite', () => {
@@ -12,12 +18,21 @@ suite('pathUtils.js Test Suite', () => {
     test('should extract basename from Windows paths', () => {
       assert.strictEqual(getBasename('C:\\Users\\file.txt'), 'file.txt');
       assert.strictEqual(getBasename('C:\\Program Files\\app.exe'), 'app.exe');
-      assert.strictEqual(getBasename('D:\\Documents\\report.docx'), 'report.docx');
+      assert.strictEqual(
+        getBasename('D:\\Documents\\report.docx'),
+        'report.docx',
+      );
     });
 
     test('should handle mixed path separators', () => {
-      assert.strictEqual(getBasename('C:/Users\\Documents/file.txt'), 'file.txt');
-      assert.strictEqual(getBasename('/home\\user/document.pdf'), 'document.pdf');
+      assert.strictEqual(
+        getBasename('C:/Users\\Documents/file.txt'),
+        'file.txt',
+      );
+      assert.strictEqual(
+        getBasename('/home\\user/document.pdf'),
+        'document.pdf',
+      );
     });
 
     test('should handle paths with trailing slashes', () => {
@@ -37,14 +52,26 @@ suite('pathUtils.js Test Suite', () => {
 
     test('should handle files with multiple dots', () => {
       assert.strictEqual(getBasename('/path/to/file.tar.gz'), 'file.tar.gz');
-      assert.strictEqual(getBasename('archive.backup.zip'), 'archive.backup.zip');
+      assert.strictEqual(
+        getBasename('archive.backup.zip'),
+        'archive.backup.zip',
+      );
       assert.strictEqual(getBasename('/home/user/.bashrc'), '.bashrc');
     });
 
     test('should handle special characters in filenames', () => {
-      assert.strictEqual(getBasename('/path/to/file with spaces.txt'), 'file with spaces.txt');
-      assert.strictEqual(getBasename('/path/to/file-with-dashes.txt'), 'file-with-dashes.txt');
-      assert.strictEqual(getBasename('/path/to/file_with_underscores.txt'), 'file_with_underscores.txt');
+      assert.strictEqual(
+        getBasename('/path/to/file with spaces.txt'),
+        'file with spaces.txt',
+      );
+      assert.strictEqual(
+        getBasename('/path/to/file-with-dashes.txt'),
+        'file-with-dashes.txt',
+      );
+      assert.strictEqual(
+        getBasename('/path/to/file_with_underscores.txt'),
+        'file_with_underscores.txt',
+      );
     });
 
     test('should handle relative paths', () => {

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -54,9 +54,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.handleInfoMessage.bind(this),
       [MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION]: async (m) =>
         showInstructionWithSuppress(m.key, m.text),
-      [MAIN_VIEW_COMMANDS.GET_THEME]: this.handleThemeRequest.bind(this),
-      [MAIN_VIEW_COMMANDS.GET_DEBUG_MODE]:
-        this.handleDebugModeRequest.bind(this),
+      [MAIN_VIEW_COMMANDS.GET_THEME]: this.handleGetTheme.bind(this),
+      [MAIN_VIEW_COMMANDS.GET_DEBUG_MODE]: this.handleGetDebugMode.bind(this),
       [MAIN_VIEW_COMMANDS.MODEL_SELECTED]: this.handleModelSelection.bind(this),
       [MAIN_VIEW_COMMANDS.EXECUTE]: async (m) =>
         this.executionManager.handleExecute(m),
@@ -281,8 +280,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     this.logger.debug(`Information message: ${message.text}`);
   }
 
-  private async handleThemeRequest(
-    message: any,
+  private async handleGetTheme(
+    _message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const theme =
@@ -295,8 +294,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
-  private async handleDebugModeRequest(
-    message: any,
+  private async handleGetDebugMode(
+    _message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const debugMode = getConfig<boolean>('logger.debugMode', false);

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -49,11 +49,6 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     MessageHandler<vscode.WebviewView>
   > {
     return {
-      // Common handlers
-      [MAIN_VIEW_COMMANDS.THEME_SET]: this.handleTheme.bind(this),
-      [MAIN_VIEW_COMMANDS.DEBUG_MODE_SET]: this.handleDebugMode.bind(this),
-      [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: this.handleWebviewReady.bind(this),
-
       // Core functionality
       [MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]:
         this.handleInfoMessage.bind(this),


### PR DESCRIPTION
## Summary
- centralize common webview handlers with new `getBaseHandlers`
- drop redundant theme/debug/ready handlers from main and progress views
- declare mocha globals in pathUtils test to satisfy lint

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d5936df08324842717f53280fe51