### PR TITLE
fix: confine google token limit detection to native stop reasons

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogle.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogle.ts
@@ -2,11 +2,12 @@
 // (none needed)
 
 // Third-party imports
+import { FinishReason } from '@google/genai';
 import OpenAI from 'openai';
 import type { CompletionUsage } from 'openai/resources/completions';
 
 // Local imports - agent
-import { hasEndTag } from '../core/AgentDataclass';
+import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
 import {
   OpenAIAPIResponseUsage,
   GenerateContentResponseUsageMetadata,
@@ -14,7 +15,15 @@ import {
 
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+
+// Token limit stop reasons reported by Google's OpenAI-compatible API.
+const TOKEN_LIMIT_REASONS = new Set<string>([
+  OPENAI_CHAT_FINISH.LENGTH.toLowerCase(),
+  'max_tokens',
+  'maxtokens',
+]);
 
 /**
  * Handler for Google models using OpenAI-compatible API.
@@ -89,12 +98,35 @@ export class ModelHandlerGoogle extends ModelHandlerOpenAI {
     return super.computeResponseUsage(normalized, responseTime);
   }
 
-  /** Determines if generation should continue based on response content. */
+  /**
+   * Determines if generation should continue based on response content and stop reason.
+   * Google surfaces FinishReason.MAX_TOKENS when output truncates; we only continue when
+   * that happens before the agent's closing tag has been emitted.
+   */
   shouldContinue(
     stopReason: ProviderStopReason,
     newResponse: string,
-    agentSetting: any,
+    agentSetting: AgentSetting,
   ): boolean {
-    return !hasEndTag(agentSetting, newResponse);
+    const containsEndTag = hasEndTag(agentSetting, newResponse);
+    const normalizedStopReason =
+      typeof stopReason === 'string' ? stopReason.toLowerCase() : undefined;
+
+    const hitTokenLimit =
+      stopReason === FinishReason.MAX_TOKENS ||
+      (normalizedStopReason !== undefined &&
+        TOKEN_LIMIT_REASONS.has(normalizedStopReason));
+
+    if (hitTokenLimit && !containsEndTag) {
+      this.logger.debug(
+        `Continuing generation: stopReason='${stopReason}' hit token limit before end tag '${agentSetting.endTag}'.`,
+      );
+      return true;
+    }
+
+    this.logger.debug(
+      `Stopping generation: stopReason='${stopReason}', hitTokenLimit=${hitTokenLimit}, hasEndTag=${containsEndTag}.`,
+    );
+    return false;
   }
 }

--- a/src/model/providers/googleModels.ts
+++ b/src/model/providers/googleModels.ts
@@ -8,6 +8,9 @@ import {
 } from '../ModelConfig';
 
 // Common capabilities for Google models
+// Continuation: ModelHandlerGoogle inspects Google's FinishReason stop signals.
+// When MAX_TOKENS triggers without emitting the closing tag we enqueue a follow-up
+// request so tuning changes should preserve the native stop reasons returned by the API.
 const GOOGLE_DEFAULT_CAPABILITIES: ModelCapabilities = {
   ...DEFAULT_MODEL_CAPABILITIES,
   cacheDiscountFactor: 0.25,

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -1,0 +1,92 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import { FinishReason } from '@google/genai';
+
+// Local imports - agent
+import type { AgentSetting } from '@agent/core/AgentDataclass';
+import { ModelHandlerGoogle } from '@agent/modelHandlers/modelHandlerGoogle';
+import { OPENAI_CHAT_FINISH } from '@agent/modelHandlers/types/StopReasonTypes';
+
+// Local imports - model config
+import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from '@model/ModelConfig';
+
+describe('ModelHandlerGoogle.shouldContinue', () => {
+  const handler = new ModelHandlerGoogle({
+    name: 'test-google-model',
+    fullName: 'google/test',
+    provider: ModelProvider.GOOGLE,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 4096,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+  });
+
+  const agentSetting = {
+    endTag: '</doc>',
+    documentTag: 'doc',
+  } as AgentSetting;
+
+  it('continues when FinishReason.MAX_TOKENS is returned without the end tag', () => {
+    const shouldContinue = handler.shouldContinue(
+      FinishReason.MAX_TOKENS,
+      'partial output',
+      agentSetting,
+    );
+
+    assert.equal(shouldContinue, true);
+  });
+
+  it('stops when the end tag is present even if FinishReason.MAX_TOKENS was returned', () => {
+    const shouldContinue = handler.shouldContinue(
+      FinishReason.MAX_TOKENS,
+      'partial output</doc>',
+      agentSetting,
+    );
+
+    assert.equal(shouldContinue, false);
+  });
+
+  it('does not continue when stop reason indicates a normal stop', () => {
+    const shouldContinue = handler.shouldContinue(
+      FinishReason.STOP,
+      'partial output',
+      agentSetting,
+    );
+
+    assert.equal(shouldContinue, false);
+  });
+
+  it('continues when the OpenAI-compatible length stop reason is returned', () => {
+    const shouldContinue = handler.shouldContinue(
+      OPENAI_CHAT_FINISH.LENGTH,
+      'partial output',
+      agentSetting,
+    );
+
+    assert.equal(shouldContinue, true);
+  });
+
+  it('continues when the stop reason is max_tokens in snake case', () => {
+    const shouldContinue = handler.shouldContinue(
+      'max_tokens',
+      'partial output',
+      agentSetting,
+    );
+
+    assert.equal(shouldContinue, true);
+  });
+
+  it('continues when the SDK reports maxTokens in camelCase', () => {
+    const shouldContinue = handler.shouldContinue(
+      'maxTokens',
+      'partial output',
+      agentSetting,
+    );
+
+    assert.equal(shouldContinue, true);
+  });
+});


### PR DESCRIPTION
## Summary
- remove dependencies on Anthropic and MCP stop reason constants when detecting Google token-limit stops
- rely on normalized native strings for token limit detection and expand tests to cover the snake_case variant

## Testing
- npm run format
- npm run lint
- npm test *(fails: VS Code binary from vscode-test is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfea80ce083248fc32ea95c2ff997