### PR TITLE
feat: auto select latex diff commit from current file

### DIFF
--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -12,6 +12,10 @@ export function registerGitCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.isGitRepository', isGitRepository),
     vscode.commands.registerCommand('texra.getRecentCommits', getRecentCommits),
+    vscode.commands.registerCommand(
+      'texra.findCommitInHistory',
+      findCommitInHistory,
+    ),
   );
 }
 
@@ -64,7 +68,47 @@ async function getRecentCommits(): Promise<string[] | null> {
   return [];
 }
 
+async function findCommitInHistory(commitHash: string): Promise<string | null> {
+  if (typeof commitHash !== 'string') {
+    return null;
+  }
+
+  const sanitizedCommit = commitHash.trim();
+  if (!/^[0-9a-fA-F]{4,40}$/.test(sanitizedCommit)) {
+    return null;
+  }
+
+  const workspacePath = WorkspaceFS.getPath();
+  if (!workspacePath) {
+    return null;
+  }
+
+  const verifyResult = execaSync(
+    'git',
+    ['rev-parse', '--verify', `${sanitizedCommit}^{commit}`],
+    { cwd: workspacePath, reject: false },
+  );
+
+  if (verifyResult.exitCode !== 0) {
+    return null;
+  }
+
+  const labelResult = execaSync(
+    'git',
+    ['show', '-s', '--format=%h: %s (%cr)', sanitizedCommit],
+    { cwd: workspacePath, reject: false },
+  );
+
+  if (labelResult.exitCode !== 0) {
+    return sanitizedCommit;
+  }
+
+  const label = labelResult.stdout.toString().trim();
+  return label || sanitizedCommit;
+}
+
 export const gitCommands = {
   isGitRepository,
   getRecentCommits,
+  findCommitInHistory,
 };

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -8,6 +8,8 @@ import * as vscode from 'vscode';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 
+const COMMIT_LABEL_FORMAT = '%h: %s (%cr)';
+
 export function registerGitCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.isGitRepository', isGitRepository),
@@ -54,7 +56,12 @@ async function getRecentCommits(): Promise<string[] | null> {
 
     const result = execaSync(
       'git',
-      ['log', '-n', numberOfCommits.toString(), '--pretty=format:%h: %s (%cr)'],
+      [
+        'log',
+        '-n',
+        numberOfCommits.toString(),
+        `--pretty=format:${COMMIT_LABEL_FORMAT}`,
+      ],
       { cwd: workspacePath, reject: false },
     );
     if (result.exitCode !== 0) {
@@ -95,7 +102,7 @@ async function findCommitInHistory(commitHash: string): Promise<string | null> {
 
   const labelResult = execaSync(
     'git',
-    ['show', '-s', '--format=%h: %s (%cr)', sanitizedCommit],
+    ['show', '-s', `--format=${COMMIT_LABEL_FORMAT}`, sanitizedCommit],
     { cwd: workspacePath, reject: false },
   );
 

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -107,6 +107,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_CURRENT_FILE: 'setCurrentFile',
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
+  SET_SELECTED_COMMIT: 'setSelectedCommit',
   SET_MODEL_OPTIONS: 'setModelOptions',
   SET_AGENT_OPTIONS: 'setAgentOptions',
 

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -107,6 +107,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_CURRENT_FILE: 'setCurrentFile',
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
+  SET_SELECTED_COMMIT: 'setSelectedCommit',
   SET_MODEL_OPTIONS: 'setModelOptions',
   SET_AGENT_OPTIONS: 'setAgentOptions',
 

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -295,9 +295,22 @@ export class FileManager {
           );
         }
       } else {
+        let filePathToSelect = currentOpenFile;
+        if (fileType === 'base') {
+          const derivedBaseFile =
+            this._deriveBaseFileFromLatexDiff(currentOpenFile);
+          if (derivedBaseFile) {
+            await this.handleRequestBaseFile(
+              { preserveBaseFile: true },
+              webviewView,
+            );
+            filePathToSelect = derivedBaseFile;
+          }
+        }
+
         webviewView.webview.postMessage({
           command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
-          filePath: currentOpenFile,
+          filePath: filePathToSelect,
           fileType,
         });
         commitCheckFile = currentOpenFile;
@@ -368,6 +381,17 @@ export class FileManager {
 
     logger.debug(CHANNEL, `Updating ${fileType} with ${files.length} files`);
     webviewView.webview.postMessage({ command: `set${fileType}`, files });
+  }
+
+  private _deriveBaseFileFromLatexDiff(filePath: string): string | null {
+    const { dir, name, ext } = path.parse(filePath);
+    const baseNameMatch = name.match(/^(.*)-diff[0-9a-fA-F]{4,40}$/);
+    if (!baseNameMatch || !baseNameMatch[1]) {
+      return null;
+    }
+
+    const baseName = baseNameMatch[1];
+    return path.join(dir, `${baseName}${ext}`);
   }
 
   async selectOutputFiles(currentInputFile: string): Promise<string[] | null> {

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -265,6 +265,7 @@ export class FileManager {
       'texra.getCurrentFile',
     );
     if (currentOpenFile) {
+      let commitCheckFile: string | null = null;
       if (fileType === 'edited') {
         const baseFile = message.baseFile;
         if (baseFile) {
@@ -282,6 +283,7 @@ export class FileManager {
               filePath: currentOpenFile,
               fileType,
             });
+            commitCheckFile = currentOpenFile;
           } else {
             vscode.window.showInformationMessage(
               'The current file is not a valid edited version of the base file.',
@@ -298,10 +300,47 @@ export class FileManager {
           filePath: currentOpenFile,
           fileType,
         });
+        commitCheckFile = currentOpenFile;
+      }
+      if (commitCheckFile) {
+        await this._maybeSelectCommitFromDiffFile(commitCheckFile, webviewView);
       }
     } else {
       vscode.window.showInformationMessage(
         'No file is currently open or the file is not part of the workspace.',
+      );
+    }
+  }
+
+  private async _maybeSelectCommitFromDiffFile(
+    filePath: string,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const fileName = path.basename(filePath);
+    const commitMatch = fileName.match(/-diff([0-9a-fA-F]{4,40})/);
+    if (!commitMatch) {
+      return;
+    }
+
+    const commitHash = commitMatch[1];
+    const commitLabel = await vscode.commands.executeCommand<string | null>(
+      'texra.findCommitInHistory',
+      commitHash,
+    );
+
+    if (commitLabel) {
+      webviewView.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.SET_SELECTED_COMMIT,
+        commitHash,
+        commitLabel,
+      });
+    } else {
+      logger.info(
+        CHANNEL,
+        `Commit ${commitHash} from ${fileName} was not found in repository history`,
+      );
+      vscode.window.showInformationMessage(
+        `The commit ${commitHash} referenced by ${fileName} was not found in the repository history.`,
       );
     }
   }

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -27,6 +27,8 @@ import { WorkspaceFS } from '@utils/files';
 const CHANNEL = 'FileManager';
 logger.initialize(CHANNEL);
 
+const LATEX_DIFF_BASENAME_PATTERN = /^(.+?)-diff([0-9a-fA-F]{4,40})$/;
+
 type FileUpdateOptions = {
   notifyWhenEmpty?: boolean;
   additionalPayload?: Record<string, unknown>;
@@ -341,12 +343,12 @@ export class FileManager {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const fileName = path.basename(filePath);
-    const commitMatch = fileName.match(/-diff([0-9a-fA-F]{4,40})/);
-    if (!commitMatch) {
+    const latexDiffMetadata = this._parseLatexDiffMetadata(filePath);
+    if (!latexDiffMetadata) {
       return;
     }
 
-    const commitHash = commitMatch[1];
+    const { commitHash } = latexDiffMetadata;
     const commitLabel = await vscode.commands.executeCommand<string | null>(
       'texra.findCommitInHistory',
       commitHash,
@@ -395,14 +397,30 @@ export class FileManager {
   }
 
   private _deriveBaseFileFromLatexDiff(filePath: string): string | null {
-    const { dir, name, ext } = path.parse(filePath);
-    const baseNameMatch = name.match(/^(.*)-diff[0-9a-fA-F]{4,40}$/);
-    if (!baseNameMatch || !baseNameMatch[1]) {
+    const metadata = this._parseLatexDiffMetadata(filePath);
+    if (!metadata) {
       return null;
     }
 
-    const baseName = baseNameMatch[1];
+    const { dir, baseName, ext } = metadata;
     return path.join(dir, `${baseName}${ext}`);
+  }
+
+  private _parseLatexDiffMetadata(
+    filePath: string,
+  ): { dir: string; baseName: string; ext: string; commitHash: string } | null {
+    const { dir, name, ext } = path.parse(filePath);
+    const match = name.match(LATEX_DIFF_BASENAME_PATTERN);
+    if (!match) {
+      return null;
+    }
+
+    const [, baseName, commitHash] = match;
+    if (!baseName || !commitHash) {
+      return null;
+    }
+
+    return { dir, baseName, ext, commitHash };
   }
 
   async selectOutputFiles(currentInputFile: string): Promise<string[] | null> {

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -300,11 +300,22 @@ export class FileManager {
           const derivedBaseFile =
             this._deriveBaseFileFromLatexDiff(currentOpenFile);
           if (derivedBaseFile) {
-            await this.handleRequestBaseFile(
-              { preserveBaseFile: true },
-              webviewView,
-            );
-            filePathToSelect = derivedBaseFile;
+            const baseExists = await WorkspaceFS.exists(derivedBaseFile);
+            if (baseExists) {
+              await this.handleRequestBaseFile(
+                { preserveBaseFile: true },
+                webviewView,
+              );
+              filePathToSelect = derivedBaseFile;
+            } else {
+              logger.info(
+                CHANNEL,
+                `Derived base file ${derivedBaseFile} from ${currentOpenFile} does not exist on disk`,
+              );
+              vscode.window.showInformationMessage(
+                `The base file ${derivedBaseFile} could not be found. Keeping ${currentOpenFile} selected.`,
+              );
+            }
           }
         }
 

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -112,6 +112,14 @@ export function createFileHandlers(ctx) {
     postHandle();
   }
 
+  function handleSetSelectedCommit(message) {
+    fileSelect.handleSetSelectedCommit({
+      commitHash: message.commitHash,
+      commitLabel: message.commitLabel,
+    });
+    postHandle();
+  }
+
   function handleSetOpenedFiles(message) {
     if (message.fileType) {
       const fileType = message.fileType.replace('Files', '');
@@ -161,6 +169,7 @@ export function createFileHandlers(ctx) {
   handlers[MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE] = handleAddMediaFile;
   handlers[MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS] = handleSetRecentCommits;
   handlers[MAIN_VIEW_COMMANDS.SET_CURRENT_FILE] = handleSetCurrentFile;
+  handlers[MAIN_VIEW_COMMANDS.SET_SELECTED_COMMIT] = handleSetSelectedCommit;
   handlers[MAIN_VIEW_COMMANDS.SET_OPENED_FILES] = handleSetOpenedFiles;
   handlers[MAIN_VIEW_COMMANDS.SET_BASE_FILE] = handleSetBaseFile;
 

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -109,7 +109,10 @@ export class FileSelect {
           ) {
             existingOption.text = manualSelection.commitLabel;
           }
-          this._manualCommitSelection = null;
+          safeSetElementValue(
+            ELEMENT_IDS.COMMIT_SELECT,
+            manualSelection.commitHash,
+          );
         }
       }
       setElementsDisabled([commitDiv, ...commitButtons], false);
@@ -143,8 +146,8 @@ export class FileSelect {
     }
 
     const options = Array.from(commitDiv.options);
-    const existingOption = options.find(
-      (option) => option.value === commitHash,
+    const existingOption = options.find((option) =>
+      this._areEquivalentCommitHashes(option.value, commitHash),
     );
 
     if (!existingOption) {

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -84,20 +84,33 @@ export class FileSelect {
 
       const manualSelection = this._manualCommitSelection;
       if (manualSelection) {
-        const hasManualCommit = message.commits.some((commit) =>
-          commit.startsWith(`${manualSelection.commitHash}:`),
+        const options = Array.from(commitDiv.options);
+        const existingOption = options.find((option) =>
+          this._areEquivalentCommitHashes(
+            option.value,
+            manualSelection.commitHash,
+          ),
         );
-        if (!hasManualCommit) {
+
+        if (!existingOption) {
           this.addOption(
             commitDiv,
             manualSelection.commitHash,
             manualSelection.commitLabel,
           );
+          safeSetElementValue(
+            ELEMENT_IDS.COMMIT_SELECT,
+            manualSelection.commitHash,
+          );
+        } else {
+          if (
+            manualSelection.commitLabel &&
+            existingOption.text !== manualSelection.commitLabel
+          ) {
+            existingOption.text = manualSelection.commitLabel;
+          }
+          this._manualCommitSelection = null;
         }
-        safeSetElementValue(
-          ELEMENT_IDS.COMMIT_SELECT,
-          manualSelection.commitHash,
-        );
       }
       setElementsDisabled([commitDiv, ...commitButtons], false);
     }
@@ -147,6 +160,23 @@ export class FileSelect {
     };
 
     commitDiv.dispatchEvent(new Event('change'));
+  }
+
+  _areEquivalentCommitHashes(hashA, hashB) {
+    if (!hashA || !hashB) {
+      return false;
+    }
+
+    const normalizedA = hashA.trim();
+    const normalizedB = hashB.trim();
+
+    if (normalizedA === normalizedB) {
+      return true;
+    }
+
+    return (
+      normalizedA.startsWith(normalizedB) || normalizedB.startsWith(normalizedA)
+    );
   }
 }
 

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -17,6 +17,7 @@ import { vscode } from '@common/webviewContext.js';
 export class FileSelect {
   constructor() {
     this._agentDefaults = [];
+    this._manualCommitSelection = null;
   }
 
   setAgentDefaultOutputFiles(files) {
@@ -73,12 +74,31 @@ export class FileSelect {
     if (message.isGitRepo === false) {
       this.addOption(commitDiv, '', 'Not a Git repository');
       setElementsDisabled([commitDiv, ...commitButtons], true);
+      this._manualCommitSelection = null;
     } else {
       this.addOption(commitDiv, 'HEAD', 'HEAD');
       message.commits.forEach((commit) => {
         const [commitHash] = commit.split(': ');
         this.addOption(commitDiv, commitHash, commit);
       });
+
+      const manualSelection = this._manualCommitSelection;
+      if (manualSelection) {
+        const hasManualCommit = message.commits.some((commit) =>
+          commit.startsWith(`${manualSelection.commitHash}:`),
+        );
+        if (!hasManualCommit) {
+          this.addOption(
+            commitDiv,
+            manualSelection.commitHash,
+            manualSelection.commitLabel,
+          );
+        }
+        safeSetElementValue(
+          ELEMENT_IDS.COMMIT_SELECT,
+          manualSelection.commitHash,
+        );
+      }
       setElementsDisabled([commitDiv, ...commitButtons], false);
     }
   }
@@ -101,6 +121,32 @@ export class FileSelect {
         text: `The current file is not in the ${fileType} file list: ${filePath}`,
       });
     }
+  }
+
+  handleSetSelectedCommit({ commitHash, commitLabel }) {
+    const commitDiv = document.getElementById(ELEMENT_IDS.COMMIT_SELECT);
+    if (!commitDiv || !commitHash) {
+      return;
+    }
+
+    const options = Array.from(commitDiv.options);
+    const existingOption = options.find(
+      (option) => option.value === commitHash,
+    );
+
+    if (!existingOption) {
+      this.addOption(commitDiv, commitHash, commitLabel || commitHash);
+    } else if (commitLabel) {
+      existingOption.text = commitLabel;
+    }
+
+    safeSetElementValue(ELEMENT_IDS.COMMIT_SELECT, commitHash);
+    this._manualCommitSelection = {
+      commitHash,
+      commitLabel: commitLabel || commitHash,
+    };
+
+    commitDiv.dispatchEvent(new Event('change'));
   }
 }
 


### PR DESCRIPTION
## Summary
- detect commit hashes from LaTeX diff files when setting the current file and request their labels from the repository history
- add a git command to resolve historical commits and a webview message to select commits outside the recent list
- persist manual commit selections in the main view so older commits stay available for packing

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1216372b08324bc168d6f59601081

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-selects commit from LaTeX diff filenames, resolves and labels it via new git command, and persists manual commit selection in the UI.
> 
> - **Git Commands**:
>   - Add `texra.findCommitInHistory` to validate/verify a commit and return a labeled string using `git show`; reuse `COMMIT_LABEL_FORMAT` across commands.
> - **Main View Commands**:
>   - Add `SET_SELECTED_COMMIT` message for selecting a commit outside the recent list.
> - **File Manager**:
>   - Detect LaTeX diff files via `-diff<hash>` pattern; derive base file from diff filename when requesting base.
>   - On current file selection, attempt to resolve commit from diff filename and post `SET_SELECTED_COMMIT` with label.
> - **Webview UI**:
>   - `FileSelect`: support programmatic commit selection (`handleSetSelectedCommit`), persist manual selection across refreshes, and match abbreviated hashes; integrate with recent commits list.
>   - Handlers: wire `SET_SELECTED_COMMIT` to update commit dropdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 398d7dd2f4abe63512e05d731987b7c3725a7410. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->