### PR TITLE
Fix Anthropic PDF uploads with Files API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Add Claude Sonnet 4.5 (thinking and regular) to the Anthropic catalog and default model list so the latest Claude release is immediately available in TeXRA.
 
+### Bug Fixes
+
+- Upload Anthropic PDF attachments to the Files API so requests reuse `file_id`s instead of resending large base64 payloads.
+
 ## [0.33.8] - 2025-09-30
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Upload Anthropic PDF attachments to the Files API so requests reuse `file_id`s instead of resending large base64 payloads.
+- Ensure follow-up Anthropic requests keep the Files API beta header when referencing previously uploaded PDFs.
 
 ## [0.33.8] - 2025-09-30
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1,8 +1,8 @@
 // Standard library imports
-// (none needed)
+import { Buffer } from 'node:buffer';
 
 // Third-party imports
-import { Anthropic } from '@anthropic-ai/sdk';
+import { Anthropic, toFile } from '@anthropic-ai/sdk';
 import type {
   BetaBase64ImageSource,
   BetaImageBlockParam,
@@ -83,6 +83,7 @@ type BetaMessageCountTokensParams = MessageCountTokensParams & {
 };
 
 const CONTEXT_1M_BETA: AnthropicBeta = 'context-1m-2025-08-07';
+const FILES_API_BETA: AnthropicBeta = 'files-api-2025-04-14';
 const SONNET_37_OUTPUT_BETA: AnthropicBeta = 'output-128k-2025-02-19';
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
@@ -120,6 +121,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       false,
     );
 
+    // Upload inline PDF documents before creating the request so we can
+    // reference them by file ID.
+    const uploadedFiles = await this.replaceDocumentDataWithUploads(
+      client,
+      messages,
+    );
+
     // Prepare options for the API call
     const options: BetaMessageCreateParams = {
       model: this.config.fullName,
@@ -129,6 +137,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       stop_sequences: endTag ? [endTag] : undefined,
       system: systemPrompt,
     };
+
+    if (uploadedFiles) {
+      const existingBetas = options.betas ?? [];
+      if (!existingBetas.includes(FILES_API_BETA)) {
+        options.betas = [...existingBetas, FILES_API_BETA];
+      }
+    }
 
     if (tools && tools.length > 0) {
       options.tools = toAnthropicTools(tools);
@@ -210,7 +225,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Strip betas that only apply to message creation (e.g., output length)
       // while keeping context headers needed for accurate token counting.
       const countTokenBetas = options.betas?.filter(
-        (beta) => beta === CONTEXT_1M_BETA,
+        (beta) => beta === CONTEXT_1M_BETA || beta === FILES_API_BETA,
       );
       if (countTokenBetas && countTokenBetas.length > 0) {
         countTokensParams.betas = countTokenBetas;
@@ -329,6 +344,79 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return response;
   }
 
+  private async replaceDocumentDataWithUploads(
+    client: Anthropic,
+    messages: MessageParam[],
+  ): Promise<boolean> {
+    if (!this.capabilities.supportsNativePdf) {
+      return false;
+    }
+
+    let uploaded = false;
+
+    for (const message of messages) {
+      const contentBlocks = message.content;
+      if (!Array.isArray(contentBlocks)) {
+        continue;
+      }
+
+      for (const block of contentBlocks) {
+        if (block.type !== 'document') {
+          continue;
+        }
+
+        const source = block.source;
+        if (!source || source.type !== 'base64') {
+          continue;
+        }
+
+        const mediaType = source.media_type;
+        if (mediaType !== 'application/pdf') {
+          continue;
+        }
+
+        const base64Data = source.data;
+        if (!base64Data) {
+          continue;
+        }
+
+        const filename =
+          (block.title ?? 'document.pdf').trim() || 'document.pdf';
+        let buffer: Buffer | undefined;
+
+        try {
+          buffer = Buffer.from(base64Data, 'base64');
+          const uploadedFile = await client.beta.files.upload({
+            file: await toFile(buffer, filename, { type: mediaType }),
+            betas: [FILES_API_BETA],
+          });
+
+          (source as { data?: string }).data = '';
+          (block as BetaRequestDocumentBlock).source = {
+            type: 'file',
+            file_id: uploadedFile.id,
+          } as BetaRequestDocumentBlock['source'];
+          uploaded = true;
+        } catch (err) {
+          this.logger.error(
+            `Failed to upload document ${filename}: ${getSdkErrorMessage(err)}`,
+            undefined,
+            undefined,
+            err,
+          );
+          throw err;
+        } finally {
+          if (buffer) {
+            buffer.fill(0);
+            buffer = undefined;
+          }
+        }
+      }
+    }
+
+    return uploaded;
+  }
+
   /** Initializes the message array for Anthropic chat models with user prefix, request, and optional media. */
   async initializeMessages(
     userPrefix: string,
@@ -357,17 +445,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       });
     }
 
-    // Add media if provided (Anthropic currently only supports images)
+    // Add media if provided (images and native PDFs)
     if (mediaFiles && this.config.capabilities.supportsVision) {
       const formattedMediaContent = await this.createMediaMessage(mediaFiles);
-      // Filter out any non-image content just in case, although createMediaContent should handle this
-      userMessageContent.push(
-        ...formattedMediaContent.filter(
-          (c) =>
-            c.type === 'image' ||
-            (c.type === 'text' && c.text?.startsWith('Image:')),
-        ),
-      );
+      userMessageContent.push(...formattedMediaContent);
     }
 
     // Add user request with optional caching
@@ -415,7 +496,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Create content list for the new round message
     const roundContent: ContentBlockParam[] = [];
 
-    // Add media if provided (Anthropic currently only supports images)
+    // Add media if provided (images and native PDFs)
     if (
       mediaFiles &&
       mediaFiles.length > 0 &&
@@ -423,14 +504,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     ) {
       try {
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
-        // Filter out any non-image content
-        roundContent.push(
-          ...formattedMediaContent.filter(
-            (c) =>
-              c.type === 'image' ||
-              (c.type === 'text' && c.text?.startsWith('Image:')),
-          ),
-        );
+        roundContent.push(...formattedMediaContent);
       } catch (err) {
         this.logger.error(
           `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
@@ -541,6 +615,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
               media_type: 'application/pdf',
               data: media.data,
             },
+            title: media.file_name,
           } satisfies BetaRequestDocumentBlock;
           return [descriptionBlock, documentBlock];
         }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -123,7 +123,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Upload inline PDF documents before creating the request so we can
     // reference them by file ID.
-    const uploadedFiles = await this.replaceDocumentDataWithUploads(
+    const { hasFileReference } = await this.replaceDocumentDataWithUploads(
       client,
       messages,
     );
@@ -138,7 +138,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       system: systemPrompt,
     };
 
-    if (uploadedFiles) {
+    if (hasFileReference) {
       const existingBetas = options.betas ?? [];
       if (!existingBetas.includes(FILES_API_BETA)) {
         options.betas = [...existingBetas, FILES_API_BETA];
@@ -347,12 +347,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
   private async replaceDocumentDataWithUploads(
     client: Anthropic,
     messages: MessageParam[],
-  ): Promise<boolean> {
+  ): Promise<{ uploaded: boolean; hasFileReference: boolean }> {
     if (!this.capabilities.supportsNativePdf) {
-      return false;
+      return { uploaded: false, hasFileReference: false };
     }
 
     let uploaded = false;
+    let hasFileReference = false;
 
     for (const message of messages) {
       const contentBlocks = message.content;
@@ -366,7 +367,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
         }
 
         const source = block.source;
-        if (!source || source.type !== 'base64') {
+        if (!source) {
+          continue;
+        }
+
+        if ('file_id' in (source as { file_id?: string })) {
+          hasFileReference = true;
+          continue;
+        }
+
+        if (source.type !== 'base64') {
           continue;
         }
 
@@ -383,6 +393,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const filename =
           (block.title ?? 'document.pdf').trim() || 'document.pdf';
         let buffer: Buffer | undefined;
+        let uploadedSource: BetaRequestDocumentBlock['source'] | undefined;
 
         try {
           buffer = Buffer.from(base64Data, 'base64');
@@ -391,12 +402,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
             betas: [FILES_API_BETA],
           });
 
-          (source as { data?: string }).data = '';
-          (block as BetaRequestDocumentBlock).source = {
+          uploadedSource = {
             type: 'file',
             file_id: uploadedFile.id,
           } as BetaRequestDocumentBlock['source'];
-          uploaded = true;
         } catch (err) {
           this.logger.error(
             `Failed to upload document ${filename}: ${getSdkErrorMessage(err)}`,
@@ -411,10 +420,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
             buffer = undefined;
           }
         }
+
+        if (uploadedSource) {
+          delete (source as { data?: string }).data;
+          (block as BetaRequestDocumentBlock).source = uploadedSource;
+          uploaded = true;
+          hasFileReference = true;
+        }
       }
     }
 
-    return uploaded;
+    return { uploaded, hasFileReference };
   }
 
   /** Initializes the message array for Anthropic chat models with user prefix, request, and optional media. */

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -276,4 +276,79 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     assert.equal(response.stop_reason, 'end_turn');
   });
+
+  it('opts into the Files API when messages already reference uploaded PDFs', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const loggerStub = {
+      channelId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Document: sample.pdf', citations: null },
+          {
+            type: 'document',
+            source: {
+              type: 'file',
+              file_id: 'file_existing',
+            },
+            title: 'sample.pdf',
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+
+    const messageOptions: any[] = [];
+
+    const client = {
+      beta: {
+        files: {
+          upload: async () => {
+            throw new Error('should not upload when file_id already provided');
+          },
+        },
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const response = await handler.createResponse(client, messages, 0);
+
+    const documentBlock = (messages[0].content as any[]).find(
+      (block) => block.type === 'document',
+    );
+    assert.ok(documentBlock, 'document block should remain in messages');
+    assert.equal(documentBlock.source.type, 'file');
+    assert.equal(documentBlock.source.file_id, 'file_existing');
+
+    const betas: string[] = messageOptions[0].betas ?? [];
+    assert.ok(
+      betas.includes('files-api-2025-04-14'),
+      'request should opt into the Files API beta when referencing file IDs',
+    );
+
+    assert.equal(response.stop_reason, 'end_turn');
+  });
 });

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -2,25 +2,34 @@
 import { strict as assert } from 'assert';
 
 // Third-party imports
-import type { ContentBlock } from '@anthropic-ai/sdk/resources/messages';
+import type {
+  ContentBlock,
+  ContentBlockParam,
+  MessageParam,
+} from '@anthropic-ai/sdk/resources/messages';
 
 // Local imports - agent
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+import type { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - model config
 import {
   DEFAULT_MODEL_CAPABILITIES,
+  ModelCapabilities,
   ModelConfig,
   ModelProvider,
 } from '@model/ModelConfig';
 
-function createAnthropicHandler(): ModelHandlerAnthropic {
+function buildAnthropicConfig(
+  capabilityOverrides: Partial<ModelCapabilities> = {},
+): ModelConfig {
   const capabilities = {
     ...DEFAULT_MODEL_CAPABILITIES,
     supportsPromptCaching: true,
+    ...capabilityOverrides,
   };
 
-  const config: ModelConfig = {
+  return {
     name: 'test-anthropic',
     fullName: 'claude-test',
     provider: ModelProvider.ANTHROPIC,
@@ -31,8 +40,12 @@ function createAnthropicHandler(): ModelHandlerAnthropic {
     capabilities,
     openRouterOnly: false,
   };
+}
 
-  return new ModelHandlerAnthropic(config);
+function createAnthropicHandler(
+  capabilityOverrides: Partial<ModelCapabilities> = {},
+): ModelHandlerAnthropic {
+  return new ModelHandlerAnthropic(buildAnthropicConfig(capabilityOverrides));
 }
 
 type TextBlock = Extract<ContentBlock, { type: 'text' }>;
@@ -49,7 +62,51 @@ function assertSingleTextBlock(content: ContentBlock[]): TextBlock {
   return textBlocks[0];
 }
 
+class PdfStubAnthropicHandler extends ModelHandlerAnthropic {
+  private mediaContent: ContentBlockParam[] = [];
+
+  setMediaContent(content: ContentBlockParam[]): void {
+    this.mediaContent = content;
+  }
+
+  override async createMediaMessage(): Promise<any[]> {
+    return this.mediaContent;
+  }
+}
+
 describe('ModelHandlerAnthropic message guards', () => {
+  it('includes native PDF document blocks when initializing messages', async () => {
+    const handler = new PdfStubAnthropicHandler(
+      buildAnthropicConfig({ supportsNativePdf: true }),
+    );
+
+    handler.setMediaContent([
+      { type: 'text', text: 'Document: sample.pdf', citations: null },
+      {
+        type: 'document',
+        source: {
+          type: 'base64',
+          media_type: 'application/pdf',
+          data: 'ZHVtbXk=',
+        },
+        title: 'sample.pdf',
+      },
+    ] as ContentBlockParam[]);
+
+    const messages = await handler.initializeMessages('', 'request text', [
+      'sample.pdf',
+    ]);
+
+    const content = messages[0].content as ContentBlock[];
+    const documentBlocks = (content as any[]).filter(
+      (block) => block.type === 'document',
+    );
+
+    assert.equal(documentBlocks.length, 1, 'should keep document blocks');
+    assert.equal(documentBlocks[0].source.type, 'base64');
+    assert.equal(documentBlocks[0].title, 'sample.pdf');
+  });
+
   it('omits whitespace-only prefix content when initializing messages', async () => {
     const handler = createAnthropicHandler();
     const messages = await handler.initializeMessages(
@@ -137,5 +194,86 @@ describe('ModelHandlerAnthropic message guards', () => {
         return true;
       },
     );
+  });
+
+  it('uploads base64 PDF documents before creating responses', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const loggerStub = {
+      channelId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Document: sample.pdf', citations: null },
+          {
+            type: 'document',
+            source: {
+              type: 'base64',
+              media_type: 'application/pdf',
+              data: 'ZHVtbXk=',
+            },
+            title: 'sample.pdf',
+          },
+        ],
+      },
+    ];
+
+    const uploadArgs: any[] = [];
+    const messageOptions: any[] = [];
+
+    const client = {
+      beta: {
+        files: {
+          upload: async (params: any) => {
+            uploadArgs.push(params);
+            return { id: 'file_uploaded' };
+          },
+        },
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const response = await handler.createResponse(client, messages, 0);
+
+    assert.equal(uploadArgs.length, 1, 'should upload the PDF document');
+    assert.deepEqual(uploadArgs[0].betas, ['files-api-2025-04-14']);
+
+    const documentBlock = (messages[0].content as any[]).find(
+      (block) => block.type === 'document',
+    );
+    assert.ok(documentBlock, 'document block should remain in messages');
+    assert.equal(documentBlock.source.type, 'file');
+    assert.equal(documentBlock.source.file_id, 'file_uploaded');
+
+    const betas: string[] = messageOptions[0].betas ?? [];
+    assert.ok(
+      betas.includes('files-api-2025-04-14'),
+      'request should opt into the Files API beta',
+    );
+
+    assert.equal(response.stop_reason, 'end_turn');
   });
 });


### PR DESCRIPTION
## Summary
- convert base64 Anthropic document blocks into uploaded files and opt into the Files API beta before creating responses
- keep native PDF attachments in user messages and tag them with filenames so requests reuse file IDs instead of inline blobs
- cover the new behavior with Anthropic unit tests for initialization and response uploads

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68dc5c67ae14832480b65b7ea3be437a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts inline PDF documents to Files API uploads and opts into the beta, updating requests to reference file_ids and adding tests for initialization and upload behavior.
> 
> - **Anthropic Handler**:
>   - Upload base64 PDF `document` blocks via `beta.files.upload` and replace with `source: { type: 'file', file_id }`.
>   - Auto-opt into `files-api-2025-04-14` beta when PDFs are uploaded or referenced; include beta for token counting.
>   - Add `title` (filename) to PDF `document` blocks; allow media handling to include images and native PDFs without filtering.
>   - Minor: import `Buffer`/`toFile`; introduce `FILES_API_BETA`; adjust betas passed to `countTokens`.
> - **Tests**:
>   - Add tests covering PDF `document` inclusion on init, upload-and-rewrite to `file_id`, and preserving existing `file_id` with Files API beta.
>   - Refactor test helpers to build configurable Anthropic handler stubs.
> - **Changelog**:
>   - Note bug fixes for uploading PDFs via Files API and retaining beta header on follow-ups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 192d6abdb9ddcd630baffa0e315ffdb909cfecf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->