### PR TITLE
feat: add tool definition helper

### DIFF
--- a/src/test/webview/BannerManager.test.ts
+++ b/src/test/webview/BannerManager.test.ts
@@ -11,7 +11,11 @@ import { JSDOM } from 'jsdom';
 
 // Mock BannerManager implementation for testing
 class BannerManager {
-  private _listeners: Array<{ element: any; event: string; handler: Function }> = [];
+  private _listeners: Array<{
+    element: any;
+    event: string;
+    handler: (...args: any[]) => unknown;
+  }> = [];
 
   showBanner(id: string, config: any = {}) {
     const element = (global as any).safeGetElementById(id);
@@ -53,19 +57,20 @@ class BannerManager {
     }
 
     if (config.provider) {
-      const providerName = config.provider.charAt(0).toUpperCase() + config.provider.slice(1);
-      
+      const providerName =
+        config.provider.charAt(0).toUpperCase() + config.provider.slice(1);
+
       // Clear existing content and use safe DOM manipulation
       textSpan.textContent = '';
-      
+
       // Create strong element for provider name
       const strongElement = document.createElement('strong');
       strongElement.textContent = providerName;
-      
+
       // Append elements safely
       textSpan.appendChild(strongElement);
       textSpan.appendChild(document.createTextNode(' API key missing.'));
-      
+
       setButton.textContent = 'Set Key';
       getButton.textContent = 'Get Key';
       element.dataset.provider = config.provider;
@@ -88,11 +93,15 @@ class BannerManager {
     }
 
     if (dirButton) {
-      dirButton.textContent = config.customDirSet ? 'Open Directory' : 'Set Directory';
+      dirButton.textContent = config.customDirSet
+        ? 'Open Directory'
+        : 'Set Directory';
     }
 
     if (!textSpan && !dirButton) {
-      console.warn('[BannerManager] Agent config banner missing all expected elements');
+      console.warn(
+        '[BannerManager] Agent config banner missing all expected elements',
+      );
     }
 
     element.dataset.customDirSet = String(config.customDirSet || false);
@@ -113,15 +122,21 @@ class BannerManager {
       return tool;
     });
 
-    textSpan.textContent = missing.length > 0
-      ? `Missing dependencies: ${formattedTools.join(', ')}`
-      : 'Missing dependencies: none';
+    textSpan.textContent =
+      missing.length > 0
+        ? `Missing dependencies: ${formattedTools.join(', ')}`
+        : 'Missing dependencies: none';
   }
 
-  addListener(elementOrId: any, event: string, handler: Function) {
-    const element = typeof elementOrId === 'string'
-      ? (global as any).safeGetElementById(elementOrId)
-      : elementOrId;
+  addListener(
+    elementOrId: any,
+    event: string,
+    handler: (...args: any[]) => unknown,
+  ) {
+    const element =
+      typeof elementOrId === 'string'
+        ? (global as any).safeGetElementById(elementOrId)
+        : elementOrId;
     if (element) {
       element.addEventListener(event, handler);
       this._listeners.push({ element, event, handler });
@@ -158,22 +173,22 @@ describe('BannerManager', () => {
         <span></span>
       </div>
     </body></html>`);
-    
+
     global.document = dom.window.document as any;
     global.HTMLElement = dom.window.HTMLElement;
-    
+
     // Mock safeGetElementById
     (global as any).safeGetElementById = (id: string) => {
       return dom.window.document.getElementById(id);
     };
-    
+
     // Capture console warnings
     warnMessages = [];
     originalConsoleWarn = console.warn;
     console.warn = (message: string) => {
       warnMessages.push(message);
     };
-    
+
     manager = new BannerManager();
   });
 
@@ -217,9 +232,9 @@ describe('BannerManager', () => {
       const textSpan = banner.querySelector('span');
       const setButton = banner.querySelector('#apiKeyBannerButton');
       const getButton = banner.querySelector('#apiKeyGuideButton');
-      
+
       manager.showBanner('apiKeyBanner');
-      
+
       assert.equal(textSpan.textContent, 'TeXRA requires an API key to run.');
       assert.equal(setButton.textContent, 'Set API Key');
       assert.equal(getButton.textContent, 'API Key Guide');
@@ -231,15 +246,15 @@ describe('BannerManager', () => {
       const textSpan = banner.querySelector('span');
       const setButton = banner.querySelector('#apiKeyBannerButton');
       const getButton = banner.querySelector('#apiKeyGuideButton');
-      
+
       manager.showBanner('apiKeyBanner', { provider: 'openai' });
-      
+
       // Check that text is set safely without innerHTML
       assert.equal(textSpan.childNodes.length, 2);
       assert.equal(textSpan.childNodes[0].nodeName, 'STRONG');
       assert.equal(textSpan.childNodes[0].textContent, 'Openai');
       assert.equal(textSpan.childNodes[1].textContent, ' API key missing.');
-      
+
       assert.equal(setButton.textContent, 'Set Key');
       assert.equal(getButton.textContent, 'Get Key');
       assert.equal(banner.dataset.provider, 'openai');
@@ -248,24 +263,27 @@ describe('BannerManager', () => {
     it('should handle XSS attempt in provider name', () => {
       const banner = dom.window.document.getElementById('apiKeyBanner');
       const textSpan = banner.querySelector('span');
-      
-      manager.showBanner('apiKeyBanner', { 
-        provider: '<script>alert("xss")</script>' 
+
+      manager.showBanner('apiKeyBanner', {
+        provider: '<script>alert("xss")</script>',
       });
-      
+
       // Verify that script tag is escaped as text, not executed
       const strongElement = textSpan.querySelector('strong');
       assert.equal(strongElement.textContent, '<script>alert("xss")</script>');
-      assert.equal(strongElement.innerHTML, '&lt;script&gt;alert("xss")&lt;/script&gt;');
+      assert.equal(
+        strongElement.innerHTML,
+        '&lt;script&gt;alert("xss")&lt;/script&gt;',
+      );
     });
 
     it('should warn when API key banner missing elements', () => {
       // Remove required elements
       const banner = dom.window.document.getElementById('apiKeyBanner');
       banner.innerHTML = '<div></div>';
-      
+
       manager.showBanner('apiKeyBanner', { provider: 'test' });
-      
+
       assert.equal(warnMessages.length, 1);
       assert.ok(warnMessages[0].includes('missing required elements'));
     });
@@ -276,9 +294,9 @@ describe('BannerManager', () => {
       const banner = dom.window.document.getElementById('agentConfigBanner');
       const textSpan = banner.querySelector('span');
       const dirButton = banner.querySelector('#agentConfigDirButton');
-      
+
       manager.showBanner('agentConfigBanner');
-      
+
       assert.equal(textSpan.textContent, 'Agent configuration is missing.');
       assert.equal(dirButton.textContent, 'Set Directory');
       assert.equal(banner.dataset.customDirSet, 'false');
@@ -288,13 +306,16 @@ describe('BannerManager', () => {
       const banner = dom.window.document.getElementById('agentConfigBanner');
       const textSpan = banner.querySelector('span');
       const dirButton = banner.querySelector('#agentConfigDirButton');
-      
+
       manager.showBanner('agentConfigBanner', {
         agentName: 'TestAgent',
-        customDirSet: true
+        customDirSet: true,
       });
-      
-      assert.equal(textSpan.textContent, 'Agent file for "TestAgent" is missing.');
+
+      assert.equal(
+        textSpan.textContent,
+        'Agent file for "TestAgent" is missing.',
+      );
       assert.equal(dirButton.textContent, 'Open Directory');
       assert.equal(banner.dataset.customDirSet, 'true');
     });
@@ -302,11 +323,11 @@ describe('BannerManager', () => {
     it('should handle missing text span gracefully', () => {
       const banner = dom.window.document.getElementById('agentConfigBanner');
       banner.innerHTML = '<button id="agentConfigDirButton"></button>';
-      
+
       assert.doesNotThrow(() => {
         manager.showBanner('agentConfigBanner', { agentName: 'Test' });
       });
-      
+
       const dirButton = banner.querySelector('#agentConfigDirButton');
       assert.equal(dirButton.textContent, 'Set Directory');
     });
@@ -314,9 +335,9 @@ describe('BannerManager', () => {
     it('should warn when all elements are missing', () => {
       const banner = dom.window.document.getElementById('agentConfigBanner');
       banner.innerHTML = '';
-      
+
       manager.showBanner('agentConfigBanner');
-      
+
       assert.equal(warnMessages.length, 1);
       assert.ok(warnMessages[0].includes('missing all expected elements'));
     });
@@ -326,43 +347,43 @@ describe('BannerManager', () => {
     it('should display missing dependencies', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       const textSpan = banner.querySelector('span');
-      
+
       manager.showBanner('dependencyBanner', {
-        missingTools: ['latex', 'gm/magick', 'nodejs']
+        missingTools: ['latex', 'gm/magick', 'nodejs'],
       });
-      
+
       assert.equal(
         textSpan.textContent,
-        'Missing dependencies: latex, GraphicsMagick or ImageMagick, nodejs'
+        'Missing dependencies: latex, GraphicsMagick or ImageMagick, nodejs',
       );
     });
 
     it('should handle empty dependencies array', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       const textSpan = banner.querySelector('span');
-      
+
       manager.showBanner('dependencyBanner', { missingTools: [] });
-      
+
       assert.equal(textSpan.textContent, 'Missing dependencies: none');
     });
 
     it('should handle missing config gracefully', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       const textSpan = banner.querySelector('span');
-      
+
       manager.showBanner('dependencyBanner');
-      
+
       assert.equal(textSpan.textContent, 'Missing dependencies: none');
     });
 
     it('should warn when text span is missing', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       banner.innerHTML = '';
-      
+
       manager.showBanner('dependencyBanner', {
-        missingTools: ['test']
+        missingTools: ['test'],
       });
-      
+
       assert.equal(warnMessages.length, 1);
       assert.ok(warnMessages[0].includes('missing text element'));
     });
@@ -370,14 +391,14 @@ describe('BannerManager', () => {
     it('should properly format gm/magick tool name', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       const textSpan = banner.querySelector('span');
-      
+
       manager.showBanner('dependencyBanner', {
-        missingTools: ['gm/magick']
+        missingTools: ['gm/magick'],
       });
-      
+
       assert.equal(
         textSpan.textContent,
-        'Missing dependencies: GraphicsMagick or ImageMagick'
+        'Missing dependencies: GraphicsMagick or ImageMagick',
       );
     });
   });
@@ -387,7 +408,7 @@ describe('BannerManager', () => {
       // Verify cleanup method exists (inherited from BaseUIManager)
       assert.equal(typeof manager.cleanup, 'function');
     });
-    
+
     it('should inherit addListener from BaseUIManager', () => {
       // Verify addListener method exists (inherited from BaseUIManager)
       assert.equal(typeof manager.addListener, 'function');

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -1,16 +1,14 @@
 // Third-party imports
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { defineTool } from './core/define';
 
 // Local imports - tools
-import { BaseTool } from './core/base';
 import { ToolResult, ToolError } from './result';
 import {
   getLinterMessages,
   countDiagnosticsBySeverity,
 } from '@frontend/latex/linter';
 import * as logger from '@logger/logUtils';
-import type { ToolDefinition } from '@model';
 
 const CHANNEL = 'DiagnosticsTool';
 logger.initialize(CHANNEL);
@@ -22,17 +20,12 @@ export const DiagnosticsInputSchema = z.object({
 
 export type DiagnosticsInput = z.infer<typeof DiagnosticsInputSchema>;
 
-export class DiagnosticsTool extends BaseTool<DiagnosticsInput> {
-  constructor() {
-    const definition: ToolDefinition = {
-      name: 'diagnostics',
-      description:
-        'Retrieve linter diagnostics. Use "list" for full messages or "count" for a summary.',
-      parameters: zodToJsonSchema(DiagnosticsInputSchema),
-    };
-    super(definition, DiagnosticsInputSchema);
-  }
-
+export class DiagnosticsTool extends defineTool({
+  name: 'diagnostics',
+  description:
+    'Retrieve linter diagnostics. Use "list" for full messages or "count" for a summary.',
+  schema: DiagnosticsInputSchema,
+}) {
   protected async execute(input: DiagnosticsInput): Promise<ToolResult> {
     const { command, path } = input;
     switch (command) {
@@ -46,7 +39,9 @@ export class DiagnosticsTool extends BaseTool<DiagnosticsInput> {
         return new ToolResult({ output: JSON.stringify(counts) });
       }
       default:
-        throw new ToolError(`Diagnostics tool error: Unrecognized command '${command}'. Expected 'list' or 'count'.`);
+        throw new ToolError(
+          `Diagnostics tool error: Unrecognized command '${command}'. Expected 'list' or 'count'.`,
+        );
     }
   }
 }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -5,18 +5,16 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { defineTool } from './core/define';
 
 // Local imports - tools
 
 // Local imports - core
-import { BaseTool } from './core/base';
 import { ToolResult, CLIResult, ToolError } from './result';
 import { ToolCallInput, EditorCommand, FileHistoryEntry } from './types';
 
 // Local imports - Log
 import * as logger from '@logger/logUtils';
-import type { ToolDefinition } from '@model';
 
 // Local imports - utilities
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
@@ -40,7 +38,11 @@ export type TextEditorInput = z.infer<typeof TextEditorInputSchema>;
 /**
  * Implementation of Anthropic's text editor tool for VS Code
  */
-export class TextEditorTool extends BaseTool<TextEditorInput> {
+export class TextEditorTool extends defineTool({
+  name: 'str_replace_editor',
+  description: 'Edit files using search and replace or insertion operations',
+  schema: TextEditorInputSchema,
+}) {
   // Tool type and name
   private apiType:
     | 'text_editor_20250124'
@@ -65,13 +67,7 @@ export class TextEditorTool extends BaseTool<TextEditorInput> {
       apiType === 'text_editor_20250429'
         ? 'str_replace_based_edit_tool'
         : 'str_replace_editor';
-    const definition: ToolDefinition = {
-      name,
-      description:
-        'Edit files using search and replace or insertion operations',
-      parameters: zodToJsonSchema(TextEditorInputSchema),
-    };
-    super(definition, TextEditorInputSchema);
+    super({ name });
     this.apiType = apiType;
     this.name = name;
   }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -3,11 +3,9 @@
 
 // Local imports - core
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { defineTool } from './core/define';
 
 // Local imports - tools
-import { BaseTool } from './core/base';
-import type { ToolDefinition } from '@model';
 import { ToolResult, ToolError } from '@tools/result';
 import { executeCommand } from '@utils/system/execUtils';
 
@@ -17,21 +15,18 @@ const BashInputSchema = z.object({
 
 export type BashInput = z.infer<typeof BashInputSchema>;
 
-export class BashTool extends BaseTool<BashInput> {
-  constructor() {
-    const definition: ToolDefinition = {
-      name: 'bash',
-      description: 'Execute a shell command within the workspace',
-      parameters: zodToJsonSchema(BashInputSchema),
-    };
-    super(definition, BashInputSchema);
-  }
-
+export class BashTool extends defineTool({
+  name: 'bash',
+  description: 'Execute a shell command within the workspace',
+  schema: BashInputSchema,
+}) {
   protected async execute(input: BashInput): Promise<ToolResult> {
     const result = await executeCommand(input.command, { truncate: true });
     if (result.success) {
       return new ToolResult({ output: result.stdout || '' });
     }
-    throw new ToolError(`Bash command failed: ${result.stderr || 'No error output available'}`);
+    throw new ToolError(
+      `Bash command failed: ${result.stderr || 'No error output available'}`,
+    );
   }
 }

--- a/src/tools/core/define.ts
+++ b/src/tools/core/define.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { ToolDefinition } from '@model';
+import { BaseTool } from './base';
+
+export function defineTool<T>(def: {
+  name: string;
+  description: string;
+  schema: z.ZodSchema<T>;
+}) {
+  const baseDefinition: ToolDefinition = {
+    name: def.name,
+    description: def.description,
+    parameters: zodToJsonSchema(def.schema),
+  };
+
+  abstract class GeneratedTool extends BaseTool<T> {
+    constructor(override?: Partial<ToolDefinition>) {
+      super({ ...baseDefinition, ...override }, def.schema);
+    }
+  }
+
+  return GeneratedTool;
+}

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -3,11 +3,9 @@
 
 // Local imports - core
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { defineTool } from './core/define';
 
 // Local imports - tools
-import { BaseTool } from './core/base';
-import type { ToolDefinition } from '@model';
 import { ToolResult, ToolError } from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
 
@@ -19,16 +17,11 @@ const FileOpInputSchema = z.object({
 
 export type FileOpInput = z.infer<typeof FileOpInputSchema>;
 
-export class FileOpTool extends BaseTool<FileOpInput> {
-  constructor() {
-    const definition: ToolDefinition = {
-      name: 'file_op',
-      description: 'Perform basic file operations',
-      parameters: zodToJsonSchema(FileOpInputSchema),
-    };
-    super(definition, FileOpInputSchema);
-  }
-
+export class FileOpTool extends defineTool({
+  name: 'file_op',
+  description: 'Perform basic file operations',
+  schema: FileOpInputSchema,
+}) {
   protected async execute(input: FileOpInput): Promise<ToolResult> {
     const { command, path, content } = input;
     switch (command) {
@@ -57,7 +50,9 @@ export class FileOpTool extends BaseTool<FileOpInput> {
         return new ToolResult({ output: 'appended' });
       }
       default:
-        throw new ToolError(`File operation error: Unknown command '${command}'. Expected 'read', 'write', or 'append'.`);
+        throw new ToolError(
+          `File operation error: Unknown command '${command}'. Expected 'read', 'write', or 'append'.`,
+        );
     }
   }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ export * from './result';
 export * from './bash';
 export * from './fileOp';
 export * from './core/base';
+export * from './core/define';
 export * from './registry';
 export * from './wolfram';
 export * from './web/WebSearchTool';

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -4,12 +4,10 @@ import axios from 'axios';
 
 // Local imports - core
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { defineTool } from '../core/define';
 
 // Local imports - tools
-import { BaseTool } from '../core/base';
 import { ToolResult, ToolError } from '../result';
-import type { ToolDefinition } from '@model';
 
 const WebSearchInputSchema = z.object({
   query: z.string(),
@@ -18,16 +16,11 @@ const WebSearchInputSchema = z.object({
 
 export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;
 
-export class WebSearchTool extends BaseTool<WebSearchInput> {
-  constructor() {
-    const definition: ToolDefinition = {
-      name: 'web_search',
-      description: 'Search the web and return top results',
-      parameters: zodToJsonSchema(WebSearchInputSchema),
-    };
-    super(definition, WebSearchInputSchema);
-  }
-
+export class WebSearchTool extends defineTool({
+  name: 'web_search',
+  description: 'Search the web and return top results',
+  schema: WebSearchInputSchema,
+}) {
   protected async execute(input: WebSearchInput): Promise<ToolResult> {
     const { query, max_results = 3 } = input;
     let response;

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -3,13 +3,11 @@
 
 // Local imports - core
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { defineTool } from '../core/define';
 
 // Local imports - tools
-import { BaseTool } from '../core/base';
 import { ToolResult, ToolError } from '../result';
 import { executeWolframCode } from './wolframScriptUtils';
-import type { ToolDefinition } from '@model';
 
 const WolframInputSchema = z.object({
   code: z.string(),
@@ -18,16 +16,11 @@ const WolframInputSchema = z.object({
 
 export type WolframInput = z.infer<typeof WolframInputSchema>;
 
-export class WolframTool extends BaseTool<WolframInput> {
-  constructor() {
-    const definition: ToolDefinition = {
-      name: 'wolfram',
-      description: 'Execute Wolfram Language code',
-      parameters: zodToJsonSchema(WolframInputSchema),
-    };
-    super(definition, WolframInputSchema);
-  }
-
+export class WolframTool extends defineTool({
+  name: 'wolfram',
+  description: 'Execute Wolfram Language code',
+  schema: WolframInputSchema,
+}) {
   protected async execute(input: WolframInput): Promise<ToolResult> {
     const result = await executeWolframCode(input.code, {
       timeout: input.timeout,
@@ -36,6 +29,8 @@ export class WolframTool extends BaseTool<WolframInput> {
     if (result.success) {
       return new ToolResult({ output: result.output ?? '' });
     }
-    throw new ToolError(`Wolfram execution failed: ${result.error ?? 'No error details available'}`);
+    throw new ToolError(
+      `Wolfram execution failed: ${result.error ?? 'No error details available'}`,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add defineTool helper to generate ToolDefinition and base class
- refactor existing tools to use defineTool and focus on execute logic
- adjust BannerManager test typing

## Testing
- `npx prettier --write src/tools/core/define.ts src/tools/bash.ts src/tools/fileOp.ts src/tools/DiagnosticsTool.ts src/tools/web/WebSearchTool.ts src/tools/wolfram/WolframTool.ts src/tools/TextEditorTool.ts src/tools/index.ts src/test/webview/BannerManager.test.ts`
- `npm run lint`
- `npm test` *(failed: requires downloading VS Code (153MB); terminated due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e042b3788324985f90e679ec35e4