### PR TITLE
feat: add install and recheck actions to dependency banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Add install actions and re-check option to dependency banner
+
 ## [0.33.6] - 2025-09-14
 
 ### Features

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -81,6 +81,8 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_AGENT_DIRECTORY: 'openAgentDirectory',
   OPEN_AGENT_DOCS: 'openAgentDocs',
   OPEN_INSTALLATION_DOCS: 'openInstallationDocs',
+  OPEN_INSTALL_GUIDE: 'openInstallGuide',
+  RECHECK_DEPENDENCIES: 'recheckDependencies',
   SHOW_AGENT_CONFIG_BANNER: 'showAgentConfigBanner',
   HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
   SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -81,6 +81,8 @@ export const MAIN_VIEW_COMMANDS = {
   OPEN_AGENT_DIRECTORY: 'openAgentDirectory',
   OPEN_AGENT_DOCS: 'openAgentDocs',
   OPEN_INSTALLATION_DOCS: 'openInstallationDocs',
+  OPEN_INSTALL_GUIDE: 'openInstallGuide',
+  RECHECK_DEPENDENCIES: 'recheckDependencies',
   SHOW_AGENT_CONFIG_BANNER: 'showAgentConfigBanner',
   HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
   SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',

--- a/src/test/webview/BannerManager.test.ts
+++ b/src/test/webview/BannerManager.test.ts
@@ -170,7 +170,11 @@ describe('BannerManager', () => {
         <button id="agentConfigDirButton"></button>
       </div>
       <div id="dependencyBanner" style="display: none;">
-        <span></span>
+        <span class="missing-tools"></span>
+        <div class="actions">
+          <button id="dependencyRecheckButton"></button>
+          <button id="dependencyDismissButton"></button>
+        </div>
       </div>
     </body></html>`);
 
@@ -344,62 +348,66 @@ describe('BannerManager', () => {
   });
 
   describe('Dependency Banner', () => {
-    it('should display missing dependencies', () => {
+    it('should display install buttons for missing tools', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
-      const textSpan = banner.querySelector('span');
 
-      manager.showBanner('dependencyBanner', {
-        missingTools: ['latex', 'gm/magick', 'nodejs'],
-      });
+      manager.showBanner('dependencyBanner', { missingTools: ['latex'] });
 
-      assert.equal(
-        textSpan.textContent,
-        'Missing dependencies: latex, GraphicsMagick or ImageMagick, nodejs',
+      const items = banner.querySelectorAll('.dependency-item');
+      assert.equal(items.length, 1);
+      const label = items[0].querySelector('span');
+      const button = items[0].querySelector('button');
+      assert.equal(label.textContent, 'latex');
+      assert.equal(button.textContent, 'Install');
+      assert.equal(button.dataset.tool, 'latex');
+    });
+
+    it('should handle gm/magick as two separate tools', () => {
+      const banner = dom.window.document.getElementById('dependencyBanner');
+
+      manager.showBanner('dependencyBanner', { missingTools: ['gm/magick'] });
+
+      const items = banner.querySelectorAll('.dependency-item');
+      assert.equal(items.length, 2);
+      const names = Array.from(items as any).map(
+        (i: any) => i.querySelector('span').textContent,
       );
+      assert.deepEqual(names, ['GraphicsMagick', 'ImageMagick']);
     });
 
     it('should handle empty dependencies array', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
-      const textSpan = banner.querySelector('span');
+      const container = banner.querySelector('.missing-tools');
 
       manager.showBanner('dependencyBanner', { missingTools: [] });
 
-      assert.equal(textSpan.textContent, 'Missing dependencies: none');
+      assert.equal(container.textContent, 'Missing dependencies: none');
     });
 
     it('should handle missing config gracefully', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
-      const textSpan = banner.querySelector('span');
+      const container = banner.querySelector('.missing-tools');
 
       manager.showBanner('dependencyBanner');
 
-      assert.equal(textSpan.textContent, 'Missing dependencies: none');
+      assert.equal(container.textContent, 'Missing dependencies: none');
     });
 
-    it('should warn when text span is missing', () => {
+    it('should warn when required elements are missing', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       banner.innerHTML = '';
 
-      manager.showBanner('dependencyBanner', {
-        missingTools: ['test'],
-      });
+      manager.showBanner('dependencyBanner', { missingTools: ['test'] });
 
       assert.equal(warnMessages.length, 1);
-      assert.ok(warnMessages[0].includes('missing text element'));
+      assert.ok(warnMessages[0].includes('missing required elements'));
     });
 
-    it('should properly format gm/magick tool name', () => {
+    it('should ensure re-check button exists', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
-      const textSpan = banner.querySelector('span');
-
-      manager.showBanner('dependencyBanner', {
-        missingTools: ['gm/magick'],
-      });
-
-      assert.equal(
-        textSpan.textContent,
-        'Missing dependencies: GraphicsMagick or ImageMagick',
-      );
+      manager.showBanner('dependencyBanner', { missingTools: [] });
+      const recheck = banner.querySelector('#dependencyRecheckButton');
+      assert.equal(recheck.textContent, 'Re-check');
     });
   });
 

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -98,6 +98,7 @@ const TOOL_CONFIGS: Record<string, ToolConfig> = {
     errorMessage:
       'ImageMagick is not installed. Please install ImageMagick to use PDF to PNG conversion.\n' +
       MAGICK_INSTRUCTIONS,
+    openDocsCommand: 'texra.openDoc,installation',
   },
 
   // GraphicsMagick
@@ -106,6 +107,7 @@ const TOOL_CONFIGS: Record<string, ToolConfig> = {
     errorMessage:
       'GraphicsMagick is not installed. Please install GraphicsMagick to use PDF to PNG conversion.\n' +
       GM_INSTRUCTIONS,
+    openDocsCommand: 'texra.openDoc,installation',
   },
 
   // System dependencies
@@ -345,6 +347,15 @@ export async function checkMultipleToolsInstalled(
     configs.map((config) => checkToolInstalled(config, showError)),
   );
   return results;
+}
+
+/**
+ * Get the documentation command for a given tool.
+ * @param tool Tool identifier
+ * @returns Command string or undefined if not available
+ */
+export function getToolDocsCommand(tool: string): string | undefined {
+  return TOOL_CONFIGS[tool]?.openDocsCommand;
 }
 
 /**

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -18,7 +18,11 @@ import {
 // @ts-ignore - Import JavaScript module
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { getConfig, setConfig } from '@utils/config';
-import { safeExecuteCommand } from '@utils/system';
+import {
+  safeExecuteCommand,
+  checkCoreDependencies,
+  getToolDocsCommand,
+} from '@utils/system';
 import { SETTINGS_QUERY } from '@utils/settingsQueries';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { computeModelOptions } from '@model/computeModelOptions';
@@ -219,6 +223,26 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       },
       [MAIN_VIEW_COMMANDS.UPDATE_DEPENDENCY_REMINDER_SETTING]: async (m) => {
         await setConfig('ui.showDependencyReminders', m.value);
+      },
+      [MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE]: async (m) => {
+        const cmd = getToolDocsCommand(m.tool);
+        if (cmd) {
+          const [command, ...args] = cmd.split(',');
+          await safeExecuteCommand(command, args);
+        }
+      },
+      [MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES]: async (_m, w) => {
+        const missingTools = await checkCoreDependencies(true);
+        if (missingTools.length > 0) {
+          w.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
+            missingTools,
+          });
+        } else {
+          w.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER,
+          });
+        }
       },
 
       // Recording commands

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -553,14 +553,14 @@
           class="dependency-banner"
           style="display: none"
         >
-          <span>Required dependencies are missing.</span>
+          <span class="missing-tools"></span>
           <div class="actions">
             <button
-              id="dependencyDocsButton"
+              id="dependencyRecheckButton"
               class="vscode-button"
-              data-icon="book"
+              data-icon="refresh"
             >
-              Installation Guide
+              Re-check
             </button>
             <button
               id="dependencyDismissButton"

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -104,6 +104,6 @@ export const ELEMENT_IDS = {
   AGENT_CONFIG_DIR_BUTTON: 'agentConfigDirButton',
   AGENT_CONFIG_DOC_BUTTON: 'agentConfigDocButton',
   DEPENDENCY_BANNER: 'dependencyBanner',
-  DEPENDENCY_DOCS_BUTTON: 'dependencyDocsButton',
+  DEPENDENCY_RECHECK_BUTTON: 'dependencyRecheckButton',
   DEPENDENCY_DISMISS_BUTTON: 'dependencyDismissButton',
 };

--- a/src/webview/modules/uiManagers/BannerManager.js
+++ b/src/webview/modules/uiManagers/BannerManager.js
@@ -132,23 +132,72 @@ export class BannerManager extends BaseUIManager {
    * @param {string[]} [config.missingTools] - Array of missing tool names
    */
   _setupDependencyBanner(element, config) {
-    const textSpan = element.querySelector('span');
+    const container = element.querySelector('.missing-tools');
+    const actions = element.querySelector('.actions');
 
-    if (!textSpan) {
-      console.warn('[BannerManager] Dependency banner missing text element');
+    if (!(container && actions)) {
+      console.warn(
+        '[BannerManager] Dependency banner missing required elements',
+      );
       return;
     }
 
-    const missing = config?.missingTools || [];
-    const formatted = missing.map((tool) =>
-      tool === 'gm/magick' ? 'GraphicsMagick or ImageMagick' : tool,
-    );
+    // Clear existing content
+    container.textContent = '';
 
-    if (formatted.length > 0) {
-      textSpan.textContent = `Missing dependencies: ${formatted.join(', ')}`;
+    const missing = config?.missingTools || [];
+    if (missing.length > 0) {
+      const intro = document.createElement('span');
+      intro.textContent = 'Missing dependencies:';
+      container.appendChild(intro);
+
+      missing.forEach((tool) => {
+        if (tool === 'gm/magick') {
+          this._addDependencyItem(container, 'GraphicsMagick', 'gm');
+          this._addDependencyItem(container, 'ImageMagick', 'magick');
+        } else {
+          this._addDependencyItem(container, tool, tool);
+        }
+      });
     } else {
-      textSpan.textContent = 'Missing dependencies: none';
+      container.textContent = 'Missing dependencies: none';
     }
+
+    // Ensure re-check button exists
+    let recheckButton = actions.querySelector('#dependencyRecheckButton');
+    if (!recheckButton) {
+      recheckButton = document.createElement('button');
+      recheckButton.id = 'dependencyRecheckButton';
+      recheckButton.className = 'vscode-button';
+      recheckButton.dataset.icon = 'refresh';
+      recheckButton.textContent = 'Re-check';
+      actions.insertBefore(recheckButton, actions.firstChild);
+    }
+  }
+
+  /**
+   * Add a dependency item with install button to the container.
+   * @private
+   * @param {HTMLElement} container - container for dependency items
+   * @param {string} label - Display name of the tool
+   * @param {string} tool - Tool identifier for install command
+   */
+  _addDependencyItem(container, label, tool) {
+    const item = document.createElement('div');
+    item.classList.add('dependency-item');
+
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = label;
+
+    const button = document.createElement('button');
+    button.className = 'vscode-button secondary dependency-install-button';
+    button.textContent = 'Install';
+    button.dataset.icon = 'cloud-download';
+    button.dataset.tool = tool;
+
+    item.appendChild(nameSpan);
+    item.appendChild(button);
+    container.appendChild(item);
   }
 }
 

--- a/src/webview/modules/uiManagers/BaseUIManager.js
+++ b/src/webview/modules/uiManagers/BaseUIManager.js
@@ -24,6 +24,30 @@ export class BaseUIManager {
   }
 
   /**
+   * Remove a previously registered event handler and stop tracking it.
+   * @param {HTMLElement|string} elementOrId - element or its ID
+   * @param {string} event - event type
+   * @param {EventListenerOrEventListenerObject} handler - handler function
+   */
+  removeListener(elementOrId, event, handler) {
+    const element =
+      typeof elementOrId === 'string'
+        ? safeGetElementById(elementOrId)
+        : elementOrId;
+    if (!element) {
+      return;
+    }
+
+    element.removeEventListener(event, handler);
+    this._listeners = this._listeners.filter(
+      (listener) =>
+        listener.element !== element ||
+        listener.event !== event ||
+        listener.handler !== handler,
+    );
+  }
+
+  /**
    * Remove all registered event listeners.
    */
   cleanup() {

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -9,6 +9,7 @@ import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
 import { BaseUIManager } from './BaseUIManager.js';
 import { webviewEventBus } from '../eventBus.js';
+import { bannerManager } from './BannerManager.js';
 import { safeGetElementById } from '@common/domUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -86,12 +87,6 @@ export class SettingsButtonManager extends BaseUIManager {
   }
 
   _setupDependencyBanner() {
-    this.addListener(ELEMENT_IDS.DEPENDENCY_DOCS_BUTTON, 'click', () => {
-      this.vscode.postMessage({
-        command: MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS,
-      });
-    });
-
     this.addListener(ELEMENT_IDS.DEPENDENCY_DISMISS_BUTTON, 'click', () => {
       // Hide the banner
       const element = safeGetElementById(ELEMENT_IDS.DEPENDENCY_BANNER);
@@ -105,30 +100,36 @@ export class SettingsButtonManager extends BaseUIManager {
       });
     });
 
+    this.addListener(ELEMENT_IDS.DEPENDENCY_RECHECK_BUTTON, 'click', () => {
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES,
+      });
+    });
+
     this.eventBus.addEventListener('showDependencyBanner', (e) => {
       const missing = e.detail?.missingTools || [];
+      bannerManager.showBanner(ELEMENT_IDS.DEPENDENCY_BANNER, {
+        missingTools: missing,
+      });
+
       const element = safeGetElementById(ELEMENT_IDS.DEPENDENCY_BANNER);
       if (element) {
-        const textSpan = element.querySelector('span');
-        if (textSpan) {
-          // Format the display of missing tools more nicely
-          const formattedTools = missing.map((tool) => {
-            if (tool === 'gm/magick') {
-              return 'GraphicsMagick or ImageMagick';
-            }
-            return tool;
+        const buttons = element.querySelectorAll('.dependency-install-button');
+        buttons.forEach((button) => {
+          const tool = button.dataset.tool;
+          this.addListener(button, 'click', () => {
+            this.vscode.postMessage({
+              command: MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE,
+              tool,
+            });
           });
-          textSpan.textContent = `Missing dependencies: ${formattedTools.join(', ')}`;
-        }
+        });
         element.style.setProperty('display', 'flex');
       }
     });
 
     this.eventBus.addEventListener('hideDependencyBanner', () => {
-      const element = safeGetElementById(ELEMENT_IDS.DEPENDENCY_BANNER);
-      if (element) {
-        element.style.setProperty('display', 'none');
-      }
+      bannerManager.hideBanner(ELEMENT_IDS.DEPENDENCY_BANNER);
     });
   }
 

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -28,6 +28,7 @@ export class SettingsButtonManager extends BaseUIManager {
     this.latexdiffManager = latexdiffManager;
     this.state = state;
     this.eventBus = eventBus;
+    this._dependencyInstallListeners = [];
   }
 
   _setupToggles() {
@@ -107,6 +108,7 @@ export class SettingsButtonManager extends BaseUIManager {
     });
 
     this.eventBus.addEventListener('showDependencyBanner', (e) => {
+      this._disposeDependencyInstallListeners();
       const missing = e.detail?.missingTools || [];
       bannerManager.showBanner(ELEMENT_IDS.DEPENDENCY_BANNER, {
         missingTools: missing,
@@ -117,11 +119,16 @@ export class SettingsButtonManager extends BaseUIManager {
         const buttons = element.querySelectorAll('.dependency-install-button');
         buttons.forEach((button) => {
           const tool = button.dataset.tool;
-          this.addListener(button, 'click', () => {
+          const handleInstallClick = () => {
             this.vscode.postMessage({
               command: MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE,
               tool,
             });
+          };
+          this.addListener(button, 'click', handleInstallClick);
+          this._dependencyInstallListeners.push({
+            element: button,
+            handler: handleInstallClick,
           });
         });
         element.style.setProperty('display', 'flex');
@@ -129,8 +136,16 @@ export class SettingsButtonManager extends BaseUIManager {
     });
 
     this.eventBus.addEventListener('hideDependencyBanner', () => {
+      this._disposeDependencyInstallListeners();
       bannerManager.hideBanner(ELEMENT_IDS.DEPENDENCY_BANNER);
     });
+  }
+
+  _disposeDependencyInstallListeners() {
+    this._dependencyInstallListeners.forEach(({ element, handler }) => {
+      this.removeListener(element, 'click', handler);
+    });
+    this._dependencyInstallListeners = [];
   }
 
   _setupDropdowns() {


### PR DESCRIPTION
## Summary
- show missing tools with per-tool Install buttons and a Re-check action
- wire webview commands to open install guides and refresh dependency checks
- expose per-tool documentation commands for dependency helpers

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c86aebf6c883249b72497a1ed02a62