### PR TITLE
fix: align progress tool use indentation

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -230,7 +230,7 @@
               <i class="codicon icon"></i>
               <span class="label"></span>
             </summary>
-            <div class="special-content markdown-content"></div>
+            <div class="special-content log-entry-content markdown-content"></div>
           </details>
         </template>
         <template id="toolUseTemplate">
@@ -240,7 +240,7 @@
               <i class="codicon codicon-wrench"></i>
               <span class="tool-use-title">Tool Use</span>
             </summary>
-            <div class="special-content"></div>
+            <div class="special-content log-entry-content"></div>
           </details>
         </template>
         <template id="modelResponseTemplate">
@@ -258,7 +258,7 @@
                 <i class="codicon codicon-copy"></i>
               </button>
             </div>
-            <div class="model-response-content markdown-content"></div>
+            <div class="model-response-content log-entry-content markdown-content"></div>
           </div>
         </template>
         <template id="userMessageTemplate">

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -258,7 +258,7 @@
                 <i class="codicon codicon-copy"></i>
               </button>
             </div>
-            <div class="model-response-content log-entry-content markdown-content"></div>
+            <div class="model-response-content markdown-content"></div>
           </div>
         </template>
         <template id="userMessageTemplate">

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -23,6 +23,11 @@
   display: block;
 }
 
+.log-entry-content {
+  padding: var(--spacing-small) 0 var(--spacing-medium) var(--spacing-large);
+  overflow: visible;
+}
+
 .log-line {
   white-space: pre-wrap;
   word-wrap: break-word;

--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -2,7 +2,6 @@
 
 /* Base layout for markdown containers */
 .markdown-content {
-  padding: var(--spacing-small) 0 var(--spacing-medium) var(--spacing-large);
   overflow: visible;
 }
 

--- a/src/test/progressView/Formatters.test.ts
+++ b/src/test/progressView/Formatters.test.ts
@@ -46,7 +46,7 @@ describe('LogEntryFormatter DOM', () => {
             <i class="codicon codicon-wrench"></i>
             <span class="tool-use-title">Tool Use</span>
           </summary>
-          <div class="special-content"></div>
+          <div class="special-content log-entry-content"></div>
         </details>
       </template>
     </body></html>`);


### PR DESCRIPTION
## Summary
- add a shared log-entry-content class so special entries share consistent padding
- update progress view templates to use the shared class and keep model responses unindented
- adjust markdown styles and tests to reflect the new structure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfbfa1264c8324bf9a63d2006ab3ae

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a shared `log-entry-content` class and applies it to special and tool-use entries, adjusting styles and tests for consistent indentation.
> 
> - **UI/Templates**:
>   - Apply `log-entry-content` to `special-details` and `toolUseTemplate` containers in `src/progressView/index.html` for consistent log entry padding.
> - **Styles**:
>   - Add `.log-entry-content` in `styles/logs.css` for shared padding/overflow.
>   - Shift padding responsibility from `.markdown-content` so model responses remain unindented.
> - **Tests**:
>   - Update `Formatters.test.ts` to expect `log-entry-content` in `toolUseTemplate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c7cbe307c0aadfd2a81085d2e60310c06d98983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->