### PR TITLE
fix: reset anthropic thinking cache after send

### DIFF
--- a/src/agent/core/ToolState.ts
+++ b/src/agent/core/ToolState.ts
@@ -21,6 +21,7 @@ export interface IToolState {
   updateLastResponse(response: string): void;
   updateAccumulatedOutput(output: string): void;
   addMediaFiles(files: string[]): void;
+  resetThinkingCache(): void;
 }
 
 /** Manages tool-specific runtime state and operations within a conversation round. */
@@ -71,5 +72,14 @@ export class ToolState implements IToolState {
    */
   addMediaFiles(files: string[]): void {
     this.mediaFiles.push(...files);
+  }
+
+  /**
+   * Resets the thinking cache by clearing thinking blocks and reset flag.
+   * Used to ensure fresh thinking blocks for subsequent responses.
+   */
+  resetThinkingCache(): void {
+    this.thinkingBlocks = [];
+    this.thinkingAdded = false;
   }
 }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -942,8 +942,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           assistantMessage.content.push(...toolState.thinkingBlocks);
         }
         // Clear cached thinking so the next response can store fresh blocks
-        toolState.thinkingBlocks = [];
-        toolState.thinkingAdded = false;
+        toolState.resetThinkingCache();
       }
 
       // Add the text content
@@ -1108,8 +1107,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Anthropic models expect thinking blocks before text
       content.push(...toolState.thinkingBlocks);
       // Clear cached thinking so the next response can store fresh blocks
-      toolState.thinkingBlocks = [];
-      toolState.thinkingAdded = false;
+      toolState.resetThinkingCache();
     }
     if (text) {
       content.push({ type: 'text', text });

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -941,6 +941,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         if (Array.isArray(assistantMessage.content)) {
           assistantMessage.content.push(...toolState.thinkingBlocks);
         }
+        // Clear cached thinking so the next response can store fresh blocks
+        toolState.thinkingBlocks = [];
+        toolState.thinkingAdded = false;
       }
 
       // Add the text content
@@ -1104,6 +1107,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
     ) {
       // Anthropic models expect thinking blocks before text
       content.push(...toolState.thinkingBlocks);
+      // Clear cached thinking so the next response can store fresh blocks
+      toolState.thinkingBlocks = [];
+      toolState.thinkingAdded = false;
     }
     if (text) {
       content.push({ type: 'text', text });


### PR DESCRIPTION
## Summary
- clear stored thinking blocks after appending them to Anthropic assistant messages
- reset the thinking cache on tool follow-ups so subsequent responses start fresh

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc2e2db1208324b23aa45bb23fc9e3