### PR TITLE
fix: keep tool-use streams visible during filtering

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -237,7 +237,15 @@ export async function executeAgentWithLogging<T extends IAgent>(
         );
 
         // Switch to this stream and set its status to running
-        bus.emit('setActiveStream', streamTabId);
+        const resolvedAgentType =
+          agentType ??
+          (agent instanceof BaseToolUseAgent
+            ? AgentType.ToolUse
+            : AgentType.CoT);
+        bus.emit('setActiveStream', {
+          stream: streamTabId,
+          agentType: resolvedAgentType,
+        });
         bus.emit('updateStreamStatus', {
           stream: streamTabId,
           status: 'running',

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -13,7 +13,7 @@ import { ProgressViewState } from '../state/ProgressViewState';
 import { buildStreamInfos } from '../streamInfoUtils';
 import type { StreamTabInfo } from '../types';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
-import { deriveAgentSessionKind } from '@agent/core/AgentDataclass';
+import { AgentType, deriveAgentSessionKind } from '@agent/core/AgentDataclass';
 
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
@@ -118,30 +118,37 @@ export class ProgressEventHandler {
   /**
    * Handle setting active stream
    */
-  private handleSetActiveStream(stream: string): void {
+  private handleSetActiveStream(
+    payload: { stream: StreamTabId; agentType?: AgentType | null } | string,
+  ): void {
+    const { stream, agentType } =
+      typeof payload === 'string'
+        ? { stream: payload, agentType: undefined }
+        : payload;
+
+    if (!stream) {
+      return;
+    }
+
     // Ensure the stream exists in streamTabs so it appears in the UI
     // This handles the case where setActiveStream is called before any logs
     this.state.streamTabs.ensureStream(stream);
 
-    // Set initial status to running for new streams
-    if (!this._streamStatus.has(stream)) {
-      this.handleUpdateStreamStatus({ stream, status: STATUS.RUNNING });
+    const sessionKindHint = deriveAgentSessionKind(agentType);
+    this.state.setSessionKindHint(stream, sessionKindHint);
+
+    const currentFilter = this.state.agentTypeFilter;
+    if (currentFilter !== 'all' && currentFilter !== sessionKindHint) {
+      this.state.agentTypeFilter = sessionKindHint;
     }
 
     this.state.activeStream = stream;
 
-    if (this.webviewUpdater.isAvailable()) {
-      const infos = buildStreamInfos(
-        this.state,
-        this._streamStatus,
-        this.state.agentTypeFilter,
-      );
-      this.webviewUpdater.updateStreams(
-        infos,
-        stream,
-        this.state.agentTypeFilter,
-      );
+    const status: StreamStatusOrReadyType =
+      this._streamStatus.get(stream) ?? STATUS.RUNNING;
+    this.handleUpdateStreamStatus({ stream, status });
 
+    if (this.webviewUpdater.isAvailable()) {
       // Update log content (will be empty for new streams)
       this.updateLogContentForStream(stream, { updateInstruction: false });
       this.sendInstructionUpdate(stream);
@@ -258,6 +265,7 @@ export class ProgressEventHandler {
     const { streamTabId, executionId, taskState } = data;
 
     this.state.setTaskState(streamTabId, taskState);
+    this.state.clearSessionKindHint(streamTabId);
 
     const normalizedState = this.state.getTaskState(streamTabId);
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -13,7 +13,10 @@ import { AgentLogger } from '@logger/AgentLogger';
 import type { AgentFilter } from '../types';
 // Local imports - agent types
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
-import { deriveAgentSessionKind } from '@agent/core/AgentDataclass';
+import {
+  AgentSessionKind,
+  deriveAgentSessionKind,
+} from '@agent/core/AgentDataclass';
 
 // Types
 import { TaskState } from '@logger/TaskState';
@@ -34,6 +37,7 @@ export class ProgressViewState {
   private _agentTypeFilter: AgentFilter = 'all';
   private _taskStates: Map<StreamTabId, TaskState> = new Map();
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
+  private _sessionKindHints: Map<StreamTabId, AgentSessionKind> = new Map();
   private readonly persistence: StatePersistenceManager;
   private readonly logger: AgentLogger;
 
@@ -97,6 +101,22 @@ export class ProgressViewState {
     this.saveAgentTypeFilter();
   }
 
+  // Session kind hint management (non-persistent)
+  setSessionKindHint(
+    streamTabId: StreamTabId,
+    sessionKind: AgentSessionKind,
+  ): void {
+    this._sessionKindHints.set(streamTabId, sessionKind);
+  }
+
+  getSessionKindHint(streamTabId: StreamTabId): AgentSessionKind | undefined {
+    return this._sessionKindHints.get(streamTabId);
+  }
+
+  clearSessionKindHint(streamTabId: StreamTabId): void {
+    this._sessionKindHints.delete(streamTabId);
+  }
+
   // Task state management
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
     const normalizedState: TaskState = {
@@ -105,6 +125,7 @@ export class ProgressViewState {
         taskState.agentSessionKind ??
         deriveAgentSessionKind(taskState.agentType),
     };
+    this.clearSessionKindHint(streamTabId);
     this._taskStates.set(streamTabId, normalizedState);
     this.saveTaskStates();
   }
@@ -115,6 +136,7 @@ export class ProgressViewState {
 
   clearTaskState(streamTabId: StreamTabId): void {
     this._taskStates.delete(streamTabId);
+    this.clearSessionKindHint(streamTabId);
     this.saveTaskStates();
   }
 
@@ -145,6 +167,7 @@ export class ProgressViewState {
     this._usageStats.deleteStream(stream);
     this._taskStates.delete(stream);
     this._executionIds.delete(stream);
+    this.clearSessionKindHint(stream);
 
     // Update active stream if necessary
     if (this._activeStream === stream) {
@@ -165,6 +188,7 @@ export class ProgressViewState {
     // Clear display-related data (matching original eraseStream behavior)
     this._taskGroups.deleteStream(stream);
     this._outputFiles.deleteStream(stream);
+    this.clearSessionKindHint(stream);
 
     // NOTE: Preserve taskStates and executionIds - these are needed for re-run functionality
     // NOTE: Preserve usageStats - these were not cleared in original implementation
@@ -178,6 +202,7 @@ export class ProgressViewState {
     this._usageStats.clear();
     this._taskStates.clear();
     this._executionIds.clear();
+    this._sessionKindHints.clear();
     this._activeStream = '';
     this.saveActiveStream();
     this.saveTaskStates();

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -59,6 +59,7 @@ export function buildStreamInfos(
 ): StreamTabInfo[] {
   const infos = state.streamTabs.keys().reduce<StreamTabInfo[]>((acc, id) => {
     const taskState = state.getTaskState(id);
+    const sessionKindHint = state.getSessionKindHint(id);
     const logs = state.streamTabs.get(id);
     const lastTimestamp =
       logs && logs.length > 0 ? logs[logs.length - 1].timestamp : undefined;
@@ -69,7 +70,9 @@ export function buildStreamInfos(
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
     const agentType = taskState?.agentType;
     const agentSessionKind =
-      taskState?.agentSessionKind ?? deriveAgentSessionKind(agentType);
+      taskState?.agentSessionKind ??
+      sessionKindHint ??
+      deriveAgentSessionKind(agentType);
     if (!matchesAgentFilter(agentSessionKind, filter)) {
       return acc;
     }


### PR DESCRIPTION
## Summary
- emit the agent type when activating a stream so the progress view can classify new sessions immediately
- track transient session kind hints in the progress view state and consult them when building stream metadata
- reconcile the agent filter and active tab handling when new tool-use sessions start while a filter is active

## Testing
- `npm run format`
- `npm run compile`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d19f7e59648324972740d96e4f6ae2