### PR TITLE
fix: handle beamer column xml replacements

### DIFF
--- a/src/replacement/constants.ts
+++ b/src/replacement/constants.ts
@@ -73,6 +73,8 @@ export const LATEX_ENVIRONMENTS = [
   'solution',
   'acknowledgment',
   'minipage',
+  'column',
+  'columns',
   'verbatim',
   'lstlisting',
   'minted',

--- a/src/replacement/rules/latexXml.ts
+++ b/src/replacement/rules/latexXml.ts
@@ -27,6 +27,7 @@ export const LATEX_XML_REPLACEMENTS: ReplacementCategory = {
       'cover_letter',
       'reflection',
       'rebuttal_package',
+      'beamer_poster',
     ];
 
     // Initialize patterns object


### PR DESCRIPTION
## Summary
- add beamer column environments to XML/LaTeX replacement map
- convert the beamer_poster environment to XML closing tags during cleanup

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca9c008dd8832491023dd9a377ddf0