### PR TITLE
refactor: centralize chevron icon helper

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -5,6 +5,24 @@ import {
   CHEVRON_RIGHT_CLASS,
 } from './iconConstants.js';
 
+function setChevronIconImpl(element, expanded, { expandedClass, collapsedClass }) {
+  if (!element) return;
+  let icon = element;
+  if (icon.tagName.toLowerCase() !== 'i') {
+    icon = element.querySelector('i');
+    if (!icon) {
+      icon = document.createElement('i');
+      element.appendChild(icon);
+    }
+  }
+  const existingClasses = icon.className
+    .split(' ')
+    .filter((cls) => cls && !cls.startsWith('codicon-chevron-') && cls !== 'codicon')
+    .join(' ');
+  const chevronClass = expanded ? expandedClass : collapsedClass;
+  icon.className = existingClasses ? `${chevronClass} ${existingClasses}` : chevronClass;
+}
+
 export function addEventListenerSafely(elementOrId, event, handler, options) {
   const element =
     typeof elementOrId === 'string'
@@ -80,25 +98,10 @@ export function setElementsDisabled(idsOrElements, disabled) {
  * @param {boolean} expanded - Whether the section is expanded.
  */
 export function setChevronIcon(element, expanded) {
-  if (!element) return;
-  let icon = element;
-  if (icon.tagName.toLowerCase() !== 'i') {
-    icon = element.querySelector('i');
-    if (!icon) {
-      icon = document.createElement('i');
-      element.appendChild(icon);
-    }
-  }
-  const existingClasses = icon.className
-    .split(' ')
-    .filter(
-      (cls) => cls && !cls.startsWith('codicon-chevron-') && cls !== 'codicon',
-    )
-    .join(' ');
-  const chevronClass = expanded ? CHEVRON_UP_CLASS : CHEVRON_DOWN_CLASS;
-  icon.className = existingClasses
-    ? `${chevronClass} ${existingClasses}`
-    : chevronClass;
+  setChevronIconImpl(element, expanded, {
+    expandedClass: CHEVRON_UP_CLASS,
+    collapsedClass: CHEVRON_DOWN_CLASS,
+  });
 }
 
 /**
@@ -107,23 +110,8 @@ export function setChevronIcon(element, expanded) {
  * @param {boolean} expanded - Whether the section is expanded.
  */
 export function setChevronIconHorizontal(element, expanded) {
-  if (!element) return;
-  let icon = element;
-  if (icon.tagName.toLowerCase() !== 'i') {
-    icon = element.querySelector('i');
-    if (!icon) {
-      icon = document.createElement('i');
-      element.appendChild(icon);
-    }
-  }
-  const existingClasses = icon.className
-    .split(' ')
-    .filter(
-      (cls) => cls && !cls.startsWith('codicon-chevron-') && cls !== 'codicon',
-    )
-    .join(' ');
-  const chevronClass = expanded ? CHEVRON_DOWN_CLASS : CHEVRON_RIGHT_CLASS;
-  icon.className = existingClasses
-    ? `${chevronClass} ${existingClasses}`
-    : chevronClass;
+  setChevronIconImpl(element, expanded, {
+    expandedClass: CHEVRON_DOWN_CLASS,
+    collapsedClass: CHEVRON_RIGHT_CLASS,
+  });
 }


### PR DESCRIPTION
## Summary
- extract a shared chevron icon helper that creates/reuses the <i> element and preserves existing classes
- delegate the vertical and horizontal chevron setters to the shared implementation with their respective icon classes

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e2efc2747883248cca615eabe430e7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes chevron icon logic into a shared helper and updates vertical/horizontal setters to use it.
> 
> - **Utilities (`src/common/modules/domUtils.js`)**:
>   - **Shared helper**: Add `setChevronIconImpl` to handle finding/creating the `i` tag, preserving non-chevron classes, and applying the correct chevron class.
>   - **Delegation**:
>     - `setChevronIcon(...)` now delegates to `setChevronIconImpl` with `CHEVRON_UP_CLASS`/`CHEVRON_DOWN_CLASS`.
>     - `setChevronIconHorizontal(...)` now delegates to `setChevronIconImpl` with `CHEVRON_DOWN_CLASS`/`CHEVRON_RIGHT_CLASS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1626e9d0f90971529bd83510491566c60d24d888. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->