### PR TITLE
feat: seed default custom agents directory

### DIFF
--- a/docs/guide/agent-explorer.md
+++ b/docs/guide/agent-explorer.md
@@ -9,7 +9,7 @@ The TeXRA extension includes a dedicated **Agent Explorer** view within the VS C
 The Agent Explorer is organized into two main sections:
 
 1.  **Built-in Agents**: This section displays the standard agents that come bundled with the TeXRA extension. These files (`.yaml`) define the core functionalities like `correct`, `polish`, `draw`, etc.
-2.  **Custom Agents**: This section displays agents that you have created or added yourself. This directory's location can be customized in the VS Code settings via `texra.explorer.agentsDirectory` and must be an absolute path. If this setting is not configured, or the directory doesn't exist, this section might not appear.
+2.  **Custom Agents**: This section displays agents that you have created or added yourself. When the `texra.explorer.agentsDirectory` setting is left blank, TeXRA seeds a `custom_agents` folder inside its global storage and shows it here automatically. You can override the location with an absolute path in VS Code settings if you want to manage the files elsewhere.
 
 ## Browsing and Viewing Agents
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -16,10 +16,10 @@ Follow these steps to create a new custom agent:
 
 ### Step 1: Locate or Configure the Custom Agents Directory
 
-Custom agents reside in a specific directory.
+Custom agents reside in a dedicated directory that TeXRA prepares for you.
 
-1.  **Find Existing**: Look for the "Custom Agents" folder within the [Agent Explorer](./agent-explorer.md).
-2.  **Configure (Optional)**: If the folder doesn't exist or you want to use a different location, set the absolute path in VS Code Settings (`Ctrl+,`) under `texra.explorer.agentsDirectory`.
+1.  **Find the Default Folder**: TeXRA automatically seeds a `custom_agents` directory inside its global storage. Look for the "Custom Agents" section in the [Agent Explorer](./agent-explorer.md); it points to this location by default.
+2.  **Override (Optional)**: If you prefer to manage agents elsewhere, set an absolute path in VS Code Settings (`Ctrl+,`) under `texra.explorer.agentsDirectory`. TeXRA will ensure that directory exists and use it instead of the default.
 
 ### Automatic Creation
 

--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -85,7 +85,7 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
         ),
       );
 
-      const customPath = await agentDirectories.custom();
+      const customPath = await agentDirectories.custom(this.context);
       if (customPath) {
         items.push(
           new FileItem(

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -50,7 +50,7 @@ async function getAgentDirectories(
   context: vscode.ExtensionContext,
 ): Promise<AgentDirectoryMap> {
   return {
-    custom: await agentDirectories.custom(),
+    custom: await agentDirectories.custom(context),
     builtIn: await agentDirectories.builtIn(context),
     builtInToolUse: await agentDirectories.builtInToolUse(context),
   };

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -73,7 +73,7 @@ export async function getAgentPath(
 ): Promise<AgentPathResolution> {
   try {
     // First check custom agents directory
-    const customDir = await agentDirectories.custom();
+    const customDir = await agentDirectories.custom(context);
     if (customDir) {
       const customMatches = await glob(`**/${agentName}.yaml`, {
         cwd: customDir,
@@ -114,7 +114,7 @@ export async function getAgentPath(
       const view = await vscode.commands.executeCommand<vscode.WebviewView>(
         'texra.getWebviewView',
       );
-      const customDir = await agentDirectories.custom();
+      const customDir = await agentDirectories.custom(context);
       view?.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER,
         agentName,

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -236,7 +236,7 @@ async function handleCreateAgentWithAI(context: vscode.ExtensionContext) {
       outputFilesYaml = files.map((f) => `    - ${f}`).join('\n');
     }
 
-    const targetDir = await agentDirectories.ensureCustom();
+    const targetDir = await agentDirectories.custom(context);
 
     const filePath = vscode.Uri.file(`${targetDir}/${agentName}.yaml`);
 

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -237,9 +237,6 @@ async function handleCreateAgentWithAI(context: vscode.ExtensionContext) {
     }
 
     const targetDir = await agentDirectories.ensureCustom();
-    if (!targetDir) {
-      return;
-    }
 
     const filePath = vscode.Uri.file(`${targetDir}/${agentName}.yaml`);
 

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -106,9 +106,6 @@ export class ExplorerOperations {
   private async createCustomCopy(uri: vscode.Uri) {
     try {
       const customPath = await agentDirectories.ensureCustom();
-      if (!customPath) {
-        return;
-      }
 
       const base = uri.fsPath.startsWith(this.builtInToolUsePath)
         ? this.builtInToolUsePath
@@ -137,9 +134,6 @@ export class ExplorerOperations {
   async create(node: FileItem | undefined, isFolder: boolean) {
     try {
       const customBase = await agentDirectories.ensureCustom();
-      if (!customBase) {
-        return;
-      }
 
       let parentPath = node?.resourceUri.fsPath || customBase;
 

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -105,7 +105,7 @@ export class ExplorerOperations {
 
   private async createCustomCopy(uri: vscode.Uri) {
     try {
-      const customPath = await agentDirectories.ensureCustom();
+      const customPath = await agentDirectories.custom(this.context);
 
       const base = uri.fsPath.startsWith(this.builtInToolUsePath)
         ? this.builtInToolUsePath
@@ -133,7 +133,7 @@ export class ExplorerOperations {
 
   async create(node: FileItem | undefined, isFolder: boolean) {
     try {
-      const customBase = await agentDirectories.ensureCustom();
+      const customBase = await agentDirectories.custom(this.context);
 
       let parentPath = node?.resourceUri.fsPath || customBase;
 

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -46,7 +46,7 @@ export class WatcherManager {
       const builtInToolUsePath = await agentDirectories.builtInToolUse(
         this.context,
       );
-      const customAgentsPath = await agentDirectories.custom();
+      const customAgentsPath = await agentDirectories.custom(this.context);
 
       const pathsToWatch = [builtInAgentsPath, builtInToolUsePath];
       if (customAgentsPath) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { initializeStateManagers } from '@common/state/stateManager';
 import { FileLister } from '@frontend/files/fileLister';
 import { bus } from '@eventBus/ProgressEventBus';
 import { ToolUseSessionManager } from '@agent/toolUse/ToolUseSessionManager';
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -89,6 +90,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize storage systems
   SecretManager.initialize(context);
   StorageFS.initialize(context);
+  agentDirectories.initialize(context);
   await StorageFS.ensureDir(TASK_RUNS_DIR);
   initializeStateManagers(context);
   FileLister.initialize(context);

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -14,7 +14,7 @@ import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
 
 const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
-const DEFAULT_CUSTOM_AGENTS_DIRNAME = 'custom_agents';
+const DEFAULT_CUSTOM_AGENTS_DIR_NAME = 'custom_agents';
 
 export class AgentDirectoryManager {
   private context: vscode.ExtensionContext | undefined;
@@ -65,8 +65,23 @@ export class AgentDirectoryManager {
 
   private async ensureDefaultCustomDir(): Promise<string> {
     this.ensureInitialized();
-    await GlobalStorageFS.ensureDir(DEFAULT_CUSTOM_AGENTS_DIRNAME);
-    const defaultPath = GlobalStorageFS.fullPath(DEFAULT_CUSTOM_AGENTS_DIRNAME);
+
+    try {
+      await GlobalStorageFS.ensureDir(DEFAULT_CUSTOM_AGENTS_DIR_NAME);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(
+        CHANNEL,
+        `Failed to create default custom agents directory: ${message}`,
+      );
+      throw new Error(
+        'Unable to create custom agents directory. Please check permissions.',
+      );
+    }
+
+    const defaultPath = GlobalStorageFS.fullPath(
+      DEFAULT_CUSTOM_AGENTS_DIR_NAME,
+    );
     logger.debug(
       CHANNEL,
       `Using default custom agents directory: ${defaultPath}`,
@@ -94,6 +109,21 @@ export class AgentDirectoryManager {
       return undefined;
     }
 
+    const parentDir = path.dirname(configuredPath);
+    const parentExists = await AbsoluteFS.exists(parentDir);
+    if (!parentExists) {
+      logger.error(
+        CHANNEL,
+        `Parent directory does not exist for custom agents directory: ${parentDir}`,
+      );
+      await showLoggedMessageWithDocs(
+        CHANNEL,
+        'Parent directory for custom agents directory does not exist',
+        'custom-agents',
+      );
+      return undefined;
+    }
+
     await AbsoluteFS.ensureDir(configuredPath);
     logger.debug(
       CHANNEL,
@@ -104,7 +134,7 @@ export class AgentDirectoryManager {
 
   async custom(context?: vscode.ExtensionContext): Promise<string> {
     if (context) {
-      this.initialize(context);
+      this.context = context;
     }
 
     const configuredPath = getConfig<string>(

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -14,9 +14,11 @@ import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
 
 const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
-const DEFAULT_CUSTOM_DIR = 'custom_agents';
+const DEFAULT_CUSTOM_AGENTS_DIRNAME = 'custom_agents';
 
 export class AgentDirectoryManager {
+  private context: vscode.ExtensionContext | undefined;
+
   /**
    * Ensure a built-in agents directory exists and return its path.
    */
@@ -38,6 +40,21 @@ export class AgentDirectoryManager {
     return basePath;
   }
 
+  initialize(context: vscode.ExtensionContext): void {
+    this.context = context;
+    StorageFS.initialize(context);
+  }
+
+  private ensureInitialized(): void {
+    if (!this.context) {
+      throw new Error(
+        'Agent directories not initialized. Call agentDirectories.initialize(context) first.',
+      );
+    }
+
+    StorageFS.initialize(this.context);
+  }
+
   async builtIn(context: vscode.ExtensionContext): Promise<string> {
     return this.ensureBuiltInDir(context, 'agents');
   }
@@ -47,8 +64,9 @@ export class AgentDirectoryManager {
   }
 
   private async ensureDefaultCustomDir(): Promise<string> {
-    await GlobalStorageFS.ensureDir(DEFAULT_CUSTOM_DIR);
-    const defaultPath = GlobalStorageFS.fullPath(DEFAULT_CUSTOM_DIR);
+    this.ensureInitialized();
+    await GlobalStorageFS.ensureDir(DEFAULT_CUSTOM_AGENTS_DIRNAME);
+    const defaultPath = GlobalStorageFS.fullPath(DEFAULT_CUSTOM_AGENTS_DIRNAME);
     logger.debug(
       CHANNEL,
       `Using default custom agents directory: ${defaultPath}`,
@@ -56,11 +74,11 @@ export class AgentDirectoryManager {
     return defaultPath;
   }
 
-  async custom(): Promise<string> {
-    const configuredPath = getConfig<string>('explorer.agentsDirectory', '').trim();
-
+  private async resolveConfiguredCustomDir(
+    configuredPath: string,
+  ): Promise<string | undefined> {
     if (!configuredPath) {
-      return this.ensureDefaultCustomDir();
+      return undefined;
     }
 
     if (!path.isAbsolute(configuredPath)) {
@@ -73,7 +91,7 @@ export class AgentDirectoryManager {
         'Custom agents directory must be an absolute path',
         'custom-agents',
       );
-      return this.ensureDefaultCustomDir();
+      return undefined;
     }
 
     await AbsoluteFS.ensureDir(configuredPath);
@@ -82,6 +100,24 @@ export class AgentDirectoryManager {
       `Using custom agents directory from setting: ${configuredPath}`,
     );
     return configuredPath;
+  }
+
+  async custom(context?: vscode.ExtensionContext): Promise<string> {
+    if (context) {
+      this.initialize(context);
+    }
+
+    const configuredPath = getConfig<string>(
+      'explorer.agentsDirectory',
+      '',
+    ).trim();
+
+    const resolvedPath = await this.resolveConfiguredCustomDir(configuredPath);
+    if (resolvedPath) {
+      return resolvedPath;
+    }
+
+    return this.ensureDefaultCustomDir();
   }
 
   async promptCustom(): Promise<string | undefined> {
@@ -102,10 +138,6 @@ export class AgentDirectoryManager {
     await updateConfig('explorer.agentsDirectory', selectedPath);
 
     return selectedPath;
-  }
-
-  async ensureCustom(): Promise<string> {
-    return this.custom();
   }
 }
 

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -14,6 +14,7 @@ import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
 
 const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
+const DEFAULT_CUSTOM_DIR = 'custom_agents';
 
 export class AgentDirectoryManager {
   /**
@@ -45,27 +46,42 @@ export class AgentDirectoryManager {
     return this.ensureBuiltInDir(context, 'tool_use_agents');
   }
 
-  async custom(): Promise<string> {
-    const customPath = getConfig<string>('explorer.agentsDirectory', '');
+  private async ensureDefaultCustomDir(): Promise<string> {
+    await GlobalStorageFS.ensureDir(DEFAULT_CUSTOM_DIR);
+    const defaultPath = GlobalStorageFS.fullPath(DEFAULT_CUSTOM_DIR);
+    logger.debug(
+      CHANNEL,
+      `Using default custom agents directory: ${defaultPath}`,
+    );
+    return defaultPath;
+  }
 
-    if (!customPath) {
-      return '';
+  async custom(): Promise<string> {
+    const configuredPath = getConfig<string>('explorer.agentsDirectory', '').trim();
+
+    if (!configuredPath) {
+      return this.ensureDefaultCustomDir();
     }
 
-    if (!path.isAbsolute(customPath)) {
+    if (!path.isAbsolute(configuredPath)) {
       logger.error(
         CHANNEL,
-        `Custom agents directory must be an absolute path: ${customPath}`,
+        `Custom agents directory must be an absolute path: ${configuredPath}`,
       );
       await showLoggedMessageWithDocs(
         CHANNEL,
         'Custom agents directory must be an absolute path',
         'custom-agents',
       );
-      return '';
+      return this.ensureDefaultCustomDir();
     }
 
-    return customPath;
+    await AbsoluteFS.ensureDir(configuredPath);
+    logger.debug(
+      CHANNEL,
+      `Using custom agents directory from setting: ${configuredPath}`,
+    );
+    return configuredPath;
   }
 
   async promptCustom(): Promise<string | undefined> {
@@ -88,12 +104,8 @@ export class AgentDirectoryManager {
     return selectedPath;
   }
 
-  async ensureCustom(): Promise<string | undefined> {
-    const current = await this.custom();
-    if (current) {
-      return current;
-    }
-    return this.promptCustom();
+  async ensureCustom(): Promise<string> {
+    return this.custom();
   }
 }
 

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -147,7 +147,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.settingsManager.openSettings(SETTINGS_QUERY.MODELS),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {
         if (m?.customDirSet) {
-          const dir = await agentDirectories.custom();
+          const dir = await agentDirectories.custom(this.context);
           if (dir) {
             await vscode.commands.executeCommand(
               'revealFileInOS',


### PR DESCRIPTION
## Summary
- ensure a default `custom_agents` folder is provisioned in global storage and reuse it across custom directory helpers
- rely on the default location when creating or copying custom agents while still supporting absolute-path overrides
- document the new default folder behavior in the custom agents and agent explorer guides

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8fd518cfc8324acc7f938b2cf2302

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Seeds a default `custom_agents` folder in global storage and refactors directory handling to use it by default with optional absolute-path overrides, updating callers and docs.
> 
> - **Core/Infrastructure**:
>   - `AgentDirectoryManager`:
>     - Adds default custom dir seeding in global storage (`custom_agents`) and context-backed initialization (`initialize`).
>     - Implements `custom(context)` to resolve configured absolute path or fall back to default; removes `ensureCustom`.
>   - Extension startup: initializes `agentDirectories` during activation.
> - **Integration Updates**:
>   - Replace `ensureCustom()` with `custom(context)` and pass context where needed in:
>     - `src/FolderExplorer.ts`, `src/explorer/ExplorerOperations.ts`, `src/explorer/WatcherManager.ts`.
>     - `src/agent/computeAgentOptions.ts`, `src/agent/runtime/executeAgent.ts`.
>     - `src/webview/MainViewMessageHandler.ts`, `src/commands/agent/agentCreatorCommands.ts`.
> - **UX Behavior**:
>   - Agent Explorer now shows "Custom Agents" by default; creation/copy actions target the default custom dir; "Open Agent Directory" resolves to the active custom path.
> - **Docs**:
>   - Update `docs/guide/agent-explorer.md` and `docs/guide/custom-agents.md` to describe default seeding and how to override with `texra.explorer.agentsDirectory`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f00c9d6adedcab2cb5fea2f09ecb8d6a4a80d6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->