### PR TITLE
feat: enhance file refresh feedback

### DIFF
--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -98,8 +98,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleGenericFileSelected(m),
 
       // Request file commands
-      [MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE]: async (_m, w) =>
-        this.fileManager.handleRequestInputFile(w),
+      [MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE]: async (m, w) =>
+        this.fileManager.handleRequestInputFile(m, w),
       [MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE]: async (m, w) =>
         this.fileManager.handleRequestFile(m, w),
       [MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE]: async (m, w) =>
@@ -108,8 +108,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleRequestFile(m, w),
       [MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE]: async (m, w) =>
         this.fileManager.handleRequestEditedFile(m, w),
-      [MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE]: async (_m, w) =>
-        this.fileManager.handleRequestBaseFile(w),
+      [MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE]: async (m, w) =>
+        this.fileManager.handleRequestBaseFile(m, w),
       [MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES]: async (m, w) =>
         this.fileManager.handleRequestDefaultOutputFiles(m, w),
 
@@ -266,8 +266,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleUpdateFiles(m, w),
 
       // Git/diff operations
-      [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: async (_m, w) =>
-        this.diffManager.handleRequestRecentCommits(w),
+      [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: async (m, w) =>
+        this.diffManager.handleRequestRecentCommits(m, w),
       [MAIN_VIEW_COMMANDS.REFRESH_COMMITS]: async (_m, w) =>
         this.diffManager.handleRefreshCommits(w),
       [MAIN_VIEW_COMMANDS.LATEXDIFF]: async (m) =>

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -93,6 +93,5 @@ export class DiffManager {
         : 'This workspace is not a Git repository.');
 
     logger.info(CHANNEL, infoMessage);
-    vscode.window.showInformationMessage(infoMessage);
   }
 }

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -86,11 +86,9 @@ export class DiffManager {
       return;
     }
 
-    const infoMessage =
-      message?.emptyMessage ||
-      (result.isGitRepo
-        ? 'No recent commits found for this repository.'
-        : 'This workspace is not a Git repository.');
+    const infoMessage = result.isGitRepo
+      ? 'No recent commits found for this repository.'
+      : 'This workspace is not a Git repository.';
 
     logger.info(CHANNEL, infoMessage);
   }

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -59,9 +59,11 @@ export class DiffManager {
   }
 
   async handleRequestRecentCommits(
+    message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const result = await this._fetchRecentCommits();
+    this._notifyWhenEmpty(message, result);
     webviewView.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
       ...result,
@@ -74,5 +76,23 @@ export class DiffManager {
       command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
       ...result,
     });
+  }
+
+  private _notifyWhenEmpty(
+    message: any,
+    result: { commits: string[]; isGitRepo: boolean },
+  ): void {
+    if (!message?.notifyWhenEmpty) {
+      return;
+    }
+
+    const infoMessage =
+      message?.emptyMessage ||
+      (result.isGitRepo
+        ? 'No recent commits found for this repository.'
+        : 'This workspace is not a Git repository.');
+
+    logger.info(CHANNEL, infoMessage);
+    vscode.window.showInformationMessage(infoMessage);
   }
 }

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -86,10 +86,13 @@ export class DiffManager {
       return;
     }
 
-    const infoMessage = result.isGitRepo
-      ? 'No recent commits found for this repository.'
-      : 'This workspace is not a Git repository.';
+    if (result.commits.length === 0 || !result.isGitRepo) {
+      const infoMessage = result.isGitRepo
+        ? 'No recent commits found for this repository.'
+        : 'This workspace is not a Git repository.';
 
-    logger.info(CHANNEL, infoMessage);
+      logger.info(CHANNEL, infoMessage);
+      vscode.window.showInformationMessage(infoMessage);
+    }
   }
 }

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -388,22 +388,10 @@ export class FileManager {
     options: FileUpdateOptions = {},
   ): Promise<void> {
     if (options.notifyWhenEmpty && files.length === 0) {
-      const defaultMessages: Record<string, string> = {
-        Input: 'No input files found. Select a LaTeX file to continue.',
-        Reference:
-          'No reference files detected. Add context files or use the Add button.',
-        Auxiliary:
-          'No auxiliary files found. Include .cls, .sty, or .bib files as needed.',
-        Media:
-          'No media assets detected. Add images or PDFs to refresh this list.',
-        Edited:
-          'No edited files were found. Select a base file or generate edits to continue.',
-        Base: 'No input files are available to serve as a base. Select an input file first.',
-      };
-      const message =
-        defaultMessages[fileType] ||
-        `No ${fileType.toLowerCase()} files were found during refresh.`;
-      logger.info(CHANNEL, message);
+      logger.debug(
+        CHANNEL,
+        `No ${fileType.toLowerCase()} files were found during refresh.`,
+      );
     }
 
     webviewView.webview.postMessage({

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -27,6 +27,12 @@ import { WorkspaceFS } from '@utils/files';
 const CHANNEL = 'FileManager';
 logger.initialize(CHANNEL);
 
+type FileUpdateOptions = {
+  notifyWhenEmpty?: boolean;
+  emptyMessage?: string;
+  additionalPayload?: Record<string, unknown>;
+};
+
 export class FileManager {
   constructor(private readonly context: vscode.ExtensionContext) {}
 
@@ -80,12 +86,20 @@ export class FileManager {
     logger.debug(CHANNEL, `${message.command}: ${message.filePath}`);
   }
 
-  async handleRequestInputFile(webviewView: vscode.WebviewView): Promise<void> {
+  async handleRequestInputFile(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
     const refreshedInputFiles =
       (await vscode.commands.executeCommand<string[]>(
         'texra.refreshInputFiles',
       )) || [];
-    this.postFileUpdate(webviewView, 'Input', refreshedInputFiles);
+    await this.postFileUpdate(webviewView, 'Input', refreshedInputFiles, {
+      notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
+      emptyMessage:
+        message?.emptyMessage ||
+        'No input files found. Select a LaTeX file to continue.',
+    });
   }
 
   async handleRequestFile(
@@ -105,7 +119,19 @@ export class FileManager {
           return [];
       }
     })();
-    this.postFileUpdate(webviewView, fileType, files);
+    const defaultMessages: Record<string, string> = {
+      Reference:
+        'No reference files detected. Add context files or use the Add button.',
+      Auxiliary:
+        'No auxiliary files found. Include .cls, .sty, or .bib files as needed.',
+      Media:
+        'No media assets detected. Add images or PDFs to refresh this list.',
+    };
+
+    await this.postFileUpdate(webviewView, fileType, files, {
+      notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
+      emptyMessage: message?.emptyMessage || defaultMessages[fileType],
+    });
   }
 
   async handleRequestEditedFile(
@@ -120,11 +146,32 @@ export class FileManager {
       );
       allEditedFiles = await fileLister.listEditedFiles(baseFileNameForEdited);
     }
-    this.postFileUpdate(webviewView, 'Edited', allEditedFiles);
+    const emptyMessage =
+      message?.emptyMessage ||
+      (message.baseFile
+        ? 'No edited files match the selected base. Generate edits or select a different base file.'
+        : 'Select a base file to load edited files.');
+
+    await this.postFileUpdate(webviewView, 'Edited', allEditedFiles, {
+      notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
+      emptyMessage,
+    });
   }
 
-  async handleRequestBaseFile(webviewView: vscode.WebviewView): Promise<void> {
-    this.postFileUpdate(webviewView, 'Base', await fileLister.list('input'));
+  async handleRequestBaseFile(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const files = await fileLister.list('input');
+    await this.postFileUpdate(webviewView, 'Base', files, {
+      notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
+      emptyMessage:
+        message?.emptyMessage ||
+        'No input files are available to serve as a base. Select an input file first.',
+      additionalPayload: message?.preserveBaseFile
+        ? { preserveBaseFile: true }
+        : undefined,
+    });
   }
 
   async handleRequestDefaultOutputFiles(
@@ -362,8 +409,21 @@ export class FileManager {
     webviewView: vscode.WebviewView,
     fileType: string,
     files: string[],
+    options: FileUpdateOptions = {},
   ): Promise<void> {
-    webviewView.webview.postMessage({ command: `set${fileType}File`, files });
+    if (options.notifyWhenEmpty && files.length === 0) {
+      const message =
+        options.emptyMessage ||
+        `No ${fileType.toLowerCase()} files were found during refresh.`;
+      logger.info(CHANNEL, message);
+      vscode.window.showInformationMessage(message);
+    }
+
+    webviewView.webview.postMessage({
+      command: `set${fileType}File`,
+      files,
+      ...(options.additionalPayload ?? {}),
+    });
   }
 
   private async updateBaseFileSelect(

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -416,7 +416,6 @@ export class FileManager {
         options.emptyMessage ||
         `No ${fileType.toLowerCase()} files were found during refresh.`;
       logger.info(CHANNEL, message);
-      vscode.window.showInformationMessage(message);
     }
 
     webviewView.webview.postMessage({

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -29,7 +29,6 @@ logger.initialize(CHANNEL);
 
 type FileUpdateOptions = {
   notifyWhenEmpty?: boolean;
-  emptyMessage?: string;
   additionalPayload?: Record<string, unknown>;
 };
 
@@ -96,9 +95,6 @@ export class FileManager {
       )) || [];
     await this.postFileUpdate(webviewView, 'Input', refreshedInputFiles, {
       notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
-      emptyMessage:
-        message?.emptyMessage ||
-        'No input files found. Select a LaTeX file to continue.',
     });
   }
 
@@ -119,18 +115,8 @@ export class FileManager {
           return [];
       }
     })();
-    const defaultMessages: Record<string, string> = {
-      Reference:
-        'No reference files detected. Add context files or use the Add button.',
-      Auxiliary:
-        'No auxiliary files found. Include .cls, .sty, or .bib files as needed.',
-      Media:
-        'No media assets detected. Add images or PDFs to refresh this list.',
-    };
-
     await this.postFileUpdate(webviewView, fileType, files, {
       notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
-      emptyMessage: message?.emptyMessage || defaultMessages[fileType],
     });
   }
 
@@ -146,15 +132,8 @@ export class FileManager {
       );
       allEditedFiles = await fileLister.listEditedFiles(baseFileNameForEdited);
     }
-    const emptyMessage =
-      message?.emptyMessage ||
-      (message.baseFile
-        ? 'No edited files match the selected base. Generate edits or select a different base file.'
-        : 'Select a base file to load edited files.');
-
     await this.postFileUpdate(webviewView, 'Edited', allEditedFiles, {
       notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
-      emptyMessage,
     });
   }
 
@@ -165,9 +144,6 @@ export class FileManager {
     const files = await fileLister.list('input');
     await this.postFileUpdate(webviewView, 'Base', files, {
       notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
-      emptyMessage:
-        message?.emptyMessage ||
-        'No input files are available to serve as a base. Select an input file first.',
       additionalPayload: message?.preserveBaseFile
         ? { preserveBaseFile: true }
         : undefined,
@@ -412,8 +388,20 @@ export class FileManager {
     options: FileUpdateOptions = {},
   ): Promise<void> {
     if (options.notifyWhenEmpty && files.length === 0) {
+      const defaultMessages: Record<string, string> = {
+        Input: 'No input files found. Select a LaTeX file to continue.',
+        Reference:
+          'No reference files detected. Add context files or use the Add button.',
+        Auxiliary:
+          'No auxiliary files found. Include .cls, .sty, or .bib files as needed.',
+        Media:
+          'No media assets detected. Add images or PDFs to refresh this list.',
+        Edited:
+          'No edited files were found. Select a base file or generate edits to continue.',
+        Base: 'No input files are available to serve as a base. Select an input file first.',
+      };
       const message =
-        options.emptyMessage ||
+        defaultMessages[fileType] ||
         `No ${fileType.toLowerCase()} files were found during refresh.`;
       logger.info(CHANNEL, message);
     }

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -212,18 +212,122 @@ export class FileInputManager extends BaseUIManager {
   }
 
   _setupRefreshIcons() {
+    const iconConfigs = [
+      {
+        className: 'codicon-file-code',
+        getRequests: () => [
+          {
+            command: MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE,
+            payload: {
+              notifyWhenEmpty: true,
+              emptyMessage:
+                'No input files found. Open a LaTeX file or use the Current button.',
+            },
+          },
+        ],
+      },
+      {
+        className: 'codicon-book',
+        getRequests: () => [
+          {
+            command: MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE,
+            payload: {
+              notifyWhenEmpty: true,
+              emptyMessage:
+                'No reference files detected. Add context files or use the Add button.',
+            },
+          },
+        ],
+      },
+      {
+        className: 'codicon-file-add',
+        getRequests: () => [
+          {
+            command: MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE,
+            payload: {
+              notifyWhenEmpty: true,
+              emptyMessage:
+                'No auxiliary files found (e.g., .cls, .sty, .bib).',
+            },
+          },
+        ],
+      },
+      {
+        className: 'codicon-file-media',
+        getRequests: () => [
+          {
+            command: MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
+            payload: {
+              notifyWhenEmpty: true,
+              emptyMessage:
+                'No media assets detected. Add images or PDFs to refresh this list.',
+            },
+          },
+        ],
+      },
+      {
+        className: 'codicon-edit',
+        getRequests: () => {
+          const baseFile = safeGetElementValue(BASE_FILE);
+          return [
+            {
+              command: MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE,
+              payload: {
+                preserveBaseFile: true,
+              },
+            },
+            {
+              command: MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE,
+              payload: {
+                baseFile,
+                preserveSelection: safeGetElementValue(EDITED_FILE),
+                notifyWhenEmpty: true,
+                emptyMessage: baseFile
+                  ? 'No edited files match the selected base. Generate edits or select a different base file.'
+                  : 'Select a base file to load edited files.',
+              },
+            },
+          ];
+        },
+      },
+      {
+        className: 'codicon-git-commit',
+        getRequests: () => [
+          {
+            command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
+            payload: {
+              notifyWhenEmpty: true,
+              emptyMessage:
+                'No recent commits found. Ensure the workspace is a Git repository.',
+            },
+          },
+        ],
+      },
+    ];
+
     const icons = document.querySelectorAll(
       '.file-select-header label .codicon.clickable',
     );
+
     icons.forEach((icon) => {
-      if (icon.classList.contains('codicon-git-commit')) {
-        const handler = () => {
-          this.vscode.postMessage({
-            command: MAIN_VIEW_COMMANDS.REFRESH_COMMITS,
-          });
-        };
-        this.addListener(icon, 'click', handler);
+      const config = iconConfigs.find((item) =>
+        icon.classList.contains(item.className),
+      );
+      if (!config) {
+        return;
       }
+
+      const handler = () => {
+        const requests = config.getRequests ? config.getRequests() : [];
+        requests.forEach(({ command, payload = {} }) => {
+          this.vscode.postMessage({
+            command,
+            ...payload,
+          });
+        });
+      };
+
+      this.addListener(icon, 'click', handler);
     });
   }
 

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -220,8 +220,6 @@ export class FileInputManager extends BaseUIManager {
             command: MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE,
             payload: {
               notifyWhenEmpty: true,
-              emptyMessage:
-                'No input files found. Open a LaTeX file or use the Current button.',
             },
           },
         ],
@@ -233,8 +231,6 @@ export class FileInputManager extends BaseUIManager {
             command: MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE,
             payload: {
               notifyWhenEmpty: true,
-              emptyMessage:
-                'No reference files detected. Add context files or use the Add button.',
             },
           },
         ],
@@ -246,8 +242,6 @@ export class FileInputManager extends BaseUIManager {
             command: MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE,
             payload: {
               notifyWhenEmpty: true,
-              emptyMessage:
-                'No auxiliary files found (e.g., .cls, .sty, .bib).',
             },
           },
         ],
@@ -259,8 +253,6 @@ export class FileInputManager extends BaseUIManager {
             command: MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
             payload: {
               notifyWhenEmpty: true,
-              emptyMessage:
-                'No media assets detected. Add images or PDFs to refresh this list.',
             },
           },
         ],
@@ -282,9 +274,6 @@ export class FileInputManager extends BaseUIManager {
                 baseFile,
                 preserveSelection: safeGetElementValue(EDITED_FILE),
                 notifyWhenEmpty: true,
-                emptyMessage: baseFile
-                  ? 'No edited files match the selected base. Generate edits or select a different base file.'
-                  : 'Select a base file to load edited files.',
               },
             },
           ];
@@ -297,8 +286,6 @@ export class FileInputManager extends BaseUIManager {
             command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
             payload: {
               notifyWhenEmpty: true,
-              emptyMessage:
-                'No recent commits found. Ensure the workspace is a Git repository.',
             },
           },
         ],

--- a/test/manual/file-refresh-checklist.md
+++ b/test/manual/file-refresh-checklist.md
@@ -1,0 +1,31 @@
+# File Refresh Icon QA Checklist
+
+Use this checklist after building the webview bundle to confirm the refresh icons repopulate their dropdowns correctly.
+
+1. **Input files (codicon-file-code)**
+   - Open a workspace with at least one `.tex` file.
+   - Remove the file from the input dropdown, then click the input refresh icon.
+   - Confirm the input dropdown repopulates with available LaTeX files.
+   - Repeat after renaming or deleting the file and ensure the info toast explains why nothing changed when no files are available.
+2. **Reference files (codicon-book)**
+   - Add a `.tex` or `.pdf` example file to the workspace and click the reference refresh icon.
+   - Verify the reference dropdown updates with the new file.
+   - Temporarily move the reference file out of the workspace, click refresh again, and confirm the empty-state toast appears.
+3. **Auxiliary files (codicon-file-add)**
+   - Place a `.cls` or `.sty` file in the workspace and refresh auxiliary files.
+   - Confirm the dropdown contains the auxiliary asset.
+   - Remove the auxiliary asset and refresh to confirm the informational toast explains the empty result.
+4. **Media files (codicon-file-media)**
+   - Add an image (e.g., `.png`) to the workspace and refresh media files.
+   - Ensure the media dropdown lists the new asset.
+   - Remove or rename the asset and refresh to check for the empty-state toast.
+5. **Base/Edited files (codicon-edit)**
+   - Select a base file, then click the edited refresh icon.
+   - Confirm the base selector stays populated and the edited dropdown shows files that match the selected base.
+   - Clear the base selection and click refresh again; verify the toast instructs you to choose a base file.
+6. **Git commits (codicon-git-commit)**
+   - Open a Git workspace and click the commit refresh icon.
+   - Ensure the commit dropdown repopulates with recent commits.
+   - Open a non-Git workspace and click refresh to confirm the toast clarifies that no commits were found.
+
+Document any discrepancies before shipping.


### PR DESCRIPTION
## Summary
- map clickable file refresh icons to their request commands and chained updates
- surface informative toasts when refreshes return no results, including commit lists
- add a manual QA checklist covering every refresh icon scenario

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6f43c01f4832493781629982bebcc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refresh icons now trigger specific file/commit requests with payloads and show informational toasts when results are empty; adds QA checklist.
> 
> - **Webview UI**:
>   - Map refresh icons to request commands with payloads (e.g., `REQUEST_INPUT_FILE`, `REQUEST_REFERENCE_FILE`, `REQUEST_AUXILIARY_FILE`, `REQUEST_MEDIA_FILE`, `REQUEST_BASE_FILE`, `REQUEST_EDITED_FILE`, `REQUEST_RECENT_COMMITS`).
>   - Include `notifyWhenEmpty`, `preserveBaseFile`, and edited-file context in payloads; remove ad-hoc `REFRESH_COMMITS` click handler.
> - **FileManager**:
>   - Request handlers accept `message` and pass options to `postFileUpdate` for empty-state awareness and extra payloads.
>   - `postFileUpdate` supports `notifyWhenEmpty` logging and `additionalPayload` (e.g., `{ preserveBaseFile: true }`).
> - **DiffManager**:
>   - `handleRequestRecentCommits` accepts `message`; when `notifyWhenEmpty` is set, logs and shows info when no commits or not a Git repo.
> - **MainViewMessageHandler**:
>   - Pass `message` to `handleRequestInputFile`, `handleRequestBaseFile`, and `handleRequestRecentCommits`.
> - **Docs**:
>   - Add `test/manual/file-refresh-checklist.md` covering all refresh icon scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bea9ff30327cc99c4ec1675d49a5f21eadbc8df0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->