### PR TITLE
fix: mark background response log as status

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -529,7 +529,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.logger.info(
           `Running OpenAI Responses in background mode for response ${response.id}; polling every 15s. Completion may take longer than usual.`,
           undefined,
-          MESSAGE_TYPES.DEFAULT,
+          MESSAGE_TYPES.PROGRESS_STATUS,
           {
             responseId: response.id,
             pollIntervalMs:


### PR DESCRIPTION
## Summary
- mark the background response status log so it uses the progress status message type

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7c6891fac8324964247052d6204e0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks the background-mode polling info log for OpenAI Responses as `PROGRESS_STATUS` instead of `DEFAULT`.
> 
> - **Logging**:
>   - Update background-mode polling info log in `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts` to use `MESSAGE_TYPES.PROGRESS_STATUS` (was `MESSAGE_TYPES.DEFAULT`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bd9dccdda714402c247385ce027734425183678. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->