### PR TITLE
docs: add changelog for 0.33.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.6] - 2025-09-12
+
+### Features
+
+- Show a banner when required dependencies are missing and check tools before running
+- Add `kimi2` to the model list
+- Clarify output file controls in the webview
+
+### Bug Fixes
+
+- Detect Ghostscript correctly on Windows and stop flagging GraphicsMagick when ImageMagick is installed
+- Show tool-use agents in the dropdown when enabled and restore agent configuration banners
+- Improve model API key banner behavior and multi-file toggle labels
+
 ## [0.33.5] - 2025-09-07 💪
 
 ### Features


### PR DESCRIPTION
## Summary
- document 0.33.6 release with new dependency check banner and tool runner
- add kimi2 model and clarify output file controls in changelog
- note fixes for dependency detection, agent dropdown, and API key banners

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c4078f0483248ffbdf459b2f4a88