### PR TITLE
feat: distinguish tool use streams

### DIFF
--- a/docs/dev/REFACTORING_PROPOSAL.md
+++ b/docs/dev/REFACTORING_PROPOSAL.md
@@ -166,7 +166,11 @@ export class ProgressEventHandler {
 export class WebviewUpdater {
   constructor(private getWebview: () => vscode.Webview | undefined) {}
 
-  updateStreams(streams: string[], activeStream: string): void;
+  updateStreams(
+    streams: string[],
+    activeStream: string,
+    agentFilter: string,
+  ): void;
   updateLogContent(stream: string, messages: LogMessageData[]): void;
   updateFiles(stream: string, files: OutputFileInfo[]): void;
   updateUsage(usage: TokenUsageStats): void;

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -35,7 +35,7 @@ This area shows the details for the stream selected in the Stream Tabs section.
 
 The header provides a summary and actions for the selected stream:
 
-- **Stream Name**: Displays the identifier of the current run (e.g., `agent@model: inputFile`).
+- **Stream Name**: Displays the identifier of the current run. Workflow agents use the familiar `agent@model: inputFile` format, while tool-use sessions display the agent name with a short execution id (for example `diagnostics #a1b2c3d4`).
 - **Status Indicator**: A colored circle shows the current status:
   - **Green (Running)**: The agent is actively processing.
   - **Grey (Stopped)**: The agent finished successfully or was stopped manually before completion.
@@ -65,4 +65,5 @@ This scrollable area displays the detailed, timestamped logs for the selected ag
 Understanding the log content is key to diagnosing problems and seeing how TeXRA and the AI models process your requests. Refer to the [Troubleshooting](../reference/troubleshooting.md) guide for more tips on using logs.
 
 At the bottom of the tab list, there is a "Delete All" button (<i class="codicon codicon-close-all"></i>) that allows you to clear all streams and their associated logs from the ProgressBoard view.
-Next to it are sorting buttons (<i class="codicon codicon-clock"></i>, <i class="codicon codicon-file"></i>, <i class="codicon codicon-account"></i>) for ordering the tabs.
+Above the sorter, the **All / Workflow / Tool Use** buttons let you focus the tab list on specific agent types.
+Next to "Delete All" are sorting buttons (<i class="codicon codicon-clock"></i>, <i class="codicon codicon-file"></i>, <i class="codicon codicon-account"></i>) for ordering the tabs.

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -35,7 +35,9 @@ This area shows the details for the stream selected in the Stream Tabs section.
 
 The header provides a summary and actions for the selected stream:
 
-- **Stream Name**: Displays the identifier of the current run. Workflow agents use the familiar `agent@model: inputFile` format, while tool-use sessions display the agent name with a short execution id (for example `diagnostics #a1b2c3d4`).
+- **Stream Name**: Displays the identifier of the current run.
+  Workflow agents use the familiar `agent@model: inputFile` format.
+  Tool-use sessions show just the agent name so they stand alone even without an associated input file.
 - **Status Indicator**: A colored circle shows the current status:
   - **Green (Running)**: The agent is actively processing.
   - **Grey (Stopped)**: The agent finished successfully or was stopped manually before completion.

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import * as path from 'path';
-
 // Local imports - agent
 
 // Local imports - agent components
@@ -15,6 +12,7 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
+import { getStreamTabId as buildStreamTabId } from '@/logger/streamUtils';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
@@ -50,12 +48,14 @@ export abstract class BaseAgent implements IAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    executionId?: ExecutionId,
   ) {
     this.modelHandler = modelHandler;
     this.agentConfig = agentConfig;
     this.agentSetting = agentSetting;
     this.agentPrompt = agentPrompt;
     this.agentPath = agentPath;
+    this.executionId = executionId;
 
     const streamTabId = this.getStreamTabId();
     this.logger = new AgentLogger(streamTabId, true);
@@ -75,13 +75,16 @@ export abstract class BaseAgent implements IAgent {
 
   /** Compute the stream tab identifier for this agent execution. */
   protected getStreamTabId(): StreamTabId {
-    const baseName = path.basename(this.agentConfig.inputFile);
-    const agentName =
-      Array.isArray(this.agentConfig.outputFiles) &&
-      this.agentConfig.outputFiles.length > 1
-        ? `${this.agentConfig.agent}_multiple`
-        : this.agentConfig.agent;
-    return `${agentName}@${this.agentConfig.model}: ${baseName}`;
+    return buildStreamTabId(
+      this.agentConfig.agent,
+      this.agentConfig.model,
+      this.agentConfig.inputFile,
+      this.agentConfig.outputFiles ?? undefined,
+      {
+        agentType: this.agentSetting.agentType,
+        executionId: this.executionId,
+      },
+    );
   }
 
   /** Gather variables used for prompt rendering. */

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -13,6 +13,7 @@ import { ToolState } from '@agent/core/ToolState';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import {
   getSystemPromptWithRules,
   getPrefillForRound,
@@ -77,8 +78,16 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    executionId?: ExecutionId,
   ) {
-    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
+    super(
+      modelHandler,
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      agentPath,
+      executionId,
+    );
 
     // Initialize basic attributes
     const numRounds = this.getNumberOfRounds();

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -17,6 +17,7 @@ import { BaseAgent } from './BaseAgent';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 export class BaseToolUseAgent extends BaseAgent {
   private toolRegistry: Record<string, BaseTool<any>>;
@@ -31,8 +32,16 @@ export class BaseToolUseAgent extends BaseAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    executionId?: ExecutionId,
   ) {
-    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
+    super(
+      modelHandler,
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      agentPath,
+      executionId,
+    );
     this.toolRegistry = DEFAULT_TOOL_REGISTRY;
   }
 

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -10,6 +10,7 @@ import { RoundOutputOptions } from './BaseReflectionAgent';
 // Local imports - agent components
 import { DirectAgent } from './DirectAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 /**
  * Specialized agent for merging multiple edited files into a consolidated output.
@@ -22,8 +23,16 @@ export class MergeAgent extends DirectAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    executionId?: ExecutionId,
   ) {
-    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
+    super(
+      modelHandler,
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      agentPath,
+      executionId,
+    );
     this.outputFile = [this.getOutputFile(0), this.getOutputFile(1)];
   }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -149,7 +149,9 @@ function getAgentName(
 ): string {
   if (outputFiles && outputFiles.length > 1) {
     // logger.info(CHANNEL, `Switching to multiple output mode`);
-    return `${baseAgent}_multiple`;
+    return baseAgent.endsWith('_multiple')
+      ? baseAgent
+      : `${baseAgent}_multiple`;
   }
   return baseAgent;
 }
@@ -394,7 +396,8 @@ export async function executeAgent(
     throw new Error('Missing required fields: model and/or agent');
   }
 
-  const agentName = getAgentName(agentConfig.agent, agentConfig.outputFiles);
+  const requestedAgentName = agentConfig.agent;
+  const agentName = getAgentName(requestedAgentName, agentConfig.outputFiles);
 
   await executeAgentWithLogging(
     agentName,
@@ -434,7 +437,7 @@ export async function executeAgent(
       // Load settings and prompts
       const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
         agentPath,
-        agentName,
+        requestedAgentName,
       );
 
       // Get appropriate agent class and create instance

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -167,15 +167,14 @@ async function executeAgentWithLogging<T extends IAgent>(
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
 
-    if (executionId && 'setExecutionId' in agent) {
-      (agent as any).setExecutionId(executionId);
+    if (executionId) {
       await ensureRunDir(executionId);
     }
 
     // Get the full stream tab ID
     const config = agent.config;
     const streamTabId = getStreamTabId(
-      agentName,
+      config.agent,
       config.model,
       config.inputFile,
       config.outputFiles ?? undefined,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -52,6 +52,7 @@ type AgentConstructor = {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
+    executionId?: ExecutionId,
   ): IAgent;
 };
 
@@ -177,6 +178,8 @@ async function executeAgentWithLogging<T extends IAgent>(
       agentName,
       config.model,
       config.inputFile,
+      config.outputFiles ?? undefined,
+      { agentType, executionId },
     );
 
     // Check if this stream is already running
@@ -443,6 +446,7 @@ export async function executeAgent(
         agentSetting,
         agentPrompt,
         agentPath,
+        executionId,
       );
       return { agent, agentType: agentSetting.agentType };
     },

--- a/src/agent/types/AgentStreamTypes.ts
+++ b/src/agent/types/AgentStreamTypes.ts
@@ -1,0 +1,15 @@
+// Local types - agent
+
+/**
+ * Allowed filter values for agent streams in the ProgressBoard.
+ * "workflow" groups traditional direct/CoT agents while
+ * "toolUse" isolates interactive tool sessions.
+ */
+export type AgentTypeFilter = 'all' | 'workflow' | 'toolUse';
+
+/**
+ * Type guard ensuring a value is a valid {@link AgentTypeFilter}.
+ */
+export function isAgentTypeFilter(value: unknown): value is AgentTypeFilter {
+  return value === 'all' || value === 'workflow' || value === 'toolUse';
+}

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -15,6 +15,7 @@ export enum WorkspaceStateKey {
   EXECUTION_IDS = 'texra.executionIds',
   USAGE_STATS = 'texra.usageStats',
   STREAM_SORT_ORDER = 'texra.streamSortOrder',
+  STREAM_AGENT_FILTER = 'texra.streamAgentFilter',
 }
 
 export enum GlobalStateKey {

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -122,6 +122,15 @@
   background-color: var(--vscode-list-activeSelectionBackground);
 }
 
+.vscode-button.toggled {
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.vscode-button.toggled .codicon {
+  color: var(--vscode-button-foreground);
+}
+
 .vscode-button:disabled {
   opacity: var(--opacity-disabled);
   cursor: not-allowed;

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -178,6 +178,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   PACK_STREAM: 'packStream',
   CLEAN_STREAM: 'cleanStream',
   SORT_STREAMS: 'sortStreams',
+  FILTER_STREAMS: 'filterStreams',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
 

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -178,6 +178,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   PACK_STREAM: 'packStream',
   CLEAN_STREAM: 'cleanStream',
   SORT_STREAMS: 'sortStreams',
+  FILTER_STREAMS: 'filterStreams',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
 

--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -1,22 +1,22 @@
 // Standard library imports
+import { randomUUID } from 'crypto';
 import * as path from 'path';
 
 // Local imports
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { AgentType } from '@agent/core/AgentDataclass';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 
 type StreamTabIdOptions = {
-  agentType?: string;
-  executionId?: string;
+  agentType?: AgentType;
+  executionId?: ExecutionId;
 };
 
 function formatToolUseStreamId(
   agent: string,
   model: string,
-  executionId?: string,
+  executionId?: ExecutionId,
 ): StreamTabId {
-  const shortId = executionId
-    ? executionId.slice(0, 8)
-    : Date.now().toString(36);
+  const shortId = executionId?.slice(0, 8) ?? randomUUID().slice(0, 8);
   const sanitizedAgent = agent || 'toolUse';
   return `${sanitizedAgent}@${model}#${shortId}`;
 }
@@ -32,7 +32,7 @@ export function getStreamTabId(
   outputFiles?: string[] | null,
   options: StreamTabIdOptions = {},
 ): StreamTabId {
-  if (options.agentType === 'toolUse') {
+  if (options.agentType === AgentType.ToolUse) {
     return formatToolUseStreamId(agent, model, options.executionId);
   }
 

--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -36,8 +36,12 @@ export function getStreamTabId(
     return formatToolUseStreamId(agent, model, options.executionId);
   }
 
-  const agentName =
-    outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
+  const hasMultipleOutputs = Boolean(outputFiles && outputFiles.length > 1);
+  const agentName = hasMultipleOutputs
+    ? agent.endsWith('_multiple')
+      ? agent
+      : `${agent}_multiple`
+    : agent;
   const baseName = inputFile ? path.basename(inputFile) : '';
   return `${agentName}@${model}: ${baseName}`;
 }

--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -4,6 +4,23 @@ import * as path from 'path';
 // Local imports
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
+type StreamTabIdOptions = {
+  agentType?: string;
+  executionId?: string;
+};
+
+function formatToolUseStreamId(
+  agent: string,
+  model: string,
+  executionId?: string,
+): StreamTabId {
+  const shortId = executionId
+    ? executionId.slice(0, 8)
+    : Date.now().toString(36);
+  const sanitizedAgent = agent || 'toolUse';
+  return `${sanitizedAgent}@${model}#${shortId}`;
+}
+
 /**
  * Build a consistent stream tab identifier based on agent, model and input file.
  * This identifier is used for UI tabs and execution deduplication.
@@ -12,9 +29,15 @@ export function getStreamTabId(
   agent: string,
   model: string,
   inputFile: string,
-  outputFiles?: string[],
+  outputFiles?: string[] | null,
+  options: StreamTabIdOptions = {},
 ): StreamTabId {
+  if (options.agentType === 'toolUse') {
+    return formatToolUseStreamId(agent, model, options.executionId);
+  }
+
   const agentName =
     outputFiles && outputFiles.length > 1 ? `${agent}_multiple` : agent;
-  return `${agentName}@${model}: ${path.basename(inputFile)}`;
+  const baseName = inputFile ? path.basename(inputFile) : '';
+  return `${agentName}@${model}: ${baseName}`;
 }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -7,6 +7,11 @@ import {
   BaseViewMessageHandler,
   MessageHandler,
 } from '@common/webview/BaseViewMessageHandler';
+// Local imports - agent types
+import {
+  AgentTypeFilter,
+  isAgentTypeFilter,
+} from '@agent/types/AgentStreamTypes';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -171,7 +176,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     _webviewView: vscode.WebviewView,
   ): Promise<void> {
-    const filter = message.filter ?? 'all';
+    const requestedFilter = message.filter;
+    const filter: AgentTypeFilter = isAgentTypeFilter(requestedFilter)
+      ? requestedFilter
+      : 'all';
     this.provider.state.agentTypeFilter = filter;
     this.provider.updateWebview();
   }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -42,6 +42,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       [PROGRESS_VIEW_COMMANDS.PACK_STREAM]: this.handlePackStream.bind(this),
       [PROGRESS_VIEW_COMMANDS.CLEAN_STREAM]: this.handleCleanStream.bind(this),
       [PROGRESS_VIEW_COMMANDS.SORT_STREAMS]: this.handleSortStreams.bind(this),
+      [PROGRESS_VIEW_COMMANDS.FILTER_STREAMS]:
+        this.handleFilterStreams.bind(this),
       [PROGRESS_VIEW_COMMANDS.RESTORE_STATE]:
         this.handleRestoreState.bind(this),
       [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]:
@@ -162,6 +164,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     this.provider.state.streamSortOrder = message.sortBy ?? 'time';
+    this.provider.updateWebview();
+  }
+
+  private async handleFilterStreams(
+    message: any,
+    _webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const filter = message.filter ?? 'all';
+    this.provider.state.agentTypeFilter = filter;
     this.provider.updateWebview();
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -128,8 +128,16 @@ export class ProgressEventHandler {
     this.state.activeStream = stream;
 
     if (this.webviewUpdater.isAvailable()) {
-      const infos = buildStreamInfos(this.state, this._streamStatus);
-      this.webviewUpdater.updateStreams(infos, stream);
+      const infos = buildStreamInfos(
+        this.state,
+        this._streamStatus,
+        this.state.agentTypeFilter,
+      );
+      this.webviewUpdater.updateStreams(
+        infos,
+        stream,
+        this.state.agentTypeFilter,
+      );
 
       // Update log content (will be empty for new streams)
       this.updateLogContentForStream(stream);
@@ -152,8 +160,16 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      const infos = buildStreamInfos(this.state, this._streamStatus);
-      this.webviewUpdater.updateStreams(infos, this.state.activeStream);
+      const infos = buildStreamInfos(
+        this.state,
+        this._streamStatus,
+        this.state.agentTypeFilter,
+      );
+      this.webviewUpdater.updateStreams(
+        infos,
+        this.state.activeStream,
+        this.state.agentTypeFilter,
+      );
 
       if (stream === this.state.activeStream) {
         this.webviewUpdater.updateStatus(status);
@@ -244,8 +260,16 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      const infos = buildStreamInfos(this.state, this._streamStatus);
-      this.webviewUpdater.updateStreams(infos, this.state.activeStream);
+      const infos = buildStreamInfos(
+        this.state,
+        this._streamStatus,
+        this.state.agentTypeFilter,
+      );
+      this.webviewUpdater.updateStreams(
+        infos,
+        this.state.activeStream,
+        this.state.agentTypeFilter,
+      );
     }
   }
 

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -276,6 +276,32 @@
           <!-- Stream tabs will be dynamically inserted here -->
         </div>
         <div class="clear-all-container">
+          <div class="button-group agent-filter-group" id="agentFilterButtons">
+            <button
+              class="vscode-button"
+              id="filterAllBtn"
+              data-filter="all"
+              aria-pressed="true"
+            >
+              All
+            </button>
+            <button
+              class="vscode-button"
+              id="filterWorkflowBtn"
+              data-filter="workflow"
+              aria-pressed="false"
+            >
+              Workflow
+            </button>
+            <button
+              class="vscode-button"
+              id="filterToolBtn"
+              data-filter="toolUse"
+              aria-pressed="false"
+            >
+              Tool Use
+            </button>
+          </div>
           <div class="button-group" id="sortButtons">
             <button
               class="vscode-button sort-btn"

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -36,7 +36,11 @@ export class WebviewUpdater {
   /**
    * Update stream tabs in the webview
    */
-  updateStreams(streams: StreamTabInfo[], activeStream: StreamTabId): void {
+  updateStreams(
+    streams: StreamTabInfo[],
+    activeStream: StreamTabId,
+    agentFilter: string,
+  ): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -44,6 +48,7 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_STREAMS,
       streams,
       activeStream,
+      agentFilter,
     });
   }
 
@@ -206,12 +211,16 @@ export class WebviewUpdater {
     const webview = this.getWebview();
     if (!webview) return;
 
-    const activeStream = state.activeStream;
+    const streams = buildStreamInfos(state, statuses, state.agentTypeFilter);
 
-    const streams = buildStreamInfos(state, statuses);
+    let activeStream = state.activeStream;
+    if (!streams.some((info) => info.name === activeStream)) {
+      activeStream = streams[0]?.name ?? '';
+      state.activeStream = activeStream;
+    }
 
     // Update streams and active stream
-    this.updateStreams(streams, activeStream);
+    this.updateStreams(streams, activeStream, state.agentTypeFilter);
 
     if (activeStream) {
       // Update log content for active stream

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -12,6 +12,7 @@ import { ProgressViewState } from '../state/ProgressViewState';
 import { buildStreamInfos } from '../streamInfoUtils';
 import type { StreamTabInfo } from '../types';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
@@ -39,7 +40,7 @@ export class WebviewUpdater {
   updateStreams(
     streams: StreamTabInfo[],
     activeStream: StreamTabId,
-    agentFilter: string,
+    agentFilter: AgentTypeFilter,
   ): void {
     const webview = this.getWebview();
     if (!webview) return;

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -32,6 +32,10 @@ export const ELEMENT_IDS = {
   FOLLOW_UP_CONTAINER: 'followUpContainer',
   FOLLOW_UP_INPUT: 'followUpInput',
   SEND_FOLLOW_UP_BTN: 'sendFollowUpBtn',
+  AGENT_FILTER_CONTAINER: 'agentFilterButtons',
+  FILTER_ALL_BTN: 'filterAllBtn',
+  FILTER_WORKFLOW_BTN: 'filterWorkflowBtn',
+  FILTER_TOOL_BTN: 'filterToolBtn',
 };
 
 // Default sizes for split view
@@ -127,5 +131,23 @@ export const SORT_BUTTONS = [
     icon: 'account',
     sort: 'agent',
     title: 'Sort by agent',
+  },
+];
+
+export const FILTER_BUTTONS = [
+  {
+    id: ELEMENT_IDS.FILTER_ALL_BTN,
+    label: 'All',
+    filter: 'all',
+  },
+  {
+    id: ELEMENT_IDS.FILTER_WORKFLOW_BTN,
+    label: 'Workflow',
+    filter: 'workflow',
+  },
+  {
+    id: ELEMENT_IDS.FILTER_TOOL_BTN,
+    label: 'Tool Use',
+    filter: 'toolUse',
   },
 ];

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -57,6 +57,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleUpdateStreams(message) {
     state.activeStream = message.activeStream;
+    state.agentFilter = message.agentFilter || 'all';
     message.streams.forEach((s) => {
       if (s.status) {
         state.streamStatuses.set(s.name, s.status);
@@ -65,6 +66,17 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
     });
     dom.streamTabs.update(message.streams, message.activeStream);
+
+    const filterContainer = document.getElementById(
+      ELEMENT_IDS.AGENT_FILTER_CONTAINER,
+    );
+    if (filterContainer) {
+      filterContainer.querySelectorAll('button[data-filter]').forEach((btn) => {
+        const isActive = btn.dataset.filter === state.agentFilter;
+        btn.classList.toggle('toggled', isActive);
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+    }
 
     this._updatePlaceholderVisibility();
 

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -171,6 +171,7 @@ export class ProgressViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
     this.activeStream = '';
+    this.agentFilter = 'all';
     this.currentGroupId = null;
 
     // Initialize managers

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -101,6 +101,16 @@ export class EventsManager {
       }
     });
 
+    addEventListenerSafely(ELEMENT_IDS.AGENT_FILTER_CONTAINER, 'click', (e) => {
+      const btn = e.target.closest('button[data-filter]');
+      if (btn && btn.dataset.filter) {
+        vscode.postMessage({
+          command: COMMANDS.FILTER_STREAMS,
+          filter: btn.dataset.filter,
+        });
+      }
+    });
+
     // Follow-up input handler
     const sendFollowUp = () => {
       const followInput = document.getElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -32,11 +32,13 @@ export class StreamTabs {
       return;
     }
     tabsContainer.innerHTML = '';
+    let activeInfo = null;
     streams.forEach((info) => {
       if (!info || typeof info !== 'object') {
         console.warn('StreamTabs.update: invalid stream value:', info);
         return;
       }
+      const tooltip = this._buildTooltip(info);
       const tabEl = createFromTemplate('streamTabTemplate', {
         text: {
           '.tab-title': info.label || info.name,
@@ -44,7 +46,8 @@ export class StreamTabs {
           '.last-active': formatRelativeTime(info.lastTimestamp),
         },
         attributes: {
-          '.tab': { title: info.name },
+          '': { title: tooltip },
+          '.tab': { title: tooltip },
           '.tab-delete': { title: 'Delete stream' },
         },
         dataset: {
@@ -77,8 +80,10 @@ export class StreamTabs {
           multiIcon.remove();
         }
       }
-      if (info.name === activeStream) tabEl.classList.add('active');
-      tabEl.title = info.name;
+      if (info.name === activeStream) {
+        tabEl.classList.add('active');
+        activeInfo = info;
+      }
       tabsContainer.appendChild(tabEl);
     });
 
@@ -87,7 +92,41 @@ export class StreamTabs {
       ELEMENT_IDS.ACTIVE_STREAM_NAME,
     );
     if (streamNameElem) {
-      streamNameElem.textContent = activeStream || '';
+      const label = activeInfo?.label || '';
+      streamNameElem.textContent = label;
+      streamNameElem.title = activeInfo
+        ? this._buildActiveTitle(activeInfo)
+        : '';
+      if (activeInfo?.name) {
+        streamNameElem.dataset.stream = activeInfo.name;
+      } else {
+        delete streamNameElem.dataset.stream;
+      }
     }
+  }
+
+  _buildTooltip(info) {
+    const parts = [];
+    if (info?.label) {
+      parts.push(info.label);
+    }
+    if (info?.model) {
+      parts.push(`Model: ${info.model}`);
+    }
+    if (info?.inputFile) {
+      parts.push(`Input: ${info.inputFile}`);
+    }
+    return parts.filter(Boolean).join(' • ');
+  }
+
+  _buildActiveTitle(info) {
+    const parts = [this._buildTooltip(info)];
+    if (info?.lastTimestamp) {
+      const lastSeen = formatRelativeTime(info.lastTimestamp);
+      if (lastSeen) {
+        parts.push(`Last activity ${lastSeen}`);
+      }
+    }
+    return parts.filter(Boolean).join('\n');
   }
 }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -10,6 +10,7 @@ import { StatePersistenceManager } from '../persistence/StatePersistenceManager'
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
+import type { AgentFilter } from '../types';
 
 // Types
 import { TaskState } from '@logger/TaskState';
@@ -27,6 +28,7 @@ export class ProgressViewState {
   private _usageStats: UsageStatsManager;
   private _activeStream: StreamTabId = '';
   private _streamSortOrder = 'time';
+  private _agentTypeFilter: AgentFilter = 'all';
   private _taskStates: Map<StreamTabId, TaskState> = new Map();
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
   private readonly persistence: StatePersistenceManager;
@@ -77,6 +79,15 @@ export class ProgressViewState {
   set streamSortOrder(order: string) {
     this._streamSortOrder = order;
     this.saveStreamSortOrder();
+  }
+
+  get agentTypeFilter(): AgentFilter {
+    return this._agentTypeFilter;
+  }
+
+  set agentTypeFilter(filter: AgentFilter) {
+    this._agentTypeFilter = filter;
+    this.saveAgentTypeFilter();
   }
 
   // Task state management
@@ -178,6 +189,7 @@ export class ProgressViewState {
       this.loadTaskStates(),
       this.loadExecutionIds(),
       this.loadStreamSortOrder(),
+      this.loadAgentTypeFilter(),
     ]);
   }
 
@@ -284,6 +296,20 @@ export class ProgressViewState {
     this.persistence.save(
       WorkspaceStateKey.STREAM_SORT_ORDER,
       this._streamSortOrder,
+    );
+  }
+
+  private async loadAgentTypeFilter(): Promise<void> {
+    this._agentTypeFilter = await this.persistence.load(
+      WorkspaceStateKey.STREAM_AGENT_FILTER,
+      'all',
+    );
+  }
+
+  private saveAgentTypeFilter(): void {
+    this.persistence.save(
+      WorkspaceStateKey.STREAM_AGENT_FILTER,
+      this._agentTypeFilter,
     );
   }
 }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -11,6 +11,8 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { AgentFilter } from '../types';
+// Local imports - agent types
+import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
 // Types
 import { TaskState } from '@logger/TaskState';
@@ -300,10 +302,13 @@ export class ProgressViewState {
   }
 
   private async loadAgentTypeFilter(): Promise<void> {
-    this._agentTypeFilter = await this.persistence.load(
+    const savedFilter = await this.persistence.load<string>(
       WorkspaceStateKey.STREAM_AGENT_FILTER,
       'all',
     );
+    this._agentTypeFilter = isAgentTypeFilter(savedFilter)
+      ? savedFilter
+      : 'all';
   }
 
   private saveAgentTypeFilter(): void {

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -88,6 +88,10 @@ export class ProgressViewState {
   }
 
   set agentTypeFilter(filter: AgentFilter) {
+    if (!isAgentTypeFilter(filter)) {
+      this.logger.warn(`Invalid agent filter: ${filter}, defaulting to 'all'`);
+      filter = 'all';
+    }
     this._agentTypeFilter = filter;
     this.saveAgentTypeFilter();
   }

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 // Local imports - progress view
 import type { ProgressViewState } from './state/ProgressViewState';
 import type { AgentFilter, StreamTabInfo } from './types';
+// Local imports - agent types
+import { AgentType } from '@agent/core/AgentDataclass';
 
 const sortComparators = {
   time: (a: StreamTabInfo, b: StreamTabInfo) =>
@@ -16,27 +18,28 @@ const sortComparators = {
 } as const;
 
 function matchesAgentFilter(
-  agentType: string | undefined,
+  agentType: AgentType | undefined,
   filter: AgentFilter,
 ): boolean {
-  if (filter === 'all') {
-    return true;
+  switch (filter) {
+    case 'all':
+      return true;
+    case 'toolUse':
+      return agentType === AgentType.ToolUse;
+    case 'workflow':
+      return agentType !== AgentType.ToolUse;
+    default:
+      return true;
   }
-  if (filter === 'toolUse') {
-    return agentType === 'toolUse';
-  }
-  return agentType !== 'toolUse';
 }
 
 function buildStreamLabel(
   agentName: string,
   inputFile: string,
-  agentType: string | undefined,
-  executionId?: string,
+  agentType: AgentType | undefined,
 ): string {
-  if (agentType === 'toolUse') {
-    const shortId = executionId ? executionId.slice(0, 8) : undefined;
-    return shortId ? `${agentName} #${shortId}` : agentName;
+  if (agentType === AgentType.ToolUse) {
+    return agentName;
   }
 
   const baseName = inputFile ? path.basename(inputFile) : '';
@@ -66,12 +69,7 @@ export function buildStreamInfos(
       return acc;
     }
     const executionId = state.getExecutionId(id);
-    const label = buildStreamLabel(
-      agentName,
-      inputFile,
-      agentType,
-      executionId,
-    );
+    const label = buildStreamLabel(agentName, inputFile, agentType);
     acc.push({
       name: id,
       label,

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 // Local imports - progress view
 import type { ProgressViewState } from './state/ProgressViewState';
-import type { StreamTabInfo } from './types';
+import type { AgentFilter, StreamTabInfo } from './types';
 
 const sortComparators = {
   time: (a: StreamTabInfo, b: StreamTabInfo) =>
@@ -15,14 +15,43 @@ const sortComparators = {
     (a.agent || '').localeCompare(b.agent || ''),
 } as const;
 
+function matchesAgentFilter(
+  agentType: string | undefined,
+  filter: AgentFilter,
+): boolean {
+  if (filter === 'all') {
+    return true;
+  }
+  if (filter === 'toolUse') {
+    return agentType === 'toolUse';
+  }
+  return agentType !== 'toolUse';
+}
+
+function buildStreamLabel(
+  agentName: string,
+  inputFile: string,
+  agentType: string | undefined,
+  executionId?: string,
+): string {
+  if (agentType === 'toolUse') {
+    const shortId = executionId ? executionId.slice(0, 8) : undefined;
+    return shortId ? `${agentName} #${shortId}` : agentName;
+  }
+
+  const baseName = inputFile ? path.basename(inputFile) : '';
+  return baseName ? `${agentName}: ${baseName}` : agentName;
+}
+
 /**
  * Build metadata objects for all streams in the given state.
  */
 export function buildStreamInfos(
   state: ProgressViewState,
   statuses?: Map<string, string>,
+  filter: AgentFilter = 'all',
 ): StreamTabInfo[] {
-  const infos = state.streamTabs.keys().map((id) => {
+  const infos = state.streamTabs.keys().reduce<StreamTabInfo[]>((acc, id) => {
     const taskState = state.getTaskState(id);
     const logs = state.streamTabs.get(id);
     const lastTimestamp =
@@ -32,20 +61,32 @@ export function buildStreamInfos(
     const outputs = taskState?.agentConfig.outputFiles || [];
     const inputFile = taskState?.agentConfig.inputFile || '';
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
-    const label = `${agentName}: ${path.basename(inputFile)}`;
-    return {
+    const agentType = taskState?.agentType;
+    if (!matchesAgentFilter(agentType, filter)) {
+      return acc;
+    }
+    const executionId = state.getExecutionId(id);
+    const label = buildStreamLabel(
+      agentName,
+      inputFile,
+      agentType,
+      executionId,
+    );
+    acc.push({
       name: id,
       label,
       model: taskState?.agentConfig.model,
       agent: taskState?.agentConfig.agent,
-      agentType: taskState?.agentType,
+      agentType,
       hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
       lastTimestamp,
       inputFile,
       creationTimestamp,
       status: statuses?.get(id),
-    } as StreamTabInfo;
-  });
+      executionId,
+    });
+    return acc;
+  }, []);
 
   const comparator =
     sortComparators[state.streamSortOrder as keyof typeof sortComparators];

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -32,6 +32,16 @@
   justify-content: space-between;
 }
 
+.agent-filter-group {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-small);
+}
+
+.agent-filter-group .vscode-button {
+  min-width: auto;
+}
+
 .tab-container {
   display: flex;
   align-items: center;

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -10,4 +10,7 @@ export interface StreamTabInfo {
   inputFile?: string;
   creationTimestamp?: number;
   status?: string;
+  executionId?: string;
 }
+
+export type AgentFilter = 'all' | 'workflow' | 'toolUse';

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,16 +1,21 @@
+// Local imports - agent types
+import type { AgentType } from '@agent/core/AgentDataclass';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
+
 export interface StreamTabInfo {
   name: string;
   /** Short label displayed in the tab UI */
   label: string;
   model?: string;
   agent?: string;
-  agentType?: string;
+  agentType?: AgentType;
   hasMultipleOutputs?: boolean;
   lastTimestamp?: number;
   inputFile?: string;
   creationTimestamp?: number;
   status?: string;
-  executionId?: string;
+  executionId?: ExecutionId;
 }
 
-export type AgentFilter = 'all' | 'workflow' | 'toolUse';
+export type AgentFilter = AgentTypeFilter;

--- a/src/test/logger/streamUtils.test.ts
+++ b/src/test/logger/streamUtils.test.ts
@@ -19,6 +19,14 @@ describe('getStreamTabId', () => {
     assert.equal(id, 'polish_multiple@sonnet: paper.tex');
   });
 
+  it('avoids duplicating the multiple suffix when already present', () => {
+    const id = getStreamTabId('polish_multiple', 'sonnet', '/tmp/paper.tex', [
+      'out1',
+      'out2',
+    ]);
+    assert.equal(id, 'polish_multiple@sonnet: paper.tex');
+  });
+
   it('uses execution id prefix for tool use streams', () => {
     const executionId = '12345678-9abc-def0-1234-56789abcdef0';
     const id = getStreamTabId('diagnostics', 'gpt4', '', undefined, {

--- a/src/test/logger/streamUtils.test.ts
+++ b/src/test/logger/streamUtils.test.ts
@@ -1,0 +1,29 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - logger utilities
+import { getStreamTabId } from '@/logger/streamUtils';
+
+describe('getStreamTabId', () => {
+  it('builds workflow identifiers using input file name', () => {
+    const id = getStreamTabId('polish', 'sonnet', '/tmp/paper.tex');
+    assert.equal(id, 'polish@sonnet: paper.tex');
+  });
+
+  it('appends multiple suffix for workflow streams with many outputs', () => {
+    const id = getStreamTabId('polish', 'sonnet', '/tmp/paper.tex', [
+      'out1',
+      'out2',
+    ]);
+    assert.equal(id, 'polish_multiple@sonnet: paper.tex');
+  });
+
+  it('uses execution id prefix for tool use streams', () => {
+    const executionId = '12345678-9abc-def0-1234-56789abcdef0';
+    const id = getStreamTabId('diagnostics', 'gpt4', '', undefined, {
+      agentType: 'toolUse',
+      executionId,
+    });
+    assert.equal(id, 'diagnostics@gpt4#12345678');
+  });
+});

--- a/src/test/logger/streamUtils.test.ts
+++ b/src/test/logger/streamUtils.test.ts
@@ -1,8 +1,9 @@
 // Standard library imports
 import { strict as assert } from 'assert';
 
-// Local imports - logger utilities
+// Local imports
 import { getStreamTabId } from '@/logger/streamUtils';
+import { AgentType } from '@agent/core/AgentDataclass';
 
 describe('getStreamTabId', () => {
   it('builds workflow identifiers using input file name', () => {
@@ -21,7 +22,7 @@ describe('getStreamTabId', () => {
   it('uses execution id prefix for tool use streams', () => {
     const executionId = '12345678-9abc-def0-1234-56789abcdef0';
     const id = getStreamTabId('diagnostics', 'gpt4', '', undefined, {
-      agentType: 'toolUse',
+      agentType: AgentType.ToolUse,
       executionId,
     });
     assert.equal(id, 'diagnostics@gpt4#12345678');


### PR DESCRIPTION
## Summary
- derive tool-use stream identifiers from execution ids and propagate them through agent constructors so concurrent runs no longer collide
- add agent-type filtering, labels, and styling to the progress view so workflow and tool-use streams can be viewed independently while persisting the chosen filter
- document the updated behaviour and cover the stream id helper with unit tests

## Testing
- npm run format
- npm run lint
- npm test *(fails: vscode-test is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5e0f538883249365ad0a43e0f0aa