### PR TITLE
Refactor reflection output pipeline for Direct and CoT agents

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -180,26 +180,27 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   }
 
   /**
-   * Processes output files for current round.
-   * This method orchestrates the overall output processing flow with clear separation of concerns:
-   * 1. Usage tracking via trackRoundUsage
-   * 2. LaTeX diff operations via handleLatexdiffofOutput (only when endTurn is true)
-   *
-   * The actual file processing is handled separately in processOutputFiles.
-   *
-   * @returns Array of processed output file paths
+   * Hook for agents that need to preprocess model output before the shared
+   * pipeline parses files. Subclasses override this to normalize XML or apply
+   * other transformations while reusing the base orchestration.
    */
-  protected async handleOutput(
+  protected async preprocessOutputForRound(
+    _currRound: number,
+    _outputFile: string,
+    _processGroupId: string,
+  ): Promise<void> {
+    // Default implementation intentionally left blank.
+  }
+
+  private async finalizeRoundOutputProcessing(
     currRound: number,
-    stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
-    // Record usage statistics at the end of each round
+    const { endTurn, processGroupId } = options;
+
     await this.trackRoundUsage(stateGlobal, processGroupId);
 
-    // If this is the end of a turn, handle latexdiff operations as a separate step
     if (
       endTurn &&
       this.outputHandler.outputFiles[currRound] &&
@@ -209,8 +210,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         this.baseFiles.map(async (f) => await WorkspaceFS.exists(f)),
       );
 
-      if (existingBase.some((e) => e)) {
-        // Pass the process group ID to maintain proper nesting in the log hierarchy
+      if (existingBase.some((exists) => exists)) {
         await this.outputHandler.handleLatexdiffofOutput(
           currRound,
           processGroupId,
@@ -224,6 +224,86 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     }
 
     return this.outputHandler.outputFiles[currRound] || [];
+  }
+
+  protected async runOutputPipeline(
+    currRound: number,
+    _stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    options: RoundOutputOptions,
+  ): Promise<string[]> {
+    const { outputFile, endTurn, processGroupId } = options;
+
+    let outputProcessGroupId = processGroupId;
+    let createdGroup = false;
+    let encounteredError = false;
+
+    if (!outputProcessGroupId) {
+      outputProcessGroupId = await this.logger.startGroup(
+        `OutputProcessing-Round${currRound}`,
+        undefined,
+        this.logger.getActiveGroupId(),
+      );
+      createdGroup = true;
+    }
+
+    this.outputHandler.outputFiles[currRound] =
+      this.outputHandler.outputFiles[currRound] || [];
+
+    try {
+      if (endTurn) {
+        this.logger.debug(
+          `Processing output for round ${currRound}`,
+          outputProcessGroupId,
+        );
+
+        await this.preprocessOutputForRound(
+          currRound,
+          outputFile,
+          outputProcessGroupId,
+        );
+
+        await this.outputHandler.processOutputFiles(
+          outputFile,
+          currRound,
+          outputProcessGroupId,
+        );
+
+        this.logger.debug(
+          `Output files processed for round ${currRound}`,
+          outputProcessGroupId,
+        );
+      }
+
+      return await this.finalizeRoundOutputProcessing(currRound, stateGlobal, {
+        outputFile,
+        endTurn,
+        processGroupId: outputProcessGroupId,
+      });
+    } catch (error) {
+      encounteredError = true;
+      this.logger.error(
+        `Error processing output for round ${currRound}: ${error}`,
+        outputProcessGroupId,
+      );
+      throw error;
+    } finally {
+      if (createdGroup && outputProcessGroupId) {
+        this.logger.endGroup(
+          outputProcessGroupId,
+          encounteredError ? 'error' : 'stopped',
+        );
+      }
+    }
+  }
+
+  protected async handleOutput(
+    currRound: number,
+    stateRound: AgentStateRound,
+    stateGlobal: AgentStateGlobal,
+    options: RoundOutputOptions,
+  ): Promise<string[]> {
+    return this.runOutputPipeline(currRound, stateRound, stateGlobal, options);
   }
 
   /**

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -1,7 +1,5 @@
-// Local imports - agent
 // Local imports - agent components
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
-import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
+import { BaseReflectionAgent } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
 
 /**
@@ -29,88 +27,14 @@ export class CoTAgent extends BaseReflectionAgent {
     );
   }
 
-  /**
-   * Processes output for the current round with XML validation.
-   * Ensures proper sequencing of XML processing, file processing, and logging.
-   * @returns Array of processed output file paths
-   */
-  protected async handleOutput(
-    currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
-    options: RoundOutputOptions,
-  ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
-    // Declare the process group ID at the function scope level
-    // Initialize with processGroupId if provided, otherwise it will be set in the try block
-    let outputProcessGroupId: string = processGroupId || '';
-
-    try {
-      // Start a main output processing group if none provided
-      if (!processGroupId) {
-        outputProcessGroupId = await this.logger.startGroup(
-          `OutputProcessing-Round${currRound}`,
-          undefined,
-          this.logger.getActiveGroupId(),
-        );
-      }
-
-      // Initialize output files array if needed
-      this.outputHandler.outputFiles[currRound] =
-        this.outputHandler.outputFiles[currRound] || [];
-
-      if (endTurn) {
-        this.logger.debug(
-          `Processing output for round ${currRound}`,
-          outputProcessGroupId,
-        );
-
-        // First fix XML structure
-        await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-          outputFile,
-          this.agentSetting.documentTag,
-        );
-
-        // Then process output files using the output handler
-        await this.outputHandler.processOutputFiles(
-          outputFile,
-          currRound,
-          outputProcessGroupId,
-        );
-
-        // Note: latexdiff processing is now handled in the parent class's handleOutput method
-      }
-
-      // Finally handle statistics in base class (but pass our group ID)
-      const result = await super.handleOutput(
-        currRound,
-        stateRound,
-        stateGlobal,
-        {
-          outputFile,
-          endTurn,
-          processGroupId: outputProcessGroupId,
-        },
-      );
-
-      // Only end the processing group if we created it
-      if (!processGroupId) {
-        this.logger.endGroup(outputProcessGroupId, 'stopped');
-      }
-
-      return result;
-    } catch (err) {
-      this.logger.error(
-        `Error in handleOutput for round ${currRound}: ${err}`,
-        processGroupId,
-      );
-
-      // Only end the processing group if we created it and we have a valid outputProcessGroupId
-      if (!processGroupId && outputProcessGroupId) {
-        this.logger.endGroup(outputProcessGroupId, 'error');
-      }
-
-      throw err; // Re-throw to maintain error propagation
-    }
+  protected async preprocessOutputForRound(
+    _currRound: number,
+    outputFile: string,
+    _processGroupId: string,
+  ): Promise<void> {
+    await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
+      outputFile,
+      this.agentSetting.documentTag,
+    );
   }
 }

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -1,7 +1,5 @@
-// Local imports - agent
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 // Local imports - agent components
-import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
+import { BaseReflectionAgent } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
 
 /**
@@ -16,96 +14,16 @@ export class DirectAgent extends BaseReflectionAgent {
    */
   protected getOutputFile(currRound: number): string {
     const baseOutputFile = this.agentConfig.inputFile;
+    const fileExtension = this.useScratchpad
+      ? 'xml'
+      : this.agentSetting.outputExt;
     return getOutputFileName(
       baseOutputFile,
       this.agentConfig.agent,
       this.modelHandler.config.name,
-      this.agentSetting.outputExt,
+      fileExtension,
       currRound,
       this.agentConfig.editedFile || undefined,
     );
-  }
-
-  /**
-   * Processes output for the current round with minimal processing.
-   * @returns Array of processed output file paths
-   */
-  protected async handleOutput(
-    currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
-    options: RoundOutputOptions,
-  ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
-    // Declare the process group ID at the function scope level
-    // Initialize with processGroupId if provided, otherwise it will be set in the try block
-    let outputProcessGroupId: string = processGroupId || '';
-
-    // These groups needs to be made consistent with the @BaseReflectionAgent.handleOutput method
-    try {
-      // Start a main output processing group if none provided
-      if (!processGroupId) {
-        outputProcessGroupId = await this.logger.startGroup(
-          `OutputProcessing-Round${currRound}`,
-          undefined,
-          this.logger.getActiveGroupId(),
-        );
-      }
-
-      // Initialize output files array if needed
-      this.outputHandler.outputFiles[currRound] =
-        this.outputHandler.outputFiles[currRound] || [];
-
-      if (endTurn) {
-        this.logger.debug(
-          `Processing output for round ${currRound}`,
-          outputProcessGroupId,
-        );
-
-        // Process output files using the output handler
-        await this.outputHandler.processOutputFiles(
-          outputFile,
-          currRound,
-          outputProcessGroupId,
-        );
-        this.logger.debug(
-          `Output files processed for round ${currRound}`,
-          outputProcessGroupId,
-        );
-
-        // Note: latexdiff processing is now handled in the parent class's handleOutput method
-      }
-
-      // Finally handle statistics in base class (but pass our group ID)
-      const result = await super.handleOutput(
-        currRound,
-        stateRound,
-        stateGlobal,
-        {
-          outputFile,
-          endTurn,
-          processGroupId: outputProcessGroupId,
-        },
-      );
-
-      // Only end the processing group if we created it
-      if (!processGroupId) {
-        this.logger.endGroup(outputProcessGroupId, 'stopped');
-      }
-
-      return result;
-    } catch (error) {
-      this.logger.error(
-        `Error in DirectAgent.handleOutput: ${error}`,
-        processGroupId,
-      );
-
-      // Only end the processing group if we created it and we have a valid outputProcessGroupId
-      if (!processGroupId && outputProcessGroupId) {
-        this.logger.endGroup(outputProcessGroupId, 'error');
-      }
-
-      throw error;
-    }
   }
 }


### PR DESCRIPTION
## Summary
- centralize reflection agents' output processing in BaseReflectionAgent with a reusable pipeline and preprocessing hook
- update DirectAgent to rely on the shared pipeline and align scratchpad outputs with XML handling
- switch CoTAgent to the new preprocessing hook for XML normalization, removing duplicate handleOutput logic

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3c255050c8324ae0cf70bd5717f09

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes output processing in BaseReflectionAgent with a reusable pipeline and preprocessing hook; CoT/Direct adopt it, and scratchpad outputs use XML.
> 
> - **Core (BaseReflectionAgent)**:
>   - Add `preprocessOutputForRound` hook for pre-parse transformations (e.g., XML normalization).
>   - Introduce `runOutputPipeline` and `finalizeRoundOutputProcessing` to orchestrate processing, stats, and `latexdiff`.
>   - Update `handleOutput` to delegate to the new pipeline; streamline log group handling.
> - **CoTAgent**:
>   - Replace custom `handleOutput` with override of `preprocessOutputForRound` to ensure correct XML structure.
>   - Uses shared base pipeline for file processing and `latexdiff`.
> - **DirectAgent**:
>   - Remove custom `handleOutput`; rely on shared pipeline.
>   - Set output extension to `xml` when `useScratchpad` is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e5f92c4fed2366b3fb9b7f57dffd7c4766c5a99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->