### PR TITLE
refactor: make reflection agent-driven

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,14 +17,14 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -46,12 +46,11 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-          
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-

--- a/docs/guide/acknowledgments.md
+++ b/docs/guide/acknowledgments.md
@@ -21,7 +21,7 @@ TeXRA's design draws inspiration from several key concepts in AI and software de
 
 - **Agentic Workflows & Tool Use [1]:** The core idea involves AI agents executing tasks augmented by specialized tools (e.g., `texcount`). This allows LLMs to leverage external capabilities for tasks requiring precision or specific knowledge beyond their training data.
 - **Chain-of-Thought (CoT) Reasoning [2]:** For complex agents, TeXRA employs techniques inspired by Chain-of-Thought prompting, encouraging models to "think step-by-step" (often visible in the `<scratchpad>` sections of logs) before producing a final output.
-- **Reflection & Action [3, 4]:** The optional "Reflect" step, combined with the agent's ability to act (edit text, use tools), draws inspiration from frameworks like ReAct and Reflexion, allowing iterative refinement based on self-critique or environmental feedback.
+- **Reflection & Action [3, 4]:** The automatic reflection passes, combined with the agent's ability to act (edit text, use tools), draw inspiration from frameworks like ReAct and Reflexion, allowing iterative refinement based on self-critique or environmental feedback.
 - **Structured Prompting (YAML + Jinja):** The use of YAML for structure and Jinja for templating within prompts allows for complex logic, dynamic content injection, and better maintainability, drawing inspiration from approaches seen in libraries like [Prompt Poet](https://github.com/character-ai/prompt-poet). The support for inheritance and modularity allows for a more flexible and reusable prompt design.
 
 We believe combining these concepts provides a robust and adaptable platform for AI-powered academic writing assistance.

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -18,7 +18,7 @@ These `.yaml` files have two main parts (and thankfully, YAML is usually less pr
     - `systemPrompt`: Sets the overall role and high-level instructions for the LLM.
     - `userPrefix`: Provides the main context, including your input file(s) (available via e.g., `{{ INPUT_CONTENT }}`) and the specific instruction you typed in the UI (available via `{{ INSTRUCTION }}`).
     - `userRequest`: Asks the LLM to perform the initial task (Round 0). Often instructs the LLM to think within `<scratchpad>` tags and then output the main content wrapped within the XML tags defined by `settings.documentTag` (e.g., `<document>...</document>`).
-    - `userReflect`: Asks the LLM to review and improve its first response (Round 1, only used if "Reflect" is enabled).
+    - `userReflect`: Asks the LLM to review and improve its first response (Round 1+). When these prompts are present, TeXRA automatically schedules the additional reflection rounds.
 
 \_(Prompts use Jinja2 templating. For a detailed list of available variables like `{{ INPUT_CONTENT }}` and how to use them, see the [Custom Agents](./custom-agents.md) guide.)\*
 
@@ -72,15 +72,17 @@ Internally, TeXRA now assembles these prompt segments through the `PromptBuilder
 
 Agents that inherit from `BaseReflectionAgent` can override the protected `getPromptBuilder()` hook to supply a subclassed builder. This makes it easy to add new phases (e.g., a planning stage) or to customize how prefills are computed without rewriting the round-processing logic. When you introduce a specialised agent, create a derived `PromptBuilder` that extends the base implementation, override or add the necessary methods, and return it from your agent's `getPromptBuilder()` override so the lifecycle automatically uses your custom prompts.
 
-**Optional Reflection (Round 1):**
+**Reflection Rounds (Round 1+):**
 
-If you enable the "Reflect" option in the Tool Config section of the UI, TeXRA performs an additional step after Round 0 finishes successfully:
+When an agent definition includes `userReflect` templates or increases `settings.rounds`, TeXRA automatically performs additional passes after Round 0 completes:
 
-1.  **Reflection Prompt:** It uses the agent's `userReflect` prompt template to ask the LLM to critique and improve its own Round 0 output (which is included in the conversation history).
+1.  **Reflection Prompt:** It renders the appropriate `userReflect` template to ask the LLM to critique and improve its own Round 0 output (which is included in the conversation history).
 2.  **LLM Interaction (Round 1):** The LLM generates a revised response.
 3.  **Processing:** TeXRA saves this refined output to a separate file (e.g., `filename_agent_r1_model.ext`).
 
-This basic flow, potentially with the reflection step, allows TeXRA agents to perform targeted tasks based on their specific definitions and your instructions. For concrete examples of built-in agents, see the [Built-in Agent Reference](./built-in-agents.md).
+You can control how many rounds execute by editing the agent YAML—adjust `settings.rounds` for the maximum number of passes and provide matching `userReflect` prompts. The run stops early whenever the model signals it is finished or when no reflection prompt content is supplied.
+
+This basic flow, potentially with the reflection rounds, allows TeXRA agents to perform targeted tasks based on their specific definitions and your instructions. For concrete examples of built-in agents, see the [Built-in Agent Reference](./built-in-agents.md).
 
 ::: warning Potential XML Issues
 Occasionally, LLMs might generate slightly malformed XML (e.g., missing closing tags), especially with very long or complex outputs. If TeXRA fails to extract content from an agent's output (`_r0_*.xml` or `_r1_*.xml` file), you might need to manually inspect the `.xml` file and correct any structural errors (like adding a missing `</document>` tag) before TeXRA can process it correctly. See the [Troubleshooting guide](../reference/troubleshooting.md#output-file-corruption) for more details.
@@ -88,7 +90,7 @@ Occasionally, LLMs might generate slightly malformed XML (e.g., missing closing 
 
 ### Reflection
 
-After generating an initial output (Round 0), TeXRA agents with reflection enabled evaluate and refine their work (Round 1):
+After generating an initial output (Round 0), TeXRA agents that define reflection prompts evaluate and refine their work (Round 1):
 
 <div class="reflection-pdf-viewer">
   <div class="pdf-tabs">

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -116,7 +116,7 @@ Refine your documents through multiple passes:
 1. Start with broader instructions
 2. Review the results and identify specific areas for improvement
 3. Use more targeted instructions in subsequent passes
-4. Enable the "Reflect" option for critical tasks
+4. Choose agents that include reflection prompts (or add them via custom agents) for critical tasks so TeXRA runs an automatic follow-up pass
 
 ### Collaborative Writing
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -398,9 +398,10 @@ These settings, accessible directly in the main TeXRA webview, control how agent
 
 **Tool Configuration Dropdown** (<i class="codicon codicon-tools"></i> ○<i class="codicon codicon-chevron-down"></i> next to Instruction label):
 
-- **Reflect** (<i class="codicon codicon-refresh"></i>): Enables CoT agents to critique/improve their output (adds round 1). Increases cost/time, potentially quality.
 - **Attach TeX Count** (<i class="codicon codicon-symbol-numeric"></i>): Includes `texcount` output (word/header/math stats) in the agent's context. Requires `texcount` installed.
 - **Attach Diagnostics** (<i class="codicon codicon-tools"></i>): Appends LaTeX compilation logs and other diagnostics to the agent prompt.
+
+Reflection rounds are now controlled entirely by the agent definition. Choose agents that provide `userReflect` prompts (or create custom ones) when you need an automatic follow-up critique.
 
 To capture the full prompt sent to the model, enable the `Save Input Prompt` debug setting in VS Code Settings (`texra.debug.saveInputPrompt`).
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -91,7 +91,7 @@ prompts:
     # Often includes guidance for thinking (<scratchpad>) and output structure (<documentTag>).
     [Define the initial task prompt, potentially including scratchpad guidance]
 
-  # userReflect: | # Optional: Only needed if you plan to use reflect=true
+  # userReflect: | # Optional: Add when you want automatic reflection rounds
   #   The prompt for the AI's second round (Round 1) asking it to critique and improve its Round 0 output.
   #   [Define the reflection prompt]
 ```

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -136,7 +136,7 @@ For example:
 - Model: `sonnet45`
 - Output: `paper_polish_r0_sonnet45.tex`
 
-When reflection is enabled, you may also see:
+When the agent definition includes reflection rounds, you may also see:
 
 - Round 1: `paper_polish_r1_sonnet45.tex`
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -94,10 +94,10 @@ Be specific about what you want! Vague instructions are like asking a genie for 
 ### Step 5: Configure Tools
 
 1. Click on the "Tool Config" dropdown
-2. Enable "Reflect" to allow the AI to review and improve its own work
-3. (Optional) Enable other tools as needed:
+2. (Optional) Enable helpers for this run:
    - "Attach TeX Count" to include document statistics
    - "Attach Diagnostics" to include LaTeX compilation logs and other troubleshooting details
+   - Reflection rounds are controlled by the selected agent—most writing agents already include a follow-up critique pass
 
 ::: tip Save Prompts for Later
 Enable the `texra.debug.saveInputPrompt` setting if you want TeXRA to store the generated prompt alongside other debug artifacts.

--- a/docs/guide/tool-integration.md
+++ b/docs/guide/tool-integration.md
@@ -55,7 +55,7 @@ The outputs of these tools are often incorporated directly or indirectly into th
 
 You have several ways to control how TeXRA uses these tools:
 
-- **Tool Config Dropdown (UI):** Quickly enable/disable features like "Attach TeX Count" or "Reflect" for the current run. See [File Management](./file-management.md#tool-config-dropdown).
+- **Tool Config Dropdown (UI):** Quickly enable/disable helpers like "Attach TeX Count" or "Attach Diagnostics" for the current run. Reflection rounds are controlled by the agent definition itself. See [File Management](./file-management.md#tool-config-dropdown).
 - **Auto Extract Dropdown (UI):** Enable/disable automatic extraction of Figures or TikZ Figures for the current run. See [File Management](./file-management.md#auto-extraction-features).
 
 For detailed configuration of specific tools (like `latexindent` or `tex-fmt`, TikZ processing paths, etc.), refer to the main [Configuration guide](./configuration.md).

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -30,7 +30,7 @@ TeXRA's logging interface that shows detailed information about the processing s
 
 ### Tool Config
 
-Settings that control how TeXRA interacts with external tools and processes, including reflection, TeX counting, and prompt logging options.
+Settings that control how TeXRA interacts with external tools and processes, including TeX counting, diagnostics attachments, and prompt logging options.
 
 ### Auto Extract
 
@@ -38,7 +38,7 @@ A feature that automatically identifies and extracts figures or TikZ diagrams fr
 
 ### Reflection
 
-A process where the AI reviews and improves its own work, leading to higher quality outputs. Enabled through the "Reflect" option in tool config.
+A process where the AI reviews and improves its own work, leading to higher quality outputs. TeXRA automatically schedules reflection rounds based on the agent definition—no manual toggle is required.
 
 ## AI and Language Model Terms
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -250,9 +250,9 @@ Even the best research assistants (human or AI) have off days. This guide helps 
    - Provide clear examples of desired outputs
    - Specify what should and shouldn't be changed
 
-2. **Enable reflection**:
-   - Turn on the "Reflect" option to allow the model to review its work
-   - This often improves output quality significantly
+2. **Leverage reflection rounds**:
+   - Use agents that define follow-up `userReflect` prompts or add them via a custom agent
+   - TeXRA automatically runs these additional rounds when they exist, often improving output quality
 
 3. **Use better models**:
    - Upgrade to more capable models for complex tasks

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "difflib": "^0.2.4",
         "dotenv": "^17.2.3",
         "execa": "^9.6.0",
-        "fast-xml-parser": "^5.2.5",
+        "fast-xml-parser": "^5.3.0",
         "glob": "^11.0.3",
         "gpt-tokenizer": "^3.0.1",
         "he": "^1.2.0",
@@ -47,7 +47,7 @@
         "zod": "^4.1.11"
       },
       "devDependencies": {
-        "@stylistic/eslint-plugin": "^5.3.1",
+        "@stylistic/eslint-plugin": "^5.4.0",
         "@types/diff-match-patch": "^1.0.36",
         "@types/difflib": "^0.2.7",
         "@types/he": "^1.2.3",
@@ -73,8 +73,8 @@
         "terser-webpack-plugin": "^5.3.14",
         "ts-loader": "^9.5.4",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.38.0",
-        "webpack": "^5.101.3",
+        "typescript-eslint": "^8.45.0",
+        "webpack": "^5.102.0",
         "webpack-cli": "^6.0.1"
       },
       "engines": {
@@ -932,14 +932,14 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.3.1.tgz",
-      "integrity": "sha512-Ykums1VYonM0TgkD0VteVq9mrlO2FhF48MDJnPyv3MktIB2ydtuhlO0AfWm7xnW1kyf5bjOqA6xc7JjviuVTxg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.4.0.tgz",
+      "integrity": "sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/types": "^8.41.0",
+        "@eslint-community/eslint-utils": "^4.9.0",
+        "@typescript-eslint/types": "^8.44.0",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -950,20 +950,6 @@
       },
       "peerDependencies": {
         "eslint": ">=9.0.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
-      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@types/diff-match-patch": {
@@ -1096,17 +1082,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.38.0.tgz",
-      "integrity": "sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
+      "integrity": "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.38.0",
-        "@typescript-eslint/type-utils": "8.38.0",
-        "@typescript-eslint/utils": "8.38.0",
-        "@typescript-eslint/visitor-keys": "8.38.0",
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/type-utils": "8.45.0",
+        "@typescript-eslint/utils": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1120,22 +1106,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.38.0",
+        "@typescript-eslint/parser": "^8.45.0",
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.38.0.tgz",
-      "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
+      "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.38.0",
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/typescript-estree": "8.38.0",
-        "@typescript-eslint/visitor-keys": "8.38.0",
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1147,18 +1133,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.38.0.tgz",
-      "integrity": "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.45.0.tgz",
+      "integrity": "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.38.0",
-        "@typescript-eslint/types": "^8.38.0",
+        "@typescript-eslint/tsconfig-utils": "^8.45.0",
+        "@typescript-eslint/types": "^8.45.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1169,18 +1155,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.38.0.tgz",
-      "integrity": "sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.45.0.tgz",
+      "integrity": "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/visitor-keys": "8.38.0"
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1191,9 +1177,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.38.0.tgz",
-      "integrity": "sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz",
+      "integrity": "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1204,19 +1190,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.38.0.tgz",
-      "integrity": "sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.45.0.tgz",
+      "integrity": "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/typescript-estree": "8.38.0",
-        "@typescript-eslint/utils": "8.38.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0",
+        "@typescript-eslint/utils": "8.45.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1229,13 +1215,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.38.0.tgz",
-      "integrity": "sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.45.0.tgz",
+      "integrity": "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1247,16 +1233,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.38.0.tgz",
-      "integrity": "sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.45.0.tgz",
+      "integrity": "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.38.0",
-        "@typescript-eslint/tsconfig-utils": "8.38.0",
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/visitor-keys": "8.38.0",
+        "@typescript-eslint/project-service": "8.45.0",
+        "@typescript-eslint/tsconfig-utils": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1272,7 +1258,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -1292,16 +1278,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.38.0.tgz",
-      "integrity": "sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.45.0.tgz",
+      "integrity": "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.38.0",
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/typescript-estree": "8.38.0"
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1312,17 +1298,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.38.0.tgz",
-      "integrity": "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.45.0.tgz",
+      "integrity": "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/types": "8.45.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -3312,9 +3298,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.0.tgz",
+      "integrity": "sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==",
       "funding": [
         {
           "type": "github",
@@ -6813,13 +6799,17 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar": {
@@ -7149,16 +7139,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.38.0.tgz",
-      "integrity": "sha512-FsZlrYK6bPDGoLeZRuvx2v6qrM03I0U0SnfCLPs/XCCPCFD80xU9Pg09H/K+XFa68uJuZo7l/Xhs+eDRg2l3hg==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.45.0.tgz",
+      "integrity": "sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.38.0",
-        "@typescript-eslint/parser": "8.38.0",
-        "@typescript-eslint/typescript-estree": "8.38.0",
-        "@typescript-eslint/utils": "8.38.0"
+        "@typescript-eslint/eslint-plugin": "8.45.0",
+        "@typescript-eslint/parser": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0",
+        "@typescript-eslint/utils": "8.45.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7169,7 +7159,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/uc.micro": {
@@ -7323,9 +7313,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.101.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
-      "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
+      "version": "5.102.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.0.tgz",
+      "integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7337,7 +7327,7 @@
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.15.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
+        "browserslist": "^4.24.5",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.17.3",
         "es-module-lexer": "^1.2.1",
@@ -7350,9 +7340,9 @@
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
+        "tapable": "^2.2.3",
         "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
+        "watchpack": "^2.4.4",
         "webpack-sources": "^3.3.3"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "prettier": "^3.6.2",
         "terser-webpack-plugin": "^5.3.14",
         "ts-loader": "^9.5.4",
-        "typescript": "^5.8.3",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.45.0",
         "webpack": "^5.102.0",
         "webpack-cli": "^6.0.1"
@@ -7125,9 +7125,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1268,7 +1268,7 @@
     "format": "prettier --write ."
   },
   "devDependencies": {
-    "@stylistic/eslint-plugin": "^5.3.1",
+    "@stylistic/eslint-plugin": "^5.4.0",
     "@types/diff-match-patch": "^1.0.36",
     "@types/difflib": "^0.2.7",
     "@types/he": "^1.2.3",
@@ -1294,8 +1294,8 @@
     "terser-webpack-plugin": "^5.3.14",
     "ts-loader": "^9.5.4",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.38.0",
-    "webpack": "^5.101.3",
+    "typescript-eslint": "^8.45.0",
+    "webpack": "^5.102.0",
     "webpack-cli": "^6.0.1"
   },
   "repository": {
@@ -1339,7 +1339,7 @@
     "difflib": "^0.2.4",
     "dotenv": "^17.2.3",
     "execa": "^9.6.0",
-    "fast-xml-parser": "^5.2.5",
+    "fast-xml-parser": "^5.3.0",
     "glob": "^11.0.3",
     "gpt-tokenizer": "^3.0.1",
     "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1293,7 +1293,7 @@
     "prettier": "^3.6.2",
     "terser-webpack-plugin": "^5.3.14",
     "ts-loader": "^9.5.4",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.45.0",
     "webpack": "^5.102.0",
     "webpack-cli": "^6.0.1"

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -2,7 +2,6 @@
 import { z } from 'zod';
 
 export const DEFAULT_TOOL_CONFIG = {
-  reflect: false,
   autoExtractFigure: false,
   autoExtractTikzFigure: false,
   attachTeXCount: false,
@@ -21,7 +20,6 @@ export const DEFAULT_TOOL_CONFIG = {
  */
 export const ToolConfigSchema = z
   .object({
-    reflect: z.boolean().prefault(DEFAULT_TOOL_CONFIG.reflect),
     autoExtractFigure: z
       .boolean()
       .prefault(DEFAULT_TOOL_CONFIG.autoExtractFigure),

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -534,12 +534,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
       const totalRounds = this.getNumberOfRounds();
       for (let currRound = 0; currRound < totalRounds; currRound++) {
-        if (
-          currRound > 0 &&
-          (!this.agentConfig.toolConfig.reflect ||
-            !continueRounds ||
-            this.isInterrupted)
-        ) {
+        if (currRound > 0 && (!continueRounds || this.isInterrupted)) {
+          break;
+        }
+
+        if (this.isInterrupted) {
           break;
         }
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -534,11 +534,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
       const totalRounds = this.getNumberOfRounds();
       for (let currRound = 0; currRound < totalRounds; currRound++) {
-        if (currRound > 0 && (!continueRounds || this.isInterrupted)) {
+        if (this.isInterrupted) {
           break;
         }
 
-        if (this.isInterrupted) {
+        if (currRound > 0 && !continueRounds) {
           break;
         }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -97,7 +97,6 @@ export abstract class ModelHandler<
       toolConfig: config.toolConfig || {
         autoExtractFigure: false,
         autoExtractTikzFigure: false,
-        reflect: false,
         attachTeXCount: false,
         attachDiagnostics: false,
         autoCompileInputPdf: false,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -254,9 +254,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     ) {
       return entry.source_path;
     }
-    if (entry.binary_data && entry.binary_data.length > 0) {
-      return new globalThis.Blob([entry.binary_data], { type: mimeType });
-    }
     if (entry.data) {
       try {
         const buffer = Buffer.from(entry.data, 'base64');

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -230,7 +230,9 @@
               <i class="codicon icon"></i>
               <span class="label"></span>
             </summary>
-            <div class="special-content log-entry-content markdown-content"></div>
+            <div
+              class="special-content log-entry-content markdown-content"
+            ></div>
           </details>
         </template>
         <template id="toolUseTemplate">

--- a/src/test/agent/core/ConfigSchemas.test.ts
+++ b/src/test/agent/core/ConfigSchemas.test.ts
@@ -13,7 +13,7 @@ describe('ToolConfigSchema', () => {
       printInputPrompt: true,
     } as Record<string, unknown>);
 
-    assert.strictEqual(parsed.reflect, true);
+    assert.strictEqual('reflect' in parsed, false);
     assert.strictEqual(parsed.autoExtractFigure, false);
     assert.strictEqual(
       (parsed as Record<string, unknown>).usePrefillFromInput,
@@ -36,7 +36,7 @@ describe('AgentConfigSchema', () => {
       },
     } as Record<string, unknown>);
 
-    assert.strictEqual(parsed.toolConfig.reflect, true);
+    assert.strictEqual('reflect' in parsed.toolConfig, false);
     assert.strictEqual(parsed.toolConfig.autoExtractFigure, false);
     assert.strictEqual('legacyFlag' in parsed, false);
     assert.strictEqual(parsed.inputFile, '');

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -48,7 +48,6 @@ const baseConfig: AgentConfig = {
   outputFiles: null,
   editedFile: null,
   toolConfig: {
-    reflect: false,
     autoExtractFigure: false,
     autoExtractTikzFigure: false,
     attachTeXCount: false,

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -73,7 +73,6 @@ describe('OutputHandler.finalizeRound', () => {
     outputFiles: null,
     editedFile: null,
     toolConfig: {
-      reflect: false,
       autoExtractFigure: false,
       autoExtractTikzFigure: false,
       attachTeXCount: false,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -44,7 +44,6 @@ describe('XmlOutputManager markdown fallback', () => {
     outputFiles: null,
     editedFile: null,
     toolConfig: {
-      reflect: false,
       autoExtractFigure: false,
       autoExtractTikzFigure: false,
       attachTeXCount: false,

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -146,7 +146,6 @@ describe('BaseToolUseAgent follow-up loop', () => {
       outputFiles: null,
       editedFile: null,
       toolConfig: {
-        reflect: false,
         autoExtractFigure: false,
         autoExtractTikzFigure: false,
         attachTeXCount: false,

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -131,9 +131,11 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     autoExtractTikzFigure,
     autoCompileInputPdf,
     attachTeXCount,
-    reflect,
+    reflect: _legacyReflect,
     ...agentConfigData
   } = obj;
+
+  void _legacyReflect;
 
   const legacyPrintInputPrompt = Object.prototype.hasOwnProperty.call(
     obj,
@@ -162,6 +164,13 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     agentConfigData.toolConfig = {};
   }
 
+  if (
+    isObjectRecord(agentConfigData.toolConfig) &&
+    Object.prototype.hasOwnProperty.call(agentConfigData.toolConfig, 'reflect')
+  ) {
+    delete (agentConfigData.toolConfig as Record<string, unknown>).reflect;
+  }
+
   // Merge top-level tool config fields into toolConfig
   // Top-level fields take precedence for backward compatibility
   agentConfigData.toolConfig = {
@@ -170,7 +179,6 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     ...(autoExtractTikzFigure !== undefined && { autoExtractTikzFigure }),
     ...(autoCompileInputPdf !== undefined && { autoCompileInputPdf }),
     ...(attachTeXCount !== undefined && { attachTeXCount }),
-    ...(reflect !== undefined && { reflect }),
   };
 
   if (

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -21,7 +21,10 @@ export const AUTO_EXTRACT_FIELDS = [
   'autoExtractTikzFigure',
   'autoCompileInputPdf',
 ] as const;
-export const TOOL_CONFIG_FIELDS = ['attachTeXCount', 'reflect'] as const;
+export const TOOL_CONFIG_FIELDS = [
+  'attachTeXCount',
+  'attachDiagnostics',
+] as const;
 
 // Length for preview slices of tool output and responses
 export const K_SLICE = 200;

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -398,10 +398,6 @@
                   style="display: none"
                 >
                   <label class="vscode-checkbox"
-                    ><input type="checkbox" id="reflect" />
-                    <i class="codicon codicon-refresh"></i> Reflect</label
-                  >
-                  <label class="vscode-checkbox"
                     ><input type="checkbox" id="attachTeXCount" />
                     <i class="codicon codicon-symbol-numeric"></i> Attach TeX
                     Count</label

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -79,7 +79,6 @@ export class ExecutionManager {
     const toolConfig: ToolConfig = {
       autoExtractFigure: message.autoExtractFigure,
       autoExtractTikzFigure: message.autoExtractTikzFigure,
-      reflect: message.reflect,
       attachTeXCount: message.attachTeXCount,
       attachDiagnostics: message.attachDiagnostics,
       autoCompileInputPdf: message.autoCompileInputPdf,

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -38,11 +38,7 @@ export const CHECK_BOXES_AUTO_EXTRACT = [
 ];
 
 // Tool configuration checkboxes
-export const CHECK_BOXES_TOOL_USE = [
-  'attachTeXCount',
-  'attachDiagnostics',
-  'reflect',
-];
+export const CHECK_BOXES_TOOL_USE = ['attachTeXCount', 'attachDiagnostics'];
 
 // All checkboxes (combined)
 export const CHECK_BOXES = [

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -570,7 +570,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       referenceFile: state.referenceFile,
       auxiliaryFile: state.auxiliaryFile,
       mediaFile: state.mediaFile,
-      reflect: state.reflect ?? toolConfig.reflect ?? false,
       autoExtractFigure:
         state.autoExtractFigure ?? toolConfig.autoExtractFigure ?? false,
       autoExtractTikzFigure:

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -283,11 +283,6 @@ export class SettingsButtonManager extends BaseUIManager {
       });
     }
 
-    const reflectCheckbox = safeGetElementById('reflect');
-    if (reflectCheckbox) {
-      reflectCheckbox.checked = !selectedAgent.startsWith('correct');
-    }
-
     this.vscode.postMessage({
       command: MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
     });


### PR DESCRIPTION
## Summary
- drop the legacy `reflect` flag from tool config defaults and rely on agent-defined rounds in `BaseReflectionAgent`
- remove the Reflect checkbox/state from the webview UI and ignore any legacy flag when converting stored state
- refresh documentation and tests to describe reflection as an automatic agent capability

## Testing
- npm run lint
- npm run compile
- npm test *(fails: VS Code test runner requires libatk-1.0.so.0 in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc053383883248c2794a4304e6f82

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates the `reflect` tool flag and UI control, shifting reflection to agent-defined rounds, updates configs/tests/docs accordingly, and bumps a few dependencies.
> 
> - **Agent/Core**:
>   - `BaseReflectionAgent`: reflection rounds now controlled by agent (`settings.rounds`/`userReflect`); removed reliance on `toolConfig.reflect`; improved interruption handling.
>   - `ToolConfig`: dropped `reflect` default/field and schema; constants updated to only include `attachTeXCount`/`attachDiagnostics`.
>   - Config conversion strips legacy `reflect` from stored state.
> - **UI (Webview)**:
>   - Removed "Reflect" checkbox and state from `index.html`, constants, message handlers, settings manager, and execution payload; tool config now only TeX Count/Diagnostics.
> - **Docs**:
>   - Rewrote reflection sections to describe automatic, agent-driven reflection rounds; updated Quick Start, Configuration, Agent Architecture, Best Practices, Tool Integration, File Management, Glossary, Troubleshooting.
> - **Model Handlers**:
>   - Google GenAI upload path handling simplified for media (minor refactor).
> - **Tests**:
>   - Updated schemas and config tests to ignore `reflect`; adjusted fixtures accordingly.
> - **Dependencies**:
>   - Bump `fast-xml-parser`, `@stylistic/eslint-plugin`, `typescript`, `typescript-eslint`, `webpack`, `tapable` and related lockfile entries.
> - **CI**:
>   - Minor workflow whitespace/permissions tidy-ups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3172cdbf02021e97b50160ee8136933b4b21e20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->