### PR TITLE
Expose agent stream identifier through interface

### DIFF
--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -1,7 +1,9 @@
 // Local imports - agent
-// Local imports - agent components
 import type { AgentConfig } from './AgentConfig';
+// Local imports - agent components
 import type { AgentSessionMetadata } from './AgentDataclass';
+// Local imports - agent types
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 /**
  * Minimal interface implemented by all agent types.
@@ -26,6 +28,11 @@ export interface IAgent {
 
   /** Interrupt the agent if it is running. */
   interrupt(): void;
+
+  /**
+   * Unique identifier used to route logs and progress updates for this agent run.
+   */
+  getStreamTabId(): StreamTabId;
 
   /**
    * Report how the agent identifies its session for logging and UI purposes.

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -89,7 +89,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   }
 
   /** Compute the stream tab identifier for this agent execution. */
-  protected getStreamTabId(): StreamTabId {
+  public getStreamTabId(): StreamTabId {
     return buildStreamTabId(
       this.agentConfig.agent,
       this.agentConfig.model,

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -46,7 +46,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   }
 
   public getSessionMetadata(): AgentSessionMetadata {
-    return resolveAgentSessionMetadata(this.agentSetting.agentType);
+    return resolveAgentSessionMetadata(
+      this.agentConfig.agentType ?? this.agentSetting.agentType,
+      this.agentConfig.agentSessionKind,
+    );
   }
 
   constructor(
@@ -90,12 +93,13 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
 
   /** Compute the stream tab identifier for this agent execution. */
   public getStreamTabId(): StreamTabId {
+    const metadata = this.getSessionMetadata();
     return buildStreamTabId(
       this.agentConfig.agent,
       this.agentConfig.model,
       this.agentConfig.inputFile,
       {
-        agentType: this.agentSetting.agentType,
+        agentType: metadata.agentType,
         executionId: this.executionId,
         useMultipleOutputs: this.agentConfig.useMultipleOutputs,
       },

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -5,9 +5,6 @@ import * as path from 'path';
 import { glob } from 'glob';
 import * as vscode from 'vscode';
 
-// Local imports - agent
-import { getStreamTabId } from '@/logger/streamUtils';
-
 // Local imports - agent components
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -196,10 +193,6 @@ export async function executeAgentWithLogging<T extends IAgent>(
     // Create agent instance and extract its declared type
     const { agent, agentType } = await createAgentFn();
     const sessionMetadata = agent.getSessionMetadata();
-    const baseMetadata = resolveAgentSessionMetadata(
-      agentType ?? sessionMetadata.agentType,
-      sessionMetadata.agentSessionKind,
-    );
 
     if (executionId) {
       await ensureRunDir(executionId);
@@ -208,17 +201,11 @@ export async function executeAgentWithLogging<T extends IAgent>(
     // Get the full stream tab ID
     const config = agent.config;
     const metadata = resolveAgentSessionMetadata(
-      config.agentType ?? baseMetadata.agentType,
-      config.agentSessionKind ?? baseMetadata.agentSessionKind,
+      config.agentType ?? agentType ?? sessionMetadata.agentType,
+      config.agentSessionKind ?? sessionMetadata.agentSessionKind,
     );
-    config.agentType = metadata.agentType;
-    config.agentSessionKind = metadata.agentSessionKind;
 
-    streamTabId = getStreamTabId(config.agent, config.model, config.inputFile, {
-      agentType: metadata.agentType,
-      executionId,
-      useMultipleOutputs: config.useMultipleOutputs,
-    });
+    streamTabId = agent.getStreamTabId();
 
     if (!streamTabId) {
       throw new Error('Failed to resolve stream tab ID for agent execution');


### PR DESCRIPTION
## Summary
- expose the agent stream identifier on the core IAgent contract
- make BaseAgent surface its computed stream tab id to consumers
- update the agent runner to rely on the agent-provided stream id and avoid mutating config metadata

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e55ff388548324a6844ba7c31ae0af

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose agent stream ID on the IAgent interface, make BaseAgent return it, and update execution to use it without mutating config metadata.
> 
> - **Core**:
>   - Add `getStreamTabId(): StreamTabId` to `IAgent` and import `StreamTabId`.
> - **Implementations**:
>   - `BaseAgent`
>     - Make `getStreamTabId` public and compute ID using resolved session metadata.
>     - `getSessionMetadata` now prefers `config.agentType`/`agentSessionKind` over settings.
> - **Runtime**:
>   - `executeAgentWithLogging`
>     - Use `agent.getStreamTabId()` instead of building via `getStreamTabId` helper.
>     - Stop mutating `config.agentType`/`agentSessionKind`; derive metadata from agent/config.
>     - Remove unused import of stream utils.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6f1dddb4abcc7cbaaa1804cd08721529fb6d6a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->