### PR TITLE
refactor: simplify response output text extraction

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -10,7 +10,6 @@ import type {
   ResponseCreateParamsBase,
   ResponseCreateParamsNonStreaming,
   ResponseOutputItem,
-  ResponseOutputMessage,
   ResponseOutputText,
   ResponseReasoningItem,
   ResponseFunctionToolCallItem,
@@ -523,9 +522,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   private collectResponseText(responseObject: Response): string {
-    const trimmedOutputText = responseObject.output_text?.trim();
-    if (trimmedOutputText) {
-      return trimmedOutputText;
+    const directOutput = this.normalizeOutputText(responseObject.output_text);
+    if (directOutput) {
+      return directOutput;
     }
 
     const outputItems = responseObject.output;
@@ -533,76 +532,49 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return '';
     }
 
-    const messageText = this.collectMessageOutput(outputItems);
-    if (messageText) {
-      return messageText;
-    }
-
-    return this.collectFallbackOutput(outputItems);
-  }
-
-  private collectMessageOutput(
-    outputItems: ResponseOutputItem[],
-  ): string | null {
-    const messageParts = outputItems.filter(
-      (part): part is ResponseOutputMessage =>
-        part.type === 'message' && 'content' in part,
-    );
-    if (messageParts.length === 0) {
-      return null;
-    }
-
-    const aggregated = messageParts
-      .map((part) => this.extractMessageText(part.content))
-      .filter((content) => content.length > 0)
+    const aggregated = outputItems
+      .map((part) => this.extractOutputText(part))
+      .filter((text) => text.length > 0)
       .join('')
       .trim();
 
-    return aggregated.length > 0 ? aggregated : null;
+    return aggregated;
   }
 
-  private collectFallbackOutput(outputItems: ResponseOutputItem[]): string {
-    return outputItems
-      .filter(
-        (part): part is ResponseOutputItem & { text: string; type: string } =>
-          this.isTextBearingOutput(part) && part.type !== 'reasoning',
-      )
-      .map((part) => part.text)
-      .join('')
-      .trim();
-  }
-
-  private extractMessageText(
-    content: ResponseOutputMessage['content'] | string | undefined,
+  private normalizeOutputText(
+    outputText: string | string[] | null | undefined,
   ): string {
-    if (!content) {
+    if (!outputText) {
       return '';
     }
 
-    if (typeof content === 'string') {
-      return content;
+    if (Array.isArray(outputText)) {
+      return outputText.join('').trim();
     }
 
-    if (!Array.isArray(content)) {
-      return '';
-    }
-
-    return content
-      .filter(
-        (item): item is ResponseOutputText =>
-          item?.type === 'output_text' && typeof item?.text === 'string',
-      )
-      .map((item) => item.text)
-      .join('');
+    return outputText.trim();
   }
 
-  private isTextBearingOutput(
-    part: ResponseOutputItem,
-  ): part is ResponseOutputItem & { text: string; type: string } {
-    return (
+  private extractOutputText(part: ResponseOutputItem): string {
+    if (part.type === 'message' && Array.isArray(part.content)) {
+      return part.content
+        .filter(
+          (item): item is ResponseOutputText =>
+            item?.type === 'output_text' && typeof item?.text === 'string',
+        )
+        .map((item) => item.text)
+        .join('');
+    }
+
+    if (
+      'text' in part &&
       typeof (part as { text?: unknown }).text === 'string' &&
-      typeof (part as { type?: unknown }).type === 'string'
-    );
+      part.type !== 'reasoning'
+    ) {
+      return (part as { text: string }).text;
+    }
+
+    return '';
   }
 
   /** Price computation adapted for Responses API token fields. */


### PR DESCRIPTION
## Summary
- normalize OpenAI Responses output handling to prefer the native `output_text` field
- trim and aggregate any remaining output segments only when the direct text is missing
- remove several bespoke helper functions in favor of a concise extraction flow

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68d63cafb040832480e7b9a46d80d72c