### PR TITLE
fix: recover missing openai response text fallback

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -17,6 +17,7 @@ import type {
   ResponseInputMessageContentList,
   ResponseInputFile,
   ResponseStreamEvent,
+  ResponseOutputText,
 } from 'openai/resources/responses/responses';
 import type { Reasoning } from 'openai/resources/shared';
 import type { ResponseStreamParams } from 'openai/lib/responses/ResponseStream';
@@ -502,8 +503,27 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     };
 
     const rawOutputText = responseObject.output_text;
-    const newResponse =
+    let newResponse =
       typeof rawOutputText === 'string' ? rawOutputText.trim() : '';
+
+    if (!newResponse) {
+      const fallbackSegments =
+        responseObject.output?.flatMap((item) => {
+          if (item.type !== 'message') {
+            return [];
+          }
+
+          return item.content
+            .filter(
+              (part): part is ResponseOutputText => part.type === 'output_text',
+            )
+            .map((part) => part.text);
+        }) ?? [];
+      const fallbackText = fallbackSegments.join('').trim();
+      if (fallbackText) {
+        newResponse = fallbackText;
+      }
+    }
 
     const stopReason =
       responseObject.status === 'completed'


### PR DESCRIPTION
## Summary
- fall back to concatenating output_text segments when the responses API omits output_text
- keep streaming finalization aligned with the recovered assistant text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8547531888324922854607977e06b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a fallback to extract and concatenate `output_text` segments from `response.output` when `response.output_text` is empty.
> 
> - **Responses handling**:
>   - In `extractResponse(...)`, if `response.output_text` is empty, fall back to concatenating `output_text` parts from `response.output` message items to recover assistant text.
> - **Types**:
>   - Import `ResponseOutputText` to filter and map output segments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fb61f8487deb7c08cb0942e86dc469906ea5398. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->