### PR TITLE
fix: isolate prompt XML files per execution

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -398,6 +398,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           userRequest,
           this.agentConfig.inputFile,
           this.agentConfig.agent,
+          this.executionId,
         );
       }
 

--- a/src/agent/utils/promptUtils.ts
+++ b/src/agent/utils/promptUtils.ts
@@ -10,8 +10,16 @@ import { getAgentFirstNameChunk } from '@housekeeping/utils';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
+// Local imports - types
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+
 // Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
+import {
+  StorageFS,
+  TASK_RUNS_DIR,
+  WorkspaceFS,
+  isValidExecutionId,
+} from '@utils/files';
 
 const CHANNEL = 'promptUtils';
 logger.initialize(CHANNEL);
@@ -138,7 +146,8 @@ export async function renderPrompt(
  * @param userRequest The user request
  * @param inputFile Path to the input file
  * @param agent Name of the agent
- * @returns Path to the created XML file
+ * @param executionId Optional execution identifier used to isolate task run files
+ * @returns Absolute path to the created XML file
  */
 export async function writePromptToXml(
   systemPrompt: string,
@@ -146,15 +155,33 @@ export async function writePromptToXml(
   userRequest: string,
   inputFile: string,
   agent: string,
+  executionId?: ExecutionId,
 ): Promise<string> {
   try {
     const { dir, name } = path.parse(inputFile);
     const agentName = getAgentFirstNameChunk(agent);
-    const outputFile = path.join(dir, `${name}_${agentName}_input.xml`);
-
-    logger.debug(CHANNEL, `Writing input prompt to ${outputFile}`);
+    const baseFilename = `${name}_${agentName}_input.xml`;
 
     const fullPrompt = `\n<system>${systemPrompt}</system>\n\n${userPrefix}\n${userRequest}\n`;
+    if (isValidExecutionId(executionId)) {
+      await StorageFS.ensureDir(TASK_RUNS_DIR);
+      await StorageFS.ensureDir(path.join(TASK_RUNS_DIR, executionId));
+
+      const storageRelativePath = path.join(
+        TASK_RUNS_DIR,
+        executionId,
+        baseFilename,
+      );
+      const storageFullPath = StorageFS.fullPath(storageRelativePath);
+
+      logger.debug(CHANNEL, `Writing input prompt to ${storageFullPath}`);
+      await StorageFS.write(storageRelativePath, fullPrompt);
+
+      return storageFullPath;
+    }
+
+    const outputFile = path.join(dir, baseFilename);
+    logger.debug(CHANNEL, `Writing input prompt to ${outputFile}`);
     await WorkspaceFS.write(outputFile, fullPrompt);
 
     return outputFile;

--- a/src/test/agent/utils/promptUtils.test.ts
+++ b/src/test/agent/utils/promptUtils.test.ts
@@ -1,0 +1,72 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports - agent utils
+import { writePromptToXml } from '@agent/utils/promptUtils';
+
+// Local imports - types
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+
+// Local imports - utilities
+import { StorageFS, TASK_RUNS_DIR, WorkspaceFS } from '@utils/files';
+
+describe('promptUtils.writePromptToXml', () => {
+  const originalStorageEnsureDir = StorageFS.ensureDir;
+  const originalStorageWrite = StorageFS.write;
+  const originalStorageFullPath = StorageFS.fullPath;
+  const originalWorkspaceWrite = WorkspaceFS.write;
+
+  afterEach(() => {
+    StorageFS.ensureDir = originalStorageEnsureDir;
+    StorageFS.write = originalStorageWrite;
+    StorageFS.fullPath = originalStorageFullPath;
+    WorkspaceFS.write = originalWorkspaceWrite;
+  });
+
+  it('stores prompts under task run storage when execution id is provided', async () => {
+    const ensureCalls: string[] = [];
+    let writePath: string | undefined;
+    let workspaceWriteCalled = false;
+    const storageRoot = path.join('/storage-root');
+    const executionId = 'exec-1234' as ExecutionId;
+
+    StorageFS.ensureDir = (async (relativePath: string) => {
+      ensureCalls.push(relativePath);
+    }) as typeof StorageFS.ensureDir;
+
+    StorageFS.write = (async (
+      relativePath: string,
+      _content: string | Uint8Array,
+    ) => {
+      writePath = relativePath;
+    }) as typeof StorageFS.write;
+
+    StorageFS.fullPath = ((relativePath: string) =>
+      path.join(storageRoot, relativePath)) as typeof StorageFS.fullPath;
+
+    WorkspaceFS.write = (async () => {
+      workspaceWriteCalled = true;
+    }) as typeof WorkspaceFS.write;
+
+    const result = await writePromptToXml(
+      'system prompt',
+      'user prefix',
+      'user request',
+      '/workspace/report.tex',
+      'reflect_agent',
+      executionId,
+    );
+
+    const expectedRelative = path.join(
+      TASK_RUNS_DIR,
+      executionId,
+      'report_reflect_input.xml',
+    );
+
+    assert.equal(writePath, expectedRelative);
+    assert.deepEqual(ensureCalls, [TASK_RUNS_DIR, path.join(TASK_RUNS_DIR, executionId)]);
+    assert.equal(result, path.join(storageRoot, expectedRelative));
+    assert.equal(workspaceWriteCalled, false);
+  });
+});


### PR DESCRIPTION
## Summary
- write prompt XMLs into execution-specific taskRuns storage when an execution id is available
- pass the current execution id from BaseReflectionAgent so prompt captures stay isolated per run
- cover the storage path selection with a unit test that stubs StorageFS writes

## Testing
- npm run compile-tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9acc65cd0832490f78dc6df2465bb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes input prompt XMLs to execution-scoped storage when `executionId` is present and wires the ID through `BaseReflectionAgent`, with a unit test for path selection.
> 
> - **Agent Utils**:
>   - `writePromptToXml`:
>     - Accepts optional `executionId` and, when valid, writes via `StorageFS` to `TASK_RUNS_DIR/<executionId>/<name>_<agent>_input.xml` and returns the absolute path.
>     - Falls back to `WorkspaceFS` in the input file directory when no valid `executionId`.
>     - Adds imports for `StorageFS`, `TASK_RUNS_DIR`, and `isValidExecutionId`.
> - **Agent**:
>   - `BaseReflectionAgent`: passes `this.executionId` to `writePromptToXml` when printing input prompts.
> - **Tests**:
>   - Adds `promptUtils.writePromptToXml` unit test verifying execution-scoped storage, directory creation, and avoiding `WorkspaceFS` writes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdecb333b3b049c98944803bfba96f44528cc966. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->