### PR TITLE
Add toggle for between-round LaTeXdiff generation

### DIFF
--- a/docs/guide/latex-diff.md
+++ b/docs/guide/latex-diff.md
@@ -8,7 +8,7 @@ This guide explains how to use TeXRA's dedicated LaTeXdiff features for comparin
 
 ### Controlling Between-Round Diffs
 
-TeXRA compares each round of agent output to your original input and, by default, also creates diffs between consecutive rounds (`_diff_rN-rM.tex`). If you prefer to skip the between-round comparisons, set **TeXRA › LaTeXdiff › Generate Between Round Diffs** (`texra.latexdiff.generateBetweenRoundDiffs`) to `false` in VS Code's settings. When disabled, the run command and progress notifications only account for the original-vs-round comparisons, reducing the number of diff files created.
+TeXRA compares each round of agent output to your original input and can also create diffs between consecutive rounds (`_diff_rN-rM.tex`). Between-round diffs are disabled by default—enable them by setting **TeXRA › LaTeXdiff › Generate Between Round Diffs** (`texra.latexdiff.generateBetweenRoundDiffs`) to `true` in VS Code's settings. When left off, the run command and progress notifications only account for the original-vs-round comparisons, reducing the number of diff files created.
 
 ## Understanding LaTeX Diff
 

--- a/docs/guide/latex-diff.md
+++ b/docs/guide/latex-diff.md
@@ -6,6 +6,10 @@ TeXRA automatically generates diff files after agent runs that modify `.tex` fil
 
 This guide explains how to use TeXRA's dedicated LaTeXdiff features for comparing arbitrary file versions and understanding the results.
 
+### Controlling Between-Round Diffs
+
+TeXRA compares each round of agent output to your original input and, by default, also creates diffs between consecutive rounds (`_diff_rN-rM.tex`). If you prefer to skip the between-round comparisons, set **TeXRA › LaTeXdiff › Generate Between Round Diffs** (`texra.latexdiff.generateBetweenRoundDiffs`) to `false` in VS Code's settings. When disabled, the run command and progress notifications only account for the original-vs-round comparisons, reducing the number of diff files created.
+
 ## Understanding LaTeX Diff
 
 Unlike standard text diff tools (which can look like hieroglyphics when comparing LaTeX source), LaTeX diff understands LaTeX syntax and produces readable, compilable LaTeX documents with changes highlighted. This approach offers several advantages:

--- a/package.json
+++ b/package.json
@@ -651,6 +651,12 @@
             "default": "(?:picture|tikzpicture|scope|DIFnomarkup)[\\w\\d*@]*",
             "description": "Regular expression pattern for environments to be treated as pictures. These environments will be processed as a unit without internal differencing.",
             "order": 3
+          },
+          "texra.latexdiff.generateBetweenRoundDiffs": {
+            "type": "boolean",
+            "default": true,
+            "description": "Generate diffs between consecutive agent rounds in addition to comparing each round to the original input.",
+            "order": 4
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -654,7 +654,7 @@
           },
           "texra.latexdiff.generateBetweenRoundDiffs": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "Generate diffs between consecutive agent rounds in addition to comparing each round to the original input.",
             "order": 4
           }

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -8,6 +8,7 @@ import { compileLatex2Pdf } from '@latex/texTools';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { createFileMapping } from '@utils/files';
+import { getConfig } from '@utils/config';
 import { checkToolInstalled } from '@utils/system';
 import { objectToLogString } from '@utils/text/stringUtils';
 
@@ -56,6 +57,10 @@ export class LatexDiffManager {
     groupId?: string,
   ): Promise<void> {
     const diffProcessGroupId = groupId ?? this.logger.getActiveGroupId();
+    const generateBetweenRoundDiffs = getConfig<boolean>(
+      'latexdiff.generateBetweenRoundDiffs',
+      false,
+    );
     const aggregated: Array<{
       base: string;
       revised: string;
@@ -143,7 +148,7 @@ export class LatexDiffManager {
         }
       }
 
-      if (currRound > 0) {
+      if (generateBetweenRoundDiffs && currRound > 0) {
         this.logger.debug(
           'Running between-rounds latexdiff operations',
           diffProcessGroupId,
@@ -204,6 +209,11 @@ export class LatexDiffManager {
             );
           }
         }
+      } else if (!generateBetweenRoundDiffs) {
+        this.logger.debug(
+          'Skipping between-round latexdiff operations: disabled in settings',
+          diffProcessGroupId,
+        );
       }
 
       if (aggregated.length > 0) {

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -274,7 +274,7 @@ async function handleRunLatexdiff(config: any) {
 
     const generateBetweenRoundDiffs = getConfig<boolean>(
       'latexdiff.generateBetweenRoundDiffs',
-      true,
+      false,
     );
     logger.debug(
       CHANNEL,

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
+import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 
@@ -271,6 +272,15 @@ async function handleRunLatexdiff(config: any) {
       return;
     }
 
+    const generateBetweenRoundDiffs = getConfig<boolean>(
+      'latexdiff.generateBetweenRoundDiffs',
+      true,
+    );
+    logger.debug(
+      CHANNEL,
+      `Between-round diffs enabled: ${generateBetweenRoundDiffs}`,
+    );
+
     // Get the agent name chunk for filename matching
     const agentNameChunk = getAgentFirstNameChunk(agent);
     logger.debug(CHANNEL, `Using agent name chunk: ${agentNameChunk}`);
@@ -375,13 +385,13 @@ async function handleRunLatexdiff(config: any) {
         let completedOperations = 0;
 
         // Count operations for better progress reporting
-        for (const [input, roundOutputs] of inputToOutputsMap.entries()) {
+        for (const [, roundOutputs] of inputToOutputsMap.entries()) {
           // 1. Count round-based diffs (original vs output)
           totalOperations += roundOutputs.size;
 
           // 2. Count between-rounds diffs
           const rounds = Array.from(roundOutputs.keys()).sort((a, b) => a - b);
-          if (rounds.length > 1) {
+          if (generateBetweenRoundDiffs && rounds.length > 1) {
             totalOperations += rounds.length - 1;
           }
         }
@@ -445,7 +455,7 @@ async function handleRunLatexdiff(config: any) {
           }
 
           // 2. Perform between-rounds diffs if there are multiple rounds
-          if (rounds.length > 1) {
+          if (generateBetweenRoundDiffs && rounds.length > 1) {
             for (let i = 0; i < rounds.length - 1; i++) {
               const currentRound = rounds[i];
               const nextRound = rounds[i + 1];


### PR DESCRIPTION
## Summary
- add a `texra.latexdiff.generateBetweenRoundDiffs` setting so users can disable between-round comparisons
- honor the new setting in `handleRunLatexdiff` when computing total operations and generating diffs
- document how to opt out of between-round diffs in the LaTeX Diff guide

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dedab5c25c8324969e92d7ea5e1940

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new setting to toggle between-round LaTeXdiff generation, wiring it into diff execution, progress counting, logging, and docs.
> 
> - **Settings**:
>   - Add `texra.latexdiff.generateBetweenRoundDiffs` (default `false`) in `package.json`.
> - **Agent/Backend**:
>   - Gate between-round diffs in `src/agent/output/LatexDiffManager.ts` via `getConfig(...)`; log when skipped.
> - **Commands**:
>   - `src/commands/latex/latexdiffCommands.ts`: read setting, adjust total operation counts and execution of between-round diffs; add debug logging.
> - **Docs**:
>   - `docs/guide/latex-diff.md`: new “Controlling Between-Round Diffs” section explaining how to enable the feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6e7c0a52305e07d4a03c3278671395d5cd58a84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->