### PR TITLE
feat: move scratchpad artifacts into execution storage

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'path';
+
 // Local imports - agent components
 import type { AgentConfig } from './AgentConfig';
 import type { AgentSetting, AgentPrompt } from './AgentDataclass';
@@ -25,7 +28,7 @@ import replacementEngine from '@replacement/engine';
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
 
 // Local imports - filesystem utilities
-import { WorkspaceFS } from '@utils/files';
+import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { getRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import xmlUtils from '@utils/text/xmlUtils';
 
@@ -78,7 +81,10 @@ export async function runResponseCycle<C = unknown>(
       break;
     }
 
-    const exists = await WorkspaceFS.exists(outputFile);
+    const isAbsoluteOutput = path.isAbsolute(outputFile);
+    const exists = isAbsoluteOutput
+      ? await AbsoluteFS.exists(outputFile)
+      : await WorkspaceFS.exists(outputFile);
     const startTime = Date.now();
     const systemPrompt = await getSystemPromptWithRules(
       agentPrompt.systemPrompt,
@@ -230,13 +236,20 @@ export async function runResponseCycle<C = unknown>(
 
     if (!exists) {
       logger.debug(`Creating new file: ${outputFile}`, taskGroupId);
-      await WorkspaceFS.write(outputFile, processedResponse);
+      if (isAbsoluteOutput) {
+        await AbsoluteFS.write(outputFile, processedResponse);
+      } else {
+        await WorkspaceFS.write(outputFile, processedResponse);
+      }
     } else {
       logger.debug(`Appending to existing file: ${outputFile}`, taskGroupId);
-      await WorkspaceFS.appendFile(
-        outputFile,
-        bestConnector + processedResponse,
-      );
+      const appendContent = bestConnector + processedResponse;
+      if (isAbsoluteOutput) {
+        const existingContent = await AbsoluteFS.read(outputFile);
+        await AbsoluteFS.write(outputFile, existingContent + appendContent);
+      } else {
+        await WorkspaceFS.appendFile(outputFile, appendContent);
+      }
     }
 
     logger.debug('Response preview:', taskGroupId);

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -1,8 +1,12 @@
+// Standard library imports
+import * as path from 'path';
+
 // Local imports - agent
 // Local imports - agent components
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
+import { StorageFS, TASK_RUNS_DIR, isValidExecutionId } from '@utils/files';
 
 /**
  * Chain of Thought (CoT) agent implementation that extends BaseReflectionAgent.
@@ -19,7 +23,7 @@ export class CoTAgent extends BaseReflectionAgent {
     const fileExtension = this.useScratchpad
       ? 'xml'
       : this.agentSetting.outputExt;
-    return getOutputFileName(
+    const computedPath = getOutputFileName(
       baseOutputFile,
       this.agentConfig.agent,
       this.modelHandler.config.name,
@@ -27,6 +31,15 @@ export class CoTAgent extends BaseReflectionAgent {
       currRound,
       this.agentConfig.editedFile || undefined,
     );
+
+    if (this.useScratchpad && isValidExecutionId(this.executionId)) {
+      const xmlFileName = path.basename(computedPath);
+      return StorageFS.fullPath(
+        path.join(TASK_RUNS_DIR, this.executionId, xmlFileName),
+      );
+    }
+
+    return computedPath;
   }
 
   /**

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -16,7 +16,7 @@ import {
   getReplacementsByCategory,
 } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
-import { WorkspaceFS } from '@utils/files';
+import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 
 export class XmlOutputManager {
@@ -25,6 +25,32 @@ export class XmlOutputManager {
     private readonly agentConfig: AgentConfig,
     private readonly logger: AgentLogger,
   ) {}
+
+  private async readOutputFile(filePath: string): Promise<string> {
+    return path.isAbsolute(filePath)
+      ? await AbsoluteFS.read(filePath)
+      : await WorkspaceFS.read(filePath);
+  }
+
+  private async writeOutputFile(
+    filePath: string,
+    content: string,
+  ): Promise<void> {
+    if (path.isAbsolute(filePath)) {
+      await AbsoluteFS.write(filePath, content);
+    } else {
+      await WorkspaceFS.write(filePath, content);
+    }
+  }
+
+  private getWorkspaceTexPath(xmlFile: string): string {
+    const { name } = path.parse(xmlFile);
+    const inputDir = path.dirname(this.agentConfig.inputFile);
+    const texPath = path.join(inputDir, `${name}.tex`);
+    return path.isAbsolute(texPath)
+      ? WorkspaceFS.relativePath(texPath)
+      : texPath;
+  }
 
   async processXmlContent(content: string): Promise<string> {
     content = replacementEngine.applyNonRegex(content);
@@ -146,10 +172,9 @@ export class XmlOutputManager {
     documentTag: string,
     thinkingTag: string = 'scratchpad',
   ): Promise<string> {
-    const { dir, name } = path.parse(outputFile);
-    const texFile = path.join(dir, `${name}.tex`);
+    const texFile = this.getWorkspaceTexPath(outputFile);
 
-    let outputContent = await WorkspaceFS.read(outputFile);
+    let outputContent = await this.readOutputFile(outputFile);
     const tagsToWrap = [documentTag, thinkingTag];
     outputContent = xmlUtils.addCdataToTags(outputContent, tagsToWrap);
 
@@ -211,7 +236,7 @@ export class XmlOutputManager {
     documentTag: string,
     thinkingTag: string = 'scratchpad',
   ): Promise<NamedOutputFile[]> {
-    let outputContent = await WorkspaceFS.read(outputFile);
+    let outputContent = await this.readOutputFile(outputFile);
 
     const tagsToWrap = [thinkingTag, 'document'];
     outputContent = xmlUtils.addCdataToTagsMultiple(outputContent, tagsToWrap);
@@ -323,7 +348,7 @@ export class XmlOutputManager {
       this.agentSetting.documentTag,
     );
 
-    const xmlContent = await WorkspaceFS.read(outputFile);
+    const xmlContent = await this.readOutputFile(outputFile);
     let original = '';
     const nameMatch = xmlContent.match(/<document[^>]*name="(.*?)"[^>]*>/);
     if (nameMatch && nameMatch[1]) {
@@ -354,7 +379,7 @@ export class XmlOutputManager {
     documentTag: string,
   ): Promise<void> {
     this.logger.debug(`Ensuring correct XML structure: ${filePath}`);
-    let content = await WorkspaceFS.read(filePath);
+    let content = await this.readOutputFile(filePath);
 
     content = await this.processXmlContent(content);
 
@@ -371,6 +396,6 @@ export class XmlOutputManager {
         }
       }
     }
-    await WorkspaceFS.write(filePath, content);
+    await this.writeOutputFile(filePath, content);
   }
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -44,7 +44,8 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { agentConfigToTaskState } from '@utils/config';
-import { ensureRunDir } from '@utils/files/taskRunStorage';
+import { ensureRunDir, getRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
+import { AbsoluteFS, StorageFS, WorkspaceFS } from '@utils/files';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
 const CHANNEL = 'executeAgent';
@@ -201,6 +202,33 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
     if (executionId) {
       await ensureRunDir(executionId);
+      try {
+        const runDir = getRunDir(executionId);
+        const inputPath = agent.config.inputFile;
+        if (inputPath) {
+          const sourcePath = path.isAbsolute(inputPath)
+            ? inputPath
+            : WorkspaceFS.fullPath(inputPath);
+          const destinationPath = path.join(runDir, path.basename(inputPath));
+          await AbsoluteFS.copy(sourcePath, destinationPath, { overwrite: true });
+        }
+        const additionalInputs = agent.config.inputFiles || [];
+        for (const extra of additionalInputs) {
+          if (!extra) continue;
+          const sourcePath = path.isAbsolute(extra)
+            ? extra
+            : WorkspaceFS.fullPath(extra);
+          const destinationPath = path.join(runDir, path.basename(extra));
+          await AbsoluteFS.copy(sourcePath, destinationPath, { overwrite: true });
+        }
+        await StorageFS.ensureDir(path.join(TASK_RUNS_DIR, executionId, 'packed'));
+      } catch (error) {
+        logger.warn(
+          `Failed to snapshot inputs for execution ${executionId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
     }
 
     // Get the full stream tab ID

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import * as vscode from 'vscode';
 
@@ -28,6 +31,9 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
       if (result.outputFolder) {
         const openFolder = 'Open Folder';
         const outputFolder = result.outputFolder;
+        const folderPath = path.isAbsolute(outputFolder)
+          ? outputFolder
+          : WorkspaceFS.fullPath(outputFolder);
         vscode.window
           .showInformationMessage(
             `Files packed into ${outputFolder}`,
@@ -37,7 +43,7 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
             if (selection === openFolder) {
               void vscode.commands.executeCommand(
                 'revealFileInOS',
-                vscode.Uri.file(WorkspaceFS.fullPath(outputFolder)),
+                vscode.Uri.file(folderPath),
               );
             }
           });
@@ -106,6 +112,7 @@ async function handlePack(config: { streamId?: string; [key: string]: any }) {
     config.inputFile,
     config.agent,
     outputFiles,
+    config.executionId ? { executionId: config.executionId } : undefined,
   );
   showPackResult(result, config.inputFile);
 

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -11,7 +11,9 @@ import type { FileOpResult } from '@agent/types/ResultTypes';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { WorkspaceFS } from '@utils/files';
+import { AbsoluteFS, StorageFS, WorkspaceFS } from '@utils/files';
+import { isValidExecutionId, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - housekeeping
 import {
@@ -30,15 +32,93 @@ import { getConfig } from '@utils/config';
 const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
 
+interface PackOptions {
+  outputFolder?: string;
+  executionId?: ExecutionId;
+}
+
+async function resolveOutputFolder(
+  inputDir: string,
+  baseName: string,
+  agent: string,
+  model: string,
+  options?: PackOptions,
+): Promise<string> {
+  const timestamp = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
+
+  if (options?.outputFolder) {
+    return options.outputFolder;
+  }
+
+  if (options?.executionId && isValidExecutionId(options.executionId)) {
+    const relativeBase = path.join(
+      TASK_RUNS_DIR,
+      options.executionId,
+      'packed',
+    );
+    await StorageFS.ensureDir(relativeBase);
+    const relativeFolder = path.join(
+      relativeBase,
+      `${timestamp}_${baseName}_${agent}_${model}`,
+    );
+    return StorageFS.fullPath(relativeFolder);
+  }
+
+  const workspaceFolder = path.join(
+    inputDir,
+    HISTORY_DIR,
+    `${timestamp}_${baseName}_${agent}_${model}`,
+  );
+  return workspaceFolder;
+}
+
+async function ensureDirectory(folder: string): Promise<void> {
+  if (path.isAbsolute(folder)) {
+    await AbsoluteFS.ensureDir(folder);
+  } else {
+    await WorkspaceFS.ensureDir(folder);
+  }
+}
+
+function getDestinationPath(folder: string, file: string): string {
+  return path.join(folder, path.basename(file));
+}
+
+async function moveFile(
+  sourceRelative: string,
+  destinationFolder: string,
+): Promise<void> {
+  const destination = getDestinationPath(destinationFolder, sourceRelative);
+  if (path.isAbsolute(destinationFolder)) {
+    const sourceAbsolute = WorkspaceFS.fullPath(sourceRelative);
+    await AbsoluteFS.rename(sourceAbsolute, destination, { overwrite: true });
+  } else {
+    await WorkspaceFS.rename(sourceRelative, destination);
+  }
+}
+
+async function copyFile(
+  sourceRelative: string,
+  destinationFolder: string,
+): Promise<void> {
+  const destination = getDestinationPath(destinationFolder, sourceRelative);
+  if (path.isAbsolute(destinationFolder)) {
+    const sourceAbsolute = WorkspaceFS.fullPath(sourceRelative);
+    await AbsoluteFS.copy(sourceAbsolute, destination, { overwrite: true });
+  } else {
+    await WorkspaceFS.copy(sourceRelative, destination);
+  }
+}
+
 export async function runPackSingle(
   model: string,
   inputFile: string,
   agent: string,
-  outputFolder?: string,
+  options?: PackOptions,
 ): Promise<FileOpResult> {
   logger.info(
     CHANNEL,
-    `Starting packing with model=${model}, inputFile=${inputFile}, agent=${agent}, outputFolder=${outputFolder}`,
+    `Starting packing with model=${model}, inputFile=${inputFile}, agent=${agent}, outputFolder=${options?.outputFolder ?? 'auto'}`,
   );
 
   if (!inputFile || !model || !agent) {
@@ -103,33 +183,37 @@ export async function runPackSingle(
           : ''),
     );
 
-    const now = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
-    outputFolder =
-      outputFolder ||
-      path.join(inputDir, HISTORY_DIR, `${now}_${baseName}_${agent}_${model}`);
-    logger.debug(CHANNEL, `Output folder: ${outputFolder}`);
-
     try {
-      await WorkspaceFS.createDir(outputFolder);
-      logger.debug(CHANNEL, `Created output directory: ${outputFolder}`);
+      const destinationFolder = await resolveOutputFolder(
+        inputDir,
+        baseName,
+        agent,
+        model,
+        options,
+      );
+      logger.debug(CHANNEL, `Output folder: ${destinationFolder}`);
+      await ensureDirectory(destinationFolder);
+      logger.debug(
+        CHANNEL,
+        `Created output directory: ${destinationFolder}`,
+      );
 
-      // Move and copy files
       const operations: string[] = [];
       for (const file of movedFiles) {
-        const destination = path.join(outputFolder, path.basename(file));
+        const destination = getDestinationPath(destinationFolder, file);
         operations.push(`Moving: ${file} -> ${destination}`);
-        await WorkspaceFS.rename(file, destination);
+        await moveFile(file, destinationFolder);
       }
       for (const file of copiedFiles) {
-        const destination = path.join(outputFolder, path.basename(file));
+        const destination = getDestinationPath(destinationFolder, file);
         operations.push(`Copying: ${file} -> ${destination}`);
-        await WorkspaceFS.copy(file, destination);
+        await copyFile(file, destinationFolder);
       }
       if (operations.length > 0 && !onlyInputFilePacked) {
-        logger.info(CHANNEL, `Files packed into ${outputFolder}`);
+        logger.info(CHANNEL, `Files packed into ${destinationFolder}`);
         logger.debug(CHANNEL, `File operations:\n${operations.join('\n')}`);
       }
-      result = { status: 'success', outputFolder };
+      result = { status: 'success', outputFolder: destinationFolder };
     } catch (err) {
       logger.error(
         CHANNEL,
@@ -165,6 +249,7 @@ export async function runPackMultiple(
   inputFile: string,
   agent: string,
   inputFiles: string[],
+  options?: PackOptions,
 ): Promise<FileOpResult> {
   logger.debug(
     CHANNEL,
@@ -176,11 +261,12 @@ export async function runPackMultiple(
   const baseName = path.parse(fileToPack).name;
   const outputDir = path.dirname(fileToPack);
 
-  const now = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
-  const commonOutputFolder = path.join(
+  const commonOutputFolder = await resolveOutputFolder(
     outputDir,
-    HISTORY_DIR,
-    `${now}_${baseName}_multiple_${agent}_${model}`,
+    baseName,
+    `${agent}_multiple`,
+    model,
+    options,
   );
   logger.debug(CHANNEL, `Common output folder: ${commonOutputFolder}`);
 
@@ -192,7 +278,7 @@ export async function runPackMultiple(
       model,
       fileToPack,
       agent,
-      commonOutputFolder,
+      { ...options, outputFolder: commonOutputFolder },
     );
     if (singleResult.status === 'success') {
       anyFilesPacked = true;
@@ -205,7 +291,7 @@ export async function runPackMultiple(
           model,
           file,
           agent,
-          commonOutputFolder,
+          { ...options, outputFolder: commonOutputFolder },
         );
         if (additionalResult.status === 'success') {
           anyFilesPacked = true;
@@ -227,13 +313,10 @@ export async function runPackMultiple(
       const filePath = path.join(outputDir, pattern);
       if (await WorkspaceFS.exists(filePath)) {
         if (!anyFilesPacked) {
-          await WorkspaceFS.createDir(commonOutputFolder);
+          await ensureDirectory(commonOutputFolder);
         }
         logger.debug(CHANNEL, `Found additional XML file: ${filePath}`);
-        await WorkspaceFS.rename(
-          filePath,
-          path.join(commonOutputFolder, pattern),
-        );
+        await moveFile(filePath, commonOutputFolder);
         anyFilesPacked = true;
       }
     }
@@ -262,6 +345,7 @@ export async function runPack(
   inputFile: string,
   agent: string,
   outputFiles: string[] = [],
+  options?: PackOptions,
 ): Promise<FileOpResult> {
   logger.debug(
     CHANNEL,
@@ -279,8 +363,14 @@ export async function runPack(
 
   // Use multiple mode if there are output files
   if (outputFiles.length > 0) {
-    return await runPackMultiple(model, inputFile, agent, outputFiles);
+    return await runPackMultiple(
+      model,
+      inputFile,
+      agent,
+      outputFiles,
+      options,
+    );
   } else {
-    return await runPackSingle(model, inputFile, agent);
+    return await runPackSingle(model, inputFile, agent, options);
   }
 }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -15,12 +15,15 @@ import {
 import { isWorkflowTaskState, type WorkflowTaskState } from '@logger/TaskState';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - storage
+import { AbsoluteFS } from '@utils/files';
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
 // Local imports - commands
 import { safeExecuteCommand } from '@utils/system/commandUtils';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+// @ts-ignore - Import JavaScript module
+import { STATUS } from './modules/constants.js';
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   constructor(private readonly provider: ProgressViewProvider) {
@@ -153,7 +156,61 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
+    const stream = message.stream as StreamTabId | undefined;
+    if (!stream) {
+      return;
+    }
+
+    const status = this.provider.eventHandler.getStreamStatus(stream);
+    if (status === STATUS.RUNNING || status === STATUS.RESUMING) {
+      this.logger.warn(
+        this.channel,
+        `Run again requested while stream ${stream} is ${status}`,
+      );
+      await vscode.window.showInformationMessage(
+        'This task is still running. Please wait for it to finish before running again.',
+      );
+      return;
+    }
+
+    const executionId = this.provider.state.getExecutionId(stream);
+    if (executionId) {
+      try {
+        const runDir = getRunDir(executionId);
+        if (await AbsoluteFS.exists(runDir)) {
+          const entries = await AbsoluteFS.readDir(runDir);
+          const xmlFiles = entries.filter(
+            ([name, type]) =>
+              type === vscode.FileType.File && name.toLowerCase().endsWith('.xml'),
+          );
+          if (xmlFiles.length > 0) {
+            const runOption = 'Run Anyway';
+            const openOption = 'Open Run Folder';
+            const selection = await vscode.window.showWarningMessage(
+              'Previous runs saved XML diagnostics for this task. Review them before starting a new run?',
+              runOption,
+              openOption,
+            );
+            if (selection === openOption) {
+              await safeExecuteCommand('revealFileInOS', [vscode.Uri.file(runDir)]);
+              return;
+            }
+            if (selection !== runOption) {
+              return;
+            }
+          }
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          this.channel,
+          `Failed to inspect run storage for rerun prompt: ${errorMessage}`,
+        );
+      }
+    }
+
+    await this.withToolbarTaskState(stream, async (taskState) => {
       await vscode.commands.executeCommand(
         'texra.execute',
         taskState.agentConfig,
@@ -364,6 +421,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     taskState: WorkflowTaskState,
     command: 'texra.pack' | 'texra.clean',
   ): Promise<void> {
+    const executionId = this.provider.state.getExecutionId(stream as StreamTabId);
     const generated = this.provider.state.outputFiles.getFiles(stream);
     const allFiles = new Set<string>(taskState.agentConfig.outputFiles || []);
     if (generated) {
@@ -390,6 +448,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         output: useMultipleOutputs,
       },
       useMultipleOutputs,
+      executionId,
     });
   }
 


### PR DESCRIPTION
## Summary
- save CoT scratchpad XML directly in the execution storage tree and snapshot the original inputs
- teach the XML output manager to read from storage while continuing to emit TeX into the workspace
- reroute packing and rerun flows through execution storage, including prompts when stored XML is present

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68dcf71830908324ae5e67f2d9d518c0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Save CoT scratchpad XML and input snapshots in per-execution storage, add absolute-path FS support, and route packing/rerun UX through execution storage.
> 
> - **Storage and I/O**:
>   - `CoTAgent`: when using scratchpad, write XML to `TASK_RUNS_DIR/<executionId>/...` via `StorageFS`.
>   - `executeAgent`: snapshot `inputFile` and additional inputs into the run directory; ensure `packed` subfolder.
>   - `XmlOutputManager`: read/write XML using `AbsoluteFS` when paths are absolute; continue emitting TeX into the workspace; map storage XML to workspace TeX paths.
>   - `ResponseCycle`: detect absolute `outputFile` and use `AbsoluteFS` for exists/write/append operations.
> - **Packing**:
>   - `pack.ts`: add `PackOptions` with `executionId`; resolve output folder to `TASK_RUNS_DIR/<executionId>/packed/...` when provided; support absolute destinations (`AbsoluteFS`) with helper move/copy utilities; ensure directory creation.
>   - `packCommands`: pass `executionId` to `runPack`; correctly reveal absolute/relative output folders.
> - **Progress View UX**:
>   - Block "Run again" while stream is running/resuming; if prior XML exists in run storage, prompt to review or open run folder.
>   - Include `executionId` in pack/clean commands and add "Open Task Storage" action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee3fc66f07b3e076f4b9b03237c050108111a1e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->