### PR TITLE
refactor: centralize round lifecycle pipeline

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -226,6 +226,92 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     return this.outputHandler.outputFiles[currRound] || [];
   }
 
+  private async runRoundPipeline(
+    currRound: number,
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    toolState: ToolState,
+    preparedMessages: any[],
+    prefill: string,
+    outputPath: string,
+    roundGroupId: string,
+  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
+    const [endTurn, updatedMessages] =
+      await this.modelHandler.initializeOutputAndPrefill(
+        this.agentConfig,
+        this.agentSetting,
+        preparedMessages,
+        toolState,
+        outputPath,
+        prefill,
+        roundGroupId,
+      );
+
+    if (!endTurn) {
+      const [
+        updatedStateRound,
+        updatedStateGlobal,
+        updatedToolState,
+        newEndTurn,
+      ] = await runResponseCycle(
+        {
+          modelHandler: this.modelHandler,
+          agentSetting: this.agentSetting,
+          agentConfig: this.agentConfig,
+          agentPrompt: this.agentPrompt,
+          userVars: this.userVars,
+          logger: this.logger,
+          client: this.client,
+          checkInterruption: () => this.checkInterruption(),
+          setAbortController: (ctrl) => {
+            this.abortController = ctrl;
+          },
+        },
+        updatedMessages,
+        stateRound,
+        stateGlobal,
+        toolState,
+        outputPath,
+        roundGroupId,
+        this.executionId,
+      );
+
+      await this.handleRoundCompletion(
+        currRound,
+        updatedStateRound,
+        updatedStateGlobal,
+        {
+          outputFile: outputPath,
+          endTurn: newEndTurn,
+          processGroupId: roundGroupId,
+        },
+      );
+
+      if (currRound === 0) {
+        this.logger.debug(
+          `stateGlobal: ${JSON.stringify(updatedStateGlobal)}`,
+          roundGroupId,
+        );
+      }
+
+      return [
+        updatedStateRound,
+        updatedStateGlobal,
+        updatedMessages,
+        newEndTurn,
+        updatedToolState,
+      ];
+    }
+
+    await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
+      outputFile: outputPath,
+      endTurn,
+      processGroupId: roundGroupId,
+    });
+
+    return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
+  }
+
   /**
    * Processes initial conversation round.
    * @returns Tuple of [round state, global state, messages, completion flag, tool state]
@@ -305,91 +391,17 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       const prefill = await promptBuilder.buildPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
-      // Initialize output and handle prefill
-      const [endTurn, updatedMessages] =
-        await this.modelHandler.initializeOutputAndPrefill(
-          this.agentConfig,
-          this.agentSetting,
-          messages,
-          toolState,
-          this.outputFile[currRound],
-          prefill,
-          roundGroupId,
-        );
-
       const stateRound = new AgentStateRound(currRound);
-      let finalEndTurn = endTurn;
-
-      if (!endTurn) {
-        const [
-          updatedStateRound,
-          updatedStateGlobal,
-          updatedToolState,
-          newEndTurn,
-        ] = await runResponseCycle(
-          {
-            modelHandler: this.modelHandler,
-            agentSetting: this.agentSetting,
-            agentConfig: this.agentConfig,
-            agentPrompt: this.agentPrompt,
-            userVars: this.userVars,
-            logger: this.logger,
-            client: this.client,
-            checkInterruption: () => this.checkInterruption(),
-            setAbortController: (ctrl) => {
-              this.abortController = ctrl;
-            },
-          },
-          updatedMessages,
-          stateRound,
-          stateGlobal,
-          toolState,
-          this.outputFile[currRound],
-          roundGroupId,
-          this.executionId,
-        );
-        finalEndTurn = newEndTurn;
-
-        // Handle output and logging
-        await this.handleRoundCompletion(
-          currRound,
-          updatedStateRound,
-          updatedStateGlobal,
-          {
-            outputFile: this.outputFile[currRound],
-            endTurn: finalEndTurn,
-            processGroupId: roundGroupId,
-          },
-        );
-
-        this.logger.debug(
-          `stateGlobal: ${JSON.stringify(updatedStateGlobal)}`,
-          roundGroupId,
-        );
-
-        return [
-          updatedStateRound,
-          updatedStateGlobal,
-          updatedMessages,
-          finalEndTurn,
-          updatedToolState,
-        ];
-      }
-
-      // Handle output and logging for early termination
-      await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
-        outputFile: this.outputFile[currRound],
-        endTurn: finalEndTurn,
-        processGroupId: roundGroupId,
-      });
-
-      return [
+      return this.runRoundPipeline(
+        currRound,
         stateRound,
         stateGlobal,
-        updatedMessages,
-        finalEndTurn,
         toolState,
-      ];
+        messages,
+        prefill,
+        this.outputFile[currRound],
+        roundGroupId,
+      );
     });
   }
 
@@ -452,75 +464,16 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       const prefill = await promptBuilder.buildPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
-      const [endTurn, updatedMessages] =
-        await this.modelHandler.initializeOutputAndPrefill(
-          this.agentConfig,
-          this.agentSetting,
-          roundMessages,
-          toolState,
-          this.outputFile[currRound],
-          prefill,
-          roundGroupId,
-        );
-
-      if (!endTurn) {
-        const [
-          updatedStateRound,
-          updatedStateGlobal,
-          updatedToolState,
-          newEndTurn,
-        ] = await runResponseCycle(
-          {
-            modelHandler: this.modelHandler,
-            agentSetting: this.agentSetting,
-            agentConfig: this.agentConfig,
-            agentPrompt: this.agentPrompt,
-            userVars: this.userVars,
-            logger: this.logger,
-            client: this.client,
-            checkInterruption: () => this.checkInterruption(),
-            setAbortController: (ctrl) => {
-              this.abortController = ctrl;
-            },
-          },
-          updatedMessages,
-          stateRound,
-          stateGlobal,
-          toolState,
-          this.outputFile[currRound],
-          roundGroupId,
-          this.executionId,
-        );
-
-        // Handle output and logging
-        await this.handleRoundCompletion(
-          currRound,
-          updatedStateRound,
-          updatedStateGlobal,
-          {
-            outputFile: this.outputFile[currRound],
-            endTurn: newEndTurn,
-            processGroupId: roundGroupId,
-          },
-        );
-
-        return [
-          updatedStateRound,
-          updatedStateGlobal,
-          updatedMessages,
-          newEndTurn,
-          updatedToolState,
-        ];
-      }
-
-      // Handle output and logging for early termination
-      await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
-        outputFile: this.outputFile[currRound],
-        endTurn,
-        processGroupId: roundGroupId,
-      });
-
-      return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
+      return this.runRoundPipeline(
+        currRound,
+        stateRound,
+        stateGlobal,
+        toolState,
+        roundMessages,
+        prefill,
+        this.outputFile[currRound],
+        roundGroupId,
+      );
     });
   }
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -226,6 +226,21 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     return this.outputHandler.outputFiles[currRound] || [];
   }
 
+  /**
+   * Executes the shared round lifecycle pipeline used by both processing and reflection flows.
+   * Handles output initialization, response generation, and round finalization to keep
+   * lifecycle responsibilities centralized.
+   *
+   * @param currRound - Zero-based index of the round being executed.
+   * @param stateRound - Mutable state scoped to the current round of execution.
+   * @param stateGlobal - Shared agent state that spans all rounds.
+   * @param toolState - Current tool invocation state passed between rounds.
+   * @param preparedMessages - Messages prepared for the model before execution.
+   * @param prefill - Initial text inserted into the model response buffer.
+   * @param outputPath - Filesystem path where model output for this round is stored.
+   * @param roundGroupId - Identifier for grouping related log and output operations.
+   * @returns Updated round/global state, messages, completion flag, and tool state after execution.
+   */
   private async runRoundPipeline(
     currRound: number,
     stateRound: AgentStateRound,


### PR DESCRIPTION
## Summary
- add a private `runRoundPipeline` helper to encapsulate the shared initialize/run/complete flow for a round
- update `process` and `reflect` to build their round-specific prompts before delegating to the helper, preserving logging and state updates

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cafda1b05c8324973c04b8798cd93b