### PR TITLE
Refactor progress events to rely on typed payloads

### DIFF
--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -84,30 +84,16 @@ async function buildToolUseAgent(
   return { agent, agentSetting };
 }
 
-type ResumeAgentCommandPayload =
-  | ToolUseSessionSnapshot
-  | { snapshot: ToolUseSessionSnapshot; followUp?: string };
+interface ResumeAgentCommandPayload {
+  snapshot: ToolUseSessionSnapshot;
+  followUp?: string;
+}
 
 const CHANNEL = 'resumeAgentCommand';
 
 export interface ResumeAgentResult {
   success: boolean;
   lostFollowUps?: number;
-}
-
-function normalizePayload(payload: ResumeAgentCommandPayload | undefined): {
-  snapshot: ToolUseSessionSnapshot | undefined;
-  followUp?: string;
-} {
-  if (!payload) {
-    return { snapshot: undefined };
-  }
-
-  if ('snapshot' in payload) {
-    return { snapshot: payload.snapshot, followUp: payload.followUp };
-  }
-
-  return { snapshot: payload };
 }
 
 export function registerResumeAgentCommand(
@@ -118,7 +104,8 @@ export function registerResumeAgentCommand(
     async (
       payload: ResumeAgentCommandPayload | undefined,
     ): Promise<ResumeAgentResult> => {
-      const { snapshot, followUp } = normalizePayload(payload);
+      const snapshot = payload?.snapshot;
+      const followUp = payload?.followUp;
       if (!snapshot || !ToolUseSessionManager.isPersistenceEnabled()) {
         return { success: false };
       }

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -35,7 +35,7 @@ interface UpdateTaskGroupPayload {
 }
 
 interface SetActiveStreamPayload {
-  stream: StreamTabId | '';
+  stream: StreamTabId | null;
   agentType?: AgentType | null;
   agentSessionKind?: AgentSessionKind | null;
 }

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -1,30 +1,84 @@
 // Standard library imports
 import { EventEmitter } from 'events';
 
+// Local imports - agent
+import type { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
+import type { OutputFileInfo } from '@agent/output/types';
+import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
+
+// Local imports - logger
+import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
+import type { TaskState } from '@logger/TaskState';
+
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
 
-export type ProgressEvent =
-  | 'addLogMessage'
-  | 'updateLogMessage'
-  | 'addTaskGroup'
-  | 'updateTaskGroup'
-  | 'setActiveStream'
-  | 'updateStreamStatus'
-  | 'addOutputFiles'
-  | 'updateMissingOutputs'
-  | 'clearMissingOutputs'
-  | 'clearOutputFiles'
-  | 'setTaskState'
-  | 'updateGroupUsage'
-  | 'clearTaskOutput'
-  | 'updateStreamUsage';
+type StreamStatus = 'running' | 'error' | 'stopped' | 'waiting' | 'resuming';
+type StreamStatusOrReady = StreamStatus | 'ready';
+
+interface AddTaskGroupPayload {
+  stream: StreamTabId;
+  groupId: string;
+  groupName: string;
+  startTime: number;
+  status: StreamStatus | 'ready';
+  endTime?: number;
+  parentGroupId?: string;
+}
+
+interface UpdateTaskGroupPayload {
+  stream: StreamTabId;
+  groupId: string;
+  status: StreamStatus | 'ready';
+  endTime?: number;
+}
+
+interface SetActiveStreamPayload {
+  stream: StreamTabId | '';
+  agentType?: AgentType | null;
+  agentSessionKind?: AgentSessionKind | null;
+}
+
+interface SetTaskStatePayload {
+  streamTabId: StreamTabId;
+  executionId?: ExecutionId;
+  taskState: TaskState;
+}
+
+export interface ProgressEventPayloads {
+  addLogMessage: { stream: StreamTabId; logMessage: LogMessageData };
+  updateLogMessage: { stream: StreamTabId; logMessage: LogMessageUpdate };
+  addTaskGroup: AddTaskGroupPayload;
+  updateTaskGroup: UpdateTaskGroupPayload;
+  setActiveStream: SetActiveStreamPayload;
+  updateStreamStatus: { stream: StreamTabId; status: StreamStatusOrReady };
+  addOutputFiles: {
+    stream: StreamTabId;
+    filesByRound: { [key: number]: OutputFileInfo[] };
+  };
+  updateMissingOutputs: {
+    stream: StreamTabId;
+    filesByRound: { [key: number]: string[] };
+  };
+  clearMissingOutputs: StreamTabId;
+  clearOutputFiles: StreamTabId;
+  setTaskState: SetTaskStatePayload;
+  updateGroupUsage: { stream: StreamTabId; groupId: string; usage: TokenUsageStats };
+  clearTaskOutput: StreamTabId;
+  updateStreamUsage: { stream: StreamTabId; usage: TokenUsageStats };
+}
+
+export type ProgressEvent = keyof ProgressEventPayloads;
 
 class ProgressEventBus {
   private emitter = new EventEmitter();
-  private buffer: { event: ProgressEvent; payload: any }[] = [];
+  private buffer: {
+    event: ProgressEvent;
+    payload: ProgressEventPayloads[ProgressEvent];
+  }[] = [];
 
-  emit(event: ProgressEvent, payload: any): void {
+  emit<K extends ProgressEvent>(event: K, payload: ProgressEventPayloads[K]): void {
     if (this.emitter.listenerCount(event) === 0) {
       this.buffer.push({ event, payload });
       if (this.buffer.length > MAX_BUFFER_SIZE) {
@@ -35,12 +89,15 @@ class ProgressEventBus {
     }
   }
 
-  on(event: ProgressEvent, listener: (payload: any) => void): () => void {
+  on<K extends ProgressEvent>(
+    event: K,
+    listener: (payload: ProgressEventPayloads[K]) => void,
+  ): () => void {
     this.emitter.on(event, listener);
     const remaining: typeof this.buffer = [];
     for (const item of this.buffer) {
       if (item.event === event) {
-        listener(item.payload);
+        listener(item.payload as ProgressEventPayloads[K]);
       } else {
         remaining.push(item);
       }

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -52,3 +52,13 @@ export interface LogMessageData {
   /** Optional structured data associated with the entry */
   data?: unknown;
 }
+
+export interface LogMessageUpdate
+  extends Partial<Omit<LogMessageData, 'id' | 'level' | 'timestamp'>> {
+  /** Identifier of the log entry being updated */
+  id: LogMessageId;
+  /** Optional severity updates for completeness */
+  level?: LogMessageData['level'];
+  /** Optional timestamp override */
+  timestamp?: number;
+}

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -124,9 +124,9 @@ export class ProgressEventHandler {
 
   /**
    * Handle setting active stream
-   */
+  */
   private handleSetActiveStream(payload: {
-    stream: StreamTabId | '';
+    stream: StreamTabId | null;
     agentType?: AgentType | null;
     agentSessionKind?: AgentSessionKind | null;
   }): void {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -13,6 +13,7 @@ import { ProgressViewState } from '../state/ProgressViewState';
 import { buildStreamInfos } from '../streamInfoUtils';
 import type { StreamTabInfo } from '../types';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type { OutputFileInfo } from '@agent/output/types';
 import {
   AgentType,
   AgentSessionKind,
@@ -23,7 +24,7 @@ import {
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import { LogMessageData, TaskGroup } from '@logger/LogTypes';
+import { LogMessageData, LogMessageUpdate, TaskGroup } from '@logger/LogTypes';
 import { parseLegacyLogData } from '@logger/logUtils';
 import { TaskState, isWorkflowTaskState } from '@logger/TaskState';
 import { getConfig } from '@utils/config';
@@ -124,19 +125,12 @@ export class ProgressEventHandler {
   /**
    * Handle setting active stream
    */
-  private handleSetActiveStream(
-    payload:
-      | {
-          stream: StreamTabId;
-          agentType?: AgentType | null;
-          agentSessionKind?: AgentSessionKind | null;
-        }
-      | string,
-  ): void {
-    const { stream, agentType, agentSessionKind } =
-      typeof payload === 'string'
-        ? { stream: payload, agentType: undefined, agentSessionKind: undefined }
-        : payload;
+  private handleSetActiveStream(payload: {
+    stream: StreamTabId | '';
+    agentType?: AgentType | null;
+    agentSessionKind?: AgentSessionKind | null;
+  }): void {
+    const { stream, agentType, agentSessionKind } = payload;
 
     if (!stream) {
       return;
@@ -208,7 +202,7 @@ export class ProgressEventHandler {
    */
   private handleAddOutputFiles(data: {
     stream: string;
-    filesByRound: { [key: number]: any[] };
+    filesByRound: { [key: number]: OutputFileInfo[] };
   }): void {
     const { stream, filesByRound } = data;
     this.state.outputFiles.addFiles(stream, filesByRound);
@@ -413,7 +407,7 @@ export class ProgressEventHandler {
    */
   private handleUpdateLogMessage(data: {
     stream: string;
-    logMessage: LogMessageData;
+    logMessage: LogMessageUpdate;
   }): void {
     const { stream, logMessage } = data;
 
@@ -426,8 +420,17 @@ export class ProgressEventHandler {
     if (logMessage.text !== undefined) {
       existing.text = logMessage.text;
     }
-    if (logMessage.messageType) {
+    if (logMessage.messageType !== undefined) {
       existing.messageType = logMessage.messageType;
+    }
+    if (logMessage.level) {
+      existing.level = logMessage.level;
+    }
+    if (logMessage.timestamp !== undefined) {
+      existing.timestamp = logMessage.timestamp;
+    }
+    if (logMessage.verbose !== undefined) {
+      existing.verbose = logMessage.verbose;
     }
     if (logMessage.data !== undefined) {
       existing.data = logMessage.data;
@@ -474,7 +477,7 @@ export class ProgressEventHandler {
       if (!this._streamStatus.has(stream)) {
         this.handleUpdateStreamStatus({ stream, status: STATUS.RUNNING });
       }
-      this.handleSetActiveStream(stream);
+      this.handleSetActiveStream({ stream });
     }
 
     const group: TaskGroup = {

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -8,15 +8,8 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { WorkspaceFS } from '@utils/files';
 
 // Types
-import type { DiffStats } from '@agent/types/DiffTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-
-interface OutputFileInfo extends DiffStats {
-  path: string;
-  base?: string | null;
-  prev?: string | null;
-  original?: string;
-}
+import type { OutputFileInfo } from '@agent/output/types';
 
 /**
  * Manages output files collection with persistence and file existence validation.

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -11,6 +11,7 @@ import { COMMANDS } from '../modules/constants.js';
 import { ProgressViewState } from '../state/ProgressViewState';
 import { buildStreamInfos } from '../streamInfoUtils';
 import type { InstructionUpdate, StreamTabInfo } from '../types';
+import type { OutputFileInfo } from '@agent/output/types';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
@@ -136,7 +137,10 @@ export class WebviewUpdater {
   /**
    * Update output files for a stream
    */
-  updateFiles(stream: StreamTabId, files: { [key: number]: any[] }): void {
+  updateFiles(
+    stream: StreamTabId,
+    files: { [key: number]: OutputFileInfo[] },
+  ): void {
     const webview = this.getWebview();
     if (!webview) return;
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -271,15 +271,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     const payload = message.instruction;
-    const text = typeof payload === 'string' ? payload : (payload?.text ?? '');
+    const text = payload?.text ?? '';
 
-    if (!text || !text.trim()) {
+    if (!text.trim()) {
       dom.instructionPanel.hide();
       return;
     }
 
-    const metadata =
-      (payload && typeof payload === 'object' && payload.metadata) || {};
+    const metadata = payload?.metadata ?? {};
     dom.instructionPanel.show(text, metadata);
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -260,6 +260,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // State persisted server-side - no direct DOM updates needed
   }
 
+  /**
+   * @param {{
+   *   stream: string | null,
+   *   instruction: import('../types').InstructionUpdate | null
+   * }} message
+   */
   handleUpdateInstruction(message) {
     const activeStream = state.activeStream || '';
 

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -309,12 +309,6 @@ export class ActionButtonManager extends BaseUIManager {
     this._setupCompareButtons();
   }
 
-  _normalizeSessionType(rawType) {
-    return rawType === SESSION_TYPES.TOOL_USE
-      ? SESSION_TYPES.TOOL_USE
-      : SESSION_TYPES.WORKFLOW;
-  }
-
   _getSessionTypeInput() {
     if (!this._sessionTypeInput) {
       const element = safeGetElementById(SESSION_TYPE_INPUT);
@@ -344,7 +338,7 @@ export class ActionButtonManager extends BaseUIManager {
   _getActiveAgentSelection() {
     const sessionTypeInput = this._getSessionTypeInput();
     const rawSessionType = sessionTypeInput?.value;
-    const sessionType = this._normalizeSessionType(rawSessionType);
+    const sessionType = rawSessionType || SESSION_TYPES.WORKFLOW;
     const selectElement = this._getAgentSelect(sessionType);
     const agent = selectElement?.value ?? '';
     return {

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -255,21 +255,14 @@ export class SettingsButtonManager extends BaseUIManager {
     this._setupDependencyBanner();
   }
 
-  _normalizeSessionType(rawType) {
-    return rawType === SESSION_TYPES.TOOL_USE
-      ? SESSION_TYPES.TOOL_USE
-      : SESSION_TYPES.WORKFLOW;
-  }
-
   _handleAgentSelection(selectElement) {
     if (!(selectElement instanceof HTMLSelectElement)) {
       return;
     }
 
-    const normalizedType = this._normalizeSessionType(
-      selectElement.dataset.sessionType,
-    );
-    this.state.applySessionType(normalizedType, { skipSave: true });
+    const sessionType =
+      selectElement.dataset.sessionType || SESSION_TYPES.WORKFLOW;
+    this.state.applySessionType(sessionType, { skipSave: true });
 
     const selectedAgent = selectElement.value;
     const selectedOption = selectElement.options[selectElement.selectedIndex];
@@ -296,7 +289,7 @@ export class SettingsButtonManager extends BaseUIManager {
 
     const sessionInput = safeGetElementById(SESSION_TYPE_INPUT);
     if (sessionInput) {
-      sessionInput.value = normalizedType;
+      sessionInput.value = sessionType;
     }
 
     this.state.save();


### PR DESCRIPTION
## Summary
- replace the resume agent command payload with a single typed object so callers no longer rely on implicit normalization
- introduce typed payloads for the progress event bus and update progress event handling, webview updates, and instruction messages to consume the native structures
- drop duplicate session-type normalization helpers in the webview managers now that DOM data attributes provide canonical values

## Testing
- `npm run lint`
- `CI=1 npm test -- --runTestsByPath src/test/commands/agent/followUpCommand.test.ts` *(fails: VS Code test harness missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e22a00d9488324bb563e31facf11b8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce strongly typed ProgressEventBus payloads and ResumeAgent command payload, update handlers/webview to consume native types and remove redundant session-type normalization.
> 
> - **Progress/Event System**:
>   - Typed `ProgressEventBus` payloads with generics and strict event maps; typed buffer and listeners.
>   - Adjust `ProgressEventHandler` to new types (e.g., `setActiveStream` object form, typed `OutputFileInfo`, `LogMessageUpdate` support; fix call sites).
> - **Commands**:
>   - Simplify `resumeAgent` payload to `{ snapshot, followUp? }`; remove normalization helper and update usage.
> - **Logger**:
>   - Add `LogMessageUpdate` type for partial log edits.
> - **Progress View/Webview**:
>   - `WebviewUpdater.updateFiles` and message handler use typed `OutputFileInfo[]`.
>   - Instruction message handling assumes structured `{ text, metadata? }` and trims before display.
>   - Remove duplicate session-type normalization in `ActionButtonManager` and `SettingsButtonManager`; rely on DOM data/default to `workflow`.
> - **State/Managers**:
>   - `OutputFilesManager` switches to shared `OutputFileInfo` type from `@agent/output/types`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c924230ab25730cf96fb7d3257da2ce51e49a2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->