### PR TITLE
fix: hide toolbar actions for tool streams

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,6 +12,7 @@ import {
   AgentTypeFilter,
   isAgentTypeFilter,
 } from '@agent/types/AgentStreamTypes';
+import { AgentType } from '@agent/core/AgentDataclass';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -126,12 +127,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(message.stream);
-    if (taskState) {
-      await vscode.commands.executeCommand(
-        'texra.execute',
-        taskState.agentConfig,
-      );
+    if (!taskState || taskState.agentType === AgentType.ToolUse) {
+      return;
     }
+
+    await vscode.commands.executeCommand(
+      'texra.execute',
+      taskState.agentConfig,
+    );
   }
 
   private async handleDiffStream(
@@ -139,21 +142,28 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(message.stream);
-    if (taskState) {
-      await vscode.commands.executeCommand('texra.runLatexdiff', {
-        agent: taskState.agentConfig.agent,
-        model: taskState.agentConfig.model,
-        inputFile: taskState.agentConfig.inputFile,
-        outputFiles: taskState.agentConfig.outputFiles,
-        outputFilesActive: taskState.activeFiles.output,
-      });
+    if (!taskState || taskState.agentType === AgentType.ToolUse) {
+      return;
     }
+
+    await vscode.commands.executeCommand('texra.runLatexdiff', {
+      agent: taskState.agentConfig.agent,
+      model: taskState.agentConfig.model,
+      inputFile: taskState.agentConfig.inputFile,
+      outputFiles: taskState.agentConfig.outputFiles,
+      outputFilesActive: taskState.activeFiles.output,
+    });
   }
 
   private async handlePackStream(
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    const taskState = this.provider.state.getTaskState(message.stream);
+    if (!taskState || taskState.agentType === AgentType.ToolUse) {
+      return;
+    }
+
     await this.handleFileOperation(message.stream, 'texra.pack');
   }
 
@@ -161,6 +171,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    const taskState = this.provider.state.getTaskState(message.stream);
+    if (!taskState || taskState.agentType === AgentType.ToolUse) {
+      return;
+    }
+
     await this.handleFileOperation(message.stream, 'texra.clean');
   }
 
@@ -290,7 +305,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     command: 'texra.pack' | 'texra.clean',
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(stream);
-    if (!taskState) return;
+    if (!taskState || taskState.agentType === AgentType.ToolUse) return;
 
     const generated = this.provider.state.outputFiles.getFiles(stream);
     const allFiles = new Set<string>(taskState.agentConfig.outputFiles || []);

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -13,6 +13,7 @@ import {
   isAgentTypeFilter,
 } from '@agent/types/AgentStreamTypes';
 import { AgentType } from '@agent/core/AgentDataclass';
+import type { TaskState } from '@logger/TaskState';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -84,6 +85,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     this.provider.markWebviewReady();
   }
 
+  private shouldBlockToolbarCommand(
+    taskState: TaskState | undefined,
+  ): taskState is undefined | (TaskState & { agentType: AgentType.ToolUse }) {
+    return !taskState || taskState.agentType === AgentType.ToolUse;
+  }
+
   private async handleSwitchStream(
     message: any,
     webviewView: vscode.WebviewView,
@@ -127,7 +134,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(message.stream);
-    if (!taskState || taskState.agentType === AgentType.ToolUse) {
+    if (this.shouldBlockToolbarCommand(taskState)) {
       return;
     }
 
@@ -142,7 +149,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(message.stream);
-    if (!taskState || taskState.agentType === AgentType.ToolUse) {
+    if (this.shouldBlockToolbarCommand(taskState)) {
       return;
     }
 
@@ -160,7 +167,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(message.stream);
-    if (!taskState || taskState.agentType === AgentType.ToolUse) {
+    if (this.shouldBlockToolbarCommand(taskState)) {
       return;
     }
 
@@ -172,7 +179,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(message.stream);
-    if (!taskState || taskState.agentType === AgentType.ToolUse) {
+    if (this.shouldBlockToolbarCommand(taskState)) {
       return;
     }
 
@@ -305,7 +312,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     command: 'texra.pack' | 'texra.clean',
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(stream);
-    if (!taskState || taskState.agentType === AgentType.ToolUse) return;
+    if (this.shouldBlockToolbarCommand(taskState)) return;
 
     const generated = this.provider.state.outputFiles.getFiles(stream);
     const allFiles = new Set<string>(taskState.agentConfig.outputFiles || []);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -80,14 +80,45 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     this._updatePlaceholderVisibility();
 
+    const activeStreamInfo = message.streams.find(
+      (s) => s.name === message.activeStream,
+    );
+    const isToolUseAgent = activeStreamInfo?.agentType === 'toolUse';
+
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
-      const active = message.streams.find(
-        (s) => s.name === message.activeStream,
-      );
-      container.style.display =
-        active && active.agentType === 'toolUse' ? 'flex' : 'none';
+      container.classList.toggle('is-visible', Boolean(isToolUseAgent));
+      container.setAttribute('aria-hidden', isToolUseAgent ? 'false' : 'true');
     }
+
+    const buttonsToToggle = [
+      ELEMENT_IDS.RUN_AGAIN_BTN,
+      ELEMENT_IDS.DIFF_STREAM_BTN,
+      ELEMENT_IDS.PACK_STREAM_BTN,
+      ELEMENT_IDS.CLEAN_STREAM_BTN,
+    ];
+
+    const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
+    if (toolbar) {
+      toolbar.dataset.agentType = activeStreamInfo?.agentType || '';
+    }
+
+    buttonsToToggle.forEach((buttonId) => {
+      const button = document.getElementById(buttonId);
+      if (!button) return;
+      const shouldHide = Boolean(isToolUseAgent);
+      button.classList.toggle('toolbar-button--hidden', shouldHide);
+      if (shouldHide) {
+        button.setAttribute('aria-hidden', 'true');
+        button.setAttribute('tabindex', '-1');
+        button.dataset.hiddenByAgent = 'true';
+        button.disabled = true;
+      } else {
+        button.removeAttribute('aria-hidden');
+        button.removeAttribute('tabindex');
+        delete button.dataset.hiddenByAgent;
+      }
+    });
 
     // Update status based on whether there's an active stream
     if (!message.activeStream) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -13,6 +13,37 @@ const dom = progressViewDomHandler;
 
 // Create formatter instances
 
+const TOOLBAR_ACTION_BUTTON_IDS = [
+  ELEMENT_IDS.RUN_AGAIN_BTN,
+  ELEMENT_IDS.DIFF_STREAM_BTN,
+  ELEMENT_IDS.PACK_STREAM_BTN,
+  ELEMENT_IDS.CLEAN_STREAM_BTN,
+];
+
+const DEFAULT_STREAM_CAPABILITIES = Object.freeze({
+  canRunAgain: true,
+  canDiffStream: true,
+  canPackStream: true,
+  canCleanStream: true,
+  canSendFollowUp: false,
+});
+
+let toolbarActionButtonCache = null;
+
+function getToolbarActionButtons() {
+  if (
+    Array.isArray(toolbarActionButtonCache) &&
+    toolbarActionButtonCache.every((button) => button?.isConnected)
+  ) {
+    return toolbarActionButtonCache;
+  }
+
+  toolbarActionButtonCache = TOOLBAR_ACTION_BUTTON_IDS.map((id) =>
+    document.getElementById(id),
+  ).filter((el) => el instanceof HTMLButtonElement);
+  return toolbarActionButtonCache;
+}
+
 export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
     super();
@@ -83,30 +114,38 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const activeStreamInfo = message.streams.find(
       (s) => s.name === message.activeStream,
     );
-    const isToolUseAgent = activeStreamInfo?.agentType === 'toolUse';
+    const capabilities = {
+      ...DEFAULT_STREAM_CAPABILITIES,
+      ...(activeStreamInfo?.capabilities || {}),
+    };
+    const isToolUseAgent = Boolean(activeStreamInfo?.isToolUseAgent);
 
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
-      container.classList.toggle('is-visible', Boolean(isToolUseAgent));
-      container.setAttribute('aria-hidden', isToolUseAgent ? 'false' : 'true');
+      const followUpVisible = Boolean(capabilities.canSendFollowUp);
+      container.classList.toggle('is-visible', followUpVisible);
+      container.setAttribute('aria-hidden', followUpVisible ? 'false' : 'true');
     }
 
-    const buttonsToToggle = [
-      ELEMENT_IDS.RUN_AGAIN_BTN,
-      ELEMENT_IDS.DIFF_STREAM_BTN,
-      ELEMENT_IDS.PACK_STREAM_BTN,
-      ELEMENT_IDS.CLEAN_STREAM_BTN,
-    ];
+    const buttonVisibility = new Map([
+      [ELEMENT_IDS.RUN_AGAIN_BTN, capabilities.canRunAgain],
+      [ELEMENT_IDS.DIFF_STREAM_BTN, capabilities.canDiffStream],
+      [ELEMENT_IDS.PACK_STREAM_BTN, capabilities.canPackStream],
+      [ELEMENT_IDS.CLEAN_STREAM_BTN, capabilities.canCleanStream],
+    ]);
 
     const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
     if (toolbar) {
       toolbar.dataset.agentType = activeStreamInfo?.agentType || '';
+      toolbar.dataset.agentMode = isToolUseAgent ? 'tool' : 'workflow';
     }
 
-    buttonsToToggle.forEach((buttonId) => {
-      const button = document.getElementById(buttonId);
-      if (!button) return;
-      const shouldHide = Boolean(isToolUseAgent);
+    const toolbarButtons = getToolbarActionButtons();
+    toolbarButtons.forEach((button) => {
+      const supportsAction = buttonVisibility.has(button.id)
+        ? buttonVisibility.get(button.id)
+        : true;
+      const shouldHide = buttonVisibility.has(button.id) && !supportsAction;
       button.classList.toggle('toolbar-button--hidden', shouldHide);
       if (shouldHide) {
         button.setAttribute('aria-hidden', 'true');

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -91,7 +91,12 @@ export class Status {
       statusIndicator.classList.add(cfg.className);
       statusIndicator.dataset.status = cfg.label;
 
-      setElementsDisabled(cfg.enable, false);
+      const elementsToEnable = cfg.enable
+        .map((id) => document.getElementById(id))
+        .filter((el) => el && el.dataset.hiddenByAgent !== 'true');
+      if (elementsToEnable.length > 0) {
+        setElementsDisabled(elementsToEnable, false);
+      }
 
       const activeStream = progressViewState.activeStream;
       if (activeStream && status !== STATUS.READY) {

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -65,7 +65,7 @@ export class Status {
 
     const buttons = (this._buttonElements ||= this.BUTTON_IDS.map((id) =>
       document.getElementById(id),
-    ).filter(Boolean));
+    ).filter((el) => el instanceof HTMLButtonElement));
 
     setElementsDisabled(buttons, true);
     // Always enable the erase button regardless of status
@@ -93,7 +93,11 @@ export class Status {
 
       const elementsToEnable = cfg.enable
         .map((id) => document.getElementById(id))
-        .filter((el) => el && el.dataset.hiddenByAgent !== 'true');
+        .filter(
+          (el) =>
+            el instanceof HTMLButtonElement &&
+            el.dataset.hiddenByAgent !== 'true',
+        );
       if (elementsToEnable.length > 0) {
         setElementsDisabled(elementsToEnable, false);
       }

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 // Local imports - progress view
 import type { ProgressViewState } from './state/ProgressViewState';
-import type { AgentFilter, StreamTabInfo } from './types';
+import type { AgentFilter, StreamCapabilities, StreamTabInfo } from './types';
 // Local imports - agent types
 import { AgentType } from '@agent/core/AgentDataclass';
 
@@ -46,6 +46,19 @@ function buildStreamLabel(
   return baseName ? `${agentName}: ${baseName}` : agentName;
 }
 
+function buildStreamCapabilities(
+  agentType: AgentType | undefined,
+): StreamCapabilities {
+  const isToolUseAgent = agentType === AgentType.ToolUse;
+  return {
+    canRunAgain: !isToolUseAgent,
+    canDiffStream: !isToolUseAgent,
+    canPackStream: !isToolUseAgent,
+    canCleanStream: !isToolUseAgent,
+    canSendFollowUp: isToolUseAgent,
+  };
+}
+
 /**
  * Build metadata objects for all streams in the given state.
  */
@@ -70,12 +83,16 @@ export function buildStreamInfos(
     }
     const executionId = state.getExecutionId(id);
     const label = buildStreamLabel(agentName, inputFile, agentType);
+    const capabilities = buildStreamCapabilities(agentType);
+    const isToolUseAgent = agentType === AgentType.ToolUse;
     acc.push({
       name: id,
       label,
       model: taskState?.agentConfig.model,
       agent: taskState?.agentConfig.agent,
       agentType,
+      capabilities,
+      isToolUseAgent,
       hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
       lastTimestamp,
       inputFile,

--- a/src/progressView/styles/buttons.css
+++ b/src/progressView/styles/buttons.css
@@ -25,6 +25,6 @@
   content: '\eb9f';
 }
 
-.button-group .toolbar-button--hidden {
-  display: none !important;
+#toolbarContainer .toolbar-button--hidden {
+  display: none;
 }

--- a/src/progressView/styles/buttons.css
+++ b/src/progressView/styles/buttons.css
@@ -24,3 +24,7 @@
 .codicon-trash:before {
   content: '\eb9f';
 }
+
+.button-group .toolbar-button--hidden {
+  display: none !important;
+}

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -12,6 +12,10 @@
   gap: var(--spacing-small);
 }
 
+.follow-up-container.is-visible {
+  display: flex;
+}
+
 /* Style the textarea for multi-line input */
 #followUpInput {
   min-height: 36px;

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -3,6 +3,14 @@ import type { AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
+export interface StreamCapabilities {
+  canRunAgain: boolean;
+  canDiffStream: boolean;
+  canPackStream: boolean;
+  canCleanStream: boolean;
+  canSendFollowUp: boolean;
+}
+
 export interface StreamTabInfo {
   name: string;
   /** Short label displayed in the tab UI */
@@ -16,6 +24,8 @@ export interface StreamTabInfo {
   creationTimestamp?: number;
   status?: string;
   executionId?: ExecutionId;
+  isToolUseAgent: boolean;
+  capabilities: StreamCapabilities;
 }
 
 export type AgentFilter = AgentTypeFilter;


### PR DESCRIPTION
## Summary
- hide rerun/diff/pack/clean buttons while a tool-use stream is active and expose the follow-up input
- prevent the status manager from re-enabling buttons hidden for tool agents and add CSS for the new toolbar state
- block backend toolbar commands for tool-use sessions to avoid invalid actions

## Testing
- npm run lint
- npm run format
- npm test *(fails: vscode-test requires libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab5e7df0c83249eb0177fb2a3790b