### PR TITLE
fix: decode user follow-up messages

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -838,7 +838,9 @@ export class LogEntryFormatter {
 
     const contentElem = element.querySelector('.user-message-content');
     if (contentElem) {
-      contentElem.textContent = content;
+      const decodedContent =
+        typeof content === 'string' ? decodeHtml(content) : '';
+      contentElem.textContent = decodedContent;
       if (logId) contentElem.dataset.logId = logId;
     }
 


### PR DESCRIPTION
## Summary
- decode HTML entities in logged user messages before rendering to the progress view
- ensure timestamps and log identifiers remain unchanged while content is decoded

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8f40c4748324bde75c29e71b3faf