### PR TITLE
refactor: extract reflection round node

### DIFF
--- a/src/agent/core/nodes/Node.ts
+++ b/src/agent/core/nodes/Node.ts
@@ -19,15 +19,16 @@ export abstract class Node<TPrep = void, TExec = void, TShared = void> {
    * Prepare any data required before execution.
    */
   protected async prep(shared: TShared): Promise<TPrep> {
-    return undefined as unknown as TPrep;
+    return undefined as TPrep;
   }
 
   /**
    * Execute the core logic for the node.
    */
-  protected async exec(prepResult: TPrep, shared: TShared): Promise<TExec> {
-    return prepResult as unknown as TExec;
-  }
+  protected abstract exec(
+    prepResult: TPrep,
+    shared: TShared,
+  ): Promise<TExec>;
 
   /**
    * Perform cleanup or additional processing after execution.

--- a/src/agent/core/nodes/Node.ts
+++ b/src/agent/core/nodes/Node.ts
@@ -1,0 +1,51 @@
+// Standard library imports
+// (none needed)
+
+// Third-party imports
+// (none needed)
+
+// Local imports
+// (none needed)
+
+/**
+ * Base class representing a unit of work in the agent pipeline.
+ *
+ * Implementations can override the lifecycle hooks to participate in the
+ * preparation, execution, and post-processing stages. Each hook is optional,
+ * allowing subclasses to implement only the stages they need.
+ */
+export abstract class Node<TPrep = void, TExec = void, TShared = void> {
+  /**
+   * Prepare any data required before execution.
+   */
+  protected async prep(shared: TShared): Promise<TPrep> {
+    return undefined as unknown as TPrep;
+  }
+
+  /**
+   * Execute the core logic for the node.
+   */
+  protected async exec(prepResult: TPrep, shared: TShared): Promise<TExec> {
+    return prepResult as unknown as TExec;
+  }
+
+  /**
+   * Perform cleanup or additional processing after execution.
+   */
+  protected async post(
+    execResult: TExec,
+    prepResult: TPrep,
+    shared: TShared,
+  ): Promise<TExec> {
+    return execResult;
+  }
+
+  /**
+   * Run the node through its lifecycle without retries.
+   */
+  public async run(shared: TShared): Promise<TExec> {
+    const prepResult = await this.prep(shared);
+    const execResult = await this.exec(prepResult, shared);
+    return await this.post(execResult, prepResult, shared);
+  }
+}

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -11,12 +11,12 @@ import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
 import { runResponseCycle } from '@agent/core/ResponseCycle';
 import { ToolState } from '@agent/core/ToolState';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
+import { ReflectionRoundNode } from '@agent/implementations/reflection/nodes/ReflectionRoundNode';
 import type { IModelHandler } from '@agent/modelHandlers';
-import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { OutputHandler, IOutputHandler } from '@agent/output';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
-import { writePromptToXml } from '@agent/utils/promptUtils';
-import { bus } from '@eventBus/ProgressEventBus';
 // Standard library imports
 // (none needed)
 
@@ -27,11 +27,8 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - latex utils
 import { LatexMediaManager } from '@latex';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import type { ToolDefinition } from '@model';
 
 // System imports - common utilities
-import { getConfig } from '@utils/config';
 
 // Local imports - utilities
 import { calculateTotalRounds } from '@agent/utils/roundUtils';
@@ -152,7 +149,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
   /**
    * Processes completion of conversation round.
    */
-  private async handleRoundCompletion(
+  protected async handleRoundCompletion(
     currRound: number,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
@@ -226,282 +223,27 @@ export abstract class BaseReflectionAgent extends BaseAgent {
     return this.outputHandler.outputFiles[currRound] || [];
   }
 
-  /**
-   * Executes the shared round lifecycle pipeline used by both processing and reflection flows.
-   * Handles output initialization, response generation, and round finalization to keep
-   * lifecycle responsibilities centralized.
-   *
-   * @param currRound - Zero-based index of the round being executed.
-   * @param stateRound - Mutable state scoped to the current round of execution.
-   * @param stateGlobal - Shared agent state that spans all rounds.
-   * @param toolState - Current tool invocation state passed between rounds.
-   * @param preparedMessages - Messages prepared for the model before execution.
-   * @param prefill - Initial text inserted into the model response buffer.
-   * @param outputPath - Filesystem path where model output for this round is stored.
-   * @param roundGroupId - Identifier for grouping related log and output operations.
-   * @returns Updated round/global state, messages, completion flag, and tool state after execution.
-   */
-  private async runRoundPipeline(
-    currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
-    toolState: ToolState,
-    preparedMessages: any[],
-    prefill: string,
-    outputPath: string,
-    roundGroupId: string,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
-    const [endTurn, updatedMessages] =
-      await this.modelHandler.initializeOutputAndPrefill(
-        this.agentConfig,
-        this.agentSetting,
-        preparedMessages,
-        toolState,
-        outputPath,
-        prefill,
-        roundGroupId,
-      );
-
-    if (!endTurn) {
-      const [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedToolState,
-        newEndTurn,
-      ] = await runResponseCycle(
-        {
-          modelHandler: this.modelHandler,
-          agentSetting: this.agentSetting,
-          agentConfig: this.agentConfig,
-          agentPrompt: this.agentPrompt,
-          userVars: this.userVars,
-          logger: this.logger,
-          client: this.client,
-          checkInterruption: () => this.checkInterruption(),
-          setAbortController: (ctrl) => {
-            this.abortController = ctrl;
-          },
-        },
-        updatedMessages,
-        stateRound,
-        stateGlobal,
-        toolState,
-        outputPath,
-        roundGroupId,
-        this.executionId,
-      );
-
-      await this.handleRoundCompletion(
-        currRound,
-        updatedStateRound,
-        updatedStateGlobal,
-        {
-          outputFile: outputPath,
-          endTurn: newEndTurn,
-          processGroupId: roundGroupId,
-        },
-      );
-
-      if (currRound === 0) {
-        this.logger.debug(
-          `stateGlobal: ${JSON.stringify(updatedStateGlobal)}`,
-          roundGroupId,
-        );
-      }
-
-      return [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedMessages,
-        newEndTurn,
-        updatedToolState,
-      ];
-    }
-
-    await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
-      outputFile: outputPath,
-      endTurn,
-      processGroupId: roundGroupId,
+  private createRoundNode(): ReflectionRoundNode {
+    return new ReflectionRoundNode({
+      agentConfig: this.agentConfig,
+      agentSetting: this.agentSetting,
+      agentPrompt: this.agentPrompt,
+      userVars: this.userVars,
+      modelHandler: this.modelHandler,
+      outputHandler: this.outputHandler,
+      latexMediaManager: this.latexMediaManager,
+      getPromptBuilder: () => this.getPromptBuilder(),
+      logger: this.logger,
+      handleRoundCompletion: (currRound, stateRound, stateGlobal, options) =>
+        this.handleRoundCompletion(currRound, stateRound, stateGlobal, options),
+      client: this.client,
+      runResponseCycle,
+      executionId: this.executionId,
+      checkInterruption: () => this.checkInterruption(),
+      setAbortController: (ctrl) => {
+        this.abortController = ctrl;
+      },
     });
-
-    return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
-  }
-
-  /**
-   * Processes initial conversation round.
-   * @returns Tuple of [round state, global state, messages, completion flag, tool state]
-   */
-  protected async process(): Promise<
-    [AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]
-  > {
-    // Initialize input files list
-    const inputFiles = [
-      this.agentConfig.inputFile,
-      ...(this.agentConfig.inputFiles || []),
-    ];
-    const toolState = new ToolState();
-
-    // Initialize state and messages
-    const currRound = 0;
-    const stateGlobal = new AgentStateGlobal();
-
-    this.logger.debug(`Processing round ${currRound}`);
-
-    return this.withRoundGroup(`r${currRound}`, async (roundGroupId) => {
-      const extraMedia: string[] = [];
-      if (this.modelHandler.capabilities.supportsVision) {
-        if (
-          this.agentConfig.mediaFile &&
-          !toolState.mediaFiles.includes(this.agentConfig.mediaFile)
-        ) {
-          extraMedia.push(this.agentConfig.mediaFile);
-        }
-        if (this.agentConfig.mediaFiles) {
-          extraMedia.push(...this.agentConfig.mediaFiles);
-        }
-      }
-
-      await this.latexMediaManager.processInputFiles(
-        inputFiles,
-        toolState,
-        this.agentConfig.toolConfig,
-        this.modelHandler.capabilities.supportsVision,
-        extraMedia,
-        roundGroupId,
-      );
-
-      const messages: any[] = [];
-
-      // Set up initial prompts
-      const promptBuilder = this.getPromptBuilder();
-      const { systemPrompt, userRequest, userPrefix } =
-        await promptBuilder.buildInitialPrompts();
-
-      let prefixWithStats = userPrefix;
-      if (toolState.texcountStats) {
-        prefixWithStats = `${toolState.texcountStats}${userPrefix}`;
-      }
-
-      // Write prompt to file if requested
-      if (this.agentConfig.toolConfig.printInputPrompt) {
-        await writePromptToXml(
-          systemPrompt,
-          prefixWithStats,
-          userRequest,
-          this.agentConfig.inputFile,
-          this.agentConfig.agent,
-        );
-      }
-
-      // Initialize messages with prompts
-      const initialMessages = await this.modelHandler.initializeMessages(
-        prefixWithStats,
-        userRequest,
-        toolState.mediaFiles,
-        systemPrompt,
-      );
-      messages.push(...initialMessages);
-
-      // Handle prefill
-      const prefill = await promptBuilder.buildPrefill(currRound);
-      toolState.updateAccumulatedOutput(prefill);
-
-      const stateRound = new AgentStateRound(currRound);
-      return this.runRoundPipeline(
-        currRound,
-        stateRound,
-        stateGlobal,
-        toolState,
-        messages,
-        prefill,
-        this.outputFile[currRound],
-        roundGroupId,
-      );
-    });
-  }
-
-  /**
-   * Processes a follow-up conversation round.
-   * @returns Tuple of [round state, global state, messages, completion flag]
-   */
-  protected async reflect(
-    stateGlobal: AgentStateGlobal,
-    messages: any[],
-    toolState: ToolState,
-    currRound: number = 1,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
-    this.logger.debug(`Processing round ${currRound}`);
-
-    return this.withRoundGroup(`r${currRound}`, async (roundGroupId) => {
-      // Handle output file processing
-      if (this.agentConfig.outputFiles) {
-        await this._handleToolStateForOutput(
-          this.agentConfig.outputFiles,
-          currRound,
-          toolState,
-        );
-      } else {
-        // Handle single output file from previous round
-        const outputFiles = this.outputHandler.outputFiles[currRound - 1];
-        if (outputFiles && outputFiles.length > 0) {
-          await this._handleToolStateForOutput(
-            [outputFiles[0]],
-            currRound,
-            toolState,
-          );
-        }
-      }
-
-      // Initialize round
-      const stateRound = new AgentStateRound(currRound);
-
-      // Prepare round message
-      const promptBuilder = this.getPromptBuilder();
-      const userRequestReflect =
-        await promptBuilder.buildReflectPrompt(currRound);
-      let userMessage = userRequestReflect ? `${userRequestReflect}\n` : '';
-      if (toolState.texcountStats) {
-        userMessage = `${toolState.texcountStats}${userMessage}`;
-      }
-
-      // Only proceed if there's actual content
-      if (!userMessage.trim()) {
-        return [stateRound, stateGlobal, messages, true, toolState];
-      }
-
-      const roundMessages = await this.modelHandler.createRoundMessages(
-        messages,
-        userMessage,
-        toolState.mediaFiles,
-      );
-
-      // Handle prefill for round
-      const prefill = await promptBuilder.buildPrefill(currRound);
-      toolState.updateAccumulatedOutput(prefill);
-
-      return this.runRoundPipeline(
-        currRound,
-        stateRound,
-        stateGlobal,
-        toolState,
-        roundMessages,
-        prefill,
-        this.outputFile[currRound],
-        roundGroupId,
-      );
-    });
-  }
-
-  private async runRound(
-    currRound: number,
-    stateGlobal: AgentStateGlobal,
-    messages: any[],
-    toolState: ToolState,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
-    if (currRound === 0) {
-      return await this.process();
-    }
-    return await this.reflect(stateGlobal, messages, toolState, currRound);
   }
 
   /**
@@ -516,7 +258,7 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       await this.initializeClient();
 
       let stateGlobal = new AgentStateGlobal();
-      let messages: any[] = [];
+      let messages: ProviderMessage[] = [];
       let continueRounds = true;
 
       const totalRounds = this.getNumberOfRounds();
@@ -530,10 +272,23 @@ export abstract class BaseReflectionAgent extends BaseAgent {
           break;
         }
 
+        this.logger.debug(`Processing round ${currRound}`);
         this.userVars.CURRENT_ROUND = currRound;
         const toolState = new ToolState();
+        const node = this.createRoundNode();
+
         const [stateRound, updatedGlobal, newMessages, endTurn, usedToolState] =
-          await this.runRound(currRound, stateGlobal, messages, toolState);
+          await this.withRoundGroup(`r${currRound}`, async (roundGroupId) =>
+            node.run({
+              currRound,
+              stateGlobal,
+              messages,
+              toolState,
+              roundGroupId,
+              outputPath: this.outputFile[currRound],
+            }),
+          );
+
         this.roundStates.push(stateRound);
         this.toolStates.push(usedToolState);
         stateGlobal = updatedGlobal;
@@ -550,32 +305,4 @@ export abstract class BaseReflectionAgent extends BaseAgent {
       this.cleanup();
     }
   }
-
-  /**
-   * Updates tool state based on output files.
-   */
-  private async _handleToolStateForOutput(
-    outputFiles: string[],
-    currRound: number,
-    toolState: ToolState,
-  ): Promise<void> {
-    await this.latexMediaManager.processOutputFiles(
-      outputFiles,
-      toolState,
-      this.agentConfig.toolConfig,
-      this.modelHandler.capabilities.supportsVision,
-      this.logger.getActiveGroupId(),
-    );
-  }
-
-  /**
-   * Processes output files from XML or direct input.
-   * This method focuses solely on extracting and processing output files.
-   * It does NOT perform any latexdiff operations - those are handled separately
-   * in the handleOutput method via handleLatexdiffofOutput.
-   *
-   * @param outputFile Path to the output file to process
-   * @param currRound Current round number
-   * @param processGroupId Optional process group ID for logging
-   */
 }

--- a/src/agent/implementations/reflection/nodes/ReflectionRoundNode.ts
+++ b/src/agent/implementations/reflection/nodes/ReflectionRoundNode.ts
@@ -63,16 +63,6 @@ interface ReflectionRoundPreparation {
   outputPath: string;
   skip: boolean;
   skipResult?: ReflectionRoundResult;
-  execution?: ReflectionRoundExecResult;
-}
-
-interface ReflectionRoundExecResult {
-  stateRound: AgentStateRound;
-  stateGlobal: AgentStateGlobal;
-  messages: ProviderMessage[];
-  endTurn: boolean;
-  toolState: ToolState;
-  skip: boolean;
 }
 
 export interface ReflectionRoundShared {
@@ -213,17 +203,7 @@ export class ReflectionRoundNode extends Node<
     shared: ReflectionRoundShared,
   ): Promise<ReflectionRoundResult> {
     if (prepResult.skip && prepResult.skipResult) {
-      const result = prepResult.skipResult;
-      const execution: ReflectionRoundExecResult = {
-        stateRound: result[0],
-        stateGlobal: result[1],
-        messages: result[2],
-        endTurn: result[3],
-        toolState: result[4],
-        skip: true,
-      };
-      prepResult.execution = execution;
-      return result;
+      return prepResult.skipResult;
     }
 
     const [endTurn, updatedMessages] =
@@ -266,39 +246,21 @@ export class ReflectionRoundNode extends Node<
         this.deps.executionId,
       );
 
-      const execution: ReflectionRoundExecResult = {
-        stateRound: updatedStateRound,
-        stateGlobal: updatedStateGlobal,
-        messages: updatedMessages,
-        endTurn: newEndTurn,
-        toolState: updatedToolState,
-        skip: false,
-      };
-      prepResult.execution = execution;
       return [
-        execution.stateRound,
-        execution.stateGlobal,
-        execution.messages,
-        execution.endTurn,
-        execution.toolState,
+        updatedStateRound,
+        updatedStateGlobal,
+        updatedMessages,
+        newEndTurn,
+        updatedToolState,
       ];
     }
 
-    const execution: ReflectionRoundExecResult = {
-      stateRound: prepResult.stateRound,
-      stateGlobal: shared.stateGlobal,
-      messages: updatedMessages,
-      endTurn,
-      toolState: shared.toolState,
-      skip: false,
-    };
-    prepResult.execution = execution;
     return [
-      execution.stateRound,
-      execution.stateGlobal,
-      execution.messages,
-      execution.endTurn,
-      execution.toolState,
+      prepResult.stateRound,
+      shared.stateGlobal,
+      updatedMessages,
+      endTurn,
+      shared.toolState,
     ];
   }
 
@@ -307,22 +269,22 @@ export class ReflectionRoundNode extends Node<
     prepResult: ReflectionRoundPreparation,
     shared: ReflectionRoundShared,
   ): Promise<ReflectionRoundResult> {
-    const execution = prepResult.execution;
-    if (execution && !execution.skip) {
+    if (!prepResult.skip) {
+      const [stateRound, stateGlobal, , endTurn] = execResult;
       await this.deps.handleRoundCompletion(
         shared.currRound,
-        execution.stateRound,
-        execution.stateGlobal,
+        stateRound,
+        stateGlobal,
         {
           outputFile: prepResult.outputPath,
-          endTurn: execution.endTurn,
+          endTurn,
           processGroupId: shared.roundGroupId,
         },
       );
 
       if (shared.currRound === 0) {
         this.deps.logger.debug(
-          `stateGlobal: ${JSON.stringify(execution.stateGlobal)}`,
+          `stateGlobal: ${JSON.stringify(stateGlobal)}`,
           shared.roundGroupId,
         );
       }

--- a/src/agent/implementations/reflection/nodes/ReflectionRoundNode.ts
+++ b/src/agent/implementations/reflection/nodes/ReflectionRoundNode.ts
@@ -1,0 +1,361 @@
+// Local imports - agent
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
+import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
+import type { RoundOutputOptions } from '@agent/implementations/BaseReflectionAgent';
+import type { IModelHandler } from '@agent/modelHandlers';
+import type { IOutputHandler } from '@agent/output';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { PromptBuilder } from '@agent/utils/PromptBuilder';
+import { writePromptToXml } from '@agent/utils/promptUtils';
+
+// Local imports - core
+import { Node } from '@agent/core/nodes/Node';
+import { ToolState } from '@agent/core/ToolState';
+
+// Local imports - latex utils
+import { LatexMediaManager } from '@latex';
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Types
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+type RunResponseCycle =
+  typeof import('@agent/core/ResponseCycle').runResponseCycle;
+
+interface ReflectionRoundNodeDependencies {
+  agentConfig: AgentConfig;
+  agentSetting: AgentSetting;
+  agentPrompt: AgentPrompt;
+  userVars: Record<string, any>;
+  modelHandler: IModelHandler;
+  outputHandler: IOutputHandler;
+  latexMediaManager: LatexMediaManager;
+  getPromptBuilder: () => PromptBuilder;
+  logger: AgentLogger;
+  handleRoundCompletion: (
+    currRound: number,
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    options: RoundOutputOptions,
+  ) => Promise<void>;
+  client: any;
+  runResponseCycle: RunResponseCycle;
+  executionId?: ExecutionId;
+  checkInterruption: () => boolean;
+  setAbortController: (ctrl: AbortController | null) => void;
+}
+
+export type ReflectionRoundResult = [
+  AgentStateRound,
+  AgentStateGlobal,
+  ProviderMessage[],
+  boolean,
+  ToolState,
+];
+
+interface ReflectionRoundPreparation {
+  stateRound: AgentStateRound;
+  messagesForModel: ProviderMessage[];
+  prefill: string;
+  outputPath: string;
+  skip: boolean;
+  skipResult?: ReflectionRoundResult;
+  execution?: ReflectionRoundExecResult;
+}
+
+interface ReflectionRoundExecResult {
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  messages: ProviderMessage[];
+  endTurn: boolean;
+  toolState: ToolState;
+  skip: boolean;
+}
+
+export interface ReflectionRoundShared {
+  currRound: number;
+  stateGlobal: AgentStateGlobal;
+  messages: ProviderMessage[];
+  toolState: ToolState;
+  roundGroupId: string;
+  outputPath: string;
+}
+
+export class ReflectionRoundNode extends Node<
+  ReflectionRoundPreparation,
+  ReflectionRoundResult,
+  ReflectionRoundShared
+> {
+  constructor(private readonly deps: ReflectionRoundNodeDependencies) {
+    super();
+  }
+
+  protected async prep(
+    shared: ReflectionRoundShared,
+  ): Promise<ReflectionRoundPreparation> {
+    const { currRound, toolState, messages, roundGroupId, outputPath } = shared;
+    const stateRound = new AgentStateRound(currRound);
+
+    if (currRound === 0) {
+      const inputFiles = [
+        this.deps.agentConfig.inputFile,
+        ...(this.deps.agentConfig.inputFiles || []),
+      ];
+
+      const extraMedia: string[] = [];
+      if (this.deps.modelHandler.capabilities.supportsVision) {
+        if (
+          this.deps.agentConfig.mediaFile &&
+          !toolState.mediaFiles.includes(this.deps.agentConfig.mediaFile)
+        ) {
+          extraMedia.push(this.deps.agentConfig.mediaFile);
+        }
+        if (this.deps.agentConfig.mediaFiles) {
+          extraMedia.push(...this.deps.agentConfig.mediaFiles);
+        }
+      }
+
+      await this.deps.latexMediaManager.processInputFiles(
+        inputFiles,
+        toolState,
+        this.deps.agentConfig.toolConfig,
+        this.deps.modelHandler.capabilities.supportsVision,
+        extraMedia,
+        roundGroupId,
+      );
+
+      const promptBuilder = this.deps.getPromptBuilder();
+      const { systemPrompt, userRequest, userPrefix } =
+        await promptBuilder.buildInitialPrompts();
+
+      let prefixWithStats = userPrefix;
+      if (toolState.texcountStats) {
+        prefixWithStats = `${toolState.texcountStats}${userPrefix}`;
+      }
+
+      if (this.deps.agentConfig.toolConfig.printInputPrompt) {
+        await writePromptToXml(
+          systemPrompt,
+          prefixWithStats,
+          userRequest,
+          this.deps.agentConfig.inputFile,
+          this.deps.agentConfig.agent,
+        );
+      }
+
+      const initialMessages = await this.deps.modelHandler.initializeMessages(
+        prefixWithStats,
+        userRequest,
+        toolState.mediaFiles,
+        systemPrompt,
+      );
+
+      const prefill = await promptBuilder.buildPrefill(currRound);
+      toolState.updateAccumulatedOutput(prefill);
+
+      return {
+        stateRound,
+        messagesForModel: initialMessages,
+        prefill,
+        outputPath,
+        skip: false,
+      };
+    }
+
+    await this.prepareToolStateForReflection(
+      currRound,
+      toolState,
+      roundGroupId,
+    );
+
+    const promptBuilder = this.deps.getPromptBuilder();
+    const userRequestReflect =
+      await promptBuilder.buildReflectPrompt(currRound);
+    let userMessage = userRequestReflect ? `${userRequestReflect}\n` : '';
+    if (toolState.texcountStats) {
+      userMessage = `${toolState.texcountStats}${userMessage}`;
+    }
+
+    if (!userMessage.trim()) {
+      return {
+        stateRound,
+        messagesForModel: messages,
+        prefill: '',
+        outputPath,
+        skip: true,
+        skipResult: [stateRound, shared.stateGlobal, messages, true, toolState],
+      };
+    }
+
+    const roundMessages = await this.deps.modelHandler.createRoundMessages(
+      messages,
+      userMessage,
+      toolState.mediaFiles,
+    );
+
+    const prefill = await promptBuilder.buildPrefill(currRound);
+    toolState.updateAccumulatedOutput(prefill);
+
+    return {
+      stateRound,
+      messagesForModel: roundMessages,
+      prefill,
+      outputPath,
+      skip: false,
+    };
+  }
+
+  protected async exec(
+    prepResult: ReflectionRoundPreparation,
+    shared: ReflectionRoundShared,
+  ): Promise<ReflectionRoundResult> {
+    if (prepResult.skip && prepResult.skipResult) {
+      const result = prepResult.skipResult;
+      const execution: ReflectionRoundExecResult = {
+        stateRound: result[0],
+        stateGlobal: result[1],
+        messages: result[2],
+        endTurn: result[3],
+        toolState: result[4],
+        skip: true,
+      };
+      prepResult.execution = execution;
+      return result;
+    }
+
+    const [endTurn, updatedMessages] =
+      await this.deps.modelHandler.initializeOutputAndPrefill(
+        this.deps.agentConfig,
+        this.deps.agentSetting,
+        prepResult.messagesForModel,
+        shared.toolState,
+        prepResult.outputPath,
+        prepResult.prefill,
+        shared.roundGroupId,
+      );
+
+    if (!endTurn) {
+      const [
+        updatedStateRound,
+        updatedStateGlobal,
+        updatedToolState,
+        newEndTurn,
+      ] = await this.deps.runResponseCycle(
+        {
+          modelHandler: this.deps.modelHandler,
+          agentSetting: this.deps.agentSetting,
+          agentConfig: this.deps.agentConfig,
+          agentPrompt: this.deps.agentPrompt,
+          userVars: this.deps.userVars,
+          logger: this.deps.logger,
+          client: this.deps.client,
+          checkInterruption: () => this.deps.checkInterruption(),
+          setAbortController: (ctrl) => {
+            this.deps.setAbortController(ctrl);
+          },
+        },
+        updatedMessages,
+        prepResult.stateRound,
+        shared.stateGlobal,
+        shared.toolState,
+        prepResult.outputPath,
+        shared.roundGroupId,
+        this.deps.executionId,
+      );
+
+      const execution: ReflectionRoundExecResult = {
+        stateRound: updatedStateRound,
+        stateGlobal: updatedStateGlobal,
+        messages: updatedMessages,
+        endTurn: newEndTurn,
+        toolState: updatedToolState,
+        skip: false,
+      };
+      prepResult.execution = execution;
+      return [
+        execution.stateRound,
+        execution.stateGlobal,
+        execution.messages,
+        execution.endTurn,
+        execution.toolState,
+      ];
+    }
+
+    const execution: ReflectionRoundExecResult = {
+      stateRound: prepResult.stateRound,
+      stateGlobal: shared.stateGlobal,
+      messages: updatedMessages,
+      endTurn,
+      toolState: shared.toolState,
+      skip: false,
+    };
+    prepResult.execution = execution;
+    return [
+      execution.stateRound,
+      execution.stateGlobal,
+      execution.messages,
+      execution.endTurn,
+      execution.toolState,
+    ];
+  }
+
+  protected async post(
+    execResult: ReflectionRoundResult,
+    prepResult: ReflectionRoundPreparation,
+    shared: ReflectionRoundShared,
+  ): Promise<ReflectionRoundResult> {
+    const execution = prepResult.execution;
+    if (execution && !execution.skip) {
+      await this.deps.handleRoundCompletion(
+        shared.currRound,
+        execution.stateRound,
+        execution.stateGlobal,
+        {
+          outputFile: prepResult.outputPath,
+          endTurn: execution.endTurn,
+          processGroupId: shared.roundGroupId,
+        },
+      );
+
+      if (shared.currRound === 0) {
+        this.deps.logger.debug(
+          `stateGlobal: ${JSON.stringify(execution.stateGlobal)}`,
+          shared.roundGroupId,
+        );
+      }
+    }
+
+    return execResult;
+  }
+
+  private async prepareToolStateForReflection(
+    currRound: number,
+    toolState: ToolState,
+    groupId: string,
+  ): Promise<void> {
+    if (this.deps.agentConfig.outputFiles) {
+      await this.deps.latexMediaManager.processOutputFiles(
+        this.deps.agentConfig.outputFiles,
+        toolState,
+        this.deps.agentConfig.toolConfig,
+        this.deps.modelHandler.capabilities.supportsVision,
+        groupId,
+      );
+      return;
+    }
+
+    const outputFiles = this.deps.outputHandler.outputFiles[currRound - 1];
+    if (outputFiles && outputFiles.length > 0) {
+      await this.deps.latexMediaManager.processOutputFiles(
+        [outputFiles[0]],
+        toolState,
+        this.deps.agentConfig.toolConfig,
+        this.deps.modelHandler.capabilities.supportsVision,
+        groupId,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `Node` base class with prep/exec/post hooks for agent pipelines
- encapsulate reflection round orchestration in `ReflectionRoundNode`
- refactor `BaseReflectionAgent` to drive each round through the node abstraction while preserving logging groups

## Testing
- npm run lint
- npm test *(fails: missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe3fe9ea08324b603df596077bb02