### PR TITLE
Refactor reflection agent to use lifecycle node

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -13,11 +13,12 @@ import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 import { ToolState } from '@agent/core/ToolState';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
-import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import { OutputHandler, IOutputHandler } from '@agent/output';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import { writePromptToXml } from '@agent/utils/promptUtils';
-import { bus } from '@eventBus/ProgressEventBus';
+import { Node } from '@agent/node';
+
 // Standard library imports
 // (none needed)
 
@@ -25,11 +26,10 @@ import { bus } from '@eventBus/ProgressEventBus';
 // (none needed)
 
 // Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - latex utils
 import { LatexMediaManager } from '@latex';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import type { ToolDefinition } from '@model';
 
 // System imports - common utilities
 import { getConfig } from '@utils/config';
@@ -49,6 +49,187 @@ export interface RoundOutputOptions {
   outputFile: string;
   endTurn: boolean;
   processGroupId?: string;
+}
+
+export interface RoundLifecycleResult {
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  messages: any[];
+  endTurn: boolean;
+  toolState: ToolState;
+}
+
+export interface RoundLifecycleSharedContext {
+  currRound: number;
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  messages: any[];
+  prefill: string;
+  outputPath: string;
+  roundGroupId: string;
+  result?: RoundLifecycleResult;
+}
+
+interface RoundLifecyclePrepResult {
+  endTurn: boolean;
+  messages: any[];
+}
+
+interface RoundLifecycleExecResult extends RoundLifecycleResult {
+  didExecuteCycle: boolean;
+}
+
+export interface ReflectionRoundNodeDeps<C> {
+  agentConfig: AgentConfig;
+  agentSetting: AgentSetting;
+  agentPrompt: AgentPrompt;
+  modelHandler: IModelHandler<any, any, any, any, C>;
+  logger: AgentLogger;
+  userVars: Record<string, any>;
+  getClient: () => C;
+  checkInterruption: () => Promise<boolean> | boolean;
+  setAbortController: (ctrl: AbortController | null) => void;
+  runResponseCycle: (
+    options: ResponseCycleOptions<C>,
+    messages: any[],
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    toolState: ToolState,
+    outputPath: string,
+    roundGroupId?: string,
+    executionId?: ExecutionId,
+  ) => Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]>;
+  handleRoundCompletion: (
+    currRound: number,
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    options: RoundOutputOptions,
+  ) => Promise<void>;
+  executionId?: ExecutionId;
+}
+
+export class ReflectionRoundNode<C> extends Node<RoundLifecycleSharedContext> {
+  private currentShared?: RoundLifecycleSharedContext;
+
+  constructor(private readonly deps: ReflectionRoundNodeDeps<C>) {
+    super();
+  }
+
+  async prep(
+    shared: RoundLifecycleSharedContext,
+  ): Promise<RoundLifecyclePrepResult> {
+    this.currentShared = shared;
+    const [endTurn, updatedMessages] =
+      await this.deps.modelHandler.initializeOutputAndPrefill(
+        this.deps.agentConfig,
+        this.deps.agentSetting,
+        shared.messages,
+        shared.toolState,
+        shared.outputPath,
+        shared.prefill,
+        shared.roundGroupId,
+      );
+    shared.messages = updatedMessages;
+    return { endTurn, messages: updatedMessages };
+  }
+
+  async exec(
+    prepRes: RoundLifecyclePrepResult,
+  ): Promise<RoundLifecycleExecResult> {
+    const shared = this.currentShared;
+    if (!shared) {
+      throw new Error('Round lifecycle executed without a shared context.');
+    }
+
+    if (prepRes.endTurn) {
+      return {
+        stateRound: shared.stateRound,
+        stateGlobal: shared.stateGlobal,
+        messages: prepRes.messages,
+        endTurn: true,
+        toolState: shared.toolState,
+        didExecuteCycle: false,
+      };
+    }
+
+    const client = this.deps.getClient();
+    const options: ResponseCycleOptions<C> = {
+      modelHandler: this.deps.modelHandler,
+      agentSetting: this.deps.agentSetting,
+      agentConfig: this.deps.agentConfig,
+      agentPrompt: this.deps.agentPrompt,
+      userVars: this.deps.userVars,
+      logger: this.deps.logger,
+      client,
+      checkInterruption: this.deps.checkInterruption,
+      setAbortController: this.deps.setAbortController,
+    };
+
+    const [
+      updatedStateRound,
+      updatedStateGlobal,
+      updatedToolState,
+      newEndTurn,
+    ] = await this.deps.runResponseCycle(
+      options,
+      prepRes.messages,
+      shared.stateRound,
+      shared.stateGlobal,
+      shared.toolState,
+      shared.outputPath,
+      shared.roundGroupId,
+      this.deps.executionId,
+    );
+
+    return {
+      stateRound: updatedStateRound,
+      stateGlobal: updatedStateGlobal,
+      messages: prepRes.messages,
+      endTurn: newEndTurn,
+      toolState: updatedToolState,
+      didExecuteCycle: true,
+    };
+  }
+
+  async post(
+    shared: RoundLifecycleSharedContext,
+    _prepRes: RoundLifecyclePrepResult,
+    execRes: RoundLifecycleExecResult,
+  ): Promise<string | undefined> {
+    await this.deps.handleRoundCompletion(
+      shared.currRound,
+      execRes.stateRound,
+      execRes.stateGlobal,
+      {
+        outputFile: shared.outputPath,
+        endTurn: execRes.endTurn,
+        processGroupId: shared.roundGroupId,
+      },
+    );
+
+    if (shared.currRound === 0 && execRes.didExecuteCycle) {
+      this.deps.logger.debug(
+        `stateGlobal: ${JSON.stringify(execRes.stateGlobal)}`,
+        shared.roundGroupId,
+      );
+    }
+
+    shared.stateRound = execRes.stateRound;
+    shared.stateGlobal = execRes.stateGlobal;
+    shared.toolState = execRes.toolState;
+    shared.messages = execRes.messages;
+    shared.result = {
+      stateRound: execRes.stateRound,
+      stateGlobal: execRes.stateGlobal,
+      messages: execRes.messages,
+      endTurn: execRes.endTurn,
+      toolState: execRes.toolState,
+    };
+
+    this.currentShared = undefined;
+    return 'default';
+  }
 }
 
 /**
@@ -150,6 +331,39 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     );
   }
 
+  protected createRoundNode(): ReflectionRoundNode<C> {
+    return new ReflectionRoundNode<C>({
+      agentConfig: this.agentConfig,
+      agentSetting: this.agentSetting,
+      agentPrompt: this.agentPrompt,
+      modelHandler: this.modelHandler,
+      logger: this.logger,
+      userVars: this.userVars,
+      getClient: () => this.getClientInstance(),
+      checkInterruption: () => this.checkInterruption(),
+      setAbortController: (ctrl) => {
+        this.abortController = ctrl;
+      },
+      runResponseCycle,
+      handleRoundCompletion: (currRound, stateRound, stateGlobal, options) =>
+        this.handleRoundCompletion(currRound, stateRound, stateGlobal, options),
+      executionId: this.executionId,
+    });
+  }
+
+  private async runRoundWithNode(
+    shared: RoundLifecycleSharedContext,
+  ): Promise<RoundLifecycleResult> {
+    const node = this.createRoundNode();
+    await node.run(shared);
+
+    if (!shared.result) {
+      throw new Error('Round execution did not produce a result.');
+    }
+
+    return shared.result;
+  }
+
   /**
    * Processes completion of conversation round.
    */
@@ -225,110 +439,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     }
 
     return this.outputHandler.outputFiles[currRound] || [];
-  }
-
-  /**
-   * Executes the shared round lifecycle pipeline used by both processing and reflection flows.
-   * Handles output initialization, response generation, and round finalization to keep
-   * lifecycle responsibilities centralized.
-   *
-   * @param currRound - Zero-based index of the round being executed.
-   * @param stateRound - Mutable state scoped to the current round of execution.
-   * @param stateGlobal - Shared agent state that spans all rounds.
-   * @param toolState - Current tool invocation state passed between rounds.
-   * @param preparedMessages - Messages prepared for the model before execution.
-   * @param prefill - Initial text inserted into the model response buffer.
-   * @param outputPath - Filesystem path where model output for this round is stored.
-   * @param roundGroupId - Identifier for grouping related log and output operations.
-   * @returns Updated round/global state, messages, completion flag, and tool state after execution.
-   */
-  private async runRoundPipeline(
-    currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
-    toolState: ToolState,
-    preparedMessages: any[],
-    prefill: string,
-    outputPath: string,
-    roundGroupId: string,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
-    const [endTurn, updatedMessages] =
-      await this.modelHandler.initializeOutputAndPrefill(
-        this.agentConfig,
-        this.agentSetting,
-        preparedMessages,
-        toolState,
-        outputPath,
-        prefill,
-        roundGroupId,
-      );
-
-    if (!endTurn) {
-      const client = this.getClientInstance();
-      const options: ResponseCycleOptions<C> = {
-        modelHandler: this.modelHandler,
-        agentSetting: this.agentSetting,
-        agentConfig: this.agentConfig,
-        agentPrompt: this.agentPrompt,
-        userVars: this.userVars,
-        logger: this.logger,
-        client,
-        checkInterruption: () => this.checkInterruption(),
-        setAbortController: (ctrl) => {
-          this.abortController = ctrl;
-        },
-      };
-
-      const [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedToolState,
-        newEndTurn,
-      ] = await runResponseCycle(
-        options,
-        updatedMessages,
-        stateRound,
-        stateGlobal,
-        toolState,
-        outputPath,
-        roundGroupId,
-        this.executionId,
-      );
-
-      await this.handleRoundCompletion(
-        currRound,
-        updatedStateRound,
-        updatedStateGlobal,
-        {
-          outputFile: outputPath,
-          endTurn: newEndTurn,
-          processGroupId: roundGroupId,
-        },
-      );
-
-      if (currRound === 0) {
-        this.logger.debug(
-          `stateGlobal: ${JSON.stringify(updatedStateGlobal)}`,
-          roundGroupId,
-        );
-      }
-
-      return [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedMessages,
-        newEndTurn,
-        updatedToolState,
-      ];
-    }
-
-    await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
-      outputFile: outputPath,
-      endTurn,
-      processGroupId: roundGroupId,
-    });
-
-    return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
   }
 
   /**
@@ -411,16 +521,25 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       toolState.updateAccumulatedOutput(prefill);
 
       const stateRound = new AgentStateRound(currRound);
-      return this.runRoundPipeline(
+      const shared: RoundLifecycleSharedContext = {
         currRound,
         stateRound,
         stateGlobal,
         toolState,
         messages,
         prefill,
-        this.outputFile[currRound],
+        outputPath: this.outputFile[currRound],
         roundGroupId,
-      );
+      };
+
+      const result = await this.runRoundWithNode(shared);
+      return [
+        result.stateRound,
+        result.stateGlobal,
+        result.messages,
+        result.endTurn,
+        result.toolState,
+      ];
     });
   }
 
@@ -483,16 +602,25 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       const prefill = await promptBuilder.buildPrefill(currRound);
       toolState.updateAccumulatedOutput(prefill);
 
-      return this.runRoundPipeline(
+      const shared: RoundLifecycleSharedContext = {
         currRound,
         stateRound,
         stateGlobal,
         toolState,
-        roundMessages,
+        messages: roundMessages,
         prefill,
-        this.outputFile[currRound],
+        outputPath: this.outputFile[currRound],
         roundGroupId,
-      );
+      };
+
+      const result = await this.runRoundWithNode(shared);
+      return [
+        result.stateRound,
+        result.stateGlobal,
+        result.messages,
+        result.endTurn,
+        result.toolState,
+      ];
     });
   }
 

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -19,10 +19,15 @@ class BaseNode<S = unknown, P extends NonIterableObject = NonIterableObject> {
     this._successors.set(action, node); return this;
   }
   getNextNode(action: Action = "default"): BaseNode | undefined {
-    const nextAction = action || 'default', next = this._successors.get(nextAction)
+    const nextAction = action || 'default';
+    const next = this._successors.get(nextAction);
     if (!next && this._successors.size > 0)
-      console.warn(`Flow ends: '${nextAction}' not found in [${Array.from(this._successors.keys())}]`)
-    return next
+      console.warn(
+        `Flow ends: '${nextAction}' not found in [${Array.from(
+          this._successors.keys(),
+        )}]`,
+      );
+    return next;
   }
   clone(): this {
     const clonedNode = Object.create(Object.getPrototypeOf(this)); Object.assign(clonedNode, this);
@@ -55,8 +60,8 @@ class BatchNode<S = unknown, P extends NonIterableObject = NonIterableObject> ex
 }
 class ParallelBatchNode<S = unknown, P extends NonIterableObject = NonIterableObject> extends Node<S, P> {
   async _exec(items: unknown[]): Promise<unknown[]> {
-    if (!items || !Array.isArray(items)) return []
-    return Promise.all(items.map((item) => super._exec(item)))
+    if (!items || !Array.isArray(items)) return [];
+    return Promise.all(items.map((item) => super._exec(item)));
   }
 }
 class Flow<S = unknown, P extends NonIterableObject = NonIterableObject> extends BaseNode<S, P> {

--- a/src/test/agent/implementations/ReflectionRoundNode.test.ts
+++ b/src/test/agent/implementations/ReflectionRoundNode.test.ts
@@ -1,0 +1,212 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - agent components
+import {
+  ReflectionRoundNode,
+  type ReflectionRoundNodeDeps,
+  type RoundLifecycleSharedContext,
+  type RoundOutputOptions,
+} from '@agent/implementations/BaseReflectionAgent';
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import {
+  AgentPromptSchema,
+  AgentSettingSchema,
+} from '@agent/core/AgentDataclass';
+import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
+import { ToolState } from '@agent/core/ToolState';
+import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
+import type { IModelHandler } from '@agent/modelHandlers';
+import type { AgentLogger } from '@logger/AgentLogger';
+
+suite('ReflectionRoundNode', () => {
+  test('executes full lifecycle when generation continues', async () => {
+    const agentConfig = AgentConfigSchema.parse({ inputFile: 'input.tex' });
+    const agentSetting = AgentSettingSchema.parse({});
+    const agentPrompt = AgentPromptSchema.parse({});
+
+    const shared: RoundLifecycleSharedContext = {
+      currRound: 0,
+      stateRound: new AgentStateRound(0),
+      stateGlobal: new AgentStateGlobal(),
+      toolState: new ToolState(),
+      messages: [],
+      prefill: 'prefill text',
+      outputPath: 'output.txt',
+      roundGroupId: 'group',
+    };
+
+    const updatedMessages = [{ role: 'user', content: 'hello' }];
+    let initializeCalls = 0;
+    const stubModelHandler = {
+      initializeOutputAndPrefill: async (
+        _agentConfig: unknown,
+        _agentSetting: unknown,
+        messages: any[],
+        _toolState: unknown,
+        outputFile: string,
+        prefill: string,
+        groupId?: string,
+      ) => {
+        initializeCalls++;
+        assert.strictEqual(outputFile, shared.outputPath);
+        assert.strictEqual(prefill, shared.prefill);
+        assert.strictEqual(groupId, shared.roundGroupId);
+        assert.strictEqual(messages, shared.messages);
+        return [false, updatedMessages] as const;
+      },
+    } as unknown as IModelHandler<any, any, any, any, unknown>;
+
+    let runCycleCalls = 0;
+    const stubRunResponseCycle = async (
+      options: ResponseCycleOptions<unknown>,
+      messages: any[],
+      stateRound: AgentStateRound,
+      stateGlobal: AgentStateGlobal,
+      toolState: ToolState,
+    ): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> => {
+      runCycleCalls++;
+      assert.strictEqual(options.agentConfig, agentConfig);
+      assert.strictEqual(options.agentSetting, agentSetting);
+      assert.strictEqual(options.agentPrompt, agentPrompt);
+      assert.strictEqual(options.logger, stubLogger);
+      assert.strictEqual(options.client, clientInstance);
+      assert.strictEqual(messages, updatedMessages);
+      assert.strictEqual(stateRound, shared.stateRound);
+      assert.strictEqual(stateGlobal, shared.stateGlobal);
+      assert.strictEqual(toolState, shared.toolState);
+      return [stateRound, stateGlobal, toolState, true];
+    };
+
+    const completions: RoundOutputOptions[] = [];
+    const stubHandleCompletion = async (
+      currRound: number,
+      stateRound: AgentStateRound,
+      stateGlobal: AgentStateGlobal,
+      options: RoundOutputOptions,
+    ) => {
+      assert.strictEqual(currRound, shared.currRound);
+      assert.strictEqual(stateRound, shared.stateRound);
+      assert.strictEqual(stateGlobal, shared.stateGlobal);
+      completions.push(options);
+    };
+
+    const debugMessages: string[] = [];
+    const stubLogger = {
+      debug(message: string) {
+        debugMessages.push(message);
+      },
+    } as unknown as AgentLogger;
+
+    const clientInstance = {};
+    const deps: ReflectionRoundNodeDeps<unknown> = {
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      modelHandler: stubModelHandler,
+      logger: stubLogger,
+      userVars: {},
+      getClient: () => clientInstance,
+      checkInterruption: () => false,
+      setAbortController: () => {},
+      runResponseCycle: stubRunResponseCycle,
+      handleRoundCompletion: stubHandleCompletion,
+    };
+
+    const node = new ReflectionRoundNode(deps);
+    await node.run(shared);
+
+    assert.strictEqual(initializeCalls, 1);
+    assert.strictEqual(runCycleCalls, 1);
+    assert.strictEqual(completions.length, 1);
+    assert.strictEqual(completions[0].outputFile, shared.outputPath);
+    assert.strictEqual(completions[0].endTurn, true);
+    assert.ok(shared.result);
+    assert.strictEqual(shared.messages, updatedMessages);
+    assert.strictEqual(shared.result?.messages, updatedMessages);
+    assert.strictEqual(shared.result?.endTurn, true);
+    assert.strictEqual(debugMessages.length, 1);
+    assert.ok(debugMessages[0].includes('stateGlobal'));
+  });
+
+  test('skips response cycle when initialization ends the turn', async () => {
+    const agentConfig = AgentConfigSchema.parse({ inputFile: 'input.tex' });
+    const agentSetting = AgentSettingSchema.parse({});
+    const agentPrompt = AgentPromptSchema.parse({});
+
+    const shared: RoundLifecycleSharedContext = {
+      currRound: 1,
+      stateRound: new AgentStateRound(1),
+      stateGlobal: new AgentStateGlobal(),
+      toolState: new ToolState(),
+      messages: [{ role: 'system', content: 'existing' }],
+      prefill: 'prefill text',
+      outputPath: 'output.txt',
+      roundGroupId: 'group',
+    };
+
+    let initializeCalls = 0;
+    const stubModelHandler = {
+      initializeOutputAndPrefill: async () => {
+        initializeCalls++;
+        return [true, shared.messages] as const;
+      },
+    } as unknown as IModelHandler<any, any, any, any, unknown>;
+
+    let runCycleCalls = 0;
+    const stubRunResponseCycle = async () => {
+      runCycleCalls++;
+      return [
+        shared.stateRound,
+        shared.stateGlobal,
+        shared.toolState,
+        false,
+      ] as [AgentStateRound, AgentStateGlobal, ToolState, boolean];
+    };
+
+    let completionCallCount = 0;
+    const stubHandleCompletion = async (
+      currRound: number,
+      stateRound: AgentStateRound,
+      stateGlobal: AgentStateGlobal,
+      options: RoundOutputOptions,
+    ) => {
+      completionCallCount++;
+      assert.strictEqual(currRound, shared.currRound);
+      assert.strictEqual(stateRound, shared.stateRound);
+      assert.strictEqual(stateGlobal, shared.stateGlobal);
+      assert.strictEqual(options.endTurn, true);
+    };
+
+    const debugMessages: string[] = [];
+    const stubLogger = {
+      debug(message: string) {
+        debugMessages.push(message);
+      },
+    } as unknown as AgentLogger;
+
+    const deps: ReflectionRoundNodeDeps<unknown> = {
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      modelHandler: stubModelHandler,
+      logger: stubLogger,
+      userVars: {},
+      getClient: () => ({}),
+      checkInterruption: () => false,
+      setAbortController: () => {},
+      runResponseCycle: stubRunResponseCycle,
+      handleRoundCompletion: stubHandleCompletion,
+    };
+
+    const node = new ReflectionRoundNode(deps);
+    await node.run(shared);
+
+    assert.strictEqual(initializeCalls, 1);
+    assert.strictEqual(runCycleCalls, 0);
+    assert.strictEqual(completionCallCount, 1);
+    assert.ok(shared.result);
+    assert.strictEqual(shared.result?.endTurn, true);
+    assert.strictEqual(debugMessages.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a `ReflectionRoundNode` with typed prep/exec/post helpers and shared lifecycle context for reflection rounds
- replace `runRoundPipeline` by wiring the new node through the `process` and `reflect` flows
- add unit coverage that exercises the node when the response cycle runs and when initialization ends the turn early

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.1/code: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cd778a5b3c832498397e7ab2d2eabf