### PR TITLE
fix: use response text getter for Google GenAI handler

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -677,21 +677,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     const candidate = responseObject.candidates[0];
 
-    let responseText = '';
-    if (candidate?.content?.parts) {
-      responseText = candidate.content.parts
-        // Exclude reasoning/thought blocks from the returned text
-        .filter((part) => !!part.text && !part.thought)
-        .map((part: Part) => part.text ?? '')
-        .join('')
-        .trim();
-    } else {
+    const rawResponseText = responseObject.text;
+    if (rawResponseText === undefined) {
       this.logger.warn(
         'Candidate content or parts missing in response object.',
       );
     }
-
-    responseText = replacementEngine.applyAll(responseText);
+    let responseText = replacementEngine.applyAll(
+      (rawResponseText ?? '').trim(),
+    );
 
     const usage = responseObject.usageMetadata;
     const stopReason: FinishReason =


### PR DESCRIPTION
## Summary
- replace manual candidate part aggregation with the SDK-provided response text getter
- log a warning when the getter returns no text before applying cleanup rules

## Testing
- npm run format
- npm run lint
- CI=1 npm test *(fails: vscode-test cannot load libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4bb665b08324aac711cfdbcf46ff