### PR TITLE
fix: align instruction controls layout

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -459,34 +459,36 @@
             class="vscode-textarea"
             placeholder="Enter your specific instruction such as: Gently correct mathematical mistakes and typos."
           ></textarea>
-          <div class="model-selection-footer">
-            <div class="select-group">
-              <i
-                id="agentSettingsButton"
-                class="codicon codicon-sparkle clickable"
-                title="Agent settings"
-              ></i>
-              <select id="agent">
-                ${agentOptions}
-              </select>
+          <div class="instruction-controls">
+            <div class="model-selection-footer">
+              <div class="select-group">
+                <i
+                  id="agentSettingsButton"
+                  class="codicon codicon-sparkle clickable"
+                  title="Agent settings"
+                ></i>
+                <select id="agent">
+                  ${agentOptions}
+                </select>
+              </div>
+              <div class="select-group">
+                <i
+                  id="modelSettingsButton"
+                  class="codicon codicon-robot clickable"
+                  title="Model settings"
+                ></i>
+                <select id="model">
+                  ${modelOptions}
+                </select>
+              </div>
             </div>
-            <div class="select-group">
-              <i
-                id="modelSettingsButton"
-                class="codicon codicon-robot clickable"
-                title="Model settings"
-              ></i>
-              <select id="model">
-                ${modelOptions}
-              </select>
-            </div>
+            <button
+              id="executeButton"
+              class="vscode-button"
+              title="Execute"
+              data-icon="play"
+            ></button>
           </div>
-          <button
-            id="executeButton"
-            class="vscode-button"
-            title="Execute"
-            data-icon="play"
-          ></button>
         </div>
 
         <!-- Agent Config Banner -->

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -5,12 +5,12 @@
 
 /* Model Selection Footer styles */
 .model-selection-footer {
-  position: absolute;
-  bottom: var(--spacing-xlarge);
-  left: var(--spacing-xlarge);
   display: flex;
   gap: var(--spacing-small);
-  z-index: 10;
+  align-items: center;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .model-selection-footer .select-group {

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -22,11 +22,20 @@
 #instruction {
   min-height: var(--height-medium);
   max-height: var(--height-xlarge);
-  padding-bottom: calc(var(--spacing-xlarge) + var(--spacing-large));
   resize: none;
   overflow-y: auto;
   transition: height 0.1s ease-out;
   margin-top: var(--spacing-medium);
+  margin-bottom: var(--spacing-medium);
+}
+
+.instruction-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-medium);
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .instruction-header {
@@ -58,10 +67,8 @@
 
 #executeButton {
   font-size: var(--font-size);
-  position: absolute;
-  bottom: var(--spacing-xlarge);
-  right: var(--spacing-xlarge);
-  z-index: 10;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 /* Recording button states */


### PR DESCRIPTION
## Summary
- wrap the instruction model selectors and execute button in a shared flex container
- refresh instruction and footer styles to use normal flow spacing instead of absolute positioning

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: VS Code binary requires libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d245f819a483249bbef2a75b95496f