### PR TITLE
fix: patch latex xml replacements

### DIFF
--- a/src/replacement/constants.ts
+++ b/src/replacement/constants.ts
@@ -73,6 +73,8 @@ export const LATEX_ENVIRONMENTS = [
   'solution',
   'acknowledgment',
   'minipage',
+  'column',
+  'columns',
   'verbatim',
   'lstlisting',
   'minted',

--- a/src/replacement/helpers.ts
+++ b/src/replacement/helpers.ts
@@ -127,6 +127,12 @@ export function generateXmlLatexConversions(environments: string[]): {
     patterns[`</${env}}`] = `\\end{${env}}`;
 
     patterns[`</${env}\n`] = `\\end{${env}}\n`;
+    patterns[`</${env}}\n`] = `\\end{${env}}\n`;
+
+    // XML begin tags incorrectly closed with leading slash
+    patterns[`</begin{${env}}`] = `\\begin{${env}}`;
+    patterns[`</begin{${env}}\n`] = `\\begin{${env}}\n`;
+    patterns[`</begin{${env}`] = `\\begin{${env}}`;
 
     // LaTeX with incorrect XML ending
     patterns[`\\end{${env}>}`] = `\\end{${env}}`;

--- a/src/replacement/rules/characters.ts
+++ b/src/replacement/rules/characters.ts
@@ -9,6 +9,8 @@ export const CHARACTER_REPLACEMENTS: ReplacementCategory = {
     ansätze: 'ans{\\"a}tze',
     Rényi: "R{\\'e}nyi",
     Schrödinger: 'Schr{\\"o}dinger',
+    'Schr{\\\\`o}dinger': 'Schr{\\"o}dinger',
+    'Schr{\\\\`o}dingers': 'Schr{\\"o}dingers',
   },
 };
 

--- a/src/replacement/rules/latexXml.ts
+++ b/src/replacement/rules/latexXml.ts
@@ -27,6 +27,7 @@ export const LATEX_XML_REPLACEMENTS: ReplacementCategory = {
       'cover_letter',
       'reflection',
       'rebuttal_package',
+      'beamer_poster',
     ];
 
     // Initialize patterns object


### PR DESCRIPTION
## Summary
- include column-style environments in the XML ↔︎ LaTeX conversion tables so stray </column} tokens resolve cleanly
- convert malformed </begin{...} entries back to corresponding \begin statements and treat <beamer_poster> as an XML-only tag
- normalize Schr{\`o}dinger variants to the umlaut spelling in character replacements

## Testing
- npm run format
- npm run lint
- npm test *(terminated in container due to hanging vscode-test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9c008dd8832491023dd9a377ddf0