### PR TITLE
fix: persist restore state context object

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -204,33 +204,45 @@ export class MainViewProvider
     if (hasStateToRestore) {
       try {
         // Get the stored state
-        const stateJson = await vscode.commands.executeCommand(
+        const storedState = await vscode.commands.executeCommand(
           'getContext',
           'texra.stateToRestore',
         );
-        if (stateJson) {
-          const state = JSON.parse(stateJson as string);
 
+        let state: unknown = storedState;
+        if (typeof storedState === 'string') {
+          try {
+            state = JSON.parse(storedState);
+          } catch (parseError) {
+            console.warn(
+              'Failed to parse legacy state stored as JSON string:',
+              parseError,
+            );
+            state = undefined;
+          }
+        }
+
+        if (state && typeof state === 'object') {
           // Send the state to the webview
           webviewView.webview.postMessage({
             command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
             state,
           });
 
-          // Clear the stored state
-          await vscode.commands.executeCommand(
-            'setContext',
-            'texra.hasStateToRestore',
-            false,
-          );
-          await vscode.commands.executeCommand(
-            'setContext',
-            'texra.stateToRestore',
-            '',
-          );
-
           console.log('Restored state from context');
         }
+
+        // Clear the stored state regardless of success to avoid loops
+        await vscode.commands.executeCommand(
+          'setContext',
+          'texra.hasStateToRestore',
+          false,
+        );
+        await vscode.commands.executeCommand(
+          'setContext',
+          'texra.stateToRestore',
+          undefined,
+        );
       } catch (error) {
         console.error('Error restoring state from context:', error);
       }

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -208,7 +208,7 @@ export class MainViewProvider
           }
         }
 
-        if (state && typeof state === 'object') {
+        if (state && typeof state === 'object' && !Array.isArray(state)) {
           // Send the state to the webview
           webviewView.webview.postMessage({
             command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
@@ -217,7 +217,9 @@ export class MainViewProvider
 
           console.log('Restored state from context');
         }
-
+      } catch (error) {
+        console.error('Error restoring state from context:', error);
+      } finally {
         // Clear the stored state regardless of success to avoid loops
         await vscode.commands.executeCommand(
           'setContext',
@@ -229,8 +231,6 @@ export class MainViewProvider
           'texra.stateToRestore',
           undefined,
         );
-      } catch (error) {
-        console.error('Error restoring state from context:', error);
       }
     }
   }

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -65,7 +65,7 @@ async function restoreState(config: any) {
         await vscode.commands.executeCommand(
           'setContext',
           'texra.stateToRestore',
-          JSON.stringify(stateToRestore),
+          stateToRestore,
         );
 
         // Try to focus the main view to trigger its activation
@@ -88,7 +88,7 @@ async function restoreState(config: any) {
       await vscode.commands.executeCommand(
         'setContext',
         'texra.stateToRestore',
-        JSON.stringify(stateToRestore),
+        stateToRestore,
       );
 
       // Try to focus the main view to trigger its activation


### PR DESCRIPTION
## Summary
- stop serializing the restore-state payload before storing it in command context
- treat the stored restore payload as an object in the main view provider while tolerating legacy string values
- clear the restore-state context by resetting it to `undefined`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6f85b00888324b1dce24a2cd66a37

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Persist restore-state as an object in context, make restore tolerant of legacy string values, and always clear context safely after handling.
> 
> - **Main view provider (`src/MainViewProvider.ts`)**:
>   - Restore: accept context state as an object or parse legacy JSON string; validate object before posting `STATE_RESTORE`.
>   - Cleanup: always clear context in `finally` (`texra.hasStateToRestore=false`, `texra.stateToRestore=undefined`).
> - **State restore command (`src/commands/history/stateRestoreCommand.ts`)**:
>   - Store raw state object in context (no JSON stringify) for both primary and fallback paths; still focuses `texra.mainView` to trigger restore.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d67d8017897925d63f2021c13acec2c5431525a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->