### PR TITLE
Fix scratchpad fallback formatting for mixed content

### DIFF
--- a/src/test/utils/text/xmlUtils.test.ts
+++ b/src/test/utils/text/xmlUtils.test.ts
@@ -18,7 +18,30 @@ describe('xmlUtils.formatContent', () => {
 
     const result = await formatContent(latexInput);
 
-    assert.equal(result, '## Plan\n- Step 1\n- Step 2');
+    assert.equal(result, '## Plan\n\n- Step 1\n- Step 2');
+  });
+
+  it('processes mixed HTML and LaTeX content sequentially', async () => {
+    const mixedInput =
+      '<div><strong>Plan</strong></div>\\begin{itemize}\\item Step 1\\item Step 2\\end{itemize>';
+
+    const result = await formatContent(mixedInput);
+
+    assert.equal(result, '**Plan**\n\n- Step 1\n- Step 2');
+  });
+
+  it('normalizes existing markdown formatting', async () => {
+    const markdownInput = 'Plan:\n-  Step 1\n-   Step 2\n\n';
+
+    const result = await formatContent(markdownInput);
+
+    assert.equal(result, 'Plan:\n- Step 1\n- Step 2');
+  });
+
+  it('returns empty string for empty content', async () => {
+    const result = await formatContent('');
+
+    assert.equal(result, '');
   });
 });
 
@@ -28,6 +51,6 @@ describe('xmlUtils.extractScratchpad', () => {
 
     const result = await extractScratchpad(response);
 
-    assert.equal(result, '## Plan\n- Step 1\n- Step 2');
+    assert.equal(result, '## Plan\n\n- Step 1\n- Step 2');
   });
 });

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -42,13 +42,17 @@ export enum outputFormat {
 }
 
 const LATEX_REPLACEMENTS: Array<[RegExp, string]> = [
-  [/\\section\{([^}]+)\}/g, '## $1'],
-  [/\\subsection\{([^}]+)\}/g, '### $1'],
+  [/\\section\{([^}]+)\}/g, '## $1\n\n'],
+  [/\\subsection\{([^}]+)\}/g, '### $1\n\n'],
   [/\\textbf\{([^}]+)\}/g, '**$1**'],
   [/\\textit\{([^}]+)\}/g, '*$1*'],
   [/\\emph\{([^}]+)\}/g, '*$1*'],
-  [/\\item\s+/g, '- '],
+  [/\\item\s+/g, '\n- '],
 ];
+
+const HTML_PATTERN = /<(?:br|p|div|strong|em|code|pre|h[1-6]|ul|ol|li)\b[^>]*>/;
+
+const LATEX_PATTERN = /\\(?:begin|end|section|subsection|textbf|textit|item)\{/;
 
 const LATEX_ENVIRONMENT_MARKERS: RegExp[] = [
   /\\begin\{itemize\}/g,
@@ -68,22 +72,51 @@ function convertLatexToMarkdown(latex: string): string {
     withoutEnvironments,
   );
 
-  return converted.trim();
+  return converted
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/^(\s*\n)+/g, '')
+    .trim();
 }
 
 function detectInputFormat(text: string): outputFormat {
   // const htmlRegex = /<[^>]+>/; // this is wrong, as we might have some xml tags to separte scratchpad
-  const htmlRegex = /<(?:br|p|div|strong|em|code|pre|h[1-6]|ul|ol|li)\b[^>]*>/;
-
-  const latexRegex = /\\(?:begin|end|section|subsection|textbf|textit|item)\{/;
-
-  if (latexRegex.test(text)) {
+  if (LATEX_PATTERN.test(text)) {
     return outputFormat.LaTeX;
-  } else if (htmlRegex.test(text)) {
+  } else if (HTML_PATTERN.test(text)) {
     return outputFormat.HTML;
   } else {
     return outputFormat.MARKDOWN;
   }
+}
+
+function containsHtml(text: string): boolean {
+  return HTML_PATTERN.test(text);
+}
+
+function containsLatex(text: string): boolean {
+  return LATEX_PATTERN.test(text);
+}
+
+function normalizeMarkdown(markdown: string): string {
+  return markdown
+    .replace(/\r\n/g, '\n')
+    .replace(/-\s{2,}/g, '- ')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function convertHtmlToMarkdown(html: string): string {
+  const turndownService = new TurndownService({
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+    emDelimiter: '*',
+    headingStyle: 'atx',
+    strongDelimiter: '**',
+  });
+  turndownService.use(gfm);
+
+  return turndownService.turndown(html);
 }
 
 async function convertWithPandoc(text: string): Promise<string | null> {
@@ -381,32 +414,19 @@ export async function formatContent(content: string): Promise<string> {
 
   const pandocResult = await convertWithPandoc(formattedContent);
 
-  if (!pandocResult) {
-    const fallbackFormat = detectInputFormat(formattedContent);
+  if (pandocResult !== null) {
+    formattedContent = pandocResult;
+  } else {
+    if (containsHtml(formattedContent)) {
+      formattedContent = convertHtmlToMarkdown(formattedContent);
+    }
 
-    if (fallbackFormat === outputFormat.HTML) {
-      const turndownService = new TurndownService({
-        bulletListMarker: '-',
-        codeBlockStyle: 'fenced',
-        emDelimiter: '*',
-        headingStyle: 'atx',
-        strongDelimiter: '**',
-      });
-      turndownService.use(gfm);
-
-      formattedContent = turndownService
-        .turndown(formattedContent)
-        .replace(/-\s{2,}/g, '- ')
-        .trim();
-    } else if (fallbackFormat === outputFormat.LaTeX) {
+    if (containsLatex(formattedContent)) {
       formattedContent = convertLatexToMarkdown(formattedContent);
     }
-  } else {
-    formattedContent = pandocResult;
   }
-  // .replace(/ +$/gm, ''); // Remove trailing spaces only
 
-  return formattedContent;
+  return normalizeMarkdown(formattedContent);
 }
 
 /**


### PR DESCRIPTION
## Summary
- normalize markdown output and reuse helpers when formatting scratchpad fallbacks
- run HTML and LaTeX fallback conversions sequentially to cover mixed content
- expand xmlUtils.formatContent tests to cover mixed, markdown, and empty inputs

## Testing
- npm run lint
- npm run compile-tests
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68d85f85559083249ab9a333078d8013

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes markdown output and sequentially converts HTML then LaTeX for mixed scratchpad content, with refactors and expanded tests.
> 
> - **Utils (`src/utils/text/xmlUtils.ts`)**:
>   - **Formatting pipeline**: If Pandoc unavailable, sequentially convert `HTML` then `LaTeX` and finally `normalizeMarkdown` for consistent output.
>   - **Normalization**: Add `normalizeMarkdown` to fix spacing, list markers, trailing spaces, and excessive newlines.
>   - **LaTeX conversion**: Insert blank line after `\section`/`\subsection`, prefix list items with newline, and collapse extra newlines.
>   - **Refactor**: Extract `convertHtmlToMarkdown`, `containsHtml`, `containsLatex`, and shared `HTML_PATTERN`/`LATEX_PATTERN`; reuse in `detectInputFormat`.
> - **Tests (`src/test/utils/text/xmlUtils.test.ts`)**:
>   - Update expectations to include blank line before lists.
>   - Add cases for mixed HTML+LaTeX, markdown normalization, and empty input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47b0961af67947f90f097977b02a0ee9f8aea6e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->