### PR TITLE
refactor: centralize OpenAI client creation

### DIFF
--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -20,14 +20,6 @@ import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
  * Handler for DashScope Qwen models using OpenAI-compatible API.
  */
 export class ModelHandlerDashScope extends ModelHandlerOpenAI {
-  /** Returns OpenAI client configured with DashScope's base URL. */
-  async getClient(): Promise<OpenAI> {
-    const apiKey = await this.getApiKey();
-    const baseURL = this.getBaseUrl();
-    this.logger.debug(`Using DashScope API key. Base URL: ${baseURL}`);
-    return new OpenAI({ apiKey, baseURL });
-  }
-
   /**
    * Process thinking blocks for DashScope models
    * @param responseObject The raw response object from the model

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -51,14 +51,6 @@ import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
  * Handler for DeepSeek models using OpenAI-compatible API.
  */
 export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
-  /** Returns OpenAI client configured with DeepSeek's base URL. */
-  async getClient(): Promise<OpenAI> {
-    const apiKey = await this.getApiKey();
-    const baseURL = this.getBaseUrl();
-    this.logger.debug(`Using DeepSeek API key. Base URL: ${baseURL}`);
-    return new OpenAI({ apiKey, baseURL });
-  }
-
   /**
    * Process thinking blocks for DeepSeek models
    * @param responseObject The raw response object from the model

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -21,14 +21,6 @@ import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
  */
 export class ModelHandlerKimi extends ModelHandlerOpenAI {
-  /** Returns OpenAI client configured with Moonshot's base URL. */
-  async getClient(): Promise<OpenAI> {
-    const apiKey = await this.getApiKey();
-    const baseURL = this.getBaseUrl();
-    this.logger.debug(`Using Moonshot API key. Base URL: ${baseURL}`);
-    return new OpenAI({ apiKey, baseURL });
-  }
-
   /**
    * Get the base URL for the Moonshot API.
    * The Moonshot API has a different base URL than OpenAI.

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -49,14 +49,24 @@ export class ModelHandlerOpenAI extends ModelHandler<
   ExtendedCompletionUsage | null,
   OpenAIAPIResponseUsage
 > {
-  /** Returns OpenAI client with configured API key. */
-  async getClient(): Promise<OpenAI> {
+  /**
+   * Creates a new OpenAI client using the stored credentials.
+   * Handles API key retrieval, base URL resolution, and logging.
+   * @param providerName Optional name used for logging purposes
+   */
+  protected async createOpenAIClient(
+    providerName: string = this.config.provider,
+  ): Promise<OpenAI> {
     const apiKey = await this.getApiKey();
     const baseURL = this.getBaseUrl();
-    this.logger.debug('Using OpenAI API.');
-
-    // there is a time out parameter that be be set; default is 10 minutes
+    this.logger.debug(`Using ${providerName} API key. Base URL: ${baseURL}`);
+    // there is a time out parameter that can be set; default is 10 minutes
     return new OpenAI({ apiKey, baseURL });
+  }
+
+  /** Returns OpenAI client with configured API key. */
+  async getClient(): Promise<OpenAI> {
+    return this.createOpenAIClient();
   }
 
   /** Creates a chat completion with model-specific parameters. */

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -17,17 +17,6 @@ import { K_SLICE } from '@utils/config';
  * Handler for models accessed through OpenRouter.
  */
 export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
-  /** Returns OpenAI client configured with OpenRouter settings. */
-  async getClient(): Promise<OpenAI> {
-    const apiKey = await this.getApiKey();
-    const baseURL = this.getBaseUrl();
-    this.logger.debug(`Using OpenRouter API key. Base URL: ${baseURL}`);
-    return new OpenAI({
-      apiKey,
-      baseURL,
-    });
-  }
-
   /** Creates a response using OpenRouter's API with model-specific configuration. */
   async createResponse(
     client: OpenAI,
@@ -149,19 +138,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
  * Handler for Anthropic models using OpenAI-compatible API via OpenRouter.
  */
 export class ModelHandlerAnthropicViaOpenRouter extends ModelHandlerOpenRouter {
-  /** Returns OpenAI client configured with OpenRouter settings for Anthropic models. */
-  async getClient(): Promise<OpenAI> {
-    const apiKey = await this.getApiKey();
-    const baseURL = this.getBaseUrl();
-    this.logger.debug(
-      `Using OpenRouter API key for Anthropic model. Base URL: ${baseURL}`,
-    );
-    return new OpenAI({
-      apiKey,
-      baseURL,
-    });
-  }
-
   updateMessageContentWithPrefill(
     messages: any[],
     bestConnector: string,
@@ -207,17 +183,4 @@ export class ModelHandlerAnthropicViaOpenRouter extends ModelHandlerOpenRouter {
   }
 }
 
-export class ModelHandlerDeepSeekViaOpenRouter extends ModelHandlerOpenRouter {
-  /** Returns OpenAI client configured with OpenRouter settings for DeepSeek models. */
-  async getClient(): Promise<OpenAI> {
-    const apiKey = await this.getApiKey();
-    const baseURL = this.getBaseUrl();
-    this.logger.debug(
-      `Using OpenRouter API key for DeepSeek model. Base URL: ${baseURL}`,
-    );
-    return new OpenAI({
-      apiKey,
-      baseURL,
-    });
-  }
-}
+export class ModelHandlerDeepSeekViaOpenRouter extends ModelHandlerOpenRouter {}

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -2,7 +2,6 @@
 // (none needed)
 
 // Third-party imports
-import OpenAI from 'openai';
 
 // Local imports - agent
 import { ToolState } from '../core/ToolState';
@@ -16,14 +15,6 @@ import { K_SLICE } from '@utils/config';
  * Handler for xAI models using OpenAI-compatible API.
  */
 export class ModelHandlerXAI extends ModelHandlerOpenAI {
-  /** Returns OpenAI client configured with xAI's base URL. */
-  async getClient(): Promise<OpenAI> {
-    const apiKey = await this.getApiKey();
-    const baseURL = this.getBaseUrl();
-    this.logger.debug(`Using xAI API key. Base URL: ${baseURL}`);
-    return new OpenAI({ apiKey, baseURL });
-  }
-
   /**
    * Process thinking blocks for xAI models
    * @param responseObject The raw response object from the model

--- a/src/test/common/modules/pathUtils.test.js
+++ b/src/test/common/modules/pathUtils.test.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+/* global suite, test */
 import * as assert from 'assert';
 import { getBasename } from '../../../common/modules/pathUtils.js';
 
@@ -12,12 +14,21 @@ suite('pathUtils.js Test Suite', () => {
     test('should extract basename from Windows paths', () => {
       assert.strictEqual(getBasename('C:\\Users\\file.txt'), 'file.txt');
       assert.strictEqual(getBasename('C:\\Program Files\\app.exe'), 'app.exe');
-      assert.strictEqual(getBasename('D:\\Documents\\report.docx'), 'report.docx');
+      assert.strictEqual(
+        getBasename('D:\\Documents\\report.docx'),
+        'report.docx',
+      );
     });
 
     test('should handle mixed path separators', () => {
-      assert.strictEqual(getBasename('C:/Users\\Documents/file.txt'), 'file.txt');
-      assert.strictEqual(getBasename('/home\\user/document.pdf'), 'document.pdf');
+      assert.strictEqual(
+        getBasename('C:/Users\\Documents/file.txt'),
+        'file.txt',
+      );
+      assert.strictEqual(
+        getBasename('/home\\user/document.pdf'),
+        'document.pdf',
+      );
     });
 
     test('should handle paths with trailing slashes', () => {
@@ -37,14 +48,26 @@ suite('pathUtils.js Test Suite', () => {
 
     test('should handle files with multiple dots', () => {
       assert.strictEqual(getBasename('/path/to/file.tar.gz'), 'file.tar.gz');
-      assert.strictEqual(getBasename('archive.backup.zip'), 'archive.backup.zip');
+      assert.strictEqual(
+        getBasename('archive.backup.zip'),
+        'archive.backup.zip',
+      );
       assert.strictEqual(getBasename('/home/user/.bashrc'), '.bashrc');
     });
 
     test('should handle special characters in filenames', () => {
-      assert.strictEqual(getBasename('/path/to/file with spaces.txt'), 'file with spaces.txt');
-      assert.strictEqual(getBasename('/path/to/file-with-dashes.txt'), 'file-with-dashes.txt');
-      assert.strictEqual(getBasename('/path/to/file_with_underscores.txt'), 'file_with_underscores.txt');
+      assert.strictEqual(
+        getBasename('/path/to/file with spaces.txt'),
+        'file with spaces.txt',
+      );
+      assert.strictEqual(
+        getBasename('/path/to/file-with-dashes.txt'),
+        'file-with-dashes.txt',
+      );
+      assert.strictEqual(
+        getBasename('/path/to/file_with_underscores.txt'),
+        'file_with_underscores.txt',
+      );
     });
 
     test('should handle relative paths', () => {


### PR DESCRIPTION
## Summary
- add helper `createOpenAIClient` to centralize API key and base URL handling
- streamline OpenAI-compatible handlers (DashScope, Kimi, XAI, DeepSeek, OpenRouter) to use shared client creation
- note: declare mocha globals in `pathUtils.test.js` so lint runs cleanly

## Testing
- `npm run lint`
- `npm test` *(fails: likely requires VS Code environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d61394d083248bb17ae47af50899