### PR TITLE
fix: simplify progress view clipboard helper

### DIFF
--- a/src/progressView/modules/utils.js
+++ b/src/progressView/modules/utils.js
@@ -104,8 +104,7 @@ function defaultChildTimestamp(child) {
 const COPY_RESET_DELAY_MS = 2000;
 
 /**
- * Attempt to copy text to the clipboard using the modern API, falling back to
- * document.execCommand when necessary.
+ * Attempt to copy text to the clipboard using the asynchronous clipboard API.
  * @param {string} text
  * @returns {Promise<boolean>} true when the copy succeeds.
  */
@@ -116,30 +115,11 @@ export async function copyTextToClipboard(text) {
 
   const normalized = text.replace(/\r?\n/g, '\n');
 
-  if (navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(normalized);
-      return true;
-    } catch {
-      // Fall back to execCommand below
-    }
-  }
-
-  const textarea = document.createElement('textarea');
-  textarea.value = normalized;
-  textarea.setAttribute('readonly', '');
-  textarea.style.position = 'fixed';
-  textarea.style.opacity = '0';
-  textarea.style.pointerEvents = 'none';
-  document.body.appendChild(textarea);
-  textarea.select();
-
   try {
-    return document.execCommand('copy');
+    await navigator.clipboard.writeText(normalized);
+    return true;
   } catch {
     return false;
-  } finally {
-    textarea.remove();
   }
 }
 


### PR DESCRIPTION
## Summary
- simplify the progress view clipboard helper to rely on the async clipboard API and return false when copying fails
- keep the copy-with-feedback UI logic unchanged so buttons still toggle success styling based on the copy result

## Testing
- npm run format
- npm run compile
- manual copy button exercise in the progress view webview

------
https://chatgpt.com/codex/tasks/task_e_68e2f06fb67483248c53c11cd716dbe4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies `copyTextToClipboard` to use `navigator.clipboard.writeText` only, removing the `execCommand` textarea fallback and updating docs.
> 
> - **Progress View Utils (`src/progressView/modules/utils.js`)**:
>   - **Clipboard**: Simplify `copyTextToClipboard` to use `navigator.clipboard.writeText` exclusively; remove textarea/`document.execCommand` fallback.
>   - **Docs**: Update JSDoc to reflect use of the asynchronous clipboard API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca469e4e2c7139eb4696905d16f93a816c7876c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->