### PR TITLE
fix: tolerate legacy tool config keys

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -37,7 +37,8 @@ export const AgentConfigSchema = z
 
     toolConfig: ToolConfigSchema.default({}),
   })
-  .strict()
+  // Strip unknown keys to tolerate stale settings from previous releases.
+  .strip()
   .refine(validateOutputFiles, {
     message:
       'Number of output files must not be greater than the number of input files.',

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -6,6 +6,9 @@ import { z } from 'zod';
  * Defaults are defined at the property level and the schema itself
  * defaults to an empty object, allowing omission of the entire
  * configuration section.
+ *
+ * We explicitly strip unknown properties to remain backward compatible
+ * with legacy settings that may still include removed flags.
  */
 export const ToolConfigSchema = z
   .object({
@@ -17,7 +20,7 @@ export const ToolConfigSchema = z
     printInputPrompt: z.boolean().default(false),
     autoCompileInputPdf: z.boolean().default(false),
   })
-  .strict()
+  .strip()
   .default({});
 
 export type ToolConfig = z.infer<typeof ToolConfigSchema>;

--- a/src/test/agent/core/ConfigSchemas.test.ts
+++ b/src/test/agent/core/ConfigSchemas.test.ts
@@ -1,0 +1,43 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - agent core
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import { ToolConfigSchema } from '@agent/core/ToolConfig';
+
+describe('ToolConfigSchema', () => {
+  it('ignores unknown toolConfig keys', () => {
+    const parsed = ToolConfigSchema.parse({
+      reflect: true,
+      usePrefillFromInput: true,
+    } as Record<string, unknown>);
+
+    assert.strictEqual(parsed.reflect, true);
+    assert.strictEqual(parsed.autoExtractFigure, false);
+    assert.strictEqual(
+      (parsed as Record<string, unknown>).usePrefillFromInput,
+      undefined,
+    );
+  });
+});
+
+describe('AgentConfigSchema', () => {
+  it('strips unknown properties for backward compatibility', () => {
+    const parsed = AgentConfigSchema.parse({
+      legacyFlag: 'remove-me',
+      toolConfig: {
+        reflect: true,
+        usePrefillFromInput: true,
+      },
+    } as Record<string, unknown>);
+
+    assert.strictEqual(parsed.toolConfig.reflect, true);
+    assert.strictEqual(parsed.toolConfig.autoExtractFigure, false);
+    assert.strictEqual('legacyFlag' in parsed, false);
+    assert.strictEqual(parsed.inputFile, '');
+    assert.strictEqual(
+      'usePrefillFromInput' in (parsed.toolConfig as Record<string, unknown>),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- strip unknown properties from the agent and tool config schemas so legacy keys no longer break activation
- document the backward-compatibility behavior in the schemas and add regression tests that cover legacy tool flags

## Testing
- npm run format
- npm run lint
- CI=1 npm test *(fails: VS Code runtime requires libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9fdb50cc8324acf5f39c30606bf8