### PR TITLE
refactor: inline structured clone usage for tool-use snapshots

### DIFF
--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -71,28 +71,6 @@ function isValidExecutionId(id: ExecutionId | undefined): id is ExecutionId {
   return !invalidPatterns.some((pattern) => id.includes(pattern));
 }
 
-function serializeMessages(messages: ProviderMessage[]): unknown[] {
-  try {
-    return JSON.parse(JSON.stringify(messages));
-  } catch (error) {
-    logger.warn(
-      `Failed to serialize provider messages: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return [];
-  }
-}
-
-function serializeToolState(state: ToolState) {
-  return {
-    texcountStats: state.texcountStats,
-    lastResponse: state.lastResponse,
-    accumulatedOutput: state.accumulatedOutput,
-    mediaFiles: [...state.mediaFiles],
-    thinkingBlocks: [...state.thinkingBlocks],
-    thinkingAdded: state.thinkingAdded,
-  };
-}
-
 function hydrateToolState(
   snapshot: ToolUseSessionSnapshot['toolState'],
 ): ToolState {
@@ -168,8 +146,8 @@ export class ToolUseSessionManager {
       agentName: payload.agentName,
       model: payload.model,
       agentSessionKind: payload.agentSessionKind,
-      messages: serializeMessages(payload.messages),
-      toolState: serializeToolState(payload.toolState),
+      messages: structuredClone(payload.messages),
+      toolState: structuredClone({ ...payload.toolState }),
       lastUpdated: Date.now(),
     };
 


### PR DESCRIPTION
## Summary
- inline structured cloning of tool-use messages and state when persisting snapshots
- drop the redundant serialization helpers now that structuredClone handles deep copies directly

## Testing
- npm run format
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d652ea47f88324adf050783ae92bd2