### PR TITLE
fix: reuse execution id validation helper

### DIFF
--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -15,7 +15,7 @@ import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - utilities
-import { StorageFS } from '@utils/files';
+import { StorageFS, isValidExecutionId } from '@utils/files';
 import {
   DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS,
   getToolUsePersistenceEnabled,
@@ -63,12 +63,6 @@ interface SavePayload {
   agentSessionKind: AgentSessionKind;
   messages: ProviderMessage[];
   toolState: ToolState;
-}
-
-function isValidExecutionId(id: ExecutionId | undefined): id is ExecutionId {
-  if (!id) return false;
-  const invalidPatterns = ['..', '/', '\\', '\0'];
-  return !invalidPatterns.some((pattern) => id.includes(pattern));
 }
 
 function serializeMessages(messages: ProviderMessage[]): unknown[] {

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -17,7 +17,7 @@ export const TASK_RUNS_DIR = 'taskRuns';
  * @param id - The execution ID to validate
  * @returns True if the ID is valid, false otherwise
  */
-function isValidExecutionId(id: ExecutionId): boolean {
+export function isValidExecutionId(id: ExecutionId): boolean {
   // Ensure ID doesn't contain path traversal characters or other unsafe patterns
   const invalidPatterns = ['..', '/', '\\', '\0'];
   return !invalidPatterns.some((pattern) => id.includes(pattern));

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -14,10 +14,12 @@ export const TASK_RUNS_DIR = 'taskRuns';
 
 /**
  * Validate an execution ID to ensure it's safe for use in file paths.
+ * Acts as a type guard to ensure the ID is defined and non-empty.
  * @param id - The execution ID to validate
  * @returns True if the ID is valid, false otherwise
  */
-export function isValidExecutionId(id: ExecutionId): boolean {
+export function isValidExecutionId(id: ExecutionId | undefined): id is ExecutionId {
+  if (!id) return false;
   // Ensure ID doesn't contain path traversal characters or other unsafe patterns
   const invalidPatterns = ['..', '/', '\\', '\0'];
   return !invalidPatterns.some((pattern) => id.includes(pattern));


### PR DESCRIPTION
## Summary
- export the execution id validation helper from the task run storage utilities so it can be shared
- update the tool-use session manager to import and reuse the shared helper instead of maintaining a duplicate implementation

## Testing
- npm run format
- npm run lint
- npm run compile
- CI=1 npm test *(fails: vscode-test requires libatk-1.0.so.0 in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d2e4bd5883249a761f07195933e9