### PR TITLE
fix: hide workflow model responses from progress view

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -166,7 +166,9 @@ export async function runResponseCycle<C = unknown>(
         logger.info(
           formattedResponse,
           taskGroupId,
-          MESSAGE_TYPES.MODEL_RESPONSE,
+          // Workflow agents should not surface final completions in the progress view,
+          // so mark the response as INTERNAL while still writing it to the output channel.
+          MESSAGE_TYPES.INTERNAL,
         );
       }
     }


### PR DESCRIPTION
## Summary
- retag workflow model responses as internal so workflow agents no longer emit long completions to the Progress View

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6689e7c0083249db661a0e17a02a9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Non-streaming model responses are now logged as INTERNAL to prevent surfacing in the Progress View while still writing to output.
> 
> - **Logging**:
>   - In `src/agent/core/ResponseCycle.ts`, change `logger.info(..., MESSAGE_TYPES.MODEL_RESPONSE)` to `MESSAGE_TYPES.INTERNAL` for non-streaming `newResponse`, preventing final completions from appearing in the Progress View.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c5adaa3b869eac14cc519e726dc1f4823a1dc74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->