### PR TITLE
refactor: remove input prefill tooling

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -398,7 +398,6 @@ These settings, accessible directly in the main TeXRA webview, control how agent
 
 - **Reflect** (<i class="codicon codicon-refresh"></i>): Enables CoT agents to critique/improve their output (adds round 1). Increases cost/time, potentially quality.
 - **Attach TeX Count** (<i class="codicon codicon-symbol-numeric"></i>): Includes `texcount` output (word/header/math stats) in the agent's context. Requires `texcount` installed.
-- **Use Prefill from Input** (<i class="codicon codicon-edit"></i>): Uses the input file content to prefill the instruction box (if agent supports it).
 - **Print Input Prompt** (<i class="codicon codicon-file-code"></i>): Adds the full final prompt sent to the LLM to the ProgressBoard log (useful for debugging, increases log size).
 
 **Model/Agent Selection:**

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -30,7 +30,7 @@ TeXRA's logging interface that shows detailed information about the processing s
 
 ### Tool Config
 
-Settings that control how TeXRA interacts with external tools and processes, including reflection, TeX counting, and prefilling options.
+Settings that control how TeXRA interacts with external tools and processes, including reflection, TeX counting, and prompt logging options.
 
 ### Auto Extract
 

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -10,7 +10,6 @@ import { z } from 'zod';
 export const ToolConfigSchema = z
   .object({
     reflect: z.boolean().default(false),
-    usePrefillFromInput: z.boolean().default(false),
     autoExtractFigure: z.boolean().default(false),
     autoExtractTikzFigure: z.boolean().default(false),
     attachTeXCount: z.boolean().default(false),

--- a/src/agent/core/ToolState.ts
+++ b/src/agent/core/ToolState.ts
@@ -3,9 +3,6 @@ export interface IToolState {
   /** Statistics about TeX document structure */
   texcountStats: string | null;
 
-  /** First K lines of TeX document */
-  firstKCharsFromInput: string | null;
-
   /** Most recent model response */
   lastResponse: string;
 
@@ -29,7 +26,6 @@ export interface IToolState {
 /** Manages tool-specific runtime state and operations within a conversation round. */
 export class ToolState implements IToolState {
   texcountStats: string | null;
-  firstKCharsFromInput: string | null;
   lastResponse: string;
   accumulatedOutput: string;
   mediaFiles: string[];
@@ -46,7 +42,6 @@ export class ToolState implements IToolState {
 
   constructor() {
     this.texcountStats = null;
-    this.firstKCharsFromInput = null;
     this.lastResponse = '';
     this.accumulatedOutput = '';
     this.mediaFiles = [];

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -18,11 +18,7 @@ import {
   getPrefillForRound,
   getReflectPromptForRound,
 } from '@agent/utils/promptHelpers';
-import {
-  renderPrompt,
-  getFirstKCharsFromDocument,
-  writePromptToXml,
-} from '@agent/utils/promptUtils';
+import { renderPrompt, writePromptToXml } from '@agent/utils/promptUtils';
 import { bus } from '@eventBus/ProgressEventBus';
 // Standard library imports
 // (none needed)
@@ -39,9 +35,6 @@ import type { ToolDefinition } from '@model';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
-
-// Shared constants
-import { K_SLICE } from '@utils/config';
 
 // Local imports - utilities
 import { calculateTotalRounds } from '@agent/utils/roundUtils';
@@ -235,14 +228,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     this.logger.debug(`Processing round ${currRound}`);
 
     return this.withRoundGroup(`r${currRound}`, async (roundGroupId) => {
-      // Handle prefill from input if enabled
-      if (this.agentConfig.toolConfig.usePrefillFromInput) {
-        toolState.firstKCharsFromInput = await getFirstKCharsFromDocument(
-          this.agentConfig.inputFile,
-          K_SLICE,
-        );
-      }
-
       const extraMedia: string[] = [];
       if (this.modelHandler.capabilities.supportsVision) {
         if (
@@ -421,13 +406,6 @@ export abstract class BaseReflectionAgent extends BaseAgent {
             toolState,
           );
         }
-      }
-
-      if (this.agentConfig.toolConfig.usePrefillFromInput) {
-        toolState.firstKCharsFromInput = await getFirstKCharsFromDocument(
-          this.agentConfig.inputFile,
-          K_SLICE,
-        );
       }
 
       // Initialize round

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -91,7 +91,6 @@ export abstract class ModelHandler<
     this.config = {
       ...config,
       toolConfig: config.toolConfig || {
-        usePrefillFromInput: false,
         autoExtractFigure: false,
         autoExtractTikzFigure: false,
         reflect: false,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -554,14 +554,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     let endTurn = false;
 
     if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
-      if (
-        agentConfig.toolConfig.usePrefillFromInput &&
-        toolState.firstKCharsFromInput
-      ) {
-        prefill += toolState.firstKCharsFromInput;
-        toolState.updateAccumulatedOutput(toolState.firstKCharsFromInput);
-      }
-
       if (this.capabilities.supportsAssistantPrefill) {
         this.logger.debug(`Adding prefill message:\n${prefill}`);
         if (

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -866,19 +866,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       this.logger.debug(
         `Output file ${outputFile} does not exist or is empty.`,
       );
-      if (
-        agentConfig.toolConfig.usePrefillFromInput &&
-        toolState.firstKCharsFromInput
-      ) {
-        prefill = `<${agentSetting.documentTag}>${toolState.firstKCharsFromInput}`;
-        toolState.updateAccumulatedOutput(prefill);
-        this.logger.debug(
-          `Using prefill from input file, updated prefill and toolState.`,
-        );
-      } else {
-        toolState.updateAccumulatedOutput(prefill);
-        // this.logger.debug(`Using standard prefill, updated toolState.`);
-      }
+      toolState.updateAccumulatedOutput(prefill);
 
       // Add pseudo-prefill instruction instead of skipping it
       const lastMessage = messages[messages.length - 1];

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -621,15 +621,6 @@ export class ModelHandlerOpenAI extends ModelHandler<
     let endTurn = false;
 
     if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
-      if (
-        agentConfig.toolConfig.usePrefillFromInput &&
-        toolState.firstKCharsFromInput
-      ) {
-        prefill += toolState.firstKCharsFromInput;
-        toolState.updateAccumulatedOutput('');
-        prefill = `<${agentSetting.documentTag}>${toolState.firstKCharsFromInput}`;
-      }
-
       const PseudoPrefillMsgContentString = `Organize your response with xml tags. Start your response with:\n${prefill}`;
       const lastMessage = messages.at(-1);
       if (lastMessage && Array.isArray(lastMessage.content)) {

--- a/src/agent/utils/promptUtils.ts
+++ b/src/agent/utils/promptUtils.ts
@@ -132,28 +132,6 @@ export async function renderPrompt(
 }
 
 /**
- * Get the first K characters from a document
- * @param inputFile Path to the input file
- * @param k Number of characters to return
- * @returns First K characters from the document, stripped of whitespace, or null if file cannot be read
- */
-export async function getFirstKCharsFromDocument(
-  inputFile: string,
-  k: number,
-): Promise<string | null> {
-  try {
-    const content = await WorkspaceFS.read(inputFile);
-    return content ? content.slice(0, k).trim() : null;
-  } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error reading first ${k} chars from ${inputFile}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return null;
-  }
-}
-
-/**
  * Write the model's input prompt to an XML file
  * @param systemPrompt The system prompt
  * @param userPrefix The user prefix

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -315,7 +315,6 @@ function getToolFlags(
     AUTO_EXTRACT_FIGURE: agentConfig.toolConfig.autoExtractFigure,
     AUTO_EXTRACT_TIKZ_FIGURE: agentConfig.toolConfig.autoExtractTikzFigure,
     INCLUDE_TEX_COUNT: agentConfig.toolConfig.attachTeXCount,
-    USE_PREFILL_FROM_INPUT: agentConfig.toolConfig.usePrefillFromInput,
     PRINT_INPUT_PROMPT: agentConfig.toolConfig.printInputPrompt,
     AUTO_COMPILE_INPUT_PDF: agentConfig.toolConfig.autoCompileInputPdf,
   };

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -72,7 +72,6 @@ describe('OutputHandler.finalizeRound', () => {
     editedFile: null,
     toolConfig: {
       reflect: false,
-      usePrefillFromInput: false,
       autoExtractFigure: false,
       autoExtractTikzFigure: false,
       attachTeXCount: false,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -43,7 +43,6 @@ describe('XmlOutputManager markdown fallback', () => {
     editedFile: null,
     toolConfig: {
       reflect: false,
-      usePrefillFromInput: false,
       autoExtractFigure: false,
       autoExtractTikzFigure: false,
       attachTeXCount: false,

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -136,7 +136,6 @@ describe('BaseToolUseAgent follow-up loop', () => {
       editedFile: null,
       toolConfig: {
         reflect: false,
-        usePrefillFromInput: false,
         autoExtractFigure: false,
         autoExtractTikzFigure: false,
         attachTeXCount: false,

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -70,7 +70,6 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     autoExtractTikzFigure,
     autoCompileInputPdf,
     attachTeXCount,
-    usePrefillFromInput,
     printInputPrompt,
     reflect,
     ...agentConfigData
@@ -93,7 +92,6 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     ...(autoExtractTikzFigure !== undefined && { autoExtractTikzFigure }),
     ...(autoCompileInputPdf !== undefined && { autoCompileInputPdf }),
     ...(attachTeXCount !== undefined && { attachTeXCount }),
-    ...(usePrefillFromInput !== undefined && { usePrefillFromInput }),
     ...(printInputPrompt !== undefined && { printInputPrompt }),
     ...(reflect !== undefined && { reflect }),
   };

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -20,7 +20,6 @@ export const AUTO_EXTRACT_FIELDS = [
 ] as const;
 export const TOOL_CONFIG_FIELDS = [
   'attachTeXCount',
-  'usePrefillFromInput',
   'printInputPrompt',
   'reflect',
 ] as const;

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -412,11 +412,6 @@
                     Diagnostics</label
                   >
                   <label class="vscode-checkbox"
-                    ><input type="checkbox" id="usePrefillFromInput" />
-                    <i class="codicon codicon-edit"></i> Use Prefill from
-                    Input</label
-                  >
-                  <label class="vscode-checkbox"
                     ><input type="checkbox" id="printInputPrompt" />
                     <i class="codicon codicon-file-code"></i> Print Input
                     Prompt</label

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -44,7 +44,6 @@ export class ExecutionManager {
       reflect: message.reflect,
       attachTeXCount: message.attachTeXCount,
       attachDiagnostics: message.attachDiagnostics,
-      usePrefillFromInput: message.usePrefillFromInput,
       printInputPrompt: message.printInputPrompt,
       autoCompileInputPdf: message.autoCompileInputPdf,
     };

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -41,7 +41,6 @@ export const CHECK_BOXES_AUTO_EXTRACT = [
 export const CHECK_BOXES_TOOL_USE = [
   'attachTeXCount',
   'attachDiagnostics',
-  'usePrefillFromInput',
   'printInputPrompt',
   'reflect',
 ];

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -349,8 +349,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         state.attachTeXCount ?? toolConfig.attachTeXCount ?? false,
       attachDiagnostics:
         state.attachDiagnostics ?? toolConfig.attachDiagnostics ?? false,
-      usePrefillFromInput:
-        state.usePrefillFromInput ?? toolConfig.usePrefillFromInput ?? false,
       printInputPrompt:
         state.printInputPrompt ?? toolConfig.printInputPrompt ?? false,
       autoCompileInputPdf:


### PR DESCRIPTION
## Summary
- remove the unused getFirstKCharsFromDocument helper and the ToolState field used to store its result
- drop the usePrefillFromInput toggle from tool configuration, model handlers, agent logic, and the webview UI
- update tests and docs to reflect the removal of the input prefill option

## Testing
- npm run format
- npm run lint
- npm test *(fails: `/workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.0/code: error while loading shared libraries: libatk-1.0.so.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68c926c3f8748324878402f97d101cd3