### PR TITLE
fix: honor 1m context window beta

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -89,6 +89,8 @@ const SONNET_37_OUTPUT_BETA: AnthropicBeta = 'output-128k-2025-02-19';
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 
+const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
+
 export class ModelHandlerAnthropic extends ModelHandler<
   MessageParam,
   AnthropicUsage,
@@ -127,7 +129,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const isAnthropic1MBetaActive =
       useAnthropic1MBeta && isAnthropic1MBetaEligibleModel;
     const effectiveContextWindow = isAnthropic1MBetaActive
-      ? 1_000_000
+      ? ANTHROPIC_1M_CONTEXT_WINDOW
       : this.config.contextWindow;
 
     const documentAnalysis = this.analyzeDocumentSources(messages);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -121,6 +121,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
       'model.useAnthropic1MBeta',
       false,
     );
+    const isAnthropic1MBetaEligibleModel =
+      this.config.fullName === 'claude-sonnet-4-20250514' ||
+      this.config.fullName === 'claude-sonnet-4-5';
+    const isAnthropic1MBetaActive =
+      useAnthropic1MBeta && isAnthropic1MBetaEligibleModel;
+    const effectiveContextWindow = isAnthropic1MBetaActive
+      ? 1_000_000
+      : this.config.contextWindow;
 
     const documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
@@ -190,11 +198,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Opt-in beta for 1M context window on Claude Sonnet 4 family
-    if (
-      useAnthropic1MBeta &&
-      (this.config.fullName === 'claude-sonnet-4-20250514' ||
-        this.config.fullName === 'claude-sonnet-4-5')
-    ) {
+    if (isAnthropic1MBetaActive) {
       options.betas = [...(options.betas ?? []), CONTEXT_1M_BETA];
     }
 
@@ -230,15 +234,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
           await client.beta.messages.countTokens(countTokensParams);
         const { input_tokens: inputTokens } = responseTokenCount;
         this.logger.debug(`Token count of message: ${inputTokens}`);
-        if (inputTokens > this.config.contextWindow) {
-          const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${this.config.contextWindow}`;
+        if (inputTokens > effectiveContextWindow) {
+          const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${effectiveContextWindow}`;
           this.logger.error(errMsg);
           throw new Error(errMsg);
         }
-        if (this.config.contextWindow - inputTokens < options.max_tokens) {
-          const warnMsg = `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${options.max_tokens} > ${this.config.contextWindow}. Reducing max tokens to ${this.config.contextWindow - inputTokens}.`;
+        if (effectiveContextWindow - inputTokens < options.max_tokens) {
+          const reducedMaxTokens = Math.max(
+            0,
+            effectiveContextWindow - inputTokens - 10,
+          );
+          const warnMsg = `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${options.max_tokens} > ${effectiveContextWindow}. Reducing max tokens to ${reducedMaxTokens}.`;
           this.logger.warn(warnMsg);
-          options.max_tokens = this.config.contextWindow - inputTokens - 10;
+          options.max_tokens = reducedMaxTokens;
 
           if (
             this.capabilities.supportsReasoning &&

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -20,6 +20,9 @@ import {
   ModelProvider,
 } from '@model/ModelConfig';
 
+// Local imports - utilities
+import * as configModule from '@utils/config';
+
 function buildAnthropicConfig(
   capabilityOverrides: Partial<ModelCapabilities> = {},
 ): ModelConfig {
@@ -570,5 +573,93 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     assert.deepEqual(callOrder, ['countTokens', 'upload', 'create']);
     assert.equal(response.stop_reason, 'end_turn');
+  });
+
+  it('does not warn about context overflow when 1M beta header is active', async () => {
+    const handler = createAnthropicHandler({ supportsTokenCounting: true });
+    handler.config.fullName = 'claude-sonnet-4-20250514';
+
+    const warnMessages: string[] = [];
+    const loggerStub = {
+      channelId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: (message: string) => {
+        warnMessages.push(message);
+      },
+      error: () => {},
+      fileList: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'hello', citations: null },
+        ] as ContentBlockParam[],
+      },
+    ];
+
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          countTokens: async () => ({ input_tokens: 900000 }),
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-sonnet-4-20250514',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const originalGetConfig = configModule.getConfig;
+
+    try {
+      (configModule as any).getConfig = (
+        path: string,
+        defaultValue?: unknown,
+      ) => {
+        if (path === 'model.useAnthropic1MBeta') {
+          return true;
+        }
+        return defaultValue as unknown;
+      };
+
+      const response = await handler.createResponse(client, messages, 0);
+      assert.equal(response.stop_reason, 'end_turn');
+    } finally {
+      (configModule as any).getConfig = originalGetConfig;
+    }
+
+    assert.equal(
+      warnMessages.length,
+      0,
+      'should not warn when 1M beta context window is active',
+    );
+
+    const options = messageOptions[0] ?? {};
+    assert.equal(
+      options.max_tokens,
+      handler.config.maxOutputTokens,
+      'should not reduce max_tokens below the configured value',
+    );
+
+    const betas: string[] = options.betas ?? [];
+    assert.ok(
+      betas.includes('context-1m-2025-08-07'),
+      'should include the 1M context beta header when enabled',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- derive an effective context window when the Anthropic 1M beta header is active and reuse it for overflow checks and max token adjustments
- clamp the reduced max token calculation to avoid negative values while retaining updated warning text
- extend the Anthropic model handler tests to cover the 1M beta flow and ensure warnings are suppressed when under the expanded limit

## Testing
- npm test -- ModelHandlerAnthropic
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e6523fd1bc8324bd226a47911d2bee

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Derives an effective 1M context window when the beta is active, applies it to token/overflow logic with clamped max_tokens, and adds tests to validate behavior.
> 
> - **Anthropic Model Handler (`src/agent/modelHandlers/modelHandlerAnthropic.ts`)**:
>   - Introduces `isAnthropic1MBetaEligibleModel`, `isAnthropic1MBetaActive`, and `effectiveContextWindow` to support the 1M context beta for `claude-sonnet-4-20250514` and `claude-sonnet-4-5`.
>   - Applies 1M beta via `options.betas` when active and uses `effectiveContextWindow` for token limit checks and overflow handling.
>   - Clamps reduced `options.max_tokens` to non-negative values and updates warning text accordingly.
>   - Passes only relevant betas (1M context) to `countTokens`.
> - **Tests (`src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts`)**:
>   - Adds test ensuring no overflow warning and no `max_tokens` reduction when 1M beta is enabled; verifies inclusion of the `context-1m-2025-08-07` beta header.
>   - Mocks `getConfig` to enable the 1M beta during tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d0390e23f22ed889509217308e3c5ef65590f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->