### PR TITLE
fix: streamline workspace append

### DIFF
--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -70,6 +70,17 @@ export class AbsoluteFS {
   }
 
   /**
+   * Append content to a file, creating it if it does not exist
+   */
+  public static async appendFile(
+    filePath: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    this.validatePath(filePath, 'appendFile');
+    await fs.promises.appendFile(filePath, content);
+  }
+
+  /**
    * Delete a file or directory
    */
   public static async delete(

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -77,10 +77,7 @@ export class WorkspaceFS extends RelativeFS {
     content: string,
   ): Promise<void> {
     try {
-      const existing = (await this.exists(filePath))
-        ? await this.read(filePath)
-        : '';
-      await this.write(filePath, existing + content);
+      await AbsoluteFS.appendFile(this.fullPath(filePath), content);
       logger.debug(CHANNEL, `Successfully appended to file: ${filePath}`);
     } catch (err) {
       logger.error(


### PR DESCRIPTION
## Summary
- add an AbsoluteFS.appendFile helper that validates absolute paths before appending
- switch WorkspaceFS.appendFile to use the new helper while preserving logging

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d65312e3188324b4baa00e0204b916