### PR TITLE
fix: scope LRa shortcut to max rules

### DIFF
--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -186,6 +186,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       Leftarrow: 'La',
       Rightarrow: 'Ra',
       Leftrightarrow: 'LRa',
+      Longleftrightarrow: 'LRa',
     };
     Object.assign(patterns, generateArrowRelationShortcuts(arrowRelationMap));
 

--- a/src/replacement/rules/spacing.ts
+++ b/src/replacement/rules/spacing.ts
@@ -103,7 +103,6 @@ export const LATEX_SPACING_REPLACEMENTS: ReplacementCategory = {
 
     // ===== Display style commands =====
     '\\displaystyle': '',
-    '\\Longleftrightarrow': '\\LRa',
 
     // ===== O1/O3 model specific fixes =====
     '=    \\': '= \\',


### PR DESCRIPTION
## Summary
- remove the global spacing rule that mapped `\Longleftrightarrow` to the Max-specific `\LRa` shortcut
- add `\Longleftrightarrow` to the Max arrow shortcut map so the behavior is preserved when Max rules are enabled

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: VS Code binary requires libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d156cb9de883249ca31051d3e5a584