### PR TITLE
feat: refresh dashscope qwen lineup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Improvements
+
+- Refresh Qwen-Max and Qwen Plus integrations with updated pricing, naming, and thinking support in the DashScope handler
+
 ## [0.33.7] - 2025-09-22
 
 ### Features

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -114,11 +114,11 @@ miss), $2.50/million output tokens. [Tech blog](https://moonshotai.github.io/Kim
 
 Cost-effective models from Alibaba with strong multilingual capabilities.
 
-| Model ID    | Key Strength / Use Case                    | Relative Cost | Relative Speed | Notes                       |
-| :---------- | :----------------------------------------- | :------------ | :------------- | :-------------------------- |
-| `qwen3max`  | Best-in-class reasoning, 256k ctx          | $$$           | Medium         | Qwen3 Max, no deep thinking |
-| `qwenplus`  | Hybrid reasoning, 1M ctx                   | $$            | Medium         | Qwen3 Plus, enable_thinking |
-| `qwenturbo` | Fast responses with optional thinking mode | $             | Fast           | Qwen Turbo, enable_thinking |
+| Model ID    | Key Strength / Use Case                    | Relative Cost | Relative Speed | Notes                              |
+| :---------- | :----------------------------------------- | :------------ | :------------- | :--------------------------------- |
+| `qwen3max`  | Flagship coding agent, 262k ctx            | $$$           | Medium         | Qwen3-Max latest, no thinking mode |
+| `qwenplus`  | Hybrid thinking, 1M ctx + tool use         | $$            | Medium         | Qwen Plus latest, enable_thinking  |
+| `qwenturbo` | Fast responses with optional thinking mode | $             | Fast           | Qwen Turbo, enable_thinking        |
 
 Deep thinking models first stream their reasoning before the final answer.
 `qwenplus` and `qwenturbo` support this mode. Pass `enable_thinking: true`
@@ -135,7 +135,7 @@ client = OpenAI(
 )
 
 resp = client.chat.completions.create(
-    model="qwen-plus-2025-07-28",
+    model="qwen-plus-latest",
     messages=[{"role": "user", "content": "Who are you?"}],
     extra_body={"enable_thinking": True},
 )

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
               "grok4",
               "kimi2"
             ],
-            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen3 Max), qwenplus (Qwen3 Plus 2025-07-28), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
+            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
             "scope": "resource"
           }
         }

--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -4,9 +4,6 @@
 // Third-party imports
 import OpenAI from 'openai';
 
-// Local imports - agent
-import { ToolState } from '../core/ToolState';
-
 // Local imports - agent components
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { MediaEntry } from '@agent/utils/mediaTypes';
@@ -19,22 +16,7 @@ import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
  * Handler for DashScope Qwen models using OpenAI-compatible API.
  */
 export class ModelHandlerDashScope extends ModelHandlerOpenAI {
-  /**
-   * Process thinking blocks for DashScope models
-   * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
-   * @param toolState Optional toolState to update with the thinking block
-   * @returns The extracted reasoning_content or null if none
-   */
-  processThinkingBlock(
-    responseObject: any,
-    groupId?: string,
-    toolState?: ToolState,
-  ): string | null {
-    // DashScope Qwen models don't currently support thinking blocks
-    return null;
-  }
-
+  /** Thinking blocks are handled by the base OpenAI handler. */
   /**
    * Override createResponse to preprocess messages for DashScope models
    */

--- a/src/model/providers/dashscopeModels.ts
+++ b/src/model/providers/dashscopeModels.ts
@@ -18,13 +18,13 @@ const DASHSCOPE_DEFAULT_CAPABILITIES: ModelCapabilities = {
 export const DASHSCOPE_MODELS: Record<string, ModelConfig> = {
   qwen3max: {
     name: 'qwen3max',
-    fullName: 'qwen3-max-latest',
-    openrouterFullName: 'qwen/qwen3-max',
+    fullName: 'qwen-max-latest',
+    openrouterFullName: 'qwen/qwen-max',
     provider: ModelProvider.DASHSCOPE,
     maxOutputTokens: 32800,
-    contextWindow: 256000,
-    inputPrice: 1.2,
-    outputPrice: 6,
+    contextWindow: 262144,
+    inputPrice: 1.6,
+    outputPrice: 6.4,
     capabilities: {
       ...DASHSCOPE_DEFAULT_CAPABILITIES,
       supportsVision: false,
@@ -33,8 +33,8 @@ export const DASHSCOPE_MODELS: Record<string, ModelConfig> = {
   },
   qwenplus: {
     name: 'qwenplus',
-    fullName: 'qwen-plus-2025-07-28',
-    openrouterFullName: 'qwen/qwen-plus-2025-07-28',
+    fullName: 'qwen-plus-latest',
+    openrouterFullName: 'qwen/qwen-plus',
     provider: ModelProvider.DASHSCOPE,
     maxOutputTokens: 32768,
     contextWindow: 1000000,


### PR DESCRIPTION
## Summary
- update the DashScope Qwen-Max and Qwen Plus entries with the latest names, pricing, and documentation guidance
- let the DashScope model handler rely on the shared OpenAI thinking support so reasoning streams surface correctly

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: vscode-test streaming output exceeds console limits in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b48cd3788324b037742d27a9644f