### PR TITLE
Add copy button for special log entries

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -229,6 +229,16 @@
               <i class="toggle-icon"></i>
               <i class="codicon icon"></i>
               <span class="label"></span>
+              <button
+                type="button"
+                class="vscode-button special-content-copy"
+                aria-label="Copy content"
+                title="Copy content"
+                data-default-title="Copy content"
+                data-success-title="Copied!"
+              >
+                <i class="codicon codicon-copy"></i>
+              </button>
             </summary>
             <div
               class="special-content log-entry-content markdown-content"

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -393,7 +393,12 @@ export class LogEntryFormatter {
 
   _formatSpecialContent(content, contentType, logId, groupId, timestamp) {
     if (!content || !content.trim()) return null;
-    const parsedMarkdown = this._processMarkdownContent(content);
+    const decodedContent = decodeHtml(content);
+    if (!decodedContent.trim()) {
+      return null;
+    }
+
+    const parsedMarkdown = this._processMarkdownContent(decodedContent, false);
     const element = createFromTemplate('specialDetailsTemplate');
     if (!element) return null;
 
@@ -422,6 +427,15 @@ export class LogEntryFormatter {
     const labelElem = element.querySelector('.label');
     if (labelElem) labelElem.textContent = labelText;
 
+    const copyButton = element.querySelector('.special-content-copy');
+    if (copyButton) {
+      const defaultTitle = `Copy ${labelText.toLowerCase()}`;
+      copyButton.dataset.defaultTitle = defaultTitle;
+      copyButton.dataset.successTitle = 'Copied!';
+      copyButton.setAttribute('title', defaultTitle);
+      copyButton.setAttribute('aria-label', defaultTitle);
+    }
+
     const contentElem = element.querySelector('.special-content');
     if (contentElem) {
       contentElem.classList.remove(
@@ -429,6 +443,7 @@ export class LogEntryFormatter {
         'special-content--scratchpad',
       );
       contentElem.classList.add(contentClass);
+      contentElem.dataset.rawContent = decodedContent;
       contentElem.innerHTML = parsedMarkdown;
     }
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -186,14 +186,23 @@ export class EventsManager {
       if (!(e.target instanceof Element)) {
         return;
       }
-      const copyButton = e.target.closest('.model-response-copy');
+      const copyButton = e.target.closest(
+        '.model-response-copy, .special-content-copy',
+      );
       if (!copyButton) {
         return;
       }
 
-      const contentElem = copyButton
-        .closest('.model-response-line')
-        ?.querySelector('.model-response-content');
+      let contentElem = null;
+      if (copyButton.classList.contains('model-response-copy')) {
+        contentElem = copyButton
+          .closest('.model-response-line')
+          ?.querySelector('.model-response-content');
+      } else {
+        contentElem = copyButton
+          .closest('.special-details')
+          ?.querySelector('.special-content');
+      }
       if (!contentElem) {
         return;
       }
@@ -208,7 +217,9 @@ export class EventsManager {
         defaultTitle:
           copyButton.dataset.defaultTitle ||
           copyButton.getAttribute('title') ||
-          'Copy model output',
+          (copyButton.classList.contains('model-response-copy')
+            ? 'Copy model output'
+            : 'Copy content'),
         successTitle: copyButton.dataset.successTitle || 'Copied!',
       });
     });

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -45,7 +45,8 @@
   column-gap: var(--spacing-small);
 }
 
-.model-response-copy {
+.model-response-copy,
+.special-content-copy {
   min-width: 0;
   padding: 0 var(--spacing-tiny);
   opacity: 0;
@@ -57,11 +58,16 @@
 .model-response-header:hover .model-response-copy,
 .model-response-line:focus-within .model-response-copy,
 .model-response-copy:focus-visible,
-.model-response-copy.copy-success {
+.model-response-copy.copy-success,
+.details-summary:hover .special-content-copy,
+.special-details:focus-within .special-content-copy,
+.special-content-copy:focus-visible,
+.special-content-copy.copy-success {
   opacity: 1;
 }
 
-.model-response-copy.copy-success {
+.model-response-copy.copy-success,
+.special-content-copy.copy-success {
   color: var(--vscode-testing-iconPassed, #2ea043);
 }
 


### PR DESCRIPTION
## Summary
- add a copy button to thinking and scratchpad summaries in the progress view
- store decoded special content and configure copy button defaults for reuse
- extend the copy handler and styling so special content uses the existing feedback affordances

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6a0d7edd08324953d8d525a860acf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds copy buttons to thinking/scratchpad entries and integrates decoding, raw-content storage, unified copy handler, and styles.
> 
> - **UI (index.html)**:
>   - Add `button.vscode-button.special-content-copy` to `#specialDetailsTemplate` summaries.
> - **Formatting (modules/formatters.js)**:
>   - Decode special content via `decodeHtml`, pass `decode=false` to `_processMarkdownContent`, and set `data-raw-content` on `.special-content`.
>   - Configure copy button titles/ARIA (`data-default-title`, `data-success-title`) based on label.
> - **Events (uiManagers/EventsManager.js)**:
>   - Extend copy handler to support `.special-content-copy` alongside `.model-response-copy`, selecting the appropriate content element and default titles.
> - **Styles (styles/logs.css)**:
>   - Style `.special-content-copy` with hover/focus visibility and copy-success color, sharing rules with `.model-response-copy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee87a6a94c1c7abc33c0c3ba6eb12cd51453a22d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->