### PR TITLE
Refactor reflection flow to remove tool toggle

### DIFF
--- a/docs/guide/acknowledgments.md
+++ b/docs/guide/acknowledgments.md
@@ -21,7 +21,7 @@ TeXRA's design draws inspiration from several key concepts in AI and software de
 
 - **Agentic Workflows & Tool Use [1]:** The core idea involves AI agents executing tasks augmented by specialized tools (e.g., `texcount`). This allows LLMs to leverage external capabilities for tasks requiring precision or specific knowledge beyond their training data.
 - **Chain-of-Thought (CoT) Reasoning [2]:** For complex agents, TeXRA employs techniques inspired by Chain-of-Thought prompting, encouraging models to "think step-by-step" (often visible in the `<scratchpad>` sections of logs) before producing a final output.
-- **Reflection & Action [3, 4]:** The optional "Reflect" step, combined with the agent's ability to act (edit text, use tools), draws inspiration from frameworks like ReAct and Reflexion, allowing iterative refinement based on self-critique or environmental feedback.
+- **Reflection & Action [3, 4]:** TeXRA's automatic reflection rounds, combined with the agent's ability to act (edit text, use tools), draw inspiration from frameworks like ReAct and Reflexion, allowing iterative refinement based on self-critique or environmental feedback.
 - **Structured Prompting (YAML + Jinja):** The use of YAML for structure and Jinja for templating within prompts allows for complex logic, dynamic content injection, and better maintainability, drawing inspiration from approaches seen in libraries like [Prompt Poet](https://github.com/character-ai/prompt-poet). The support for inheritance and modularity allows for a more flexible and reusable prompt design.
 
 We believe combining these concepts provides a robust and adaptable platform for AI-powered academic writing assistance.

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -72,9 +72,9 @@ Internally, TeXRA now assembles these prompt segments through the `PromptBuilder
 
 Agents that inherit from `BaseReflectionAgent` can override the protected `getPromptBuilder()` hook to supply a subclassed builder. This makes it easy to add new phases (e.g., a planning stage) or to customize how prefills are computed without rewriting the round-processing logic. When you introduce a specialised agent, create a derived `PromptBuilder` that extends the base implementation, override or add the necessary methods, and return it from your agent's `getPromptBuilder()` override so the lifecycle automatically uses your custom prompts.
 
-**Optional Reflection (Round 1):**
+**Automatic Reflection (Round 1):**
 
-If you enable the "Reflect" option in the Tool Config section of the UI, TeXRA performs an additional step after Round 0 finishes successfully:
+When an agent defines `userReflect` templates or configures multiple rounds, TeXRA automatically performs an additional step after Round 0 finishes successfully:
 
 1.  **Reflection Prompt:** It uses the agent's `userReflect` prompt template to ask the LLM to critique and improve its own Round 0 output (which is included in the conversation history).
 2.  **LLM Interaction (Round 1):** The LLM generates a revised response.
@@ -88,7 +88,7 @@ Occasionally, LLMs might generate slightly malformed XML (e.g., missing closing 
 
 ### Reflection
 
-After generating an initial output (Round 0), TeXRA agents with reflection enabled evaluate and refine their work (Round 1):
+After generating an initial output (Round 0), TeXRA agents that define reflection prompts evaluate and refine their work (Round 1):
 
 <div class="reflection-pdf-viewer">
   <div class="pdf-tabs">

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -116,7 +116,7 @@ Refine your documents through multiple passes:
 1. Start with broader instructions
 2. Review the results and identify specific areas for improvement
 3. Use more targeted instructions in subsequent passes
-4. Enable the "Reflect" option for critical tasks
+4. Choose agents with built-in reflection prompts for critical tasks
 
 ### Collaborative Writing
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -398,7 +398,8 @@ These settings, accessible directly in the main TeXRA webview, control how agent
 
 **Tool Configuration Dropdown** (<i class="codicon codicon-tools"></i> ○<i class="codicon codicon-chevron-down"></i> next to Instruction label):
 
-- **Reflect** (<i class="codicon codicon-refresh"></i>): Enables CoT agents to critique/improve their output (adds round 1). Increases cost/time, potentially quality.
+Reflection rounds are controlled by the agent definition (via `settings.rounds` and `prompts.userReflect`) and run automatically when present. The dropdown exposes additional per-run toggles:
+
 - **Attach TeX Count** (<i class="codicon codicon-symbol-numeric"></i>): Includes `texcount` output (word/header/math stats) in the agent's context. Requires `texcount` installed.
 - **Attach Diagnostics** (<i class="codicon codicon-tools"></i>): Appends LaTeX compilation logs and other diagnostics to the agent prompt.
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -91,7 +91,7 @@ prompts:
     # Often includes guidance for thinking (<scratchpad>) and output structure (<documentTag>).
     [Define the initial task prompt, potentially including scratchpad guidance]
 
-  # userReflect: | # Optional: Only needed if you plan to use reflect=true
+  # userReflect: | # Optional: Add when you want the agent to run an automatic reflection round
   #   The prompt for the AI's second round (Round 1) asking it to critique and improve its Round 0 output.
   #   [Define the reflection prompt]
 ```

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -136,7 +136,7 @@ For example:
 - Model: `sonnet45`
 - Output: `paper_polish_r0_sonnet45.tex`
 
-When reflection is enabled, you may also see:
+When the selected agent includes a reflection round, you may also see:
 
 - Round 1: `paper_polish_r1_sonnet45.tex`
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -60,7 +60,7 @@ graph LR
     B --> C[Plan Changes];
     C --> D["Execute Plan (LLM Call - Round 0)"];
     D --> E["Process Output (Save *_r0_* File)"];
-    E --> F{"Reflect on Output? (Optional)"};
+    E --> F{"Agent Defines Reflection Round?"};
     F -- Yes --> G[Refine Plan];
     G --> H["Execute Refined Plan (LLM Call - Round 1)"];
     H --> I["Process Output (Save *_r1_* File)"];
@@ -68,7 +68,7 @@ graph LR
     F -- No --> J[End];
 ```
 
-This process leverages the strengths of language models while addressing their limitations through structured workflows, optional self-reflection, and specialized tools.
+This process leverages the strengths of language models while addressing their limitations through structured workflows, agent-configured self-reflection, and specialized tools.
 
 ## Who Should Use TeXRA?
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -94,10 +94,10 @@ Be specific about what you want! Vague instructions are like asking a genie for 
 ### Step 5: Configure Tools
 
 1. Click on the "Tool Config" dropdown
-2. Enable "Reflect" to allow the AI to review and improve its own work
-3. (Optional) Enable other tools as needed:
-   - "Attach TeX Count" to include document statistics
-   - "Attach Diagnostics" to include LaTeX compilation logs and other troubleshooting details
+2. Review the available options:
+   - Reflection runs automatically when the selected agent defines follow-up prompts, so no toggle is required
+   - "Attach TeX Count" includes document statistics in the prompt
+   - "Attach Diagnostics" bundles LaTeX compilation logs and other troubleshooting details when available
 
 ::: tip Save Prompts for Later
 Enable the `texra.debug.saveInputPrompt` setting if you want TeXRA to store the generated prompt alongside other debug artifacts.

--- a/docs/guide/tool-integration.md
+++ b/docs/guide/tool-integration.md
@@ -55,7 +55,7 @@ The outputs of these tools are often incorporated directly or indirectly into th
 
 You have several ways to control how TeXRA uses these tools:
 
-- **Tool Config Dropdown (UI):** Quickly enable/disable features like "Attach TeX Count" or "Reflect" for the current run. See [File Management](./file-management.md#tool-config-dropdown).
+- **Tool Config Dropdown (UI):** Quickly enable/disable features like "Attach TeX Count" for the current run. Agents with reflection prompts automatically run extra rounds without a toggle. See [File Management](./file-management.md#tool-config-dropdown).
 - **Auto Extract Dropdown (UI):** Enable/disable automatic extraction of Figures or TikZ Figures for the current run. See [File Management](./file-management.md#auto-extraction-features).
 
 For detailed configuration of specific tools (like `latexindent` or `tex-fmt`, TikZ processing paths, etc.), refer to the main [Configuration guide](./configuration.md).

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -30,7 +30,7 @@ TeXRA's logging interface that shows detailed information about the processing s
 
 ### Tool Config
 
-Settings that control how TeXRA interacts with external tools and processes, including reflection, TeX counting, and prompt logging options.
+Settings that control how TeXRA interacts with external tools and processes, including TeX counting, prompt logging, and optional figure extraction features.
 
 ### Auto Extract
 
@@ -38,7 +38,7 @@ A feature that automatically identifies and extracts figures or TikZ diagrams fr
 
 ### Reflection
 
-A process where the AI reviews and improves its own work, leading to higher quality outputs. Enabled through the "Reflect" option in tool config.
+A process where the AI automatically reviews and improves its own work between rounds. Reflection runs when an agent defines follow-up prompts or multiple rounds—no manual toggle is required.
 
 ## AI and Language Model Terms
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -250,9 +250,9 @@ Even the best research assistants (human or AI) have off days. This guide helps 
    - Provide clear examples of desired outputs
    - Specify what should and shouldn't be changed
 
-2. **Enable reflection**:
-   - Turn on the "Reflect" option to allow the model to review its work
-   - This often improves output quality significantly
+2. **Use reflection-ready agents**:
+   - Pick agents that define follow-up reflection prompts or multiple rounds
+   - TeXRA automatically runs those additional rounds, which often improves quality
 
 3. **Use better models**:
    - Upgrade to more capable models for complex tasks

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -46,7 +46,7 @@ export interface ResponseCycleOptions<C = unknown> {
 
 /**
  * Executes a response cycle.
- * @returns Tuple of [round state, global state, tool state, completion flag]
+ * @returns Tuple of [round state, global state, tool state, endTurn, shouldStop]
  */
 export async function runResponseCycle<C = unknown>(
   options: ResponseCycleOptions<C>,
@@ -57,7 +57,7 @@ export async function runResponseCycle<C = unknown>(
   outputFile: string,
   roundGroupId?: string,
   executionId?: ExecutionId,
-): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
+): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean, boolean]> {
   const {
     modelHandler,
     agentSetting,
@@ -73,6 +73,7 @@ export async function runResponseCycle<C = unknown>(
   const taskGroupId = roundGroupId;
 
   let endTurn = false;
+  let conversationStopped = false;
   while (!endTurn) {
     if (await checkInterruption()) {
       break;
@@ -274,6 +275,7 @@ export async function runResponseCycle<C = unknown>(
     );
     endTurn = shouldEndTurn;
     if (shouldStop) {
+      conversationStopped = true;
       break;
     }
 
@@ -312,5 +314,5 @@ export async function runResponseCycle<C = unknown>(
     }
   }
 
-  return [stateRound, stateGlobal, toolState, endTurn];
+  return [stateRound, stateGlobal, toolState, endTurn, conversationStopped];
 }

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -2,7 +2,6 @@
 import { z } from 'zod';
 
 export const DEFAULT_TOOL_CONFIG = {
-  reflect: false,
   autoExtractFigure: false,
   autoExtractTikzFigure: false,
   attachTeXCount: false,
@@ -21,7 +20,6 @@ export const DEFAULT_TOOL_CONFIG = {
  */
 export const ToolConfigSchema = z
   .object({
-    reflect: z.boolean().prefault(DEFAULT_TOOL_CONFIG.reflect),
     autoExtractFigure: z
       .boolean()
       .prefault(DEFAULT_TOOL_CONFIG.autoExtractFigure),

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -47,6 +47,11 @@ export interface RoundOutputOptions {
   processGroupId?: string;
 }
 
+interface RoundProgress {
+  endTurn: boolean;
+  shouldStop: boolean;
+}
+
 /**
  * Abstract base class for agents that support multi-turn reflection and refinement.
  * Provides core functionality for processing inputs, managing state, and handling outputs
@@ -250,7 +255,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     prefill: string,
     outputPath: string,
     roundGroupId: string,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
+  ): Promise<
+    [AgentStateRound, AgentStateGlobal, any[], RoundProgress, ToolState]
+  > {
     const [endTurn, updatedMessages] =
       await this.modelHandler.initializeOutputAndPrefill(
         this.agentConfig,
@@ -283,6 +290,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         updatedStateGlobal,
         updatedToolState,
         newEndTurn,
+        shouldStop,
       ] = await runResponseCycle(
         options,
         updatedMessages,
@@ -316,7 +324,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         updatedStateRound,
         updatedStateGlobal,
         updatedMessages,
-        newEndTurn,
+        { endTurn: newEndTurn, shouldStop },
         updatedToolState,
       ];
     }
@@ -327,7 +335,13 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       processGroupId: roundGroupId,
     });
 
-    return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
+    return [
+      stateRound,
+      stateGlobal,
+      updatedMessages,
+      { endTurn: true, shouldStop: false },
+      toolState,
+    ];
   }
 
   /**
@@ -335,7 +349,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * @returns Tuple of [round state, global state, messages, completion flag, tool state]
    */
   protected async process(): Promise<
-    [AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]
+    [AgentStateRound, AgentStateGlobal, any[], RoundProgress, ToolState]
   > {
     // Initialize input files list
     const inputFiles = [
@@ -442,7 +456,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     messages: any[],
     toolState: ToolState,
     currRound: number = 1,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
+  ): Promise<
+    [AgentStateRound, AgentStateGlobal, any[], RoundProgress, ToolState]
+  > {
     this.logger.debug(`Processing round ${currRound}`);
 
     return this.withRoundGroup(`r${currRound}`, async (roundGroupId) => {
@@ -479,7 +495,13 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
       // Only proceed if there's actual content
       if (!userMessage.trim()) {
-        return [stateRound, stateGlobal, messages, true, toolState];
+        return [
+          stateRound,
+          stateGlobal,
+          messages,
+          { endTurn: true, shouldStop: true },
+          toolState,
+        ];
       }
 
       const roundMessages = await this.modelHandler.createRoundMessages(
@@ -510,7 +532,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     stateGlobal: AgentStateGlobal,
     messages: any[],
     toolState: ToolState,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
+  ): Promise<
+    [AgentStateRound, AgentStateGlobal, any[], RoundProgress, ToolState]
+  > {
     if (currRound === 0) {
       return await this.process();
     }
@@ -530,28 +554,36 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
       let stateGlobal = new AgentStateGlobal();
       let messages: any[] = [];
-      let continueRounds = true;
+      let roundProgress: RoundProgress = {
+        endTurn: true,
+        shouldStop: false,
+      };
 
       const totalRounds = this.getNumberOfRounds();
       for (let currRound = 0; currRound < totalRounds; currRound++) {
         if (
           currRound > 0 &&
-          (!this.agentConfig.toolConfig.reflect ||
-            !continueRounds ||
-            this.isInterrupted)
+          (this.isInterrupted ||
+            roundProgress.shouldStop ||
+            !roundProgress.endTurn)
         ) {
           break;
         }
 
         this.userVars.CURRENT_ROUND = currRound;
         const toolState = new ToolState();
-        const [stateRound, updatedGlobal, newMessages, endTurn, usedToolState] =
-          await this.runRound(currRound, stateGlobal, messages, toolState);
+        const [
+          stateRound,
+          updatedGlobal,
+          newMessages,
+          nextProgress,
+          usedToolState,
+        ] = await this.runRound(currRound, stateGlobal, messages, toolState);
         this.roundStates.push(stateRound);
         this.toolStates.push(usedToolState);
         stateGlobal = updatedGlobal;
         messages = newMessages;
-        continueRounds = endTurn;
+        roundProgress = nextProgress;
         stateGlobal.incrementRounds();
       }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -97,7 +97,6 @@ export abstract class ModelHandler<
       toolConfig: config.toolConfig || {
         autoExtractFigure: false,
         autoExtractTikzFigure: false,
-        reflect: false,
         attachTeXCount: false,
         attachDiagnostics: false,
         autoCompileInputPdf: false,

--- a/src/test/agent/core/ConfigSchemas.test.ts
+++ b/src/test/agent/core/ConfigSchemas.test.ts
@@ -13,7 +13,7 @@ describe('ToolConfigSchema', () => {
       printInputPrompt: true,
     } as Record<string, unknown>);
 
-    assert.strictEqual(parsed.reflect, true);
+    assert.strictEqual((parsed as Record<string, unknown>).reflect, undefined);
     assert.strictEqual(parsed.autoExtractFigure, false);
     assert.strictEqual(
       (parsed as Record<string, unknown>).usePrefillFromInput,
@@ -36,7 +36,10 @@ describe('AgentConfigSchema', () => {
       },
     } as Record<string, unknown>);
 
-    assert.strictEqual(parsed.toolConfig.reflect, true);
+    assert.strictEqual(
+      (parsed.toolConfig as Record<string, unknown>).reflect,
+      undefined,
+    );
     assert.strictEqual(parsed.toolConfig.autoExtractFigure, false);
     assert.strictEqual('legacyFlag' in parsed, false);
     assert.strictEqual(parsed.inputFile, '');

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -48,7 +48,6 @@ const baseConfig: AgentConfig = {
   outputFiles: null,
   editedFile: null,
   toolConfig: {
-    reflect: false,
     autoExtractFigure: false,
     autoExtractTikzFigure: false,
     attachTeXCount: false,

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -73,7 +73,6 @@ describe('OutputHandler.finalizeRound', () => {
     outputFiles: null,
     editedFile: null,
     toolConfig: {
-      reflect: false,
       autoExtractFigure: false,
       autoExtractTikzFigure: false,
       attachTeXCount: false,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -44,7 +44,6 @@ describe('XmlOutputManager markdown fallback', () => {
     outputFiles: null,
     editedFile: null,
     toolConfig: {
-      reflect: false,
       autoExtractFigure: false,
       autoExtractTikzFigure: false,
       attachTeXCount: false,

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -146,7 +146,6 @@ describe('BaseToolUseAgent follow-up loop', () => {
       outputFiles: null,
       editedFile: null,
       toolConfig: {
-        reflect: false,
         autoExtractFigure: false,
         autoExtractTikzFigure: false,
         attachTeXCount: false,

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -131,9 +131,11 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     autoExtractTikzFigure,
     autoCompileInputPdf,
     attachTeXCount,
-    reflect,
+    reflect: _legacyReflect,
     ...agentConfigData
   } = obj;
+
+  void _legacyReflect;
 
   const legacyPrintInputPrompt = Object.prototype.hasOwnProperty.call(
     obj,
@@ -170,7 +172,6 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     ...(autoExtractTikzFigure !== undefined && { autoExtractTikzFigure }),
     ...(autoCompileInputPdf !== undefined && { autoCompileInputPdf }),
     ...(attachTeXCount !== undefined && { attachTeXCount }),
-    ...(reflect !== undefined && { reflect }),
   };
 
   if (

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -21,7 +21,7 @@ export const AUTO_EXTRACT_FIELDS = [
   'autoExtractTikzFigure',
   'autoCompileInputPdf',
 ] as const;
-export const TOOL_CONFIG_FIELDS = ['attachTeXCount', 'reflect'] as const;
+export const TOOL_CONFIG_FIELDS = ['attachTeXCount'] as const;
 
 // Length for preview slices of tool output and responses
 export const K_SLICE = 200;

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -398,10 +398,6 @@
                   style="display: none"
                 >
                   <label class="vscode-checkbox"
-                    ><input type="checkbox" id="reflect" />
-                    <i class="codicon codicon-refresh"></i> Reflect</label
-                  >
-                  <label class="vscode-checkbox"
                     ><input type="checkbox" id="attachTeXCount" />
                     <i class="codicon codicon-symbol-numeric"></i> Attach TeX
                     Count</label

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -79,7 +79,6 @@ export class ExecutionManager {
     const toolConfig: ToolConfig = {
       autoExtractFigure: message.autoExtractFigure,
       autoExtractTikzFigure: message.autoExtractTikzFigure,
-      reflect: message.reflect,
       attachTeXCount: message.attachTeXCount,
       attachDiagnostics: message.attachDiagnostics,
       autoCompileInputPdf: message.autoCompileInputPdf,

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -38,11 +38,7 @@ export const CHECK_BOXES_AUTO_EXTRACT = [
 ];
 
 // Tool configuration checkboxes
-export const CHECK_BOXES_TOOL_USE = [
-  'attachTeXCount',
-  'attachDiagnostics',
-  'reflect',
-];
+export const CHECK_BOXES_TOOL_USE = ['attachTeXCount', 'attachDiagnostics'];
 
 // All checkboxes (combined)
 export const CHECK_BOXES = [

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -570,7 +570,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       referenceFile: state.referenceFile,
       auxiliaryFile: state.auxiliaryFile,
       mediaFile: state.mediaFile,
-      reflect: state.reflect ?? toolConfig.reflect ?? false,
       autoExtractFigure:
         state.autoExtractFigure ?? toolConfig.autoExtractFigure ?? false,
       autoExtractTikzFigure:

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -283,11 +283,6 @@ export class SettingsButtonManager extends BaseUIManager {
       });
     }
 
-    const reflectCheckbox = safeGetElementById('reflect');
-    if (reflectCheckbox) {
-      reflectCheckbox.checked = !selectedAgent.startsWith('correct');
-    }
-
     this.vscode.postMessage({
       command: MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
     });


### PR DESCRIPTION
## Summary
- drop the legacy `reflect` flag from tool configuration defaults, schema parsing, and model handler fallbacks
- derive reflection continuation from configured rounds and stop conditions while cleaning up UI/state handling that previously persisted the toggle
- refresh docs and tests to describe reflection as automatic and ensure fixtures ignore the removed flag

## Testing
- npm run format
- npm run lint
- npm run compile
- npm test *(fails: `/workspace/TeXRA/.vscode-test/vscode-linux-x64-1.104.3/code: error while loading shared libraries: libatk-1.0.so.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc053383883248c2794a4304e6f82

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the manual “Reflect” tool toggle in favor of agent-configured reflection rounds, updates core stop/continuation flow, and aligns UI, schemas, tests, and docs.
> 
> - **Core/runtime**:
>   - `runResponseCycle()` now returns `[... , endTurn, shouldStop]` (tracks conversation stop); integrated into `BaseReflectionAgent` via a `RoundProgress` object to control subsequent rounds.
>   - Reflection rounds proceed based on agent config (`settings.rounds`, `prompts.userReflect`), not a tool toggle; loop gating updated to use `shouldStop/endTurn` instead of `toolConfig.reflect`.
> - **Config/Schema**:
>   - Drop `toolConfig.reflect` from `DEFAULT_TOOL_CONFIG`, `ToolConfigSchema`, constants, model handler defaults, and config conversion (legacy reflect ignored).
> - **UI/Webview**:
>   - Remove Reflect checkbox and all related state/plumbing (`index.html`, constants, messageHandlers, SettingsButtonManager, ExecutionManager); tool config dropdown now only includes TeX Count/Diagnostics.
> - **Docs**:
>   - Update guides to describe automatic reflection based on agent definitions; replace toggle-based wording in architecture, quick start, best practices, configuration, tool integration, file management, glossary, troubleshooting.
> - **Tests**:
>   - Adjust schema and config tests to expect no `reflect`; update fixtures and defaults accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d56b19d7367fadf7dcfa437496a5b46053ba100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->