### PR TITLE
Refactor tool-use separation across runtime and progress view

### DIFF
--- a/package.json
+++ b/package.json
@@ -408,7 +408,8 @@
               "__pycache__",
               "versions",
               "history",
-              "venv"
+              "venv",
+              "Diffs"
             ],
             "description": "Directories to ignore in the figure path",
             "editPresentation": "multilineText",

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 // Local imports - agent
 // Local imports - agent components
+import { AgentSessionKind, AgentType } from './AgentDataclass';
 import { ToolConfigSchema } from './ToolConfig';
 
 /**
@@ -24,6 +25,9 @@ export const AgentConfigSchema = z
     agent: z.string().default('correct'),
     instruction: z.string().default(''),
     useMultipleOutputs: z.boolean().default(false),
+
+    agentType: z.nativeEnum(AgentType).optional(),
+    agentSessionKind: z.nativeEnum(AgentSessionKind).optional(),
 
     inputFile: z.string().default(''),
     inputFiles: z.array(z.string()).nullable().default(null),

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -141,7 +141,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       );
 
       this.userVars = await this.getUserVars();
-      BaseAgent.runningAgents.set(this.getStreamTabId(), this);
+      this.registerRunningAgent(this.getStreamTabId());
 
       if (createGroup && initGroupId) {
         this.logger.endGroup(initGroupId, 'stopped');
@@ -248,6 +248,14 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
 
   protected cleanup(): void {
     const streamTabId = this.getStreamTabId();
+    this.unregisterRunningAgent(streamTabId);
+  }
+
+  protected registerRunningAgent(streamTabId: StreamTabId): void {
+    BaseAgent.runningAgents.set(streamTabId, this);
+  }
+
+  protected unregisterRunningAgent(streamTabId: StreamTabId): void {
     BaseAgent.runningAgents.delete(streamTabId);
   }
 

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -24,12 +24,16 @@ import { BaseAgent } from './BaseAgent';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   ToolUseSessionManager,
   type ToolUseSessionSnapshot,
 } from '@agent/toolUse/ToolUseSessionManager';
+import {
+  registerToolUseAgent,
+  unregisterToolUseAgent,
+} from '@agent/toolUse/ToolUseAgentRegistry';
 
 export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
   private toolRegistry: Record<string, BaseTool<any>>;
@@ -58,6 +62,14 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       executionId,
     );
     this.toolRegistry = DEFAULT_TOOL_REGISTRY;
+  }
+
+  protected override registerRunningAgent(streamTabId: StreamTabId): void {
+    registerToolUseAgent(streamTabId, this);
+  }
+
+  protected override unregisterRunningAgent(streamTabId: StreamTabId): void {
+    unregisterToolUseAgent(streamTabId);
   }
 
   public override getSessionMetadata() {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -194,7 +194,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
     const sessionMetadata = agent.getSessionMetadata();
-    const metadata = resolveAgentSessionMetadata(
+    const baseMetadata = resolveAgentSessionMetadata(
       agentType ?? sessionMetadata.agentType,
       sessionMetadata.agentSessionKind,
     );
@@ -205,6 +205,13 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
     // Get the full stream tab ID
     const config = agent.config;
+    const metadata = resolveAgentSessionMetadata(
+      config.agentType ?? baseMetadata.agentType,
+      config.agentSessionKind ?? baseMetadata.agentSessionKind,
+    );
+    config.agentType = metadata.agentType;
+    config.agentSessionKind = metadata.agentSessionKind;
+
     streamTabId = getStreamTabId(config.agent, config.model, config.inputFile, {
       agentType: metadata.agentType,
       executionId,

--- a/src/agent/toolUse/ToolUseAgentRegistry.ts
+++ b/src/agent/toolUse/ToolUseAgentRegistry.ts
@@ -1,0 +1,26 @@
+// Local imports - agent
+import type { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+
+const registry = new Map<StreamTabId, BaseToolUseAgent>();
+
+export function registerToolUseAgent(
+  streamTabId: StreamTabId,
+  agent: BaseToolUseAgent,
+): void {
+  registry.set(streamTabId, agent);
+}
+
+export function unregisterToolUseAgent(streamTabId: StreamTabId): void {
+  registry.delete(streamTabId);
+}
+
+export function getToolUseAgent(
+  streamTabId: StreamTabId,
+): BaseToolUseAgent | undefined {
+  return registry.get(streamTabId);
+}
+
+export function clearToolUseAgents(): void {
+  registry.clear();
+}

--- a/src/agent/toolUse/ToolUseAgentRegistry.ts
+++ b/src/agent/toolUse/ToolUseAgentRegistry.ts
@@ -24,3 +24,14 @@ export function getToolUseAgent(
 export function clearToolUseAgents(): void {
   registry.clear();
 }
+
+/**
+ * Remove registry entries for streams that no longer have an active tool-use session.
+ */
+export function cleanupInactiveAgents(activeStreams: Set<StreamTabId>): void {
+  for (const streamId of registry.keys()) {
+    if (!activeStreams.has(streamId)) {
+      registry.delete(streamId);
+    }
+  }
+}

--- a/src/agent/toolUse/index.ts
+++ b/src/agent/toolUse/index.ts
@@ -7,6 +7,7 @@
 
 // Local imports - agents
 export { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+export * from './ToolUseAgentRegistry';
 
 // Export individual classes
 export * from '@tools/TextEditorTool';

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - agent
 import { BaseAgent } from '@agent/implementations/BaseAgent';
+import { getToolUseAgent } from '@agent/toolUse/ToolUseAgentRegistry';
 import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - log
@@ -19,7 +20,7 @@ export function registerAgentCommands(context: vscode.ExtensionContext) {
 
 async function handleStopAgent(stream: string) {
   // Get the running agent instance
-  const agent = BaseAgent.getRunningAgent(stream);
+  const agent = BaseAgent.getRunningAgent(stream) ?? getToolUseAgent(stream);
   if (agent) {
     // Interrupt the agent's execution
     agent.interrupt();

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -316,13 +316,13 @@ async function handleCreateAgentWithAI(context: vscode.ExtensionContext) {
 
     await AbsoluteFS.write(filePath.fsPath, yamlContent);
     vscode.window.showInformationMessage(`Created agent at ${filePath.fsPath}`);
-    const isMultipleVariant = outputChoice === 'Multiple output files';
+    const isMultipleOutput = outputChoice === 'Multiple output files';
     await promptToAddAgentToConfig(agentName, false, {
-      isMultipleVariant,
-      baseAgentName: isMultipleVariant
+      isMultipleOutput,
+      baseAgentName: isMultipleOutput
         ? agentName.replace(/_multiple$/, '')
         : undefined,
-      multipleAgentName: !isMultipleVariant
+      multipleAgentName: !isMultipleOutput
         ? `${agentName}_multiple`
         : agentName,
     });

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { BaseAgent } from '@agent/implementations/BaseAgent';
+import { getToolUseAgent } from '@agent/toolUse/ToolUseAgentRegistry';
 
 // Local imports - utilities
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
@@ -15,10 +15,10 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'texra.sendFollowUp',
       async (payload: { stream: string; text: string }) => {
-        const agent = BaseAgent.getRunningAgent(payload.stream);
-        if (agent && typeof (agent as any).appendFollowUp === 'function') {
+        const agent = getToolUseAgent(payload.stream);
+        if (agent) {
           try {
-            (agent as any).appendFollowUp(payload.text);
+            agent.appendFollowUp(payload.text);
           } catch (err) {
             await showLoggedErrorMessage(
               CHANNEL,

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -18,7 +18,7 @@ logger.initialize(CHANNEL);
  * `autoAdd` is true, the agent is added without prompting.
  */
 export interface AgentVariantMetadata {
-  isMultipleVariant?: boolean;
+  isMultipleOutput?: boolean;
   baseAgentName?: string;
   multipleAgentName?: string;
 }
@@ -31,7 +31,7 @@ export async function promptToAddAgentToConfig(
   const current = getConfig<string[]>('agents', []);
 
   const {
-    isMultipleVariant = false,
+    isMultipleOutput = false,
     baseAgentName,
     multipleAgentName,
   } = variant;
@@ -43,7 +43,7 @@ export async function promptToAddAgentToConfig(
   }
 
   // Check if the base/multiple counterpart already exists
-  if (isMultipleVariant) {
+  if (isMultipleOutput) {
     const baseName = baseAgentName;
     if (baseName && current.includes(baseName)) {
       logger.debug(
@@ -128,12 +128,12 @@ export async function validateYamlAndPromptAdd(
     const hasMultipleDefaults = defaultOutputs.length > 1;
     const useMultipleOutputs =
       settings?.useMultipleOutputs ?? hasMultipleDefaults;
-    const isMultipleVariant = Boolean(useMultipleOutputs);
+    const isMultipleOutput = Boolean(useMultipleOutputs);
     const metadata: AgentVariantMetadata = {
-      isMultipleVariant,
+      isMultipleOutput,
     };
 
-    if (isMultipleVariant) {
+    if (isMultipleOutput) {
       metadata.baseAgentName = internalName.includes('_multiple')
         ? internalName.replace(/_multiple$/, '')
         : undefined;

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -91,10 +91,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
           historyItem.agentType,
           historyItem.agentSessionKind,
         );
-        const taskState = agentConfigToTaskState(
-          historyItem.config,
-          metadata,
-        );
+        const taskState = agentConfigToTaskState(historyItem.config, metadata);
         await vscode.commands.executeCommand('texra.restoreState', taskState);
       } else {
         await vscode.window.showErrorMessage('History item not found');

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -14,6 +14,7 @@ import {
 
 // @ts-ignore - Import JavaScript module
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands';
+import { resolveAgentSessionMetadata } from '@agent/core/AgentDataclass';
 import { AgentHistoryManager } from '@historyView/managers';
 import { agentConfigToTaskState } from '@utils/config';
 
@@ -86,7 +87,14 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
       const historyItem =
         await AgentHistoryManager.getHistoryItemById(historyId);
       if (historyItem) {
-        const taskState = agentConfigToTaskState(historyItem.config);
+        const metadata = resolveAgentSessionMetadata(
+          historyItem.agentType,
+          historyItem.agentSessionKind,
+        );
+        const taskState = agentConfigToTaskState(
+          historyItem.config,
+          metadata,
+        );
         await vscode.commands.executeCommand('texra.restoreState', taskState);
       } else {
         await vscode.window.showErrorMessage('History item not found');

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -11,6 +11,11 @@ import * as vscode from 'vscode';
 
 // Local imports
 import type { AgentConfig } from '@agent/core/AgentConfig';
+import {
+  AgentSessionKind,
+  AgentType,
+  resolveAgentSessionMetadata,
+} from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { workspaceSM } from '@common/state/stateManager';
 
@@ -21,6 +26,8 @@ export interface AgentHistoryItem {
   id: ExecutionId;
   timestamp: string;
   config: AgentConfig;
+  agentType?: AgentType;
+  agentSessionKind?: AgentSessionKind;
 }
 
 /**
@@ -34,10 +41,22 @@ export class AgentHistoryManager {
    * Add a new agent execution to history
    */
   public static async addToHistory(config: AgentConfig): Promise<string> {
+    const metadata = resolveAgentSessionMetadata(
+      config.agentType,
+      config.agentSessionKind,
+    );
+    const normalizedConfig: AgentConfig = {
+      ...config,
+      agentType: metadata.agentType,
+      agentSessionKind: metadata.agentSessionKind,
+    };
+
     const historyItem: AgentHistoryItem = {
       id: randomUUID(),
       timestamp: new Date().toISOString(),
-      config,
+      config: normalizedConfig,
+      agentType: metadata.agentType,
+      agentSessionKind: metadata.agentSessionKind,
     };
 
     // Get current workspace-specific history
@@ -62,7 +81,8 @@ export class AgentHistoryManager {
    */
   public static async getHistory(): Promise<AgentHistoryItem[]> {
     const storageKey = this.getWorkspaceStorageKey();
-    return workspaceSM.get<AgentHistoryItem[]>(storageKey, []);
+    const history = workspaceSM.get<AgentHistoryItem[]>(storageKey, []);
+    return history.map((item) => this.normalizeHistoryItem(item));
   }
 
   /**
@@ -71,6 +91,28 @@ export class AgentHistoryManager {
   private static async saveHistory(history: AgentHistoryItem[]): Promise<void> {
     const storageKey = this.getWorkspaceStorageKey();
     await workspaceSM.update(storageKey, history);
+  }
+
+  private static normalizeHistoryItem(
+    item: AgentHistoryItem,
+  ): AgentHistoryItem {
+    const metadata = resolveAgentSessionMetadata(
+      item.agentType ?? item.config.agentType,
+      item.agentSessionKind ?? item.config.agentSessionKind,
+    );
+
+    const normalizedConfig: AgentConfig = {
+      ...item.config,
+      agentType: metadata.agentType,
+      agentSessionKind: metadata.agentSessionKind,
+    };
+
+    return {
+      ...item,
+      config: normalizedConfig,
+      agentType: metadata.agentType,
+      agentSessionKind: metadata.agentSessionKind,
+    };
   }
 
   /**

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -229,15 +229,15 @@ export class ProgressViewProvider
    */
   public clearTaskOutput(streamTabId: StreamTabId): void {
     const taskState = this.state.getTaskState(streamTabId);
-    if (taskState) {
-      // Only clear output-related fields, preserve other task state data
-      taskState.agentConfig.outputFiles = [];
-      taskState.agentConfig.useMultipleOutputs = false;
-      if (isWorkflowTaskState(taskState)) {
-        taskState.activeFiles.output = false;
-      }
-      this.state.setTaskState(streamTabId, taskState);
+    if (!taskState || !isWorkflowTaskState(taskState)) {
+      return;
     }
+
+    // Only clear output-related fields, preserve other task state data
+    taskState.agentConfig.outputFiles = [];
+    taskState.agentConfig.useMultipleOutputs = false;
+    taskState.activeFiles.output = false;
+    this.state.setTaskState(streamTabId, taskState);
   }
 
   /**

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -351,15 +351,15 @@ export class ProgressEventHandler {
    */
   private handleClearTaskOutput(streamTabId: StreamTabId): void {
     const taskState = this.state.getTaskState(streamTabId);
-    if (taskState) {
-      // Only clear output-related fields, preserve other task state data
-      taskState.agentConfig.outputFiles = [];
-      taskState.agentConfig.useMultipleOutputs = false;
-      if (isWorkflowTaskState(taskState)) {
-        taskState.activeFiles.output = false;
-      }
-      this.state.setTaskState(streamTabId, taskState);
+    if (!taskState || !isWorkflowTaskState(taskState)) {
+      return;
     }
+
+    // Only clear output-related fields, preserve other task state data
+    taskState.agentConfig.outputFiles = [];
+    taskState.agentConfig.useMultipleOutputs = false;
+    taskState.activeFiles.output = false;
+    this.state.setTaskState(streamTabId, taskState);
   }
 
   /**

--- a/src/progressView/managers/BaseTaskStateManager.ts
+++ b/src/progressView/managers/BaseTaskStateManager.ts
@@ -1,0 +1,62 @@
+// Local imports - agent types
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { TaskState } from '@logger/TaskState';
+
+/**
+ * Shared map-backed storage for task state keyed by stream identifier.
+ *
+ * Subclasses provide cloning logic appropriate for their task-state variant so
+ * callers receive isolated copies while shared collection helpers remain DRY.
+ */
+export abstract class BaseTaskStateManager<TState extends TaskState> {
+  protected readonly states = new Map<StreamTabId, TState>();
+
+  protected abstract cloneState(state: TState): TState;
+
+  set(streamTabId: StreamTabId, state: TState): void {
+    this.states.set(streamTabId, this.cloneState(state));
+  }
+
+  get(streamTabId: StreamTabId): TState | undefined {
+    return this.states.get(streamTabId);
+  }
+
+  has(streamTabId: StreamTabId): boolean {
+    return this.states.has(streamTabId);
+  }
+
+  delete(streamTabId: StreamTabId): void {
+    this.states.delete(streamTabId);
+  }
+
+  clear(): void {
+    this.states.clear();
+  }
+
+  size(): number {
+    return this.states.size;
+  }
+
+  entries(): IterableIterator<[StreamTabId, TState]> {
+    return this.states.entries();
+  }
+
+  keys(): IterableIterator<StreamTabId> {
+    return this.states.keys();
+  }
+
+  values(): IterableIterator<TState> {
+    return this.states.values();
+  }
+
+  setAll(states: Map<StreamTabId, TState>): void {
+    this.states.clear();
+    for (const [stream, state] of states.entries()) {
+      this.set(stream, state);
+    }
+  }
+
+  toObject(): Record<string, TState> {
+    return Object.fromEntries(this.states.entries());
+  }
+}

--- a/src/progressView/managers/ToolUseTaskStateManager.ts
+++ b/src/progressView/managers/ToolUseTaskStateManager.ts
@@ -1,0 +1,57 @@
+// Local imports - agent types
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { ToolUseTaskState } from '@logger/TaskState';
+
+/**
+ * Maintains task state for tool-use sessions separately from workflow runs.
+ */
+export class ToolUseTaskStateManager {
+  private readonly states = new Map<StreamTabId, ToolUseTaskState>();
+
+  set(streamTabId: StreamTabId, state: ToolUseTaskState): void {
+    this.states.set(streamTabId, { ...state });
+  }
+
+  get(streamTabId: StreamTabId): ToolUseTaskState | undefined {
+    return this.states.get(streamTabId);
+  }
+
+  has(streamTabId: StreamTabId): boolean {
+    return this.states.has(streamTabId);
+  }
+
+  delete(streamTabId: StreamTabId): void {
+    this.states.delete(streamTabId);
+  }
+
+  clear(): void {
+    this.states.clear();
+  }
+
+  size(): number {
+    return this.states.size;
+  }
+
+  entries(): IterableIterator<[StreamTabId, ToolUseTaskState]> {
+    return this.states.entries();
+  }
+
+  keys(): IterableIterator<StreamTabId> {
+    return this.states.keys();
+  }
+
+  values(): IterableIterator<ToolUseTaskState> {
+    return this.states.values();
+  }
+
+  setAll(states: Map<StreamTabId, ToolUseTaskState>): void {
+    this.states.clear();
+    for (const [stream, state] of states.entries()) {
+      this.states.set(stream, { ...state });
+    }
+  }
+
+  toObject(): Record<string, ToolUseTaskState> {
+    return Object.fromEntries(this.states.entries());
+  }
+}

--- a/src/progressView/managers/ToolUseTaskStateManager.ts
+++ b/src/progressView/managers/ToolUseTaskStateManager.ts
@@ -1,57 +1,20 @@
-// Local imports - agent types
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+// Local imports - logger
 import type { ToolUseTaskState } from '@logger/TaskState';
+
+// Local imports - progress view
+import { BaseTaskStateManager } from './BaseTaskStateManager';
 
 /**
  * Maintains task state for tool-use sessions separately from workflow runs.
  */
-export class ToolUseTaskStateManager {
-  private readonly states = new Map<StreamTabId, ToolUseTaskState>();
-
-  set(streamTabId: StreamTabId, state: ToolUseTaskState): void {
-    this.states.set(streamTabId, { ...state });
-  }
-
-  get(streamTabId: StreamTabId): ToolUseTaskState | undefined {
-    return this.states.get(streamTabId);
-  }
-
-  has(streamTabId: StreamTabId): boolean {
-    return this.states.has(streamTabId);
-  }
-
-  delete(streamTabId: StreamTabId): void {
-    this.states.delete(streamTabId);
-  }
-
-  clear(): void {
-    this.states.clear();
-  }
-
-  size(): number {
-    return this.states.size;
-  }
-
-  entries(): IterableIterator<[StreamTabId, ToolUseTaskState]> {
-    return this.states.entries();
-  }
-
-  keys(): IterableIterator<StreamTabId> {
-    return this.states.keys();
-  }
-
-  values(): IterableIterator<ToolUseTaskState> {
-    return this.states.values();
-  }
-
-  setAll(states: Map<StreamTabId, ToolUseTaskState>): void {
-    this.states.clear();
-    for (const [stream, state] of states.entries()) {
-      this.states.set(stream, { ...state });
-    }
-  }
-
-  toObject(): Record<string, ToolUseTaskState> {
-    return Object.fromEntries(this.states.entries());
+export class ToolUseTaskStateManager extends BaseTaskStateManager<ToolUseTaskState> {
+  protected cloneState(state: ToolUseTaskState): ToolUseTaskState {
+    return {
+      ...state,
+      agentConfig: { ...state.agentConfig },
+      toolSessionState: state.toolSessionState
+        ? { ...state.toolSessionState }
+        : undefined,
+    };
   }
 }

--- a/src/progressView/managers/WorkflowTaskStateManager.ts
+++ b/src/progressView/managers/WorkflowTaskStateManager.ts
@@ -1,0 +1,18 @@
+// Local imports - logger
+import type { WorkflowTaskState } from '@logger/TaskState';
+
+// Local imports - progress view
+import { BaseTaskStateManager } from './BaseTaskStateManager';
+
+/**
+ * Stores workflow task state keyed by stream identifier.
+ */
+export class WorkflowTaskStateManager extends BaseTaskStateManager<WorkflowTaskState> {
+  protected cloneState(state: WorkflowTaskState): WorkflowTaskState {
+    return {
+      ...state,
+      agentConfig: { ...state.agentConfig },
+      activeFiles: { ...state.activeFiles },
+    };
+  }
+}

--- a/src/progressView/managers/index.ts
+++ b/src/progressView/managers/index.ts
@@ -1,5 +1,6 @@
 export { OutputFilesManager } from './OutputFilesManager';
 export { StreamTabsManager } from './StreamTabsManager';
 export { TaskGroupManager } from './TaskGroupManager';
+export { ToolUseTaskStateManager } from './ToolUseTaskStateManager';
 export { UsageStatsManager } from './UsageStatsManager';
 export { WebviewUpdater } from './WebviewUpdater';

--- a/src/progressView/managers/index.ts
+++ b/src/progressView/managers/index.ts
@@ -4,3 +4,4 @@ export { TaskGroupManager } from './TaskGroupManager';
 export { ToolUseTaskStateManager } from './ToolUseTaskStateManager';
 export { UsageStatsManager } from './UsageStatsManager';
 export { WebviewUpdater } from './WebviewUpdater';
+export { WorkflowTaskStateManager } from './WorkflowTaskStateManager';

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -4,6 +4,7 @@ import {
   TaskGroupManager,
   OutputFilesManager,
   UsageStatsManager,
+  ToolUseTaskStateManager,
 } from '../managers';
 // Local imports
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
@@ -23,6 +24,8 @@ import {
   TaskState,
   isToolUseTaskState,
   isWorkflowTaskState,
+  type ToolUseTaskState,
+  type WorkflowTaskState,
 } from '@logger/TaskState';
 import {
   objectToTaskState,
@@ -43,7 +46,7 @@ export class ProgressViewState {
   private _activeStream: StreamTabId = '';
   private _streamSortOrder = 'time';
   private _agentTypeFilter: AgentFilter = 'all';
-  private _taskStates: Map<StreamTabId, TaskState> = new Map();
+  private _workflowTaskStates: Map<StreamTabId, WorkflowTaskState> = new Map();
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
   /**
    * Ephemeral session-kind hints keyed by stream ID.
@@ -54,12 +57,14 @@ export class ProgressViewState {
    * is cleared, so there is no need to persist these hints across sessions.
    */
   private _sessionKindHints: Map<StreamTabId, AgentSessionKind> = new Map();
+  private readonly toolUseTaskStates: ToolUseTaskStateManager;
   private readonly persistence: StatePersistenceManager;
   private readonly logger: AgentLogger;
 
   constructor(persistence: StatePersistenceManager) {
     this.persistence = persistence;
     this.logger = new AgentLogger('ProgressViewState');
+    this.toolUseTaskStates = new ToolUseTaskStateManager();
 
     // Initialize focused managers
     this._streamTabs = new StreamTabsManager(persistence);
@@ -155,22 +160,39 @@ export class ProgressViewState {
     }
 
     this.clearSessionKindHint(streamTabId);
-    this._taskStates.set(streamTabId, normalizedState);
+    if (isWorkflowTaskState(normalizedState)) {
+      this._workflowTaskStates.set(streamTabId, normalizedState);
+      this.toolUseTaskStates.delete(streamTabId);
+    } else {
+      this.toolUseTaskStates.set(streamTabId, normalizedState);
+      this._workflowTaskStates.delete(streamTabId);
+    }
     this.saveTaskStates();
   }
 
   getTaskState(streamTabId: StreamTabId): TaskState | undefined {
-    return this._taskStates.get(streamTabId);
+    return (
+      this._workflowTaskStates.get(streamTabId) ||
+      this.toolUseTaskStates.get(streamTabId)
+    );
   }
 
   clearTaskState(streamTabId: StreamTabId): void {
-    this._taskStates.delete(streamTabId);
+    this._workflowTaskStates.delete(streamTabId);
+    this.toolUseTaskStates.delete(streamTabId);
     this.clearSessionKindHint(streamTabId);
     this.saveTaskStates();
   }
 
   getAllTaskStates(): Map<StreamTabId, TaskState> {
-    return new Map(this._taskStates);
+    const combined = new Map<StreamTabId, TaskState>();
+    for (const [stream, state] of this._workflowTaskStates.entries()) {
+      combined.set(stream, state);
+    }
+    for (const [stream, state] of this.toolUseTaskStates.entries()) {
+      combined.set(stream, state);
+    }
+    return combined;
   }
 
   // Execution ID management
@@ -194,7 +216,8 @@ export class ProgressViewState {
     this._taskGroups.deleteStream(stream);
     this._outputFiles.deleteStream(stream);
     this._usageStats.deleteStream(stream);
-    this._taskStates.delete(stream);
+    this._workflowTaskStates.delete(stream);
+    this.toolUseTaskStates.delete(stream);
     this._executionIds.delete(stream);
     this.clearSessionKindHint(stream);
 
@@ -229,7 +252,8 @@ export class ProgressViewState {
     this._taskGroups.clear();
     this._outputFiles.clear();
     this._usageStats.clear();
-    this._taskStates.clear();
+    this._workflowTaskStates.clear();
+    this.toolUseTaskStates.clear();
     this._executionIds.clear();
     this._sessionKindHints.clear();
     this._activeStream = '';
@@ -281,29 +305,58 @@ export class ProgressViewState {
    */
   private async loadTaskStates(): Promise<void> {
     const savedTaskStates = await this.persistence.load<
-      { [key: string]: Record<string, any> } | [string, Record<string, any>][]
+      | {
+          workflow?: Record<string, Record<string, any>>;
+          toolUse?: Record<string, Record<string, any>>;
+        }
+      | { [key: string]: Record<string, any> }
+      | [string, Record<string, any>][]
     >(WorkspaceStateKey.TASK_STATES, {});
 
-    if (savedTaskStates) {
-      const processedStates = new Map<StreamTabId, TaskState>();
+    this._workflowTaskStates.clear();
+    this.toolUseTaskStates.clear();
 
-      if (Array.isArray(savedTaskStates)) {
-        // Backwards compatibility: convert from array format if encountered
-        for (const [stream, state] of savedTaskStates) {
-          processedStates.set(stream, objectToTaskState(state));
-        }
-      } else {
-        for (const [stream, state] of Object.entries(savedTaskStates)) {
-          processedStates.set(stream, objectToTaskState(state));
-        }
+    const processState = (
+      stream: string,
+      rawState: Record<string, any>,
+    ): void => {
+      const taskState = objectToTaskState(rawState);
+      if (isWorkflowTaskState(taskState)) {
+        this._workflowTaskStates.set(stream, taskState);
+      } else if (isToolUseTaskState(taskState)) {
+        this.toolUseTaskStates.set(stream, taskState);
       }
+    };
 
-      this._taskStates = processedStates;
-      this.logger.debug(
-        `Loaded task states for ${this._taskStates.size} streams`,
-      );
+    if (!savedTaskStates) {
+      return;
+    }
+
+    if (Array.isArray(savedTaskStates)) {
+      for (const [stream, state] of savedTaskStates) {
+        processState(stream, state);
+      }
+    } else if ('workflow' in savedTaskStates || 'toolUse' in savedTaskStates) {
+      const { workflow = {}, toolUse = {} } = savedTaskStates as {
+        workflow?: Record<string, Record<string, any>>;
+        toolUse?: Record<string, Record<string, any>>;
+      };
+      for (const [stream, state] of Object.entries(workflow)) {
+        processState(stream, state);
+      }
+      for (const [stream, state] of Object.entries(toolUse)) {
+        processState(stream, state);
+      }
     } else {
-      this._taskStates.clear();
+      for (const [stream, state] of Object.entries(savedTaskStates)) {
+        processState(stream, state);
+      }
+    }
+
+    const totalStates =
+      this._workflowTaskStates.size + this.toolUseTaskStates.size();
+    if (totalStates > 0) {
+      this.logger.debug(`Loaded task states for ${totalStates} streams`);
     }
   }
 
@@ -339,8 +392,14 @@ export class ProgressViewState {
    * Save task states to persistence
    */
   private saveTaskStates(): void {
-    const taskStatesObj = Object.fromEntries(this._taskStates.entries());
-    this.persistence.save(WorkspaceStateKey.TASK_STATES, taskStatesObj);
+    const workflowStates = Object.fromEntries(
+      this._workflowTaskStates.entries(),
+    );
+    const toolUseStates = this.toolUseTaskStates.toObject();
+    this.persistence.save(WorkspaceStateKey.TASK_STATES, {
+      workflow: workflowStates,
+      toolUse: toolUseStates,
+    });
   }
 
   /**

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -4,6 +4,7 @@ import {
   TaskGroupManager,
   OutputFilesManager,
   UsageStatsManager,
+  WorkflowTaskStateManager,
   ToolUseTaskStateManager,
 } from '../managers';
 // Local imports
@@ -24,14 +25,14 @@ import {
   TaskState,
   isToolUseTaskState,
   isWorkflowTaskState,
-  type ToolUseTaskState,
-  type WorkflowTaskState,
 } from '@logger/TaskState';
 import {
   objectToTaskState,
   getConfig,
   agentConfigToTaskState,
 } from '@utils/config';
+// Local imports - agents
+import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
 
 /**
  * Core state management for the progress view.
@@ -46,7 +47,7 @@ export class ProgressViewState {
   private _activeStream: StreamTabId = '';
   private _streamSortOrder = 'time';
   private _agentTypeFilter: AgentFilter = 'all';
-  private _workflowTaskStates: Map<StreamTabId, WorkflowTaskState> = new Map();
+  private readonly workflowTaskStates: WorkflowTaskStateManager;
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
   /**
    * Ephemeral session-kind hints keyed by stream ID.
@@ -64,6 +65,7 @@ export class ProgressViewState {
   constructor(persistence: StatePersistenceManager) {
     this.persistence = persistence;
     this.logger = new AgentLogger('ProgressViewState');
+    this.workflowTaskStates = new WorkflowTaskStateManager();
     this.toolUseTaskStates = new ToolUseTaskStateManager();
 
     // Initialize focused managers
@@ -149,11 +151,14 @@ export class ProgressViewState {
       metadata,
     );
 
-    if (isWorkflowTaskState(normalizedState) && 'activeFiles' in taskState) {
+    if (
+      isWorkflowTaskState(normalizedState) &&
+      isWorkflowTaskState(taskState)
+    ) {
       normalizedState.activeFiles = { ...taskState.activeFiles };
     } else if (
       isToolUseTaskState(normalizedState) &&
-      'toolSessionState' in taskState &&
+      isToolUseTaskState(taskState) &&
       taskState.toolSessionState
     ) {
       normalizedState.toolSessionState = { ...taskState.toolSessionState };
@@ -161,32 +166,33 @@ export class ProgressViewState {
 
     this.clearSessionKindHint(streamTabId);
     if (isWorkflowTaskState(normalizedState)) {
-      this._workflowTaskStates.set(streamTabId, normalizedState);
+      this.workflowTaskStates.set(streamTabId, normalizedState);
       this.toolUseTaskStates.delete(streamTabId);
     } else {
       this.toolUseTaskStates.set(streamTabId, normalizedState);
-      this._workflowTaskStates.delete(streamTabId);
+      this.workflowTaskStates.delete(streamTabId);
     }
     this.saveTaskStates();
   }
 
   getTaskState(streamTabId: StreamTabId): TaskState | undefined {
     return (
-      this._workflowTaskStates.get(streamTabId) ||
+      this.workflowTaskStates.get(streamTabId) ||
       this.toolUseTaskStates.get(streamTabId)
     );
   }
 
   clearTaskState(streamTabId: StreamTabId): void {
-    this._workflowTaskStates.delete(streamTabId);
+    this.workflowTaskStates.delete(streamTabId);
     this.toolUseTaskStates.delete(streamTabId);
     this.clearSessionKindHint(streamTabId);
     this.saveTaskStates();
+    this.cleanupToolUseAgentRegistry();
   }
 
   getAllTaskStates(): Map<StreamTabId, TaskState> {
     const combined = new Map<StreamTabId, TaskState>();
-    for (const [stream, state] of this._workflowTaskStates.entries()) {
+    for (const [stream, state] of this.workflowTaskStates.entries()) {
       combined.set(stream, state);
     }
     for (const [stream, state] of this.toolUseTaskStates.entries()) {
@@ -216,10 +222,11 @@ export class ProgressViewState {
     this._taskGroups.deleteStream(stream);
     this._outputFiles.deleteStream(stream);
     this._usageStats.deleteStream(stream);
-    this._workflowTaskStates.delete(stream);
+    this.workflowTaskStates.delete(stream);
     this.toolUseTaskStates.delete(stream);
     this._executionIds.delete(stream);
     this.clearSessionKindHint(stream);
+    this.cleanupToolUseAgentRegistry();
 
     // Update active stream if necessary
     if (this._activeStream === stream) {
@@ -252,7 +259,7 @@ export class ProgressViewState {
     this._taskGroups.clear();
     this._outputFiles.clear();
     this._usageStats.clear();
-    this._workflowTaskStates.clear();
+    this.workflowTaskStates.clear();
     this.toolUseTaskStates.clear();
     this._executionIds.clear();
     this._sessionKindHints.clear();
@@ -260,6 +267,7 @@ export class ProgressViewState {
     this.saveActiveStream();
     this.saveTaskStates();
     this.saveExecutionIds();
+    this.cleanupToolUseAgentRegistry();
   }
 
   /**
@@ -313,7 +321,7 @@ export class ProgressViewState {
       | [string, Record<string, any>][]
     >(WorkspaceStateKey.TASK_STATES, {});
 
-    this._workflowTaskStates.clear();
+    this.workflowTaskStates.clear();
     this.toolUseTaskStates.clear();
 
     const processState = (
@@ -322,9 +330,9 @@ export class ProgressViewState {
     ): void => {
       const taskState = objectToTaskState(rawState);
       if (isWorkflowTaskState(taskState)) {
-        this._workflowTaskStates.set(stream, taskState);
+        this.workflowTaskStates.set(stream as StreamTabId, taskState);
       } else if (isToolUseTaskState(taskState)) {
-        this.toolUseTaskStates.set(stream, taskState);
+        this.toolUseTaskStates.set(stream as StreamTabId, taskState);
       }
     };
 
@@ -354,10 +362,12 @@ export class ProgressViewState {
     }
 
     const totalStates =
-      this._workflowTaskStates.size + this.toolUseTaskStates.size();
+      this.workflowTaskStates.size() + this.toolUseTaskStates.size();
     if (totalStates > 0) {
       this.logger.debug(`Loaded task states for ${totalStates} streams`);
     }
+
+    this.cleanupToolUseAgentRegistry();
   }
 
   /**
@@ -392,14 +402,20 @@ export class ProgressViewState {
    * Save task states to persistence
    */
   private saveTaskStates(): void {
-    const workflowStates = Object.fromEntries(
-      this._workflowTaskStates.entries(),
-    );
+    const workflowStates = this.workflowTaskStates.toObject();
     const toolUseStates = this.toolUseTaskStates.toObject();
     this.persistence.save(WorkspaceStateKey.TASK_STATES, {
       workflow: workflowStates,
       toolUse: toolUseStates,
     });
+  }
+
+  private cleanupToolUseAgentRegistry(): void {
+    const activeStreams = new Set<StreamTabId>();
+    for (const stream of this.toolUseTaskStates.keys()) {
+      activeStreams.add(stream);
+    }
+    cleanupInactiveAgents(activeStreams);
   }
 
   /**

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -72,12 +72,15 @@ export function agentConfigToTaskState(
       )
     : configMetadata;
 
-  config.agentType = resolvedMetadata.agentType;
-  config.agentSessionKind = resolvedMetadata.agentSessionKind;
+  const normalizedConfig: AgentConfig = {
+    ...config,
+    agentType: resolvedMetadata.agentType,
+    agentSessionKind: resolvedMetadata.agentSessionKind,
+  };
 
   if (resolvedMetadata.agentSessionKind === AgentSessionKind.ToolUse) {
     return {
-      agentConfig: config,
+      agentConfig: normalizedConfig,
       agentType: resolvedMetadata.agentType,
       agentSessionKind: AgentSessionKind.ToolUse,
       toolSessionState: {},
@@ -85,10 +88,10 @@ export function agentConfigToTaskState(
   }
 
   return {
-    agentConfig: config,
+    agentConfig: normalizedConfig,
     agentType: resolvedMetadata.agentType,
     agentSessionKind: AgentSessionKind.Workflow,
-    activeFiles: createActiveFilesFromArrays(config),
+    activeFiles: createActiveFilesFromArrays(normalizedConfig),
   };
 }
 

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -50,13 +50,30 @@ export function agentConfigToTaskState(
   config: AgentConfig,
   metadata?: AgentSessionMetadata | AgentType,
 ): TaskState {
-  const resolvedMetadata =
+  const configMetadata = resolveAgentSessionMetadata(
+    config.agentType,
+    config.agentSessionKind,
+  );
+
+  const providedMetadata =
     typeof metadata === 'object' && metadata !== null
       ? resolveAgentSessionMetadata(
           metadata.agentType,
           metadata.agentSessionKind,
         )
-      : resolveAgentSessionMetadata(metadata);
+      : metadata !== undefined
+        ? resolveAgentSessionMetadata(metadata)
+        : null;
+
+  const resolvedMetadata = providedMetadata
+    ? resolveAgentSessionMetadata(
+        providedMetadata.agentType ?? configMetadata.agentType,
+        providedMetadata.agentSessionKind ?? configMetadata.agentSessionKind,
+      )
+    : configMetadata;
+
+  config.agentType = resolvedMetadata.agentType;
+  config.agentSessionKind = resolvedMetadata.agentSessionKind;
 
   if (resolvedMetadata.agentSessionKind === AgentSessionKind.ToolUse) {
     return {

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 
 // Local imports - agent
+import { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
 import { ToolConfig } from '@agent/core/ToolConfig';
 
 // Local imports - utils
@@ -33,8 +34,21 @@ export class ExecutionManager {
 
   async handleExecute(message: any): Promise<void> {
     const isToolUseAgent = Boolean(message.isToolUseAgent);
+    const config = isToolUseAgent
+      ? this.buildToolUseCommandPayload(message)
+      : await this.buildWorkflowCommandPayload(message);
 
-    if (!message.inputFile && !isToolUseAgent) {
+    if (!config) {
+      return;
+    }
+
+    await vscode.commands.executeCommand('texra.execute', config);
+  }
+
+  private async buildWorkflowCommandPayload(
+    message: any,
+  ): Promise<AgentConfig | null> {
+    if (!message.inputFile) {
       const openDocs = 'File Management Guide';
       const choice = await vscode.window.showErrorMessage(
         'Please select an input file.',
@@ -43,9 +57,25 @@ export class ExecutionManager {
       if (choice === openDocs) {
         vscode.commands.executeCommand('texra.openDoc', 'file-management');
       }
-      return;
+      return null;
     }
 
+    return this.composeAgentConfig(message, {
+      agentSessionKind: AgentSessionKind.Workflow,
+    });
+  }
+
+  private buildToolUseCommandPayload(message: any): AgentConfig {
+    return this.composeAgentConfig(message, {
+      agentType: AgentType.ToolUse,
+      agentSessionKind: AgentSessionKind.ToolUse,
+    });
+  }
+
+  private composeAgentConfig(
+    message: any,
+    metadata: { agentType?: AgentType; agentSessionKind: AgentSessionKind },
+  ): AgentConfig {
     const toolConfig: ToolConfig = {
       autoExtractFigure: message.autoExtractFigure,
       autoExtractTikzFigure: message.autoExtractTikzFigure,
@@ -70,18 +100,18 @@ export class ExecutionManager {
         (Array.isArray(outputFiles) && outputFiles.length > 1),
     );
 
-    const agentConfig: AgentConfig = {
+    return {
       agent: message.agent,
       model: message.model,
       instruction: message.instruction,
       useMultipleOutputs,
-      inputFile: message.inputFile,
+      inputFile: message.inputFile ?? '',
       inputFiles: getFilesIfNotEmpty<string>(message.inputFiles),
-      referenceFile: message.referenceFile,
+      referenceFile: message.referenceFile ?? null,
       referenceFiles: getFilesIfNotEmpty<string>(message.referenceFiles),
-      auxiliaryFile: message.auxiliaryFile,
+      auxiliaryFile: message.auxiliaryFile ?? null,
       auxiliaryFiles: getFilesIfNotEmpty<string>(message.auxiliaryFiles),
-      mediaFile: mapMediaPath(message.mediaFile),
+      mediaFile: mapMediaPath(message.mediaFile ?? null),
       mediaFiles: message.mediaFiles
         ? getFilesIfNotEmpty<string>(
             message.mediaFiles
@@ -92,9 +122,9 @@ export class ExecutionManager {
       outputFiles,
       editedFile: null,
       toolConfig,
+      agentType: metadata.agentType,
+      agentSessionKind: metadata.agentSessionKind,
     };
-
-    await vscode.commands.executeCommand('texra.execute', agentConfig);
   }
 
   private handleFileOperation(message: any): void {


### PR DESCRIPTION
## Summary
- add explicit agent type metadata to agent configs and history records while propagating it through execution
- introduce a tool-use agent registry, refactor command handling, and branch execution payload construction for tool-use vs. workflow agents
- separate progress view task state storage with a dedicated tool-use manager to keep cleanup and persistence paths distinct

## Testing
- npm run format
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8fb551560832497e790a793412c79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce agent type/session metadata and a tool-use agent registry; split ProgressView task-state persistence into workflow vs. tool-use; update execution, history, commands, and webview payloads to honor these paths.
> 
> - **Core/Config**:
>   - Add `agentType` and `agentSessionKind` to `AgentConfig` and propagate via `executeAgent` (normalize metadata on config and stream IDs).
>   - Enhance `agentConfigToTaskState` to merge metadata from config/inputs and normalize task state.
> - **Tool-Use**:
>   - Introduce `ToolUseAgentRegistry` with register/unregister/get/cleanup APIs and export via `@agent/toolUse`.
>   - `BaseToolUseAgent` registers in the new registry (overrides running-agent hooks).
> - **Commands**:
>   - `texra.stopAgent` and `texra.sendFollowUp` resolve agents from `BaseAgent` or the new tool-use registry.
>   - Agent creator/registration: rename metadata flag to `isMultipleOutput`.
> - **Execution/History**:
>   - `executeAgent` resolves and writes session metadata into config; stream activation includes `agentType`/`agentSessionKind`.
>   - History items now store and normalize `agentType`/`agentSessionKind`; restore uses resolved metadata.
> - **Progress View**:
>   - Split task-state storage into `WorkflowTaskStateManager` and `ToolUseTaskStateManager`; persist as `{ workflow, toolUse }` with backward-compatible load.
>   - Add cleanup of inactive tool-use agents; tighten clear-output behavior to workflow tasks only.
> - **Misc**:
>   - Base agent now uses register/unregister helpers for running-agent tracking.
>   - Minor config tweak to ignored directories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71f2532acfd58f9714f6f5669aa0f71eb764c0e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->