### PR TITLE
fix: preserve tool use structured data

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -187,6 +187,7 @@ export async function runToolUseCycle<C = unknown>(
         JSON.stringify(toolUseLog, null, 2),
         groupId,
         MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
       );
       break;
     }
@@ -207,6 +208,7 @@ export async function runToolUseCycle<C = unknown>(
         JSON.stringify(toolUseLog, null, 2),
         groupId,
         MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
       );
       break;
     }
@@ -288,6 +290,7 @@ export async function runToolUseCycle<C = unknown>(
       JSON.stringify(toolUseLog, null, 2),
       groupId,
       MESSAGE_TYPES.TOOL_USE,
+      toolUseLog,
     );
 
     // Build provider-specific message containing the tool result

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -251,9 +251,9 @@ export class LogEntryFormatter {
             ),
           'scratchpad',
         ),
-      toolUse: (text, id, groupId, timestamp) =>
+      toolUse: (text, data, id, groupId, timestamp) =>
         this._safeFormat(
-          () => this._formatToolUse(text, id, groupId, timestamp),
+          () => this._formatToolUse(text, data, id, groupId, timestamp),
           'tool use',
         ),
       modelResponse: (params) =>
@@ -348,7 +348,7 @@ export class LogEntryFormatter {
       ) {
         // Pass the full logMessage for access to groupId and timestamp
         // Note: timestamp here is numeric (from Date.now())
-        result = formatter(text, id, groupId, timestamp);
+        result = formatter(text, data, id, groupId, timestamp);
       } else if (messageType === 'userMessage') {
         // User message needs text, id, and timestamp
         result = formatter(text, id, timestamp);
@@ -428,7 +428,7 @@ export class LogEntryFormatter {
     return element;
   }
 
-  _formatToolUse(content, logId, groupId, timestamp) {
+  _formatToolUse(content, structuredData, logId, groupId, timestamp) {
     const element = createFromTemplate('toolUseTemplate');
     if (!element) return null;
 
@@ -459,189 +459,225 @@ export class LogEntryFormatter {
       return `${normalized.slice(0, MAX_PREVIEW_CHARS - 1)}…`;
     };
 
-    const decodedContent = decodeHtml(content);
-    try {
-      const parsed = JSON.parse(decodedContent);
+    const rawContent =
+      typeof content === 'string' && content.length > 0
+        ? decodeHtml(content)
+        : '';
+    const hasStructuredData =
+      structuredData &&
+      typeof structuredData === 'object' &&
+      !Array.isArray(structuredData);
+    let parsed = hasStructuredData ? structuredData : null;
 
-      const toolName =
-        typeof parsed.tool === 'string'
-          ? parsed.tool.trim()
-          : typeof parsed.name === 'string'
-            ? parsed.name.trim()
-            : '';
-
-      const outputCandidate =
-        parsed.output &&
-        typeof parsed.output === 'object' &&
-        !Array.isArray(parsed.output)
-          ? parsed.output
-          : parsed.result &&
-              typeof parsed.result === 'object' &&
-              !Array.isArray(parsed.result)
-            ? parsed.result
-            : {};
-
-      const summaryText =
-        typeof outputCandidate.summary === 'string' &&
-        outputCandidate.summary.trim()
-          ? outputCandidate.summary.trim()
-          : typeof parsed.summary === 'string' && parsed.summary.trim()
-            ? parsed.summary.trim()
-            : '';
-
-      const errorText =
-        typeof outputCandidate.error === 'string'
-          ? outputCandidate.error
-          : typeof parsed.error === 'string'
-            ? parsed.error
-            : '';
-
-      let outputText = '';
-      if (typeof outputCandidate.output === 'string') {
-        outputText = outputCandidate.output;
-      } else if (typeof parsed.output === 'string') {
-        outputText = parsed.output;
+    if (!parsed && rawContent) {
+      try {
+        parsed = JSON.parse(rawContent);
+      } catch (error) {
+        parsed = null;
       }
+    }
 
-      const isError = Boolean(
-        (typeof outputCandidate.isError === 'boolean' &&
-          outputCandidate.isError) ||
-          (typeof parsed.isError === 'boolean' && parsed.isError) ||
-          (typeof errorText === 'string' && errorText.trim().length > 0),
-      );
-
-      const headerSummary =
-        summaryText || makePreview(errorText || outputText || '');
-
-      const titlePrefix = isError ? 'Tool Error' : 'Tool Use';
-      const titleBase = toolName ? `${titlePrefix}: ${toolName}` : titlePrefix;
-      const titleText = headerSummary
-        ? `${titleBase} — ${headerSummary}`
-        : titleBase;
-
-      if (headerLabel) headerLabel.textContent = titleText;
-      if (iconElem) {
-        iconElem.className = isError
-          ? 'codicon codicon-error'
-          : 'codicon codicon-wrench';
-      }
-      element.classList.toggle('tool-use-error', isError);
-
-      const sections = [];
-
-      if (parsed.input !== undefined) {
-        const inputValue =
-          typeof parsed.input === 'string'
-            ? parsed.input
-            : JSON.stringify(parsed.input, null, 2);
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Input:</span>
-              <pre>${encodeHtml(inputValue)}</pre>
-            </div>
-          </div>
-        `);
-      }
-
-      if (errorText) {
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Error:</span>
-              <pre>${encodeHtml(errorText)}</pre>
-            </div>
-          </div>
-        `);
-      }
-
-      if (outputText) {
-        const encodedOutput = encodeHtml(outputText);
-        if (!summaryText && outputText.length > MAX_PREVIEW_CHARS) {
-          const preview = encodeHtml(
-            `${outputText.slice(0, MAX_PREVIEW_CHARS).trimEnd()}…`,
-          );
-          sections.push(`
-            <div class="tool-use-section">
-              <div class="tool-use-subsection">
-                <span class="tool-use-sublabel">Output:</span>
-                <pre class="tool-output-preview">${preview}</pre>
-                <details class="tool-output-details">
-                  <summary>Show full output</summary>
-                  <pre class="tool-output-full">${encodedOutput}</pre>
-                </details>
-              </div>
-            </div>
-          `);
-        } else {
-          sections.push(`
-            <div class="tool-use-section">
-              <div class="tool-use-subsection">
-                <span class="tool-use-sublabel">Output:</span>
-                <pre class="tool-output-full">${encodedOutput}</pre>
-              </div>
-            </div>
-          `);
-        }
-      }
-
-      if (outputCandidate && outputCandidate.diagnostics !== undefined) {
-        const diagnosticsJson = JSON.stringify(
-          outputCandidate.diagnostics,
-          null,
-          2,
-        );
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Diagnostics:</span>
-              <pre>${encodeHtml(diagnosticsJson)}</pre>
-            </div>
-          </div>
-        `);
-      }
-
-      if (outputCandidate && typeof outputCandidate.system === 'string') {
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">System:</span>
-              <pre>${encodeHtml(outputCandidate.system)}</pre>
-            </div>
-          </div>
-        `);
-      }
-
-      if (outputCandidate && typeof outputCandidate.base64Image === 'string') {
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Image:</span>
-              <pre>(base64 image omitted)</pre>
-            </div>
-          </div>
-        `);
-      }
-
-      if (sections.length === 0) {
-        contentElem.innerHTML = `<pre>${encodeHtml(decodedContent)}</pre>`;
-      } else {
-        contentElem.innerHTML = sections.join(
-          '<hr class="tool-use-separator">',
-        );
-      }
-    } catch {
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       if (headerLabel) headerLabel.textContent = 'Tool Use (raw entry)';
       if (iconElem) iconElem.className = 'codicon codicon-wrench';
       element.classList.remove('tool-use-error');
+
+      let fallbackContent = rawContent;
+      if (!fallbackContent && structuredData !== undefined) {
+        if (typeof structuredData === 'string') {
+          fallbackContent = structuredData;
+        } else {
+          try {
+            fallbackContent = JSON.stringify(structuredData, null, 2);
+          } catch (error) {
+            fallbackContent = String(structuredData);
+          }
+        }
+      }
+
       contentElem.innerHTML = `
         <div class="tool-use-section">
           <div class="tool-use-subsection">
             <span class="tool-use-sublabel">Raw log:</span>
-            <pre>${encodeHtml(decodedContent)}</pre>
+            <pre>${encodeHtml(fallbackContent || '')}</pre>
           </div>
         </div>
       `;
+
+      return element;
+    }
+
+    const toolName =
+      typeof parsed.tool === 'string'
+        ? parsed.tool.trim()
+        : typeof parsed.name === 'string'
+          ? parsed.name.trim()
+          : '';
+
+    const outputCandidate =
+      parsed.output &&
+      typeof parsed.output === 'object' &&
+      !Array.isArray(parsed.output)
+        ? parsed.output
+        : parsed.result &&
+            typeof parsed.result === 'object' &&
+            !Array.isArray(parsed.result)
+          ? parsed.result
+          : {};
+
+    const summaryText =
+      typeof outputCandidate.summary === 'string' &&
+      outputCandidate.summary.trim()
+        ? outputCandidate.summary.trim()
+        : typeof parsed.summary === 'string' && parsed.summary.trim()
+          ? parsed.summary.trim()
+          : '';
+
+    const errorText =
+      typeof outputCandidate.error === 'string'
+        ? outputCandidate.error
+        : typeof parsed.error === 'string'
+          ? parsed.error
+          : '';
+
+    let outputText = '';
+    if (typeof outputCandidate.output === 'string') {
+      outputText = outputCandidate.output;
+    } else if (typeof parsed.output === 'string') {
+      outputText = parsed.output;
+    }
+
+    const isError = Boolean(
+      (typeof outputCandidate.isError === 'boolean' &&
+        outputCandidate.isError) ||
+        (typeof parsed.isError === 'boolean' && parsed.isError) ||
+        (typeof errorText === 'string' && errorText.trim().length > 0),
+    );
+
+    const headerSummary =
+      summaryText || makePreview(errorText || outputText || '');
+
+    const titlePrefix = isError ? 'Tool Error' : 'Tool Use';
+    const titleBase = toolName ? `${titlePrefix}: ${toolName}` : titlePrefix;
+    const titleText = headerSummary
+      ? `${titleBase} — ${headerSummary}`
+      : titleBase;
+
+    if (headerLabel) headerLabel.textContent = titleText;
+    if (iconElem) {
+      iconElem.className = isError
+        ? 'codicon codicon-error'
+        : 'codicon codicon-wrench';
+    }
+    element.classList.toggle('tool-use-error', isError);
+
+    const sections = [];
+
+    if (parsed.input !== undefined) {
+      const inputValue =
+        typeof parsed.input === 'string'
+          ? parsed.input
+          : JSON.stringify(parsed.input, null, 2);
+      sections.push(`
+        <div class="tool-use-section">
+          <div class="tool-use-subsection">
+            <span class="tool-use-sublabel">Input:</span>
+            <pre>${encodeHtml(inputValue)}</pre>
+          </div>
+        </div>
+      `);
+    }
+
+    if (errorText) {
+      sections.push(`
+        <div class="tool-use-section">
+          <div class="tool-use-subsection">
+            <span class="tool-use-sublabel">Error:</span>
+            <pre>${encodeHtml(errorText)}</pre>
+          </div>
+        </div>
+      `);
+    }
+
+    if (outputText) {
+      const encodedOutput = encodeHtml(outputText);
+      if (!summaryText && outputText.length > MAX_PREVIEW_CHARS) {
+        const preview = encodeHtml(
+          `${outputText.slice(0, MAX_PREVIEW_CHARS).trimEnd()}…`,
+        );
+        sections.push(`
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">Output:</span>
+              <pre class="tool-output-preview">${preview}</pre>
+              <details class="tool-output-details">
+                <summary>Show full output</summary>
+                <pre class="tool-output-full">${encodedOutput}</pre>
+              </details>
+            </div>
+          </div>
+        `);
+      } else {
+        sections.push(`
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">Output:</span>
+              <pre class="tool-output-full">${encodedOutput}</pre>
+            </div>
+          </div>
+        `);
+      }
+    }
+
+    if (outputCandidate && outputCandidate.diagnostics !== undefined) {
+      const diagnosticsJson = JSON.stringify(
+        outputCandidate.diagnostics,
+        null,
+        2,
+      );
+      sections.push(`
+        <div class="tool-use-section">
+          <div class="tool-use-subsection">
+            <span class="tool-use-sublabel">Diagnostics:</span>
+            <pre>${encodeHtml(diagnosticsJson)}</pre>
+          </div>
+        </div>
+      `);
+    }
+
+    if (outputCandidate && typeof outputCandidate.system === 'string') {
+      sections.push(`
+        <div class="tool-use-section">
+          <div class="tool-use-subsection">
+            <span class="tool-use-sublabel">System:</span>
+            <pre>${encodeHtml(outputCandidate.system)}</pre>
+          </div>
+        </div>
+      `);
+    }
+
+    if (outputCandidate && typeof outputCandidate.base64Image === 'string') {
+      sections.push(`
+        <div class="tool-use-section">
+          <div class="tool-use-subsection">
+            <span class="tool-use-sublabel">Image:</span>
+            <pre>(base64 image omitted)</pre>
+          </div>
+        </div>
+      `);
+    }
+
+    if (sections.length === 0) {
+      const fallbackJson = (() => {
+        try {
+          return JSON.stringify(parsed, null, 2);
+        } catch (error) {
+          return rawContent;
+        }
+      })();
+      contentElem.innerHTML = `<pre>${encodeHtml(fallbackJson || '')}</pre>`;
+    } else {
+      contentElem.innerHTML = sections.join('<hr class="tool-use-separator">');
     }
 
     return element;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -341,13 +341,12 @@ export class LogEntryFormatter {
           content: text,
           level,
         });
-      } else if (
-        messageType === 'thinking' ||
-        messageType === 'scratchpad' ||
-        messageType === 'toolUse'
-      ) {
-        // Pass the full logMessage for access to groupId and timestamp
+      } else if (messageType === 'thinking' || messageType === 'scratchpad') {
+        // Pass identifiers so the formatter can apply grouping metadata
         // Note: timestamp here is numeric (from Date.now())
+        result = formatter(text, id, groupId, timestamp);
+      } else if (messageType === 'toolUse') {
+        // Tool use needs both the rendered text and the structured payload
         result = formatter(text, data, id, groupId, timestamp);
       } else if (messageType === 'userMessage') {
         // User message needs text, id, and timestamp

--- a/src/test/progressView/Formatters.test.ts
+++ b/src/test/progressView/Formatters.test.ts
@@ -19,6 +19,7 @@ describe('LogEntryFormatter DOM', () => {
       </template>
     </body></html>`);
     global.document = dom.window.document as any;
+    global.window = dom.window as any;
 
     const formatter = new LogEntryFormatter();
     const el = formatter.format({
@@ -34,5 +35,57 @@ describe('LogEntryFormatter DOM', () => {
 
     assert.ok(el instanceof dom.window.HTMLElement);
     assert.equal(el.querySelector('.message')?.textContent, 'hello');
+  });
+
+  it('renders tool use entries from structured data', () => {
+    const dom = new JSDOM(`<!doctype html><html><body>
+      <template id="toolUseTemplate">
+        <details class="special-details">
+          <summary class="details-summary">
+            <i class="toggle-icon"></i>
+            <i class="codicon codicon-wrench"></i>
+            <span class="tool-use-title">Tool Use</span>
+          </summary>
+          <div class="special-content"></div>
+        </details>
+      </template>
+    </body></html>`);
+    global.document = dom.window.document as any;
+    global.window = dom.window as any;
+
+    const formatter = new LogEntryFormatter();
+    const toolLog = {
+      tool: 'read_file',
+      input: { path: '/tmp/example.tex', range: { start: 1, end: 15 } },
+      output: {
+        summary: 'Read 3 lines from example.tex',
+        output: 'Line 1: α & β\nLine 2: <section>\nLine 3: "quotes" and more',
+      },
+    };
+
+    const el = formatter.format({
+      id: 'tool-1',
+      text: 'not-json-content',
+      level: 'info',
+      timestamp: Date.now(),
+      groupId: 'g1',
+      messageType: 'toolUse',
+      verbose: false,
+      data: toolLog,
+    } as any);
+
+    assert.ok(el instanceof dom.window.HTMLElement);
+    const title = el.querySelector('.tool-use-title')?.textContent ?? '';
+    assert.ok(title.includes('Tool Use: read_file'));
+    assert.ok(title.includes('Read 3 lines from example.tex'));
+
+    const inputPre = el.querySelector('.tool-use-section pre');
+    assert.ok(inputPre);
+    assert.ok(inputPre.textContent?.includes('/tmp/example.tex'));
+
+    const outputFull = el.querySelector('.tool-output-full');
+    assert.ok(outputFull);
+    assert.ok(outputFull.textContent?.includes('Line 2: <section>'));
+    assert.ok(outputFull.textContent?.includes('"quotes" and more'));
   });
 });

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -143,6 +143,14 @@ describe('runToolUseCycle DeepSeek', () => {
       (e) => e.logMessage.messageType === MESSAGE_TYPES.TOOL_USE,
     );
     assert.equal(toolEvents.length, 2);
+    const structuredLog = toolEvents.find(
+      (e) => e.logMessage.data && e.logMessage.data.tool === 'echo',
+    );
+    assert.ok(structuredLog, 'Tool use log entry missing structured payload');
+    assert.deepEqual(structuredLog?.logMessage.data?.input, { value: 'hello' });
+    assert.deepEqual(structuredLog?.logMessage.data?.output, {
+      output: 'hello',
+    });
     assert.deepEqual(messages[0], {
       role: 'assistant',
       tool_calls: [

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -153,6 +153,14 @@ describe('runToolUseCycle OpenAIResponse', () => {
       (e) => e.logMessage.messageType === MESSAGE_TYPES.TOOL_USE,
     );
     assert.equal(toolEvents.length, 2);
+    const structuredLog = toolEvents.find(
+      (e) => e.logMessage.data && e.logMessage.data.tool === 'echo',
+    );
+    assert.ok(structuredLog, 'Tool use log entry missing structured payload');
+    assert.deepEqual(structuredLog?.logMessage.data?.input, { value: 'hello' });
+    assert.deepEqual(structuredLog?.logMessage.data?.output, {
+      output: 'hello',
+    });
     const assistantMsg = messages[0] as any;
     assert.equal(assistantMsg.role, 'assistant');
     assert.equal(assistantMsg.type, 'message');


### PR DESCRIPTION
## Summary
- pass the tool use log object through AgentLogger so structured payloads reach the progress view
- update the progress view formatter to prefer structured tool use data with a safe JSON fallback
- extend tool-use and formatter tests to assert the structured payload is used for complex read_file output

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: vscode-test requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ad9806008324b5bb61790486e9fb