### PR TITLE
Refactor DOM ID handling for file selectors

### DIFF
--- a/docs/dev/dom-id-utils.md
+++ b/docs/dev/dom-id-utils.md
@@ -1,0 +1,29 @@
+# DOM ID utilities
+
+TeXRA's webviews rely on consistent DOM ids for file selectors, multi-file lists, and their controls. The
+`@common/domIdUtils.js` module centralizes these naming patterns so that UI code does not recreate template
+literals in multiple places.
+
+## Helper functions
+
+All helpers accept a flexible `type` parameter. You can pass a base type such as `"input"`, a capitalized variant
+like `"Input"`, or an existing identifier (`"inputFiles"`, `"InputFilesButton"`, etc.). The helpers normalize the
+input before building the final id and throw if the type cannot be parsed.
+
+- `getSingleFileId(type)` → returns the select element id (e.g., `inputFile`).
+- `getMultipleFilesId(type)` → returns the multi-select list id (`inputFiles`).
+- `getMultipleFilesContainerId(type)` → returns the container id that wraps the list (`inputFilesContainer`).
+- `getToggleId(type)` → returns the toggle chevron id (`toggleInputFiles`).
+- `getEmptySingleButtonId(type)` → returns the id for the single-file "Empty" button (`emptyInputFileButton`).
+- `getEmptyMultipleButtonId(type)` → returns the id for the multi-file "Empty" button (`emptyInputFilesButton`).
+- `getSelectMultipleButtonId(type)` → returns the id for the multi-file "Add" button (`selectInputFilesButton`).
+- `getAddOpenedButtonId(type)` → returns the id for the "Add opened" button (`addOpenedInputFilesButton`).
+- `getCurrentFileButtonId(type)` → returns the id for the "Current" button (`currentInputFileButton`).
+
+## Usage guidelines
+
+- Always derive DOM ids for file selectors and related controls with these helpers instead of inline template
+  literals.
+- Reuse the helpers when deriving keys from existing ids (e.g., `getSingleFileId('inputFiles')` → `inputFile`).
+- When you introduce a new control that follows the same naming scheme, add a helper rather than duplicating the
+  string pattern.

--- a/src/common/modules/domIdUtils.js
+++ b/src/common/modules/domIdUtils.js
@@ -1,0 +1,110 @@
+import { capitalize, uncapitalize } from './stringUtils.js';
+
+function normalizeType(rawType) {
+  if (!rawType) {
+    return '';
+  }
+
+  const value = `${rawType}`.trim();
+  if (!value) {
+    return '';
+  }
+
+  const withoutPrefixes = value.replace(
+    /^(toggle|select|empty|addOpened|current)/i,
+    '',
+  );
+
+  const withoutSuffixes = withoutPrefixes
+    .replace(/(Files|File)(Container|Button)?$/i, '')
+    .replace(/Files$/i, '')
+    .replace(/File$/i, '');
+
+  return uncapitalize(withoutSuffixes);
+}
+
+function getTypeParts(type) {
+  const normalized = normalizeType(type);
+  if (!normalized) {
+    throw new Error(`[domIdUtils] Invalid file type: ${type}`);
+  }
+
+  return {
+    lower: normalized,
+    upper: capitalize(normalized),
+  };
+}
+
+/**
+ * Return the DOM id for a single-file select element.
+ * Accepts raw types ("input"), capitalized types ("Input"),
+ * or existing identifiers such as "InputFiles".
+ */
+export function getSingleFileId(type) {
+  const { lower } = getTypeParts(type);
+  return `${lower}File`;
+}
+
+/**
+ * Return the DOM id for the multi-file list element for a type.
+ * Works with values like "input", "Input", or "inputFiles".
+ */
+export function getMultipleFilesId(type) {
+  const { lower } = getTypeParts(type);
+  return `${lower}Files`;
+}
+
+/**
+ * Return the DOM id for the container wrapping a multi-file list.
+ */
+export function getMultipleFilesContainerId(type) {
+  return `${getMultipleFilesId(type)}Container`;
+}
+
+/**
+ * Return the DOM id for the toggle element tied to a multi-file list.
+ */
+export function getToggleId(type) {
+  const { upper } = getTypeParts(type);
+  return `toggle${upper}Files`;
+}
+
+/**
+ * Return the DOM id for the "Empty" button next to a single-file selector.
+ */
+export function getEmptySingleButtonId(type) {
+  const { upper } = getTypeParts(type);
+  return `empty${upper}FileButton`;
+}
+
+/**
+ * Return the DOM id for the "Empty" button on a multi-file list header.
+ */
+export function getEmptyMultipleButtonId(type) {
+  const { upper } = getTypeParts(type);
+  return `empty${upper}FilesButton`;
+}
+
+/**
+ * Return the DOM id for the "Select" button on a multi-file list header.
+ */
+export function getSelectMultipleButtonId(type) {
+  const { upper } = getTypeParts(type);
+  return `select${upper}FilesButton`;
+}
+
+/**
+ * Return the DOM id for the "Add opened" button for a multi-file list.
+ */
+export function getAddOpenedButtonId(type) {
+  const { upper } = getTypeParts(type);
+  return `addOpened${upper}FilesButton`;
+}
+
+/**
+ * Return the DOM id for the "Current" button for a single-file selector.
+ */
+export function getCurrentFileButtonId(type) {
+  const { upper } = getTypeParts(type);
+  return `current${upper}FileButton`;
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -164,6 +164,7 @@ export abstract class BaseViewContentProvider {
         webview,
         'modules/BaseWebviewMessageHandler.js',
       ),
+      domIdUtilsUri: this.getCommonUri(webview, 'modules/domIdUtils.js'),
       domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
       baseDomHandlerUri: this.getCommonUri(
         webview,

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -28,6 +28,7 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -51,6 +51,7 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -39,6 +39,7 @@
           "@common/webview/themeHandlers.js": "${webviewThemeHandlersUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/domIdUtils.js": "${domIdUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -1,4 +1,5 @@
 // Local imports - webview
+import { getMultipleFilesId } from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 // Basic file types
@@ -28,7 +29,9 @@ export const SINGLE_FILE_ELEMENTS = [
 ];
 
 // Multiple file selection element IDs (derived from FILE_TYPES)
-export const MULTIPLE_SELECTIONS = FILE_TYPES.map((type) => `${type}Files`);
+export const MULTIPLE_SELECTIONS = FILE_TYPES.map((type) =>
+  getMultipleFilesId(type),
+);
 
 // Auto extract checkboxes
 export const CHECK_BOXES_AUTO_EXTRACT = [

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -9,7 +9,11 @@ import { mainViewState } from '../mainViewState.js';
 import { fileList } from '../uiManagers/FileList.js';
 import { fileSelect } from '../uiManagers/FileSelect.js';
 import { safeSetElementValue } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import {
+  getMultipleFilesId,
+  getSingleFileId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - utilities
 
@@ -46,17 +50,19 @@ export function createFileHandlers(ctx) {
 
   for (const fileType of FILE_TYPES) {
     const listId =
-      fileType === 'output' ? ELEMENT_IDS.OUTPUT_FILES : `${fileType}Files`;
+      fileType === 'output'
+        ? ELEMENT_IDS.OUTPUT_FILES
+        : getMultipleFilesId(fileType);
     const toggleId =
       fileType === 'output'
         ? ELEMENT_IDS.TOGGLE_OUTPUT_FILES
-        : `toggle${capitalize(fileType)}Files`;
+        : getToggleId(fileType);
 
     handlers[MAIN_VIEW_COMMANDS[`SET_${fileType.toUpperCase()}_FILES`]] =
       createSetFilesHandler(fileType, listId, toggleId);
 
     if (fileType !== 'output') {
-      const domId = `${fileType}File`;
+      const domId = getSingleFileId(fileType);
       handlers[MAIN_VIEW_COMMANDS[`SET_${fileType.toUpperCase()}_FILE`]] =
         createSetFileHandler(fileType, domId);
       handlers[MAIN_VIEW_COMMANDS[`${fileType.toUpperCase()}_FILE_SELECTED`]] =
@@ -115,9 +121,9 @@ export function createFileHandlers(ctx) {
   function handleSetOpenedFiles(message) {
     if (message.fileType) {
       const fileType = message.fileType.replace('Files', '');
-      const singleFileId = `${uncapitalize(fileType)}File`;
-      const multipleFileId = `${uncapitalize(fileType)}Files`;
-      const toggleId = `toggle${capitalize(fileType)}Files`;
+      const singleFileId = getSingleFileId(fileType);
+      const multipleFileId = getMultipleFilesId(fileType);
+      const toggleId = getToggleId(fileType);
 
       let filesToAdd = message.files ?? [];
       if (message.shouldFilter) {

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -16,7 +16,10 @@ import {
   safeSetElementChecked,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import {
+  getMultipleFilesContainerId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { WebviewStateManager } from '@common/webviewState.js';
 
@@ -55,7 +58,7 @@ export class MainViewState {
     }
 
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const toggleId = `toggle${capitalize(id)}`;
+      const toggleId = getToggleId(id);
       fileList.setVisibility(id, toggleId, false);
       const listDiv = safeGetElementById(id);
       if (listDiv) {
@@ -120,7 +123,7 @@ export class MainViewState {
       }
 
       MULTIPLE_SELECTIONS.forEach((id) => {
-        const toggleId = `toggle${capitalize(id)}`;
+        const toggleId = getToggleId(id);
         const selectDiv = safeGetElementById(id);
         if (!selectDiv) {
           console.warn(`Element with id '${id}' not found`);
@@ -185,7 +188,7 @@ export class MainViewState {
     MULTIPLE_SELECTIONS.forEach((id) => {
       const elementDiv = safeGetElementById(id);
       if (!elementDiv) return;
-      const containerDiv = safeGetElementById(`${id}Container`);
+      const containerDiv = safeGetElementById(getMultipleFilesContainerId(id));
       state[`${id}Visible`] =
         containerDiv && containerDiv.style.display === 'block';
       state[id] = fileList.getSelected(elementDiv);

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -25,8 +25,13 @@ import {
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { capitalize } from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
+import {
+  getMultipleFilesContainerId,
+  getMultipleFilesId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -368,16 +373,16 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         state[`multiple${capitalize(fileType)}FilesActive`] ||
         false;
 
-      const targetArrayName = `${fileType}Files`;
+      const targetArrayName = getMultipleFilesId(fileType);
       const visibilityName = `${targetArrayName}Active`;
       savedState[targetArrayName] = filesArray;
       savedState[visibilityName] = isVisible;
 
-      const multipleFilesId = `${fileType}Files`;
+      const multipleFilesId = getMultipleFilesId(fileType);
       const multipleFiles = this._getElement(multipleFilesId);
       if (filesArray.length > 0 || isVisible) {
-        const containerId = `${fileType}FilesContainer`;
-        const toggleId = `toggle${capitalize(fileType)}Files`;
+        const containerId = getMultipleFilesContainerId(fileType);
+        const toggleId = getToggleId(fileType);
 
         const container = this._getElement(containerId);
         if (container) {

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -12,6 +12,10 @@ import {
   safeGetElementValue,
   safeGetElementChecked,
 } from '@common/domUtils.js';
+import {
+  getMultipleFilesContainerId,
+  getSingleFileId,
+} from '@common/domIdUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -28,7 +32,8 @@ export class ActionButtonManager extends BaseUIManager {
   _getSingleFileData(fileTypes = ['input', 'reference', 'auxiliary', 'media']) {
     const data = {};
     fileTypes.forEach((type) => {
-      data[`${type}File`] = safeGetElementValue(`${type}File`);
+      const key = getSingleFileId(type);
+      data[key] = safeGetElementValue(key);
     });
     return data;
   }
@@ -36,11 +41,11 @@ export class ActionButtonManager extends BaseUIManager {
   _getMultipleFileData(singleFiles = {}) {
     const multipleFilesData = {};
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const container = safeGetElementById(`${id}Container`);
+      const container = safeGetElementById(getMultipleFilesContainerId(id));
       const isActive = container?.style.display !== 'none';
       multipleFilesData[`${id}Active`] = isActive;
 
-      const singleFileKey = id.replace('Files', 'File');
+      const singleFileKey = getSingleFileId(id);
       const singleFile = singleFiles[singleFileKey];
 
       const filesDiv = safeGetElementById(id);

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -20,6 +20,16 @@ import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
 import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
+import {
+  getAddOpenedButtonId,
+  getCurrentFileButtonId,
+  getEmptyMultipleButtonId,
+  getEmptySingleButtonId,
+  getMultipleFilesId,
+  getSelectMultipleButtonId,
+  getSingleFileId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -41,13 +51,12 @@ export class FileInputManager extends BaseUIManager {
   }
 
   _getFileIds(type) {
-    const cap = capitalize(type);
     const ids = {
-      singleId: `${type}File`,
-      emptySingleId: `empty${cap}FileButton`,
-      listId: `${type}Files`,
-      toggleId: `toggle${cap}Files`,
-      emptyListId: `empty${cap}FilesButton`,
+      singleId: getSingleFileId(type),
+      emptySingleId: getEmptySingleButtonId(type),
+      listId: getMultipleFilesId(type),
+      toggleId: getToggleId(type),
+      emptyListId: getEmptyMultipleButtonId(type),
     };
 
     if (type === 'output') {
@@ -122,17 +131,18 @@ export class FileInputManager extends BaseUIManager {
 
   _setupMultipleFileButtons() {
     const selectors = FILE_TYPES.map((type) => ({
-      id: `${capitalize(type)}Files`,
-      selectId: type === 'output' ? INPUT_FILE : `${type}File`,
+      type,
+      commandType: `${capitalize(type)}Files`,
+      selectId: type === 'output' ? INPUT_FILE : getSingleFileId(type),
     }));
 
-    selectors.forEach(({ id, selectId }) => {
-      const buttonId = `select${id}Button`;
+    selectors.forEach(({ type, commandType, selectId }) => {
+      const buttonId = getSelectMultipleButtonId(type);
       this.addListener(buttonId, 'click', () => {
         const currentFile = safeGetElementValue(selectId);
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES,
-          fileType: id,
+          fileType: commandType,
           currentFile,
         });
       });
@@ -146,23 +156,20 @@ export class FileInputManager extends BaseUIManager {
 
     const buttonConfigs = [
       {
-        prefix: 'addOpened',
-        suffix: 'FilesButton',
+        getId: getAddOpenedButtonId,
         command: MAIN_VIEW_COMMANDS.ADD_OPENED_FILES,
         types: baseTypes,
       },
       {
-        prefix: 'current',
-        suffix: 'FileButton',
+        getId: getCurrentFileButtonId,
         command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
         types: [...baseTypes, 'base', 'edited'],
       },
     ];
 
-    buttonConfigs.forEach(({ prefix, suffix, command, types }) => {
+    buttonConfigs.forEach(({ getId, command, types }) => {
       types.forEach((type) => {
-        const cap = capitalize(type);
-        const id = `${prefix}${cap}${suffix}`;
+        const id = getId(type);
         this.addListener(id, 'click', () => {
           const payload = { command, fileType: type };
           if (

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -4,7 +4,10 @@ import {
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
+import {
+  getMultipleFilesContainerId,
+  getToggleId,
+} from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
@@ -26,7 +29,7 @@ export class FileList {
    */
   add(containerId, file) {
     const container = safeGetElementById(containerId);
-    const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
+    const toggleIcon = safeGetElementById(getToggleId(containerId));
     if (!container || !toggleIcon) return;
 
     const placeholder = container.querySelector('.file-list-placeholder');
@@ -48,7 +51,7 @@ export class FileList {
           container.removeChild(fileElement);
         }
         if (container.children.length === 0) {
-          this.empty(containerId, `toggle${capitalize(containerId)}`);
+          this.empty(containerId, getToggleId(containerId));
         }
         this._saveFn();
       });
@@ -70,7 +73,7 @@ export class FileList {
       listDiv.style.display = 'block';
       setChevronIcon(toggleIcon, true);
 
-      const container = safeGetElementById(`${listId}Container`);
+      const container = safeGetElementById(getMultipleFilesContainerId(listId));
       if (container) {
         container.style.display = 'block';
       }
@@ -86,7 +89,9 @@ export class FileList {
 
   /** Show or hide a file list container */
   setVisibility(containerId, toggleId, isVisible) {
-    const container = safeGetElementById(`${containerId}Container`);
+    const container = safeGetElementById(
+      getMultipleFilesContainerId(containerId),
+    );
     const toggleIcon = safeGetElementById(toggleId);
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
@@ -95,7 +100,9 @@ export class FileList {
 
   /** Toggle visibility of a file list container */
   toggle(containerId, toggleId) {
-    const container = safeGetElementById(`${containerId}Container`);
+    const container = safeGetElementById(
+      getMultipleFilesContainerId(containerId),
+    );
     if (!container) return;
     const isVisible = container.style.display !== 'none';
     this.setVisibility(containerId, toggleId, !isVisible);
@@ -105,7 +112,9 @@ export class FileList {
   /** Empty all files from a container and hide it */
   empty(containerId, toggleId) {
     const listDiv = safeGetElementById(containerId);
-    const container = safeGetElementById(`${containerId}Container`);
+    const container = safeGetElementById(
+      getMultipleFilesContainerId(containerId),
+    );
     if (!listDiv || !container) return;
 
     listDiv.innerHTML = '';
@@ -122,7 +131,7 @@ export class FileList {
     ids.forEach((id) => {
       const selectDiv = safeGetElementById(id);
       if (!selectDiv) return;
-      const toggleId = `toggle${capitalize(id)}`;
+      const toggleId = getToggleId(id);
       if (selectDiv.children.length === 0) {
         this.setVisibility(id, toggleId, false);
       }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -5,7 +5,7 @@ import {
   safeSetElementValue,
   setElementsDisabled,
 } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { getSingleFileId } from '@common/domIdUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports
@@ -84,7 +84,7 @@ export class FileSelect {
   }
 
   handleSetCurrentFile({ fileType, filePath }) {
-    const fileId = `${uncapitalize(fileType)}File`;
+    const fileId = getSingleFileId(fileType);
     const fileDiv = document.getElementById(fileId);
     if (!fileDiv) {
       console.warn(`Element with id '${fileId}' not found`);


### PR DESCRIPTION
## Summary
- add a `domIdUtils` module with helper functions for building file/toggle DOM ids and document its usage
- expose the new helper to every webview via shared URI mappings and import maps
- refactor file handlers, state restoration, and UI managers to call the helpers instead of assembling ids inline

## Testing
- npm run lint
- npm test *(fails: VS Code test runner output exceeded environment log limits)*

------
https://chatgpt.com/codex/tasks/task_e_68c95eb97688832491eb317816f39382