### PR TITLE
feat: enrich tool result summaries

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -9,6 +9,21 @@ import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 // Utility to run iterative tool-use cycles
 
+// Helper to extract defined fields from objects
+const extractDefinedFields = (
+  obj: Record<string, any>,
+  allowedKeys?: string[],
+): Record<string, any> => {
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) continue;
+    if (key === 'isError' && value !== true) continue;
+    if (allowedKeys && !allowedKeys.includes(key)) continue;
+    result[key] = value;
+  }
+  return result;
+};
+
 // Third-party imports
 
 // Local imports - log
@@ -178,18 +193,12 @@ export async function runToolUseCycle<C = unknown>(
       const errorMsg = `Malformed tool JSON: ${err instanceof Error ? err.message : String(err)}`;
 
       // Log the failed tool use attempt
-      const errorResult = new ToolResult({ error: errorMsg, isError: true });
-      const errorPayload = errorResult.toLogPayload();
-      const toolUseLog: Record<string, unknown> = {
+      const toolUseLog = {
         tool: 'unknown',
         input: toolInfo,
+        error: errorMsg,
+        isError: true,
       };
-      if (errorResult.summary !== undefined) {
-        toolUseLog.summary = errorResult.summary;
-      }
-      if (errorPayload !== undefined) {
-        toolUseLog.output = errorPayload;
-      }
       logger.info(
         JSON.stringify(toolUseLog, null, 2),
         groupId,
@@ -205,14 +214,13 @@ export async function runToolUseCycle<C = unknown>(
     if (!name) {
       const errorMsg = `Tool JSON missing name: ${JSON.stringify(parsed)}`;
 
-      // Log the failed tool use attempt with available info
-      const errorResult = new ToolResult({ error: errorMsg, isError: true });
-      const toolUseLog: Record<string, unknown> = {
+      // Log the failed tool use attempt
+      const toolUseLog = {
         tool: 'unknown',
         input: parsed,
         error: errorMsg,
         isError: true,
-      }
+      };
       logger.info(
         JSON.stringify(toolUseLog, null, 2),
         groupId,
@@ -289,20 +297,12 @@ export async function runToolUseCycle<C = unknown>(
       toolInput = parsed;
     }
 
-    // Build the tool use log entry with all relevant fields
-    const toolUseLog: Record<string, unknown> = {
+    // Build the tool use log entry
+    const toolUseLog = {
       tool: name,
       input: toolInput,
+      ...extractDefinedFields(result),
     };
-    
-    // Add all result fields to the log
-    if (result.summary !== undefined) toolUseLog.summary = result.summary;
-    if (result.output !== undefined) toolUseLog.output = result.output;
-    if (result.error !== undefined) toolUseLog.error = result.error;
-    if (result.base64Image !== undefined) toolUseLog.base64Image = result.base64Image;
-    if (result.system !== undefined) toolUseLog.system = result.system;
-    if (result.diagnostics !== undefined) toolUseLog.diagnostics = result.diagnostics;
-    if (result.isError) toolUseLog.isError = true;
 
     logger.info(
       JSON.stringify(toolUseLog, null, 2),
@@ -311,13 +311,13 @@ export async function runToolUseCycle<C = unknown>(
       toolUseLog,
     );
 
-    // Build provider-specific message containing the tool result
-    // Build result object for model API - only include defined fields
-    const resultObj: Record<string, unknown> = {};
-    if (result.output !== undefined) resultObj.output = result.output;
-    if (result.error !== undefined) resultObj.error = result.error;
-    if (result.base64Image !== undefined) resultObj.base64Image = result.base64Image;
-    if (result.system !== undefined) resultObj.system = result.system;
+    // Build result object for model API - only include content fields
+    const resultObj = extractDefinedFields(result, [
+      'output',
+      'error',
+      'base64Image',
+      'system',
+    ]);
 
     const followUpMsgs = modelHandler.createToolUseFollowUpMessages(
       id,

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -178,15 +178,23 @@ export async function runToolUseCycle<C = unknown>(
       const errorMsg = `Malformed tool JSON: ${err instanceof Error ? err.message : String(err)}`;
 
       // Log the failed tool use attempt
-      const toolUseLog = {
+      const errorResult = new ToolResult({ error: errorMsg, isError: true });
+      const errorPayload = errorResult.toLogPayload();
+      const toolUseLog: Record<string, unknown> = {
         tool: 'unknown',
         input: toolInfo,
-        output: new ToolResult({ error: errorMsg, isError: true }),
       };
+      if (errorResult.summary !== undefined) {
+        toolUseLog.summary = errorResult.summary;
+      }
+      if (errorPayload !== undefined) {
+        toolUseLog.output = errorPayload;
+      }
       logger.info(
         JSON.stringify(toolUseLog, null, 2),
         groupId,
         MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
       );
       break;
     }
@@ -198,15 +206,23 @@ export async function runToolUseCycle<C = unknown>(
       const errorMsg = `Tool JSON missing name: ${JSON.stringify(parsed)}`;
 
       // Log the failed tool use attempt with available info
-      const toolUseLog = {
+      const errorResult = new ToolResult({ error: errorMsg, isError: true });
+      const errorPayload = errorResult.toLogPayload();
+      const toolUseLog: Record<string, unknown> = {
         tool: 'unknown',
         input: parsed,
-        output: new ToolResult({ error: errorMsg, isError: true }),
       };
+      if (errorResult.summary !== undefined) {
+        toolUseLog.summary = errorResult.summary;
+      }
+      if (errorPayload !== undefined) {
+        toolUseLog.output = errorPayload;
+      }
       logger.info(
         JSON.stringify(toolUseLog, null, 2),
         groupId,
         MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
       );
       break;
     }
@@ -278,25 +294,27 @@ export async function runToolUseCycle<C = unknown>(
       toolInput = parsed;
     }
 
-    const toolUseLog = {
+    const logPayload = result.toLogPayload();
+    const toolUseLog: Record<string, unknown> = {
       tool: name,
       input: toolInput,
-      output: result,
     };
+    if (result.summary !== undefined) {
+      toolUseLog.summary = result.summary;
+    }
+    if (logPayload !== undefined) {
+      toolUseLog.output = logPayload;
+    }
 
     logger.info(
       JSON.stringify(toolUseLog, null, 2),
       groupId,
       MESSAGE_TYPES.TOOL_USE,
+      toolUseLog,
     );
 
     // Build provider-specific message containing the tool result
-    const resultObj: Record<string, unknown> = {};
-    if (result.output !== undefined) resultObj.output = result.output;
-    if (result.error !== undefined) resultObj.error = result.error;
-    if (result.base64Image !== undefined)
-      resultObj.base64Image = result.base64Image;
-    if (result.system !== undefined) resultObj.system = result.system;
+    const resultObj = result.toModelPayload();
 
     const followUpMsgs = modelHandler.createToolUseFollowUpMessages(
       id,

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -207,16 +207,11 @@ export async function runToolUseCycle<C = unknown>(
 
       // Log the failed tool use attempt with available info
       const errorResult = new ToolResult({ error: errorMsg, isError: true });
-      const errorPayload = errorResult.toLogPayload();
       const toolUseLog: Record<string, unknown> = {
         tool: 'unknown',
         input: parsed,
-      };
-      if (errorResult.summary !== undefined) {
-        toolUseLog.summary = errorResult.summary;
-      }
-      if (errorPayload !== undefined) {
-        toolUseLog.output = errorPayload;
+        error: errorMsg,
+        isError: true,
       }
       logger.info(
         JSON.stringify(toolUseLog, null, 2),
@@ -294,17 +289,20 @@ export async function runToolUseCycle<C = unknown>(
       toolInput = parsed;
     }
 
-    const logPayload = result.toLogPayload();
+    // Build the tool use log entry with all relevant fields
     const toolUseLog: Record<string, unknown> = {
       tool: name,
       input: toolInput,
     };
-    if (result.summary !== undefined) {
-      toolUseLog.summary = result.summary;
-    }
-    if (logPayload !== undefined) {
-      toolUseLog.output = logPayload;
-    }
+    
+    // Add all result fields to the log
+    if (result.summary !== undefined) toolUseLog.summary = result.summary;
+    if (result.output !== undefined) toolUseLog.output = result.output;
+    if (result.error !== undefined) toolUseLog.error = result.error;
+    if (result.base64Image !== undefined) toolUseLog.base64Image = result.base64Image;
+    if (result.system !== undefined) toolUseLog.system = result.system;
+    if (result.diagnostics !== undefined) toolUseLog.diagnostics = result.diagnostics;
+    if (result.isError) toolUseLog.isError = true;
 
     logger.info(
       JSON.stringify(toolUseLog, null, 2),
@@ -314,7 +312,12 @@ export async function runToolUseCycle<C = unknown>(
     );
 
     // Build provider-specific message containing the tool result
-    const resultObj = result.toModelPayload();
+    // Build result object for model API - only include defined fields
+    const resultObj: Record<string, unknown> = {};
+    if (result.output !== undefined) resultObj.output = result.output;
+    if (result.error !== undefined) resultObj.error = result.error;
+    if (result.base64Image !== undefined) resultObj.base64Image = result.base64Image;
+    if (result.system !== undefined) resultObj.system = result.system;
 
     const followUpMsgs = modelHandler.createToolUseFollowUpMessages(
       id,

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -586,8 +586,11 @@ export class LogEntryFormatter {
         .map((section) => section.trim())
         .join('<hr class="tool-use-separator">');
 
-      formattedContent = detailMarkup || `<pre>${safeContent}</pre>`;
+      // Use formatted sections if we have any, otherwise show a minimal view
+      formattedContent =
+        detailMarkup || '<div class="tool-use-empty">Tool executed</div>';
     } else if (parsed !== undefined) {
+      // Fallback for other parsed formats (shouldn't normally reach here for tool use)
       formattedContent = `<pre>${encodeHtml(JSON.stringify(parsed, null, 2))}</pre>`;
     } else {
       // If not valid JSON, just display as-is in a pre block

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -459,9 +459,16 @@ export class LogEntryFormatter {
 
     let formattedContent;
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      // Extract tool name
-      const toolName =
-        typeof parsed.tool === 'string'
+      // Check if this is a raw tool result (has output/summary but no tool field)
+      // vs a proper tool use log (has tool field)
+      const isRawResult =
+        !parsed.tool &&
+        (parsed.output !== undefined || parsed.summary !== undefined);
+
+      // Extract tool name - for raw results, we won't have a tool name
+      const toolName = isRawResult
+        ? 'Tool Result' // Generic name for raw results
+        : typeof parsed.tool === 'string'
           ? parsed.tool.trim()
           : typeof parsed.name === 'string'
             ? parsed.name.trim()

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -458,7 +458,18 @@ export class LogEntryFormatter {
     }
 
     let formattedContent;
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    // First, check if this looks like any kind of tool-related data
+    const looksLikeToolData =
+      parsed &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      (parsed.tool !== undefined ||
+        parsed.input !== undefined ||
+        parsed.output !== undefined ||
+        parsed.error !== undefined ||
+        parsed.summary !== undefined);
+
+    if (looksLikeToolData) {
       // Check if this is a raw tool result (has output/summary but no tool field)
       // vs a proper tool use log (has tool field)
       const isRawResult =
@@ -597,8 +608,10 @@ export class LogEntryFormatter {
       formattedContent =
         detailMarkup || '<div class="tool-use-empty">Tool executed</div>';
     } else if (parsed !== undefined) {
-      // Fallback for other parsed formats (shouldn't normally reach here for tool use)
-      formattedContent = `<pre>${encodeHtml(JSON.stringify(parsed, null, 2))}</pre>`;
+      // This shouldn't happen for tool use logs, but if we get here with tool-like data,
+      // show a minimal view instead of the raw JSON
+      console.warn('Unexpected parsed data in tool use formatter:', parsed);
+      formattedContent = '<div class="tool-use-empty">Tool data received</div>';
     } else {
       // If not valid JSON, just display as-is in a pre block
       // This preserves any HTML entities in error messages

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -488,18 +488,23 @@ export class LogEntryFormatter {
         headerLabel.textContent = headerText;
       }
 
-      // Check if there's a summary
+      // Check if there's a non-trivial summary
       const summaryText =
         typeof parsed.summary === 'string' && parsed.summary.trim().length > 0
           ? parsed.summary.trim()
           : undefined;
 
-      // If there's a summary, only show the summary
+      const sections = [];
+
+      // If there's a summary, show it prominently
       if (summaryText) {
-        formattedContent = `<div class="tool-use-summary">${encodeHtml(summaryText)}</div>`;
+        sections.push(
+          `<div class="tool-use-summary">${encodeHtml(summaryText)}</div>`,
+        );
+        // When we have a summary, we DON'T show input/output details
+        // This keeps the UI clean and focused on the summary
       } else {
-        // No summary, show the full output with vertical limit
-        const sections = [];
+        // No summary, show the full details with vertical limit
 
         // Add input section if present
         if (Object.prototype.hasOwnProperty.call(parsed, 'input')) {
@@ -559,29 +564,29 @@ export class LogEntryFormatter {
             </div>
           `);
         }
-
-        // Add error section if present (and no summary)
-        if (parsed.error) {
-          const errorText =
-            typeof parsed.error === 'string'
-              ? parsed.error
-              : JSON.stringify(parsed.error, null, 2);
-          sections.push(`
-            <div class="tool-use-section">
-              <div class="tool-use-subsection">
-                <span class="tool-use-sublabel" style="color: #ff6b6b;">Error:</span>
-                <pre style="color: #ff6b6b;">${encodeHtml(errorText)}</pre>
-              </div>
-            </div>
-          `);
-        }
-
-        const detailMarkup = sections
-          .map((section) => section.trim())
-          .join('<hr class="tool-use-separator">');
-
-        formattedContent = detailMarkup || `<pre>${safeContent}</pre>`;
       }
+
+      // Always add error section if present (regardless of summary)
+      if (parsed.error) {
+        const errorText =
+          typeof parsed.error === 'string'
+            ? parsed.error
+            : JSON.stringify(parsed.error, null, 2);
+        sections.push(`
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel" style="color: #ff6b6b;">Error:</span>
+              <pre style="color: #ff6b6b;">${encodeHtml(errorText)}</pre>
+            </div>
+          </div>
+        `);
+      }
+
+      const detailMarkup = sections
+        .map((section) => section.trim())
+        .join('<hr class="tool-use-separator">');
+
+      formattedContent = detailMarkup || `<pre>${safeContent}</pre>`;
     } else if (parsed !== undefined) {
       formattedContent = `<pre>${encodeHtml(JSON.stringify(parsed, null, 2))}</pre>`;
     } else {

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -466,21 +466,25 @@ export class LogEntryFormatter {
           : typeof parsed.name === 'string'
             ? parsed.name.trim()
             : '';
-      
+
       // Update header to show tool name and error state
       if (headerLabel && toolName) {
         let headerText = `Tool Use: ${toolName}`;
-        
+
         // Add error information to the header if present
         if (parsed.error) {
-          const errorText = typeof parsed.error === 'string' ? parsed.error : 'Error occurred';
+          const errorText =
+            typeof parsed.error === 'string' ? parsed.error : 'Error occurred';
           // Truncate error message if too long
-          const truncatedError = errorText.length > 50 ? errorText.substring(0, 50) + '...' : errorText;
+          const truncatedError =
+            errorText.length > 50
+              ? errorText.substring(0, 50) + '...'
+              : errorText;
           headerText = `Tool Use: ${toolName} - ❌ ${truncatedError}`;
         } else if (parsed.isError === true) {
           headerText = `Tool Use: ${toolName} - ❌ Error`;
         }
-        
+
         headerLabel.textContent = headerText;
       }
 
@@ -496,10 +500,11 @@ export class LogEntryFormatter {
       } else {
         // No summary, show the full output with vertical limit
         const sections = [];
-        
+
         // Add input section if present
         if (Object.prototype.hasOwnProperty.call(parsed, 'input')) {
-          const inputJson = JSON.stringify(parsed.input, null, 2) ?? 'undefined';
+          const inputJson =
+            JSON.stringify(parsed.input, null, 2) ?? 'undefined';
           sections.push(`
             <div class="tool-use-section">
               <div class="tool-use-subsection">
@@ -511,11 +516,14 @@ export class LogEntryFormatter {
         }
 
         // Add output section with vertical limit
-        const hasOutput = Object.prototype.hasOwnProperty.call(parsed, 'output');
+        const hasOutput = Object.prototype.hasOwnProperty.call(
+          parsed,
+          'output',
+        );
         if (hasOutput) {
           const outputValue = parsed.output;
           let outputDisplay;
-          
+
           if (typeof outputValue === 'string') {
             // Limit the number of lines for display
             const MAX_LINES = 10;
@@ -528,7 +536,8 @@ export class LogEntryFormatter {
               outputDisplay = encodeHtml(outputValue);
             }
           } else {
-            const outputJson = JSON.stringify(outputValue, null, 2) ?? 'undefined';
+            const outputJson =
+              JSON.stringify(outputValue, null, 2) ?? 'undefined';
             // Also limit JSON output
             const lines = outputJson.split('\n');
             const MAX_LINES = 10;
@@ -540,7 +549,7 @@ export class LogEntryFormatter {
               outputDisplay = encodeHtml(outputJson);
             }
           }
-          
+
           sections.push(`
             <div class="tool-use-section">
               <div class="tool-use-subsection">
@@ -553,7 +562,10 @@ export class LogEntryFormatter {
 
         // Add error section if present (and no summary)
         if (parsed.error) {
-          const errorText = typeof parsed.error === 'string' ? parsed.error : JSON.stringify(parsed.error, null, 2);
+          const errorText =
+            typeof parsed.error === 'string'
+              ? parsed.error
+              : JSON.stringify(parsed.error, null, 2);
           sections.push(`
             <div class="tool-use-section">
               <div class="tool-use-subsection">

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -459,79 +459,117 @@ export class LogEntryFormatter {
 
     let formattedContent;
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      // Extract tool name
       const toolName =
         typeof parsed.tool === 'string'
           ? parsed.tool.trim()
           : typeof parsed.name === 'string'
             ? parsed.name.trim()
             : '';
+      
+      // Update header to show tool name and error state
       if (headerLabel && toolName) {
-        headerLabel.textContent = `Tool Use: ${toolName}`;
+        let headerText = `Tool Use: ${toolName}`;
+        
+        // Add error information to the header if present
+        if (parsed.error) {
+          const errorText = typeof parsed.error === 'string' ? parsed.error : 'Error occurred';
+          // Truncate error message if too long
+          const truncatedError = errorText.length > 50 ? errorText.substring(0, 50) + '...' : errorText;
+          headerText = `Tool Use: ${toolName} - ❌ ${truncatedError}`;
+        } else if (parsed.isError === true) {
+          headerText = `Tool Use: ${toolName} - ❌ Error`;
+        }
+        
+        headerLabel.textContent = headerText;
       }
 
+      // Check if there's a summary
       const summaryText =
         typeof parsed.summary === 'string' && parsed.summary.trim().length > 0
           ? parsed.summary.trim()
           : undefined;
 
-      const hasOutput = Object.prototype.hasOwnProperty.call(parsed, 'output');
-      const outputValue = hasOutput ? parsed.output : undefined;
-      let fallbackSummary;
-      if (!summaryText && typeof outputValue === 'string') {
-        const trimmedOutput = outputValue.trim();
-        if (trimmedOutput.length > 0) {
-          fallbackSummary = trimmedOutput;
-        }
-      }
-
-      const summaryMarkup =
-        summaryText || fallbackSummary
-          ? `<div class="tool-use-summary">${encodeHtml(
-              summaryText || fallbackSummary,
-            )}</div>`
-          : '';
-
-      const sections = [];
-      if (Object.prototype.hasOwnProperty.call(parsed, 'input')) {
-        const inputJson = JSON.stringify(parsed.input, null, 2) ?? 'undefined';
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Input:</span>
-              <pre>${encodeHtml(inputJson)}</pre>
+      // If there's a summary, only show the summary
+      if (summaryText) {
+        formattedContent = `<div class="tool-use-summary">${encodeHtml(summaryText)}</div>`;
+      } else {
+        // No summary, show the full output with vertical limit
+        const sections = [];
+        
+        // Add input section if present
+        if (Object.prototype.hasOwnProperty.call(parsed, 'input')) {
+          const inputJson = JSON.stringify(parsed.input, null, 2) ?? 'undefined';
+          sections.push(`
+            <div class="tool-use-section">
+              <div class="tool-use-subsection">
+                <span class="tool-use-sublabel">Input:</span>
+                <pre>${encodeHtml(inputJson)}</pre>
+              </div>
             </div>
-          </div>
-        `);
-      }
-
-      if (hasOutput) {
-        let outputMarkup;
-        if (typeof outputValue === 'string') {
-          outputMarkup = `<pre>${encodeHtml(outputValue)}</pre>`;
-        } else {
-          const outputJson = JSON.stringify(outputValue, null, 2);
-          outputMarkup = `<pre>${encodeHtml(outputJson ?? 'undefined')}</pre>`;
+          `);
         }
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Output:</span>
-              ${outputMarkup}
+
+        // Add output section with vertical limit
+        const hasOutput = Object.prototype.hasOwnProperty.call(parsed, 'output');
+        if (hasOutput) {
+          const outputValue = parsed.output;
+          let outputDisplay;
+          
+          if (typeof outputValue === 'string') {
+            // Limit the number of lines for display
+            const MAX_LINES = 10;
+            const lines = outputValue.split('\n');
+            if (lines.length > MAX_LINES) {
+              const truncatedOutput = lines.slice(0, MAX_LINES).join('\n');
+              const remainingLines = lines.length - MAX_LINES;
+              outputDisplay = `${encodeHtml(truncatedOutput)}\n<span style="color: #888;">... (${remainingLines} more lines)</span>`;
+            } else {
+              outputDisplay = encodeHtml(outputValue);
+            }
+          } else {
+            const outputJson = JSON.stringify(outputValue, null, 2) ?? 'undefined';
+            // Also limit JSON output
+            const lines = outputJson.split('\n');
+            const MAX_LINES = 10;
+            if (lines.length > MAX_LINES) {
+              const truncatedOutput = lines.slice(0, MAX_LINES).join('\n');
+              const remainingLines = lines.length - MAX_LINES;
+              outputDisplay = `${encodeHtml(truncatedOutput)}\n<span style="color: #888;">... (${remainingLines} more lines)</span>`;
+            } else {
+              outputDisplay = encodeHtml(outputJson);
+            }
+          }
+          
+          sections.push(`
+            <div class="tool-use-section">
+              <div class="tool-use-subsection">
+                <span class="tool-use-sublabel">Output:</span>
+                <pre>${outputDisplay}</pre>
+              </div>
             </div>
-          </div>
-        `);
+          `);
+        }
+
+        // Add error section if present (and no summary)
+        if (parsed.error) {
+          const errorText = typeof parsed.error === 'string' ? parsed.error : JSON.stringify(parsed.error, null, 2);
+          sections.push(`
+            <div class="tool-use-section">
+              <div class="tool-use-subsection">
+                <span class="tool-use-sublabel" style="color: #ff6b6b;">Error:</span>
+                <pre style="color: #ff6b6b;">${encodeHtml(errorText)}</pre>
+              </div>
+            </div>
+          `);
+        }
+
+        const detailMarkup = sections
+          .map((section) => section.trim())
+          .join('<hr class="tool-use-separator">');
+
+        formattedContent = detailMarkup || `<pre>${safeContent}</pre>`;
       }
-
-      const detailMarkup = sections
-        .map((section) => section.trim())
-        .join('<hr class="tool-use-separator">');
-      const divider =
-        summaryMarkup && detailMarkup ? '<hr class="tool-use-separator">' : '';
-
-      formattedContent =
-        summaryMarkup || detailMarkup
-          ? `${summaryMarkup}${divider}${detailMarkup}`
-          : `<pre>${safeContent}</pre>`;
     } else if (parsed !== undefined) {
       formattedContent = `<pre>${encodeHtml(JSON.stringify(parsed, null, 2))}</pre>`;
     } else {

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -251,9 +251,9 @@ export class LogEntryFormatter {
             ),
           'scratchpad',
         ),
-      toolUse: (text, id, groupId, timestamp) =>
+      toolUse: (text, id, groupId, timestamp, data) =>
         this._safeFormat(
-          () => this._formatToolUse(text, id, groupId, timestamp),
+          () => this._formatToolUse(text, id, groupId, timestamp, data),
           'tool use',
         ),
       modelResponse: (params) =>
@@ -348,7 +348,7 @@ export class LogEntryFormatter {
       ) {
         // Pass the full logMessage for access to groupId and timestamp
         // Note: timestamp here is numeric (from Date.now())
-        result = formatter(text, id, groupId, timestamp);
+        result = formatter(text, id, groupId, timestamp, data);
       } else if (messageType === 'userMessage') {
         // User message needs text, id, and timestamp
         result = formatter(text, id, timestamp);
@@ -428,7 +428,7 @@ export class LogEntryFormatter {
     return element;
   }
 
-  _formatToolUse(content, logId, groupId, timestamp) {
+  _formatToolUse(content, logId, groupId, timestamp, data) {
     const element = createFromTemplate('toolUseTemplate');
     if (!element) return null;
 
@@ -442,12 +442,23 @@ export class LogEntryFormatter {
       headerLabel.textContent = 'Tool Use';
     }
 
-    let formattedContent;
-    try {
-      // Decode HTML entities before parsing - log messages are encoded in transport
-      const decodedContent = decodeHtml(content);
-      const parsed = JSON.parse(decodedContent);
+    const safeContent = content ?? '';
+    const decodedContent = decodeHtml(safeContent);
 
+    const logData =
+      data && typeof data === 'object' && data !== null ? data : undefined;
+
+    let parsed = logData;
+    if (!parsed) {
+      try {
+        parsed = JSON.parse(decodedContent);
+      } catch {
+        parsed = undefined;
+      }
+    }
+
+    let formattedContent;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       const toolName =
         typeof parsed.tool === 'string'
           ? parsed.tool.trim()
@@ -458,34 +469,72 @@ export class LogEntryFormatter {
         headerLabel.textContent = `Tool Use: ${toolName}`;
       }
 
-      // Check if this is the new combined format
-      if (parsed.tool && parsed.input && parsed.output) {
-        // Format combined tool input/output
-        const inputJson = JSON.stringify(parsed.input, null, 2);
-        const outputJson = JSON.stringify(parsed.output, null, 2);
+      const summaryText =
+        typeof parsed.summary === 'string' && parsed.summary.trim().length > 0
+          ? parsed.summary.trim()
+          : undefined;
 
-        formattedContent = `
+      const hasOutput = Object.prototype.hasOwnProperty.call(parsed, 'output');
+      const outputValue = hasOutput ? parsed.output : undefined;
+      const fallbackSummary =
+        !summaryText && typeof outputValue === 'string' && outputValue.trim()
+          ? outputValue
+          : undefined;
+
+      const summaryMarkup =
+        summaryText || fallbackSummary
+          ? `<div class="tool-use-summary">${encodeHtml(
+              summaryText || fallbackSummary,
+            )}</div>`
+          : '';
+
+      const sections = [];
+      if (Object.prototype.hasOwnProperty.call(parsed, 'input')) {
+        const inputJson = JSON.stringify(parsed.input, null, 2) ?? 'undefined';
+        sections.push(`
           <div class="tool-use-section">
             <div class="tool-use-subsection">
               <span class="tool-use-sublabel">Input:</span>
-              <pre>${inputJson}</pre>
+              <pre>${encodeHtml(inputJson)}</pre>
             </div>
           </div>
-          <hr class="tool-use-separator">
+        `);
+      }
+
+      if (hasOutput) {
+        let outputMarkup;
+        if (typeof outputValue === 'string') {
+          outputMarkup = `<pre>${encodeHtml(outputValue)}</pre>`;
+        } else {
+          const outputJson = JSON.stringify(outputValue, null, 2);
+          outputMarkup = `<pre>${encodeHtml(outputJson ?? 'undefined')}</pre>`;
+        }
+        sections.push(`
           <div class="tool-use-section">
             <div class="tool-use-subsection">
               <span class="tool-use-sublabel">Output:</span>
-              <pre>${outputJson}</pre>
+              ${outputMarkup}
             </div>
-          </div>`;
-      } else {
-        // Legacy format - just display as before
-        formattedContent = `<pre>${JSON.stringify(parsed, null, 2)}</pre>`;
+          </div>
+        `);
       }
-    } catch {
+
+      const detailMarkup = sections
+        .map((section) => section.trim())
+        .join('<hr class="tool-use-separator">');
+      const divider =
+        summaryMarkup && detailMarkup ? '<hr class="tool-use-separator">' : '';
+
+      formattedContent =
+        summaryMarkup || detailMarkup
+          ? `${summaryMarkup}${divider}${detailMarkup}`
+          : `<pre>${safeContent}</pre>`;
+    } else if (parsed !== undefined) {
+      formattedContent = `<pre>${encodeHtml(JSON.stringify(parsed, null, 2))}</pre>`;
+    } else {
       // If not valid JSON, just display as-is in a pre block
       // This preserves any HTML entities in error messages
-      formattedContent = `<pre>${content}</pre>`;
+      formattedContent = `<pre>${safeContent}</pre>`;
     }
 
     const toggleIcon = element.querySelector('.toggle-icon');

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -476,10 +476,13 @@ export class LogEntryFormatter {
 
       const hasOutput = Object.prototype.hasOwnProperty.call(parsed, 'output');
       const outputValue = hasOutput ? parsed.output : undefined;
-      const fallbackSummary =
-        !summaryText && typeof outputValue === 'string' && outputValue.trim()
-          ? outputValue
-          : undefined;
+      let fallbackSummary;
+      if (!summaryText && typeof outputValue === 'string') {
+        const trimmedOutput = outputValue.trim();
+        if (trimmedOutput.length > 0) {
+          fallbackSummary = trimmedOutput;
+        }
+      }
 
       const summaryMarkup =
         summaryText || fallbackSummary

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -24,15 +24,15 @@ import {
   DEFAULT_MODEL_CAPABILITIES,
 } from '@model/ModelConfig';
 import { BaseTool } from '@tools/core/base';
-import { ToolResult } from '@tools/result';
+import type { ToolResultLike } from '@tools/result';
 import type OpenAI from 'openai';
 
 class EchoTool extends BaseTool<{ value: string }> {
   constructor() {
     super({ name: 'echo' }, z.object({ value: z.string() }));
   }
-  protected async execute(input: { value: string }): Promise<ToolResult> {
-    return new ToolResult({ output: input.value });
+  protected async execute(input: { value: string }): Promise<ToolResultLike> {
+    return { summary: `Echo: ${input.value}`, output: input.value };
   }
 }
 
@@ -143,6 +143,10 @@ describe('runToolUseCycle DeepSeek', () => {
       (e) => e.logMessage.messageType === MESSAGE_TYPES.TOOL_USE,
     );
     assert.equal(toolEvents.length, 2);
+    const toolLog = toolEvents.find((e) => e.logMessage.data?.tool === 'echo');
+    assert.ok(toolLog);
+    assert.equal(toolLog?.logMessage.data?.summary, 'Echo: hello');
+    assert.equal(toolLog?.logMessage.data?.output, 'hello');
     assert.deepEqual(messages[0], {
       role: 'assistant',
       tool_calls: [

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -26,15 +26,15 @@ import {
   DEFAULT_MODEL_CAPABILITIES,
 } from '@model/ModelConfig';
 import { BaseTool } from '@tools/core/base';
-import { ToolResult } from '@tools/result';
+import type { ToolResultLike } from '@tools/result';
 import type OpenAI from 'openai';
 
 class EchoTool extends BaseTool<{ value: string }> {
   constructor() {
     super({ name: 'echo' }, z.object({ value: z.string() }));
   }
-  protected async execute(input: { value: string }): Promise<ToolResult> {
-    return new ToolResult({ output: input.value });
+  protected async execute(input: { value: string }): Promise<ToolResultLike> {
+    return { summary: `Echo: ${input.value}`, output: input.value };
   }
 }
 
@@ -153,6 +153,10 @@ describe('runToolUseCycle OpenAIResponse', () => {
       (e) => e.logMessage.messageType === MESSAGE_TYPES.TOOL_USE,
     );
     assert.equal(toolEvents.length, 2);
+    const toolLog = toolEvents.find((e) => e.logMessage.data?.tool === 'echo');
+    assert.ok(toolLog);
+    assert.equal(toolLog?.logMessage.data?.summary, 'Echo: hello');
+    assert.equal(toolLog?.logMessage.data?.output, 'hello');
     const assistantMsg = messages[0] as any;
     assert.equal(assistantMsg.role, 'assistant');
     assert.equal(assistantMsg.type, 'message');

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolResult } from '@tools/result';
+import type { ToolResultLike } from '@tools/result';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
@@ -24,8 +24,11 @@ export class ReadFileTool extends defineTool({
   description: 'Read and return the contents of a workspace file.',
   schema: ReadInputSchema,
 }) {
-  protected async execute(input: ReadInput): Promise<ToolResult> {
+  protected async execute(input: ReadInput): Promise<ToolResultLike> {
     const content = await WorkspaceFS.read(input.path);
-    return new ToolResult({ output: content });
+    return {
+      summary: `Read ${input.path}`,
+      output: content,
+    };
   }
 }

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolResult } from '@tools/result';
+import type { ToolResultLike } from '@tools/result';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
@@ -26,8 +26,11 @@ export class WriteFileTool extends defineTool({
     'Overwrite a workspace file with the provided content. Creates the file if it does not exist.',
   schema: WriteInputSchema,
 }) {
-  protected async execute(input: WriteInput): Promise<ToolResult> {
+  protected async execute(input: WriteInput): Promise<ToolResultLike> {
     await WorkspaceFS.write(input.path, input.content);
-    return new ToolResult({ output: 'written' });
+    return {
+      summary: `Wrote ${input.path}`,
+      output: 'written',
+    };
   }
 }

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -3,7 +3,7 @@ import { z, ZodError } from 'zod';
 
 // Local imports - tools
 import type { ToolDefinition } from '@model';
-import { ToolResult } from '@tools/result';
+import { ToolResult, type ToolResultLike } from '@tools/result';
 
 export abstract class BaseTool<T> {
   readonly definition: ToolDefinition;
@@ -36,7 +36,8 @@ export abstract class BaseTool<T> {
   async call(rawInput: unknown): Promise<ToolResult> {
     try {
       const input = this.validate(rawInput);
-      return await this.execute(input);
+      const executionResult = await this.execute(input);
+      return ToolResult.from(executionResult);
     } catch (err) {
       if (err instanceof ZodError) {
         return new ToolResult({
@@ -56,5 +57,5 @@ export abstract class BaseTool<T> {
     }
   }
 
-  protected abstract execute(input: T): Promise<ToolResult>;
+  protected abstract execute(input: T): Promise<ToolResultLike>;
 }

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -7,6 +7,7 @@ import { defineTool } from './core/define';
 
 // Local imports - tools
 import { ToolResult, ToolError } from '@tools/result';
+import type { ToolResultLike } from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
 
 const FileOpInputSchema = z.object({
@@ -22,12 +23,15 @@ export class FileOpTool extends defineTool({
   description: 'Perform basic file operations',
   schema: FileOpInputSchema,
 }) {
-  protected async execute(input: FileOpInput): Promise<ToolResult> {
+  protected async execute(input: FileOpInput): Promise<ToolResultLike> {
     const { command, path, content } = input;
     switch (command) {
       case 'read': {
         const data = await WorkspaceFS.read(path);
-        return new ToolResult({ output: data });
+        return {
+          summary: `Read ${path}`,
+          output: data,
+        };
       }
       case 'write': {
         if (content === undefined) {
@@ -37,7 +41,10 @@ export class FileOpTool extends defineTool({
           });
         }
         await WorkspaceFS.write(path, content);
-        return new ToolResult({ output: 'written' });
+        return {
+          summary: `Wrote ${path}`,
+          output: 'written',
+        };
       }
       case 'append': {
         if (content === undefined) {
@@ -47,7 +54,10 @@ export class FileOpTool extends defineTool({
           });
         }
         await WorkspaceFS.appendFile(path, content);
-        return new ToolResult({ output: 'appended' });
+        return {
+          summary: `Appended to ${path}`,
+          output: 'appended',
+        };
       }
       default:
         throw new ToolError(

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -6,7 +6,7 @@ export type ErrorDiagnostics =
   | { name: string; stack?: string } // For regular errors
   | unknown; // For other types of diagnostics
 
-export interface ToolResultInit {
+type ToolResultInit = {
   output?: string;
   error?: string;
   base64Image?: string;
@@ -14,9 +14,9 @@ export interface ToolResultInit {
   isError?: boolean;
   diagnostics?: ErrorDiagnostics;
   summary?: string;
-}
+};
 
-export type ToolResultLike = ToolResult | ToolResultInit | string;
+export type ToolResultLike = ToolResult | string | ToolResultInit;
 
 export class ToolResult {
   output?: string;
@@ -35,7 +35,7 @@ export class ToolResult {
     isError = false,
     diagnostics,
     summary,
-  }: ToolResultInit) {
+  }: ToolResultInit = {}) {
     this.output = output;
     this.error = error;
     this.base64Image = base64Image;

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -6,6 +6,18 @@ export type ErrorDiagnostics =
   | { name: string; stack?: string } // For regular errors
   | unknown; // For other types of diagnostics
 
+export interface ToolResultInit {
+  output?: string;
+  error?: string;
+  base64Image?: string;
+  system?: string;
+  isError?: boolean;
+  diagnostics?: ErrorDiagnostics;
+  summary?: string;
+}
+
+export type ToolResultLike = ToolResult | ToolResultInit | string;
+
 export class ToolResult {
   output?: string;
   error?: string;
@@ -13,6 +25,7 @@ export class ToolResult {
   system?: string;
   isError: boolean;
   diagnostics?: ErrorDiagnostics; // Additional error details like validation issues
+  summary?: string;
 
   constructor({
     output,
@@ -21,20 +34,60 @@ export class ToolResult {
     system,
     isError = false,
     diagnostics,
-  }: {
-    output?: string;
-    error?: string;
-    base64Image?: string;
-    system?: string;
-    isError?: boolean;
-    diagnostics?: ErrorDiagnostics;
-  }) {
+    summary,
+  }: ToolResultInit) {
     this.output = output;
     this.error = error;
     this.base64Image = base64Image;
     this.system = system;
     this.isError = isError;
     this.diagnostics = diagnostics;
+    this.summary = summary;
+  }
+
+  static from(result: ToolResultLike): ToolResult {
+    if (result instanceof ToolResult) {
+      return result;
+    }
+    if (typeof result === 'string') {
+      return new ToolResult({ output: result });
+    }
+    return new ToolResult(result ?? {});
+  }
+
+  toModelPayload(): Record<string, unknown> {
+    const payload: Record<string, unknown> = {};
+    if (this.output !== undefined) payload.output = this.output;
+    if (this.error !== undefined) payload.error = this.error;
+    if (this.base64Image !== undefined) payload.base64Image = this.base64Image;
+    if (this.system !== undefined) payload.system = this.system;
+    return payload;
+  }
+
+  toLogPayload(): unknown {
+    const payload: Record<string, unknown> = {};
+    if (this.summary !== undefined) payload.summary = this.summary;
+    if (this.output !== undefined) payload.output = this.output;
+    if (this.error !== undefined) payload.error = this.error;
+    if (this.base64Image !== undefined) payload.base64Image = this.base64Image;
+    if (this.system !== undefined) payload.system = this.system;
+    if (this.diagnostics !== undefined) payload.diagnostics = this.diagnostics;
+    if (this.isError) payload.isError = true;
+
+    const hasOnlyStringOutput =
+      this.summary === undefined &&
+      this.error === undefined &&
+      this.base64Image === undefined &&
+      this.system === undefined &&
+      this.diagnostics === undefined &&
+      !this.isError &&
+      typeof this.output === 'string';
+
+    if (hasOnlyStringOutput) {
+      return this.output;
+    }
+
+    return Object.keys(payload).length > 0 ? payload : undefined;
   }
 
   add(other: ToolResult): ToolResult {
@@ -57,6 +110,7 @@ export class ToolResult {
       system: combine(this.system, other.system),
       isError: this.isError || other.isError,
       diagnostics: this.diagnostics || other.diagnostics,
+      summary: this.summary ?? other.summary,
     });
   }
 }

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -55,39 +55,13 @@ export class ToolResult {
     return new ToolResult(result ?? {});
   }
 
-  toModelPayload(): Record<string, unknown> {
-    const payload: Record<string, unknown> = {};
-    if (this.output !== undefined) payload.output = this.output;
-    if (this.error !== undefined) payload.error = this.error;
-    if (this.base64Image !== undefined) payload.base64Image = this.base64Image;
-    if (this.system !== undefined) payload.system = this.system;
-    return payload;
-  }
-
-  toLogPayload(): unknown {
-    const payload: Record<string, unknown> = {};
-    if (this.summary !== undefined) payload.summary = this.summary;
-    if (this.output !== undefined) payload.output = this.output;
-    if (this.error !== undefined) payload.error = this.error;
-    if (this.base64Image !== undefined) payload.base64Image = this.base64Image;
-    if (this.system !== undefined) payload.system = this.system;
-    if (this.diagnostics !== undefined) payload.diagnostics = this.diagnostics;
-    if (this.isError) payload.isError = true;
-
-    const hasOnlyStringOutput =
-      this.summary === undefined &&
-      this.error === undefined &&
-      this.base64Image === undefined &&
-      this.system === undefined &&
-      this.diagnostics === undefined &&
-      !this.isError &&
-      typeof this.output === 'string';
-
-    if (hasOnlyStringOutput) {
-      return this.output;
-    }
-
-    return Object.keys(payload).length > 0 ? payload : undefined;
+  // Simple method to get the content for model API
+  toContent(): string {
+    // For API responses, we need the actual content, not the summary
+    if (this.error) return this.error;
+    if (this.output) return this.output;
+    if (this.system) return this.system;
+    return '';
   }
 
   add(other: ToolResult): ToolResult {


### PR DESCRIPTION
## Summary
- add summary-aware payload helpers to `ToolResult` and update the base tool plumbing
- enrich the file operation tool and tool-use logging with structured log payloads and summaries
- surface tool summaries in the progress view formatter and update the tool-use tests

## Testing
- npm run format
- npm run lint
- npm run compile
- npm test *(fails: vscode-test missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d17304a26c8324a9ae8f904ed29019