### PR TITLE
Add native progress status styling for continuation logs

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -281,6 +281,7 @@ export async function runResponseCycle<C = unknown>(
     logger.info(
       `Starting continuation #${stateRound.continuationCount}`,
       taskGroupId,
+      MESSAGE_TYPES.PROGRESS_STATUS,
     );
 
     if (

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -15,6 +15,7 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { getStreamTabId as buildStreamTabId } from '@/logger/streamUtils';
 
 // Local imports - utilities
@@ -170,7 +171,11 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   /** Check if the agent should stop due to user interruption. */
   protected checkInterruption(): boolean {
     if (this.isInterrupted) {
-      this.logger.info('Stopping due to user interruption');
+      this.logger.info(
+        'Stopping due to user interruption',
+        undefined,
+        MESSAGE_TYPES.PROGRESS_STATUS,
+      );
       return true;
     }
     return false;

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -46,6 +46,7 @@ export interface LogMessageData {
     | 'modelResponse'
     | 'toolUse'
     | 'userMessage'
+    | 'progressStatus'
     | 'internal';
   /** Whether verbose details should be displayed */
   verbose?: boolean;

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -8,6 +8,7 @@ export const MESSAGE_TYPES = {
   TOOL_USE: 'toolUse',
   MODEL_RESPONSE: 'modelResponse',
   USER_MESSAGE: 'userMessage',
+  PROGRESS_STATUS: 'progressStatus',
   /** Messages that should be hidden from the progress view */
   INTERNAL: 'internal',
   DEFAULT: 'default',

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -223,6 +223,12 @@
             ><span class="message"></span>
           </div>
         </template>
+        <template id="nativeStatusTemplate">
+          <div class="native-status-line" role="status">
+            <span class="native-status-time"></span>
+            <span class="native-status-text"></span>
+          </div>
+        </template>
         <template id="specialDetailsTemplate">
           <details class="special-details">
             <summary class="details-summary">

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -286,6 +286,11 @@ export class LogEntryFormatter {
           () => this._formatUserMessage(text, id, timestamp),
           'user message',
         ),
+      progressStatus: (text, id, timestamp) =>
+        this._safeFormat(
+          () => this._formatProgressStatus(text, id, timestamp),
+          'progress status',
+        ),
     };
   }
 
@@ -350,6 +355,8 @@ export class LogEntryFormatter {
         result = formatter(text, data, id, groupId, timestamp);
       } else if (messageType === 'userMessage') {
         // User message needs text, id, and timestamp
+        result = formatter(text, id, timestamp);
+      } else if (messageType === 'progressStatus') {
         result = formatter(text, id, timestamp);
       } else {
         // File list, missing outputs, latexdiff, statistics need data
@@ -1040,6 +1047,34 @@ export class LogEntryFormatter {
     if (contentElem) {
       contentElem.innerHTML = items.join('');
       if (logId) contentElem.dataset.logId = logId;
+    }
+
+    return element;
+  }
+
+  _formatProgressStatus(content, logId, timestamp) {
+    const element = createFromTemplate('nativeStatusTemplate');
+    if (!element) return null;
+
+    const date = new Date(timestamp ?? Date.now());
+    const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
+
+    element.dataset.fullTimestamp = fullTimestamp;
+    if (logId) {
+      element.dataset.logId = logId;
+    }
+
+    const timeElem = element.querySelector('.native-status-time');
+    if (timeElem) {
+      timeElem.textContent = timeDisplay;
+      timeElem.title = fullTimestamp;
+    }
+
+    const textElem = element.querySelector('.native-status-text');
+    if (textElem) {
+      const decodedContent =
+        typeof content === 'string' ? decodeHtml(content) : '';
+      textElem.textContent = decodedContent;
     }
 
     return element;

--- a/src/progressView/modules/utils.js
+++ b/src/progressView/modules/utils.js
@@ -91,7 +91,8 @@ function defaultChildTimestamp(child) {
   if (
     child.classList.contains('log-line') ||
     child.classList.contains('model-response-line') ||
-    child.classList.contains('special-details')
+    child.classList.contains('special-details') ||
+    child.classList.contains('native-status-line')
   ) {
     const fullTs = child.dataset.fullTimestamp;
     if (fullTs) {

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'streamTabTemplate',
     'roundHeaderTemplate',
     'logLineTemplate',
+    'nativeStatusTemplate',
     'specialDetailsTemplate',
     'toolUseTemplate',
     'modelResponseTemplate',

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -13,6 +13,7 @@
 @import './tabs.css';
 @import './buttons.css';
 @import './logs.css';
+@import './native-status.css';
 @import './placeholder.css';
 @import './groups.css';
 @import './markdown.css';

--- a/src/progressView/styles/native-status.css
+++ b/src/progressView/styles/native-status.css
@@ -1,0 +1,38 @@
+/**
+ * Styling for native-style status log entries.
+ * Presents lightweight inline updates with a subtle vertical accent.
+ */
+
+.native-status-line {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-small) var(--spacing-medium);
+  margin: var(--spacing-small) 0;
+  border-left: var(--border-thin) solid var(--vscode-panel-border);
+  border-radius: var(--border-radius-large);
+  background-color: var(--vscode-sideBarSectionHeader-background, transparent);
+  font-size: var(--font-size-sm);
+  color: var(--vscode-foreground);
+  min-height: calc(var(--spacing-large) + var(--spacing-small));
+  word-break: break-word;
+}
+
+.native-status-line:hover {
+  background-color: var(
+    --vscode-list-hoverBackground,
+    var(--vscode-sideBarSectionHeader-background)
+  );
+}
+
+.native-status-time {
+  color: var(--vscode-descriptionForeground);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.native-status-text {
+  flex: 1;
+  white-space: pre-wrap;
+}

--- a/src/test/progressView/Formatters.test.ts
+++ b/src/test/progressView/Formatters.test.ts
@@ -37,6 +37,41 @@ describe('LogEntryFormatter DOM', () => {
     assert.equal(el.querySelector('.message')?.textContent, 'hello');
   });
 
+  it('renders progress status entries with native styling', () => {
+    const dom = new JSDOM(`<!doctype html><html><body>
+      <template id="nativeStatusTemplate">
+        <div class="native-status-line" role="status">
+          <span class="native-status-time"></span>
+          <span class="native-status-text"></span>
+        </div>
+      </template>
+    </body></html>`);
+    global.document = dom.window.document as any;
+    global.window = dom.window as any;
+
+    const formatter = new LogEntryFormatter();
+    const timestamp = Date.now();
+
+    const el = formatter.format({
+      id: 'status-1',
+      text: '🟢 Starting continuation #1',
+      level: 'info',
+      timestamp,
+      groupId: null,
+      messageType: 'progressStatus',
+      verbose: false,
+      data: null,
+    } as any);
+
+    assert.ok(el instanceof dom.window.HTMLElement);
+    assert.equal(el?.classList.contains('native-status-line'), true);
+    assert.equal(
+      el?.querySelector('.native-status-text')?.textContent,
+      '🟢 Starting continuation #1',
+    );
+    assert.equal(el?.dataset.logId, 'status-1');
+  });
+
   it('renders tool use entries from structured data', () => {
     const dom = new JSDOM(`<!doctype html><html><body>
       <template id="toolUseTemplate">


### PR DESCRIPTION
## Summary
- add a `progressStatus` message type so continuation and interruption notices render as dedicated entries
- render the new message type with a native-style template and CSS accent in the progress view
- cover the formatter with a focused unit test for the new status entry

## Testing
- npm run format
- npm run lint
- npm run compile
- npm test -- Formatters (fails: missing libatk-1.0.so.0 in vscode-test environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6597b18808324bb05076860de648d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a `progressStatus` message type and native-styled rendering for continuation and interruption logs, wiring agents/logger to emit and the progress view to display them with tests.
> 
> - **Progress View UI**:
>   - Add native-style status entry template `nativeStatusTemplate`, formatter `_formatProgressStatus`, and CSS `src/progressView/styles/native-status.css` with import in `styles/index.css`.
>   - Support `progressStatus` in `modules/formatters.js` and chronological insertion in `modules/utils.js`; validate new template in `script.js`.
> - **Logging**:
>   - Add `progressStatus` to `MESSAGE_TYPES` and `LogMessageData.messageType`.
> - **Agent/Core**:
>   - Emit `progressStatus` for continuation starts in `src/agent/core/ResponseCycle.ts`.
>   - Tag interruption info logs with `MESSAGE_TYPES.PROGRESS_STATUS` in `src/agent/implementations/BaseAgent.ts`.
> - **Tests**:
>   - Add unit test for rendering `progressStatus` entries in `Formatters.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e58f2a78f41544c4b70d1110bf6ccc5d229f537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->