### PR TITLE
feat: persist and resume tool use sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -767,6 +767,24 @@
             "scope": "resource"
           }
         }
+      },
+      {
+        "title": "Tool Use Agents",
+        "properties": {
+          "texra.toolUse.persistence.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Persist tool-use conversations across VS Code restarts",
+            "scope": "resource"
+          },
+          "texra.toolUse.persistence.ttlHours": {
+            "type": "number",
+            "default": 72,
+            "minimum": 1,
+            "description": "Maximum age (in hours) to keep saved tool-use sessions before automatic cleanup",
+            "scope": "resource"
+          }
+        }
       }
     ],
     "commands": [
@@ -809,6 +827,11 @@
         "category": "TeXRA",
         "icon": "$(indent)",
         "enablement": "!virtualWorkspace"
+      },
+      {
+        "command": "texra.resumeAgent",
+        "title": "Resume Tool-Use Agent",
+        "category": "TeXRA"
       },
       {
         "command": "texra.applyReplacements",

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -1,6 +1,6 @@
 // Local imports - agent
 import type { AgentConfig } from '../core/AgentConfig';
-import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
+import { AgentPrompt, AgentSessionKind, AgentSetting } from '../core/AgentDataclass';
 import { ToolState } from '../core/ToolState';
 import { runToolUseCycle } from '../core/ToolUseCycle';
 import type { IModelHandler } from '../modelHandlers';
@@ -18,6 +18,11 @@ import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { bus } from '@eventBus/ProgressEventBus';
+import {
+  ToolUseSessionManager,
+  type ToolUseSessionSnapshot,
+} from '@agent/toolUse/ToolUseSessionManager';
 
 export class BaseToolUseAgent extends BaseAgent {
   private toolRegistry: Record<string, BaseTool<any>>;
@@ -25,6 +30,8 @@ export class BaseToolUseAgent extends BaseAgent {
   private followUpResolver: ((v: string | null) => void) | null = null;
   private messages: ProviderMessage[] = [];
   private toolState: ToolState | null = null;
+  private resumeSnapshot: ToolUseSessionSnapshot | null = null;
+  private hasPersistedSnapshot = false;
 
   constructor(
     modelHandler: IModelHandler,
@@ -76,6 +83,11 @@ export class BaseToolUseAgent extends BaseAgent {
     }
   }
 
+  public resumeFromSnapshot(snapshot: ToolUseSessionSnapshot): void {
+    this.resumeSnapshot = snapshot;
+    this.hasPersistedSnapshot = true;
+  }
+
   private async waitForFollowUp(): Promise<string | null> {
     if (this.followUpQueue.length > 0) {
       return this.followUpQueue.shift()!;
@@ -92,6 +104,7 @@ export class BaseToolUseAgent extends BaseAgent {
       this.followUpResolver(null);
       this.followUpResolver = null;
     }
+    void this.clearPersistedSnapshot();
   }
 
   public async run(): Promise<void> {
@@ -99,23 +112,35 @@ export class BaseToolUseAgent extends BaseAgent {
       await this.init(undefined, { createGroup: false });
       await this.initializeClient();
 
-      const [systemPrompt, userRequest, userPrefix] = await Promise.all([
-        getSystemPromptWithRules(
-          `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
-          this.userVars,
-        ),
-        renderPrompt(this.agentPrompt.userRequest, this.userVars),
-        renderPrompt(this.agentPrompt.userPrefix, this.userVars),
-      ]);
+      let shouldSkipCycle = false;
 
-      this.messages = await this.modelHandler.initializeMessages(
-        userPrefix,
-        userRequest,
-        undefined,
-        systemPrompt,
-      );
+      if (this.resumeSnapshot) {
+        this.logger.info('Resuming tool-use session from saved state.');
+        this.messages = (this.resumeSnapshot.messages ?? []) as ProviderMessage[];
+        this.toolState = ToolUseSessionManager.hydrateToolStateFromSnapshot(
+          this.resumeSnapshot,
+        );
+        shouldSkipCycle = true;
+        this.resumeSnapshot = null;
+      } else {
+        const [systemPrompt, userRequest, userPrefix] = await Promise.all([
+          getSystemPromptWithRules(
+            `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
+            this.userVars,
+          ),
+          renderPrompt(this.agentPrompt.userRequest, this.userVars),
+          renderPrompt(this.agentPrompt.userPrefix, this.userVars),
+        ]);
 
-      this.toolState = new ToolState();
+        this.messages = await this.modelHandler.initializeMessages(
+          userPrefix,
+          userRequest,
+          undefined,
+          systemPrompt,
+        );
+
+        this.toolState = new ToolState();
+      }
 
       const resolvedSetting = {
         ...this.agentSetting,
@@ -139,10 +164,27 @@ export class BaseToolUseAgent extends BaseAgent {
       } as const;
 
       while (true) {
-        await runToolUseCycle(cycleOptions, this.messages);
+        if (!shouldSkipCycle) {
+          await runToolUseCycle(cycleOptions, this.messages);
+        } else {
+          shouldSkipCycle = false;
+        }
+
         if (this.checkInterruption()) break;
+
+        const hasQueuedFollowUp = this.followUpQueue.length > 0;
+        if (!hasQueuedFollowUp) {
+          await this.enterWaitingState();
+        } else {
+          await this.clearPersistedSnapshot();
+        }
+
         const followUp = await this.waitForFollowUp();
         if (!followUp || this.checkInterruption()) break;
+
+        await this.markRunning();
+        await this.clearPersistedSnapshot();
+
         this.logger.userMessage(followUp);
         this.messages = await this.modelHandler.createUserFollowUpMessages(
           this.messages,
@@ -150,7 +192,70 @@ export class BaseToolUseAgent extends BaseAgent {
         );
       }
     } finally {
+      await this.clearPersistedSnapshot();
       this.cleanup();
+    }
+  }
+
+  private async enterWaitingState(): Promise<void> {
+    if (this.followUpQueue.length > 0) {
+      return;
+    }
+    const stream = this.getStreamTabId();
+    const executionId = this.getExecutionId();
+    const state = this.toolState;
+
+    if (
+      state &&
+      executionId &&
+      ToolUseSessionManager.isPersistenceEnabled() &&
+      this.followUpQueue.length === 0
+    ) {
+      await ToolUseSessionManager.saveSnapshot({
+        executionId,
+        streamId: stream,
+        agentName: this.agentConfig.agent,
+        model: this.agentConfig.model,
+        agentSessionKind: AgentSessionKind.ToolUse,
+        messages: this.messages,
+        toolState: state,
+      });
+
+      if (this.followUpQueue.length > 0) {
+        await ToolUseSessionManager.deleteSnapshot(executionId);
+        this.hasPersistedSnapshot = false;
+        return;
+      }
+
+      this.hasPersistedSnapshot = true;
+    }
+
+    bus.emit('updateStreamStatus', {
+      stream,
+      status: 'waiting',
+    });
+  }
+
+  private async markRunning(): Promise<void> {
+    bus.emit('updateStreamStatus', {
+      stream: this.getStreamTabId(),
+      status: 'running',
+    });
+  }
+
+  private async clearPersistedSnapshot(): Promise<void> {
+    if (!this.hasPersistedSnapshot) {
+      return;
+    }
+    const executionId = this.getExecutionId();
+    if (!executionId) {
+      this.hasPersistedSnapshot = false;
+      return;
+    }
+    try {
+      await ToolUseSessionManager.deleteSnapshot(executionId);
+    } finally {
+      this.hasPersistedSnapshot = false;
     }
   }
 }

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -1,6 +1,10 @@
 // Local imports - agent
 import type { AgentConfig } from '../core/AgentConfig';
-import { AgentPrompt, AgentSessionKind, AgentSetting } from '../core/AgentDataclass';
+import {
+  AgentPrompt,
+  AgentSessionKind,
+  AgentSetting,
+} from '../core/AgentDataclass';
 import { ToolState } from '../core/ToolState';
 import { runToolUseCycle } from '../core/ToolUseCycle';
 import type { IModelHandler } from '../modelHandlers';
@@ -221,20 +225,16 @@ export class BaseToolUseAgent extends BaseAgent {
     if (this.followUpQueue.length > 0) {
       return;
     }
-    
+
     const stream = this.getStreamTabId();
     const executionId = this.getExecutionId();
     const state = this.toolState;
 
     // Persist snapshot with lock to prevent race conditions
-    if (
-      state &&
-      executionId &&
-      ToolUseSessionManager.isPersistenceEnabled()
-    ) {
+    if (state && executionId && ToolUseSessionManager.isPersistenceEnabled()) {
       // Acquire lock to prevent race conditions
       this.persistenceLock = true;
-      
+
       try {
         // Double-check queue is still empty under lock
         if (this.followUpQueue.length === 0) {
@@ -247,7 +247,7 @@ export class BaseToolUseAgent extends BaseAgent {
             messages: this.messages,
             toolState: state,
           });
-          
+
           // Final check after save completes
           if (this.followUpQueue.length > 0) {
             // A follow-up arrived while we were saving

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -32,6 +32,7 @@ export class BaseToolUseAgent extends BaseAgent {
   private toolState: ToolState | null = null;
   private resumeSnapshot: ToolUseSessionSnapshot | null = null;
   private hasPersistedSnapshot = false;
+  private persistenceLock = false; // Lock to prevent race conditions during persistence
 
   constructor(
     modelHandler: IModelHandler,
@@ -74,6 +75,10 @@ export class BaseToolUseAgent extends BaseAgent {
     return tools;
   }
 
+  /**
+   * Appends a follow-up message to the queue or resolves a waiting promise
+   * @param text - The follow-up message text
+   */
   public appendFollowUp(text: string): void {
     if (this.followUpResolver) {
       this.followUpResolver(text);
@@ -81,8 +86,16 @@ export class BaseToolUseAgent extends BaseAgent {
     } else {
       this.followUpQueue.push(text);
     }
+    // If we're in the middle of persisting, mark for cleanup
+    if (this.persistenceLock) {
+      this.hasPersistedSnapshot = true; // Will trigger cleanup in the next cycle
+    }
   }
 
+  /**
+   * Configures the agent to resume from a persisted snapshot
+   * @param snapshot - The snapshot to resume from
+   */
   public resumeFromSnapshot(snapshot: ToolUseSessionSnapshot): void {
     this.resumeSnapshot = snapshot;
     this.hasPersistedSnapshot = true;
@@ -116,7 +129,13 @@ export class BaseToolUseAgent extends BaseAgent {
 
       if (this.resumeSnapshot) {
         this.logger.info('Resuming tool-use session from saved state.');
-        this.messages = (this.resumeSnapshot.messages ?? []) as ProviderMessage[];
+        // Validate messages before hydrating
+        const messages = this.resumeSnapshot.messages ?? [];
+        if (!Array.isArray(messages)) {
+          throw new Error('Invalid snapshot: messages must be an array');
+        }
+        // Cast with confidence after validation
+        this.messages = messages as ProviderMessage[];
         this.toolState = ToolUseSessionManager.hydrateToolStateFromSnapshot(
           this.resumeSnapshot,
         );
@@ -198,48 +217,62 @@ export class BaseToolUseAgent extends BaseAgent {
   }
 
   private async enterWaitingState(): Promise<void> {
+    // Early check to avoid unnecessary work
     if (this.followUpQueue.length > 0) {
       return;
     }
+    
     const stream = this.getStreamTabId();
     const executionId = this.getExecutionId();
     const state = this.toolState;
 
+    // Persist snapshot with lock to prevent race conditions
     if (
       state &&
       executionId &&
-      ToolUseSessionManager.isPersistenceEnabled() &&
-      this.followUpQueue.length === 0
+      ToolUseSessionManager.isPersistenceEnabled()
     ) {
-      await ToolUseSessionManager.saveSnapshot({
-        executionId,
-        streamId: stream,
-        agentName: this.agentConfig.agent,
-        model: this.agentConfig.model,
-        agentSessionKind: AgentSessionKind.ToolUse,
-        messages: this.messages,
-        toolState: state,
-      });
-
-      if (this.followUpQueue.length > 0) {
-        await ToolUseSessionManager.deleteSnapshot(executionId);
-        this.hasPersistedSnapshot = false;
-        return;
+      // Acquire lock to prevent race conditions
+      this.persistenceLock = true;
+      
+      try {
+        // Double-check queue is still empty under lock
+        if (this.followUpQueue.length === 0) {
+          await ToolUseSessionManager.saveSnapshot({
+            executionId,
+            streamId: stream,
+            agentName: this.agentConfig.agent,
+            model: this.agentConfig.model,
+            agentSessionKind: AgentSessionKind.ToolUse,
+            messages: this.messages,
+            toolState: state,
+          });
+          
+          // Final check after save completes
+          if (this.followUpQueue.length > 0) {
+            // A follow-up arrived while we were saving
+            await ToolUseSessionManager.deleteSnapshot(executionId);
+            this.hasPersistedSnapshot = false;
+          } else {
+            this.hasPersistedSnapshot = true;
+          }
+        }
+      } finally {
+        // Always release lock
+        this.persistenceLock = false;
       }
-
-      this.hasPersistedSnapshot = true;
     }
 
     bus.emit('updateStreamStatus', {
       stream,
-      status: 'waiting',
+      status: 'waiting', // Using string literal here as it's part of the bus event API
     });
   }
 
   private async markRunning(): Promise<void> {
     bus.emit('updateStreamStatus', {
       stream: this.getStreamTabId(),
-      status: 'running',
+      status: 'running', // Using string literal here as it's part of the bus event API
     });
   }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -209,11 +209,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
       // Create a log group for execution details as a sub-group
       const taskDetailsGroupId = isResume
         ? undefined
-        : await logger.startGroup(
-            `Task Details`,
-            undefined,
-            mainTaskGroupId,
-          );
+        : await logger.startGroup(`Task Details`, undefined, mainTaskGroupId);
 
       if (!isResume && taskDetailsGroupId) {
         logger.info(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -159,12 +159,18 @@ function getAgentName(
 /**
  * Common function to execute any agent with proper logging and status handling
  */
-async function executeAgentWithLogging<T extends IAgent>(
+interface ExecuteAgentOptions {
+  resume?: boolean;
+}
+
+export async function executeAgentWithLogging<T extends IAgent>(
   agentName: string,
   createAgentFn: () => Promise<{ agent: T; agentType?: AgentType }>,
   context: vscode.ExtensionContext,
   executionId?: ExecutionId,
+  options?: ExecuteAgentOptions,
 ): Promise<void> {
+  const isResume = options?.resume ?? false;
   try {
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
@@ -189,29 +195,33 @@ async function executeAgentWithLogging<T extends IAgent>(
     // Check if this stream is already running
     const provider = ProgressViewProvider.getInstance();
     const currentStatus = provider?.eventHandler.getStreamStatus(streamTabId);
-    if (currentStatus === 'running') {
+    if (!isResume && currentStatus === 'running') {
       const errorMsg = `Task "${streamTabId}" is already running. Please wait for it to complete or stop it first.`;
       throw new Error(errorMsg);
     }
 
     // Create a main task group for the entire execution
-    const mainTaskGroupId = await logger.startGroup(
-      `Task: ${agentName}@${config.model}`,
-    );
+    const mainTaskGroupId = isResume
+      ? undefined
+      : await logger.startGroup(`Task: ${agentName}@${config.model}`);
 
     try {
       // Create a log group for execution details as a sub-group
-      const taskDetailsGroupId = await logger.startGroup(
-        `Task Details`,
-        undefined,
-        mainTaskGroupId,
-      );
+      const taskDetailsGroupId = isResume
+        ? undefined
+        : await logger.startGroup(
+            `Task Details`,
+            undefined,
+            mainTaskGroupId,
+          );
 
-      logger.info(
-        `Starting task execution for ${streamTabId}`,
-        taskDetailsGroupId,
-      );
-      logger.info(`Input file: ${config.inputFile}`, taskDetailsGroupId);
+      if (!isResume && taskDetailsGroupId) {
+        logger.info(
+          `Starting task execution for ${streamTabId}`,
+          taskDetailsGroupId,
+        );
+        logger.info(`Input file: ${config.inputFile}`, taskDetailsGroupId);
+      }
 
       try {
         logger.debug(
@@ -234,65 +244,69 @@ async function executeAgentWithLogging<T extends IAgent>(
           status: 'running',
         });
 
-        const viewVisible = provider?.isViewVisible() ?? false;
-        if (!viewVisible) {
-          await vscode.commands.executeCommand('texra.showProgressView');
+        if (!isResume) {
+          const viewVisible = provider?.isViewVisible() ?? false;
+          if (!viewVisible) {
+            await vscode.commands.executeCommand('texra.showProgressView');
+          }
+
+          if (!provider?.isViewVisible()) {
+            const inputFileName = path.basename(config.inputFile);
+            const outputInfo = config.useMultipleOutputs
+              ? config.outputFiles?.length
+                ? `to ${
+                    config.outputFiles.length > 1
+                      ? `${config.outputFiles.length} files`
+                      : path.basename(config.outputFiles[0])
+                  }`
+                : 'for multiple outputs'
+              : config.outputFiles?.length
+                ? `to ${path.basename(config.outputFiles[0])}`
+                : '';
+
+            vscode.window
+              .showInformationMessage(
+                `TeXRA Agent Started: "${agentName}" is processing ${inputFileName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
+                {
+                  modal: false,
+                  detail:
+                    'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
+                },
+                'Show ProgressBoard',
+              )
+              .then((selection) => {
+                if (selection === 'Show ProgressBoard') {
+                  vscode.commands.executeCommand('texra.showProgressView');
+                }
+              });
+          }
+
+          // Store taskState
+          logger.debug(
+            `Storing taskState for stream: ${streamTabId}`,
+            taskDetailsGroupId,
+          );
+          logger.debug(
+            `Config for taskState: ${JSON.stringify(config)}`,
+            taskDetailsGroupId,
+          );
+
+          // End the task details group
+          if (taskDetailsGroupId) {
+            logger.endGroup(taskDetailsGroupId, 'stopped');
+          }
+
+          // Convert AgentConfig to TaskState using utility function
+          bus.emit('setTaskState', {
+            streamTabId: streamTabId,
+            executionId,
+            taskState: agentConfigToTaskState(config, agentType),
+          });
+          logger.debug(
+            `Task state stored for stream: ${streamTabId}`,
+            mainTaskGroupId,
+          );
         }
-
-        if (!provider?.isViewVisible()) {
-          const inputFileName = path.basename(config.inputFile);
-          const outputInfo = config.useMultipleOutputs
-            ? config.outputFiles?.length
-              ? `to ${
-                  config.outputFiles.length > 1
-                    ? `${config.outputFiles.length} files`
-                    : path.basename(config.outputFiles[0])
-                }`
-              : 'for multiple outputs'
-            : config.outputFiles?.length
-              ? `to ${path.basename(config.outputFiles[0])}`
-              : '';
-
-          vscode.window
-            .showInformationMessage(
-              `TeXRA Agent Started: "${agentName}" is processing ${inputFileName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
-              {
-                modal: false,
-                detail:
-                  'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
-              },
-              'Show ProgressBoard',
-            )
-            .then((selection) => {
-              if (selection === 'Show ProgressBoard') {
-                vscode.commands.executeCommand('texra.showProgressView');
-              }
-            });
-        }
-
-        // Store taskState
-        logger.debug(
-          `Storing taskState for stream: ${streamTabId}`,
-          taskDetailsGroupId,
-        );
-        logger.debug(
-          `Config for taskState: ${JSON.stringify(config)}`,
-          taskDetailsGroupId,
-        );
-
-        // End the task details group
-        logger.endGroup(taskDetailsGroupId, 'stopped');
-
-        // Convert AgentConfig to TaskState using utility function
-        bus.emit('setTaskState', {
-          streamTabId: streamTabId,
-          executionId,
-          taskState: agentConfigToTaskState(config, agentType),
-        });
-        logger.debug(
-          `Task state stored for stream: ${streamTabId}`,
-          mainTaskGroupId,
-        );
 
         try {
           // Run the agent
@@ -304,7 +318,9 @@ async function executeAgentWithLogging<T extends IAgent>(
           // await checkExpectedOutputs(config.outputFiles, agent);
           // Mark the task as completed successfully
           logger.debug(`Task completed successfully`, mainTaskGroupId);
-          logger.endGroup(mainTaskGroupId, 'stopped');
+          if (mainTaskGroupId) {
+            logger.endGroup(mainTaskGroupId, 'stopped');
+          }
           // Update status to stopped on successful completion
           bus.emit('updateStreamStatus', {
             stream: streamTabId,
@@ -325,7 +341,9 @@ async function executeAgentWithLogging<T extends IAgent>(
             `Task failed: ${err instanceof Error ? err.message : String(err)}`,
             mainTaskGroupId,
           );
-          logger.endGroup(mainTaskGroupId, 'error');
+          if (mainTaskGroupId) {
+            logger.endGroup(mainTaskGroupId, 'error');
+          }
           // Update status to error if agent run fails
           bus.emit('updateStreamStatus', {
             stream: streamTabId,
@@ -344,7 +362,9 @@ async function executeAgentWithLogging<T extends IAgent>(
           `Task initialization failed: ${err instanceof Error ? err.message : String(err)}`,
           mainTaskGroupId,
         );
-        logger.endGroup(mainTaskGroupId, 'error');
+        if (mainTaskGroupId) {
+          logger.endGroup(mainTaskGroupId, 'error');
+        }
         throw err;
       }
     } catch (err) {
@@ -474,6 +494,7 @@ export async function executeAgent(
     },
     context,
     executionId,
+    { resume: false },
   );
 }
 

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -9,10 +9,7 @@ import * as vscode from 'vscode';
 import { AgentSessionKind } from '@agent/core/AgentDataclass';
 import { ToolState } from '@agent/core/ToolState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import type {
-  ExecutionId,
-  StreamTabId,
-} from '@agent/types/IdentifierTypes';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
@@ -96,7 +93,9 @@ function serializeToolState(state: ToolState) {
   };
 }
 
-function hydrateToolState(snapshot: ToolUseSessionSnapshot['toolState']): ToolState {
+function hydrateToolState(
+  snapshot: ToolUseSessionSnapshot['toolState'],
+): ToolState {
   const state = new ToolState();
   state.texcountStats = snapshot.texcountStats;
   state.lastResponse = snapshot.lastResponse;
@@ -217,7 +216,9 @@ export class ToolUseSessionManager {
    * Deletes a tool-use session snapshot from persistent storage
    * @param executionId - The ID of the session to delete
    */
-  public static async deleteSnapshot(executionId: ExecutionId | undefined): Promise<void> {
+  public static async deleteSnapshot(
+    executionId: ExecutionId | undefined,
+  ): Promise<void> {
     if (!executionId || !isValidExecutionId(executionId)) {
       return;
     }

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -136,10 +136,18 @@ function getSnapshotPath(executionId: ExecutionId): string {
 }
 
 export class ToolUseSessionManager {
+  /**
+   * Checks if tool-use session persistence is enabled
+   * @returns True if persistence is enabled, false otherwise
+   */
   public static isPersistenceEnabled(): boolean {
     return getToolUsePersistenceEnabled();
   }
 
+  /**
+   * Saves a tool-use session snapshot to persistent storage
+   * @param payload - The snapshot data to save
+   */
   public static async saveSnapshot(payload: SavePayload): Promise<void> {
     if (!this.isPersistenceEnabled()) {
       return;
@@ -176,6 +184,11 @@ export class ToolUseSessionManager {
     }
   }
 
+  /**
+   * Loads a tool-use session snapshot from persistent storage
+   * @param executionId - The ID of the session to load
+   * @returns The snapshot if found and valid, null otherwise
+   */
   public static async loadSnapshot(
     executionId: ExecutionId,
   ): Promise<ToolUseSessionSnapshot | null> {
@@ -200,6 +213,10 @@ export class ToolUseSessionManager {
     }
   }
 
+  /**
+   * Deletes a tool-use session snapshot from persistent storage
+   * @param executionId - The ID of the session to delete
+   */
   public static async deleteSnapshot(executionId: ExecutionId | undefined): Promise<void> {
     if (!executionId || !isValidExecutionId(executionId)) {
       return;
@@ -218,6 +235,10 @@ export class ToolUseSessionManager {
     }
   }
 
+  /**
+   * Lists all persisted tool-use session snapshots
+   * @returns Array of valid snapshots, expired snapshots are automatically cleaned up
+   */
   public static async listSnapshots(): Promise<ToolUseSessionSnapshot[]> {
     if (!this.isPersistenceEnabled()) {
       return [];
@@ -252,12 +273,14 @@ export class ToolUseSessionManager {
     }
   }
 
+  /**
+   * Hydrates a ToolState object from a snapshot
+   * @param snapshot - The snapshot containing the tool state data
+   * @returns A new ToolState instance with the hydrated data
+   */
   public static hydrateToolStateFromSnapshot(
     snapshot: ToolUseSessionSnapshot,
   ): ToolState {
     return hydrateToolState(snapshot.toolState);
   }
 }
-
-export const TOOL_USE_PERSISTENCE_DEFAULT_TTL_HOURS =
-  DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS;

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -284,4 +284,25 @@ export class ToolUseSessionManager {
   ): ToolState {
     return hydrateToolState(snapshot.toolState);
   }
+  
+  /**
+   * Deletes all persisted tool-use session snapshots
+   * @returns Promise that resolves when all snapshots are deleted
+   */
+  public static async deleteAllSnapshots(): Promise<void> {
+    if (!this.isPersistenceEnabled()) {
+      return;
+    }
+    
+    try {
+      const snapshots = await this.listSnapshots();
+      await Promise.all(
+        snapshots.map((snapshot) => this.deleteSnapshot(snapshot.executionId)),
+      );
+    } catch (error) {
+      logger.warn(
+        `Failed to delete all snapshots: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
 }

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -284,7 +284,7 @@ export class ToolUseSessionManager {
   ): ToolState {
     return hydrateToolState(snapshot.toolState);
   }
-  
+
   /**
    * Deletes all persisted tool-use session snapshots
    * @returns Promise that resolves when all snapshots are deleted
@@ -293,7 +293,7 @@ export class ToolUseSessionManager {
     if (!this.isPersistenceEnabled()) {
       return;
     }
-    
+
     try {
       const snapshots = await this.listSnapshots();
       await Promise.all(

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -1,0 +1,263 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import { z } from 'zod';
+import * as vscode from 'vscode';
+
+// Local imports - agent
+import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import { ToolState } from '@agent/core/ToolState';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type {
+  ExecutionId,
+  StreamTabId,
+} from '@agent/types/IdentifierTypes';
+
+// Local imports - logging
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - utilities
+import { StorageFS } from '@utils/files';
+import {
+  DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS,
+  getToolUsePersistenceEnabled,
+  getToolUsePersistenceTtlHours,
+} from '@utils/config';
+
+const CHANNEL = 'ToolUseSessionManager';
+const logger = new AgentLogger(CHANNEL);
+
+const STORAGE_DIR = 'toolUseSessions';
+const SNAPSHOT_VERSION = 1;
+
+const ToolStateSnapshotSchema = z.object({
+  texcountStats: z.string().nullable(),
+  lastResponse: z.string(),
+  accumulatedOutput: z.string(),
+  mediaFiles: z.array(z.string()),
+  thinkingBlocks: z.array(z.unknown()),
+  thinkingAdded: z.boolean(),
+});
+
+const ToolUseSessionSnapshotSchema = z
+  .object({
+    version: z.literal(SNAPSHOT_VERSION),
+    executionId: z.string(),
+    streamId: z.string(),
+    agentName: z.string(),
+    model: z.string(),
+    agentSessionKind: z.nativeEnum(AgentSessionKind),
+    messages: z.array(z.unknown()),
+    toolState: ToolStateSnapshotSchema,
+    lastUpdated: z.number(),
+  })
+  .strict();
+
+export type ToolUseSessionSnapshot = z.infer<
+  typeof ToolUseSessionSnapshotSchema
+>;
+
+interface SavePayload {
+  executionId: ExecutionId;
+  streamId: StreamTabId;
+  agentName: string;
+  model: string;
+  agentSessionKind: AgentSessionKind;
+  messages: ProviderMessage[];
+  toolState: ToolState;
+}
+
+function isValidExecutionId(id: ExecutionId | undefined): id is ExecutionId {
+  if (!id) return false;
+  const invalidPatterns = ['..', '/', '\\', '\0'];
+  return !invalidPatterns.some((pattern) => id.includes(pattern));
+}
+
+function serializeMessages(messages: ProviderMessage[]): unknown[] {
+  try {
+    return JSON.parse(JSON.stringify(messages));
+  } catch (error) {
+    logger.warn(
+      `Failed to serialize provider messages: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return [];
+  }
+}
+
+function serializeToolState(state: ToolState) {
+  return {
+    texcountStats: state.texcountStats,
+    lastResponse: state.lastResponse,
+    accumulatedOutput: state.accumulatedOutput,
+    mediaFiles: [...state.mediaFiles],
+    thinkingBlocks: [...state.thinkingBlocks],
+    thinkingAdded: state.thinkingAdded,
+  };
+}
+
+function hydrateToolState(snapshot: ToolUseSessionSnapshot['toolState']): ToolState {
+  const state = new ToolState();
+  state.texcountStats = snapshot.texcountStats;
+  state.lastResponse = snapshot.lastResponse;
+  state.accumulatedOutput = snapshot.accumulatedOutput;
+  state.mediaFiles = [...snapshot.mediaFiles];
+  state.thinkingBlocks = [...snapshot.thinkingBlocks];
+  state.thinkingAdded = snapshot.thinkingAdded;
+  return state;
+}
+
+async function ensureStorageDir(): Promise<boolean> {
+  try {
+    await StorageFS.ensureDir(STORAGE_DIR);
+    return true;
+  } catch (error) {
+    logger.warn(
+      `Unable to ensure tool-use session directory: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}
+
+async function cleanupExpiredSnapshots(): Promise<void> {
+  const hours = getToolUsePersistenceTtlHours();
+  const ttlMs = Math.max(hours, 1) * 60 * 60 * 1000;
+  try {
+    await StorageFS.cleanupOldFiles(STORAGE_DIR, ttlMs);
+  } catch (error) {
+    logger.debug(
+      `Failed to run tool-use snapshot cleanup: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function getSnapshotPath(executionId: ExecutionId): string {
+  return path.join(STORAGE_DIR, `${executionId}.json`);
+}
+
+export class ToolUseSessionManager {
+  public static isPersistenceEnabled(): boolean {
+    return getToolUsePersistenceEnabled();
+  }
+
+  public static async saveSnapshot(payload: SavePayload): Promise<void> {
+    if (!this.isPersistenceEnabled()) {
+      return;
+    }
+    if (!isValidExecutionId(payload.executionId)) {
+      logger.warn(
+        `Skipping snapshot save due to invalid execution id: ${payload.executionId}`,
+      );
+      return;
+    }
+    if (!(await ensureStorageDir())) {
+      return;
+    }
+
+    const snapshot: ToolUseSessionSnapshot = {
+      version: SNAPSHOT_VERSION,
+      executionId: payload.executionId,
+      streamId: payload.streamId,
+      agentName: payload.agentName,
+      model: payload.model,
+      agentSessionKind: payload.agentSessionKind,
+      messages: serializeMessages(payload.messages),
+      toolState: serializeToolState(payload.toolState),
+      lastUpdated: Date.now(),
+    };
+
+    const json = JSON.stringify(snapshot, null, 2);
+    try {
+      await StorageFS.write(getSnapshotPath(payload.executionId), json);
+    } catch (error) {
+      logger.warn(
+        `Failed to write tool-use session snapshot: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  public static async loadSnapshot(
+    executionId: ExecutionId,
+  ): Promise<ToolUseSessionSnapshot | null> {
+    if (!this.isPersistenceEnabled() || !isValidExecutionId(executionId)) {
+      return null;
+    }
+
+    try {
+      const raw = await StorageFS.read(getSnapshotPath(executionId));
+      const parsed = JSON.parse(raw);
+      return ToolUseSessionSnapshotSchema.parse(parsed);
+    } catch (error) {
+      if (error instanceof vscode.FileSystemError) {
+        if (error.code === 'FileNotFound') {
+          return null;
+        }
+      }
+      logger.warn(
+        `Failed to load tool-use session snapshot: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
+  }
+
+  public static async deleteSnapshot(executionId: ExecutionId | undefined): Promise<void> {
+    if (!executionId || !isValidExecutionId(executionId)) {
+      return;
+    }
+    try {
+      await StorageFS.delete(getSnapshotPath(executionId));
+    } catch (error) {
+      if (error instanceof vscode.FileSystemError) {
+        if (error.code === 'FileNotFound') {
+          return;
+        }
+      }
+      logger.debug(
+        `Unable to delete snapshot ${executionId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  public static async listSnapshots(): Promise<ToolUseSessionSnapshot[]> {
+    if (!this.isPersistenceEnabled()) {
+      return [];
+    }
+    if (!(await ensureStorageDir())) {
+      return [];
+    }
+    await cleanupExpiredSnapshots();
+
+    try {
+      const entries = await StorageFS.readDir(STORAGE_DIR);
+      const snapshots: ToolUseSessionSnapshot[] = [];
+      for (const [name, type] of entries) {
+        if (!name.endsWith('.json') || type !== vscode.FileType.File) {
+          continue;
+        }
+        const executionId = name.replace(/\.json$/, '');
+        if (!isValidExecutionId(executionId as ExecutionId)) {
+          continue;
+        }
+        const snapshot = await this.loadSnapshot(executionId as ExecutionId);
+        if (snapshot) {
+          snapshots.push(snapshot);
+        }
+      }
+      return snapshots;
+    } catch (error) {
+      logger.warn(
+        `Failed to enumerate tool-use session snapshots: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return [];
+    }
+  }
+
+  public static hydrateToolStateFromSnapshot(
+    snapshot: ToolUseSessionSnapshot,
+  ): ToolState {
+    return hydrateToolState(snapshot.toolState);
+  }
+}
+
+export const TOOL_USE_PERSISTENCE_DEFAULT_TTL_HOURS =
+  DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,6 +20,7 @@ import { registerAgentCreatorCommands } from '@commands/agent/agentCreatorComman
 import { registerApiKeyCommands } from '@commands/api/apiKeyCommands';
 import { registerStateRestoreCommand } from '@commands/history/stateRestoreCommand';
 import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
+import { registerResumeAgentCommand } from '@commands/agent/resumeCommand';
 import { registerTextEditorCommands } from '@commands/system/textEditorCommands';
 import { registerLinterCommands } from '@commands/latex/linterCommands';
 import { registerWolframScriptCommands } from '@commands/wolfram/wolframScriptCommands';
@@ -72,6 +73,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     compare: registerCompareCommands(context),
     progressView: registerProgressViewCommands(context),
     followUp: registerFollowUpCommand(context),
+    resumeAgent: registerResumeAgentCommand(context),
     openFile: registerOpenFileCommands(context),
     help: registerHelpCommands(context),
     mainView: registerMainViewCommands(context),

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -1,0 +1,131 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import {
+  AgentSessionKind,
+  AgentSetting,
+  AgentPrompt,
+  AgentType,
+} from '@agent/core/AgentDataclass';
+import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
+import { ModelFactory } from '@agent/runtime/ModelFactory';
+import {
+  executeAgentWithLogging,
+  getAgentPath,
+} from '@agent/runtime/executeAgent';
+import {
+  ToolUseSessionManager,
+  type ToolUseSessionSnapshot,
+} from '@agent/toolUse/ToolUseSessionManager';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
+
+function isToolUseAgent(setting: AgentSetting): boolean {
+  return setting.agentType === AgentType.ToolUse;
+}
+
+async function buildToolUseAgent(
+  snapshot: ToolUseSessionSnapshot,
+  context: vscode.ExtensionContext,
+): Promise<{ agent: BaseToolUseAgent; agentSetting: AgentSetting }> {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    throw new Error('Progress view provider is not initialized.');
+  }
+
+  const taskState = provider.state.getTaskState(snapshot.streamId);
+  if (!taskState) {
+    throw new Error('No saved task state found for stream.');
+  }
+
+  if (
+    (taskState.agentSessionKind ?? AgentSessionKind.Workflow) !==
+    AgentSessionKind.ToolUse
+  ) {
+    throw new Error('Saved task state is not a tool-use session.');
+  }
+
+  const fullConfig = AgentConfigSchema.parse(taskState.agentConfig);
+  const modelName = fullConfig.model;
+  if (!(modelName in MODEL_CONFIGS)) {
+    throw new Error(`Model ${modelName} not found in MODEL_CONFIGS`);
+  }
+
+  const modelHandler = ModelFactory.createHandler(MODEL_CONFIGS[modelName]);
+  const agentPath = await getAgentPath(fullConfig.agent, context);
+  const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
+    agentPath,
+    fullConfig.agent,
+  );
+
+  if (!isToolUseAgent(agentSetting)) {
+    throw new Error('Attempted to resume a non tool-use agent.');
+  }
+
+  const agent = new BaseToolUseAgent(
+    modelHandler,
+    fullConfig,
+    agentSetting,
+    agentPrompt as AgentPrompt,
+    agentPath,
+    snapshot.executionId as ExecutionId,
+  );
+
+  agent.resumeFromSnapshot(snapshot);
+  return { agent, agentSetting };
+}
+
+export function registerResumeAgentCommand(
+  context: vscode.ExtensionContext,
+): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'texra.resumeAgent',
+    async (snapshot: ToolUseSessionSnapshot | undefined) => {
+      if (!snapshot || !ToolUseSessionManager.isPersistenceEnabled()) {
+        return;
+      }
+
+      try {
+        const provider = ProgressViewProvider.getInstance();
+        if (!provider) {
+          return;
+        }
+
+        const executionId = snapshot.executionId as ExecutionId;
+        const existingStatus = provider.eventHandler.getStreamStatus(
+          snapshot.streamId,
+        );
+        if (existingStatus === 'running') {
+          return;
+        }
+
+        const { agent, agentSetting } = await buildToolUseAgent(
+          snapshot,
+          context,
+        );
+
+        await executeAgentWithLogging(
+          snapshot.agentName,
+          async () => ({
+            agent,
+            agentType: agentSetting.agentType,
+          }),
+          context,
+          executionId,
+          { resume: true },
+        );
+      } catch (error) {
+        await ToolUseSessionManager.deleteSnapshot(snapshot.executionId);
+        const message =
+          error instanceof Error ? error.message : String(error ?? 'unknown');
+        vscode.window.showWarningMessage(
+          `Failed to resume tool-use session: ${message}`,
+        );
+      }
+    },
+  );
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,17 +152,14 @@ export async function activate(context: vscode.ExtensionContext) {
   refreshApiKeyStatus().catch(console.error);
 
   const runningStreams = new Set<string>();
+  const NON_RUNNING_STATUSES = ['stopped', 'error', 'cancelled', 'waiting'];
+  
   disposeStatusListener = bus.on(
     'updateStreamStatus',
     ({ stream, status }: { stream: string; status: string }) => {
       if (status === 'running') {
         runningStreams.add(stream);
-      } else if (
-        status === 'stopped' ||
-        status === 'error' ||
-        status === 'cancelled' ||
-        status === 'waiting'
-      ) {
+      } else if (NON_RUNNING_STATUSES.includes(status)) {
         runningStreams.delete(stream);
       }
       statusBarItem!.text =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,18 +120,18 @@ export async function activate(context: vscode.ExtensionContext) {
   registerCommands(context);
 
   if (persistedToolUseSessions.length > 0) {
-    const resumeOperations = persistedToolUseSessions.map((snapshot) =>
-      Promise.resolve(
-        vscode.commands.executeCommand('texra.resumeAgent', snapshot),
-      ).catch((error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
-        logger.error(
-          'extension',
-          `Failed to resume tool-use session ${snapshot.executionId}: ${message}`,
-        );
-      }),
-    );
-    void Promise.allSettled(resumeOperations);
+    for (const snapshot of persistedToolUseSessions) {
+      void vscode.commands
+        .executeCommand('texra.resumeAgent', snapshot)
+        .catch((error: unknown) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          logger.error(
+            'extension',
+            `Failed to resume tool-use session ${snapshot.executionId}: ${message}`,
+          );
+        });
+    }
   }
 
   // Create a status bar item to show TeXRA progress

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,8 +234,12 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 }
 
-export function deactivate() {
+export async function deactivate() {
   disposeStatusListener?.();
+  
+  // Clean up persisted tool-use sessions when extension deactivates
+  await ToolUseSessionManager.deleteAllSnapshots();
+  
   // Get the ProgressViewProvider instance
   const progressViewProvider = ProgressViewProvider.getInstance();
   if (progressViewProvider) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { initializeStateManagers } from '@common/state/stateManager';
 import { FileLister } from '@frontend/files/fileLister';
 import { bus } from '@eventBus/ProgressEventBus';
+import { ToolUseSessionManager } from '@agent/toolUse/ToolUseSessionManager';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -99,11 +100,19 @@ export async function activate(context: vscode.ExtensionContext) {
   const progressViewProvider = new ProgressViewProvider(context);
   await progressViewProvider.initialize();
 
+  const persistedToolUseSessions =
+    ToolUseSessionManager.isPersistenceEnabled()
+      ? await ToolUseSessionManager.listSnapshots()
+      : [];
+  const waitingStreams = new Set(
+    persistedToolUseSessions.map((snapshot) => snapshot.streamId),
+  );
+
   // Log activation message to ensure the logger is working correctly
   logger.info('extension', 'TeXRA extension activated');
 
   // Clean up any tasks that were left in "running" state from previous session
-  progressViewProvider.cleanupTasksAfterRestart();
+  await progressViewProvider.cleanupTasksAfterRestart(waitingStreams);
 
   // Copy default agents
   await copyDefaultAgents(context);
@@ -113,6 +122,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register commands first - this will create and store the MainViewProvider
   registerCommands(context);
+
+  if (persistedToolUseSessions.length > 0) {
+    for (const snapshot of persistedToolUseSessions) {
+      await vscode.commands.executeCommand('texra.resumeAgent', snapshot);
+    }
+  }
 
   // Create a status bar item to show TeXRA progress
   statusBarItem = vscode.window.createStatusBarItem(
@@ -138,7 +153,8 @@ export async function activate(context: vscode.ExtensionContext) {
       } else if (
         status === 'stopped' ||
         status === 'error' ||
-        status === 'cancelled'
+        status === 'cancelled' ||
+        status === 'waiting'
       ) {
         runningStreams.delete(stream);
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,19 @@ let statusBarItem: vscode.StatusBarItem | undefined;
 let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
 
+function promptToOpenFolder(message: string): void {
+  const openAction = 'Open Folder';
+  void vscode.window
+    .showInformationMessage(message, openAction)
+    .then((choice) => {
+      if (choice === openAction) {
+        void vscode.commands.executeCommand(
+          'workbench.action.files.openFolder',
+        );
+      }
+    });
+}
+
 async function refreshApiKeyStatus() {
   if (!apiKeyStatusBarItem) {
     return;
@@ -57,30 +70,14 @@ async function refreshApiKeyStatus() {
 export async function activate(context: vscode.ExtensionContext) {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (!workspaceFolders || workspaceFolders.length === 0) {
-    const openAction = 'Open Folder';
-    vscode.window
-      .showInformationMessage(
-        'TeXRA requires an open workspace. Please open a folder to enable the extension.',
-        openAction,
-      )
-      .then((choice) => {
-        if (choice === openAction) {
-          vscode.commands.executeCommand('workbench.action.files.openFolder');
-        }
-      });
+    promptToOpenFolder(
+      'TeXRA requires an open workspace. Please open a folder to enable the extension.',
+    );
     return; // Exit before further initialization
   } else if (workspaceFolders.length > 1) {
-    const openAction = 'Open Folder';
-    vscode.window
-      .showInformationMessage(
-        'TeXRA supports only a single-folder workspace. Please open one folder to enable the extension.',
-        openAction,
-      )
-      .then((choice) => {
-        if (choice === openAction) {
-          vscode.commands.executeCommand('workbench.action.files.openFolder');
-        }
-      });
+    promptToOpenFolder(
+      'TeXRA supports only a single-folder workspace. Please open one folder to enable the extension.',
+    );
     return;
   }
   const workspaceRoot = workspaceFolders[0].uri.fsPath;
@@ -124,9 +121,19 @@ export async function activate(context: vscode.ExtensionContext) {
   registerCommands(context);
 
   if (persistedToolUseSessions.length > 0) {
-    for (const snapshot of persistedToolUseSessions) {
-      await vscode.commands.executeCommand('texra.resumeAgent', snapshot);
-    }
+    const resumeOperations = persistedToolUseSessions.map((snapshot) =>
+      vscode.commands
+        .executeCommand('texra.resumeAgent', snapshot)
+        .catch((error) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          logger.error(
+            'extension',
+            `Failed to resume tool-use session ${snapshot.executionId}: ${message}`,
+          );
+        }),
+    );
+    void Promise.allSettled(resumeOperations);
   }
 
   // Create a status bar item to show TeXRA progress

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,16 +121,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
   if (persistedToolUseSessions.length > 0) {
     for (const snapshot of persistedToolUseSessions) {
-      void vscode.commands
-        .executeCommand('texra.resumeAgent', snapshot)
-        .catch((error: unknown) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          logger.error(
-            'extension',
-            `Failed to resume tool-use session ${snapshot.executionId}: ${message}`,
-          );
-        });
+      void Promise.resolve(
+        vscode.commands.executeCommand('texra.resumeAgent', snapshot),
+      ).catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(
+          'extension',
+          `Failed to resume tool-use session ${snapshot.executionId}: ${message}`,
+        );
+      });
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,10 +236,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
   disposeStatusListener?.();
-  
+
   // Clean up persisted tool-use sessions when extension deactivates
   await ToolUseSessionManager.deleteAllSnapshots();
-  
+
   // Get the ProgressViewProvider instance
   const progressViewProvider = ProgressViewProvider.getInstance();
   if (progressViewProvider) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,10 +97,9 @@ export async function activate(context: vscode.ExtensionContext) {
   const progressViewProvider = new ProgressViewProvider(context);
   await progressViewProvider.initialize();
 
-  const persistedToolUseSessions =
-    ToolUseSessionManager.isPersistenceEnabled()
-      ? await ToolUseSessionManager.listSnapshots()
-      : [];
+  const persistedToolUseSessions = ToolUseSessionManager.isPersistenceEnabled()
+    ? await ToolUseSessionManager.listSnapshots()
+    : [];
   const waitingStreams = new Set(
     persistedToolUseSessions.map((snapshot) => snapshot.streamId),
   );
@@ -122,16 +121,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
   if (persistedToolUseSessions.length > 0) {
     const resumeOperations = persistedToolUseSessions.map((snapshot) =>
-      vscode.commands
-        .executeCommand('texra.resumeAgent', snapshot)
-        .catch((error) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          logger.error(
-            'extension',
-            `Failed to resume tool-use session ${snapshot.executionId}: ${message}`,
-          );
-        }),
+      Promise.resolve(
+        vscode.commands.executeCommand('texra.resumeAgent', snapshot),
+      ).catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(
+          'extension',
+          `Failed to resume tool-use session ${snapshot.executionId}: ${message}`,
+        );
+      }),
     );
     void Promise.allSettled(resumeOperations);
   }
@@ -153,7 +151,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const runningStreams = new Set<string>();
   const NON_RUNNING_STATUSES = ['stopped', 'error', 'cancelled', 'waiting'];
-  
+
   disposeStatusListener = bus.on(
     'updateStreamStatus',
     ({ stream, status }: { stream: string; status: string }) => {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -26,7 +26,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   constructor(private readonly provider: ProgressViewProvider) {
     super('ProgressView');
   }
-  
+
   private async deleteSessionSnapshot(stream: StreamTabId): Promise<void> {
     const executionId = this.provider.state.getExecutionId(stream);
     if (executionId) {
@@ -135,7 +135,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     for (const [stream] of allStates) {
       await this.deleteSessionSnapshot(stream);
     }
-    
+
     this.provider.state.clearAll();
     this.provider.updateWebview();
   }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -17,6 +17,7 @@ import {
   deriveAgentSessionKind,
 } from '@agent/core/AgentDataclass';
 import type { TaskState } from '@logger/TaskState';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -24,6 +25,16 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   constructor(private readonly provider: ProgressViewProvider) {
     super('ProgressView');
+  }
+  
+  private async deleteSessionSnapshot(stream: StreamTabId): Promise<void> {
+    const executionId = this.provider.state.getExecutionId(stream);
+    if (executionId) {
+      const { ToolUseSessionManager } = await import(
+        '@agent/toolUse/ToolUseSessionManager'
+      );
+      await ToolUseSessionManager.deleteSnapshot(executionId);
+    }
   }
 
   protected createHandlers(): Record<
@@ -99,6 +110,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    // Delete persisted session data if any
+    await this.deleteSessionSnapshot(message.stream);
     this.provider.state.clearStream(message.stream);
     this.provider.updateWebview();
   }
@@ -107,6 +120,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    // Delete persisted session data when erasing stream
+    await this.deleteSessionSnapshot(message.stream);
     this.provider.state.eraseStreamContent(message.stream);
     this.provider.updateWebview();
   }
@@ -115,6 +130,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    // Delete all persisted session data
+    const allStates = this.provider.state.getAllTaskStates();
+    for (const [stream] of allStates) {
+      await this.deleteSessionSnapshot(stream);
+    }
+    
     this.provider.state.clearAll();
     this.provider.updateWebview();
   }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -266,9 +266,8 @@ export class ProgressViewProvider
     waitingStreams?: Set<string>,
   ): Promise<void> {
     // Get affected streams and set their status to ERROR
-    const affectedStreams = this.eventHandler.resetRunningTasksToError(
-      waitingStreams,
-    );
+    const affectedStreams =
+      this.eventHandler.resetRunningTasksToError(waitingStreams);
 
     // Also check ALL streams for running groups, not just affected streams
     // This ensures we catch any groups that might be running even if stream status is not

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -30,7 +30,8 @@ import { TaskState } from '@logger/TaskState';
 type StreamStatusType =
   | typeof STATUS.RUNNING
   | typeof STATUS.ERROR
-  | typeof STATUS.STOPPED;
+  | typeof STATUS.STOPPED
+  | typeof STATUS.WAITING;
 
 /**
  * Refactored ProgressViewProvider using the new modular architecture.
@@ -242,9 +243,11 @@ export class ProgressViewProvider
   /**
    * Cleanup tasks after restart (legacy compatibility)
    */
-  public cleanupTasksAfterRestart(): void {
+  public async cleanupTasksAfterRestart(
+    waitingStreams?: Set<string>,
+  ): Promise<void> {
     // Use the same logic as webview reload to mark all running tasks/groups as ERROR
-    this.resetRunningStreamStatuses();
+    await this.resetRunningStreamStatuses(waitingStreams);
     this.updateWebview();
   }
 
@@ -259,9 +262,13 @@ export class ProgressViewProvider
    * Reset running stream statuses when webview reloads
    * Sets all running streams and their groups to ERROR status
    */
-  private resetRunningStreamStatuses(): void {
+  private async resetRunningStreamStatuses(
+    waitingStreams?: Set<string>,
+  ): Promise<void> {
     // Get affected streams and set their status to ERROR
-    const affectedStreams = this.eventHandler.resetRunningTasksToError();
+    const affectedStreams = this.eventHandler.resetRunningTasksToError(
+      waitingStreams,
+    );
 
     // Also check ALL streams for running groups, not just affected streams
     // This ensures we catch any groups that might be running even if stream status is not

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -380,6 +380,8 @@ export class ProgressEventHandler {
       parseLegacyLogData(existing, this.logger, true);
     }
 
+    this.state.streamTabs.save();
+
     if (
       this.webviewUpdater.isAvailable() &&
       stream === this.state.activeStream

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -28,11 +28,13 @@ type StatusType =
   | typeof STATUS.RUNNING
   | typeof STATUS.ERROR
   | typeof STATUS.STOPPED
-  | typeof STATUS.READY;
+  | typeof STATUS.READY
+  | typeof STATUS.WAITING;
 type StreamStatusType =
   | typeof STATUS.RUNNING
   | typeof STATUS.ERROR
-  | typeof STATUS.STOPPED;
+  | typeof STATUS.STOPPED
+  | typeof STATUS.WAITING;
 type StreamStatusOrReadyType = StreamStatusType | typeof STATUS.READY;
 
 /**
@@ -520,16 +522,24 @@ export class ProgressEventHandler {
    * Reset running tasks to ERROR status (used during webview reload)
    * Returns the list of affected streams for further processing
    */
-  resetRunningTasksToError(): string[] {
+  resetRunningTasksToError(waitingStreams?: Set<string>): string[] {
     const affectedStreams: string[] = [];
+    const waitingSet = waitingStreams ?? new Set<string>();
 
     for (const [stream, status] of this._streamStatus.entries()) {
       if (status === STATUS.RUNNING) {
-        this._streamStatus.set(stream, STATUS.ERROR);
-        affectedStreams.push(stream);
-        this.logger.debug(
-          `Stream ${stream} set to ERROR due to webview reload`,
-        );
+        if (waitingSet.has(stream)) {
+          this._streamStatus.set(stream, STATUS.WAITING);
+          this.logger.debug(
+            `Stream ${stream} restored to WAITING after reload`,
+          );
+        } else {
+          this._streamStatus.set(stream, STATUS.ERROR);
+          affectedStreams.push(stream);
+          this.logger.debug(
+            `Stream ${stream} set to ERROR due to webview reload`,
+          );
+        }
       }
     }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -20,7 +20,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 
 // Type aliases for status values
-type StatusType = 'running' | 'error' | 'stopped' | 'ready';
+type StatusType = 'running' | 'error' | 'stopped' | 'ready' | 'waiting';
 
 /**
  * Manages webview updates for the progress view.

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -53,7 +53,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Use standardized commands directly (OPEN_LABEL is already included)
 export const COMMANDS = PROGRESS_VIEW_COMMANDS;
 
-export const TOOLBAR_BUTTONS = [
+const WORKFLOW_TOOLBAR = [
   {
     id: ELEMENT_IDS.STOP_STREAM_BTN,
     icon: 'debug-stop',
@@ -112,6 +112,46 @@ export const TOOLBAR_BUTTONS = [
     disabled: false,
   },
 ];
+
+const TOOL_USE_TOOLBAR = [
+  {
+    id: ELEMENT_IDS.STOP_STREAM_BTN,
+    icon: 'debug-stop',
+    command: COMMANDS.STOP_STREAM,
+    title:
+      'Request task interruption (current API call will be aborted if supported)',
+    className: 'vscode-button stop-button',
+    disabled: true,
+  },
+  {
+    id: ELEMENT_IDS.RESTORE_STATE_BTN,
+    icon: 'reply',
+    command: COMMANDS.RESTORE_STATE,
+    title: 'Restore this configuration to the main view',
+    className: 'vscode-button restore-button',
+    disabled: true,
+  },
+  {
+    id: ELEMENT_IDS.ERASE_STREAM_BTN,
+    icon: 'clear-all',
+    command: COMMANDS.ERASE_STREAM,
+    title: 'Erase the stream output for this agent',
+    className: 'vscode-button clear-button',
+    disabled: false,
+  },
+];
+
+export const TOOLBAR_BUTTONS = {
+  workflow: WORKFLOW_TOOLBAR,
+  toolUse: TOOL_USE_TOOLBAR,
+};
+
+export const ALL_TOOLBAR_BUTTON_IDS = Array.from(
+  new Set([
+    ...WORKFLOW_TOOLBAR.map((btn) => btn.id),
+    ...TOOL_USE_TOOLBAR.map((btn) => btn.id),
+  ]),
+);
 
 export const SORT_BUTTONS = [
   {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -270,7 +270,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleDeleteAll() {
     state.toggleStates.clearAll();
   }
-
 }
 
 export const messageHandler = new ProgressViewMessageHandler();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -7,13 +7,6 @@ import { appendFormatted } from './utils.js';
 import { progressViewState } from './progressViewState.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
 
-const TOOLBAR_ACTION_BUTTON_IDS = [
-  ELEMENT_IDS.RUN_AGAIN_BTN,
-  ELEMENT_IDS.DIFF_STREAM_BTN,
-  ELEMENT_IDS.PACK_STREAM_BTN,
-  ELEMENT_IDS.CLEAN_STREAM_BTN,
-];
-
 // Session kind values match TypeScript AgentSessionKind enum
 // No need to duplicate - we use the actual values from messages
 
@@ -27,9 +20,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
     super();
     this._entryFormatter = new LogEntryFormatter();
-    this._toolbarButtonCache = null;
-    this._toolbarMutationObserver = null;
-    this._toolbarObserverTarget = null;
     this._handlers = {
       ...createThemeHandlers(),
       ...this._createHandlers(),
@@ -108,47 +98,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       container.setAttribute('aria-hidden', isToolAgent ? 'false' : 'true');
     }
 
-    const toolbarButtons = this._getToolbarButtons();
-
-    const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
-    if (toolbar) {
-      toolbar.dataset.agentType = activeStreamInfo?.agentType || '';
-      toolbar.dataset.agentMode = sessionKind;
-    }
-
-    toolbarButtons.forEach((button) => {
-      const shouldHide = isToolAgent;
-      const wasHidden = button.dataset.hiddenByAgent === 'true';
-      if (shouldHide === wasHidden) {
-        return;
-      }
-
-      button.classList.toggle('toolbar-button--hidden', shouldHide);
-
-      if (shouldHide) {
-        button.setAttribute('aria-hidden', 'true');
-        button.setAttribute('tabindex', '-1');
-        button.dataset.hiddenByAgent = 'true';
-        if (button.dataset.disabledBeforeAgentHide === undefined) {
-          button.dataset.disabledBeforeAgentHide = button.disabled
-            ? 'true'
-            : 'false';
-        }
-        if ('disabled' in button) {
-          button.disabled = true;
-        }
-        return;
-      }
-
-      button.removeAttribute('aria-hidden');
-      button.removeAttribute('tabindex');
-      const previousDisabledState = button.dataset.disabledBeforeAgentHide;
-      if ('disabled' in button && previousDisabledState !== undefined) {
-        button.disabled = previousDisabledState === 'true';
-      }
-      delete button.dataset.hiddenByAgent;
-      delete button.dataset.disabledBeforeAgentHide;
-    });
+    dom.toolbar.render(sessionKind);
 
     // Update status based on whether there's an active stream
     if (!message.activeStream) {
@@ -321,69 +271,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.toggleStates.clearAll();
   }
 
-  _getToolbarButtons() {
-    const ensureCache = () => {
-      try {
-        return TOOLBAR_ACTION_BUTTON_IDS.map((buttonId) =>
-          document.getElementById(buttonId),
-        ).filter((button) => button instanceof HTMLElement);
-      } catch (error) {
-        console.warn('Failed to cache toolbar buttons:', error);
-        return [];
-      }
-    };
-
-    const toolbar = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
-    if (!toolbar) {
-      if (this._toolbarMutationObserver) {
-        this._toolbarMutationObserver.disconnect();
-        this._toolbarMutationObserver = null;
-      }
-      this._toolbarObserverTarget = null;
-      this._toolbarButtonCache = null;
-    } else if (this._toolbarObserverTarget !== toolbar) {
-      if (this._toolbarMutationObserver) {
-        this._toolbarMutationObserver.disconnect();
-        this._toolbarMutationObserver = null;
-      }
-
-      if (typeof MutationObserver === 'function') {
-        this._toolbarMutationObserver = new MutationObserver(() => {
-          this._toolbarButtonCache = null;
-        });
-        this._toolbarMutationObserver.observe(toolbar, {
-          childList: true,
-          subtree: false,
-          attributes: false,
-        });
-      }
-
-      this._toolbarObserverTarget = toolbar;
-      this._toolbarButtonCache = null;
-    }
-
-    if (!this._toolbarButtonCache || this._toolbarButtonCache.length === 0) {
-      this._toolbarButtonCache = ensureCache();
-      return this._toolbarButtonCache;
-    }
-
-    const cacheIsStale = TOOLBAR_ACTION_BUTTON_IDS.some((id) => {
-      const cached = this._toolbarButtonCache?.find(
-        (button) => button.id === id,
-      );
-      if (!cached) {
-        return true;
-      }
-      const current = document.getElementById(id);
-      return !current || current !== cached;
-    });
-
-    if (cacheIsStale) {
-      this._toolbarButtonCache = ensureCache();
-    }
-
-    return this._toolbarButtonCache;
-  }
 }
 
 export const messageHandler = new ProgressViewMessageHandler();

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -79,9 +79,7 @@ export class Status {
 
     setElementsDisabled(buttons, true);
     // Always enable the erase button regardless of status
-    const eraseButton = document.getElementById(
-      ELEMENT_IDS.ERASE_STREAM_BTN,
-    );
+    const eraseButton = document.getElementById(ELEMENT_IDS.ERASE_STREAM_BTN);
     if (eraseButton) {
       setElementsDisabled([eraseButton], false);
     }

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -89,7 +89,7 @@ export class Status {
         return;
       }
 
-      statusIndicator.classList.remove('running', 'error', 'stopped', 'ready');
+      statusIndicator.classList.remove(STATUS.RUNNING, STATUS.ERROR, STATUS.STOPPED, STATUS.READY, STATUS.WAITING);
 
       const cfg = this.STATUS_MAP[status] || {
         className: 'stopped',

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -79,7 +79,12 @@ export class Status {
 
     setElementsDisabled(buttons, true);
     // Always enable the erase button regardless of status
-    setElementsDisabled(ELEMENT_IDS.ERASE_STREAM_BTN, false);
+    const eraseButton = document.getElementById(
+      ELEMENT_IDS.ERASE_STREAM_BTN,
+    );
+    if (eraseButton) {
+      setElementsDisabled([eraseButton], false);
+    }
 
     statusIndicator.className = 'status-indicator';
     statusIndicator.dataset.status = 'Ready';

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -1,5 +1,5 @@
 // Local imports - progress view
-import { STATUS, TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
+import { STATUS, ALL_TOOLBAR_BUTTON_IDS, ELEMENT_IDS } from '../constants.js';
 // Local imports
 import { progressViewState } from '../progressViewState.js';
 import { setElementsDisabled } from '@common/domUtils.js';
@@ -44,9 +44,18 @@ export class Status {
         label: 'Ready',
         enable: [ELEMENT_IDS.RESTORE_STATE_BTN, ELEMENT_IDS.ERASE_STREAM_BTN],
       },
+      [STATUS.WAITING]: {
+        className: 'waiting',
+        label: 'Waiting for follow-up',
+        enable: [
+          ELEMENT_IDS.STOP_STREAM_BTN,
+          ELEMENT_IDS.RESTORE_STATE_BTN,
+          ELEMENT_IDS.ERASE_STREAM_BTN,
+        ],
+      },
     };
 
-    this.BUTTON_IDS = TOOLBAR_BUTTONS.map((b) => b.id);
+    this.BUTTON_IDS = ALL_TOOLBAR_BUTTON_IDS;
     this._buttonElements = null; // Cache for button elements
   }
 

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -72,9 +72,10 @@ export class Status {
       return;
     }
 
-    const buttons = (this._buttonElements ||= this.BUTTON_IDS.map((id) =>
+    // Query buttons fresh each time to handle toolbar re-rendering
+    const buttons = this.BUTTON_IDS.map((id) =>
       document.getElementById(id),
-    ).filter(Boolean));
+    ).filter(Boolean);
 
     setElementsDisabled(buttons, true);
     // Always enable the erase button regardless of status
@@ -89,7 +90,13 @@ export class Status {
         return;
       }
 
-      statusIndicator.classList.remove(STATUS.RUNNING, STATUS.ERROR, STATUS.STOPPED, STATUS.READY, STATUS.WAITING);
+      statusIndicator.classList.remove(
+        STATUS.RUNNING,
+        STATUS.ERROR,
+        STATUS.STOPPED,
+        STATUS.READY,
+        STATUS.WAITING,
+      );
 
       const cfg = this.STATUS_MAP[status] || {
         className: 'stopped',

--- a/src/progressView/modules/uiManagers/Toolbar.js
+++ b/src/progressView/modules/uiManagers/Toolbar.js
@@ -7,14 +7,17 @@ import { createIconButton } from '@common/templateUtils.js';
  * Manages toolbar rendering.
  */
 export class Toolbar {
-  render() {
+  render(sessionKind = 'workflow') {
     const container = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
     if (!container) {
       console.error('Toolbar.render: toolbarContainer not found');
       return;
     }
     container.innerHTML = '';
-    TOOLBAR_BUTTONS.forEach((def) => {
+    const buttons =
+      TOOLBAR_BUTTONS[sessionKind] ?? TOOLBAR_BUTTONS.workflow;
+    container.dataset.agentMode = sessionKind;
+    buttons.forEach((def) => {
       try {
         const btn = createIconButton({
           id: def.id,

--- a/src/progressView/modules/uiManagers/Toolbar.js
+++ b/src/progressView/modules/uiManagers/Toolbar.js
@@ -14,8 +14,7 @@ export class Toolbar {
       return;
     }
     container.innerHTML = '';
-    const buttons =
-      TOOLBAR_BUTTONS[sessionKind] ?? TOOLBAR_BUTTONS.workflow;
+    const buttons = TOOLBAR_BUTTONS[sessionKind] ?? TOOLBAR_BUTTONS.workflow;
     container.dataset.agentMode = sessionKind;
     buttons.forEach((def) => {
       try {

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'groupHeaderTemplate',
   ]);
   initializeIconButtons();
-  progressViewDomHandler.toolbar.render();
+  progressViewDomHandler.toolbar.render('workflow');
   progressViewDomHandler.placeholder.show();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -1,3 +1,6 @@
+// Local imports - config utils
+import { getConfig } from './configUtils';
+
 // Common file type constants
 export const FILE_TYPES = [
   'input',
@@ -44,3 +47,24 @@ export const DIFF_REGISTRATION_DELAY_MS = 300;
 export const LATEX_VIEWER_OPEN_DELAY_MS = 5000;
 export const LATEX_VIEWER_REFRESH_DELAY_MS = 5000;
 export const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
+
+// Tool-use persistence defaults
+export const DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS = 72;
+
+/** Determine whether tool-use session persistence is enabled. */
+export function getToolUsePersistenceEnabled(): boolean {
+  return getConfig<boolean>('toolUse.persistence.enabled', true);
+}
+
+/** Resolve the configured TTL (in hours) for persisted tool-use sessions. */
+export function getToolUsePersistenceTtlHours(): number {
+  const value = getConfig<number>(
+    'toolUse.persistence.ttlHours',
+    DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS,
+  );
+  const hours = Number(value);
+  if (!Number.isFinite(hours) || hours < 1) {
+    return DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS;
+  }
+  return hours;
+}

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -64,6 +64,10 @@ export function getToolUsePersistenceTtlHours(): number {
   );
   const hours = Number(value);
   if (!Number.isFinite(hours) || hours < 1) {
+    // Log a warning when invalid configuration is detected
+    console.warn(
+      `Invalid tool-use persistence TTL value: ${value}. Using default of ${DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS} hours.`,
+    );
     return DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS;
   }
   return hours;


### PR DESCRIPTION
## Summary
- add a tool-use session manager to persist conversation snapshots and expose a resume command
- teach BaseToolUseAgent, the runtime, and extension startup to resume waiting sessions and emit a waiting status
- update progress view toolbar/status handling so tool-use agents show the correct controls and state

## Testing
- npm run lint
- npm test *(fails: VS Code runtime missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68caf13535ec8324b705c60dcdcd88e4