### PR TITLE
feat: split agent selection by session type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 - Enable interleaved thinking by default for supported Claude tool-use agents so follow-up reasoning stays in sync with tool results.
 - Rebuild the agent selector footer with a compact session toggle and per-session dropdowns so the UI stays narrow and focused.
 - Populate the tool-use dropdown from the dedicated `texra.toolUseAgents` list and automatic discovery so the old include toggle is no longer needed.
+- Trim the default tool-use agent list to the conversational presets so specialized utilities stay opt-in per workspace.
+- Narrow the model selector width and streamline tool-use labelling so dropdowns stay tidy without superscript markers.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - Cap `read_file` tool responses at the first 400 lines to keep large files from overwhelming tool-use transcripts.
 - Enable interleaved thinking by default for supported Claude tool-use agents so follow-up reasoning stays in sync with tool results.
 - Rebuild the agent selector footer with a compact session toggle and per-session dropdowns so the UI stays narrow and focused.
-- Add a `texra.toolUseAgents` setting that controls which tool-use agents appear in the dedicated dropdown.
+- Populate the tool-use dropdown from the dedicated `texra.toolUseAgents` list and automatic discovery so the old include toggle is no longer needed.
 
 ### Bug Fixes
 
@@ -162,7 +162,7 @@ All notable changes to this project will be documented in this file.
 - Allow disabling LaTeX formatting and silencing missing `latexindent` warnings
 - Added configurable `texra.maxImageDimension` setting to control the maximum image size threshold
 - Add "New" button in main view to reset all fields
-- Add `texra.includeToolUseAgents` setting to optionally show built-in tool-use agents in the agent dropdown
+- Add `texra.includeToolUseAgents` setting to optionally show built-in tool-use agents in the agent dropdown (deprecated in 0.33.8)
 - Prompt users to install LaTeX Workshop extension with "Never remind again" option for enhanced LaTeX features
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ All notable changes to this project will be documented in this file.
 - Restore main view configurations using the shared task-state helper so history entries hydrate without manual JSON juggling.
 - Cap `read_file` tool responses at the first 400 lines to keep large files from overwhelming tool-use transcripts.
 - Enable interleaved thinking by default for supported Claude tool-use agents so follow-up reasoning stays in sync with tool results.
+- Rebuild the agent selector footer with a compact session toggle and per-session dropdowns so the UI stays narrow and focused.
+- Add a `texra.toolUseAgents` setting that controls which tool-use agents appear in the dedicated dropdown.
 
 ### Bug Fixes
 
 - Migrate history view toggle state persistence from JSON strings to structured arrays so expansion settings reliably load across versions.
 - Clear queued restore context when the main view fails to initialize, preventing stale state from resurfacing on the next activation.
+- Guard the model select observer lifecycle and update queue so successive model option messages render reliably without leaking observers.
 
 ## [0.33.7] - 2025-09-22
 

--- a/package.json
+++ b/package.json
@@ -54,10 +54,7 @@
             },
             "default": [
               "ask",
-              "chat",
-              "file_edit",
-              "tex_linter_fix",
-              "xml_validator"
+              "chat"
             ],
             "description": "List of tool-use agents shown in the dedicated dropdown",
             "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
               "type": "string"
             },
             "default": [
-              "chat",
-              "ask",
               "correct",
               "polish",
               "draw",
@@ -62,12 +60,6 @@
               "xml_validator"
             ],
             "description": "List of tool-use agents shown in the dedicated dropdown",
-            "scope": "resource"
-          },
-          "texra.includeToolUseAgents": {
-            "type": "boolean",
-            "default": false,
-            "description": "Include built-in tool-use agents (e.g., xml_validator, tex_linter_fix) in the agent list",
             "scope": "resource"
           },
           "texra.models": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,21 @@
             "description": "List of available agents",
             "scope": "resource"
           },
+          "texra.toolUseAgents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "ask",
+              "chat",
+              "file_edit",
+              "tex_linter_fix",
+              "xml_validator"
+            ],
+            "description": "List of tool-use agents shown in the dedicated dropdown",
+            "scope": "resource"
+          },
           "texra.includeToolUseAgents": {
             "type": "boolean",
             "default": false,

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -14,20 +14,21 @@ import { getConfig } from '@utils/config';
 export type { AgentOptionsPayload };
 
 /**
- * Get all available agents including tool-use agents if enabled.
+ * Collect configured workflow agents alongside configured and discovered tool-use agents.
  */
+export interface AgentNameBuckets {
+  allAgents: string[];
+  toolUseAgents: string[];
+}
+
 export async function getAllAgents(
   context: vscode.ExtensionContext,
-): Promise<string[]> {
+): Promise<AgentNameBuckets> {
   const workflowAgents = getConfig<string[]>('agents', []);
   const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
-  const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
-
-  if (!includeToolUse) {
-    return Array.from(new Set([...workflowAgents, ...configuredToolUseAgents]));
-  }
 
   const toolUseDir = await agentDirectories.builtInToolUse(context);
+  let discoveredToolUseAgents: string[] = [];
   try {
     const toolUseFiles = await glob('**/*.yaml', {
       cwd: toolUseDir,
@@ -35,19 +36,19 @@ export async function getAllAgents(
       nodir: true,
       absolute: false,
     });
-    const discoveredToolUseAgents = toolUseFiles.map((f) =>
+    discoveredToolUseAgents = toolUseFiles.map((f) =>
       f.replace(/\.yaml$/, '').replace(/.*\//, ''),
     );
-    return Array.from(
-      new Set([
-        ...workflowAgents,
-        ...configuredToolUseAgents,
-        ...discoveredToolUseAgents,
-      ]),
-    );
   } catch {
-    return Array.from(new Set([...workflowAgents, ...configuredToolUseAgents]));
+    discoveredToolUseAgents = [];
   }
+
+  const toolUseAgents = Array.from(
+    new Set([...configuredToolUseAgents, ...discoveredToolUseAgents]),
+  );
+  const allAgents = Array.from(new Set([...workflowAgents, ...toolUseAgents]));
+
+  return { allAgents, toolUseAgents };
 }
 
 /**
@@ -72,8 +73,8 @@ async function getAgentDirectories(
 export async function computeAgentOptions(
   context: vscode.ExtensionContext,
 ): Promise<AgentOptionsPayload> {
-  const allAgents = await getAllAgents(context);
+  const { allAgents, toolUseAgents } = await getAllAgents(context);
   const dirs = await getAgentDirectories(context);
 
-  return buildAgentOptionsPayload(allAgents, dirs);
+  return buildAgentOptionsPayload(allAgents, dirs, toolUseAgents);
 }

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -11,6 +11,11 @@ import {
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { getConfig } from '@utils/config';
 
+export interface AgentOptionsPayload {
+  workflow: string;
+  toolUse: string;
+}
+
 /**
  * Get all available agents including tool-use agents if enabled.
  */
@@ -64,14 +69,26 @@ async function getAgentDirectories(
  */
 export async function computeAgentOptions(
   context: vscode.ExtensionContext,
-): Promise<string> {
+): Promise<AgentOptionsPayload> {
   const allAgents = await getAllAgents(context);
   const dirs = await getAgentDirectories(context);
 
-  const optionTags = allAgents.map((agent) => {
+  const optionBuckets: AgentOptionsPayload = { workflow: '', toolUse: '' };
+  const workflowOptions: string[] = [];
+  const toolUseOptions: string[] = [];
+
+  allAgents.forEach((agent) => {
     const metadata = getAgentOptionMetadata(agent, dirs);
-    return createAgentOptionTag(agent, metadata);
+    const optionTag = createAgentOptionTag(agent, metadata);
+    if (metadata.isToolUse) {
+      toolUseOptions.push(optionTag);
+    } else {
+      workflowOptions.push(optionTag);
+    }
   });
 
-  return optionTags.join('\n');
+  optionBuckets.workflow = workflowOptions.join('\n');
+  optionBuckets.toolUse = toolUseOptions.join('\n');
+
+  return optionBuckets;
 }

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -4,17 +4,14 @@ import * as vscode from 'vscode';
 
 // Local imports - agent utilities
 import {
-  createAgentOptionTag,
-  getAgentOptionMetadata,
+  buildAgentOptionsPayload,
   type AgentDirectoryMap,
+  type AgentOptionsPayload,
 } from '@agent/utils/agentOptionMetadata';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { getConfig } from '@utils/config';
 
-export interface AgentOptionsPayload {
-  workflow: string;
-  toolUse: string;
-}
+export type { AgentOptionsPayload };
 
 /**
  * Get all available agents including tool-use agents if enabled.
@@ -22,14 +19,14 @@ export interface AgentOptionsPayload {
 export async function getAllAgents(
   context: vscode.ExtensionContext,
 ): Promise<string[]> {
-  const agents = getConfig<string[]>('agents', []);
+  const workflowAgents = getConfig<string[]>('agents', []);
+  const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
   const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
 
   if (!includeToolUse) {
-    return agents;
+    return Array.from(new Set([...workflowAgents, ...configuredToolUseAgents]));
   }
 
-  // Get tool-use agents
   const toolUseDir = await agentDirectories.builtInToolUse(context);
   try {
     const toolUseFiles = await glob('**/*.yaml', {
@@ -38,13 +35,18 @@ export async function getAllAgents(
       nodir: true,
       absolute: false,
     });
-    const toolUseAgents = toolUseFiles.map((f) =>
+    const discoveredToolUseAgents = toolUseFiles.map((f) =>
       f.replace(/\.yaml$/, '').replace(/.*\//, ''),
     );
-    return Array.from(new Set([...agents, ...toolUseAgents]));
+    return Array.from(
+      new Set([
+        ...workflowAgents,
+        ...configuredToolUseAgents,
+        ...discoveredToolUseAgents,
+      ]),
+    );
   } catch {
-    // If tool-use directory doesn't exist or can't be read, just use base agents
-    return agents;
+    return Array.from(new Set([...workflowAgents, ...configuredToolUseAgents]));
   }
 }
 
@@ -73,22 +75,5 @@ export async function computeAgentOptions(
   const allAgents = await getAllAgents(context);
   const dirs = await getAgentDirectories(context);
 
-  const optionBuckets: AgentOptionsPayload = { workflow: '', toolUse: '' };
-  const workflowOptions: string[] = [];
-  const toolUseOptions: string[] = [];
-
-  allAgents.forEach((agent) => {
-    const metadata = getAgentOptionMetadata(agent, dirs);
-    const optionTag = createAgentOptionTag(agent, metadata);
-    if (metadata.isToolUse) {
-      toolUseOptions.push(optionTag);
-    } else {
-      workflowOptions.push(optionTag);
-    }
-  });
-
-  optionBuckets.workflow = workflowOptions.join('\n');
-  optionBuckets.toolUse = toolUseOptions.join('\n');
-
-  return optionBuckets;
+  return buildAgentOptionsPayload(allAgents, dirs);
 }

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -26,6 +26,11 @@ export interface AgentOptionMetadata {
   isToolUse: boolean;
 }
 
+export interface AgentOptionsPayload {
+  workflow: string;
+  toolUse: string;
+}
+
 const DIRECTORY_KEYS: (keyof AgentDirectoryMap)[] = [
   'custom',
   'builtIn',
@@ -148,4 +153,51 @@ export function createAgentOptionTag(
 
   const label = decorateLabel(agentName, metadata);
   return `<option ${attributes.join(' ')}>${encodeHtml(label)}</option>`;
+}
+
+export function buildAgentOptionsPayload(
+  agentNames: Iterable<string>,
+  directories: AgentDirectoryMap,
+): AgentOptionsPayload {
+  const workflowOptions: string[] = [];
+  const toolUseOptions: string[] = [];
+
+  const seen = new Set<string>();
+  for (const agentName of agentNames) {
+    if (!agentName || seen.has(agentName)) {
+      continue;
+    }
+    seen.add(agentName);
+    const metadata = getAgentOptionMetadata(agentName, directories);
+    const optionTag = createAgentOptionTag(agentName, metadata);
+    if (metadata.isToolUse) {
+      toolUseOptions.push(optionTag);
+    } else {
+      workflowOptions.push(optionTag);
+    }
+  }
+
+  const ensureOptions = (
+    options: string[],
+    placeholder: string,
+    emptyMessage: string,
+  ): string => {
+    if (options.length === 0) {
+      return `<option value="">${emptyMessage}</option>`;
+    }
+    return [`<option value="">${placeholder}</option>`, ...options].join('\n');
+  };
+
+  return {
+    workflow: ensureOptions(
+      workflowOptions,
+      'Select a workflow agent',
+      'No workflow agents available',
+    ),
+    toolUse: ensureOptions(
+      toolUseOptions,
+      'Select a tool-use agent',
+      'No tool-use agents available',
+    ),
+  };
 }

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -158,9 +158,11 @@ export function createAgentOptionTag(
 export function buildAgentOptionsPayload(
   agentNames: Iterable<string>,
   directories: AgentDirectoryMap,
+  configuredToolUseAgents: Iterable<string> = [],
 ): AgentOptionsPayload {
   const workflowOptions: string[] = [];
   const toolUseOptions: string[] = [];
+  const configuredToolUseSet = new Set(configuredToolUseAgents);
 
   const seen = new Set<string>();
   for (const agentName of agentNames) {
@@ -169,8 +171,11 @@ export function buildAgentOptionsPayload(
     }
     seen.add(agentName);
     const metadata = getAgentOptionMetadata(agentName, directories);
-    const optionTag = createAgentOptionTag(agentName, metadata);
-    if (metadata.isToolUse) {
+    const metadataWithConfig = configuredToolUseSet.has(agentName)
+      ? { ...metadata, isToolUse: true }
+      : metadata;
+    const optionTag = createAgentOptionTag(agentName, metadataWithConfig);
+    if (metadataWithConfig.isToolUse) {
       toolUseOptions.push(optionTag);
     } else {
       workflowOptions.push(optionTag);

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -126,9 +126,6 @@ function decorateLabel(
   if (metadata.hasMultipleSibling || metadata.isMultipleOutput) {
     label += ' ∶∶';
   }
-  if (metadata.isToolUse) {
-    label += 'ᵗ';
-  }
   return label;
 }
 

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -10,6 +10,7 @@ import {
   getAgentOptionMetadata,
   type AgentDirectoryMap,
 } from '@agent/utils/agentOptionMetadata';
+import { AgentOptionsPayload } from '@agent/computeAgentOptions';
 
 // Local imports - webview
 import {
@@ -111,12 +112,22 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       }
     }
     const allAgents = Array.from(new Set([...agents, ...extraAgents]));
-    const agentOptions = allAgents
-      .map((agent) => {
-        const metadata = getAgentOptionMetadata(agent, agentDirectories);
-        return createAgentOptionTag(agent, metadata);
-      })
-      .join('\n');
+    const optionBuckets: AgentOptionsPayload = { workflow: '', toolUse: '' };
+    const workflowOptions: string[] = [];
+    const toolUseOptions: string[] = [];
+
+    allAgents.forEach((agent) => {
+      const metadata = getAgentOptionMetadata(agent, agentDirectories);
+      const optionTag = createAgentOptionTag(agent, metadata);
+      if (metadata.isToolUse) {
+        toolUseOptions.push(optionTag);
+      } else {
+        workflowOptions.push(optionTag);
+      }
+    });
+
+    optionBuckets.workflow = workflowOptions.join('\n');
+    optionBuckets.toolUse = toolUseOptions.join('\n');
 
     const models = getConfig<string[]>('models', []);
     const modelOptions = models
@@ -124,7 +135,8 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       .join('\n');
 
     return {
-      agentOptions,
+      workflowAgentOptions: optionBuckets.workflow,
+      toolUseAgentOptions: optionBuckets.toolUse,
       modelOptions,
     };
   }

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -83,7 +83,6 @@ export class MainViewContentProvider extends BaseViewContentProvider {
     // Note: This uses synchronous approach for template generation
     // Agent options with metadata are computed asynchronously via computeAgentOptions
     const agents = getConfig<string[]>('agents', []);
-    const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
     const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
     const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
     const builtInDir = GlobalStorageFS.fullPath('agents');
@@ -95,30 +94,28 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       ? configuredCustomDir
       : '';
 
-    const shouldIncludeToolUseDir =
-      includeToolUse || configuredToolUseAgents.length > 0;
     const agentDirectories: AgentDirectoryMap = {
       custom: customDir,
       builtIn: builtInDir,
-      builtInToolUse: shouldIncludeToolUseDir ? toolUseDir : '',
+      builtInToolUse: toolUseDir,
     };
-    let extraAgents: string[] = [];
-    if (includeToolUse) {
-      try {
-        const files = AbsoluteFS.readDirSync(toolUseDir);
-        extraAgents = files
-          .filter((f) => f.endsWith('.yaml'))
-          .map((f) => path.basename(f, '.yaml'));
-      } catch {
-        extraAgents = [];
-      }
+    let discoveredToolUseAgents: string[] = [];
+    try {
+      const files = AbsoluteFS.readDirSync(toolUseDir);
+      discoveredToolUseAgents = files
+        .filter((f) => f.endsWith('.yaml'))
+        .map((f) => path.basename(f, '.yaml'));
+    } catch {
+      discoveredToolUseAgents = [];
     }
-    const allAgents = Array.from(
-      new Set([...agents, ...configuredToolUseAgents, ...extraAgents]),
+    const toolUseAgents = Array.from(
+      new Set([...configuredToolUseAgents, ...discoveredToolUseAgents]),
     );
+    const allAgents = Array.from(new Set([...agents, ...toolUseAgents]));
     const optionBuckets: AgentOptionsPayload = buildAgentOptionsPayload(
       allAgents,
       agentDirectories,
+      toolUseAgents,
     );
 
     const models = getConfig<string[]>('models', []);

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -6,11 +6,10 @@ import * as vscode from 'vscode';
 
 // Local imports - agent utilities
 import {
-  createAgentOptionTag,
-  getAgentOptionMetadata,
+  buildAgentOptionsPayload,
   type AgentDirectoryMap,
 } from '@agent/utils/agentOptionMetadata';
-import { AgentOptionsPayload } from '@agent/computeAgentOptions';
+import type { AgentOptionsPayload } from '@agent/computeAgentOptions';
 
 // Local imports - webview
 import {
@@ -85,6 +84,7 @@ export class MainViewContentProvider extends BaseViewContentProvider {
     // Agent options with metadata are computed asynchronously via computeAgentOptions
     const agents = getConfig<string[]>('agents', []);
     const includeToolUse = getConfig<boolean>('includeToolUseAgents', false);
+    const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
     const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
     const builtInDir = GlobalStorageFS.fullPath('agents');
     const configuredCustomDir = getConfig<string>(
@@ -95,10 +95,12 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       ? configuredCustomDir
       : '';
 
+    const shouldIncludeToolUseDir =
+      includeToolUse || configuredToolUseAgents.length > 0;
     const agentDirectories: AgentDirectoryMap = {
       custom: customDir,
       builtIn: builtInDir,
-      builtInToolUse: includeToolUse ? toolUseDir : '',
+      builtInToolUse: shouldIncludeToolUseDir ? toolUseDir : '',
     };
     let extraAgents: string[] = [];
     if (includeToolUse) {
@@ -111,23 +113,13 @@ export class MainViewContentProvider extends BaseViewContentProvider {
         extraAgents = [];
       }
     }
-    const allAgents = Array.from(new Set([...agents, ...extraAgents]));
-    const optionBuckets: AgentOptionsPayload = { workflow: '', toolUse: '' };
-    const workflowOptions: string[] = [];
-    const toolUseOptions: string[] = [];
-
-    allAgents.forEach((agent) => {
-      const metadata = getAgentOptionMetadata(agent, agentDirectories);
-      const optionTag = createAgentOptionTag(agent, metadata);
-      if (metadata.isToolUse) {
-        toolUseOptions.push(optionTag);
-      } else {
-        workflowOptions.push(optionTag);
-      }
-    });
-
-    optionBuckets.workflow = workflowOptions.join('\n');
-    optionBuckets.toolUse = toolUseOptions.join('\n');
+    const allAgents = Array.from(
+      new Set([...agents, ...configuredToolUseAgents, ...extraAgents]),
+    );
+    const optionBuckets: AgentOptionsPayload = buildAgentOptionsPayload(
+      allAgents,
+      agentDirectories,
+    );
 
     const models = getConfig<string[]>('models', []);
     const modelOptions = models

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -494,26 +494,28 @@
                       Tool Use
                     </button>
                   </div>
-                  <select
-                    id="workflowAgent"
-                    class="agent-select agent-select--active"
-                    data-session-type="workflow"
-                    aria-label="Select a workflow agent"
-                    title="Select a workflow agent"
-                  >
-                    ${workflowAgentOptions}
-                  </select>
-                  <select
-                    id="toolUseAgent"
-                    class="agent-select agent-select--hidden"
-                    data-session-type="toolUse"
-                    aria-label="Select a tool-use agent"
-                    title="Select a tool-use agent"
-                    tabindex="-1"
-                    aria-hidden="true"
-                  >
-                    ${toolUseAgentOptions}
-                  </select>
+                  <div class="agent-select-dropdowns">
+                    <select
+                      id="workflowAgent"
+                      class="agent-select agent-select--active"
+                      data-session-type="workflow"
+                      aria-label="Select a workflow agent"
+                      title="Select a workflow agent"
+                    >
+                      ${workflowAgentOptions}
+                    </select>
+                    <select
+                      id="toolUseAgent"
+                      class="agent-select agent-select--hidden"
+                      data-session-type="toolUse"
+                      aria-label="Select a tool-use agent"
+                      title="Select a tool-use agent"
+                      tabindex="-1"
+                      aria-hidden="true"
+                    >
+                      ${toolUseAgentOptions}
+                    </select>
+                  </div>
                 </div>
               </div>
               <div class="select-group">

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -461,15 +461,60 @@
           ></textarea>
           <div class="instruction-controls">
             <div class="model-selection-footer">
-              <div class="select-group">
+              <div class="select-group agent-select-group">
                 <i
                   id="agentSettingsButton"
                   class="codicon codicon-sparkle clickable"
                   title="Agent settings"
                 ></i>
-                <select id="agent">
-                  ${agentOptions}
-                </select>
+                <div class="agent-select-controls">
+                  <input type="hidden" id="sessionType" value="workflow" />
+                  <div
+                    id="sessionTypeToggle"
+                    class="session-toggle"
+                    role="radiogroup"
+                    aria-label="Choose the session type"
+                  >
+                    <button
+                      type="button"
+                      class="session-toggle__option active"
+                      data-session-type="workflow"
+                      aria-pressed="true"
+                      title="Workflow agents automate document editing tasks"
+                    >
+                      Workflow
+                    </button>
+                    <button
+                      type="button"
+                      class="session-toggle__option"
+                      data-session-type="toolUse"
+                      aria-pressed="false"
+                      title="Tool-use agents execute commands and scripts"
+                    >
+                      Tool Use
+                    </button>
+                  </div>
+                  <select
+                    id="workflowAgent"
+                    class="agent-select agent-select--active"
+                    data-session-type="workflow"
+                    aria-label="Select a workflow agent"
+                    title="Select a workflow agent"
+                  >
+                    ${workflowAgentOptions}
+                  </select>
+                  <select
+                    id="toolUseAgent"
+                    class="agent-select agent-select--hidden"
+                    data-session-type="toolUse"
+                    aria-label="Select a tool-use agent"
+                    title="Select a tool-use agent"
+                    tabindex="-1"
+                    aria-hidden="true"
+                  >
+                    ${toolUseAgentOptions}
+                  </select>
+                </div>
               </div>
               <div class="select-group">
                 <i

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -54,7 +54,9 @@ export const CHECK_BOXES = [
 // Form elements with values to save
 export const VALUE_ELEMENTS = [
   // parameters
-  'agent',
+  'sessionType',
+  'workflowAgent',
+  'toolUseAgent',
   'model',
   // files (single)
   ...SINGLE_FILE_ELEMENTS,
@@ -105,4 +107,21 @@ export const ELEMENT_IDS = {
   DEPENDENCY_BANNER: 'dependencyBanner',
   DEPENDENCY_RECHECK_BUTTON: 'dependencyRecheckButton',
   DEPENDENCY_DISMISS_BUTTON: 'dependencyDismissButton',
+  SESSION_TYPE_TOGGLE: 'sessionTypeToggle',
+  WORKFLOW_AGENT_SELECT: 'workflowAgent',
+  TOOL_USE_AGENT_SELECT: 'toolUseAgent',
 };
+
+export const SESSION_TYPES = {
+  WORKFLOW: 'workflow',
+  TOOL_USE: 'toolUse',
+};
+
+export const SESSION_TYPE_INPUT = 'sessionType';
+
+export const AGENT_SELECT_IDS = {
+  [SESSION_TYPES.WORKFLOW]: 'workflowAgent',
+  [SESSION_TYPES.TOOL_USE]: 'toolUseAgent',
+};
+
+export const AGENT_SELECT_LIST = Object.values(AGENT_SELECT_IDS);

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -6,6 +6,10 @@ import {
   CHECK_BOXES_TOOL_USE,
   CHECK_BOXES_AUTO_EXTRACT,
   ELEMENT_IDS,
+  SESSION_TYPES,
+  SESSION_TYPE_INPUT,
+  AGENT_SELECT_IDS,
+  AGENT_SELECT_LIST,
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
@@ -42,6 +46,8 @@ export class MainViewState {
 
   /** Initialize UI with default state */
   setDefaults() {
+    this.applySessionType(SESSION_TYPES.WORKFLOW, { skipSave: true });
+
     const autoExtractToggle = safeGetElementById(
       ELEMENT_IDS.TOGGLE_AUTO_EXTRACT,
     );
@@ -79,9 +85,37 @@ export class MainViewState {
   restore() {
     const previousState = this.stateManager.getState();
     if (previousState) {
-      const defaults = { agent: 'correct', model: 'gemini25p', commit: 'HEAD' };
+      const defaults = {
+        sessionType: SESSION_TYPES.WORKFLOW,
+        workflowAgent: 'correct',
+        toolUseAgent: '',
+        model: 'gemini25p',
+        commit: 'HEAD',
+      };
+
+      const legacyAgent = previousState.agent;
+      const legacyToolUse = previousState.isToolUseAgent === true;
+      const normalizedValues = {
+        sessionType: previousState.sessionType
+          ? previousState.sessionType
+          : legacyToolUse
+            ? SESSION_TYPES.TOOL_USE
+            : defaults.sessionType,
+        workflowAgent:
+          previousState.workflowAgent ??
+          (!legacyToolUse ? legacyAgent : undefined) ??
+          defaults.workflowAgent,
+        toolUseAgent:
+          previousState.toolUseAgent ??
+          (legacyToolUse ? legacyAgent : undefined) ??
+          defaults.toolUseAgent,
+      };
 
       VALUE_ELEMENTS.forEach((id) => {
+        if (id in normalizedValues) {
+          safeSetElementValue(id, normalizedValues[id]);
+          return;
+        }
         safeSetElementValue(id, previousState[id] ?? defaults[id] ?? '');
       });
 
@@ -156,6 +190,11 @@ export class MainViewState {
         latexdiffsContent.style.display = visible ? 'block' : 'none';
         setChevronIcon(toggleLatexdiffs, visible);
       }
+
+      this.applySessionType(
+        normalizedValues.sessionType ?? defaults.sessionType,
+        { skipSave: true },
+      );
     } else {
       this.setDefaults();
     }
@@ -191,7 +230,61 @@ export class MainViewState {
       state[id] = fileList.getSelected(elementDiv);
     });
 
+    const sessionTypeValue =
+      state.sessionType ?? safeGetElementValue(SESSION_TYPE_INPUT);
+    const normalizedSessionType =
+      sessionTypeValue === SESSION_TYPES.TOOL_USE
+        ? SESSION_TYPES.TOOL_USE
+        : SESSION_TYPES.WORKFLOW;
+    const activeSelectId = AGENT_SELECT_IDS[normalizedSessionType];
+    if (activeSelectId) {
+      state.agent = safeGetElementValue(activeSelectId) ?? '';
+      state.isToolUseAgent = normalizedSessionType === SESSION_TYPES.TOOL_USE;
+    }
+
     this.stateManager.setState(state);
+  }
+
+  applySessionType(sessionType, options = {}) {
+    const { skipSave = false } = options;
+    const normalized =
+      sessionType === SESSION_TYPES.TOOL_USE
+        ? SESSION_TYPES.TOOL_USE
+        : SESSION_TYPES.WORKFLOW;
+
+    const sessionInput = safeGetElementById(SESSION_TYPE_INPUT);
+    if (sessionInput) {
+      sessionInput.value = normalized;
+    }
+
+    const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
+    if (toggleContainer) {
+      const buttons = toggleContainer.querySelectorAll('[data-session-type]');
+      buttons.forEach((button) => {
+        if (!(button instanceof HTMLElement)) {
+          return;
+        }
+        const isActive = button.dataset.sessionType === normalized;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+    }
+
+    AGENT_SELECT_LIST.forEach((selectId) => {
+      const selectEl = safeGetElementById(selectId);
+      if (!selectEl) {
+        return;
+      }
+      const isActive = selectId === AGENT_SELECT_IDS[normalized];
+      selectEl.classList.toggle('agent-select--active', isActive);
+      selectEl.classList.toggle('agent-select--hidden', !isActive);
+      selectEl.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      selectEl.tabIndex = isActive ? 0 : -1;
+    });
+
+    if (!skipSave) {
+      this.save();
+    }
   }
 }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -191,25 +191,12 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _decorateAgentOption(opt) {
-    let baseLabel = opt.dataset.label;
-    if (!baseLabel) {
-      const textLabel = opt.textContent?.trim();
-      if (textLabel) {
-        baseLabel = textLabel;
-        opt.dataset.label = baseLabel;
-      } else {
-        const valueAttr = opt.getAttribute('value');
-        baseLabel = valueAttr ?? '';
-        if (baseLabel) {
-          opt.dataset.label = baseLabel;
-        }
-      }
-    }
+    const { label, isMultiple, isToolUse } = this._readAgentOptionMetadata(opt);
 
     const hints = [];
-    let displayLabel = baseLabel;
+    let displayLabel = label;
 
-    if (opt.dataset.multiple === 'true') {
+    if (isMultiple) {
       displayLabel += ' ∶∶';
       hints.push('Supports multi-file inputs.');
       opt.style.opacity = '0.9';
@@ -217,8 +204,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       opt.style.opacity = '';
     }
 
-    if (opt.dataset.toolUse === 'true') {
-      displayLabel += 'ᵗ';
+    if (isToolUse) {
       hints.push('Uses tools for actions.');
     }
 
@@ -226,11 +212,35 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
     if (hints.length > 0) {
       opt.title = hints.join('\n');
-      opt.setAttribute('aria-label', `${baseLabel} (${hints.join(', ')})`);
+      opt.setAttribute('aria-label', `${label} (${hints.join(', ')})`);
+      opt.setAttribute('aria-description', hints.join(' '));
     } else {
       opt.removeAttribute('title');
-      opt.setAttribute('aria-label', baseLabel);
+      opt.setAttribute('aria-label', label);
+      opt.removeAttribute('aria-description');
     }
+  }
+
+  _readAgentOptionMetadata(opt) {
+    let label = opt.dataset.label ?? '';
+    if (!label) {
+      const textLabel = opt.textContent?.trim();
+      if (textLabel) {
+        label = textLabel;
+      } else {
+        const valueAttr = opt.getAttribute('value');
+        label = valueAttr ?? '';
+      }
+      if (label) {
+        opt.dataset.label = label;
+      }
+    }
+
+    return {
+      label,
+      isMultiple: opt.dataset.multiple === 'true',
+      isToolUse: opt.dataset.toolUse === 'true',
+    };
   }
 
   _getSessionTypeValue() {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -53,7 +53,8 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     this._fileListHandlers = {};
     // Track pending model option updates until the select element is ready
     this._latestModelOptions = null;
-    this._modelOptionsQueue = Promise.resolve();
+    this._modelFlushScheduled = false;
+    this._isModelFlushRunning = false;
     this._modelSelectPromise = null;
     this._modelSelectResolver = null;
     this._modelSelectObserver = null;
@@ -192,9 +193,17 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   _decorateAgentOption(opt) {
     let baseLabel = opt.dataset.label;
     if (!baseLabel) {
-      const valueAttr = opt.getAttribute('value');
-      baseLabel = valueAttr ?? '';
-      opt.dataset.label = baseLabel;
+      const textLabel = opt.textContent?.trim();
+      if (textLabel) {
+        baseLabel = textLabel;
+        opt.dataset.label = baseLabel;
+      } else {
+        const valueAttr = opt.getAttribute('value');
+        baseLabel = valueAttr ?? '';
+        if (baseLabel) {
+          opt.dataset.label = baseLabel;
+        }
+      }
     }
 
     const hints = [];
@@ -249,30 +258,55 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _enqueueModelOptionsFlush() {
-    this._modelOptionsQueue = this._modelOptionsQueue
-      .then(() => this._flushPendingModelOptions())
-      .catch((error) => {
-        console.error('SET_MODEL_OPTIONS: Failed to apply options', error);
-      });
-  }
-
-  async _flushPendingModelOptions() {
     if (this._isDisposed) {
       return;
     }
 
-    const select = await this._waitForModelSelect();
-    if (!select || this._isDisposed) {
+    if (this._modelFlushScheduled) {
       return;
     }
 
-    if (!this._latestModelOptions) {
+    this._modelFlushScheduled = true;
+    Promise.resolve().then(() => this._drainModelOptions());
+  }
+
+  async _drainModelOptions() {
+    if (this._isDisposed) {
+      this._modelFlushScheduled = false;
       return;
     }
 
-    const html = this._latestModelOptions;
-    this._latestModelOptions = null;
-    this._applyModelOptions(select, html);
+    if (this._isModelFlushRunning) {
+      return;
+    }
+
+    this._isModelFlushRunning = true;
+
+    try {
+      while (!this._isDisposed && this._latestModelOptions) {
+        const select = await this._waitForModelSelect();
+        if (!select || this._isDisposed) {
+          break;
+        }
+
+        const html = this._latestModelOptions;
+        if (!html) {
+          break;
+        }
+
+        this._latestModelOptions = null;
+        this._applyModelOptions(select, html);
+      }
+    } catch (error) {
+      console.error('SET_MODEL_OPTIONS: Failed to apply options', error);
+    } finally {
+      this._isModelFlushRunning = false;
+      this._modelFlushScheduled = false;
+    }
+
+    if (!this._isDisposed && this._latestModelOptions) {
+      this._enqueueModelOptionsFlush();
+    }
   }
 
   _waitForModelSelect() {
@@ -308,10 +342,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _resolveModelSelectWaiter(result) {
-    if (this._modelSelectObserver) {
-      this._modelSelectObserver.disconnect();
-      this._modelSelectObserver = null;
-    }
+    this._disposeModelSelectObserver();
 
     if (this._modelSelectResolver) {
       const resolver = this._modelSelectResolver;
@@ -324,12 +355,20 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     }
   }
 
+  _disposeModelSelectObserver() {
+    if (this._modelSelectObserver) {
+      this._modelSelectObserver.disconnect();
+      this._modelSelectObserver = null;
+    }
+  }
+
   /** Register handlers and optionally request initial data. */
   setup(options = {}) {
     const { requestData = true } = options;
     this._isDisposed = false;
     this._latestModelOptions = null;
-    this._modelOptionsQueue = Promise.resolve();
+    this._modelFlushScheduled = false;
+    this._isModelFlushRunning = false;
     this._resolveModelSelectWaiter(null);
     super.setup();
     if (requestData) {
@@ -340,7 +379,9 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   cleanup() {
     this._isDisposed = true;
     this._latestModelOptions = null;
-    this._modelOptionsQueue = Promise.resolve();
+    this._modelFlushScheduled = false;
+    this._isModelFlushRunning = false;
+    this._disposeModelSelectObserver();
     this._resolveModelSelectWaiter(null);
 
     super.cleanup();

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -8,6 +8,10 @@ import {
   EDITED_FILE,
   BASE_FILE,
   ELEMENT_IDS,
+  SESSION_TYPES,
+  SESSION_TYPE_INPUT,
+  AGENT_SELECT_IDS,
+  AGENT_SELECT_LIST,
 } from './constants.js';
 import { webviewEventBus } from './eventBus.js';
 import { createFileHandlers } from './handlers/fileHandlers.js';
@@ -100,57 +104,33 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         this._enqueueModelOptionsFlush();
       },
       [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: (m) => {
-        if (!m.options) {
-          console.warn('SET_AGENT_OPTIONS: No options provided');
-          return;
-        }
-        const select = document.getElementById('agent');
-        if (!select) {
-          console.warn('SET_AGENT_OPTIONS: Agent select element not found');
-          return;
-        }
-        const previous = select.value;
-        select.innerHTML = m.options;
-        if (previous) {
-          select.value = previous;
-        }
-        Array.from(select.options).forEach((opt) => {
-          let baseLabel = opt.dataset.label;
-          if (!baseLabel) {
-            const valueAttr = opt.getAttribute('value');
-            baseLabel = valueAttr ?? '';
-            opt.dataset.label = baseLabel;
+        const optionsPayload = m.options ?? {};
+        let applied = false;
+
+        [
+          {
+            id: AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
+            html: optionsPayload.workflow ?? '',
+          },
+          {
+            id: AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
+            html: optionsPayload.toolUse ?? '',
+          },
+        ].forEach(({ id, html }) => {
+          if (!id) {
+            return;
           }
-
-          const hints = [];
-          let displayLabel = baseLabel;
-
-          if (opt.dataset.multiple === 'true') {
-            displayLabel += ' ∶∶';
-            hints.push('Supports multi-file inputs.');
-            opt.style.opacity = '0.9';
-          } else {
-            opt.style.opacity = '';
+          const select = document.getElementById(id);
+          if (!(select instanceof HTMLSelectElement)) {
+            return;
           }
-
-          if (opt.dataset.toolUse === 'true') {
-            displayLabel += 'ᵗ';
-            hints.push('Uses tools for actions.');
-          }
-
-          opt.textContent = displayLabel;
-
-          if (hints.length > 0) {
-            opt.title = hints.join('\n');
-            opt.setAttribute(
-              'aria-label',
-              `${baseLabel} (${hints.join(', ')})`,
-            );
-          } else {
-            opt.removeAttribute('title');
-            opt.setAttribute('aria-label', baseLabel);
-          }
+          this._applyAgentOptions(select, html);
+          applied = true;
         });
+
+        if (!applied) {
+          console.warn('SET_AGENT_OPTIONS: Agent select elements not found');
+        }
       },
     };
   }
@@ -184,6 +164,88 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         opt.title = `Provider: ${provider ?? 'N/A'}, Context: ${context ?? 'N/A'}, Cost: ${cost ?? 'N/A'}`;
       }
     });
+  }
+
+  _applyAgentOptions(selectElement, optionsHtml) {
+    const previous = selectElement.value;
+    selectElement.innerHTML = optionsHtml ?? '';
+    if (previous) {
+      selectElement.value = previous;
+      if (
+        selectElement.value !== previous &&
+        selectElement.options.length > 0
+      ) {
+        const fallbackOption = Array.from(selectElement.options).find(
+          (option) => !option.disabled,
+        );
+        if (fallbackOption) {
+          selectElement.value = fallbackOption.value;
+        }
+      }
+    }
+
+    Array.from(selectElement.options).forEach((opt) => {
+      this._decorateAgentOption(opt);
+    });
+  }
+
+  _decorateAgentOption(opt) {
+    let baseLabel = opt.dataset.label;
+    if (!baseLabel) {
+      const valueAttr = opt.getAttribute('value');
+      baseLabel = valueAttr ?? '';
+      opt.dataset.label = baseLabel;
+    }
+
+    const hints = [];
+    let displayLabel = baseLabel;
+
+    if (opt.dataset.multiple === 'true') {
+      displayLabel += ' ∶∶';
+      hints.push('Supports multi-file inputs.');
+      opt.style.opacity = '0.9';
+    } else {
+      opt.style.opacity = '';
+    }
+
+    if (opt.dataset.toolUse === 'true') {
+      displayLabel += 'ᵗ';
+      hints.push('Uses tools for actions.');
+    }
+
+    opt.textContent = displayLabel;
+
+    if (hints.length > 0) {
+      opt.title = hints.join('\n');
+      opt.setAttribute('aria-label', `${baseLabel} (${hints.join(', ')})`);
+    } else {
+      opt.removeAttribute('title');
+      opt.setAttribute('aria-label', baseLabel);
+    }
+  }
+
+  _getSessionTypeValue() {
+    const input = this._getElement(SESSION_TYPE_INPUT);
+    const rawValue = input?.value ?? '';
+    return rawValue === SESSION_TYPES.TOOL_USE
+      ? SESSION_TYPES.TOOL_USE
+      : SESSION_TYPES.WORKFLOW;
+  }
+
+  _getAgentElementByType(sessionType) {
+    const selectId = AGENT_SELECT_IDS[sessionType];
+    if (!selectId) {
+      return null;
+    }
+    const element = this._getElement(selectId);
+    return element instanceof HTMLSelectElement ? element : null;
+  }
+
+  _getActiveAgentSelection() {
+    const sessionType = this._getSessionTypeValue();
+    const select = this._getAgentElementByType(sessionType);
+    const value = select?.value ?? '';
+    return { sessionType, select, value };
   }
 
   _enqueueModelOptionsFlush() {
@@ -376,11 +438,11 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     });
 
     // Also request default output files for the current agent
-    const agentElement = this._getElement('agent');
-    if (agentElement && agentElement.value) {
+    const { value: agentValue } = this._getActiveAgentSelection();
+    if (agentValue) {
       vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES,
-        agent: agentElement.value,
+        agent: agentValue,
       });
     }
   }
@@ -400,7 +462,29 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _restoreFormFields(state, savedState) {
-    if (state.agent) safeSetElementValue('agent', state.agent);
+    const sessionType = state.sessionType
+      ? state.sessionType
+      : state.isToolUseAgent
+        ? SESSION_TYPES.TOOL_USE
+        : SESSION_TYPES.WORKFLOW;
+    const workflowAgentValue =
+      state.workflowAgent ??
+      (!state.isToolUseAgent ? state.agent : undefined) ??
+      '';
+    const toolUseAgentValue =
+      state.toolUseAgent ??
+      (state.isToolUseAgent ? state.agent : undefined) ??
+      '';
+
+    safeSetElementValue(SESSION_TYPE_INPUT, sessionType);
+    safeSetElementValue(
+      AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
+      workflowAgentValue,
+    );
+    safeSetElementValue(
+      AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
+      toolUseAgentValue,
+    );
     if (state.model) safeSetElementValue('model', state.model);
 
     const instructionContent = state.instruction || '';
@@ -421,7 +505,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
     const toolConfig = state.toolConfig || {};
     Object.assign(savedState, {
-      agent: state.agent,
+      sessionType,
+      workflowAgent: workflowAgentValue,
+      toolUseAgent: toolUseAgentValue,
+      agent:
+        state.agent ??
+        (sessionType === SESSION_TYPES.TOOL_USE
+          ? toolUseAgentValue
+          : workflowAgentValue),
       model: state.model,
       instruction: instructionContent,
       inputFile: state.inputFile,

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -26,6 +26,8 @@ export class ActionButtonManager extends BaseUIManager {
     this.fileList = fileList;
     this.state = state;
     this.instructionManager = instructionMgr;
+    this._sessionTypeInput = null;
+    this._agentSelectCache = new Map();
   }
 
   _getSingleFileData(fileTypes = ['input', 'reference', 'auxiliary', 'media']) {
@@ -299,6 +301,8 @@ export class ActionButtonManager extends BaseUIManager {
   }
 
   setup() {
+    this._sessionTypeInput = null;
+    this._agentSelectCache.clear();
     this._setupInstructionButtons();
     this._setupExecuteButtons();
     this._setupLatexdiffButtons();
@@ -311,17 +315,42 @@ export class ActionButtonManager extends BaseUIManager {
       : SESSION_TYPES.WORKFLOW;
   }
 
-  _getActiveAgentSelection() {
-    const rawSessionType = safeGetElementValue(SESSION_TYPE_INPUT);
-    const sessionType = this._normalizeSessionType(rawSessionType);
+  _getSessionTypeInput() {
+    if (!this._sessionTypeInput) {
+      const element = safeGetElementById(SESSION_TYPE_INPUT);
+      this._sessionTypeInput =
+        element instanceof HTMLInputElement ? element : null;
+    }
+    return this._sessionTypeInput;
+  }
+
+  _getAgentSelect(sessionType) {
     const selectId = AGENT_SELECT_IDS[sessionType];
-    const agent = selectId ? (safeGetElementValue(selectId) ?? '') : '';
-    const selectElement = selectId ? safeGetElementById(selectId) : null;
+    if (!selectId) {
+      return null;
+    }
+
+    if (!this._agentSelectCache.has(selectId)) {
+      const element = safeGetElementById(selectId);
+      this._agentSelectCache.set(
+        selectId,
+        element instanceof HTMLSelectElement ? element : null,
+      );
+    }
+
+    return this._agentSelectCache.get(selectId) || null;
+  }
+
+  _getActiveAgentSelection() {
+    const sessionTypeInput = this._getSessionTypeInput();
+    const rawSessionType = sessionTypeInput?.value;
+    const sessionType = this._normalizeSessionType(rawSessionType);
+    const selectElement = this._getAgentSelect(sessionType);
+    const agent = selectElement?.value ?? '';
     return {
       agent,
       sessionType,
-      selectElement:
-        selectElement instanceof HTMLSelectElement ? selectElement : null,
+      selectElement,
     };
   }
 }

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -5,6 +5,9 @@ import {
   ELEMENT_IDS,
   BASE_FILE,
   EDITED_FILE,
+  SESSION_TYPES,
+  SESSION_TYPE_INPUT,
+  AGENT_SELECT_IDS,
 } from '../constants.js';
 import { BaseUIManager } from './BaseUIManager.js';
 import {
@@ -68,7 +71,7 @@ export class ActionButtonManager extends BaseUIManager {
     this.addListener(ELEMENT_IDS.MAGIC_POLISH_BUTTON, 'click', () => {
       const instruction = safeGetElementById(ELEMENT_IDS.INSTRUCTION);
       if (instruction && instruction.value.trim()) {
-        const agent = safeGetElementValue('agent');
+        const { agent } = this._getActiveAgentSelection();
         const model = safeGetElementValue('model');
         const singleFiles = this._getSingleFileData();
         const multipleFilesData = this._getMultipleFileData(singleFiles);
@@ -87,17 +90,10 @@ export class ActionButtonManager extends BaseUIManager {
 
   _setupExecuteButtons() {
     this.addListener(ELEMENT_IDS.EXECUTE_BUTTON, 'click', () => {
-      const agent = safeGetElementValue('agent');
+      const { agent, sessionType } = this._getActiveAgentSelection();
       const model = safeGetElementValue('model');
       const instruction = safeGetElementValue(ELEMENT_IDS.INSTRUCTION);
-      const agentSelect = safeGetElementById('agent');
-      const selectedOption =
-        agentSelect &&
-        'options' in agentSelect &&
-        'selectedIndex' in agentSelect
-          ? agentSelect.options[agentSelect.selectedIndex]
-          : null;
-      const isToolUseAgent = selectedOption?.dataset?.toolUse === 'true';
+      const isToolUseAgent = sessionType === SESSION_TYPES.TOOL_USE;
       const singleFiles = this._getSingleFileData();
       const multipleFilesData = this._getMultipleFileData(singleFiles);
 
@@ -140,7 +136,7 @@ export class ActionButtonManager extends BaseUIManager {
     ].forEach(({ id, action }) => {
       this.addListener(id, 'click', () => {
         const { inputFile } = this._getSingleFileData(['input']);
-        const agent = safeGetElementValue('agent');
+        const { agent } = this._getActiveAgentSelection();
         const model = safeGetElementValue('model');
 
         const outputFiles = this.fileList.getSelected(
@@ -307,5 +303,25 @@ export class ActionButtonManager extends BaseUIManager {
     this._setupExecuteButtons();
     this._setupLatexdiffButtons();
     this._setupCompareButtons();
+  }
+
+  _normalizeSessionType(rawType) {
+    return rawType === SESSION_TYPES.TOOL_USE
+      ? SESSION_TYPES.TOOL_USE
+      : SESSION_TYPES.WORKFLOW;
+  }
+
+  _getActiveAgentSelection() {
+    const rawSessionType = safeGetElementValue(SESSION_TYPE_INPUT);
+    const sessionType = this._normalizeSessionType(rawSessionType);
+    const selectId = AGENT_SELECT_IDS[sessionType];
+    const agent = selectId ? (safeGetElementValue(selectId) ?? '') : '';
+    const selectElement = selectId ? safeGetElementById(selectId) : null;
+    return {
+      agent,
+      sessionType,
+      selectElement:
+        selectElement instanceof HTMLSelectElement ? selectElement : null,
+    };
   }
 }

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -320,7 +320,12 @@ export class FileInputManager extends BaseUIManager {
 
   _setupSaveListeners() {
     ELEMENTS_TO_SAVE.forEach((id) => {
-      if (id === 'agent' || id === 'model') {
+      if (
+        id === 'model' ||
+        id === 'workflowAgent' ||
+        id === 'toolUseAgent' ||
+        id === 'sessionType'
+      ) {
         return; // handled by SettingsButtonManager
       }
       if (id !== 'instruction') {

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -3,8 +3,12 @@ import {
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
   CHECK_BOXES,
+  ELEMENT_IDS,
+  SESSION_TYPES,
+  SESSION_TYPE_INPUT,
+  AGENT_SELECT_IDS,
+  AGENT_SELECT_LIST,
 } from '../constants.js';
-import { ELEMENT_IDS } from '../constants.js';
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
 import { BaseUIManager } from './BaseUIManager.js';
@@ -149,41 +153,59 @@ export class SettingsButtonManager extends BaseUIManager {
   }
 
   _setupDropdowns() {
-    // Show instruction on focus, before user makes selection
-    this.addListener('agent', 'focus', () => {
-      this.vscode.postMessage({
-        command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
-        key: 'agentPicker',
-        text: 'Select which agent will handle your request.',
-      });
-    });
-
-    this.addListener('agent', 'change', (e) => {
-      const selectedAgent = e.target.value;
-      const selectedOption = e.target.options[e.target.selectedIndex];
-
-      // Hide agent config banner if a valid (non-disabled) agent is selected
-      if (
-        selectedOption &&
-        !selectedOption.classList.contains('disabled-option')
-      ) {
-        this.vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER,
+    const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
+    if (toggleContainer) {
+      const buttons = toggleContainer.querySelectorAll('[data-session-type]');
+      buttons.forEach((button) => {
+        this.addListener(button, 'click', () => {
+          if (!(button instanceof HTMLElement)) {
+            return;
+          }
+          const sessionType = button.dataset.sessionType;
+          if (!sessionType) {
+            return;
+          }
+          this.state.applySessionType(sessionType);
+          const selectId =
+            AGENT_SELECT_IDS[sessionType] ??
+            AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW];
+          const selectElement = safeGetElementById(selectId);
+          if (selectElement instanceof HTMLSelectElement) {
+            this._handleAgentSelection(selectElement);
+            selectElement.focus();
+          } else {
+            this.state.save();
+          }
         });
-      }
+      });
+    }
 
-      const reflectCheckbox = safeGetElementById('reflect');
-      if (reflectCheckbox) {
-        reflectCheckbox.checked = !selectedAgent.startsWith('correct');
-      }
-      this.vscode.postMessage({
-        command: MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
+    AGENT_SELECT_LIST.forEach((id) => {
+      this.addListener(id, 'focus', (event) => {
+        const target = event.target;
+        if (
+          !(target instanceof HTMLSelectElement) ||
+          target.classList.contains('agent-select--hidden')
+        ) {
+          return;
+        }
+        this.vscode.postMessage({
+          command: MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
+          key: 'agentPicker',
+          text: 'Select which agent will handle your request.',
+        });
       });
-      this.vscode.postMessage({
-        command: MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES,
-        agent: selectedAgent,
+
+      this.addListener(id, 'change', (event) => {
+        const target = event.target;
+        if (
+          !(target instanceof HTMLSelectElement) ||
+          target.classList.contains('agent-select--hidden')
+        ) {
+          return;
+        }
+        this._handleAgentSelection(target);
       });
-      this.state.save();
     });
 
     // Show instruction on focus, before user makes selection
@@ -231,5 +253,57 @@ export class SettingsButtonManager extends BaseUIManager {
     this._setupSettingsButtons();
     this._setupDropdowns();
     this._setupDependencyBanner();
+  }
+
+  _normalizeSessionType(rawType) {
+    return rawType === SESSION_TYPES.TOOL_USE
+      ? SESSION_TYPES.TOOL_USE
+      : SESSION_TYPES.WORKFLOW;
+  }
+
+  _handleAgentSelection(selectElement) {
+    if (!(selectElement instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    const normalizedType = this._normalizeSessionType(
+      selectElement.dataset.sessionType,
+    );
+    this.state.applySessionType(normalizedType, { skipSave: true });
+
+    const selectedAgent = selectElement.value;
+    const selectedOption = selectElement.options[selectElement.selectedIndex];
+
+    if (
+      selectedOption &&
+      !selectedOption.classList.contains('disabled-option')
+    ) {
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER,
+      });
+    }
+
+    const reflectCheckbox = safeGetElementById('reflect');
+    if (reflectCheckbox) {
+      reflectCheckbox.checked = !selectedAgent.startsWith('correct');
+    }
+
+    this.vscode.postMessage({
+      command: MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
+    });
+
+    if (selectedAgent) {
+      this.vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES,
+        agent: selectedAgent,
+      });
+    }
+
+    const sessionInput = safeGetElementById(SESSION_TYPE_INPUT);
+    if (sessionInput) {
+      sessionInput.value = normalizedType;
+    }
+
+    this.state.save();
   }
 }

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -19,6 +19,64 @@
   max-width: 150px;
 }
 
+.model-selection-footer .agent-select-group {
+  align-items: flex-start;
+  gap: var(--spacing-small);
+  max-width: none;
+}
+
+.agent-select-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.session-toggle {
+  display: inline-flex;
+  border: 1px solid var(--vscode-button-border);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  background: var(--vscode-input-background);
+}
+
+.session-toggle__option {
+  flex: 1 1 50%;
+  padding: var(--spacing-tiny) var(--spacing-small);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  color: var(--vscode-foreground);
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.session-toggle__option:hover,
+.session-toggle__option:focus {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.session-toggle__option.active {
+  background: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
+}
+
+.session-toggle__option:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
+}
+
+.agent-select {
+  width: 100%;
+}
+
+.agent-select--hidden {
+  display: none;
+}
+
 .model-selection-footer .select-group select {
   height: var(--height-control);
   font-size: var(--font-size);

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -16,21 +16,30 @@
 .model-selection-footer .select-group {
   display: flex;
   align-items: center;
-  max-width: 150px;
+  gap: var(--spacing-small);
 }
 
 .model-selection-footer .agent-select-group {
-  align-items: flex-start;
+  align-items: center;
   gap: var(--spacing-small);
-  max-width: none;
 }
 
 .agent-select-controls {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
   gap: var(--spacing-small);
   flex: 1 1 auto;
   min-width: 0;
+}
+
+.agent-select-dropdowns {
+  position: relative;
+  width: min(16rem, 100%);
+}
+
+.agent-select-dropdowns select {
+  width: 100%;
 }
 
 .session-toggle {
@@ -71,10 +80,19 @@
 
 .agent-select {
   width: 100%;
+  min-width: 0;
 }
 
 .agent-select--hidden {
-  display: none;
+  position: absolute;
+  inset: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.agent-select--active {
+  position: relative;
+  visibility: visible;
 }
 
 .model-selection-footer .select-group select {

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -29,17 +29,20 @@
   flex-direction: row;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   min-width: 0;
 }
 
 .agent-select-dropdowns {
   position: relative;
-  width: min(16rem, 100%);
+  flex: 0 0 auto;
+  min-width: 10rem;
+  max-width: 14rem;
 }
 
 .agent-select-dropdowns select {
   width: 100%;
+  min-width: 0;
 }
 
 .session-toggle {
@@ -95,7 +98,15 @@
   visibility: visible;
 }
 
+.model-selection-footer .select-group {
+  flex: 0 0 auto;
+}
+
 .model-selection-footer .select-group select {
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 10rem;
+  max-width: 14rem;
   height: var(--height-control);
   font-size: var(--font-size);
   padding: var(--spacing-tiny) var(--spacing-small);

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -105,8 +105,8 @@
 .model-selection-footer .select-group select {
   flex: 0 0 auto;
   width: auto;
-  min-width: 10rem;
-  max-width: 14rem;
+  min-width: 8rem;
+  max-width: 11rem;
   height: var(--height-control);
   font-size: var(--font-size);
   padding: var(--spacing-tiny) var(--spacing-small);


### PR DESCRIPTION
## Summary
- return separate workflow and tool-use option payloads for agent metadata and adjust the HTML fallback
- restructure the main view footer with a session-type toggle plus dedicated selects and persist their state in the webview
- update message handlers, UI managers, and styling so execution picks the correct agent and accessibility hints remain intact

## Testing
- npm run compile
- npm run lint
- npm run format
- npm test *(fails: VS Code test runner output exceeded terminal limits)*

------
https://chatgpt.com/codex/tasks/task_e_68d97e560da083248e60d7e27f5231df

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split agent selection into Workflow/Tool Use with a toggle and per-session dropdowns, introduce configurable/discovered tool-use agents, and update option payloads, state, handlers, and styles.
> 
> - **UI/Main Webview**:
>   - **Session Toggle + Dual Selects**: Add `workflow`/`toolUse` session toggle and separate `#workflowAgent`/`#toolUseAgent` selects in `index.html`, with new state fields (`sessionType`, `workflowAgent`, `toolUseAgent`) and migration from legacy `agent`/`isToolUseAgent`.
>   - **State & Handlers**: Update `mainViewState.js`, `messageHandlers.js`, `ActionButtonManager.js`, `SettingsButtonManager.js`, and `FileInputManager.js` to persist/restore session type, route execute/polish to the active agent, request default outputs, and keep accessibility hints; guard model option observer/flush lifecycle for reliable updates.
>   - **Styles**: Rework footer CSS (`styles/footer.css`) for compact toggle and narrower selectors.
> - **Agent Options**:
>   - Replace single HTML with structured payload via `buildAgentOptionsPayload` returning separate `workflow` and `toolUse` option HTML; update `computeAgentOptions` to return `AgentOptionsPayload` and `getAllAgents` to produce `{ allAgents, toolUseAgents }` with auto-discovery in built-in tool-use dir.
> - **Config**:
>   - Replace `texra.includeToolUseAgents` with `texra.toolUseAgents` (array) and trim defaults to conversational presets; populate tool-use dropdown from config + discovery.
> - **Docs**:
>   - Update `CHANGELOG.md` with UI rebuild, dropdown population, default list trim, narrower model selector, and observer lifecycle guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 818d0f91cba40d7eb8c7d0280a4d83c8541ccaed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->