### PR TITLE
fix: hide default workflow agent when not configured

### DIFF
--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -42,7 +42,7 @@ export async function getAllAgents(
     DEFAULT_WORKFLOW_AGENT,
   )
     ? DEFAULT_WORKFLOW_AGENT
-    : workflowAgents[0] ?? DEFAULT_WORKFLOW_AGENT;
+    : (workflowAgents[0] ?? DEFAULT_WORKFLOW_AGENT);
 
   return { allAgents, toolUseAgents, defaultWorkflowAgent };
 }

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -20,6 +20,7 @@ export type { AgentOptionsPayload };
 export interface AgentNameBuckets {
   allAgents: string[];
   toolUseAgents: string[];
+  defaultWorkflowAgent: string;
 }
 
 export async function getAllAgents(
@@ -28,15 +29,22 @@ export async function getAllAgents(
   const configuredWorkflowAgents = getConfig<string[]>('agents', []);
   const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
 
-  const workflowAgents = Array.from(
-    new Set([DEFAULT_WORKFLOW_AGENT, ...configuredWorkflowAgents]),
-  );
+  const hasConfiguredWorkflowAgents = configuredWorkflowAgents.length > 0;
+  const workflowAgents = hasConfiguredWorkflowAgents
+    ? Array.from(new Set(configuredWorkflowAgents))
+    : [DEFAULT_WORKFLOW_AGENT];
   const toolUseAgents = Array.from(
     new Set([DEFAULT_TOOL_USE_AGENT, ...configuredToolUseAgents]),
   );
   const allAgents = Array.from(new Set([...workflowAgents, ...toolUseAgents]));
 
-  return { allAgents, toolUseAgents };
+  const defaultWorkflowAgent = configuredWorkflowAgents.includes(
+    DEFAULT_WORKFLOW_AGENT,
+  )
+    ? DEFAULT_WORKFLOW_AGENT
+    : workflowAgents[0] ?? DEFAULT_WORKFLOW_AGENT;
+
+  return { allAgents, toolUseAgents, defaultWorkflowAgent };
 }
 
 /**
@@ -61,11 +69,12 @@ async function getAgentDirectories(
 export async function computeAgentOptions(
   context: vscode.ExtensionContext,
 ): Promise<AgentOptionsPayload> {
-  const { allAgents, toolUseAgents } = await getAllAgents(context);
+  const { allAgents, toolUseAgents, defaultWorkflowAgent } =
+    await getAllAgents(context);
   const dirs = await getAgentDirectories(context);
 
   return buildAgentOptionsPayload(allAgents, dirs, toolUseAgents, {
-    workflowAgent: DEFAULT_WORKFLOW_AGENT,
+    workflowAgent: defaultWorkflowAgent,
     toolUseAgent: DEFAULT_TOOL_USE_AGENT,
   });
 }

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -101,21 +101,25 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       builtIn: builtInDir,
       builtInToolUse: toolUseDir,
     };
-    const workflowAgents = Array.from(
-      new Set([DEFAULT_WORKFLOW_AGENT, ...agents]),
-    );
+    const hasConfiguredWorkflowAgents = agents.length > 0;
+    const workflowAgents = hasConfiguredWorkflowAgents
+      ? Array.from(new Set(agents))
+      : [DEFAULT_WORKFLOW_AGENT];
     const toolUseAgents = Array.from(
       new Set([DEFAULT_TOOL_USE_AGENT, ...configuredToolUseAgents]),
     );
     const allAgents = Array.from(
       new Set([...workflowAgents, ...toolUseAgents]),
     );
+    const defaultWorkflowAgent = agents.includes(DEFAULT_WORKFLOW_AGENT)
+      ? DEFAULT_WORKFLOW_AGENT
+      : workflowAgents[0] ?? DEFAULT_WORKFLOW_AGENT;
     const optionBuckets: AgentOptionsPayload = buildAgentOptionsPayload(
       allAgents,
       agentDirectories,
       toolUseAgents,
       {
-        workflowAgent: DEFAULT_WORKFLOW_AGENT,
+        workflowAgent: defaultWorkflowAgent,
         toolUseAgent: DEFAULT_TOOL_USE_AGENT,
       },
     );

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -84,7 +84,7 @@ export class MainViewContentProvider extends BaseViewContentProvider {
   protected getTemplateVariables(): Record<string, any> {
     // Note: This uses synchronous approach for template generation
     // Agent options with metadata are computed asynchronously via computeAgentOptions
-    const agents = getConfig<string[]>('agents', []);
+    const configuredWorkflowAgents = getConfig<string[]>('agents', []);
     const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
     const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
     const builtInDir = GlobalStorageFS.fullPath('agents');
@@ -101,9 +101,9 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       builtIn: builtInDir,
       builtInToolUse: toolUseDir,
     };
-    const hasConfiguredWorkflowAgents = agents.length > 0;
+    const hasConfiguredWorkflowAgents = configuredWorkflowAgents.length > 0;
     const workflowAgents = hasConfiguredWorkflowAgents
-      ? Array.from(new Set(agents))
+      ? Array.from(new Set(configuredWorkflowAgents))
       : [DEFAULT_WORKFLOW_AGENT];
     const toolUseAgents = Array.from(
       new Set([DEFAULT_TOOL_USE_AGENT, ...configuredToolUseAgents]),
@@ -111,9 +111,11 @@ export class MainViewContentProvider extends BaseViewContentProvider {
     const allAgents = Array.from(
       new Set([...workflowAgents, ...toolUseAgents]),
     );
-    const defaultWorkflowAgent = agents.includes(DEFAULT_WORKFLOW_AGENT)
+    const defaultWorkflowAgent = configuredWorkflowAgents.includes(
+      DEFAULT_WORKFLOW_AGENT,
+    )
       ? DEFAULT_WORKFLOW_AGENT
-      : workflowAgents[0] ?? DEFAULT_WORKFLOW_AGENT;
+      : (workflowAgents[0] ?? DEFAULT_WORKFLOW_AGENT);
     const optionBuckets: AgentOptionsPayload = buildAgentOptionsPayload(
       allAgents,
       agentDirectories,

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -24,6 +24,22 @@ import { capitalize } from '@common/stringUtils.js';
 import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { WebviewStateManager } from '@common/webviewState.js';
 
+const DEFAULT_WORKFLOW_AGENT = 'correct';
+const DEFAULT_TOOL_USE_AGENT = 'chat';
+
+function getSelectDefaultValue(selectId, fallback) {
+  const element = safeGetElementById(selectId);
+  if (element instanceof HTMLSelectElement) {
+    if (element.value) {
+      return element.value;
+    }
+    if (element.options.length > 0) {
+      return element.options[0].value;
+    }
+  }
+  return fallback;
+}
+
 /**
  * Manages persistent state for the main webview.
  */
@@ -87,8 +103,14 @@ export class MainViewState {
     if (previousState) {
       const defaults = {
         sessionType: SESSION_TYPES.WORKFLOW,
-        workflowAgent: 'correct',
-        toolUseAgent: 'chat',
+        workflowAgent: getSelectDefaultValue(
+          AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
+          DEFAULT_WORKFLOW_AGENT,
+        ),
+        toolUseAgent: getSelectDefaultValue(
+          AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
+          DEFAULT_TOOL_USE_AGENT,
+        ),
         model: 'gemini25p',
         commit: 'HEAD',
       };


### PR DESCRIPTION
## Summary
- select the first configured workflow agent when the default "correct" agent is absent from user settings
- stop injecting the default workflow agent into the main view template so it is hidden when not configured

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1284a691883248fd0e45c939fd05f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop auto-injecting the default workflow agent; compute and use a config-based default (first configured or fallback) across agent options and webview state.
> 
> - **Agent options**:
>   - Update `getAllAgents` to not auto-include `DEFAULT_WORKFLOW_AGENT` unless no workflow agents are configured; return `defaultWorkflowAgent` (preferred default based on config).
>   - Use `defaultWorkflowAgent` in `computeAgentOptions` when building option payloads.
> - **Webview**:
>   - `MainViewContentProvider`: mirror the new workflow-agent bucketing and pass `defaultWorkflowAgent` to `buildAgentOptionsPayload`.
>   - `modules/mainViewState.js`: add defaults for workflow/tool-use agents and derive initial selection from the current select value or first option, falling back to constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c32c5eb429759ee3a229ccbb0af493034b85e7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->