### PR TITLE
fix: show tool name in tool use header

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -198,7 +198,7 @@
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-wrench"></i>
-              <span>Tool Use</span>
+              <span class="tool-use-title">Tool Use</span>
             </summary>
             <div class="special-content"></div>
           </details>

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -437,16 +437,30 @@ export class LogEntryFormatter {
     if (groupId) element.dataset.groupId = groupId;
     if (timestamp) element.dataset.fullTimestamp = timestamp;
 
+    const headerLabel = element.querySelector('.tool-use-title');
+    if (headerLabel) {
+      headerLabel.textContent = 'Tool Use';
+    }
+
     let formattedContent;
     try {
       // Decode HTML entities before parsing - log messages are encoded in transport
       const decodedContent = decodeHtml(content);
       const parsed = JSON.parse(decodedContent);
 
+      const toolName =
+        typeof parsed.tool === 'string'
+          ? parsed.tool.trim()
+          : typeof parsed.name === 'string'
+            ? parsed.name.trim()
+            : '';
+      if (headerLabel && toolName) {
+        headerLabel.textContent = `Tool Use: ${toolName}`;
+      }
+
       // Check if this is the new combined format
       if (parsed.tool && parsed.input && parsed.output) {
         // Format combined tool input/output
-        const toolName = parsed.tool;
         const inputJson = JSON.stringify(parsed.input, null, 2);
         const outputJson = JSON.stringify(parsed.output, null, 2);
 

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -466,7 +466,6 @@ export class LogEntryFormatter {
 
         formattedContent = `
           <div class="tool-use-section">
-            <div class="tool-use-label">${toolName}</div>
             <div class="tool-use-subsection">
               <span class="tool-use-sublabel">Input:</span>
               <pre>${inputJson}</pre>


### PR DESCRIPTION
## Summary
- add a dedicated label element in the tool use log template so the header can be updated dynamically
- adjust the tool use formatter to populate the header with the parsed tool name when available

## Testing
- npm run format
- npm run lint
- npm test *(fails: VS Code binary requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2331110883248ccf10f585b94330