### PR TITLE
feat: centralize DOM id generation with helpers

### DIFF
--- a/docs/dev/DOM_ID_UTILS.md
+++ b/docs/dev/DOM_ID_UTILS.md
@@ -1,0 +1,15 @@
+# DOM ID Helpers
+
+The `@common/domIdUtils` module centralizes DOM id generation.
+Use these helpers instead of hand-written template literals to
+ensure consistent naming across modules.
+
+| Function                            | Purpose                                                | Example                             |
+| ----------------------------------- | ------------------------------------------------------ | ----------------------------------- |
+| `getSingleFileId(type)`             | ID for single-file select elements                     | `input` → `inputFile`               |
+| `getMultipleFilesId(type)`          | ID for multi-file list elements                        | `output` → `outputFiles`            |
+| `getMultipleFilesContainerId(type)` | ID for multi-file containers                           | `media` → `mediaFilesContainer`     |
+| `getToggleId(id)`                   | ID for toggle elements controlling a list or container | `outputFiles` → `toggleOutputFiles` |
+
+Always prefer these helpers when manipulating related DOM elements
+so future code remains easy to follow and maintain.

--- a/src/common/modules/domIdUtils.js
+++ b/src/common/modules/domIdUtils.js
@@ -1,0 +1,37 @@
+import { capitalize, uncapitalize } from './stringUtils.js';
+
+/**
+ * Get the DOM id for a single-file select element.
+ * @param {string} type - File type (e.g., 'input')
+ * @returns {string} DOM id like 'inputFile'
+ */
+export function getSingleFileId(type) {
+  return `${uncapitalize(type)}File`;
+}
+
+/**
+ * Get the DOM id for a multi-file list element.
+ * @param {string} type - File type (e.g., 'input')
+ * @returns {string} DOM id like 'inputFiles'
+ */
+export function getMultipleFilesId(type) {
+  return `${uncapitalize(type)}Files`;
+}
+
+/**
+ * Get the DOM id for a multi-file container element.
+ * @param {string} type - File type (e.g., 'input')
+ * @returns {string} DOM id like 'inputFilesContainer'
+ */
+export function getMultipleFilesContainerId(type) {
+  return `${getMultipleFilesId(type)}Container`;
+}
+
+/**
+ * Get the DOM id for a toggle element controlling a list or container.
+ * @param {string} id - Base element id (e.g., 'outputFiles')
+ * @returns {string} DOM id like 'toggleOutputFiles'
+ */
+export function getToggleId(id) {
+  return `toggle${capitalize(id)}`;
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -158,6 +158,7 @@ export abstract class BaseViewContentProvider {
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
+      domIdUtilsUri: this.getCommonUri(webview, 'modules/domIdUtils.js'),
       codiconUri: this.getNodeModulesUri(
         webview,
         '@vscode/codicons/dist/codicon.css',

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -38,6 +38,7 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -13,7 +13,12 @@ import { mainViewState } from '../mainViewState.js';
 import { fileList } from '../uiManagers/FileList.js';
 import { fileSelect } from '../uiManagers/FileSelect.js';
 import { safeSetElementValue } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import {
+  getSingleFileId,
+  getMultipleFilesId,
+  getMultipleFilesContainerId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - utilities
 import { vscode } from '@common/webviewContext.js';
@@ -85,8 +90,9 @@ export function createFileHandlers(ctx) {
   }
 
   function handleSetInputFiles(message) {
-    fileList.update('inputFiles', 'toggleInputFiles', message.files);
-    const listEl = getElement('inputFiles');
+    const listId = getMultipleFilesId('input');
+    fileList.update(listId, getToggleId(listId), message.files);
+    const listEl = getElement(listId);
     if (listEl) {
       setupFileListHandler('input', listEl);
     }
@@ -94,8 +100,9 @@ export function createFileHandlers(ctx) {
   }
 
   function handleSetReferenceFiles(message) {
-    fileList.update('referenceFiles', 'toggleReferenceFiles', message.files);
-    const listEl = getElement('referenceFiles');
+    const listId = getMultipleFilesId('reference');
+    fileList.update(listId, getToggleId(listId), message.files);
+    const listEl = getElement(listId);
     if (listEl) {
       setupFileListHandler('reference', listEl);
     }
@@ -103,8 +110,9 @@ export function createFileHandlers(ctx) {
   }
 
   function handleSetAuxiliaryFiles(message) {
-    fileList.update('auxiliaryFiles', 'toggleAuxiliaryFiles', message.files);
-    const listEl = getElement('auxiliaryFiles');
+    const listId = getMultipleFilesId('auxiliary');
+    fileList.update(listId, getToggleId(listId), message.files);
+    const listEl = getElement(listId);
     if (listEl) {
       setupFileListHandler('auxiliary', listEl);
     }
@@ -112,8 +120,9 @@ export function createFileHandlers(ctx) {
   }
 
   function handleSetMediaFiles(message) {
-    fileList.update('mediaFiles', 'toggleMediaFiles', message.files);
-    const listEl = getElement('mediaFiles');
+    const listId = getMultipleFilesId('media');
+    fileList.update(listId, getToggleId(listId), message.files);
+    const listEl = getElement(listId);
     if (listEl) {
       setupFileListHandler('media', listEl);
     }
@@ -121,9 +130,10 @@ export function createFileHandlers(ctx) {
   }
 
   function handleAddMediaFile(message) {
-    const listDiv = getElement('mediaFiles');
+    const listId = getMultipleFilesId('media');
+    const listDiv = getElement(listId);
     const existingFiles = listDiv ? fileList.getSelected(listDiv) : [];
-    fileList.update('mediaFiles', 'toggleMediaFiles', [
+    fileList.update(listId, getToggleId(listId), [
       ...existingFiles,
       message.file,
     ]);
@@ -131,10 +141,10 @@ export function createFileHandlers(ctx) {
       setupFileListHandler('media', listDiv);
     }
 
-    const container = getElement('mediaFilesContainer');
+    const container = getElement(getMultipleFilesContainerId('media'));
     if (container && container.style.display === 'none') {
       container.style.display = 'block';
-      const toggleIcon = getElement('toggleMediaFiles');
+      const toggleIcon = getElement(getToggleId(listId));
       setToggleIcon(toggleIcon, true);
     }
 
@@ -170,9 +180,9 @@ export function createFileHandlers(ctx) {
   function handleSetOpenedFiles(message) {
     if (message.fileType) {
       const fileType = message.fileType.replace('Files', '');
-      const singleFileId = `${uncapitalize(fileType)}File`;
-      const multipleFileId = `${uncapitalize(fileType)}Files`;
-      const toggleId = `toggle${capitalize(fileType)}Files`;
+      const singleFileId = getSingleFileId(fileType);
+      const multipleFileId = getMultipleFilesId(fileType);
+      const toggleId = getToggleId(multipleFileId);
 
       let filesToAdd = message.files ?? [];
       if (message.shouldFilter) {

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -16,7 +16,7 @@ import {
   safeSetElementChecked,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import { getToggleId } from '@common/domIdUtils.js';
 import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { WebviewStateManager } from '@common/webviewState.js';
 
@@ -55,7 +55,7 @@ export class MainViewState {
     }
 
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const toggleId = `toggle${capitalize(id)}`;
+      const toggleId = getToggleId(id);
       fileList.setVisibility(id, toggleId, false);
       const listDiv = safeGetElementById(id);
       if (listDiv) {
@@ -120,7 +120,7 @@ export class MainViewState {
       }
 
       MULTIPLE_SELECTIONS.forEach((id) => {
-        const toggleId = `toggle${capitalize(id)}`;
+        const toggleId = getToggleId(id);
         const selectDiv = safeGetElementById(id);
         if (!selectDiv) {
           console.warn(`Element with id '${id}' not found`);

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -25,6 +25,11 @@ import {
   setChevronIcon,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import {
+  getMultipleFilesId,
+  getMultipleFilesContainerId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 // Import standardized commands
@@ -434,11 +439,11 @@ export class MainViewMessageHandler {
       savedState[targetArrayName] = filesArray;
       savedState[visibilityName] = isVisible;
 
-      const multipleFilesId = `${fileType}Files`;
+      const multipleFilesId = getMultipleFilesId(fileType);
       const multipleFiles = this._getElement(multipleFilesId);
       if (filesArray.length > 0 || isVisible) {
-        const containerId = `${fileType}FilesContainer`;
-        const toggleId = `toggle${capitalize(fileType)}Files`;
+        const containerId = getMultipleFilesContainerId(fileType);
+        const toggleId = getToggleId(multipleFilesId);
 
         const container = this._getElement(containerId);
         if (container) {

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -13,6 +13,10 @@ import {
   safeGetElementChecked,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
+import {
+  getSingleFileId,
+  getMultipleFilesContainerId,
+} from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -28,7 +32,8 @@ export class ActionButtonManager extends BaseUIManager {
   _getSingleFileData(fileTypes = ['input', 'reference', 'auxiliary', 'media']) {
     const data = {};
     fileTypes.forEach((type) => {
-      data[`${type}File`] = safeGetElementValue(`${type}File`);
+      const id = getSingleFileId(type);
+      data[id] = safeGetElementValue(id);
     });
     return data;
   }
@@ -36,11 +41,12 @@ export class ActionButtonManager extends BaseUIManager {
   _getMultipleFileData(singleFiles = {}) {
     const multipleFilesData = {};
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const container = safeGetElementById(`${id}Container`);
+      const type = id.replace('Files', '');
+      const container = safeGetElementById(getMultipleFilesContainerId(type));
       const isActive = container?.style.display !== 'none';
       multipleFilesData[`${id}Active`] = isActive;
 
-      const singleFileKey = id.replace('Files', 'File');
+      const singleFileKey = getSingleFileId(type);
       const singleFile = singleFiles[singleFileKey];
 
       const filesDiv = safeGetElementById(id);

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -20,6 +20,11 @@ import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
 import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
+import {
+  getSingleFileId,
+  getMultipleFilesId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -98,8 +103,8 @@ export class FileInputManager extends BaseUIManager {
 
   _setupMultipleFileButtons() {
     const selectors = FILE_TYPES.map((type) => ({
-      id: `${capitalize(type)}Files`,
-      selectId: type === 'output' ? INPUT_FILE : `${type}File`,
+      id: capitalize(getMultipleFilesId(type)),
+      selectId: type === 'output' ? INPUT_FILE : getSingleFileId(type),
     }));
 
     selectors.forEach(({ id, selectId }) => {
@@ -147,7 +152,7 @@ export class FileInputManager extends BaseUIManager {
 
   _setupEmptyAndToggleButtons() {
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const toggleId = `toggle${capitalize(id)}`;
+      const toggleId = getToggleId(id);
       const emptyButtonId = `empty${capitalize(id)}Button`;
       this.addListener(emptyButtonId, 'click', () =>
         this.fileList.empty(id, toggleId),
@@ -189,7 +194,7 @@ export class FileInputManager extends BaseUIManager {
     ];
     types.forEach((type) => {
       this.addListener(`empty${capitalize(type)}FileButton`, 'click', () => {
-        const selectEl = safeGetElementById(`${type}File`);
+        const selectEl = safeGetElementById(getSingleFileId(type));
         if (selectEl) {
           selectEl.value = '';
           this.state.save();

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -4,7 +4,7 @@ import {
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import { getToggleId } from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
@@ -26,7 +26,7 @@ export class FileList {
    */
   add(containerId, file) {
     const container = safeGetElementById(containerId);
-    const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
+    const toggleIcon = safeGetElementById(getToggleId(containerId));
     if (!container || !toggleIcon) return;
 
     const placeholder = container.querySelector('.file-list-placeholder');
@@ -48,7 +48,7 @@ export class FileList {
           container.removeChild(fileElement);
         }
         if (container.children.length === 0) {
-          this.empty(containerId, `toggle${capitalize(containerId)}`);
+          this.empty(containerId, getToggleId(containerId));
         }
         this._saveFn();
       });
@@ -122,7 +122,7 @@ export class FileList {
     ids.forEach((id) => {
       const selectDiv = safeGetElementById(id);
       if (!selectDiv) return;
-      const toggleId = `toggle${capitalize(id)}`;
+      const toggleId = getToggleId(id);
       if (selectDiv.children.length === 0) {
         this.setVisibility(id, toggleId, false);
       }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,10 +1,9 @@
 // Local imports - webview
 import { ELEMENT_IDS, EDITED_FILE } from '../constants.js';
 import { safeGetElementById, safeSetElementValue } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
-// Local imports
+import { getSingleFileId } from '@common/domIdUtils.js';
 import { vscode } from '@common/webviewContext.js';
 
 /**
@@ -91,7 +90,7 @@ export class FileSelect {
   }
 
   handleSetCurrentFile({ fileType, filePath }) {
-    const fileId = `${uncapitalize(fileType)}File`;
+    const fileId = getSingleFileId(fileType);
     const fileDiv = document.getElementById(fileId);
     if (!fileDiv) {
       console.warn(`Element with id '${fileId}' not found`);


### PR DESCRIPTION
## Summary
- add domIdUtils with helpers like getSingleFileId and getToggleId
- replace inline DOM id template strings across webview modules
- document DOM id helpers for consistent usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17b74ab14832496e8011ce7960ac6