### PR TITLE
Refactor Google GenAI handler to use native SDK message types

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -53,95 +53,103 @@ import { K_SLICE } from '@utils/config';
 import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 
-// Internal type definition
-type InternalMessagePart = {
-  type: 'text' | 'file_uri' | string;
-  text?: string;
-  uri?: string;
-  mimeType?: string;
-};
-
-// For the Message interface, I kept a simple version because:
-// 1. Google's Content type has role?: string (optional), while our internal messages always have a role
-// 2. Google's Content uses parts?: Part[] while our internal structure uses content: string | InternalMessagePart[]
-
-// Define a message interface that matches our internal structure
-// but is compatible with Google's Content type
-interface Message {
-  role: string;
-  content?: string | InternalMessagePart[]; // Used for internal message representation
-  parts?: Part[]; // Used for Google-specific message format when sending to API
-}
+// Internal type aliases
+type GoogleSendMessage = SendMessageParameters['message'];
+type GooglePart = Part;
+type GoogleMessage = Content & Required<Pick<Content, 'role' | 'parts'>>;
 
 // Helper function
 function convertInternalPartsToGoogleParts(
-  internalParts: InternalMessagePart[],
+  messageParts: GoogleSendMessage,
   logger: AgentLogger,
 ): Part[] {
-  return internalParts
-    .map((part: InternalMessagePart): Part | null => {
-      if (part.type === 'text' && typeof part.text === 'string') {
-        return { text: part.text };
-      } else if (part.type === 'file_uri' && part.uri && part.mimeType) {
-        return createPartFromUri(part.uri, part.mimeType);
-      } else {
-        logger.warn(
-          `Skipping unsupported internal part type for sendMessage: ${JSON.stringify(part)}`,
-        );
-        return null;
-      }
-    })
-    .filter((part: Part | null): part is Part => part !== null);
+  const partList = Array.isArray(messageParts) ? messageParts : [messageParts];
+  const resolved: Part[] = [];
+
+  for (const entry of partList) {
+    if (typeof entry === 'string') {
+      resolved.push({ text: entry });
+      continue;
+    }
+
+    if (!entry) {
+      logger.warn('Skipping undefined part while converting message payload.');
+      continue;
+    }
+
+    const legacyPart = entry as unknown as {
+      type?: string;
+      text?: string;
+      uri?: string;
+      mimeType?: string;
+      name?: string;
+      args?: unknown;
+      input?: unknown;
+    };
+
+    if (
+      legacyPart.type === 'file_uri' &&
+      legacyPart.uri &&
+      legacyPart.mimeType
+    ) {
+      resolved.push(createPartFromUri(legacyPart.uri, legacyPart.mimeType));
+      continue;
+    }
+
+    if (legacyPart.type === 'function_call' && legacyPart.name) {
+      resolved.push(
+        createPartFromFunctionCall(
+          legacyPart.name,
+          typeof legacyPart.args === 'object'
+            ? (legacyPart.args as Record<string, unknown>)
+            : (legacyPart.input ?? {}),
+        ),
+      );
+      continue;
+    }
+
+    resolved.push(entry);
+  }
+
+  return resolved;
 }
 
 // Helper function
 function convertMessagesToGoogleContentHistory(
-  messages: Message[],
+  messages: GoogleMessage[],
   logger: AgentLogger,
 ): Content[] {
   const history: Content[] = [];
   let currentRole: 'user' | 'model' | null = null;
   let currentParts: Part[] = [];
 
-  messages.forEach((msg) => {
-    const role =
-      msg.role === 'assistant' ? 'model' : msg.role === 'user' ? 'user' : null;
-    if (!role) return;
+  for (const message of messages) {
+    const normalizedRole =
+      message.role === 'assistant'
+        ? 'model'
+        : message.role === 'user' || message.role === 'model'
+          ? (message.role as 'user' | 'model')
+          : null;
 
-    let parts: Part[] = [];
-    if (Array.isArray(msg.parts)) {
-      parts = msg.parts;
-    } else if (Array.isArray(msg.content)) {
-      parts = msg.content
-        .map((part: InternalMessagePart): Part | null => {
-          if (part.type === 'text' && typeof part.text === 'string') {
-            return { text: part.text };
-          } else if (part.type === 'file_uri' && part.uri && part.mimeType) {
-            return { fileData: { fileUri: part.uri, mimeType: part.mimeType } };
-          } else {
-            logger.warn(
-              `Skipping unsupported internal part type for history conversion: ${JSON.stringify(part)}`,
-            );
-            return null;
-          }
-        })
-        .filter((part: Part | null): part is Part => part !== null);
-    } else if (typeof msg.content === 'string') {
-      parts = [{ text: msg.content }];
+    if (!normalizedRole) {
+      continue;
     }
 
-    if (parts.length === 0) return;
+    const parts = convertInternalPartsToGoogleParts(message.parts, logger);
+    if (parts.length === 0) {
+      continue;
+    }
 
-    if (role === currentRole) {
+    if (normalizedRole === currentRole) {
       currentParts.push(...parts);
     } else {
       if (currentRole && currentParts.length > 0) {
         history.push({ role: currentRole, parts: currentParts });
       }
-      currentRole = role;
-      currentParts = parts;
+      currentRole = normalizedRole;
+      currentParts = [...parts];
     }
-  });
+  }
 
   if (currentRole && currentParts.length > 0) {
     history.push({ role: currentRole, parts: currentParts });
@@ -183,7 +191,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   /** Creates a chat completion response using Google's GenAI API with specified parameters and optional system prompt. */
   async createResponse(
     client: GoogleGenAI,
-    messages: Message[],
+    messages: GoogleMessage[],
     temperature: number,
     systemPrompt?: string,
     endTag?: string,
@@ -206,19 +214,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       this.logger,
     );
 
-    let lastMessageParts: Part[] = [];
-    if (lastMessage) {
-      if (Array.isArray(lastMessage.parts)) {
-        lastMessageParts = lastMessage.parts;
-      } else if (Array.isArray(lastMessage.content)) {
-        lastMessageParts = convertInternalPartsToGoogleParts(
-          lastMessage.content,
-          this.logger,
-        );
-      } else if (typeof lastMessage.content === 'string') {
-        lastMessageParts = [{ text: lastMessage.content }];
-      }
-    }
+    const lastMessageParts = lastMessage
+      ? convertInternalPartsToGoogleParts(lastMessage.parts, this.logger)
+      : [];
     if (lastMessageParts.length === 0) {
       this.logger.error('Could not extract valid parts from the last message.');
       throw new Error('Last message conversion resulted in empty parts.');
@@ -421,11 +419,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     userRequest: string,
     mediaFiles?: string[],
     systemPrompt?: string,
-  ): Promise<any[]> {
+  ): Promise<GoogleMessage[]> {
     const client = await this.getClient();
-    const userContentParts: InternalMessagePart[] = [
-      { type: 'text', text: userPrefix },
-    ];
+    const userContentParts: GooglePart[] = [{ text: userPrefix }];
 
     if (
       mediaFiles &&
@@ -473,14 +469,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           );
 
           userContentParts.push({
-            type: 'text',
             text: `\nFile attached: ${path.basename(mediaFile)}`,
           });
-          userContentParts.push({
-            type: 'file_uri',
-            uri: uploadResult.uri,
-            mimeType: uploadResult.mimeType,
-          });
+          userContentParts.push(
+            createPartFromUri(uploadResult.uri, uploadResult.mimeType),
+          );
           mediaFileResults.push({ path: mediaFile, ok: true });
         } catch (error) {
           this.logger.error(
@@ -501,9 +494,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       }
     }
 
-    userContentParts.push({ type: 'text', text: `\n${userRequest}` });
+    userContentParts.push({ text: `\n${userRequest}` });
 
-    return [{ role: 'user', content: userContentParts }];
+    return [{ role: 'user', parts: userContentParts }];
   }
 
   private determineMimeType(filePath: string): string | null {
@@ -527,12 +520,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   /** Creates message array for subsequent rounds, managing image content and message structure. */
   async createRoundMessages(
-    messages: Message[],
+    messages: GoogleMessage[],
     userMessage: string,
     mediaFiles?: string[],
-  ): Promise<Message[]> {
+  ): Promise<GoogleMessage[]> {
     const client = await this.getClient();
-    const roundParts: InternalMessagePart[] = [];
+    const roundParts: GooglePart[] = [];
 
     if (
       mediaFiles &&
@@ -589,14 +582,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           }
 
           roundParts.push({
-            type: 'text',
             text: `\nProcessing file: ${path.basename(mediaFile)}`,
           });
-          roundParts.push({
-            type: 'file_uri',
-            uri: uploadResult.uri,
-            mimeType: uploadResult.mimeType,
-          });
+          roundParts.push(
+            createPartFromUri(uploadResult.uri, uploadResult.mimeType),
+          );
           mediaFileResults.push({ path: mediaFile, ok: true });
         } catch (error) {
           this.logger.error(
@@ -617,22 +607,22 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       }
     }
 
-    roundParts.push({ type: 'text', text: userMessage });
+    roundParts.push({ text: userMessage });
 
-    messages.push({ role: 'user', content: roundParts });
+    messages.push({ role: 'user', parts: roundParts });
     return messages;
   }
 
   async createUserFollowUpMessages(
-    messages: Message[],
+    messages: GoogleMessage[],
     userMessage: string,
-  ): Promise<Message[]> {
+  ): Promise<GoogleMessage[]> {
     messages.push({ role: 'user', parts: [{ text: userMessage }] });
     return messages;
   }
 
-  createAssistantMessage(text: string): Message {
-    return { role: 'model', parts: [{ text }] };
+  createAssistantMessage(text: string): GoogleMessage {
+    return { role: 'assistant', parts: [{ text }] };
   }
 
   createMediaContent(mediaMessage: MediaEntry[]): MediaEntry[] {
@@ -766,7 +756,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   }
 
   addContinueMessageWithoutPrefill(
-    messages: Message[],
+    messages: GoogleMessage[],
     _stateRound: AgentStateRound,
     toolState: ToolState,
     agentSetting: AgentSetting,
@@ -775,10 +765,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const prefillTokens = toolState.lastResponse.slice(-K_SLICE);
     const userMessageContinuation = `Your response got cut off. Continue responding exactly where you left off, starting after: "${prefillTokens}". Do not repeat yourself or start over. Ensure you end with ${agentSetting.endTag}.`;
     this.logger.debug(`Adding continuation message.`);
-    messages.push({
-      role: 'user',
-      content: [{ type: 'text', text: userMessageContinuation }],
-    });
+    messages.push({ role: 'user', parts: [{ text: userMessageContinuation }] });
   }
 
   updateMessageContentWithPrefill(/* ... */): void {
@@ -788,7 +775,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   }
 
   updateMessageContentWithoutPrefill(
-    messages: Message[],
+    messages: GoogleMessage[],
     bestConnector: string,
     newResponse: string,
     toolState: ToolState,
@@ -799,8 +786,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const lastMessage = messages.at(-1);
     if (
       lastMessage?.role === 'user' &&
-      lastMessage.content &&
-      this.containCutOffMessage(lastMessage.content)
+      this.containCutOffMessage(lastMessage.parts)
     ) {
       messages.pop();
       this.logger.debug('Removed user continuation prompt.');
@@ -808,42 +794,29 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     const modelMessage = messages.at(-1);
     if (modelMessage?.role === 'assistant') {
-      if (Array.isArray(modelMessage.content)) {
-        let lastTextPart = null;
-        for (let i = modelMessage.content.length - 1; i >= 0; i--) {
-          if (
-            modelMessage.content[i] &&
-            modelMessage.content[i].type === 'text'
-          ) {
-            lastTextPart = modelMessage.content[i];
-            break;
-          }
+      const parts = modelMessage.parts ?? [];
+      let lastTextPart: Part | undefined;
+      for (let i = parts.length - 1; i >= 0; i--) {
+        if (parts[i]?.text) {
+          lastTextPart = parts[i];
+          break;
         }
-        if (lastTextPart) {
-          lastTextPart.text =
-            (lastTextPart.text || '') + bestConnector + newResponse;
-        } else {
-          modelMessage.content.push({
-            type: 'text',
-            text: bestConnector + newResponse,
-          });
-          this.logger.warn(
-            'Added new text part to last model message as none existed.',
-          );
-        }
+      }
+      if (lastTextPart) {
+        lastTextPart.text =
+          (lastTextPart.text || '') + bestConnector + newResponse;
       } else {
-        modelMessage.content = [
-          { type: 'text', text: toolState.accumulatedOutput },
-        ];
-        this.logger.error(
-          'Last model message content was not an array. Resetting content.',
+        parts.push({ text: bestConnector + newResponse });
+        this.logger.warn(
+          'Added new text part to last model message as none existed.',
         );
       }
+      modelMessage.parts = parts;
     } else {
       this.logger.debug('Adding new model message for the response.');
       messages.push({
         role: 'assistant',
-        content: [{ type: 'text', text: toolState.accumulatedOutput }],
+        parts: [{ text: toolState.accumulatedOutput }],
       });
     }
   }
@@ -851,12 +824,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   async initializeOutputAndPrefill(
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
-    messages: Message[],
+    messages: GoogleMessage[],
     toolState: ToolState,
     outputFile: string,
     prefill: string,
     groupId?: string,
-  ): Promise<[boolean, Message[]]> {
+  ): Promise<[boolean, GoogleMessage[]]> {
     let endTurn = false;
     this.logger.debug(
       `Initializing output and prefill for ${outputFile}. Prefill content: "${prefill.slice(0, 100)}..."`,
@@ -873,15 +846,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       const pseudoPrefillMsg = `Organize your response with XML tags. Start your response with:\n${prefill}`;
 
       if (lastMessage) {
-        if (Array.isArray(lastMessage.content)) {
-          lastMessage.content.push({ type: 'text', text: pseudoPrefillMsg });
-        } else {
-          lastMessage.content = [{ type: 'text', text: pseudoPrefillMsg }];
-        }
+        lastMessage.parts.push({ text: pseudoPrefillMsg });
       } else {
         messages.push({
           role: 'assistant',
-          content: [{ type: 'text', text: pseudoPrefillMsg }],
+          parts: [{ text: pseudoPrefillMsg }],
         });
       }
 
@@ -906,10 +875,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     await WorkspaceFS.write(outputFile, fileContent);
     this.logger.debug(`Cleaned and saved existing content to ${outputFile}.`);
-    messages.push({
-      role: 'assistant',
-      content: [{ type: 'text', text: fileContent }],
-    });
+    messages.push({ role: 'assistant', parts: [{ text: fileContent }] });
     this.logger.debug(
       `Added existing file content to messages as 'assistant' role.`,
     );


### PR DESCRIPTION
## Summary
- replace the handler's custom message interfaces with aliases that wrap `SendMessageParameters['message']`, `Content`, and `Part`
- update message conversion, initialization, and round-building helpers to work directly with the SDK message types and native part builders
- adjust continuation and prefill flows to mutate `Content` parts directly so token counting, streaming, and tool responses use the same shapes

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc4c226e688324afd66c5236875fe1