### PR TITLE
fix: escape underscores in texttt blocks

### DIFF
--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -108,68 +108,40 @@ export function applyLatexQuotesFormatting(text: string): string {
 /**
  * Escapes bare underscores inside \texttt commands so they compile correctly.
  *
- * Replaces every `_` that is not already escaped inside a \texttt{...} block
- * with `\_`. Nested braces are handled so commands like \texttt{a_{b}} are
- * processed safely, and repeated runs are idempotent.
+ * Each \texttt{...} span is processed independently and underscores that are
+ * already escaped are preserved so the helper is idempotent.
  */
 export function escapeTextttUnderscores(text: string): string {
-  const textttRegex = /\\texttt\{/g;
-  let result = '';
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
+  const textttRegex = /\\texttt\{([^}]*)\}/g;
+  let totalReplacements = 0;
 
-  while ((match = textttRegex.exec(text)) !== null) {
-    const startIndex = match.index;
-    const contentStart = textttRegex.lastIndex;
-    let braceDepth = 1;
-    let i = contentStart;
+  const processedText = text.replace(
+    textttRegex,
+    (_match, rawContent: string) => {
+      let replacementCount = 0;
+      // (?<!\\)_ matches underscore not preceded by backslash
+      // This ensures we don't double-escape already escaped underscores
+      const processedContent = rawContent.replace(/(?<!\\)_/g, () => {
+        replacementCount += 1;
+        totalReplacements += 1;
+        return '\\_';
+      });
 
-    while (i < text.length && braceDepth > 0) {
-      const char = text[i];
+      logger.debug(
+        CHANNEL,
+        `Escaped ${replacementCount} underscores in texttt block`,
+      );
 
-      if (char === '\\') {
-        // Skip escaped characters so \{ and \} don't affect brace depth
-        i += 2;
-        continue;
-      }
+      return `\\texttt{${processedContent}}`;
+    },
+  );
 
-      if (char === '{') {
-        braceDepth += 1;
-      } else if (char === '}') {
-        braceDepth -= 1;
-        if (braceDepth === 0) {
-          break;
-        }
-      }
+  logger.debug(
+    CHANNEL,
+    `Finished escaping texttt underscores: ${totalReplacements} replacements total`,
+  );
 
-      i += 1;
-    }
-
-    if (braceDepth !== 0) {
-      // Unbalanced braces – append the rest of the string untouched
-      result += text.slice(lastIndex);
-      lastIndex = text.length;
-      break;
-    }
-
-    const contentEnd = i;
-    const rawContent = text.slice(contentStart, contentEnd);
-    const processedContent = rawContent.replace(/(?<!\\)_/g, '\\_');
-
-    result += text.slice(lastIndex, startIndex);
-    result += text.slice(startIndex, contentStart); // include the \texttt{
-    result += processedContent;
-    result += '}';
-
-    lastIndex = contentEnd + 1;
-    textttRegex.lastIndex = lastIndex;
-  }
-
-  if (lastIndex < text.length) {
-    result += text.slice(lastIndex);
-  }
-
-  return result;
+  return processedText;
 }
 
 /**

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -106,6 +106,73 @@ export function applyLatexQuotesFormatting(text: string): string {
 }
 
 /**
+ * Escapes bare underscores inside \texttt commands so they compile correctly.
+ *
+ * Replaces every `_` that is not already escaped inside a \texttt{...} block
+ * with `\_`. Nested braces are handled so commands like \texttt{a_{b}} are
+ * processed safely, and repeated runs are idempotent.
+ */
+export function escapeTextttUnderscores(text: string): string {
+  const textttRegex = /\\texttt\{/g;
+  let result = '';
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = textttRegex.exec(text)) !== null) {
+    const startIndex = match.index;
+    const contentStart = textttRegex.lastIndex;
+    let braceDepth = 1;
+    let i = contentStart;
+
+    while (i < text.length && braceDepth > 0) {
+      const char = text[i];
+
+      if (char === '\\') {
+        // Skip escaped characters so \{ and \} don't affect brace depth
+        i += 2;
+        continue;
+      }
+
+      if (char === '{') {
+        braceDepth += 1;
+      } else if (char === '}') {
+        braceDepth -= 1;
+        if (braceDepth === 0) {
+          break;
+        }
+      }
+
+      i += 1;
+    }
+
+    if (braceDepth !== 0) {
+      // Unbalanced braces – append the rest of the string untouched
+      result += text.slice(lastIndex);
+      lastIndex = text.length;
+      break;
+    }
+
+    const contentEnd = i;
+    const rawContent = text.slice(contentStart, contentEnd);
+    const processedContent = rawContent.replace(/(?<!\\)_/g, '\\_');
+
+    result += text.slice(lastIndex, startIndex);
+    result += text.slice(startIndex, contentStart); // include the \texttt{
+    result += processedContent;
+    result += '}';
+
+    lastIndex = contentEnd + 1;
+    textttRegex.lastIndex = lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    result += text.slice(lastIndex);
+  }
+
+  return result;
+}
+
+/**
  * Helper function to convert Unicode characters to LaTeX commands
  * within math environments only
  */

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -16,6 +16,7 @@ import {
   applyLatexQuotesFormatting,
   replaceMathUnicode,
   fixLatexQuoteIssues,
+  escapeTextttUnderscores,
   wrapCritiqueInAlign,
 } from './advanced';
 
@@ -278,6 +279,9 @@ export function applyReplacements(
 
   // Cleanup common quote issues
   text = fixLatexQuoteIssues(text);
+
+  // Escape underscores inside \texttt commands for LaTeX compatibility
+  text = escapeTextttUnderscores(text);
 
   return text;
 }

--- a/src/test/replacement/textttUnderscore.test.ts
+++ b/src/test/replacement/textttUnderscore.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from 'assert';
+
+import { escapeTextttUnderscores } from '@replacement/advanced';
+import { applyReplacements } from '@replacement/engine';
+import { EQUATION_STYLE_REPLACEMENTS } from '@replacement/rulesRegex';
+
+describe('escapeTextttUnderscores', () => {
+  it('escapes bare underscores inside texttt blocks', () => {
+    const input = '\\texttt{ch:BELIEF_PROP}';
+    const expected = '\\texttt{ch:BELIEF\\_PROP}';
+    assert.strictEqual(escapeTextttUnderscores(input), expected);
+  });
+
+  it('escapes multiple bare underscores', () => {
+    const input = '\\texttt{multi_part_identifier}';
+    const expected = '\\texttt{multi\\_part\\_identifier}';
+    assert.strictEqual(escapeTextttUnderscores(input), expected);
+  });
+
+  it('preserves already escaped underscores', () => {
+    const input = '\\texttt{already\\_escaped}';
+    assert.strictEqual(escapeTextttUnderscores(input), input);
+  });
+
+  it('handles nested braces safely', () => {
+    const input = '\\texttt{outer_{inner_value}}';
+    const expected = '\\texttt{outer\\_{inner\\_value}}';
+    assert.strictEqual(escapeTextttUnderscores(input), expected);
+  });
+
+  it('leaves content without texttt unchanged', () => {
+    const input = 'plain_text_with_underscores';
+    assert.strictEqual(escapeTextttUnderscores(input), input);
+  });
+});
+
+describe('escapeTextttUnderscores integration', () => {
+  it('runs as part of applyReplacements', () => {
+    const input = 'See \\texttt{file_name} for details';
+    const expected = 'See \\texttt{file\\_name} for details';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+});

--- a/src/test/replacement/textttUnderscore.test.ts
+++ b/src/test/replacement/textttUnderscore.test.ts
@@ -22,7 +22,7 @@ describe('escapeTextttUnderscores', () => {
     assert.strictEqual(escapeTextttUnderscores(input), input);
   });
 
-  it('handles nested braces safely', () => {
+  it('handles underscores adjacent to braces', () => {
     const input = '\\texttt{outer_{inner_value}}';
     const expected = '\\texttt{outer\\_{inner\\_value}}';
     assert.strictEqual(escapeTextttUnderscores(input), expected);


### PR DESCRIPTION
## Summary
- add a helper that escapes bare underscores inside `\texttt{...}` blocks so generated LaTeX compiles
- invoke the helper from the replacement engine alongside existing cleanup passes
- cover the new behaviour with unit tests for the helper and its integration path

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: `/workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.1/code: error while loading shared libraries: libatk-1.0.so.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68d146abbcbc832498532755542d52ee