### PR TITLE
fix: ensure prompt xml fallback path is absolute

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -398,6 +398,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           userRequest,
           this.agentConfig.inputFile,
           this.agentConfig.agent,
+          this.executionId,
         );
       }
 

--- a/src/agent/utils/promptUtils.ts
+++ b/src/agent/utils/promptUtils.ts
@@ -5,13 +5,19 @@ import * as path from 'path';
 import * as nunjucks from 'nunjucks';
 
 // Local imports - agent
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { getAgentFirstNameChunk } from '@housekeeping/utils';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
+import {
+  StorageFS,
+  TASK_RUNS_DIR,
+  WorkspaceFS,
+  isValidExecutionId,
+} from '@utils/files';
 
 const CHANNEL = 'promptUtils';
 logger.initialize(CHANNEL);
@@ -138,7 +144,8 @@ export async function renderPrompt(
  * @param userRequest The user request
  * @param inputFile Path to the input file
  * @param agent Name of the agent
- * @returns Path to the created XML file
+ * @param executionId Optional execution identifier used to scope storage writes
+ * @returns Absolute path to the created XML file
  */
 export async function writePromptToXml(
   systemPrompt: string,
@@ -146,18 +153,36 @@ export async function writePromptToXml(
   userRequest: string,
   inputFile: string,
   agent: string,
+  executionId?: ExecutionId,
 ): Promise<string> {
   try {
     const { dir, name } = path.parse(inputFile);
     const agentName = getAgentFirstNameChunk(agent);
-    const outputFile = path.join(dir, `${name}_${agentName}_input.xml`);
-
-    logger.debug(CHANNEL, `Writing input prompt to ${outputFile}`);
-
     const fullPrompt = `\n<system>${systemPrompt}</system>\n\n${userPrefix}\n${userRequest}\n`;
+
+    if (isValidExecutionId(executionId)) {
+      const runDir = path.join(TASK_RUNS_DIR, executionId);
+      const relativeOutputFile = path.join(
+        runDir,
+        `${name}_${agentName}_input.xml`,
+      );
+
+      await StorageFS.ensureDir(TASK_RUNS_DIR);
+      await StorageFS.ensureDir(runDir);
+
+      const storagePath = StorageFS.fullPath(relativeOutputFile);
+      logger.debug(CHANNEL, `Writing input prompt to ${storagePath}`);
+      await StorageFS.write(relativeOutputFile, fullPrompt);
+
+      return storagePath;
+    }
+
+    const outputFile = path.join(dir, `${name}_${agentName}_input.xml`);
+    const workspacePath = WorkspaceFS.fullPath(outputFile);
+    logger.debug(CHANNEL, `Writing input prompt to ${workspacePath}`);
     await WorkspaceFS.write(outputFile, fullPrompt);
 
-    return outputFile;
+    return workspacePath;
   } catch (err) {
     logger.error(
       CHANNEL,

--- a/src/test/agent/utils/promptUtils.test.ts
+++ b/src/test/agent/utils/promptUtils.test.ts
@@ -1,0 +1,125 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports - agent
+import { writePromptToXml } from '@agent/utils/promptUtils';
+
+// Local imports - storage
+import { StorageFS, TASK_RUNS_DIR, WorkspaceFS } from '@utils/files';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+
+describe('promptUtils.writePromptToXml', () => {
+  type StorageFsMutable = {
+    write: typeof StorageFS.write;
+    ensureDir: typeof StorageFS.ensureDir;
+    fullPath: typeof StorageFS.fullPath;
+  };
+
+  type WorkspaceFsMutable = {
+    write: typeof WorkspaceFS.write;
+    fullPath: typeof WorkspaceFS.fullPath;
+  };
+
+  const storageFs = StorageFS as unknown as StorageFsMutable;
+  const workspaceFs = WorkspaceFS as unknown as WorkspaceFsMutable;
+
+  const originalStorageWrite = storageFs.write;
+  const originalStorageEnsureDir = storageFs.ensureDir;
+  const originalStorageFullPath = storageFs.fullPath;
+  const originalWorkspaceWrite = workspaceFs.write;
+  const originalWorkspaceFullPath = workspaceFs.fullPath;
+
+  let writes: {
+    relativePath: string;
+    content: string | Uint8Array<ArrayBufferLike>;
+  }[];
+  let ensured: string[];
+  let workspaceWrites: {
+    relativePath: string;
+    content: string | Uint8Array<ArrayBufferLike>;
+  }[];
+
+  beforeEach(() => {
+    writes = [];
+    ensured = [];
+    workspaceWrites = [];
+
+    storageFs.write = async (relativePath, content) => {
+      writes.push({ relativePath, content });
+    };
+
+    storageFs.ensureDir = async (relativePath) => {
+      ensured.push(relativePath);
+    };
+
+    storageFs.fullPath = (relativePath) =>
+      path.join('/mock/storage', relativePath);
+
+    workspaceFs.write = async (relativePath, content) => {
+      workspaceWrites.push({ relativePath, content });
+    };
+
+    workspaceFs.fullPath = (relativePath) =>
+      path.join('/mock/workspace', relativePath);
+  });
+
+  afterEach(() => {
+    storageFs.write = originalStorageWrite;
+    storageFs.ensureDir = originalStorageEnsureDir;
+    storageFs.fullPath = originalStorageFullPath;
+    workspaceFs.write = originalWorkspaceWrite;
+    workspaceFs.fullPath = originalWorkspaceFullPath;
+  });
+
+  it('writes prompts under the task run storage directory when executionId is provided', async () => {
+    const executionId = 'run-123' as ExecutionId;
+
+    const result = await writePromptToXml(
+      'system message',
+      'prefix',
+      'request',
+      '/tmp/input.tex',
+      'write-agent',
+      executionId,
+    );
+
+    assert.equal(writes.length, 1);
+    assert.deepEqual(ensured, [TASK_RUNS_DIR, path.join(TASK_RUNS_DIR, executionId)]);
+
+    const expectedRelative = path.join(
+      TASK_RUNS_DIR,
+      executionId,
+      'input_agent_input.xml',
+    );
+    assert.equal(writes[0].relativePath, expectedRelative);
+    assert.equal(result, path.join('/mock/storage', expectedRelative));
+    assert.equal(typeof writes[0].content, 'string');
+    if (typeof writes[0].content === 'string') {
+      assert.ok(
+        writes[0].content.includes('<system>system message</system>'),
+        'Prompt content should include the system message',
+      );
+    }
+
+    assert.equal(workspaceWrites.length, 0);
+  });
+
+  it('writes prompts under the workspace when executionId is absent', async () => {
+    const result = await writePromptToXml(
+      'system message',
+      'prefix',
+      'request',
+      'docs/input.tex',
+      'write-agent',
+    );
+
+    assert.equal(writes.length, 0);
+    assert.deepEqual(ensured, []);
+    assert.equal(workspaceWrites.length, 1);
+
+    const expectedRelative = path.join('docs', 'input_agent_input.xml');
+    assert.equal(workspaceWrites[0].relativePath, expectedRelative);
+    assert.equal(result, path.join('/mock/workspace', expectedRelative));
+  });
+});


### PR DESCRIPTION
## Summary
- ensure writePromptToXml resolves workspace prompt paths to absolute locations when storage is not used
- extend the prompt utility tests to cover workspace writes and stub the filesystem fullPath helpers

## Testing
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68d9acc65cd0832490f78dc6df2465bb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route prompt XML to per-run storage when `executionId` is provided, otherwise write to workspace, always returning absolute paths; update agent to pass `executionId` and add tests.
> 
> - **Agent Utils (`@agent/utils/promptUtils`)**:
>   - **`writePromptToXml`**: Accepts optional `executionId` and writes:
>     - To storage under `TASK_RUNS_DIR/<executionId>` via `StorageFS` when valid, ensuring dirs and returning `StorageFS.fullPath`.
>     - To workspace via `WorkspaceFS` when absent/invalid, returning `WorkspaceFS.fullPath`.
>   - Logs updated to show absolute paths.
> - **Agent (`BaseReflectionAgent`)**:
>   - Passes `this.executionId` to `writePromptToXml` when printing input prompts.
> - **Tests**:
>   - New unit tests for storage-vs-workspace behaviors, directory ensuring, absolute path returns, and prompt content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fea1582017e9894a2543795454e18187d7c85ba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->