### PR TITLE
refactor: centralize message normalization helpers

### DIFF
--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -10,7 +10,6 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - utilities
 import type { ToolDefinition } from '@model';
-import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 /**
  * Handler for DashScope Qwen models using OpenAI-compatible API.
@@ -30,24 +29,13 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
     tools?: ToolDefinition[],
   ): Promise<any> {
     // Preprocess messages for DashScope compatibility
-    const processedMessages = this.normalizeMessages(messages, {
-      convertContentToString: true,
-    });
-
-    if (processedMessages.length !== messages.length) {
-      this.logger.info(
-        `Preprocessed message array from ${messages.length} to ${processedMessages.length} messages for DashScope model compatibility`,
-      );
-    }
-
-    // Log the first few characters of each processed message for debugging
-    processedMessages.forEach((msg, index) => {
-      const contentPreview =
-        typeof msg.content === 'string'
-          ? msg.content.substring(0, MESSAGE_PREVIEW_LENGTH)
-          : 'non-string content';
-      this.logger.debug(`Message ${index} (${msg.role}): ${contentPreview}...`);
-    });
+    const processedMessages = this.prepareNormalizedMessages(
+      messages,
+      {
+        convertContentToString: true,
+      },
+      'DashScope',
+    );
 
     // Call the parent implementation with the processed messages
     return super.createResponse(

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -18,7 +18,7 @@ import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 
 // Local imports - utilities
 import type { ToolDefinition } from '@model';
-import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
+import { K_SLICE } from '@utils/config';
 
 // TODO: prompt_cache_hit_tokens can also be used here to correct the price and response usage computation in the base class (just overwrite the computePrice and computeResponseUsage methods with a revalues responseUsage.prompt_tokens_details?.cached_tokens and then call the super methods)
 // DEEPSEEK RESPONSE USAGE FORMAT:
@@ -172,25 +172,14 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     tools?: ToolDefinition[],
   ): Promise<any> {
     // Preprocess messages to merge consecutive messages and convert content to strings
-    const processedMessages = this.normalizeMessages(messages, {
-      mergeConsecutiveRoles: true,
-      convertContentToString: true,
-    });
-
-    if (processedMessages.length !== messages.length) {
-      this.logger.info(
-        `Preprocessed message array from ${messages.length} to ${processedMessages.length} messages for Deepseek model compatibility`,
-      );
-    }
-
-    // Log the first few characters of each processed message for debugging
-    processedMessages.forEach((msg, index) => {
-      const contentPreview =
-        typeof msg.content === 'string'
-          ? msg.content.substring(0, MESSAGE_PREVIEW_LENGTH)
-          : 'non-string content';
-      this.logger.debug(`Message ${index} (${msg.role}): ${contentPreview}...`);
-    });
+    const processedMessages = this.prepareNormalizedMessages(
+      messages,
+      {
+        mergeConsecutiveRoles: true,
+        convertContentToString: true,
+      },
+      'Deepseek',
+    );
 
     // Call the parent implementation with the processed messages
     return super.createResponse(

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -14,7 +14,7 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 // Local imports - utilities
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import type { ToolDefinition } from '@model';
-import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
+import { K_SLICE } from '@utils/config';
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
@@ -103,24 +103,13 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     tools?: ToolDefinition[],
   ): Promise<any> {
     // Preprocess messages for Kimi compatibility
-    const processedMessages = this.normalizeMessages(messages, {
-      convertContentToString: true,
-    });
-
-    if (processedMessages.length !== messages.length) {
-      this.logger.info(
-        `Preprocessed message array from ${messages.length} to ${processedMessages.length} messages for Kimi model compatibility`,
-      );
-    }
-
-    // Log the first few characters of each processed message for debugging
-    processedMessages.forEach((msg, index) => {
-      const contentPreview =
-        typeof msg.content === 'string'
-          ? msg.content.substring(0, MESSAGE_PREVIEW_LENGTH)
-          : 'non-string content';
-      this.logger.debug(`Message ${index} (${msg.role}): ${contentPreview}...`);
-    });
+    const processedMessages = this.prepareNormalizedMessages(
+      messages,
+      {
+        convertContentToString: true,
+      },
+      'Kimi',
+    );
 
     // For Kimi thinking model, add the thinking parameter
     const isThinkingModel =

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -36,7 +36,7 @@ import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
 import { cleanFileContent } from '@replacement/engine';
-import { K_SLICE } from '@utils/config';
+import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
 // Local imports - filesystem utilities
 import { WorkspaceFS } from '@utils/files';
@@ -432,6 +432,36 @@ export class ModelHandlerOpenAI extends ModelHandler<
       return messages;
     }
     return normalizeOpenAIMessageContent(messages, options);
+  }
+
+  /**
+   * Normalizes messages and logs diagnostics about any changes.
+   * @param messages Original message array passed to the handler.
+   * @param options Normalization options passed to the OpenAI utilities.
+   * @param providerLabel Label used to identify the provider in logs.
+   */
+  protected prepareNormalizedMessages<T extends ChatCompletionMessageParam>(
+    messages: T[],
+    options?: NormalizeOpenAIMessageContentOptions,
+    providerLabel: string = this.config.provider,
+  ): T[] {
+    const normalizedMessages = this.normalizeMessages(messages, options);
+
+    if (normalizedMessages.length !== messages.length) {
+      this.logger.info(
+        `Preprocessed message array from ${messages.length} to ${normalizedMessages.length} messages for ${providerLabel} model compatibility`,
+      );
+    }
+
+    normalizedMessages.forEach((msg, index) => {
+      const contentPreview =
+        typeof msg.content === 'string'
+          ? msg.content.substring(0, MESSAGE_PREVIEW_LENGTH)
+          : 'non-string content';
+      this.logger.debug(`Message ${index} (${msg.role}): ${contentPreview}...`);
+    });
+
+    return normalizedMessages;
   }
 
   /** Initializes message array with system prompt and user content. */

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
@@ -152,6 +152,9 @@ describe('ModelHandlerOpenAI.normalizeMessages hook', () => {
       'Message 1 (assistant): Assistant reply...',
       'assistant preview should remain intact',
     );
+    assert.deepEqual(loggerStub.infoMessages, [
+      'Preprocessed message array from 3 to 2 messages for Deepseek model compatibility',
+    ]);
   });
 
   it('Kimi handler logs each message preview', async () => {
@@ -177,6 +180,7 @@ describe('ModelHandlerOpenAI.normalizeMessages hook', () => {
       'Message 1 (user): Second part...',
       'Message 2 (assistant): Assistant reply...',
     ]);
+    assert.deepEqual(loggerStub.infoMessages, []);
   });
 
   it('DashScope handler logs each message preview', async () => {
@@ -202,5 +206,6 @@ describe('ModelHandlerOpenAI.normalizeMessages hook', () => {
       'Message 1 (user): Second part...',
       'Message 2 (assistant): Assistant reply...',
     ]);
+    assert.deepEqual(loggerStub.infoMessages, []);
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable helper in the OpenAI model handler to normalize messages and emit diagnostic logs
- refactor the DeepSeek, DashScope, and Kimi handlers to call the shared helper while preserving provider-specific behavior
- extend the normalization unit tests to assert the expected info/debug logging for each handler

## Testing
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68e56120a9488324be833a4bf2d018d0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes message normalization/logging in the OpenAI handler and updates DeepSeek, DashScope, and Kimi handlers and tests to use the shared helper.
> 
> - **Core (OpenAI handler)**:
>   - Add `prepareNormalizedMessages` to normalize messages and emit debug previews and length-change info, using `MESSAGE_PREVIEW_LENGTH`.
> - **Provider handlers**:
>   - **DeepSeek**: Use `prepareNormalizedMessages` with `{ mergeConsecutiveRoles: true, convertContentToString: true }` and provider label `Deepseek`.
>   - **DashScope**: Use `prepareNormalizedMessages` with `{ convertContentToString: true }` and label `DashScope`.
>   - **Kimi**: Use `prepareNormalizedMessages` with `{ convertContentToString: true }` and label `Kimi`; preserve thinking-model branch.
> - **Tests**:
>   - Update normalization tests to assert merged preview logging for `Deepseek` and absence of info logs for `Kimi` and `DashScope`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dc2a48f88d26f2c94388ad4c9900dfac7a197c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->