### PR TITLE
refactor: centralize file dialogs

### DIFF
--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -5,11 +5,11 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { showInfoMessage, showErrorMessage } from '@frontend/ui/messageUtils';
+import { showInfoMessage } from '@frontend/ui/messageUtils';
 import { WorkspaceFS } from '@utils/files';
 import { fileLister } from '@frontend/files/fileLister';
 import { getIncludedExtensions } from '@common/files/fileTypeUtils';
-import { selectFile, selectFiles } from '@frontend/files/dialog';
+import { selectFile, selectFiles } from '@utils/dialogs';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 const CHANNEL = 'fileSelectionCommands';
 logger.initialize(CHANNEL);

--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
+import { selectFile } from '@utils/dialogs';
 import {
   countPdfPages,
   getBase64EncodedMedia,
@@ -36,22 +36,13 @@ export function registerImageCommands(context: vscode.ExtensionContext) {
 
 async function handleCountPdfPages(): Promise<void> {
   try {
-    // Open file picker dialog
-    const fileUris = await vscode.window.showOpenDialog({
-      canSelectFiles: true,
-      canSelectFolders: false,
-      canSelectMany: false,
-      filters: {
-        'PDF files': ['pdf'],
-      },
-      title: 'Select PDF file to count pages',
+    const selectedFile = await selectFile({
+      openLabel: 'Select PDF file',
+      filters: { 'PDF files': ['pdf'] },
     });
-
-    if (!fileUris || fileUris.length === 0) {
+    if (!selectedFile) {
       return;
     }
-
-    const selectedFile = WorkspaceFS.relativePath(fileUris[0].fsPath);
     logger.debug(CHANNEL, `Processing PDF file: ${selectedFile}`);
 
     const pageCount = await countPdfPages(selectedFile);
@@ -71,23 +62,18 @@ async function handleCountPdfPages(): Promise<void> {
 
 async function handleEncodeImageToBase64(): Promise<string | undefined> {
   try {
-    // Open file picker dialog
-    const fileUris = await vscode.window.showOpenDialog({
-      canSelectFiles: true,
-      canSelectFolders: false,
-      canSelectMany: false,
+    const selectedFile = await selectFile({
+      openLabel: 'Select Media File',
       filters: {
         'Image files': ['png', 'jpg', 'jpeg', 'gif', 'heic', 'heif', 'webp'],
         'Audio files': ['wav', 'm4a', 'mp3', 'aiff', 'aac', 'ogg', 'flac'],
       },
-      title: 'Select image or audio file to encode',
     });
 
-    if (!fileUris || fileUris.length === 0) {
+    if (!selectedFile) {
       return undefined;
     }
 
-    const selectedFile = WorkspaceFS.relativePath(fileUris[0].fsPath);
     logger.debug(CHANNEL, `Processing image file: ${selectedFile}`);
 
     const base64String = await getBase64EncodedMedia(selectedFile);
@@ -114,22 +100,13 @@ async function handleConvertPdfToImages(): Promise<
   string[] | string | undefined
 > {
   try {
-    // Open file picker dialog
-    const fileUris = await vscode.window.showOpenDialog({
-      canSelectFiles: true,
-      canSelectFolders: false,
-      canSelectMany: false,
-      filters: {
-        'PDF files': ['pdf'],
-      },
-      title: 'Select PDF file to convert to images',
+    const selectedFile = await selectFile({
+      openLabel: 'Select PDF file',
+      filters: { 'PDF files': ['pdf'] },
     });
-
-    if (!fileUris || fileUris.length === 0) {
+    if (!selectedFile) {
       return undefined;
     }
-
-    const selectedFile = WorkspaceFS.relativePath(fileUris[0].fsPath);
     logger.debug(CHANNEL, `Processing PDF file: ${selectedFile}`);
 
     // Get quality from user
@@ -187,22 +164,13 @@ async function handleConvertPdfToImages(): Promise<
 
 async function handleTestPdfToImage(): Promise<string | undefined> {
   try {
-    // Open file picker dialog
-    const fileUris = await vscode.window.showOpenDialog({
-      canSelectFiles: true,
-      canSelectFolders: false,
-      canSelectMany: false,
-      filters: {
-        'PDF files': ['pdf'],
-      },
-      title: 'Select PDF file to test conversion',
+    const selectedFile = await selectFile({
+      openLabel: 'Select PDF file',
+      filters: { 'PDF files': ['pdf'] },
     });
-
-    if (!fileUris || fileUris.length === 0) {
+    if (!selectedFile) {
       return undefined;
     }
-
-    const selectedFile = WorkspaceFS.relativePath(fileUris[0].fsPath);
     logger.debug(CHANNEL, `Testing PDF to PNG conversion for: ${selectedFile}`);
 
     // Get page number from user

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,6 +1,5 @@
 export * from './files/fileLister';
 export * from './files/listing';
-export * from './files/dialog';
 export * from './files/vars';
 export * from './files/rules';
 export * from './latex/openBuild';

--- a/src/test/common/modules/pathUtils.test.js
+++ b/src/test/common/modules/pathUtils.test.js
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import { suite, test } from 'mocha';
 import { getBasename } from '../../../common/modules/pathUtils.js';
 
 suite('pathUtils.js Test Suite', () => {
@@ -12,12 +13,21 @@ suite('pathUtils.js Test Suite', () => {
     test('should extract basename from Windows paths', () => {
       assert.strictEqual(getBasename('C:\\Users\\file.txt'), 'file.txt');
       assert.strictEqual(getBasename('C:\\Program Files\\app.exe'), 'app.exe');
-      assert.strictEqual(getBasename('D:\\Documents\\report.docx'), 'report.docx');
+      assert.strictEqual(
+        getBasename('D:\\Documents\\report.docx'),
+        'report.docx',
+      );
     });
 
     test('should handle mixed path separators', () => {
-      assert.strictEqual(getBasename('C:/Users\\Documents/file.txt'), 'file.txt');
-      assert.strictEqual(getBasename('/home\\user/document.pdf'), 'document.pdf');
+      assert.strictEqual(
+        getBasename('C:/Users\\Documents/file.txt'),
+        'file.txt',
+      );
+      assert.strictEqual(
+        getBasename('/home\\user/document.pdf'),
+        'document.pdf',
+      );
     });
 
     test('should handle paths with trailing slashes', () => {
@@ -37,14 +47,26 @@ suite('pathUtils.js Test Suite', () => {
 
     test('should handle files with multiple dots', () => {
       assert.strictEqual(getBasename('/path/to/file.tar.gz'), 'file.tar.gz');
-      assert.strictEqual(getBasename('archive.backup.zip'), 'archive.backup.zip');
+      assert.strictEqual(
+        getBasename('archive.backup.zip'),
+        'archive.backup.zip',
+      );
       assert.strictEqual(getBasename('/home/user/.bashrc'), '.bashrc');
     });
 
     test('should handle special characters in filenames', () => {
-      assert.strictEqual(getBasename('/path/to/file with spaces.txt'), 'file with spaces.txt');
-      assert.strictEqual(getBasename('/path/to/file-with-dashes.txt'), 'file-with-dashes.txt');
-      assert.strictEqual(getBasename('/path/to/file_with_underscores.txt'), 'file_with_underscores.txt');
+      assert.strictEqual(
+        getBasename('/path/to/file with spaces.txt'),
+        'file with spaces.txt',
+      );
+      assert.strictEqual(
+        getBasename('/path/to/file-with-dashes.txt'),
+        'file-with-dashes.txt',
+      );
+      assert.strictEqual(
+        getBasename('/path/to/file_with_underscores.txt'),
+        'file_with_underscores.txt',
+      );
     });
 
     test('should handle relative paths', () => {

--- a/src/utils/dialogs/fileDialog.ts
+++ b/src/utils/dialogs/fileDialog.ts
@@ -6,7 +6,6 @@ import * as vscode from 'vscode';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
-import { showErrorMessage } from '../ui/messageUtils';
 
 export interface FileDialogOptions {
   /** Whether multiple files can be selected */
@@ -43,7 +42,7 @@ export async function selectFiles(
       ? getDefaultUri(options.currentFile)
       : getDefaultUri(''));
   if (!defaultUri) {
-    showErrorMessage('No workspace folder open');
+    vscode.window.showErrorMessage('No workspace folder open');
     return null;
   }
 

--- a/src/utils/dialogs/index.ts
+++ b/src/utils/dialogs/index.ts
@@ -1,0 +1,1 @@
+export * from './fileDialog';


### PR DESCRIPTION
## Summary
- move file selection helpers to `src/utils/dialogs` for backend use
- streamline LaTeX image commands to use shared `selectFile` helper
- fix mocha test imports to satisfy lint

## Testing
- `npm run format`
- `npm run lint`
- `CI=1 npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d57d35388324a721469ebc8145ef