### PR TITLE
Fix progress view filter for tool-use sessions

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -259,20 +259,29 @@ export class ProgressEventHandler {
     this.state.setTaskState(streamTabId, taskState);
 
     const normalizedState = this.state.getTaskState(streamTabId);
-    const sessionKind =
-      normalizedState?.agentSessionKind ||
-      deriveAgentSessionKind(normalizedState?.agentType);
-    const currentFilter = this.state.agentTypeFilter;
 
-    if (
-      this.state.activeStream === streamTabId &&
-      currentFilter !== 'all' &&
-      currentFilter !== sessionKind
-    ) {
-      this.logger.debug(
-        `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
+    if (!normalizedState) {
+      this.logger.warn(
+        `Received setTaskState for ${streamTabId} but no state was stored`,
       );
-      this.state.agentTypeFilter = sessionKind;
+    } else {
+      const sessionKind =
+        normalizedState.agentSessionKind ??
+        deriveAgentSessionKind(normalizedState.agentType);
+      const currentFilter = this.state.agentTypeFilter;
+      const activeStream = this.state.activeStream;
+
+      if (
+        activeStream &&
+        activeStream === streamTabId &&
+        currentFilter !== 'all' &&
+        currentFilter !== sessionKind
+      ) {
+        this.logger.debug(
+          `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
+        );
+        this.state.agentTypeFilter = sessionKind;
+      }
     }
 
     if (executionId) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -13,6 +13,7 @@ import { ProgressViewState } from '../state/ProgressViewState';
 import { buildStreamInfos } from '../streamInfoUtils';
 import type { StreamTabInfo } from '../types';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import { deriveAgentSessionKind } from '@agent/core/AgentDataclass';
 
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
@@ -256,6 +257,23 @@ export class ProgressEventHandler {
     const { streamTabId, executionId, taskState } = data;
 
     this.state.setTaskState(streamTabId, taskState);
+
+    const normalizedState = this.state.getTaskState(streamTabId);
+    const sessionKind =
+      normalizedState?.agentSessionKind ||
+      deriveAgentSessionKind(normalizedState?.agentType);
+    const currentFilter = this.state.agentTypeFilter;
+
+    if (
+      this.state.activeStream === streamTabId &&
+      currentFilter !== 'all' &&
+      currentFilter !== sessionKind
+    ) {
+      this.logger.debug(
+        `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
+      );
+      this.state.agentTypeFilter = sessionKind;
+    }
 
     if (executionId) {
       this.state.setExecutionId(streamTabId, executionId);


### PR DESCRIPTION
## Summary
- adjust the progress view event handler to derive the session kind after storing task state
- automatically realign the agent type filter with the active stream so newly launched tool-use sessions become visible

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: vscode-test requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd44558520832489b4d78bd00a0aab