### PR TITLE
fix: run latexdiff before previous round compare

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -22,6 +22,18 @@ import { safeExecuteCommand } from '@utils/system/commandUtils';
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
+interface FileCommandMessage {
+  file: string;
+}
+
+interface BaseFileCommandMessage extends FileCommandMessage {
+  base?: string;
+}
+
+interface CompareMessage extends BaseFileCommandMessage {
+  prev?: string;
+}
+
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   constructor(private readonly provider: ProgressViewProvider) {
     super('ProgressView');
@@ -279,23 +291,35 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleOpenFile(
-    message: any,
+    message: FileCommandMessage,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     await vscode.commands.executeCommand('texra.openFile', message.file);
   }
 
   private async handleOpenFileCompile(
-    message: any,
+    message: FileCommandMessage,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     await vscode.commands.executeCommand('texra.openFileCompile', message.file);
   }
 
   private async handleCompareOriginal(
-    message: any,
+    message: BaseFileCommandMessage,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    if (!message.base) {
+      this.logger.warn(
+        this.channel,
+        'Compare original requested without a base path.',
+        undefined,
+        undefined,
+        undefined,
+        { file: message.file },
+      );
+      return;
+    }
+
     await vscode.commands.executeCommand(
       'texra.compare',
       undefined,
@@ -305,7 +329,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleComparePrevious(
-    message: any,
+    message: CompareMessage,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     const previousFile = message.prev || message.base;
@@ -328,9 +352,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleAcceptFile(
-    message: any,
+    message: BaseFileCommandMessage,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    if (!message.base) {
+      this.logger.warn(
+        this.channel,
+        'Accept requested without a base path.',
+        undefined,
+        undefined,
+        undefined,
+        { file: message.file },
+      );
+      return;
+    }
+
     await vscode.commands.executeCommand(
       'texra.acceptEdited',
       undefined,
@@ -340,9 +376,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleMergeFile(
-    message: any,
+    message: BaseFileCommandMessage,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    if (!message.base) {
+      this.logger.warn(
+        this.channel,
+        'Merge requested without a base path.',
+        undefined,
+        undefined,
+        undefined,
+        { file: message.file },
+      );
+      return;
+    }
+
     await vscode.commands.executeCommand(
       'texra.merge',
       undefined,
@@ -352,9 +400,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleLatexdiffFile(
-    message: any,
+    message: BaseFileCommandMessage,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    if (!message.base) {
+      this.logger.warn(
+        this.channel,
+        'Latexdiff requested without a base path.',
+        undefined,
+        undefined,
+        undefined,
+        { file: message.file },
+      );
+      return;
+    }
+
     await vscode.commands.executeCommand(
       'texra.latexdiff',
       undefined,

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -308,10 +308,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
+    const previousFile = message.prev || message.base;
+
+    if (previousFile) {
+      await vscode.commands.executeCommand(
+        'texra.latexdiff',
+        undefined,
+        previousFile,
+        message.file,
+      );
+    }
+
     await vscode.commands.executeCommand(
       'texra.compare',
       undefined,
-      message.prev,
+      previousFile,
       message.file,
     );
   }

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -191,9 +191,11 @@ export class FileList {
         selector: '.prev-btn',
         command: COMMANDS.COMPARE_PREVIOUS,
         condition: file.prev,
-        configure: (btn) => {
+        configure: (btn, basePath) => {
           btn.dataset.prev = file.prev;
-          btn.dataset.base = file.prev;
+          if (basePath) {
+            btn.dataset.base = basePath;
+          }
         },
       },
     ];
@@ -207,7 +209,7 @@ export class FileList {
         button.dataset.command = command;
         button.dataset.file = file.path;
         if (configure) {
-          configure(button);
+          configure(button, effectiveBase);
         } else {
           button.dataset.base = effectiveBase;
         }

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -193,6 +193,7 @@ export class FileList {
         condition: file.prev,
         configure: (btn) => {
           btn.dataset.prev = file.prev;
+          btn.dataset.base = file.prev;
         },
       },
     ];


### PR DESCRIPTION
## Summary
- ensure the previous round compare button also triggers a LaTeX diff
- persist the previous round path on the button so the handler can use it

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6c457e48083249dd03726e9863d11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Trigger LaTeX diff before previous-round compare and persist prev/base on the button; add typed messages and input validation in handlers.
> 
> - **ProgressView handlers (`src/progressView/ProgressViewMessageHandler.ts`)**:
>   - Run `texra.latexdiff` before `texra.compare` in `handleComparePrevious`, using `prev || base`.
>   - Add lightweight message types (`FileCommandMessage`, `BaseFileCommandMessage`, `CompareMessage`) and use them in file handlers.
>   - Validate required `base` in compare/accept/merge/latexdiff handlers; log warnings and return if missing.
>   - Type updates for `handleOpenFile`/`handleOpenFileCompile`.
> - **Webview UI (`src/progressView/modules/uiManagers/FileList.js`)**:
>   - For the previous-compare button, persist both `data-prev` and (if available) `data-base` by passing `effectiveBase` into the config.
>   - Generalize button configure function to receive `basePath`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ab9fcaa557f664e155ff679d6d8114bc67d3fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->