### PR TITLE
refactor: centralize round group helper

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -162,6 +162,32 @@ export abstract class BaseAgent implements IAgent {
   }
 
   /**
+   * Run a callback within a nested log group tied to the current run.
+   * @param groupLabel Label to use for the new log group
+   * @param callback Callback to execute with the created group ID
+   */
+  protected async withRoundGroup<T>(
+    groupLabel: string,
+    callback: (groupId: string) => Promise<T>,
+  ): Promise<T> {
+    const groupId = await this.logger.startGroup(
+      groupLabel,
+      undefined,
+      this.runGroupId,
+    );
+
+    let status: 'stopped' | 'error' = 'stopped';
+    try {
+      return await callback(groupId);
+    } catch (error) {
+      status = 'error';
+      throw error;
+    } finally {
+      this.logger.endGroup(groupId, status);
+    }
+  }
+
+  /**
    * Start a log group for this agent's run and store its ID.
    * @param parentGroupId Optional parent group
    * @returns The created group ID

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -534,27 +534,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     });
   }
 
-  private async withRoundGroup<T>(
-    roundLabel: string,
-    callback: (groupId: string) => Promise<T>,
-  ): Promise<T> {
-    const groupId = await this.logger.startGroup(
-      roundLabel,
-      undefined,
-      this.runGroupId,
-    );
-
-    let status: 'stopped' | 'error' = 'stopped';
-    try {
-      return await callback(groupId);
-    } catch (error) {
-      status = 'error';
-      throw error;
-    } finally {
-      this.logger.endGroup(groupId, status);
-    }
-  }
-
   private async runRound(
     currRound: number,
     stateGlobal: AgentStateGlobal,


### PR DESCRIPTION
## Summary
- add a reusable withRoundGroup helper to BaseAgent using the instance logger
- remove the duplicate helper from BaseReflectionAgent and rely on the base implementation

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9270fc8748324ba9c79d866c93d60