### PR TITLE
fix: defer api key reminder until webview ready

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -7,7 +7,6 @@ import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
 // Local imports - webview
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';
 import { MainViewContentProvider } from './webview/MainViewContentProvider';
-import { SecretManager } from '@frontend/secretManager';
 import { watchConfig, getConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
@@ -159,19 +158,6 @@ export class MainViewProvider
     super.resolveWebviewViewInternal(webviewView);
 
     this.setupInitialState(webviewView);
-
-    // Check if any API keys are set and display banner if needed
-    const showReminders = getConfig<boolean>('ui.showApiKeyReminders', true);
-
-    if (showReminders) {
-      SecretManager.anyApiKeyExists().then((exists) => {
-        if (!exists) {
-          webviewView.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
-          });
-        }
-      });
-    }
 
     // Check for missing core dependencies and display banner if needed
     const showDependencyReminders = getConfig<boolean>(

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -25,6 +25,7 @@ import {
 } from '@utils/system';
 import { SETTINGS_QUERY } from '@utils/settingsQueries';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+import { SecretManager } from '@frontend/secretManager';
 import { computeModelOptions } from '@model/computeModelOptions';
 import { computeAgentOptions } from '@agent/computeAgentOptions';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
@@ -365,6 +366,17 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
         options: modelOptions,
       });
+
+      const showReminders = getConfig<boolean>('ui.showApiKeyReminders', true);
+      if (showReminders) {
+        const hasAnyApiKey = await SecretManager.anyApiKeyExists();
+        if (!hasAnyApiKey) {
+          webviewView.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+          });
+        }
+      }
+
       const agentOptions = await computeAgentOptions(this.context);
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,


### PR DESCRIPTION
## Summary
- stop the main view provider from sending the API key banner before the webview is ready
- rerun the API key reminder check once the webview signals readiness so the banner appears immediately when needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d85532c1c08324b75dffd65ab68f03

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves API key banner check from `MainViewProvider.resolveWebviewView` to `MainViewMessageHandler.handleWebviewReady` so it triggers after the webview initializes.
> 
> - **Webview initialization and banners**:
>   - Remove early API key reminder from `src/MainViewProvider.ts` (drops `SecretManager` import and banner post in `resolveWebviewView`).
>   - Add API key reminder in `src/webview/MainViewMessageHandler.ts` during `handleWebviewReady`: checks `ui.showApiKeyReminders` and `SecretManager.anyApiKeyExists()`, posts `SHOW_API_KEY_BANNER` if none.
> - **Dependency reminders**:
>   - Dependency banner logic in `MainViewProvider` remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd39a6331081ee8946e072e9fc6f1ce06431b925. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->