### PR TITLE
fix: preserve run group for agent error logs

### DIFF
--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -38,4 +38,9 @@ export interface IAgent {
    * Report how the agent identifies its session for logging and UI purposes.
    */
   getSessionMetadata(): AgentSessionMetadata;
+
+  /**
+   * Return the most recent run group identifier for logging fallbacks.
+   */
+  getLastRunGroupId(): string | undefined;
 }

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -33,6 +33,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   protected logger: AgentLogger;
   protected usageMonitor: UsageMonitor;
   protected runGroupId?: string;
+  private lastRunGroupId?: string;
   protected userVars: Record<string, any> = {};
   protected client: C | null = null;
   protected isInterrupted = false;
@@ -228,6 +229,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       undefined,
       parentGroupId,
     );
+    this.lastRunGroupId = this.runGroupId;
     return this.runGroupId;
   }
 
@@ -237,9 +239,17 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
    */
   protected endRunGroup(status: 'stopped' | 'error' = 'stopped'): void {
     if (this.runGroupId) {
+      this.lastRunGroupId = this.runGroupId;
       this.logger.endGroup(this.runGroupId, status);
       this.runGroupId = undefined;
     }
+  }
+
+  /**
+   * Retrieve the most recently used run group identifier.
+   */
+  public getLastRunGroupId(): string | undefined {
+    return this.lastRunGroupId;
   }
 
   public static getRunningAgent(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -189,9 +189,12 @@ export async function executeAgentWithLogging<T extends IAgent>(
   const isResume = options?.resume ?? false;
   let streamTabId: StreamTabId | undefined;
   let agentStreamLogger: AgentLogger | undefined;
+  let agent: T | undefined;
   try {
     // Create agent instance and extract its declared type
-    const { agent, agentType } = await createAgentFn();
+    const created = await createAgentFn();
+    agent = created.agent;
+    const { agentType } = created;
     const sessionMetadata = agent.getSessionMetadata();
 
     if (executionId) {
@@ -428,9 +431,10 @@ export async function executeAgentWithLogging<T extends IAgent>(
         agentStreamLogger = new AgentLogger(streamTabId, true);
       }
       if (agentStreamLogger) {
-        const activeGroupId = agentStreamLogger.getActiveGroupId();
-        if (activeGroupId) {
-          agentStreamLogger.error(errorMsg, activeGroupId);
+        const fallbackGroupId =
+          agentStreamLogger.getActiveGroupId() ?? agent?.getLastRunGroupId();
+        if (fallbackGroupId) {
+          agentStreamLogger.error(errorMsg, fallbackGroupId);
         } else {
           const agentErrorGroupId = await agentStreamLogger.startGroup(
             `Error: ${agentName}`,


### PR DESCRIPTION
## Summary
- track the most recent run group in BaseAgent and expose it through the IAgent contract
- reuse the preserved run group when logging execution failures so errors stay within the original run

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e68bfa2c7083248f024a85d4a4459a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track and expose the last run group on agents and use it as a fallback target for error logging when no active group exists.
> 
> - **Logging/Runtime**:
>   - `executeAgentWithLogging`: On errors, log to `agentStreamLogger.getActiveGroupId()` or fallback to `agent.getLastRunGroupId()`; otherwise create a new error group. Keeps a reference to `agent` for fallback.
> - **Agent Base**:
>   - `BaseAgent`: Add `lastRunGroupId` state; set on `startRunGroup` and `endRunGroup`; expose `getLastRunGroupId()`.
> - **Core Interface**:
>   - `IAgent`: Add `getLastRunGroupId()` to surface the most recent run group ID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f65db0bc04d2fec0a69dceb2f8b5fc033791737. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->