### PR TITLE
fix: scope scratchpad reflection styling

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -400,6 +400,9 @@ export class LogEntryFormatter {
     const isThinking = contentType.includes('Thinking');
     const labelText = isThinking ? 'Thinking' : 'Scratchpad';
     const icon = isThinking ? 'codicon-lightbulb' : 'codicon-pencil';
+    const contentClass = isThinking
+      ? 'special-content--thinking'
+      : 'special-content--scratchpad';
 
     // Add necessary attributes for proper group placement (but not log-line class which affects whitespace)
     if (logId) element.dataset.logId = logId;
@@ -421,6 +424,11 @@ export class LogEntryFormatter {
 
     const contentElem = element.querySelector('.special-content');
     if (contentElem) {
+      contentElem.classList.remove(
+        'special-content--thinking',
+        'special-content--scratchpad',
+      );
+      contentElem.classList.add(contentClass);
       contentElem.innerHTML = parsedMarkdown;
     }
 

--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -198,7 +198,7 @@
 }
 
 /* Special handling for reflection patterns */
-.markdown-content p:has(strong:first-child) {
+.special-content--scratchpad p:has(strong:first-child) {
   border-left: calc(var(--spacing-small) - 1px) solid
     var(--vscode-notificationsInfoIcon-foreground, #75beff);
   padding-left: var(--spacing-medium);


### PR DESCRIPTION
## Summary
- add dedicated modifier classes for thinking and scratchpad special content
- scope the reflection styling so it only affects scratchpad previews

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e631ab02f48324bf02380a490d1642

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Thinking/Scratchpad modifier classes to `special-content` and scopes reflection styling to only scratchpad previews.
> 
> - **UI/Rendering**:
>   - Assigns modifier classes on `special-content` in `src/progressView/modules/formatters.js`:
>     - Adds `special-content--thinking` or `special-content--scratchpad` based on content type (removing the other if present).
> - **Styles**:
>   - Scopes reflection paragraph styling from `.markdown-content p:has(strong:first-child)` to `.special-content--scratchpad p:has(strong:first-child)` in `src/progressView/styles/markdown.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d2c97b637303bc1b53d07f79b75f9a4fdf3886e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->