### PR TITLE
Fix history view toggle state persistence

### DIFF
--- a/src/historyView/modules/historyViewState.js
+++ b/src/historyView/modules/historyViewState.js
@@ -40,26 +40,23 @@ export class HistoryViewState {
   }
 
   initialize() {
-    const saved = this.stateManager.getState();
+    const saved = this.stateManager.getState() ?? {};
     this.searchIndex = saved.searchIndex || 0;
     this.totalMatches = saved.totalMatches || 0;
-    if (saved.toggleStates) {
-      try {
-        const data = JSON.parse(saved.toggleStates);
-        this.toggleStates.load(data);
-      } catch (e) {
-        console.error('Failed to restore toggle states', e);
-      }
+    const { toggleStates } = saved;
+    if (Array.isArray(toggleStates)) {
+      this.toggleStates.load(toggleStates);
+    } else if (toggleStates !== undefined) {
+      console.error('Failed to restore toggle states: expected an array.');
     }
   }
 
   save() {
     try {
-      const serialized = JSON.stringify(this.toggleStates.entries());
       this.stateManager.update({
         searchIndex: this.searchIndex,
         totalMatches: this.totalMatches,
-        toggleStates: serialized,
+        toggleStates: this.toggleStates.entries(),
       });
     } catch (e) {
       console.error('Failed to save state', e);

--- a/src/historyView/modules/historyViewState.js
+++ b/src/historyView/modules/historyViewState.js
@@ -40,12 +40,25 @@ export class HistoryViewState {
   }
 
   initialize() {
-    const saved = this.stateManager.getState() ?? {};
+    const state = this.stateManager.getState();
+    const saved = typeof state === 'object' && state !== null ? state : {};
     this.searchIndex = saved.searchIndex || 0;
     this.totalMatches = saved.totalMatches || 0;
     const { toggleStates } = saved;
     if (Array.isArray(toggleStates)) {
       this.toggleStates.load(toggleStates);
+    } else if (typeof toggleStates === 'string') {
+      try {
+        const parsed = JSON.parse(toggleStates);
+        if (Array.isArray(parsed)) {
+          this.toggleStates.load(parsed);
+          this.save();
+        } else {
+          console.error('Failed to restore toggle states: expected an array.');
+        }
+      } catch (e) {
+        console.error('Failed to migrate toggle states from string.', e);
+      }
     } else if (toggleStates !== undefined) {
       console.error('Failed to restore toggle states: expected an array.');
     }


### PR DESCRIPTION
## Summary
- store history view toggle state data without JSON serialization
- gracefully restore toggle states only when the saved payload is an array

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6f86fe2108324a10bf9cdd25b2a30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Store `toggleStates` as an array instead of a JSON string and add safe restoration/migration with validation and error handling.
> 
> - **History View State (`src/historyView/modules/historyViewState.js`)**:
>   - **State persistence**: Save `toggleStates` directly as an array via `this.toggleStates.entries()` instead of a JSON string.
>   - **Initialization/migration**:
>     - Safely read saved state; default to `{}` when `getState()` is non-object.
>     - Restore `toggleStates` when it's an array; if it's a string, JSON-parse and validate as array, then migrate and save.
>     - Add validation and clearer error logs when payload is invalid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c80454c0aecf2f6c76c496e8a11350e32b4ab94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->