### PR TITLE
Streamline tool result reporting

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -16,7 +16,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
-import { ToolResult } from '@tools/result';
+import { ToolResult, toolResult } from '@tools/result';
 import xmlUtils from '@utils/text/xmlUtils';
 
 export interface ToolUseCycleOptions<C = unknown> {
@@ -181,7 +181,7 @@ export async function runToolUseCycle<C = unknown>(
       const toolUseLog = {
         tool: 'unknown',
         input: toolInfo,
-        output: new ToolResult({ error: errorMsg, isError: true }),
+        output: toolResult({ error: errorMsg, isError: true }),
       };
       logger.info(
         JSON.stringify(toolUseLog, null, 2),
@@ -201,7 +201,7 @@ export async function runToolUseCycle<C = unknown>(
       const toolUseLog = {
         tool: 'unknown',
         input: parsed,
-        output: new ToolResult({ error: errorMsg, isError: true }),
+        output: toolResult({ error: errorMsg, isError: true }),
       };
       logger.info(
         JSON.stringify(toolUseLog, null, 2),
@@ -229,7 +229,7 @@ export async function runToolUseCycle<C = unknown>(
     const tool = toolRegistry[name];
     let result: ToolResult;
     if (!tool) {
-      result = new ToolResult({ error: `Unknown tool ${name}`, isError: true });
+      result = toolResult({ error: `Unknown tool ${name}`, isError: true });
     } else {
       try {
         result = await tool.call(input);
@@ -262,7 +262,7 @@ export async function runToolUseCycle<C = unknown>(
               : `${name}: ${String(err)}`;
         }
 
-        result = new ToolResult({
+        result = toolResult({
           error: errorMessage,
           isError: true,
           diagnostics,
@@ -292,11 +292,15 @@ export async function runToolUseCycle<C = unknown>(
 
     // Build provider-specific message containing the tool result
     const resultObj: Record<string, unknown> = {};
+    if (result.summary !== undefined) resultObj.summary = result.summary;
     if (result.output !== undefined) resultObj.output = result.output;
     if (result.error !== undefined) resultObj.error = result.error;
     if (result.base64Image !== undefined)
       resultObj.base64Image = result.base64Image;
     if (result.system !== undefined) resultObj.system = result.system;
+    if (result.isError) resultObj.isError = true;
+    if (result.diagnostics !== undefined)
+      resultObj.diagnostics = result.diagnostics;
 
     const followUpMsgs = modelHandler.createToolUseFollowUpMessages(
       id,

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -432,20 +432,35 @@ export class LogEntryFormatter {
     const element = createFromTemplate('toolUseTemplate');
     if (!element) return null;
 
-    // Add necessary attributes for proper group placement (but not log-line class which affects whitespace)
     if (logId) element.dataset.logId = logId;
     if (groupId) element.dataset.groupId = groupId;
     if (timestamp) element.dataset.fullTimestamp = timestamp;
 
     const headerLabel = element.querySelector('.tool-use-title');
-    if (headerLabel) {
-      headerLabel.textContent = 'Tool Use';
+    const iconElem = headerLabel ? headerLabel.previousElementSibling : null;
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+    if (headerLabel) headerLabel.textContent = 'Tool Use';
+    if (iconElem) iconElem.className = 'codicon codicon-wrench';
+    element.classList.remove('tool-use-error');
+
+    const contentElem = element.querySelector('.special-content');
+    if (!contentElem) {
+      return element;
     }
 
-    let formattedContent;
+    const MAX_PREVIEW_CHARS = 240;
+    const makePreview = (value) => {
+      if (!value) return '';
+      const normalized = value.replace(/\s+/g, ' ').trim();
+      if (normalized.length <= MAX_PREVIEW_CHARS) {
+        return normalized;
+      }
+      return `${normalized.slice(0, MAX_PREVIEW_CHARS - 1)}…`;
+    };
+
+    const decodedContent = decodeHtml(content);
     try {
-      // Decode HTML entities before parsing - log messages are encoded in transport
-      const decodedContent = decodeHtml(content);
       const parsed = JSON.parse(decodedContent);
 
       const toolName =
@@ -454,46 +469,179 @@ export class LogEntryFormatter {
           : typeof parsed.name === 'string'
             ? parsed.name.trim()
             : '';
-      if (headerLabel && toolName) {
-        headerLabel.textContent = `Tool Use: ${toolName}`;
+
+      const outputCandidate =
+        parsed.output &&
+        typeof parsed.output === 'object' &&
+        !Array.isArray(parsed.output)
+          ? parsed.output
+          : parsed.result &&
+              typeof parsed.result === 'object' &&
+              !Array.isArray(parsed.result)
+            ? parsed.result
+            : {};
+
+      const summaryText =
+        typeof outputCandidate.summary === 'string' &&
+        outputCandidate.summary.trim()
+          ? outputCandidate.summary.trim()
+          : typeof parsed.summary === 'string' && parsed.summary.trim()
+            ? parsed.summary.trim()
+            : '';
+
+      const errorText =
+        typeof outputCandidate.error === 'string'
+          ? outputCandidate.error
+          : typeof parsed.error === 'string'
+            ? parsed.error
+            : '';
+
+      let outputText = '';
+      if (typeof outputCandidate.output === 'string') {
+        outputText = outputCandidate.output;
+      } else if (typeof parsed.output === 'string') {
+        outputText = parsed.output;
       }
 
-      // Check if this is the new combined format
-      if (parsed.tool && parsed.input && parsed.output) {
-        // Format combined tool input/output
-        const inputJson = JSON.stringify(parsed.input, null, 2);
-        const outputJson = JSON.stringify(parsed.output, null, 2);
+      const isError = Boolean(
+        (typeof outputCandidate.isError === 'boolean' &&
+          outputCandidate.isError) ||
+          (typeof parsed.isError === 'boolean' && parsed.isError) ||
+          (typeof errorText === 'string' && errorText.trim().length > 0),
+      );
 
-        formattedContent = `
+      const headerSummary =
+        summaryText || makePreview(errorText || outputText || '');
+
+      const titlePrefix = isError ? 'Tool Error' : 'Tool Use';
+      const titleBase = toolName ? `${titlePrefix}: ${toolName}` : titlePrefix;
+      const titleText = headerSummary
+        ? `${titleBase} — ${headerSummary}`
+        : titleBase;
+
+      if (headerLabel) headerLabel.textContent = titleText;
+      if (iconElem) {
+        iconElem.className = isError
+          ? 'codicon codicon-error'
+          : 'codicon codicon-wrench';
+      }
+      element.classList.toggle('tool-use-error', isError);
+
+      const sections = [];
+
+      if (parsed.input !== undefined) {
+        const inputValue =
+          typeof parsed.input === 'string'
+            ? parsed.input
+            : JSON.stringify(parsed.input, null, 2);
+        sections.push(`
           <div class="tool-use-section">
             <div class="tool-use-subsection">
               <span class="tool-use-sublabel">Input:</span>
-              <pre>${inputJson}</pre>
+              <pre>${encodeHtml(inputValue)}</pre>
             </div>
           </div>
-          <hr class="tool-use-separator">
+        `);
+      }
+
+      if (errorText) {
+        sections.push(`
           <div class="tool-use-section">
             <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Output:</span>
-              <pre>${outputJson}</pre>
+              <span class="tool-use-sublabel">Error:</span>
+              <pre>${encodeHtml(errorText)}</pre>
             </div>
-          </div>`;
+          </div>
+        `);
+      }
+
+      if (outputText) {
+        const encodedOutput = encodeHtml(outputText);
+        if (!summaryText && outputText.length > MAX_PREVIEW_CHARS) {
+          const preview = encodeHtml(
+            `${outputText.slice(0, MAX_PREVIEW_CHARS).trimEnd()}…`,
+          );
+          sections.push(`
+            <div class="tool-use-section">
+              <div class="tool-use-subsection">
+                <span class="tool-use-sublabel">Output:</span>
+                <pre class="tool-output-preview">${preview}</pre>
+                <details class="tool-output-details">
+                  <summary>Show full output</summary>
+                  <pre>${encodedOutput}</pre>
+                </details>
+              </div>
+            </div>
+          `);
+        } else {
+          sections.push(`
+            <div class="tool-use-section">
+              <div class="tool-use-subsection">
+                <span class="tool-use-sublabel">Output:</span>
+                <pre>${encodedOutput}</pre>
+              </div>
+            </div>
+          `);
+        }
+      }
+
+      if (outputCandidate && outputCandidate.diagnostics !== undefined) {
+        const diagnosticsJson = JSON.stringify(
+          outputCandidate.diagnostics,
+          null,
+          2,
+        );
+        sections.push(`
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">Diagnostics:</span>
+              <pre>${encodeHtml(diagnosticsJson)}</pre>
+            </div>
+          </div>
+        `);
+      }
+
+      if (outputCandidate && typeof outputCandidate.system === 'string') {
+        sections.push(`
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">System:</span>
+              <pre>${encodeHtml(outputCandidate.system)}</pre>
+            </div>
+          </div>
+        `);
+      }
+
+      if (outputCandidate && typeof outputCandidate.base64Image === 'string') {
+        sections.push(`
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">Image:</span>
+              <pre>(base64 image omitted)</pre>
+            </div>
+          </div>
+        `);
+      }
+
+      if (sections.length === 0) {
+        contentElem.innerHTML = `<pre>${encodeHtml(decodedContent)}</pre>`;
       } else {
-        // Legacy format - just display as before
-        formattedContent = `<pre>${JSON.stringify(parsed, null, 2)}</pre>`;
+        contentElem.innerHTML = sections.join(
+          '<hr class="tool-use-separator">',
+        );
       }
     } catch {
-      // If not valid JSON, just display as-is in a pre block
-      // This preserves any HTML entities in error messages
-      formattedContent = `<pre>${content}</pre>`;
-    }
-
-    const toggleIcon = element.querySelector('.toggle-icon');
-    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
-
-    const contentElem = element.querySelector('.special-content');
-    if (contentElem) {
-      contentElem.innerHTML = formattedContent;
+      if (headerLabel) headerLabel.textContent = 'Tool Use (raw entry)';
+      if (iconElem) iconElem.className = 'codicon codicon-wrench';
+      element.classList.remove('tool-use-error');
+      contentElem.innerHTML = `
+        <div class="tool-use-section">
+          <div class="tool-use-subsection">
+            <span class="tool-use-sublabel">Raw log:</span>
+            <pre>${encodeHtml(decodedContent)}</pre>
+          </div>
+        </div>
+      `;
     }
 
     return element;

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -36,3 +36,22 @@
   border-top: 1px solid var(--vscode-panel-border);
   opacity: 0.3;
 }
+
+.tool-use-error > .details-summary .tool-use-title,
+.tool-use-error > .details-summary .codicon {
+  color: var(--vscode-errorForeground);
+}
+
+.tool-output-preview {
+  margin-bottom: var(--spacing-tiny);
+}
+
+.tool-output-details {
+  margin-top: var(--spacing-tiny);
+}
+
+.tool-output-details summary {
+  cursor: pointer;
+  color: var(--vscode-textLink-foreground);
+  font-size: var(--font-size-sm);
+}

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -24,7 +24,7 @@ import {
   DEFAULT_MODEL_CAPABILITIES,
 } from '@model/ModelConfig';
 import { BaseTool } from '@tools/core/base';
-import { ToolResult } from '@tools/result';
+import { ToolResult, toolResult } from '@tools/result';
 import type OpenAI from 'openai';
 
 class EchoTool extends BaseTool<{ value: string }> {
@@ -32,7 +32,7 @@ class EchoTool extends BaseTool<{ value: string }> {
     super({ name: 'echo' }, z.object({ value: z.string() }));
   }
   protected async execute(input: { value: string }): Promise<ToolResult> {
-    return new ToolResult({ output: input.value });
+    return toolResult({ output: input.value });
   }
 }
 

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -26,7 +26,7 @@ import {
   DEFAULT_MODEL_CAPABILITIES,
 } from '@model/ModelConfig';
 import { BaseTool } from '@tools/core/base';
-import { ToolResult } from '@tools/result';
+import { ToolResult, toolResult } from '@tools/result';
 import type OpenAI from 'openai';
 
 class EchoTool extends BaseTool<{ value: string }> {
@@ -34,7 +34,7 @@ class EchoTool extends BaseTool<{ value: string }> {
     super({ name: 'echo' }, z.object({ value: z.string() }));
   }
   protected async execute(input: { value: string }): Promise<ToolResult> {
-    return new ToolResult({ output: input.value });
+    return toolResult({ output: input.value });
   }
 }
 

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolResult, ToolError } from './result';
+import { ToolResult, ToolError, toolResult } from './result';
 import {
   getLinterMessages,
   countDiagnosticsBySeverity,
@@ -31,12 +31,18 @@ export class DiagnosticsTool extends defineTool({
     switch (command) {
       case 'list': {
         const messages = await getLinterMessages(path);
-        return new ToolResult({ output: JSON.stringify(messages) });
+        return toolResult({
+          summary: `Diagnostics list for ${path}`,
+          output: JSON.stringify(messages),
+        });
       }
       case 'count': {
         const messages = await getLinterMessages(path);
         const counts = countDiagnosticsBySeverity(messages);
-        return new ToolResult({ output: JSON.stringify(counts) });
+        return toolResult({
+          summary: `Diagnostics count for ${path}`,
+          output: JSON.stringify(counts),
+        });
       }
       default:
         throw new ToolError(

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolError, ToolResult } from '@tools/result';
+import { ToolError, ToolResult, toolResult } from '@tools/result';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
@@ -80,7 +80,15 @@ export class EditFileTool extends defineTool({
     const replacementSummary = replace_all
       ? `Replaced ${occurrences} occurrence${occurrences === 1 ? '' : 's'}.`
       : 'Replaced 1 occurrence.';
+    const summary = replace_all
+      ? `Edited ${targetPath}: replaced ${occurrences} occurrence${
+          occurrences === 1 ? '' : 's'
+        }`
+      : `Edited ${targetPath}: replaced 1 occurrence`;
 
-    return new ToolResult({ output: replacementSummary });
+    return toolResult({
+      summary,
+      output: replacementSummary,
+    });
   }
 }

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolResult } from '@tools/result';
+import { ToolResult, toolResult } from '@tools/result';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
@@ -26,6 +26,9 @@ export class ReadFileTool extends defineTool({
 }) {
   protected async execute(input: ReadInput): Promise<ToolResult> {
     const content = await WorkspaceFS.read(input.path);
-    return new ToolResult({ output: content });
+    return toolResult({
+      summary: `Read ${input.path}`,
+      output: content,
+    });
   }
 }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -10,7 +10,7 @@ import { defineTool } from './core/define';
 // Local imports - tools
 
 // Local imports - core
-import { ToolResult, CLIResult, ToolError } from './result';
+import { ToolResult, ToolError, cliResult, toolResult } from './result';
 import { ToolCallInput, EditorCommand, FileHistoryEntry } from './types';
 
 // Local imports - Log
@@ -221,7 +221,8 @@ export class TextEditorTool extends defineTool({
           })
           .join('\n');
 
-        return new CLIResult({
+        return cliResult({
+          summary: `View directory ${filePath}`,
           output: `Here's the files and directories in ${filePath}:\n${formattedContents}`,
         });
       }
@@ -272,7 +273,16 @@ export class TextEditorTool extends defineTool({
         }
       }
 
-      return new CLIResult({
+      let rangeSummary: string | undefined;
+      if (viewRange) {
+        const [startLine, endLine] = viewRange;
+        rangeSummary = `${startLine}-${endLine === -1 ? 'end' : endLine}`;
+      }
+
+      return cliResult({
+        summary: rangeSummary
+          ? `View ${filePath} (${rangeSummary})`
+          : `View ${filePath}`,
         output: this.makeOutput(fileContent, filePath, initLine),
       });
     } catch (error) {
@@ -300,7 +310,8 @@ export class TextEditorTool extends defineTool({
       // Write file content
       await WorkspaceFS.write(filePath, content);
 
-      return new ToolResult({
+      return toolResult({
+        summary: `Created file ${filePath}`,
         output: `File created successfully at: ${filePath}`,
       });
     } catch (error) {
@@ -381,7 +392,8 @@ export class TextEditorTool extends defineTool({
         startLine,
       )}Review the changes and make sure they are as expected. Edit the file again if necessary.`;
 
-      return new CLIResult({
+      return cliResult({
+        summary: `Updated ${filePath}`,
         output: successMsg,
       });
     } catch (error) {
@@ -457,7 +469,8 @@ export class TextEditorTool extends defineTool({
         startLine,
       )}Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.`;
 
-      return new CLIResult({
+      return cliResult({
+        summary: `Inserted text into ${filePath}`,
         output: successMsg,
       });
     } catch (error) {
@@ -492,7 +505,8 @@ export class TextEditorTool extends defineTool({
         this.fileHistory.delete(filePath);
       }
 
-      return new CLIResult({
+      return cliResult({
+        summary: `Undid edit on ${filePath}`,
         output: `Last edit to ${filePath} undone successfully. ${this.makeOutput(oldContent, filePath)}`,
       });
     } catch (error) {

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolResult } from '@tools/result';
+import { ToolResult, toolResult } from '@tools/result';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
@@ -28,6 +28,9 @@ export class WriteFileTool extends defineTool({
 }) {
   protected async execute(input: WriteInput): Promise<ToolResult> {
     await WorkspaceFS.write(input.path, input.content);
-    return new ToolResult({ output: 'written' });
+    return toolResult({
+      summary: `Wrote ${input.path}`,
+      output: 'written',
+    });
   }
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolResult, ToolError } from '@tools/result';
+import { ToolResult, ToolError, toolResult } from '@tools/result';
 import { executeCommand } from '@utils/system/execUtils';
 
 const BashInputSchema = z.object({
@@ -24,7 +24,14 @@ export class BashTool extends defineTool({
   protected async execute(input: BashInput): Promise<ToolResult> {
     const result = await executeCommand(input.command, { truncate: true });
     if (result.success) {
-      return new ToolResult({ output: result.stdout || '' });
+      const commandPreview =
+        input.command.length > 60
+          ? `${input.command.slice(0, 57)}…`
+          : input.command;
+      return toolResult({
+        summary: `Ran bash: ${commandPreview}`,
+        output: result.stdout || '',
+      });
     }
     throw new ToolError(
       `Bash command failed: ${result.stderr || 'No error output available'}`,

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -3,7 +3,7 @@ import { z, ZodError } from 'zod';
 
 // Local imports - tools
 import type { ToolDefinition } from '@model';
-import { ToolResult } from '@tools/result';
+import { ToolResult, toolResult } from '@tools/result';
 
 export abstract class BaseTool<T> {
   readonly definition: ToolDefinition;
@@ -39,7 +39,7 @@ export abstract class BaseTool<T> {
       return await this.execute(input);
     } catch (err) {
       if (err instanceof ZodError) {
-        return new ToolResult({
+        return toolResult({
           error: 'Invalid input',
           isError: true,
           diagnostics: err.issues,
@@ -48,7 +48,7 @@ export abstract class BaseTool<T> {
       const message = err instanceof Error ? err.message : String(err);
       const diagnostics =
         err instanceof Error ? { name: err.name, stack: err.stack } : undefined;
-      return new ToolResult({
+      return toolResult({
         error: message,
         isError: true,
         diagnostics,

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolResult, ToolError } from '@tools/result';
+import { ToolResult, ToolError, toolResult } from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
 
 const FileOpInputSchema = z.object({
@@ -27,27 +27,36 @@ export class FileOpTool extends defineTool({
     switch (command) {
       case 'read': {
         const data = await WorkspaceFS.read(path);
-        return new ToolResult({ output: data });
+        return toolResult({
+          summary: `Read ${path}`,
+          output: data,
+        });
       }
       case 'write': {
         if (content === undefined) {
-          return new ToolResult({
+          return toolResult({
             error: 'content parameter is required for write',
             isError: true,
           });
         }
         await WorkspaceFS.write(path, content);
-        return new ToolResult({ output: 'written' });
+        return toolResult({
+          summary: `Wrote ${path}`,
+          output: 'written',
+        });
       }
       case 'append': {
         if (content === undefined) {
-          return new ToolResult({
+          return toolResult({
             error: 'content parameter is required for append',
             isError: true,
           });
         }
         await WorkspaceFS.appendFile(path, content);
-        return new ToolResult({ output: 'appended' });
+        return toolResult({
+          summary: `Appended to ${path}`,
+          output: 'appended',
+        });
       }
       default:
         throw new ToolError(

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolError, ToolResult } from '@tools/result';
+import { ToolError, ToolResult, toolResult } from '@tools/result';
 import {
   joinWorkspaceRelativePath,
   resolveAndFormat,
@@ -97,7 +97,8 @@ export class GlobTool extends defineTool({
 
     const header = `Matches for pattern "${input.pattern}" under ${display}`;
     const lines = sorted.map((item) => toPosixPath(item.relativePath));
-    return new ToolResult({
+    return toolResult({
+      summary: `glob "${input.pattern}" under ${display}`,
       output: formatToolOutput(header, lines, '(no matches)'),
     });
   }

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolError, ToolResult } from '@tools/result';
+import { ToolError, ToolResult, toolResult } from '@tools/result';
 import { resolveAndFormat } from '@tools/utils';
 
 // Local imports - utils
@@ -122,11 +122,15 @@ export class GrepTool extends defineTool({
     }
 
     const limitedOutput = applyHeadLimit(result.stdout, input.head_limit);
-
+    const outputText =
+      limitedOutput || `No matches found for pattern in ${display}`;
     const summary = limitedOutput
-      ? limitedOutput
-      : `No matches found for pattern in ${display}`;
+      ? `Matches for "${input.pattern}" in ${display}`
+      : `No matches for "${input.pattern}" in ${display}`;
 
-    return new ToolResult({ output: summary });
+    return toolResult({
+      summary,
+      output: outputText,
+    });
   }
 }

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolError, ToolResult } from '@tools/result';
+import { ToolError, ToolResult, toolResult } from '@tools/result';
 import {
   createGlobMatcher,
   joinWorkspaceRelativePath,
@@ -51,6 +51,7 @@ export class LsTool extends defineTool({
     const { resolved: target, display } = resolveAndFormat(input.path);
     const relative = target.relative === '.' ? '.' : target.relative;
     const gitignore = await getGitignoreMatcher();
+    const summary = `Listing for ${display}`;
 
     let stats: vscode.FileStat | undefined;
     try {
@@ -75,7 +76,8 @@ export class LsTool extends defineTool({
         matchesCustomIgnore(display) ||
         matchesCustomIgnore(relativePosix)
       ) {
-        return new ToolResult({
+        return toolResult({
+          summary,
           output: formatToolOutput(
             `Listing for ${display}`,
             null,
@@ -83,7 +85,8 @@ export class LsTool extends defineTool({
           ),
         });
       }
-      return new ToolResult({
+      return toolResult({
+        summary,
         output: formatToolOutput(
           `Listing for ${display}`,
           formatEntry(display, vscode.FileType.File),
@@ -92,7 +95,8 @@ export class LsTool extends defineTool({
     }
 
     if (relative !== '.' && gitignore.ignores(relative)) {
-      return new ToolResult({
+      return toolResult({
+        summary,
         output: formatToolOutput(
           `Listing for ${display}`,
           null,
@@ -124,7 +128,8 @@ export class LsTool extends defineTool({
     const sorted = filtered.sort(([a], [b]) => a.localeCompare(b));
     const formatted = sorted.map(([name, type]) => formatEntry(name, type));
 
-    return new ToolResult({
+    return toolResult({
+      summary,
       output: formatToolOutput(`Listing for ${display}`, formatted),
     });
   }

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -6,72 +6,21 @@ export type ErrorDiagnostics =
   | { name: string; stack?: string } // For regular errors
   | unknown; // For other types of diagnostics
 
-export class ToolResult {
+export interface ToolResult {
   output?: string;
+  summary?: string;
   error?: string;
   base64Image?: string;
   system?: string;
-  isError: boolean;
+  isError?: boolean;
   diagnostics?: ErrorDiagnostics; // Additional error details like validation issues
-
-  constructor({
-    output,
-    error,
-    base64Image,
-    system,
-    isError = false,
-    diagnostics,
-  }: {
-    output?: string;
-    error?: string;
-    base64Image?: string;
-    system?: string;
-    isError?: boolean;
-    diagnostics?: ErrorDiagnostics;
-  }) {
-    this.output = output;
-    this.error = error;
-    this.base64Image = base64Image;
-    this.system = system;
-    this.isError = isError;
-    this.diagnostics = diagnostics;
-  }
-
-  add(other: ToolResult): ToolResult {
-    function combine(
-      a: string | undefined,
-      b: string | undefined,
-      concat = true,
-    ): string | undefined {
-      if (a && b) {
-        if (concat) return a + b;
-        throw new Error('Cannot combine tool results');
-      }
-      return a || b;
-    }
-
-    return new ToolResult({
-      output: combine(this.output, other.output),
-      error: combine(this.error, other.error),
-      base64Image: combine(this.base64Image, other.base64Image, false),
-      system: combine(this.system, other.system),
-      isError: this.isError || other.isError,
-      diagnostics: this.diagnostics || other.diagnostics,
-    });
-  }
 }
 
-export class CLIResult extends ToolResult {
-  constructor(opts: {
-    output?: string;
-    error?: string;
-    base64Image?: string;
-    system?: string;
-    isError?: boolean;
-  }) {
-    super(opts);
-  }
+export function toolResult(result: ToolResult): ToolResult {
+  return result;
 }
+
+export const cliResult = toolResult;
 
 export class ToolError extends Error {
   constructor(message: string) {

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { defineTool } from '../core/define';
 
 // Local imports - tools
-import { ToolError, ToolResult } from '../result';
+import { ToolError, ToolResult, toolResult } from '../result';
 
 const WebFetchInputSchema = z
   .object({
@@ -144,6 +144,9 @@ export class WebFetchTool extends defineTool({
       sections.push('No readable content was extracted from the provided URL.');
     }
 
-    return new ToolResult({ output: sections.join('\n\n') });
+    return toolResult({
+      summary: `Fetched ${url}`,
+      output: sections.join('\n\n'),
+    });
   }
 }

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { defineTool } from '../core/define';
 
 // Local imports - tools
-import { ToolResult, ToolError } from '../result';
+import { ToolResult, ToolError, toolResult } from '../result';
 
 const WebSearchInputSchema = z.object({
   query: z.string(),
@@ -45,8 +45,14 @@ export class WebSearchTool extends defineTool({
       }
     }
     if (results.length === 0) {
-      return new ToolResult({ output: 'No results found.' });
+      return toolResult({
+        summary: `Search "${query}" (no results)`,
+        output: 'No results found.',
+      });
     }
-    return new ToolResult({ output: results.join('\n') });
+    return toolResult({
+      summary: `Search "${query}"`,
+      output: results.join('\n'),
+    });
   }
 }

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { defineTool } from '../core/define';
 
 // Local imports - tools
-import { ToolResult, ToolError } from '../result';
+import { ToolResult, ToolError, toolResult } from '../result';
 import { executeWolframCode } from './wolframScriptUtils';
 
 const WolframInputSchema = z.object({
@@ -27,7 +27,10 @@ export class WolframTool extends defineTool({
       showErrorsToUser: false,
     });
     if (result.success) {
-      return new ToolResult({ output: result.output ?? '' });
+      return toolResult({
+        summary: 'Executed Wolfram code',
+        output: result.output ?? '',
+      });
     }
     throw new ToolError(
       `Wolfram execution failed: ${result.error ?? 'No error details available'}`,


### PR DESCRIPTION
## Summary
- replace the ToolResult class with a plain-object helper and update the tool runtime to preserve summaries and diagnostics
- add human-readable summaries across file, search, and editor tools so responses surface concise context
- refresh the progress view tool-use formatter to prefer summaries, highlight errors, and offer expandable long output

## Testing
- npm run format
- npm run lint
- npm run compile
- npm test *(fails: missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d18d0739fc83249e5d949f3ed41006