### PR TITLE
fix: harden tool toolbar gating

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -323,12 +323,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
+  /**
+   * Guards toolbar actions from running when the task state is missing or belongs to a tool-use agent.
+   * @param taskState - The currently resolved task state for the active stream.
+   * @returns True when the caller should skip executing the toolbar action.
+   */
   private shouldSkipToolbarAction(
     taskState: TaskState | undefined,
   ): taskState is undefined | ToolUseTaskState {
     return !taskState || taskState.agentType === AgentType.ToolUse;
   }
 
+  /**
+   * Fetches a task state for a toolbar action, short-circuiting execution for tool-use agents.
+   * @param stream - The stream identifier whose task state should be fetched.
+   * @param action - The callback to execute when a valid workflow task state is available.
+   */
   private async withToolbarTaskState(
     stream: string,
     action: (taskState: TaskState) => Promise<void>,

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,6 +12,10 @@ import {
   AgentTypeFilter,
   isAgentTypeFilter,
 } from '@agent/types/AgentStreamTypes';
+import { AgentType } from '@agent/core/AgentDataclass';
+import type { TaskState } from '@logger/TaskState';
+
+type ToolUseTaskState = TaskState & { agentType: AgentType.ToolUse };
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -125,21 +129,19 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    const taskState = this.provider.state.getTaskState(message.stream);
-    if (taskState) {
+    await this.withToolbarTaskState(message.stream, async (taskState) => {
       await vscode.commands.executeCommand(
         'texra.execute',
         taskState.agentConfig,
       );
-    }
+    });
   }
 
   private async handleDiffStream(
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    const taskState = this.provider.state.getTaskState(message.stream);
-    if (taskState) {
+    await this.withToolbarTaskState(message.stream, async (taskState) => {
       await vscode.commands.executeCommand('texra.runLatexdiff', {
         agent: taskState.agentConfig.agent,
         model: taskState.agentConfig.model,
@@ -147,21 +149,25 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         outputFiles: taskState.agentConfig.outputFiles,
         outputFilesActive: taskState.activeFiles.output,
       });
-    }
+    });
   }
 
   private async handlePackStream(
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    await this.handleFileOperation(message.stream, 'texra.pack');
+    await this.withToolbarTaskState(message.stream, async (taskState) => {
+      await this.handleFileOperation(message.stream, taskState, 'texra.pack');
+    });
   }
 
   private async handleCleanStream(
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    await this.handleFileOperation(message.stream, 'texra.clean');
+    await this.withToolbarTaskState(message.stream, async (taskState) => {
+      await this.handleFileOperation(message.stream, taskState, 'texra.clean');
+    });
   }
 
   private async handleSortStreams(
@@ -287,11 +293,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleFileOperation(
     stream: string,
+    taskState: TaskState,
     command: 'texra.pack' | 'texra.clean',
   ): Promise<void> {
-    const taskState = this.provider.state.getTaskState(stream);
-    if (!taskState) return;
-
     const generated = this.provider.state.outputFiles.getFiles(stream);
     const allFiles = new Set<string>(taskState.agentConfig.outputFiles || []);
     if (generated) {
@@ -317,5 +321,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         output: outputActive,
       },
     });
+  }
+
+  private shouldSkipToolbarAction(
+    taskState: TaskState | undefined,
+  ): taskState is undefined | ToolUseTaskState {
+    return !taskState || taskState.agentType === AgentType.ToolUse;
+  }
+
+  private async withToolbarTaskState(
+    stream: string,
+    action: (taskState: TaskState) => Promise<void>,
+  ): Promise<void> {
+    const taskState = this.provider.state.getTaskState(stream);
+    if (this.shouldSkipToolbarAction(taskState)) {
+      return;
+    }
+
+    await action(taskState);
   }
 }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -14,6 +14,11 @@ const TOOLBAR_ACTION_BUTTON_IDS = [
   ELEMENT_IDS.CLEAN_STREAM_BTN,
 ];
 
+const AGENT_MODES = Object.freeze({
+  TOOL: 'tool',
+  WORKFLOW: 'workflow',
+});
+
 // Create shorter aliases for internal use
 const state = progressViewState;
 const dom = progressViewDomHandler;
@@ -106,7 +111,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
     if (toolbar) {
       toolbar.dataset.agentType = activeStreamInfo?.agentType || '';
-      toolbar.dataset.agentMode = isToolAgent ? 'tool' : 'workflow';
+      toolbar.dataset.agentMode = isToolAgent
+        ? AGENT_MODES.TOOL
+        : AGENT_MODES.WORKFLOW;
     }
 
     toolbarButtons.forEach((button) => {
@@ -122,6 +129,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         button.setAttribute('aria-hidden', 'true');
         button.setAttribute('tabindex', '-1');
         button.dataset.hiddenByAgent = 'true';
+        if (button.dataset.disabledBeforeAgentHide === undefined) {
+          button.dataset.disabledBeforeAgentHide = button.disabled
+            ? 'true'
+            : 'false';
+        }
         if ('disabled' in button) {
           button.disabled = true;
         }
@@ -130,7 +142,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
       button.removeAttribute('aria-hidden');
       button.removeAttribute('tabindex');
+      const previousDisabledState = button.dataset.disabledBeforeAgentHide;
+      if ('disabled' in button && previousDisabledState !== undefined) {
+        button.disabled = previousDisabledState === 'true';
+      }
       delete button.dataset.hiddenByAgent;
+      delete button.dataset.disabledBeforeAgentHide;
     });
 
     // Update status based on whether there's an active stream
@@ -305,10 +322,16 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _getToolbarButtons() {
-    const ensureCache = () =>
-      TOOLBAR_ACTION_BUTTON_IDS.map((buttonId) =>
-        document.getElementById(buttonId),
-      ).filter((button) => button instanceof HTMLElement);
+    const ensureCache = () => {
+      try {
+        return TOOLBAR_ACTION_BUTTON_IDS.map((buttonId) =>
+          document.getElementById(buttonId),
+        ).filter((button) => button instanceof HTMLElement);
+      } catch (error) {
+        console.warn('Failed to cache toolbar buttons:', error);
+        return [];
+      }
+    };
 
     const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
     if (!toolbar) {
@@ -330,6 +353,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         });
         this._toolbarMutationObserver.observe(toolbar, {
           childList: true,
+          subtree: false,
+          attributes: false,
         });
       }
 
@@ -350,7 +375,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         return true;
       }
       const current = document.getElementById(id);
-      return current && current !== cached;
+      return !current || current !== cached;
     });
 
     if (cacheIsStale) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -7,6 +7,13 @@ import { appendFormatted } from './utils.js';
 import { progressViewState } from './progressViewState.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
 
+const TOOLBAR_ACTION_BUTTON_IDS = [
+  ELEMENT_IDS.RUN_AGAIN_BTN,
+  ELEMENT_IDS.DIFF_STREAM_BTN,
+  ELEMENT_IDS.PACK_STREAM_BTN,
+  ELEMENT_IDS.CLEAN_STREAM_BTN,
+];
+
 // Create shorter aliases for internal use
 const state = progressViewState;
 const dom = progressViewDomHandler;
@@ -17,6 +24,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
     super();
     this._entryFormatter = new LogEntryFormatter();
+    this._toolbarButtonCache = null;
+    this._toolbarMutationObserver = null;
+    this._toolbarObserverTarget = null;
     this._handlers = {
       ...createThemeHandlers(),
       ...this._createHandlers(),
@@ -80,14 +90,48 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     this._updatePlaceholderVisibility();
 
+    const activeStreamInfo = message.streams.find(
+      (s) => s.name === message.activeStream,
+    );
+    const isToolAgent = activeStreamInfo?.uiTraits?.isToolAgent ?? false;
+
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
-      const active = message.streams.find(
-        (s) => s.name === message.activeStream,
-      );
-      container.style.display =
-        active && active.agentType === 'toolUse' ? 'flex' : 'none';
+      container.classList.toggle('is-visible', isToolAgent);
+      container.setAttribute('aria-hidden', isToolAgent ? 'false' : 'true');
     }
+
+    const toolbarButtons = this._getToolbarButtons();
+
+    const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
+    if (toolbar) {
+      toolbar.dataset.agentType = activeStreamInfo?.agentType || '';
+      toolbar.dataset.agentMode = isToolAgent ? 'tool' : 'workflow';
+    }
+
+    toolbarButtons.forEach((button) => {
+      const shouldHide = isToolAgent;
+      const wasHidden = button.dataset.hiddenByAgent === 'true';
+      if (shouldHide === wasHidden) {
+        return;
+      }
+
+      button.classList.toggle('toolbar-button--hidden', shouldHide);
+
+      if (shouldHide) {
+        button.setAttribute('aria-hidden', 'true');
+        button.setAttribute('tabindex', '-1');
+        button.dataset.hiddenByAgent = 'true';
+        if ('disabled' in button) {
+          button.disabled = true;
+        }
+        return;
+      }
+
+      button.removeAttribute('aria-hidden');
+      button.removeAttribute('tabindex');
+      delete button.dataset.hiddenByAgent;
+    });
 
     // Update status based on whether there's an active stream
     if (!message.activeStream) {
@@ -258,6 +302,62 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleDeleteAll() {
     state.toggleStates.clearAll();
+  }
+
+  _getToolbarButtons() {
+    const ensureCache = () =>
+      TOOLBAR_ACTION_BUTTON_IDS.map((buttonId) =>
+        document.getElementById(buttonId),
+      ).filter((button) => button instanceof HTMLElement);
+
+    const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
+    if (!toolbar) {
+      if (this._toolbarMutationObserver) {
+        this._toolbarMutationObserver.disconnect();
+        this._toolbarMutationObserver = null;
+      }
+      this._toolbarObserverTarget = null;
+      this._toolbarButtonCache = null;
+    } else if (this._toolbarObserverTarget !== toolbar) {
+      if (this._toolbarMutationObserver) {
+        this._toolbarMutationObserver.disconnect();
+        this._toolbarMutationObserver = null;
+      }
+
+      if (typeof MutationObserver === 'function') {
+        this._toolbarMutationObserver = new MutationObserver(() => {
+          this._toolbarButtonCache = null;
+        });
+        this._toolbarMutationObserver.observe(toolbar, {
+          childList: true,
+        });
+      }
+
+      this._toolbarObserverTarget = toolbar;
+      this._toolbarButtonCache = null;
+    }
+
+    if (!this._toolbarButtonCache || this._toolbarButtonCache.length === 0) {
+      this._toolbarButtonCache = ensureCache();
+      return this._toolbarButtonCache;
+    }
+
+    const cacheIsStale = TOOLBAR_ACTION_BUTTON_IDS.some((id) => {
+      const cached = this._toolbarButtonCache?.find(
+        (button) => button.id === id,
+      );
+      if (!cached) {
+        return true;
+      }
+      const current = document.getElementById(id);
+      return current && current !== cached;
+    });
+
+    if (cacheIsStale) {
+      this._toolbarButtonCache = ensureCache();
+    }
+
+    return this._toolbarButtonCache;
   }
 }
 

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -91,7 +91,17 @@ export class Status {
       statusIndicator.classList.add(cfg.className);
       statusIndicator.dataset.status = cfg.label;
 
-      setElementsDisabled(cfg.enable, false);
+      const elementsToEnable = cfg.enable
+        .map((id) => document.getElementById(id))
+        .filter((el) => {
+          if (!el) {
+            return false;
+          }
+          return el.dataset.hiddenByAgent !== 'true';
+        });
+      if (elementsToEnable.length > 0) {
+        setElementsDisabled(elementsToEnable, false);
+      }
 
       const activeStream = progressViewState.activeStream;
       if (activeStream && status !== STATUS.READY) {

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -68,6 +68,7 @@ export function buildStreamInfos(
     if (!matchesAgentFilter(agentType, filter)) {
       return acc;
     }
+    const isToolAgent = agentType === AgentType.ToolUse;
     const executionId = state.getExecutionId(id);
     const label = buildStreamLabel(agentName, inputFile, agentType);
     acc.push({
@@ -76,6 +77,9 @@ export function buildStreamInfos(
       model: taskState?.agentConfig.model,
       agent: taskState?.agentConfig.agent,
       agentType,
+      uiTraits: {
+        isToolAgent,
+      },
       hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
       lastTimestamp,
       inputFile,

--- a/src/progressView/styles/buttons.css
+++ b/src/progressView/styles/buttons.css
@@ -24,3 +24,7 @@
 .codicon-trash:before {
   content: '\eb9f';
 }
+
+#toolbarContainer .toolbar-button--hidden {
+  display: none;
+}

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -12,6 +12,10 @@
   gap: var(--spacing-small);
 }
 
+.follow-up-container.is-visible {
+  display: flex;
+}
+
 /* Style the textarea for multi-line input */
 #followUpInput {
   min-height: 36px;

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -3,6 +3,11 @@ import type { AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
+export interface StreamUITraits {
+  /** Indicates whether the associated agent is a tool-use session. */
+  isToolAgent: boolean;
+}
+
 export interface StreamTabInfo {
   name: string;
   /** Short label displayed in the tab UI */
@@ -10,6 +15,7 @@ export interface StreamTabInfo {
   model?: string;
   agent?: string;
   agentType?: AgentType;
+  uiTraits: StreamUITraits;
   hasMultipleOutputs?: boolean;
   lastTimestamp?: number;
   inputFile?: string;


### PR DESCRIPTION
## Summary
- reuse a helper to guard progress view toolbar commands so tool-use streams skip rerun/diff/pack/clean without repeating the same task-state fetches
- cache the toolbar action buttons with MutationObserver-backed invalidation so follow-up toggling reuses DOM nodes and short-circuits when the hidden state is unchanged
- rely on the boolean `uiTraits.isToolAgent` flag when showing the follow-up form and hiding actions, keeping ARIA attributes in sync when tool sessions end

## Testing
- npm run format
- npm run lint
- CI=1 npm test *(fails: vscode-test needs libatk-1.0.so.0 in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab5e7df0c83249eb0177fb2a3790b