### PR TITLE
fix: clamp tool output height

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -568,7 +568,7 @@ export class LogEntryFormatter {
                 <pre class="tool-output-preview">${preview}</pre>
                 <details class="tool-output-details">
                   <summary>Show full output</summary>
-                  <pre>${encodedOutput}</pre>
+                  <pre class="tool-output-full">${encodedOutput}</pre>
                 </details>
               </div>
             </div>
@@ -578,7 +578,7 @@ export class LogEntryFormatter {
             <div class="tool-use-section">
               <div class="tool-use-subsection">
                 <span class="tool-use-sublabel">Output:</span>
-                <pre>${encodedOutput}</pre>
+                <pre class="tool-output-full">${encodedOutput}</pre>
               </div>
             </div>
           `);

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -55,3 +55,8 @@
   color: var(--vscode-textLink-foreground);
   font-size: var(--font-size-sm);
 }
+
+.tool-output-full {
+  max-height: 20rem;
+  overflow: auto;
+}


### PR DESCRIPTION
## Summary
- add a dedicated class to full tool output blocks in the progress view formatter
- constrain tool output height in the progress view scratchpad styles so long results scroll

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: VS Code test runner requires libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a56504848324b5530d28947e2525