### PR TITLE
refactor: centralize prompt building

### DIFF
--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -62,6 +62,16 @@ sequenceDiagram
 
 TeXRA constructs the conversation by merging your agent's `systemPrompt`, the context-filled `userPrefix`, and the `userRequest`. Depending on settings, the extension may insert additional messages in between—for example the output of `texcount` when you enable **Attach TeX Count**, or encoded images and audio files selected in the file panel. The sequence is not a fixed "system–user–system" pattern: attachments or tool results can be inserted at any point before the LLM generates a single response containing `<scratchpad>` reasoning followed by the XML-wrapped output defined by `settings.documentTag`.
 
+### PromptBuilder utility
+
+Internally, TeXRA now assembles these prompt segments through the `PromptBuilder` helper. The builder collects the agent's templates and rendered variables once and exposes focused methods:
+
+- `buildInitialPrompts()` returns the trio of system, prefix, and request messages used for round 0.
+- `buildReflectPrompt(round)` renders the appropriate `userReflect` template for a given reflection round.
+- `getPrefill(round)` provides the prefill seed that is streamed to the assistant before each model turn.
+
+Agents that inherit from `BaseReflectionAgent` can override the protected `getPromptBuilder()` hook to supply a subclassed builder. This makes it easy to add new phases (e.g., a planning stage) or to customize how prefills are computed without rewriting the round-processing logic. When you introduce a specialised agent, create a derived `PromptBuilder` that extends the base implementation, override or add the necessary methods, and return it from your agent's `getPromptBuilder()` override so the lifecycle automatically uses your custom prompts.
+
 **Optional Reflection (Round 1):**
 
 If you enable the "Reflect" option in the Tool Config section of the UI, TeXRA performs an additional step after Round 0 finishes successfully:

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -13,13 +13,8 @@ import { ToolState } from '@agent/core/ToolState';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import {
-  getSystemPromptWithRules,
-  getPrefillForRound,
-  getReflectPromptForRound,
-} from '@agent/utils/promptHelpers';
-import {
-  renderPrompt,
   getFirstKCharsFromDocument,
   writePromptToXml,
 } from '@agent/utils/promptUtils';
@@ -75,6 +70,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /** Handler for output file processing and validation. */
   protected outputHandler: IOutputHandler;
   protected latexMediaManager: LatexMediaManager;
+  protected promptBuilder?: PromptBuilder;
   public roundStates: AgentStateRound[] = [];
   public toolStates: ToolState[] = [];
 
@@ -120,6 +116,18 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     );
 
     this.latexMediaManager = new LatexMediaManager(this.logger);
+  }
+
+  protected getPromptBuilder(): PromptBuilder {
+    if (!this.promptBuilder) {
+      this.promptBuilder = new PromptBuilder(
+        this.agentPrompt,
+        this.agentSetting,
+        this.userVars,
+      );
+    }
+
+    return this.promptBuilder;
   }
 
   /**
@@ -268,11 +276,9 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       const messages: any[] = [];
 
       // Set up initial prompts
-      const [systemPrompt, userRequest, userPrefix] = await Promise.all([
-        getSystemPromptWithRules(this.agentPrompt.systemPrompt, this.userVars),
-        renderPrompt(this.agentPrompt.userRequest, this.userVars),
-        renderPrompt(this.agentPrompt.userPrefix, this.userVars),
-      ]);
+      const promptBuilder = this.getPromptBuilder();
+      const { systemPrompt, userRequest, userPrefix } =
+        await promptBuilder.buildInitialPrompts();
 
       let prefixWithStats = userPrefix;
       if (toolState.texcountStats) {
@@ -300,7 +306,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       messages.push(...initialMessages);
 
       // Handle prefill
-      const prefill = getPrefillForRound(this.agentSetting.prefills, currRound);
+      const prefill = promptBuilder.getPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
       // Initialize output and handle prefill
@@ -434,14 +440,9 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       const stateRound = new AgentStateRound(currRound);
 
       // Prepare round message
-      const reflectTemplate = getReflectPromptForRound(
-        this.agentPrompt,
-        currRound,
-      );
-      const userRequestReflect = await renderPrompt(
-        reflectTemplate,
-        this.userVars,
-      );
+      const promptBuilder = this.getPromptBuilder();
+      const userRequestReflect =
+        await promptBuilder.buildReflectPrompt(currRound);
       let userMessage = userRequestReflect ? `${userRequestReflect}\n` : '';
       if (toolState.texcountStats) {
         userMessage = `${toolState.texcountStats}${userMessage}`;
@@ -459,7 +460,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       );
 
       // Handle prefill for round
-      const prefill = getPrefillForRound(this.agentSetting.prefills, currRound);
+      const prefill = promptBuilder.getPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
       const [endTurn, updatedMessages] =
@@ -575,6 +576,11 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
     try {
       await this.init(this.runGroupId);
+      this.promptBuilder = new PromptBuilder(
+        this.agentPrompt,
+        this.agentSetting,
+        this.userVars,
+      );
       await this.initializeClient();
 
       let stateGlobal = new AgentStateGlobal();

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -118,6 +118,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
         this.agentPrompt,
         this.agentSetting,
         this.userVars,
+        this.logger,
       );
     }
 
@@ -292,7 +293,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       messages.push(...initialMessages);
 
       // Handle prefill
-      const prefill = promptBuilder.getPrefill(currRound);
+      const prefill = await promptBuilder.buildPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
       // Initialize output and handle prefill
@@ -439,7 +440,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       );
 
       // Handle prefill for round
-      const prefill = promptBuilder.getPrefill(currRound);
+      const prefill = await promptBuilder.buildPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
       const [endTurn, updatedMessages] =
@@ -534,11 +535,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
 
     try {
       await this.init(this.runGroupId);
-      this.promptBuilder = new PromptBuilder(
-        this.agentPrompt,
-        this.agentSetting,
-        this.userVars,
-      );
+      this.promptBuilder = undefined;
       await this.initializeClient();
 
       let stateGlobal = new AgentStateGlobal();

--- a/src/agent/utils/PromptBuilder.ts
+++ b/src/agent/utils/PromptBuilder.ts
@@ -5,11 +5,7 @@ import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
 import type { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import {
-  getPrefillForRound,
-  getReflectPromptForRound,
-  getSystemPromptWithRules,
-} from './promptHelpers';
+import { getSystemPromptWithRules } from './promptHelpers';
 import { renderPrompt } from './promptUtils';
 
 /**
@@ -57,15 +53,36 @@ export class PromptBuilder {
    * Render the reflection prompt for the supplied round.
    *
    * @param currRound The reflection round (1-indexed for reflection rounds)
+   * @remarks Falls back to the first reflection template when a later round is undefined.
    */
   public async buildReflectPrompt(currRound: number): Promise<string> {
-    const reflectTemplate = getReflectPromptForRound(
-      this.agentPrompt,
-      currRound,
-    );
+    const groupId = this.logger?.getActiveGroupId();
+    const { userReflect } = this.agentPrompt;
+    const normalizedRound = Math.max(1, currRound);
+
+    let reflectTemplate: string | undefined;
+
+    if (Array.isArray(userReflect)) {
+      const index = normalizedRound - 1;
+      reflectTemplate = userReflect[index];
+
+      if (reflectTemplate === undefined) {
+        const fallback = userReflect[0];
+
+        if (fallback) {
+          this.logger?.debug(
+            `No reflection prompt configured for round ${currRound}. Falling back to first template.`,
+            groupId,
+          );
+        }
+
+        reflectTemplate = fallback;
+      }
+    } else {
+      reflectTemplate = userReflect;
+    }
 
     if (!reflectTemplate) {
-      const groupId = this.logger?.getActiveGroupId();
       this.logger?.warn(
         `No reflection prompt configured for round ${currRound}. Returning empty prompt.`,
         groupId,
@@ -80,9 +97,26 @@ export class PromptBuilder {
    * Return the prefill value that should seed the assistant response.
    *
    * @param currRound The current round number (0-based for process, 1+ for reflection)
+   * @remarks Reuses the first configured prefill when subsequent rounds omit a value.
    */
   public async buildPrefill(currRound: number): Promise<string> {
-    return getPrefillForRound(this.agentSetting.prefills, currRound);
+    const prefills = this.agentSetting.prefills;
+    if (!prefills || prefills.length === 0) {
+      return '';
+    }
+
+    const normalizedRound = Math.max(0, currRound);
+    if (normalizedRound < prefills.length) {
+      return prefills[normalizedRound] ?? '';
+    }
+
+    const groupId = this.logger?.getActiveGroupId();
+    this.logger?.debug(
+      `No prefill configured for round ${currRound}. Reusing first prefill.`,
+      groupId,
+    );
+
+    return prefills[0] ?? '';
   }
 }
 

--- a/src/agent/utils/PromptBuilder.ts
+++ b/src/agent/utils/PromptBuilder.ts
@@ -1,0 +1,69 @@
+// Local imports - agent
+import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
+
+// Local imports - utilities
+import {
+  getPrefillForRound,
+  getReflectPromptForRound,
+  getSystemPromptWithRules,
+} from './promptHelpers';
+import { renderPrompt } from './promptUtils';
+
+/**
+ * Bundles prompt construction logic so agents can share consistent behaviour.
+ */
+export class PromptBuilder {
+  constructor(
+    private readonly agentPrompt: AgentPrompt,
+    private readonly agentSetting: AgentSetting,
+    private readonly userVars: Record<string, any>,
+  ) {}
+
+  /**
+   * Render the initial system, prefix, and request prompts for round 0.
+   */
+  public async buildInitialPrompts(): Promise<{
+    systemPrompt: string;
+    userPrefix: string;
+    userRequest: string;
+  }> {
+    const [systemPrompt, userRequest, userPrefix] = await Promise.all([
+      getSystemPromptWithRules(this.agentPrompt.systemPrompt, this.userVars),
+      renderPrompt(this.agentPrompt.userRequest, this.userVars),
+      renderPrompt(this.agentPrompt.userPrefix, this.userVars),
+    ]);
+
+    return { systemPrompt, userPrefix, userRequest };
+  }
+
+  /**
+   * Render the reflection prompt for the supplied round.
+   *
+   * @param currRound The reflection round (1-indexed for reflection rounds)
+   */
+  public async buildReflectPrompt(currRound: number): Promise<string> {
+    const reflectTemplate = getReflectPromptForRound(
+      this.agentPrompt,
+      currRound,
+    );
+
+    if (!reflectTemplate) {
+      return '';
+    }
+
+    return renderPrompt(reflectTemplate, this.userVars);
+  }
+
+  /**
+   * Return the prefill value that should seed the assistant response.
+   *
+   * @param currRound The current round number (0-based for process, 1+ for reflection)
+   */
+  public getPrefill(currRound: number): string {
+    return getPrefillForRound(this.agentSetting.prefills, currRound);
+  }
+}
+
+export type InitialPrompts = Awaited<
+  ReturnType<PromptBuilder['buildInitialPrompts']>
+>;

--- a/src/agent/utils/PromptBuilder.ts
+++ b/src/agent/utils/PromptBuilder.ts
@@ -1,6 +1,9 @@
 // Local imports - agent
 import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
 
+// Local imports - log
+import type { AgentLogger } from '@logger/AgentLogger';
+
 // Local imports - utilities
 import {
   getPrefillForRound,
@@ -10,13 +13,27 @@ import {
 import { renderPrompt } from './promptUtils';
 
 /**
- * Bundles prompt construction logic so agents can share consistent behaviour.
+ * Centralises prompt construction logic for reflection-capable agents.
+ *
+ * @remarks
+ * The builder renders all prompts lazily so callers can defer work until the
+ * relevant conversation stage. Reflection rounds are 1-indexed while process
+ * rounds begin at 0.
+ *
+ * @example
+ * ```ts
+ * const builder = new PromptBuilder(prompt, setting, vars, logger);
+ * const initial = await builder.buildInitialPrompts();
+ * const firstReflect = await builder.buildReflectPrompt(1);
+ * const prefill = await builder.buildPrefill(0);
+ * ```
  */
 export class PromptBuilder {
   constructor(
     private readonly agentPrompt: AgentPrompt,
     private readonly agentSetting: AgentSetting,
     private readonly userVars: Record<string, any>,
+    private readonly logger?: AgentLogger,
   ) {}
 
   /**
@@ -48,6 +65,11 @@ export class PromptBuilder {
     );
 
     if (!reflectTemplate) {
+      const groupId = this.logger?.getActiveGroupId();
+      this.logger?.warn(
+        `No reflection prompt configured for round ${currRound}. Returning empty prompt.`,
+        groupId,
+      );
       return '';
     }
 
@@ -59,7 +81,7 @@ export class PromptBuilder {
    *
    * @param currRound The current round number (0-based for process, 1+ for reflection)
    */
-  public getPrefill(currRound: number): string {
+  public async buildPrefill(currRound: number): Promise<string> {
     return getPrefillForRound(this.agentSetting.prefills, currRound);
   }
 }

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -3,6 +3,7 @@ export * from './userVars';
 export * from './mediaTypes';
 export * from './promptUtils';
 export * from './promptHelpers';
+export * from './PromptBuilder';
 export * from './outputFileUtils';
 export * from './priceUtils';
 export * from './text';

--- a/src/agent/utils/promptHelpers.ts
+++ b/src/agent/utils/promptHelpers.ts
@@ -4,7 +4,6 @@
 // Local imports
 import { renderPrompt } from './promptUtils';
 import { loadTexraRules } from '@frontend/files/rules';
-import type { AgentPrompt } from '@agent/core/AgentDataclass';
 
 /**
  * Combine the base system prompt with optional rules from `.texrarules`.
@@ -22,54 +21,4 @@ export async function getSystemPromptWithRules(
   return rules ? `${basePrompt}\n${rules}` : basePrompt;
 }
 
-/**
- * Get the assistant prefill text for a specific round.
- *
- * @param prefills Prefill array from agent settings
- * @param currRound Current conversation round index
- * @returns Prefill string for the round
- */
-export function getPrefillForRound(
-  prefills: string[] | undefined,
-  currRound: number,
-): string {
-  if (!prefills || prefills.length === 0) {
-    return '';
-  }
-  return currRound < prefills.length ? prefills[currRound] : prefills[0];
-}
-
-/**
- * Convert reflection round number to array index.
- * Reflection rounds start at 1, arrays start at 0.
- *
- * @param reflectionRound The reflection round number (1-based)
- * @returns Array index (0-based)
- */
-export function reflectionRoundToIndex(reflectionRound: number): number {
-  // Round 0 is the initial process, reflection starts at round 1
-  // So round 1 should map to index 0, round 2 to index 1, etc.
-  return Math.max(0, reflectionRound - 1);
-}
-
-/**
- * Retrieve the reflection prompt template for a given round.
- *
- * @param agentPrompt The agent prompt configuration
- * @param currRound Current conversation round index (1-based for reflections)
- * @returns Reflection prompt template string
- */
-export function getReflectPromptForRound(
-  agentPrompt: AgentPrompt,
-  currRound: number,
-): string {
-  const { userReflect } = agentPrompt;
-  if (Array.isArray(userReflect)) {
-    const index = reflectionRoundToIndex(currRound);
-    // Use the specific round template if available, otherwise fall back to first
-    return index < userReflect.length
-      ? userReflect[index]
-      : userReflect[0] || '';
-  }
-  return userReflect || '';
-}
+// (other prompt helper utilities are intentionally kept colocated with their consumers)


### PR DESCRIPTION
## Summary
- add a PromptBuilder utility that renders initial, reflection, and prefill prompts in one place
- update BaseReflectionAgent to consume PromptBuilder for both process and reflect flows
- document how to override PromptBuilder when building future agents

## Testing
- npm run format
- npm run lint
- npm test *(fails: vscode-test cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9272af7c08324855635f2bdcee45e