### PR TITLE
refactor: deepen diagnostics tool output

### DIFF
--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -4,7 +4,12 @@ import { z } from 'zod';
 import { defineTool } from './core/define';
 
 // Local imports - tools
-import { ToolResult, ToolError, toolResult } from './result';
+import {
+  type DiagnosticsPayload,
+  ToolResult,
+  ToolError,
+  toolResult,
+} from './result';
 import {
   getLinterMessages,
   countDiagnosticsBySeverity,
@@ -22,13 +27,6 @@ export const DiagnosticsInputSchema = z.object({
 export type DiagnosticsInput = z.infer<typeof DiagnosticsInputSchema>;
 
 type DiagnosticsSeverityCounts = ReturnType<typeof countDiagnosticsBySeverity>;
-
-interface DiagnosticsPayload {
-  path: string;
-  command: DiagnosticsInput['command'];
-  severity: DiagnosticsSeverityCounts;
-  messages?: Diagnostic[];
-}
 
 export class DiagnosticsTool extends defineTool({
   name: 'diagnostics',
@@ -70,9 +68,15 @@ export class DiagnosticsTool extends defineTool({
     messages: Diagnostic[];
     severity: DiagnosticsSeverityCounts;
   }> {
-    const messages = await getLinterMessages(path);
-    const severity = countDiagnosticsBySeverity(messages);
-    return { messages, severity };
+    try {
+      const messages = await getLinterMessages(path);
+      const severity = countDiagnosticsBySeverity(messages);
+      return { messages, severity };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logger.error(CHANNEL, `Failed to collect diagnostics for ${path}: ${detail}`);
+      throw new ToolError(`Failed to collect diagnostics: ${detail}`);
+    }
   }
 
   /**
@@ -98,7 +102,7 @@ export class DiagnosticsTool extends defineTool({
       path: args.path,
       command: args.command,
       severity: args.severity,
-      messages: 'messages' in args ? args.messages : undefined,
+      ...('messages' in args ? { messages: args.messages } : {}),
     };
 
     return toolResult({

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import type { Diagnostic } from 'vscode';
 import { z } from 'zod';
 import { defineTool } from './core/define';
 
@@ -20,6 +21,15 @@ export const DiagnosticsInputSchema = z.object({
 
 export type DiagnosticsInput = z.infer<typeof DiagnosticsInputSchema>;
 
+type DiagnosticsSeverityCounts = ReturnType<typeof countDiagnosticsBySeverity>;
+
+interface DiagnosticsPayload {
+  path: string;
+  command: DiagnosticsInput['command'];
+  severity: DiagnosticsSeverityCounts;
+  messages?: Diagnostic[];
+}
+
 export class DiagnosticsTool extends defineTool({
   name: 'diagnostics',
   description:
@@ -28,26 +38,69 @@ export class DiagnosticsTool extends defineTool({
 }) {
   protected async execute(input: DiagnosticsInput): Promise<ToolResult> {
     const { command, path } = input;
+    const { messages, severity } = await this.collectDiagnostics(path);
+
     switch (command) {
-      case 'list': {
-        const messages = await getLinterMessages(path);
-        return toolResult({
+      case 'list':
+        return this.createResult({
+          command,
+          path,
           summary: `Diagnostics list for ${path}`,
-          output: JSON.stringify(messages),
+          output: messages,
+          severity,
+          includeMessages: true,
         });
-      }
-      case 'count': {
-        const messages = await getLinterMessages(path);
-        const counts = countDiagnosticsBySeverity(messages);
-        return toolResult({
+      case 'count':
+        return this.createResult({
+          command,
+          path,
           summary: `Diagnostics count for ${path}`,
-          output: JSON.stringify(counts),
+          output: severity,
+          severity,
+          includeMessages: false,
         });
-      }
       default:
         throw new ToolError(
           `Diagnostics tool error: Unrecognized command '${command}'. Expected 'list' or 'count'.`,
         );
     }
+  }
+
+  private async collectDiagnostics(path: string): Promise<{
+    messages: Diagnostic[];
+    severity: DiagnosticsSeverityCounts;
+  }> {
+    const messages = await getLinterMessages(path);
+    const severity = countDiagnosticsBySeverity(messages);
+    return { messages, severity };
+  }
+
+  private createResult({
+    command,
+    path,
+    summary,
+    output,
+    severity,
+    includeMessages,
+  }: {
+    command: DiagnosticsInput['command'];
+    path: string;
+    summary: string;
+    output: DiagnosticsPayload['messages'] | DiagnosticsPayload['severity'];
+    severity: DiagnosticsSeverityCounts;
+    includeMessages: boolean;
+  }): ToolResult {
+    const payload: DiagnosticsPayload = {
+      path,
+      command,
+      severity,
+      messages: includeMessages ? (output as Diagnostic[]) : undefined,
+    };
+
+    return toolResult({
+      summary,
+      output: JSON.stringify(output, null, 2),
+      diagnostics: payload,
+    });
   }
 }

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -46,18 +46,15 @@ export class DiagnosticsTool extends defineTool({
           command,
           path,
           summary: `Diagnostics list for ${path}`,
-          output: messages,
           severity,
-          includeMessages: true,
+          messages,
         });
       case 'count':
         return this.createResult({
           command,
           path,
           summary: `Diagnostics count for ${path}`,
-          output: severity,
           severity,
-          includeMessages: false,
         });
       default:
         throw new ToolError(
@@ -66,6 +63,9 @@ export class DiagnosticsTool extends defineTool({
     }
   }
 
+  /**
+   * Resolve diagnostics for a given path and compute their severity totals.
+   */
   private async collectDiagnostics(path: string): Promise<{
     messages: Diagnostic[];
     severity: DiagnosticsSeverityCounts;
@@ -75,31 +75,35 @@ export class DiagnosticsTool extends defineTool({
     return { messages, severity };
   }
 
-  private createResult({
-    command,
-    path,
-    summary,
-    output,
-    severity,
-    includeMessages,
-  }: {
-    command: DiagnosticsInput['command'];
-    path: string;
-    summary: string;
-    output: DiagnosticsPayload['messages'] | DiagnosticsPayload['severity'];
-    severity: DiagnosticsSeverityCounts;
-    includeMessages: boolean;
-  }): ToolResult {
+  /**
+   * Wrap diagnostics data in the shared tool result format.
+   */
+  private createResult(
+    args:
+      | {
+          command: 'list';
+          path: string;
+          summary: string;
+          severity: DiagnosticsSeverityCounts;
+          messages: Diagnostic[];
+        }
+      | {
+          command: 'count';
+          path: string;
+          summary: string;
+          severity: DiagnosticsSeverityCounts;
+        },
+  ): ToolResult {
     const payload: DiagnosticsPayload = {
-      path,
-      command,
-      severity,
-      messages: includeMessages ? (output as Diagnostic[]) : undefined,
+      path: args.path,
+      command: args.command,
+      severity: args.severity,
+      messages: 'messages' in args ? args.messages : undefined,
     };
 
     return toolResult({
-      summary,
-      output: JSON.stringify(output, null, 2),
+      summary: args.summary,
+      output: JSON.stringify(payload, null, 2),
       diagnostics: payload,
     });
   }

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -1,9 +1,18 @@
+import type { Diagnostic } from 'vscode';
 import type { ZodIssue } from 'zod';
+
+export interface DiagnosticsPayload {
+  path: string;
+  command: 'list' | 'count';
+  severity: Record<string, number>;
+  messages?: Diagnostic[];
+}
 
 // Define proper type for diagnostic information
 export type ErrorDiagnostics =
   | ZodIssue[] // For validation errors
   | { name: string; stack?: string } // For regular errors
+  | DiagnosticsPayload // For diagnostics payloads returned by tools
   | unknown; // For other types of diagnostics
 
 export interface ToolResult {


### PR DESCRIPTION
## Summary
- refactor the diagnostics tool to fetch messages once and reuse severity counts for each command
- emit structured diagnostics payloads alongside formatted JSON output for both list and count responses

## Testing
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68db6a4b0e208324af0e3e96425d947e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors diagnostics to collect once, compute severity, and emit structured payloads in both list and count results.
> 
> - **Diagnostics Tool (`src/tools/DiagnosticsTool.ts`)**:
>   - Single-pass collection via `collectDiagnostics`; computes `severity` once and reuses for `list` and `count`.
>   - New `createResult` returns formatted JSON plus `diagnostics` payload; `messages` included only for `list`.
>   - Enhanced error handling with logged detail and `ToolError` wrapping.
> - **Result Types (`src/tools/result.ts`)**:
>   - Add `DiagnosticsPayload` and include it in `ErrorDiagnostics`.
>   - `ToolResult` now supports structured `diagnostics`; import `Diagnostic` type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36da167dd3a915ea2055d0ca95d028defa44d822. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->