### PR TITLE
feat: track agent session kinds

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -16,6 +16,28 @@ export enum AgentType {
   ToolUse = 'toolUse',
 }
 
+/**
+ * Canonical session groupings used throughout the extension UI.
+ * Workflow sessions represent traditional direct/CoT executions while
+ * toolUse isolates interactive tool panels.
+ */
+export enum AgentSessionKind {
+  Workflow = 'workflow',
+  ToolUse = 'toolUse',
+}
+
+/**
+ * Derive the canonical {@link AgentSessionKind} from a specific agent type.
+ * Defaults to {@link AgentSessionKind.Workflow} when the type is unknown.
+ */
+export function deriveAgentSessionKind(
+  agentType?: AgentType | null,
+): AgentSessionKind {
+  return agentType === AgentType.ToolUse
+    ? AgentSessionKind.ToolUse
+    : AgentSessionKind.Workflow;
+}
+
 /** Zod schema for AgentSetting validation */
 export const AgentSettingSchema = z
   .object({

--- a/src/agent/types/AgentStreamTypes.ts
+++ b/src/agent/types/AgentStreamTypes.ts
@@ -1,15 +1,20 @@
 // Local types - agent
+import { AgentSessionKind } from '@agent/core/AgentDataclass';
 
 /**
  * Allowed filter values for agent streams in the ProgressBoard.
  * "workflow" groups traditional direct/CoT agents while
  * "toolUse" isolates interactive tool sessions.
  */
-export type AgentTypeFilter = 'all' | 'workflow' | 'toolUse';
+export type AgentTypeFilter = 'all' | AgentSessionKind;
 
 /**
  * Type guard ensuring a value is a valid {@link AgentTypeFilter}.
  */
 export function isAgentTypeFilter(value: unknown): value is AgentTypeFilter {
-  return value === 'all' || value === 'workflow' || value === 'toolUse';
+  return (
+    value === 'all' ||
+    value === AgentSessionKind.Workflow ||
+    value === AgentSessionKind.ToolUse
+  );
 }

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -1,7 +1,7 @@
 // Local imports
 import type { FileType } from '@utils/config';
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import type { AgentType } from '@agent/core/AgentDataclass';
+import type { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
 
 /**
  * Interface for storing task execution state.
@@ -23,6 +23,12 @@ export interface TaskState {
    * compatibility with older saved states.
    */
   agentType?: AgentType;
+
+  /**
+   * Canonical grouping for the agent session (workflow vs toolUse).
+   * Persisted alongside {@link agentType} for consistent filtering logic.
+   */
+  agentSessionKind?: AgentSessionKind;
 
   /**
    * UI-specific state for managing file type visibility in the interface.

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,10 +12,11 @@ import {
   AgentTypeFilter,
   isAgentTypeFilter,
 } from '@agent/types/AgentStreamTypes';
-import { AgentType } from '@agent/core/AgentDataclass';
+import {
+  AgentSessionKind,
+  deriveAgentSessionKind,
+} from '@agent/core/AgentDataclass';
 import type { TaskState } from '@logger/TaskState';
-
-type ToolUseTaskState = TaskState & { agentType: AgentType.ToolUse };
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -330,10 +331,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
    * @param taskState - The currently resolved task state for the active stream.
    * @returns True when the caller should skip executing the toolbar action.
    */
-  private shouldSkipToolbarAction(
-    taskState: TaskState | undefined,
-  ): taskState is undefined | ToolUseTaskState {
-    return !taskState || taskState.agentType === AgentType.ToolUse;
+  private shouldSkipToolbarAction(taskState: TaskState): boolean {
+    const sessionKind =
+      taskState.agentSessionKind ?? deriveAgentSessionKind(taskState.agentType);
+    return sessionKind === AgentSessionKind.ToolUse;
   }
 
   /**
@@ -346,6 +347,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     action: (taskState: TaskState) => Promise<void>,
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(stream);
+    if (!taskState) {
+      return;
+    }
+
     if (this.shouldSkipToolbarAction(taskState)) {
       return;
     }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -14,8 +14,8 @@ const TOOLBAR_ACTION_BUTTON_IDS = [
   ELEMENT_IDS.CLEAN_STREAM_BTN,
 ];
 
-const AGENT_MODES = Object.freeze({
-  TOOL: 'tool',
+const AGENT_SESSION_KINDS = Object.freeze({
+  TOOL_USE: 'toolUse',
   WORKFLOW: 'workflow',
 });
 
@@ -98,7 +98,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const activeStreamInfo = message.streams.find(
       (s) => s.name === message.activeStream,
     );
-    const isToolAgent = activeStreamInfo?.uiTraits?.isToolAgent ?? false;
+    const sessionKind =
+      activeStreamInfo?.agentSessionKind ||
+      activeStreamInfo?.uiTraits?.sessionKind ||
+      AGENT_SESSION_KINDS.WORKFLOW;
+    const isToolAgent = sessionKind === AGENT_SESSION_KINDS.TOOL_USE;
 
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
@@ -111,9 +115,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
     if (toolbar) {
       toolbar.dataset.agentType = activeStreamInfo?.agentType || '';
-      toolbar.dataset.agentMode = isToolAgent
-        ? AGENT_MODES.TOOL
-        : AGENT_MODES.WORKFLOW;
+      toolbar.dataset.agentMode = sessionKind;
     }
 
     toolbarButtons.forEach((button) => {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -14,10 +14,8 @@ const TOOLBAR_ACTION_BUTTON_IDS = [
   ELEMENT_IDS.CLEAN_STREAM_BTN,
 ];
 
-const AGENT_SESSION_KINDS = Object.freeze({
-  TOOL_USE: 'toolUse',
-  WORKFLOW: 'workflow',
-});
+// Session kind values match TypeScript AgentSessionKind enum
+// No need to duplicate - we use the actual values from messages
 
 // Create shorter aliases for internal use
 const state = progressViewState;
@@ -101,8 +99,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const sessionKind =
       activeStreamInfo?.agentSessionKind ||
       activeStreamInfo?.uiTraits?.sessionKind ||
-      AGENT_SESSION_KINDS.WORKFLOW;
-    const isToolAgent = sessionKind === AGENT_SESSION_KINDS.TOOL_USE;
+      'workflow'; // Default fallback
+    const isToolAgent = sessionKind === 'toolUse';
 
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -13,6 +13,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import type { AgentFilter } from '../types';
 // Local imports - agent types
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
+import { deriveAgentSessionKind } from '@agent/core/AgentDataclass';
 
 // Types
 import { TaskState } from '@logger/TaskState';
@@ -98,7 +99,13 @@ export class ProgressViewState {
 
   // Task state management
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
-    this._taskStates.set(streamTabId, taskState);
+    const normalizedState: TaskState = {
+      ...taskState,
+      agentSessionKind:
+        taskState.agentSessionKind ??
+        deriveAgentSessionKind(taskState.agentType),
+    };
+    this._taskStates.set(streamTabId, normalizedState);
     this.saveTaskStates();
   }
 

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -5,7 +5,10 @@ import * as path from 'path';
 import type { ProgressViewState } from './state/ProgressViewState';
 import type { AgentFilter, StreamTabInfo } from './types';
 // Local imports - agent types
-import { AgentType } from '@agent/core/AgentDataclass';
+import {
+  AgentSessionKind,
+  deriveAgentSessionKind,
+} from '@agent/core/AgentDataclass';
 
 const sortComparators = {
   time: (a: StreamTabInfo, b: StreamTabInfo) =>
@@ -18,16 +21,16 @@ const sortComparators = {
 } as const;
 
 function matchesAgentFilter(
-  agentType: AgentType | undefined,
+  sessionKind: AgentSessionKind,
   filter: AgentFilter,
 ): boolean {
   switch (filter) {
     case 'all':
       return true;
     case 'toolUse':
-      return agentType === AgentType.ToolUse;
+      return sessionKind === AgentSessionKind.ToolUse;
     case 'workflow':
-      return agentType !== AgentType.ToolUse;
+      return sessionKind === AgentSessionKind.Workflow;
     default:
       return true;
   }
@@ -36,9 +39,9 @@ function matchesAgentFilter(
 function buildStreamLabel(
   agentName: string,
   inputFile: string,
-  agentType: AgentType | undefined,
+  sessionKind: AgentSessionKind,
 ): string {
-  if (agentType === AgentType.ToolUse) {
+  if (sessionKind === AgentSessionKind.ToolUse) {
     return agentName;
   }
 
@@ -65,19 +68,23 @@ export function buildStreamInfos(
     const inputFile = taskState?.agentConfig.inputFile || '';
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
     const agentType = taskState?.agentType;
-    if (!matchesAgentFilter(agentType, filter)) {
+    const agentSessionKind =
+      taskState?.agentSessionKind ?? deriveAgentSessionKind(agentType);
+    if (!matchesAgentFilter(agentSessionKind, filter)) {
       return acc;
     }
-    const isToolAgent = agentType === AgentType.ToolUse;
+    const isToolAgent = agentSessionKind === AgentSessionKind.ToolUse;
     const executionId = state.getExecutionId(id);
-    const label = buildStreamLabel(agentName, inputFile, agentType);
+    const label = buildStreamLabel(agentName, inputFile, agentSessionKind);
     acc.push({
       name: id,
       label,
       model: taskState?.agentConfig.model,
       agent: taskState?.agentConfig.agent,
       agentType,
+      agentSessionKind,
       uiTraits: {
+        sessionKind: agentSessionKind,
         isToolAgent,
       },
       hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,9 +1,11 @@
 // Local imports - agent types
-import type { AgentType } from '@agent/core/AgentDataclass';
+import type { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
 export interface StreamUITraits {
+  /** Canonical session grouping for the stream. */
+  sessionKind: AgentSessionKind;
   /** Indicates whether the associated agent is a tool-use session. */
   isToolAgent: boolean;
 }
@@ -15,6 +17,7 @@ export interface StreamTabInfo {
   model?: string;
   agent?: string;
   agentType?: AgentType;
+  agentSessionKind: AgentSessionKind;
   uiTraits: StreamUITraits;
   hasMultipleOutputs?: boolean;
   lastTimestamp?: number;

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -67,8 +67,7 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     // Already in new format, just ensure it's valid
     const agentType = obj.agentType as AgentType | undefined;
     const agentSessionKind =
-      (obj.agentSessionKind as AgentSessionKind | undefined) ??
-      deriveAgentSessionKind(agentType);
+      obj.agentSessionKind ?? deriveAgentSessionKind(agentType);
     return {
       agentConfig: AgentConfigSchema.parse(obj.agentConfig),
       activeFiles:
@@ -117,8 +116,7 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     const normalized = AgentConfigSchema.parse(agentConfigData);
     const agentType = obj.agentType as AgentType | undefined;
     const agentSessionKind =
-      (obj.agentSessionKind as AgentSessionKind | undefined) ??
-      deriveAgentSessionKind(agentType);
+      obj.agentSessionKind ?? deriveAgentSessionKind(agentType);
     const taskState = agentConfigToTaskState(normalized, agentType);
     taskState.agentSessionKind = agentSessionKind;
 

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -66,10 +66,9 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   if (obj.agentConfig && typeof obj.agentConfig === 'object') {
     // Already in new format, just ensure it's valid
     const agentType = obj.agentType as AgentType | undefined;
-    const agentSessionKind = ((): AgentSessionKind => {
-      const rawKind = obj.agentSessionKind as AgentSessionKind | undefined;
-      return rawKind ?? deriveAgentSessionKind(agentType);
-    })();
+    const agentSessionKind =
+      (obj.agentSessionKind as AgentSessionKind | undefined) ??
+      deriveAgentSessionKind(agentType);
     return {
       agentConfig: AgentConfigSchema.parse(obj.agentConfig),
       activeFiles:
@@ -117,10 +116,9 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   try {
     const normalized = AgentConfigSchema.parse(agentConfigData);
     const agentType = obj.agentType as AgentType | undefined;
-    const agentSessionKind = ((): AgentSessionKind => {
-      const rawKind = obj.agentSessionKind as AgentSessionKind | undefined;
-      return rawKind ?? deriveAgentSessionKind(agentType);
-    })();
+    const agentSessionKind =
+      (obj.agentSessionKind as AgentSessionKind | undefined) ??
+      deriveAgentSessionKind(agentType);
     const taskState = agentConfigToTaskState(normalized, agentType);
     taskState.agentSessionKind = agentSessionKind;
 

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -8,7 +8,11 @@
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { TaskState } from '@logger/TaskState';
-import type { AgentType } from '@agent/core/AgentDataclass';
+import {
+  AgentSessionKind,
+  type AgentType,
+  deriveAgentSessionKind,
+} from '@agent/core/AgentDataclass';
 
 import { FILE_TYPES, type FileType } from './constants';
 
@@ -41,10 +45,12 @@ export function agentConfigToTaskState(
   config: AgentConfig,
   agentType?: AgentType,
 ): TaskState {
+  const agentSessionKind = deriveAgentSessionKind(agentType);
   return {
     agentConfig: config,
     activeFiles: createActiveFilesFromArrays(config),
-    ...(agentType ? { agentType } : {}),
+    agentType,
+    agentSessionKind,
   };
 }
 
@@ -59,11 +65,17 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   // Check if this is already in the new format with nested agentConfig
   if (obj.agentConfig && typeof obj.agentConfig === 'object') {
     // Already in new format, just ensure it's valid
+    const agentType = obj.agentType as AgentType | undefined;
+    const agentSessionKind = ((): AgentSessionKind => {
+      const rawKind = obj.agentSessionKind as AgentSessionKind | undefined;
+      return rawKind ?? deriveAgentSessionKind(agentType);
+    })();
     return {
       agentConfig: AgentConfigSchema.parse(obj.agentConfig),
       activeFiles:
         obj.activeFiles || createActiveFilesFromArrays(obj.agentConfig),
-      agentType: obj.agentType,
+      agentType,
+      agentSessionKind,
     };
   }
 
@@ -104,7 +116,13 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   // Parse only AgentConfig-compatible fields
   try {
     const normalized = AgentConfigSchema.parse(agentConfigData);
-    const taskState = agentConfigToTaskState(normalized, obj.agentType);
+    const agentType = obj.agentType as AgentType | undefined;
+    const agentSessionKind = ((): AgentSessionKind => {
+      const rawKind = obj.agentSessionKind as AgentSessionKind | undefined;
+      return rawKind ?? deriveAgentSessionKind(agentType);
+    })();
+    const taskState = agentConfigToTaskState(normalized, agentType);
+    taskState.agentSessionKind = agentSessionKind;
 
     // Add back TaskState-specific fields
     if (activeFiles) {
@@ -116,7 +134,10 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     // If parsing fails, create a minimal valid state
     console.error('Failed to parse task state, using defaults:', error);
     const defaultConfig = AgentConfigSchema.parse({});
-    const taskState = agentConfigToTaskState(defaultConfig, obj.agentType);
+    const agentType = obj.agentType as AgentType | undefined;
+    const agentSessionKind = deriveAgentSessionKind(agentType);
+    const taskState = agentConfigToTaskState(defaultConfig, agentType);
+    taskState.agentSessionKind = agentSessionKind;
 
     // Preserve activeFiles if available
     if (activeFiles) {


### PR DESCRIPTION
## Summary
- add the AgentSessionKind enum and helper to derive it from AgentType so session metadata is standardized
- persist the derived session kind on TaskState and expose it through stream info, progress state, and type definitions
- update filters, toolbar gating, and the progress view webview to rely on the canonical session kind for tool-use handling

## Testing
- npm run lint
- CI=1 npm test *(fails: vscode-test requires libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae5ee6c5883248e3f00cccc74cf1e