### PR TITLE
Allow tool-use agents to run without input file

### DIFF
--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -26,7 +26,9 @@ export class ExecutionManager {
   constructor() {}
 
   async handleExecute(message: any): Promise<void> {
-    if (!message.inputFile) {
+    const isToolUseAgent = Boolean(message.isToolUseAgent);
+
+    if (!message.inputFile && !isToolUseAgent) {
       const openDocs = 'File Management Guide';
       const choice = await vscode.window.showErrorMessage(
         'Please select an input file.',

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -90,6 +90,14 @@ export class ActionButtonManager extends BaseUIManager {
       const agent = safeGetElementValue('agent');
       const model = safeGetElementValue('model');
       const instruction = safeGetElementValue(ELEMENT_IDS.INSTRUCTION);
+      const agentSelect = safeGetElementById('agent');
+      const selectedOption =
+        agentSelect &&
+        'options' in agentSelect &&
+        'selectedIndex' in agentSelect
+          ? agentSelect.options[agentSelect.selectedIndex]
+          : null;
+      const isToolUseAgent = selectedOption?.dataset?.toolUse === 'true';
       const singleFiles = this._getSingleFileData();
       const multipleFilesData = this._getMultipleFileData(singleFiles);
 
@@ -103,6 +111,7 @@ export class ActionButtonManager extends BaseUIManager {
         agent,
         model,
         instruction,
+        isToolUseAgent,
         ...singleFiles,
         ...multipleFilesData,
         ...checkboxValues,


### PR DESCRIPTION
## Summary
- detect tool-use agents in the main view so the execution message includes their type
- skip the input-file requirement in the execution manager when the selected agent uses tools

## Testing
- npm run format
- npm run lint
- CI=1 npm test *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.0/code: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2cc9891083248ac8686571aa0e5f