### PR TITLE
fix: limit tool output height in progress view

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -568,7 +568,7 @@ export class LogEntryFormatter {
                 <pre class="tool-output-preview">${preview}</pre>
                 <details class="tool-output-details">
                   <summary>Show full output</summary>
-                  <pre>${encodedOutput}</pre>
+                  <pre class="tool-output-full">${encodedOutput}</pre>
                 </details>
               </div>
             </div>
@@ -578,7 +578,7 @@ export class LogEntryFormatter {
             <div class="tool-use-section">
               <div class="tool-use-subsection">
                 <span class="tool-use-sublabel">Output:</span>
-                <pre>${encodedOutput}</pre>
+                <pre class="tool-output-full">${encodedOutput}</pre>
               </div>
             </div>
           `);

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -46,6 +46,13 @@
   margin-bottom: var(--spacing-tiny);
 }
 
+.tool-output-full {
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .tool-output-details {
   margin-top: var(--spacing-tiny);
 }


### PR DESCRIPTION
## Summary
- add a dedicated class to tool output blocks in the progress view scratchpad
- cap tool output height and enable scrolling so large results don't stretch the UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a56504848324b5530d28947e2525