### PR TITLE
fix: persist toggle states as arrays

### DIFF
--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -115,7 +115,9 @@ class ToggleStates {
 
   clearAll() {
     this.states.clear();
-    this.saveCallback();
+    if (this.saveCallback) {
+      this.saveCallback();
+    }
   }
 
   /** Get all entries for serialization */
@@ -184,9 +186,28 @@ export class ProgressViewState {
   initialize() {
     const previous = this.stateManager.getState();
     if (previous.groupToggleStates) {
-      const data = previous.groupToggleStates;
-      const isValidArray = Array.isArray(data);
-      if (!isValidArray) {
+      let data = previous.groupToggleStates;
+      if (!Array.isArray(data) && typeof data === 'string') {
+        try {
+          const parsed = JSON.parse(data);
+          if (Array.isArray(parsed)) {
+            data = parsed;
+          } else {
+            console.error(
+              'Failed to restore group toggle states: parsed data is not an array',
+            );
+            return;
+          }
+        } catch (error) {
+          console.error(
+            'Failed to restore group toggle states: could not parse legacy string data',
+            error,
+          );
+          return;
+        }
+      }
+
+      if (!Array.isArray(data)) {
         console.error(
           'Failed to restore group toggle states: data is not an array',
         );

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -184,20 +184,40 @@ export class ProgressViewState {
   initialize() {
     const previous = this.stateManager.getState();
     if (previous.groupToggleStates) {
-      try {
-        const data = JSON.parse(previous.groupToggleStates);
-        this.toggleStates.load(data);
-      } catch (e) {
-        console.error('Failed to restore group toggle states:', e);
+      const data = previous.groupToggleStates;
+      const isValidArray = Array.isArray(data);
+      if (!isValidArray) {
+        console.error(
+          'Failed to restore group toggle states: data is not an array',
+        );
+        return;
       }
+
+      const hasValidEntries = data.every((entry) => {
+        if (!Array.isArray(entry) || entry.length !== 2) {
+          return false;
+        }
+        const [id, collapsed] = entry;
+        return typeof id === 'string' && typeof collapsed === 'boolean';
+      });
+
+      if (!hasValidEntries) {
+        console.error(
+          'Failed to restore group toggle states: invalid entry format',
+        );
+        return;
+      }
+
+      this.toggleStates.load(data);
     }
   }
 
   /** Persist the current group toggle states. */
   save() {
     try {
-      const serialized = JSON.stringify(this.toggleStates.entries());
-      this.stateManager.update({ groupToggleStates: serialized });
+      this.stateManager.update({
+        groupToggleStates: this.toggleStates.entries(),
+      });
     } catch (e) {
       console.error('Failed to save state:', e);
     }


### PR DESCRIPTION
## Summary
- store progress view toggle state entries directly in the webview state manager
- validate restored toggle state arrays before loading them into the map

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68d6f87e38e883249c6e371e11e445ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Store `groupToggleStates` as arrays with validation and legacy parsing; guard save-callback usage.
> 
> - **Progress View State**:
>   - **Persistence**: Save `groupToggleStates` directly as arrays (remove JSON stringification).
>   - **Initialization**: Handle legacy string format, parse if needed, and validate entries are `[id: string, collapsed: boolean]` before loading; log and exit on invalid data.
> - **Toggle States**:
>   - **clearAll**: Only call `saveCallback` if defined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f87d117964cc876cf40f99bb7b424860e93640e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->