### PR TITLE
fix: escape history renderer user strings

### DIFF
--- a/src/common/modules/htmlEncoding.js
+++ b/src/common/modules/htmlEncoding.js
@@ -1,0 +1,28 @@
+// Third-party imports
+import { encode as encodeEntities, decode as decodeEntities } from 'he';
+
+/**
+ * Encode a value for safe HTML insertion.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export const encodeHtml = (value) => encodeEntities(String(value ?? ''));
+
+/**
+ * Decode an HTML-encoded string.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export const decodeHtml = (value) => decodeEntities(String(value ?? ''));
+
+/**
+ * Encode a list of values for safe HTML insertion as a comma-separated string.
+ * @param {unknown[]} values
+ * @returns {string}
+ */
+export const encodeListForHtml = (values) => {
+  if (!Array.isArray(values) || values.length === 0) {
+    return '';
+  }
+  return values.map((entry) => encodeHtml(entry)).join(', ');
+};

--- a/src/common/modules/htmlEncoding.js
+++ b/src/common/modules/htmlEncoding.js
@@ -18,11 +18,12 @@ export const decodeHtml = (value) => decodeEntities(String(value ?? ''));
 /**
  * Encode a list of values for safe HTML insertion as a comma-separated string.
  * @param {unknown[]} values
+ * @param {string} separator - The separator to use between values (default: ', ')
  * @returns {string}
  */
-export const encodeListForHtml = (values) => {
+export const encodeListForHtml = (values, separator = ', ') => {
   if (!Array.isArray(values) || values.length === 0) {
     return '';
   }
-  return values.map((entry) => encodeHtml(entry)).join(', ');
+  return values.map((entry) => encodeHtml(entry)).join(separator);
 };

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -159,6 +159,7 @@ export abstract class BaseViewContentProvider {
         webview,
         'modules/iconButtonInitializer.js',
       ),
+      htmlEncodingUri: this.getCommonUri(webview, 'modules/htmlEncoding.js'),
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       baseWebviewMessageHandlerUri: this.getCommonUri(
         webview,

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -31,8 +31,10 @@
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
-          "@common/BaseDomHandler.js": "${baseDomHandlerUri}"
+          "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
+          "he": "https://esm.sh/he@1.2.0"
         }
       }
     </script>

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -1,3 +1,6 @@
+// Third-party imports
+import { encode as encodeHtml } from 'he';
+
 // Local imports - history view
 import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
 import { historyViewState } from '../historyViewState.js';
@@ -9,6 +12,10 @@ import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { createFromTemplate, createCodicon } from '@common/templateUtils.js';
 // Local imports
 import { vscode } from '@common/webviewContext.js';
+
+const encodeValueForHtml = (value) => encodeHtml(String(value ?? ''));
+const encodeListForHtml = (values) =>
+  values.map((entry) => encodeValueForHtml(entry)).join(', ');
 
 /**
  * Renders history items and manages per-item events.
@@ -89,13 +96,19 @@ export class HistoryRenderer {
       return document.createElement('div');
     }
 
+    const encodedAgent = encodeValueForHtml(config.agent);
+    const encodedModel = encodeValueForHtml(config.model);
+    const encodedInstruction = config.instruction
+      ? encodeValueForHtml(config.instruction)
+      : 'None';
+
     let basicHTML = `
       <span class="history-label">Agent:</span>
-      <span class="history-value">${config.agent}</span>
+      <span class="history-value">${encodedAgent}</span>
       <span class="history-label">Model:</span>
-      <span class="history-value">${config.model}</span>
+      <span class="history-value">${encodedModel}</span>
       <span class="history-label">Instruction:</span>
-      <span class="history-value">${config.instruction || 'None'}</span>`;
+      <span class="history-value">${encodedInstruction}</span>`;
 
     const basicFileTypes = [
       { type: 'input', singular: 'InputFile', plural: 'InputFiles' },
@@ -105,18 +118,20 @@ export class HistoryRenderer {
       const single = config[`${type}File`];
       const multiple = config[`${type}Files`];
       if (single) {
+        const encodedSingle = encodeValueForHtml(single);
         basicHTML += `
           <span class="history-label">${singular}:</span>
-          <span class="history-value">${single}</span>`;
+          <span class="history-value">${encodedSingle}</span>`;
       } else if (type === 'input') {
         basicHTML += `
           <span class="history-label">${singular}:</span>
           <span class="history-value">None</span>`;
       }
       if (multiple && multiple.length > 0) {
+        const encodedMultiple = encodeListForHtml(multiple);
         basicHTML += `
           <span class="history-label">${plural}:</span>
-          <span class="history-value">${multiple.join(', ')}</span>`;
+          <span class="history-value">${encodedMultiple}</span>`;
       }
     });
     basicDetails.innerHTML = basicHTML;
@@ -138,21 +153,24 @@ export class HistoryRenderer {
       const single = config[`${type}File`];
       const multiple = config[`${type}Files`];
       if (single) {
+        const encodedSingle = encodeValueForHtml(single);
         detailsHTML += `
           <span class="history-label">${singular}:</span>
-          <span class="history-value">${single}</span>`;
+          <span class="history-value">${encodedSingle}</span>`;
       }
       if (multiple && multiple.length > 0) {
+        const encodedMultiple = encodeListForHtml(multiple);
         detailsHTML += `
           <span class="history-label">${plural}:</span>
-          <span class="history-value">${multiple.join(', ')}</span>`;
+          <span class="history-value">${encodedMultiple}</span>`;
       }
     });
 
     if (config.outputFiles && config.outputFiles.length > 0) {
+      const encodedOutputs = encodeListForHtml(config.outputFiles);
       detailsHTML += `
         <span class="history-label">Output Files:</span>
-        <span class="history-value">${config.outputFiles.join(', ')}</span>`;
+        <span class="history-value">${encodedOutputs}</span>`;
     }
 
     if (config.toolConfig) {
@@ -189,14 +207,24 @@ export class HistoryRenderer {
       <span class="history-label">${label}:</span>
       <div class="history-value config-section">`;
     entries.forEach(([key, value]) => {
-      const display = Array.isArray(value)
-        ? value.join(', ')
-        : typeof value === 'boolean'
-          ? value
-            ? 'Yes'
-            : 'No'
-          : value;
-      html += `<div class="config-item"><span class="config-key">${key}:</span> ${display}</div>`;
+      const encodedKey = encodeValueForHtml(key);
+      let display;
+      let alreadyEncoded = false;
+
+      if (Array.isArray(value)) {
+        display = encodeListForHtml(value);
+        alreadyEncoded = true;
+      } else if (typeof value === 'boolean') {
+        display = value ? 'Yes' : 'No';
+      } else {
+        display = encodeValueForHtml(value);
+        alreadyEncoded = true;
+      }
+
+      const safeDisplay = alreadyEncoded
+        ? display
+        : encodeValueForHtml(display);
+      html += `<div class="config-item"><span class="config-key">${encodedKey}:</span> ${safeDisplay}</div>`;
     });
     html += `</div>`;
     return html;

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -1,6 +1,3 @@
-// Third-party imports
-import { encode as encodeHtml } from 'he';
-
 // Local imports - history view
 import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
 import { historyViewState } from '../historyViewState.js';
@@ -10,12 +7,9 @@ import {
 } from '@common/domUtils.js';
 import { initializeIconButtons } from '@common/iconButtonInitializer.js';
 import { createFromTemplate, createCodicon } from '@common/templateUtils.js';
+import { encodeHtml, encodeListForHtml } from '@common/htmlEncoding.js';
 // Local imports
 import { vscode } from '@common/webviewContext.js';
-
-const encodeValueForHtml = (value) => encodeHtml(String(value ?? ''));
-const encodeListForHtml = (values) =>
-  values.map((entry) => encodeValueForHtml(entry)).join(', ');
 
 /**
  * Renders history items and manages per-item events.
@@ -96,10 +90,10 @@ export class HistoryRenderer {
       return document.createElement('div');
     }
 
-    const encodedAgent = encodeValueForHtml(config.agent);
-    const encodedModel = encodeValueForHtml(config.model);
+    const encodedAgent = encodeHtml(config.agent);
+    const encodedModel = encodeHtml(config.model);
     const encodedInstruction = config.instruction
-      ? encodeValueForHtml(config.instruction)
+      ? encodeHtml(config.instruction)
       : 'None';
 
     let basicHTML = `
@@ -118,7 +112,7 @@ export class HistoryRenderer {
       const single = config[`${type}File`];
       const multiple = config[`${type}Files`];
       if (single) {
-        const encodedSingle = encodeValueForHtml(single);
+        const encodedSingle = encodeHtml(single);
         basicHTML += `
           <span class="history-label">${singular}:</span>
           <span class="history-value">${encodedSingle}</span>`;
@@ -153,7 +147,7 @@ export class HistoryRenderer {
       const single = config[`${type}File`];
       const multiple = config[`${type}Files`];
       if (single) {
-        const encodedSingle = encodeValueForHtml(single);
+        const encodedSingle = encodeHtml(single);
         detailsHTML += `
           <span class="history-label">${singular}:</span>
           <span class="history-value">${encodedSingle}</span>`;
@@ -207,7 +201,7 @@ export class HistoryRenderer {
       <span class="history-label">${label}:</span>
       <div class="history-value config-section">`;
     entries.forEach(([key, value]) => {
-      const encodedKey = encodeValueForHtml(key);
+      const encodedKey = encodeHtml(key);
       let display;
       let alreadyEncoded = false;
 
@@ -217,13 +211,11 @@ export class HistoryRenderer {
       } else if (typeof value === 'boolean') {
         display = value ? 'Yes' : 'No';
       } else {
-        display = encodeValueForHtml(value);
+        display = encodeHtml(value);
         alreadyEncoded = true;
       }
 
-      const safeDisplay = alreadyEncoded
-        ? display
-        : encodeValueForHtml(display);
+      const safeDisplay = alreadyEncoded ? display : encodeHtml(display);
       html += `<div class="config-item"><span class="config-key">${encodedKey}:</span> ${safeDisplay}</div>`;
     });
     html += `</div>`;

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -52,6 +52,7 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1,6 +1,5 @@
 // Third-party imports
 import markdownItKatex from '@vscode/markdown-it-katex';
-import { encode as encodeHtml, decode as decodeHtml } from 'he';
 /**
  * Formatters for log entries in the progress view.
  *
@@ -29,6 +28,7 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/iconConstants.js';
 import { getBasename } from '@common/pathUtils.js';
+import { encodeHtml, decodeHtml } from '@common/htmlEncoding.js';
 
 // Constants
 export const BULLET_MARKUP =


### PR DESCRIPTION
## Summary
- import the `he` encode helper and add utilities to sanitize history renderer output
- encode all user-provided fields, including comma-separated file lists, before inserting HTML
- escape tool configuration keys and values so snippets render safely

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: VS Code binary is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2adb61d188324b3304ca7f1270226