### PR TITLE
fix: guard anthropic empty message blocks

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -262,10 +262,21 @@ export class ModelHandlerAnthropic extends ModelHandler<
     mediaFiles?: string[],
     systemPrompt?: string,
   ): Promise<MessageParam[]> {
+    const prefixText = userPrefix ?? '';
+    const requestText = userRequest ?? '';
+    const trimmedPrefix = prefixText.trim();
+    const trimmedRequest = requestText.trim();
+
     // Create content list for the user message
-    const userMessageContent: ContentBlock[] = [
-      { type: 'text', text: userPrefix, citations: null },
-    ];
+    const userMessageContent: ContentBlock[] = [];
+
+    if (trimmedPrefix.length > 0) {
+      userMessageContent.push({
+        type: 'text',
+        text: prefixText,
+        citations: null,
+      });
+    }
 
     // Add media if provided (Anthropic currently only supports images)
     if (mediaFiles && this.config.capabilities.supportsVision) {
@@ -281,15 +292,24 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Add user request with optional caching
-    const requestBlock: ContentBlock = {
-      type: 'text',
-      text: userRequest,
-      citations: null,
-      ...(this.capabilities.supportsPromptCaching
-        ? { cache_control: { type: 'ephemeral' } }
-        : {}),
-    };
-    userMessageContent.push(requestBlock);
+    if (trimmedRequest.length > 0) {
+      const requestBlock: ContentBlock = {
+        type: 'text',
+        text: requestText,
+        citations: null,
+        ...(this.capabilities.supportsPromptCaching
+          ? { cache_control: { type: 'ephemeral' } }
+          : {}),
+      };
+      userMessageContent.push(requestBlock);
+    }
+
+    if (userMessageContent.length === 0) {
+      const errMsg =
+        'Anthropic message initialization requires non-empty user prefix or request.';
+      this.logger.error(errMsg);
+      throw new Error(errMsg);
+    }
 
     // Note: Anthropic handles system prompts differently via createResponse()
     const messages: MessageParam[] = [
@@ -349,16 +369,27 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
+    const trimmedMessage = userMessage.trim();
+
     // Add message text with optional caching
-    const messageBlock: ContentBlock = {
-      type: 'text',
-      text: userMessage,
-      citations: null,
-      ...(this.capabilities.supportsPromptCaching
-        ? { cache_control: { type: 'ephemeral' } }
-        : {}),
-    };
-    roundContent.push(messageBlock);
+    if (trimmedMessage.length > 0) {
+      const messageBlock: ContentBlock = {
+        type: 'text',
+        text: userMessage,
+        citations: null,
+        ...(this.capabilities.supportsPromptCaching
+          ? { cache_control: { type: 'ephemeral' } }
+          : {}),
+      };
+      roundContent.push(messageBlock);
+    }
+
+    if (roundContent.length === 0) {
+      const errMsg =
+        'Anthropic follow-up message requires non-empty text or media content.';
+      this.logger.error(errMsg);
+      throw new Error(errMsg);
+    }
 
     // We need to ensure we don't exceed Anthropic's limit of 4 cache_control blocks
     // Remove cache_control from ALL previous message contents
@@ -378,6 +409,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
     messages: MessageParam[],
     userMessage: string,
   ): Promise<MessageParam[]> {
+    const trimmedMessage = userMessage.trim();
+    if (trimmedMessage.length === 0) {
+      const errMsg =
+        'Anthropic follow-up user message cannot be empty after trimming.';
+      this.logger.error(errMsg);
+      throw new Error(errMsg);
+    }
+
     messages.push({
       role: 'user',
       content: [{ type: 'text', text: userMessage, citations: null }],

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1,0 +1,111 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - model handler
+import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+import { MODEL_CONFIGS } from '@model/ModelRegistry';
+
+function createHandler(): ModelHandlerAnthropic {
+  return new ModelHandlerAnthropic(MODEL_CONFIGS['sonnet37']);
+}
+
+describe('ModelHandlerAnthropic message guards', () => {
+  it('omits empty prefix text when initializing tool-use messages', async () => {
+    const handler = createHandler();
+
+    const messages = await handler.initializeMessages(
+      '   ',
+      '  Request content  ',
+    );
+
+    assert.strictEqual(messages.length, 1);
+    const userMessage = messages[0];
+    assert.strictEqual(userMessage.role, 'user');
+    assert.ok(Array.isArray(userMessage.content));
+
+    const textBlocks = (
+      userMessage.content as Array<{ type: string; text?: string }>
+    ).filter((block) => block.type === 'text');
+
+    assert.strictEqual(textBlocks.length, 1);
+    assert.strictEqual(textBlocks[0]?.text, '  Request content  ');
+    assert.ok(textBlocks[0]?.text?.trim().length);
+  });
+
+  it('throws when both prefix and request are empty after trimming', async () => {
+    const handler = createHandler();
+
+    await assert.rejects(
+      handler.initializeMessages('   ', '\n\t  '),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(
+          error.message,
+          /requires non-empty user prefix or request/i,
+        );
+        return true;
+      },
+    );
+  });
+
+  it('skips empty text when creating follow-up round messages', async () => {
+    const handler = createHandler();
+    const baseMessages = await handler.initializeMessages(
+      '',
+      'Initial request',
+    );
+
+    const updatedMessages = await handler.createRoundMessages(
+      [...baseMessages],
+      '  Follow-up text  ',
+    );
+
+    const lastMessage = updatedMessages[updatedMessages.length - 1];
+    assert.strictEqual(lastMessage.role, 'user');
+    assert.ok(Array.isArray(lastMessage.content));
+
+    const textBlocks = (
+      lastMessage.content as Array<{ type: string; text?: string }>
+    ).filter((block) => block.type === 'text');
+    assert.strictEqual(textBlocks.length, 1);
+    assert.strictEqual(textBlocks[0]?.text, '  Follow-up text  ');
+    assert.ok(textBlocks[0]?.text?.trim().length);
+  });
+
+  it('rejects follow-up rounds that contain no text or media', async () => {
+    const handler = createHandler();
+    const baseMessages = await handler.initializeMessages(
+      '',
+      'Initial request',
+    );
+
+    await assert.rejects(
+      handler.createRoundMessages([...baseMessages], '    '),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(
+          error.message,
+          /requires non-empty text or media content/i,
+        );
+        return true;
+      },
+    );
+  });
+
+  it('rejects empty follow-up user messages', async () => {
+    const handler = createHandler();
+    const baseMessages = await handler.initializeMessages(
+      '',
+      'Initial request',
+    );
+
+    await assert.rejects(
+      handler.createUserFollowUpMessages([...baseMessages], '\n\n'),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /cannot be empty after trimming/i);
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- skip whitespace-only prefix and request blocks when building Anthropic messages and raise errors when no user content remains
- apply the same trimming guard to follow-up and user follow-up helpers to prevent empty text payloads
- add regression coverage ensuring Anthropic tool-use flows omit empty text blocks and surface descriptive errors

## Testing
- npm run format
- npm run lint
- npm test *(fails: vscode-test cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3a9447308324bfbd069d557032fe