### PR TITLE
chore: upgrade zod to v4 and use native JSON schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,7 @@
         "turndown-plugin-gfm": "^1.0.2",
         "winston": "^3.18.3",
         "yaml": "^2.8.1",
-        "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.24.6"
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^5.3.1",
@@ -771,6 +770,24 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7916,21 +7933,12 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1362,7 +1362,6 @@
     "turndown-plugin-gfm": "^1.0.2",
     "winston": "^3.18.3",
     "yaml": "^2.8.1",
-    "zod": "^3.25.76",
-    "zod-to-json-schema": "^3.24.6"
+    "zod": "^4.1.11"
   }
 }

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -21,33 +21,31 @@ export const validateOutputFiles = (cfg: Record<string, any>): boolean => {
 /** Zod schema for validating AgentConfig objects */
 export const AgentConfigSchema = z
   .object({
-    model: z.string().default('gemini25p'),
-    agent: z.string().default('correct'),
-    instruction: z.string().default(''),
-    useMultipleOutputs: z.boolean().default(false),
+    model: z.string().prefault('gemini25p'),
+    agent: z.string().prefault('correct'),
+    instruction: z.string().prefault(''),
+    useMultipleOutputs: z.boolean().prefault(false),
 
-    agentType: z.nativeEnum(AgentType).optional(),
-    agentSessionKind: z.nativeEnum(AgentSessionKind).optional(),
+    agentType: z.enum(AgentType).optional(),
+    agentSessionKind: z.enum(AgentSessionKind).optional(),
 
-    inputFile: z.string().default(''),
-    inputFiles: z.array(z.string()).nullable().default(null),
-    referenceFile: z.string().nullable().default(null),
-    referenceFiles: z.array(z.string()).nullable().default(null),
-    auxiliaryFile: z.string().nullable().default(null),
-    auxiliaryFiles: z.array(z.string()).nullable().default(null),
-    mediaFile: z.string().nullable().default(null),
-    mediaFiles: z.array(z.string()).nullable().default(null),
-    outputFiles: z.array(z.string()).nullable().default(null),
-    editedFile: z.string().nullable().default(null),
+    inputFile: z.string().prefault(''),
+    inputFiles: z.array(z.string()).nullable().prefault(null),
+    referenceFile: z.string().nullable().prefault(null),
+    referenceFiles: z.array(z.string()).nullable().prefault(null),
+    auxiliaryFile: z.string().nullable().prefault(null),
+    auxiliaryFiles: z.array(z.string()).nullable().prefault(null),
+    mediaFile: z.string().nullable().prefault(null),
+    mediaFiles: z.array(z.string()).nullable().prefault(null),
+    outputFiles: z.array(z.string()).nullable().prefault(null),
+    editedFile: z.string().nullable().prefault(null),
 
-    toolConfig: ToolConfigSchema.default(DEFAULT_TOOL_CONFIG),
+    toolConfig: ToolConfigSchema.prefault(DEFAULT_TOOL_CONFIG),
   })
-  // Strip unknown keys to tolerate stale settings from previous releases.
-  .strip()
   .refine(validateOutputFiles, {
-    message:
-      'Number of output files must not be greater than the number of input files.',
     path: ['outputFiles'],
+    error:
+      'Number of output files must not be greater than the number of input files.',
   });
 
 export type AgentConfig = z.infer<typeof AgentConfigSchema>;

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 // Local imports - agent
 // Local imports - agent components
 import { AgentSessionKind, AgentType } from './AgentDataclass';
-import { ToolConfigSchema } from './ToolConfig';
+import { DEFAULT_TOOL_CONFIG, ToolConfigSchema } from './ToolConfig';
 
 /**
  * Checks that the number of output files does not exceed the number of input files.
@@ -40,7 +40,7 @@ export const AgentConfigSchema = z
     outputFiles: z.array(z.string()).nullable().default(null),
     editedFile: z.string().nullable().default(null),
 
-    toolConfig: ToolConfigSchema.default({}),
+    toolConfig: ToolConfigSchema.default(DEFAULT_TOOL_CONFIG),
   })
   // Strip unknown keys to tolerate stale settings from previous releases.
   .strip()

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -80,8 +80,8 @@ export const AgentSettingBaseSchema = z
       .max(MAX_TEMPERATURE)
       .nullable()
       .default(0.0),
-    requiredFiles: z.record(z.string()).default({}),
-    requiredFilesInternal: z.record(z.string()).default({}),
+    requiredFiles: z.record(z.string(), z.string()).default({}),
+    requiredFilesInternal: z.record(z.string(), z.string()).default({}),
     defaultOutputFiles: z.array(z.string()).default([]),
     filePatternsContain: z
       .array(
@@ -190,8 +190,8 @@ export const AgentDefinitionSchema = z
   .object({
     name: z.string().trim().min(1),
     inherits: z.string().optional(),
-    settings: z.record(z.unknown()).optional(),
-    prompts: z.record(z.unknown()).optional(),
+    settings: z.record(z.string(), z.unknown()).optional(),
+    prompts: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -66,51 +66,49 @@ export function resolveAgentSessionMetadata(
  * Base schema shared by workflow and tool-use agent settings. Individual
  * variants extend this schema to add variant-specific constraints.
  */
-export const AgentSettingBaseSchema = z
-  .object({
-    agentType: z.nativeEnum(AgentType).default(AgentType.CoT),
-    documentTag: z
-      .string()
-      .min(1, 'documentTag cannot be empty')
-      .default('document'),
-    endTag: z.string().default('</latex_document>'),
-    temperature: z
-      .number()
-      .min(MIN_TEMPERATURE)
-      .max(MAX_TEMPERATURE)
-      .nullable()
-      .default(0.0),
-    requiredFiles: z.record(z.string(), z.string()).default({}),
-    requiredFilesInternal: z.record(z.string(), z.string()).default({}),
-    defaultOutputFiles: z.array(z.string()).default([]),
-    filePatternsContain: z
-      .array(
-        z.object({
-          pattern: z.string(),
-          varName: z.string(),
-          categories: z.array(z.string()).default([]),
-        }),
-      )
-      .default([]),
+export const AgentSettingBaseSchema = z.strictObject({
+  agentType: z.enum(AgentType).prefault(AgentType.CoT),
+  documentTag: z
+    .string()
+    .min(1, 'documentTag cannot be empty')
+    .prefault('document'),
+  endTag: z.string().prefault('</latex_document>'),
+  temperature: z
+    .number()
+    .min(MIN_TEMPERATURE)
+    .max(MAX_TEMPERATURE)
+    .nullable()
+    .prefault(0.0),
+  requiredFiles: z.record(z.string(), z.string()).prefault({}),
+  requiredFilesInternal: z.record(z.string(), z.string()).prefault({}),
+  defaultOutputFiles: z.array(z.string()).prefault([]),
+  filePatternsContain: z
+    .array(
+      z.strictObject({
+        pattern: z.string(),
+        varName: z.string(),
+        categories: z.array(z.string()).prefault([]),
+      }),
+    )
+    .prefault([]),
 
-    tools: z.array(ToolDefinitionSchema).default([]),
-  })
-  .strict();
+  tools: z.array(ToolDefinitionSchema).prefault([]),
+});
 
 /**
  * Workflow agent settings support multiple-output workflows and therefore
  * expose the {@code isMultipleOutput} toggle.
  */
 export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
-  isRewrite: z.boolean().default(true),
-  rounds: z.number().default(2),
-  prefills: z.array(z.string()).default([]),
-  outputExt: z.string().default('txt'),
-  isMultipleOutput: z.boolean().default(false),
+  isRewrite: z.boolean().prefault(true),
+  rounds: z.number().prefault(2),
+  prefills: z.array(z.string()).prefault([]),
+  outputExt: z.string().prefault('txt'),
+  isMultipleOutput: z.boolean().prefault(false),
 }).superRefine((data, ctx) => {
   if (data.agentType === AgentType.ToolUse) {
     ctx.addIssue({
-      code: z.ZodIssueCode.custom,
+      code: 'custom',
       path: ['agentType'],
       message:
         'Workflow agent settings cannot use the toolUse agent type. Use the tool-use schema instead.',
@@ -120,7 +118,7 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
 
 /** Tool-use agents never expose workflow-specific flags. */
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
-  agentType: z.literal(AgentType.ToolUse).default(AgentType.ToolUse),
+  agentType: z.literal(AgentType.ToolUse).prefault(AgentType.ToolUse),
 });
 
 /**
@@ -170,14 +168,12 @@ export function hasEndTag(
 }
 
 /** Zod schema for AgentPrompt validation */
-export const AgentPromptSchema = z
-  .object({
-    systemPrompt: z.string().default(''),
-    userPrefix: z.string().default(''),
-    userRequest: z.string().default(''),
-    userReflect: z.union([z.string(), z.array(z.string())]).default(''),
-  })
-  .strict();
+export const AgentPromptSchema = z.strictObject({
+  systemPrompt: z.string().prefault(''),
+  userPrefix: z.string().prefault(''),
+  userRequest: z.string().prefault(''),
+  userReflect: z.union([z.string(), z.array(z.string())]).prefault(''),
+});
 
 export type AgentPrompt = z.infer<typeof AgentPromptSchema>;
 
@@ -186,14 +182,12 @@ export type AgentPrompt = z.infer<typeof AgentPromptSchema>;
  * Includes the root name, optional inheritance target,
  * settings block and prompt configuration.
  */
-export const AgentDefinitionSchema = z
-  .object({
-    name: z.string().trim().min(1),
-    inherits: z.string().optional(),
-    settings: z.record(z.string(), z.unknown()).optional(),
-    prompts: z.record(z.string(), z.unknown()).optional(),
-  })
-  .strict();
+export const AgentDefinitionSchema = z.strictObject({
+  name: z.string().trim().min(1),
+  inherits: z.string().optional(),
+  settings: z.record(z.string(), z.unknown()).optional(),
+  prompts: z.record(z.string(), z.unknown()).optional(),
+});
 
 export type AgentDefinition = z.infer<typeof AgentDefinitionSchema>;
 

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -1,7 +1,7 @@
 // Third-party imports
 import { z } from 'zod';
 
-const TOOL_CONFIG_DEFAULTS = {
+export const DEFAULT_TOOL_CONFIG = {
   reflect: false,
   autoExtractFigure: false,
   autoExtractTikzFigure: false,
@@ -21,24 +21,21 @@ const TOOL_CONFIG_DEFAULTS = {
  */
 export const ToolConfigSchema = z
   .object({
-    reflect: z.boolean().default(TOOL_CONFIG_DEFAULTS.reflect),
+    reflect: z.boolean().prefault(DEFAULT_TOOL_CONFIG.reflect),
     autoExtractFigure: z
       .boolean()
-      .default(TOOL_CONFIG_DEFAULTS.autoExtractFigure),
+      .prefault(DEFAULT_TOOL_CONFIG.autoExtractFigure),
     autoExtractTikzFigure: z
       .boolean()
-      .default(TOOL_CONFIG_DEFAULTS.autoExtractTikzFigure),
-    attachTeXCount: z.boolean().default(TOOL_CONFIG_DEFAULTS.attachTeXCount),
+      .prefault(DEFAULT_TOOL_CONFIG.autoExtractTikzFigure),
+    attachTeXCount: z.boolean().prefault(DEFAULT_TOOL_CONFIG.attachTeXCount),
     attachDiagnostics: z
       .boolean()
-      .default(TOOL_CONFIG_DEFAULTS.attachDiagnostics),
+      .prefault(DEFAULT_TOOL_CONFIG.attachDiagnostics),
     autoCompileInputPdf: z
       .boolean()
-      .default(TOOL_CONFIG_DEFAULTS.autoCompileInputPdf),
+      .prefault(DEFAULT_TOOL_CONFIG.autoCompileInputPdf),
   })
-  .strip()
-  .default(TOOL_CONFIG_DEFAULTS);
-
-export const DEFAULT_TOOL_CONFIG = TOOL_CONFIG_DEFAULTS;
+  .prefault(DEFAULT_TOOL_CONFIG);
 
 export type ToolConfig = z.infer<typeof ToolConfigSchema>;

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -1,6 +1,15 @@
 // Third-party imports
 import { z } from 'zod';
 
+const TOOL_CONFIG_DEFAULTS = {
+  reflect: false,
+  autoExtractFigure: false,
+  autoExtractTikzFigure: false,
+  attachTeXCount: false,
+  attachDiagnostics: false,
+  autoCompileInputPdf: false,
+} as const;
+
 /**
  * Zod schema for validating ToolConfig objects.
  * Defaults are defined at the property level and the schema itself
@@ -12,14 +21,24 @@ import { z } from 'zod';
  */
 export const ToolConfigSchema = z
   .object({
-    reflect: z.boolean().default(false),
-    autoExtractFigure: z.boolean().default(false),
-    autoExtractTikzFigure: z.boolean().default(false),
-    attachTeXCount: z.boolean().default(false),
-    attachDiagnostics: z.boolean().default(false),
-    autoCompileInputPdf: z.boolean().default(false),
+    reflect: z.boolean().default(TOOL_CONFIG_DEFAULTS.reflect),
+    autoExtractFigure: z
+      .boolean()
+      .default(TOOL_CONFIG_DEFAULTS.autoExtractFigure),
+    autoExtractTikzFigure: z
+      .boolean()
+      .default(TOOL_CONFIG_DEFAULTS.autoExtractTikzFigure),
+    attachTeXCount: z.boolean().default(TOOL_CONFIG_DEFAULTS.attachTeXCount),
+    attachDiagnostics: z
+      .boolean()
+      .default(TOOL_CONFIG_DEFAULTS.attachDiagnostics),
+    autoCompileInputPdf: z
+      .boolean()
+      .default(TOOL_CONFIG_DEFAULTS.autoCompileInputPdf),
   })
   .strip()
-  .default({});
+  .default(TOOL_CONFIG_DEFAULTS);
+
+export const DEFAULT_TOOL_CONFIG = TOOL_CONFIG_DEFAULTS;
 
 export type ToolConfig = z.infer<typeof ToolConfigSchema>;

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -37,19 +37,17 @@ const ToolStateSnapshotSchema = z.object({
   thinkingAdded: z.boolean(),
 });
 
-const ToolUseSessionSnapshotSchema = z
-  .object({
-    version: z.literal(SNAPSHOT_VERSION),
-    executionId: z.string(),
-    streamId: z.string(),
-    agentName: z.string(),
-    model: z.string(),
-    agentSessionKind: z.nativeEnum(AgentSessionKind),
-    messages: z.array(z.unknown()),
-    toolState: ToolStateSnapshotSchema,
-    lastUpdated: z.number(),
-  })
-  .strict();
+const ToolUseSessionSnapshotSchema = z.strictObject({
+  version: z.literal(SNAPSHOT_VERSION),
+  executionId: z.string(),
+  streamId: z.string(),
+  agentName: z.string(),
+  model: z.string(),
+  agentSessionKind: z.enum(AgentSessionKind),
+  messages: z.array(z.unknown()),
+  toolState: ToolStateSnapshotSchema,
+  lastUpdated: z.number(),
+});
 
 export type ToolUseSessionSnapshot = z.infer<
   typeof ToolUseSessionSnapshotSchema

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -13,7 +13,7 @@ export const ToolDefinitionSchema = z
     /** Optional description for the model */
     description: z.string().optional(),
     /** Parameter schema or provider specific metadata */
-    parameters: z.record(z.unknown()).optional(),
+    parameters: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -6,16 +6,14 @@ import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages
 import type { Schema as GeminiSchema } from '@google/genai/dist/genai';
 
 /** Zod schema describing a tool/function that a provider can execute. */
-export const ToolDefinitionSchema = z
-  .object({
-    /** Name of the tool or function */
-    name: z.string(),
-    /** Optional description for the model */
-    description: z.string().optional(),
-    /** Parameter schema or provider specific metadata */
-    parameters: z.record(z.string(), z.unknown()).optional(),
-  })
-  .strict();
+export const ToolDefinitionSchema = z.strictObject({
+  /** Name of the tool or function */
+  name: z.string(),
+  /** Optional description for the model */
+  description: z.string().optional(),
+  /** Parameter schema or provider specific metadata */
+  parameters: z.record(z.string(), z.unknown()).optional(),
+});
 
 /**
  * Generic tool definition used across model providers. The parameters field

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -11,14 +11,12 @@ import { ToolError, ToolResult, toolResult } from '@tools/result';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
-const EditInputSchema = z
-  .object({
-    path: z.string(),
-    old_string: z.string(),
-    new_string: z.string(),
-    replace_all: z.boolean().optional(),
-  })
-  .strict();
+const EditInputSchema = z.strictObject({
+  path: z.string(),
+  old_string: z.string(),
+  new_string: z.string(),
+  replace_all: z.boolean().optional(),
+});
 
 export type EditInput = z.infer<typeof EditInputSchema>;
 

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -13,11 +13,9 @@ import { WorkspaceFS } from '@utils/files';
 
 export const READ_FILE_MAX_LINES = 400;
 
-const ReadInputSchema = z
-  .object({
-    path: z.string(),
-  })
-  .strict();
+const ReadInputSchema = z.strictObject({
+  path: z.string(),
+});
 
 export type ReadInput = z.infer<typeof ReadInputSchema>;
 

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -11,12 +11,10 @@ import { ToolResult, toolResult } from '@tools/result';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
-const WriteInputSchema = z
-  .object({
-    path: z.string(),
-    content: z.string(),
-  })
-  .strict();
+const WriteInputSchema = z.strictObject({
+  path: z.string(),
+  content: z.string(),
+});
 
 export type WriteInput = z.infer<typeof WriteInputSchema>;
 

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { z, ZodError } from 'zod';
+import { ZodError, type ZodType } from 'zod';
 
 // Local imports - tools
 import type { ToolDefinition } from '@model';
@@ -7,9 +7,9 @@ import { ToolResult, toolResult } from '@tools/result';
 
 export abstract class BaseTool<T> {
   readonly definition: ToolDefinition;
-  readonly schema: z.ZodSchema<T>;
+  readonly schema: ZodType<T>;
 
-  protected constructor(definition: ToolDefinition, schema: z.ZodSchema<T>) {
+  protected constructor(definition: ToolDefinition, schema: ZodType<T>) {
     this.definition = definition;
     this.schema = schema;
   }

--- a/src/tools/core/define.ts
+++ b/src/tools/core/define.ts
@@ -1,17 +1,20 @@
-import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { toJSONSchema, type ZodType } from 'zod';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from './base';
 
 export function defineTool<T>(def: {
   name: string;
   description: string;
-  schema: z.ZodSchema<T>;
+  schema: ZodType<T>;
 }) {
   const baseDefinition: ToolDefinition = {
     name: def.name,
     description: def.description,
-    parameters: zodToJsonSchema(def.schema),
+    parameters: toJSONSchema(def.schema, {
+      target: 'openapi-3.0',
+      unrepresentable: 'any',
+      io: 'input',
+    }) as Record<string, unknown>,
   };
 
   abstract class GeneratedTool extends BaseTool<T> {

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -18,12 +18,10 @@ import { getGitignoreMatcher } from '@tools/gitignore';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
-const GlobInputSchema = z
-  .object({
-    pattern: z.string().min(1, 'pattern is required'),
-    path: z.string().optional(),
-  })
-  .strict();
+const GlobInputSchema = z.strictObject({
+  pattern: z.string().min(1, 'pattern is required'),
+  path: z.string().optional(),
+});
 
 export type GlobInput = z.infer<typeof GlobInputSchema>;
 

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -16,22 +16,20 @@ const OUTPUT_MODES = ['content', 'files_with_matches', 'count'] as const;
 
 type OutputMode = (typeof OUTPUT_MODES)[number];
 
-const GrepInputSchema = z
-  .object({
-    pattern: z.string().min(1, 'pattern is required'),
-    path: z.string().optional(),
-    glob: z.string().optional(),
-    output_mode: z.enum(OUTPUT_MODES).optional(),
-    '-B': z.number().int().min(0).optional(),
-    '-A': z.number().int().min(0).optional(),
-    '-C': z.number().int().min(0).optional(),
-    '-n': z.boolean().optional(),
-    '-i': z.boolean().optional(),
-    type: z.string().optional(),
-    head_limit: z.number().int().min(1).optional(),
-    multiline: z.boolean().optional(),
-  })
-  .strict();
+const GrepInputSchema = z.strictObject({
+  pattern: z.string().min(1, 'pattern is required'),
+  path: z.string().optional(),
+  glob: z.string().optional(),
+  output_mode: z.enum(OUTPUT_MODES).optional(),
+  '-B': z.int().min(0).optional(),
+  '-A': z.int().min(0).optional(),
+  '-C': z.int().min(0).optional(),
+  '-n': z.boolean().optional(),
+  '-i': z.boolean().optional(),
+  type: z.string().optional(),
+  head_limit: z.int().min(1).optional(),
+  multiline: z.boolean().optional(),
+});
 
 export type GrepInput = z.infer<typeof GrepInputSchema>;
 

--- a/src/tools/latex/ArxivDownloadTool.ts
+++ b/src/tools/latex/ArxivDownloadTool.ts
@@ -13,12 +13,10 @@ import { formatToolOutput, toPosixPath } from '@tools/utils';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
-const ArxivDownloadInputSchema = z
-  .object({
-    id: z.string(),
-    autoIndent: z.boolean().optional(),
-  })
-  .strict();
+const ArxivDownloadInputSchema = z.strictObject({
+  id: z.string(),
+  autoIndent: z.boolean().optional(),
+});
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;
 

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -19,12 +19,10 @@ import { getGitignoreMatcher } from '@tools/gitignore';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
-const LsInputSchema = z
-  .object({
-    path: z.string(),
-    ignore: z.array(z.string()).optional(),
-  })
-  .strict();
+const LsInputSchema = z.strictObject({
+  path: z.string(),
+  ignore: z.array(z.string()).optional(),
+});
 
 export type LsInput = z.infer<typeof LsInputSchema>;
 

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -12,18 +12,15 @@ import { defineTool } from '../core/define';
 // Local imports - tools
 import { ToolError, ToolResult, toolResult } from '../result';
 
-const WebFetchInputSchema = z
-  .object({
-    url: z
-      .string()
-      .url('Provide a valid absolute URL to fetch.')
-      .refine(
-        (value) => value.startsWith('http://') || value.startsWith('https://'),
-        'URL must use HTTP or HTTPS protocol',
-      ),
-    prompt: z.string().min(1).optional(),
-  })
-  .strict();
+const WebFetchInputSchema = z.strictObject({
+  url: z
+    .url('Provide a valid absolute URL to fetch.')
+    .refine(
+      (value) => value.startsWith('http://') || value.startsWith('https://'),
+      'URL must use HTTP or HTTPS protocol',
+    ),
+  prompt: z.string().min(1).optional(),
+});
 
 export type WebFetchInput = z.infer<typeof WebFetchInputSchema>;
 


### PR DESCRIPTION
## Summary
- upgrade the extension to zod 4.1.11 and drop the direct zod-to-json-schema dependency
- reuse zod's built-in toJSONSchema helper in the tool factory and tighten BaseTool typing
- refresh agent/tool schemas to use explicit record key types and share default tool configuration values

## Testing
- npm run compile
- npm run lint
- npm test *(fails: VS Code binary requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa82a41d08324baeb2417eafa79ab

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade to Zod v4, replace zod-to-json-schema with Zod’s toJSONSchema, and refactor schemas/typing across agents and tools with centralized default tool config.
> 
> - **Dependencies/Build**:
>   - Bump `zod` to `^4.1.11`; remove `zod-to-json-schema`.
> - **Schema/Typing Refactor (Zod v4)**:
>   - Replace `nativeEnum` with `enum`, `.object().strict()` with `z.strictObject`, add `.prefault(...)` defaults, and use `z.int()` where appropriate.
>   - Tighten `z.record` key typings and switch nested objects to `z.strictObject`.
>   - Centralize tool defaults via `DEFAULT_TOOL_CONFIG`; set `AgentConfig.toolConfig` to `prefault(DEFAULT_TOOL_CONFIG)`.
>   - Update refinement/error codes to Zod v4 style.
> - **Tool/Factory Changes**:
>   - Swap JSON schema generation to `toJSONSchema` from Zod.
>   - Update `BaseTool`/factory to use `ZodType<T>`; adjust tool input schemas (`read`, `write`, `edit`, `ls`, `glob`, `grep`, `web_fetch`, `download_arxiv_source`).
> - **Agent Models**:
>   - Refresh `AgentConfig`, `AgentSetting*`, `AgentPrompt`, `AgentDefinition`, and session snapshot schemas to Zod v4 patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66d589a9302ec049a002e0109a6d229e233dc161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->