### PR TITLE
fix: log agent errors to stream logger

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -193,7 +193,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
       throw new Error('Failed to resolve stream tab ID for agent execution');
     }
 
-    agentStreamLogger = agentStreamLogger ?? new AgentLogger(streamTabId, true);
+    agentStreamLogger = new AgentLogger(streamTabId, true);
 
     // Check if this stream is already running
     const provider = ProgressViewProvider.getInstance();
@@ -405,17 +405,20 @@ export async function executeAgentWithLogging<T extends IAgent>(
     }
 
     if (agentStreamLogger || streamTabId) {
-      agentStreamLogger =
-        agentStreamLogger ?? new AgentLogger(streamTabId!, true);
-      const activeGroupId = agentStreamLogger.getActiveGroupId();
-      if (activeGroupId) {
-        agentStreamLogger.error(errorMsg, activeGroupId);
-      } else {
-        const agentErrorGroupId = await agentStreamLogger.startGroup(
-          `Error: ${agentName}`,
-        );
-        agentStreamLogger.error(errorMsg, agentErrorGroupId);
-        agentStreamLogger.endGroup(agentErrorGroupId, 'error');
+      if (!agentStreamLogger && streamTabId) {
+        agentStreamLogger = new AgentLogger(streamTabId, true);
+      }
+      if (agentStreamLogger) {
+        const activeGroupId = agentStreamLogger.getActiveGroupId();
+        if (activeGroupId) {
+          agentStreamLogger.error(errorMsg, activeGroupId);
+        } else {
+          const agentErrorGroupId = await agentStreamLogger.startGroup(
+            `Error: ${agentName}`,
+          );
+          agentStreamLogger.error(errorMsg, agentErrorGroupId);
+          agentStreamLogger.endGroup(agentErrorGroupId, 'error');
+        }
       }
     }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -171,6 +171,8 @@ export async function executeAgentWithLogging<T extends IAgent>(
   options?: ExecuteAgentOptions,
 ): Promise<void> {
   const isResume = options?.resume ?? false;
+  let streamTabId: StreamTabId | undefined;
+  let agentStreamLogger: AgentLogger | undefined;
   try {
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
@@ -181,16 +183,17 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
     // Get the full stream tab ID
     const config = agent.config;
-    const streamTabId = getStreamTabId(
-      config.agent,
-      config.model,
-      config.inputFile,
-      {
-        agentType,
-        executionId,
-        useMultipleOutputs: config.useMultipleOutputs,
-      },
-    );
+    streamTabId = getStreamTabId(config.agent, config.model, config.inputFile, {
+      agentType,
+      executionId,
+      useMultipleOutputs: config.useMultipleOutputs,
+    });
+
+    if (!streamTabId) {
+      throw new Error('Failed to resolve stream tab ID for agent execution');
+    }
+
+    agentStreamLogger = agentStreamLogger ?? new AgentLogger(streamTabId, true);
 
     // Check if this stream is already running
     const provider = ProgressViewProvider.getInstance();
@@ -399,6 +402,21 @@ export async function executeAgentWithLogging<T extends IAgent>(
     } else {
       // Show regular error message for other errors
       vscode.window.showErrorMessage(errorMsg);
+    }
+
+    if (agentStreamLogger || streamTabId) {
+      agentStreamLogger =
+        agentStreamLogger ?? new AgentLogger(streamTabId!, true);
+      const activeGroupId = agentStreamLogger.getActiveGroupId();
+      if (activeGroupId) {
+        agentStreamLogger.error(errorMsg, activeGroupId);
+      } else {
+        const agentErrorGroupId = await agentStreamLogger.startGroup(
+          `Error: ${agentName}`,
+        );
+        agentStreamLogger.error(errorMsg, agentErrorGroupId);
+        agentStreamLogger.endGroup(agentErrorGroupId, 'error');
+      }
     }
 
     // Create a temporary error group if no active group exists


### PR DESCRIPTION
## Summary
- cache the computed stream tab id and dedicated AgentLogger across executeAgentWithLogging so they are available to the outer catch block
- reuse the active agent log group when handling errors or create a temporary error group before emitting the failure message
- keep the existing shared channel logging so the progress view still receives the error notification

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test 2>&1 | tail -n 200 (fails: missing libatk-1.0.so.0 when launching VS Code test harness)


------
https://chatgpt.com/codex/tasks/task_e_68d17095a2bc8324994a233528290013