### PR TITLE
Group main view agents by workflow vs tool-use

### DIFF
--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -4,9 +4,10 @@ import * as vscode from 'vscode';
 
 // Local imports - agent utilities
 import {
-  createAgentOptionTag,
+  createGroupedAgentOptionMarkup,
   getAgentOptionMetadata,
   type AgentDirectoryMap,
+  type AgentOptionEntry,
 } from '@agent/utils/agentOptionMetadata';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { getConfig } from '@utils/config';
@@ -68,10 +69,10 @@ export async function computeAgentOptions(
   const allAgents = await getAllAgents(context);
   const dirs = await getAgentDirectories(context);
 
-  const optionTags = allAgents.map((agent) => {
-    const metadata = getAgentOptionMetadata(agent, dirs);
-    return createAgentOptionTag(agent, metadata);
-  });
+  const optionEntries: AgentOptionEntry[] = allAgents.map((agent) => ({
+    agentName: agent,
+    metadata: getAgentOptionMetadata(agent, dirs),
+  }));
 
-  return optionTags.join('\n');
+  return createGroupedAgentOptionMarkup(optionEntries);
 }

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -26,6 +26,26 @@ export interface AgentOptionMetadata {
   isToolUse: boolean;
 }
 
+export interface AgentOptionEntry {
+  agentName: string;
+  metadata: AgentOptionMetadata;
+}
+
+export const AGENT_OPTION_GROUP_LABELS = {
+  workflow: 'Workflows',
+  toolUse: 'Tool-use agents',
+} as const;
+
+const AGENT_OPTION_GROUP_CLASSES = {
+  workflow: 'agent-group agent-group--workflow',
+  toolUse: 'agent-group agent-group--tool-use',
+} as const;
+
+const AGENT_OPTION_GROUP_DATA = {
+  workflow: 'workflow',
+  toolUse: 'tool-use',
+} as const;
+
 const DIRECTORY_KEYS: (keyof AgentDirectoryMap)[] = [
   'custom',
   'builtIn',
@@ -148,4 +168,68 @@ export function createAgentOptionTag(
 
   const label = decorateLabel(agentName, metadata);
   return `<option ${attributes.join(' ')}>${encodeHtml(label)}</option>`;
+}
+
+function createOptgroupMarkup(
+  label: string,
+  className: string,
+  dataGroup: string,
+  options: string[],
+): string {
+  if (options.length === 0) {
+    return '';
+  }
+
+  return [
+    `<optgroup class="${className}" data-group="${encodeHtml(
+      dataGroup,
+    )}" label="${encodeHtml(label)}">`,
+    options.join('\n'),
+    '</optgroup>',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function createGroupedAgentOptionMarkup(
+  entries: AgentOptionEntry[],
+): string {
+  if (entries.length === 0) {
+    return '';
+  }
+
+  const workflowOptions: string[] = [];
+  const toolUseOptions: string[] = [];
+
+  for (const { agentName, metadata } of entries) {
+    const optionMarkup = createAgentOptionTag(agentName, metadata);
+    if (metadata.isToolUse) {
+      toolUseOptions.push(optionMarkup);
+    } else {
+      workflowOptions.push(optionMarkup);
+    }
+  }
+
+  const groups: string[] = [];
+  const workflowGroup = createOptgroupMarkup(
+    AGENT_OPTION_GROUP_LABELS.workflow,
+    AGENT_OPTION_GROUP_CLASSES.workflow,
+    AGENT_OPTION_GROUP_DATA.workflow,
+    workflowOptions,
+  );
+  if (workflowGroup) {
+    groups.push(workflowGroup);
+  }
+
+  const toolUseGroup = createOptgroupMarkup(
+    AGENT_OPTION_GROUP_LABELS.toolUse,
+    AGENT_OPTION_GROUP_CLASSES.toolUse,
+    AGENT_OPTION_GROUP_DATA.toolUse,
+    toolUseOptions,
+  );
+  if (toolUseGroup) {
+    groups.push(toolUseGroup);
+  }
+
+  return groups.join('\n');
 }

--- a/src/test/agent/utils/agentOptionMetadata.test.ts
+++ b/src/test/agent/utils/agentOptionMetadata.test.ts
@@ -7,6 +7,8 @@ import * as path from 'path';
 // Local imports
 import {
   createAgentOptionTag,
+  createGroupedAgentOptionMarkup,
+  AGENT_OPTION_GROUP_LABELS,
   getAgentOptionMetadata,
   type AgentDirectoryMap,
 } from '@agent/utils/agentOptionMetadata';
@@ -62,5 +64,44 @@ describe('agentOptionMetadata', () => {
     const optionTag = createAgentOptionTag('writer', metadata);
     assert.ok(optionTag.includes('data-multiple="true"'));
     assert.ok(optionTag.includes('∶∶'));
+  });
+
+  it('wraps workflow and tool-use agents in separate optgroups', () => {
+    const workflowAgent = 'workflow_agent';
+    const toolAgent = 'tool_agent';
+
+    fs.writeFileSync(
+      path.join(tempDir, `${workflowAgent}.yaml`),
+      ['name: workflow_agent', 'settings:', '  agentType: direct'].join('\n'),
+      'utf8',
+    );
+
+    fs.writeFileSync(
+      path.join(tempDir, `${toolAgent}.yaml`),
+      ['name: tool_agent', 'settings:', '  agentType: toolUse'].join('\n'),
+      'utf8',
+    );
+
+    const entries = [workflowAgent, toolAgent].map((agentName) => ({
+      agentName,
+      metadata: getAgentOptionMetadata(agentName, directories),
+    }));
+
+    const markup = createGroupedAgentOptionMarkup(entries);
+
+    assert.ok(markup.includes('<optgroup'));
+    assert.ok(markup.includes(`label="${AGENT_OPTION_GROUP_LABELS.workflow}"`));
+    assert.ok(markup.includes(`label="${AGENT_OPTION_GROUP_LABELS.toolUse}"`));
+
+    const workflowGroupIndex = markup.indexOf('agent-group--workflow');
+    const toolUseGroupIndex = markup.indexOf('agent-group--tool-use');
+    assert.ok(workflowGroupIndex >= 0, 'workflow group should exist');
+    assert.ok(
+      toolUseGroupIndex > workflowGroupIndex,
+      'tool-use group should follow workflows',
+    );
+
+    assert.ok(markup.includes(`value="${workflowAgent}"`));
+    assert.ok(markup.includes(`value="${toolAgent}"`));
   });
 });

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -6,9 +6,10 @@ import * as vscode from 'vscode';
 
 // Local imports - agent utilities
 import {
-  createAgentOptionTag,
+  createGroupedAgentOptionMarkup,
   getAgentOptionMetadata,
   type AgentDirectoryMap,
+  type AgentOptionEntry,
 } from '@agent/utils/agentOptionMetadata';
 
 // Local imports - webview
@@ -111,12 +112,11 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       }
     }
     const allAgents = Array.from(new Set([...agents, ...extraAgents]));
-    const agentOptions = allAgents
-      .map((agent) => {
-        const metadata = getAgentOptionMetadata(agent, agentDirectories);
-        return createAgentOptionTag(agent, metadata);
-      })
-      .join('\n');
+    const agentEntries: AgentOptionEntry[] = allAgents.map((agent) => ({
+      agentName: agent,
+      metadata: getAgentOptionMetadata(agent, agentDirectories),
+    }));
+    const agentOptions = createGroupedAgentOptionMarkup(agentEntries);
 
     const models = getConfig<string[]>('models', []);
     const modelOptions = models

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -114,43 +114,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         if (previous) {
           select.value = previous;
         }
-        Array.from(select.options).forEach((opt) => {
-          let baseLabel = opt.dataset.label;
-          if (!baseLabel) {
-            const valueAttr = opt.getAttribute('value');
-            baseLabel = valueAttr ?? '';
-            opt.dataset.label = baseLabel;
-          }
-
-          const hints = [];
-          let displayLabel = baseLabel;
-
-          if (opt.dataset.multiple === 'true') {
-            displayLabel += ' ∶∶';
-            hints.push('Supports multi-file inputs.');
-            opt.style.opacity = '0.9';
-          } else {
-            opt.style.opacity = '';
-          }
-
-          if (opt.dataset.toolUse === 'true') {
-            displayLabel += 'ᵗ';
-            hints.push('Uses tools for actions.');
-          }
-
-          opt.textContent = displayLabel;
-
-          if (hints.length > 0) {
-            opt.title = hints.join('\n');
-            opt.setAttribute(
-              'aria-label',
-              `${baseLabel} (${hints.join(', ')})`,
-            );
-          } else {
-            opt.removeAttribute('title');
-            opt.setAttribute('aria-label', baseLabel);
-          }
-        });
+        this._decorateAgentOptions(select);
       },
     };
   }
@@ -547,6 +511,61 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
     );
     this._postHandle();
+  }
+
+  _decorateAgentOptions(select) {
+    if (!select) {
+      return;
+    }
+
+    const optgroups = Array.from(
+      select.querySelectorAll('optgroup.agent-group'),
+    );
+    optgroups.forEach((group) => {
+      const label = group.getAttribute('label');
+      if (label && label.trim()) {
+        group.setAttribute('aria-label', label);
+        group.setAttribute('title', label);
+      } else {
+        group.removeAttribute('title');
+        group.removeAttribute('aria-label');
+      }
+    });
+
+    Array.from(select.querySelectorAll('option')).forEach((opt) => {
+      let baseLabel = opt.dataset.label;
+      if (!baseLabel) {
+        const valueAttr = opt.getAttribute('value');
+        baseLabel = valueAttr ?? '';
+        opt.dataset.label = baseLabel;
+      }
+
+      const hints = [];
+      let displayLabel = baseLabel;
+
+      if (opt.dataset.multiple === 'true') {
+        displayLabel += ' ∶∶';
+        hints.push('Supports multi-file inputs.');
+        opt.style.opacity = '0.9';
+      } else {
+        opt.style.opacity = '';
+      }
+
+      if (opt.dataset.toolUse === 'true') {
+        displayLabel += 'ᵗ';
+        hints.push('Uses tools for actions.');
+      }
+
+      opt.textContent = displayLabel;
+
+      if (hints.length > 0) {
+        opt.title = hints.join('\n');
+        opt.setAttribute('aria-label', `${baseLabel} (${hints.join(', ')})`);
+      } else {
+        opt.removeAttribute('title');
+        opt.setAttribute('aria-label', baseLabel);
+      }
+    });
   }
 }
 

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -109,3 +109,34 @@ option[data-multiple='true'] {
 option[data-tool-use='true'] {
   font-style: italic;
 }
+
+select optgroup.agent-group {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vscode-descriptionForeground);
+  font-size: calc(var(--vscode-editor-font-size) * 0.8);
+  padding: var(--spacing-small) 0 var(--spacing-tiny);
+  background: var(--vscode-input-background);
+}
+
+select optgroup.agent-group:first-of-type {
+  padding-top: 0;
+}
+
+select optgroup.agent-group option {
+  font-weight: normal;
+  text-transform: none;
+  letter-spacing: normal;
+  color: var(--vscode-foreground);
+  padding-left: var(--spacing-medium);
+}
+
+select optgroup.agent-group--tool-use {
+  margin-top: var(--spacing-small);
+  border-top: 1px solid var(--vscode-menu-border);
+}
+
+select optgroup.agent-group--tool-use option {
+  padding-left: calc(var(--spacing-medium) * 1.2);
+}


### PR DESCRIPTION
## Summary
- group agent option markup into workflow and tool-use optgroups for both async and server-rendered paths
- refresh the webview message handler to decorate grouped options and update accessibility hints
- add dropdown styling for optgroup headers and a regression test covering grouped markup

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68d97e67d9148324bee5242756d37fc9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Groups agent options into workflow vs tool-use optgroups, adds rendering helpers, webview decoration, styles, and tests.
> 
> - **UI/Dropdowns**:
>   - Group agent options into two optgroups: `Workflows` and `Tool-use agents` with classes/data attributes for styling and a11y.
>   - Add styling for optgroup headers and nested options in `webview/styles/dropdown.css`.
> - **Agent option generation**:
>   - Introduce `AgentOptionEntry` and constants for group labels/classes/data.
>   - Add `createGroupedAgentOptionMarkup` and internal optgroup builder; reuse `createAgentOptionTag`.
>   - Update `computeAgentOptions` and `MainViewContentProvider` to build grouped markup instead of flat option lists.
> - **Webview behavior**:
>   - Replace inline option decoration with `_decorateAgentOptions` to set titles/aria and format labels for grouped options.
> - **Tests**:
>   - Add regression test verifying grouped markup and order in `agentOptionMetadata.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d7936b60a35b2a63c58e823631e490d66e7455c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->