### PR TITLE
feat: default agent selection to correct and chat

### DIFF
--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -1,10 +1,11 @@
 // Third-party imports
-import { glob } from 'glob';
 import * as vscode from 'vscode';
 
 // Local imports - agent utilities
 import {
   buildAgentOptionsPayload,
+  DEFAULT_TOOL_USE_AGENT,
+  DEFAULT_WORKFLOW_AGENT,
   type AgentDirectoryMap,
   type AgentOptionsPayload,
 } from '@agent/utils/agentOptionMetadata';
@@ -14,7 +15,7 @@ import { getConfig } from '@utils/config';
 export type { AgentOptionsPayload };
 
 /**
- * Collect configured workflow agents alongside configured and discovered tool-use agents.
+ * Collect configured workflow agents alongside configured tool-use agents and defaults.
  */
 export interface AgentNameBuckets {
   allAgents: string[];
@@ -24,27 +25,14 @@ export interface AgentNameBuckets {
 export async function getAllAgents(
   context: vscode.ExtensionContext,
 ): Promise<AgentNameBuckets> {
-  const workflowAgents = getConfig<string[]>('agents', []);
+  const configuredWorkflowAgents = getConfig<string[]>('agents', []);
   const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
 
-  const toolUseDir = await agentDirectories.builtInToolUse(context);
-  let discoveredToolUseAgents: string[] = [];
-  try {
-    const toolUseFiles = await glob('**/*.yaml', {
-      cwd: toolUseDir,
-      dot: false,
-      nodir: true,
-      absolute: false,
-    });
-    discoveredToolUseAgents = toolUseFiles.map((f) =>
-      f.replace(/\.yaml$/, '').replace(/.*\//, ''),
-    );
-  } catch {
-    discoveredToolUseAgents = [];
-  }
-
+  const workflowAgents = Array.from(
+    new Set([DEFAULT_WORKFLOW_AGENT, ...configuredWorkflowAgents]),
+  );
   const toolUseAgents = Array.from(
-    new Set([...configuredToolUseAgents, ...discoveredToolUseAgents]),
+    new Set([DEFAULT_TOOL_USE_AGENT, ...configuredToolUseAgents]),
   );
   const allAgents = Array.from(new Set([...workflowAgents, ...toolUseAgents]));
 
@@ -76,5 +64,8 @@ export async function computeAgentOptions(
   const { allAgents, toolUseAgents } = await getAllAgents(context);
   const dirs = await getAgentDirectories(context);
 
-  return buildAgentOptionsPayload(allAgents, dirs, toolUseAgents);
+  return buildAgentOptionsPayload(allAgents, dirs, toolUseAgents, {
+    workflowAgent: DEFAULT_WORKFLOW_AGENT,
+    toolUseAgent: DEFAULT_TOOL_USE_AGENT,
+  });
 }

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -31,6 +31,14 @@ export interface AgentOptionsPayload {
   toolUse: string;
 }
 
+export interface AgentOptionDefaults {
+  workflowAgent?: string;
+  toolUseAgent?: string;
+}
+
+export const DEFAULT_WORKFLOW_AGENT = 'correct';
+export const DEFAULT_TOOL_USE_AGENT = 'chat';
+
 const DIRECTORY_KEYS: (keyof AgentDirectoryMap)[] = [
   'custom',
   'builtIn',
@@ -129,9 +137,14 @@ function decorateLabel(
   return label;
 }
 
+interface AgentOptionTagOptions {
+  isSelected?: boolean;
+}
+
 export function createAgentOptionTag(
   agentName: string,
   metadata: AgentOptionMetadata,
+  options: AgentOptionTagOptions = {},
 ): string {
   const attributes = [
     `value="${encodeHtml(agentName)}"`,
@@ -147,6 +160,9 @@ export function createAgentOptionTag(
   if (metadata.isToolUse) {
     attributes.push('data-tool-use="true"');
   }
+  if (options.isSelected) {
+    attributes.push('selected');
+  }
 
   const label = decorateLabel(agentName, metadata);
   return `<option ${attributes.join(' ')}>${encodeHtml(label)}</option>`;
@@ -156,9 +172,16 @@ export function buildAgentOptionsPayload(
   agentNames: Iterable<string>,
   directories: AgentDirectoryMap,
   configuredToolUseAgents: Iterable<string> = [],
+  defaults: AgentOptionDefaults = {},
 ): AgentOptionsPayload {
-  const workflowOptions: string[] = [];
-  const toolUseOptions: string[] = [];
+  interface OptionEntry {
+    name: string;
+    metadata: AgentOptionMetadata;
+    isSelected: boolean;
+  }
+
+  const workflowEntries: OptionEntry[] = [];
+  const toolUseEntries: OptionEntry[] = [];
   const configuredToolUseSet = new Set(configuredToolUseAgents);
 
   const seen = new Set<string>();
@@ -171,34 +194,65 @@ export function buildAgentOptionsPayload(
     const metadataWithConfig = configuredToolUseSet.has(agentName)
       ? { ...metadata, isToolUse: true }
       : metadata;
-    const optionTag = createAgentOptionTag(agentName, metadataWithConfig);
+    const isDefaultWorkflow =
+      defaults.workflowAgent && agentName === defaults.workflowAgent;
+    const isDefaultToolUse =
+      defaults.toolUseAgent && agentName === defaults.toolUseAgent;
+    const entry: OptionEntry = {
+      name: agentName,
+      metadata: metadataWithConfig,
+      isSelected: metadataWithConfig.isToolUse
+        ? Boolean(isDefaultToolUse)
+        : Boolean(isDefaultWorkflow),
+    };
     if (metadataWithConfig.isToolUse) {
-      toolUseOptions.push(optionTag);
+      toolUseEntries.push(entry);
     } else {
-      workflowOptions.push(optionTag);
+      workflowEntries.push(entry);
     }
   }
 
   const ensureOptions = (
-    options: string[],
-    placeholder: string,
+    entries: OptionEntry[],
+    defaultName: string | undefined,
     emptyMessage: string,
   ): string => {
-    if (options.length === 0) {
+    if (entries.length === 0) {
       return `<option value="">${emptyMessage}</option>`;
     }
-    return [`<option value="">${placeholder}</option>`, ...options].join('\n');
+
+    if (defaultName) {
+      const defaultIndex = entries.findIndex(
+        (entry) => entry.name === defaultName,
+      );
+      if (defaultIndex > 0) {
+        const [defaultEntry] = entries.splice(defaultIndex, 1);
+        entries.unshift(defaultEntry);
+      }
+    }
+
+    if (!entries.some((entry) => entry.isSelected)) {
+      entries[0].isSelected = true;
+    }
+
+    return entries
+      .map((entry) =>
+        createAgentOptionTag(entry.name, entry.metadata, {
+          isSelected: entry.isSelected,
+        }),
+      )
+      .join('\n');
   };
 
   return {
     workflow: ensureOptions(
-      workflowOptions,
-      'Select a workflow agent',
+      workflowEntries,
+      defaults.workflowAgent,
       'No workflow agents available',
     ),
     toolUse: ensureOptions(
-      toolUseOptions,
-      'Select a tool-use agent',
+      toolUseEntries,
+      defaults.toolUseAgent,
       'No tool-use agents available',
     ),
   };

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -221,24 +221,46 @@ export function buildAgentOptionsPayload(
       return `<option value="">${emptyMessage}</option>`;
     }
 
-    if (defaultName) {
-      const defaultIndex = entries.findIndex(
-        (entry) => entry.name === defaultName,
-      );
-      if (defaultIndex > 0) {
-        const [defaultEntry] = entries.splice(defaultIndex, 1);
-        entries.unshift(defaultEntry);
+    let orderedEntries = [...entries];
+    let selectedName =
+      orderedEntries.find((entry) => entry.isSelected)?.name ?? defaultName;
+
+    let selectedIndex = selectedName
+      ? orderedEntries.findIndex((entry) => entry.name === selectedName)
+      : -1;
+
+    if (
+      selectedIndex === -1 ||
+      !orderedEntries[selectedIndex]?.metadata.hasDefinition
+    ) {
+      const fallbackEntry =
+        orderedEntries.find((entry) => entry.metadata.hasDefinition) ??
+        orderedEntries[0];
+
+      if (defaultName) {
+        console.warn(
+          `Default agent "${defaultName}" is missing or disabled. Falling back to "${fallbackEntry.name}".`,
+        );
       }
+
+      selectedName = fallbackEntry.name;
+      selectedIndex = orderedEntries.findIndex(
+        (entry) => entry.name === selectedName,
+      );
     }
 
-    if (!entries.some((entry) => entry.isSelected)) {
-      entries[0].isSelected = true;
+    if (selectedIndex > 0) {
+      orderedEntries = [
+        orderedEntries[selectedIndex],
+        ...orderedEntries.slice(0, selectedIndex),
+        ...orderedEntries.slice(selectedIndex + 1),
+      ];
     }
 
-    return entries
+    return orderedEntries
       .map((entry) =>
         createAgentOptionTag(entry.name, entry.metadata, {
-          isSelected: entry.isSelected,
+          isSelected: entry.name === selectedName,
         }),
       )
       .join('\n');

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -7,6 +7,8 @@ import * as vscode from 'vscode';
 // Local imports - agent utilities
 import {
   buildAgentOptionsPayload,
+  DEFAULT_TOOL_USE_AGENT,
+  DEFAULT_WORKFLOW_AGENT,
   type AgentDirectoryMap,
 } from '@agent/utils/agentOptionMetadata';
 import type { AgentOptionsPayload } from '@agent/computeAgentOptions';
@@ -17,7 +19,7 @@ import {
   ModuleDescriptor,
 } from '@common/webview/BaseViewContentProvider';
 import { getConfig } from '@utils/config';
-import { GlobalStorageFS, AbsoluteFS } from '@utils/files';
+import { GlobalStorageFS } from '@utils/files';
 
 export class MainViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
@@ -99,23 +101,23 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       builtIn: builtInDir,
       builtInToolUse: toolUseDir,
     };
-    let discoveredToolUseAgents: string[] = [];
-    try {
-      const files = AbsoluteFS.readDirSync(toolUseDir);
-      discoveredToolUseAgents = files
-        .filter((f) => f.endsWith('.yaml'))
-        .map((f) => path.basename(f, '.yaml'));
-    } catch {
-      discoveredToolUseAgents = [];
-    }
-    const toolUseAgents = Array.from(
-      new Set([...configuredToolUseAgents, ...discoveredToolUseAgents]),
+    const workflowAgents = Array.from(
+      new Set([DEFAULT_WORKFLOW_AGENT, ...agents]),
     );
-    const allAgents = Array.from(new Set([...agents, ...toolUseAgents]));
+    const toolUseAgents = Array.from(
+      new Set([DEFAULT_TOOL_USE_AGENT, ...configuredToolUseAgents]),
+    );
+    const allAgents = Array.from(
+      new Set([...workflowAgents, ...toolUseAgents]),
+    );
     const optionBuckets: AgentOptionsPayload = buildAgentOptionsPayload(
       allAgents,
       agentDirectories,
       toolUseAgents,
+      {
+        workflowAgent: DEFAULT_WORKFLOW_AGENT,
+        toolUseAgent: DEFAULT_TOOL_USE_AGENT,
+      },
     );
 
     const models = getConfig<string[]>('models', []);

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -494,8 +494,8 @@
                       id="workflowAgent"
                       class="agent-select agent-select--active"
                       data-session-type="workflow"
-                      aria-label="Select a workflow agent"
-                      title="Select a workflow agent"
+                      aria-label="Workflow agent"
+                      title="Workflow agent"
                     >
                       ${workflowAgentOptions}
                     </select>
@@ -503,8 +503,8 @@
                       id="toolUseAgent"
                       class="agent-select agent-select--hidden"
                       data-session-type="toolUse"
-                      aria-label="Select a tool-use agent"
-                      title="Select a tool-use agent"
+                      aria-label="Tool-use agent"
+                      title="Tool-use agent"
                       tabindex="-1"
                       aria-hidden="true"
                     >

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -88,7 +88,7 @@ export class MainViewState {
       const defaults = {
         sessionType: SESSION_TYPES.WORKFLOW,
         workflowAgent: 'correct',
-        toolUseAgent: '',
+        toolUseAgent: 'chat',
         model: 'gemini25p',
         commit: 'HEAD',
       };


### PR DESCRIPTION
## Summary
- make "correct" and "chat" the default workflow and tool-use agents, selecting them automatically
- update agent option payload construction to support default selections and remove placeholder labels
- limit default tool-use agent discovery to the configured list while updating main view state defaults

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68dfc29a11708324be4c54a568724df1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set default agents to correct/chat, auto-select them in dropdowns, and limit tool-use agents to the configured list while updating UI labels/state.
> 
> - **Agent options**:
>   - Add `DEFAULT_WORKFLOW_AGENT` (`correct`) and `DEFAULT_TOOL_USE_AGENT` (`chat`); include them in `getAllAgents` buckets.
>   - Remove filesystem discovery of tool-use agents; use only configured list.
>   - Enhance `buildAgentOptionsPayload` to accept defaults, auto-select valid defaults, ensure fallback selection, and omit placeholder options; support `selected` flag in `createAgentOptionTag`.
> - **Webview**:
>   - `MainViewContentProvider`: stop scanning tool-use dir; build agent lists with defaults and pass them to `buildAgentOptionsPayload`.
>   - `index.html`: simplify agent select aria-label/title text.
>   - `mainViewState.js`: default `toolUseAgent` to `chat`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95b44fc520656a03f11739185d9f7ec287e340c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->