### PR TITLE
fix: respect gitignore in search and listings

### DIFF
--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { Minimatch } from 'minimatch';
 
 // Local imports - utils
+import { toPosixPath } from '@tools/pathUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 
 type GitignoreRule = {
@@ -40,13 +41,6 @@ function createGlobMatcher(pattern: string): (value: string) => boolean {
   });
 
   return (value: string) => matcher.match(value.replace(/\\/g, '/'));
-}
-
-function toPosixPath(relativePath: string): string {
-  if (!relativePath || relativePath === '.') {
-    return '.';
-  }
-  return relativePath.split(/[\\/]/).join('/');
 }
 
 function expandGitignorePattern(

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -13,14 +13,21 @@ type GitignoreRule = {
   negated: boolean;
 };
 
+type GitignoreSource = {
+  absolutePath: string;
+  rules: GitignoreRule[];
+};
+
 export type GitignoreMatcher = {
   hasRules: boolean;
   ignores: (relativePath: string) => boolean;
+  ignoreFiles: string[];
 };
 
 const EMPTY_GITIGNORE_MATCHER: GitignoreMatcher = {
   hasRules: false,
   ignores: () => false,
+  ignoreFiles: [],
 };
 
 let gitignoreMatcherPromise: Promise<GitignoreMatcher> | undefined;
@@ -117,37 +124,49 @@ function parseGitignore(content: string): GitignoreRule[] {
 
 async function readWorkspaceGitignore(
   relativePath: string,
-): Promise<GitignoreRule[]> {
+): Promise<GitignoreSource | null> {
   try {
-    const exists = await WorkspaceFS.exists(relativePath);
-    if (!exists) {
-      return [];
+    const workspacePath = WorkspaceFS.getPath();
+    if (!workspacePath) {
+      return null;
     }
 
-    const content = await WorkspaceFS.read(relativePath);
-    return parseGitignore(content);
+    const normalized = relativePath.replace(/^\/+/, '');
+    const exists = await WorkspaceFS.exists(normalized);
+    if (!exists) {
+      return null;
+    }
+
+    const content = await WorkspaceFS.read(normalized);
+    return {
+      absolutePath: path.join(workspacePath, normalized),
+      rules: parseGitignore(content),
+    };
   } catch {
-    return [];
+    return null;
   }
 }
 
 async function readAbsoluteGitignore(
   absolutePath: string,
-): Promise<GitignoreRule[]> {
+): Promise<GitignoreSource | null> {
   try {
     const exists = await AbsoluteFS.exists(absolutePath);
     if (!exists) {
-      return [];
+      return null;
     }
 
     const content = await AbsoluteFS.read(absolutePath);
-    return parseGitignore(content);
+    return {
+      absolutePath,
+      rules: parseGitignore(content),
+    };
   } catch {
-    return [];
+    return null;
   }
 }
 
-async function readGlobalGitignore(): Promise<GitignoreRule[]> {
+async function readGlobalGitignore(): Promise<GitignoreSource[]> {
   try {
     const homeDirectory = os.homedir();
     if (!homeDirectory) {
@@ -156,10 +175,10 @@ async function readGlobalGitignore(): Promise<GitignoreRule[]> {
 
     const candidates = [path.join(homeDirectory, '.gitignore_global')];
 
-    const ruleSets = await Promise.all(
+    const sources = await Promise.all(
       candidates.map((candidate) => readAbsoluteGitignore(candidate)),
     );
-    return ruleSets.flat();
+    return sources.filter((source): source is GitignoreSource => source !== null);
   } catch {
     return [];
   }
@@ -172,16 +191,25 @@ async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
   }
 
   try {
-    const [globalRules, workspaceGlobalRules, workspaceRules] =
+    const [globalSources, workspaceGlobalSource, workspaceSource] =
       await Promise.all([
         readGlobalGitignore(),
         readWorkspaceGitignore('.gitignore_global'),
         readWorkspaceGitignore('.gitignore'),
       ]);
-    const rules = [...globalRules, ...workspaceGlobalRules, ...workspaceRules];
+
+    const sources: GitignoreSource[] = [
+      ...globalSources,
+      ...(workspaceGlobalSource ? [workspaceGlobalSource] : []),
+      ...(workspaceSource ? [workspaceSource] : []),
+    ];
+
+    const rules = sources.flatMap((source) => source.rules);
     if (rules.length === 0) {
       return EMPTY_GITIGNORE_MATCHER;
     }
+
+    const ignoreFiles = sources.map((source) => source.absolutePath);
 
     return {
       hasRules: true,
@@ -198,6 +226,7 @@ async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
         }
         return ignored;
       },
+      ignoreFiles,
     };
   } catch {
     return EMPTY_GITIGNORE_MATCHER;

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -104,13 +104,7 @@ export class GrepTool extends defineTool({
     const { resolved: searchPath, display } = resolveAndFormat(input.path);
     const gitignore = await getGitignoreMatcher();
     const args = buildArguments(input, outputMode);
-    const ignoreFilesCandidate = (
-      gitignore as { ignoreFiles?: unknown }
-    ).ignoreFiles;
-    const ignoreFiles = Array.isArray(ignoreFilesCandidate)
-      ? (ignoreFilesCandidate as string[])
-      : [];
-    const ignoreArgs = ignoreFiles.flatMap((ignoreFile) => [
+    const ignoreArgs = gitignore.ignoreFiles.flatMap((ignoreFile) => [
       '--ignore-file',
       ignoreFile,
     ]);

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -103,20 +103,20 @@ export class GrepTool extends defineTool({
     const outputMode: OutputMode = input.output_mode ?? 'files_with_matches';
     const { resolved: searchPath, display } = resolveAndFormat(input.path);
     const gitignore = await getGitignoreMatcher();
-
     const args = buildArguments(input, outputMode);
-    const command = [
-      'rg',
-      ...args,
-      input.pattern,
-      searchPath.relative === '.' ? '.' : searchPath.relative,
-    ];
+    const ignoreFilesCandidate = (
+      gitignore as { ignoreFiles?: unknown }
+    ).ignoreFiles;
+    const ignoreFiles = Array.isArray(ignoreFilesCandidate)
+      ? (ignoreFilesCandidate as string[])
+      : [];
+    const ignoreArgs = ignoreFiles.flatMap((ignoreFile) => [
+      '--ignore-file',
+      ignoreFile,
+    ]);
 
-    if (gitignore.ignoreFiles.length > 0) {
-      for (const ignoreFile of gitignore.ignoreFiles) {
-        command.push('--ignore-file', ignoreFile);
-      }
-    }
+    const targetPath = searchPath.relative === '.' ? '.' : searchPath.relative;
+    const command = ['rg', ...args, ...ignoreArgs, input.pattern, targetPath];
 
     const result = await executeCommand(command, {
       channel: CHANNEL,

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -6,6 +6,7 @@ import { defineTool } from './core/define';
 
 // Local imports - tools
 import { ToolError, ToolResult, toolResult } from '@tools/result';
+import { getGitignoreMatcher } from '@tools/gitignore';
 import { resolveAndFormat } from '@tools/utils';
 
 // Local imports - utils
@@ -101,6 +102,7 @@ export class GrepTool extends defineTool({
   protected async execute(input: GrepInput): Promise<ToolResult> {
     const outputMode: OutputMode = input.output_mode ?? 'files_with_matches';
     const { resolved: searchPath, display } = resolveAndFormat(input.path);
+    const gitignore = await getGitignoreMatcher();
 
     const args = buildArguments(input, outputMode);
     const command = [
@@ -109,6 +111,12 @@ export class GrepTool extends defineTool({
       input.pattern,
       searchPath.relative === '.' ? '.' : searchPath.relative,
     ];
+
+    if (gitignore.ignoreFiles.length > 0) {
+      for (const ignoreFile of gitignore.ignoreFiles) {
+        command.push('--ignore-file', ignoreFile);
+      }
+    }
 
     const result = await executeCommand(command, {
       channel: CHANNEL,

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -28,6 +28,12 @@ const LsInputSchema = z
 
 export type LsInput = z.infer<typeof LsInputSchema>;
 
+const DEFAULT_HIDDEN_NAMES = new Set(['.git', '.gitignore']);
+
+function isDefaultHiddenName(name: string): boolean {
+  return DEFAULT_HIDDEN_NAMES.has(name);
+}
+
 function formatEntry(name: string, type: vscode.FileType): string {
   const suffix = type === vscode.FileType.Directory ? '/' : '';
   const label =
@@ -71,7 +77,9 @@ export class LsTool extends defineTool({
 
     if (stats.type === vscode.FileType.File) {
       const relativePosix = toPosixPath(relative);
+      const fileName = relativePosix.split('/').pop() ?? relativePosix;
       if (
+        isDefaultHiddenName(fileName) ||
         gitignore.ignores(relative) ||
         matchesCustomIgnore(display) ||
         matchesCustomIgnore(relativePosix)
@@ -106,24 +114,21 @@ export class LsTool extends defineTool({
     }
 
     const entries = await WorkspaceFS.readDir(relative);
-    const shouldFilter = ignorePatterns.length > 0 || gitignore.hasRules;
-    const filtered = shouldFilter
-      ? entries.filter(([name, _type]) => {
-          const resolvedChild = joinWorkspaceRelativePath(
-            target.relative,
-            name,
-          );
-          const entryRelative = resolvedChild.relative;
-          const entryPath = toPosixPath(entryRelative);
-          if (gitignore.ignores(entryRelative)) {
-            return false;
-          }
-          if (matchesCustomIgnore(entryPath) || matchesCustomIgnore(name)) {
-            return false;
-          }
-          return true;
-        })
-      : entries;
+    const filtered = entries.filter(([name, _type]) => {
+      const resolvedChild = joinWorkspaceRelativePath(target.relative, name);
+      const entryRelative = resolvedChild.relative;
+      const entryPath = toPosixPath(entryRelative);
+      if (isDefaultHiddenName(name)) {
+        return false;
+      }
+      if (gitignore.ignores(entryRelative)) {
+        return false;
+      }
+      if (matchesCustomIgnore(entryPath) || matchesCustomIgnore(name)) {
+        return false;
+      }
+      return true;
+    });
 
     const sorted = filtered.sort(([a], [b]) => a.localeCompare(b));
     const formatted = sorted.map(([name, type]) => formatEntry(name, type));

--- a/src/tools/pathUtils.ts
+++ b/src/tools/pathUtils.ts
@@ -1,0 +1,11 @@
+/**
+ * Convert a workspace-relative path into a POSIX style string for display or
+ * tool output. Keeps `.` as-is for the workspace root.
+ */
+export function toPosixPath(relativePath: string): string {
+  if (!relativePath || relativePath === '.') {
+    return '.';
+  }
+
+  return relativePath.split(/[\\/]/).join('/');
+}

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -73,17 +73,6 @@ export function resolveWorkspaceRelativePath(
 }
 
 /**
- * Convert a workspace-relative path into a POSIX style string for display or
- * tool output. Keeps `.` as-is for the workspace root.
- */
-export function toPosixPath(relativePath: string): string {
-  if (!relativePath || relativePath === '.') {
-    return '.';
-  }
-  return relativePath.split(path.sep).join('/');
-}
-
-/**
  * Join a workspace-relative base path with a child segment and ensure the
  * result stays within the workspace root.
  */
@@ -109,6 +98,8 @@ export function createGlobMatcher(pattern: string): (value: string) => boolean {
 
   return (value: string) => matcher.match(value.replace(/\\/g, '/'));
 }
+
+export { toPosixPath } from './pathUtils';
 
 // Re-export gitignore utilities from standalone module
 export { getGitignoreMatcher, clearGitignoreCache } from './gitignore';

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -6,6 +6,7 @@ import { Minimatch } from 'minimatch';
 
 // Local imports - tools
 import { ToolError } from '@tools/result';
+import { toPosixPath } from '@tools/pathUtils';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
@@ -99,7 +100,7 @@ export function createGlobMatcher(pattern: string): (value: string) => boolean {
   return (value: string) => matcher.match(value.replace(/\\/g, '/'));
 }
 
-export { toPosixPath } from './pathUtils';
+export { toPosixPath } from '@tools/pathUtils';
 
 // Re-export gitignore utilities from standalone module
 export { getGitignoreMatcher, clearGitignoreCache } from './gitignore';


### PR DESCRIPTION
## Summary
- cache gitignore file paths alongside matchers so tools can reuse them
- ensure the grep tool passes gitignore files to ripgrep and ls hides .git artifacts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9519ecec8832499cc7e6a552c8638

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass .gitignore files to ripgrep and hide Git artifacts in ls by caching ignore sources and sharing path normalization.
> 
> - **Search and Listing**:
>   - **`grep`**: Uses `getGitignoreMatcher()` and passes collected `--ignore-file` paths to `rg`.
>   - **`ls`**: Hides default Git artifacts (e.g., `.git`, `.gitignore`) and filters entries via `.gitignore` and optional custom globs.
> - **Gitignore Handling**:
>   - Track gitignore sources with absolute paths and expose `ignoreFiles` on `GitignoreMatcher`.
>   - Normalize workspace paths and parse rules from global (`~/.gitignore_global`) and workspace `.gitignore*`.
> - **Utils/Refactor**:
>   - Extract `toPosixPath` to `src/tools/pathUtils.ts` and re-export from `utils`.
>   - Update imports and remove duplicated path conversion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86dcfb8dfac8596f259c3a24147f211a56960694. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->