### PR TITLE
fix: load multiple output agent definitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,12 @@ The core of TeXRA is its agent architecture located in `src/agent/`:
 - **Model handlers** abstract different AI provider APIs (Anthropic, OpenAI, Google, etc.)
 - Agents are configured via YAML files in `resources/agents/`
 
+**Multiple-output agent variants**: `_multiple` YAML files may provide alternate
+prompts for agents that support multiple outputs. The preference for these
+variants is only applied to the initial agent requested by the runtime. Parent
+definitions loaded through the `inherits` field always use their base files so
+that shared prompts and defaults remain consistent across the inheritance chain.
+
 ### Command Organization
 
 Commands in `src/commands/` are organized by domain:

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -65,12 +65,71 @@ export async function loadYaml(absolutePath: string): Promise<object> {
  * Loads agent settings and prompts with inheritance support.
  * Merges with parent configurations if specified in the inherits field.
  */
+interface LoadAgentOptions {
+  preferMultiple?: boolean;
+}
+
+async function resolveAgentDefinition(
+  agentPath: string,
+  agentNameFromFile: string,
+  options?: LoadAgentOptions,
+): Promise<{ filePath: string; resolvedName: string }> {
+  const preferMultiple = options?.preferMultiple ?? false;
+  const candidateNames: string[] = [];
+
+  if (preferMultiple) {
+    const preferredName = agentNameFromFile.endsWith('_multiple')
+      ? agentNameFromFile
+      : `${agentNameFromFile}_multiple`;
+    candidateNames.push(preferredName);
+  }
+
+  candidateNames.push(agentNameFromFile);
+
+  const seenCandidates = new Set<string>();
+  for (const candidate of candidateNames) {
+    if (seenCandidates.has(candidate)) {
+      continue;
+    }
+    seenCandidates.add(candidate);
+
+    const candidatePath = path.join(agentPath, `${candidate}.yaml`);
+    if (await AbsoluteFS.exists(candidatePath)) {
+      if (
+        preferMultiple &&
+        candidate === agentNameFromFile &&
+        !agentNameFromFile.endsWith('_multiple')
+      ) {
+        logger.warn(
+          CHANNEL,
+          `Requested multiple outputs for agent "${agentNameFromFile}" but no _multiple definition was found. Falling back to base definition.`,
+        );
+      }
+      return { filePath: candidatePath, resolvedName: candidate };
+    }
+  }
+
+  const fallbackPath = path.join(agentPath, `${agentNameFromFile}.yaml`);
+  if (preferMultiple && !agentNameFromFile.endsWith('_multiple')) {
+    logger.warn(
+      CHANNEL,
+      `Requested multiple outputs for agent "${agentNameFromFile}" but no _multiple definition was found. Falling back to base definition.`,
+    );
+  }
+  return { filePath: fallbackPath, resolvedName: agentNameFromFile };
+}
+
 export async function loadAgentSettingAndPrompts(
   agentPath: string,
   agentNameFromFile: string,
+  options?: LoadAgentOptions,
 ): Promise<[AgentSetting, AgentPrompt]> {
   try {
-    const agentFile = path.join(agentPath, `${agentNameFromFile}.yaml`);
+    const { filePath: agentFile, resolvedName } = await resolveAgentDefinition(
+      agentPath,
+      agentNameFromFile,
+      options,
+    );
     const rawConfig = await loadYaml(agentFile);
     const config = AgentDefinitionSchema.parse(rawConfig);
 
@@ -141,6 +200,17 @@ export async function loadAgentSettingAndPrompts(
 
     // The function returns the validated settings block and prompts.
     // The agent's name (declaredAgentName) is known in this scope but not part of AgentSetting.
+    if (
+      options?.preferMultiple &&
+      resolvedName.endsWith('_multiple') &&
+      !agentNameFromFile.endsWith('_multiple')
+    ) {
+      logger.debug(
+        CHANNEL,
+        `Using _multiple agent definition "${resolvedName}" for base agent "${agentNameFromFile}".`,
+      );
+    }
+
     return [settings as AgentSetting, prompts as AgentPrompt];
   } catch (err) {
     vscode.window.showErrorMessage(

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -64,6 +64,10 @@ export async function loadYaml(absolutePath: string): Promise<object> {
 /**
  * Loads agent settings and prompts with inheritance support.
  * Merges with parent configurations if specified in the inherits field.
+ *
+ * The {@link LoadAgentOptions.preferMultiple} flag only affects the initial
+ * agent being resolved. Parent definitions always load their base variant so
+ * that inherited prompts remain consistent with the author's expectations.
  */
 interface LoadAgentOptions {
   preferMultiple?: boolean;
@@ -150,6 +154,8 @@ export async function loadAgentSettingAndPrompts(
       const [parentSettings, parentPrompts] = await loadAgentSettingAndPrompts(
         agentPath,
         parent, // Parent's name (from its filename or root 'name') is used for recursive loading
+        // Intentionally omit options so parents always load their base
+        // definition instead of inheriting multiple-output preferences.
       );
 
       // Get current agent's specific settings and prompts from its YAML

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -474,6 +474,7 @@ export async function executeAgent(
       const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
         agentPath,
         requestedAgentName,
+        { preferMultiple: fullConfig.useMultipleOutputs },
       );
 
       // Get appropriate agent class and create instance

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -60,6 +60,7 @@ async function buildToolUseAgent(
   const [agentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
     agentPath,
     fullConfig.agent,
+    { preferMultiple: fullConfig.useMultipleOutputs },
   );
 
   if (!isToolUseAgent(agentSetting)) {

--- a/src/test/agent/runtime/agentLoad.test.ts
+++ b/src/test/agent/runtime/agentLoad.test.ts
@@ -1,0 +1,106 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports - agent runtime
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
+import { AbsoluteFS } from '@utils/files';
+
+suite('loadAgentSettingAndPrompts', () => {
+  const absoluteFsAny = AbsoluteFS as unknown as {
+    exists: (filePath: string) => Promise<boolean>;
+    read: (filePath: string) => Promise<string>;
+  };
+  const originalExists = absoluteFsAny.exists;
+  const originalRead = absoluteFsAny.read;
+
+  const fileContents = new Map<string, string>();
+
+  function normalize(filePath: string): string {
+    return path.normalize(filePath);
+  }
+
+  setup(() => {
+    fileContents.clear();
+
+    absoluteFsAny.exists = async (filePath: string) =>
+      fileContents.has(normalize(filePath));
+
+    absoluteFsAny.read = async (filePath: string) => {
+      const normalized = normalize(filePath);
+      const content = fileContents.get(normalized);
+      if (!content) {
+        throw new Error(`File not found: ${filePath}`);
+      }
+      return content;
+    };
+  });
+
+  teardown(() => {
+    absoluteFsAny.exists = originalExists;
+    absoluteFsAny.read = originalRead;
+  });
+
+  test('uses the _multiple definition when available', async () => {
+    const agentPath = path.join('/', 'tmp', 'agents');
+    const baseDefinitionPath = path.join(agentPath, 'polish.yaml');
+    const multipleDefinitionPath = path.join(agentPath, 'polish_multiple.yaml');
+
+    fileContents.set(
+      normalize(multipleDefinitionPath),
+      [
+        'name: polish_multiple',
+        'settings:',
+        '  agentType: direct',
+        'prompts:',
+        '  userRequest: multiple variant',
+        '',
+      ].join('\n'),
+    );
+
+    fileContents.set(
+      normalize(baseDefinitionPath),
+      [
+        'name: polish',
+        'settings:',
+        '  agentType: direct',
+        'prompts:',
+        '  userRequest: base variant',
+        '',
+      ].join('\n'),
+    );
+
+    const [, prompts] = await loadAgentSettingAndPrompts(agentPath, 'polish', {
+      preferMultiple: true,
+    });
+
+    assert.strictEqual(prompts.userRequest, 'multiple variant');
+  });
+
+  test('falls back to the base definition when _multiple is missing', async () => {
+    const agentPath = path.join('/', 'tmp', 'agents');
+    const baseDefinitionPath = path.join(agentPath, 'summarize.yaml');
+
+    fileContents.set(
+      normalize(baseDefinitionPath),
+      [
+        'name: summarize',
+        'settings:',
+        '  agentType: direct',
+        'prompts:',
+        '  userRequest: base only',
+        '',
+      ].join('\n'),
+    );
+
+    const [, prompts] = await loadAgentSettingAndPrompts(
+      agentPath,
+      'summarize',
+      {
+        preferMultiple: true,
+      },
+    );
+
+    assert.strictEqual(prompts.userRequest, 'base only');
+  });
+});


### PR DESCRIPTION
## Summary
- allow the agent loader to prefer `_multiple` definitions when multiple outputs are requested
- update runtime execution and resume flow to pass the new preference flag
- add unit coverage proving `_multiple` variants are selected with a fallback to the base agent

## Testing
- npm run lint
- npm test *(fails: vscode binary requires libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3ce61c5483249eddf737ca833482