### PR TITLE
Fix: streamline Google media uploads

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1,6 +1,7 @@
 // Standard library imports
 import * as path from 'path';
 import { randomUUID } from 'crypto';
+import { Buffer } from 'buffer';
 
 // Third-party imports
 import { FinishReason } from '@google/genai';
@@ -68,6 +69,8 @@ interface MarkerFlags {
   endTurn: boolean;
   encounterDocumentTag: boolean;
 }
+
+type MediaFileResult = { path: string; ok: boolean };
 
 /**
  * Abstract base class for model-specific handlers that manage API interactions, message processing, and response handling.
@@ -565,15 +568,33 @@ export abstract class ModelHandler<
    * Individual providers can override if needed.
    */
   public async createMediaMessage(mediaFiles: string[]): Promise<any[]> {
+    const { entries, results } = await this.buildMediaEntries(mediaFiles);
+    this.logMediaResults(results);
+    return this.createMediaContent(entries);
+  }
+
+  protected logMediaResults(results: MediaFileResult[]): void {
+    if (results.length === 0) {
+      return;
+    }
+    if (results.some((result) => !result.ok)) {
+      this.logger.warn('Some media files failed to load');
+    }
+    this.logger.fileList(results);
+  }
+
+  protected async buildMediaEntries(
+    mediaFiles: string[],
+  ): Promise<{ entries: MediaEntry[]; results: MediaFileResult[] }> {
     const mediaMessage: MediaEntry[] = [];
-    const mediaFileResults: Array<{ path: string; ok: boolean }> = [];
+    const mediaFileResults: MediaFileResult[] = [];
 
     for (const mediaFile of mediaFiles) {
-      // Check if this is an absolute path (for pasted images in storage)
       const isAbsolutePath = path.isAbsolute(mediaFile);
-      const fileExistsResult = isAbsolutePath
-        ? await AbsoluteFS.exists(mediaFile)
-        : await WorkspaceFS.exists(mediaFile);
+      const absolutePath = isAbsolutePath
+        ? mediaFile
+        : WorkspaceFS.fullPath(mediaFile);
+      const fileExistsResult = await AbsoluteFS.exists(absolutePath);
 
       if (!fileExistsResult) {
         this.logger.error(`File not found: ${mediaFile}`);
@@ -583,9 +604,7 @@ export abstract class ModelHandler<
 
       let fileSize: number | null = null;
       try {
-        const stats = isAbsolutePath
-          ? await AbsoluteFS.stat(mediaFile)
-          : await WorkspaceFS.stat(mediaFile);
+        const stats = await AbsoluteFS.stat(absolutePath);
         fileSize = stats.size;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -613,20 +632,26 @@ export abstract class ModelHandler<
           `Processed ${mediaCategory}: ${mediaFile}, type: ${mediaType}`,
         );
 
-        // Special handling for OpenAI native PDF support
+        const createEntry = (fileName: string, data: string): MediaEntry => ({
+          file_name: fileName,
+          data,
+          media_type: mediaType,
+          media_category: mediaCategory,
+          binary_data: Buffer.from(data, 'base64'),
+          source_path: absolutePath,
+        });
+
         if (
           this.isOpenai &&
           this.capabilities.supportsVision &&
           this.capabilities.supportsNativePdf &&
           mediaType === 'application/pdf'
         ) {
-          const imageEntry: MediaEntry = {
-            file_name: path.basename(mediaFile),
-            data: Array.isArray(mediaData) ? mediaData[0] : mediaData,
-            media_type: mediaType,
-            media_category: mediaCategory,
-          };
-          mediaMessage.push(imageEntry);
+          const pdfEntry = createEntry(
+            path.basename(mediaFile),
+            Array.isArray(mediaData) ? mediaData[0] : mediaData,
+          );
+          mediaMessage.push(pdfEntry);
           mediaFileResults.push({ path: mediaFile, ok: true });
           this.logger.debug(`Added native PDF: ${mediaFile}`);
           continue;
@@ -637,26 +662,15 @@ export abstract class ModelHandler<
             `Adding ${mediaData.length} pages/parts to the media contents`,
           );
           for (let i = 0; i < mediaData.length; i++) {
-            const mediaEntry: MediaEntry = {
-              file_name: `${path.basename(mediaFile)}_page_${i + 1}`,
-              data: mediaData[i],
-              media_type: mediaType,
-              media_category: mediaCategory,
-            };
-            mediaMessage.push(mediaEntry);
+            const fileName = `${path.basename(mediaFile)}_page_${i + 1}`;
+            mediaMessage.push(createEntry(fileName, mediaData[i]));
           }
           mediaFileResults.push({ path: mediaFile, ok: true });
         } else {
           this.logger.debug(
             `Adding single part to the media contents: ${mediaFile}`,
           );
-          const mediaEntry: MediaEntry = {
-            file_name: path.basename(mediaFile),
-            data: mediaData,
-            media_type: mediaType,
-            media_category: mediaCategory,
-          };
-          mediaMessage.push(mediaEntry);
+          mediaMessage.push(createEntry(path.basename(mediaFile), mediaData));
           mediaFileResults.push({ path: mediaFile, ok: true });
         }
       } catch (err) {
@@ -667,18 +681,10 @@ export abstract class ModelHandler<
           err,
         );
         mediaFileResults.push({ path: mediaFile, ok: false });
-        continue;
       }
     }
 
-    if (mediaFileResults.length > 0) {
-      if (mediaFileResults.some((r) => !r.ok)) {
-        this.logger.warn('Some media files failed to load');
-      }
-      this.logger.fileList(mediaFileResults);
-    }
-
-    return this.createMediaContent(mediaMessage);
+    return { entries: mediaMessage, results: mediaFileResults };
   }
 
   /** Calculates token-based stop flags. */

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1,5 +1,6 @@
 // Standard library imports
 import * as path from 'path';
+import { Buffer } from 'buffer';
 
 // Third-party imports
 import {
@@ -52,7 +53,7 @@ import replacementEngine from '@replacement/engine';
 import { K_SLICE } from '@utils/config';
 
 // Local imports - utilities
-import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 
 type GoogleRole = 'user' | 'model';
@@ -160,6 +161,120 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   GoogleGenAI
 > {
   private googleClient: GoogleGenAI | null = null;
+
+  private supportsFileUploads(): boolean {
+    return (
+      this.config.capabilities.supportsVision ||
+      this.config.capabilities.supportsNativeAudio
+    );
+  }
+
+  protected async uploadMediaEntries(entries: MediaEntry[]): Promise<Part[]> {
+    if (entries.length === 0) {
+      return [];
+    }
+
+    const client = await this.getClient();
+    const uploadedParts: Part[] = [];
+    const uploadSummaries: Array<{ path: string; ok: boolean }> = [];
+
+    for (const entry of entries) {
+      const fileName = entry.file_name || 'unnamed-file';
+      const mimeType = entry.media_type || 'application/octet-stream';
+      const uploadSource = this.getUploadSource(entry, mimeType);
+
+      if (!uploadSource) {
+        this.logger.error(
+          `Skipping media entry ${fileName} due to missing data or mime type`,
+        );
+        uploadSummaries.push({ path: fileName, ok: false });
+        continue;
+      }
+
+      try {
+        const uploadParams: UploadFileParameters = {
+          file: uploadSource,
+          config: {
+            mimeType,
+            displayName: fileName,
+          },
+        };
+
+        const uploadDescription =
+          typeof uploadSource === 'string'
+            ? `path ${uploadSource}`
+            : `in-memory payload (${mimeType})`;
+        this.logger.debug(
+          `Uploading media entry ${fileName} via Google GenAI SDK using ${uploadDescription}`,
+        );
+
+        const uploadResult: File = await client.files.upload(uploadParams);
+        const fileUri = uploadResult.uri;
+
+        if (!fileUri) {
+          this.logger.error(
+            `Upload result for ${fileName} is missing a URI. Skipping entry.`,
+          );
+          uploadSummaries.push({ path: fileName, ok: false });
+          continue;
+        }
+
+        const resolvedMimeType = this.resolveUploadMimeType(
+          entry,
+          uploadResult,
+        );
+        uploadedParts.push(createPartFromUri(fileUri, resolvedMimeType));
+        uploadSummaries.push({ path: fileName, ok: true });
+      } catch (error) {
+        this.logger.error(
+          `Failed to upload media entry ${fileName}: ${getSdkErrorMessage(error)}`,
+          undefined,
+          undefined,
+          error,
+        );
+        uploadSummaries.push({ path: fileName, ok: false });
+      }
+    }
+
+    this.logMediaResults(uploadSummaries);
+    return uploadedParts;
+  }
+
+  private getUploadSource(
+    entry: MediaEntry,
+    mimeType: string,
+  ): string | globalThis.Blob | null {
+    if (entry.source_path && entry.source_path.length > 0) {
+      return entry.source_path;
+    }
+    if (entry.binary_data && entry.binary_data.length > 0) {
+      return new globalThis.Blob([entry.binary_data], { type: mimeType });
+    }
+    if (entry.data) {
+      try {
+        const buffer = Buffer.from(entry.data, 'base64');
+        return new globalThis.Blob([buffer], { type: mimeType });
+      } catch (error) {
+        this.logger.error(
+          `Failed to decode base64 media for ${entry.file_name}: ${getSdkErrorMessage(error)}`,
+          undefined,
+          undefined,
+          error,
+        );
+      }
+    }
+    return null;
+  }
+
+  private resolveUploadMimeType(entry: MediaEntry, uploaded: File): string {
+    if (uploaded.mimeType && uploaded.mimeType.length > 0) {
+      return uploaded.mimeType;
+    }
+    if (entry.media_type && entry.media_type.length > 0) {
+      return entry.media_type;
+    }
+    return 'application/octet-stream';
+  }
   async getClient(): Promise<GoogleGenAI> {
     if (!this.googleClient) {
       const apiKey = await this.getApiKey();
@@ -414,85 +529,21 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     mediaFiles?: string[],
     _systemPrompt?: string,
   ): Promise<Content[]> {
-    const client = await this.getClient();
     const userContentParts: Part[] = [createPartFromText(userPrefix)];
 
-    if (
-      mediaFiles &&
-      mediaFiles.length > 0 &&
-      (this.config.capabilities.supportsVision ||
-        this.config.capabilities.supportsNativeAudio)
-    ) {
-      this.logger.debug(
-        `Uploading ${mediaFiles.length} media files via native SDK...`,
-      );
-      const mediaFileResults: Array<{ path: string; ok: boolean }> = [];
-
-      for (const mediaFile of mediaFiles) {
-        try {
-          const absolutePath = WorkspaceFS.fullPath(mediaFile);
-          if (!(await AbsoluteFS.exists(absolutePath))) {
-            this.logger.error(`File does not exist: ${absolutePath}`);
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          const explicitMimeType = this.determineMimeType(absolutePath);
-
-          if (!explicitMimeType) {
-            this.logger.error(
-              `Cannot determine mime type for ${mediaFile}. Skipping file.`,
-            );
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          const uploadParams: UploadFileParameters = {
-            file: absolutePath,
-            config: { mimeType: explicitMimeType },
-          };
-
-          this.logger.debug(
-            `Attempting upload for ${mediaFile} with params: ${JSON.stringify(uploadParams)}`,
-          );
-
-          const uploadResult: File = await client.files.upload(uploadParams);
-
-          this.logger.debug(
-            `Uploaded ${mediaFile}, URI: ${uploadResult.uri}, MimeType: ${uploadResult.mimeType}`,
-          );
-
-          const fileUri = uploadResult.uri;
-          const fileMimeType = uploadResult.mimeType;
-          if (!fileUri || !fileMimeType) {
-            this.logger.error(
-              `Upload result for file ${mediaFile} missing URI or MimeType. API might have failed inference. Skipping file.`,
-            );
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          userContentParts.push(
-            createPartFromText(`\nFile attached: ${path.basename(mediaFile)}`),
-          );
-          userContentParts.push(createPartFromUri(fileUri, fileMimeType));
-          mediaFileResults.push({ path: mediaFile, ok: true });
-        } catch (error) {
-          this.logger.error(
-            `Failed to upload media file ${mediaFile} via native SDK: ${getSdkErrorMessage(error)}`,
-            undefined,
-            undefined,
-            error,
-          );
-          mediaFileResults.push({ path: mediaFile, ok: false });
-        }
-      }
-
-      if (mediaFileResults.length > 0) {
-        if (mediaFileResults.some((r) => !r.ok)) {
-          this.logger.warn('Some media files failed to load');
-        }
-        this.logger.fileList(mediaFileResults);
+    if (mediaFiles && mediaFiles.length > 0 && this.supportsFileUploads()) {
+      const formattedMedia = await this.createMediaMessage(mediaFiles);
+      if (formattedMedia.length > 0) {
+        const pluralSuffix = mediaFiles.length > 1 ? 's' : '';
+        const attachmentLabel = mediaFiles
+          .map((filePath) => path.basename(filePath))
+          .join(', ');
+        userContentParts.push(
+          createPartFromText(
+            `\nAttached file${pluralSuffix}: ${attachmentLabel}`,
+          ),
+        );
+        userContentParts.push(...formattedMedia);
       }
     }
 
@@ -501,113 +552,27 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return [{ role: 'user', parts: userContentParts }];
   }
 
-  private determineMimeType(filePath: string): string | null {
-    const ext = path.extname(filePath).toLowerCase();
-    this.logger.debug(
-      `Determining MIME type for extension: '${ext}' from file: ${filePath}`,
-    );
-
-    const mimeType = getMimeType(filePath);
-    if (!mimeType) {
-      this.logger.warn(
-        `Cannot determine mime type for ${filePath} from extension '${ext}'.`,
-      );
-    } else {
-      this.logger.debug(
-        `Determined MIME type: ${mimeType} for file: ${filePath}`,
-      );
-    }
-    return mimeType;
-  }
-
   /** Creates message array for subsequent rounds, managing image content and message structure. */
   async createRoundMessages(
     messages: Content[],
     userMessage: string,
     mediaFiles?: string[],
   ): Promise<Content[]> {
-    const client = await this.getClient();
     const roundParts: Part[] = [];
 
-    if (
-      mediaFiles &&
-      mediaFiles.length > 0 &&
-      (this.config.capabilities.supportsVision ||
-        this.config.capabilities.supportsNativeAudio)
-    ) {
-      this.logger.debug(
-        `Uploading ${mediaFiles.length} media files for reflection via native SDK...`,
-      );
-      const mediaFileResults: Array<{ path: string; ok: boolean }> = [];
-
-      for (const mediaFile of mediaFiles) {
-        try {
-          const absolutePath = WorkspaceFS.fullPath(mediaFile);
-          if (!(await AbsoluteFS.exists(absolutePath))) {
-            this.logger.error(`File does not exist: ${absolutePath}`);
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          const explicitMimeType = this.determineMimeType(absolutePath);
-
-          if (!explicitMimeType) {
-            this.logger.error(
-              `Cannot determine mime type for file ${mediaFile}. Skipping file.`,
-            );
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          const uploadParams: UploadFileParameters = {
-            file: absolutePath,
-            config: { mimeType: explicitMimeType },
-          };
-
-          this.logger.debug(
-            `Attempting upload for ${mediaFile} with params: ${JSON.stringify(uploadParams)}`,
-          );
-          this.logger.debug(`MIME type being used: ${explicitMimeType}`);
-
-          const uploadResult: File = await client.files.upload(uploadParams);
-
-          this.logger.debug(
-            `Uploaded reflection file ${mediaFile}, URI: ${uploadResult.uri}, MimeType: ${uploadResult.mimeType}`,
-          );
-
-          const fileUri = uploadResult.uri;
-          const fileMimeType = uploadResult.mimeType;
-          if (!fileUri || !fileMimeType) {
-            this.logger.error(
-              `Upload result for file ${mediaFile} missing URI or MimeType. API might have failed inference. Skipping file.`,
-            );
-            mediaFileResults.push({ path: mediaFile, ok: false });
-            continue;
-          }
-
-          roundParts.push(
-            createPartFromText(
-              `\nProcessing file: ${path.basename(mediaFile)}`,
-            ),
-          );
-          roundParts.push(createPartFromUri(fileUri, fileMimeType));
-          mediaFileResults.push({ path: mediaFile, ok: true });
-        } catch (error) {
-          this.logger.error(
-            `Failed to upload media file ${mediaFile} for follow-up round: ${getSdkErrorMessage(error)}`,
-            undefined,
-            undefined,
-            error,
-          );
-          mediaFileResults.push({ path: mediaFile, ok: false });
-        }
-      }
-
-      if (mediaFileResults.length > 0) {
-        if (mediaFileResults.some((r) => !r.ok)) {
-          this.logger.warn('Some media files failed to load');
-        }
-        this.logger.fileList(mediaFileResults);
+    if (mediaFiles && mediaFiles.length > 0 && this.supportsFileUploads()) {
+      const formattedMedia = await this.createMediaMessage(mediaFiles);
+      if (formattedMedia.length > 0) {
+        const pluralSuffix = mediaFiles.length > 1 ? 's' : '';
+        const attachmentLabel = mediaFiles
+          .map((filePath) => path.basename(filePath))
+          .join(', ');
+        roundParts.push(
+          createPartFromText(
+            `\nProcessing file${pluralSuffix}: ${attachmentLabel}`,
+          ),
+        );
+        roundParts.push(...formattedMedia);
       }
     }
 
@@ -631,6 +596,21 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   createAssistantMessage(text: string): Content {
     // Note: Method name retained for interface compatibility, but returns 'model' role per Google SDK
     return { role: 'model', parts: [createPartFromText(text)] };
+  }
+
+  override async createMediaMessage(mediaFiles: string[]): Promise<Part[]> {
+    if (!mediaFiles || mediaFiles.length === 0 || !this.supportsFileUploads()) {
+      return [];
+    }
+
+    const { entries, results } = await this.buildMediaEntries(mediaFiles);
+    this.logMediaResults(results);
+
+    if (entries.length === 0) {
+      return [];
+    }
+
+    return this.uploadMediaEntries(entries);
   }
 
   createMediaContent(mediaMessage: MediaEntry[]): MediaEntry[] {

--- a/src/agent/utils/mediaTypes.ts
+++ b/src/agent/utils/mediaTypes.ts
@@ -2,6 +2,8 @@
  * Structured representation of media data used when constructing
  * multi-modal messages before provider-specific formatting.
  */
+import type { Buffer } from 'buffer';
+
 export interface MediaEntry {
   /** File name for reference, typically without directory */
   file_name: string;
@@ -11,4 +13,8 @@ export interface MediaEntry {
   media_type: string;
   /** Category of the media, e.g. 'image' or 'audio' */
   media_category: string;
+  /** Optional binary payload for providers that accept raw bytes */
+  binary_data?: Buffer;
+  /** Absolute path to the original file when available */
+  source_path?: string;
 }

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -1,0 +1,278 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import type { File, Part, UploadFileParameters } from '@google/genai';
+import { createPartFromUri } from '@google/genai';
+
+// Local imports - agent
+import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
+import { MediaEntry } from '@agent/utils/mediaTypes';
+import type { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - model config
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelCapabilities,
+  ModelConfig,
+  ModelProvider,
+} from '@model/ModelConfig';
+
+interface LoggerStub extends Partial<AgentLogger> {
+  channelId: string;
+  fileListEntries: Array<Array<{ path: string; ok: boolean }>>;
+}
+
+function createLoggerStub(): { logger: AgentLogger; stub: LoggerStub } {
+  const stub: LoggerStub = {
+    channelId: 'test-channel',
+    fileListEntries: [],
+    debug: () => {
+      /* no-op for tests */
+    },
+    info: () => {
+      /* no-op for tests */
+    },
+    warn: () => {
+      /* no-op for tests */
+    },
+    error: () => {
+      /* no-op for tests */
+    },
+    fileList(entries: Array<{ path: string; ok: boolean }>) {
+      this.fileListEntries.push(entries);
+    },
+    getActiveGroupId: () => undefined,
+  };
+
+  return { logger: stub as unknown as AgentLogger, stub };
+}
+
+function buildGoogleConfig(
+  overrides: Partial<ModelCapabilities> = {},
+): ModelConfig {
+  const capabilities: ModelCapabilities = {
+    ...DEFAULT_MODEL_CAPABILITIES,
+    supportsVision: true,
+    supportsNativePdf: true,
+    ...overrides,
+  };
+
+  return {
+    name: 'test-google',
+    fullName: 'test-google',
+    provider: ModelProvider.GOOGLE,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 100000,
+    capabilities,
+    openRouterOnly: false,
+  };
+}
+
+class GoogleHandlerTestDouble extends ModelHandlerGoogleGenAI {
+  constructor(
+    config: ModelConfig,
+    private readonly clientStub: any,
+  ) {
+    super(config);
+  }
+
+  override async getClient(): Promise<any> {
+    return this.clientStub;
+  }
+
+  async invokeUpload(entries: MediaEntry[]): Promise<Part[]> {
+    return this.uploadMediaEntries(entries);
+  }
+}
+
+describe('ModelHandlerGoogleGenAI media uploads', () => {
+  it('uploads MediaEntry instances via files.upload using file paths when available', async () => {
+    const uploadCalls: UploadFileParameters[] = [];
+
+    const clientStub = {
+      files: {
+        upload: async (params: UploadFileParameters) => {
+          uploadCalls.push(params);
+          return {
+            name: 'files/test-file',
+            uri: 'files/test-file',
+            mimeType: params.config?.mimeType ?? 'application/pdf',
+            displayName: params.config?.displayName ?? 'test.pdf',
+          };
+        },
+      },
+    };
+
+    const handler = new GoogleHandlerTestDouble(
+      buildGoogleConfig(),
+      clientStub,
+    );
+    const { logger } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const entry: MediaEntry = {
+      file_name: 'sample.pdf',
+      data: Buffer.from('%PDF-1.7').toString('base64'),
+      media_type: 'application/pdf',
+      media_category: 'image',
+      source_path: '/tmp/sample.pdf',
+    };
+
+    const parts = await handler.invokeUpload([entry]);
+
+    assert.equal(uploadCalls.length, 1, 'should invoke files.upload once');
+    const [uploadParams] = uploadCalls;
+    assert.equal(
+      uploadParams.file,
+      '/tmp/sample.pdf',
+      'file payload should reference the source path',
+    );
+    assert.equal(uploadParams.config?.mimeType, 'application/pdf');
+    assert.equal(uploadParams.config?.displayName, 'sample.pdf');
+
+    assert.deepEqual(parts, [
+      createPartFromUri('files/test-file', 'application/pdf'),
+    ]);
+  });
+
+  it('prefers binary payloads when provided on media entries', async () => {
+    let uploadInvocationCount = 0;
+    const clientStub = {
+      files: {
+        upload: async (params: UploadFileParameters) => {
+          uploadInvocationCount += 1;
+          return {
+            name: 'files/audio',
+            uri: 'files/audio',
+            mimeType: params.config?.mimeType ?? 'audio/wav',
+            displayName: params.config?.displayName ?? 'audio.wav',
+          } satisfies Partial<File> as File;
+        },
+      },
+    };
+
+    const handler = new GoogleHandlerTestDouble(
+      buildGoogleConfig({ supportsNativeAudio: true }),
+      clientStub,
+    );
+    const { logger } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const binaryPayload = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+    const entry: MediaEntry = {
+      file_name: 'audio.wav',
+      data: 'not-valid-base64',
+      media_type: 'audio/wav',
+      media_category: 'audio',
+      binary_data: binaryPayload,
+    };
+
+    const parts = await handler.invokeUpload([entry]);
+
+    assert.equal(uploadInvocationCount, 1, 'should still upload once');
+    assert.deepEqual(parts, [createPartFromUri('files/audio', 'audio/wav')]);
+  });
+
+  it('falls back to Blob payloads when media entries only contain encoded data', async () => {
+    const uploadCalls: UploadFileParameters[] = [];
+
+    const clientStub = {
+      files: {
+        upload: async (params: UploadFileParameters) => {
+          uploadCalls.push(params);
+          return {
+            name: 'files/base64',
+            uri: 'files/base64',
+            mimeType: params.config?.mimeType ?? 'application/pdf',
+            displayName: params.config?.displayName ?? 'fallback.pdf',
+          } satisfies Partial<File> as File;
+        },
+      },
+    };
+
+    const handler = new GoogleHandlerTestDouble(
+      buildGoogleConfig(),
+      clientStub,
+    );
+    const { logger } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const entry: MediaEntry = {
+      file_name: 'no-path.pdf',
+      data: Buffer.from('%PDF-1.5').toString('base64'),
+      media_type: 'application/pdf',
+      media_category: 'image',
+    };
+
+    const parts = await handler.invokeUpload([entry]);
+
+    assert.equal(uploadCalls.length, 1, 'should invoke files.upload once');
+    const [uploadParams] = uploadCalls;
+    assert.ok(
+      uploadParams.file instanceof globalThis.Blob,
+      'file payload should be a Blob when no file path is provided',
+    );
+
+    assert.deepEqual(parts, [
+      createPartFromUri('files/base64', 'application/pdf'),
+    ]);
+  });
+
+  it('builds media entries once and delegates upload inside createMediaMessage', async () => {
+    const uploadedEntries: MediaEntry[][] = [];
+    const buildCalls: string[][] = [];
+
+    class RecordingHandler extends ModelHandlerGoogleGenAI {
+      constructor(config: ModelConfig) {
+        super(config);
+      }
+
+      override async getClient(): Promise<any> {
+        throw new Error('getClient should not be called in this test');
+      }
+
+      override async buildMediaEntries(mediaFiles: string[]): Promise<{
+        entries: MediaEntry[];
+        results: Array<{ path: string; ok: boolean }>;
+      }> {
+        buildCalls.push(mediaFiles);
+        return {
+          entries: [
+            {
+              file_name: 'doc.pdf',
+              data: Buffer.from('%PDF-1.4').toString('base64'),
+              media_type: 'application/pdf',
+              media_category: 'image',
+              binary_data: Buffer.from('%PDF-1.4'),
+            },
+          ],
+          results: [{ path: 'doc.pdf', ok: true }],
+        };
+      }
+
+      override async uploadMediaEntries(
+        entries: MediaEntry[],
+      ): Promise<Part[]> {
+        uploadedEntries.push(entries);
+        return [createPartFromUri('files/doc', 'application/pdf')];
+      }
+    }
+
+    const handler = new RecordingHandler(buildGoogleConfig());
+    const { logger, stub } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const parts = await handler.createMediaMessage(['doc.pdf']);
+
+    assert.deepEqual(parts, [
+      createPartFromUri('files/doc', 'application/pdf'),
+    ]);
+    assert.deepEqual(buildCalls, [['doc.pdf']]);
+    assert.equal(uploadedEntries.length, 1, 'uploads should run once');
+    assert.equal(uploadedEntries[0][0].file_name, 'doc.pdf');
+    assert.equal(stub.fileListEntries.length, 1, 'should log processed media');
+  });
+});


### PR DESCRIPTION
## Summary
- extend the shared media entry structure and ModelHandler helpers to preserve binary payloads and centralize logging
- update the Google GenAI handler to reuse the shared media pipeline, prefer binary data, clarify its file upload capability check, and prefer direct file path uploads when available to avoid redundant conversions
- expand the Google handler tests to cover binary payload handling, createMediaMessage delegation, and file path plus base64 fallbacks

## Testing
- npm run format
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68dd17dfa4688324a9eb8d6c0694fefc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes media entry building and logging, adds binary/path payload support, and updates Google GenAI handler to upload using shared entries with new tests.
> 
> - **Media pipeline (shared)**:
>   - Refactor `createMediaMessage` into `buildMediaEntries`, `logMediaResults`, and `createMediaContent` in `src/agent/modelHandlers/ModelHandler.ts`.
>   - Use absolute paths via `WorkspaceFS.fullPath` + `AbsoluteFS` for existence/stat checks; include `source_path` and `binary_data` (decoded via `Buffer`) in `MediaEntry`.
>   - Add concise result logging via `logMediaResults` and `fileList`.
> - **Google GenAI handler**:
>   - Reuse shared media pipeline and override `createMediaMessage` to upload entries (`uploadMediaEntries`) using `client.files.upload`.
>   - Prefer direct file paths (`source_path`), then `binary_data`, then base64-to-Blob; resolve MIME type with `resolveUploadMimeType`.
>   - Simplify `initializeMessages`/`createRoundMessages` to attach uploaded parts; add `supportsFileUploads` helper.
> - **Types**:
>   - Extend `MediaEntry` (`src/agent/utils/mediaTypes.ts`) with optional `binary_data` and `source_path`.
> - **Tests**:
>   - Add `ModelHandlerGoogleGenAI.test.ts` covering file-path uploads, binary payload preference, base64 Blob fallback, and `createMediaMessage` delegation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba281b3255ef26b689a40c40418cdffb3117face. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->