### PR TITLE
refactor: centralize webview module URIs

### DIFF
--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -18,6 +18,7 @@ export interface ModuleDescriptor {
 export abstract class BaseViewContentProvider {
   protected readonly logger: any;
   protected readonly channel: string;
+  protected moduleDescriptors: ModuleDescriptor[] = [];
 
   constructor(
     protected readonly context: vscode.ExtensionContext,
@@ -32,13 +33,6 @@ export abstract class BaseViewContentProvider {
    * Subclasses must provide the relative path to their view directory
    */
   protected abstract getViewPath(): string;
-
-  /**
-   * Subclasses must provide their specific module URIs
-   */
-  protected abstract getModuleUris(
-    webview: vscode.Webview,
-  ): Record<string, vscode.Uri>;
 
   /**
    * Optional: Override to provide additional template variables
@@ -103,6 +97,14 @@ export abstract class BaseViewContentProvider {
     webview: vscode.Webview,
   ): Record<string, vscode.Uri> {
     return this.buildUriRecord(webview, this.sharedModuleDescriptors);
+  }
+
+  /**
+   * View-specific module URIs built from {@link moduleDescriptors}.
+   * Subclasses may override for custom behavior.
+   */
+  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
+    return this.buildUriRecord(webview, this.moduleDescriptors);
   }
 
   /**

--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -16,7 +16,7 @@ export class HistoryViewContentProvider extends BaseViewContentProvider {
     return 'historyView';
   }
 
-  private readonly moduleDescriptors: ModuleDescriptor[] = [
+  protected override moduleDescriptors: ModuleDescriptor[] = [
     { key: 'eventsUri', path: 'modules/uiManagers/HistoryEventsManager.js' },
     {
       key: 'historyRendererUri',
@@ -25,8 +25,4 @@ export class HistoryViewContentProvider extends BaseViewContentProvider {
     { key: 'historyViewStateUri', path: 'modules/historyViewState.js' },
     { key: 'searchManagerUri', path: 'modules/uiManagers/SearchManager.js' },
   ];
-
-  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return this.buildUriRecord(webview, this.moduleDescriptors);
-  }
 }

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -16,7 +16,7 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
     return 'progressView';
   }
 
-  private readonly moduleDescriptors: ModuleDescriptor[] = [
+  protected override moduleDescriptors: ModuleDescriptor[] = [
     { key: 'progressViewStateUri', path: 'modules/progressViewState.js' },
     { key: 'formattersUri', path: 'modules/formatters.js' },
     { key: 'taskManagersUri', path: 'modules/taskManagers.js' },
@@ -34,9 +34,11 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
     { key: 'placeholderUri', path: 'modules/uiManagers/Placeholder.js' },
   ];
 
-  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
+  protected override getModuleUris(
+    webview: vscode.Webview,
+  ): Record<string, vscode.Uri> {
     return {
-      ...this.buildUriRecord(webview, this.moduleDescriptors),
+      ...super.getModuleUris(webview),
       splitJsUri: this.getNodeModulesUri(webview, 'split.js/dist/split.es.js'),
     };
   }

--- a/src/test/common/modules/pathUtils.test.js
+++ b/src/test/common/modules/pathUtils.test.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+/* eslint-disable no-undef */
 import * as assert from 'assert';
 import { getBasename } from '../../../common/modules/pathUtils.js';
 
@@ -12,12 +14,21 @@ suite('pathUtils.js Test Suite', () => {
     test('should extract basename from Windows paths', () => {
       assert.strictEqual(getBasename('C:\\Users\\file.txt'), 'file.txt');
       assert.strictEqual(getBasename('C:\\Program Files\\app.exe'), 'app.exe');
-      assert.strictEqual(getBasename('D:\\Documents\\report.docx'), 'report.docx');
+      assert.strictEqual(
+        getBasename('D:\\Documents\\report.docx'),
+        'report.docx',
+      );
     });
 
     test('should handle mixed path separators', () => {
-      assert.strictEqual(getBasename('C:/Users\\Documents/file.txt'), 'file.txt');
-      assert.strictEqual(getBasename('/home\\user/document.pdf'), 'document.pdf');
+      assert.strictEqual(
+        getBasename('C:/Users\\Documents/file.txt'),
+        'file.txt',
+      );
+      assert.strictEqual(
+        getBasename('/home\\user/document.pdf'),
+        'document.pdf',
+      );
     });
 
     test('should handle paths with trailing slashes', () => {
@@ -37,14 +48,26 @@ suite('pathUtils.js Test Suite', () => {
 
     test('should handle files with multiple dots', () => {
       assert.strictEqual(getBasename('/path/to/file.tar.gz'), 'file.tar.gz');
-      assert.strictEqual(getBasename('archive.backup.zip'), 'archive.backup.zip');
+      assert.strictEqual(
+        getBasename('archive.backup.zip'),
+        'archive.backup.zip',
+      );
       assert.strictEqual(getBasename('/home/user/.bashrc'), '.bashrc');
     });
 
     test('should handle special characters in filenames', () => {
-      assert.strictEqual(getBasename('/path/to/file with spaces.txt'), 'file with spaces.txt');
-      assert.strictEqual(getBasename('/path/to/file-with-dashes.txt'), 'file-with-dashes.txt');
-      assert.strictEqual(getBasename('/path/to/file_with_underscores.txt'), 'file_with_underscores.txt');
+      assert.strictEqual(
+        getBasename('/path/to/file with spaces.txt'),
+        'file with spaces.txt',
+      );
+      assert.strictEqual(
+        getBasename('/path/to/file-with-dashes.txt'),
+        'file-with-dashes.txt',
+      );
+      assert.strictEqual(
+        getBasename('/path/to/file_with_underscores.txt'),
+        'file_with_underscores.txt',
+      );
     });
 
     test('should handle relative paths', () => {

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -21,7 +21,7 @@ export class MainViewContentProvider extends BaseViewContentProvider {
     return 'webview';
   }
 
-  private readonly moduleDescriptors: ModuleDescriptor[] = [
+  protected override moduleDescriptors: ModuleDescriptor[] = [
     { key: 'webviewStateModuleUri', path: 'modules/mainViewState.js' },
     { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
     { key: 'fileMessageHandlersUri', path: 'modules/handlers/fileHandlers.js' },
@@ -63,10 +63,6 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       path: 'modules/uiManagers/LatexdiffManager.js',
     },
   ];
-
-  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return this.buildUriRecord(webview, this.moduleDescriptors);
-  }
 
   protected getTemplateVariables(): Record<string, any> {
     // Note: This uses synchronous approach for template generation


### PR DESCRIPTION
## Summary
- add default module URI handling to BaseViewContentProvider
- rely on module descriptors in main and history views
- extend ProgressViewContentProvider from base URI handling

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d59953fc8324901c2e30419c6247