### PR TITLE
feat: add ranged reads to read_file tool

### DIFF
--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -167,7 +167,7 @@ workspace utilities like `bash`, `read_file`, `write_file`, `edit_file`,
 `str_replace_editor`, `wolfram`,
 `web_fetch`, and `web_search`.
 
-> **Tip:** The `read_file` tool returns only the first 400 lines of a file to prevent massive responses from overwhelming the progress log.
+> **Tip:** The `read_file` tool returns only the first 400 lines of a file to prevent massive responses from overwhelming the progress log. Provide an optional `range` object (for example, `{"start": 401, "end": 450}`) to page through a file beyond the first 400 lines. The tool enforces the same 400-line limit on each requested window and reports the specific line range that was returned.
 
 For a minimal read-only configuration, see the built-in `ask` agent
 (`resources/tool_use_agents/ask.yaml`), which only grants `read_file`, `glob`,

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -167,7 +167,7 @@ workspace utilities like `bash`, `read_file`, `write_file`, `edit_file`,
 `str_replace_editor`, `wolfram`,
 `web_fetch`, and `web_search`.
 
-> **Tip:** The `read_file` tool returns only the first 400 lines of a file to prevent massive responses from overwhelming the progress log. Provide an optional `range` object (for example, `{"start": 401, "end": 450}`) to page through a file beyond the first 400 lines. The tool enforces the same 400-line limit on each requested window and reports the specific line range that was returned.
+> **Tip:** The `read_file` tool returns only the first 400 lines of a file to prevent massive responses from overwhelming the progress log. Provide an optional `range` object (for example, `{"start": 401, "end": 450}`) to page through a file beyond the first 400 lines. The tool enforces the same 400-line limit on each requested window, reports the specific line range that was returned, and notes when the requested end exceeds the file length so you know the response was clipped.
 
 For a minimal read-only configuration, see the built-in `ask` agent
 (`resources/tool_use_agents/ask.yaml`), which only grants `read_file`, `glob`,

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -186,4 +186,30 @@ suite('ReadFileTool', () => {
     assert.strictEqual(outputLines[0], 'line 100');
     assert.strictEqual(outputLines[399], 'line 499');
   });
+
+  test('handles range starting at line 1 with end exceeding file length', async () => {
+    const tool = new ReadFileTool();
+
+    const totalLines = 50;
+    const content = Array.from(
+      { length: totalLines },
+      (_, index) => `line ${index + 1}`,
+    ).join('\n');
+
+    WorkspaceFS.read = async () => content;
+
+    const result = await tool.call({
+      path: 'clipped-start.txt',
+      range: { start: 1, end: totalLines + 50 },
+    });
+
+    assert.strictEqual(
+      result.summary,
+      `Read lines 1-50 of clipped-start.txt (requested end ${totalLines + 50} exceeds file length ${totalLines})`,
+    );
+    const outputLines = result.output?.split('\n') ?? [];
+    assert.strictEqual(outputLines.length, 50);
+    assert.strictEqual(outputLines[0], 'line 1');
+    assert.strictEqual(outputLines[49], 'line 50');
+  });
 });

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -4,9 +4,18 @@ import { ReadFileTool, READ_FILE_MAX_LINES } from '@tools/ReadTool';
 import { WorkspaceFS } from '@utils/files';
 
 suite('ReadFileTool', () => {
+  let originalRead: typeof WorkspaceFS.read;
+
+  setup(() => {
+    originalRead = WorkspaceFS.read;
+  });
+
+  teardown(() => {
+    WorkspaceFS.read = originalRead;
+  });
+
   test('truncates output when file exceeds maximum lines', async () => {
     const tool = new ReadFileTool();
-    const originalRead = WorkspaceFS.read;
 
     const totalLines = READ_FILE_MAX_LINES + 10;
     const content = Array.from(
@@ -14,40 +23,33 @@ suite('ReadFileTool', () => {
       (_, index) => `line ${index + 1}`,
     ).join('\n');
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async () => content;
+    WorkspaceFS.read = async () => content;
 
-    try {
-      const result = await tool.call({ path: 'long.txt' });
+    const result = await tool.call({ path: 'long.txt' });
 
-      assert.strictEqual(result.summary, 'Read lines 1-400 of long.txt');
+    assert.strictEqual(result.summary, 'Read lines 1-400 of long.txt');
 
-      assert.ok(result.output, 'Expected tool output when truncating file');
+    assert.ok(result.output, 'Expected tool output when truncating file');
 
-      const outputLines = result.output!.split('\n');
-      assert.strictEqual(
-        outputLines.length,
-        READ_FILE_MAX_LINES + 1,
-        'Output should include the limit and truncation marker line',
-      );
-      assert.strictEqual(outputLines[0], 'line 1');
-      assert.strictEqual(
-        outputLines[READ_FILE_MAX_LINES - 1],
-        `line ${READ_FILE_MAX_LINES}`,
-      );
-      assert.strictEqual(
-        outputLines[READ_FILE_MAX_LINES],
-        `...(truncated, ${totalLines - READ_FILE_MAX_LINES} more lines)`,
-      );
-    } finally {
-      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-        originalRead;
-    }
+    const outputLines = result.output!.split('\n');
+    assert.strictEqual(
+      outputLines.length,
+      READ_FILE_MAX_LINES + 1,
+      'Output should include the limit and truncation marker line',
+    );
+    assert.strictEqual(outputLines[0], 'line 1');
+    assert.strictEqual(
+      outputLines[READ_FILE_MAX_LINES - 1],
+      `line ${READ_FILE_MAX_LINES}`,
+    );
+    assert.strictEqual(
+      outputLines[READ_FILE_MAX_LINES],
+      `...(truncated, ${totalLines - READ_FILE_MAX_LINES} more lines)`,
+    );
   });
 
   test('returns complete content when file is within limit', async () => {
     const tool = new ReadFileTool();
-    const originalRead = WorkspaceFS.read;
 
     const totalLines = READ_FILE_MAX_LINES - 5;
     const content = Array.from(
@@ -55,23 +57,16 @@ suite('ReadFileTool', () => {
       (_, index) => `entry ${index + 1}`,
     ).join('\n');
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async () => content;
+    WorkspaceFS.read = async () => content;
 
-    try {
-      const result = await tool.call({ path: 'short.txt' });
+    const result = await tool.call({ path: 'short.txt' });
 
-      assert.strictEqual(result.summary, 'Read short.txt');
-      assert.strictEqual(result.output, content);
-    } finally {
-      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-        originalRead;
-    }
+    assert.strictEqual(result.summary, 'Read short.txt');
+    assert.strictEqual(result.output, content);
   });
 
   test('reads requested range beyond 400th line', async () => {
     const tool = new ReadFileTool();
-    const originalRead = WorkspaceFS.read;
 
     const totalLines = READ_FILE_MAX_LINES + 50;
     const content = Array.from(
@@ -79,29 +74,22 @@ suite('ReadFileTool', () => {
       (_, index) => `row ${index + 1}`,
     ).join('\n');
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async () => content;
+    WorkspaceFS.read = async () => content;
 
-    try {
-      const result = await tool.call({
-        path: 'paged.txt',
-        range: { start: 401, end: 450 },
-      });
+    const result = await tool.call({
+      path: 'paged.txt',
+      range: { start: 401, end: 450 },
+    });
 
-      assert.strictEqual(result.summary, 'Read lines 401-450 of paged.txt');
-      const outputLines = result.output?.split('\n') ?? [];
-      assert.strictEqual(outputLines.length, 50);
-      assert.strictEqual(outputLines[0], 'row 401');
-      assert.strictEqual(outputLines[outputLines.length - 1], 'row 450');
-    } finally {
-      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-        originalRead;
-    }
+    assert.strictEqual(result.summary, 'Read lines 401-450 of paged.txt');
+    const outputLines = result.output?.split('\n') ?? [];
+    assert.strictEqual(outputLines.length, 50);
+    assert.strictEqual(outputLines[0], 'row 401');
+    assert.strictEqual(outputLines[outputLines.length - 1], 'row 450');
   });
 
   test('notes when requested range exceeds file length', async () => {
     const tool = new ReadFileTool();
-    const originalRead = WorkspaceFS.read;
 
     const totalLines = READ_FILE_MAX_LINES + 50;
     const content = Array.from(
@@ -109,28 +97,21 @@ suite('ReadFileTool', () => {
       (_, index) => `row ${index + 1}`,
     ).join('\n');
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async () => content;
+    WorkspaceFS.read = async () => content;
 
-    try {
-      const result = await tool.call({
-        path: 'clipped.txt',
-        range: { start: 401, end: totalLines + 50 },
-      });
+    const result = await tool.call({
+      path: 'clipped.txt',
+      range: { start: 401, end: totalLines + 50 },
+    });
 
-      assert.strictEqual(
-        result.summary,
-        `Read lines 401-450 of clipped.txt (requested end ${totalLines + 50} exceeds file length ${totalLines})`,
-      );
-    } finally {
-      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-        originalRead;
-    }
+    assert.strictEqual(
+      result.summary,
+      `Read lines 401-450 of clipped.txt (requested end ${totalLines + 50} exceeds file length ${totalLines})`,
+    );
   });
 
   test('indicates when the requested window lies beyond the file bounds', async () => {
     const tool = new ReadFileTool();
-    const originalRead = WorkspaceFS.read;
 
     const totalLines = READ_FILE_MAX_LINES;
     const content = Array.from(
@@ -138,23 +119,71 @@ suite('ReadFileTool', () => {
       (_, index) => `row ${index + 1}`,
     ).join('\n');
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async () => content;
+    WorkspaceFS.read = async () => content;
 
-    try {
-      const result = await tool.call({
-        path: 'out-of-range.txt',
-        range: { start: totalLines + 10, end: totalLines + 20 },
-      });
+    const result = await tool.call({
+      path: 'out-of-range.txt',
+      range: { start: totalLines + 10, end: totalLines + 20 },
+    });
 
-      assert.strictEqual(
-        result.summary,
-        'Read out-of-range.txt (no lines in requested range)',
-      );
-      assert.strictEqual(result.output, '');
-    } finally {
-      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-        originalRead;
-    }
+    assert.strictEqual(
+      result.summary,
+      'Read out-of-range.txt (no lines in requested range)',
+    );
+    assert.strictEqual(result.output, '');
+  });
+
+  test('handles single-line range correctly', async () => {
+    const tool = new ReadFileTool();
+
+    const content = Array.from(
+      { length: 10 },
+      (_, index) => `line ${index + 1}`,
+    ).join('\n');
+
+    WorkspaceFS.read = async () => content;
+
+    const result = await tool.call({
+      path: 'single.txt',
+      range: { start: 5, end: 5 },
+    });
+
+    assert.strictEqual(result.summary, 'Read line 5 of single.txt');
+    assert.strictEqual(result.output, 'line 5');
+  });
+
+  test('handles empty file gracefully', async () => {
+    const tool = new ReadFileTool();
+
+    WorkspaceFS.read = async () => '';
+
+    const result = await tool.call({ path: 'empty.txt' });
+
+    assert.strictEqual(result.summary, 'Read empty.txt (file is empty)');
+    assert.strictEqual(result.output, '');
+  });
+
+  test('defaults range end to start + 399 when only start provided', async () => {
+    const tool = new ReadFileTool();
+
+    const totalLines = 1000;
+    const content = Array.from(
+      { length: totalLines },
+      (_, index) => `line ${index + 1}`,
+    ).join('\n');
+
+    WorkspaceFS.read = async () => content;
+
+    const result = await tool.call({
+      path: 'windowed.txt',
+      range: { start: 100 },
+    });
+
+    // Should read lines 100-499 (400 lines)
+    assert.strictEqual(result.summary, 'Read lines 100-499 of windowed.txt');
+    const outputLines = result.output?.split('\n') ?? [];
+    assert.strictEqual(outputLines.length, 400);
+    assert.strictEqual(outputLines[0], 'line 100');
+    assert.strictEqual(outputLines[399], 'line 499');
   });
 });

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -127,4 +127,34 @@ suite('ReadFileTool', () => {
         originalRead;
     }
   });
+
+  test('indicates when the requested window lies beyond the file bounds', async () => {
+    const tool = new ReadFileTool();
+    const originalRead = WorkspaceFS.read;
+
+    const totalLines = READ_FILE_MAX_LINES;
+    const content = Array.from(
+      { length: totalLines },
+      (_, index) => `row ${index + 1}`,
+    ).join('\n');
+
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+      async () => content;
+
+    try {
+      const result = await tool.call({
+        path: 'out-of-range.txt',
+        range: { start: totalLines + 10, end: totalLines + 20 },
+      });
+
+      assert.strictEqual(
+        result.summary,
+        'Read out-of-range.txt (no lines in requested range)',
+      );
+      assert.strictEqual(result.output, '');
+    } finally {
+      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+        originalRead;
+    }
+  });
 });

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -98,4 +98,33 @@ suite('ReadFileTool', () => {
         originalRead;
     }
   });
+
+  test('notes when requested range exceeds file length', async () => {
+    const tool = new ReadFileTool();
+    const originalRead = WorkspaceFS.read;
+
+    const totalLines = READ_FILE_MAX_LINES + 50;
+    const content = Array.from(
+      { length: totalLines },
+      (_, index) => `row ${index + 1}`,
+    ).join('\n');
+
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+      async () => content;
+
+    try {
+      const result = await tool.call({
+        path: 'clipped.txt',
+        range: { start: 401, end: totalLines + 50 },
+      });
+
+      assert.strictEqual(
+        result.summary,
+        `Read lines 401-450 of clipped.txt (requested end ${totalLines + 50} exceeds file length ${totalLines})`,
+      );
+    } finally {
+      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+        originalRead;
+    }
+  });
 });

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -20,10 +20,7 @@ suite('ReadFileTool', () => {
     try {
       const result = await tool.call({ path: 'long.txt' });
 
-      assert.strictEqual(
-        result.summary,
-        `Read long.txt (first ${READ_FILE_MAX_LINES} of ${totalLines} lines)`,
-      );
+      assert.strictEqual(result.summary, 'Read lines 1-400 of long.txt');
 
       assert.ok(result.output, 'Expected tool output when truncating file');
 
@@ -66,6 +63,36 @@ suite('ReadFileTool', () => {
 
       assert.strictEqual(result.summary, 'Read short.txt');
       assert.strictEqual(result.output, content);
+    } finally {
+      (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+        originalRead;
+    }
+  });
+
+  test('reads requested range beyond 400th line', async () => {
+    const tool = new ReadFileTool();
+    const originalRead = WorkspaceFS.read;
+
+    const totalLines = READ_FILE_MAX_LINES + 50;
+    const content = Array.from(
+      { length: totalLines },
+      (_, index) => `row ${index + 1}`,
+    ).join('\n');
+
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+      async () => content;
+
+    try {
+      const result = await tool.call({
+        path: 'paged.txt',
+        range: { start: 401, end: 450 },
+      });
+
+      assert.strictEqual(result.summary, 'Read lines 401-450 of paged.txt');
+      const outputLines = result.output?.split('\n') ?? [];
+      assert.strictEqual(outputLines.length, 50);
+      assert.strictEqual(outputLines[0], 'row 401');
+      assert.strictEqual(outputLines[outputLines.length - 1], 'row 450');
     } finally {
       (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
         originalRead;

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -15,6 +15,16 @@ export const READ_FILE_MAX_LINES = 400;
 
 const ReadInputSchema = z.strictObject({
   path: z.string(),
+  range: z
+    .strictObject({
+      start: z.number().int().positive(),
+      end: z.number().int().positive().optional(),
+    })
+    .refine((value) => value.end === undefined || value.end >= value.start, {
+      message: 'range.end must be greater than or equal to range.start',
+      path: ['end'],
+    })
+    .optional(),
 });
 
 export type ReadInput = z.infer<typeof ReadInputSchema>;
@@ -32,19 +42,61 @@ export class ReadFileTool extends defineTool({
     }
 
     const totalLines = lines.length;
-    if (totalLines > READ_FILE_MAX_LINES) {
-      const visibleLines = lines.slice(0, READ_FILE_MAX_LINES);
-      const truncatedOutput = `${visibleLines.join('\n')}\n...(truncated, ${totalLines - READ_FILE_MAX_LINES} more lines)`;
+    const requestedStartLine = Math.max(input.range?.start ?? 1, 1);
+    const requestedEndLine = Math.max(
+      input.range?.end ?? totalLines,
+      input.range?.start ?? 1,
+    );
+    const startIndex = Math.min(Math.max(requestedStartLine - 1, 0), totalLines);
+    const endIndexExclusive = Math.min(
+      Math.max(requestedEndLine, requestedStartLine - 1),
+      totalLines,
+    );
 
-      return toolResult({
-        summary: `Read ${input.path} (first ${READ_FILE_MAX_LINES} of ${totalLines} lines)`,
-        output: truncatedOutput,
-      });
+    const selectedLines = lines.slice(startIndex, endIndexExclusive);
+    const truncated = selectedLines.length > READ_FILE_MAX_LINES;
+    const visibleLines = truncated
+      ? selectedLines.slice(0, READ_FILE_MAX_LINES)
+      : selectedLines;
+    const visibleCount = visibleLines.length;
+    const actualStartLine = visibleCount > 0 ? requestedStartLine : undefined;
+    const actualEndLine =
+      visibleCount > 0 ? requestedStartLine + visibleCount - 1 : undefined;
+
+    const segments: string[] = [];
+    if (visibleLines.length > 0) {
+      segments.push(visibleLines.join('\n'));
+    }
+    if (truncated) {
+      segments.push(
+        `...(truncated, ${selectedLines.length - READ_FILE_MAX_LINES} more lines)`,
+      );
     }
 
+    const summary = (() => {
+      if (visibleCount === 0) {
+        return `Read ${input.path} (no lines in requested range)`;
+      }
+
+      if (
+        input.range ||
+        truncated ||
+        actualStartLine !== 1 ||
+        actualEndLine !== totalLines
+      ) {
+        const rangeLabel =
+          actualStartLine === actualEndLine
+            ? `line ${actualStartLine}`
+            : `lines ${actualStartLine}-${actualEndLine}`;
+        return `Read ${rangeLabel} of ${input.path}`;
+      }
+
+      return `Read ${input.path}`;
+    })();
+
     return toolResult({
-      summary: `Read ${input.path}`,
-      output: content,
+      summary,
+      output: segments.join('\n'),
     });
   }
 }

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -17,8 +17,8 @@ const ReadInputSchema = z.strictObject({
   path: z.string(),
   range: z
     .strictObject({
-      start: z.number().int().positive(),
-      end: z.number().int().positive().optional(),
+      start: z.number().int().min(1),
+      end: z.number().int().min(1).optional(),
     })
     .refine((value) => value.end === undefined || value.end >= value.start, {
       message: 'range.end must be greater than or equal to range.start',
@@ -28,6 +28,19 @@ const ReadInputSchema = z.strictObject({
 });
 
 export type ReadInput = z.infer<typeof ReadInputSchema>;
+
+interface BuildSummaryParams {
+  path: string;
+  totalLines: number;
+  visibleCount: number;
+  actualStartLine: number | null;
+  actualEndLine: number | null;
+  requestedStartLine: number;
+  requestedEndLine: number;
+  truncated: boolean;
+  rangeProvided: boolean;
+  rangeEndExceeded: boolean;
+}
 
 export class ReadFileTool extends defineTool({
   name: 'read_file',
@@ -45,20 +58,16 @@ export class ReadFileTool extends defineTool({
     const clamp = (value: number, min: number, max: number) =>
       Math.min(Math.max(value, min), max);
 
-    const requestedStartLine = Math.max(input.range?.start ?? 1, 1);
+    const requestedStartLine = input.range?.start ?? 1;
     const requestedEndLine = input.range?.end ?? totalLines;
 
     // Convert the requested 1-based range into zero-based indices and clamp them to the
     // available file length so callers can safely request windows beyond the file bounds.
-    const startIndex = clamp(requestedStartLine - 1, 0, totalLines);
-    const endIndexExclusive = (() => {
-      const requestedExclusiveOneBased = clamp(
-        requestedEndLine,
-        requestedStartLine,
-        totalLines,
-      );
-      return Math.max(startIndex, requestedExclusiveOneBased);
-    })();
+    const startIndex = Math.min(requestedStartLine - 1, totalLines);
+    const endIndexExclusive = Math.min(
+      Math.max(requestedEndLine, requestedStartLine),
+      totalLines,
+    );
 
     const selectedLines = lines.slice(startIndex, endIndexExclusive);
     const truncated = selectedLines.length > READ_FILE_MAX_LINES;
@@ -111,18 +120,7 @@ export class ReadFileTool extends defineTool({
     truncated,
     rangeProvided,
     rangeEndExceeded,
-  }: {
-    path: string;
-    totalLines: number;
-    visibleCount: number;
-    actualStartLine: number | null;
-    actualEndLine: number | null;
-    requestedStartLine: number;
-    requestedEndLine: number;
-    truncated: boolean;
-    rangeProvided: boolean;
-    rangeEndExceeded: boolean;
-  }): string {
+  }: BuildSummaryParams): string {
     if (visibleCount === 0) {
       return rangeProvided
         ? `Read ${path} (no lines in requested range)`

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -44,7 +44,8 @@ interface BuildSummaryParams {
 
 export class ReadFileTool extends defineTool({
   name: 'read_file',
-  description: 'Read and return the contents of a workspace file.',
+  description:
+    'Read and return the contents of a workspace file. Optionally specify a line range to read specific sections.',
   schema: ReadInputSchema,
 }) {
   protected async execute(input: ReadInput): Promise<ToolResult> {
@@ -58,7 +59,10 @@ export class ReadFileTool extends defineTool({
 
     const requestedStartLine = input.range?.start ?? 1;
     const requestedEndLine =
-      input.range?.end ?? Math.max(requestedStartLine, totalLines);
+      input.range?.end ??
+      (input.range?.start
+        ? Math.min(requestedStartLine + READ_FILE_MAX_LINES - 1, totalLines)
+        : totalLines);
 
     // Convert the requested 1-based range into zero-based indices and clamp them to the
     // available file length so callers can safely request windows beyond the file bounds.

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -66,6 +66,7 @@ export class ReadFileTool extends defineTool({
 
     // Convert the requested 1-based range into zero-based indices and clamp them to the
     // available file length so callers can safely request windows beyond the file bounds.
+    // If startIndex >= totalLines, slice will return empty array (which is correct behavior).
     const startIndex = Math.min(requestedStartLine - 1, totalLines);
     const endIndexExclusive = Math.min(
       Math.max(requestedEndLine, requestedStartLine),
@@ -125,9 +126,10 @@ export class ReadFileTool extends defineTool({
     rangeEndExceeded,
   }: BuildSummaryParams): string {
     if (visibleCount === 0) {
-      return rangeProvided
-        ? `Read ${path} (no lines in requested range)`
-        : `Read ${path} (file is empty)`;
+      if (totalLines === 0) {
+        return `Read ${path} (file is empty)`;
+      }
+      return `Read ${path} (no lines in requested range)`;
     }
 
     const safeActualStartLine = actualStartLine ?? 1;

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -51,7 +51,14 @@ export class ReadFileTool extends defineTool({
     // Convert the requested 1-based range into zero-based indices and clamp them to the
     // available file length so callers can safely request windows beyond the file bounds.
     const startIndex = clamp(requestedStartLine - 1, 0, totalLines);
-    const endIndexExclusive = clamp(requestedEndLine, startIndex, totalLines);
+    const endIndexExclusive = (() => {
+      const requestedExclusiveOneBased = clamp(
+        requestedEndLine,
+        requestedStartLine,
+        totalLines,
+      );
+      return Math.max(startIndex, requestedExclusiveOneBased);
+    })();
 
     const selectedLines = lines.slice(startIndex, endIndexExclusive);
     const truncated = selectedLines.length > READ_FILE_MAX_LINES;
@@ -70,10 +77,15 @@ export class ReadFileTool extends defineTool({
       );
     }
 
+    const actualStartLine = visibleCount > 0 ? startIndex + 1 : null;
+    const actualEndLine = visibleCount > 0 ? startIndex + visibleCount : null;
+
     const summary = this.buildSummary({
       path: input.path,
       totalLines,
       visibleCount,
+      actualStartLine,
+      actualEndLine,
       requestedStartLine,
       requestedEndLine,
       truncated,
@@ -92,6 +104,8 @@ export class ReadFileTool extends defineTool({
     path,
     totalLines,
     visibleCount,
+    actualStartLine,
+    actualEndLine,
     requestedStartLine,
     requestedEndLine,
     truncated,
@@ -101,6 +115,8 @@ export class ReadFileTool extends defineTool({
     path: string;
     totalLines: number;
     visibleCount: number;
+    actualStartLine: number | null;
+    actualEndLine: number | null;
     requestedStartLine: number;
     requestedEndLine: number;
     truncated: boolean;
@@ -113,17 +129,18 @@ export class ReadFileTool extends defineTool({
         : `Read ${path} (file is empty)`;
     }
 
-    const actualStartLine = requestedStartLine;
-    const actualEndLine = requestedStartLine + visibleCount - 1;
+    const safeActualStartLine = actualStartLine ?? 1;
+    const safeActualEndLine =
+      actualEndLine ?? safeActualStartLine + visibleCount - 1;
     const describeRange =
       rangeProvided ||
       truncated ||
-      actualStartLine !== 1 ||
-      actualEndLine !== totalLines;
+      safeActualStartLine !== 1 ||
+      safeActualEndLine !== totalLines;
     const rangeLabel =
-      actualStartLine === actualEndLine
-        ? `line ${actualStartLine}`
-        : `lines ${actualStartLine}-${actualEndLine}`;
+      safeActualStartLine === safeActualEndLine
+        ? `line ${safeActualStartLine}`
+        : `lines ${safeActualStartLine}-${safeActualEndLine}`;
 
     let summary = describeRange
       ? `Read ${rangeLabel} of ${path}`

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -55,11 +55,10 @@ export class ReadFileTool extends defineTool({
     }
 
     const totalLines = lines.length;
-    const clamp = (value: number, min: number, max: number) =>
-      Math.min(Math.max(value, min), max);
 
     const requestedStartLine = input.range?.start ?? 1;
-    const requestedEndLine = input.range?.end ?? totalLines;
+    const requestedEndLine =
+      input.range?.end ?? Math.max(requestedStartLine, totalLines);
 
     // Convert the requested 1-based range into zero-based indices and clamp them to the
     // available file length so callers can safely request windows beyond the file bounds.

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -42,16 +42,16 @@ export class ReadFileTool extends defineTool({
     }
 
     const totalLines = lines.length;
+    const clamp = (value: number, min: number, max: number) =>
+      Math.min(Math.max(value, min), max);
+
     const requestedStartLine = Math.max(input.range?.start ?? 1, 1);
-    const requestedEndLine = Math.max(
-      input.range?.end ?? totalLines,
-      input.range?.start ?? 1,
-    );
-    const startIndex = Math.min(Math.max(requestedStartLine - 1, 0), totalLines);
-    const endIndexExclusive = Math.min(
-      Math.max(requestedEndLine, requestedStartLine - 1),
-      totalLines,
-    );
+    const requestedEndLine = input.range?.end ?? totalLines;
+
+    // Convert the requested 1-based range into zero-based indices and clamp them to the
+    // available file length so callers can safely request windows beyond the file bounds.
+    const startIndex = clamp(requestedStartLine - 1, 0, totalLines);
+    const endIndexExclusive = clamp(requestedEndLine, startIndex, totalLines);
 
     const selectedLines = lines.slice(startIndex, endIndexExclusive);
     const truncated = selectedLines.length > READ_FILE_MAX_LINES;
@@ -59,9 +59,6 @@ export class ReadFileTool extends defineTool({
       ? selectedLines.slice(0, READ_FILE_MAX_LINES)
       : selectedLines;
     const visibleCount = visibleLines.length;
-    const actualStartLine = visibleCount > 0 ? requestedStartLine : undefined;
-    const actualEndLine =
-      visibleCount > 0 ? requestedStartLine + visibleCount - 1 : undefined;
 
     const segments: string[] = [];
     if (visibleLines.length > 0) {
@@ -73,30 +70,69 @@ export class ReadFileTool extends defineTool({
       );
     }
 
-    const summary = (() => {
-      if (visibleCount === 0) {
-        return `Read ${input.path} (no lines in requested range)`;
-      }
-
-      if (
-        input.range ||
-        truncated ||
-        actualStartLine !== 1 ||
-        actualEndLine !== totalLines
-      ) {
-        const rangeLabel =
-          actualStartLine === actualEndLine
-            ? `line ${actualStartLine}`
-            : `lines ${actualStartLine}-${actualEndLine}`;
-        return `Read ${rangeLabel} of ${input.path}`;
-      }
-
-      return `Read ${input.path}`;
-    })();
+    const summary = this.buildSummary({
+      path: input.path,
+      totalLines,
+      visibleCount,
+      requestedStartLine,
+      requestedEndLine,
+      truncated,
+      rangeProvided: Boolean(input.range),
+      rangeEndExceeded:
+        input.range?.end !== undefined && input.range.end > totalLines,
+    });
 
     return toolResult({
       summary,
       output: segments.join('\n'),
     });
+  }
+
+  private buildSummary({
+    path,
+    totalLines,
+    visibleCount,
+    requestedStartLine,
+    requestedEndLine,
+    truncated,
+    rangeProvided,
+    rangeEndExceeded,
+  }: {
+    path: string;
+    totalLines: number;
+    visibleCount: number;
+    requestedStartLine: number;
+    requestedEndLine: number;
+    truncated: boolean;
+    rangeProvided: boolean;
+    rangeEndExceeded: boolean;
+  }): string {
+    if (visibleCount === 0) {
+      return rangeProvided
+        ? `Read ${path} (no lines in requested range)`
+        : `Read ${path} (file is empty)`;
+    }
+
+    const actualStartLine = requestedStartLine;
+    const actualEndLine = requestedStartLine + visibleCount - 1;
+    const describeRange =
+      rangeProvided ||
+      truncated ||
+      actualStartLine !== 1 ||
+      actualEndLine !== totalLines;
+    const rangeLabel =
+      actualStartLine === actualEndLine
+        ? `line ${actualStartLine}`
+        : `lines ${actualStartLine}-${actualEndLine}`;
+
+    let summary = describeRange
+      ? `Read ${rangeLabel} of ${path}`
+      : `Read ${path}`;
+
+    if (rangeEndExceeded) {
+      summary += ` (requested end ${requestedEndLine} exceeds file length ${totalLines})`;
+    }
+
+    return summary;
   }
 }


### PR DESCRIPTION
## Summary
- allow the `read_file` tool to accept a `range` object so callers can request specific line windows
- return summaries that reflect the requested range and slice the file before enforcing the max line limit
- expand unit coverage and documentation to cover the new range behaviour

## Testing
- npm run lint
- npm test -- --grep ReadFileTool *(fails in this environment: spinner output exceeds terminal limit)*

------
https://chatgpt.com/codex/tasks/task_e_68e6314ed1fc832498a89e2d1ded3cb9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional `range` to `read_file` to page specific line windows (400-line window limit) with clearer summaries; updates tests and docs accordingly.
> 
> - **Tools**:
>   - **`src/tools/ReadTool.ts`**: Add optional `range` (validated with Zod) to request 1-based line windows; clamp to file bounds; enforce `READ_FILE_MAX_LINES` per selected window; generate detailed summaries (e.g., `lines X-Y`, note when requested end exceeds file length, handle empty-range windows); keep truncation marker for overflow.
> - **Tests**:
>   - Update long-file summary expectation to `Read lines 1-400 of long.txt`.
>   - Add tests for ranged reads beyond 400th line, end beyond file length, and windows entirely out of bounds.
> - **Docs**:
>   - **`docs/guide/custom-agents.md`**: Expand tip for `read_file` to document the `range` parameter, paging, 400-line window limit, and clipping notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5464945dd5db68baacb0487de7cfb7f05baed7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->