### PR TITLE
fix: skip empty thinking logs

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -130,7 +130,9 @@ export async function runToolUseCycle(
     const useStreaming = modelHandler.getStreamingConfig();
     if (thinking && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinking);
-      logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
+      if (formatted.trim().length > 0) {
+        logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
+      }
     }
 
     const toolInfo = modelHandler.extractToolUse(response);

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -360,6 +360,9 @@ export class LogEntryFormatter {
       if (result) {
         return result;
       }
+      if (messageType === 'thinking' || messageType === 'scratchpad') {
+        return null;
+      }
     }
 
     // Default formatting for regular log messages
@@ -386,6 +389,7 @@ export class LogEntryFormatter {
   }
 
   _formatSpecialContent(content, contentType, logId, groupId, timestamp) {
+    if (!content || !content.trim()) return null;
     const parsedMarkdown = this._processMarkdownContent(content);
     const element = createFromTemplate('specialDetailsTemplate');
     if (!element) return null;

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -258,6 +258,9 @@ export class LogEntryManager {
       );
       if (groupContent) {
         const logLineElement = this.entryFormatter.format(logMessage);
+        if (!logLineElement) {
+          return true;
+        }
 
         // Extract timestamp from the message for chronological ordering
         const msgDate = new Date(logMessage.timestamp);
@@ -282,6 +285,10 @@ export class LogEntryManager {
       // Preserve the expanded/collapsed state for thinking and scratchpad
       const wasOpen = existing.hasAttribute('open');
       const newEl = this.entryFormatter.format(logMessage);
+      if (!newEl) {
+        existing.remove();
+        return true;
+      }
 
       // Restore the expanded state if it was open
       if (


### PR DESCRIPTION
## Summary
- avoid logging empty thinking blocks in tool-use cycle
- hide empty thinking/scratchpad blocks in progress view

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c71ea0612483248659282baee1a3cf