### PR TITLE
Fix Anthropic Files API filename sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - Add Claude Sonnet 4.5 (thinking and regular) to the Anthropic catalog and default model list so the latest Claude release is immediately available in TeXRA.
 
+### Bug Fixes
+
+- Upload Anthropic PDF attachments to the Files API so requests reuse `file_id`s instead of resending large base64 payloads.
+- Ensure follow-up Anthropic requests keep the Files API beta header when referencing previously uploaded PDFs.
+- Sanitize Anthropic PDF filenames before uploading so nested paths with forbidden characters no longer trigger Files API errors.
+
 ## [0.33.8] - 2025-09-30
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Upload Anthropic PDF attachments to the Files API so requests reuse `file_id`s instead of resending large base64 payloads.
 - Ensure follow-up Anthropic requests keep the Files API beta header when referencing previously uploaded PDFs.
 - Sanitize Anthropic PDF filenames before uploading so nested paths with forbidden characters no longer trigger Files API errors.
+- Skip Anthropic token counting when requests already reference Files API assets and defer PDF uploads until after token usage is calculated to avoid countTokens errors.
 
 ## [0.33.8] - 2025-09-30
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -122,12 +122,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
       false,
     );
 
-    // Upload inline PDF documents before creating the request so we can
-    // reference them by file ID.
-    const { hasFileReference } = await this.replaceDocumentDataWithUploads(
-      client,
-      messages,
-    );
+    const documentAnalysis = this.analyzeDocumentSources(messages);
+    let hasFileReference = documentAnalysis.hasFileSource;
 
     // Prepare options for the API call
     const options: BetaMessageCreateParams = {
@@ -138,13 +134,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       stop_sequences: endTag ? [endTag] : undefined,
       system: systemPrompt,
     };
-
-    if (hasFileReference) {
-      const existingBetas = options.betas ?? [];
-      if (!existingBetas.includes(FILES_API_BETA)) {
-        options.betas = [...existingBetas, FILES_API_BETA];
-      }
-    }
 
     if (tools && tools.length > 0) {
       options.tools = toAnthropicTools(tools);
@@ -210,63 +199,86 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     if (this.capabilities.supportsTokenCounting) {
-      const countTokensParams: BetaMessageCountTokensParams = {
-        model: this.config.fullName,
-        system: systemPrompt,
-        messages,
-      };
+      if (documentAnalysis.hasFileSource) {
+        this.logger.debug(
+          'Skipping token counting because Anthropic countTokens does not support file-based document sources.',
+        );
+      } else {
+        const countTokensParams: BetaMessageCountTokensParams = {
+          model: this.config.fullName,
+          system: systemPrompt,
+          messages,
+        };
 
-      // If thinking is enabled, we need to pass it to countTokens as well
-      // to ensure consistency with the actual message creation.
-      // Without this, the API returns an error when messages contain thinking blocks.
-      if (options.thinking) {
-        countTokensParams.thinking = options.thinking;
-      }
+        // If thinking is enabled, we need to pass it to countTokens as well
+        // to ensure consistency with the actual message creation.
+        // Without this, the API returns an error when messages contain thinking blocks.
+        if (options.thinking) {
+          countTokensParams.thinking = options.thinking;
+        }
 
-      // Strip betas that only apply to message creation (e.g., output length)
-      // while keeping context headers needed for accurate token counting.
-      const countTokenBetas = options.betas?.filter(
-        (beta) => beta === CONTEXT_1M_BETA || beta === FILES_API_BETA,
-      );
-      if (countTokenBetas && countTokenBetas.length > 0) {
-        countTokensParams.betas = countTokenBetas;
-      }
+        // Strip betas that only apply to message creation (e.g., output length)
+        // while keeping context headers needed for accurate token counting.
+        const countTokenBetas = options.betas?.filter(
+          (beta) => beta === CONTEXT_1M_BETA,
+        );
+        if (countTokenBetas && countTokenBetas.length > 0) {
+          countTokensParams.betas = countTokenBetas;
+        }
 
-      const responseTokenCount =
-        await client.beta.messages.countTokens(countTokensParams);
-      const { input_tokens: inputTokens } = responseTokenCount;
-      this.logger.debug(`Token count of message: ${inputTokens}`);
-      if (inputTokens > this.config.contextWindow) {
-        const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${this.config.contextWindow}`;
-        this.logger.error(errMsg);
-        throw new Error(errMsg);
-      }
-      if (this.config.contextWindow - inputTokens < options.max_tokens) {
-        const warnMsg = `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${options.max_tokens} > ${this.config.contextWindow}. Reducing max tokens to ${this.config.contextWindow - inputTokens}.`;
-        this.logger.warn(warnMsg);
-        options.max_tokens = this.config.contextWindow - inputTokens - 10;
+        const responseTokenCount =
+          await client.beta.messages.countTokens(countTokensParams);
+        const { input_tokens: inputTokens } = responseTokenCount;
+        this.logger.debug(`Token count of message: ${inputTokens}`);
+        if (inputTokens > this.config.contextWindow) {
+          const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${this.config.contextWindow}`;
+          this.logger.error(errMsg);
+          throw new Error(errMsg);
+        }
+        if (this.config.contextWindow - inputTokens < options.max_tokens) {
+          const warnMsg = `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${options.max_tokens} > ${this.config.contextWindow}. Reducing max tokens to ${this.config.contextWindow - inputTokens}.`;
+          this.logger.warn(warnMsg);
+          options.max_tokens = this.config.contextWindow - inputTokens - 10;
 
-        if (
-          this.capabilities.supportsReasoning &&
-          options.thinking &&
-          options.thinking.type === 'enabled'
-        ) {
-          const adjustedBudget = Math.max(
-            1,
-            Math.min(
-              options.thinking.budget_tokens,
-              Math.floor(options.max_tokens * 0.5),
-            ),
-          );
-          if (adjustedBudget !== options.thinking.budget_tokens) {
-            this.logger.debug(
-              `Adjusted thinking budget to ${adjustedBudget} due to reduced max_tokens`,
+          if (
+            this.capabilities.supportsReasoning &&
+            options.thinking &&
+            options.thinking.type === 'enabled'
+          ) {
+            const adjustedBudget = Math.max(
+              1,
+              Math.min(
+                options.thinking.budget_tokens,
+                Math.floor(options.max_tokens * 0.5),
+              ),
             );
-            options.thinking.budget_tokens = adjustedBudget;
+            if (adjustedBudget !== options.thinking.budget_tokens) {
+              this.logger.debug(
+                `Adjusted thinking budget to ${adjustedBudget} due to reduced max_tokens`,
+              );
+              options.thinking.budget_tokens = adjustedBudget;
+            }
           }
         }
+        // in the future we log this in firstInputTokens of the AgentStateGlobal
       }
-      // in the future we log this in firstInputTokens of the AgentStateGlobal
+    }
+
+    if (documentAnalysis.hasBase64Pdf) {
+      const uploadResult = await this.replaceDocumentDataWithUploads(
+        client,
+        messages,
+      );
+      if (uploadResult.hasFileReference) {
+        hasFileReference = true;
+      }
+    }
+
+    if (hasFileReference) {
+      const existingBetas = options.betas ?? [];
+      if (!existingBetas.includes(FILES_API_BETA)) {
+        options.betas = [...existingBetas, FILES_API_BETA];
+      }
     }
 
     // this.logger.debug(
@@ -433,6 +445,46 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     return { uploaded, hasFileReference };
+  }
+
+  private analyzeDocumentSources(messages: MessageParam[]): {
+    hasFileSource: boolean;
+    hasBase64Pdf: boolean;
+  } {
+    let hasFileSource = false;
+    let hasBase64Pdf = false;
+
+    for (const message of messages) {
+      const contentBlocks = message.content;
+      if (!Array.isArray(contentBlocks)) {
+        continue;
+      }
+
+      for (const block of contentBlocks) {
+        if (block.type !== 'document') {
+          continue;
+        }
+
+        const source = block.source;
+        if (!source) {
+          continue;
+        }
+
+        if ('file_id' in (source as { file_id?: string })) {
+          hasFileSource = true;
+        } else if (source.type === 'base64') {
+          if (source.media_type === 'application/pdf' && source.data) {
+            hasBase64Pdf = true;
+          }
+        }
+
+        if (hasFileSource && hasBase64Pdf) {
+          return { hasFileSource: true, hasBase64Pdf: true };
+        }
+      }
+    }
+
+    return { hasFileSource, hasBase64Pdf };
   }
 
   private sanitizeFilename(filename: string): string {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1,8 +1,9 @@
 // Standard library imports
-// (none needed)
+import { Buffer } from 'node:buffer';
+import { basename } from 'node:path';
 
 // Third-party imports
-import { Anthropic } from '@anthropic-ai/sdk';
+import { Anthropic, toFile } from '@anthropic-ai/sdk';
 import type {
   BetaBase64ImageSource,
   BetaImageBlockParam,
@@ -83,6 +84,7 @@ type BetaMessageCountTokensParams = MessageCountTokensParams & {
 };
 
 const CONTEXT_1M_BETA: AnthropicBeta = 'context-1m-2025-08-07';
+const FILES_API_BETA: AnthropicBeta = 'files-api-2025-04-14';
 const SONNET_37_OUTPUT_BETA: AnthropicBeta = 'output-128k-2025-02-19';
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
@@ -120,6 +122,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       false,
     );
 
+    // Upload inline PDF documents before creating the request so we can
+    // reference them by file ID.
+    const { hasFileReference } = await this.replaceDocumentDataWithUploads(
+      client,
+      messages,
+    );
+
     // Prepare options for the API call
     const options: BetaMessageCreateParams = {
       model: this.config.fullName,
@@ -129,6 +138,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       stop_sequences: endTag ? [endTag] : undefined,
       system: systemPrompt,
     };
+
+    if (hasFileReference) {
+      const existingBetas = options.betas ?? [];
+      if (!existingBetas.includes(FILES_API_BETA)) {
+        options.betas = [...existingBetas, FILES_API_BETA];
+      }
+    }
 
     if (tools && tools.length > 0) {
       options.tools = toAnthropicTools(tools);
@@ -210,7 +226,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Strip betas that only apply to message creation (e.g., output length)
       // while keeping context headers needed for accurate token counting.
       const countTokenBetas = options.betas?.filter(
-        (beta) => beta === CONTEXT_1M_BETA,
+        (beta) => beta === CONTEXT_1M_BETA || beta === FILES_API_BETA,
       );
       if (countTokenBetas && countTokenBetas.length > 0) {
         countTokensParams.betas = countTokenBetas;
@@ -329,6 +345,111 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return response;
   }
 
+  private async replaceDocumentDataWithUploads(
+    client: Anthropic,
+    messages: MessageParam[],
+  ): Promise<{ uploaded: boolean; hasFileReference: boolean }> {
+    if (!this.capabilities.supportsNativePdf) {
+      return { uploaded: false, hasFileReference: false };
+    }
+
+    let uploaded = false;
+    let hasFileReference = false;
+
+    for (const message of messages) {
+      const contentBlocks = message.content;
+      if (!Array.isArray(contentBlocks)) {
+        continue;
+      }
+
+      for (const block of contentBlocks) {
+        if (block.type !== 'document') {
+          continue;
+        }
+
+        const source = block.source;
+        if (!source) {
+          continue;
+        }
+
+        if ('file_id' in (source as { file_id?: string })) {
+          hasFileReference = true;
+          continue;
+        }
+
+        if (source.type !== 'base64') {
+          continue;
+        }
+
+        const mediaType = source.media_type;
+        if (mediaType !== 'application/pdf') {
+          continue;
+        }
+
+        const base64Data = source.data;
+        if (!base64Data) {
+          continue;
+        }
+
+        const filename =
+          (block.title ?? 'document.pdf').trim() || 'document.pdf';
+        const sanitizedFilename = this.sanitizeFilename(filename);
+        let buffer: Buffer | undefined;
+        let uploadedSource: BetaRequestDocumentBlock['source'] | undefined;
+
+        try {
+          buffer = Buffer.from(base64Data, 'base64');
+          const uploadedFile = await client.beta.files.upload({
+            file: await toFile(buffer, sanitizedFilename, { type: mediaType }),
+            betas: [FILES_API_BETA],
+          });
+
+          uploadedSource = {
+            type: 'file',
+            file_id: uploadedFile.id,
+          } as BetaRequestDocumentBlock['source'];
+        } catch (err) {
+          this.logger.error(
+            `Failed to upload document ${filename}: ${getSdkErrorMessage(err)}`,
+            undefined,
+            undefined,
+            err,
+          );
+          throw err;
+        } finally {
+          if (buffer) {
+            buffer.fill(0);
+            buffer = undefined;
+          }
+        }
+
+        if (uploadedSource) {
+          delete (source as { data?: string }).data;
+          (block as BetaRequestDocumentBlock).source = uploadedSource;
+          uploaded = true;
+          hasFileReference = true;
+        }
+      }
+    }
+
+    return { uploaded, hasFileReference };
+  }
+
+  private sanitizeFilename(filename: string): string {
+    const baseName = basename(filename) || filename;
+    const trimmed = baseName.trim();
+    const withoutControlChars = Array.from(trimmed, (char) =>
+      char.charCodeAt(0) < 32 ? '_' : char,
+    ).join('');
+    const withoutForbidden = withoutControlChars.replace(/[:<>"|?*\\/]/g, '_');
+    const sanitized = withoutForbidden || 'document.pdf';
+    // Removing directory information avoids Anthropic rejecting names that contain
+    // slashes, but it also means the model loses subdirectory context when
+    // generating citations for assets or pictures that originally lived in nested
+    // folders.
+    return sanitized.slice(0, 255);
+  }
+
   /** Initializes the message array for Anthropic chat models with user prefix, request, and optional media. */
   async initializeMessages(
     userPrefix: string,
@@ -357,17 +478,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       });
     }
 
-    // Add media if provided (Anthropic currently only supports images)
+    // Add media if provided (images and native PDFs)
     if (mediaFiles && this.config.capabilities.supportsVision) {
       const formattedMediaContent = await this.createMediaMessage(mediaFiles);
-      // Filter out any non-image content just in case, although createMediaContent should handle this
-      userMessageContent.push(
-        ...formattedMediaContent.filter(
-          (c) =>
-            c.type === 'image' ||
-            (c.type === 'text' && c.text?.startsWith('Image:')),
-        ),
-      );
+      userMessageContent.push(...formattedMediaContent);
     }
 
     // Add user request with optional caching
@@ -415,7 +529,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Create content list for the new round message
     const roundContent: ContentBlockParam[] = [];
 
-    // Add media if provided (Anthropic currently only supports images)
+    // Add media if provided (images and native PDFs)
     if (
       mediaFiles &&
       mediaFiles.length > 0 &&
@@ -423,14 +537,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     ) {
       try {
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
-        // Filter out any non-image content
-        roundContent.push(
-          ...formattedMediaContent.filter(
-            (c) =>
-              c.type === 'image' ||
-              (c.type === 'text' && c.text?.startsWith('Image:')),
-          ),
-        );
+        roundContent.push(...formattedMediaContent);
       } catch (err) {
         this.logger.error(
           `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
@@ -541,6 +648,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
               media_type: 'application/pdf',
               data: media.data,
             },
+            title: media.file_name,
           } satisfies BetaRequestDocumentBlock;
           return [descriptionBlock, documentBlock];
         }

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -425,4 +425,150 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     assert.equal(response.stop_reason, 'end_turn');
   });
+
+  it('skips token counting when messages include file-based document sources', async () => {
+    const handler = createAnthropicHandler({
+      supportsNativePdf: true,
+      supportsTokenCounting: true,
+    });
+    const loggerStub = {
+      channelId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Document: sample.pdf', citations: null },
+          {
+            type: 'document',
+            source: {
+              type: 'file',
+              file_id: 'file_existing',
+            },
+            title: 'sample.pdf',
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+
+    const countTokenCalls: string[] = [];
+
+    const client = {
+      beta: {
+        files: {
+          upload: async () => {
+            throw new Error('should not upload existing file sources');
+          },
+        },
+        messages: {
+          countTokens: async () => {
+            countTokenCalls.push('countTokens');
+            throw new Error(
+              'countTokens should not be invoked for file sources',
+            );
+          },
+          create: async () =>
+            ({
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }) as any,
+        },
+      },
+    } as any;
+
+    const response = await handler.createResponse(client, messages, 0);
+
+    assert.equal(
+      countTokenCalls.length,
+      0,
+      'should skip token counting for file sources',
+    );
+    assert.equal(response.stop_reason, 'end_turn');
+  });
+
+  it('counts tokens before uploading PDF documents', async () => {
+    const handler = createAnthropicHandler({
+      supportsNativePdf: true,
+      supportsTokenCounting: true,
+    });
+    const loggerStub = {
+      channelId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Document: sample.pdf', citations: null },
+          {
+            type: 'document',
+            source: {
+              type: 'base64',
+              media_type: 'application/pdf',
+              data: 'ZHVtbXk=',
+            },
+            title: 'sample.pdf',
+          },
+        ],
+      },
+    ];
+
+    const callOrder: string[] = [];
+
+    const client = {
+      beta: {
+        files: {
+          upload: async () => {
+            callOrder.push('upload');
+            return { id: 'file_uploaded' };
+          },
+        },
+        messages: {
+          countTokens: async () => {
+            callOrder.push('countTokens');
+            return { input_tokens: 5 } as any;
+          },
+          create: async () => {
+            callOrder.push('create');
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const response = await handler.createResponse(client, messages, 0);
+
+    assert.deepEqual(callOrder, ['countTokens', 'upload', 'create']);
+    assert.equal(response.stop_reason, 'end_turn');
+  });
 });

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -2,25 +2,34 @@
 import { strict as assert } from 'assert';
 
 // Third-party imports
-import type { ContentBlock } from '@anthropic-ai/sdk/resources/messages';
+import type {
+  ContentBlock,
+  ContentBlockParam,
+  MessageParam,
+} from '@anthropic-ai/sdk/resources/messages';
 
 // Local imports - agent
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+import type { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - model config
 import {
   DEFAULT_MODEL_CAPABILITIES,
+  ModelCapabilities,
   ModelConfig,
   ModelProvider,
 } from '@model/ModelConfig';
 
-function createAnthropicHandler(): ModelHandlerAnthropic {
+function buildAnthropicConfig(
+  capabilityOverrides: Partial<ModelCapabilities> = {},
+): ModelConfig {
   const capabilities = {
     ...DEFAULT_MODEL_CAPABILITIES,
     supportsPromptCaching: true,
+    ...capabilityOverrides,
   };
 
-  const config: ModelConfig = {
+  return {
     name: 'test-anthropic',
     fullName: 'claude-test',
     provider: ModelProvider.ANTHROPIC,
@@ -31,8 +40,12 @@ function createAnthropicHandler(): ModelHandlerAnthropic {
     capabilities,
     openRouterOnly: false,
   };
+}
 
-  return new ModelHandlerAnthropic(config);
+function createAnthropicHandler(
+  capabilityOverrides: Partial<ModelCapabilities> = {},
+): ModelHandlerAnthropic {
+  return new ModelHandlerAnthropic(buildAnthropicConfig(capabilityOverrides));
 }
 
 type TextBlock = Extract<ContentBlock, { type: 'text' }>;
@@ -49,7 +62,51 @@ function assertSingleTextBlock(content: ContentBlock[]): TextBlock {
   return textBlocks[0];
 }
 
+class PdfStubAnthropicHandler extends ModelHandlerAnthropic {
+  private mediaContent: ContentBlockParam[] = [];
+
+  setMediaContent(content: ContentBlockParam[]): void {
+    this.mediaContent = content;
+  }
+
+  override async createMediaMessage(): Promise<any[]> {
+    return this.mediaContent;
+  }
+}
+
 describe('ModelHandlerAnthropic message guards', () => {
+  it('includes native PDF document blocks when initializing messages', async () => {
+    const handler = new PdfStubAnthropicHandler(
+      buildAnthropicConfig({ supportsNativePdf: true }),
+    );
+
+    handler.setMediaContent([
+      { type: 'text', text: 'Document: sample.pdf', citations: null },
+      {
+        type: 'document',
+        source: {
+          type: 'base64',
+          media_type: 'application/pdf',
+          data: 'ZHVtbXk=',
+        },
+        title: 'sample.pdf',
+      },
+    ] as ContentBlockParam[]);
+
+    const messages = await handler.initializeMessages('', 'request text', [
+      'sample.pdf',
+    ]);
+
+    const content = messages[0].content as ContentBlock[];
+    const documentBlocks = (content as any[]).filter(
+      (block) => block.type === 'document',
+    );
+
+    assert.equal(documentBlocks.length, 1, 'should keep document blocks');
+    assert.equal(documentBlocks[0].source.type, 'base64');
+    assert.equal(documentBlocks[0].title, 'sample.pdf');
+  });
+
   it('omits whitespace-only prefix content when initializing messages', async () => {
     const handler = createAnthropicHandler();
     const messages = await handler.initializeMessages(
@@ -137,5 +194,235 @@ describe('ModelHandlerAnthropic message guards', () => {
         return true;
       },
     );
+  });
+
+  it('uploads base64 PDF documents before creating responses', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const loggerStub = {
+      channelId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Document: sample.pdf', citations: null },
+          {
+            type: 'document',
+            source: {
+              type: 'base64',
+              media_type: 'application/pdf',
+              data: 'ZHVtbXk=',
+            },
+            title: 'sample.pdf',
+          },
+        ],
+      },
+    ];
+
+    const uploadArgs: any[] = [];
+    const messageOptions: any[] = [];
+
+    const client = {
+      beta: {
+        files: {
+          upload: async (params: any) => {
+            uploadArgs.push(params);
+            return { id: 'file_uploaded' };
+          },
+        },
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const response = await handler.createResponse(client, messages, 0);
+
+    assert.equal(uploadArgs.length, 1, 'should upload the PDF document');
+    assert.deepEqual(uploadArgs[0].betas, ['files-api-2025-04-14']);
+
+    const documentBlock = (messages[0].content as any[]).find(
+      (block) => block.type === 'document',
+    );
+    assert.ok(documentBlock, 'document block should remain in messages');
+    assert.equal(documentBlock.source.type, 'file');
+    assert.equal(documentBlock.source.file_id, 'file_uploaded');
+
+    const betas: string[] = messageOptions[0].betas ?? [];
+    assert.ok(
+      betas.includes('files-api-2025-04-14'),
+      'request should opt into the Files API beta',
+    );
+
+    assert.equal(response.stop_reason, 'end_turn');
+  });
+
+  it('sanitizes uploaded PDF filenames to strip directories and forbidden characters', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const loggerStub = {
+      channelId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Document: nested/diagram?.pdf',
+            citations: null,
+          },
+          {
+            type: 'document',
+            source: {
+              type: 'base64',
+              media_type: 'application/pdf',
+              data: 'ZHVtbXk=',
+            },
+            title: 'nested/diagram?.pdf',
+          },
+        ],
+      },
+    ];
+
+    const uploadArgs: any[] = [];
+
+    const client = {
+      beta: {
+        files: {
+          upload: async (params: any) => {
+            uploadArgs.push(params);
+            return { id: 'file_uploaded' };
+          },
+        },
+        messages: {
+          create: async () =>
+            ({
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }) as any,
+        },
+      },
+    } as any;
+
+    await handler.createResponse(client, messages, 0);
+
+    assert.equal(uploadArgs.length, 1, 'should upload the PDF document once');
+    const uploadedFile = uploadArgs[0].file;
+    assert.ok(uploadedFile, 'upload should include a file payload');
+    assert.equal(uploadedFile.name, 'diagram_.pdf');
+
+    const documentBlock = (messages[0].content as any[]).find(
+      (block) => block.type === 'document',
+    );
+    assert.equal(documentBlock.title, 'nested/diagram?.pdf');
+  });
+
+  it('opts into the Files API when messages already reference uploaded PDFs', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const loggerStub = {
+      channelId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Document: sample.pdf', citations: null },
+          {
+            type: 'document',
+            source: {
+              type: 'file',
+              file_id: 'file_existing',
+            },
+            title: 'sample.pdf',
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+
+    const messageOptions: any[] = [];
+
+    const client = {
+      beta: {
+        files: {
+          upload: async () => {
+            throw new Error('should not upload when file_id already provided');
+          },
+        },
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const response = await handler.createResponse(client, messages, 0);
+
+    const documentBlock = (messages[0].content as any[]).find(
+      (block) => block.type === 'document',
+    );
+    assert.ok(documentBlock, 'document block should remain in messages');
+    assert.equal(documentBlock.source.type, 'file');
+    assert.equal(documentBlock.source.file_id, 'file_existing');
+
+    const betas: string[] = messageOptions[0].betas ?? [];
+    assert.ok(
+      betas.includes('files-api-2025-04-14'),
+      'request should opt into the Files API beta when referencing file IDs',
+    );
+
+    assert.equal(response.stop_reason, 'end_turn');
   });
 });


### PR DESCRIPTION
## Summary
- sanitize Anthropic document filenames before uploading so Files API calls no longer fail on nested paths
- leave message titles intact while documenting the filename change in the changelog
- add unit coverage that asserts the upload payload uses the sanitized name

## Testing
- npm run format
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68dc5c67ae14832480b65b7ea3be437a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Uploads Anthropic PDF documents via Files API (with sanitized filenames), preserves Files API beta on follow-ups, skips/defer token counting for file sources, and adds unit tests.
> 
> - **Anthropic model handler**:
>   - Upload base64 PDF `document` blocks to Files API and replace with `file_id` sources; add `FILES_API_BETA` when files are referenced.
>   - Sanitize PDF filenames (strip paths/forbidden chars, limit length) before upload.
>   - Skip token counting when messages reference `file_id`s; count tokens before performing PDF uploads.
>   - Support native PDFs throughout media handling; include document `title` from media file name.
> - **Tests**:
>   - Add coverage for PDF block inclusion, file upload flow, Files API beta propagation, filename sanitization, skipping token counting with files, and call order (countTokens → upload → create).
> - **Changelog**:
>   - Document Files API upload, beta header preservation, filename sanitization, and token-counting adjustments for Anthropic PDFs.
> - **Models**:
>   - Add Claude Sonnet 4.5 to Anthropic catalog/default list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e52d4c1a7a7498251c511081b700881914e53fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->