### PR TITLE
refactor: share latex file processing helper

### DIFF
--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -90,24 +90,83 @@ export class LatexMediaManager {
     });
   }
 
-  /**
-   * Process input files to extract figures, compile TikZ pictures and PDFs.
-   * Adds resulting media paths to the provided ToolState.
-   */
-  async processInputFiles(
-    inputFiles: string[],
+  private async extractFiguresFromFiles(
+    files: string[],
+    toolState: ToolState,
+    groupId?: string,
+  ): Promise<void> {
+    const figureResults = await Promise.allSettled(
+      files.map((file) => extractFigurePathsFromLatex(file)),
+    );
+    figureResults.forEach((result, idx) => {
+      if (
+        result.status === 'fulfilled' &&
+        result.value &&
+        result.value.length > 0
+      ) {
+        const file = files[idx];
+        this.logger.debug(
+          `Extracted ${result.value.length} figures from ${file}`,
+          groupId,
+        );
+        toolState.addMediaFiles(result.value);
+      }
+    });
+  }
+
+  private async compileTikzFigures(
+    files: string[],
+    toolState: ToolState,
+    logSummary: boolean,
+    groupId?: string,
+  ): Promise<void> {
+    const tikzResults = await Promise.allSettled(
+      files.map((file) => tikzPictureManager.compile(file)),
+    );
+    tikzResults.forEach((result) => {
+      if (
+        result.status === 'fulfilled' &&
+        result.value &&
+        result.value.length > 0
+      ) {
+        toolState.addMediaFiles(result.value);
+      }
+    });
+    if (logSummary) {
+      this.logger.debug(
+        `Extracted ${tikzResults.length} TikZ figures`,
+        groupId,
+      );
+    }
+  }
+
+  private async processFiles(
+    files: string[],
     toolState: ToolState,
     cfg: ToolConfig,
     supportsVision: boolean,
-    extraMediaFiles: string[] = [],
-    groupId?: string,
+    {
+      includeFigureExtraction,
+      includeTikzCompilation,
+      includePdfCompilation,
+      extraMediaFiles = [],
+      logTikzSummary = false,
+      groupId,
+    }: {
+      includeFigureExtraction: boolean;
+      includeTikzCompilation: boolean;
+      includePdfCompilation: boolean;
+      extraMediaFiles?: string[];
+      logTikzSummary?: boolean;
+      groupId?: string;
+    },
   ): Promise<void> {
-    if (!inputFiles || inputFiles.length === 0) {
+    if (!files || files.length === 0) {
       return;
     }
 
     const existingFilesInfo = await Promise.all(
-      inputFiles.map(async (file) => ({
+      files.map(async (file) => ({
         file,
         exists: await WorkspaceFS.exists(file),
       })),
@@ -130,48 +189,44 @@ export class LatexMediaManager {
       toolState.addMediaFiles(extraMediaFiles);
     }
 
-    if (cfg.autoExtractFigure) {
-      const figureResults = await Promise.allSettled(
-        existingFiles.map((file) => extractFigurePathsFromLatex(file)),
-      );
-      figureResults.forEach((result, idx) => {
-        if (
-          result.status === 'fulfilled' &&
-          result.value &&
-          result.value.length > 0
-        ) {
-          const file = existingFiles[idx];
-          this.logger.debug(
-            `Extracted ${result.value.length} figures from ${file}`,
-            groupId,
-          );
-          toolState.addMediaFiles(result.value);
-        }
-      });
+    if (includeFigureExtraction && cfg.autoExtractFigure) {
+      await this.extractFiguresFromFiles(existingFiles, toolState, groupId);
     }
 
-    if (cfg.autoExtractTikzFigure) {
-      const tikzResults = await Promise.allSettled(
-        existingFiles.map((file) => tikzPictureManager.compile(file)),
-      );
-      tikzResults.forEach((result) => {
-        if (
-          result.status === 'fulfilled' &&
-          result.value &&
-          result.value.length > 0
-        ) {
-          toolState.addMediaFiles(result.value);
-        }
-      });
-      this.logger.debug(
-        `Extracted ${tikzResults.length} TikZ figures`,
+    if (includeTikzCompilation && cfg.autoExtractTikzFigure) {
+      await this.compileTikzFigures(
+        existingFiles,
+        toolState,
+        logTikzSummary,
         groupId,
       );
     }
 
-    if (cfg.autoCompileInputPdf) {
+    if (includePdfCompilation && cfg.autoCompileInputPdf) {
       await this.compilePdfs(existingFiles, toolState, groupId);
     }
+  }
+
+  /**
+   * Process input files to extract figures, compile TikZ pictures and PDFs.
+   * Adds resulting media paths to the provided ToolState.
+   */
+  async processInputFiles(
+    inputFiles: string[],
+    toolState: ToolState,
+    cfg: ToolConfig,
+    supportsVision: boolean,
+    extraMediaFiles: string[] = [],
+    groupId?: string,
+  ): Promise<void> {
+    await this.processFiles(inputFiles, toolState, cfg, supportsVision, {
+      includeFigureExtraction: true,
+      includeTikzCompilation: true,
+      includePdfCompilation: true,
+      extraMediaFiles,
+      logTikzSummary: true,
+      groupId,
+    });
   }
 
   /**
@@ -184,43 +239,11 @@ export class LatexMediaManager {
     supportsVision: boolean,
     groupId?: string,
   ): Promise<void> {
-    if (!outputFiles || outputFiles.length === 0) {
-      return;
-    }
-
-    const existingFilesInfo = await Promise.all(
-      outputFiles.map(async (file) => ({
-        file,
-        exists: await WorkspaceFS.exists(file),
-      })),
-    );
-    const existingFiles = existingFilesInfo
-      .filter((f) => f.exists)
-      .map((f) => f.file);
-
-    if (existingFiles.length === 0) {
-      return;
-    }
-
-    await this.attachTeXCount(existingFiles, toolState, cfg);
-
-    if (supportsVision && cfg.autoExtractTikzFigure) {
-      const tikzResults = await Promise.allSettled(
-        existingFiles.map((file) => tikzPictureManager.compile(file)),
-      );
-      tikzResults.forEach((result) => {
-        if (
-          result.status === 'fulfilled' &&
-          result.value &&
-          result.value.length > 0
-        ) {
-          toolState.addMediaFiles(result.value);
-        }
-      });
-    }
-
-    if (supportsVision && cfg.autoCompileInputPdf) {
-      await this.compilePdfs(existingFiles, toolState, groupId);
-    }
+    await this.processFiles(outputFiles, toolState, cfg, supportsVision, {
+      includeFigureExtraction: false,
+      includeTikzCompilation: true,
+      includePdfCompilation: true,
+      groupId,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- centralize shared latex media processing logic in a reusable helper
- extract reusable TikZ and figure pipelines while preserving existing logging
- delegate input/output handlers to the shared helper with scoped options and extra media support

## Testing
- npm run format
- npm run lint
- npm run compile
- CI=1 npm test *(fails: VS Code binary requires libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d28d19b08324af9df055b6edcb49