### PR TITLE
refactor: centralize dom id helpers

### DIFF
--- a/docs/dev/DOM_ID_HELPERS.md
+++ b/docs/dev/DOM_ID_HELPERS.md
@@ -1,0 +1,50 @@
+# DOM ID Helpers
+
+Frontend modules frequently derive DOM ids from file types (e.g., converting
+`input` to `inputFile`, `inputFiles`, or `toggleInputFiles`). Ad-hoc template
+strings tended to drift and made it easy to reference the wrong element. The
+`@common/domIdUtils.js` helpers provide a single source of truth for these
+patterns.
+
+## Available helpers
+
+| Helper                                 | Purpose                                                         | Notes                                                             |
+| -------------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `getSingleFileId(type)`                | Returns the single-file `<select>` id (e.g., `inputFile`).      | Undefined for types without a single selector (such as `output`). |
+| `getMultipleFilesId(type)`             | Returns the multi-select list id (e.g., `inputFiles`).          | Handles camel-cased values like `InputFiles`.                     |
+| `getToggleId(type)`                    | Returns the chevron toggle id for a multi-select list.          | Useful for `fileList` visibility updates.                         |
+| `getFilesContainerId(type)`            | Returns the container wrapper id (e.g., `inputFilesContainer`). |                                                                   |
+| `getEmptySingleFileButtonId(type)`     | Id for the "Empty" button next to a single selector.            | Undefined when the control does not exist.                        |
+| `getEmptyMultipleFilesButtonId(type)`  | Id for the "Empty" button next to a multi-select list.          |                                                                   |
+| `getSelectMultipleFilesButtonId(type)` | Id for the "Select" button that opens the multi-file picker.    |                                                                   |
+| `getAddOpenedFilesButtonId(type)`      | Id for the "Add opened" button.                                 | Only returns a value for `input`, `reference`, and `auxiliary`.   |
+| `getCurrentFileButtonId(type)`         | Id for the "Current" button tied to a single-file selector.     |                                                                   |
+
+The helpers accept plain types (`'input'`), DOM ids (`'inputFiles'`), or camel
+case variants (`'InputFiles'`). Internally they normalize the value before
+building the id. When an id does not exist (for example, `getSingleFileId('output')`)
+the helper returns `undefined` so callers can skip the corresponding logic.
+
+## Usage guidelines
+
+- Always import helpers from `@common/domIdUtils.js` instead of constructing ids
+  manually:
+
+  ```javascript
+  import { getToggleId, getMultipleFilesId } from '@common/domIdUtils.js';
+
+  const listId = getMultipleFilesId(fileType);
+  const toggleId = getToggleId(fileType);
+  if (listId && toggleId) {
+    fileList.update(listId, toggleId, files);
+  }
+  ```
+
+- Reuse the helpers even when the input is already an id (e.g., `'inputFiles'`).
+  They normalize the string and ensure consistent casing.
+- Check for `undefined` when working with optional controls. This prevents calls
+  to `document.getElementById` with ids that are not rendered in the DOM.
+
+Centralizing these conversions keeps the UI managers, message handlers, and
+state management code aligned. Any future adjustments to id formats only need to
+be made in `domIdUtils`, and all dependent modules will follow the new pattern.

--- a/src/common/modules/domIdUtils.js
+++ b/src/common/modules/domIdUtils.js
@@ -1,0 +1,131 @@
+// Local imports - common
+import { capitalize } from './stringUtils.js';
+
+const SINGLE_FILE_TYPES = new Set([
+  'input',
+  'reference',
+  'auxiliary',
+  'media',
+  'base',
+  'edited',
+]);
+
+const MULTIPLE_FILE_TYPES = new Set([
+  'input',
+  'reference',
+  'auxiliary',
+  'media',
+  'output',
+]);
+
+const ADD_OPENED_TYPES = new Set(['input', 'reference', 'auxiliary']);
+
+/**
+ * Normalize file type values to their canonical lower-case form.
+ * Accepts plain types ("input"), camel case variants ("InputFiles"),
+ * or DOM ids ("inputFiles").
+ * @param {string} type
+ * @returns {string}
+ */
+function normalizeFileType(type) {
+  if (!type) return '';
+  const base = `${type}`.trim().replace(/(Files|File)$/i, '');
+  return base.toLowerCase();
+}
+
+/**
+ * Build the DOM id for a single-file <select> element.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getSingleFileId(type) {
+  const normalized = normalizeFileType(type);
+  return SINGLE_FILE_TYPES.has(normalized) ? `${normalized}File` : undefined;
+}
+
+/**
+ * Build the DOM id for a multi-select container.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getMultipleFilesId(type) {
+  const normalized = normalizeFileType(type);
+  return MULTIPLE_FILE_TYPES.has(normalized) ? `${normalized}Files` : undefined;
+}
+
+/**
+ * Build the DOM id for the chevron toggle attached to a multi-select list.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getToggleId(type) {
+  const listId = getMultipleFilesId(type);
+  return listId ? `toggle${capitalize(listId)}` : undefined;
+}
+
+/**
+ * Build the DOM id for the wrapper element around a multi-select list.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getFilesContainerId(type) {
+  const listId = getMultipleFilesId(type);
+  return listId ? `${listId}Container` : undefined;
+}
+
+/**
+ * Build the DOM id for the "Empty" button next to a single-file selector.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getEmptySingleFileButtonId(type) {
+  const normalized = normalizeFileType(type);
+  return SINGLE_FILE_TYPES.has(normalized)
+    ? `empty${capitalize(normalized)}FileButton`
+    : undefined;
+}
+
+/**
+ * Build the DOM id for the "Empty" button next to a multi-select list.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getEmptyMultipleFilesButtonId(type) {
+  const listId = getMultipleFilesId(type);
+  return listId ? `empty${capitalize(listId)}Button` : undefined;
+}
+
+/**
+ * Build the DOM id for the "Select" button that opens the multi-file picker.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getSelectMultipleFilesButtonId(type) {
+  const listId = getMultipleFilesId(type);
+  return listId ? `select${capitalize(listId)}Button` : undefined;
+}
+
+/**
+ * Build the DOM id for the "Add opened" button for supported file types.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getAddOpenedFilesButtonId(type) {
+  const normalized = normalizeFileType(type);
+  const listId = getMultipleFilesId(type);
+  return listId && ADD_OPENED_TYPES.has(normalized)
+    ? `addOpened${capitalize(listId)}Button`
+    : undefined;
+}
+
+/**
+ * Build the DOM id for the "Current" button tied to single-file selectors.
+ * @param {string} type
+ * @returns {string | undefined}
+ */
+export function getCurrentFileButtonId(type) {
+  const normalized = normalizeFileType(type);
+  return SINGLE_FILE_TYPES.has(normalized)
+    ? `current${capitalize(normalized)}FileButton`
+    : undefined;
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -165,6 +165,7 @@ export abstract class BaseViewContentProvider {
         'modules/BaseWebviewMessageHandler.js',
       ),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
+      domIdUtilsUri: this.getCommonUri(webview, 'modules/domIdUtils.js'),
       baseDomHandlerUri: this.getCommonUri(
         webview,
         'modules/BaseDomHandler.js',

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -29,6 +29,7 @@
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -52,6 +52,7 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/pathUtils.js": "${pathUtilsUri}",

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -40,6 +40,7 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -9,7 +9,12 @@ import { mainViewState } from '../mainViewState.js';
 import { fileList } from '../uiManagers/FileList.js';
 import { fileSelect } from '../uiManagers/FileSelect.js';
 import { safeSetElementValue } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import {
+  getFilesContainerId,
+  getMultipleFilesId,
+  getSingleFileId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - utilities
 
@@ -45,22 +50,21 @@ export function createFileHandlers(ctx) {
   const handlers = {};
 
   for (const fileType of FILE_TYPES) {
-    const listId =
-      fileType === 'output' ? ELEMENT_IDS.OUTPUT_FILES : `${fileType}Files`;
-    const toggleId =
-      fileType === 'output'
-        ? ELEMENT_IDS.TOGGLE_OUTPUT_FILES
-        : `toggle${capitalize(fileType)}Files`;
+    const listId = getMultipleFilesId(fileType) ?? ELEMENT_IDS.OUTPUT_FILES;
+    const toggleId = getToggleId(fileType) ?? ELEMENT_IDS.TOGGLE_OUTPUT_FILES;
 
     handlers[MAIN_VIEW_COMMANDS[`SET_${fileType.toUpperCase()}_FILES`]] =
       createSetFilesHandler(fileType, listId, toggleId);
 
     if (fileType !== 'output') {
-      const domId = `${fileType}File`;
-      handlers[MAIN_VIEW_COMMANDS[`SET_${fileType.toUpperCase()}_FILE`]] =
-        createSetFileHandler(fileType, domId);
-      handlers[MAIN_VIEW_COMMANDS[`${fileType.toUpperCase()}_FILE_SELECTED`]] =
-        createFileSelectedHandler(fileType, domId);
+      const domId = getSingleFileId(fileType);
+      if (domId) {
+        handlers[MAIN_VIEW_COMMANDS[`SET_${fileType.toUpperCase()}_FILE`]] =
+          createSetFileHandler(fileType, domId);
+        handlers[
+          MAIN_VIEW_COMMANDS[`${fileType.toUpperCase()}_FILE_SELECTED`]
+        ] = createFileSelectedHandler(fileType, domId);
+      }
     }
   }
 
@@ -74,20 +78,23 @@ export function createFileHandlers(ctx) {
   );
 
   function handleAddMediaFile(message) {
-    const listDiv = getElement('mediaFiles');
+    const listId = getMultipleFilesId('media');
+    const toggleId = getToggleId('media');
+    const listDiv = listId ? getElement(listId) : null;
     const existingFiles = listDiv ? fileList.getSelected(listDiv) : [];
-    fileList.update('mediaFiles', 'toggleMediaFiles', [
-      ...existingFiles,
-      message.file,
-    ]);
+    if (listId && toggleId) {
+      fileList.update(listId, toggleId, [...existingFiles, message.file]);
+    }
     if (listDiv) {
       setupFileListHandler('media', listDiv);
     }
 
-    const container = getElement('mediaFilesContainer');
+    const containerId = getFilesContainerId('media');
+    const container = containerId ? getElement(containerId) : null;
     if (container && container.style.display === 'none') {
       container.style.display = 'block';
-      const toggleIcon = getElement('toggleMediaFiles');
+      const toggleIconId = getToggleId('media');
+      const toggleIcon = toggleIconId ? getElement(toggleIconId) : null;
       setToggleIcon(toggleIcon, true);
     }
 
@@ -114,20 +121,21 @@ export function createFileHandlers(ctx) {
 
   function handleSetOpenedFiles(message) {
     if (message.fileType) {
-      const fileType = message.fileType.replace('Files', '');
-      const singleFileId = `${uncapitalize(fileType)}File`;
-      const multipleFileId = `${uncapitalize(fileType)}Files`;
-      const toggleId = `toggle${capitalize(fileType)}Files`;
+      const multipleFileId = getMultipleFilesId(message.fileType);
+      const toggleId = getToggleId(message.fileType);
+      const singleFileId = getSingleFileId(message.fileType);
 
       let filesToAdd = message.files ?? [];
       if (message.shouldFilter) {
-        const singleFileSelect = getElement(singleFileId);
+        const singleFileSelect = singleFileId ? getElement(singleFileId) : null;
         if (singleFileSelect && singleFileSelect.value) {
           filesToAdd = filesToAdd.filter((f) => f !== singleFileSelect.value);
         }
       }
 
-      fileList.update(multipleFileId, toggleId, filesToAdd);
+      if (multipleFileId && toggleId) {
+        fileList.update(multipleFileId, toggleId, filesToAdd);
+      }
     }
     postHandle();
   }

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -16,7 +16,7 @@ import {
   safeSetElementChecked,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import { getFilesContainerId, getToggleId } from '@common/domIdUtils.js';
 import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { WebviewStateManager } from '@common/webviewState.js';
 
@@ -55,8 +55,10 @@ export class MainViewState {
     }
 
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const toggleId = `toggle${capitalize(id)}`;
-      fileList.setVisibility(id, toggleId, false);
+      const toggleId = getToggleId(id);
+      if (toggleId) {
+        fileList.setVisibility(id, toggleId, false);
+      }
       const listDiv = safeGetElementById(id);
       if (listDiv) {
         listDiv.innerHTML = '';
@@ -120,7 +122,7 @@ export class MainViewState {
       }
 
       MULTIPLE_SELECTIONS.forEach((id) => {
-        const toggleId = `toggle${capitalize(id)}`;
+        const toggleId = getToggleId(id);
         const selectDiv = safeGetElementById(id);
         if (!selectDiv) {
           console.warn(`Element with id '${id}' not found`);
@@ -135,13 +137,17 @@ export class MainViewState {
           filesArray.forEach((file) => {
             fileList.add(id, file);
           });
-          fileList.setVisibility(
-            id,
-            toggleId,
-            isVisible !== undefined ? isVisible : true,
-          );
+          if (toggleId) {
+            fileList.setVisibility(
+              id,
+              toggleId,
+              isVisible !== undefined ? isVisible : true,
+            );
+          }
         } else {
-          fileList.setVisibility(id, toggleId, false);
+          if (toggleId) {
+            fileList.setVisibility(id, toggleId, false);
+          }
         }
       });
 
@@ -185,9 +191,9 @@ export class MainViewState {
     MULTIPLE_SELECTIONS.forEach((id) => {
       const elementDiv = safeGetElementById(id);
       if (!elementDiv) return;
-      const containerDiv = safeGetElementById(`${id}Container`);
-      state[`${id}Visible`] =
-        containerDiv && containerDiv.style.display === 'block';
+      const containerId = getFilesContainerId(id);
+      const containerDiv = containerId ? safeGetElementById(containerId) : null;
+      state[`${id}Visible`] = containerDiv?.style.display === 'block';
       state[id] = fileList.getSelected(elementDiv);
     });
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -25,7 +25,12 @@ import {
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import {
+  getFilesContainerId,
+  getMultipleFilesId,
+  getToggleId,
+} from '@common/domIdUtils.js';
+import { capitalize } from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 // Import standardized commands
@@ -373,18 +378,20 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       savedState[targetArrayName] = filesArray;
       savedState[visibilityName] = isVisible;
 
-      const multipleFilesId = `${fileType}Files`;
+      const multipleFilesId = getMultipleFilesId(fileType);
+      if (!multipleFilesId) continue;
+
       const multipleFiles = this._getElement(multipleFilesId);
       if (filesArray.length > 0 || isVisible) {
-        const containerId = `${fileType}FilesContainer`;
-        const toggleId = `toggle${capitalize(fileType)}Files`;
+        const containerId = getFilesContainerId(fileType);
+        const toggleId = getToggleId(fileType);
 
-        const container = this._getElement(containerId);
+        const container = containerId ? this._getElement(containerId) : null;
         if (container) {
           container.style.display = isVisible ? 'block' : 'none';
         }
 
-        const toggleElement = this._getElement(toggleId);
+        const toggleElement = toggleId ? this._getElement(toggleId) : null;
         this._setToggleIcon(toggleElement, isVisible);
 
         if (filesArray.length > 0 && multipleFiles) {

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -12,6 +12,7 @@ import {
   safeGetElementValue,
   safeGetElementChecked,
 } from '@common/domUtils.js';
+import { getFilesContainerId, getSingleFileId } from '@common/domIdUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -28,7 +29,9 @@ export class ActionButtonManager extends BaseUIManager {
   _getSingleFileData(fileTypes = ['input', 'reference', 'auxiliary', 'media']) {
     const data = {};
     fileTypes.forEach((type) => {
-      data[`${type}File`] = safeGetElementValue(`${type}File`);
+      const singleId = getSingleFileId(type);
+      if (!singleId) return;
+      data[singleId] = safeGetElementValue(singleId);
     });
     return data;
   }
@@ -36,12 +39,13 @@ export class ActionButtonManager extends BaseUIManager {
   _getMultipleFileData(singleFiles = {}) {
     const multipleFilesData = {};
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const container = safeGetElementById(`${id}Container`);
+      const containerId = getFilesContainerId(id);
+      const container = containerId ? safeGetElementById(containerId) : null;
       const isActive = container?.style.display !== 'none';
       multipleFilesData[`${id}Active`] = isActive;
 
-      const singleFileKey = id.replace('Files', 'File');
-      const singleFile = singleFiles[singleFileKey];
+      const singleFileKey = getSingleFileId(id);
+      const singleFile = singleFileKey ? singleFiles[singleFileKey] : undefined;
 
       const filesDiv = safeGetElementById(id);
       const files =

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -19,6 +19,16 @@ import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
 import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
+import {
+  getAddOpenedFilesButtonId,
+  getCurrentFileButtonId,
+  getEmptyMultipleFilesButtonId,
+  getEmptySingleFileButtonId,
+  getMultipleFilesId,
+  getSelectMultipleFilesButtonId,
+  getSingleFileId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -41,27 +51,13 @@ export class FileInputManager extends BaseUIManager {
   }
 
   _getFileIds(type) {
-    const cap = capitalize(type);
-    const ids = {
-      singleId: `${type}File`,
-      emptySingleId: `empty${cap}FileButton`,
-      listId: `${type}Files`,
-      toggleId: `toggle${cap}Files`,
-      emptyListId: `empty${cap}FilesButton`,
+    return {
+      singleId: getSingleFileId(type),
+      emptySingleId: getEmptySingleFileButtonId(type),
+      listId: getMultipleFilesId(type),
+      toggleId: getToggleId(type),
+      emptyListId: getEmptyMultipleFilesButtonId(type),
     };
-
-    if (type === 'output') {
-      ids.singleId = undefined;
-      ids.emptySingleId = undefined;
-    }
-
-    if (type === 'base' || type === 'edited') {
-      ids.listId = undefined;
-      ids.toggleId = undefined;
-      ids.emptyListId = undefined;
-    }
-
-    return ids;
   }
 
   _setupSortable() {
@@ -121,18 +117,23 @@ export class FileInputManager extends BaseUIManager {
   }
 
   _setupMultipleFileButtons() {
-    const selectors = FILE_TYPES.map((type) => ({
-      id: `${capitalize(type)}Files`,
-      selectId: type === 'output' ? INPUT_FILE : `${type}File`,
-    }));
+    const selectors = FILE_TYPES.map((type) => {
+      const listId = getMultipleFilesId(type);
+      const selectId = type === 'output' ? INPUT_FILE : getSingleFileId(type);
+      const buttonId = getSelectMultipleFilesButtonId(type);
+      const fileType = listId ? capitalize(listId) : undefined;
 
-    selectors.forEach(({ id, selectId }) => {
-      const buttonId = `select${id}Button`;
+      return { buttonId, selectId, fileType };
+    }).filter(({ buttonId, selectId, fileType }) =>
+      Boolean(buttonId && selectId && fileType),
+    );
+
+    selectors.forEach(({ buttonId, selectId, fileType }) => {
       this.addListener(buttonId, 'click', () => {
         const currentFile = safeGetElementValue(selectId);
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES,
-          fileType: id,
+          fileType,
           currentFile,
         });
       });
@@ -146,24 +147,22 @@ export class FileInputManager extends BaseUIManager {
 
     const buttonConfigs = [
       {
-        prefix: 'addOpened',
-        suffix: 'FilesButton',
+        getId: getAddOpenedFilesButtonId,
         command: MAIN_VIEW_COMMANDS.ADD_OPENED_FILES,
         types: baseTypes,
       },
       {
-        prefix: 'current',
-        suffix: 'FileButton',
+        getId: getCurrentFileButtonId,
         command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
         types: [...baseTypes, 'base', 'edited'],
       },
     ];
 
-    buttonConfigs.forEach(({ prefix, suffix, command, types }) => {
+    buttonConfigs.forEach(({ getId, command, types }) => {
       types.forEach((type) => {
-        const cap = capitalize(type);
-        const id = `${prefix}${cap}${suffix}`;
-        this.addListener(id, 'click', () => {
+        const buttonId = getId(type);
+        if (!buttonId) return;
+        this.addListener(buttonId, 'click', () => {
           const payload = { command, fileType: type };
           if (
             (type === 'edited' || type === 'base') &&

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -4,7 +4,7 @@ import {
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import { getFilesContainerId, getToggleId } from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
@@ -26,7 +26,8 @@ export class FileList {
    */
   add(containerId, file) {
     const container = safeGetElementById(containerId);
-    const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
+    const toggleId = getToggleId(containerId);
+    const toggleIcon = toggleId ? safeGetElementById(toggleId) : undefined;
     if (!container || !toggleIcon) return;
 
     const placeholder = container.querySelector('.file-list-placeholder');
@@ -47,8 +48,8 @@ export class FileList {
         if (container.contains(fileElement)) {
           container.removeChild(fileElement);
         }
-        if (container.children.length === 0) {
-          this.empty(containerId, `toggle${capitalize(containerId)}`);
+        if (container.children.length === 0 && toggleId) {
+          this.empty(containerId, toggleId);
         }
         this._saveFn();
       });
@@ -59,7 +60,7 @@ export class FileList {
   /** Update a multi-file list, showing the toggle when files exist */
   update(listId, toggleId, files) {
     const listDiv = safeGetElementById(listId);
-    const toggleIcon = safeGetElementById(toggleId);
+    const toggleIcon = toggleId ? safeGetElementById(toggleId) : undefined;
     if (!listDiv || !toggleIcon) return;
 
     const existing = this.getSelected(listDiv);
@@ -70,7 +71,8 @@ export class FileList {
       listDiv.style.display = 'block';
       setChevronIcon(toggleIcon, true);
 
-      const container = safeGetElementById(`${listId}Container`);
+      const containerId = getFilesContainerId(listId);
+      const container = containerId ? safeGetElementById(containerId) : null;
       if (container) {
         container.style.display = 'block';
       }
@@ -86,8 +88,11 @@ export class FileList {
 
   /** Show or hide a file list container */
   setVisibility(containerId, toggleId, isVisible) {
-    const container = safeGetElementById(`${containerId}Container`);
-    const toggleIcon = safeGetElementById(toggleId);
+    const containerIdStr = getFilesContainerId(containerId);
+    const container = containerIdStr
+      ? safeGetElementById(containerIdStr)
+      : null;
+    const toggleIcon = toggleId ? safeGetElementById(toggleId) : undefined;
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
     setChevronIcon(toggleIcon, isVisible);
@@ -95,7 +100,10 @@ export class FileList {
 
   /** Toggle visibility of a file list container */
   toggle(containerId, toggleId) {
-    const container = safeGetElementById(`${containerId}Container`);
+    const containerIdStr = getFilesContainerId(containerId);
+    const container = containerIdStr
+      ? safeGetElementById(containerIdStr)
+      : null;
     if (!container) return;
     const isVisible = container.style.display !== 'none';
     this.setVisibility(containerId, toggleId, !isVisible);
@@ -105,7 +113,10 @@ export class FileList {
   /** Empty all files from a container and hide it */
   empty(containerId, toggleId) {
     const listDiv = safeGetElementById(containerId);
-    const container = safeGetElementById(`${containerId}Container`);
+    const containerIdStr = getFilesContainerId(containerId);
+    const container = containerIdStr
+      ? safeGetElementById(containerIdStr)
+      : null;
     if (!listDiv || !container) return;
 
     listDiv.innerHTML = '';
@@ -122,8 +133,8 @@ export class FileList {
     ids.forEach((id) => {
       const selectDiv = safeGetElementById(id);
       if (!selectDiv) return;
-      const toggleId = `toggle${capitalize(id)}`;
-      if (selectDiv.children.length === 0) {
+      const toggleId = getToggleId(id);
+      if (toggleId && selectDiv.children.length === 0) {
         this.setVisibility(id, toggleId, false);
       }
     });

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -5,7 +5,7 @@ import {
   safeSetElementValue,
   setElementsDisabled,
 } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { getSingleFileId } from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports
@@ -84,7 +84,11 @@ export class FileSelect {
   }
 
   handleSetCurrentFile({ fileType, filePath }) {
-    const fileId = `${uncapitalize(fileType)}File`;
+    const fileId = getSingleFileId(fileType);
+    if (!fileId) {
+      console.warn(`No single-file selector for type '${fileType}'`);
+      return;
+    }
     const fileDiv = document.getElementById(fileId);
     if (!fileDiv) {
       console.warn(`Element with id '${fileId}' not found`);


### PR DESCRIPTION
## Summary
- add a shared @common/domIdUtils module that normalizes file-type driven DOM ids
- map the helper into each webview import map and refactor file selection modules to use it
- document the new helpers so future UI code uses the common utilities

## Testing
- npm run lint
- npm test *(fails: VS Code runtime missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c95eb97688832491eb317816f39382