### PR TITLE
feat: add json helpers for storage snapshots

### DIFF
--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -145,8 +145,7 @@ export class ToolUseSessionManager {
         lastUpdated: Date.now(),
       };
 
-      const json = JSON.stringify(snapshot, null, 2);
-      await StorageFS.write(getSnapshotPath(payload.executionId), json);
+      await StorageFS.writeJson(getSnapshotPath(payload.executionId), snapshot);
     } catch (error) {
       logger.warn(
         `Failed to save tool-use session snapshot: ${error instanceof Error ? error.message : String(error)}`,
@@ -166,20 +165,51 @@ export class ToolUseSessionManager {
       return null;
     }
 
+    const snapshotPath = getSnapshotPath(executionId);
+
     try {
-      const raw = await StorageFS.read(getSnapshotPath(executionId));
-      const parsed = JSON.parse(raw);
-      return ToolUseSessionSnapshotSchema.parse(parsed);
+      const stored = await StorageFS.readJson<ToolUseSessionSnapshot | string>(
+        snapshotPath,
+      );
+      const normalized =
+        typeof stored === 'string' ? JSON.parse(stored) : stored;
+      return ToolUseSessionSnapshotSchema.parse(normalized);
     } catch (error) {
-      if (error instanceof vscode.FileSystemError) {
-        if (error.code === 'FileNotFound') {
+      if (
+        error instanceof vscode.FileSystemError &&
+        error.code === 'FileNotFound'
+      ) {
+        return null;
+      }
+
+      try {
+        const raw = await StorageFS.read(snapshotPath);
+        const fallbackParsed = JSON.parse(raw);
+        const normalized =
+          typeof fallbackParsed === 'string'
+            ? JSON.parse(fallbackParsed)
+            : fallbackParsed;
+        return ToolUseSessionSnapshotSchema.parse(normalized);
+      } catch (fallbackError) {
+        if (
+          fallbackError instanceof vscode.FileSystemError &&
+          fallbackError.code === 'FileNotFound'
+        ) {
           return null;
         }
+
+        const originalMessage =
+          error instanceof Error ? error.message : String(error);
+        const fallbackMessage =
+          fallbackError instanceof Error
+            ? fallbackError.message
+            : String(fallbackError);
+
+        logger.warn(
+          `Failed to load tool-use session snapshot: original=${originalMessage}; fallback=${fallbackMessage}`,
+        );
+        return null;
       }
-      logger.warn(
-        `Failed to load tool-use session snapshot: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return null;
     }
   }
 

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -91,11 +91,13 @@ export async function maybeSaveDebugObject({
     : WorkspaceFS.fullPath(debugFileName);
 
   try {
-    const content = JSON.stringify(object, null, 2);
     if (executionId) {
-      await StorageFS.write(debugFilePath, content);
+      await StorageFS.writeJson(debugFilePath, object);
     } else {
-      await WorkspaceFS.write(WorkspaceFS.relativePath(debugFilePath), content);
+      await WorkspaceFS.writeJson(
+        WorkspaceFS.relativePath(debugFilePath),
+        object,
+      );
     }
     logger.info(`Saved ${objectType} object to ${debugFilePath}`, groupId);
   } catch (error) {

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -61,10 +61,7 @@ export async function handleTestAgentLoading(
 
     // Create base agent
     const baseYamlPath = path.join(testDir, 'base.yaml');
-    await GlobalStorageFS.write(
-      'test_agents/base.yaml',
-      JSON.stringify(testYaml),
-    );
+    await GlobalStorageFS.writeJson('test_agents/base.yaml', testYaml);
 
     // Create child agent that inherits from base
     const childYaml = {
@@ -79,10 +76,7 @@ export async function handleTestAgentLoading(
     };
 
     const childYamlPath = path.join(testDir, 'child.yaml');
-    await GlobalStorageFS.write(
-      'test_agents/child.yaml',
-      JSON.stringify(childYaml),
-    );
+    await GlobalStorageFS.writeJson('test_agents/child.yaml', childYaml);
 
     // Test loading base agent
     logger.info(CHANNEL, '\nTesting base agent loading:');

--- a/src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts
+++ b/src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts
@@ -1,0 +1,151 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import { promises as fs } from 'fs';
+
+import * as vscode from 'vscode';
+
+import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import { ToolState } from '@agent/core/ToolState';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import {
+  ToolUseSessionManager,
+  type ToolUseSessionSnapshot,
+} from '@agent/toolUse/ToolUseSessionManager';
+import StorageFS from '@utils/files/storageFS';
+
+const STORAGE_DIR = path.join(os.tmpdir(), 'texra-tooluse-snapshot-tests');
+
+function createContext(): vscode.ExtensionContext {
+  const uri = vscode.Uri.file(STORAGE_DIR);
+  return {
+    storageUri: uri,
+    globalStorageUri: uri,
+  } as unknown as vscode.ExtensionContext;
+}
+
+async function resetStorageDir(): Promise<void> {
+  await fs
+    .rm(STORAGE_DIR, { recursive: true, force: true })
+    .catch(() => undefined);
+  await fs.mkdir(STORAGE_DIR, { recursive: true });
+}
+
+suite('ToolUseSessionManager snapshot compatibility', () => {
+  suiteSetup(async () => {
+    await resetStorageDir();
+    StorageFS.initialize(createContext());
+  });
+
+  setup(async () => {
+    await fs
+      .rm(path.join(STORAGE_DIR, 'toolUseSessions'), {
+        recursive: true,
+        force: true,
+      })
+      .catch(() => undefined);
+  });
+
+  suiteTeardown(async () => {
+    await resetStorageDir();
+  });
+
+  function buildPayload(executionId: ExecutionId) {
+    const toolState = new ToolState();
+    toolState.updateLastResponse('response');
+    toolState.updateAccumulatedOutput('response');
+
+    return {
+      executionId,
+      streamId: 'stream-id',
+      agentName: 'demo-agent',
+      model: 'demo-model',
+      agentSessionKind: AgentSessionKind.ToolUse,
+      messages: [] as ProviderMessage[],
+      toolState,
+    };
+  }
+
+  function buildSnapshot(executionId: ExecutionId): ToolUseSessionSnapshot {
+    return {
+      version: 1,
+      executionId,
+      streamId: 'stream-id',
+      agentName: 'demo-agent',
+      model: 'demo-model',
+      agentSessionKind: AgentSessionKind.ToolUse,
+      messages: [],
+      toolState: {
+        texcountStats: null,
+        lastResponse: 'response',
+        accumulatedOutput: 'response',
+        mediaFiles: [],
+        thinkingBlocks: [],
+        thinkingAdded: false,
+      },
+      lastUpdated: Date.now(),
+    };
+  }
+
+  test('saveSnapshot and loadSnapshot round trip', async () => {
+    const executionId = 'round-trip' as ExecutionId;
+    const payload = buildPayload(executionId);
+
+    await ToolUseSessionManager.saveSnapshot(payload);
+    const loaded = await ToolUseSessionManager.loadSnapshot(executionId);
+
+    assert.ok(loaded, 'expected snapshot to be returned');
+    assert.strictEqual(loaded?.executionId, executionId);
+    assert.strictEqual(loaded?.toolState.lastResponse, 'response');
+  });
+
+  test('loadSnapshot reads snapshots saved before helper migration', async () => {
+    const executionId = 'legacy-snapshot' as ExecutionId;
+    const snapshot = buildSnapshot(executionId);
+
+    await StorageFS.ensureDir('toolUseSessions');
+    await StorageFS.write(
+      path.join('toolUseSessions', `${executionId}.json`),
+      JSON.stringify(snapshot, null, 2),
+    );
+
+    const loaded = await ToolUseSessionManager.loadSnapshot(executionId);
+
+    assert.ok(loaded, 'expected legacy snapshot to load');
+    assert.strictEqual(loaded?.executionId, executionId);
+  });
+
+  test('loadSnapshot falls back to raw JSON parsing when helper fails', async () => {
+    const executionId = 'fallback-snapshot' as ExecutionId;
+    const snapshot = buildSnapshot(executionId);
+
+    await StorageFS.ensureDir('toolUseSessions');
+    await StorageFS.write(
+      path.join('toolUseSessions', `${executionId}.json`),
+      JSON.stringify(snapshot, null, 2),
+    );
+
+    const originalReadJson = StorageFS.readJson;
+
+    (
+      StorageFS as typeof StorageFS & {
+        readJson: typeof StorageFS.readJson;
+      }
+    ).readJson = async () => {
+      throw new SyntaxError('forced failure');
+    };
+
+    try {
+      const loaded = await ToolUseSessionManager.loadSnapshot(executionId);
+      assert.ok(loaded, 'expected fallback parsing to succeed');
+      assert.strictEqual(loaded?.executionId, executionId);
+    } finally {
+      (
+        StorageFS as typeof StorageFS & {
+          readJson: typeof StorageFS.readJson;
+        }
+      ).readJson = originalReadJson;
+    }
+  });
+});

--- a/src/test/utils/files/RelativeFSJson.test.ts
+++ b/src/test/utils/files/RelativeFSJson.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import { promises as fs } from 'fs';
+
+import { RelativeFS } from '../../../utils/files/relativeFS';
+
+const BASE_DIR = path.join(os.tmpdir(), 'texra-relativefs-json-tests');
+
+class TestRelativeFS extends RelativeFS {
+  protected static override getBasePath(): string {
+    return BASE_DIR;
+  }
+
+  protected static override getChannel(): string {
+    return 'TestRelativeFS';
+  }
+}
+
+suite('RelativeFS JSON helpers', () => {
+  suiteSetup(async () => {
+    await fs
+      .rm(BASE_DIR, { recursive: true, force: true })
+      .catch(() => undefined);
+    await fs.mkdir(BASE_DIR, { recursive: true });
+  });
+
+  setup(async () => {
+    // Ensure each test starts with a clean directory
+    await fs
+      .rm(BASE_DIR, { recursive: true, force: true })
+      .catch(() => undefined);
+    await fs.mkdir(BASE_DIR, { recursive: true });
+  });
+
+  suiteTeardown(async () => {
+    await fs
+      .rm(BASE_DIR, { recursive: true, force: true })
+      .catch(() => undefined);
+  });
+
+  test('writeJson and readJson round trip preserves data', async () => {
+    const payload = {
+      foo: 'bar',
+      nested: { count: 3 },
+      list: [1, 2, 3],
+    };
+
+    await TestRelativeFS.writeJson('sample.json', payload);
+    const result = await TestRelativeFS.readJson<typeof payload>('sample.json');
+
+    assert.deepStrictEqual(result, payload);
+  });
+});

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -71,6 +71,51 @@ export abstract class RelativeFS {
   }
 
   /**
+   * Serialize an object to JSON and persist it to disk.
+   */
+  public static async writeJson<T>(
+    relativePath: string,
+    value: T,
+  ): Promise<void> {
+    try {
+      const json = JSON.stringify(value, null, 2);
+      await this.write(relativePath, json);
+    } catch (error) {
+      logger.warn(
+        this.getChannel(),
+        `Failed to write JSON file ${relativePath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Read a JSON file and deserialize it into a native object.
+   */
+  public static async readJson<T>(relativePath: string): Promise<T> {
+    try {
+      const raw = await this.read(relativePath);
+      return JSON.parse(raw) as T;
+    } catch (error) {
+      if (
+        error instanceof vscode.FileSystemError &&
+        error.code === 'FileNotFound'
+      ) {
+        throw error;
+      }
+      logger.warn(
+        this.getChannel(),
+        `Failed to read JSON file ${relativePath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Delete a file or directory.
    */
   public static async delete(


### PR DESCRIPTION
## Summary
- add shared JSON read/write helpers to the relative filesystem utilities with logging
- migrate tool-use snapshot persistence to the helpers and add legacy string fallbacks during load
- introduce regression tests covering the helpers and legacy snapshot compatibility

## Testing
- npm run compile-tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d90671915483249471c43eb586f741

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds JSON helpers to RelativeFS and migrates snapshot/debug persistence to them with robust, legacy-compatible loading and new tests.
> 
> - **Filesystem Utilities**:
>   - **JSON Helpers**: Add `RelativeFS.writeJson` and `RelativeFS.readJson` with logging.
> - **Tool-Use Snapshots**:
>   - Use `StorageFS.writeJson` for `saveSnapshot`.
>   - Enhance `loadSnapshot` to use `readJson`, normalize string/obj formats, handle `FileNotFound`, and fall back to raw `read` + `JSON.parse`.
> - **Debug Utilities**:
>   - Switch `debugMessageSaver` to `StorageFS.writeJson`/`WorkspaceFS.writeJson`.
> - **YAML Test Command**:
>   - Use `GlobalStorageFS.writeJson` when creating test agent files.
> - **Tests**:
>   - Add `ToolUseSessionManagerSnapshot.test.ts` covering round-trip, legacy snapshot reading, and fallback path.
>   - Add `RelativeFSJson.test.ts` for `writeJson`/`readJson` round-trip.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76fa4c0e5b24172742a866e90427b4110e4c9ae0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->