### PR TITLE
Fix: enable Gemini handler media uploads

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -620,9 +620,13 @@ export abstract class ModelHandler<
           this.capabilities.supportsNativePdf &&
           mediaType === 'application/pdf'
         ) {
+          const base64Payload = Array.isArray(mediaData)
+            ? mediaData[0]
+            : mediaData;
           const imageEntry: MediaEntry = {
             file_name: path.basename(mediaFile),
-            data: Array.isArray(mediaData) ? mediaData[0] : mediaData,
+            data: base64Payload,
+            binaryData: Buffer.from(base64Payload, 'base64'),
             media_type: mediaType,
             media_category: mediaCategory,
           };
@@ -637,9 +641,11 @@ export abstract class ModelHandler<
             `Adding ${mediaData.length} pages/parts to the media contents`,
           );
           for (let i = 0; i < mediaData.length; i++) {
+            const base64Payload = mediaData[i];
             const mediaEntry: MediaEntry = {
               file_name: `${path.basename(mediaFile)}_page_${i + 1}`,
-              data: mediaData[i],
+              data: base64Payload,
+              binaryData: Buffer.from(base64Payload, 'base64'),
               media_type: mediaType,
               media_category: mediaCategory,
             };
@@ -650,9 +656,11 @@ export abstract class ModelHandler<
           this.logger.debug(
             `Adding single part to the media contents: ${mediaFile}`,
           );
+          const base64Payload = mediaData;
           const mediaEntry: MediaEntry = {
             file_name: path.basename(mediaFile),
-            data: mediaData,
+            data: base64Payload,
+            binaryData: Buffer.from(base64Payload, 'base64'),
             media_type: mediaType,
             media_category: mediaCategory,
           };

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -531,7 +531,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Add media if provided (images and native PDFs)
-    if (mediaFiles && this.config.capabilities.supportsVision) {
+    if (this.canAttachFiles(mediaFiles)) {
       const formattedMediaContent = await this.createMediaMessage(mediaFiles);
       userMessageContent.push(...formattedMediaContent);
     }
@@ -582,11 +582,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const roundContent: ContentBlockParam[] = [];
 
     // Add media if provided (images and native PDFs)
-    if (
-      mediaFiles &&
-      mediaFiles.length > 0 &&
-      this.config.capabilities.supportsVision
-    ) {
+    if (this.canAttachFiles(mediaFiles)) {
       try {
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
         roundContent.push(...formattedMediaContent);
@@ -658,6 +654,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
       role: 'assistant',
       content: [{ type: 'text', text, citations: null }],
     };
+  }
+
+  private canAttachFiles(
+    mediaFiles?: string[],
+  ): mediaFiles is string[] {
+    return (
+      Array.isArray(mediaFiles) &&
+      mediaFiles.length > 0 &&
+      this.capabilities.supportsVision
+    );
   }
 
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -161,10 +161,20 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 > {
   private googleClient: GoogleGenAI | null = null;
 
-  private supportsMediaUploads(): boolean {
+  private supportsFileUploads(): boolean {
     return (
-      this.config.capabilities.supportsVision ||
-      this.config.capabilities.supportsNativeAudio
+      this.capabilities.supportsVision ||
+      this.capabilities.supportsNativeAudio
+    );
+  }
+
+  private canAttachFiles(
+    mediaFiles?: string[],
+  ): mediaFiles is string[] {
+    return (
+      Array.isArray(mediaFiles) &&
+      mediaFiles.length > 0 &&
+      this.supportsFileUploads()
     );
   }
 
@@ -180,17 +190,20 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     for (const entry of entries) {
       const fileName = entry.file_name || 'unnamed-file';
       const mimeType = entry.media_type;
-      if (!entry.data || !mimeType) {
+      const binaryData =
+        entry.binaryData ??
+        (entry.data ? Buffer.from(entry.data, 'base64') : null);
+
+      if (!binaryData || !mimeType) {
         this.logger.error(
-          `Skipping media entry ${fileName} due to missing data or mime type`,
+          `Skipping media entry ${fileName} due to missing binary payload or mime type`,
         );
         uploadSummaries.push({ path: fileName, ok: false });
         continue;
       }
 
       try {
-        const buffer = Buffer.from(entry.data, 'base64');
-        const blob = new globalThis.Blob([buffer], { type: mimeType });
+        const blob = new globalThis.Blob([binaryData], { type: mimeType });
         const uploadParams: UploadFileParameters = {
           file: blob,
           config: {
@@ -205,7 +218,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
         const uploadResult: File = await client.files.upload(uploadParams);
         const fileUri = uploadResult.uri;
-        const resolvedMimeType = uploadResult.mimeType ?? mimeType;
+        const resolvedMimeType = this.resolveUploadedMimeType(
+          uploadResult,
+          mimeType,
+        );
 
         if (!fileUri) {
           this.logger.error(
@@ -238,6 +254,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     }
 
     return uploadedParts;
+  }
+
+  private resolveUploadedMimeType(result: File, fallback: string): string {
+    return result.mimeType ?? fallback;
   }
   async getClient(): Promise<GoogleGenAI> {
     if (!this.googleClient) {
@@ -495,7 +515,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   ): Promise<Content[]> {
     const userContentParts: Part[] = [createPartFromText(userPrefix)];
 
-    if (mediaFiles && mediaFiles.length > 0 && this.supportsMediaUploads()) {
+    if (this.canAttachFiles(mediaFiles)) {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
       if (formattedMedia.length > 0) {
         const pluralSuffix = mediaFiles.length > 1 ? 's' : '';
@@ -524,7 +544,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   ): Promise<Content[]> {
     const roundParts: Part[] = [];
 
-    if (mediaFiles && mediaFiles.length > 0 && this.supportsMediaUploads()) {
+    if (this.canAttachFiles(mediaFiles)) {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
       if (formattedMedia.length > 0) {
         const pluralSuffix = mediaFiles.length > 1 ? 's' : '';

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -52,7 +52,7 @@ import replacementEngine from '@replacement/engine';
 import { K_SLICE } from '@utils/config';
 
 // Local imports - utilities
-import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 
 type GoogleRole = 'user' | 'model';
@@ -160,6 +160,85 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   GoogleGenAI
 > {
   private googleClient: GoogleGenAI | null = null;
+
+  private supportsMediaUploads(): boolean {
+    return (
+      this.config.capabilities.supportsVision ||
+      this.config.capabilities.supportsNativeAudio
+    );
+  }
+
+  protected async uploadMediaEntries(entries: MediaEntry[]): Promise<Part[]> {
+    if (entries.length === 0) {
+      return [];
+    }
+
+    const client = await this.getClient();
+    const uploadedParts: Part[] = [];
+    const uploadSummaries: Array<{ path: string; ok: boolean }> = [];
+
+    for (const entry of entries) {
+      const fileName = entry.file_name || 'unnamed-file';
+      const mimeType = entry.media_type;
+      if (!entry.data || !mimeType) {
+        this.logger.error(
+          `Skipping media entry ${fileName} due to missing data or mime type`,
+        );
+        uploadSummaries.push({ path: fileName, ok: false });
+        continue;
+      }
+
+      try {
+        const buffer = Buffer.from(entry.data, 'base64');
+        const blob = new globalThis.Blob([buffer], { type: mimeType });
+        const uploadParams: UploadFileParameters = {
+          file: blob,
+          config: {
+            mimeType,
+            displayName: fileName,
+          },
+        };
+
+        this.logger.debug(
+          `Uploading media entry ${fileName} (${mimeType}) via Google GenAI SDK`,
+        );
+
+        const uploadResult: File = await client.files.upload(uploadParams);
+        const fileUri = uploadResult.uri;
+        const resolvedMimeType = uploadResult.mimeType ?? mimeType;
+
+        if (!fileUri) {
+          this.logger.error(
+            `Upload result for ${fileName} is missing a URI. Skipping entry.`,
+          );
+          uploadSummaries.push({ path: fileName, ok: false });
+          continue;
+        }
+
+        uploadedParts.push(createPartFromUri(fileUri, resolvedMimeType));
+        uploadSummaries.push({ path: fileName, ok: true });
+      } catch (error) {
+        this.logger.error(
+          `Failed to upload media entry ${fileName}: ${getSdkErrorMessage(error)}`,
+          undefined,
+          undefined,
+          error,
+        );
+        uploadSummaries.push({ path: fileName, ok: false });
+      }
+    }
+
+    if (uploadSummaries.length > 0) {
+      if (uploadSummaries.some((summary) => !summary.ok)) {
+        this.logger.warn(
+          'Some media entries failed to upload via Google GenAI',
+        );
+      }
+      this.logger.fileList(uploadSummaries);
+    }
+
+    return uploadedParts;
+  }
   async getClient(): Promise<GoogleGenAI> {
     if (!this.googleClient) {
       const apiKey = await this.getApiKey();
@@ -414,85 +493,21 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     mediaFiles?: string[],
     _systemPrompt?: string,
   ): Promise<Content[]> {
-    const client = await this.getClient();
     const userContentParts: Part[] = [createPartFromText(userPrefix)];
 
-    if (
-      mediaFiles &&
-      mediaFiles.length > 0 &&
-      (this.config.capabilities.supportsVision ||
-        this.config.capabilities.supportsNativeAudio)
-    ) {
-      this.logger.debug(
-        `Uploading ${mediaFiles.length} media files via native SDK...`,
-      );
-      const mediaFileResults: Array<{ path: string; ok: boolean }> = [];
-
-      for (const mediaFile of mediaFiles) {
-        try {
-          const absolutePath = WorkspaceFS.fullPath(mediaFile);
-          if (!(await AbsoluteFS.exists(absolutePath))) {
-            this.logger.error(`File does not exist: ${absolutePath}`);
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          const explicitMimeType = this.determineMimeType(absolutePath);
-
-          if (!explicitMimeType) {
-            this.logger.error(
-              `Cannot determine mime type for ${mediaFile}. Skipping file.`,
-            );
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          const uploadParams: UploadFileParameters = {
-            file: absolutePath,
-            config: { mimeType: explicitMimeType },
-          };
-
-          this.logger.debug(
-            `Attempting upload for ${mediaFile} with params: ${JSON.stringify(uploadParams)}`,
-          );
-
-          const uploadResult: File = await client.files.upload(uploadParams);
-
-          this.logger.debug(
-            `Uploaded ${mediaFile}, URI: ${uploadResult.uri}, MimeType: ${uploadResult.mimeType}`,
-          );
-
-          const fileUri = uploadResult.uri;
-          const fileMimeType = uploadResult.mimeType;
-          if (!fileUri || !fileMimeType) {
-            this.logger.error(
-              `Upload result for file ${mediaFile} missing URI or MimeType. API might have failed inference. Skipping file.`,
-            );
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          userContentParts.push(
-            createPartFromText(`\nFile attached: ${path.basename(mediaFile)}`),
-          );
-          userContentParts.push(createPartFromUri(fileUri, fileMimeType));
-          mediaFileResults.push({ path: mediaFile, ok: true });
-        } catch (error) {
-          this.logger.error(
-            `Failed to upload media file ${mediaFile} via native SDK: ${getSdkErrorMessage(error)}`,
-            undefined,
-            undefined,
-            error,
-          );
-          mediaFileResults.push({ path: mediaFile, ok: false });
-        }
-      }
-
-      if (mediaFileResults.length > 0) {
-        if (mediaFileResults.some((r) => !r.ok)) {
-          this.logger.warn('Some media files failed to load');
-        }
-        this.logger.fileList(mediaFileResults);
+    if (mediaFiles && mediaFiles.length > 0 && this.supportsMediaUploads()) {
+      const formattedMedia = await this.createMediaMessage(mediaFiles);
+      if (formattedMedia.length > 0) {
+        const pluralSuffix = mediaFiles.length > 1 ? 's' : '';
+        const attachmentLabel = mediaFiles
+          .map((filePath) => path.basename(filePath))
+          .join(', ');
+        userContentParts.push(
+          createPartFromText(
+            `\nAttached file${pluralSuffix}: ${attachmentLabel}`,
+          ),
+        );
+        userContentParts.push(...formattedMedia);
       }
     }
 
@@ -501,113 +516,27 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return [{ role: 'user', parts: userContentParts }];
   }
 
-  private determineMimeType(filePath: string): string | null {
-    const ext = path.extname(filePath).toLowerCase();
-    this.logger.debug(
-      `Determining MIME type for extension: '${ext}' from file: ${filePath}`,
-    );
-
-    const mimeType = getMimeType(filePath);
-    if (!mimeType) {
-      this.logger.warn(
-        `Cannot determine mime type for ${filePath} from extension '${ext}'.`,
-      );
-    } else {
-      this.logger.debug(
-        `Determined MIME type: ${mimeType} for file: ${filePath}`,
-      );
-    }
-    return mimeType;
-  }
-
   /** Creates message array for subsequent rounds, managing image content and message structure. */
   async createRoundMessages(
     messages: Content[],
     userMessage: string,
     mediaFiles?: string[],
   ): Promise<Content[]> {
-    const client = await this.getClient();
     const roundParts: Part[] = [];
 
-    if (
-      mediaFiles &&
-      mediaFiles.length > 0 &&
-      (this.config.capabilities.supportsVision ||
-        this.config.capabilities.supportsNativeAudio)
-    ) {
-      this.logger.debug(
-        `Uploading ${mediaFiles.length} media files for reflection via native SDK...`,
-      );
-      const mediaFileResults: Array<{ path: string; ok: boolean }> = [];
-
-      for (const mediaFile of mediaFiles) {
-        try {
-          const absolutePath = WorkspaceFS.fullPath(mediaFile);
-          if (!(await AbsoluteFS.exists(absolutePath))) {
-            this.logger.error(`File does not exist: ${absolutePath}`);
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          const explicitMimeType = this.determineMimeType(absolutePath);
-
-          if (!explicitMimeType) {
-            this.logger.error(
-              `Cannot determine mime type for file ${mediaFile}. Skipping file.`,
-            );
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          const uploadParams: UploadFileParameters = {
-            file: absolutePath,
-            config: { mimeType: explicitMimeType },
-          };
-
-          this.logger.debug(
-            `Attempting upload for ${mediaFile} with params: ${JSON.stringify(uploadParams)}`,
-          );
-          this.logger.debug(`MIME type being used: ${explicitMimeType}`);
-
-          const uploadResult: File = await client.files.upload(uploadParams);
-
-          this.logger.debug(
-            `Uploaded reflection file ${mediaFile}, URI: ${uploadResult.uri}, MimeType: ${uploadResult.mimeType}`,
-          );
-
-          const fileUri = uploadResult.uri;
-          const fileMimeType = uploadResult.mimeType;
-          if (!fileUri || !fileMimeType) {
-            this.logger.error(
-              `Upload result for file ${mediaFile} missing URI or MimeType. API might have failed inference. Skipping file.`,
-            );
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          roundParts.push(
-            createPartFromText(
-              `\nProcessing file: ${path.basename(mediaFile)}`,
-            ),
-          );
-          roundParts.push(createPartFromUri(fileUri, fileMimeType));
-          mediaFileResults.push({ path: mediaFile, ok: true });
-        } catch (error) {
-          this.logger.error(
-            `Failed to upload media file ${mediaFile} for follow-up round: ${getSdkErrorMessage(error)}`,
-            undefined,
-            undefined,
-            error,
-          );
-          mediaFileResults.push({ path: mediaFile, ok: false });
-        }
-      }
-
-      if (mediaFileResults.length > 0) {
-        if (mediaFileResults.some((r) => !r.ok)) {
-          this.logger.warn('Some media files failed to load');
-        }
-        this.logger.fileList(mediaFileResults);
+    if (mediaFiles && mediaFiles.length > 0 && this.supportsMediaUploads()) {
+      const formattedMedia = await this.createMediaMessage(mediaFiles);
+      if (formattedMedia.length > 0) {
+        const pluralSuffix = mediaFiles.length > 1 ? 's' : '';
+        const attachmentLabel = mediaFiles
+          .map((filePath) => path.basename(filePath))
+          .join(', ');
+        roundParts.push(
+          createPartFromText(
+            `\nProcessing file${pluralSuffix}: ${attachmentLabel}`,
+          ),
+        );
+        roundParts.push(...formattedMedia);
       }
     }
 
@@ -631,6 +560,16 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   createAssistantMessage(text: string): Content {
     // Note: Method name retained for interface compatibility, but returns 'model' role per Google SDK
     return { role: 'model', parts: [createPartFromText(text)] };
+  }
+
+  override async createMediaMessage(mediaFiles: string[]): Promise<Part[]> {
+    const mediaEntries = (await super.createMediaMessage(
+      mediaFiles,
+    )) as MediaEntry[];
+    if (!mediaEntries || mediaEntries.length === 0) {
+      return [];
+    }
+    return this.uploadMediaEntries(mediaEntries);
   }
 
   createMediaContent(mediaMessage: MediaEntry[]): MediaEntry[] {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -466,11 +466,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     ];
 
     // Add media if provided
-    if (
-      mediaFiles &&
-      (this.config.capabilities.supportsVision ||
-        this.config.capabilities.supportsNativeAudio)
-    ) {
+    if (this.canAttachFiles(mediaFiles)) {
       // createMediaMessage returns an array of objects formatted by createMediaContent
       const formattedMediaContent = await this.createMediaMessage(mediaFiles);
       userMessageContent.push(...formattedMediaContent);
@@ -541,12 +537,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     // system role does not support images/audio
     const role = 'user';
 
-    if (
-      mediaFiles &&
-      mediaFiles.length > 0 &&
-      (this.config.capabilities.supportsVision ||
-        this.config.capabilities.supportsNativeAudio)
-    ) {
+    if (this.canAttachFiles(mediaFiles)) {
       try {
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
         roundContent.push(...formattedMediaContent);
@@ -578,6 +569,16 @@ export class ModelHandlerOpenAI extends ModelHandler<
 
   createAssistantMessage(text: string): ChatCompletionMessageParam {
     return { role: 'assistant', content: [{ type: 'text', text }] };
+  }
+
+  private canAttachFiles(
+    mediaFiles?: string[],
+  ): mediaFiles is string[] {
+    return (
+      Array.isArray(mediaFiles) &&
+      mediaFiles.length > 0 &&
+      (this.capabilities.supportsVision || this.capabilities.supportsNativeAudio)
+    );
   }
 
   /** Formats image/audio content for OpenAI/Google's vision/audio API. */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -118,13 +118,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       } as ResponseInputItem);
     }
 
-    const supportsMedia =
-      this.capabilities.supportsVision || this.capabilities.supportsNativeAudio;
     const userContent: ResponseInputMessageContentList = [
       this.createInputText(userPrefix),
     ];
 
-    if (mediaFiles && mediaFiles.length > 0 && supportsMedia) {
+    if (this.canAttachFiles(mediaFiles)) {
       try {
         const mediaContent = (await this.createMediaMessage(
           mediaFiles,
@@ -175,12 +173,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   ): Promise<ResponseInputItem[]> {
     const roundContent: ResponseInputMessageContentList = [];
 
-    if (
-      mediaFiles &&
-      mediaFiles.length > 0 &&
-      (this.capabilities.supportsVision ||
-        this.capabilities.supportsNativeAudio)
-    ) {
+    if (this.canAttachFiles(mediaFiles)) {
       try {
         const formattedMediaContent = (await this.createMediaMessage(
           mediaFiles,
@@ -284,6 +277,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.logger.warn(`Unknown media category: ${media.media_category}`);
       return [];
     });
+  }
+
+  private canAttachFiles(
+    mediaFiles?: string[],
+  ): mediaFiles is string[] {
+    return (
+      Array.isArray(mediaFiles) &&
+      mediaFiles.length > 0 &&
+      (this.capabilities.supportsVision || this.capabilities.supportsNativeAudio)
+    );
   }
 
   private isInputFileContent(

--- a/src/agent/utils/mediaTypes.ts
+++ b/src/agent/utils/mediaTypes.ts
@@ -7,6 +7,8 @@ export interface MediaEntry {
   file_name: string;
   /** Base64 encoded media content */
   data: string;
+  /** Binary representation of the media payload when available */
+  binaryData?: Uint8Array;
   /** MIME type of the media */
   media_type: string;
   /** Category of the media, e.g. 'image' or 'audio' */

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -112,9 +112,11 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
     );
     handler.setLogger(createLoggerStub());
 
+    const binaryPayload = Buffer.from('%PDF-1.7');
     const entry: MediaEntry = {
       file_name: 'sample.pdf',
-      data: Buffer.from('%PDF-1.7').toString('base64'),
+      data: binaryPayload.toString('base64'),
+      binaryData: new Uint8Array(binaryPayload),
       media_type: 'application/pdf',
       media_category: 'image',
     };
@@ -129,6 +131,15 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
     );
     assert.equal(uploadParams.config?.mimeType, 'application/pdf');
     assert.equal(uploadParams.config?.displayName, 'sample.pdf');
+
+    const blobBuffer = Buffer.from(
+      await (uploadParams.file as Blob).arrayBuffer(),
+    );
+    assert.equal(
+      blobBuffer.equals(binaryPayload),
+      true,
+      'blob payload should match provided binary data',
+    );
 
     assert.deepEqual(parts, [
       createPartFromUri('files/test-file', 'application/pdf'),

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -1,0 +1,137 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import type { Part, UploadFileParameters } from '@google/genai';
+import { createPartFromUri } from '@google/genai';
+
+// Local imports - agent
+import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
+import { MediaEntry } from '@agent/utils/mediaTypes';
+import type { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - model config
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelCapabilities,
+  ModelConfig,
+  ModelProvider,
+} from '@model/ModelConfig';
+
+interface LoggerStub extends Partial<AgentLogger> {
+  channelId: string;
+  fileListEntries: Array<Array<{ path: string; ok: boolean }>>;
+}
+
+function createLoggerStub(): AgentLogger {
+  const stub: LoggerStub = {
+    channelId: 'test-channel',
+    fileListEntries: [],
+    debug: () => {
+      /* no-op for tests */
+    },
+    info: () => {
+      /* no-op for tests */
+    },
+    warn: () => {
+      /* no-op for tests */
+    },
+    error: () => {
+      /* no-op for tests */
+    },
+    fileList(entries: Array<{ path: string; ok: boolean }>) {
+      this.fileListEntries.push(entries);
+    },
+    getActiveGroupId: () => undefined,
+  };
+
+  return stub as unknown as AgentLogger;
+}
+
+function buildGoogleConfig(
+  overrides: Partial<ModelCapabilities> = {},
+): ModelConfig {
+  const capabilities: ModelCapabilities = {
+    ...DEFAULT_MODEL_CAPABILITIES,
+    supportsVision: true,
+    supportsNativePdf: true,
+    ...overrides,
+  };
+
+  return {
+    name: 'test-google',
+    fullName: 'test-google',
+    provider: ModelProvider.GOOGLE,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 100000,
+    capabilities,
+    openRouterOnly: false,
+  };
+}
+
+class GoogleHandlerTestDouble extends ModelHandlerGoogleGenAI {
+  constructor(
+    config: ModelConfig,
+    private readonly clientStub: any,
+  ) {
+    super(config);
+  }
+
+  override async getClient(): Promise<any> {
+    return this.clientStub;
+  }
+
+  async invokeUpload(entries: MediaEntry[]): Promise<Part[]> {
+    return this.uploadMediaEntries(entries);
+  }
+}
+
+describe('ModelHandlerGoogleGenAI media uploads', () => {
+  it('uploads MediaEntry instances via files.upload and returns URI parts', async () => {
+    const uploadCalls: UploadFileParameters[] = [];
+
+    const clientStub = {
+      files: {
+        upload: async (params: UploadFileParameters) => {
+          uploadCalls.push(params);
+          return {
+            name: 'files/test-file',
+            uri: 'files/test-file',
+            mimeType: params.config?.mimeType ?? 'application/pdf',
+            displayName: params.config?.displayName ?? 'test.pdf',
+          };
+        },
+      },
+    };
+
+    const handler = new GoogleHandlerTestDouble(
+      buildGoogleConfig(),
+      clientStub,
+    );
+    handler.setLogger(createLoggerStub());
+
+    const entry: MediaEntry = {
+      file_name: 'sample.pdf',
+      data: Buffer.from('%PDF-1.7').toString('base64'),
+      media_type: 'application/pdf',
+      media_category: 'image',
+    };
+
+    const parts = await handler.invokeUpload([entry]);
+
+    assert.equal(uploadCalls.length, 1, 'should invoke files.upload once');
+    const [uploadParams] = uploadCalls;
+    assert.ok(
+      uploadParams.file instanceof globalThis.Blob,
+      'file payload should be a Blob',
+    );
+    assert.equal(uploadParams.config?.mimeType, 'application/pdf');
+    assert.equal(uploadParams.config?.displayName, 'sample.pdf');
+
+    assert.deepEqual(parts, [
+      createPartFromUri('files/test-file', 'application/pdf'),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Google GenAI helper to upload shared MediaEntry payloads via files.upload and reuse it across message builders
- remove bespoke path-based upload loops in initializeMessages/createRoundMessages and override createMediaMessage to integrate the shared pipeline
- add a unit test that verifies MediaEntry uploads yield createPartFromUri parts

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68dd17dfa4688324a9eb8d6c0694fefc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Google GenAI media uploads via a shared MediaEntry pipeline with binary payloads, and unifies file-attach logic across handlers.
> 
> - **Google GenAI handler**:
>   - Introduces `supportsFileUploads`/`canAttachFiles` and centralizes uploads with `uploadMediaEntries` (Blob + `files.upload`), returning `createPartFromUri` parts.
>   - Replaces path-based upload loops in `initializeMessages`/`createRoundMessages` with `createMediaMessage`; adds concise attachment labels.
>   - Overrides `createMediaMessage` to upload processed `MediaEntry`s; removes bespoke MIME/path logic.
> - **Core media pipeline**:
>   - Extends `MediaEntry` with optional `binaryData` and populates it in `ModelHandler` for PDFs, multi-page images, and single parts (via `Buffer.from(base64)`).
> - **Other handlers**:
>   - Adds `canAttachFiles` gating in Anthropic, OpenAI (Chat), and OpenAI Responses handlers to consistently attach media only when supported.
> - **Tests**:
>   - Adds unit test verifying Google upload of `MediaEntry` yields URI parts (`createPartFromUri`) and correct metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8a6726d2c41df2639f964e46f3d8b5dc46d9334. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->