### PR TITLE
fix: hide file selection toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Detect Ghostscript correctly on Windows and stop flagging GraphicsMagick when ImageMagick is installed
 - Show tool-use agents in the dropdown when enabled and restore agent configuration banners
 - Improve model API key banner behavior and multi-file toggle labels
+- Hide file selection notification when choosing reference, auxiliary, or media files in the main view
 
 ## [0.33.5] - 2025-09-07 💪
 
@@ -28,10 +29,6 @@ All notable changes to this project will be documented in this file.
 - Add configuration banner for missing agent files with quick setup actions
 - Add visual indicator for agents with multiple output support in dropdown
 - Replace "(no key)" with ✗ symbol for cleaner model dropdown display
-
-### Bug Fixes
-
-- Hide file selection notification when choosing reference, auxiliary, or media files in the main view
 
 ## [0.33.4] - 2025-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - Add visual indicator for agents with multiple output support in dropdown
 - Replace "(no key)" with ✗ symbol for cleaner model dropdown display
 
+### Bug Fixes
+
+- Hide file selection notification when choosing reference, auxiliary, or media files in the main view
+
 ## [0.33.4] - 2025-09-03
 
 ### Features

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -77,9 +77,7 @@ export class FileManager {
   }
 
   handleGenericFileSelected(message: any): void {
-    vscode.window.showInformationMessage(
-      `${message.command}: ${message.filePath}`,
-    );
+    logger.debug(CHANNEL, `${message.command}: ${message.filePath}`);
   }
 
   async handleRequestInputFile(webviewView: vscode.WebviewView): Promise<void> {


### PR DESCRIPTION
## Summary
- hide reference/auxiliary/media file selection toast in main view
- document suppression of file selection notification

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c460b9003c83248e1f3ca5dfb7df99