### PR TITLE
fix: mark background response log as status

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -529,7 +529,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.logger.info(
           `Running OpenAI Responses in background mode for response ${response.id}; polling every 15s. Completion may take longer than usual.`,
           undefined,
-          MESSAGE_TYPES.DEFAULT,
+          MESSAGE_TYPES.PROGRESS_STATUS,
           {
             responseId: response.id,
             pollIntervalMs:


### PR DESCRIPTION
## Summary
- mark the background response status log so it uses the progress status message type

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7c6891fac8324964247052d6204e0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `PROGRESS_STATUS` message type for background polling log in OpenAI Responses handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8361c3599c6a3ce0a1948b93d0797e412acf4fd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->