### PR TITLE
fix: route apply_path tool through git apply

### DIFF
--- a/src/tools/applyPath.ts
+++ b/src/tools/applyPath.ts
@@ -1,0 +1,60 @@
+// Third-party imports
+import { execa } from 'execa';
+
+// Local imports - core
+import { z } from 'zod';
+import { defineTool } from './core/define';
+
+// Local imports - tools
+import { ToolError, toolResult, type ToolResult } from '@tools/result';
+import { WorkspaceFS } from '@utils/files';
+
+const ApplyPathInputSchema = z.object({
+  patch: z.string().min(1, 'patch content is required'),
+});
+
+export type ApplyPathInput = z.infer<typeof ApplyPathInputSchema>;
+
+const COMMAND = 'git';
+const ARGS = ['apply'];
+
+export class ApplyPathTool extends defineTool({
+  name: 'apply_path',
+  description: 'Apply a unified diff patch using git apply.',
+  schema: ApplyPathInputSchema,
+}) {
+  protected async execute(input: ApplyPathInput): Promise<ToolResult> {
+    const workspacePath = WorkspaceFS.getPath();
+    if (!workspacePath) {
+      throw new ToolError('apply_path error: workspace path is not available');
+    }
+
+    try {
+      const result = await execa(COMMAND, ARGS, {
+        cwd: workspacePath,
+        input: input.patch,
+        encoding: 'utf8',
+        reject: false,
+      });
+
+      if (result.exitCode === 0) {
+        return toolResult({
+          summary: 'Applied patch',
+          output: result.stdout ?? '',
+        });
+      }
+
+      throw new ToolError(
+        `apply_path error: ${result.stderr || 'Unknown failure applying patch'}`,
+      );
+    } catch (error) {
+      if (error instanceof ToolError) {
+        throw error;
+      }
+
+      const message =
+        error instanceof Error ? error.message : 'Unknown error applying patch';
+      throw new ToolError(`apply_path error: ${message}`);
+    }
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,6 +8,7 @@ export * from './fileOp';
 export * from './ReadTool';
 export * from './WriteTool';
 export * from './EditTool';
+export * from './applyPath';
 export * from './ls';
 export * from './core/base';
 export * from './core/define';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,7 @@
 import { BashTool } from './bash';
 import { BaseTool } from './core/base';
 import { DiagnosticsTool } from './DiagnosticsTool';
+import { ApplyPathTool } from './applyPath';
 import { EditFileTool } from './EditTool';
 import { FileOpTool } from './fileOp';
 import { GlobTool } from './glob';
@@ -22,6 +23,7 @@ export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   write_file: new WriteFileTool(),
   edit_file: new EditFileTool(),
   file_op: new FileOpTool(),
+  apply_path: new ApplyPathTool(),
   glob: new GlobTool(),
   grep: new GrepTool(),
   ls: new LsTool(),


### PR DESCRIPTION
## Summary
- update the apply_path tool to execute patches using `git apply` instead of the unavailable `apply_patch`

## Testing
- npm run format
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d954a6d39883248d684c6f889efc56

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `ApplyPathTool` to apply unified diff patches via `git apply`, and registers/exports it.
> 
> - **Tools**:
>   - **New `ApplyPathTool`** (`src/tools/applyPath.ts`): applies unified diff patches using `git apply` via `execa`; validates input with `zod`; returns `ToolResult` with error handling.
>   - **Exports**: add `apply_path` export in `src/tools/index.ts`.
>   - **Registry**: register `apply_path` in `DEFAULT_TOOL_REGISTRY` (`src/tools/registry.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfa18b2f19e56f37620c96d26cbd1f9d29e06828. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->