### PR TITLE
docs: update changelog and guidance for recent state fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ When updating CHANGELOG.md:
 ### Pragmatic implementations
 
 - **Lead with Occam's Razor**: prioritize the simplest implementation that fully solves the problem before considering additional abstractions or indirection. Each new helper, class, or configuration option must earn its place by clearly reducing complexity.
+- Default to "stupid simple" solutions that rely on core JavaScript/TypeScript data structures, native VS Code APIs, and structured objects. Avoid stringifying state or inventing custom serialization when SDK helpers, JSON objects, or Maps/Sets already solve the problem.
 - Favor solutions that are readable and straightforward over exhaustive edge-case handling.
 - Avoid over-engineering and unnecessary abstractions when a direct approach communicates intent better.
 - Keep generated code tight: trim redundant helpers, repeated type checks, or defensive guards that do not serve a demonstrated scenario.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Improvements
 
 - Update Gemini 2.5 Flash preview entries to the September 2025 release.
+- Refresh Qwen-Max and Qwen Plus integrations with updated pricing, naming, and thinking support in the DashScope handler.
+- Harden progress view state handling with validation on task groups, toggles, and stream statuses to prevent invalid data from corrupting summaries.
+- Restore main view configurations using the shared task-state helper so history entries hydrate without manual JSON juggling.
 
-### Improvements
+### Bug Fixes
 
-- Refresh Qwen-Max and Qwen Plus integrations with updated pricing, naming, and thinking support in the DashScope handler
+- Migrate history view toggle state persistence from JSON strings to structured arrays so expansion settings reliably load across versions.
+- Clear queued restore context when the main view fails to initialize, preventing stale state from resurfacing on the next activation.
 
 ## [0.33.7] - 2025-09-22
 


### PR DESCRIPTION
## Summary
- document the recent progress view and state restore changes in the unreleased changelog entry
- note the history view toggle migration and failure handling fixes for state restoration
- reinforce the repository guidelines to favor simple solutions using native data structures over stringified state

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d8805584e48324a12fd5a0251fec36

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `CHANGELOG.md` (0.33.8) with state-handling improvements/bug fixes and Qwen/DashScope details, and adds guidance in `AGENTS.md` to favor simple native data structures over stringified state.
> 
> - **Documentation**:
>   - Add guidance in `AGENTS.md` to default to simple native structures and VS Code APIs; avoid stringified state/custom serialization.
> - **Changelog (`0.33.8` Unreleased)**:
>   - **Improvements**:
>     - Refresh Qwen-Max/Qwen Plus entries with updated pricing/naming and thinking support in DashScope handler.
>     - Harden progress view state handling with validation for task groups, toggles, and stream statuses.
>     - Restore main view configurations via shared task-state helper (no manual JSON).
>   - **Bug Fixes**:
>     - Migrate history view toggle persistence from JSON strings to structured arrays.
>     - Clear queued restore context when main view initialization fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5095a703f95a146529966001b37634d3eef78d87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->