### PR TITLE
feat: support texcount modes

### DIFF
--- a/docs/guide/tool-integration.md
+++ b/docs/guide/tool-integration.md
@@ -16,7 +16,13 @@ Ensuring clean, consistent, and valid LaTeX code.
 - **Comparison:** `latexdiff` is used to visualize changes between document versions, including automatic diff generation after agent runs. See the [LaTeX Diff guide](./latex-diff.md) for details on usage and configuration.
 
 **TeX Count Integration:**
-TeXRA can use `texcount` (often included with LaTeX) to provide document statistics (words, headers, math) to the AI agent. This is enabled via the "Attach TeX Count" (<i class="codicon codicon-symbol-numeric"></i>) checkbox in the Tool Configuration dropdown (see [Configuration Guide](./configuration.md#agent-execution-settings)). Ensure `texcount` is in your system's PATH.
+TeXRA can use `texcount` (often included with LaTeX) to provide document statistics (words, headers, math) to the AI agent. This is enabled via the "Attach TeX Count" (<i class="codicon codicon-symbol-numeric"></i>) checkbox in the Tool Configuration dropdown (see [Configuration Guide](./configuration.md#agent-execution-settings)). Tool-use sessions can also invoke the dedicated `texcount` tool to analyze arbitrary `.tex` files on demand. Choose a `mode` based on the task:
+
+- `separate` (default) counts each provided file individually.
+- `include` adds `-inc` so `texcount` follows `\input{}`/`\include{}` directives from the main file.
+- `sum` aggregates independent top-level files in a single total (uses `-sum`).
+
+Ensure `texcount` is in your system's PATH.
 
 ### 2. Figure & Media Handling
 
@@ -29,7 +35,7 @@ Processing visual elements for analysis and inclusion.
 
 Providing quantitative insights into your document structure.
 
-- **Statistics:** `texcount` analyzes your document to provide statistics like word counts, heading counts, and math element counts. This information can optionally be included in prompts to give the LLM better context about the document's scale and complexity. See the "Attach TeX Count" option in the UI ([File Management guide](./file-management.md#tool-config-dropdown)) and the `texra.getTeXCount` command.
+- **Statistics:** `texcount` analyzes your document to provide statistics like word counts, heading counts, and math element counts. This information can optionally be included in prompts to give the LLM better context about the document's scale and complexity. See the "Attach TeX Count" option in the UI ([File Management guide](./file-management.md#tool-config-dropdown)), the `texra.getTeXCount` command, or call the `texcount` tool directly from a tool-use workflow.
 - **Symbolic Math:** The `wolfram` tool runs Wolfram Language code through `wolframscript`, letting agents verify calculations or perform algebra before responding.
 
 _(Note: These tools often rely on external programs that need to be installed separately. See the [Installation guide](./installation.md) for requirements.)_

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -169,20 +169,20 @@ async function handleGetTeXCount(): Promise<void> {
       async (progress) => {
         progress.report({ message: 'Running texcount...' });
 
-        const result = await getTeXCount(filePath, {
+        const { output, errors } = await getTeXCount(filePath, {
           mode: countingMode.value,
           channel: CHANNEL,
         });
 
-        if (result) {
+        if (output) {
           // Extract key statistics using regex
-          const wordMatch = result.match(/Words in text:\s*(\d+)/);
-          const headerMatch = result.match(/Words in headers:\s*(\d+)/);
-          const captionMatch = result.match(/Words in float captions:\s*(\d+)/);
-          const mathInlineMatch = result.match(
+          const wordMatch = output.match(/Words in text:\s*(\d+)/);
+          const headerMatch = output.match(/Words in headers:\s*(\d+)/);
+          const captionMatch = output.match(/Words in float captions:\s*(\d+)/);
+          const mathInlineMatch = output.match(
             /Number of inline math:\s*(\d+)/,
           );
-          const mathDisplayMatch = result.match(
+          const mathDisplayMatch = output.match(
             /Number of displayed math:\s*(\d+)/,
           );
 
@@ -204,7 +204,10 @@ async function handleGetTeXCount(): Promise<void> {
             canPickMany: false,
           });
         } else {
-          vscode.window.showErrorMessage('Failed to get tex count');
+          const message =
+            errors[0] ??
+            'Failed to get tex count. Please verify the file path.';
+          vscode.window.showErrorMessage(message);
         }
       },
     );

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -11,7 +11,7 @@ import replacementEngine from '@replacement/engine';
 
 // Local imports - latex utils
 import { runLatexFormatter } from '@latex/texFormatter';
-import { getTeXCount } from '@latex/texcount';
+import { getTeXCount, type TexcountMode } from '@latex/texcount';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 
 // Local imports - commands
@@ -139,10 +139,15 @@ async function handleGetTeXCount(): Promise<void> {
     logger.debug(CHANNEL, `Getting tex count for: ${filePath}`);
 
     // Ask if user wants to merge included files
-    const mergeOption = await vscode.window.showQuickPick(
+    const countingMode = await vscode.window.showQuickPick<
+      vscode.QuickPickItem & { value: TexcountMode }
+    >(
       [
-        { label: 'Count main file only', value: false },
-        { label: 'Merge included files', value: true },
+        { label: 'Count main file only', value: 'separate' as const },
+        {
+          label: 'Follow \\input/\\include and combine',
+          value: 'include' as const,
+        },
       ],
       {
         placeHolder: 'Count options',
@@ -150,7 +155,7 @@ async function handleGetTeXCount(): Promise<void> {
       },
     );
 
-    if (!mergeOption) {
+    if (!countingMode) {
       return;
     }
 
@@ -164,7 +169,10 @@ async function handleGetTeXCount(): Promise<void> {
       async (progress) => {
         progress.report({ message: 'Running texcount...' });
 
-        const result = await getTeXCount(filePath, mergeOption.value, CHANNEL);
+        const result = await getTeXCount(filePath, {
+          mode: countingMode.value,
+          channel: CHANNEL,
+        });
 
         if (result) {
           // Extract key statistics using regex

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -21,6 +21,7 @@ export {
   formatTeXCountStats,
   type TexcountOptions,
   type TexcountMode,
+  type TexcountResult,
 } from './texcount';
 
 // Export latexdiff service

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -15,7 +15,13 @@ export {
 export { compileLatex2Pdf } from './texTools';
 
 // Export texcount functionality
-export { getTeXCountStats } from './texcount';
+export {
+  getTeXCount,
+  getTeXCountStats,
+  formatTeXCountStats,
+  type TexcountOptions,
+  type TexcountMode,
+} from './texcount';
 
 // Export latexdiff service
 export { LaTeXdiffService } from './latexdiff';

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -21,7 +21,6 @@ async function hasChinesePackages(filePath: string): Promise<boolean> {
       'ctexart',
       'ctex',
       'CJK',
-      'xeCJK',
       'ctexrep',
       'ctexbook',
     ];
@@ -43,7 +42,7 @@ async function hasChinesePackages(filePath: string): Promise<boolean> {
  * Get full statistics for LaTeX documents using the texcount Perl script
  * @param filePaths Single file path or array of file paths
  * @param options Options to control merging behavior and logging channel
- * @returns Promise<string | null> String containing full texcount output for all files, or null if an error occurred
+ * @returns Promise<TexcountResult> Combined texcount output and any errors encountered during processing
  */
 export type TexcountMode = 'separate' | 'include' | 'sum';
 
@@ -52,24 +51,39 @@ export interface TexcountOptions {
   channel?: string;
 }
 
+interface ValidationSuccess {
+  valid: true;
+}
+
+interface ValidationFailure {
+  valid: false;
+  reason: string;
+}
+
+type ValidationResult = ValidationSuccess | ValidationFailure;
+
+export interface TexcountResult {
+  output: string | null;
+  errors: string[];
+}
+
 async function validateTexFile(
   filePath: string,
   channel: string,
-): Promise<boolean> {
+): Promise<ValidationResult> {
   if (!(await WorkspaceFS.exists(filePath))) {
-    logger.warn(channel, `File ${filePath} does not exist.`);
-    return false;
+    const reason = `File ${filePath} does not exist.`;
+    logger.warn(channel, reason);
+    return { valid: false, reason };
   }
 
   if (!filePath.endsWith('.tex')) {
-    logger.warn(
-      channel,
-      `Error: File ${filePath} is not a LaTeX file. Skipping.`,
-    );
-    return false;
+    const reason = `Error: File ${filePath} is not a LaTeX file. Skipping.`;
+    logger.warn(channel, reason);
+    return { valid: false, reason };
   }
 
-  return true;
+  return { valid: true };
 }
 
 async function detectChineseMode(
@@ -91,7 +105,7 @@ async function runTexcount(
   args: string[],
   channel: string,
   context: string,
-): Promise<string | null> {
+): Promise<{ stdout: string | null; error?: string }> {
   const result = await runToolWithCheck('texcount', args, {
     channel,
     truncate: false,
@@ -99,12 +113,15 @@ async function runTexcount(
   });
 
   if (!result) {
-    return null;
+    return {
+      stdout: null,
+      error: `texcount did not return a result for ${context}.`,
+    };
   }
 
   if (result.success && result.stdout) {
     logger.debug(channel, `Successfully counted ${context}`);
-    return result.stdout;
+    return { stdout: result.stdout };
   }
 
   logger.error(channel, `Error getting tex count for ${context}`);
@@ -115,64 +132,93 @@ async function runTexcount(
     logger.error(channel, `Stderr: ${result.stderr}`);
   }
 
-  return null;
+  return {
+    stdout: null,
+    error:
+      `texcount failed while processing ${context}.` +
+      (result.stderr ? ` Details: ${result.stderr}` : ''),
+  };
 }
 
 async function getIndividualCounts(
   paths: string[],
   channel: string,
   includeReferenced: boolean,
-): Promise<string[]> {
-  const outputs: string[] = [];
+): Promise<{ outputs: string[]; errors: string[] }> {
+  const results = await Promise.all(
+    paths.map(async (filePath) => {
+      const localErrors: string[] = [];
+      const validation = await validateTexFile(filePath, channel);
+      if (!validation.valid) {
+        localErrors.push(validation.reason);
+        return { output: null, errors: localErrors };
+      }
 
-  for (const filePath of paths) {
-    if (!(await validateTexFile(filePath, channel))) {
-      continue;
-    }
+      const args: string[] = [];
+      if (includeReferenced) {
+        args.push('-inc');
+      }
+      if (await detectChineseMode(filePath, channel)) {
+        args.push('-ch-only');
+      }
+      args.push(filePath);
 
-    const args: string[] = [];
-    if (includeReferenced) {
-      args.push('-inc');
-    }
-    if (await detectChineseMode(filePath, channel)) {
-      args.push('-ch-only');
-    }
-    args.push(filePath);
+      const { stdout, error } = await runTexcount(args, channel, filePath);
+      if (stdout) {
+        return {
+          output: `TeX Count Results for ${filePath}:\n${stdout}`,
+          errors: localErrors,
+        };
+      }
+      if (error) {
+        localErrors.push(error);
+      }
+      return { output: null, errors: localErrors };
+    }),
+  );
 
-    const stdout = await runTexcount(args, channel, filePath);
-    if (stdout) {
-      outputs.push(`TeX Count Results for ${filePath}:\n${stdout}`);
-    }
-  }
+  const outputs = results
+    .map((result) => result.output)
+    .filter((output): output is string => output !== null);
+  const errors = results.flatMap((result) => result.errors);
 
-  return outputs;
+  return { outputs, errors };
 }
 
 async function getSummedCount(
   paths: string[],
   channel: string,
-): Promise<string | null> {
+): Promise<{ output: string | null; errors: string[] }> {
   const validPaths: string[] = [];
+  const errors: string[] = [];
   let enableChineseMode = false;
 
   for (const filePath of paths) {
-    if (!(await validateTexFile(filePath, channel))) {
+    const validation = await validateTexFile(filePath, channel);
+    if (!validation.valid) {
+      errors.push(validation.reason);
       continue;
     }
 
     validPaths.push(filePath);
 
-    if (!enableChineseMode && (await hasChinesePackages(filePath))) {
-      enableChineseMode = true;
-      logger.debug(
-        channel,
-        `Chinese packages detected in ${filePath}, enabling Chinese character counting`,
-      );
+    if (!enableChineseMode) {
+      const hasChinese = await hasChinesePackages(filePath);
+      if (hasChinese) {
+        enableChineseMode = true;
+        logger.debug(
+          channel,
+          `Chinese packages detected in ${filePath}, enabling Chinese character counting`,
+        );
+      }
     }
   }
 
   if (validPaths.length === 0) {
-    return null;
+    if (errors.length === 0) {
+      errors.push('No valid LaTeX files were provided for texcount sum mode.');
+    }
+    return { output: null, errors };
   }
 
   const args: string[] = ['-sum'];
@@ -181,45 +227,64 @@ async function getSummedCount(
   }
   args.push(...validPaths);
 
-  const stdout = await runTexcount(
+  const { stdout, error } = await runTexcount(
     args,
     channel,
     `sum for ${validPaths.join(', ')}`,
   );
   if (!stdout) {
-    return null;
+    if (error) {
+      errors.push(error);
+    }
+    return { output: null, errors };
   }
 
-  return `Combined TeX Count Results (sum):\n${stdout}`;
+  return {
+    output: `Combined TeX Count Results (sum):\n${stdout}`,
+    errors,
+  };
 }
 
 export async function getTeXCount(
   filePaths: string | string[],
-  { mode = 'separate', channel = CHANNEL }: TexcountOptions = {},
-): Promise<string | null> {
+  { mode = 'separate', channel }: TexcountOptions = {},
+): Promise<TexcountResult> {
+  const resolvedChannel = channel ?? CHANNEL;
+
   try {
     const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
-    const resolvedChannel = channel ?? CHANNEL;
+    const trimmedPaths = paths
+      .map((filePath) => filePath.trim())
+      .filter((filePath) => filePath.length > 0);
+
+    if (trimmedPaths.length === 0) {
+      const message = 'No LaTeX files provided for texcount.';
+      logger.warn(resolvedChannel, message);
+      return { output: null, errors: [message] };
+    }
 
     if (mode === 'sum') {
-      const sumOutput = await getSummedCount(paths, resolvedChannel);
-      if (sumOutput) {
-        logger.info(
-          resolvedChannel,
-          `Combined TeX Count Results:\n${sumOutput}`,
-        );
+      const { output, errors } = await getSummedCount(
+        trimmedPaths,
+        resolvedChannel,
+      );
+      if (output) {
+        logger.info(resolvedChannel, `Combined TeX Count Results:\n${output}`);
       }
-      return sumOutput;
+      return { output, errors };
     }
 
     const includeReferenced = mode === 'include';
-    const outputs = await getIndividualCounts(
-      paths,
+    const { outputs, errors } = await getIndividualCounts(
+      trimmedPaths,
       resolvedChannel,
       includeReferenced,
     );
     if (outputs.length === 0) {
-      return null;
+      if (errors.length === 0) {
+        errors.push('texcount did not return output for the requested files.');
+      }
+      return { output: null, errors };
     }
 
     const combinedOutput = outputs.join('\n\n');
@@ -227,13 +292,13 @@ export async function getTeXCount(
       resolvedChannel,
       `Combined TeX Count Results:\n${combinedOutput}`,
     );
-    return combinedOutput;
+    return { output: combinedOutput, errors };
   } catch (err) {
-    logger.error(
-      channel ?? CHANNEL,
-      `Error in getTeXCount: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return null;
+    const errorMessage = `Error in getTeXCount: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+    logger.error(resolvedChannel, errorMessage);
+    return { output: null, errors: [errorMessage] };
   }
 }
 
@@ -251,6 +316,6 @@ export async function getTeXCountStats(
   filePaths: string | string[],
   channel: string = CHANNEL,
 ): Promise<string | null> {
-  const texcountStats = await getTeXCount(filePaths, { channel });
-  return texcountStats ? formatTeXCountStats(texcountStats) : null;
+  const { output } = await getTeXCount(filePaths, { channel });
+  return output ? formatTeXCountStats(output) : null;
 }

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -42,82 +42,195 @@ async function hasChinesePackages(filePath: string): Promise<boolean> {
 /**
  * Get full statistics for LaTeX documents using the texcount Perl script
  * @param filePaths Single file path or array of file paths
- * @param merge Whether to merge included files in the count
- * @param channel The channel to use for logging
+ * @param options Options to control merging behavior and logging channel
  * @returns Promise<string | null> String containing full texcount output for all files, or null if an error occurred
  */
+export type TexcountMode = 'separate' | 'include' | 'sum';
+
+export interface TexcountOptions {
+  mode?: TexcountMode;
+  channel?: string;
+}
+
+async function validateTexFile(
+  filePath: string,
+  channel: string,
+): Promise<boolean> {
+  if (!(await WorkspaceFS.exists(filePath))) {
+    logger.warn(channel, `File ${filePath} does not exist.`);
+    return false;
+  }
+
+  if (!filePath.endsWith('.tex')) {
+    logger.warn(
+      channel,
+      `Error: File ${filePath} is not a LaTeX file. Skipping.`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+async function detectChineseMode(
+  filePath: string,
+  channel: string,
+): Promise<boolean> {
+  if (await hasChinesePackages(filePath)) {
+    logger.debug(
+      channel,
+      `Chinese packages detected in ${filePath}, enabling Chinese character counting`,
+    );
+    return true;
+  }
+
+  return false;
+}
+
+async function runTexcount(
+  args: string[],
+  channel: string,
+  context: string,
+): Promise<string | null> {
+  const result = await runToolWithCheck('texcount', args, {
+    channel,
+    truncate: false,
+    showError: true,
+  });
+
+  if (!result) {
+    return null;
+  }
+
+  if (result.success && result.stdout) {
+    logger.debug(channel, `Successfully counted ${context}`);
+    return result.stdout;
+  }
+
+  logger.error(channel, `Error getting tex count for ${context}`);
+  if (result.stdout) {
+    logger.error(channel, `Stdout: ${result.stdout}`);
+  }
+  if (result.stderr) {
+    logger.error(channel, `Stderr: ${result.stderr}`);
+  }
+
+  return null;
+}
+
+async function getIndividualCounts(
+  paths: string[],
+  channel: string,
+  includeReferenced: boolean,
+): Promise<string[]> {
+  const outputs: string[] = [];
+
+  for (const filePath of paths) {
+    if (!(await validateTexFile(filePath, channel))) {
+      continue;
+    }
+
+    const args: string[] = [];
+    if (includeReferenced) {
+      args.push('-inc');
+    }
+    if (await detectChineseMode(filePath, channel)) {
+      args.push('-ch-only');
+    }
+    args.push(filePath);
+
+    const stdout = await runTexcount(args, channel, filePath);
+    if (stdout) {
+      outputs.push(`TeX Count Results for ${filePath}:\n${stdout}`);
+    }
+  }
+
+  return outputs;
+}
+
+async function getSummedCount(
+  paths: string[],
+  channel: string,
+): Promise<string | null> {
+  const validPaths: string[] = [];
+  let enableChineseMode = false;
+
+  for (const filePath of paths) {
+    if (!(await validateTexFile(filePath, channel))) {
+      continue;
+    }
+
+    validPaths.push(filePath);
+
+    if (!enableChineseMode && (await hasChinesePackages(filePath))) {
+      enableChineseMode = true;
+      logger.debug(
+        channel,
+        `Chinese packages detected in ${filePath}, enabling Chinese character counting`,
+      );
+    }
+  }
+
+  if (validPaths.length === 0) {
+    return null;
+  }
+
+  const args: string[] = ['-sum'];
+  if (enableChineseMode) {
+    args.push('-ch-only');
+  }
+  args.push(...validPaths);
+
+  const stdout = await runTexcount(
+    args,
+    channel,
+    `sum for ${validPaths.join(', ')}`,
+  );
+  if (!stdout) {
+    return null;
+  }
+
+  return `Combined TeX Count Results (sum):\n${stdout}`;
+}
+
 export async function getTeXCount(
   filePaths: string | string[],
-  merge: boolean = false,
-  channel: string = CHANNEL,
+  { mode = 'separate', channel = CHANNEL }: TexcountOptions = {},
 ): Promise<string | null> {
   try {
-    // Convert single path to array
     const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
-    const allOutputs: string[] = [];
+    const resolvedChannel = channel ?? CHANNEL;
 
-    for (const filePath of paths) {
-      if (!(await WorkspaceFS.exists(filePath))) {
-        logger.warn(channel, `File ${filePath} does not exist.`);
-        continue;
-      }
-
-      if (!filePath.endsWith('.tex')) {
-        logger.warn(
-          channel,
-          `Error: File ${filePath} is not a LaTeX file. Skipping.`,
-        );
-        continue;
-      }
-
-      const args: string[] = [];
-      if (merge) {
-        args.push('-merge');
-      }
-
-      // Add Chinese counting support if Chinese packages are detected
-      if (await hasChinesePackages(filePath)) {
-        args.push('-ch-only'); // Use Chinese-only mode for accurate character counting
-        logger.debug(
-          channel,
-          `Chinese packages detected in ${filePath}, enabling Chinese character counting`,
+    if (mode === 'sum') {
+      const sumOutput = await getSummedCount(paths, resolvedChannel);
+      if (sumOutput) {
+        logger.info(
+          resolvedChannel,
+          `Combined TeX Count Results:\n${sumOutput}`,
         );
       }
-
-      args.push(filePath);
-
-      const result = await runToolWithCheck('texcount', args, {
-        channel,
-        truncate: false, // Don't truncate texcount output as we need the full statistics
-        showError: true, // Show error for missing texcount
-      });
-      if (!result) {
-        return null;
-      }
-      if (result.success && result.stdout) {
-        allOutputs.push(`TeX Count Results for ${filePath}:\n${result.stdout}`);
-        logger.debug(channel, `Successfully counted ${filePath}`);
-      } else {
-        logger.error(channel, `Error getting tex count for ${filePath}`);
-        if (result.stdout) {
-          logger.error(channel, `Stdout: ${result.stdout}`);
-        }
-        if (result.stderr) {
-          logger.error(channel, `Stderr: ${result.stderr}`);
-        }
-      }
+      return sumOutput;
     }
 
-    if (allOutputs.length > 0) {
-      const combinedOutput = allOutputs.join('\n\n');
-      logger.info(channel, `Combined TeX Count Results:\n${combinedOutput}`);
-      return combinedOutput;
+    const includeReferenced = mode === 'include';
+    const outputs = await getIndividualCounts(
+      paths,
+      resolvedChannel,
+      includeReferenced,
+    );
+    if (outputs.length === 0) {
+      return null;
     }
 
-    return null;
+    const combinedOutput = outputs.join('\n\n');
+    logger.info(
+      resolvedChannel,
+      `Combined TeX Count Results:\n${combinedOutput}`,
+    );
+    return combinedOutput;
   } catch (err) {
     logger.error(
-      channel,
+      channel ?? CHANNEL,
       `Error in getTeXCount: ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;
@@ -130,12 +243,14 @@ export async function getTeXCount(
  * @param channel The channel to use for logging
  * @returns Promise<string | null> String containing formatted texcount statistics with XML tags, or null if an error occurred
  */
+export function formatTeXCountStats(texcountOutput: string): string {
+  return `TeX Count Statistics:<texcount>\n${texcountOutput}\n</texcount>\n\n`;
+}
+
 export async function getTeXCountStats(
   filePaths: string | string[],
   channel: string = CHANNEL,
 ): Promise<string | null> {
-  const texcountStats = await getTeXCount(filePaths, false, channel);
-  return texcountStats
-    ? `TeX Count Statistics:<texcount>\n${texcountStats}\n</texcount>\n\n`
-    : null;
+  const texcountStats = await getTeXCount(filePaths, { channel });
+  return texcountStats ? formatTeXCountStats(texcountStats) : null;
 }

--- a/src/test/agent/utils/promptUtils.test.ts
+++ b/src/test/agent/utils/promptUtils.test.ts
@@ -85,7 +85,10 @@ describe('promptUtils.writePromptToXml', () => {
     );
 
     assert.equal(writes.length, 1);
-    assert.deepEqual(ensured, [TASK_RUNS_DIR, path.join(TASK_RUNS_DIR, executionId)]);
+    assert.deepEqual(ensured, [
+      TASK_RUNS_DIR,
+      path.join(TASK_RUNS_DIR, executionId),
+    ]);
 
     const expectedRelative = path.join(
       TASK_RUNS_DIR,

--- a/src/test/tools/TexcountTool.test.ts
+++ b/src/test/tools/TexcountTool.test.ts
@@ -27,7 +27,7 @@ suite('TexcountTool', () => {
         files: Array.isArray(files) ? files : [files],
         options,
       });
-      return 'Words in text: 42';
+      return { output: 'Words in text: 42', errors: [] };
     };
 
     const tool = new TexcountTool();
@@ -43,7 +43,10 @@ suite('TexcountTool', () => {
   test('formats output when stats format requested', async () => {
     (
       texcountModule as { getTeXCount: typeof originalGetTeXCount }
-    ).getTeXCount = async () => 'Words in text: 100';
+    ).getTeXCount = async () => ({
+      output: 'Words in text: 100',
+      errors: [],
+    });
 
     const tool = new TexcountTool();
     const result = await tool.call({
@@ -59,13 +62,16 @@ suite('TexcountTool', () => {
   test('returns error result when texcount output is missing', async () => {
     (
       texcountModule as { getTeXCount: typeof originalGetTeXCount }
-    ).getTeXCount = async () => null;
+    ).getTeXCount = async () => ({
+      output: null,
+      errors: ['File missing.tex does not exist.'],
+    });
 
     const tool = new TexcountTool();
     const result = await tool.call({ files: ['missing.tex'], mode: 'sum' });
 
     assert.strictEqual(result.isError, true);
-    assert.ok(result.error?.includes('texcount did not return any output'));
+    assert.ok(result.error?.includes('missing.tex'));
   });
 
   test('passes selected mode to texcount implementation', async () => {
@@ -80,7 +86,7 @@ suite('TexcountTool', () => {
         files: Array.isArray(files) ? files : [files],
         options,
       });
-      return 'Words in text: 21';
+      return { output: 'Words in text: 21', errors: [] };
     };
 
     const tool = new TexcountTool();

--- a/src/test/tools/TexcountTool.test.ts
+++ b/src/test/tools/TexcountTool.test.ts
@@ -1,0 +1,98 @@
+import * as assert from 'assert';
+
+// Local imports - tools
+import { TexcountTool } from '@tools/texcount';
+
+// Local imports - latex utilities
+import * as texcountModule from '@latex/texcount';
+
+suite('TexcountTool', () => {
+  const originalGetTeXCount = texcountModule.getTeXCount;
+
+  teardown(() => {
+    (
+      texcountModule as { getTeXCount: typeof originalGetTeXCount }
+    ).getTeXCount = originalGetTeXCount;
+  });
+
+  test('returns raw texcount output for single file input', async () => {
+    const calls: Array<{
+      files: string[];
+      options?: texcountModule.TexcountOptions;
+    }> = [];
+    (
+      texcountModule as { getTeXCount: typeof originalGetTeXCount }
+    ).getTeXCount = async (files, options) => {
+      calls.push({
+        files: Array.isArray(files) ? files : [files],
+        options,
+      });
+      return 'Words in text: 42';
+    };
+
+    const tool = new TexcountTool();
+    const result = await tool.call({ files: 'main.tex' });
+
+    assert.strictEqual(result.summary, 'texcount analysis for 1 file');
+    assert.strictEqual(result.output, 'Words in text: 42');
+    assert.strictEqual(calls.length, 1);
+    assert.deepStrictEqual(calls[0].files, ['main.tex']);
+    assert.strictEqual(calls[0].options?.mode, 'separate');
+  });
+
+  test('formats output when stats format requested', async () => {
+    (
+      texcountModule as { getTeXCount: typeof originalGetTeXCount }
+    ).getTeXCount = async () => 'Words in text: 100';
+
+    const tool = new TexcountTool();
+    const result = await tool.call({
+      files: ['chapter1.tex', 'chapter2.tex'],
+      format: 'stats',
+    });
+
+    assert.strictEqual(result.summary, 'texcount analysis for 2 files');
+    assert.ok(result.output?.includes('<texcount>'));
+    assert.ok(result.output?.includes('Words in text: 100'));
+  });
+
+  test('returns error result when texcount output is missing', async () => {
+    (
+      texcountModule as { getTeXCount: typeof originalGetTeXCount }
+    ).getTeXCount = async () => null;
+
+    const tool = new TexcountTool();
+    const result = await tool.call({ files: ['missing.tex'], mode: 'sum' });
+
+    assert.strictEqual(result.isError, true);
+    assert.ok(result.error?.includes('texcount did not return any output'));
+  });
+
+  test('passes selected mode to texcount implementation', async () => {
+    const calls: Array<{
+      files: string[];
+      options?: texcountModule.TexcountOptions;
+    }> = [];
+    (
+      texcountModule as { getTeXCount: typeof originalGetTeXCount }
+    ).getTeXCount = async (files, options) => {
+      calls.push({
+        files: Array.isArray(files) ? files : [files],
+        options,
+      });
+      return 'Words in text: 21';
+    };
+
+    const tool = new TexcountTool();
+    const result = await tool.call({
+      files: ['file1.tex', 'file2.tex'],
+      mode: 'sum',
+    });
+
+    assert.strictEqual(result.summary, 'texcount analysis for 2 files');
+    assert.strictEqual(result.output, 'Words in text: 21');
+    assert.strictEqual(calls.length, 1);
+    assert.deepStrictEqual(calls[0].files, ['file1.tex', 'file2.tex']);
+    assert.strictEqual(calls[0].options?.mode, 'sum');
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,5 +14,6 @@ export * from './core/base';
 export * from './core/define';
 export * from './registry';
 export * from './wolfram';
+export * from './texcount';
 export * from './web/WebFetchTool';
 export * from './web/WebSearchTool';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -14,6 +14,7 @@ import { WriteFileTool } from './WriteTool';
 import { WebFetchTool } from './web/WebFetchTool';
 import { WebSearchTool } from './web/WebSearchTool';
 import { WolframTool } from './wolfram';
+import { TexcountTool } from './texcount';
 
 export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   str_replace_editor: new TextEditorTool(),
@@ -28,6 +29,7 @@ export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   grep: new GrepTool(),
   ls: new LsTool(),
   wolfram: new WolframTool(),
+  texcount: new TexcountTool(),
   web_fetch: new WebFetchTool(),
   web_search: new WebSearchTool(),
 };

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -1,0 +1,67 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - latex utilities
+import {
+  formatTeXCountStats,
+  getTeXCount,
+  type TexcountMode,
+} from '@latex/texcount';
+
+// Local imports - tool core
+import { defineTool } from '@tools/core/define';
+import { ToolError, toolResult, type ToolResult } from '@tools/result';
+
+const TexcountInputSchema = z.object({
+  files: z.union([z.string(), z.array(z.string()).min(1)]),
+  mode: z.enum(['separate', 'include', 'sum']).optional(),
+  format: z.enum(['raw', 'stats']).optional(),
+});
+
+type TexcountInput = z.infer<typeof TexcountInputSchema>;
+
+function toFileArray(files: TexcountInput['files']): string[] {
+  return Array.isArray(files) ? files : [files];
+}
+
+function formatOutput(output: string, format: TexcountInput['format']): string {
+  if (format === 'stats') {
+    return formatTeXCountStats(output);
+  }
+  return output;
+}
+
+export class TexcountTool extends defineTool({
+  name: 'texcount',
+  description:
+    'Run texcount on one or more LaTeX files. Use mode="separate" (default) for individual files, "include" to follow \\input/\\include, or "sum" to aggregate independent sources.',
+  schema: TexcountInputSchema,
+}) {
+  protected async execute(input: TexcountInput): Promise<ToolResult> {
+    const files = toFileArray(input.files)
+      .map((file) => file.trim())
+      .filter((file) => file.length > 0);
+    if (files.length === 0) {
+      throw new ToolError('No LaTeX files provided for texcount.');
+    }
+
+    const mode: TexcountMode = input.mode ?? 'separate';
+    const output = await getTeXCount(files, { mode });
+
+    if (!output) {
+      return toolResult({
+        error: 'texcount did not return any output. Ensure the files exist.',
+        isError: true,
+      });
+    }
+
+    const summary = `texcount analysis for ${files.length} file${
+      files.length === 1 ? '' : 's'
+    }`;
+
+    return toolResult({
+      summary,
+      output: formatOutput(output, input.format),
+    });
+  }
+}

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -46,11 +46,14 @@ export class TexcountTool extends defineTool({
     }
 
     const mode: TexcountMode = input.mode ?? 'separate';
-    const output = await getTeXCount(files, { mode });
+    const { output, errors } = await getTeXCount(files, { mode });
 
     if (!output) {
+      const errorMessage =
+        errors.join('\n') ||
+        'texcount did not return any output. Ensure the files exist.';
       return toolResult({
-        error: 'texcount did not return any output. Ensure the files exist.',
+        error: errorMessage,
         isError: true,
       });
     }

--- a/src/tools/texcount/index.ts
+++ b/src/tools/texcount/index.ts
@@ -1,0 +1,1 @@
+export { TexcountTool } from './TexcountTool';


### PR DESCRIPTION
## Summary
- refine texcount execution to support separate, include, and sum modes with shared validation and logging
- expose the new mode option through the texcount tool schema and VS Code command, updating prompt docs accordingly
- expand texcount tool unit tests to cover mode forwarding and error handling

## Testing
- npm run format
- npm run lint
- npm run compile
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68da4407bd3c83248953e08eceae6604

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a texcount tool with separate/include/sum modes and refactors texcount APIs; updates VS Code command, exports, docs, and tests.
> 
> - **Texcount**:
>   - **New tool**: Introduces `tools/texcount` with schema (`files`, `mode`, `format`) and error handling; registers in `DEFAULT_TOOL_REGISTRY` and exports from `tools/index`.
>   - **API refactor**: `@latex/texcount` now returns `{ output, errors }`, adds `TexcountMode` (`separate` | `include` | `sum`), `TexcountOptions`, `TexcountResult`, and `formatTeXCountStats`; supports `-inc`, `-sum`, file validation, and Chinese package detection.
>   - **Command update**: `texra.getTeXCount` QuickPick now selects a `TexcountMode`; calls `getTeXCount` with options and improved error reporting.
>   - **Exports**: `src/latex/index.ts` now exports `getTeXCount`, `getTeXCountStats`, `formatTeXCountStats`, and related types.
> - **Docs**:
>   - Expands `docs/guide/tool-integration.md` to document texcount tool usage and modes; notes direct tool invocation from workflows.
> - **Tests**:
>   - Adds `TexcountTool` unit tests covering mode forwarding, formatting, and error paths.
>   - Minor formatting adjustment in `promptUtils` test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e3678bc127d9429fdb6390fc6c644509710c144. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->