### PR TITLE
Lazily resume persisted tool-use sessions on follow-up

### DIFF
--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -105,10 +105,18 @@ function getSnapshotPath(executionId: ExecutionId): string {
   return path.join(STORAGE_DIR, `${executionId}.json`);
 }
 
+interface ResumingSessionState {
+  queuedFollowUps: string[];
+}
+
 export class ToolUseSessionManager {
   private static readonly pendingSnapshots = new Map<
     StreamTabId,
     ToolUseSessionSnapshot
+  >();
+  private static readonly resumingSessions = new Map<
+    StreamTabId,
+    ResumingSessionState
   >();
 
   /**
@@ -150,11 +158,61 @@ export class ToolUseSessionManager {
     const snapshot = this.pendingSnapshots.get(streamId);
     if (snapshot) {
       this.pendingSnapshots.delete(streamId);
+      this.resumingSessions.set(streamId, { queuedFollowUps: [] });
       logger.debug(
         `Consuming pending snapshot for stream ${streamId} to resume lazily.`,
       );
     }
     return snapshot;
+  }
+
+  /**
+   * Adds a follow-up to the queue while a snapshot is being resumed.
+   * @param streamId - The stream identifier to enqueue under.
+   * @param followUp - The follow-up text to queue.
+   * @returns True if the follow-up was queued, false if no resuming session exists.
+   */
+  public static enqueueFollowUpWhileResuming(
+    streamId: StreamTabId,
+    followUp: string,
+  ): boolean {
+    const entry = this.resumingSessions.get(streamId);
+    if (!entry) {
+      return false;
+    }
+
+    entry.queuedFollowUps.push(followUp);
+    logger.debug(
+      `Queued follow-up while resuming stream ${streamId}; ${entry.queuedFollowUps.length} waiting.`,
+    );
+    return true;
+  }
+
+  /**
+   * Retrieves and clears queued follow-ups for a resuming session.
+   * @param streamId - The stream identifier to drain.
+   */
+  public static drainQueuedFollowUps(streamId: StreamTabId): string[] {
+    const entry = this.resumingSessions.get(streamId);
+    if (!entry) {
+      return [];
+    }
+
+    const queued = entry.queuedFollowUps.splice(0);
+    logger.debug(
+      `Drained ${queued.length} queued follow-ups for stream ${streamId} after resume.`,
+    );
+    return queued;
+  }
+
+  /**
+   * Clears a resuming session without draining queued follow-ups (used on failure).
+   * @param streamId - The stream identifier to clear.
+   */
+  public static clearResumingSession(streamId: StreamTabId): void {
+    if (this.resumingSessions.delete(streamId)) {
+      logger.debug(`Cleared resuming session tracking for stream ${streamId}.`);
+    }
   }
 
   /**

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -120,6 +120,14 @@ export class ToolUseSessionManager {
   >();
 
   /**
+   * Determines whether the provided stream is currently marked as resuming.
+   * @param streamId - The stream identifier to check.
+   */
+  public static isResumingSession(streamId: StreamTabId): boolean {
+    return this.resumingSessions.has(streamId);
+  }
+
+  /**
    * Checks if tool-use session persistence is enabled
    * @returns True if persistence is enabled, false otherwise
    */

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -106,12 +106,63 @@ function getSnapshotPath(executionId: ExecutionId): string {
 }
 
 export class ToolUseSessionManager {
+  private static readonly pendingSnapshots = new Map<
+    StreamTabId,
+    ToolUseSessionSnapshot
+  >();
+
   /**
    * Checks if tool-use session persistence is enabled
    * @returns True if persistence is enabled, false otherwise
    */
   public static isPersistenceEnabled(): boolean {
     return getToolUsePersistenceEnabled();
+  }
+
+  /**
+   * Registers persisted snapshots so they can be resumed lazily.
+   * @param snapshots - The snapshots to cache for later use.
+   */
+  public static registerPendingSnapshots(
+    snapshots: ToolUseSessionSnapshot[],
+  ): void {
+    if (snapshots.length === 0) {
+      return;
+    }
+
+    for (const snapshot of snapshots) {
+      this.pendingSnapshots.set(snapshot.streamId as StreamTabId, snapshot);
+    }
+
+    logger.debug(
+      `Registered ${snapshots.length} pending tool-use snapshots for lazy resume.`,
+    );
+  }
+
+  /**
+   * Retrieves and removes a cached snapshot for the provided stream.
+   * @param streamId - The stream identifier to lookup.
+   * @returns The cached snapshot if found.
+   */
+  public static consumeSnapshotForStream(
+    streamId: StreamTabId,
+  ): ToolUseSessionSnapshot | undefined {
+    const snapshot = this.pendingSnapshots.get(streamId);
+    if (snapshot) {
+      this.pendingSnapshots.delete(streamId);
+      logger.debug(
+        `Consuming pending snapshot for stream ${streamId} to resume lazily.`,
+      );
+    }
+    return snapshot;
+  }
+
+  /**
+   * Checks if a snapshot is cached for the provided stream identifier.
+   * @param streamId - The stream identifier to check.
+   */
+  public static hasPendingSnapshot(streamId: StreamTabId): boolean {
+    return this.pendingSnapshots.has(streamId);
   }
 
   /**
@@ -223,6 +274,14 @@ export class ToolUseSessionManager {
     if (!executionId || !isValidExecutionId(executionId)) {
       return;
     }
+
+    for (const [streamId, snapshot] of this.pendingSnapshots.entries()) {
+      if (snapshot.executionId === executionId) {
+        this.pendingSnapshots.delete(streamId);
+        break;
+      }
+    }
+
     try {
       await StorageFS.delete(getSnapshotPath(executionId));
     } catch (error) {

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -152,13 +152,36 @@ export class ToolUseSessionManager {
    * @param streamId - The stream identifier to lookup.
    * @returns The cached snapshot if found.
    */
+  public static getSnapshotForStream(
+    streamId: StreamTabId,
+  ): ToolUseSessionSnapshot | undefined {
+    return this.pendingSnapshots.get(streamId);
+  }
+
+  /**
+   * Marks a stream as resuming so follow-ups can be queued until the agent is ready.
+   * @param streamId - The stream identifier being resumed.
+   */
+  public static setResumingSession(streamId: StreamTabId): void {
+    if (this.resumingSessions.has(streamId)) {
+      return;
+    }
+
+    this.resumingSessions.set(streamId, { queuedFollowUps: [] });
+    logger.debug(`Marked stream ${streamId} as resuming.`);
+  }
+
+  /**
+   * Removes and returns a cached snapshot for the provided stream.
+   * @param streamId - The stream identifier to lookup.
+   * @returns The cached snapshot if found.
+   */
   public static consumeSnapshotForStream(
     streamId: StreamTabId,
   ): ToolUseSessionSnapshot | undefined {
     const snapshot = this.pendingSnapshots.get(streamId);
     if (snapshot) {
       this.pendingSnapshots.delete(streamId);
-      this.resumingSessions.set(streamId, { queuedFollowUps: [] });
       logger.debug(
         `Consuming pending snapshot for stream ${streamId} to resume lazily.`,
       );

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -38,18 +38,31 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
           console.log(
             `[${CHANNEL}] resuming agent lazily for stream ${payload.stream}`,
           );
-          void Promise.resolve(
-            vscode.commands.executeCommand('texra.resumeAgent', {
+          try {
+            await vscode.commands.executeCommand('texra.resumeAgent', {
               snapshot: pendingSnapshot,
               followUp: payload.text,
-            }),
-          ).catch((err: unknown) => {
-            void showLoggedErrorMessage(
+            });
+          } catch (err) {
+            ToolUseSessionManager.clearResumingSession(streamId);
+            await showLoggedErrorMessage(
               CHANNEL,
               'Failed to resume tool-use session for follow-up',
               err,
             );
-          });
+          }
+          return;
+        }
+
+        if (
+          ToolUseSessionManager.enqueueFollowUpWhileResuming(
+            streamId,
+            payload.text,
+          )
+        ) {
+          console.log(
+            `[${CHANNEL}] queued follow-up while stream ${payload.stream} is resuming`,
+          );
           return;
         }
 

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -8,6 +8,7 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports - utilities
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import type { ResumeAgentResult } from './resumeCommand';
 
 const CHANNEL = 'followUpCommand';
 console.log(`[${CHANNEL}] command registered`);
@@ -32,6 +33,19 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
           return;
         }
 
+        if (
+          ToolUseSessionManager.isResumingSession(streamId) &&
+          ToolUseSessionManager.enqueueFollowUpWhileResuming(
+            streamId,
+            payload.text,
+          )
+        ) {
+          console.log(
+            `[${CHANNEL}] queued follow-up while stream ${payload.stream} is resuming`,
+          );
+          return;
+        }
+
         const pendingSnapshot =
           ToolUseSessionManager.getSnapshotForStream(streamId);
         if (pendingSnapshot) {
@@ -40,12 +54,18 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
           );
           ToolUseSessionManager.setResumingSession(streamId);
           try {
-            await vscode.commands.executeCommand('texra.resumeAgent', {
-              snapshot: pendingSnapshot,
-              followUp: payload.text,
-            });
-            // Only consume the snapshot after successful resume
-            ToolUseSessionManager.consumeSnapshotForStream(streamId);
+            const result = (await vscode.commands.executeCommand(
+              'texra.resumeAgent',
+              {
+                snapshot: pendingSnapshot,
+                followUp: payload.text,
+              },
+            )) as ResumeAgentResult | undefined;
+
+            if (result?.success) {
+              // Only consume the snapshot after successful resume
+              ToolUseSessionManager.consumeSnapshotForStream(streamId);
+            }
           } catch (err) {
             const lostFollowUps =
               ToolUseSessionManager.drainQueuedFollowUps(streamId);
@@ -65,18 +85,6 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
               err,
             );
           }
-          return;
-        }
-
-        if (
-          ToolUseSessionManager.enqueueFollowUpWhileResuming(
-            streamId,
-            payload.text,
-          )
-        ) {
-          console.log(
-            `[${CHANNEL}] queued follow-up while stream ${payload.stream} is resuming`,
-          );
           return;
         }
 

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -44,6 +44,15 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
               followUp: payload.text,
             });
           } catch (err) {
+            const lostFollowUps =
+              ToolUseSessionManager.drainQueuedFollowUps(streamId);
+            if (lostFollowUps.length > 0) {
+              const followUpLabel =
+                lostFollowUps.length === 1 ? 'follow-up was' : 'follow-ups were';
+              await vscode.window.showWarningMessage(
+                `Resume failed. ${lostFollowUps.length} queued ${followUpLabel} lost.`,
+              );
+            }
             ToolUseSessionManager.clearResumingSession(streamId);
             await showLoggedErrorMessage(
               CHANNEL,

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -33,11 +33,13 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
         }
 
         const pendingSnapshot =
-          ToolUseSessionManager.consumeSnapshotForStream(streamId);
+          ToolUseSessionManager.getSnapshotForStream(streamId);
         if (pendingSnapshot) {
           console.log(
             `[${CHANNEL}] resuming agent lazily for stream ${payload.stream}`,
           );
+          ToolUseSessionManager.setResumingSession(streamId);
+          ToolUseSessionManager.consumeSnapshotForStream(streamId);
           try {
             await vscode.commands.executeCommand('texra.resumeAgent', {
               snapshot: pendingSnapshot,
@@ -48,7 +50,9 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
               ToolUseSessionManager.drainQueuedFollowUps(streamId);
             if (lostFollowUps.length > 0) {
               const followUpLabel =
-                lostFollowUps.length === 1 ? 'follow-up was' : 'follow-ups were';
+                lostFollowUps.length === 1
+                  ? 'follow-up was'
+                  : 'follow-ups were';
               await vscode.window.showWarningMessage(
                 `Resume failed. ${lostFollowUps.length} queued ${followUpLabel} lost.`,
               );

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 
 // Local imports - agent
 import { getToolUseAgent } from '@agent/toolUse/ToolUseAgentRegistry';
+import { ToolUseSessionManager } from '@agent/toolUse/ToolUseSessionManager';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports - utilities
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
@@ -15,7 +17,8 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'texra.sendFollowUp',
       async (payload: { stream: string; text: string }) => {
-        const agent = getToolUseAgent(payload.stream);
+        const streamId = payload.stream as StreamTabId;
+        const agent = getToolUseAgent(streamId);
         if (agent) {
           try {
             agent.appendFollowUp(payload.text);
@@ -26,7 +29,36 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
               err,
             );
           }
+          return;
         }
+
+        const pendingSnapshot =
+          ToolUseSessionManager.consumeSnapshotForStream(streamId);
+        if (pendingSnapshot) {
+          console.log(
+            `[${CHANNEL}] resuming agent lazily for stream ${payload.stream}`,
+          );
+          void Promise.resolve(
+            vscode.commands.executeCommand('texra.resumeAgent', {
+              snapshot: pendingSnapshot,
+              followUp: payload.text,
+            }),
+          ).catch((err: unknown) => {
+            void showLoggedErrorMessage(
+              CHANNEL,
+              'Failed to resume tool-use session for follow-up',
+              err,
+            );
+          });
+          return;
+        }
+
+        console.log(
+          `[${CHANNEL}] no active session found for stream ${payload.stream}`,
+        );
+        void vscode.window.showWarningMessage(
+          'No active tool-use session found for this follow-up.',
+        );
       },
     ),
   );

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -39,12 +39,13 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
             `[${CHANNEL}] resuming agent lazily for stream ${payload.stream}`,
           );
           ToolUseSessionManager.setResumingSession(streamId);
-          ToolUseSessionManager.consumeSnapshotForStream(streamId);
           try {
             await vscode.commands.executeCommand('texra.resumeAgent', {
               snapshot: pendingSnapshot,
               followUp: payload.text,
             });
+            // Only consume the snapshot after successful resume
+            ToolUseSessionManager.consumeSnapshotForStream(streamId);
           } catch (err) {
             const lostFollowUps =
               ToolUseSessionManager.drainQueuedFollowUps(streamId);

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -167,13 +167,16 @@ export function registerResumeAgentCommand(
           snapshot.streamId as StreamTabId,
         );
       } catch (error) {
+        // Clear resuming session first to ensure cleanup
         ToolUseSessionManager.clearResumingSession(
           snapshot.streamId as StreamTabId,
         );
+        // Then update UI status
         provider.eventHandler.setStreamStatus(
           snapshot.streamId,
           STATUS.WAITING,
         );
+        // Finally delete the snapshot
         await ToolUseSessionManager.deleteSnapshot(snapshot.executionId);
         throw error instanceof Error
           ? error

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -167,6 +167,9 @@ export function registerResumeAgentCommand(
           snapshot.streamId as StreamTabId,
         );
       } catch (error) {
+        ToolUseSessionManager.clearResumingSession(
+          snapshot.streamId as StreamTabId,
+        );
         provider.eventHandler.setStreamStatus(
           snapshot.streamId,
           STATUS.WAITING,

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -79,9 +79,26 @@ async function buildToolUseAgent(
     agentPath.directory,
     snapshot.executionId as ExecutionId,
   );
-
-  agent.resumeFromSnapshot(snapshot);
   return { agent, agentSetting };
+}
+
+type ResumeAgentCommandPayload =
+  | ToolUseSessionSnapshot
+  | { snapshot: ToolUseSessionSnapshot; followUp?: string };
+
+function normalizePayload(payload: ResumeAgentCommandPayload | undefined): {
+  snapshot: ToolUseSessionSnapshot | undefined;
+  followUp?: string;
+} {
+  if (!payload) {
+    return { snapshot: undefined };
+  }
+
+  if ('snapshot' in payload) {
+    return { snapshot: payload.snapshot, followUp: payload.followUp };
+  }
+
+  return { snapshot: payload };
 }
 
 export function registerResumeAgentCommand(
@@ -89,7 +106,8 @@ export function registerResumeAgentCommand(
 ): vscode.Disposable {
   return vscode.commands.registerCommand(
     'texra.resumeAgent',
-    async (snapshot: ToolUseSessionSnapshot | undefined) => {
+    async (payload: ResumeAgentCommandPayload | undefined) => {
+      const { snapshot, followUp } = normalizePayload(payload);
       if (!snapshot || !ToolUseSessionManager.isPersistenceEnabled()) {
         return;
       }
@@ -112,6 +130,11 @@ export function registerResumeAgentCommand(
           snapshot,
           context,
         );
+
+        agent.resumeFromSnapshot(snapshot);
+        if (followUp !== undefined) {
+          agent.appendFollowUp(followUp);
+        }
 
         await executeAgentWithLogging(
           snapshot.agentName,

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -22,8 +22,9 @@ import {
   ToolUseSessionManager,
   type ToolUseSessionSnapshot,
 } from '@agent/toolUse/ToolUseSessionManager';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { STATUS } from '@progressView/modules/constants.js';
 import { isToolUseTaskState } from '@logger/TaskState';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 
@@ -122,9 +123,17 @@ export function registerResumeAgentCommand(
         const existingStatus = provider.eventHandler.getStreamStatus(
           snapshot.streamId,
         );
-        if (existingStatus === 'running') {
+        if (
+          existingStatus === STATUS.RUNNING ||
+          existingStatus === STATUS.RESUMING
+        ) {
           return;
         }
+
+        provider.eventHandler.setStreamStatus(
+          snapshot.streamId,
+          STATUS.RESUMING,
+        );
 
         const { agent, agentSetting } = await buildToolUseAgent(
           snapshot,
@@ -134,6 +143,13 @@ export function registerResumeAgentCommand(
         agent.resumeFromSnapshot(snapshot);
         if (followUp !== undefined) {
           agent.appendFollowUp(followUp);
+        }
+
+        const queuedFollowUps = ToolUseSessionManager.drainQueuedFollowUps(
+          snapshot.streamId as StreamTabId,
+        );
+        for (const queuedFollowUp of queuedFollowUps) {
+          agent.appendFollowUp(queuedFollowUp);
         }
 
         await executeAgentWithLogging(
@@ -146,7 +162,14 @@ export function registerResumeAgentCommand(
           executionId,
           { resume: true },
         );
+
+        ToolUseSessionManager.clearResumingSession(
+          snapshot.streamId as StreamTabId,
+        );
       } catch (error) {
+        ToolUseSessionManager.clearResumingSession(
+          snapshot.streamId as StreamTabId,
+        );
         await ToolUseSessionManager.deleteSnapshot(snapshot.executionId);
         const message =
           error instanceof Error ? error.message : String(error ?? 'unknown');

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -113,12 +113,12 @@ export function registerResumeAgentCommand(
         return;
       }
 
-      try {
-        const provider = ProgressViewProvider.getInstance();
-        if (!provider) {
-          return;
-        }
+      const provider = ProgressViewProvider.getInstance();
+      if (!provider) {
+        return;
+      }
 
+      try {
         const executionId = snapshot.executionId as ExecutionId;
         const existingStatus = provider.eventHandler.getStreamStatus(
           snapshot.streamId,
@@ -167,15 +167,14 @@ export function registerResumeAgentCommand(
           snapshot.streamId as StreamTabId,
         );
       } catch (error) {
-        ToolUseSessionManager.clearResumingSession(
-          snapshot.streamId as StreamTabId,
+        provider.eventHandler.setStreamStatus(
+          snapshot.streamId,
+          STATUS.WAITING,
         );
         await ToolUseSessionManager.deleteSnapshot(snapshot.executionId);
-        const message =
-          error instanceof Error ? error.message : String(error ?? 'unknown');
-        vscode.window.showWarningMessage(
-          `Failed to resume tool-use session: ${message}`,
-        );
+        throw error instanceof Error
+          ? error
+          : new Error(String(error ?? 'unknown'));
       }
     },
   );

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -27,6 +27,7 @@ import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { STATUS } from '@progressView/modules/constants.js';
 import { isToolUseTaskState } from '@logger/TaskState';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
+import { logErrorMessage } from '@common/errors/errorHandlingUtils';
 
 function isToolUseAgent(setting: AgentSetting): boolean {
   return setting.agentType === AgentType.ToolUse;
@@ -87,6 +88,13 @@ type ResumeAgentCommandPayload =
   | ToolUseSessionSnapshot
   | { snapshot: ToolUseSessionSnapshot; followUp?: string };
 
+const CHANNEL = 'resumeAgentCommand';
+
+export interface ResumeAgentResult {
+  success: boolean;
+  lostFollowUps?: number;
+}
+
 function normalizePayload(payload: ResumeAgentCommandPayload | undefined): {
   snapshot: ToolUseSessionSnapshot | undefined;
   followUp?: string;
@@ -107,16 +115,21 @@ export function registerResumeAgentCommand(
 ): vscode.Disposable {
   return vscode.commands.registerCommand(
     'texra.resumeAgent',
-    async (payload: ResumeAgentCommandPayload | undefined) => {
+    async (
+      payload: ResumeAgentCommandPayload | undefined,
+    ): Promise<ResumeAgentResult> => {
       const { snapshot, followUp } = normalizePayload(payload);
       if (!snapshot || !ToolUseSessionManager.isPersistenceEnabled()) {
-        return;
+        return { success: false };
       }
 
       const provider = ProgressViewProvider.getInstance();
       if (!provider) {
-        return;
+        return { success: false };
       }
+
+      const streamId = snapshot.streamId as StreamTabId;
+      let queuedFollowUps: string[] = [];
 
       try {
         const executionId = snapshot.executionId as ExecutionId;
@@ -127,7 +140,7 @@ export function registerResumeAgentCommand(
           existingStatus === STATUS.RUNNING ||
           existingStatus === STATUS.RESUMING
         ) {
-          return;
+          return { success: false };
         }
 
         provider.eventHandler.setStreamStatus(
@@ -145,9 +158,7 @@ export function registerResumeAgentCommand(
           agent.appendFollowUp(followUp);
         }
 
-        const queuedFollowUps = ToolUseSessionManager.drainQueuedFollowUps(
-          snapshot.streamId as StreamTabId,
-        );
+        queuedFollowUps = ToolUseSessionManager.drainQueuedFollowUps(streamId);
         for (const queuedFollowUp of queuedFollowUps) {
           agent.appendFollowUp(queuedFollowUp);
         }
@@ -163,24 +174,40 @@ export function registerResumeAgentCommand(
           { resume: true },
         );
 
-        ToolUseSessionManager.clearResumingSession(
-          snapshot.streamId as StreamTabId,
-        );
-      } catch (error) {
-        // Clear resuming session first to ensure cleanup
-        ToolUseSessionManager.clearResumingSession(
-          snapshot.streamId as StreamTabId,
-        );
-        // Then update UI status
+        ToolUseSessionManager.clearResumingSession(streamId);
         provider.eventHandler.setStreamStatus(
           snapshot.streamId,
           STATUS.WAITING,
         );
-        // Finally delete the snapshot
-        await ToolUseSessionManager.deleteSnapshot(snapshot.executionId);
-        throw error instanceof Error
-          ? error
-          : new Error(String(error ?? 'unknown'));
+
+        return { success: true };
+      } catch (error) {
+        const lostFollowUps =
+          queuedFollowUps.length > 0
+            ? queuedFollowUps
+            : ToolUseSessionManager.drainQueuedFollowUps(streamId);
+
+        ToolUseSessionManager.clearResumingSession(streamId);
+        provider.eventHandler.setStreamStatus(
+          snapshot.streamId,
+          STATUS.WAITING,
+        );
+
+        const baseMessage = logErrorMessage(
+          CHANNEL,
+          'Failed to resume tool-use session',
+          error,
+        );
+        const lostCount = lostFollowUps.length;
+        const followUpSuffix =
+          lostCount > 0
+            ? ` ${lostCount} queued ${
+                lostCount === 1 ? 'follow-up was' : 'follow-ups were'
+              } lost.`
+            : '';
+        await vscode.window.showWarningMessage(`${baseMessage}${followUpSuffix}`);
+
+        return { success: false, lostFollowUps: lostCount };
       }
     },
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,6 +102,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const persistedToolUseSessions = ToolUseSessionManager.isPersistenceEnabled()
     ? await ToolUseSessionManager.listSnapshots()
     : [];
+  ToolUseSessionManager.registerPendingSnapshots(persistedToolUseSessions);
   const waitingStreams = new Set(
     persistedToolUseSessions.map((snapshot) => snapshot.streamId),
   );
@@ -120,20 +121,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register commands first - this will create and store the MainViewProvider
   registerCommands(context);
-
-  if (persistedToolUseSessions.length > 0) {
-    for (const snapshot of persistedToolUseSessions) {
-      void Promise.resolve(
-        vscode.commands.executeCommand('texra.resumeAgent', snapshot),
-      ).catch((error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
-        logger.error(
-          'extension',
-          `Failed to resume tool-use session ${snapshot.executionId}: ${message}`,
-        );
-      });
-    }
-  }
 
   // Create a status bar item to show TeXRA progress
   statusBarItem = vscode.window.createStatusBarItem(

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -31,7 +31,8 @@ type StreamStatusType =
   | typeof STATUS.RUNNING
   | typeof STATUS.ERROR
   | typeof STATUS.STOPPED
-  | typeof STATUS.WAITING;
+  | typeof STATUS.WAITING
+  | typeof STATUS.RESUMING;
 
 /**
  * Refactored ProgressViewProvider using the new modular architecture.

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -34,12 +34,14 @@ type StatusType =
   | typeof STATUS.ERROR
   | typeof STATUS.STOPPED
   | typeof STATUS.READY
-  | typeof STATUS.WAITING;
+  | typeof STATUS.WAITING
+  | typeof STATUS.RESUMING;
 type StreamStatusType =
   | typeof STATUS.RUNNING
   | typeof STATUS.ERROR
   | typeof STATUS.STOPPED
-  | typeof STATUS.WAITING;
+  | typeof STATUS.WAITING
+  | typeof STATUS.RESUMING;
 type StreamStatusOrReadyType = StreamStatusType | typeof STATUS.READY;
 
 /**
@@ -586,6 +588,13 @@ export class ProgressEventHandler {
    */
   getStreamStatus(stream: string): StreamStatusType | undefined {
     return this._streamStatus.get(stream);
+  }
+
+  /**
+   * Set the status for a specific stream synchronously.
+   */
+  setStreamStatus(stream: string, status: StreamStatusOrReadyType): void {
+    this.handleUpdateStreamStatus({ stream, status });
   }
 
   /**

--- a/src/progressView/modules/constants.d.ts
+++ b/src/progressView/modules/constants.d.ts
@@ -1,0 +1,32 @@
+declare module '@progressView/modules/constants.js' {
+  export const STATUS: {
+    RUNNING: 'running';
+    ERROR: 'error';
+    STOPPED: 'stopped';
+    READY: 'ready';
+    WAITING: 'waiting';
+    RESUMING: 'resuming';
+  };
+
+  export const ELEMENT_IDS: Record<string, string>;
+  export const SPLIT_SIZES: { CONTENT: number; TABS: number };
+  export const MAX_HEIGHT: number;
+  export const COMMANDS: Record<string, string>;
+  export const TOOLBAR_BUTTONS: Record<string, unknown>;
+  export const ALL_TOOLBAR_BUTTON_IDS: string[];
+  export const SORT_BUTTONS: Array<{
+    id: string;
+    icon: string;
+    sort: string;
+    title: string;
+  }>;
+  export const FILTER_BUTTONS: Array<{
+    id: string;
+    label: string;
+    filter: string;
+  }>;
+}
+
+declare module '*modules/constants.js' {
+  export * from '@progressView/modules/constants.js';
+}

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -5,6 +5,7 @@ export const STATUS = {
   STOPPED: 'stopped',
   READY: 'ready',
   WAITING: 'waiting',
+  RESUMING: 'resuming',
 };
 
 // DOM element IDs used across the progress view

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -36,6 +36,14 @@ describe('followUpCommand', () => {
   let enqueueImplementation:
     | ((streamId: StreamTabId, followUp: string) => boolean)
     | undefined;
+  let drainCalls: StreamTabId[];
+  let drainImplementation:
+    | ((streamId: StreamTabId) => string[])
+    | undefined;
+  let clearCalls: StreamTabId[];
+  let executeImplementation:
+    | ((command: string, ...args: any[]) => Promise<unknown>)
+    | undefined;
 
   const originalRegisterCommand = vscode.commands.registerCommand;
   const originalExecuteCommand = vscode.commands.executeCommand;
@@ -46,6 +54,8 @@ describe('followUpCommand', () => {
     ToolUseSessionManager.enqueueFollowUpWhileResuming;
   const originalClearResumingSession =
     ToolUseSessionManager.clearResumingSession;
+  const originalDrainQueuedFollowUps =
+    ToolUseSessionManager.drainQueuedFollowUps;
 
   beforeEach(() => {
     context = {
@@ -59,6 +69,10 @@ describe('followUpCommand', () => {
     consumeImplementation = undefined;
     enqueueCalls = [];
     enqueueImplementation = undefined;
+    drainCalls = [];
+    drainImplementation = undefined;
+    clearCalls = [];
+    executeImplementation = undefined;
 
     (vscode.commands as any).registerCommand = (
       command: string,
@@ -73,6 +87,9 @@ describe('followUpCommand', () => {
       ...args: any[]
     ) => {
       executeCalls.push({ command, args });
+      if (executeImplementation) {
+        return executeImplementation(command, ...args);
+      }
       return undefined;
     };
 
@@ -86,6 +103,7 @@ describe('followUpCommand', () => {
         consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
         enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
       }
     ).consumeSnapshotForStream = (streamId: StreamTabId) => {
       consumeCalls.push(streamId);
@@ -99,6 +117,7 @@ describe('followUpCommand', () => {
         consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
         enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
       }
     ).enqueueFollowUpWhileResuming = (
       streamId: StreamTabId,
@@ -115,9 +134,24 @@ describe('followUpCommand', () => {
         consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
         enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
       }
-    ).clearResumingSession = () => {
-      /* noop for tests */
+    ).drainQueuedFollowUps = (streamId: StreamTabId) => {
+      drainCalls.push(streamId);
+      if (drainImplementation) {
+        return drainImplementation(streamId);
+      }
+      return [];
+    };
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      }
+    ).clearResumingSession = (streamId: StreamTabId) => {
+      clearCalls.push(streamId);
     };
 
     registerFollowUpCommand(context);
@@ -149,6 +183,11 @@ describe('followUpCommand', () => {
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
       }
     ).clearResumingSession = originalClearResumingSession;
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      }
+    ).drainQueuedFollowUps = originalDrainQueuedFollowUps;
   });
 
   function createSnapshot(streamId: StreamTabId): ToolUseSessionSnapshot {
@@ -246,5 +285,28 @@ describe('followUpCommand', () => {
       'No active tool-use session found for this follow-up.',
     );
     assert.strictEqual(enqueueCalls.length, 0);
+  });
+
+  it('drains queued follow-ups and warns when resume fails', async () => {
+    const streamId = 'stream-5' as StreamTabId;
+    const snapshot = createSnapshot(streamId);
+
+    consumeImplementation = () => snapshot;
+    drainImplementation = () => ['first follow-up', 'second follow-up'];
+    executeImplementation = async () => {
+      throw new Error('resume failure');
+    };
+
+    await followUpHandler!({ stream: streamId, text: 'trigger resume' });
+
+    assert.strictEqual(executeCalls.length, 1);
+    assert.strictEqual(executeCalls[0].command, 'texra.resumeAgent');
+    assert.deepStrictEqual(drainCalls, [streamId]);
+    assert.deepStrictEqual(clearCalls, [streamId]);
+    assert.strictEqual(warningMessages.length, 1);
+    assert.strictEqual(
+      warningMessages[0],
+      'Resume failed. 2 queued follow-ups were lost.',
+    );
   });
 });

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -1,0 +1,184 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent
+import type { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import {
+  registerToolUseAgent,
+  clearToolUseAgents,
+} from '@agent/toolUse/ToolUseAgentRegistry';
+import {
+  ToolUseSessionManager,
+  type ToolUseSessionSnapshot,
+} from '@agent/toolUse/ToolUseSessionManager';
+
+// Local imports - commands
+import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
+
+describe('followUpCommand', () => {
+  let context: vscode.ExtensionContext;
+  let registeredCommands: Map<string, (...args: any[]) => unknown>;
+  let warningMessages: string[];
+  let executeCalls: { command: string; args: any[] }[];
+  let followUpHandler:
+    | ((payload: { stream: string; text: string }) => Promise<void>)
+    | undefined;
+  let consumeCalls: StreamTabId[];
+  let consumeImplementation:
+    | ((streamId: StreamTabId) => ToolUseSessionSnapshot | undefined)
+    | undefined;
+
+  const originalRegisterCommand = vscode.commands.registerCommand;
+  const originalExecuteCommand = vscode.commands.executeCommand;
+  const originalShowWarningMessage = vscode.window.showWarningMessage;
+  const originalConsumeSnapshot =
+    ToolUseSessionManager.consumeSnapshotForStream;
+
+  beforeEach(() => {
+    context = {
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+
+    registeredCommands = new Map();
+    warningMessages = [];
+    executeCalls = [];
+    consumeCalls = [];
+    consumeImplementation = undefined;
+
+    (vscode.commands as any).registerCommand = (
+      command: string,
+      callback: (...args: unknown[]) => unknown,
+    ) => {
+      registeredCommands.set(command, callback);
+      return { dispose() {} };
+    };
+
+    (vscode.commands as any).executeCommand = async (
+      command: string,
+      ...args: any[]
+    ) => {
+      executeCalls.push({ command, args });
+      return undefined;
+    };
+
+    (vscode.window as any).showWarningMessage = (message: string) => {
+      warningMessages.push(message);
+      return Promise.resolve(undefined);
+    };
+
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      }
+    ).consumeSnapshotForStream = (streamId: StreamTabId) => {
+      consumeCalls.push(streamId);
+      if (consumeImplementation) {
+        return consumeImplementation(streamId);
+      }
+      return undefined;
+    };
+
+    registerFollowUpCommand(context);
+    followUpHandler = registeredCommands.get('texra.sendFollowUp') as
+      | ((payload: { stream: string; text: string }) => Promise<void>)
+      | undefined;
+    assert.ok(followUpHandler, 'follow-up command should be registered');
+  });
+
+  afterEach(() => {
+    clearToolUseAgents();
+    (vscode.commands as any).registerCommand = originalRegisterCommand;
+    (vscode.commands as any).executeCommand = originalExecuteCommand;
+    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      }
+    ).consumeSnapshotForStream = originalConsumeSnapshot;
+  });
+
+  function createSnapshot(streamId: StreamTabId): ToolUseSessionSnapshot {
+    return {
+      version: 1,
+      executionId: 'exec-id',
+      streamId,
+      agentName: 'demo-agent',
+      model: 'demo-model',
+      agentSessionKind: AgentSessionKind.ToolUse,
+      messages: [],
+      toolState: {
+        texcountStats: null,
+        lastResponse: '',
+        accumulatedOutput: '',
+        mediaFiles: [],
+        thinkingBlocks: [],
+        thinkingAdded: false,
+      },
+      lastUpdated: Date.now(),
+    };
+  }
+
+  it('sends follow-up to an active agent', async () => {
+    const streamId = 'stream-1' as StreamTabId;
+    const received: string[] = [];
+    const agent = {
+      appendFollowUp: (text: string) => {
+        received.push(text);
+      },
+    } as unknown as BaseToolUseAgent;
+
+    registerToolUseAgent(streamId, agent);
+
+    await followUpHandler!({ stream: streamId, text: 'hello' });
+
+    assert.deepStrictEqual(received, ['hello']);
+    assert.strictEqual(executeCalls.length, 0);
+    assert.strictEqual(warningMessages.length, 0);
+    assert.strictEqual(consumeCalls.length, 0);
+  });
+
+  it('resumes lazily when a pending snapshot exists', async () => {
+    const streamId = 'stream-2' as StreamTabId;
+    const snapshot = createSnapshot(streamId);
+    let snapshotAvailable: ToolUseSessionSnapshot | undefined = snapshot;
+
+    consumeImplementation = () => {
+      const current = snapshotAvailable;
+      snapshotAvailable = undefined;
+      return current;
+    };
+
+    await followUpHandler!({ stream: streamId, text: 'resume me' });
+
+    assert.strictEqual(consumeCalls.length, 1);
+    assert.strictEqual(executeCalls.length, 1);
+    assert.strictEqual(executeCalls[0].command, 'texra.resumeAgent');
+    assert.strictEqual(executeCalls[0].args.length, 1);
+    const payload = executeCalls[0].args[0] as {
+      snapshot: ToolUseSessionSnapshot;
+      followUp?: string;
+    };
+    assert.strictEqual(payload.followUp, 'resume me');
+    assert.strictEqual(payload.snapshot, snapshot);
+    assert.strictEqual(warningMessages.length, 0);
+  });
+
+  it('warns when no session is available', async () => {
+    const streamId = 'stream-3' as StreamTabId;
+
+    await followUpHandler!({ stream: streamId, text: 'missing' });
+
+    assert.strictEqual(consumeCalls.length, 1);
+    assert.strictEqual(executeCalls.length, 0);
+    assert.strictEqual(warningMessages.length, 1);
+    assert.strictEqual(
+      warningMessages[0],
+      'No active tool-use session found for this follow-up.',
+    );
+  });
+});

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -32,12 +32,20 @@ describe('followUpCommand', () => {
   let consumeImplementation:
     | ((streamId: StreamTabId) => ToolUseSessionSnapshot | undefined)
     | undefined;
+  let enqueueCalls: { streamId: StreamTabId; followUp: string }[];
+  let enqueueImplementation:
+    | ((streamId: StreamTabId, followUp: string) => boolean)
+    | undefined;
 
   const originalRegisterCommand = vscode.commands.registerCommand;
   const originalExecuteCommand = vscode.commands.executeCommand;
   const originalShowWarningMessage = vscode.window.showWarningMessage;
   const originalConsumeSnapshot =
     ToolUseSessionManager.consumeSnapshotForStream;
+  const originalEnqueueFollowUp =
+    ToolUseSessionManager.enqueueFollowUpWhileResuming;
+  const originalClearResumingSession =
+    ToolUseSessionManager.clearResumingSession;
 
   beforeEach(() => {
     context = {
@@ -49,6 +57,8 @@ describe('followUpCommand', () => {
     executeCalls = [];
     consumeCalls = [];
     consumeImplementation = undefined;
+    enqueueCalls = [];
+    enqueueImplementation = undefined;
 
     (vscode.commands as any).registerCommand = (
       command: string,
@@ -74,6 +84,8 @@ describe('followUpCommand', () => {
     (
       ToolUseSessionManager as typeof ToolUseSessionManager & {
         consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
       }
     ).consumeSnapshotForStream = (streamId: StreamTabId) => {
       consumeCalls.push(streamId);
@@ -81,6 +93,31 @@ describe('followUpCommand', () => {
         return consumeImplementation(streamId);
       }
       return undefined;
+    };
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      }
+    ).enqueueFollowUpWhileResuming = (
+      streamId: StreamTabId,
+      followUp: string,
+    ) => {
+      enqueueCalls.push({ streamId, followUp });
+      if (enqueueImplementation) {
+        return enqueueImplementation(streamId, followUp);
+      }
+      return false;
+    };
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      }
+    ).clearResumingSession = () => {
+      /* noop for tests */
     };
 
     registerFollowUpCommand(context);
@@ -98,8 +135,20 @@ describe('followUpCommand', () => {
     (
       ToolUseSessionManager as typeof ToolUseSessionManager & {
         consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
       }
     ).consumeSnapshotForStream = originalConsumeSnapshot;
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      }
+    ).enqueueFollowUpWhileResuming = originalEnqueueFollowUp;
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      }
+    ).clearResumingSession = originalClearResumingSession;
   });
 
   function createSnapshot(streamId: StreamTabId): ToolUseSessionSnapshot {
@@ -166,6 +215,22 @@ describe('followUpCommand', () => {
     assert.strictEqual(payload.followUp, 'resume me');
     assert.strictEqual(payload.snapshot, snapshot);
     assert.strictEqual(warningMessages.length, 0);
+    assert.strictEqual(enqueueCalls.length, 0);
+  });
+
+  it('queues follow-ups when resume is already in progress', async () => {
+    const streamId = 'stream-4' as StreamTabId;
+
+    enqueueImplementation = () => true;
+
+    await followUpHandler!({ stream: streamId, text: 'queued follow-up' });
+
+    assert.strictEqual(consumeCalls.length, 1);
+    assert.deepStrictEqual(enqueueCalls, [
+      { streamId, followUp: 'queued follow-up' },
+    ]);
+    assert.strictEqual(executeCalls.length, 0);
+    assert.strictEqual(warningMessages.length, 0);
   });
 
   it('warns when no session is available', async () => {
@@ -180,5 +245,6 @@ describe('followUpCommand', () => {
       warningMessages[0],
       'No active tool-use session found for this follow-up.',
     );
+    assert.strictEqual(enqueueCalls.length, 0);
   });
 });

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -28,18 +28,21 @@ describe('followUpCommand', () => {
   let followUpHandler:
     | ((payload: { stream: string; text: string }) => Promise<void>)
     | undefined;
+  let getSnapshotCalls: StreamTabId[];
+  let getSnapshotImplementation:
+    | ((streamId: StreamTabId) => ToolUseSessionSnapshot | undefined)
+    | undefined;
   let consumeCalls: StreamTabId[];
   let consumeImplementation:
     | ((streamId: StreamTabId) => ToolUseSessionSnapshot | undefined)
     | undefined;
+  let setResumingCalls: StreamTabId[];
   let enqueueCalls: { streamId: StreamTabId; followUp: string }[];
   let enqueueImplementation:
     | ((streamId: StreamTabId, followUp: string) => boolean)
     | undefined;
   let drainCalls: StreamTabId[];
-  let drainImplementation:
-    | ((streamId: StreamTabId) => string[])
-    | undefined;
+  let drainImplementation: ((streamId: StreamTabId) => string[]) | undefined;
   let clearCalls: StreamTabId[];
   let executeImplementation:
     | ((command: string, ...args: any[]) => Promise<unknown>)
@@ -48,8 +51,10 @@ describe('followUpCommand', () => {
   const originalRegisterCommand = vscode.commands.registerCommand;
   const originalExecuteCommand = vscode.commands.executeCommand;
   const originalShowWarningMessage = vscode.window.showWarningMessage;
+  const originalGetSnapshot = ToolUseSessionManager.getSnapshotForStream;
   const originalConsumeSnapshot =
     ToolUseSessionManager.consumeSnapshotForStream;
+  const originalSetResumingSession = ToolUseSessionManager.setResumingSession;
   const originalEnqueueFollowUp =
     ToolUseSessionManager.enqueueFollowUpWhileResuming;
   const originalClearResumingSession =
@@ -65,8 +70,11 @@ describe('followUpCommand', () => {
     registeredCommands = new Map();
     warningMessages = [];
     executeCalls = [];
+    getSnapshotCalls = [];
+    getSnapshotImplementation = undefined;
     consumeCalls = [];
     consumeImplementation = undefined;
+    setResumingCalls = [];
     enqueueCalls = [];
     enqueueImplementation = undefined;
     drainCalls = [];
@@ -100,10 +108,28 @@ describe('followUpCommand', () => {
 
     (
       ToolUseSessionManager as typeof ToolUseSessionManager & {
+        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
         consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
         enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
         drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      }
+    ).getSnapshotForStream = (streamId: StreamTabId) => {
+      getSnapshotCalls.push(streamId);
+      if (getSnapshotImplementation) {
+        return getSnapshotImplementation(streamId);
+      }
+      return undefined;
+    };
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
       }
     ).consumeSnapshotForStream = (streamId: StreamTabId) => {
       consumeCalls.push(streamId);
@@ -111,6 +137,18 @@ describe('followUpCommand', () => {
         return consumeImplementation(streamId);
       }
       return undefined;
+    };
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      }
+    ).setResumingSession = (streamId: StreamTabId) => {
+      setResumingCalls.push(streamId);
     };
     (
       ToolUseSessionManager as typeof ToolUseSessionManager & {
@@ -168,9 +206,20 @@ describe('followUpCommand', () => {
     (vscode.window as any).showWarningMessage = originalShowWarningMessage;
     (
       ToolUseSessionManager as typeof ToolUseSessionManager & {
+        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
         consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
         enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      }
+    ).getSnapshotForStream = originalGetSnapshot;
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
       }
     ).consumeSnapshotForStream = originalConsumeSnapshot;
     (
@@ -188,6 +237,11 @@ describe('followUpCommand', () => {
         drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
       }
     ).drainQueuedFollowUps = originalDrainQueuedFollowUps;
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      }
+    ).setResumingSession = originalSetResumingSession;
   });
 
   function createSnapshot(streamId: StreamTabId): ToolUseSessionSnapshot {
@@ -235,6 +289,7 @@ describe('followUpCommand', () => {
     const snapshot = createSnapshot(streamId);
     let snapshotAvailable: ToolUseSessionSnapshot | undefined = snapshot;
 
+    getSnapshotImplementation = () => snapshotAvailable;
     consumeImplementation = () => {
       const current = snapshotAvailable;
       snapshotAvailable = undefined;
@@ -243,7 +298,9 @@ describe('followUpCommand', () => {
 
     await followUpHandler!({ stream: streamId, text: 'resume me' });
 
+    assert.deepStrictEqual(getSnapshotCalls, [streamId]);
     assert.strictEqual(consumeCalls.length, 1);
+    assert.deepStrictEqual(setResumingCalls, [streamId]);
     assert.strictEqual(executeCalls.length, 1);
     assert.strictEqual(executeCalls[0].command, 'texra.resumeAgent');
     assert.strictEqual(executeCalls[0].args.length, 1);
@@ -261,23 +318,28 @@ describe('followUpCommand', () => {
     const streamId = 'stream-4' as StreamTabId;
 
     enqueueImplementation = () => true;
+    getSnapshotImplementation = () => undefined;
 
     await followUpHandler!({ stream: streamId, text: 'queued follow-up' });
 
-    assert.strictEqual(consumeCalls.length, 1);
+    assert.deepStrictEqual(getSnapshotCalls, [streamId]);
+    assert.strictEqual(consumeCalls.length, 0);
     assert.deepStrictEqual(enqueueCalls, [
       { streamId, followUp: 'queued follow-up' },
     ]);
     assert.strictEqual(executeCalls.length, 0);
     assert.strictEqual(warningMessages.length, 0);
+    assert.strictEqual(setResumingCalls.length, 0);
   });
 
   it('warns when no session is available', async () => {
     const streamId = 'stream-3' as StreamTabId;
 
+    getSnapshotImplementation = () => undefined;
     await followUpHandler!({ stream: streamId, text: 'missing' });
 
-    assert.strictEqual(consumeCalls.length, 1);
+    assert.deepStrictEqual(getSnapshotCalls, [streamId]);
+    assert.strictEqual(consumeCalls.length, 0);
     assert.strictEqual(executeCalls.length, 0);
     assert.strictEqual(warningMessages.length, 1);
     assert.strictEqual(
@@ -285,12 +347,14 @@ describe('followUpCommand', () => {
       'No active tool-use session found for this follow-up.',
     );
     assert.strictEqual(enqueueCalls.length, 0);
+    assert.strictEqual(setResumingCalls.length, 0);
   });
 
   it('drains queued follow-ups and warns when resume fails', async () => {
     const streamId = 'stream-5' as StreamTabId;
     const snapshot = createSnapshot(streamId);
 
+    getSnapshotImplementation = () => snapshot;
     consumeImplementation = () => snapshot;
     drainImplementation = () => ['first follow-up', 'second follow-up'];
     executeImplementation = async () => {
@@ -299,10 +363,12 @@ describe('followUpCommand', () => {
 
     await followUpHandler!({ stream: streamId, text: 'trigger resume' });
 
+    assert.deepStrictEqual(getSnapshotCalls, [streamId]);
     assert.strictEqual(executeCalls.length, 1);
     assert.strictEqual(executeCalls[0].command, 'texra.resumeAgent');
     assert.deepStrictEqual(drainCalls, [streamId]);
     assert.deepStrictEqual(clearCalls, [streamId]);
+    assert.deepStrictEqual(setResumingCalls, [streamId]);
     assert.strictEqual(warningMessages.length, 1);
     assert.strictEqual(
       warningMessages[0],

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -37,6 +37,10 @@ describe('followUpCommand', () => {
     | ((streamId: StreamTabId) => ToolUseSessionSnapshot | undefined)
     | undefined;
   let setResumingCalls: StreamTabId[];
+  let isResumingCalls: StreamTabId[];
+  let isResumingImplementation:
+    | ((streamId: StreamTabId) => boolean)
+    | undefined;
   let enqueueCalls: { streamId: StreamTabId; followUp: string }[];
   let enqueueImplementation:
     | ((streamId: StreamTabId, followUp: string) => boolean)
@@ -55,6 +59,8 @@ describe('followUpCommand', () => {
   const originalConsumeSnapshot =
     ToolUseSessionManager.consumeSnapshotForStream;
   const originalSetResumingSession = ToolUseSessionManager.setResumingSession;
+  const originalIsResumingSession =
+    ToolUseSessionManager.isResumingSession;
   const originalEnqueueFollowUp =
     ToolUseSessionManager.enqueueFollowUpWhileResuming;
   const originalClearResumingSession =
@@ -75,6 +81,8 @@ describe('followUpCommand', () => {
     consumeCalls = [];
     consumeImplementation = undefined;
     setResumingCalls = [];
+    isResumingCalls = [];
+    isResumingImplementation = undefined;
     enqueueCalls = [];
     enqueueImplementation = undefined;
     drainCalls = [];
@@ -114,6 +122,7 @@ describe('followUpCommand', () => {
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
         drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
         setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
       }
     ).getSnapshotForStream = (streamId: StreamTabId) => {
       getSnapshotCalls.push(streamId);
@@ -130,6 +139,7 @@ describe('followUpCommand', () => {
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
         drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
         setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
       }
     ).consumeSnapshotForStream = (streamId: StreamTabId) => {
       consumeCalls.push(streamId);
@@ -146,6 +156,7 @@ describe('followUpCommand', () => {
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
         drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
         setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
       }
     ).setResumingSession = (streamId: StreamTabId) => {
       setResumingCalls.push(streamId);
@@ -164,6 +175,21 @@ describe('followUpCommand', () => {
       enqueueCalls.push({ streamId, followUp });
       if (enqueueImplementation) {
         return enqueueImplementation(streamId, followUp);
+      }
+      return false;
+    };
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+      }
+    ).isResumingSession = (streamId: StreamTabId) => {
+      isResumingCalls.push(streamId);
+      if (isResumingImplementation) {
+        return isResumingImplementation(streamId);
       }
       return false;
     };
@@ -220,6 +246,7 @@ describe('followUpCommand', () => {
         enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
         setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
       }
     ).consumeSnapshotForStream = originalConsumeSnapshot;
     (
@@ -232,6 +259,11 @@ describe('followUpCommand', () => {
         clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
       }
     ).clearResumingSession = originalClearResumingSession;
+    (
+      ToolUseSessionManager as typeof ToolUseSessionManager & {
+        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+      }
+    ).isResumingSession = originalIsResumingSession;
     (
       ToolUseSessionManager as typeof ToolUseSessionManager & {
         drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
@@ -295,12 +327,14 @@ describe('followUpCommand', () => {
       snapshotAvailable = undefined;
       return current;
     };
+    executeImplementation = async () => ({ success: true });
 
     await followUpHandler!({ stream: streamId, text: 'resume me' });
 
     assert.deepStrictEqual(getSnapshotCalls, [streamId]);
     assert.strictEqual(consumeCalls.length, 1);
     assert.deepStrictEqual(setResumingCalls, [streamId]);
+    assert.deepStrictEqual(isResumingCalls, [streamId]);
     assert.strictEqual(executeCalls.length, 1);
     assert.strictEqual(executeCalls[0].command, 'texra.resumeAgent');
     assert.strictEqual(executeCalls[0].args.length, 1);
@@ -318,11 +352,13 @@ describe('followUpCommand', () => {
     const streamId = 'stream-4' as StreamTabId;
 
     enqueueImplementation = () => true;
+    isResumingImplementation = () => true;
     getSnapshotImplementation = () => undefined;
 
     await followUpHandler!({ stream: streamId, text: 'queued follow-up' });
 
-    assert.deepStrictEqual(getSnapshotCalls, [streamId]);
+    assert.deepStrictEqual(isResumingCalls, [streamId]);
+    assert.strictEqual(getSnapshotCalls.length, 0);
     assert.strictEqual(consumeCalls.length, 0);
     assert.deepStrictEqual(enqueueCalls, [
       { streamId, followUp: 'queued follow-up' },
@@ -338,6 +374,7 @@ describe('followUpCommand', () => {
     getSnapshotImplementation = () => undefined;
     await followUpHandler!({ stream: streamId, text: 'missing' });
 
+    assert.deepStrictEqual(isResumingCalls, [streamId]);
     assert.deepStrictEqual(getSnapshotCalls, [streamId]);
     assert.strictEqual(consumeCalls.length, 0);
     assert.strictEqual(executeCalls.length, 0);
@@ -358,7 +395,11 @@ describe('followUpCommand', () => {
     consumeImplementation = () => snapshot;
     drainImplementation = () => ['first follow-up', 'second follow-up'];
     executeImplementation = async () => {
-      throw new Error('resume failure');
+      await ToolUseSessionManager.clearResumingSession(streamId);
+      await vscode.window.showWarningMessage(
+        'Resume failed. 2 queued follow-ups were lost.',
+      );
+      return { success: false, lostFollowUps: 2 };
     };
 
     await followUpHandler!({ stream: streamId, text: 'trigger resume' });
@@ -366,7 +407,7 @@ describe('followUpCommand', () => {
     assert.deepStrictEqual(getSnapshotCalls, [streamId]);
     assert.strictEqual(executeCalls.length, 1);
     assert.strictEqual(executeCalls[0].command, 'texra.resumeAgent');
-    assert.deepStrictEqual(drainCalls, [streamId]);
+    assert.strictEqual(drainCalls.length, 0);
     assert.deepStrictEqual(clearCalls, [streamId]);
     assert.deepStrictEqual(setResumingCalls, [streamId]);
     assert.strictEqual(warningMessages.length, 1);
@@ -374,5 +415,6 @@ describe('followUpCommand', () => {
       warningMessages[0],
       'Resume failed. 2 queued follow-ups were lost.',
     );
+    assert.strictEqual(consumeCalls.length, 0);
   });
 });


### PR DESCRIPTION
## Summary
- add an in-memory cache for persisted tool-use snapshots and register pending sessions during activation
- defer resuming agents until a follow-up arrives and queue the follow-up when resuming
- cover the lazy resume path with a dedicated follow-up command unit test

## Testing
- npm run lint
- npm run compile
- npm run compile-tests
- npm test *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.2/code: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d93ade265c8324b1d77e54fb2bc30d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements lazy on-demand resume of persisted tool-use sessions using an in-memory snapshot cache, queuing follow-ups during resume, and adding RESUMING status with tests.
> 
> - **Tool-use session management**:
>   - Add in-memory cache for pending snapshots (`pendingSnapshots`) and resuming tracking with queued follow-ups (`resumingSessions`) in `ToolUseSessionManager`.
>   - New APIs: `registerPendingSnapshots`, `getSnapshotForStream`, `consumeSnapshotForStream`, `setResumingSession`, `isResumingSession`, `enqueueFollowUpWhileResuming`, `drainQueuedFollowUps`, `clearResumingSession`, `hasPendingSnapshot`; ensure `deleteSnapshot` also clears cached snapshot.
> - **Commands**:
>   - `texra.sendFollowUp` (`followUpCommand.ts`): if agent exists append; if resuming, enqueue; else lazily resume via `texra.resumeAgent` with `{ snapshot, followUp }`; user warnings on failure or no session.
>   - `texra.resumeAgent` (`resumeCommand.ts`): accept `{ snapshot, followUp? }`, return `{ success, lostFollowUps? }`; set stream status to `RESUMING`/`WAITING`; resume agent, append initial and queued follow-ups; improved error handling/logging; avoid duplicate resume when already running/resuming.
> - **Progress view**:
>   - Add `STATUS.RESUMING`; include in status types; expose synchronous `setStreamStatus`; update `constants.d.ts/js`.
> - **Activation** (`extension.ts`): register pending snapshots for lazy resume and stop auto-resuming on activation; maintain waiting streams for cleanup.
> - **Tests**:
>   - Add `followUpCommand.test.ts` covering active agent path, lazy resume, queuing during resume, no-session warning, and failure draining/notice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67bc890aca8379d688ace1bc76c09d7f503aaa20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->