### PR TITLE
fix: type google usage methods

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogle.ts
@@ -62,7 +62,12 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
   }
 
   /** Computes cost based on Google's token usage format. */
-  computePrice(responseUsage: any): number {
+  computePrice(
+    responseUsage:
+      | GenerateContentResponseUsageMetadata
+      | CompletionUsage
+      | null,
+  ): number {
     if (!responseUsage) return 0;
 
     const normalized = this.normalizeToOpenAIFormat(responseUsage);
@@ -72,10 +77,11 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
   }
 
   /** Creates usage statistics from Google's response format. */
-
-  // In the future i want to type this to GenerateContentResponseUsageMetadata | CompletionUsage, but this needs to change the base class
   computeResponseUsage(
-    responseUsage: any,
+    responseUsage:
+      | GenerateContentResponseUsageMetadata
+      | CompletionUsage
+      | null,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
     if (!responseUsage) {


### PR DESCRIPTION
## Summary
- type the Google model usage helpers to accept GenerateContentResponseUsageMetadata or CompletionUsage
- ensure null usage is handled before normalizing and delegate to the OpenAI base implementation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc4c32fbf88324b472e7e2a1e5dfc8