### PR TITLE
Add Claude Sonnet 4.5 models and refresh defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Add Claude Sonnet 4.5 (thinking and regular) to the Anthropic catalog and default model list so the latest Claude release is immediately available in TeXRA.
+
 ## [0.33.8] - 2025-09-30
 
 ### Features

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -49,7 +49,7 @@ default list is maintained in the [Models Guide](./models.md). Override it by
 specifying your own model identifiers:
 
 ```json
-"texra.models": ["sonnet37T", "gpt5"]
+"texra.models": ["sonnet45T", "gpt5"]
 ```
 
 ### API Provider Settings

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -133,12 +133,12 @@ For example:
 
 - Input: `paper.tex`
 - Agent: `polish`
-- Model: `sonnet37`
-- Output: `paper_polish_r0_sonnet37.tex`
+- Model: `sonnet45`
+- Output: `paper_polish_r0_sonnet45.tex`
 
 When reflection is enabled, you may also see:
 
-- Round 1: `paper_polish_r1_sonnet37.tex`
+- Round 1: `paper_polish_r1_sonnet45.tex`
 
 ## File Management Commands
 

--- a/docs/guide/intelligent-merge.md
+++ b/docs/guide/intelligent-merge.md
@@ -30,7 +30,7 @@ TeXRA will then invoke the specialized `merge` agent:
 
 When you click the Merge button (prepare for some AI wizardry):
 
-1.  TeXRA sends the content of both the Base File and the Edited File to a selected AI model (defaults can be configured in settings, `sonnet37` is often a good choice).
+1.  TeXRA sends the content of both the Base File and the Edited File to a selected AI model (defaults can be configured in settings, `sonnet45` is often a good choice).
 2.  The model is instructed to intelligently synthesize a new, complete document that preserves the structure and unchanged content of the Base File while incorporating the modifications present in the Edited File.
 3.  TeXRA saves this synthesized result.
 
@@ -40,7 +40,7 @@ The merge process generates a new file, typically named following the pattern:
 
 `basename_agent_rX_full_model.tex`
 
-(e.g., `paper_polish_r0_full_sonnet37.tex`)
+(e.g., `paper_polish_r0_full_sonnet45.tex`)
 
 This `_full_` file contains the complete document content, incorporating the changes from the agent's output.
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -22,21 +22,23 @@ Here's a quick comparison of the models available by default in TeXRA:
 
 Known for strong instruction following and context handling.
 
-| Model ID    | Key Strength / Use Case                     | Relative Cost | Relative Speed | Notes                         |
-| :---------- | :------------------------------------------ | :------------ | :------------- | :---------------------------- |
-| `opus41T`   | Latest Opus with explicit reasoning steps   | $$$$          | Slow           | Claude 4.1 Opus with thinking |
-| `opus41`    | Latest high quality, complex tasks          | $$$$          | Slow           | Claude 4.1 Opus               |
-| `opus4T`    | Opus 4 with explicit reasoning steps        | $$$$          | Slow           | Claude 4 Opus with thinking   |
-| `opus4`     | Opus 4 high quality, complex tasks          | $$$$          | Slow           | Claude 4 Opus                 |
-| `sonnet4T`  | Latest Sonnet with explicit reasoning steps | $$$           | Medium         | Claude 4 Sonnet with thinking |
-| `sonnet4`   | Latest strong all-rounder                   | $$$           | Medium         | Claude 4 Sonnet               |
-| `sonnet37T` | `sonnet37` with explicit reasoning steps    | $$$           | Medium         | Good for math, complex logic  |
-| `sonnet37`  | Strong all-rounder, good context            | $$$           | Medium         |                               |
-| `sonnet35`  | Good balance of quality/cost (older Sonnet) | $$$           | Medium         |                               |
+| Model ID    | Key Strength / Use Case                     | Relative Cost | Relative Speed | Notes                           |
+| :---------- | :------------------------------------------ | :------------ | :------------- | :------------------------------ |
+| `opus41T`   | Latest Opus with explicit reasoning steps   | $$$$          | Slow           | Claude 4.1 Opus with thinking   |
+| `opus41`    | Latest high quality, complex tasks          | $$$$          | Slow           | Claude 4.1 Opus                 |
+| `opus4T`    | Opus 4 with explicit reasoning steps        | $$$$          | Slow           | Claude 4 Opus with thinking     |
+| `opus4`     | Opus 4 high quality, complex tasks          | $$$$          | Slow           | Claude 4 Opus                   |
+| `sonnet45T` | Latest Sonnet with explicit reasoning steps | $$$           | Medium         | Claude 4.5 Sonnet with thinking |
+| `sonnet45`  | Latest strong all-rounder                   | $$$           | Medium         | Claude 4.5 Sonnet               |
+| `sonnet4T`  | Sonnet 4 with explicit reasoning steps      | $$$           | Medium         | Claude 4 Sonnet with thinking   |
+| `sonnet4`   | Sonnet 4 strong all-rounder                 | $$$           | Medium         | Claude 4 Sonnet                 |
+| `sonnet37T` | `sonnet37` with explicit reasoning steps    | $$$           | Medium         | Good for math, complex logic    |
+| `sonnet37`  | Strong all-rounder, good context            | $$$           | Medium         |                                 |
+| `sonnet35`  | Good balance of quality/cost (older Sonnet) | $$$           | Medium         |                                 |
 
-#### Sonnet 4 1M Context (Beta)
+#### Sonnet 4 / 4.5 1M Context (Beta)
 
-To experiment with Anthropic's 1M-token context window for Sonnet 4, enable `"texra.model.useAnthropic1MBeta": true` in VS Code settings. The extension attaches the `context-1m-2025-08-07` beta header for these requests. Only Sonnet 4 supports this beta, and TeXRA still enforces the tier‑4 limit of 200 K tokens.
+To experiment with Anthropic's 1M-token context window for Sonnet 4 or 4.5, enable `"texra.model.useAnthropic1MBeta": true` in VS Code settings. The extension attaches the `context-1m-2025-08-07` beta header for these requests. Only Sonnet 4-family models support this beta, and TeXRA still enforces the tier‑4 limit of 200 K tokens.
 
 ### OpenAI Models
 
@@ -183,7 +185,7 @@ Consider these factors:
 - **Task Complexity**: Simple corrections might only need a `$`/Fast model (`gemini2f`), while complex paper transformations benefit from `$$$$`/Slow models (`opus`, `o1`).
 - **Budget**: Use cost indicators ($ - $$$$) to guide selection.
 - **Speed**: If quick turnaround is needed, prefer Fast/Very Fast models.
-- **Special Capabilities**: Do you need explicit reasoning (`sonnet37T`, `gemini2fT`, `o1`, `o3-`, `o1-`, `gptoss`, `gptoss-`, `dsr1`), vision (`gpt5`, `gpt4o`, `gemini*`), native PDF/audio (`gemini*`), or very large context (`gemini*`, `gpt41`, `gpt5`)?
+- **Special Capabilities**: Do you need explicit reasoning (`sonnet45T`, `sonnet37T`, `gemini2fT`, `o1`, `o3-`, `o1-`, `gptoss`, `gptoss-`, `dsr1`), vision (`gpt5`, `gpt4o`, `gemini*`), native PDF/audio (`gemini*`), or very large context (`gemini*`, `gpt41`, `gpt5`)?
 
 Experimentation is often key to finding the best model for your specific needs and writing style.
 
@@ -192,34 +194,23 @@ Experimentation is often key to finding the best model for your specific needs a
 You can customize which models appear in the TeXRA dropdown list via VS Code Settings (`Ctrl+,`). Search for `texra.models` and edit the JSON array. Here are the defaults:
 
 ::: tip Model Availability
-The specific models available by default and their identifiers (`sonnet37`, `gpt5`, etc.) are maintained by the TeXRA developers and may change in future updates based on new releases and performance evaluations.
+The specific models available by default and their identifiers (`sonnet45`, `gpt5`, etc.) are maintained by the TeXRA developers and may change in future updates based on new releases and performance evaluations.
 :::
 
 ```json
 "texra.models": [
-  "sonnet37T",
-  "sonnet37",
-  "o3",
-  "o4-",
-  "o3-",
-  "gptoss",
-  "gptoss-",
-  "o1",
-  "gpt41",
-  "gpt5",
-  "gpt4o",
   "gemini25p",
   "gemini25f",
-  "gemini2fT",
-  "dsv3",
-  "dsr1",
-  "grok4",
-  "grok3",
-  "qwenplus",
-  "kimit",
-  "kimiv",
+  "opus41T",
+  "sonnet45T",
+  "sonnet4T",
+  "gpt5",
+  "gpt41",
+  "deepseek",
+  "deepseekT",
   "kimi2",
-  "copilot4o"
+  "qwen3max",
+  "grok4"
 ]
 ```
 

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -22,7 +22,7 @@ The ProgressBoard interface is split into two main sections (usually side-by-sid
 
 This section lists all the agent execution streams from your current VS Code session.
 
-- **Switching Streams**: Click on a stream name (e.g., `polish@sonnet37: paper.tex`) to view its specific logs and status in the Content Area.
+- **Switching Streams**: Click on a stream name (e.g., `polish@sonnet45: paper.tex`) to view its specific logs and status in the Content Area.
 - **Delete All**: The <i class="codicon codicon-trash"></i> **Delete All** button at the bottom permanently removes all streams and their logs from the ProgressBoard view for the current session.
 - **Metadata**: Tabs display the model and when the stream was last active on a second line. Icons indicate the agent type and if multiple output files were generated.
 - **Sorting**: Use the buttons below the tab list to order streams by time, input file, or agent name. The chosen order is saved for the workspace.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -68,7 +68,7 @@ For complex documents with multiple input files, use the "Multiple" dropdown to 
 
 1. In the dropdown menus at the bottom of the instruction box, select:
    - **Agent**: `polish` (for improving writing)
-   - **Model**: `sonnet37` (Claude 3.7 Sonnet) or another available model
+   - **Model**: `sonnet45` (Claude Sonnet 4.5) or another available model
 
 ::: tip Onboarding Prompt
 When you first open the agent or model dropdown, a tooltip explains its role.
@@ -238,13 +238,13 @@ Here are some common tasks you can try with TeXRA:
 ### Converting a Paper to Slides
 
 - **Agent**: `paper2slide`
-- **Model**: `sonnet37T` or `gpt5`
+- **Model**: `sonnet45T` or `gpt5`
 - **Instruction**: "Convert this paper into presentation slides using the beamer template. Create approximately 12-15 slides highlighting the key points, methodology, and results."
 
 ### Improving Writing Style
 
 - **Agent**: `polish`
-- **Model**: `opus41` or `sonnet37T`
+- **Model**: `opus41` or `sonnet45T`
 - **Instruction**: "Improve the writing style to make it more engaging and clear. Enhance the flow between paragraphs while preserving all technical content."
 
 ## Understanding the Output
@@ -258,8 +258,8 @@ When TeXRA completes a task, it produces:
 Output files are saved in the same directory as your input file with a naming pattern:
 `original_filename_agent_r0_model.extension`
 
-For example, if your input file is `paper.tex` and you used the `polish` agent with `sonnet37` model, the output file would be named:
-`paper_polish_r0_sonnet37.tex`
+For example, if your input file is `paper.tex` and you used the `polish` agent with `sonnet45` model, the output file would be named:
+`paper_polish_r0_sonnet45.tex`
 
 ## Next Steps
 

--- a/docs/guide/tikz-figures.md
+++ b/docs/guide/tikz-figures.md
@@ -41,7 +41,7 @@ TeXRA's `draw` agent is specifically designed to work with TikZ figures (think o
 To create a new TikZ figure:
 
 1. Select the agent: `draw`
-2. Choose a model (Models like `o1`, `sonnet37T`, or `gemini25p` are often good choices for complex drawing tasks).
+2. Choose a model (Models like `o1`, `sonnet45T`, or `gemini25p` are often good choices for complex drawing tasks).
 3. Provide a detailed description of the desired figure
 4. Execute the agent
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
                 "opus41",
                 "opus4T",
                 "opus4",
+                "sonnet45T",
+                "sonnet45",
                 "sonnet4T",
                 "sonnet4",
                 "sonnet37T",
@@ -107,6 +109,7 @@
               "gemini25p",
               "gemini25f",
               "opus41T",
+              "sonnet45T",
               "sonnet4T",
               "gpt5",
               "gpt41",
@@ -116,7 +119,7 @@
               "qwen3max",
               "grok4"
             ],
-            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
+            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet45T/sonnet45 (Claude Sonnet 4.5 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
             "scope": "resource"
           }
         }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -165,6 +165,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Remove temperature for Claude 4 models when thinking is enabled as per Anthropic docs
       if (
         this.config.fullName.includes('claude-opus-4') ||
+        this.config.fullName.includes('claude-sonnet-4-5') ||
         this.config.fullName.includes('claude-sonnet-4') ||
         this.config.fullName.includes('claude-3-7-sonnet')
       ) {
@@ -183,10 +184,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // The thinking configuration is now handled above for all reasoning models
     }
 
-    // Opt-in beta for 1M context window on Claude Sonnet 4
+    // Opt-in beta for 1M context window on Claude Sonnet 4 family
     if (
       useAnthropic1MBeta &&
-      this.config.fullName === 'claude-sonnet-4-20250514'
+      (this.config.fullName === 'claude-sonnet-4-20250514' ||
+        this.config.fullName === 'claude-sonnet-4-5')
     ) {
       options.betas = [...(options.betas ?? []), CONTEXT_1M_BETA];
     }

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -102,6 +102,43 @@ export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
+  sonnet45T: {
+    name: 'sonnet45T',
+    fullName: 'claude-sonnet-4-5',
+    openrouterFullName: 'anthropic/claude-sonnet-4.5:thinking',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 64000, // Official Claude Sonnet 4.5 limit - streaming recommended for large outputs
+    contextWindow: 200000,
+    inputPrice: 3.0,
+    outputPrice: 15.0,
+    capabilities: {
+      ...ANTHROPIC_DEFAULT_CAPABILITIES,
+      supportsNativeWebSearch: true,
+      supportsNativeCodeExecution: true,
+      supportsAssistantPrefill: false,
+      supportsReasoning: true,
+      supportsInterleavedThinking: true,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
+  sonnet45: {
+    name: 'sonnet45',
+    fullName: 'claude-sonnet-4-5',
+    openrouterFullName: 'anthropic/claude-sonnet-4.5',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 64000, // Official Claude Sonnet 4.5 limit - streaming recommended for large outputs
+    contextWindow: 200000,
+    inputPrice: 3.0,
+    outputPrice: 15.0,
+    capabilities: {
+      ...ANTHROPIC_DEFAULT_CAPABILITIES,
+      supportsNativeWebSearch: true,
+      supportsNativeCodeExecution: true,
+      supportsAssistantPrefill: true,
+      supportsReasoning: false,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
   sonnet4T: {
     name: 'sonnet4T',
     fullName: 'claude-sonnet-4-20250514',


### PR DESCRIPTION
## Summary
- add Claude Sonnet 4.5 thinking and standard configurations to the Anthropic registry
- extend Sonnet 4.x handler logic and VS Code defaults to surface Sonnet 4.5 by default
- refresh documentation and changelog references to highlight the new model availability

## Testing
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68dad6fa2d948324b14b910cd16d3e9e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Claude Sonnet 4.5 (thinking and regular) across model registry, handler, settings, and docs; make it part of the default model list and extend 1M-context beta/temperature handling.
> 
> - **Models/Backend**:
>   - **Anthropic registry**: Add `sonnet45T` and `sonnet45` with configs, pricing, and capabilities (`supportsReasoning`, `supportsInterleavedThinking`).
>   - **Handler** (`src/agent/modelHandlers/modelHandlerAnthropic.ts`):
>     - Include `claude-sonnet-4-5` in temperature removal for reasoning runs.
>     - Extend 1M-context beta opt-in to Sonnet 4.5.
> - **Extension Settings** (`package.json`):
>   - Expose `sonnet45T`/`sonnet45` in `texra.models` enum; add `sonnet45T` to defaults; update model description.
> - **Docs**:
>   - Refresh references/examples from `sonnet37*` → `sonnet45*` across guides (`configuration.md`, `file-management.md`, `intelligent-merge.md`, `quick-start.md`, `tikz-figures.md`, `progress-board.md`).
>   - Update Models Guide table to include Sonnet 4.5 and expand 1M context beta note to Sonnet 4/4.5; adjust default list.
> - **Changelog**: Note new Sonnet 4.5 availability under `[Unreleased]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 361b9696ae82521a5f12e01ce22ad6cc703ac7c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->