### PR TITLE
fix: improve instruction box and footer layout

### DIFF
--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -5,21 +5,21 @@
 
 /* Model Selection Footer styles */
 .model-selection-footer {
-  position: absolute;
-  bottom: var(--spacing-xlarge);
-  left: var(--spacing-xlarge);
   display: flex;
+  flex-wrap: wrap;
   gap: var(--spacing-small);
-  z-index: 10;
+  margin-top: var(--spacing-medium);
 }
 
 .model-selection-footer .select-group {
   display: flex;
   align-items: center;
-  max-width: 150px;
+  flex: 1 1 200px;
 }
 
 .model-selection-footer .select-group select {
+  flex: 1 1 auto;
+  width: 100%;
   height: var(--height-control);
   font-size: var(--font-size);
   padding: var(--spacing-tiny) var(--spacing-small);

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -5,7 +5,9 @@
 
 .instruction-box {
   margin-bottom: var(--spacing-small);
-  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-medium);
   background-color: var(--background-color);
   border: var(--border-thin) solid
     var(--vscode-widget-border, var(--dropdown-border));
@@ -22,11 +24,9 @@
 #instruction {
   min-height: var(--height-medium);
   max-height: var(--height-xlarge);
-  padding-bottom: calc(var(--spacing-xlarge) + var(--spacing-large));
   resize: none;
   overflow-y: auto;
   transition: height 0.1s ease-out;
-  margin-top: var(--spacing-medium);
 }
 
 .instruction-header {
@@ -58,10 +58,8 @@
 
 #executeButton {
   font-size: var(--font-size);
-  position: absolute;
-  bottom: var(--spacing-xlarge);
-  right: var(--spacing-xlarge);
-  z-index: 10;
+  align-self: flex-end;
+  margin-top: var(--spacing-medium);
 }
 
 /* Recording button states */


### PR DESCRIPTION
## Summary
- convert the instruction box into a vertical flex container, aligning the Execute button with flex spacing
- let the model selection footer wrap within the flow and allow its selects to grow without clipping

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: VS Code test runner requires libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d245e68ff883248190dc755db8b5ea