### PR TITLE
fix: type openai response streaming events

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -13,6 +13,7 @@ import type {
   ResponseFunctionToolCallItem,
   ResponseFunctionToolCall,
   ResponseInputItem,
+  ResponseStreamEvent,
 } from 'openai/resources/responses/responses';
 
 // Local imports - agent
@@ -240,15 +241,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandlerOpenAI {
       const output = this.isOutputStreamingEnabled()
         ? this.createOutputStream(groupId)
         : undefined;
-      for await (const event of stream) {
-        if (
-          event.type === 'response.reasoning_text.delta' ||
-          event.type === 'response.reasoning_summary_text.delta'
-        ) {
-          thinking.append((event as any).delta);
-        }
-        if (event.type === 'response.output_text.delta') {
-          output?.append((event as any).delta);
+      const responseStream: AsyncIterable<ResponseStreamEvent> = stream;
+      for await (const event of responseStream) {
+        switch (event.type) {
+          case 'response.reasoning_text.delta':
+          case 'response.reasoning_summary_text.delta': {
+            thinking.append(event.delta);
+            break;
+          }
+          case 'response.output_text.delta': {
+            output?.append(event.delta);
+            break;
+          }
+          default:
+            break;
         }
       }
 


### PR DESCRIPTION
## Summary
- import the OpenAI `ResponseStreamEvent` type for the Responses handler
- switch on typed stream events so reasoning and output deltas feed the logger safely

## Testing
- npm run format
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68cc40d29ce88324be177402d4cc334a