### PR TITLE
feat: add DOM ID helpers

### DIFF
--- a/docs/reference/dom-id-utils.md
+++ b/docs/reference/dom-id-utils.md
@@ -1,0 +1,18 @@
+# DOM ID Helpers
+
+TeXRA uses structured helpers in `@common/domIdUtils` to generate DOM element identifiers. These utilities replace inline
+template literals and keep ID conventions consistent across modules.
+
+## Available helpers
+
+- `getToggleId(type)` – returns the ID for a toggle element, e.g. `toggleInputFiles`.
+- `getSingleFileId(type)` – builds IDs like `inputFile`.
+- `getMultipleFilesId(type)` – builds IDs like `inputFiles`.
+- `getCapitalizedMultipleFilesId(type)` – same as above but capitalized (`InputFiles`).
+- `getMultipleFilesContainerId(type)` – returns IDs such as `inputFilesContainer`.
+- `getSelectButtonId(id)` – creates button IDs like `selectInputFilesButton`.
+- `getEmptyButtonId(id)` – creates IDs such as `emptyInputFileButton` or `emptyInputFilesButton`.
+- `getCurrentFileButtonId(type)` – builds IDs like `currentInputFileButton`.
+- `getAddOpenedFilesButtonId(type)` – builds IDs like `addOpenedInputFilesButton`.
+
+Use these helpers instead of manual string interpolation when constructing DOM IDs in webview code.

--- a/src/common/modules/domIdUtils.js
+++ b/src/common/modules/domIdUtils.js
@@ -1,0 +1,37 @@
+import { capitalize, uncapitalize } from './stringUtils.js';
+
+export function getToggleId(type) {
+  return `toggle${capitalize(type)}`;
+}
+
+export function getSingleFileId(type) {
+  return `${uncapitalize(type)}File`;
+}
+
+export function getMultipleFilesId(type) {
+  return `${uncapitalize(type)}Files`;
+}
+
+export function getCapitalizedMultipleFilesId(type) {
+  return capitalize(getMultipleFilesId(type));
+}
+
+export function getMultipleFilesContainerId(type) {
+  return `${getMultipleFilesId(type)}Container`;
+}
+
+export function getSelectButtonId(id) {
+  return `select${capitalize(id)}Button`;
+}
+
+export function getEmptyButtonId(id) {
+  return `empty${capitalize(id)}Button`;
+}
+
+export function getCurrentFileButtonId(type) {
+  return `current${capitalize(type)}FileButton`;
+}
+
+export function getAddOpenedFilesButtonId(type) {
+  return `addOpened${capitalize(type)}FilesButton`;
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -157,6 +157,7 @@ export abstract class BaseViewContentProvider {
       ),
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
+      domIdUtilsUri: this.getCommonUri(webview, 'modules/domIdUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
       codiconUri: this.getNodeModulesUri(
         webview,

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -29,6 +29,7 @@
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}"
         }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -51,6 +51,7 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "he": "https://esm.sh/he@1.2.0",

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -38,6 +38,7 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -13,7 +13,11 @@ import { mainViewState } from '../mainViewState.js';
 import { fileList } from '../uiManagers/FileList.js';
 import { fileSelect } from '../uiManagers/FileSelect.js';
 import { safeSetElementValue } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import {
+  getToggleId,
+  getSingleFileId,
+  getMultipleFilesId,
+} from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - utilities
 import { vscode } from '@common/webviewContext.js';
@@ -170,9 +174,9 @@ export function createFileHandlers(ctx) {
   function handleSetOpenedFiles(message) {
     if (message.fileType) {
       const fileType = message.fileType.replace('Files', '');
-      const singleFileId = `${uncapitalize(fileType)}File`;
-      const multipleFileId = `${uncapitalize(fileType)}Files`;
-      const toggleId = `toggle${capitalize(fileType)}Files`;
+      const singleFileId = getSingleFileId(fileType);
+      const multipleFileId = getMultipleFilesId(fileType);
+      const toggleId = getToggleId(multipleFileId);
 
       let filesToAdd = message.files ?? [];
       if (message.shouldFilter) {

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -16,7 +16,7 @@ import {
   safeSetElementChecked,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import { getToggleId } from '@common/domIdUtils.js';
 import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { WebviewStateManager } from '@common/webviewState.js';
 
@@ -55,7 +55,7 @@ export class MainViewState {
     }
 
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const toggleId = `toggle${capitalize(id)}`;
+      const toggleId = getToggleId(id);
       fileList.setVisibility(id, toggleId, false);
       const listDiv = safeGetElementById(id);
       if (listDiv) {
@@ -120,7 +120,7 @@ export class MainViewState {
       }
 
       MULTIPLE_SELECTIONS.forEach((id) => {
-        const toggleId = `toggle${capitalize(id)}`;
+        const toggleId = getToggleId(id);
         const selectDiv = safeGetElementById(id);
         if (!selectDiv) {
           console.warn(`Element with id '${id}' not found`);

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -24,7 +24,12 @@ import {
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { capitalize } from '@common/stringUtils.js';
+import {
+  getToggleId,
+  getMultipleFilesId,
+  getMultipleFilesContainerId,
+} from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 // Import standardized commands
@@ -434,11 +439,11 @@ export class MainViewMessageHandler {
       savedState[targetArrayName] = filesArray;
       savedState[visibilityName] = isVisible;
 
-      const multipleFilesId = `${fileType}Files`;
+      const multipleFilesId = getMultipleFilesId(fileType);
       const multipleFiles = this._getElement(multipleFilesId);
       if (filesArray.length > 0 || isVisible) {
-        const containerId = `${fileType}FilesContainer`;
-        const toggleId = `toggle${capitalize(fileType)}Files`;
+        const containerId = getMultipleFilesContainerId(fileType);
+        const toggleId = getToggleId(getMultipleFilesId(fileType));
 
         const container = this._getElement(containerId);
         if (container) {

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -19,7 +19,16 @@ import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
 import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import {
+  getToggleId,
+  getSingleFileId,
+  getMultipleFilesId,
+  getCapitalizedMultipleFilesId,
+  getSelectButtonId,
+  getEmptyButtonId,
+  getAddOpenedFilesButtonId,
+  getCurrentFileButtonId,
+} from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -98,12 +107,12 @@ export class FileInputManager extends BaseUIManager {
 
   _setupMultipleFileButtons() {
     const selectors = FILE_TYPES.map((type) => ({
-      id: `${capitalize(type)}Files`,
-      selectId: type === 'output' ? INPUT_FILE : `${type}File`,
+      id: getCapitalizedMultipleFilesId(type),
+      selectId: type === 'output' ? INPUT_FILE : getSingleFileId(type),
     }));
 
     selectors.forEach(({ id, selectId }) => {
-      const buttonId = `select${id}Button`;
+      const buttonId = getSelectButtonId(id);
       this.addListener(buttonId, 'click', () => {
         const currentFile = safeGetElementValue(selectId);
         this.vscode.postMessage({
@@ -118,14 +127,13 @@ export class FileInputManager extends BaseUIManager {
   _setupFileTypeButtons() {
     const fileTypes = ['input', 'reference', 'auxiliary'];
     fileTypes.forEach((type) => {
-      const cap = capitalize(type);
-      this.addListener(`addOpened${cap}FilesButton`, 'click', () => {
+      this.addListener(getAddOpenedFilesButtonId(type), 'click', () => {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.ADD_OPENED_FILES,
           fileType: type,
         });
       });
-      this.addListener(`current${cap}FileButton`, 'click', () => {
+      this.addListener(getCurrentFileButtonId(type), 'click', () => {
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
           fileType: type,
@@ -134,7 +142,7 @@ export class FileInputManager extends BaseUIManager {
     });
 
     ['base', 'edited'].forEach((type) => {
-      this.addListener(`current${capitalize(type)}FileButton`, 'click', () => {
+      this.addListener(getCurrentFileButtonId(type), 'click', () => {
         const baseFile = safeGetElementValue(BASE_FILE);
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
@@ -147,8 +155,8 @@ export class FileInputManager extends BaseUIManager {
 
   _setupEmptyAndToggleButtons() {
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const toggleId = `toggle${capitalize(id)}`;
-      const emptyButtonId = `empty${capitalize(id)}Button`;
+      const toggleId = getToggleId(id);
+      const emptyButtonId = getEmptyButtonId(id);
       this.addListener(emptyButtonId, 'click', () =>
         this.fileList.empty(id, toggleId),
       );
@@ -188,8 +196,8 @@ export class FileInputManager extends BaseUIManager {
       'edited',
     ];
     types.forEach((type) => {
-      this.addListener(`empty${capitalize(type)}FileButton`, 'click', () => {
-        const selectEl = safeGetElementById(`${type}File`);
+      this.addListener(getEmptyButtonId(getSingleFileId(type)), 'click', () => {
+        const selectEl = safeGetElementById(getSingleFileId(type));
         if (selectEl) {
           selectEl.value = '';
           this.state.save();

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -4,7 +4,7 @@ import {
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import { getToggleId } from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
@@ -26,7 +26,7 @@ export class FileList {
    */
   add(containerId, file) {
     const container = safeGetElementById(containerId);
-    const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
+    const toggleIcon = safeGetElementById(getToggleId(containerId));
     if (!container || !toggleIcon) return;
 
     const placeholder = container.querySelector('.file-list-placeholder');
@@ -48,7 +48,7 @@ export class FileList {
           container.removeChild(fileElement);
         }
         if (container.children.length === 0) {
-          this.empty(containerId, `toggle${capitalize(containerId)}`);
+          this.empty(containerId, getToggleId(containerId));
         }
         this._saveFn();
       });
@@ -122,7 +122,7 @@ export class FileList {
     ids.forEach((id) => {
       const selectDiv = safeGetElementById(id);
       if (!selectDiv) return;
-      const toggleId = `toggle${capitalize(id)}`;
+      const toggleId = getToggleId(id);
       if (selectDiv.children.length === 0) {
         this.setVisibility(id, toggleId, false);
       }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,7 +1,7 @@
 // Local imports - webview
 import { ELEMENT_IDS, EDITED_FILE } from '../constants.js';
 import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { getSingleFileId } from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports
@@ -91,7 +91,7 @@ export class FileSelect {
   }
 
   handleSetCurrentFile({ fileType, filePath }) {
-    const fileId = `${uncapitalize(fileType)}File`;
+    const fileId = getSingleFileId(fileType);
     const fileDiv = document.getElementById(fileId);
     if (!fileDiv) {
       console.warn(`Element with id '${fileId}' not found`);


### PR DESCRIPTION
## Summary
- add domIdUtils helper module for consistent DOM id generation
- use domIdUtils helpers instead of template literals in webview modules
- document DOM ID helper functions

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c17b74ab14832496e8011ce7960ac6