### PR TITLE
docs: reinforce Occam's Razor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ When updating CHANGELOG.md:
 
 ### Pragmatic implementations
 
+- **Lead with Occam's Razor**: prioritize the simplest implementation that fully solves the problem before considering additional abstractions or indirection. Each new helper, class, or configuration option must earn its place by clearly reducing complexity.
 - Favor solutions that are readable and straightforward over exhaustive edge-case handling.
 - Avoid over-engineering and unnecessary abstractions when a direct approach communicates intent better.
 - Keep generated code tight: trim redundant helpers, repeated type checks, or defensive guards that do not serve a demonstrated scenario.


### PR DESCRIPTION
## Summary
- highlight Occam's Razor at the top of the pragmatic implementations section so contributors default to the simplest viable design

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.1/code: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d19096c59083248a56580c45872e89