### PR TITLE
Limit read_file tool output to first 400 lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Refresh Qwen-Max and Qwen Plus integrations with updated pricing, naming, and thinking support in the DashScope handler.
 - Harden progress view state handling with validation on task groups, toggles, and stream statuses to prevent invalid data from corrupting summaries.
 - Restore main view configurations using the shared task-state helper so history entries hydrate without manual JSON juggling.
+- Cap `read_file` tool responses at the first 400 lines to keep large files from overwhelming tool-use transcripts.
 
 ### Bug Fixes
 

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -20,6 +20,8 @@ Use the `glob`, `grep`, and `ls` tools to explore the workspace without leaving 
 When derivations are required, it presents steps inside `\begin{aligned} ... \end{aligned}` blocks
 to keep mathematical discussions accurate.
 
+> **Heads up:** `read_file` returns at most the first 400 lines of a file so tool outputs stay readable.
+
 ### `ask`
 
 The `ask` agent provides a read-only workspace companion for exploratory

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -167,6 +167,8 @@ workspace utilities like `bash`, `read_file`, `write_file`, `edit_file`,
 `str_replace_editor`, `wolfram`,
 `web_fetch`, and `web_search`.
 
+> **Tip:** The `read_file` tool returns only the first 400 lines of a file to prevent massive responses from overwhelming the progress log.
+
 For a minimal read-only configuration, see the built-in `ask` agent
 (`resources/tool_use_agents/ask.yaml`), which only grants `read_file`, `glob`,
 `grep`, and `ls` access.

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -1,0 +1,74 @@
+import * as assert from 'assert';
+
+import { ReadFileTool, READ_FILE_MAX_LINES } from '@tools/ReadTool';
+import { WorkspaceFS } from '@utils/files';
+
+suite('ReadFileTool', () => {
+  test('truncates output when file exceeds maximum lines', async () => {
+    const tool = new ReadFileTool();
+    const originalRead = WorkspaceFS.read;
+
+    const totalLines = READ_FILE_MAX_LINES + 10;
+    const content = Array.from(
+      { length: totalLines },
+      (_, index) => `line ${index + 1}`,
+    ).join('\n');
+
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+      async () => content;
+
+    try {
+      const result = await tool.call({ path: 'long.txt' });
+
+      assert.strictEqual(
+        result.summary,
+        `Read long.txt (first ${READ_FILE_MAX_LINES} of ${totalLines} lines)`,
+      );
+
+      assert.ok(result.output, 'Expected tool output when truncating file');
+
+      const outputLines = result.output!.split('\n');
+      assert.strictEqual(
+        outputLines.length,
+        READ_FILE_MAX_LINES + 1,
+        'Output should include the limit and truncation marker line',
+      );
+      assert.strictEqual(outputLines[0], 'line 1');
+      assert.strictEqual(
+        outputLines[READ_FILE_MAX_LINES - 1],
+        `line ${READ_FILE_MAX_LINES}`,
+      );
+      assert.strictEqual(
+        outputLines[READ_FILE_MAX_LINES],
+        `...(truncated, ${totalLines - READ_FILE_MAX_LINES} more lines)`,
+      );
+    } finally {
+      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+        originalRead;
+    }
+  });
+
+  test('returns complete content when file is within limit', async () => {
+    const tool = new ReadFileTool();
+    const originalRead = WorkspaceFS.read;
+
+    const totalLines = READ_FILE_MAX_LINES - 5;
+    const content = Array.from(
+      { length: totalLines },
+      (_, index) => `entry ${index + 1}`,
+    ).join('\n');
+
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+      async () => content;
+
+    try {
+      const result = await tool.call({ path: 'short.txt' });
+
+      assert.strictEqual(result.summary, 'Read short.txt');
+      assert.strictEqual(result.output, content);
+    } finally {
+      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+        originalRead;
+    }
+  });
+});

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -11,6 +11,8 @@ import { ToolResult, toolResult } from '@tools/result';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
+export const READ_FILE_MAX_LINES = 400;
+
 const ReadInputSchema = z
   .object({
     path: z.string(),
@@ -26,6 +28,22 @@ export class ReadFileTool extends defineTool({
 }) {
   protected async execute(input: ReadInput): Promise<ToolResult> {
     const content = await WorkspaceFS.read(input.path);
+    const lines = content.split(/\r?\n/);
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+
+    const totalLines = lines.length;
+    if (totalLines > READ_FILE_MAX_LINES) {
+      const visibleLines = lines.slice(0, READ_FILE_MAX_LINES);
+      const truncatedOutput = `${visibleLines.join('\n')}\n...(truncated, ${totalLines - READ_FILE_MAX_LINES} more lines)`;
+
+      return toolResult({
+        summary: `Read ${input.path} (first ${READ_FILE_MAX_LINES} of ${totalLines} lines)`,
+        output: truncatedOutput,
+      });
+    }
+
     return toolResult({
       summary: `Read ${input.path}`,
       output: content,


### PR DESCRIPTION
## Summary
- cap read_file tool responses at 400 lines and include a truncation marker in the output summary
- add unit coverage for truncated and full read_file responses
- document the new limit in the changelog and agent guides

## Testing
- npm run lint
- npm test *(fails: `/workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.2/code: error while loading shared libraries: libatk-1.0.so.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68d9479e4674832496abcb548a9629d7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caps `read_file` outputs at 400 lines with a truncation marker, adds unit tests, and documents the limit in guides and changelog.
> 
> - **Tools**:
>   - Update `src/tools/ReadTool.ts` to cap `read_file` output at `READ_FILE_MAX_LINES = 400` with a trailing `...(truncated, N more lines)` marker and summary showing `(first 400 of TOTAL lines)`.
> - **Tests**:
>   - Add `src/test/tools/ReadTool.test.ts` covering truncation behavior and full-content case.
> - **Docs**:
>   - Note the `read_file` 400-line limit in `docs/guide/built-in-agents.md` and `docs/guide/custom-agents.md`.
> - **Changelog**:
>   - Add improvement entry about capping `read_file` tool responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4b7165e7b3d850379f7f029222332eee64b621b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->