### PR TITLE
fix: guard personal style trace replacements

### DIFF
--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -41,6 +41,7 @@ import {
   LATEXDIFF_MARKUP_REPLACEMENTS,
   INLINE_MATH_REPLACEMENTS,
   EQUATION_STYLE_REPLACEMENTS,
+  PERSONAL_STYLE_CONTEXTUAL_REPLACEMENTS,
 } from './rulesRegex';
 
 export interface ReplacementEngine {
@@ -119,6 +120,7 @@ const REGEX_CATEGORIES: ReplacementCategory[] = [
   PARENTHESES_REPLACEMENTS,
   LATEXDIFF_MARKUP_REPLACEMENTS,
   EQUATION_STYLE_REPLACEMENTS,
+  PERSONAL_STYLE_CONTEXTUAL_REPLACEMENTS,
   MAX_REGEX_REPLACEMENTS,
 ];
 
@@ -176,6 +178,7 @@ export function getAllReplacementsRegex(): ReplacementCategory[] {
     'parentheses',
     'latexdiff_markup',
     'equation_style',
+    'personal_style_contextual',
   ]);
   const customReplacements = getConfig('latex.customReplacementsRegex', {});
 

--- a/src/replacement/rules/personalStyle.ts
+++ b/src/replacement/rules/personalStyle.ts
@@ -46,8 +46,6 @@ export const PERSONAL_STYLE_REPLACEMENTS: ReplacementCategory = {
 
     // ===== Math operator standardization =====
     // Preferred operator command forms
-    '\\mathrm{tr}': '\\tr',
-    '\\mathrm{Tr}': '\\Tr',
     '\\mathrm{KL}': '\\KL',
 
     // ===== Reference formatting =====

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -70,6 +70,29 @@ export const INLINE_MATH_REPLACEMENTS: ReplacementCategory = {
   },
 };
 
+// Context-aware personal style conversions
+export const PERSONAL_STYLE_CONTEXTUAL_REPLACEMENTS: ReplacementCategory = {
+  name: 'personal_style_contextual',
+  description:
+    'Context-aware replacements for personal style rules that avoid macro definitions',
+  isRegex: true,
+  flags: 'g',
+  patterns: {
+    // Temporarily protect \mathrm{Tr} inside command definitions
+    '((?:\\\\(?:re)?newcommand|\\\\providecommand|\\\\DeclareMathOperator\\\\*?)\\\\{[^}]+\\\\}(?:\\\\[[^\\]]*\\\\])?\\\\{)\\\\mathrm{Tr}':
+      '$1__TEXRA_PRESERVE_TR__',
+    // Temporarily protect \mathrm{tr} inside command definitions
+    '((?:\\\\(?:re)?newcommand|\\\\providecommand|\\\\DeclareMathOperator\\\\*?)\\\\{[^}]+\\\\}(?:\\\\[[^\\]]*\\\\])?\\\\{)\\\\mathrm{tr}':
+      '$1__TEXRA_PRESERVE_tr__',
+    // Apply preferred operator command forms
+    '\\\\mathrm{Tr}': '\\\\Tr',
+    '\\\\mathrm{tr}': '\\\\tr',
+    // Restore protected command definitions
+    '__TEXRA_PRESERVE_TR__': '\\\\mathrm{Tr}',
+    '__TEXRA_PRESERVE_tr__': '\\\\mathrm{tr}',
+  },
+};
+
 /**
  * LATEXDIFF USAGE NOTE:
  *

--- a/src/test/replacement/personalStyleContextual.test.ts
+++ b/src/test/replacement/personalStyleContextual.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from 'assert';
+
+import { replacementEngine } from '@replacement/engine';
+
+describe('personal style contextual replacements', () => {
+  it('keeps macro definitions intact while rewriting usages', () => {
+    const input = [
+      '\\newcommand{\\tr}{\\mathrm{Tr}}',
+      '\\newcommand{\\trace}[1]{\\mathrm{Tr}(#1)}',
+      '\\renewcommand{\\Tr}{\\mathrm{tr}}',
+      '\\providecommand{\\smalltr}{\\mathrm{tr}}',
+      '$\\mathrm{Tr}$ and $\\mathrm{tr}$',
+    ].join('\n');
+
+    const result = replacementEngine.applyAll(input);
+
+    const expected = [
+      '\\newcommand{\\tr}{\\mathrm{Tr}}',
+      '\\newcommand{\\trace}[1]{\\mathrm{Tr}(#1)}',
+      '\\renewcommand{\\Tr}{\\mathrm{tr}}',
+      '\\providecommand{\\smalltr}{\\mathrm{tr}}',
+      '$\\Tr$ and $\\tr$',
+    ].join('\n');
+
+    assert.strictEqual(result, expected);
+  });
+});


### PR DESCRIPTION
## Summary
- remove the direct personal-style replacements that forced `\mathrm{Tr}`/`\mathrm{tr}` into operator macros
- add a context-aware regex category that skips command definitions while rewriting standalone `\mathrm{Tr}` and `\mathrm{tr}`
- register the new category with the engine and cover the regression with a replacement-engine test

## Testing
- npm run lint
- npm test -- --runGlob src/test/replacement/personalStyleContextual.test.js *(fails: vscode-test needs libatk-1.0 on this runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d92d48cc408324a6bd5a15136c4d14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a contextual regex that converts `\mathrm{Tr}`/`\mathrm{tr}` to `\Tr`/`\tr` while skipping macro definitions, remove the old direct replacements, register the new category, and add a test.
> 
> - **Regex Rules**:
>   - **New `personal_style_contextual`**: Adds context-aware replacements to transform `\mathrm{Tr}`/`\mathrm{tr}` → `\Tr`/`\tr`, preserving occurrences inside command definitions.
> - **Engine**:
>   - Registers `personal_style_contextual` in `REGEX_CATEGORIES` and default `enabledReplacementsRegex`.
> - **Personal Style Rules**:
>   - Removes direct non-regex mappings for `\\mathrm{tr}`/`\\mathrm{Tr}` from `personal_style`.
> - **Tests**:
>   - Adds `personalStyleContextual.test.ts` validating macro definitions remain intact while usages are rewritten.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b9b6acdd5834441f06227afcc4cac6e89674fcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->