### PR TITLE
refactor: adopt node lifecycle for reflection flow

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -12,6 +12,7 @@ import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
 import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
+import { BaseNode } from '@agent/node';
 
 // Local imports - latex utils
 import { bestConnectionMethod } from '@latex';
@@ -30,7 +31,6 @@ import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
-import { getRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import xmlUtils from '@utils/text/xmlUtils';
 
 /**
@@ -48,6 +48,340 @@ export interface ResponseCycleOptions<C = unknown> {
   setAbortController: (ctrl: AbortController | null) => void;
 }
 
+interface ResponseIterationResult {
+  endTurn: boolean;
+  shouldStop: boolean;
+}
+
+interface ResponseIterationSharedContext<C> {
+  messages: ProviderMessage[];
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  outputFile: string;
+  roundGroupId?: string;
+  iterationResult?: ResponseIterationResult;
+}
+
+interface DebugContext {
+  logger: AgentLogger;
+  modelName: string;
+  executionId?: ExecutionId;
+  groupId?: string;
+}
+
+interface DebugFileOptions {
+  continuationCount: number;
+  outputFile: string;
+}
+
+interface ResponseIterationPrepResult {
+  exists: boolean;
+  startTime: number;
+  systemPrompt: string;
+  debugContext: DebugContext;
+  debugFileOptions: DebugFileOptions;
+  abortController: AbortController;
+}
+
+function createResponseIterationNode<C>(
+  options: ResponseCycleOptions<C>,
+  executionId?: ExecutionId,
+): BaseNode<ResponseIterationSharedContext<C>> {
+  const {
+    modelHandler,
+    agentSetting,
+    agentConfig,
+    agentPrompt,
+    userVars,
+    logger,
+    client,
+  } = options;
+
+  return new (class extends BaseNode<ResponseIterationSharedContext<C>> {
+    private shared!: ResponseIterationSharedContext<C>;
+
+    async prep(
+      shared: ResponseIterationSharedContext<C>,
+    ): Promise<ResponseIterationPrepResult> {
+      this.shared = shared;
+      shared.iterationResult = undefined;
+
+      const exists = await WorkspaceFS.exists(shared.outputFile);
+      const startTime = Date.now();
+      const systemPrompt = await getSystemPromptWithRules(
+        agentPrompt.systemPrompt,
+        userVars,
+      );
+
+      const debugContext: DebugContext = {
+        logger,
+        modelName: agentConfig.model,
+        executionId,
+        groupId: shared.roundGroupId,
+      };
+      const debugFileOptions: DebugFileOptions = {
+        continuationCount: shared.stateRound.continuationCount,
+        outputFile: shared.outputFile,
+      };
+
+      await maybeSaveDebugObject({
+        object: shared.messages,
+        objectType: 'messages',
+        context: debugContext,
+        fileOptions: debugFileOptions,
+      });
+
+      const abortController = new AbortController();
+      options.setAbortController(abortController);
+      modelHandler.setOutputStreaming(false);
+
+      return {
+        exists,
+        startTime,
+        systemPrompt,
+        debugContext,
+        debugFileOptions,
+        abortController,
+      };
+    }
+
+    async exec(prepRes: ResponseIterationPrepResult): Promise<any> {
+      const { abortController, systemPrompt, debugContext, debugFileOptions } =
+        prepRes;
+      let responseObject: any;
+      try {
+        responseObject = await modelHandler.createResponse(
+          client,
+          this.shared.messages,
+          agentSetting.temperature || 0.0,
+          systemPrompt,
+          agentSetting.endTag,
+          abortController.signal,
+          modelHandler.capabilities.supportsFunctionCalling
+            ? agentSetting.tools
+            : undefined,
+        );
+        return responseObject;
+      } finally {
+        await maybeSaveDebugObject({
+          object: responseObject,
+          objectType: 'response',
+          context: debugContext,
+          fileOptions: debugFileOptions,
+        });
+        options.setAbortController(null);
+      }
+    }
+
+    async post(
+      shared: ResponseIterationSharedContext<C>,
+      prepRes: ResponseIterationPrepResult,
+      responseObject: any,
+    ): Promise<string | undefined> {
+      await maybeSaveDebugObject({
+        object: responseObject,
+        objectType: 'response',
+        context: prepRes.debugContext,
+        fileOptions: prepRes.debugFileOptions,
+      });
+
+      const taskGroupId = shared.roundGroupId;
+
+      if (!responseObject) {
+        logger.warn(
+          'Model response was aborted or returned no data; output may be incomplete.',
+          taskGroupId,
+        );
+        shared.iterationResult = { endTurn: false, shouldStop: true };
+        return 'default';
+      }
+
+      const responseTime = (Date.now() - prepRes.startTime) / 1000;
+      shared.stateRound.updateResponseTime(responseTime);
+      logger.debug(`Response time: ${responseTime.toFixed(2)}s`, taskGroupId);
+
+      const [newResponse, responseUsage, stopReason] =
+        modelHandler.extractResponse(responseObject, agentSetting.endTag);
+
+      logger.debug(`Stop reason: ${stopReason}`, taskGroupId);
+      logger.debug(
+        `Token usage: ${JSON.stringify(responseUsage)}`,
+        taskGroupId,
+      );
+
+      const thinkingContent = modelHandler.processThinkingBlock(
+        responseObject,
+        taskGroupId,
+        shared.toolState,
+      );
+      const useStreaming = modelHandler.getStreamingConfig();
+
+      if (newResponse) {
+        logger.debug(
+          `Model response: ${newResponse.slice(0, 100)}`,
+          taskGroupId,
+        );
+        if (!useStreaming) {
+          const formattedResponse = await xmlUtils.formatContent(newResponse);
+          logger.info(
+            formattedResponse,
+            taskGroupId,
+            MESSAGE_TYPES.MODEL_RESPONSE,
+          );
+        }
+      }
+
+      if (thinkingContent && !useStreaming) {
+        const formatted = await xmlUtils.formatContent(thinkingContent);
+        logger.info(formatted, taskGroupId, MESSAGE_TYPES.THINKING);
+      }
+
+      const scratchpad = await xmlUtils.extractScratchpad(
+        newResponse,
+        'scratchpad',
+      );
+      if (scratchpad) {
+        logger.info(scratchpad, taskGroupId, MESSAGE_TYPES.SCRATCHPAD);
+      }
+
+      const APIUsage = modelHandler.computeResponseUsage(
+        responseUsage,
+        responseTime,
+      );
+      shared.stateRound.updateTokenCounts(APIUsage);
+      shared.stateGlobal.updateFromCurrRound(shared.stateRound);
+
+      const repetitionResult = checkForMassiveRepetition(
+        shared.toolState.lastResponse,
+        newResponse,
+      );
+      if (repetitionResult.massiveRepetitionDetected) {
+        logger.error(
+          `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(
+            0,
+            REPETITION_DETECTION_THRESHOLD,
+          )}`,
+          taskGroupId,
+        );
+        logger.error(
+          'Massive repetition detected - skipping this response',
+          taskGroupId,
+        );
+        logger.error(
+          'Message structure when repetition detected:',
+          taskGroupId,
+        );
+        logger.error(
+          JSON.stringify(messageToSkeleton(shared.messages), null, 2),
+          taskGroupId,
+        );
+        shared.iterationResult = { endTurn: false, shouldStop: true };
+        return 'default';
+      }
+
+      const processedResponse = replacementEngine.applyAll(newResponse);
+      shared.toolState.updateLastResponse(processedResponse);
+
+      const result = await bestConnectionMethod(
+        shared.toolState.lastResponse.slice(-K_SLICE),
+        processedResponse.slice(0, K_SLICE),
+      );
+      const bestConnector = result.connector;
+
+      shared.toolState.updateAccumulatedOutput(
+        shared.toolState.accumulatedOutput + bestConnector + processedResponse,
+      );
+
+      if (!prepRes.exists) {
+        logger.debug(`Creating new file: ${shared.outputFile}`, taskGroupId);
+        await WorkspaceFS.write(shared.outputFile, processedResponse);
+      } else {
+        logger.debug(
+          `Appending to existing file: ${shared.outputFile}`,
+          taskGroupId,
+        );
+        await WorkspaceFS.appendFile(
+          shared.outputFile,
+          bestConnector + processedResponse,
+        );
+      }
+
+      logger.debug('Response preview:', taskGroupId);
+      logger.debug(
+        `First ${K_SLICE} chars:\n${processedResponse.slice(0, K_SLICE)}`,
+        taskGroupId,
+      );
+      logger.debug(
+        `Last ${K_SLICE} chars:\n${processedResponse.slice(-K_SLICE)}`,
+        taskGroupId,
+      );
+
+      if (modelHandler.capabilities.supportsAssistantPrefill) {
+        modelHandler.updateMessageContentWithPrefill(
+          shared.messages,
+          bestConnector,
+          processedResponse,
+          shared.toolState,
+        );
+      } else {
+        modelHandler.updateMessageContentWithoutPrefill(
+          shared.messages,
+          bestConnector,
+          processedResponse,
+          shared.toolState,
+        );
+      }
+
+      const [shouldEndTurn, shouldStop] = modelHandler.checkStopConditions(
+        stopReason,
+        processedResponse,
+        shared.stateRound,
+        shared.stateGlobal,
+        agentSetting,
+      );
+      shared.iterationResult = { endTurn: shouldEndTurn, shouldStop };
+      if (shouldStop) {
+        return 'default';
+      }
+
+      shared.stateRound.incrementContinuation();
+      logger.info(
+        `Starting continuation #${shared.stateRound.continuationCount}`,
+        taskGroupId,
+      );
+
+      if (
+        modelHandler.shouldContinue(stopReason, processedResponse, agentSetting)
+      ) {
+        logger.debug(
+          'Should continue - adding continuation message to conversation',
+          taskGroupId,
+        );
+        if (modelHandler.capabilities.supportsAssistantPrefill) {
+          modelHandler.addContinueMessageWithPrefill(
+            shared.messages,
+            shared.stateRound,
+            shared.toolState,
+            agentSetting,
+            agentConfig,
+          );
+        } else {
+          modelHandler.addContinueMessageWithoutPrefill(
+            shared.messages,
+            shared.stateRound,
+            shared.toolState,
+            agentSetting,
+            agentConfig,
+          );
+        }
+      }
+
+      return 'default';
+    }
+  })();
+}
+
 /**
  * Executes a response cycle.
  * @returns Tuple of [round state, global state, tool state, completion flag]
@@ -62,19 +396,16 @@ export async function runResponseCycle<C = unknown>(
   roundGroupId?: string,
   executionId?: ExecutionId,
 ): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
-  const {
-    modelHandler,
-    agentSetting,
-    agentConfig,
-    agentPrompt,
-    userVars,
-    logger,
-    client,
-    checkInterruption,
-    setAbortController,
-  } = options;
-
-  const taskGroupId = roundGroupId;
+  const { checkInterruption } = options;
+  const shared: ResponseIterationSharedContext<C> = {
+    messages,
+    stateRound,
+    stateGlobal,
+    toolState,
+    outputFile,
+    roundGroupId,
+  };
+  const iterationNode = createResponseIterationNode(options, executionId);
 
   let endTurn = false;
   while (!endTurn) {
@@ -82,239 +413,17 @@ export async function runResponseCycle<C = unknown>(
       break;
     }
 
-    const exists = await WorkspaceFS.exists(outputFile);
-    const startTime = Date.now();
-    const systemPrompt = await getSystemPromptWithRules(
-      agentPrompt.systemPrompt,
-      userVars,
-    );
-
-    // Common debug save parameters
-    const debugContext = {
-      logger,
-      modelName: agentConfig.model,
-      executionId,
-      groupId: taskGroupId,
-    };
-    const debugFileOptions = {
-      continuationCount: stateRound.continuationCount,
-      outputFile,
-    };
-
-    await maybeSaveDebugObject({
-      object: messages,
-      objectType: 'messages',
-      context: debugContext,
-      fileOptions: debugFileOptions,
-    });
-
-    const abortController = new AbortController();
-    setAbortController(abortController);
-    modelHandler.setOutputStreaming(false);
-    let responseObject;
-    try {
-      responseObject = await modelHandler.createResponse(
-        client,
-        messages,
-        agentSetting.temperature || 0.0,
-        systemPrompt,
-        agentSetting.endTag,
-        abortController.signal,
-        modelHandler.capabilities.supportsFunctionCalling
-          ? agentSetting.tools
-          : undefined,
-      );
-    } finally {
-      await maybeSaveDebugObject({
-        object: responseObject,
-        objectType: 'response',
-        context: debugContext,
-        fileOptions: debugFileOptions,
-      });
-      setAbortController(null);
-    }
-    await maybeSaveDebugObject({
-      object: responseObject,
-      objectType: 'response',
-      context: debugContext,
-      fileOptions: debugFileOptions,
-    });
-    if (!responseObject) {
-      logger.warn(
-        'Model response was aborted or returned no data; output may be incomplete.',
-        taskGroupId,
-      );
-      break;
-    }
-    const responseTime = (Date.now() - startTime) / 1000;
-    stateRound.updateResponseTime(responseTime);
-    logger.debug(`Response time: ${responseTime.toFixed(2)}s`, taskGroupId);
-
-    const [newResponse, responseUsage, stopReason] =
-      modelHandler.extractResponse(responseObject, agentSetting.endTag);
-
-    logger.debug(`Stop reason: ${stopReason}`, taskGroupId);
-    logger.debug(`Token usage: ${JSON.stringify(responseUsage)}`, taskGroupId);
-
-    const thinkingContent = modelHandler.processThinkingBlock(
-      responseObject,
-      taskGroupId,
-      toolState,
-    );
-    const useStreaming = modelHandler.getStreamingConfig();
-
-    if (newResponse) {
-      logger.debug(`Model response: ${newResponse.slice(0, 100)}`, taskGroupId);
-      if (!useStreaming) {
-        const formattedResponse = await xmlUtils.formatContent(newResponse);
-        logger.info(
-          formattedResponse,
-          taskGroupId,
-          MESSAGE_TYPES.MODEL_RESPONSE,
-        );
-      }
-    }
-
-    // Only log thinking content for non-streaming responses
-    // Streaming responses display thinking content progressively via createThinkingStream()
-    // so we avoid duplicate logging here
-    if (thinkingContent && !useStreaming) {
-      const formatted = await xmlUtils.formatContent(thinkingContent);
-      logger.info(formatted, taskGroupId, MESSAGE_TYPES.THINKING);
-    }
-
-    const scratchpad = await xmlUtils.extractScratchpad(
-      newResponse,
-      'scratchpad',
-    );
-    if (scratchpad) {
-      logger.info(scratchpad, taskGroupId, MESSAGE_TYPES.SCRATCHPAD);
-    }
-
-    const APIUsage = modelHandler.computeResponseUsage(
-      responseUsage,
-      responseTime,
-    );
-    stateRound.updateTokenCounts(APIUsage);
-    stateGlobal.updateFromCurrRound(stateRound);
-
-    const repetitionResult = checkForMassiveRepetition(
-      toolState.lastResponse,
-      newResponse,
-    );
-    if (repetitionResult.massiveRepetitionDetected) {
-      logger.error(
-        `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-        taskGroupId,
-      );
-      logger.error(
-        'Massive repetition detected - skipping this response',
-        taskGroupId,
-      );
-      logger.error('Message structure when repetition detected:', taskGroupId);
-      logger.error(
-        JSON.stringify(messageToSkeleton(messages), null, 2),
-        taskGroupId,
-      );
+    await iterationNode.run(shared);
+    const iteration = shared.iterationResult;
+    if (!iteration) {
       break;
     }
 
-    const processedResponse = replacementEngine.applyAll(newResponse);
-    toolState.updateLastResponse(processedResponse);
-
-    const result = await bestConnectionMethod(
-      toolState.lastResponse.slice(-K_SLICE),
-      processedResponse.slice(0, K_SLICE),
-    );
-    const bestConnector = result.connector;
-
-    toolState.updateAccumulatedOutput(
-      toolState.accumulatedOutput + bestConnector + processedResponse,
-    );
-
-    if (!exists) {
-      logger.debug(`Creating new file: ${outputFile}`, taskGroupId);
-      await WorkspaceFS.write(outputFile, processedResponse);
-    } else {
-      logger.debug(`Appending to existing file: ${outputFile}`, taskGroupId);
-      await WorkspaceFS.appendFile(
-        outputFile,
-        bestConnector + processedResponse,
-      );
-    }
-
-    logger.debug('Response preview:', taskGroupId);
-    logger.debug(
-      `First ${K_SLICE} chars:\n${processedResponse.slice(0, K_SLICE)}`,
-      taskGroupId,
-    );
-    logger.debug(
-      `Last ${K_SLICE} chars:\n${processedResponse.slice(-K_SLICE)}`,
-      taskGroupId,
-    );
-
-    if (modelHandler.capabilities.supportsAssistantPrefill) {
-      modelHandler.updateMessageContentWithPrefill(
-        messages,
-        bestConnector,
-        processedResponse,
-        toolState,
-      );
-    } else {
-      modelHandler.updateMessageContentWithoutPrefill(
-        messages,
-        bestConnector,
-        processedResponse,
-        toolState,
-      );
-    }
-
-    const [shouldEndTurn, shouldStop] = modelHandler.checkStopConditions(
-      stopReason,
-      processedResponse,
-      stateRound,
-      stateGlobal,
-      agentSetting,
-    );
-    endTurn = shouldEndTurn;
-    if (shouldStop) {
+    endTurn = iteration.endTurn;
+    if (iteration.shouldStop) {
       break;
-    }
-
-    stateRound.incrementContinuation();
-    logger.info(
-      `Starting continuation #${stateRound.continuationCount}`,
-      taskGroupId,
-    );
-
-    if (
-      modelHandler.shouldContinue(stopReason, processedResponse, agentSetting)
-    ) {
-      logger.debug(
-        'Should continue - adding continuation message to conversation',
-        taskGroupId,
-      );
-      if (modelHandler.capabilities.supportsAssistantPrefill) {
-        modelHandler.addContinueMessageWithPrefill(
-          messages,
-          stateRound,
-          toolState,
-          agentSetting,
-          agentConfig,
-        );
-        continue;
-      } else {
-        modelHandler.addContinueMessageWithoutPrefill(
-          messages,
-          stateRound,
-          toolState,
-          agentSetting,
-          agentConfig,
-        );
-        continue;
-      }
     }
   }
 
-  return [stateRound, stateGlobal, toolState, endTurn];
+  return [shared.stateRound, shared.stateGlobal, shared.toolState, endTurn];
 }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -15,6 +15,7 @@ import { BaseAgent } from '@agent/implementations/BaseAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { BaseNode } from '@agent/node';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import { writePromptToXml } from '@agent/utils/promptUtils';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -49,6 +50,39 @@ export interface RoundOutputOptions {
   outputFile: string;
   endTurn: boolean;
   processGroupId?: string;
+}
+
+type RoundExecutionResult = [
+  AgentStateRound,
+  AgentStateGlobal,
+  any[],
+  boolean,
+  ToolState,
+];
+
+interface RoundNodeSharedContext {
+  currRound: number;
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  messages: any[];
+  prefill: string;
+  outputPath: string;
+  roundGroupId: string;
+  result?: RoundExecutionResult;
+}
+
+interface RoundNodePrepResult {
+  endTurn: boolean;
+  messages: any[];
+}
+
+interface RoundNodeExecResult {
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  messages: any[];
+  endTurn: boolean;
 }
 
 /**
@@ -242,112 +276,173 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * @param roundGroupId - Identifier for grouping related log and output operations.
    * @returns Updated round/global state, messages, completion flag, and tool state after execution.
    */
-  private async runRoundPipeline(
-    currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
-    toolState: ToolState,
-    preparedMessages: any[],
-    prefill: string,
-    outputPath: string,
-    roundGroupId: string,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
-    const [endTurn, updatedMessages] =
-      await this.modelHandler.initializeOutputAndPrefill(
-        this.agentConfig,
-        this.agentSetting,
-        preparedMessages,
-        toolState,
-        outputPath,
-        prefill,
-        roundGroupId,
-      );
+  private createRoundNode(): BaseNode<RoundNodeSharedContext> {
+    const {
+      modelHandler,
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      userVars,
+      logger,
+    } = this;
+    const getClientInstance = this.getClientInstance.bind(this);
+    const checkInterruption = this.checkInterruption.bind(this);
+    const setAbortController = (ctrl: AbortController | null) => {
+      this.abortController = ctrl;
+    };
+    const finalizeRound = this.handleRoundCompletion.bind(this);
+    const executionId = this.executionId;
 
-    if (!endTurn) {
-      const client = this.getClientInstance();
-      const options: ResponseCycleOptions<C> = {
-        modelHandler: this.modelHandler,
-        agentSetting: this.agentSetting,
-        agentConfig: this.agentConfig,
-        agentPrompt: this.agentPrompt,
-        userVars: this.userVars,
-        logger: this.logger,
-        client,
-        checkInterruption: () => this.checkInterruption(),
-        setAbortController: (ctrl) => {
-          this.abortController = ctrl;
-        },
-      };
+    return new (class extends BaseNode<RoundNodeSharedContext> {
+      private context!: RoundNodeSharedContext;
 
-      const [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedToolState,
-        newEndTurn,
-      ] = await runResponseCycle(
-        options,
-        updatedMessages,
-        stateRound,
-        stateGlobal,
-        toolState,
-        outputPath,
-        roundGroupId,
-        this.executionId,
-      );
+      async prep(shared: RoundNodeSharedContext): Promise<RoundNodePrepResult> {
+        this.context = shared;
+        const [endTurn, updatedMessages] =
+          await modelHandler.initializeOutputAndPrefill(
+            agentConfig,
+            agentSetting,
+            shared.messages,
+            shared.toolState,
+            shared.outputPath,
+            shared.prefill,
+            shared.roundGroupId,
+          );
 
-      await this.handleRoundCompletion(
-        currRound,
-        updatedStateRound,
-        updatedStateGlobal,
-        {
-          outputFile: outputPath,
-          endTurn: newEndTurn,
-          processGroupId: roundGroupId,
-        },
-      );
+        shared.messages = updatedMessages;
 
-      if (currRound === 0) {
-        this.logger.debug(
-          `stateGlobal: ${JSON.stringify(updatedStateGlobal)}`,
-          roundGroupId,
-        );
+        return { endTurn, messages: updatedMessages };
       }
 
-      return [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedMessages,
-        newEndTurn,
-        updatedToolState,
-      ];
+      async exec(prepRes: RoundNodePrepResult): Promise<RoundNodeExecResult> {
+        const shared = this.context;
+
+        if (prepRes.endTurn) {
+          return {
+            stateRound: shared.stateRound,
+            stateGlobal: shared.stateGlobal,
+            toolState: shared.toolState,
+            messages: prepRes.messages,
+            endTurn: true,
+          };
+        }
+
+        const client = getClientInstance();
+        const options: ResponseCycleOptions<C> = {
+          modelHandler,
+          agentSetting,
+          agentConfig,
+          agentPrompt,
+          userVars,
+          logger,
+          client,
+          checkInterruption,
+          setAbortController,
+        };
+
+        const [
+          updatedStateRound,
+          updatedStateGlobal,
+          updatedToolState,
+          newEndTurn,
+        ] = await runResponseCycle(
+          options,
+          prepRes.messages,
+          shared.stateRound,
+          shared.stateGlobal,
+          shared.toolState,
+          shared.outputPath,
+          shared.roundGroupId,
+          executionId,
+        );
+
+        return {
+          stateRound: updatedStateRound,
+          stateGlobal: updatedStateGlobal,
+          toolState: updatedToolState,
+          messages: prepRes.messages,
+          endTurn: newEndTurn,
+        };
+      }
+
+      async post(
+        shared: RoundNodeSharedContext,
+        prepRes: RoundNodePrepResult,
+        execRes: RoundNodeExecResult,
+      ): Promise<string | undefined> {
+        const result = execRes ?? {
+          stateRound: shared.stateRound,
+          stateGlobal: shared.stateGlobal,
+          toolState: shared.toolState,
+          messages: prepRes.messages,
+          endTurn: prepRes.endTurn,
+        };
+
+        await finalizeRound(
+          shared.currRound,
+          result.stateRound,
+          result.stateGlobal,
+          {
+            outputFile: shared.outputPath,
+            endTurn: result.endTurn,
+            processGroupId: shared.roundGroupId,
+          },
+        );
+
+        shared.stateRound = result.stateRound;
+        shared.stateGlobal = result.stateGlobal;
+        shared.toolState = result.toolState;
+        shared.messages = result.messages;
+        shared.result = [
+          result.stateRound,
+          result.stateGlobal,
+          result.messages,
+          result.endTurn,
+          result.toolState,
+        ];
+
+        if (shared.currRound === 0) {
+          logger.debug(
+            `stateGlobal: ${JSON.stringify(result.stateGlobal)}`,
+            shared.roundGroupId,
+          );
+        }
+
+        return 'default';
+      }
+    })();
+  }
+
+  private async runRoundNode(
+    context: RoundNodeSharedContext,
+  ): Promise<RoundExecutionResult> {
+    const node = this.createRoundNode();
+    context.result = undefined;
+    await node.run(context);
+    if (!context.result) {
+      throw new Error('Round execution did not produce a result.');
     }
-
-    await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
-      outputFile: outputPath,
-      endTurn,
-      processGroupId: roundGroupId,
-    });
-
-    return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
+    return context.result;
   }
 
   /**
    * Processes initial conversation round.
    * @returns Tuple of [round state, global state, messages, completion flag, tool state]
    */
-  protected async process(): Promise<
-    [AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]
-  > {
+  protected async process(
+    stateGlobal: AgentStateGlobal,
+    messages: any[],
+    toolState: ToolState,
+  ): Promise<RoundExecutionResult> {
     // Initialize input files list
     const inputFiles = [
       this.agentConfig.inputFile,
       ...(this.agentConfig.inputFiles || []),
     ];
-    const toolState = new ToolState();
 
     // Initialize state and messages
     const currRound = 0;
-    const stateGlobal = new AgentStateGlobal();
+    messages.length = 0;
 
     this.logger.debug(`Processing round ${currRound}`);
 
@@ -373,8 +468,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         extraMedia,
         roundGroupId,
       );
-
-      const messages: any[] = [];
 
       // Set up initial prompts
       const promptBuilder = this.getPromptBuilder();
@@ -411,16 +504,18 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       toolState.updateAccumulatedOutput(prefill);
 
       const stateRound = new AgentStateRound(currRound);
-      return this.runRoundPipeline(
+      const context: RoundNodeSharedContext = {
         currRound,
         stateRound,
         stateGlobal,
         toolState,
         messages,
         prefill,
-        this.outputFile[currRound],
+        outputPath: this.outputFile[currRound],
         roundGroupId,
-      );
+      };
+
+      return this.runRoundNode(context);
     });
   }
 
@@ -433,7 +528,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     messages: any[],
     toolState: ToolState,
     currRound: number = 1,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
+  ): Promise<RoundExecutionResult> {
     this.logger.debug(`Processing round ${currRound}`);
 
     return this.withRoundGroup(`r${currRound}`, async (roundGroupId) => {
@@ -483,16 +578,18 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       const prefill = await promptBuilder.buildPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
-      return this.runRoundPipeline(
+      const context: RoundNodeSharedContext = {
         currRound,
         stateRound,
         stateGlobal,
         toolState,
-        roundMessages,
+        messages: roundMessages,
         prefill,
-        this.outputFile[currRound],
+        outputPath: this.outputFile[currRound],
         roundGroupId,
-      );
+      };
+
+      return this.runRoundNode(context);
     });
   }
 
@@ -501,9 +598,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     stateGlobal: AgentStateGlobal,
     messages: any[],
     toolState: ToolState,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
+  ): Promise<RoundExecutionResult> {
     if (currRound === 0) {
-      return await this.process();
+      return await this.process(stateGlobal, messages, toolState);
     }
     return await this.reflect(stateGlobal, messages, toolState, currRound);
   }


### PR DESCRIPTION
## Summary
- restructure the BaseReflectionAgent round handling to run through a reusable Node lifecycle that centralizes output prep, response execution, and completion steps
- wrap the response cycle iteration logic in a Node so provider requests now run through explicit prep, exec, and post hooks before driving the loop

## Testing
- npm run lint
- npm test *(fails: VS Code binary missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cd778a5b3c832498397e7ab2d2eabf