### PR TITLE
refactor: reuse Google text part helper

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -10,6 +10,7 @@ import {
   FinishReason,
   type Candidate,
   File,
+  createPartFromText,
   createPartFromUri,
   createPartFromFunctionCall,
   createPartFromFunctionResponse,
@@ -81,7 +82,7 @@ function convertInternalPartsToGoogleParts(
   return internalParts
     .map((part: InternalMessagePart): Part | null => {
       if (part.type === 'text' && typeof part.text === 'string') {
-        return { text: part.text };
+        return createPartFromText(part.text);
       } else if (part.type === 'file_uri' && part.uri && part.mimeType) {
         return createPartFromUri(part.uri, part.mimeType);
       } else {
@@ -115,9 +116,9 @@ function convertMessagesToGoogleContentHistory(
       parts = msg.content
         .map((part: InternalMessagePart): Part | null => {
           if (part.type === 'text' && typeof part.text === 'string') {
-            return { text: part.text };
+            return createPartFromText(part.text);
           } else if (part.type === 'file_uri' && part.uri && part.mimeType) {
-            return { fileData: { fileUri: part.uri, mimeType: part.mimeType } };
+            return createPartFromUri(part.uri, part.mimeType);
           } else {
             logger.warn(
               `Skipping unsupported internal part type for history conversion: ${JSON.stringify(part)}`,
@@ -127,7 +128,7 @@ function convertMessagesToGoogleContentHistory(
         })
         .filter((part: Part | null): part is Part => part !== null);
     } else if (typeof msg.content === 'string') {
-      parts = [{ text: msg.content }];
+      parts = [createPartFromText(msg.content)];
     }
 
     if (parts.length === 0) return;
@@ -216,7 +217,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           this.logger,
         );
       } else if (typeof lastMessage.content === 'string') {
-        lastMessageParts = [{ text: lastMessage.content }];
+        lastMessageParts = [createPartFromText(lastMessage.content)];
       }
     }
     if (lastMessageParts.length === 0) {
@@ -246,7 +247,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       history: chatHistory,
       config: generationConfig,
       ...(systemPrompt && {
-        systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] },
+        systemInstruction: {
+          role: 'system',
+          parts: [createPartFromText(systemPrompt)],
+        },
       }),
     };
 
@@ -256,7 +260,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         if (systemPrompt) {
           countContents.push({
             role: 'system',
-            parts: [{ text: systemPrompt }],
+            parts: [createPartFromText(systemPrompt)],
           });
         }
         countContents.push(...chatHistory);
@@ -627,12 +631,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     messages: Message[],
     userMessage: string,
   ): Promise<Message[]> {
-    messages.push({ role: 'user', parts: [{ text: userMessage }] });
+    messages.push({
+      role: 'user',
+      parts: [createPartFromText(userMessage)],
+    });
     return messages;
   }
 
   createAssistantMessage(text: string): Message {
-    return { role: 'model', parts: [{ text }] };
+    return { role: 'model', parts: [createPartFromText(text)] };
   }
 
   createMediaContent(mediaMessage: MediaEntry[]): MediaEntry[] {
@@ -1041,7 +1048,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const resultPart = createPartFromFunctionResponse(id, name, result);
     const callParts: Part[] = [];
     if (text) {
-      callParts.push({ text });
+      callParts.push(createPartFromText(text));
     }
     callParts.push(callPart);
     const callMsg: Content = { role: 'assistant', parts: callParts };


### PR DESCRIPTION
## Summary
- reuse the @google/genai createPartFromText helper across Google model handler message conversions and follow-up builders
- rely on SDK helpers when constructing chat history and tool follow-up parts to avoid manual `{ text: ... }` objects

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68cc4b9786c88324be76362f39ab0ecc