### PR TITLE
feat: refresh qwen max and plus support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Refresh Qwen Max/Plus model entries with latest identifiers, pricing, and reasoning support
+
 ## [0.33.7] - 2025-09-22
 
 ### Features

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -114,16 +114,16 @@ miss), $2.50/million output tokens. [Tech blog](https://moonshotai.github.io/Kim
 
 Cost-effective models from Alibaba with strong multilingual capabilities.
 
-| Model ID    | Key Strength / Use Case                    | Relative Cost | Relative Speed | Notes                       |
-| :---------- | :----------------------------------------- | :------------ | :------------- | :-------------------------- |
-| `qwen3max`  | Best-in-class reasoning, 256k ctx          | $$$           | Medium         | Qwen3 Max, no deep thinking |
-| `qwenplus`  | Hybrid reasoning, 1M ctx                   | $$            | Medium         | Qwen3 Plus, enable_thinking |
-| `qwenturbo` | Fast responses with optional thinking mode | $             | Fast           | Qwen Turbo, enable_thinking |
+| Model ID    | Key Strength / Use Case                    | Relative Cost | Relative Speed | Notes                               |
+| :---------- | :----------------------------------------- | :------------ | :------------- | :---------------------------------- |
+| `qwen3max`  | Flagship reasoning, 262k ctx               | $$$           | Medium         | Qwen Max (latest); no thinking      |
+| `qwenplus`  | Hybrid reasoning, 1M ctx                   | $$            | Medium         | Qwen Plus; toggle `enable_thinking` |
+| `qwenturbo` | Fast responses with optional thinking mode | $             | Fast           | Qwen Turbo; `enable_thinking`       |
 
 Deep thinking models first stream their reasoning before the final answer.
 `qwenplus` and `qwenturbo` support this mode. Pass `enable_thinking: true`
 in the request body to turn it on; commercial tiers disable it by default.
-`qwen3max` always runs in non-thinking mode.
+`qwen3max` remains non-thinking only.
 
 ```python
 from openai import OpenAI
@@ -135,7 +135,7 @@ client = OpenAI(
 )
 
 resp = client.chat.completions.create(
-    model="qwen-plus-2025-07-28",
+    model="qwen-plus-latest",
     messages=[{"role": "user", "content": "Who are you?"}],
     extra_body={"enable_thinking": True},
 )

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
               "grok4",
               "kimi2"
             ],
-            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen3 Max), qwenplus (Qwen3 Plus 2025-07-28), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
+            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
             "scope": "resource"
           }
         }

--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -13,7 +13,7 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - utilities
 import type { ToolDefinition } from '@model';
-import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
+import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 /**
  * Handler for DashScope Qwen models using OpenAI-compatible API.
@@ -31,8 +31,24 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     groupId?: string,
     toolState?: ToolState,
   ): string | null {
-    // DashScope Qwen models don't currently support thinking blocks
-    return null;
+    const reasoning =
+      responseObject?.choices?.[0]?.message?.reasoning_content ?? null;
+
+    if (typeof reasoning !== 'string' || !reasoning.trim()) {
+      return null;
+    }
+
+    if (toolState && !toolState.thinkingAdded) {
+      toolState.thinkingBlocks = [{ type: 'thinking', thinking: reasoning }];
+      toolState.thinkingAdded = true;
+    }
+
+    this.logger.debug(
+      `DashScope reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
+      groupId,
+    );
+
+    return reasoning;
   }
 
   /**

--- a/src/model/providers/dashscopeModels.ts
+++ b/src/model/providers/dashscopeModels.ts
@@ -18,13 +18,13 @@ const DASHSCOPE_DEFAULT_CAPABILITIES: ModelCapabilities = {
 export const DASHSCOPE_MODELS: Record<string, ModelConfig> = {
   qwen3max: {
     name: 'qwen3max',
-    fullName: 'qwen3-max-latest',
-    openrouterFullName: 'qwen/qwen3-max',
+    fullName: 'qwen-max-latest',
+    openrouterFullName: 'qwen/qwen-max',
     provider: ModelProvider.DASHSCOPE,
     maxOutputTokens: 32800,
-    contextWindow: 256000,
-    inputPrice: 1.2,
-    outputPrice: 6,
+    contextWindow: 262144,
+    inputPrice: 1.6,
+    outputPrice: 6.4,
     capabilities: {
       ...DASHSCOPE_DEFAULT_CAPABILITIES,
       supportsVision: false,
@@ -33,8 +33,8 @@ export const DASHSCOPE_MODELS: Record<string, ModelConfig> = {
   },
   qwenplus: {
     name: 'qwenplus',
-    fullName: 'qwen-plus-2025-07-28',
-    openrouterFullName: 'qwen/qwen-plus-2025-07-28',
+    fullName: 'qwen-plus-latest',
+    openrouterFullName: 'qwen/qwen-plus',
     provider: ModelProvider.DASHSCOPE,
     maxOutputTokens: 32768,
     contextWindow: 1000000,


### PR DESCRIPTION
## Summary
- update DashScope Qwen Max/Plus metadata to the latest identifiers, pricing, and context limits
- capture DashScope reasoning_content so Qwen Plus thinking streams surface in the UI
- refresh documentation, settings descriptions, and changelog with the new Qwen naming and usage guidance

## Testing
- npm run format
- npm run lint
- npm run compile
- CI=1 npm test *(fails: vscode-test needs libatk-1.0 shared library in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b48cd3788324b037742d27a9644f