### PR TITLE
fix: allow tool agents to log without groups

### DIFF
--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -10,7 +10,10 @@ export interface IAgent {
   readonly config: AgentConfig;
 
   /** Initialize the agent before running. */
-  init(parentGroupId?: string): Promise<void>;
+  init(
+    parentGroupId?: string,
+    options?: { createGroup?: boolean },
+  ): Promise<void>;
 
   /** Execute the agent. */
   run(): Promise<void>;

--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -9,7 +9,12 @@ export interface IAgent {
   /** Agent configuration used during execution. */
   readonly config: AgentConfig;
 
-  /** Initialize the agent before running. */
+  /**
+   * Initialize the agent before running.
+   * @param parentGroupId - Optional parent group ID for nested logging
+   * @param options - Initialization options
+   * @param options.createGroup - Whether to create a new log group (default: true)
+   */
   init(
     parentGroupId?: string,
     options?: { createGroup?: boolean },

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -100,12 +100,15 @@ export abstract class BaseAgent implements IAgent {
   }
 
   /** Perform asynchronous initialization work. */
-  public async init(parentGroupId?: string): Promise<void> {
-    const initGroupId = await this.logger.startGroup(
-      `Init`,
-      undefined,
-      parentGroupId,
-    );
+  public async init(
+    parentGroupId?: string,
+    options?: { createGroup?: boolean },
+  ): Promise<void> {
+    const { createGroup = true } = options ?? {};
+    const initGroupId = createGroup
+      ? await this.logger.startGroup(`Init`, undefined, parentGroupId)
+      : parentGroupId;
+
     try {
       this.logger.debug(
         `AgentConfig: ${JSON.stringify(this.agentConfig)}`,
@@ -122,9 +125,14 @@ export abstract class BaseAgent implements IAgent {
 
       this.userVars = await this.getUserVars();
       BaseAgent.runningAgents.set(this.getStreamTabId(), this);
-      this.logger.endGroup(initGroupId, 'stopped');
+
+      if (createGroup && initGroupId) {
+        this.logger.endGroup(initGroupId, 'stopped');
+      }
     } catch (error) {
-      this.logger.endGroup(initGroupId, 'error');
+      if (createGroup && initGroupId) {
+        this.logger.endGroup(initGroupId, 'error');
+      }
       throw error;
     }
   }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -543,7 +543,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     await this.startRunGroup();
 
     try {
-      await this.init(this.runGroupId);
+      await this.init(this.runGroupId, { createGroup: true });
       this.promptBuilder = undefined;
       await this.initializeClient();
 

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -53,10 +53,7 @@ export class BaseToolUseAgent extends BaseAgent {
     for (const t of cfg) {
       const def = typeof t === 'string' ? { name: t } : t;
       if (!this.toolRegistry[def.name]) {
-        this.logger.warn(
-          `Tool "${def.name}" not found in registry`,
-          this.runGroupId,
-        );
+        this.logger.warn(`Tool "${def.name}" not found in registry`);
         continue;
       }
       tools.push(def);
@@ -98,9 +95,8 @@ export class BaseToolUseAgent extends BaseAgent {
   }
 
   public async run(): Promise<void> {
-    await this.startRunGroup();
     try {
-      await this.init(this.runGroupId);
+      await this.init(undefined, { createGroup: false });
       await this.initializeClient();
 
       const [systemPrompt, userRequest, userPrefix] = await Promise.all([
@@ -143,21 +139,16 @@ export class BaseToolUseAgent extends BaseAgent {
       } as const;
 
       while (true) {
-        await runToolUseCycle(cycleOptions, this.messages, this.runGroupId);
+        await runToolUseCycle(cycleOptions, this.messages);
         if (this.checkInterruption()) break;
         const followUp = await this.waitForFollowUp();
         if (!followUp || this.checkInterruption()) break;
-        this.logger.userMessage(followUp, this.runGroupId);
+        this.logger.userMessage(followUp);
         this.messages = await this.modelHandler.createUserFollowUpMessages(
           this.messages,
           followUp,
         );
       }
-
-      this.endRunGroup('stopped');
-    } catch (err) {
-      this.endRunGroup('error');
-      throw err;
     } finally {
       this.cleanup();
     }


### PR DESCRIPTION
## Summary
- allow `BaseAgent.init` to skip creating a log group when requested so workflow agents keep grouping by default
- update `BaseToolUseAgent` to initialize without starting a run group so tool-use logs stream directly
- ensure tool-use warnings and follow-ups no longer depend on a group id

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caea91b304832496476dd8613e74ba