### PR TITLE
fix: handle anthropic stream abort cleanup

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -219,28 +219,55 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
         // we should also make sure partial results can be returned in the presence of errors!
         const stream = client.beta.messages.stream(options, { signal });
-        const groupId = this.logger.getActiveGroupId();
-        const thinking = this.createThinkingStream(groupId);
-        const output = this.isOutputStreamingEnabled()
-          ? this.createOutputStream(groupId)
-          : undefined;
-        stream.on('thinking', (delta: string) => {
-          thinking.append(delta);
-        });
-        stream.on('text', (delta: string) => {
-          output?.append(delta);
-        });
 
-        // Note that there is no second consumption problem as per anthropic sdk examples
-        response = await stream.finalMessage();
-        const finalReasoning = this.processThinkingBlock(response);
-        thinking.finalize(finalReasoning ?? undefined);
-        const finalOutput =
-          response.content
-            ?.filter((c: any) => c.type === 'text')
-            ?.map((c: any) => c.text)
-            .join('') ?? '';
-        if (output) output.finalize(finalOutput);
+        if (signal?.aborted) {
+          stream.controller.abort();
+          const abortError =
+            signal.reason ??
+            Object.assign(new Error('The operation was aborted.'), {
+              name: 'AbortError',
+            });
+          throw abortError;
+        }
+
+        let cleanupAbortListener: (() => void) | undefined;
+        if (signal) {
+          const abortListener = () => {
+            stream.controller.abort();
+            signal.removeEventListener('abort', abortListener);
+          };
+          signal.addEventListener('abort', abortListener);
+          cleanupAbortListener = () => {
+            signal.removeEventListener('abort', abortListener);
+          };
+        }
+
+        try {
+          const groupId = this.logger.getActiveGroupId();
+          const thinking = this.createThinkingStream(groupId);
+          const output = this.isOutputStreamingEnabled()
+            ? this.createOutputStream(groupId)
+            : undefined;
+          stream.on('thinking', (delta: string) => {
+            thinking.append(delta);
+          });
+          stream.on('text', (delta: string) => {
+            output?.append(delta);
+          });
+
+          // Note that there is no second consumption problem as per anthropic sdk examples
+          response = await stream.finalMessage();
+          const finalReasoning = this.processThinkingBlock(response);
+          thinking.finalize(finalReasoning ?? undefined);
+          const finalOutput =
+            response.content
+              ?.filter((c: any) => c.type === 'text')
+              ?.map((c: any) => c.text)
+              .join('') ?? '';
+          if (output) output.finalize(finalOutput);
+        } finally {
+          cleanupAbortListener?.();
+        }
       } else {
         response = await client.beta.messages.create(options, { signal });
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1192,8 +1192,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
       tool_call_id: toolCall.id ?? id,
       content: JSON.stringify(result),
     };
-    let messages: ChatCompletionMessageParam[] = [];
-    messages.push(callMsg, resultMsg);
+    const messages: ChatCompletionMessageParam[] = [callMsg, resultMsg];
     return messages;
   }
 


### PR DESCRIPTION
## Summary
- abort Anthropic streaming responses when the request signal is already aborted and tie listener cleanup to stream completion
- register and remove abort listeners around the Anthropic stream to prevent leaked handlers across runs
- simplify OpenAI tool call message assembly to satisfy linting requirements

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.1/code: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68cd61f00ad4832489f1d6f16f94a2c2