### PR TITLE
Refactor output file processing into strategies

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -10,10 +10,13 @@ import type { IOutputHandler } from './IOutputHandler';
 import { LatexDiffManager } from './LatexDiffManager';
 import type { NamedOutputFile, OutputFileInfo } from './types';
 import { XmlOutputManager } from './XmlOutputManager';
+import type { OutputProcessingStrategy } from './strategies/OutputProcessingStrategy';
+import { MultipleOutputStrategy } from './strategies/MultipleOutputStrategy';
+import { SingleOutputStrategy } from './strategies/SingleOutputStrategy';
 
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { AgentSetting } from '@agent/core/AgentDataclass';
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -24,11 +27,9 @@ import { runLatexFormatter } from '@latex/texFormatter';
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - utilities
-import { replaceInputCommands, createFileMapping } from '@utils/files';
-import { WorkspaceFS, AbsoluteFS } from '@utils/files';
+import { createFileMapping, WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 
 // Local imports - types
@@ -47,6 +48,7 @@ export class OutputHandler implements IOutputHandler {
   public readonly xmlManager: XmlOutputManager;
   private diffManager: LatexDiffManager;
   private diffStatsManager: DiffStatsManager;
+  private activeLogGroupId?: string;
 
   constructor(
     agentSetting: AgentSetting,
@@ -77,6 +79,17 @@ export class OutputHandler implements IOutputHandler {
       this.channel,
     );
     this.diffStatsManager = new DiffStatsManager();
+  }
+
+  private createProcessingStrategy(): OutputProcessingStrategy {
+    if (
+      Array.isArray(this.agentConfig.outputFiles) &&
+      this.agentConfig.outputFiles.length > 0
+    ) {
+      return new MultipleOutputStrategy();
+    }
+
+    return new SingleOutputStrategy();
   }
 
   private ensureRound(round: number): void {
@@ -146,6 +159,21 @@ export class OutputHandler implements IOutputHandler {
     for (const filePath of filePaths) {
       await this.indentLatexFile(filePath);
     }
+  }
+
+  /** Accessor for the underlying logger. */
+  public getLogger(): AgentLogger {
+    return this.logger;
+  }
+
+  /** Retrieve the output channel identifier. */
+  public getChannel(): string {
+    return this.channel;
+  }
+
+  /** Retrieve the active log group identifier for the current operation. */
+  public getActiveLogGroupId(): string | undefined {
+    return this.activeLogGroupId;
   }
 
   /**
@@ -326,110 +354,15 @@ export class OutputHandler implements IOutputHandler {
     currRound: number,
     groupId?: string,
   ): Promise<void> {
-    const activeGroupId = groupId || this.logger.getActiveGroupId();
     this.ensureRound(currRound);
+    const strategy = this.createProcessingStrategy();
+    const activeGroupId = groupId || this.logger.getActiveGroupId();
+    this.activeLogGroupId = activeGroupId;
 
-    if (
-      Array.isArray(this.agentConfig.outputFiles) &&
-      this.agentConfig.outputFiles.length > 0
-    ) {
-      // Multiple output files case
-      this.logger.debug(
-        `Processing multiple outputs for ${outputFile}; outputFiles: ${this.agentConfig.outputFiles}`,
-        activeGroupId,
-      );
-
-      try {
-        const processedPairs =
-          await this.xmlManager.processMultipleXmlOutputs(outputFile);
-
-        if (processedPairs && processedPairs.length > 0) {
-          const processedFiles = processedPairs.map((p) => p.path);
-          await this.indentLatexFiles(processedFiles);
-          this.logger.debug(
-            `Indented multiple output files: ${processedFiles.join(',')}`,
-            activeGroupId,
-          );
-
-          this.outputFiles[currRound] = processedFiles;
-          this.outputMappings[currRound] = processedPairs;
-
-          if (this.baseFiles && this.baseFiles.length > 0) {
-            await replaceInputCommands(
-              this.baseFiles,
-              processedFiles,
-              this.logger,
-            );
-          }
-        } else {
-          this.logger.debug(
-            `No processed files were generated from ${outputFile}`,
-            activeGroupId,
-          );
-          this.outputFiles[currRound] = [];
-          this.outputMappings[currRound] = [];
-        }
-      } catch (err) {
-        this.logger.debug(
-          `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
-          activeGroupId,
-          MESSAGE_TYPES.INTERNAL,
-        );
-        this.outputFiles[currRound] = [];
-        this.outputMappings[currRound] = [];
-      }
-    } else {
-      // Single output file case
-      this.logger.debug(
-        `Processing single output for ${outputFile}`,
-        activeGroupId,
-      );
-
-      try {
-        let processed: NamedOutputFile = {
-          source: outputFile,
-          path: outputFile,
-        };
-        if (this.agentSetting.agentType === AgentType.CoT) {
-          processed = await this.xmlManager.processSingleXmlOutput(outputFile);
-        }
-
-        if (processed && processed.path) {
-          await this.indentLatexFile(processed.path);
-          this.logger.debug(
-            `Indented single output file: ${processed.path}`,
-            activeGroupId,
-          );
-
-          this.outputFiles[currRound] = [processed.path];
-          this.outputMappings[currRound] = [processed];
-        } else {
-          this.logger.debug(
-            `No processed file was generated from ${outputFile}`,
-            activeGroupId,
-          );
-          this.outputFiles[currRound] = [];
-          this.outputMappings[currRound] = [];
-        }
-      } catch (err) {
-        this.logger.debug(
-          `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
-          activeGroupId,
-          MESSAGE_TYPES.INTERNAL,
-        );
-        const missingOutputsData = {
-          missing: [],
-          xmlFile: outputFile,
-          documentTag: this.agentSetting.documentTag,
-        };
-        this.logger.missingOutputs(missingOutputsData, activeGroupId);
-        bus.emit('updateMissingOutputs', {
-          stream: this.channel,
-          filesByRound: { [currRound]: [] },
-        });
-        this.outputFiles[currRound] = [];
-        this.outputMappings[currRound] = [];
-      }
+    try {
+      await strategy.process(outputFile, currRound, this);
+    } finally {
+      this.activeLogGroupId = undefined;
     }
   }
   /** Processes output files for current round. */

--- a/src/agent/output/strategies/MultipleOutputStrategy.ts
+++ b/src/agent/output/strategies/MultipleOutputStrategy.ts
@@ -1,0 +1,67 @@
+// Local imports - agent
+import type { NamedOutputFile } from '../types';
+import type { OutputHandler } from '../OutputHandler';
+import type { OutputProcessingStrategy } from './OutputProcessingStrategy';
+
+// Local imports - log
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+// Local imports - utilities
+import { replaceInputCommands } from '@utils/files';
+
+/** Strategy for processing multiple output files. */
+export class MultipleOutputStrategy implements OutputProcessingStrategy {
+  public async process(
+    outputFile: string,
+    currRound: number,
+    handler: OutputHandler,
+  ): Promise<void> {
+    const logger = handler.getLogger();
+    const activeGroupId = handler.getActiveLogGroupId();
+
+    logger.debug(
+      `Processing multiple outputs for ${outputFile}; outputFiles: ${handler.agentConfig.outputFiles}`,
+      activeGroupId,
+    );
+
+    try {
+      const processedPairs =
+        await handler.xmlManager.processMultipleXmlOutputs(outputFile);
+
+      if (processedPairs && processedPairs.length > 0) {
+        const processedFiles = processedPairs.map(
+          (p: NamedOutputFile) => p.path,
+        );
+        await handler.indentLatexFiles(processedFiles);
+        logger.debug(
+          `Indented multiple output files: ${processedFiles.join(',')}`,
+          activeGroupId,
+        );
+
+        handler.outputFiles[currRound] = processedFiles;
+        handler.outputMappings[currRound] = processedPairs;
+
+        if (handler.baseFiles && handler.baseFiles.length > 0) {
+          await replaceInputCommands(handler.baseFiles, processedFiles, logger);
+        }
+      } else {
+        logger.debug(
+          `No processed files were generated from ${outputFile}`,
+          activeGroupId,
+        );
+        handler.outputFiles[currRound] = [];
+        handler.outputMappings[currRound] = [];
+      }
+    } catch (err) {
+      logger.debug(
+        `Error processing output files: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        activeGroupId,
+        MESSAGE_TYPES.INTERNAL,
+      );
+      handler.outputFiles[currRound] = [];
+      handler.outputMappings[currRound] = [];
+    }
+  }
+}

--- a/src/agent/output/strategies/OutputProcessingStrategy.ts
+++ b/src/agent/output/strategies/OutputProcessingStrategy.ts
@@ -1,0 +1,17 @@
+// Local imports - agent
+import type { OutputHandler } from '../OutputHandler';
+
+/** Strategy interface for processing agent output files. */
+export interface OutputProcessingStrategy {
+  /**
+   * Process output files for a given round.
+   * @param outputFile The output file produced by the agent.
+   * @param currRound The round index being processed.
+   * @param handler The handler coordinating output processing.
+   */
+  process(
+    outputFile: string,
+    currRound: number,
+    handler: OutputHandler,
+  ): Promise<void>;
+}

--- a/src/agent/output/strategies/SingleOutputStrategy.ts
+++ b/src/agent/output/strategies/SingleOutputStrategy.ts
@@ -1,0 +1,77 @@
+// Local imports - agent
+import { AgentType } from '@agent/core/AgentDataclass';
+import type { NamedOutputFile } from '../types';
+import type { OutputHandler } from '../OutputHandler';
+import type { OutputProcessingStrategy } from './OutputProcessingStrategy';
+
+// Local imports - events
+import { bus } from '@eventBus/ProgressEventBus';
+
+// Local imports - log
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+/** Strategy for processing a single output file. */
+export class SingleOutputStrategy implements OutputProcessingStrategy {
+  public async process(
+    outputFile: string,
+    currRound: number,
+    handler: OutputHandler,
+  ): Promise<void> {
+    const logger = handler.getLogger();
+    const activeGroupId = handler.getActiveLogGroupId();
+
+    logger.debug(`Processing single output for ${outputFile}`, activeGroupId);
+
+    try {
+      let processed: NamedOutputFile = {
+        source: outputFile,
+        path: outputFile,
+      };
+
+      if (handler.agentSetting.agentType === AgentType.CoT) {
+        processed = await handler.xmlManager.processSingleXmlOutput(outputFile);
+      }
+
+      if (processed && processed.path) {
+        await handler.indentLatexFile(processed.path);
+        logger.debug(
+          `Indented single output file: ${processed.path}`,
+          activeGroupId,
+        );
+
+        handler.outputFiles[currRound] = [processed.path];
+        handler.outputMappings[currRound] = [processed];
+      } else {
+        logger.debug(
+          `No processed file was generated from ${outputFile}`,
+          activeGroupId,
+        );
+        handler.outputFiles[currRound] = [];
+        handler.outputMappings[currRound] = [];
+      }
+    } catch (err) {
+      logger.debug(
+        `Error processing output file: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        activeGroupId,
+        MESSAGE_TYPES.INTERNAL,
+      );
+
+      const missingOutputsData = {
+        missing: [],
+        xmlFile: outputFile,
+        documentTag: handler.agentSetting.documentTag,
+      };
+      logger.missingOutputs(missingOutputsData, activeGroupId);
+
+      bus.emit('updateMissingOutputs', {
+        stream: handler.getChannel(),
+        filesByRound: { [currRound]: [] },
+      });
+
+      handler.outputFiles[currRound] = [];
+      handler.outputMappings[currRound] = [];
+    }
+  }
+}

--- a/src/test/output/MultipleOutputStrategy.test.ts
+++ b/src/test/output/MultipleOutputStrategy.test.ts
@@ -1,0 +1,126 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - test
+import type { AgentConfig } from '@agent/core/AgentConfig';
+
+// Local imports
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { OutputHandler } from '@agent/output/OutputHandler';
+import { MultipleOutputStrategy } from '@agent/output/strategies/MultipleOutputStrategy';
+import { AgentLogger } from '@logger/AgentLogger';
+
+const baseSetting: AgentSetting = {
+  agentType: AgentType.CoT,
+  documentTag: 'document',
+  temperature: 0,
+  isRewrite: true,
+  rounds: 1,
+  prefills: [],
+  outputExt: 'tex',
+  endTag: '</latex_document>',
+  requiredFiles: {},
+  requiredFilesInternal: {},
+  defaultOutputFiles: [],
+  filePatternsContain: [],
+  tools: [],
+};
+
+const baseConfig: AgentConfig = {
+  model: 'test',
+  agent: 'a',
+  instruction: '',
+  inputFile: 'input.tex',
+  inputFiles: null,
+  referenceFile: null,
+  referenceFiles: null,
+  auxiliaryFile: null,
+  auxiliaryFiles: null,
+  mediaFile: null,
+  mediaFiles: null,
+  outputFiles: ['paper.tex'],
+  editedFile: null,
+  toolConfig: {
+    reflect: false,
+    usePrefillFromInput: false,
+    autoExtractFigure: false,
+    autoExtractTikzFigure: false,
+    attachTeXCount: false,
+    attachDiagnostics: false,
+    printInputPrompt: false,
+    autoCompileInputPdf: false,
+  },
+};
+
+function createHandler(): OutputHandler {
+  const logger = new AgentLogger('MultipleOutputStrategyTest');
+  const handler = new OutputHandler(
+    { ...baseSetting },
+    { ...baseConfig },
+    0,
+    [],
+    logger,
+  );
+  return handler;
+}
+
+describe('MultipleOutputStrategy', () => {
+  it('records processed files from the XML manager', async () => {
+    const handler = createHandler();
+    const strategy = new MultipleOutputStrategy();
+    const indentCalls: string[][] = [];
+
+    handler.xmlManager.processMultipleXmlOutputs = async () => [
+      { source: 'round0.xml', path: 'output_a.tex' },
+      { source: 'round0.xml', path: 'output_b.tex' },
+    ];
+    handler.indentLatexFiles = async (files: string[]) => {
+      indentCalls.push(files);
+    };
+
+    await strategy.process('round0.xml', 0, handler);
+
+    assert.deepEqual(handler.outputFiles[0], ['output_a.tex', 'output_b.tex']);
+    assert.deepEqual(handler.outputMappings[0], [
+      { source: 'round0.xml', path: 'output_a.tex' },
+      { source: 'round0.xml', path: 'output_b.tex' },
+    ]);
+    assert.deepEqual(indentCalls, [['output_a.tex', 'output_b.tex']]);
+  });
+
+  it('handles cases where no files are produced', async () => {
+    const handler = createHandler();
+    const strategy = new MultipleOutputStrategy();
+    const indentCalls: string[][] = [];
+
+    handler.xmlManager.processMultipleXmlOutputs = async () => [];
+    handler.indentLatexFiles = async (files: string[]) => {
+      indentCalls.push(files);
+    };
+
+    await strategy.process('round1.xml', 1, handler);
+
+    assert.deepEqual(handler.outputFiles[1], []);
+    assert.deepEqual(handler.outputMappings[1], []);
+    assert.deepEqual(indentCalls, []);
+  });
+
+  it('clears state when processing throws an error', async () => {
+    const handler = createHandler();
+    const strategy = new MultipleOutputStrategy();
+    const indentCalls: string[][] = [];
+
+    handler.xmlManager.processMultipleXmlOutputs = async () => {
+      throw new Error('failure');
+    };
+    handler.indentLatexFiles = async (files: string[]) => {
+      indentCalls.push(files);
+    };
+
+    await strategy.process('round2.xml', 2, handler);
+
+    assert.deepEqual(handler.outputFiles[2], []);
+    assert.deepEqual(handler.outputMappings[2], []);
+    assert.deepEqual(indentCalls, []);
+  });
+});

--- a/src/test/output/SingleOutputStrategy.test.ts
+++ b/src/test/output/SingleOutputStrategy.test.ts
@@ -1,0 +1,136 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - test
+import type { AgentConfig } from '@agent/core/AgentConfig';
+
+// Local imports
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { OutputHandler } from '@agent/output/OutputHandler';
+import { SingleOutputStrategy } from '@agent/output/strategies/SingleOutputStrategy';
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
+
+const baseSetting: AgentSetting = {
+  agentType: AgentType.CoT,
+  documentTag: 'document',
+  temperature: 0,
+  isRewrite: true,
+  rounds: 1,
+  prefills: [],
+  outputExt: 'tex',
+  endTag: '</latex_document>',
+  requiredFiles: {},
+  requiredFilesInternal: {},
+  defaultOutputFiles: [],
+  filePatternsContain: [],
+  tools: [],
+};
+
+const baseConfig: AgentConfig = {
+  model: 'test',
+  agent: 'a',
+  instruction: '',
+  inputFile: 'input.tex',
+  inputFiles: null,
+  referenceFile: null,
+  referenceFiles: null,
+  auxiliaryFile: null,
+  auxiliaryFiles: null,
+  mediaFile: null,
+  mediaFiles: null,
+  outputFiles: null,
+  editedFile: null,
+  toolConfig: {
+    reflect: false,
+    usePrefillFromInput: false,
+    autoExtractFigure: false,
+    autoExtractTikzFigure: false,
+    attachTeXCount: false,
+    attachDiagnostics: false,
+    printInputPrompt: false,
+    autoCompileInputPdf: false,
+  },
+};
+
+function createHandler(settingOverride?: Partial<AgentSetting>): OutputHandler {
+  const setting = { ...baseSetting, ...settingOverride };
+  const logger = new AgentLogger('SingleOutputStrategyTest');
+  const handler = new OutputHandler(setting, { ...baseConfig }, 0, [], logger);
+  return handler;
+}
+
+describe('SingleOutputStrategy', () => {
+  it('processes a single output file and records mappings', async () => {
+    const handler = createHandler();
+    const strategy = new SingleOutputStrategy();
+    const indentCalls: string[] = [];
+
+    handler.xmlManager.processSingleXmlOutput = async () => ({
+      source: 'round0.xml',
+      path: 'round0.tex',
+    });
+    handler.indentLatexFile = async (filePath: string) => {
+      indentCalls.push(filePath);
+    };
+
+    await strategy.process('round0.xml', 0, handler);
+
+    assert.deepEqual(handler.outputFiles[0], ['round0.tex']);
+    assert.deepEqual(handler.outputMappings[0], [
+      { source: 'round0.xml', path: 'round0.tex' },
+    ]);
+    assert.deepEqual(indentCalls, ['round0.tex']);
+  });
+
+  it('skips XML processing for direct agents', async () => {
+    const handler = createHandler({ agentType: AgentType.Direct });
+    const strategy = new SingleOutputStrategy();
+    let xmlCalled = false;
+    const indentCalls: string[] = [];
+
+    handler.xmlManager.processSingleXmlOutput = async () => {
+      xmlCalled = true;
+      return { source: 'unused', path: 'unused.tex' };
+    };
+    handler.indentLatexFile = async (filePath: string) => {
+      indentCalls.push(filePath);
+    };
+
+    await strategy.process('direct.tex', 1, handler);
+
+    assert.strictEqual(xmlCalled, false);
+    assert.deepEqual(handler.outputFiles[1], ['direct.tex']);
+    assert.deepEqual(handler.outputMappings[1], [
+      { source: 'direct.tex', path: 'direct.tex' },
+    ]);
+    assert.deepEqual(indentCalls, ['direct.tex']);
+  });
+
+  it('emits missing outputs when processing fails', async () => {
+    const handler = createHandler();
+    const strategy = new SingleOutputStrategy();
+    const indentCalls: string[] = [];
+    handler.xmlManager.processSingleXmlOutput = async () => {
+      throw new Error('fail');
+    };
+    handler.indentLatexFile = async (filePath: string) => {
+      indentCalls.push(filePath);
+    };
+
+    const events: any[] = [];
+    const dispose = bus.on('updateMissingOutputs', (payload) => {
+      events.push(payload);
+    });
+
+    await strategy.process('error.xml', 2, handler);
+
+    assert.deepEqual(handler.outputFiles[2], []);
+    assert.deepEqual(handler.outputMappings[2], []);
+    assert.deepEqual(indentCalls, []);
+    assert.strictEqual(events.length, 1);
+    assert.deepEqual(events[0].filesByRound[2], []);
+
+    dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- add an `OutputProcessingStrategy` interface with single and multiple strategy implementations
- update `OutputHandler` to pick the correct strategy and expose logger helpers for them
- introduce unit tests covering both strategy paths

## Testing
- npm run format
- npm run lint
- npm run compile-tests
- CI=1 npm test *(fails: vscode-test requires libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c9253d280c8324872613cc4cd94e06