### PR TITLE
refactor: centralize context window adjustment logic

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -459,6 +459,48 @@ export abstract class ModelHandler<
     return effort;
   }
 
+  /**
+   * Adjusts request options to respect the model's context window.
+   *
+   * Throws an error if the input token count alone exceeds the context window.
+   * When the combined input and output tokens would overflow the context window,
+   * this helper reduces the configured max output tokens and invokes the
+   * optional provider-specific hook.
+   *
+   * @param inputTokens Number of tokens in the prompt.
+   * @param options Mutable options/kwargs object to adjust.
+   * @param maxOutputKey Property name containing the max output tokens.
+   * @param buffer Optional safety buffer to leave unused in the window.
+   * @param hooks Optional callbacks for provider-specific adjustments.
+   */
+  protected adjustForContextWindow(
+    inputTokens: number,
+    options: Record<string, any>,
+    maxOutputKey: string,
+    buffer = 0,
+    hooks?: { onMaxOutputTokensReduced?: (newMax: number) => void },
+  ): void {
+    if (inputTokens > this.config.contextWindow) {
+      const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${this.config.contextWindow}`;
+      this.logger.error(errMsg);
+      throw new Error(errMsg);
+    }
+
+    const maxOutput = options[maxOutputKey];
+    if (
+      typeof maxOutput === 'number' &&
+      this.config.contextWindow - inputTokens < maxOutput
+    ) {
+      const newMax = this.config.contextWindow - inputTokens - buffer;
+      const warnMsg =
+        `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${maxOutput} > ${this.config.contextWindow}. ` +
+        `Reducing ${maxOutputKey} to ${newMax}.`;
+      this.logger.warn(warnMsg);
+      options[maxOutputKey] = newMax;
+      hooks?.onMaxOutputTokensReduced?.(newMax);
+    }
+  }
+
   /** Determine if extension corresponds to an audio format. */
   private isAudio(ext: string): boolean {
     const mimeType = getMimeType(ext);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -169,40 +169,35 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.logger.debug(
         `Token count of message: ${responseTokenCount.input_tokens}`,
       );
-      if (responseTokenCount.input_tokens > this.config.contextWindow) {
-        const errMsg = `Token count of message exceeds context window: ${responseTokenCount.input_tokens} > ${this.config.contextWindow}`;
-        this.logger.error(errMsg);
-        throw new Error(errMsg);
-      }
-      if (
-        this.config.contextWindow - responseTokenCount.input_tokens <
-        options.max_tokens
-      ) {
-        const warnMsg = `Token count of message plus max tokens exceeds context window: ${responseTokenCount.input_tokens} + ${options.max_tokens} > ${this.config.contextWindow}. Reducing max tokens to ${this.config.contextWindow - responseTokenCount.input_tokens}.`;
-        this.logger.warn(warnMsg);
-        options.max_tokens =
-          this.config.contextWindow - responseTokenCount.input_tokens - 10;
-
-        if (
-          this.capabilities.supportsReasoning &&
-          options.thinking &&
-          options.thinking.type === 'enabled'
-        ) {
-          const adjustedBudget = Math.max(
-            1,
-            Math.min(
-              options.thinking.budget_tokens,
-              Math.floor(options.max_tokens * 0.5),
-            ),
-          );
-          if (adjustedBudget !== options.thinking.budget_tokens) {
-            this.logger.debug(
-              `Adjusted thinking budget to ${adjustedBudget} due to reduced max_tokens`,
-            );
-            options.thinking.budget_tokens = adjustedBudget;
-          }
-        }
-      }
+      this.adjustForContextWindow(
+        responseTokenCount.input_tokens,
+        options,
+        'max_tokens',
+        10,
+        {
+          onMaxOutputTokensReduced: (newMax) => {
+            if (
+              this.capabilities.supportsReasoning &&
+              options.thinking &&
+              options.thinking.type === 'enabled'
+            ) {
+              const adjustedBudget = Math.max(
+                1,
+                Math.min(
+                  options.thinking.budget_tokens,
+                  Math.floor(newMax * 0.5),
+                ),
+              );
+              if (adjustedBudget !== options.thinking.budget_tokens) {
+                this.logger.debug(
+                  `Adjusted thinking budget to ${adjustedBudget} due to reduced max_tokens`,
+                );
+                options.thinking.budget_tokens = adjustedBudget;
+              }
+            }
+          },
+        },
+      );
       // in the future we log this in firstInputTokens of the AgentStateGlobal
     }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -119,27 +119,15 @@ export class ModelHandlerOpenAI extends ModelHandler<
       this.logger.debug(
         `Approximate token count of message: ${approximateInputTokens}`,
       );
-
-      if (approximateInputTokens > this.config.contextWindow) {
-        const errorMsg = `Approximate token count of message exceeds context window: ${approximateInputTokens} > ${this.config.contextWindow}`;
-        this.logger.error(errorMsg);
-        throw new Error(errorMsg);
-      }
-
       const maxOutputKey = this.isOReasoningModel
         ? 'max_completion_tokens'
         : 'max_tokens';
-      if (
-        this.config.contextWindow - approximateInputTokens <
-        kwargs[maxOutputKey]
-      ) {
-        const originalMaxTokens = kwargs[maxOutputKey];
-        kwargs[maxOutputKey] =
-          this.config.contextWindow - approximateInputTokens - 5000; // Add a small buffer
-        this.logger.warn(
-          `Approximate token count (${approximateInputTokens}) + max tokens (${originalMaxTokens}) exceeds context window (${this.config.contextWindow}). Reducing max tokens to ${kwargs[maxOutputKey]}.`,
-        );
-      }
+      this.adjustForContextWindow(
+        approximateInputTokens,
+        kwargs,
+        maxOutputKey,
+        5000,
+      );
     } catch (err) {
       this.logger.error(
         `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,

--- a/src/test/webview/BannerManager.test.ts
+++ b/src/test/webview/BannerManager.test.ts
@@ -11,7 +11,11 @@ import { JSDOM } from 'jsdom';
 
 // Mock BannerManager implementation for testing
 class BannerManager {
-  private _listeners: Array<{ element: any; event: string; handler: Function }> = [];
+  private _listeners: Array<{
+    element: any;
+    event: string;
+    handler: (...args: any[]) => unknown;
+  }> = [];
 
   showBanner(id: string, config: any = {}) {
     const element = (global as any).safeGetElementById(id);
@@ -53,19 +57,20 @@ class BannerManager {
     }
 
     if (config.provider) {
-      const providerName = config.provider.charAt(0).toUpperCase() + config.provider.slice(1);
-      
+      const providerName =
+        config.provider.charAt(0).toUpperCase() + config.provider.slice(1);
+
       // Clear existing content and use safe DOM manipulation
       textSpan.textContent = '';
-      
+
       // Create strong element for provider name
       const strongElement = document.createElement('strong');
       strongElement.textContent = providerName;
-      
+
       // Append elements safely
       textSpan.appendChild(strongElement);
       textSpan.appendChild(document.createTextNode(' API key missing.'));
-      
+
       setButton.textContent = 'Set Key';
       getButton.textContent = 'Get Key';
       element.dataset.provider = config.provider;
@@ -88,11 +93,15 @@ class BannerManager {
     }
 
     if (dirButton) {
-      dirButton.textContent = config.customDirSet ? 'Open Directory' : 'Set Directory';
+      dirButton.textContent = config.customDirSet
+        ? 'Open Directory'
+        : 'Set Directory';
     }
 
     if (!textSpan && !dirButton) {
-      console.warn('[BannerManager] Agent config banner missing all expected elements');
+      console.warn(
+        '[BannerManager] Agent config banner missing all expected elements',
+      );
     }
 
     element.dataset.customDirSet = String(config.customDirSet || false);
@@ -113,15 +122,21 @@ class BannerManager {
       return tool;
     });
 
-    textSpan.textContent = missing.length > 0
-      ? `Missing dependencies: ${formattedTools.join(', ')}`
-      : 'Missing dependencies: none';
+    textSpan.textContent =
+      missing.length > 0
+        ? `Missing dependencies: ${formattedTools.join(', ')}`
+        : 'Missing dependencies: none';
   }
 
-  addListener(elementOrId: any, event: string, handler: Function) {
-    const element = typeof elementOrId === 'string'
-      ? (global as any).safeGetElementById(elementOrId)
-      : elementOrId;
+  addListener(
+    elementOrId: any,
+    event: string,
+    handler: (...args: any[]) => unknown,
+  ) {
+    const element =
+      typeof elementOrId === 'string'
+        ? (global as any).safeGetElementById(elementOrId)
+        : elementOrId;
     if (element) {
       element.addEventListener(event, handler);
       this._listeners.push({ element, event, handler });
@@ -158,22 +173,22 @@ describe('BannerManager', () => {
         <span></span>
       </div>
     </body></html>`);
-    
+
     global.document = dom.window.document as any;
     global.HTMLElement = dom.window.HTMLElement;
-    
+
     // Mock safeGetElementById
     (global as any).safeGetElementById = (id: string) => {
       return dom.window.document.getElementById(id);
     };
-    
+
     // Capture console warnings
     warnMessages = [];
     originalConsoleWarn = console.warn;
     console.warn = (message: string) => {
       warnMessages.push(message);
     };
-    
+
     manager = new BannerManager();
   });
 
@@ -217,9 +232,9 @@ describe('BannerManager', () => {
       const textSpan = banner.querySelector('span');
       const setButton = banner.querySelector('#apiKeyBannerButton');
       const getButton = banner.querySelector('#apiKeyGuideButton');
-      
+
       manager.showBanner('apiKeyBanner');
-      
+
       assert.equal(textSpan.textContent, 'TeXRA requires an API key to run.');
       assert.equal(setButton.textContent, 'Set API Key');
       assert.equal(getButton.textContent, 'API Key Guide');
@@ -231,15 +246,15 @@ describe('BannerManager', () => {
       const textSpan = banner.querySelector('span');
       const setButton = banner.querySelector('#apiKeyBannerButton');
       const getButton = banner.querySelector('#apiKeyGuideButton');
-      
+
       manager.showBanner('apiKeyBanner', { provider: 'openai' });
-      
+
       // Check that text is set safely without innerHTML
       assert.equal(textSpan.childNodes.length, 2);
       assert.equal(textSpan.childNodes[0].nodeName, 'STRONG');
       assert.equal(textSpan.childNodes[0].textContent, 'Openai');
       assert.equal(textSpan.childNodes[1].textContent, ' API key missing.');
-      
+
       assert.equal(setButton.textContent, 'Set Key');
       assert.equal(getButton.textContent, 'Get Key');
       assert.equal(banner.dataset.provider, 'openai');
@@ -248,24 +263,27 @@ describe('BannerManager', () => {
     it('should handle XSS attempt in provider name', () => {
       const banner = dom.window.document.getElementById('apiKeyBanner');
       const textSpan = banner.querySelector('span');
-      
-      manager.showBanner('apiKeyBanner', { 
-        provider: '<script>alert("xss")</script>' 
+
+      manager.showBanner('apiKeyBanner', {
+        provider: '<script>alert("xss")</script>',
       });
-      
+
       // Verify that script tag is escaped as text, not executed
       const strongElement = textSpan.querySelector('strong');
       assert.equal(strongElement.textContent, '<script>alert("xss")</script>');
-      assert.equal(strongElement.innerHTML, '&lt;script&gt;alert("xss")&lt;/script&gt;');
+      assert.equal(
+        strongElement.innerHTML,
+        '&lt;script&gt;alert("xss")&lt;/script&gt;',
+      );
     });
 
     it('should warn when API key banner missing elements', () => {
       // Remove required elements
       const banner = dom.window.document.getElementById('apiKeyBanner');
       banner.innerHTML = '<div></div>';
-      
+
       manager.showBanner('apiKeyBanner', { provider: 'test' });
-      
+
       assert.equal(warnMessages.length, 1);
       assert.ok(warnMessages[0].includes('missing required elements'));
     });
@@ -276,9 +294,9 @@ describe('BannerManager', () => {
       const banner = dom.window.document.getElementById('agentConfigBanner');
       const textSpan = banner.querySelector('span');
       const dirButton = banner.querySelector('#agentConfigDirButton');
-      
+
       manager.showBanner('agentConfigBanner');
-      
+
       assert.equal(textSpan.textContent, 'Agent configuration is missing.');
       assert.equal(dirButton.textContent, 'Set Directory');
       assert.equal(banner.dataset.customDirSet, 'false');
@@ -288,13 +306,16 @@ describe('BannerManager', () => {
       const banner = dom.window.document.getElementById('agentConfigBanner');
       const textSpan = banner.querySelector('span');
       const dirButton = banner.querySelector('#agentConfigDirButton');
-      
+
       manager.showBanner('agentConfigBanner', {
         agentName: 'TestAgent',
-        customDirSet: true
+        customDirSet: true,
       });
-      
-      assert.equal(textSpan.textContent, 'Agent file for "TestAgent" is missing.');
+
+      assert.equal(
+        textSpan.textContent,
+        'Agent file for "TestAgent" is missing.',
+      );
       assert.equal(dirButton.textContent, 'Open Directory');
       assert.equal(banner.dataset.customDirSet, 'true');
     });
@@ -302,11 +323,11 @@ describe('BannerManager', () => {
     it('should handle missing text span gracefully', () => {
       const banner = dom.window.document.getElementById('agentConfigBanner');
       banner.innerHTML = '<button id="agentConfigDirButton"></button>';
-      
+
       assert.doesNotThrow(() => {
         manager.showBanner('agentConfigBanner', { agentName: 'Test' });
       });
-      
+
       const dirButton = banner.querySelector('#agentConfigDirButton');
       assert.equal(dirButton.textContent, 'Set Directory');
     });
@@ -314,9 +335,9 @@ describe('BannerManager', () => {
     it('should warn when all elements are missing', () => {
       const banner = dom.window.document.getElementById('agentConfigBanner');
       banner.innerHTML = '';
-      
+
       manager.showBanner('agentConfigBanner');
-      
+
       assert.equal(warnMessages.length, 1);
       assert.ok(warnMessages[0].includes('missing all expected elements'));
     });
@@ -326,43 +347,43 @@ describe('BannerManager', () => {
     it('should display missing dependencies', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       const textSpan = banner.querySelector('span');
-      
+
       manager.showBanner('dependencyBanner', {
-        missingTools: ['latex', 'gm/magick', 'nodejs']
+        missingTools: ['latex', 'gm/magick', 'nodejs'],
       });
-      
+
       assert.equal(
         textSpan.textContent,
-        'Missing dependencies: latex, GraphicsMagick or ImageMagick, nodejs'
+        'Missing dependencies: latex, GraphicsMagick or ImageMagick, nodejs',
       );
     });
 
     it('should handle empty dependencies array', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       const textSpan = banner.querySelector('span');
-      
+
       manager.showBanner('dependencyBanner', { missingTools: [] });
-      
+
       assert.equal(textSpan.textContent, 'Missing dependencies: none');
     });
 
     it('should handle missing config gracefully', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       const textSpan = banner.querySelector('span');
-      
+
       manager.showBanner('dependencyBanner');
-      
+
       assert.equal(textSpan.textContent, 'Missing dependencies: none');
     });
 
     it('should warn when text span is missing', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       banner.innerHTML = '';
-      
+
       manager.showBanner('dependencyBanner', {
-        missingTools: ['test']
+        missingTools: ['test'],
       });
-      
+
       assert.equal(warnMessages.length, 1);
       assert.ok(warnMessages[0].includes('missing text element'));
     });
@@ -370,14 +391,14 @@ describe('BannerManager', () => {
     it('should properly format gm/magick tool name', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       const textSpan = banner.querySelector('span');
-      
+
       manager.showBanner('dependencyBanner', {
-        missingTools: ['gm/magick']
+        missingTools: ['gm/magick'],
       });
-      
+
       assert.equal(
         textSpan.textContent,
-        'Missing dependencies: GraphicsMagick or ImageMagick'
+        'Missing dependencies: GraphicsMagick or ImageMagick',
       );
     });
   });
@@ -387,7 +408,7 @@ describe('BannerManager', () => {
       // Verify cleanup method exists (inherited from BaseUIManager)
       assert.equal(typeof manager.cleanup, 'function');
     });
-    
+
     it('should inherit addListener from BaseUIManager', () => {
       // Verify addListener method exists (inherited from BaseUIManager)
       assert.equal(typeof manager.addListener, 'function');


### PR DESCRIPTION
## Summary
- add `adjustForContextWindow` helper to base `ModelHandler`
- use helper in Anthropic and OpenAI handlers with provider-specific hooks
- clarify test handler typing for lint compliance

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e1f467a4832484e8e8d9ce178601