### PR TITLE
feat: move prompt capture to debug setting

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -245,11 +245,13 @@ Control logging behavior:
 
 ```json
 "texra.logger.debugMode": false,
-"texra.debug.saveDebugObjects": false
+"texra.debug.saveDebugObjects": false,
+"texra.debug.saveInputPrompt": false
 ```
 
 - `debugMode`: Show detailed debug messages in the logger view
 - `saveDebugObjects`: Save message and response objects to JSON files for debugging purposes (includes both API messages and raw responses)
+- `saveInputPrompt`: Persist the final model input prompt as an XML file (stored alongside other debug artifacts when an execution ID is available)
 
 ## Environment-Specific Configuration
 
@@ -398,7 +400,9 @@ These settings, accessible directly in the main TeXRA webview, control how agent
 
 - **Reflect** (<i class="codicon codicon-refresh"></i>): Enables CoT agents to critique/improve their output (adds round 1). Increases cost/time, potentially quality.
 - **Attach TeX Count** (<i class="codicon codicon-symbol-numeric"></i>): Includes `texcount` output (word/header/math stats) in the agent's context. Requires `texcount` installed.
-- **Print Input Prompt** (<i class="codicon codicon-file-code"></i>): Adds the full final prompt sent to the LLM to the ProgressBoard log (useful for debugging, increases log size).
+- **Attach Diagnostics** (<i class="codicon codicon-tools"></i>): Appends LaTeX compilation logs and other diagnostics to the agent prompt.
+
+To capture the full prompt sent to the model, enable the `Save Input Prompt` debug setting in VS Code Settings (`texra.debug.saveInputPrompt`).
 
 **Model/Agent Selection:**
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -97,7 +97,11 @@ Be specific about what you want! Vague instructions are like asking a genie for 
 2. Enable "Reflect" to allow the AI to review and improve its own work
 3. (Optional) Enable other tools as needed:
    - "Attach TeX Count" to include document statistics
-   - "Print Input Prompt" to save the generated prompt for reference (which you can also feed to ChatGPT or Claude to process with your subscription)
+   - "Attach Diagnostics" to include LaTeX compilation logs and other troubleshooting details
+
+::: tip Save Prompts for Later
+Enable the `texra.debug.saveInputPrompt` setting if you want TeXRA to store the generated prompt alongside other debug artifacts.
+:::
 
 ![Tool Configuration](/images/tool-config.png)
 

--- a/package.json
+++ b/package.json
@@ -761,6 +761,12 @@
             "default": false,
             "description": "Save message and response objects to JSON files for debugging purposes",
             "scope": "resource"
+          },
+          "texra.debug.saveInputPrompt": {
+            "type": "boolean",
+            "default": false,
+            "description": "Save the final input prompt sent to the model as an XML file for debugging purposes",
+            "scope": "resource"
           }
         }
       },

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -17,7 +17,6 @@ export const ToolConfigSchema = z
     autoExtractTikzFigure: z.boolean().default(false),
     attachTeXCount: z.boolean().default(false),
     attachDiagnostics: z.boolean().default(false),
-    printInputPrompt: z.boolean().default(false),
     autoCompileInputPdf: z.boolean().default(false),
   })
   .strip()

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -385,15 +385,24 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         prefixWithStats = `${toolState.texcountStats}${userPrefix}`;
       }
 
-      // Write prompt to file if requested
-      if (this.agentConfig.toolConfig.printInputPrompt) {
-        await writePromptToXml(
+      // Write prompt to file if debug setting is enabled
+      const shouldSaveInputPrompt = getConfig<boolean>(
+        'debug.saveInputPrompt',
+        false,
+      );
+      if (shouldSaveInputPrompt) {
+        const promptPath = await writePromptToXml(
           systemPrompt,
           prefixWithStats,
           userRequest,
           this.agentConfig.inputFile,
           this.agentConfig.agent,
           this.executionId,
+        );
+        this.logger.info(
+          `Saved input prompt to ${promptPath}`,
+          roundGroupId,
+          MESSAGE_TYPES.DEFAULT,
         );
       }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -97,7 +97,6 @@ export abstract class ModelHandler<
         reflect: false,
         attachTeXCount: false,
         attachDiagnostics: false,
-        printInputPrompt: false,
         autoCompileInputPdf: false,
       },
     };

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -16,6 +16,7 @@ import { setVarFromFile } from '@frontend/files/vars';
 // Local imports
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 
 /**
@@ -305,16 +306,20 @@ function getOutputFilesOrder(
   return userVars;
 }
 
-function getToolFlags(
+export function getToolFlags(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
   agentPrompt: AgentPrompt,
 ): Record<string, any> {
+  const shouldSaveInputPrompt = getConfig<boolean>(
+    'debug.saveInputPrompt',
+    false,
+  );
   const flags: Record<string, any> = {
     AUTO_EXTRACT_FIGURE: agentConfig.toolConfig.autoExtractFigure,
     AUTO_EXTRACT_TIKZ_FIGURE: agentConfig.toolConfig.autoExtractTikzFigure,
     INCLUDE_TEX_COUNT: agentConfig.toolConfig.attachTeXCount,
-    PRINT_INPUT_PROMPT: agentConfig.toolConfig.printInputPrompt,
+    PRINT_INPUT_PROMPT: shouldSaveInputPrompt,
     AUTO_COMPILE_INPUT_PDF: agentConfig.toolConfig.autoCompileInputPdf,
   };
 

--- a/src/test/agent/core/ConfigSchemas.test.ts
+++ b/src/test/agent/core/ConfigSchemas.test.ts
@@ -10,12 +10,17 @@ describe('ToolConfigSchema', () => {
     const parsed = ToolConfigSchema.parse({
       reflect: true,
       usePrefillFromInput: true,
+      printInputPrompt: true,
     } as Record<string, unknown>);
 
     assert.strictEqual(parsed.reflect, true);
     assert.strictEqual(parsed.autoExtractFigure, false);
     assert.strictEqual(
       (parsed as Record<string, unknown>).usePrefillFromInput,
+      undefined,
+    );
+    assert.strictEqual(
+      (parsed as Record<string, unknown>).printInputPrompt,
       undefined,
     );
   });

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -1,0 +1,94 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - agent components
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import type { AgentPrompt } from '@agent/core/AgentDataclass';
+import { getToolFlags } from '@agent/utils/userVars';
+import * as configModule from '@utils/config';
+
+const baseSetting: AgentSetting = {
+  agentType: AgentType.CoT,
+  documentTag: 'document',
+  temperature: 0,
+  isRewrite: true,
+  rounds: 1,
+  prefills: [],
+  outputExt: 'tex',
+  endTag: '</latex_document>',
+  requiredFiles: {},
+  requiredFilesInternal: {},
+  defaultOutputFiles: [],
+  isMultipleOutput: false,
+  filePatternsContain: [],
+  tools: [],
+};
+
+const basePrompt: AgentPrompt = {
+  systemPrompt: '',
+  userPrefix: '',
+  userRequest: '',
+  userReflect: '',
+};
+
+const baseConfig: AgentConfig = {
+  model: 'test',
+  agent: 'agent',
+  instruction: '',
+  useMultipleOutputs: false,
+  inputFile: 'input.tex',
+  inputFiles: null,
+  referenceFile: null,
+  referenceFiles: null,
+  auxiliaryFile: null,
+  auxiliaryFiles: null,
+  mediaFile: null,
+  mediaFiles: null,
+  outputFiles: null,
+  editedFile: null,
+  toolConfig: {
+    reflect: false,
+    autoExtractFigure: false,
+    autoExtractTikzFigure: false,
+    attachTeXCount: false,
+    attachDiagnostics: false,
+    autoCompileInputPdf: false,
+  },
+};
+
+describe('getToolFlags', () => {
+  it('uses texra.debug.saveInputPrompt setting for PRINT_INPUT_PROMPT', () => {
+    const originalGetConfig = configModule.getConfig;
+
+    try {
+      (configModule as any).getConfig = (
+        path: string,
+        defaultValue?: unknown,
+      ) => {
+        if (path === 'debug.saveInputPrompt') {
+          return true;
+        }
+        return defaultValue as unknown;
+      };
+
+      const enabledFlags = getToolFlags(baseConfig, baseSetting, basePrompt);
+      assert.equal(enabledFlags.PRINT_INPUT_PROMPT, true);
+
+      (configModule as any).getConfig = (
+        path: string,
+        defaultValue?: unknown,
+      ) => {
+        if (path === 'debug.saveInputPrompt') {
+          return false;
+        }
+        return defaultValue as unknown;
+      };
+
+      const disabledFlags = getToolFlags(baseConfig, baseSetting, basePrompt);
+      assert.equal(disabledFlags.PRINT_INPUT_PROMPT, false);
+    } finally {
+      (configModule as any).getConfig = originalGetConfig;
+    }
+  });
+});

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -78,7 +78,6 @@ describe('OutputHandler.finalizeRound', () => {
       autoExtractTikzFigure: false,
       attachTeXCount: false,
       attachDiagnostics: false,
-      printInputPrompt: false,
       autoCompileInputPdf: false,
     },
   };

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -49,7 +49,6 @@ describe('XmlOutputManager markdown fallback', () => {
       autoExtractTikzFigure: false,
       attachTeXCount: false,
       attachDiagnostics: false,
-      printInputPrompt: false,
       autoCompileInputPdf: false,
     },
   };

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -151,7 +151,6 @@ describe('BaseToolUseAgent follow-up loop', () => {
         autoExtractTikzFigure: false,
         attachTeXCount: false,
         attachDiagnostics: false,
-        printInputPrompt: false,
         autoCompileInputPdf: false,
       },
     };

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -131,10 +131,27 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     autoExtractTikzFigure,
     autoCompileInputPdf,
     attachTeXCount,
-    printInputPrompt,
     reflect,
     ...agentConfigData
   } = obj;
+
+  const legacyPrintInputPrompt = Object.prototype.hasOwnProperty.call(
+    obj,
+    'printInputPrompt',
+  )
+    ? obj.printInputPrompt
+    : undefined;
+
+  const nestedLegacyPrintInputPrompt =
+    isObjectRecord(agentConfigData.toolConfig) &&
+    Object.prototype.hasOwnProperty.call(
+      agentConfigData.toolConfig,
+      'printInputPrompt',
+    )
+      ? (agentConfigData.toolConfig as Record<string, unknown>)[
+          'printInputPrompt'
+        ]
+      : undefined;
 
   // Build toolConfig from extracted fields (backward compatibility)
   // Ensure toolConfig is an object, handling cases where it might be malformed
@@ -153,9 +170,20 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     ...(autoExtractTikzFigure !== undefined && { autoExtractTikzFigure }),
     ...(autoCompileInputPdf !== undefined && { autoCompileInputPdf }),
     ...(attachTeXCount !== undefined && { attachTeXCount }),
-    ...(printInputPrompt !== undefined && { printInputPrompt }),
     ...(reflect !== undefined && { reflect }),
   };
+
+  if (
+    legacyPrintInputPrompt !== undefined ||
+    nestedLegacyPrintInputPrompt !== undefined
+  ) {
+    console.warn(
+      'Ignoring legacy printInputPrompt setting. Enable texra.debug.saveInputPrompt instead.',
+    );
+    delete (agentConfigData.toolConfig as Record<string, unknown>)[
+      'printInputPrompt'
+    ];
+  }
 
   // Parse only AgentConfig-compatible fields
   try {

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -21,11 +21,7 @@ export const AUTO_EXTRACT_FIELDS = [
   'autoExtractTikzFigure',
   'autoCompileInputPdf',
 ] as const;
-export const TOOL_CONFIG_FIELDS = [
-  'attachTeXCount',
-  'printInputPrompt',
-  'reflect',
-] as const;
+export const TOOL_CONFIG_FIELDS = ['attachTeXCount', 'reflect'] as const;
 
 // Length for preview slices of tool output and responses
 export const K_SLICE = 200;

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -411,11 +411,6 @@
                     <i class="codicon codicon-tools"></i> Attach
                     Diagnostics</label
                   >
-                  <label class="vscode-checkbox"
-                    ><input type="checkbox" id="printInputPrompt" />
-                    <i class="codicon codicon-file-code"></i> Print Input
-                    Prompt</label
-                  >
                 </div>
               </div>
             </div>

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -82,7 +82,6 @@ export class ExecutionManager {
       reflect: message.reflect,
       attachTeXCount: message.attachTeXCount,
       attachDiagnostics: message.attachDiagnostics,
-      printInputPrompt: message.printInputPrompt,
       autoCompileInputPdf: message.autoCompileInputPdf,
     };
 

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -41,7 +41,6 @@ export const CHECK_BOXES_AUTO_EXTRACT = [
 export const CHECK_BOXES_TOOL_USE = [
   'attachTeXCount',
   'attachDiagnostics',
-  'printInputPrompt',
   'reflect',
 ];
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -581,8 +581,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         state.attachTeXCount ?? toolConfig.attachTeXCount ?? false,
       attachDiagnostics:
         state.attachDiagnostics ?? toolConfig.attachDiagnostics ?? false,
-      printInputPrompt:
-        state.printInputPrompt ?? toolConfig.printInputPrompt ?? false,
       autoCompileInputPdf:
         state.autoCompileInputPdf ?? toolConfig.autoCompileInputPdf ?? false,
     });


### PR DESCRIPTION
## Summary
- add a `texra.debug.saveInputPrompt` setting and document how to enable prompt capture
- gate input prompt persistence on the new debug flag, log the saved location, and remove the obsolete tool-config toggle
- keep legacy task states compatible and add unit coverage for the new configuration flow

## Testing
- npm run compile-tests
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc5987ef308324973847856cd8fdec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `texra.debug.saveInputPrompt` to control prompt capture, removes the `printInputPrompt` tool toggle across code/UI, routes saving via config with logging, migrates legacy configs, updates tests, and documents the change (also adds “Attach Diagnostics”).
> 
> - **Debug/Config**:
>   - Introduce `texra.debug.saveInputPrompt` setting (JSON/XML prompt persistence) and log saved path.
>   - Remove legacy `printInputPrompt` tool flag; config conversion ignores/warns and maps behavior via the new setting.
> - **Backend**:
>   - BaseReflectionAgent/userVars read `debug.saveInputPrompt` via `getConfig`; write prompt XML and expose `PRINT_INPUT_PROMPT` flag accordingly.
>   - Strip `printInputPrompt` from `ToolConfigSchema`, defaults, and constants; update ModelHandler defaults.
> - **Webview/UI**:
>   - Remove "Print Input Prompt" checkbox and related wiring; keep "Attach Diagnostics" option.
>   - ExecutionManager/constants/messageHandlers updated to drop `printInputPrompt`.
> - **Docs**:
>   - Update configuration and quick-start guides to use `texra.debug.saveInputPrompt` and mention "Attach Diagnostics".
> - **Tests**:
>   - Add unit test for `getToolFlags` honoring `debug.saveInputPrompt`.
>   - Update schema/output/tool-use tests to remove `printInputPrompt` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd3f77e83eb2b166049edb1b7b09d9de156cf812. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->