### PR TITLE
Refactor media helpers to centralize path resolution

### DIFF
--- a/src/frontend/media/img.ts
+++ b/src/frontend/media/img.ts
@@ -12,7 +12,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { getConfig } from '@utils/config';
-import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
+import { AbsoluteFS, getMimeType, resolveFilePath } from '@utils/files';
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { executeCommand } from '@utils/system/execUtils';
 
@@ -31,6 +31,27 @@ function getMaxImageDimension(): number {
 const TEMP_DIR = path.join(os.tmpdir(), 'texra-pdf-conversion');
 
 // ImageMagick configuration is now in toolUtils.ts
+
+/** Ensure the pdf2pic temporary directory exists. */
+function ensureTempDir(): void {
+  if (!AbsoluteFS.existsSync(TEMP_DIR)) {
+    AbsoluteFS.mkdirSync(TEMP_DIR, { recursive: true });
+  }
+}
+
+/** Resolve a file path and ensure it exists. */
+async function resolveExistingFile(
+  filePath: string,
+): Promise<{ absolutePath: string; exists: boolean }> {
+  const absolutePath = resolveFilePath(filePath);
+  const exists = await AbsoluteFS.exists(absolutePath);
+
+  if (!exists) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  return { absolutePath, exists };
+}
 
 /**
  * Clean up temporary files with a given base name pattern
@@ -81,14 +102,15 @@ async function selectImageTool(): Promise<{ tool: string; prefix: string[] }> {
 async function getImageDimensions(
   imagePath: string,
 ): Promise<{ width: number; height: number }> {
-  const { tool, prefix } = await selectImageTool();
-  let command: string[];
-  if (tool === 'magick') {
-    command = [...prefix, 'identify', '-format', '%w %h', imagePath];
-  } else {
-    command = [...prefix, 'identify', '-format', '%w %h', imagePath];
-  }
-  const result = await executeCommand(command, { channel: CHANNEL });
+  const { prefix } = await selectImageTool();
+  const identifyArgs = [
+    ...prefix,
+    'identify',
+    '-format',
+    '%w %h',
+    imagePath,
+  ];
+  const result = await executeCommand(identifyArgs, { channel: CHANNEL });
   if (!result.success || !result.stdout) {
     throw new Error(result.stderr || 'Failed to get image dimensions');
   }
@@ -122,26 +144,15 @@ async function resizeImageIfNeeded(imagePath: string): Promise<string> {
     `texra-resized-${crypto.randomUUID()}${ext}`,
   );
   const { tool, prefix } = await selectImageTool();
-  let command: string[];
-  if (tool === 'magick') {
-    command = [
-      ...prefix,
-      imagePath,
-      '-resize',
-      `${maxDimension}x${maxDimension}>`,
-      tempPath,
-    ];
-  } else {
-    command = [
-      ...prefix,
-      'convert',
-      imagePath,
-      '-resize',
-      `${maxDimension}x${maxDimension}>`,
-      tempPath,
-    ];
-  }
-  const result = await executeCommand(command, { channel: CHANNEL });
+  const convertArgs = [
+    ...prefix,
+    ...(tool === 'gm' ? ['convert'] : []),
+    imagePath,
+    '-resize',
+    `${maxDimension}x${maxDimension}>`,
+    tempPath,
+  ];
+  const result = await executeCommand(convertArgs, { channel: CHANNEL });
   if (!result.success) {
     throw new Error(result.stderr || 'Failed to resize image');
   }
@@ -161,17 +172,7 @@ export async function getBase64EncodedMedia(
   mediaPath: string,
 ): Promise<string> {
   try {
-    const isAbsolutePath = path.isAbsolute(mediaPath);
-    const absolutePath = isAbsolutePath
-      ? mediaPath
-      : WorkspaceFS.fullPath(mediaPath);
-
-    const fileExistsResult = await AbsoluteFS.exists(absolutePath);
-    if (!fileExistsResult) {
-      logger.error(CHANNEL, `Image file not found: ${mediaPath}`);
-      throw new Error(`Image file not found: ${mediaPath}`);
-    }
-
+    const { absolutePath } = await resolveExistingFile(mediaPath);
     const mimeType = getMimeType(absolutePath);
     let tempPath: string | null = null;
     let pathToRead = absolutePath;
@@ -191,6 +192,7 @@ export async function getBase64EncodedMedia(
         throw new Error(`File is empty: ${mediaPath}`);
       }
       const base64String = mediaBytes.toString('base64');
+      logger.debug(CHANNEL, `Successfully encoded image: ${mediaPath}`);
       return base64String;
     } finally {
       if (tempPath) {
@@ -205,8 +207,6 @@ export async function getBase64EncodedMedia(
         }
       }
     }
-
-    logger.debug(CHANNEL, `Successfully encoded image: ${mediaPath}`);
   } catch (err) {
     logger.error(
       CHANNEL,
@@ -223,23 +223,8 @@ export async function getBase64EncodedMedia(
  */
 export async function countPdfPages(pdfPath: string): Promise<number> {
   try {
-    // Check if this is an absolute path
-    const isAbsolutePath = path.isAbsolute(pdfPath);
-
-    // Check if file exists
-    const fileExistsResult = isAbsolutePath
-      ? await AbsoluteFS.exists(pdfPath)
-      : await WorkspaceFS.exists(pdfPath);
-
-    if (!fileExistsResult) {
-      logger.error(CHANNEL, `PDF file not found: ${pdfPath}`);
-      return 0;
-    }
-
-    // Read the PDF file using pdf-lib
-    const pdfBytes = isAbsolutePath
-      ? AbsoluteFS.readBytesSync(pdfPath)
-      : WorkspaceFS.readFileBytesSync(pdfPath);
+    const { absolutePath } = await resolveExistingFile(pdfPath);
+    const pdfBytes = AbsoluteFS.readBytesSync(absolutePath);
     const pdfDoc = await PDFDocument.load(pdfBytes, {
       updateMetadata: false,
       ignoreEncryption: true,
@@ -289,25 +274,10 @@ export async function singlePagePdf2Png(
       throw new Error('GraphicsMagick/ImageMagick is not installed.');
     }
 
-    // Check if this is an absolute path
-    const isAbsolutePath = path.isAbsolute(pdfPath);
+    const { absolutePath } = await resolveExistingFile(pdfPath);
+    logger.debug(CHANNEL, `Full path to PDF: ${absolutePath}`);
 
-    // Verify file exists
-    const fileExistsResult = isAbsolutePath
-      ? await AbsoluteFS.exists(pdfPath)
-      : await WorkspaceFS.exists(pdfPath);
-
-    if (!fileExistsResult) {
-      throw new Error(`PDF file not found: ${pdfPath}`);
-    }
-
-    const fullPath = isAbsolutePath ? pdfPath : WorkspaceFS.fullPath(pdfPath);
-    logger.debug(CHANNEL, `Full path to PDF: ${fullPath}`);
-
-    // Ensure the temporary directory exists
-    if (!AbsoluteFS.existsSync(TEMP_DIR)) {
-      AbsoluteFS.mkdirSync(TEMP_DIR, { recursive: true });
-    }
+    ensureTempDir();
 
     const options = {
       density: quality,
@@ -320,7 +290,7 @@ export async function singlePagePdf2Png(
     };
     logger.debug(CHANNEL, `pdf2pic options: ${JSON.stringify(options)}`);
 
-    const convert = fromPath(fullPath, options);
+    const convert = fromPath(absolutePath, options);
     logger.debug(CHANNEL, `pdf2pic convert object created`);
 
     const result = await convert(pageNum);
@@ -418,20 +388,8 @@ export async function processPdf2Png(
   maxSize?: [number, number],
 ): Promise<string | string[] | null> {
   try {
-    // Check if this is an absolute path
-    const isAbsolutePath = path.isAbsolute(pdfPath);
-
-    // Verify file exists
-    const fileExistsResult = isAbsolutePath
-      ? await AbsoluteFS.exists(pdfPath)
-      : await WorkspaceFS.exists(pdfPath);
-
-    if (!fileExistsResult) {
-      logger.debug(CHANNEL, `PDF file not found: ${pdfPath}`);
-      return null;
-    }
-
-    const pageCount = await countPdfPages(pdfPath);
+    const { absolutePath } = await resolveExistingFile(pdfPath);
+    const pageCount = await countPdfPages(absolutePath);
     if (pageCount === 0) {
       return null;
     }
@@ -441,10 +399,15 @@ export async function processPdf2Png(
     const finalMaxSize: [number, number] = maxSize || [1024, 1024];
 
     if (pageCount === 1) {
-      return await singlePagePdf2Png(pdfPath, 1, finalQuality, finalMaxSize);
+      return await singlePagePdf2Png(
+        absolutePath,
+        1,
+        finalQuality,
+        finalMaxSize,
+      );
     } else {
       return await multiPagePdf2Png(
-        pdfPath,
+        absolutePath,
         finalQuality,
         finalMaxSize,
         maxPages,

--- a/src/frontend/media/img.ts
+++ b/src/frontend/media/img.ts
@@ -39,16 +39,43 @@ function ensureTempDir(): void {
   }
 }
 
-/** Resolve a file path and ensure it exists. */
-async function resolveExistingFile(filePath: string): Promise<string> {
+/** Try to resolve a file path and return the absolute path when it exists. */
+async function resolveFileIfExists(filePath: string): Promise<string | null> {
   const absolutePath = resolveFilePath(filePath);
   const exists = await AbsoluteFS.exists(absolutePath);
 
-  if (!exists) {
-    throw new Error(`File not found: ${filePath}`);
+  return exists ? absolutePath : null;
+}
+
+/** Resolve a file path and ensure it exists. */
+async function resolveExistingFile(
+  filePath: string,
+  resourceLabel: string = 'File',
+): Promise<string> {
+  const absolutePath = await resolveFileIfExists(filePath);
+
+  if (!absolutePath) {
+    throw new Error(`${resourceLabel} not found: ${filePath}`);
   }
 
   return absolutePath;
+}
+
+/** Load a PDF and return its page count. Expects an absolute path. */
+async function loadPdfPageCount(
+  absolutePath: string,
+  displayPath: string,
+): Promise<number> {
+  const pdfBytes = AbsoluteFS.readBytesSync(absolutePath);
+  const pdfDoc = await PDFDocument.load(pdfBytes, {
+    updateMetadata: false,
+    ignoreEncryption: true,
+  });
+
+  const pageCount = pdfDoc.getPageCount();
+
+  logger.debug(CHANNEL, `PDF page count for ${displayPath}: ${pageCount}`);
+  return pageCount;
 }
 
 /**
@@ -215,16 +242,14 @@ export async function getBase64EncodedMedia(
  */
 export async function countPdfPages(pdfPath: string): Promise<number> {
   try {
-    const absolutePath = await resolveExistingFile(pdfPath);
-    const pdfBytes = AbsoluteFS.readBytesSync(absolutePath);
-    const pdfDoc = await PDFDocument.load(pdfBytes, {
-      updateMetadata: false,
-      ignoreEncryption: true,
-    });
-    const pageCount = pdfDoc.getPageCount();
+    const absolutePath = await resolveFileIfExists(pdfPath);
 
-    logger.debug(CHANNEL, `PDF page count for ${pdfPath}: ${pageCount}`);
-    return pageCount;
+    if (!absolutePath) {
+      logger.debug(CHANNEL, `PDF file not found: ${pdfPath}`);
+      return 0;
+    }
+
+    return await loadPdfPageCount(absolutePath, pdfPath);
   } catch (err) {
     logger.error(
       CHANNEL,
@@ -266,7 +291,7 @@ export async function singlePagePdf2Png(
       throw new Error('GraphicsMagick/ImageMagick is not installed.');
     }
 
-    const absolutePath = await resolveExistingFile(pdfPath);
+    const absolutePath = await resolveExistingFile(pdfPath, 'PDF file');
     logger.debug(CHANNEL, `Full path to PDF: ${absolutePath}`);
 
     ensureTempDir();
@@ -380,7 +405,14 @@ export async function processPdf2Png(
   maxSize?: [number, number],
 ): Promise<string | string[] | null> {
   try {
-    const pageCount = await countPdfPages(pdfPath);
+    const absolutePath = await resolveFileIfExists(pdfPath);
+
+    if (!absolutePath) {
+      logger.debug(CHANNEL, `PDF file not found: ${pdfPath}`);
+      return null;
+    }
+
+    const pageCount = await loadPdfPageCount(absolutePath, pdfPath);
     if (pageCount === 0) {
       return null;
     }

--- a/src/frontend/media/img.ts
+++ b/src/frontend/media/img.ts
@@ -40,9 +40,7 @@ function ensureTempDir(): void {
 }
 
 /** Resolve a file path and ensure it exists. */
-async function resolveExistingFile(
-  filePath: string,
-): Promise<{ absolutePath: string; exists: boolean }> {
+async function resolveExistingFile(filePath: string): Promise<string> {
   const absolutePath = resolveFilePath(filePath);
   const exists = await AbsoluteFS.exists(absolutePath);
 
@@ -50,7 +48,7 @@ async function resolveExistingFile(
     throw new Error(`File not found: ${filePath}`);
   }
 
-  return { absolutePath, exists };
+  return absolutePath;
 }
 
 /**
@@ -103,13 +101,7 @@ async function getImageDimensions(
   imagePath: string,
 ): Promise<{ width: number; height: number }> {
   const { prefix } = await selectImageTool();
-  const identifyArgs = [
-    ...prefix,
-    'identify',
-    '-format',
-    '%w %h',
-    imagePath,
-  ];
+  const identifyArgs = [...prefix, 'identify', '-format', '%w %h', imagePath];
   const result = await executeCommand(identifyArgs, { channel: CHANNEL });
   if (!result.success || !result.stdout) {
     throw new Error(result.stderr || 'Failed to get image dimensions');
@@ -172,7 +164,7 @@ export async function getBase64EncodedMedia(
   mediaPath: string,
 ): Promise<string> {
   try {
-    const { absolutePath } = await resolveExistingFile(mediaPath);
+    const absolutePath = await resolveExistingFile(mediaPath);
     const mimeType = getMimeType(absolutePath);
     let tempPath: string | null = null;
     let pathToRead = absolutePath;
@@ -223,7 +215,7 @@ export async function getBase64EncodedMedia(
  */
 export async function countPdfPages(pdfPath: string): Promise<number> {
   try {
-    const { absolutePath } = await resolveExistingFile(pdfPath);
+    const absolutePath = await resolveExistingFile(pdfPath);
     const pdfBytes = AbsoluteFS.readBytesSync(absolutePath);
     const pdfDoc = await PDFDocument.load(pdfBytes, {
       updateMetadata: false,
@@ -274,7 +266,7 @@ export async function singlePagePdf2Png(
       throw new Error('GraphicsMagick/ImageMagick is not installed.');
     }
 
-    const { absolutePath } = await resolveExistingFile(pdfPath);
+    const absolutePath = await resolveExistingFile(pdfPath);
     logger.debug(CHANNEL, `Full path to PDF: ${absolutePath}`);
 
     ensureTempDir();
@@ -388,8 +380,7 @@ export async function processPdf2Png(
   maxSize?: [number, number],
 ): Promise<string | string[] | null> {
   try {
-    const { absolutePath } = await resolveExistingFile(pdfPath);
-    const pageCount = await countPdfPages(absolutePath);
+    const pageCount = await countPdfPages(pdfPath);
     if (pageCount === 0) {
       return null;
     }
@@ -399,15 +390,10 @@ export async function processPdf2Png(
     const finalMaxSize: [number, number] = maxSize || [1024, 1024];
 
     if (pageCount === 1) {
-      return await singlePagePdf2Png(
-        absolutePath,
-        1,
-        finalQuality,
-        finalMaxSize,
-      );
+      return await singlePagePdf2Png(pdfPath, 1, finalQuality, finalMaxSize);
     } else {
       return await multiPagePdf2Png(
-        absolutePath,
+        pdfPath,
         finalQuality,
         finalMaxSize,
         maxPages,


### PR DESCRIPTION
## Summary
- add shared helpers for resolving media paths and ensuring the pdf2pic temp directory
- refactor image/pdf workflows to reuse the helpers and consolidate ImageMagick argument construction

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2efe512a08324828a4595effe87b8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes file resolution and temp-dir helpers, unifies PDF page counting, and streamlines ImageMagick/GM argument construction across image/PDF workflows.
> 
> - **Media utilities (`src/frontend/media/img.ts`)**:
>   - **Path & FS helpers**: Add `resolveFileIfExists`, `resolveExistingFile`, and use `resolveFilePath`; replace `WorkspaceFS` lookups with `AbsoluteFS`-based resolution.
>   - **Temp dir**: Add `ensureTempDir` for `pdf2pic` outputs.
>   - **PDF**: Extract `loadPdfPageCount` and reuse in `countPdfPages` and `processPdf2Png`; return 0/null when files missing; `singlePagePdf2Png` now resolves full path and ensures temp dir before conversion.
>   - **ImageMagick/GM args**: Simplify command building in `getImageDimensions`; in `resizeImageIfNeeded` add `convert` only for `gm`.
>   - **Media encoding**: `getBase64EncodedMedia` uses new resolvers; adds success debug; cleans temp files reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf6ec66d84a7dc084e047dbfe992bc5c86f6967c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->