### PR TITLE
refactor: structure reflection agent lifecycle

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -13,11 +13,11 @@ import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 import { ToolState } from '@agent/core/ToolState';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
-import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import { Node } from '@agent/node';
+import { OutputHandler, IOutputHandler } from '@agent/output';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import { writePromptToXml } from '@agent/utils/promptUtils';
-import { bus } from '@eventBus/ProgressEventBus';
 // Standard library imports
 // (none needed)
 
@@ -25,10 +25,11 @@ import { bus } from '@eventBus/ProgressEventBus';
 // (none needed)
 
 // Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - latex utils
 import { LatexMediaManager } from '@latex';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
 
 // System imports - common utilities
@@ -51,6 +52,178 @@ export interface RoundOutputOptions {
   processGroupId?: string;
 }
 
+type RoundResult = [
+  AgentStateRound,
+  AgentStateGlobal,
+  any[],
+  boolean,
+  ToolState,
+];
+
+interface RoundLifecycleShared<C = unknown> {
+  agentConfig: AgentConfig;
+  agentSetting: AgentSetting;
+  agentPrompt: AgentPrompt;
+  userVars: Record<string, any>;
+  logger: AgentLogger;
+  modelHandler: IModelHandler<any, any, any, any, C>;
+  executionId?: ExecutionId;
+  currRound: number;
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  messages: any[];
+  prefill: string;
+  outputPath: string;
+  roundGroupId: string;
+  client: C;
+  handleCompletion: (
+    currRound: number,
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    options: RoundOutputOptions,
+  ) => Promise<void>;
+  checkInterruption: () => Promise<boolean> | boolean;
+  setAbortController: (ctrl: AbortController | null) => void;
+  executedCycle?: boolean;
+  result?: RoundResult;
+}
+
+interface RoundPrepResult {
+  endTurn: boolean;
+  messages: any[];
+}
+
+interface RoundExecResult {
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  messages: any[];
+  endTurn: boolean;
+  ranResponseCycle: boolean;
+}
+
+class RoundLifecycleNode<C = unknown> extends Node<RoundLifecycleShared<C>> {
+  private context?: RoundLifecycleShared<C>;
+
+  async run(shared: RoundLifecycleShared<C>): Promise<string | undefined> {
+    this.context = shared;
+    try {
+      return await super.run(shared);
+    } finally {
+      this.context = undefined;
+    }
+  }
+
+  private ensureContext(): RoundLifecycleShared<C> {
+    if (!this.context) {
+      throw new Error('RoundLifecycleNode requires an active context.');
+    }
+    return this.context;
+  }
+
+  async prep(shared: RoundLifecycleShared<C>): Promise<RoundPrepResult> {
+    const [endTurn, updatedMessages] =
+      await shared.modelHandler.initializeOutputAndPrefill(
+        shared.agentConfig,
+        shared.agentSetting,
+        shared.messages,
+        shared.toolState,
+        shared.outputPath,
+        shared.prefill,
+        shared.roundGroupId,
+      );
+
+    shared.messages = updatedMessages;
+
+    return { endTurn, messages: updatedMessages };
+  }
+
+  async exec(prepRes: RoundPrepResult): Promise<RoundExecResult> {
+    const context = this.ensureContext();
+
+    if (prepRes.endTurn) {
+      return {
+        stateRound: context.stateRound,
+        stateGlobal: context.stateGlobal,
+        toolState: context.toolState,
+        messages: prepRes.messages,
+        endTurn: true,
+        ranResponseCycle: false,
+      };
+    }
+
+    const options: ResponseCycleOptions<C> = {
+      modelHandler: context.modelHandler,
+      agentSetting: context.agentSetting,
+      agentConfig: context.agentConfig,
+      agentPrompt: context.agentPrompt,
+      userVars: context.userVars,
+      logger: context.logger,
+      client: context.client,
+      checkInterruption: context.checkInterruption,
+      setAbortController: context.setAbortController,
+    };
+
+    const [
+      updatedStateRound,
+      updatedStateGlobal,
+      updatedToolState,
+      newEndTurn,
+    ] = await runResponseCycle(
+      options,
+      prepRes.messages,
+      context.stateRound,
+      context.stateGlobal,
+      context.toolState,
+      context.outputPath,
+      context.roundGroupId,
+      context.executionId,
+    );
+
+    return {
+      stateRound: updatedStateRound,
+      stateGlobal: updatedStateGlobal,
+      toolState: updatedToolState,
+      messages: prepRes.messages,
+      endTurn: newEndTurn,
+      ranResponseCycle: true,
+    };
+  }
+
+  async post(
+    shared: RoundLifecycleShared<C>,
+    _prepRes: RoundPrepResult,
+    execRes: RoundExecResult,
+  ): Promise<string | undefined> {
+    await shared.handleCompletion(
+      shared.currRound,
+      execRes.stateRound,
+      execRes.stateGlobal,
+      {
+        outputFile: shared.outputPath,
+        endTurn: execRes.endTurn,
+        processGroupId: shared.roundGroupId,
+      },
+    );
+
+    shared.stateRound = execRes.stateRound;
+    shared.stateGlobal = execRes.stateGlobal;
+    shared.toolState = execRes.toolState;
+    shared.messages = execRes.messages;
+    shared.executedCycle = execRes.ranResponseCycle;
+    shared.result = [
+      execRes.stateRound,
+      execRes.stateGlobal,
+      execRes.messages,
+      execRes.endTurn,
+      execRes.toolState,
+    ];
+
+    return undefined;
+  }
+}
+
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.
  * Provides core functionality for processing inputs, managing state, and handling outputs
@@ -69,6 +242,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   protected promptBuilder?: PromptBuilder;
   public roundStates: AgentStateRound[] = [];
   public toolStates: ToolState[] = [];
+  private readonly roundNode: RoundLifecycleNode<C>;
 
   constructor(
     modelHandler: IModelHandler<any, any, any, any, C>,
@@ -120,6 +294,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     );
 
     this.latexMediaManager = new LatexMediaManager(this.logger);
+    this.roundNode = new RoundLifecycleNode<C>();
   }
 
   protected getPromptBuilder(): PromptBuilder {
@@ -227,22 +402,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     return this.outputHandler.outputFiles[currRound] || [];
   }
 
-  /**
-   * Executes the shared round lifecycle pipeline used by both processing and reflection flows.
-   * Handles output initialization, response generation, and round finalization to keep
-   * lifecycle responsibilities centralized.
-   *
-   * @param currRound - Zero-based index of the round being executed.
-   * @param stateRound - Mutable state scoped to the current round of execution.
-   * @param stateGlobal - Shared agent state that spans all rounds.
-   * @param toolState - Current tool invocation state passed between rounds.
-   * @param preparedMessages - Messages prepared for the model before execution.
-   * @param prefill - Initial text inserted into the model response buffer.
-   * @param outputPath - Filesystem path where model output for this round is stored.
-   * @param roundGroupId - Identifier for grouping related log and output operations.
-   * @returns Updated round/global state, messages, completion flag, and tool state after execution.
-   */
-  private async runRoundPipeline(
+  private async executeRoundLifecycle(
     currRound: number,
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
@@ -251,84 +411,45 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     prefill: string,
     outputPath: string,
     roundGroupId: string,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
-    const [endTurn, updatedMessages] =
-      await this.modelHandler.initializeOutputAndPrefill(
-        this.agentConfig,
-        this.agentSetting,
-        preparedMessages,
-        toolState,
-        outputPath,
-        prefill,
-        roundGroupId,
-      );
+  ): Promise<RoundResult> {
+    const shared: RoundLifecycleShared<C> = {
+      agentConfig: this.agentConfig,
+      agentSetting: this.agentSetting,
+      agentPrompt: this.agentPrompt,
+      userVars: this.userVars,
+      logger: this.logger,
+      modelHandler: this.modelHandler,
+      executionId: this.executionId,
+      currRound,
+      stateRound,
+      stateGlobal,
+      toolState,
+      messages: preparedMessages,
+      prefill,
+      outputPath,
+      roundGroupId,
+      client: this.getClientInstance(),
+      handleCompletion: this.handleRoundCompletion.bind(this),
+      checkInterruption: () => this.checkInterruption(),
+      setAbortController: (ctrl) => {
+        this.abortController = ctrl;
+      },
+    };
 
-    if (!endTurn) {
-      const client = this.getClientInstance();
-      const options: ResponseCycleOptions<C> = {
-        modelHandler: this.modelHandler,
-        agentSetting: this.agentSetting,
-        agentConfig: this.agentConfig,
-        agentPrompt: this.agentPrompt,
-        userVars: this.userVars,
-        logger: this.logger,
-        client,
-        checkInterruption: () => this.checkInterruption(),
-        setAbortController: (ctrl) => {
-          this.abortController = ctrl;
-        },
-      };
+    await this.roundNode.run(shared);
 
-      const [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedToolState,
-        newEndTurn,
-      ] = await runResponseCycle(
-        options,
-        updatedMessages,
-        stateRound,
-        stateGlobal,
-        toolState,
-        outputPath,
-        roundGroupId,
-        this.executionId,
-      );
-
-      await this.handleRoundCompletion(
-        currRound,
-        updatedStateRound,
-        updatedStateGlobal,
-        {
-          outputFile: outputPath,
-          endTurn: newEndTurn,
-          processGroupId: roundGroupId,
-        },
-      );
-
-      if (currRound === 0) {
-        this.logger.debug(
-          `stateGlobal: ${JSON.stringify(updatedStateGlobal)}`,
-          roundGroupId,
-        );
-      }
-
-      return [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedMessages,
-        newEndTurn,
-        updatedToolState,
-      ];
+    if (!shared.result) {
+      throw new Error('Round lifecycle did not produce a result.');
     }
 
-    await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
-      outputFile: outputPath,
-      endTurn,
-      processGroupId: roundGroupId,
-    });
+    if (currRound === 0 && shared.executedCycle) {
+      this.logger.debug(
+        `stateGlobal: ${JSON.stringify(shared.result[1])}`,
+        roundGroupId,
+      );
+    }
 
-    return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
+    return shared.result;
   }
 
   /**
@@ -411,7 +532,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       toolState.updateAccumulatedOutput(prefill);
 
       const stateRound = new AgentStateRound(currRound);
-      return this.runRoundPipeline(
+      return this.executeRoundLifecycle(
         currRound,
         stateRound,
         stateGlobal,
@@ -483,7 +604,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       const prefill = await promptBuilder.buildPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
-      return this.runRoundPipeline(
+      return this.executeRoundLifecycle(
         currRound,
         stateRound,
         stateGlobal,

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -1,82 +1,153 @@
-type NonIterableObject = Partial<Record<string, unknown>> & { [Symbol.iterator]?: never }; type Action = string;
+type NonIterableObject = Partial<Record<string, unknown>> & {
+  [Symbol.iterator]?: never;
+};
+type Action = string;
 class BaseNode<S = unknown, P extends NonIterableObject = NonIterableObject> {
-  protected _params: P = {} as P; protected _successors: Map<Action, BaseNode> = new Map();
-  protected async _exec(prepRes: unknown): Promise<unknown> { return await this.exec(prepRes); }
-  async prep(shared: S): Promise<unknown> { return undefined; }
-  async exec(prepRes: unknown): Promise<unknown> { return undefined; }
-  async post(shared: S, prepRes: unknown, execRes: unknown): Promise<Action | undefined> { return undefined; }
+  protected _params: P = {} as P;
+  protected _successors: Map<Action, BaseNode> = new Map();
+  protected async _exec(prepRes: unknown): Promise<unknown> {
+    return await this.exec(prepRes);
+  }
+  async prep(shared: S): Promise<unknown> {
+    return undefined;
+  }
+  async exec(prepRes: unknown): Promise<unknown> {
+    return undefined;
+  }
+  async post(
+    shared: S,
+    prepRes: unknown,
+    execRes: unknown,
+  ): Promise<Action | undefined> {
+    return undefined;
+  }
   async _run(shared: S): Promise<Action | undefined> {
-    const p = await this.prep(shared), e = await this._exec(p); return await this.post(shared, p, e);
+    const p = await this.prep(shared),
+      e = await this._exec(p);
+    return await this.post(shared, p, e);
   }
   async run(shared: S): Promise<Action | undefined> {
-    if (this._successors.size > 0) console.warn("Node won't run successors. Use Flow.");
+    if (this._successors.size > 0)
+      console.warn("Node won't run successors. Use Flow.");
     return await this._run(shared);
   }
-  setParams(params: P): this { this._params = params; return this; }
-  next<T extends BaseNode>(node: T): T { this.on("default", node); return node; }
-  on(action: Action, node: BaseNode): this {
-    if (this._successors.has(action)) console.warn(`Overwriting successor for action '${action}'`);
-    this._successors.set(action, node); return this;
+  setParams(params: P): this {
+    this._params = params;
+    return this;
   }
-  getNextNode(action: Action = "default"): BaseNode | undefined {
-    const nextAction = action || 'default', next = this._successors.get(nextAction)
+  next<T extends BaseNode>(node: T): T {
+    this.on('default', node);
+    return node;
+  }
+  on(action: Action, node: BaseNode): this {
+    if (this._successors.has(action))
+      console.warn(`Overwriting successor for action '${action}'`);
+    this._successors.set(action, node);
+    return this;
+  }
+  getNextNode(action: Action = 'default'): BaseNode | undefined {
+    const nextAction = action || 'default',
+      next = this._successors.get(nextAction);
     if (!next && this._successors.size > 0)
-      console.warn(`Flow ends: '${nextAction}' not found in [${Array.from(this._successors.keys())}]`)
-    return next
+      console.warn(
+        `Flow ends: '${nextAction}' not found in [${Array.from(this._successors.keys())}]`,
+      );
+    return next;
   }
   clone(): this {
-    const clonedNode = Object.create(Object.getPrototypeOf(this)); Object.assign(clonedNode, this);
-    clonedNode._params = { ...this._params }; clonedNode._successors = new Map(this._successors);
+    const clonedNode = Object.create(Object.getPrototypeOf(this));
+    Object.assign(clonedNode, this);
+    clonedNode._params = { ...this._params };
+    clonedNode._successors = new Map(this._successors);
     return clonedNode;
   }
 }
-class Node<S = unknown, P extends NonIterableObject = NonIterableObject> extends BaseNode<S, P> {
-  maxRetries: number; wait: number; currentRetry: number = 0;
+class Node<
+  S = unknown,
+  P extends NonIterableObject = NonIterableObject,
+> extends BaseNode<S, P> {
+  maxRetries: number;
+  wait: number;
+  currentRetry: number = 0;
   constructor(maxRetries: number = 1, wait: number = 0) {
-    super(); this.maxRetries = maxRetries; this.wait = wait;
+    super();
+    this.maxRetries = maxRetries;
+    this.wait = wait;
   }
-  async execFallback(prepRes: unknown, error: Error): Promise<unknown> { throw error; }
+  async execFallback(prepRes: unknown, error: Error): Promise<unknown> {
+    throw error;
+  }
   async _exec(prepRes: unknown): Promise<unknown> {
-    for (this.currentRetry = 0; this.currentRetry < this.maxRetries; this.currentRetry++) {
-      try { return await this.exec(prepRes); } 
-      catch (e) {
-        if (this.currentRetry === this.maxRetries - 1) return await this.execFallback(prepRes, e as Error);
-        if (this.wait > 0) await new Promise(resolve => setTimeout(resolve, this.wait * 1000));
+    for (
+      this.currentRetry = 0;
+      this.currentRetry < this.maxRetries;
+      this.currentRetry++
+    ) {
+      try {
+        return await this.exec(prepRes);
+      } catch (e) {
+        if (this.currentRetry === this.maxRetries - 1)
+          return await this.execFallback(prepRes, e as Error);
+        if (this.wait > 0)
+          await new Promise((resolve) => setTimeout(resolve, this.wait * 1000));
       }
     }
     return undefined;
   }
 }
-class BatchNode<S = unknown, P extends NonIterableObject = NonIterableObject> extends Node<S, P> {
+class BatchNode<
+  S = unknown,
+  P extends NonIterableObject = NonIterableObject,
+> extends Node<S, P> {
   async _exec(items: unknown[]): Promise<unknown[]> {
     if (!items || !Array.isArray(items)) return [];
-    const results = []; for (const item of items) results.push(await super._exec(item)); return results;
+    const results = [];
+    for (const item of items) results.push(await super._exec(item));
+    return results;
   }
 }
-class ParallelBatchNode<S = unknown, P extends NonIterableObject = NonIterableObject> extends Node<S, P> {
+class ParallelBatchNode<
+  S = unknown,
+  P extends NonIterableObject = NonIterableObject,
+> extends Node<S, P> {
   async _exec(items: unknown[]): Promise<unknown[]> {
-    if (!items || !Array.isArray(items)) return []
-    return Promise.all(items.map((item) => super._exec(item)))
+    if (!items || !Array.isArray(items)) return [];
+    return Promise.all(items.map((item) => super._exec(item)));
   }
 }
-class Flow<S = unknown, P extends NonIterableObject = NonIterableObject> extends BaseNode<S, P> {
+class Flow<
+  S = unknown,
+  P extends NonIterableObject = NonIterableObject,
+> extends BaseNode<S, P> {
   start: BaseNode;
-  constructor(start: BaseNode) { super(); this.start = start; }
+  constructor(start: BaseNode) {
+    super();
+    this.start = start;
+  }
   protected async _orchestrate(shared: S, params?: P): Promise<void> {
     let current: BaseNode | undefined = this.start.clone();
     const p = params || this._params;
     while (current) {
-      current.setParams(p); const action = await current._run(shared);
-      current = current.getNextNode(action); current = current?.clone();
+      current.setParams(p);
+      const action = await current._run(shared);
+      current = current.getNextNode(action);
+      current = current?.clone();
     }
   }
   async _run(shared: S): Promise<Action | undefined> {
-    const pr = await this.prep(shared); await this._orchestrate(shared);
+    const pr = await this.prep(shared);
+    await this._orchestrate(shared);
     return await this.post(shared, pr, undefined);
   }
-  async exec(prepRes: unknown): Promise<unknown> { throw new Error("Flow can't exec."); }
+  async exec(prepRes: unknown): Promise<unknown> {
+    throw new Error("Flow can't exec.");
+  }
 }
-class BatchFlow<S = unknown, P extends NonIterableObject = NonIterableObject, NP extends NonIterableObject[] = NonIterableObject[]> extends Flow<S, P> {
+class BatchFlow<
+  S = unknown,
+  P extends NonIterableObject = NonIterableObject,
+  NP extends NonIterableObject[] = NonIterableObject[],
+> extends Flow<S, P> {
   async _run(shared: S): Promise<Action | undefined> {
     const batchParams = await this.prep(shared);
     for (const bp of batchParams) {
@@ -85,16 +156,33 @@ class BatchFlow<S = unknown, P extends NonIterableObject = NonIterableObject, NP
     }
     return await this.post(shared, batchParams, undefined);
   }
-  async prep(shared: S): Promise<NP> { const empty: readonly NonIterableObject[] = []; return empty as NP; }
+  async prep(shared: S): Promise<NP> {
+    const empty: readonly NonIterableObject[] = [];
+    return empty as NP;
+  }
 }
-class ParallelBatchFlow<S = unknown, P extends NonIterableObject = NonIterableObject, NP extends NonIterableObject[] = NonIterableObject[]> extends BatchFlow<S, P, NP> {
+class ParallelBatchFlow<
+  S = unknown,
+  P extends NonIterableObject = NonIterableObject,
+  NP extends NonIterableObject[] = NonIterableObject[],
+> extends BatchFlow<S, P, NP> {
   async _run(shared: S): Promise<Action | undefined> {
     const batchParams = await this.prep(shared);
-    await Promise.all(batchParams.map(bp => {
-      const mergedParams = { ...this._params, ...bp };
-      return this._orchestrate(shared, mergedParams);
-    }));
+    await Promise.all(
+      batchParams.map((bp) => {
+        const mergedParams = { ...this._params, ...bp };
+        return this._orchestrate(shared, mergedParams);
+      }),
+    );
     return await this.post(shared, batchParams, undefined);
   }
 }
-export { BaseNode, Node, BatchNode, ParallelBatchNode, Flow, BatchFlow, ParallelBatchFlow };
+export {
+  BaseNode,
+  Node,
+  BatchNode,
+  ParallelBatchNode,
+  Flow,
+  BatchFlow,
+  ParallelBatchFlow,
+};


### PR DESCRIPTION
## Summary
- introduce a `RoundLifecycleNode` to split round prep, execution, and post-processing inside `BaseReflectionAgent`
- add a reusable `executeRoundLifecycle` helper and wire both `process` and `reflect` through the node-driven lifecycle
- reformat the shared node utilities to follow the repository's Prettier style

## Testing
- npm run format
- npm run compile *(fails: missing optional dependency `turndown` required by WebFetchTool)*
- npm run lint
- npm test *(fails: missing optional dependency `turndown` required by WebFetchTool)*

------
https://chatgpt.com/codex/tasks/task_e_68cd778a5b3c832498397e7ab2d2eabf