### PR TITLE
refactor: centralize continuation message template

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -55,6 +55,7 @@ import {
 } from '@agent/core/ResponseUsage';
 import { ToolState } from '@agent/core/ToolState';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 
@@ -818,12 +819,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
   ): void {
     // Create continuation message with last K tokens
     const prefillTokens = toolState.lastResponse.slice(-K_SLICE);
-    const userMessageContinuation =
-      `Your response got cut off, because you only have limited response space. ` +
-      `Continue responding exactly from where you left off until the very end, ` +
-      `marked by ${agentSetting.endTag}. ` +
-      'Avoid repeat yourself and avoid starting over. ' +
-      `Start your response at the next token after: "${prefillTokens}"`;
+    const userMessageContinuation = createContinuationMessage(
+      agentSetting.endTag,
+      prefillTokens,
+    );
 
     // Add continuation message
     this.logger.debug(

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -41,6 +41,7 @@ import {
   ModelHandler,
   type MediaFileResult,
 } from '@agent/modelHandlers/ModelHandler';
+import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
@@ -750,7 +751,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     _agentConfig: AgentConfig,
   ): void {
     const prefillTokens = toolState.lastResponse.slice(-K_SLICE);
-    const userMessageContinuation = `Your response got cut off. Continue responding exactly where you left off, starting after: "${prefillTokens}". Do not repeat yourself or start over. Ensure you end with ${agentSetting.endTag}.`;
+    const userMessageContinuation = createContinuationMessage(
+      agentSetting.endTag,
+      prefillTokens,
+    );
     this.logger.debug(`Adding continuation message.`);
     messages.push({
       role: 'user',

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -30,6 +30,7 @@ import {
 } from './openAIMessageUtils';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
+import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
@@ -790,12 +791,10 @@ export class ModelHandlerOpenAI extends ModelHandler<
   ): void {
     // Create continuation message with last K tokens
     const prefillTokens = toolState.lastResponse.slice(-K_SLICE);
-    const userMessageContinuation =
-      `Your response got cut off, because you only have limited response space. ` +
-      `Continue responding exactly from where you left off until the very end, ` +
-      `marked by ${agentSetting.endTag}. ` +
-      'Avoid repeat yourself and avoid starting over. ' +
-      `Start your response at the next token after: "${prefillTokens}"`;
+    const userMessageContinuation = createContinuationMessage(
+      agentSetting.endTag,
+      prefillTokens,
+    );
 
     // Add continuation message
     this.logger.debug(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -41,6 +41,7 @@ import type { ProviderStopReason } from './types/StopReasonTypes';
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 
 // Local imports - utilities
+import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
@@ -641,12 +642,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     _agentConfig: AgentConfig,
   ): void {
     const prefillTokens = toolState.lastResponse.slice(-K_SLICE);
-    const userMessageContinuation =
-      `Your response got cut off, because you only have limited response space. ` +
-      `Continue responding exactly from where you left off until the very end, ` +
-      `marked by ${agentSetting.endTag}. ` +
-      'Avoid repeat yourself and avoid starting over. ' +
-      `Start your response at the next token after: "${prefillTokens}"`;
+    const userMessageContinuation = createContinuationMessage(
+      agentSetting.endTag,
+      prefillTokens,
+    );
 
     const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
     messages.push({

--- a/src/agent/utils/continuationMessage.ts
+++ b/src/agent/utils/continuationMessage.ts
@@ -1,0 +1,10 @@
+export const createContinuationMessage = (
+  endTag: string,
+  prefillTokens: string,
+): string =>
+  `Your response got cut off, because you only have limited response space. ` +
+  `Continue responding exactly from where you left off until the very end, ` +
+  `marked by ${endTag}. ` +
+  'Avoid repeat yourself and avoid starting over. ' +
+  `Start your response at the next token after: "${prefillTokens}"`;
+

--- a/src/agent/utils/continuationMessage.ts
+++ b/src/agent/utils/continuationMessage.ts
@@ -1,3 +1,9 @@
+/**
+ * Creates a continuation message prompting the model to resume from where it left off.
+ * @param endTag - The tag that marks the end of the response
+ * @param prefillTokens - The last K tokens from the previous response
+ * @returns Formatted continuation prompt
+ */
 export const createContinuationMessage = (
   endTag: string,
   prefillTokens: string,
@@ -5,6 +11,6 @@ export const createContinuationMessage = (
   `Your response got cut off, because you only have limited response space. ` +
   `Continue responding exactly from where you left off until the very end, ` +
   `marked by ${endTag}. ` +
-  'Avoid repeat yourself and avoid starting over. ' +
+  'Avoid repeating yourself and avoid starting over. ' +
   `Start your response at the next token after: "${prefillTokens}"`;
 

--- a/src/agent/utils/index.ts
+++ b/src/agent/utils/index.ts
@@ -10,3 +10,4 @@ export * from './text';
 export * from './UsageMonitor';
 export * from './debugMessageSaver';
 export * from './roundUtils';
+export * from './continuationMessage';

--- a/src/test/agent/utils/continuationMessage.test.ts
+++ b/src/test/agent/utils/continuationMessage.test.ts
@@ -1,0 +1,42 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { createContinuationMessage } from '@agent/utils/continuationMessage';
+
+describe('continuationMessage.createContinuationMessage', () => {
+  it('should create a properly formatted continuation message', () => {
+    const endTag = '</response>';
+    const prefillTokens = 'last few tokens';
+    const result = createContinuationMessage(endTag, prefillTokens);
+
+    assert.ok(result.includes('Your response got cut off'));
+    assert.ok(result.includes('Continue responding exactly from where you left off'));
+    assert.ok(result.includes(`marked by ${endTag}`));
+    assert.ok(result.includes('Avoid repeating yourself and avoid starting over'));
+    assert.ok(result.includes(`Start your response at the next token after: "${prefillTokens}"`));
+  });
+
+  it('should handle special characters in endTag', () => {
+    const endTag = '</response:special>';
+    const prefillTokens = 'test tokens';
+    const result = createContinuationMessage(endTag, prefillTokens);
+
+    assert.ok(result.includes(`marked by ${endTag}`));
+  });
+
+  it('should handle special characters in prefillTokens', () => {
+    const endTag = '</response>';
+    const prefillTokens = 'tokens with "quotes" and \\backslash';
+    const result = createContinuationMessage(endTag, prefillTokens);
+
+    assert.ok(result.includes(`Start your response at the next token after: "${prefillTokens}"`));
+  });
+
+  it('should return a non-empty string', () => {
+    const result = createContinuationMessage('</end>', 'tokens');
+
+    assert.ok(result.length > 0);
+    assert.strictEqual(typeof result, 'string');
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared helper to build the user continuation message template
- replace hardcoded continuation strings in OpenAI, Anthropic, and Google GenAI model handlers with the new helper

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e623d03c5c832493616518067703a1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a shared `createContinuationMessage` utility and refactor Anthropic, OpenAI (chat/responses), and Google GenAI handlers to use it instead of hardcoded strings.
> 
> - **Utils**:
>   - Add `@agent/utils/continuationMessage` with `createContinuationMessage(endTag, prefillTokens)`.
>   - Export helper via `@agent/utils/index`.
> - **Model Handlers**:
>   - Replace inline continuation strings with `createContinuationMessage` in:
>     - `src/agent/modelHandlers/modelHandlerAnthropic.ts`
>     - `src/agent/modelHandlers/modelHandlerOpenAI.ts`
>     - `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`
>     - `src/agent/modelHandlers/modelHandlerGoogleGenAI.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9bb14ce11d96fbec452bdba2043c46e7e7f7fee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->