### PR TITLE
fix: prioritize math markup default in quick pick

### DIFF
--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -63,8 +63,12 @@ async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
       picked: mode === currentMode,
       value: mode,
     }));
+  const prioritizedItems = [
+    ...items.filter((item) => item.value === currentMode),
+    ...items.filter((item) => item.value !== currentMode),
+  ];
 
-  const selection = await vscode.window.showQuickPick(items, {
+  const selection = await vscode.window.showQuickPick(prioritizedItems, {
     title: 'Latexdiff math markup',
     placeHolder: 'Select math markup granularity for this diff run',
     ignoreFocusOut: true,


### PR DESCRIPTION
## Summary
- ensure the latexdiff math markup quick pick lists the configured option first so coarse/whole defaults are selected automatically

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e660cad8bc8324a993ca71a5247ebc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders the math markup quick pick to list the configured option first while keeping it selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 661fe378b2edb15b711de9a4d2269153374c7dd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->