### PR TITLE
Fix Anthropic message sanitization for tool-use flows

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -262,10 +262,26 @@ export class ModelHandlerAnthropic extends ModelHandler<
     mediaFiles?: string[],
     systemPrompt?: string,
   ): Promise<MessageParam[]> {
+    const trimmedPrefix = userPrefix.trim();
+    const trimmedRequest = userRequest.trim();
+
+    if (!trimmedPrefix && !trimmedRequest) {
+      const errMsg =
+        'Anthropic messages require a non-empty user prefix or request.';
+      this.logger.error(errMsg);
+      throw new Error(errMsg);
+    }
+
     // Create content list for the user message
-    const userMessageContent: ContentBlock[] = [
-      { type: 'text', text: userPrefix, citations: null },
-    ];
+    const userMessageContent: ContentBlock[] = [];
+
+    if (trimmedPrefix) {
+      userMessageContent.push({
+        type: 'text',
+        text: trimmedPrefix,
+        citations: null,
+      });
+    }
 
     // Add media if provided (Anthropic currently only supports images)
     if (mediaFiles && this.config.capabilities.supportsVision) {
@@ -281,15 +297,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Add user request with optional caching
-    const requestBlock: ContentBlock = {
-      type: 'text',
-      text: userRequest,
-      citations: null,
-      ...(this.capabilities.supportsPromptCaching
-        ? { cache_control: { type: 'ephemeral' } }
-        : {}),
-    };
-    userMessageContent.push(requestBlock);
+    if (trimmedRequest) {
+      const requestBlock: ContentBlock = {
+        type: 'text',
+        text: trimmedRequest,
+        citations: null,
+        ...(this.capabilities.supportsPromptCaching
+          ? { cache_control: { type: 'ephemeral' } }
+          : {}),
+      };
+      userMessageContent.push(requestBlock);
+    }
 
     // Note: Anthropic handles system prompts differently via createResponse()
     const messages: MessageParam[] = [
@@ -350,15 +368,25 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Add message text with optional caching
-    const messageBlock: ContentBlock = {
-      type: 'text',
-      text: userMessage,
-      citations: null,
-      ...(this.capabilities.supportsPromptCaching
-        ? { cache_control: { type: 'ephemeral' } }
-        : {}),
-    };
-    roundContent.push(messageBlock);
+    const trimmedMessage = userMessage.trim();
+    if (trimmedMessage) {
+      const messageBlock: ContentBlock = {
+        type: 'text',
+        text: trimmedMessage,
+        citations: null,
+        ...(this.capabilities.supportsPromptCaching
+          ? { cache_control: { type: 'ephemeral' } }
+          : {}),
+      };
+      roundContent.push(messageBlock);
+    }
+
+    if (roundContent.length === 0) {
+      const errMsg =
+        'Anthropic follow-up messages require at least one non-empty content block.';
+      this.logger.error(errMsg);
+      throw new Error(errMsg);
+    }
 
     // We need to ensure we don't exceed Anthropic's limit of 4 cache_control blocks
     // Remove cache_control from ALL previous message contents
@@ -378,9 +406,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
     messages: MessageParam[],
     userMessage: string,
   ): Promise<MessageParam[]> {
+    const trimmedMessage = userMessage.trim();
+    if (!trimmedMessage) {
+      const errMsg =
+        'Anthropic follow-up messages require non-empty user text.';
+      this.logger.error(errMsg);
+      throw new Error(errMsg);
+    }
     messages.push({
       role: 'user',
-      content: [{ type: 'text', text: userMessage, citations: null }],
+      content: [{ type: 'text', text: trimmedMessage, citations: null }],
     });
     return messages;
   }

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1,0 +1,135 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import type { ContentBlock } from '@anthropic-ai/sdk/resources/messages';
+
+// Local imports - agent
+import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+
+// Local imports - model config
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelConfig,
+  ModelProvider,
+} from '@model/ModelConfig';
+
+function createAnthropicHandler(): ModelHandlerAnthropic {
+  const capabilities = {
+    ...DEFAULT_MODEL_CAPABILITIES,
+    supportsPromptCaching: true,
+  };
+
+  const config: ModelConfig = {
+    name: 'test-anthropic',
+    fullName: 'claude-test',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities,
+    openRouterOnly: false,
+  };
+
+  return new ModelHandlerAnthropic(config);
+}
+
+type TextBlock = Extract<ContentBlock, { type: 'text' }>;
+
+function assertSingleTextBlock(content: ContentBlock[]): TextBlock {
+  const textBlocks = content.filter(
+    (block): block is TextBlock => block.type === 'text',
+  );
+  assert.equal(
+    textBlocks.length,
+    1,
+    'expected exactly one text block in Anthropic message content',
+  );
+  return textBlocks[0];
+}
+
+describe('ModelHandlerAnthropic message guards', () => {
+  it('omits whitespace-only prefix content when initializing messages', async () => {
+    const handler = createAnthropicHandler();
+    const messages = await handler.initializeMessages('   ', '  request text  ');
+
+    assert.equal(messages.length, 1, 'should return a single user message');
+    const content = messages[0].content as ContentBlock[];
+    const textBlock = assertSingleTextBlock(content);
+    assert.equal(textBlock.text, 'request text');
+  });
+
+  it('omits whitespace-only request content when initializing messages', async () => {
+    const handler = createAnthropicHandler();
+    const messages = await handler.initializeMessages('  prefix value  ', '   ');
+
+    assert.equal(messages.length, 1, 'should return a single user message');
+    const content = messages[0].content as ContentBlock[];
+    const textBlock = assertSingleTextBlock(content);
+    assert.equal(textBlock.text, 'prefix value');
+  });
+
+  it('throws when both prefix and request are empty', async () => {
+    const handler = createAnthropicHandler();
+
+    await assert.rejects(
+      handler.initializeMessages('   ', '\n\t  '),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(
+          err.message,
+          /non-empty user prefix or request/i,
+          'should surface a descriptive error',
+        );
+        return true;
+      },
+    );
+  });
+
+  it('trims round message text and rejects empty content', async () => {
+    const handler = createAnthropicHandler();
+    const baseMessages = await handler.initializeMessages('prefix', 'request');
+
+    const updated = await handler.createRoundMessages(
+      [...baseMessages],
+      '  follow up text  ',
+    );
+    const followUp = updated[updated.length - 1];
+    const followUpContent = followUp.content as ContentBlock[];
+    const textBlock = assertSingleTextBlock(followUpContent);
+    assert.equal(textBlock.text, 'follow up text');
+
+    await assert.rejects(
+      handler.createRoundMessages([...baseMessages], '   '),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /non-empty content block/i);
+        return true;
+      },
+    );
+  });
+
+  it('trims follow-up text and rejects empty follow-ups', async () => {
+    const handler = createAnthropicHandler();
+    const baseMessages = await handler.initializeMessages('prefix', 'request');
+
+    const withFollowUp = await handler.createUserFollowUpMessages(
+      [...baseMessages],
+      '  another follow up  ',
+    );
+    const followUp = withFollowUp[withFollowUp.length - 1];
+    const followUpContent = followUp.content as ContentBlock[];
+    const textBlock = assertSingleTextBlock(followUpContent);
+    assert.equal(textBlock.text, 'another follow up');
+
+    await assert.rejects(
+      handler.createUserFollowUpMessages([...baseMessages], '   '),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /non-empty user text/i);
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- trim Anthropic user prefix/request content and fail fast when both render empty
- skip enqueuing blank user text blocks in round and follow-up helpers
- add regression coverage to ensure sanitized Anthropic tool-use messages omit empty blocks

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68cb3a9447308324bfbd069d557032fe