### PR TITLE
Refine agent category handling

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports - agent
 // Local imports - agent components
-import { AgentSessionKind, AgentType } from './AgentDataclass';
+import { AgentCategorySchema, AgentType } from './AgentDataclass';
 import { DEFAULT_TOOL_CONFIG, ToolConfigSchema } from './ToolConfig';
 
 /**
@@ -27,7 +27,7 @@ export const AgentConfigSchema = z
     useMultipleOutputs: z.boolean().prefault(false),
 
     agentType: z.enum(AgentType).optional(),
-    agentSessionKind: z.enum(AgentSessionKind).optional(),
+    agentCategory: AgentCategorySchema.optional(),
 
     inputFile: z.string().prefault(''),
     inputFiles: z.array(z.string()).nullable().prefault(null),

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -21,10 +21,9 @@ export enum AgentType {
  * Workflow sessions represent traditional direct/CoT executions while
  * toolUse isolates interactive tool panels.
  */
-export enum AgentSessionKind {
-  Workflow = 'workflow',
-  ToolUse = 'toolUse',
-}
+export const AgentCategorySchema = z.enum(['workflow', 'toolUse'] as const);
+
+export type AgentCategory = z.infer<typeof AgentCategorySchema>;
 
 /**
  * Shared metadata describing how an agent session should be classified.
@@ -33,33 +32,17 @@ export interface AgentSessionMetadata {
   /** Specific agent implementation type if known. */
   agentType?: AgentType;
   /** Canonical grouping used by the UI to filter sessions. */
-  agentSessionKind: AgentSessionKind;
+  agentCategory: AgentCategory;
 }
 
 /**
- * Derive the canonical {@link AgentSessionKind} from a specific agent type.
- * Defaults to {@link AgentSessionKind.Workflow} when the type is unknown.
+ * Derive the canonical {@link AgentCategory} from a specific agent type.
+ * Defaults to {@code workflow} when the type is unknown.
  */
-export function deriveAgentSessionKind(
+export function deriveAgentCategory(
   agentType?: AgentType | null,
-): AgentSessionKind {
-  return agentType === AgentType.ToolUse
-    ? AgentSessionKind.ToolUse
-    : AgentSessionKind.Workflow;
-}
-
-/**
- * Resolve canonical session metadata from optional hints.
- */
-export function resolveAgentSessionMetadata(
-  agentType?: AgentType | null,
-  sessionKindHint?: AgentSessionKind | null,
-): AgentSessionMetadata {
-  const agentSessionKind = sessionKindHint ?? deriveAgentSessionKind(agentType);
-  return {
-    agentType: agentType ?? undefined,
-    agentSessionKind,
-  };
+): AgentCategory {
+  return agentType === AgentType.ToolUse ? 'toolUse' : 'workflow';
 }
 
 /**
@@ -68,6 +51,7 @@ export function resolveAgentSessionMetadata(
  */
 export const AgentSettingBaseSchema = z.strictObject({
   agentType: z.enum(AgentType).prefault(AgentType.CoT),
+  agentCategory: AgentCategorySchema.optional(),
   documentTag: z
     .string()
     .min(1, 'documentTag cannot be empty')
@@ -105,6 +89,7 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
   prefills: z.array(z.string()).prefault([]),
   outputExt: z.string().prefault('txt'),
   isMultipleOutput: z.boolean().prefault(false),
+  agentCategory: z.literal('workflow').prefault('workflow'),
 }).superRefine((data, ctx) => {
   if (data.agentType === AgentType.ToolUse) {
     ctx.addIssue({
@@ -119,6 +104,7 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
 /** Tool-use agents never expose workflow-specific flags. */
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
   agentType: z.literal(AgentType.ToolUse).prefault(AgentType.ToolUse),
+  agentCategory: z.literal('toolUse').prefault('toolUse'),
 });
 
 /**
@@ -132,6 +118,12 @@ export const AgentSettingSchema = z.union([
 export type AgentWorkflowSetting = z.infer<typeof AgentWorkflowSettingSchema>;
 export type AgentToolUseSetting = z.infer<typeof AgentToolUseSettingSchema>;
 export type AgentSetting = z.infer<typeof AgentSettingSchema>;
+
+/** Resolve the canonical agent category from validated settings. */
+export function getAgentCategory(setting: AgentSetting): AgentCategory {
+  const agentType = (setting as { agentType?: AgentType }).agentType;
+  return setting.agentCategory ?? deriveAgentCategory(agentType);
+}
 
 /** Narrow an {@link AgentSetting} to the workflow variant. */
 export function requireWorkflowSetting(

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -4,7 +4,7 @@ import {
   AgentPrompt,
   AgentSetting,
   AgentSessionMetadata,
-  resolveAgentSessionMetadata,
+  getAgentCategory,
 } from '../core/AgentDataclass';
 import { AgentStateGlobal } from '../core/AgentState';
 import { IAgent } from '../core/IAgent';
@@ -46,7 +46,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   }
 
   public getSessionMetadata(): AgentSessionMetadata {
-    return resolveAgentSessionMetadata(this.agentSetting.agentType);
+    return {
+      agentType: this.agentSetting.agentType,
+      agentCategory: getAgentCategory(this.agentSetting),
+    };
   }
 
   constructor(

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -1,12 +1,6 @@
 // Local imports - agent
 import type { AgentConfig } from '../core/AgentConfig';
-import {
-  AgentPrompt,
-  AgentSessionKind,
-  AgentSetting,
-  AgentType,
-  resolveAgentSessionMetadata,
-} from '../core/AgentDataclass';
+import { AgentPrompt, AgentSetting } from '../core/AgentDataclass';
 import { ToolState } from '../core/ToolState';
 import { runToolUseCycle } from '../core/ToolUseCycle';
 import type { ToolUseCycleOptions } from '../core/ToolUseCycle';
@@ -70,13 +64,6 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
 
   protected override unregisterRunningAgent(streamTabId: StreamTabId): void {
     unregisterToolUseAgent(streamTabId);
-  }
-
-  public override getSessionMetadata() {
-    return resolveAgentSessionMetadata(
-      AgentType.ToolUse,
-      AgentSessionKind.ToolUse,
-    );
   }
 
   private getTools(): ToolDefinition[] {
@@ -266,7 +253,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
             streamId: stream,
             agentName: this.agentConfig.agent,
             model: this.agentConfig.model,
-            agentSessionKind: AgentSessionKind.ToolUse,
+            agentCategory: 'toolUse',
             messages: this.messages,
             toolState: state,
           });

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -14,6 +14,7 @@ import {
   AgentDefinitionSchema,
   AgentType,
   parseAgentSetting,
+  type AgentCategory,
 } from '@agent/core/AgentDataclass';
 
 // Local imports - utils
@@ -72,15 +73,20 @@ interface LoadAgentOptions {
   preferMultiple?: boolean;
 }
 
-export function ensureAgentTypeForSource<T extends { agentType?: AgentType }>(
-  settings: T,
-  source: AgentDirectorySource,
-): T {
+export function ensureAgentTypeForSource<
+  T extends {
+    agentType?: AgentType;
+    agentCategory?: AgentCategory;
+  },
+>(settings: T, source: AgentDirectorySource): T {
   if (
     source === AgentDirectorySource.BuiltInToolUse &&
     settings.agentType === undefined
   ) {
     settings.agentType = AgentType.ToolUse;
+    if (settings.agentCategory === undefined) {
+      settings.agentCategory = 'toolUse';
+    }
   }
   return settings;
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -15,7 +15,8 @@ import {
   AgentSetting,
   AgentPrompt,
   AgentType,
-  resolveAgentSessionMetadata,
+  deriveAgentCategory,
+  type AgentSessionMetadata,
 } from '@agent/core/AgentDataclass';
 import { IAgent } from '@agent/core/IAgent';
 import {
@@ -194,10 +195,10 @@ export async function executeAgentWithLogging<T extends IAgent>(
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
     const sessionMetadata = agent.getSessionMetadata();
-    const baseMetadata = resolveAgentSessionMetadata(
-      agentType ?? sessionMetadata.agentType,
-      sessionMetadata.agentSessionKind,
-    );
+    const baseMetadata: AgentSessionMetadata = {
+      agentType: agentType ?? sessionMetadata.agentType,
+      agentCategory: sessionMetadata.agentCategory,
+    };
 
     if (executionId) {
       await ensureRunDir(executionId);
@@ -205,12 +206,17 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
     // Get the full stream tab ID
     const config = agent.config;
-    const metadata = resolveAgentSessionMetadata(
-      config.agentType ?? baseMetadata.agentType,
-      config.agentSessionKind ?? baseMetadata.agentSessionKind,
-    );
+    const agentTypeForRun = config.agentType ?? baseMetadata.agentType;
+    const agentCategoryForRun =
+      config.agentCategory ??
+      baseMetadata.agentCategory ??
+      deriveAgentCategory(agentTypeForRun);
+    const metadata: AgentSessionMetadata = {
+      agentType: agentTypeForRun,
+      agentCategory: agentCategoryForRun,
+    };
     config.agentType = metadata.agentType;
-    config.agentSessionKind = metadata.agentSessionKind;
+    config.agentCategory = metadata.agentCategory;
 
     streamTabId = getStreamTabId(config.agent, config.model, config.inputFile, {
       agentType: metadata.agentType,
@@ -269,7 +275,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
         bus.emit('setActiveStream', {
           stream: streamTabId,
           agentType: metadata.agentType,
-          agentSessionKind: metadata.agentSessionKind,
+          agentCategory: metadata.agentCategory,
         });
         bus.emit('updateStreamStatus', {
           stream: streamTabId,

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import type { AgentCategory } from '@agent/core/AgentDataclass';
 import { ToolState } from '@agent/core/ToolState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
@@ -37,19 +37,38 @@ const ToolStateSnapshotSchema = z.object({
   thinkingAdded: z.boolean(),
 });
 
-const ToolUseSessionSnapshotSchema = z.strictObject({
-  version: z.literal(SNAPSHOT_VERSION),
-  executionId: z.string(),
-  streamId: z.string(),
-  agentName: z.string(),
-  model: z.string(),
-  agentSessionKind: z.enum(AgentSessionKind),
-  messages: z.array(z.unknown()),
-  toolState: ToolStateSnapshotSchema,
-  lastUpdated: z.number(),
-});
+const ToolUseSessionSnapshotSchema = z
+  .strictObject({
+    version: z.literal(SNAPSHOT_VERSION),
+    executionId: z.string(),
+    streamId: z.string(),
+    agentName: z.string(),
+    model: z.string(),
+    agentCategory: z.literal('toolUse').optional(),
+    agentSessionKind: z.literal('toolUse').optional(),
+    messages: z.array(z.unknown()),
+    toolState: ToolStateSnapshotSchema,
+    lastUpdated: z.number(),
+  })
+  .transform((snapshot) => {
+    const { agentCategory, agentSessionKind, ...rest } = snapshot;
+    return {
+      ...rest,
+      agentCategory: agentCategory ?? agentSessionKind ?? 'toolUse',
+    } satisfies {
+      version: number;
+      executionId: string;
+      streamId: string;
+      agentName: string;
+      model: string;
+      agentCategory: AgentCategory;
+      messages: unknown[];
+      toolState: z.infer<typeof ToolStateSnapshotSchema>;
+      lastUpdated: number;
+    };
+  });
 
-export type ToolUseSessionSnapshot = z.infer<
+export type ToolUseSessionSnapshot = z.output<
   typeof ToolUseSessionSnapshotSchema
 >;
 
@@ -58,7 +77,7 @@ interface SavePayload {
   streamId: StreamTabId;
   agentName: string;
   model: string;
-  agentSessionKind: AgentSessionKind;
+  agentCategory: 'toolUse';
   messages: ProviderMessage[];
   toolState: ToolState;
 }
@@ -277,7 +296,7 @@ export class ToolUseSessionManager {
         streamId: payload.streamId,
         agentName: payload.agentName,
         model: payload.model,
-        agentSessionKind: payload.agentSessionKind,
+        agentCategory: payload.agentCategory,
         messages: structuredClone(payload.messages),
         toolState: toToolStateSnapshot(payload.toolState),
         lastUpdated: Date.now(),

--- a/src/agent/types/AgentStreamTypes.ts
+++ b/src/agent/types/AgentStreamTypes.ts
@@ -1,20 +1,16 @@
 // Local types - agent
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import type { AgentCategory } from '@agent/core/AgentDataclass';
 
 /**
  * Allowed filter values for agent streams in the ProgressBoard.
  * "workflow" groups traditional direct/CoT agents while
  * "toolUse" isolates interactive tool sessions.
  */
-export type AgentTypeFilter = 'all' | AgentSessionKind;
+export type AgentTypeFilter = 'all' | AgentCategory;
 
 /**
  * Type guard ensuring a value is a valid {@link AgentTypeFilter}.
  */
 export function isAgentTypeFilter(value: unknown): value is AgentTypeFilter {
-  return (
-    value === 'all' ||
-    value === AgentSessionKind.Workflow ||
-    value === AgentSessionKind.ToolUse
-  );
+  return value === 'all' || value === 'workflow' || value === 'toolUse';
 }

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -3,7 +3,10 @@ import * as vscode from 'vscode';
 
 // Local imports - agent commands
 import { executeCommand } from '@commands/agent/executeCommand';
-import { resolveAgentSessionMetadata } from '@agent/core/AgentDataclass';
+import {
+  deriveAgentCategory,
+  type AgentSessionMetadata,
+} from '@agent/core/AgentDataclass';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 
 // Local imports - history view
@@ -89,10 +92,21 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
       const historyItem =
         await AgentHistoryManager.getHistoryItemById(historyId);
       if (historyItem) {
-        const metadata = resolveAgentSessionMetadata(
-          historyItem.agentType,
-          historyItem.agentSessionKind,
-        );
+        const agentType = historyItem.agentType ?? historyItem.config.agentType;
+        const rawCategory =
+          historyItem.agentCategory ??
+          (historyItem as { agentSessionKind?: string }).agentSessionKind ??
+          historyItem.config.agentCategory ??
+          (historyItem.config as { agentSessionKind?: string })
+            .agentSessionKind;
+        const agentCategory =
+          rawCategory === 'toolUse' || rawCategory === 'workflow'
+            ? rawCategory
+            : deriveAgentCategory(agentType);
+        const metadata: AgentSessionMetadata = {
+          agentType: agentType ?? undefined,
+          agentCategory,
+        };
         const taskState = agentConfigToTaskState(historyItem.config, metadata);
         await vscode.commands.executeCommand('texra.restoreState', taskState);
       } else {

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -7,9 +7,9 @@ import * as vscode from 'vscode';
 // Local imports - agent metadata
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import {
-  AgentSessionKind,
   AgentType,
-  resolveAgentSessionMetadata,
+  deriveAgentCategory,
+  type AgentCategory,
 } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
@@ -24,7 +24,16 @@ export interface AgentHistoryItem {
   timestamp: string;
   config: AgentConfig;
   agentType?: AgentType;
-  agentSessionKind?: AgentSessionKind;
+  agentCategory?: AgentCategory;
+}
+
+function resolveCategory(
+  candidate: unknown,
+  agentType?: AgentType | null,
+): AgentCategory {
+  return candidate === 'toolUse' || candidate === 'workflow'
+    ? candidate
+    : deriveAgentCategory(agentType);
 }
 
 /**
@@ -38,22 +47,26 @@ export class AgentHistoryManager {
    * Add a new agent execution to history
    */
   public static async addToHistory(config: AgentConfig): Promise<string> {
-    const metadata = resolveAgentSessionMetadata(
+    const sessionKind = resolveCategory(
+      config.agentCategory ??
+        (config as { agentSessionKind?: AgentCategory }).agentSessionKind,
       config.agentType,
-      config.agentSessionKind,
     );
+    const agentType =
+      config.agentType ??
+      (sessionKind === 'toolUse' ? AgentType.ToolUse : undefined);
     const normalizedConfig: AgentConfig = {
       ...config,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType,
+      agentCategory: sessionKind,
     };
 
     const historyItem: AgentHistoryItem = {
       id: randomUUID(),
       timestamp: new Date().toISOString(),
       config: normalizedConfig,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType,
+      agentCategory: sessionKind,
     };
 
     // Get current workspace-specific history
@@ -93,22 +106,28 @@ export class AgentHistoryManager {
   private static normalizeHistoryItem(
     item: AgentHistoryItem,
   ): AgentHistoryItem {
-    const metadata = resolveAgentSessionMetadata(
-      item.agentType ?? item.config.agentType,
-      item.agentSessionKind ?? item.config.agentSessionKind,
-    );
+    const rawAgentType = item.agentType ?? item.config.agentType;
+    const rawSessionKind =
+      item.agentCategory ??
+      (item as { agentSessionKind?: AgentCategory }).agentSessionKind ??
+      item.config.agentCategory ??
+      (item.config as { agentSessionKind?: AgentCategory }).agentSessionKind;
+    const sessionKind = resolveCategory(rawSessionKind, rawAgentType);
+    const agentType =
+      rawAgentType ??
+      (sessionKind === 'toolUse' ? AgentType.ToolUse : undefined);
 
     const normalizedConfig: AgentConfig = {
       ...item.config,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType,
+      agentCategory: sessionKind,
     };
 
     return {
       ...item,
       config: normalizedConfig,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType,
+      agentCategory: sessionKind,
     };
   }
 

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -1,21 +1,20 @@
 // Local imports
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
-import type { AgentType } from '@agent/core/AgentDataclass';
+import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import type { FileType } from '@utils/config';
 
 /** Shared properties for all task state variants. */
 interface BaseTaskState {
   agentConfig: AgentConfig;
   agentType?: AgentType;
-  agentSessionKind: AgentSessionKind;
+  agentCategory: AgentCategory;
 }
 
 /**
  * Workflow task state stores file visibility information for toolbar actions.
  */
 export interface WorkflowTaskState extends BaseTaskState {
-  agentSessionKind: AgentSessionKind.Workflow;
+  agentCategory: 'workflow';
   activeFiles: Record<FileType, boolean>;
 }
 
@@ -27,7 +26,7 @@ export interface ToolSessionState {
 }
 
 export interface ToolUseTaskState extends BaseTaskState {
-  agentSessionKind: AgentSessionKind.ToolUse;
+  agentCategory: 'toolUse';
   toolSessionState?: ToolSessionState;
 }
 
@@ -36,11 +35,11 @@ export type TaskState = WorkflowTaskState | ToolUseTaskState;
 export function isWorkflowTaskState(
   taskState: TaskState,
 ): taskState is WorkflowTaskState {
-  return taskState.agentSessionKind === AgentSessionKind.Workflow;
+  return taskState.agentCategory === 'workflow';
 }
 
 export function isToolUseTaskState(
   taskState: TaskState,
 ): taskState is ToolUseTaskState {
-  return taskState.agentSessionKind === AgentSessionKind.ToolUse;
+  return taskState.agentCategory === 'toolUse';
 }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -15,8 +15,8 @@ import type { StreamTabInfo } from '../types';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import {
   AgentType,
-  AgentSessionKind,
-  resolveAgentSessionMetadata,
+  deriveAgentCategory,
+  type AgentCategory,
 } from '@agent/core/AgentDataclass';
 
 // Types
@@ -129,13 +129,13 @@ export class ProgressEventHandler {
       | {
           stream: StreamTabId;
           agentType?: AgentType | null;
-          agentSessionKind?: AgentSessionKind | null;
+          agentCategory?: AgentCategory | null;
         }
       | string,
   ): void {
-    const { stream, agentType, agentSessionKind } =
+    const { stream, agentType, agentCategory } =
       typeof payload === 'string'
-        ? { stream: payload, agentType: undefined, agentSessionKind: undefined }
+        ? { stream: payload, agentType: undefined, agentCategory: undefined }
         : payload;
 
     if (!stream) {
@@ -146,15 +146,12 @@ export class ProgressEventHandler {
     // This handles the case where setActiveStream is called before any logs
     this.state.streamTabs.ensureStream(stream);
 
-    const metadata = resolveAgentSessionMetadata(agentType, agentSessionKind);
-    this.state.setSessionKindHint(stream, metadata.agentSessionKind);
+    const resolvedCategory = agentCategory ?? deriveAgentCategory(agentType);
+    this.state.setCategoryHint(stream, resolvedCategory);
 
     const currentFilter = this.state.agentTypeFilter;
-    if (
-      currentFilter !== 'all' &&
-      currentFilter !== metadata.agentSessionKind
-    ) {
-      this.state.agentTypeFilter = metadata.agentSessionKind;
+    if (currentFilter !== 'all' && currentFilter !== resolvedCategory) {
+      this.state.agentTypeFilter = resolvedCategory;
     }
 
     this.state.activeStream = stream;
@@ -280,7 +277,7 @@ export class ProgressEventHandler {
     const { streamTabId, executionId, taskState } = data;
 
     this.state.setTaskState(streamTabId, taskState);
-    this.state.clearSessionKindHint(streamTabId);
+    this.state.clearCategoryHint(streamTabId);
 
     const normalizedState = this.state.getTaskState(streamTabId);
 
@@ -289,10 +286,7 @@ export class ProgressEventHandler {
         `Received setTaskState for ${streamTabId} but no state was stored`,
       );
     } else {
-      const sessionKind = resolveAgentSessionMetadata(
-        normalizedState.agentType,
-        normalizedState.agentSessionKind,
-      ).agentSessionKind;
+      const sessionCategory = normalizedState.agentCategory;
       const currentFilter = this.state.agentTypeFilter;
       const activeStream = this.state.activeStream;
 
@@ -300,12 +294,12 @@ export class ProgressEventHandler {
         activeStream &&
         activeStream === streamTabId &&
         currentFilter !== 'all' &&
-        currentFilter !== sessionKind
+        currentFilter !== sessionCategory
       ) {
         this.logger.debug(
-          `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
+          `Adjusting agent filter from ${currentFilter} to ${sessionCategory} for stream ${streamTabId}`,
         );
-        this.state.agentTypeFilter = sessionKind;
+        this.state.agentTypeFilter = sessionCategory;
       }
     }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -7,7 +7,7 @@ import { appendFormatted } from './utils.js';
 import { progressViewState } from './progressViewState.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
 
-// Session kind values match TypeScript AgentSessionKind enum
+// Agent category values match the TypeScript AgentCategory union
 // No need to duplicate - we use the actual values from messages
 
 // Create shorter aliases for internal use
@@ -89,11 +89,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const activeStreamInfo = message.streams.find(
       (s) => s.name === message.activeStream,
     );
-    const sessionKind =
-      activeStreamInfo?.agentSessionKind ||
-      activeStreamInfo?.uiTraits?.sessionKind ||
+    const agentCategory =
+      activeStreamInfo?.agentCategory ||
+      activeStreamInfo?.uiTraits?.category ||
       'workflow'; // Default fallback
-    const isToolAgent = sessionKind === 'toolUse';
+    const isToolAgent = agentCategory === 'toolUse';
 
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
@@ -101,7 +101,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       container.setAttribute('aria-hidden', isToolAgent ? 'false' : 'true');
     }
 
-    dom.toolbar.render(sessionKind);
+    dom.toolbar.render(agentCategory);
 
     const hasExecution = state.getExecutionAvailability(message.activeStream);
     dom.status.setExecutionAvailability(Boolean(hasExecution));

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -16,8 +16,8 @@ import type { AgentFilter } from '../types';
 // Local imports - agent types
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
 import {
-  AgentSessionKind,
-  resolveAgentSessionMetadata,
+  type AgentCategory,
+  type AgentSessionMetadata,
 } from '@agent/core/AgentDataclass';
 
 // Types
@@ -50,14 +50,14 @@ export class ProgressViewState {
   private readonly workflowTaskStates: WorkflowTaskStateManager;
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
   /**
-   * Ephemeral session-kind hints keyed by stream ID.
+   * Ephemeral agent category hints keyed by stream ID.
    *
    * When a stream becomes active before its {@link TaskState} is persisted,
    * progress events populate this map so the UI can immediately classify the
    * tab as workflow vs. tool-use. Once canonical metadata is stored the entry
    * is cleared, so there is no need to persist these hints across sessions.
    */
-  private _sessionKindHints: Map<StreamTabId, AgentSessionKind> = new Map();
+  private _categoryHints: Map<StreamTabId, AgentCategory> = new Map();
   private readonly toolUseTaskStates: ToolUseTaskStateManager;
   private readonly persistence: StatePersistenceManager;
   private readonly logger: AgentLogger;
@@ -125,27 +125,24 @@ export class ProgressViewState {
   }
 
   // Session kind hint management (non-persistent)
-  setSessionKindHint(
-    streamTabId: StreamTabId,
-    sessionKind: AgentSessionKind,
-  ): void {
-    this._sessionKindHints.set(streamTabId, sessionKind);
+  setCategoryHint(streamTabId: StreamTabId, category: AgentCategory): void {
+    this._categoryHints.set(streamTabId, category);
   }
 
-  getSessionKindHint(streamTabId: StreamTabId): AgentSessionKind | undefined {
-    return this._sessionKindHints.get(streamTabId);
+  getCategoryHint(streamTabId: StreamTabId): AgentCategory | undefined {
+    return this._categoryHints.get(streamTabId);
   }
 
-  clearSessionKindHint(streamTabId: StreamTabId): void {
-    this._sessionKindHints.delete(streamTabId);
+  clearCategoryHint(streamTabId: StreamTabId): void {
+    this._categoryHints.delete(streamTabId);
   }
 
   // Task state management
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
-    const metadata = resolveAgentSessionMetadata(
-      taskState.agentType,
-      taskState.agentSessionKind,
-    );
+    const metadata: AgentSessionMetadata = {
+      agentType: taskState.agentType,
+      agentCategory: taskState.agentCategory,
+    };
     const normalizedState = agentConfigToTaskState(
       taskState.agentConfig,
       metadata,
@@ -164,7 +161,7 @@ export class ProgressViewState {
       normalizedState.toolSessionState = { ...taskState.toolSessionState };
     }
 
-    this.clearSessionKindHint(streamTabId);
+    this.clearCategoryHint(streamTabId);
     if (isWorkflowTaskState(normalizedState)) {
       this.workflowTaskStates.set(streamTabId, normalizedState);
       this.toolUseTaskStates.delete(streamTabId);
@@ -185,7 +182,7 @@ export class ProgressViewState {
   clearTaskState(streamTabId: StreamTabId): void {
     this.workflowTaskStates.delete(streamTabId);
     this.toolUseTaskStates.delete(streamTabId);
-    this.clearSessionKindHint(streamTabId);
+    this.clearCategoryHint(streamTabId);
     this.saveTaskStates();
     this.cleanupToolUseAgentRegistry();
   }
@@ -225,7 +222,7 @@ export class ProgressViewState {
     this.workflowTaskStates.delete(stream);
     this.toolUseTaskStates.delete(stream);
     this._executionIds.delete(stream);
-    this.clearSessionKindHint(stream);
+    this.clearCategoryHint(stream);
     this.cleanupToolUseAgentRegistry();
 
     // Update active stream if necessary
@@ -247,7 +244,7 @@ export class ProgressViewState {
     // Clear display-related data (matching original eraseStream behavior)
     this._taskGroups.deleteStream(stream);
     this._outputFiles.deleteStream(stream);
-    this.clearSessionKindHint(stream);
+    this.clearCategoryHint(stream);
 
     // NOTE: Preserve taskStates and executionIds - these are needed for re-run functionality
     // NOTE: Preserve usageStats - these were not cleared in original implementation
@@ -262,7 +259,7 @@ export class ProgressViewState {
     this.workflowTaskStates.clear();
     this.toolUseTaskStates.clear();
     this._executionIds.clear();
-    this._sessionKindHints.clear();
+    this._categoryHints.clear();
     this._activeStream = '';
     this.saveActiveStream();
     this.saveTaskStates();

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -6,8 +6,8 @@ import type { ProgressViewState } from './state/ProgressViewState';
 import type { AgentFilter, StreamTabInfo } from './types';
 // Local imports - agent types
 import {
-  AgentSessionKind,
-  resolveAgentSessionMetadata,
+  deriveAgentCategory,
+  type AgentCategory,
 } from '@agent/core/AgentDataclass';
 
 const sortComparators = {
@@ -21,16 +21,16 @@ const sortComparators = {
 } as const;
 
 function matchesAgentFilter(
-  sessionKind: AgentSessionKind,
+  category: AgentCategory,
   filter: AgentFilter,
 ): boolean {
   switch (filter) {
     case 'all':
       return true;
     case 'toolUse':
-      return sessionKind === AgentSessionKind.ToolUse;
+      return category === 'toolUse';
     case 'workflow':
-      return sessionKind === AgentSessionKind.Workflow;
+      return category === 'workflow';
     default:
       return true;
   }
@@ -39,9 +39,9 @@ function matchesAgentFilter(
 function buildStreamLabel(
   agentName: string,
   inputFile: string,
-  sessionKind: AgentSessionKind,
+  category: AgentCategory,
 ): string {
-  if (sessionKind === AgentSessionKind.ToolUse) {
+  if (category === 'toolUse') {
     return agentName;
   }
 
@@ -59,7 +59,7 @@ export function buildStreamInfos(
 ): StreamTabInfo[] {
   const infos = state.streamTabs.keys().reduce<StreamTabInfo[]>((acc, id) => {
     const taskState = state.getTaskState(id);
-    const sessionKindHint = state.getSessionKindHint(id);
+    const sessionKindHint = state.getCategoryHint(id);
     const logs = state.streamTabs.get(id);
     const lastTimestamp =
       logs && logs.length > 0 ? logs[logs.length - 1].timestamp : undefined;
@@ -68,27 +68,26 @@ export function buildStreamInfos(
     const outputs = taskState?.agentConfig.outputFiles || [];
     const inputFile = taskState?.agentConfig.inputFile || '';
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
-    const metadata = resolveAgentSessionMetadata(
-      taskState?.agentType,
-      taskState?.agentSessionKind ?? sessionKindHint,
-    );
-    const agentType = metadata.agentType ?? taskState?.agentType;
-    const agentSessionKind = metadata.agentSessionKind;
-    if (!matchesAgentFilter(agentSessionKind, filter)) {
+    const agentType = taskState?.agentType;
+    const agentCategory =
+      taskState?.agentCategory ??
+      sessionKindHint ??
+      deriveAgentCategory(agentType);
+    if (!matchesAgentFilter(agentCategory, filter)) {
       return acc;
     }
-    const isToolAgent = agentSessionKind === AgentSessionKind.ToolUse;
+    const isToolAgent = agentCategory === 'toolUse';
     const executionId = state.getExecutionId(id);
-    const label = buildStreamLabel(agentName, inputFile, agentSessionKind);
+    const label = buildStreamLabel(agentName, inputFile, agentCategory);
     acc.push({
       name: id,
       label,
       model: taskState?.agentConfig.model,
       agent: taskState?.agentConfig.agent,
       agentType,
-      agentSessionKind,
+      agentCategory,
       uiTraits: {
-        sessionKind: agentSessionKind,
+        category: agentCategory,
         isToolAgent,
       },
       hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,11 +1,11 @@
 // Local imports - agent types
-import type { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
+import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
 export interface StreamUITraits {
   /** Canonical session grouping for the stream. */
-  sessionKind: AgentSessionKind;
+  category: AgentCategory;
   /** Indicates whether the associated agent is a tool-use session. */
   isToolAgent: boolean;
 }
@@ -17,7 +17,7 @@ export interface StreamTabInfo {
   model?: string;
   agent?: string;
   agentType?: AgentType;
-  agentSessionKind: AgentSessionKind;
+  agentCategory: AgentCategory;
   uiTraits: StreamUITraits;
   hasMultipleOutputs?: boolean;
   lastTimestamp?: number;

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -10,6 +10,7 @@ import * as configModule from '@utils/config';
 
 const baseSetting: AgentSetting = {
   agentType: AgentType.CoT,
+  agentCategory: 'workflow',
   documentTag: 'document',
   temperature: 0,
   isRewrite: true,

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 // Local imports - agent
 import type { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
 import {
   registerToolUseAgent,
   clearToolUseAgents,
@@ -282,7 +281,7 @@ describe('followUpCommand', () => {
       streamId,
       agentName: 'demo-agent',
       model: 'demo-model',
-      agentSessionKind: AgentSessionKind.ToolUse,
+      agentCategory: 'toolUse',
       messages: [],
       toolState: {
         texcountStats: null,

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -28,6 +28,7 @@ describe('ModelHandlerGoogle.shouldContinue', () => {
   const agentSetting = {
     endTag: '</doc>',
     documentTag: 'doc',
+    agentCategory: 'workflow',
   } as AgentSetting;
 
   it('continues when FinishReason.MAX_TOKENS is returned without the end tag', () => {

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -42,6 +42,7 @@ class MockOutputHandler extends OutputHandler {
 describe('OutputHandler.finalizeRound', () => {
   const setting: AgentSetting = {
     agentType: AgentType.CoT,
+    agentCategory: 'workflow',
     documentTag: 'document',
     temperature: 0,
     isRewrite: true,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -13,6 +13,7 @@ import { WorkspaceFS } from '@utils/files';
 describe('XmlOutputManager markdown fallback', () => {
   const setting: AgentSetting = {
     agentType: AgentType.CoT,
+    agentCategory: 'workflow',
     documentTag: 'latex_document',
     temperature: 0,
     isRewrite: true,

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -115,6 +115,7 @@ describe('BaseToolUseAgent follow-up loop', () => {
     const handler = new DummyHandler();
     const setting: AgentSetting = {
       agentType: AgentType.ToolUse,
+      agentCategory: 'toolUse',
       documentTag: 'doc',
       temperature: 0,
       endTag: '</doc>',

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -98,6 +98,7 @@ describe('runToolUseCycle DeepSeek', () => {
     const toolRegistry = { echo: new EchoTool() };
     const setting: AgentSetting = {
       agentType: AgentType.ToolUse,
+      agentCategory: 'toolUse',
       documentTag: 'doc',
       temperature: 0,
       endTag: '</doc>',

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -110,6 +110,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
     const toolRegistry = { echo: new EchoTool() };
     const setting: AgentSetting = {
       agentType: AgentType.ToolUse,
+      agentCategory: 'toolUse',
       documentTag: 'doc',
       temperature: 0,
       endTag: '</doc>',

--- a/src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts
+++ b/src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts
@@ -5,14 +5,10 @@ import { promises as fs } from 'fs';
 
 import * as vscode from 'vscode';
 
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
 import { ToolState } from '@agent/core/ToolState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
-import {
-  ToolUseSessionManager,
-  type ToolUseSessionSnapshot,
-} from '@agent/toolUse/ToolUseSessionManager';
+import { ToolUseSessionManager } from '@agent/toolUse/ToolUseSessionManager';
 import StorageFS from '@utils/files/storageFS';
 
 const STORAGE_DIR = path.join(os.tmpdir(), 'texra-tooluse-snapshot-tests');
@@ -61,20 +57,20 @@ suite('ToolUseSessionManager snapshot compatibility', () => {
       streamId: 'stream-id',
       agentName: 'demo-agent',
       model: 'demo-model',
-      agentSessionKind: AgentSessionKind.ToolUse,
+      agentCategory: 'toolUse' as const,
       messages: [] as ProviderMessage[],
       toolState,
     };
   }
 
-  function buildSnapshot(executionId: ExecutionId): ToolUseSessionSnapshot {
+  function buildSnapshot(executionId: ExecutionId): Record<string, unknown> {
     return {
       version: 1,
       executionId,
       streamId: 'stream-id',
       agentName: 'demo-agent',
       model: 'demo-model',
-      agentSessionKind: AgentSessionKind.ToolUse,
+      agentCategory: 'toolUse',
       messages: [],
       toolState: {
         texcountStats: null,
@@ -103,6 +99,8 @@ suite('ToolUseSessionManager snapshot compatibility', () => {
   test('loadSnapshot reads snapshots saved before helper migration', async () => {
     const executionId = 'legacy-snapshot' as ExecutionId;
     const snapshot = buildSnapshot(executionId);
+    delete (snapshot as { agentCategory?: unknown }).agentCategory;
+    (snapshot as { agentSessionKind?: string }).agentSessionKind = 'toolUse';
 
     await StorageFS.ensureDir('toolUseSessions');
     await StorageFS.write(

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -9,10 +9,11 @@ import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { TaskState, isWorkflowTaskState } from '@logger/TaskState';
 import {
-  AgentSessionKind,
+  AgentCategorySchema,
+  deriveAgentCategory,
+  type AgentCategory,
   type AgentType,
   type AgentSessionMetadata,
-  resolveAgentSessionMetadata,
 } from '@agent/core/AgentDataclass';
 
 import { FILE_TYPES, type FileType } from './constants';
@@ -48,49 +49,43 @@ function createActiveFilesFromArrays(
  */
 export function agentConfigToTaskState(
   config: AgentConfig,
-  metadata?: AgentSessionMetadata | AgentType,
+  metadata?: Partial<AgentSessionMetadata> | AgentType,
 ): TaskState {
-  const configMetadata = resolveAgentSessionMetadata(
-    config.agentType,
-    config.agentSessionKind,
-  );
+  let providedType: AgentType | undefined;
+  let providedCategory: AgentCategory | undefined;
 
-  const providedMetadata =
-    typeof metadata === 'object' && metadata !== null
-      ? resolveAgentSessionMetadata(
-          metadata.agentType,
-          metadata.agentSessionKind,
-        )
-      : metadata !== undefined
-        ? resolveAgentSessionMetadata(metadata)
-        : null;
+  if (typeof metadata === 'object' && metadata !== null) {
+    providedType = metadata.agentType;
+    providedCategory = metadata.agentCategory;
+  } else if (metadata !== undefined) {
+    providedType = metadata;
+  }
 
-  const resolvedMetadata = providedMetadata
-    ? resolveAgentSessionMetadata(
-        providedMetadata.agentType ?? configMetadata.agentType,
-        providedMetadata.agentSessionKind ?? configMetadata.agentSessionKind,
-      )
-    : configMetadata;
+  const agentType = config.agentType ?? providedType;
+  const agentCategory =
+    config.agentCategory ??
+    providedCategory ??
+    deriveAgentCategory(agentType);
 
   const normalizedConfig: AgentConfig = {
     ...config,
-    agentType: resolvedMetadata.agentType,
-    agentSessionKind: resolvedMetadata.agentSessionKind,
+    agentType,
+    agentCategory,
   };
 
-  if (resolvedMetadata.agentSessionKind === AgentSessionKind.ToolUse) {
+  if (agentCategory === 'toolUse') {
     return {
       agentConfig: normalizedConfig,
-      agentType: resolvedMetadata.agentType,
-      agentSessionKind: AgentSessionKind.ToolUse,
+      agentType,
+      agentCategory: 'toolUse',
       toolSessionState: {},
     };
   }
 
   return {
     agentConfig: normalizedConfig,
-    agentType: resolvedMetadata.agentType,
-    agentSessionKind: AgentSessionKind.Workflow,
+    agentType,
+    agentCategory: 'workflow',
     activeFiles: createActiveFilesFromArrays(normalizedConfig),
   };
 }
@@ -106,8 +101,15 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   // Check if this is already in the new format with nested agentConfig
   if (obj.agentConfig && typeof obj.agentConfig === 'object') {
     const agentType = obj.agentType as AgentType | undefined;
-    const sessionKind = normalizeSessionKind(obj.agentSessionKind);
-    const metadata = resolveAgentSessionMetadata(agentType, sessionKind);
+    const rawCategory =
+      obj.agentCategory ??
+      (obj as { agentSessionKind?: unknown }).agentSessionKind;
+    const categoryResult = AgentCategorySchema.safeParse(rawCategory);
+    const agentCategory = categoryResult.success ? categoryResult.data : undefined;
+    const metadata =
+      agentType !== undefined || agentCategory !== undefined
+        ? { agentType, agentCategory }
+        : undefined;
     const state = agentConfigToTaskState(
       AgentConfigSchema.parse(obj.agentConfig),
       metadata,
@@ -197,8 +199,15 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   try {
     const normalized = AgentConfigSchema.parse(agentConfigData);
     const agentType = obj.agentType as AgentType | undefined;
-    const sessionKind = normalizeSessionKind(obj.agentSessionKind);
-    const metadata = resolveAgentSessionMetadata(agentType, sessionKind);
+    const rawCategory =
+      obj.agentCategory ??
+      (obj as { agentSessionKind?: unknown }).agentSessionKind;
+    const categoryResult = AgentCategorySchema.safeParse(rawCategory);
+    const agentCategory = categoryResult.success ? categoryResult.data : undefined;
+    const metadata =
+      agentType !== undefined || agentCategory !== undefined
+        ? { agentType, agentCategory }
+        : undefined;
     const taskState = agentConfigToTaskState(normalized, metadata);
 
     if (isWorkflowTaskState(taskState)) {
@@ -215,7 +224,7 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     console.error('Failed to parse task state, using defaults:', error);
     const defaultConfig = AgentConfigSchema.parse({});
     const agentType = obj.agentType as AgentType | undefined;
-    const metadata = resolveAgentSessionMetadata(agentType);
+    const metadata = agentType !== undefined ? { agentType } : undefined;
     const taskState = agentConfigToTaskState(defaultConfig, metadata);
 
     if (isWorkflowTaskState(taskState) && activeFiles) {
@@ -231,14 +240,4 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
 
     return taskState;
   }
-}
-
-function normalizeSessionKind(value: unknown): AgentSessionKind | undefined {
-  if (
-    value === AgentSessionKind.Workflow ||
-    value === AgentSessionKind.ToolUse
-  ) {
-    return value;
-  }
-  return undefined;
 }

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 
 // Local imports - agent
-import { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
+import { AgentType, type AgentCategory } from '@agent/core/AgentDataclass';
 import { ToolConfig } from '@agent/core/ToolConfig';
 
 // Local imports - utils
@@ -61,20 +61,20 @@ export class ExecutionManager {
     }
 
     return this.composeAgentConfig(message, {
-      agentSessionKind: AgentSessionKind.Workflow,
+      agentCategory: 'workflow',
     });
   }
 
   private buildToolUseCommandPayload(message: any): AgentConfig {
     return this.composeAgentConfig(message, {
       agentType: AgentType.ToolUse,
-      agentSessionKind: AgentSessionKind.ToolUse,
+      agentCategory: 'toolUse',
     });
   }
 
   private composeAgentConfig(
     message: any,
-    metadata: { agentType?: AgentType; agentSessionKind: AgentSessionKind },
+    metadata: { agentType?: AgentType; agentCategory: AgentCategory },
   ): AgentConfig {
     const toolConfig: ToolConfig = {
       autoExtractFigure: message.autoExtractFigure,
@@ -121,7 +121,7 @@ export class ExecutionManager {
       editedFile: null,
       toolConfig,
       agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentCategory: metadata.agentCategory,
     };
   }
 


### PR DESCRIPTION
## Summary
- remove the resolveAgentSessionMetadata helpers and rely on stored settings to derive agent categories
- simplify agent runtime metadata propagation and task-state conversion to use the derived category without extra normalization
- update tool-use persistence tests to expect the agentCategory field while keeping legacy snapshot coverage

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e228fd9cd48324a333c671f722f941

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces session-kind metadata with `agentCategory` derived from `agentType`, updating schemas, runtime, persistence, UI, history, and tests with legacy compatibility.
> 
> - **Core Schemas/Types**:
>   - Introduce `AgentCategorySchema` (`'workflow' | 'toolUse'`) and `deriveAgentCategory`; remove `AgentSessionKind` usage and `resolveAgentSessionMetadata` helper.
>   - `AgentConfigSchema`/settings: add `agentCategory` (with variant literals); add `getAgentCategory`.
> - **Runtime/Agents**:
>   - `BaseAgent.getSessionMetadata` now returns `{ agentType, agentCategory }`.
>   - `executeAgent` derives and propagates `agentCategory`; bus events emit `agentCategory`.
>   - `agentLoad.ensureAgentTypeForSource` also sets `agentCategory` for built-in tool-use.
> - **Persistence (Tool-use)**:
>   - `ToolUseSessionManager` snapshot schema stores `agentCategory` (transforms legacy `agentSessionKind`); save payload updated.
> - **Progress View/UI**:
>   - Replace all filters, hints, and stream info fields from `agentSessionKind` to `agentCategory`; DOM handlers render by category.
> - **History**:
>   - Store/normalize `agentCategory`; derive category when missing (legacy compatibility).
> - **Logger/TaskState**:
>   - Replace `agentSessionKind` with `agentCategory` in task state types and guards.
> - **Config Conversion**:
>   - `agentConfigToTaskState`/`objectToTaskState` use/derive `agentCategory` and drop resolver.
> - **Webview Execution**:
>   - Commands compose configs with `agentCategory` instead of session kind.
> - **Tests**:
>   - Update tests and snapshots to use `agentCategory`, keep legacy snapshot coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45db1f976de4c66a34c671551d3a27ed4a1e97aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->