### PR TITLE
Simplify OpenAI Responses text extraction

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -9,9 +9,6 @@ import type {
   ResponseUsage,
   ResponseCreateParamsBase,
   ResponseCreateParamsNonStreaming,
-  ResponseOutputItem,
-  ResponseOutputMessage,
-  ResponseOutputText,
   ResponseReasoningItem,
   ResponseFunctionToolCallItem,
   ResponseFunctionToolCall,
@@ -523,86 +520,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   private collectResponseText(responseObject: Response): string {
-    const trimmedOutputText = responseObject.output_text?.trim();
-    if (trimmedOutputText) {
-      return trimmedOutputText;
-    }
-
-    const outputItems = responseObject.output;
-    if (!Array.isArray(outputItems) || outputItems.length === 0) {
+    const { output_text: outputText } = responseObject;
+    if (typeof outputText !== 'string') {
       return '';
     }
 
-    const messageText = this.collectMessageOutput(outputItems);
-    if (messageText) {
-      return messageText;
-    }
-
-    return this.collectFallbackOutput(outputItems);
-  }
-
-  private collectMessageOutput(
-    outputItems: ResponseOutputItem[],
-  ): string | null {
-    const messageParts = outputItems.filter(
-      (part): part is ResponseOutputMessage =>
-        part.type === 'message' && 'content' in part,
-    );
-    if (messageParts.length === 0) {
-      return null;
-    }
-
-    const aggregated = messageParts
-      .map((part) => this.extractMessageText(part.content))
-      .filter((content) => content.length > 0)
-      .join('')
-      .trim();
-
-    return aggregated.length > 0 ? aggregated : null;
-  }
-
-  private collectFallbackOutput(outputItems: ResponseOutputItem[]): string {
-    return outputItems
-      .filter(
-        (part): part is ResponseOutputItem & { text: string; type: string } =>
-          this.isTextBearingOutput(part) && part.type !== 'reasoning',
-      )
-      .map((part) => part.text)
-      .join('')
-      .trim();
-  }
-
-  private extractMessageText(
-    content: ResponseOutputMessage['content'] | string | undefined,
-  ): string {
-    if (!content) {
-      return '';
-    }
-
-    if (typeof content === 'string') {
-      return content;
-    }
-
-    if (!Array.isArray(content)) {
-      return '';
-    }
-
-    return content
-      .filter(
-        (item): item is ResponseOutputText =>
-          item?.type === 'output_text' && typeof item?.text === 'string',
-      )
-      .map((item) => item.text)
-      .join('');
-  }
-
-  private isTextBearingOutput(
-    part: ResponseOutputItem,
-  ): part is ResponseOutputItem & { text: string; type: string } {
-    return (
-      typeof (part as { text?: unknown }).text === 'string' &&
-      typeof (part as { type?: unknown }).type === 'string'
-    );
+    return outputText.trim();
   }
 
   /** Price computation adapted for Responses API token fields. */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -501,7 +501,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       output_tokens_details: { reasoning_tokens: 0 },
     };
 
-    const newResponse = this.collectResponseText(responseObject);
+    const rawOutputText = responseObject.output_text;
+    const newResponse =
+      typeof rawOutputText === 'string' ? rawOutputText.trim() : '';
 
     const stopReason =
       responseObject.status === 'completed'
@@ -517,15 +519,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     return [newResponse, usage, stopReason];
-  }
-
-  private collectResponseText(responseObject: Response): string {
-    const { output_text: outputText } = responseObject;
-    if (typeof outputText !== 'string') {
-      return '';
-    }
-
-    return outputText.trim();
   }
 
   /** Price computation adapted for Responses API token fields. */

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -49,6 +49,7 @@ class MockHandler extends ModelHandlerOpenAIResponse {
       return {
         id: 'r1',
         status: 'completed',
+        output_text: 'intro',
         output: [
           {
             type: 'message',
@@ -68,6 +69,7 @@ class MockHandler extends ModelHandlerOpenAIResponse {
     return {
       id: 'r2',
       status: 'completed',
+      output_text: 'done',
       output: [
         {
           type: 'message',


### PR DESCRIPTION
## Summary
- rely solely on the Responses API `output_text` field when collecting assistant output
- update the OpenAI Responses tool-use test fixture to populate `output_text`

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: VS Code binary requires libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d63cafb040832480e7b9a46d80d72c