### PR TITLE
feat: prompt for latexdiff math markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Add OpenAI GPT-5 Pro (`gpt5pro`) to the model catalog with updated pricing and documentation.
+- Add interactive prompt to select latexdiff math markup granularity before each run.
 
 ## [0.33.9] - 2025-10-03
 

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -14,6 +14,11 @@ import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 
 // Local imports - latex utils
 import { LaTeXdiffService } from '@latex/latexdiff';
+import {
+  MATH_MARKUP_OPTIONS,
+  describeMathMarkupOption,
+  type MathMarkupOption,
+} from '@latex/latexdiff/mathMarkup';
 import { checkToolInstalled } from '@utils/system';
 
 // Local imports - housekeeping
@@ -39,14 +44,11 @@ logger.initialize(CHANNEL);
 
 const service = new LaTeXdiffService(CHANNEL);
 
-const MATH_MARKUP_OPTIONS = ['off', 'whole', 'coarse', 'fine'] as const;
-type MathMarkupOption = (typeof MATH_MARKUP_OPTIONS)[number];
-
 async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
   const currentMode = getConfig<string>('latexdiff.mathMarkup', 'coarse');
   const items: vscode.QuickPickItem[] = MATH_MARKUP_OPTIONS.map((mode) => ({
     label: mode,
-    description: mode === 'coarse' ? 'Default mode' : undefined,
+    description: describeMathMarkupOption(mode),
     picked: mode === currentMode,
   }));
 
@@ -165,8 +167,17 @@ async function handleLatexdiffvc(
       return;
     }
 
+    const mathMarkup = await promptForMathMarkup();
+    if (!mathMarkup) {
+      return;
+    }
+    logger.info(
+      CHANNEL,
+      `Running latexdiff-vc with math markup mode: ${mathMarkup}`,
+    );
+
     // Get the result from LaTeXdiffService
-    const result = await service.runDiffVc(fileToUse, commitHash);
+    const result = await service.runDiffVc(fileToUse, commitHash, mathMarkup);
 
     if (!result.success || !result.diffFileName) {
       throw new Error(result.message || 'Failed to generate diff file');

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -46,6 +46,10 @@ logger.initialize(CHANNEL);
 
 const service = new LaTeXdiffService(CHANNEL);
 
+/**
+ * Prompts the user to select a math markup granularity for latexdiff operations.
+ * @returns The selected math markup option, or undefined if the user cancels.
+ */
 async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
   const configuredMode = getConfig<string>(
     'latexdiff.mathMarkup',
@@ -128,6 +132,7 @@ async function handleLatexdiff(
 
     const mathMarkup = await promptForMathMarkup();
     if (!mathMarkup) {
+      logger.debug(CHANNEL, 'Math markup selection cancelled by user');
       return;
     }
     logger.info(
@@ -181,6 +186,7 @@ async function handleLatexdiffvc(
 
     const mathMarkup = await promptForMathMarkup();
     if (!mathMarkup) {
+      logger.debug(CHANNEL, 'Math markup selection cancelled by user');
       return;
     }
     logger.info(
@@ -328,6 +334,7 @@ async function handleRunLatexdiff(config: any) {
 
     const mathMarkup = await promptForMathMarkup();
     if (!mathMarkup) {
+      logger.debug(CHANNEL, 'Math markup selection cancelled by user');
       return;
     }
     logger.info(

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_MATH_MARKUP,
   MATH_MARKUP_OPTIONS,
   describeMathMarkupOption,
+  normalizeMathMarkup,
   type MathMarkupOption,
 } from '@latex/latexdiff/mathMarkup';
 import { checkToolInstalled } from '@utils/system';
@@ -50,11 +51,7 @@ async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
     'latexdiff.mathMarkup',
     DEFAULT_MATH_MARKUP,
   );
-  const currentMode = MATH_MARKUP_OPTIONS.includes(
-    configuredMode as MathMarkupOption,
-  )
-    ? (configuredMode as MathMarkupOption)
-    : DEFAULT_MATH_MARKUP;
+  const currentMode = normalizeMathMarkup(configuredMode);
   const items: (vscode.QuickPickItem & { value: MathMarkupOption })[] =
     MATH_MARKUP_OPTIONS.map((mode) => ({
       label: mode,
@@ -137,9 +134,6 @@ async function handleLatexdiff(
       CHANNEL,
       `Running latexdiff with math markup mode: ${mathMarkup}`,
     );
-    vscode.window.showInformationMessage(
-      `Running LaTeX diff with math markup mode "${mathMarkup}"`,
-    );
 
     // Get the result from LaTeXdiffService
     const result = await service.runDiff(
@@ -192,9 +186,6 @@ async function handleLatexdiffvc(
     logger.info(
       CHANNEL,
       `Running latexdiff-vc with math markup mode: ${mathMarkup}`,
-    );
-    vscode.window.showInformationMessage(
-      `Running latexdiff-vc with math markup mode "${mathMarkup}"`,
     );
 
     // Get the result from LaTeXdiffService
@@ -342,9 +333,6 @@ async function handleRunLatexdiff(config: any) {
     logger.info(
       CHANNEL,
       `Running latexdiff with math markup mode: ${mathMarkup}`,
-    );
-    vscode.window.showInformationMessage(
-      `Running LaTeX diffs with math markup mode "${mathMarkup}"`,
     );
 
     const generateBetweenRoundDiffs = getConfig<boolean>(
@@ -572,14 +560,17 @@ async function handleRunLatexdiff(config: any) {
         const successCount = results.filter((r) => r.success).length;
 
         if (successCount === 0) {
-          await showLoggedMessage(CHANNEL, 'All LaTeX diff operations failed');
+          await showLoggedMessage(
+            CHANNEL,
+            `All LaTeX diff operations failed (math markup: "${mathMarkup}")`,
+          );
         } else if (successCount < totalOperations) {
           vscode.window.showWarningMessage(
-            `${successCount} of ${totalOperations} LaTeX diff operations completed successfully`,
+            `${successCount} of ${totalOperations} LaTeX diff operations completed successfully (math markup: "${mathMarkup}")`,
           );
         } else {
           vscode.window.showInformationMessage(
-            'All LaTeX diffs completed successfully',
+            `All LaTeX diffs completed successfully (math markup: "${mathMarkup}")`,
           );
         }
 

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -15,6 +15,7 @@ import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 // Local imports - latex utils
 import { LaTeXdiffService } from '@latex/latexdiff';
 import {
+  DEFAULT_MATH_MARKUP,
   MATH_MARKUP_OPTIONS,
   describeMathMarkupOption,
   type MathMarkupOption,
@@ -45,12 +46,22 @@ logger.initialize(CHANNEL);
 const service = new LaTeXdiffService(CHANNEL);
 
 async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
-  const currentMode = getConfig<string>('latexdiff.mathMarkup', 'coarse');
-  const items: vscode.QuickPickItem[] = MATH_MARKUP_OPTIONS.map((mode) => ({
-    label: mode,
-    description: describeMathMarkupOption(mode),
-    picked: mode === currentMode,
-  }));
+  const configuredMode = getConfig<string>(
+    'latexdiff.mathMarkup',
+    DEFAULT_MATH_MARKUP,
+  );
+  const currentMode = MATH_MARKUP_OPTIONS.includes(
+    configuredMode as MathMarkupOption,
+  )
+    ? (configuredMode as MathMarkupOption)
+    : DEFAULT_MATH_MARKUP;
+  const items: (vscode.QuickPickItem & { value: MathMarkupOption })[] =
+    MATH_MARKUP_OPTIONS.map((mode) => ({
+      label: mode,
+      description: describeMathMarkupOption(mode),
+      picked: mode === currentMode,
+      value: mode,
+    }));
 
   const selection = await vscode.window.showQuickPick(items, {
     title: 'Latexdiff math markup',
@@ -58,7 +69,7 @@ async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
     ignoreFocusOut: true,
   });
 
-  return selection?.label as MathMarkupOption | undefined;
+  return selection?.value;
 }
 
 // Removed showLatexdiffError wrapper - using showLoggedMessageWithDocs directly
@@ -122,6 +133,13 @@ async function handleLatexdiff(
     if (!mathMarkup) {
       return;
     }
+    logger.info(
+      CHANNEL,
+      `Running latexdiff with math markup mode: ${mathMarkup}`,
+    );
+    vscode.window.showInformationMessage(
+      `Running LaTeX diff with math markup mode "${mathMarkup}"`,
+    );
 
     // Get the result from LaTeXdiffService
     const result = await service.runDiff(
@@ -174,6 +192,9 @@ async function handleLatexdiffvc(
     logger.info(
       CHANNEL,
       `Running latexdiff-vc with math markup mode: ${mathMarkup}`,
+    );
+    vscode.window.showInformationMessage(
+      `Running latexdiff-vc with math markup mode "${mathMarkup}"`,
     );
 
     // Get the result from LaTeXdiffService

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -39,6 +39,26 @@ logger.initialize(CHANNEL);
 
 const service = new LaTeXdiffService(CHANNEL);
 
+const MATH_MARKUP_OPTIONS = ['off', 'whole', 'coarse', 'fine'] as const;
+type MathMarkupOption = (typeof MATH_MARKUP_OPTIONS)[number];
+
+async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
+  const currentMode = getConfig<string>('latexdiff.mathMarkup', 'coarse');
+  const items: vscode.QuickPickItem[] = MATH_MARKUP_OPTIONS.map((mode) => ({
+    label: mode,
+    description: mode === 'coarse' ? 'Default mode' : undefined,
+    picked: mode === currentMode,
+  }));
+
+  const selection = await vscode.window.showQuickPick(items, {
+    title: 'Latexdiff math markup',
+    placeHolder: 'Select math markup granularity for this diff run',
+    ignoreFocusOut: true,
+  });
+
+  return selection?.label as MathMarkupOption | undefined;
+}
+
 // Removed showLatexdiffError wrapper - using showLoggedMessageWithDocs directly
 
 export function registerLatexdiffCommands(context: vscode.ExtensionContext) {
@@ -96,8 +116,19 @@ async function handleLatexdiff(
       return;
     }
 
+    const mathMarkup = await promptForMathMarkup();
+    if (!mathMarkup) {
+      return;
+    }
+
     // Get the result from LaTeXdiffService
-    const result = await service.runDiff(fileToUse, editedFile, '_diff', false);
+    const result = await service.runDiff(
+      fileToUse,
+      editedFile,
+      '_diff',
+      false,
+      mathMarkup,
+    );
 
     if (!result.success || !result.diffFileName) {
       throw new Error(result.message || 'Failed to generate diff file');
@@ -272,6 +303,18 @@ async function handleRunLatexdiff(config: any) {
       return;
     }
 
+    const mathMarkup = await promptForMathMarkup();
+    if (!mathMarkup) {
+      return;
+    }
+    logger.info(
+      CHANNEL,
+      `Running latexdiff with math markup mode: ${mathMarkup}`,
+    );
+    vscode.window.showInformationMessage(
+      `Running LaTeX diffs with math markup mode "${mathMarkup}"`,
+    );
+
     const generateBetweenRoundDiffs = getConfig<boolean>(
       'latexdiff.generateBetweenRoundDiffs',
       false,
@@ -437,6 +480,7 @@ async function handleRunLatexdiff(config: any) {
               inputFile,
               outputFile,
               round,
+              mathMarkup,
             );
 
             results.push({
@@ -472,6 +516,7 @@ async function handleRunLatexdiff(config: any) {
               const result = await service.runDiffBetweenRounds(
                 currentFile,
                 nextFile,
+                mathMarkup,
               );
 
               results.push({

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -23,6 +23,7 @@ import { runLatexFormatter } from './texFormatter';
 import { DiffFileNameManager } from './latexdiff/diffFileNameManager';
 import { DiffFileProcessor } from './latexdiff/diffFileProcessor';
 import { DiffCommandExecutor } from './latexdiff/diffCommandExecutor';
+import type { MathMarkupOption } from './latexdiff/mathMarkup';
 
 export interface LaTeXdiffResult {
   success: boolean;
@@ -70,7 +71,7 @@ export class LaTeXdiffService {
     editedFile: string,
     suffix = '_diff',
     runIndent = true,
-    mathMarkup?: string,
+    mathMarkup?: MathMarkupOption,
   ): Promise<LaTeXdiffResult> {
     let diffFileName = '';
     let outputPath = '';
@@ -155,6 +156,7 @@ export class LaTeXdiffService {
   async runDiffVc(
     inputFile: string,
     commitHash: string,
+    mathMarkup?: MathMarkupOption,
   ): Promise<LaTeXdiffResult> {
     try {
       if (!(await this.validateDocumentStructure(inputFile))) {
@@ -172,7 +174,9 @@ export class LaTeXdiffService {
         path.basename(diffFileName),
       );
 
-      await this.commandExecutor.executeDiffVc(inputFile, commitHash);
+      await this.commandExecutor.executeDiffVc(inputFile, commitHash, {
+        mathMarkup,
+      });
       await this.fileProcessor.processDiffFile(outputPath);
 
       return {
@@ -253,7 +257,7 @@ export class LaTeXdiffService {
     baseFile: string,
     outputFile: string,
     _round: number,
-    mathMarkup?: string,
+    mathMarkup?: MathMarkupOption,
   ): Promise<LaTeXdiffResult> {
     try {
       if (
@@ -282,7 +286,7 @@ export class LaTeXdiffService {
   async runDiffBetweenRounds(
     outputFile1: string,
     outputFile2: string,
-    mathMarkup?: string,
+    mathMarkup?: MathMarkupOption,
   ): Promise<LaTeXdiffResult> {
     try {
       if (

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -194,6 +194,7 @@ export class LaTeXdiffService {
   async runDiffVcMultiple(
     inputFiles: string[],
     commitHash: string,
+    mathMarkup?: MathMarkupOption,
   ): Promise<LaTeXdiffMultipleResult> {
     try {
       if (!inputFiles || inputFiles.length === 0) {
@@ -210,7 +211,7 @@ export class LaTeXdiffService {
 
       for (const inputFile of inputFiles) {
         try {
-          const result = await this.runDiffVc(inputFile, commitHash);
+          const result = await this.runDiffVc(inputFile, commitHash, mathMarkup);
           if (result.success) {
             results.success.push(inputFile);
           } else {

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -70,6 +70,7 @@ export class LaTeXdiffService {
     editedFile: string,
     suffix = '_diff',
     runIndent = true,
+    mathMarkup?: string,
   ): Promise<LaTeXdiffResult> {
     let diffFileName = '';
     let outputPath = '';
@@ -118,6 +119,7 @@ export class LaTeXdiffService {
       const result = await this.commandExecutor.executeDiff(
         inputFile,
         editedFile,
+        { mathMarkup },
       );
       if (!result.stdout) {
         throw new Error('Latexdiff produced no output');
@@ -251,13 +253,20 @@ export class LaTeXdiffService {
     baseFile: string,
     outputFile: string,
     _round: number,
+    mathMarkup?: string,
   ): Promise<LaTeXdiffResult> {
     try {
       if (
         (await WorkspaceFS.exists(baseFile)) &&
         (await WorkspaceFS.exists(outputFile))
       ) {
-        return await this.runDiff(baseFile, outputFile, '_diff', false);
+        return await this.runDiff(
+          baseFile,
+          outputFile,
+          '_diff',
+          false,
+          mathMarkup,
+        );
       }
 
       const message = `Could not generate latexdiff for round ${_round}. Files not found: ${baseFile} or ${outputFile}`;
@@ -273,6 +282,7 @@ export class LaTeXdiffService {
   async runDiffBetweenRounds(
     outputFile1: string,
     outputFile2: string,
+    mathMarkup?: string,
   ): Promise<LaTeXdiffResult> {
     try {
       if (
@@ -291,7 +301,13 @@ export class LaTeXdiffService {
         const firstRound = firstRoundMatch[1];
         const secondRound = secondRoundMatch[1];
         const diffSuffix = `_diffr${secondRound}r${firstRound}`;
-        return await this.runDiff(outputFile1, outputFile2, diffSuffix, false);
+        return await this.runDiff(
+          outputFile1,
+          outputFile2,
+          diffSuffix,
+          false,
+          mathMarkup,
+        );
       }
 
       const message = `Could not generate latexdiff between rounds. Files not found: ${outputFile1} or ${outputFile2}`;

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -27,6 +27,10 @@ const ERROR_MESSAGES = {
   FAILED_GENERAL: (commandType: string) => `Failed to run ${commandType}`,
 } as const;
 
+interface DiffExecutionOptions {
+  mathMarkup?: string;
+}
+
 export class DiffCommandExecutor {
   constructor(
     private readonly channel: string,
@@ -36,10 +40,16 @@ export class DiffCommandExecutor {
   async executeDiff(
     inputFile: string,
     editedFile: string,
+    options?: DiffExecutionOptions,
   ): Promise<ExecResult> {
     return this.executeWithFallback(
       (useFlatten) =>
-        this.buildLatexdiffCommand(inputFile, editedFile, useFlatten),
+        this.buildLatexdiffCommand(
+          inputFile,
+          editedFile,
+          useFlatten,
+          options?.mathMarkup,
+        ),
       'latexdiff',
     );
   }
@@ -47,10 +57,16 @@ export class DiffCommandExecutor {
   async executeDiffVc(
     inputFile: string,
     commitHash: string,
+    options?: DiffExecutionOptions,
   ): Promise<ExecResult> {
     return this.executeWithFallback(
       (useFlatten) =>
-        this.buildLatexdiffVcCommand(inputFile, commitHash, useFlatten),
+        this.buildLatexdiffVcCommand(
+          inputFile,
+          commitHash,
+          useFlatten,
+          options?.mathMarkup,
+        ),
       'latexdiff-vc',
     );
   }
@@ -59,8 +75,10 @@ export class DiffCommandExecutor {
     inputFile: string,
     editedFile: string,
     useFlatten = true,
+    mathMarkupOverride?: string,
   ): string[] {
-    const { mathMarkup, pictureEnvs } = this.getLatexdiffConfig();
+    const { mathMarkup, pictureEnvs } =
+      this.getLatexdiffConfig(mathMarkupOverride);
     const baseCommand = [
       'latexdiff',
       '--encoding=utf8',
@@ -82,8 +100,10 @@ export class DiffCommandExecutor {
     inputFile: string,
     commitHash: string,
     useFlatten = true,
+    mathMarkupOverride?: string,
   ): string[] {
-    const { mathMarkup, pictureEnvs } = this.getLatexdiffConfig();
+    const { mathMarkup, pictureEnvs } =
+      this.getLatexdiffConfig(mathMarkupOverride);
     const baseCommand = [
       'latexdiff-vc',
       '--encoding=utf8',
@@ -167,12 +187,14 @@ export class DiffCommandExecutor {
     );
   }
 
-  private getLatexdiffConfig(): { mathMarkup: string; pictureEnvs: string } {
+  private getLatexdiffConfig(mathMarkupOverride?: string): {
+    mathMarkup: string;
+    pictureEnvs: string;
+  } {
     return {
-      mathMarkup: getConfig<string>(
-        'latexdiff.mathMarkup',
-        DEFAULT_MATH_MARKUP,
-      ),
+      mathMarkup:
+        mathMarkupOverride ??
+        getConfig<string>('latexdiff.mathMarkup', DEFAULT_MATH_MARKUP),
       pictureEnvs: getConfig<string>(
         'latexdiff.pictureEnvironments',
         DEFAULT_PICTURE_ENVS,

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -7,7 +7,7 @@ import { getConfig } from '@utils/config';
 import type { ExecResult } from '@agent/types/ResultTypes';
 import {
   DEFAULT_MATH_MARKUP,
-  MATH_MARKUP_OPTIONS,
+  normalizeMathMarkup,
   type MathMarkupOption,
 } from './mathMarkup';
 
@@ -200,18 +200,12 @@ export class DiffCommandExecutor {
     mathMarkup: MathMarkupOption;
     pictureEnvs: string;
   } {
-    const configuredMathMarkup = getConfig<string>(
-      'latexdiff.mathMarkup',
-      DEFAULT_MATH_MARKUP,
-    );
-    const normalizedConfig = MATH_MARKUP_OPTIONS.includes(
-      configuredMathMarkup as MathMarkupOption,
-    )
-      ? (configuredMathMarkup as MathMarkupOption)
-      : DEFAULT_MATH_MARKUP;
-
     return {
-      mathMarkup: mathMarkupOverride ?? normalizedConfig,
+      mathMarkup:
+        mathMarkupOverride ??
+        normalizeMathMarkup(
+          getConfig<string>('latexdiff.mathMarkup', DEFAULT_MATH_MARKUP),
+        ),
       pictureEnvs: getConfig<string>(
         'latexdiff.pictureEnvironments',
         DEFAULT_PICTURE_ENVS,

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -5,10 +5,14 @@ import * as logger from '@logger/logUtils';
 import { executeCommand } from '@utils/system';
 import { getConfig } from '@utils/config';
 import type { ExecResult } from '@agent/types/ResultTypes';
+import {
+  DEFAULT_MATH_MARKUP,
+  MATH_MARKUP_OPTIONS,
+  type MathMarkupOption,
+} from './mathMarkup';
 
 const DEFAULT_PICTURE_ENVS =
   '(?:picture|tikzpicture|scope|DIFnomarkup)[\\w\\d*@]*';
-const DEFAULT_MATH_MARKUP = 'coarse';
 
 const BIBLIOGRAPHY_ERROR_PATTERNS = [
   'bibtex',
@@ -27,8 +31,13 @@ const ERROR_MESSAGES = {
   FAILED_GENERAL: (commandType: string) => `Failed to run ${commandType}`,
 } as const;
 
+/**
+ * Options for diff execution.
+ * @property mathMarkup - Math markup mode ('off' | 'whole' | 'coarse' | 'fine').
+ * Overrides the configured default for this execution.
+ */
 interface DiffExecutionOptions {
-  mathMarkup?: string;
+  mathMarkup?: MathMarkupOption;
 }
 
 export class DiffCommandExecutor {
@@ -75,7 +84,7 @@ export class DiffCommandExecutor {
     inputFile: string,
     editedFile: string,
     useFlatten = true,
-    mathMarkupOverride?: string,
+    mathMarkupOverride?: MathMarkupOption,
   ): string[] {
     const { mathMarkup, pictureEnvs } =
       this.getLatexdiffConfig(mathMarkupOverride);
@@ -100,7 +109,7 @@ export class DiffCommandExecutor {
     inputFile: string,
     commitHash: string,
     useFlatten = true,
-    mathMarkupOverride?: string,
+    mathMarkupOverride?: MathMarkupOption,
   ): string[] {
     const { mathMarkup, pictureEnvs } =
       this.getLatexdiffConfig(mathMarkupOverride);
@@ -187,14 +196,22 @@ export class DiffCommandExecutor {
     );
   }
 
-  private getLatexdiffConfig(mathMarkupOverride?: string): {
-    mathMarkup: string;
+  private getLatexdiffConfig(mathMarkupOverride?: MathMarkupOption): {
+    mathMarkup: MathMarkupOption;
     pictureEnvs: string;
   } {
+    const configuredMathMarkup = getConfig<string>(
+      'latexdiff.mathMarkup',
+      DEFAULT_MATH_MARKUP,
+    );
+    const normalizedConfig = MATH_MARKUP_OPTIONS.includes(
+      configuredMathMarkup as MathMarkupOption,
+    )
+      ? (configuredMathMarkup as MathMarkupOption)
+      : DEFAULT_MATH_MARKUP;
+
     return {
-      mathMarkup:
-        mathMarkupOverride ??
-        getConfig<string>('latexdiff.mathMarkup', DEFAULT_MATH_MARKUP),
+      mathMarkup: mathMarkupOverride ?? normalizedConfig,
       pictureEnvs: getConfig<string>(
         'latexdiff.pictureEnvironments',
         DEFAULT_PICTURE_ENVS,

--- a/src/latex/latexdiff/mathMarkup.ts
+++ b/src/latex/latexdiff/mathMarkup.ts
@@ -1,0 +1,19 @@
+export const MATH_MARKUP_OPTIONS = ['off', 'whole', 'coarse', 'fine'] as const;
+
+export type MathMarkupOption = (typeof MATH_MARKUP_OPTIONS)[number];
+
+export const DEFAULT_MATH_MARKUP: MathMarkupOption = 'coarse';
+
+export function describeMathMarkupOption(option: MathMarkupOption): string {
+  switch (option) {
+    case 'coarse':
+      return 'Default - recommended for most documents';
+    case 'fine':
+      return 'Detailed math markup';
+    case 'whole':
+      return 'Mark entire math environments';
+    case 'off':
+    default:
+      return 'No math markup';
+  }
+}

--- a/src/latex/latexdiff/mathMarkup.ts
+++ b/src/latex/latexdiff/mathMarkup.ts
@@ -4,6 +4,16 @@ export type MathMarkupOption = (typeof MATH_MARKUP_OPTIONS)[number];
 
 export const DEFAULT_MATH_MARKUP: MathMarkupOption = 'coarse';
 
+const MATH_MARKUP_OPTION_SET = new Set<string>(MATH_MARKUP_OPTIONS);
+
+export function isMathMarkupOption(value: unknown): value is MathMarkupOption {
+  return typeof value === 'string' && MATH_MARKUP_OPTION_SET.has(value);
+}
+
+export function normalizeMathMarkup(configured?: string): MathMarkupOption {
+  return isMathMarkupOption(configured) ? configured : DEFAULT_MATH_MARKUP;
+}
+
 export function describeMathMarkupOption(option: MathMarkupOption): string {
   switch (option) {
     case 'coarse':


### PR DESCRIPTION
## Summary
- prompt the user to choose a math-markup mode before running latexdiff from the toolbar commands
- reuse the selected math-markup level across all generated diffs and surface it in logs and notifications
- pass one-off math-markup overrides through the latexdiff service down to the command executor

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e625143e44832492d33e46623019fd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an interactive picker for `latexdiff` math markup and threads the selected mode through commands, service, and executor with logging/notifications.
> 
> - **Latexdiff UX**:
>   - Add interactive quick-pick to choose math markup granularity before each run (applies to `latexdiff`, `latexdiff-vc`, round and between-round diffs).
>   - Surface chosen mode in logs and operation result notifications.
> - **Service/Executor plumbing**:
>   - Extend `LaTeXdiffService` methods (`runDiff`, `runDiffVc`, `runDiffForRound`, `runDiffBetweenRounds`) to accept optional `mathMarkup` and pass to `DiffCommandExecutor`.
>   - Update `DiffCommandExecutor` to accept per-call options and override configured `latexdiff.mathMarkup`; include `--math-markup=<mode>` in built commands for both `latexdiff` and `latexdiff-vc`.
> - **New module**:
>   - Introduce `src/latex/latexdiff/mathMarkup.ts` with `MATH_MARKUP_OPTIONS`, `MathMarkupOption`, defaults, normalization, and descriptions.
> - **Changelog**:
>   - Note new interactive math markup selection under Unreleased.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec5545feb9233e9109594bd2a266f8fa0aba5390. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->