### PR TITLE
feat: add ask agent to default agent list

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
             },
             "default": [
               "chat",
+              "ask",
               "correct",
               "polish",
               "draw",


### PR DESCRIPTION
## Summary
- add the ask tool-use agent to the default TeXRA agent list so it shows up without manual configuration

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: `/workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.1/code: error while loading shared libraries: libatk-1.0.so.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68d16786859c83248f82525a8c578c32