### PR TITLE
Add copy control to model response entries

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -205,7 +205,17 @@
         </template>
         <template id="modelResponseTemplate">
           <div class="model-response-line">
-            <span class="timestamp"></span>
+            <div class="model-response-header">
+              <span class="timestamp"></span>
+              <button
+                type="button"
+                class="vscode-button model-response-copy"
+                title="Copy model output"
+                aria-label="Copy model output"
+              >
+                <i class="codicon codicon-copy"></i>
+              </button>
+            </div>
             <div class="model-response-content markdown-content"></div>
           </div>
         </template>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -212,6 +212,8 @@
                 class="vscode-button model-response-copy"
                 title="Copy model output"
                 aria-label="Copy model output"
+                data-default-title="Copy model output"
+                data-success-title="Copied!"
               >
                 <i class="codicon codicon-copy"></i>
               </button>

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -506,9 +506,13 @@ export class LogEntryFormatter {
 
     const contentElem = element.querySelector('.model-response-content');
     if (contentElem) {
+      const decodedContent = decodeHtml(content);
       contentElem.classList.add(`message-${level}`);
-      contentElem.dataset.rawContent = encodeHtml(content);
-      contentElem.innerHTML = this._processMarkdownContent(content);
+      contentElem.dataset.rawContent = decodedContent;
+      contentElem.innerHTML = this._processMarkdownContent(
+        decodedContent,
+        false,
+      );
     }
 
     return element;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -507,6 +507,7 @@ export class LogEntryFormatter {
     const contentElem = element.querySelector('.model-response-content');
     if (contentElem) {
       contentElem.classList.add(`message-${level}`);
+      contentElem.dataset.rawContent = encodeHtml(content);
       contentElem.innerHTML = this._processMarkdownContent(content);
     }
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -1,6 +1,5 @@
 // Third-party imports
 import Split from 'split.js';
-import { decode as decodeHtml } from 'he';
 
 // Local imports - progress view
 import { COMMANDS, SPLIT_SIZES, ELEMENT_IDS } from '../constants.js';
@@ -199,16 +198,50 @@ export class EventsManager {
       }
 
       const rawContent = contentElem.dataset.rawContent;
-      const textToCopy = rawContent
-        ? decodeHtml(rawContent)
-        : contentElem.textContent || '';
-      if (!textToCopy) {
+      const textToCopy = rawContent ?? contentElem.textContent ?? '';
+      if (!textToCopy.trim()) {
         return;
       }
 
+      const defaultTitle =
+        copyButton.dataset.defaultTitle ||
+        copyButton.getAttribute('title') ||
+        'Copy model output';
+      const successTitle = copyButton.dataset.successTitle || 'Copied!';
+      const existingTimeoutId = copyButton.dataset.copyResetTimeoutId;
+      if (existingTimeoutId) {
+        window.clearTimeout(Number(existingTimeoutId));
+        delete copyButton.dataset.copyResetTimeoutId;
+      }
+
+      copyButton.classList.remove('copy-success');
+      copyButton.setAttribute('title', defaultTitle);
+      copyButton.setAttribute('aria-label', defaultTitle);
+
+      const normalizedText = textToCopy.replace(/\r?\n/g, '\n');
+
+      const scheduleReset = () => {
+        const timeoutId = window.setTimeout(() => {
+          copyButton.classList.remove('copy-success');
+          copyButton.setAttribute('title', defaultTitle);
+          copyButton.setAttribute('aria-label', defaultTitle);
+          delete copyButton.dataset.copyResetTimeoutId;
+        }, 2000);
+
+        copyButton.dataset.copyResetTimeoutId = `${timeoutId}`;
+      };
+
+      const markSuccess = () => {
+        copyButton.classList.add('copy-success');
+        copyButton.setAttribute('title', successTitle);
+        copyButton.setAttribute('aria-label', successTitle);
+        scheduleReset();
+      };
+
       if (navigator.clipboard?.writeText) {
         try {
-          await navigator.clipboard.writeText(textToCopy);
+          await navigator.clipboard.writeText(normalizedText);
+          markSuccess();
           return;
         } catch {
           // Fallback to execCommand below
@@ -216,7 +249,7 @@ export class EventsManager {
       }
 
       const textarea = document.createElement('textarea');
-      textarea.value = textToCopy;
+      textarea.value = normalizedText;
       textarea.setAttribute('readonly', '');
       textarea.style.position = 'fixed';
       textarea.style.opacity = '0';
@@ -224,7 +257,10 @@ export class EventsManager {
       document.body.appendChild(textarea);
       textarea.select();
       try {
-        document.execCommand('copy');
+        const copied = document.execCommand('copy');
+        if (copied) {
+          markSuccess();
+        }
       } finally {
         textarea.remove();
       }

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -1,5 +1,6 @@
 // Third-party imports
 import Split from 'split.js';
+import { decode as decodeHtml } from 'he';
 
 // Local imports - progress view
 import { COMMANDS, SPLIT_SIZES, ELEMENT_IDS } from '../constants.js';
@@ -168,6 +169,9 @@ export class EventsManager {
 
     // Handle clicks on file links inside file-list-details blocks
     document.addEventListener('click', (e) => {
+      if (!(e.target instanceof Element)) {
+        return;
+      }
       const link = e.target.closest('.file-link');
       if (link && link.dataset.file) {
         vscode.postMessage({
@@ -177,8 +181,60 @@ export class EventsManager {
       }
     });
 
+    // Handle copy actions for model responses
+    document.addEventListener('click', async (e) => {
+      if (!(e.target instanceof Element)) {
+        return;
+      }
+      const copyButton = e.target.closest('.model-response-copy');
+      if (!copyButton) {
+        return;
+      }
+
+      const contentElem = copyButton
+        .closest('.model-response-line')
+        ?.querySelector('.model-response-content');
+      if (!contentElem) {
+        return;
+      }
+
+      const rawContent = contentElem.dataset.rawContent;
+      const textToCopy = rawContent
+        ? decodeHtml(rawContent)
+        : contentElem.textContent || '';
+      if (!textToCopy) {
+        return;
+      }
+
+      if (navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(textToCopy);
+          return;
+        } catch {
+          // Fallback to execCommand below
+        }
+      }
+
+      const textarea = document.createElement('textarea');
+      textarea.value = textToCopy;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      textarea.style.pointerEvents = 'none';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        document.execCommand('copy');
+      } finally {
+        textarea.remove();
+      }
+    });
+
     // Handle clicks on LaTeX references within logs
     document.addEventListener('click', (e) => {
+      if (!(e.target instanceof Element)) {
+        return;
+      }
       const ref = e.target.closest('.latex-ref');
       if (ref && ref.dataset.label) {
         vscode.postMessage({

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -33,6 +33,21 @@
   white-space: normal;
 }
 
+.model-response-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.model-response-copy {
+  margin-left: auto;
+  min-width: 0;
+}
+
+.model-response-content {
+  margin-top: var(--spacing-tiny);
+}
+
 /* Timestamp color */
 .timestamp {
   color: var(--vscode-descriptionForeground);

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -36,12 +36,28 @@
 .model-response-header {
   display: flex;
   align-items: center;
-  gap: var(--spacing-small);
+  justify-content: space-between;
+  column-gap: var(--spacing-small);
 }
 
 .model-response-copy {
-  margin-left: auto;
   min-width: 0;
+  padding: 0 var(--spacing-tiny);
+  opacity: 0;
+  transition:
+    opacity 0.2s ease,
+    color 0.2s ease;
+}
+
+.model-response-header:hover .model-response-copy,
+.model-response-line:focus-within .model-response-copy,
+.model-response-copy:focus-visible,
+.model-response-copy.copy-success {
+  opacity: 1;
+}
+
+.model-response-copy.copy-success {
+  color: var(--vscode-testing-iconPassed, #2ea043);
 }
 
 .model-response-content {


### PR DESCRIPTION
## Summary
- add a header with a copy button to model response log entries in the progress view
- store the original markdown on each model response element so it can be copied intact
- wire up a document-level handler that decodes and copies the response text with clipboard API and fallback, plus styling to keep the control minimal

## Testing
- npm run format
- npm run lint
- npm test *(fails to complete in this environment; terminated after the pretest stage due to excessive console output/hanging spinner)*

------
https://chatgpt.com/codex/tasks/task_e_68caa2517e148324b67cecdd9927881c