### PR TITLE
fix: hide empty model responses

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -360,7 +360,11 @@ export class LogEntryFormatter {
       if (result) {
         return result;
       }
-      if (messageType === 'thinking' || messageType === 'scratchpad') {
+      if (
+        messageType === 'thinking' ||
+        messageType === 'scratchpad' ||
+        messageType === 'modelResponse'
+      ) {
         return null;
       }
     }
@@ -488,6 +492,15 @@ export class LogEntryFormatter {
    * @returns {HTMLElement|null} DOM element for the model response
    */
   _formatModelResponse({ id, groupId, timestamp, verbose, content, level }) {
+    if (!content) {
+      return null;
+    }
+
+    const decodedContent = decodeHtml(content);
+    if (!decodedContent.trim()) {
+      return null;
+    }
+
     const element = createFromTemplate('modelResponseTemplate');
     if (!element) return null;
 
@@ -506,7 +519,6 @@ export class LogEntryFormatter {
 
     const contentElem = element.querySelector('.model-response-content');
     if (contentElem) {
-      const decodedContent = decodeHtml(content);
       contentElem.classList.add(`message-${level}`);
       contentElem.dataset.rawContent = decodedContent;
       contentElem.innerHTML = this._processMarkdownContent(


### PR DESCRIPTION
## Summary
- skip rendering model responses when the decoded text is empty
- prevent default log fallback when a model response produces no element

## Testing
- npm run format
- npm run lint
- npm test *(fails: VS Code runtime requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cab8cd3fe48324aacf830450768d85