### PR TITLE
docs: require compile step before commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ When updating CHANGELOG.md:
 1. **Install dependencies**: run `npm install` if needed.
 2. **Run checks before committing**:
    - Format code using `npm run format`.
+   - Build the extension bundle with `npm run compile` to ensure the webpack build succeeds.
    - Lint TypeScript sources with `npm run lint`.
    - Execute `npm test` to run the VS Code test suite when possible.
 3. Commit only when `npm run lint` completes without errors. If tests fail due to environment issues, note this in the PR.


### PR DESCRIPTION
## Summary
- update AGENTS.md to instruct contributors to run `npm run compile` before committing

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68cd25b7bdfc8324b1270b72d7d2ec47