### PR TITLE
fix: capture deepseek reasoning messages

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -185,7 +185,18 @@ export class ModelHandlerOpenAI extends ModelHandler<
 
         if (this.config.fullName.includes('deepseek')) {
           // Aggregate stream chunks manually for DeepSeek models
-          const collectText = (value: any): string => {
+          const REASONING_CONTENT_TYPES = new Set<string>([
+            'reasoning_content',
+            'reasoning',
+            'thinking',
+            'thought',
+            'chain_of_thought',
+          ]);
+
+          const collectText = (
+            value: any,
+            allowedTypes?: Set<string>,
+          ): string => {
             if (!value) {
               return '';
             }
@@ -194,24 +205,63 @@ export class ModelHandlerOpenAI extends ModelHandler<
             }
             if (Array.isArray(value)) {
               return value
-                .map((entry) => {
-                  if (!entry) {
-                    return '';
-                  }
-                  if (typeof entry === 'string') {
-                    return entry;
-                  }
-                  if (typeof entry === 'object' && 'text' in entry) {
-                    return (entry as { text?: string }).text ?? '';
-                  }
-                  return '';
-                })
+                .map((entry) => collectText(entry, allowedTypes))
                 .join('');
             }
-            if (typeof value === 'object' && 'text' in value) {
-              return (value as { text?: string }).text ?? '';
+            if (typeof value === 'object') {
+              const entry: Record<string, any> = value;
+              const entryType =
+                typeof entry.type === 'string' ? entry.type : undefined;
+              const typeAllowed =
+                !allowedTypes || !entryType || allowedTypes.has(entryType);
+              let result = '';
+
+              if (
+                typeAllowed &&
+                typeof entry.text === 'string' &&
+                entry.text.length > 0
+              ) {
+                result += entry.text;
+              }
+
+              if (typeAllowed) {
+                if (typeof entry.content === 'string') {
+                  result += entry.content;
+                }
+                if (typeof entry.reasoning_content === 'string') {
+                  result += entry.reasoning_content;
+                } else if (Array.isArray(entry.reasoning_content)) {
+                  result += collectText(entry.reasoning_content, allowedTypes);
+                }
+              } else if (entry.reasoning_content) {
+                result += collectText(entry.reasoning_content, allowedTypes);
+              }
+
+              if (Array.isArray(entry.content)) {
+                result += entry.content
+                  .map((part: any) => collectText(part, allowedTypes))
+                  .join('');
+              }
+
+              if (Array.isArray(entry.messages)) {
+                result += collectText(entry.messages, allowedTypes);
+              }
+
+              if (entry.delta) {
+                result += collectText(entry.delta, allowedTypes);
+              }
+
+              return result;
             }
             return '';
+          };
+
+          const appendReasoning = (segment: string) => {
+            if (!segment) {
+              return;
+            }
+            reasoningParts.push(segment);
+            thinking.append(segment);
           };
 
           const appendStringValue = (
@@ -246,11 +296,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
               role = delta.role;
             }
 
-            const reasoningDelta = collectText(delta?.reasoning_content);
-            if (reasoningDelta) {
-              reasoningParts.push(reasoningDelta);
-              thinking.append(reasoningDelta);
-            }
+            appendReasoning(collectText(delta?.reasoning_content));
+            appendReasoning(
+              collectText(delta?.messages, REASONING_CONTENT_TYPES),
+            );
 
             const contentDelta = collectText(delta?.content);
             if (contentDelta) {

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -84,7 +84,7 @@ describe('runToolUseCycle DeepSeek', () => {
   it('logs tool calls and creates follow-up message', async () => {
     const config: ModelConfig = {
       name: 'ds',
-      fullName: 'ds',
+      fullName: 'deepseek-chat',
       provider: ModelProvider.DEEPSEEK,
       maxOutputTokens: 10,
       inputPrice: 0,
@@ -159,5 +159,134 @@ describe('runToolUseCycle DeepSeek', () => {
       tool_call_id: 'c1',
       content: JSON.stringify({ output: 'hello' }),
     });
+  });
+  it('streams reasoning messages as thinking logs', async () => {
+    const config: ModelConfig = {
+      name: 'ds',
+      fullName: 'deepseek-chat',
+      provider: ModelProvider.DEEPSEEK,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    };
+    const handler = new ModelHandlerDeepSeek(config);
+    const logger = new AgentLogger('StreamingTest', true);
+    handler.setLogger(logger);
+    handler.setOutputStreaming(true);
+    (handler as any).getStreamingConfig = () => true;
+
+    const streamChunks = [
+      {
+        id: 'chunk-1',
+        choices: [
+          {
+            delta: {
+              role: 'assistant',
+              messages: [
+                {
+                  role: 'assistant',
+                  content: [
+                    { type: 'thinking', text: 'First thought. ' },
+                    { type: 'reasoning_content', text: 'Second thought.' },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: 'chunk-2',
+        choices: [
+          {
+            delta: {
+              content: [{ type: 'output_text', text: 'Final answer.' }],
+            },
+          },
+        ],
+      },
+      {
+        id: 'chunk-3',
+        model: 'deepseek-chat',
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+        choices: [
+          {
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+      },
+    ];
+
+    const mockStream = {
+      [Symbol.asyncIterator]() {
+        let index = 0;
+        return {
+          async next() {
+            if (index < streamChunks.length) {
+              return { value: streamChunks[index++], done: false };
+            }
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    };
+
+    const client = {
+      chat: {
+        completions: {
+          stream: () => mockStream,
+        },
+      },
+    } as unknown as OpenAI;
+
+    const addEvents: any[] = [];
+    const updateEvents: any[] = [];
+    const disposeAdd = bus.on('addLogMessage', (event) =>
+      addEvents.push(event),
+    );
+    const disposeUpdate = bus.on('updateLogMessage', (event) =>
+      updateEvents.push(event),
+    );
+
+    const response = await handler.createResponse(
+      client,
+      [{ role: 'user', content: 'Hello' }],
+      0,
+      undefined,
+      undefined,
+      undefined,
+      [],
+    );
+
+    disposeAdd();
+    disposeUpdate();
+
+    const allEvents = [...addEvents, ...updateEvents];
+    const thinkingEvents = allEvents.filter(
+      (event) => event.logMessage?.messageType === MESSAGE_TYPES.THINKING,
+    );
+    assert.ok(
+      thinkingEvents.length > 0,
+      'Expected reasoning segments to emit thinking logs',
+    );
+    const combinedLogText = thinkingEvents
+      .map((event) => event.logMessage?.text ?? '')
+      .join('');
+    assert.ok(
+      combinedLogText.includes('First thought.'),
+      'Thinking log should contain reasoning text from messages',
+    );
+    assert.equal(
+      response.choices?.[0]?.message?.reasoning_content,
+      'First thought. Second thought.',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- parse DeepSeek streaming deltas for reasoning segments inside `messages` entries and append them to the thinking stream and final reasoning payload
- extend the DeepSeek tool-use test to mock streamed reasoning text and assert a thinking log entry is emitted

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.1/code: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d17a13826c8324b64663cfce7f05e1