### PR TITLE
refactor: track multi-output mode with boolean flag

### DIFF
--- a/docs/guide/multiple-output.md
+++ b/docs/guide/multiple-output.md
@@ -54,9 +54,9 @@ This is the crucial part for generating multiple distinct files:
 
 **Key Point:** The agent doesn't magically know how to split output (it hasn't mastered telepathy... yet). It must be explicitly instructed via its prompts (like in `polish_multiple.yaml`) to generate the `<document name=\"...\">` structure matching the list you provide in the UI.
 
-## The `_multiple` Suffix
+## Tracking Multi-Output Runs
 
-You might notice `_multiple` appended to the agent name in logs or temporary filenames when using the "Multiple Outputs" feature. This internal suffix indicates that TeXRA is operating in a context where multiple output files are expected based on your UI selection; it doesn't necessarily mean a different agent `.yaml` file (like `polish_multiple.yaml`) was automatically chosen unless you selected it explicitly.
+TeXRA records whether a run expects multiple files through the `useMultipleOutputs` flag stored in each agent configuration. The UI toggles this flag whenever you expand the "Multiple Outputs" section, and the backend propagates it through task history, housekeeping commands, and progress logs. Stream identifiers still append `_multiple` for readability, but that suffix is now derived from the flag rather than being hard-coded into agent names.
 
 ## Example: `polish_multiple` Agent Prompts
 

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -23,6 +23,7 @@ export const AgentConfigSchema = z
     model: z.string().default('gemini25p'),
     agent: z.string().default('correct'),
     instruction: z.string().default(''),
+    useMultipleOutputs: z.boolean().default(false),
 
     inputFile: z.string().default(''),
     inputFiles: z.array(z.string()).nullable().default(null),

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -40,6 +40,7 @@ export const AgentSettingSchema = z
     requiredFiles: z.record(z.string()).default({}),
     requiredFilesInternal: z.record(z.string()).default({}),
     defaultOutputFiles: z.array(z.string()).default([]),
+    useMultipleOutputs: z.boolean().default(false),
     filePatternsContain: z
       .array(
         z.object({

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -79,10 +79,10 @@ export abstract class BaseAgent implements IAgent {
       this.agentConfig.agent,
       this.agentConfig.model,
       this.agentConfig.inputFile,
-      this.agentConfig.outputFiles ?? undefined,
       {
         agentType: this.agentSetting.agentType,
         executionId: this.executionId,
+        useMultipleOutputs: this.agentConfig.useMultipleOutputs,
       },
     );
   }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -416,11 +416,13 @@ export async function executeAgent(
       const fullConfig = AgentConfigSchema.parse(agentConfig);
 
       if (
-        !fullConfig.useMultipleOutputs &&
         Array.isArray(fullConfig.outputFiles) &&
-        fullConfig.outputFiles.length > 1
+        fullConfig.outputFiles.length > 1 &&
+        !fullConfig.useMultipleOutputs
       ) {
-        fullConfig.useMultipleOutputs = true;
+        logger.warn(
+          `Multiple output files provided (${fullConfig.outputFiles.length}) but useMultipleOutputs flag is disabled. Update the agent configuration to ensure consistent stream handling.`,
+        );
       }
 
       // Get model configuration

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -145,9 +145,9 @@ function getAgentClass(settings: AgentSetting): AgentConstructor {
  */
 function getAgentName(
   baseAgent: string,
-  outputFiles: string[] | null | undefined,
+  useMultipleOutputs: boolean | undefined,
 ): string {
-  if (outputFiles && outputFiles.length > 1) {
+  if (useMultipleOutputs) {
     // logger.info(CHANNEL, `Switching to multiple output mode`);
     return baseAgent.endsWith('_multiple')
       ? baseAgent
@@ -179,8 +179,11 @@ async function executeAgentWithLogging<T extends IAgent>(
       config.agent,
       config.model,
       config.inputFile,
-      config.outputFiles ?? undefined,
-      { agentType, executionId },
+      {
+        agentType,
+        executionId,
+        useMultipleOutputs: config.useMultipleOutputs,
+      },
     );
 
     // Check if this stream is already running
@@ -220,7 +223,7 @@ async function executeAgentWithLogging<T extends IAgent>(
           taskDetailsGroupId,
         );
         logger.debug(
-          `Config has output files: ${!!config.outputFiles}, Number of output files: ${config.outputFiles?.length || 0}`,
+          `Config has output files: ${!!config.outputFiles}, Number of output files: ${config.outputFiles?.length || 0}, useMultipleOutputs: ${config.useMultipleOutputs}`,
           taskDetailsGroupId,
         );
 
@@ -238,13 +241,17 @@ async function executeAgentWithLogging<T extends IAgent>(
 
         if (!provider?.isViewVisible()) {
           const inputFileName = path.basename(config.inputFile);
-          const outputInfo = config.outputFiles?.length
-            ? `to ${
-                config.outputFiles.length > 1
-                  ? config.outputFiles.length + ' files'
-                  : path.basename(config.outputFiles[0])
-              }`
-            : '';
+          const outputInfo = config.useMultipleOutputs
+            ? config.outputFiles?.length
+              ? `to ${
+                  config.outputFiles.length > 1
+                    ? `${config.outputFiles.length} files`
+                    : path.basename(config.outputFiles[0])
+                }`
+              : 'for multiple outputs'
+            : config.outputFiles?.length
+              ? `to ${path.basename(config.outputFiles[0])}`
+              : '';
 
           vscode.window
             .showInformationMessage(
@@ -397,13 +404,24 @@ export async function executeAgent(
   }
 
   const requestedAgentName = agentConfig.agent;
-  const agentName = getAgentName(requestedAgentName, agentConfig.outputFiles);
+  const agentName = getAgentName(
+    requestedAgentName,
+    agentConfig.useMultipleOutputs,
+  );
 
   await executeAgentWithLogging(
     agentName,
     async () => {
       // Create full agent config
       const fullConfig = AgentConfigSchema.parse(agentConfig);
+
+      if (
+        !fullConfig.useMultipleOutputs &&
+        Array.isArray(fullConfig.outputFiles) &&
+        fullConfig.outputFiles.length > 1
+      ) {
+        fullConfig.useMultipleOutputs = true;
+      }
 
       // Get model configuration
       const modelName = fullConfig.model;

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -316,7 +316,16 @@ async function handleCreateAgentWithAI(context: vscode.ExtensionContext) {
 
     await AbsoluteFS.write(filePath.fsPath, yamlContent);
     vscode.window.showInformationMessage(`Created agent at ${filePath.fsPath}`);
-    await promptToAddAgentToConfig(agentName);
+    const isMultipleVariant = outputChoice === 'Multiple output files';
+    await promptToAddAgentToConfig(agentName, false, {
+      isMultipleVariant,
+      baseAgentName: isMultipleVariant
+        ? agentName.replace(/_multiple$/, '')
+        : undefined,
+      multipleAgentName: !isMultipleVariant
+        ? `${agentName}_multiple`
+        : agentName,
+    });
     const doc = await vscode.workspace.openTextDocument(filePath);
     await vscode.window.showTextDocument(doc);
   } catch (err) {

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -138,14 +138,30 @@ export async function handleClean(config: {
     return;
   }
 
-  const outputFiles = config.activeFiles?.output
-    ? config.outputFiles || []
+  const declaredOutputFiles = Array.isArray(config.outputFiles)
+    ? config.outputFiles
     : [];
-  const useMultipleOutputs = Boolean(
-    config.useMultipleOutputs ?? config.activeFiles?.output,
-  );
+  const legacyActiveFlag =
+    typeof config.activeFiles?.output === 'boolean'
+      ? config.activeFiles.output
+      : undefined;
+  const useMultipleOutputs =
+    typeof config.useMultipleOutputs === 'boolean'
+      ? config.useMultipleOutputs
+      : typeof legacyActiveFlag === 'boolean'
+        ? legacyActiveFlag
+        : declaredOutputFiles.length > 1;
 
-  if (outputFiles.length > 0) {
+  if (declaredOutputFiles.length > 1 && !useMultipleOutputs) {
+    logger.warn(
+      CHANNEL,
+      'Clean command received multiple output files but multi-output mode is disabled. Verify stored task state.',
+    );
+  }
+
+  const outputFiles = useMultipleOutputs ? declaredOutputFiles : [];
+
+  if (useMultipleOutputs && outputFiles.length > 0) {
     logger.info(
       CHANNEL,
       `Running clean multiple with ${outputFiles.length} files`,

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -81,7 +81,9 @@ async function handleCleanSingle(
   const result = await runCleanSingle(model, inputFile, agent);
   showCleanResult(result, inputFile);
 
-  const streamId = getStreamTabId(agent, model, inputFile);
+  const streamId = getStreamTabId(agent, model, inputFile, {
+    useMultipleOutputs: false,
+  });
   bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
   bus.emit('clearTaskOutput', streamId);
@@ -114,7 +116,9 @@ async function handleCleanMultiple(
   const result = await runCleanMultiple(model, inputFile, agent, outputFiles);
   showCleanResult(result, inputFile);
 
-  const streamId = getStreamTabId(agent, model, inputFile, outputFiles);
+  const streamId = getStreamTabId(agent, model, inputFile, {
+    useMultipleOutputs: true,
+  });
   bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
   bus.emit('clearTaskOutput', streamId);
@@ -137,6 +141,9 @@ export async function handleClean(config: {
   const outputFiles = config.activeFiles?.output
     ? config.outputFiles || []
     : [];
+  const useMultipleOutputs = Boolean(
+    config.useMultipleOutputs ?? config.activeFiles?.output,
+  );
 
   if (outputFiles.length > 0) {
     logger.info(
@@ -162,7 +169,9 @@ export async function handleClean(config: {
 
   const streamId =
     config.streamId ||
-    getStreamTabId(config.agent, config.model, config.inputFile, outputFiles);
+    getStreamTabId(config.agent, config.model, config.inputFile, {
+      useMultipleOutputs,
+    });
   bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
   bus.emit('clearTaskOutput', streamId);

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -82,6 +82,9 @@ async function handlePack(config: { streamId?: string; [key: string]: any }) {
   const outputFiles = config.activeFiles?.output
     ? config.outputFiles || []
     : [];
+  const useMultipleOutputs = Boolean(
+    config.useMultipleOutputs ?? config.activeFiles?.output,
+  );
 
   const result = await runPack(
     config.model,
@@ -93,7 +96,9 @@ async function handlePack(config: { streamId?: string; [key: string]: any }) {
 
   const streamId =
     config.streamId ||
-    getStreamTabId(config.agent, config.model, config.inputFile, outputFiles);
+    getStreamTabId(config.agent, config.model, config.inputFile, {
+      useMultipleOutputs,
+    });
   bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
   bus.emit('clearTaskOutput', streamId);
@@ -124,7 +129,9 @@ async function handlePackSingle(
   const result = await runPackSingle(model, inputFile, agent);
   showPackResult(result, inputFile);
 
-  const streamId = getStreamTabId(agent, model, inputFile);
+  const streamId = getStreamTabId(agent, model, inputFile, {
+    useMultipleOutputs: false,
+  });
   bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
   bus.emit('clearTaskOutput', streamId);
@@ -158,7 +165,9 @@ async function handlePackMultiple(
   const result = await runPackMultiple(model, inputFile, agent, outputFiles);
   showPackResult(result, inputFile);
 
-  const streamId = getStreamTabId(agent, model, inputFile, outputFiles);
+  const streamId = getStreamTabId(agent, model, inputFile, {
+    useMultipleOutputs: true,
+  });
   bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
   bus.emit('clearTaskOutput', streamId);

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -78,13 +78,28 @@ async function handlePack(config: { streamId?: string; [key: string]: any }) {
     return;
   }
 
-  // Get output files if multiple files mode is enabled
-  const outputFiles = config.activeFiles?.output
-    ? config.outputFiles || []
+  const declaredOutputFiles = Array.isArray(config.outputFiles)
+    ? config.outputFiles
     : [];
-  const useMultipleOutputs = Boolean(
-    config.useMultipleOutputs ?? config.activeFiles?.output,
-  );
+  const legacyActiveFlag =
+    typeof config.activeFiles?.output === 'boolean'
+      ? config.activeFiles.output
+      : undefined;
+  const useMultipleOutputs =
+    typeof config.useMultipleOutputs === 'boolean'
+      ? config.useMultipleOutputs
+      : typeof legacyActiveFlag === 'boolean'
+        ? legacyActiveFlag
+        : declaredOutputFiles.length > 1;
+
+  if (declaredOutputFiles.length > 1 && !useMultipleOutputs) {
+    logger.warn(
+      CHANNEL,
+      'Pack command received multiple output files but multi-output mode is disabled. Verify stored task state.',
+    );
+  }
+
+  const outputFiles = useMultipleOutputs ? declaredOutputFiles : [];
 
   const result = await runPack(
     config.model,

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as logger from '@logger/logUtils';
 import { isValidAgentYaml } from '@agent/runtime/agentLoad';
+import type { AgentSetting } from '@agent/core/AgentDataclass';
 import { getConfig, updateConfig } from '@utils/config';
 
 const CHANNEL = 'AgentRegister';
@@ -122,10 +123,11 @@ export async function validateYamlAndPromptAdd(
 
   const configuredAgents = getConfig<string[]>('agents', []);
   if (!configuredAgents.includes(filenameBase)) {
-    const defaultOutputs = validationResult.settings?.defaultOutputFiles ?? [];
-    const isMultipleVariant = Array.isArray(defaultOutputs)
-      ? defaultOutputs.length > 0
-      : false;
+    const settings = validationResult.settings as AgentSetting | undefined;
+    const defaultOutputs: string[] = settings?.defaultOutputFiles ?? [];
+    const hasMultipleDefaults = defaultOutputs.length > 1;
+    const useMultipleOutputs = settings?.useMultipleOutputs ?? hasMultipleDefaults;
+    const isMultipleVariant = Boolean(useMultipleOutputs);
     const metadata: AgentVariantMetadata = {
       isMultipleVariant,
     };

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -16,18 +16,24 @@ logger.initialize(CHANNEL);
  * Prompt to add a newly created agent to the `texra.agents` setting. When
  * `autoAdd` is true, the agent is added without prompting.
  */
+export interface AgentVariantMetadata {
+  isMultipleVariant?: boolean;
+  baseAgentName?: string;
+  multipleAgentName?: string;
+}
+
 export async function promptToAddAgentToConfig(
   agentName: string,
   autoAdd = false,
+  variant: AgentVariantMetadata = {},
 ): Promise<void> {
   const current = getConfig<string[]>('agents', []);
 
-  const baseName = agentName.endsWith('_multiple')
-    ? agentName.replace(/_multiple$/, '')
-    : agentName;
-  const multipleName = agentName.endsWith('_multiple')
-    ? agentName
-    : `${agentName}_multiple`;
+  const {
+    isMultipleVariant = false,
+    baseAgentName,
+    multipleAgentName,
+  } = variant;
 
   // Check if agent already exists (exact match)
   if (current.includes(agentName)) {
@@ -36,9 +42,9 @@ export async function promptToAddAgentToConfig(
   }
 
   // Check if the base/multiple counterpart already exists
-  if (agentName.endsWith('_multiple')) {
-    // Adding a _multiple variant, check if base agent exists
-    if (current.includes(baseName)) {
+  if (isMultipleVariant) {
+    const baseName = baseAgentName;
+    if (baseName && current.includes(baseName)) {
       logger.debug(
         CHANNEL,
         `Base agent "${baseName}" already in configuration, skipping "${agentName}"`,
@@ -46,11 +52,11 @@ export async function promptToAddAgentToConfig(
       return;
     }
   } else {
-    // Adding a base agent, check if _multiple variant exists
-    if (current.includes(multipleName)) {
+    const siblingMultiple = multipleAgentName;
+    if (siblingMultiple && current.includes(siblingMultiple)) {
       logger.debug(
         CHANNEL,
-        `Multiple variant "${multipleName}" already in configuration, skipping "${agentName}"`,
+        `Multiple variant "${siblingMultiple}" already in configuration, skipping "${agentName}"`,
       );
       return;
     }
@@ -116,6 +122,22 @@ export async function validateYamlAndPromptAdd(
 
   const configuredAgents = getConfig<string[]>('agents', []);
   if (!configuredAgents.includes(filenameBase)) {
-    await promptToAddAgentToConfig(filenameBase, !prompt);
+    const defaultOutputs = validationResult.settings?.defaultOutputFiles ?? [];
+    const isMultipleVariant = Array.isArray(defaultOutputs)
+      ? defaultOutputs.length > 0
+      : false;
+    const metadata: AgentVariantMetadata = {
+      isMultipleVariant,
+    };
+
+    if (isMultipleVariant) {
+      metadata.baseAgentName = internalName.includes('_multiple')
+        ? internalName.replace(/_multiple$/, '')
+        : undefined;
+    } else {
+      metadata.multipleAgentName = `${internalName}_multiple`;
+    }
+
+    await promptToAddAgentToConfig(filenameBase, !prompt, metadata);
   }
 }

--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -9,6 +9,7 @@ import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 type StreamTabIdOptions = {
   agentType?: AgentType;
   executionId?: ExecutionId;
+  useMultipleOutputs?: boolean;
 };
 
 function formatToolUseStreamId(
@@ -29,15 +30,13 @@ export function getStreamTabId(
   agent: string,
   model: string,
   inputFile: string,
-  outputFiles?: string[] | null,
   options: StreamTabIdOptions = {},
 ): StreamTabId {
   if (options.agentType === AgentType.ToolUse) {
     return formatToolUseStreamId(agent, model, options.executionId);
   }
 
-  const hasMultipleOutputs = Boolean(outputFiles && outputFiles.length > 1);
-  const agentName = hasMultipleOutputs
+  const agentName = options.useMultipleOutputs
     ? agent.endsWith('_multiple')
       ? agent
       : `${agent}_multiple`

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -306,16 +306,18 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     }
 
     const outputFilesArray = Array.from(allFiles);
-    const outputActive = taskState.activeFiles.output;
+    const useMultipleOutputs =
+      taskState.agentConfig.useMultipleOutputs || taskState.activeFiles.output;
     await vscode.commands.executeCommand(command, {
       streamId: stream,
       agent: taskState.agentConfig.agent,
       model: taskState.agentConfig.model,
       inputFile: taskState.agentConfig.inputFile,
-      outputFiles: outputActive ? outputFilesArray : [],
+      outputFiles: useMultipleOutputs ? outputFilesArray : [],
       activeFiles: {
-        output: outputActive,
+        output: useMultipleOutputs,
       },
+      useMultipleOutputs,
     });
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -231,6 +231,7 @@ export class ProgressViewProvider
     if (taskState) {
       // Only clear output-related fields, preserve other task state data
       taskState.agentConfig.outputFiles = [];
+      taskState.agentConfig.useMultipleOutputs = false;
       if (taskState.activeFiles) {
         taskState.activeFiles.output = false;
       }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -298,6 +298,7 @@ export class ProgressEventHandler {
     if (taskState) {
       // Only clear output-related fields, preserve other task state data
       taskState.agentConfig.outputFiles = [];
+      taskState.agentConfig.useMultipleOutputs = false;
       if (taskState.activeFiles) {
         taskState.activeFiles.output = false;
       }

--- a/src/test/logger/streamUtils.test.ts
+++ b/src/test/logger/streamUtils.test.ts
@@ -12,24 +12,22 @@ describe('getStreamTabId', () => {
   });
 
   it('appends multiple suffix for workflow streams with many outputs', () => {
-    const id = getStreamTabId('polish', 'sonnet', '/tmp/paper.tex', [
-      'out1',
-      'out2',
-    ]);
+    const id = getStreamTabId('polish', 'sonnet', '/tmp/paper.tex', {
+      useMultipleOutputs: true,
+    });
     assert.equal(id, 'polish_multiple@sonnet: paper.tex');
   });
 
   it('avoids duplicating the multiple suffix when already present', () => {
-    const id = getStreamTabId('polish_multiple', 'sonnet', '/tmp/paper.tex', [
-      'out1',
-      'out2',
-    ]);
+    const id = getStreamTabId('polish_multiple', 'sonnet', '/tmp/paper.tex', {
+      useMultipleOutputs: true,
+    });
     assert.equal(id, 'polish_multiple@sonnet: paper.tex');
   });
 
   it('uses execution id prefix for tool use streams', () => {
     const executionId = '12345678-9abc-def0-1234-56789abcdef0';
-    const id = getStreamTabId('diagnostics', 'gpt4', '', undefined, {
+    const id = getStreamTabId('diagnostics', 'gpt4', '', {
       agentType: AgentType.ToolUse,
       executionId,
     });

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -52,6 +52,7 @@ describe('OutputHandler.finalizeRound', () => {
     requiredFiles: {},
     requiredFilesInternal: {},
     defaultOutputFiles: [],
+    useMultipleOutputs: false,
     filePatternsContain: [],
     tools: [],
   };

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -60,6 +60,7 @@ describe('OutputHandler.finalizeRound', () => {
     model: 'test',
     agent: 'a',
     instruction: '',
+    useMultipleOutputs: false,
     inputFile: 'input.tex',
     inputFiles: null,
     referenceFile: null,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -31,6 +31,7 @@ describe('XmlOutputManager markdown fallback', () => {
     model: 'test',
     agent: 'a',
     instruction: '',
+    useMultipleOutputs: false,
     inputFile: 'input.tex',
     inputFiles: null,
     referenceFile: null,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -23,6 +23,7 @@ describe('XmlOutputManager markdown fallback', () => {
     requiredFiles: {},
     requiredFilesInternal: {},
     defaultOutputFiles: [],
+    useMultipleOutputs: false,
     filePatternsContain: [],
     tools: [],
   };

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -111,6 +111,7 @@ describe('BaseToolUseAgent follow-up loop', () => {
       requiredFiles: {},
       requiredFilesInternal: {},
       defaultOutputFiles: [],
+      useMultipleOutputs: false,
       filePatternsContain: [],
       tools: [],
     } as any;

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -124,6 +124,7 @@ describe('BaseToolUseAgent follow-up loop', () => {
       model: 'dummy',
       agent: 'test',
       instruction: '',
+      useMultipleOutputs: false,
       inputFile: '',
       inputFiles: null,
       referenceFile: null,

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -106,6 +106,7 @@ describe('runToolUseCycle DeepSeek', () => {
       requiredFiles: {},
       requiredFilesInternal: {},
       defaultOutputFiles: [],
+      useMultipleOutputs: false,
       filePatternsContain: [],
       tools: [{ name: 'echo' }],
     };

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -116,6 +116,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       requiredFiles: {},
       requiredFilesInternal: {},
       defaultOutputFiles: [],
+      useMultipleOutputs: false,
       filePatternsContain: [],
       tools: [{ name: 'echo' }],
     };

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -19,9 +19,14 @@ function createActiveFilesFromArrays(
   FILE_TYPES.forEach((type) => {
     const filesField = `${type}Files`;
     const flagField = `${filesField}Active`;
+    const useMultipleOutputs = Boolean(
+      (src as { useMultipleOutputs?: boolean }).useMultipleOutputs,
+    );
+    const multipleFlag = type === 'output' && useMultipleOutputs;
     active[type] =
       (Array.isArray(src[filesField]) && src[filesField].length > 0) ||
-      !!src[flagField];
+      !!src[flagField] ||
+      multipleFlag;
   });
   return active;
 }

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -59,7 +59,7 @@ export class ExecutionManager {
     const outputFiles = getFilesIfNotEmpty<string>(message.outputFiles);
     const useMultipleOutputs = Boolean(
       message.outputFilesActive ||
-        (Array.isArray(outputFiles) && outputFiles.length > 0),
+        (Array.isArray(outputFiles) && outputFiles.length > 1),
     );
 
     const agentConfig: AgentConfig = {

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -56,25 +56,32 @@ export class ExecutionManager {
       return f;
     };
 
+    const outputFiles = getFilesIfNotEmpty<string>(message.outputFiles);
+    const useMultipleOutputs = Boolean(
+      message.outputFilesActive ||
+        (Array.isArray(outputFiles) && outputFiles.length > 0),
+    );
+
     const agentConfig: AgentConfig = {
       agent: message.agent,
       model: message.model,
       instruction: message.instruction,
+      useMultipleOutputs,
       inputFile: message.inputFile,
-      inputFiles: getFilesIfNotEmpty(message.inputFiles),
+      inputFiles: getFilesIfNotEmpty<string>(message.inputFiles),
       referenceFile: message.referenceFile,
-      referenceFiles: getFilesIfNotEmpty(message.referenceFiles),
+      referenceFiles: getFilesIfNotEmpty<string>(message.referenceFiles),
       auxiliaryFile: message.auxiliaryFile,
-      auxiliaryFiles: getFilesIfNotEmpty(message.auxiliaryFiles),
+      auxiliaryFiles: getFilesIfNotEmpty<string>(message.auxiliaryFiles),
       mediaFile: mapMediaPath(message.mediaFile),
       mediaFiles: message.mediaFiles
-        ? getFilesIfNotEmpty(
+        ? getFilesIfNotEmpty<string>(
             message.mediaFiles
               .map(mapMediaPath)
               .filter((f: string | null): f is string => f !== null),
           )
         : null,
-      outputFiles: getFilesIfNotEmpty(message.outputFiles),
+      outputFiles,
       editedFile: null,
       toolConfig,
     };


### PR DESCRIPTION
## Summary
- add a `useMultipleOutputs` flag to the agent configuration schema and task-state conversion helpers
- propagate the new flag through execution, stream ID, housekeeping, and progress view plumbing instead of inferring `_multiple`
- update agent registration utilities, documentation, and tests to reflect the boolean-driven multi-output flow

## Testing
- npm run format
- npm run lint
- npm test *(fails: missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caa453a4f08324b3305f8e07ee0c29