### PR TITLE
fix: decode tool log content before parsing

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -439,8 +439,9 @@ export class LogEntryFormatter {
 
     let formattedContent;
     try {
-      // Try to parse as JSON first - don't decode HTML entities
-      const parsed = JSON.parse(content);
+      // Decode HTML entities before parsing - log messages are encoded in transport
+      const decodedContent = decodeHtml(content);
+      const parsed = JSON.parse(decodedContent);
 
       // Check if this is the new combined format
       if (parsed.tool && parsed.input && parsed.output) {


### PR DESCRIPTION
## Summary
- decode HTML entities in tool-use log entries before parsing so the Progress Board can render structured tool cards

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc1c150b908324827c8e3bd635d329