### PR TITLE
fix: harden progress event modules

### DIFF
--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -8,21 +8,31 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 
 // Local imports - logger
-import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
+import type {
+  LogMessageData,
+  LogMessageUpdate,
+  TaskGroup,
+} from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
 
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
 
-type StreamStatus = 'running' | 'error' | 'stopped' | 'waiting' | 'resuming';
-type StreamStatusOrReady = StreamStatus | 'ready';
+export type StreamStatus =
+  | 'running'
+  | 'error'
+  | 'stopped'
+  | 'waiting'
+  | 'resuming';
+export type StreamStatusOrReady = StreamStatus | 'ready';
+export type TaskGroupStatus = TaskGroup['status'];
 
 interface AddTaskGroupPayload {
   stream: StreamTabId;
   groupId: string;
   groupName: string;
   startTime: number;
-  status: StreamStatus | 'ready';
+  status: TaskGroupStatus;
   endTime?: number;
   parentGroupId?: string;
 }
@@ -30,7 +40,7 @@ interface AddTaskGroupPayload {
 interface UpdateTaskGroupPayload {
   stream: StreamTabId;
   groupId: string;
-  status: StreamStatus | 'ready';
+  status: TaskGroupStatus;
   endTime?: number;
 }
 

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -1,0 +1,132 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - progress view
+import type { WebviewUpdater } from '../managers';
+import type { ProgressViewState } from '../state/ProgressViewState';
+
+// Local imports - events
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+// Local imports - logger
+import { parseLegacyLogData } from '@logger/logUtils';
+import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
+import { getConfig } from '@utils/config';
+
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ProgressEventBusLike } from './types';
+import { createErrorBoundary } from './errorHandling';
+
+interface LogEventsShared {
+  logger: AgentLogger;
+}
+
+export interface LogEventsModule {
+  register(
+    bus: ProgressEventBusLike,
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): vscode.Disposable[];
+}
+
+export function createLogEvents(shared: LogEventsShared): LogEventsModule {
+  const withErrorBoundary = createErrorBoundary(shared.logger, 'LogEvents');
+
+  const safelyParseLegacyLogData = (
+    data: LogMessageData,
+    isUpdate = false,
+  ): void => {
+    withErrorBoundary('failed to parse legacy log data', () => {
+      parseLegacyLogData(data, shared.logger, isUpdate);
+    });
+  };
+
+  const handleAddLogMessage = (
+    data: ProgressEventPayloads['addLogMessage'],
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): void => {
+    withErrorBoundary('failed to handle addLogMessage', () => {
+      const { stream, logMessage } = data;
+
+      safelyParseLegacyLogData(logMessage);
+
+      if (
+        logMessage.level === 'debug' &&
+        !getConfig<boolean>('logger.debugMode', false)
+      ) {
+        return;
+      }
+
+      state.streamTabs.addMessage(stream, logMessage);
+
+      if (updater.isAvailable()) {
+        updater.appendLogMessage(stream, logMessage);
+      }
+    });
+  };
+
+  const handleUpdateLogMessage = (
+    data: ProgressEventPayloads['updateLogMessage'],
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): void => {
+    withErrorBoundary('failed to handle updateLogMessage', () => {
+      const { stream, logMessage } = data;
+
+      const messages = state.streamTabs.get(stream);
+      if (!messages) return;
+
+      const existing = messages.find((m) => m.id === logMessage.id);
+      if (!existing) return;
+
+      if (logMessage.text !== undefined) {
+        existing.text = logMessage.text;
+      }
+      if (logMessage.messageType !== undefined) {
+        existing.messageType = logMessage.messageType;
+      }
+      if (logMessage.level) {
+        existing.level = logMessage.level;
+      }
+      if (logMessage.timestamp !== undefined) {
+        existing.timestamp = logMessage.timestamp;
+      }
+      if (logMessage.verbose !== undefined) {
+        existing.verbose = logMessage.verbose;
+      }
+      if (logMessage.data !== undefined) {
+        existing.data = logMessage.data;
+      } else {
+        safelyParseLegacyLogData(existing, true);
+      }
+
+      state.streamTabs.save();
+
+      if (updater.isAvailable() && stream === state.activeStream) {
+        updater.updateLogMessage(stream, existing);
+      }
+    });
+  };
+
+  return {
+    register(
+      bus: ProgressEventBusLike,
+      state: ProgressViewState,
+      updater: WebviewUpdater,
+    ): vscode.Disposable[] {
+      return [
+        new vscode.Disposable(
+          bus.on('addLogMessage', (payload) =>
+            handleAddLogMessage(payload, state, updater),
+          ),
+        ),
+        new vscode.Disposable(
+          bus.on('updateLogMessage', (payload) =>
+            handleUpdateLogMessage(payload, state, updater),
+          ),
+        ),
+      ];
+    },
+  };
+}

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -1,0 +1,143 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - progress view
+import type { WebviewUpdater } from '../managers';
+import type { ProgressViewState } from '../state/ProgressViewState';
+
+// Local imports - agent
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { OutputFileInfo } from '@agent/output/types';
+
+// Local imports - events
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { isWorkflowTaskState } from '@logger/TaskState';
+
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ErrorBoundary, ProgressEventBusLike } from './types';
+import { createErrorBoundary } from './errorHandling';
+
+export interface OutputEventsModule {
+  register(
+    bus: ProgressEventBusLike,
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): vscode.Disposable[];
+}
+
+type FilesByRound<T> = { [key: number]: T[] };
+
+interface OutputEventsShared {
+  logger: AgentLogger;
+}
+
+const updateActiveStreamOutputs = (
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+  stream: string,
+  updates: {
+    files?: FilesByRound<OutputFileInfo> | undefined;
+    missing?: FilesByRound<string> | undefined;
+  },
+): void => {
+  if (state.activeStream !== stream || !updater.isAvailable()) {
+    return;
+  }
+
+  if (updates.files !== undefined) {
+    updater.updateFiles(stream, updates.files ?? {});
+  }
+
+  if (updates.missing !== undefined) {
+    updater.updateMissingOutputs(stream, updates.missing ?? {});
+  }
+};
+
+const registerOutputFileListeners = (
+  bus: ProgressEventBusLike,
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+  withErrorBoundary: ErrorBoundary,
+): vscode.Disposable[] => {
+  const addFiles = bus.on('addOutputFiles', ({ stream, filesByRound }) => {
+    withErrorBoundary('failed to handle addOutputFiles', () => {
+      state.outputFiles.addFiles(stream, filesByRound);
+      const files = state.outputFiles.getFiles(stream);
+      updateActiveStreamOutputs(state, updater, stream, { files });
+    });
+  });
+
+  const updateMissing = bus.on(
+    'updateMissingOutputs',
+    ({ stream, filesByRound }) => {
+      withErrorBoundary('failed to handle updateMissingOutputs', () => {
+        state.outputFiles.updateMissingOutputs(stream, filesByRound);
+        const missing = state.outputFiles.getMissingOutputs(stream);
+        updateActiveStreamOutputs(state, updater, stream, { missing });
+      });
+    },
+  );
+
+  const clearMissing = bus.on('clearMissingOutputs', (stream) => {
+    withErrorBoundary('failed to handle clearMissingOutputs', () => {
+      state.outputFiles.clearMissingOutputs(stream);
+      updateActiveStreamOutputs(state, updater, stream, { missing: {} });
+    });
+  });
+
+  const clearFiles = bus.on('clearOutputFiles', (stream) => {
+    withErrorBoundary('failed to handle clearOutputFiles', () => {
+      state.outputFiles.clearFiles(stream);
+      updateActiveStreamOutputs(state, updater, stream, { files: {} });
+    });
+  });
+
+  return [addFiles, updateMissing, clearMissing, clearFiles].map(
+    (dispose) => new vscode.Disposable(dispose),
+  );
+};
+
+const registerClearTaskOutput = (
+  bus: ProgressEventBusLike,
+  state: ProgressViewState,
+  withErrorBoundary: ErrorBoundary,
+): vscode.Disposable => {
+  return new vscode.Disposable(
+    bus.on('clearTaskOutput', (streamTabId: StreamTabId) => {
+      withErrorBoundary('failed to handle clearTaskOutput', () => {
+        const taskState = state.getTaskState(streamTabId);
+        if (!taskState || !isWorkflowTaskState(taskState)) {
+          return;
+        }
+
+        taskState.agentConfig.outputFiles = [];
+        taskState.agentConfig.useMultipleOutputs = false;
+        taskState.activeFiles.output = false;
+        state.setTaskState(streamTabId, taskState);
+      });
+    }),
+  );
+};
+
+export function createOutputEvents(
+  shared: OutputEventsShared,
+): OutputEventsModule {
+  const withErrorBoundary = createErrorBoundary(shared.logger, 'OutputEvents');
+
+  return {
+    register(
+      bus: ProgressEventBusLike,
+      state: ProgressViewState,
+      updater: WebviewUpdater,
+    ): vscode.Disposable[] {
+      const disposables = registerOutputFileListeners(
+        bus,
+        state,
+        updater,
+        withErrorBoundary,
+      );
+      disposables.push(registerClearTaskOutput(bus, state, withErrorBoundary));
+      return disposables;
+    },
+  };
+}

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -1,49 +1,37 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports - progress view
 import { WebviewUpdater } from '../managers';
 
-// @ts-ignore - Import JavaScript module
 import { STATUS } from '../modules/constants.js';
 
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
 import { buildStreamInfos } from '../streamInfoUtils';
-import type { StreamTabInfo } from '../types';
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
-import type { OutputFileInfo } from '@agent/output/types';
-import {
-  AgentType,
-  AgentSessionKind,
-  resolveAgentSessionMetadata,
-} from '@agent/core/AgentDataclass';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Types
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import { LogMessageData, LogMessageUpdate, TaskGroup } from '@logger/LogTypes';
-import { parseLegacyLogData } from '@logger/logUtils';
-import { TaskState, isWorkflowTaskState } from '@logger/TaskState';
-import { getConfig } from '@utils/config';
+import {
+  createStreamStatusEvents,
+  type StreamStatusEventModule,
+} from './StreamStatusEvents';
+import { createOutputEvents, type OutputEventsModule } from './OutputEvents';
+import { createUsageEvents, type UsageEventsModule } from './UsageEvents';
+import { createLogEvents, type LogEventsModule } from './LogEvents';
+import {
+  createTaskGroupEvents,
+  type TaskGroupEventsModule,
+} from './TaskGroupEvents';
 
-// Type aliases for status values
-type StatusType =
-  | typeof STATUS.RUNNING
-  | typeof STATUS.ERROR
-  | typeof STATUS.STOPPED
-  | typeof STATUS.READY
-  | typeof STATUS.WAITING
-  | typeof STATUS.RESUMING;
-type StreamStatusType =
-  | typeof STATUS.RUNNING
-  | typeof STATUS.ERROR
-  | typeof STATUS.STOPPED
-  | typeof STATUS.WAITING
-  | typeof STATUS.RESUMING;
-type StreamStatusOrReadyType = StreamStatusType | typeof STATUS.READY;
+// Local imports - events
+import type {
+  StatusType,
+  StreamStatusOrReadyType,
+  StreamStatusType,
+} from './types';
 
 /**
  * Handles progress event bus subscriptions for the progress view.
@@ -53,476 +41,60 @@ type StreamStatusOrReadyType = StreamStatusType | typeof STATUS.READY;
 export class ProgressEventHandler {
   private readonly logger: AgentLogger;
   private _streamStatus: Map<string, StreamStatusType> = new Map();
+  private readonly streamStatusEvents: StreamStatusEventModule;
+  private readonly outputEvents: OutputEventsModule;
+  private readonly logEvents: LogEventsModule;
+  private readonly usageEvents: UsageEventsModule;
+  private readonly taskGroupEvents: TaskGroupEventsModule;
 
   constructor(
     private state: ProgressViewState,
     private webviewUpdater: WebviewUpdater,
   ) {
     this.logger = new AgentLogger('ProgressEventHandler');
+    this.streamStatusEvents = createStreamStatusEvents({
+      logger: this.logger,
+      streamStatus: this._streamStatus,
+      setStreamStatus: (stream, status) => this.setStreamStatus(stream, status),
+      sendInstructionUpdate: (stream) => this.sendInstructionUpdate(stream),
+      updateLogContentForStream: (stream, options) =>
+        this.updateLogContentForStream(stream, options),
+    });
+    this.outputEvents = createOutputEvents({
+      logger: this.logger,
+    });
+    this.usageEvents = createUsageEvents({
+      logger: this.logger,
+    });
+    this.logEvents = createLogEvents({
+      logger: this.logger,
+    });
+    this.taskGroupEvents = createTaskGroupEvents({
+      logger: this.logger,
+    });
   }
 
-  /**
-   * Parse legacy JSON content from the log message text when structured data is
-   * missing. Parsed results are stored back into the log object so that future
-   * lookups don't require re-parsing.
-   */
   /**
    * Setup all event bus listeners
    */
   setupEventListeners(): vscode.Disposable[] {
-    return [
-      new vscode.Disposable(
-        bus.on('setActiveStream', this.handleSetActiveStream.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('updateStreamStatus', this.handleUpdateStreamStatus.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('addOutputFiles', this.handleAddOutputFiles.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on(
-          'updateMissingOutputs',
-          this.handleUpdateMissingOutputs.bind(this),
-        ),
-      ),
-      new vscode.Disposable(
-        bus.on(
-          'clearMissingOutputs',
-          this.handleClearMissingOutputs.bind(this),
-        ),
-      ),
-      new vscode.Disposable(
-        bus.on('clearOutputFiles', this.handleClearOutputFiles.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('setTaskState', this.handleSetTaskState.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('updateGroupUsage', this.handleUpdateGroupUsage.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('clearTaskOutput', this.handleClearTaskOutput.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('updateStreamUsage', this.handleUpdateStreamUsage.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('addLogMessage', this.handleAddLogMessage.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('updateLogMessage', this.handleUpdateLogMessage.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('addTaskGroup', this.handleAddTaskGroup.bind(this)),
-      ),
-      new vscode.Disposable(
-        bus.on('updateTaskGroup', this.handleUpdateTaskGroup.bind(this)),
-      ),
-    ];
-  }
-
-  /**
-   * Handle setting active stream
-   */
-  private handleSetActiveStream(payload: {
-    stream: StreamTabId | null;
-    agentType?: AgentType | null;
-    agentSessionKind?: AgentSessionKind | null;
-  }): void {
-    const { stream, agentType, agentSessionKind } = payload;
-
-    if (!stream) {
-      return;
-    }
-
-    // Ensure the stream exists in streamTabs so it appears in the UI
-    // This handles the case where setActiveStream is called before any logs
-    this.state.streamTabs.ensureStream(stream);
-
-    const metadata = resolveAgentSessionMetadata(agentType, agentSessionKind);
-    this.state.setSessionKindHint(stream, metadata.agentSessionKind);
-
-    const currentFilter = this.state.agentTypeFilter;
-    if (
-      currentFilter !== 'all' &&
-      currentFilter !== metadata.agentSessionKind
-    ) {
-      this.state.agentTypeFilter = metadata.agentSessionKind;
-    }
-
-    this.state.activeStream = stream;
-
-    const status: StreamStatusOrReadyType =
-      this._streamStatus.get(stream) ?? STATUS.RUNNING;
-    this.handleUpdateStreamStatus({ stream, status });
-
-    if (this.webviewUpdater.isAvailable()) {
-      // Update log content (will be empty for new streams)
-      this.updateLogContentForStream(stream, { updateInstruction: false });
-      this.sendInstructionUpdate(stream);
-    }
-  }
-
-  /**
-   * Handle stream status updates
-   */
-  private handleUpdateStreamStatus(data: {
-    stream: string;
-    status: StreamStatusOrReadyType;
-  }): void {
-    const { stream, status } = data;
-
-    if (status !== STATUS.READY) {
-      this._streamStatus.set(stream, status as StreamStatusType);
-    } else {
-      this._streamStatus.delete(stream);
-    }
-
-    if (this.webviewUpdater.isAvailable()) {
-      const infos = buildStreamInfos(
-        this.state,
-        this._streamStatus,
-        this.state.agentTypeFilter,
-      );
-      this.webviewUpdater.updateStreams(
-        infos,
-        this.state.activeStream,
-        this.state.agentTypeFilter,
-      );
-
-      if (stream === this.state.activeStream) {
-        this.webviewUpdater.updateStatus(status);
-      }
-    }
-  }
-
-  /**
-   * Handle adding output files
-   */
-  private handleAddOutputFiles(data: {
-    stream: string;
-    filesByRound: { [key: number]: OutputFileInfo[] };
-  }): void {
-    const { stream, filesByRound } = data;
-    this.state.outputFiles.addFiles(stream, filesByRound);
-
-    if (
-      this.webviewUpdater.isAvailable() &&
-      stream === this.state.activeStream
-    ) {
-      const files = this.state.outputFiles.getFiles(stream) || {};
-      this.webviewUpdater.updateFiles(stream, files);
-    }
-  }
-
-  /**
-   * Handle updating missing outputs
-   */
-  private handleUpdateMissingOutputs(data: {
-    stream: string;
-    filesByRound: { [key: number]: string[] };
-  }): void {
-    const { stream, filesByRound } = data;
-    this.state.outputFiles.updateMissingOutputs(stream, filesByRound);
-
-    if (
-      this.webviewUpdater.isAvailable() &&
-      stream === this.state.activeStream
-    ) {
-      const missing = this.state.outputFiles.getMissingOutputs(stream) || {};
-      this.webviewUpdater.updateMissingOutputs(stream, missing);
-    }
-  }
-
-  /**
-   * Handle clearing missing outputs
-   */
-  private handleClearMissingOutputs(stream: string): void {
-    this.state.outputFiles.clearMissingOutputs(stream);
-
-    if (
-      this.webviewUpdater.isAvailable() &&
-      stream === this.state.activeStream
-    ) {
-      this.webviewUpdater.updateMissingOutputs(stream, {});
-    }
-  }
-
-  /**
-   * Handle clearing output files
-   */
-  private handleClearOutputFiles(stream: string): void {
-    this.state.outputFiles.clearFiles(stream);
-
-    if (
-      this.webviewUpdater.isAvailable() &&
-      stream === this.state.activeStream
-    ) {
-      this.webviewUpdater.updateFiles(stream, {});
-    }
-  }
-
-  /**
-   * Handle setting task state
-   */
-  private handleSetTaskState(data: {
-    streamTabId: StreamTabId;
-    executionId?: ExecutionId;
-    taskState: TaskState;
-  }): void {
-    const { streamTabId, executionId, taskState } = data;
-
-    this.state.setTaskState(streamTabId, taskState);
-    this.state.clearSessionKindHint(streamTabId);
-
-    const normalizedState = this.state.getTaskState(streamTabId);
-
-    if (!normalizedState) {
-      this.logger.warn(
-        `Received setTaskState for ${streamTabId} but no state was stored`,
-      );
-    } else {
-      const sessionKind = resolveAgentSessionMetadata(
-        normalizedState.agentType,
-        normalizedState.agentSessionKind,
-      ).agentSessionKind;
-      const currentFilter = this.state.agentTypeFilter;
-      const activeStream = this.state.activeStream;
-
-      if (
-        activeStream &&
-        activeStream === streamTabId &&
-        currentFilter !== 'all' &&
-        currentFilter !== sessionKind
-      ) {
-        this.logger.debug(
-          `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
-        );
-        this.state.agentTypeFilter = sessionKind;
-      }
-    }
-
-    if (executionId) {
-      this.state.setExecutionId(streamTabId, executionId);
-    }
-
-    if (this.state.activeStream === streamTabId) {
-      this.sendInstructionUpdate(streamTabId);
-    }
-
-    if (this.webviewUpdater.isAvailable()) {
-      const infos = buildStreamInfos(
-        this.state,
-        this._streamStatus,
-        this.state.agentTypeFilter,
-      );
-      this.webviewUpdater.updateStreams(
-        infos,
-        this.state.activeStream,
-        this.state.agentTypeFilter,
-      );
-    }
-  }
-
-  /**
-   * Handle updating group usage
-   */
-  private handleUpdateGroupUsage(data: {
-    stream: string;
-    groupId: string;
-    usage: TokenUsageStats;
-  }): void {
-    const { stream, groupId, usage } = data;
-
-    // Update the group with usage information
-    const group = this.state.taskGroups.getGroup(stream, groupId);
-    if (group) {
-      this.state.taskGroups.updateGroup(stream, groupId, { usage });
-    }
-  }
-
-  /**
-   * Handle clearing task output
-   */
-  private handleClearTaskOutput(streamTabId: StreamTabId): void {
-    const taskState = this.state.getTaskState(streamTabId);
-    if (!taskState || !isWorkflowTaskState(taskState)) {
-      return;
-    }
-
-    // Only clear output-related fields, preserve other task state data
-    taskState.agentConfig.outputFiles = [];
-    taskState.agentConfig.useMultipleOutputs = false;
-    taskState.activeFiles.output = false;
-    this.state.setTaskState(streamTabId, taskState);
-  }
-
-  /**
-   * Handle updating stream usage
-   */
-  private handleUpdateStreamUsage(data: {
-    stream: string;
-    usage: TokenUsageStats;
-  }): void {
-    const { stream, usage } = data;
-    this.state.usageStats.updateStreamUsage(stream, usage);
-
-    if (
-      this.webviewUpdater.isAvailable() &&
-      stream === this.state.activeStream
-    ) {
-      this.webviewUpdater.updateUsage(usage);
-    }
-  }
-
-  /**
-   * Handle adding log message
-   */
-  private handleAddLogMessage(data: {
-    stream: string;
-    logMessage: LogMessageData;
-  }): void {
-    const { stream, logMessage } = data;
-
-    parseLegacyLogData(logMessage, this.logger);
-
-    // Skip debug messages if debug mode is disabled
-    if (
-      logMessage.level === 'debug' &&
-      !getConfig<boolean>('logger.debugMode', false)
-    ) {
-      return;
-    }
-
-    this.state.streamTabs.addMessage(stream, logMessage);
-
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.appendLogMessage(stream, logMessage);
-    }
-  }
-
-  /**
-   * Handle updating log message
-   */
-  private handleUpdateLogMessage(data: {
-    stream: string;
-    logMessage: LogMessageUpdate;
-  }): void {
-    const { stream, logMessage } = data;
-
-    const messages = this.state.streamTabs.get(stream);
-    if (!messages) return;
-
-    const existing = messages.find((m) => m.id === logMessage.id);
-    if (!existing) return;
-
-    if (logMessage.text !== undefined) {
-      existing.text = logMessage.text;
-    }
-    if (logMessage.messageType !== undefined) {
-      existing.messageType = logMessage.messageType;
-    }
-    if (logMessage.level) {
-      existing.level = logMessage.level;
-    }
-    if (logMessage.timestamp !== undefined) {
-      existing.timestamp = logMessage.timestamp;
-    }
-    if (logMessage.verbose !== undefined) {
-      existing.verbose = logMessage.verbose;
-    }
-    if (logMessage.data !== undefined) {
-      existing.data = logMessage.data;
-    } else {
-      // Re-parse the updated text even if existing data is present
-      parseLegacyLogData(existing, this.logger, true);
-    }
-
-    this.state.streamTabs.save();
-
-    if (
-      this.webviewUpdater.isAvailable() &&
-      stream === this.state.activeStream
-    ) {
-      this.webviewUpdater.updateLogMessage(stream, existing);
-    }
-  }
-
-  /**
-   * Handle adding task group
-   */
-  private handleAddTaskGroup(data: {
-    stream: string;
-    groupId: string;
-    groupName: string;
-    startTime: number;
-    status: StatusType;
-    endTime?: number;
-    parentGroupId?: string;
-  }): void {
-    const {
-      stream,
-      groupId,
-      groupName,
-      startTime,
-      status,
-      endTime,
-      parentGroupId,
-    } = data;
-
-    // Ensure the stream exists
-    if (!this.state.streamTabs.has(stream)) {
-      this.logger.debug(`Creating stream from addTaskGroup: ${stream}`);
-      if (!this._streamStatus.has(stream)) {
-        this.handleUpdateStreamStatus({ stream, status: STATUS.RUNNING });
-      }
-      this.handleSetActiveStream({ stream });
-    }
-
-    const group: TaskGroup = {
-      id: groupId,
-      name: groupName,
-      startTime,
-      endTime,
-      status,
-      parentGroupId,
-    };
-
-    this.state.taskGroups.addGroup(stream, groupId, group);
-
-    // Send webview update for the active stream
-    if (
-      this.webviewUpdater.isAvailable() &&
-      stream === this.state.activeStream
-    ) {
-      this.webviewUpdater.addTaskGroup(stream, group);
-    }
-  }
-
-  /**
-   * Handle updating task group
-   */
-  private handleUpdateTaskGroup(data: {
-    stream: string;
-    groupId: string;
-    status: StatusType;
-    endTime?: number;
-  }): void {
-    const { stream, groupId, status, endTime } = data;
-
-    this.state.taskGroups.updateGroup(stream, groupId, {
-      status,
-      endTime,
-    });
-
-    // Send webview update for the active stream
-    if (
-      this.webviewUpdater.isAvailable() &&
-      stream === this.state.activeStream
-    ) {
-      this.webviewUpdater.updateTaskGroup(stream, groupId, status, endTime);
-    }
+    const disposables: vscode.Disposable[] = [];
+    disposables.push(
+      ...this.streamStatusEvents.register(bus, this.state, this.webviewUpdater),
+    );
+    disposables.push(
+      ...this.outputEvents.register(bus, this.state, this.webviewUpdater),
+    );
+    disposables.push(
+      ...this.usageEvents.register(bus, this.state, this.webviewUpdater),
+    );
+    disposables.push(
+      ...this.logEvents.register(bus, this.state, this.webviewUpdater),
+    );
+    disposables.push(
+      ...this.taskGroupEvents.register(bus, this.state, this.webviewUpdater),
+    );
+    return disposables;
   }
 
   /**
@@ -597,7 +169,29 @@ export class ProgressEventHandler {
    * Set the status for a specific stream synchronously.
    */
   setStreamStatus(stream: string, status: StreamStatusOrReadyType): void {
-    this.handleUpdateStreamStatus({ stream, status });
+    if (status === STATUS.READY) {
+      this._streamStatus.delete(stream);
+    } else {
+      const nextStatus: StreamStatusType = status;
+      this._streamStatus.set(stream, nextStatus);
+    }
+
+    if (this.webviewUpdater.isAvailable()) {
+      const infos = buildStreamInfos(
+        this.state,
+        this._streamStatus,
+        this.state.agentTypeFilter,
+      );
+      this.webviewUpdater.updateStreams(
+        infos,
+        this.state.activeStream,
+        this.state.agentTypeFilter,
+      );
+
+      if (stream === this.state.activeStream) {
+        this.webviewUpdater.updateStatus(status);
+      }
+    }
   }
 
   /**

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -1,0 +1,179 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - progress view
+import type { WebviewUpdater } from '../managers';
+import { buildStreamInfos } from '../streamInfoUtils';
+import type { ProgressViewState } from '../state/ProgressViewState';
+import type { StreamTabInfo } from '../types';
+
+import { STATUS } from '../modules/constants.js';
+
+// Local imports - agent
+import {
+  AgentType,
+  resolveAgentSessionMetadata,
+} from '@agent/core/AgentDataclass';
+import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+
+// Local imports - events
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type {
+  ErrorBoundary,
+  ProgressEventBusLike,
+  StreamStatusType,
+  StreamStatusOrReadyType,
+} from './types';
+import { createErrorBoundary } from './errorHandling';
+import type { AgentLogger } from '@logger/AgentLogger';
+
+export interface StreamStatusEventShared {
+  logger: AgentLogger;
+  streamStatus: Map<string, StreamStatusType>;
+  setStreamStatus(stream: string, status: StreamStatusOrReadyType): void;
+  sendInstructionUpdate(stream: StreamTabId | ''): void;
+  updateLogContentForStream(
+    stream: string,
+    options?: { updateInstruction?: boolean },
+  ): void;
+}
+
+export interface StreamStatusEventModule {
+  register(
+    bus: ProgressEventBusLike,
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): vscode.Disposable[];
+}
+
+export function createStreamStatusEvents(
+  shared: StreamStatusEventShared,
+): StreamStatusEventModule {
+  const withErrorBoundary: ErrorBoundary = createErrorBoundary(
+    shared.logger,
+    'StreamStatusEvents',
+  );
+
+  const handleSetActiveStream = (
+    payload: ProgressEventPayloads['setActiveStream'],
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): void => {
+    const { stream, agentType, agentSessionKind } = payload;
+
+    if (!stream) {
+      return;
+    }
+
+    state.streamTabs.ensureStream(stream);
+
+    const metadata = resolveAgentSessionMetadata(agentType, agentSessionKind);
+    state.setSessionKindHint(stream, metadata.agentSessionKind);
+
+    const currentFilter = state.agentTypeFilter;
+    if (
+      currentFilter !== 'all' &&
+      currentFilter !== metadata.agentSessionKind
+    ) {
+      state.agentTypeFilter = metadata.agentSessionKind;
+    }
+
+    state.activeStream = stream;
+
+    const status: StreamStatusOrReadyType =
+      shared.streamStatus.get(stream) ?? STATUS.RUNNING;
+    shared.setStreamStatus(stream, status);
+
+    if (updater.isAvailable()) {
+      shared.updateLogContentForStream(stream, { updateInstruction: false });
+      shared.sendInstructionUpdate(stream);
+    }
+  };
+
+  const handleSetTaskState = (
+    data: ProgressEventPayloads['setTaskState'],
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): void => {
+    const { streamTabId, executionId, taskState } = data;
+
+    state.setTaskState(streamTabId, taskState);
+    state.clearSessionKindHint(streamTabId);
+
+    const normalizedState = state.getTaskState(streamTabId);
+
+    if (!normalizedState) {
+      shared.logger.warn(
+        `Received setTaskState for ${streamTabId} but no state was stored`,
+      );
+    } else {
+      const sessionKind = resolveAgentSessionMetadata(
+        normalizedState.agentType,
+        normalizedState.agentSessionKind,
+      ).agentSessionKind;
+      const currentFilter = state.agentTypeFilter;
+      const activeStream = state.activeStream;
+
+      if (
+        activeStream &&
+        activeStream === streamTabId &&
+        currentFilter !== 'all' &&
+        currentFilter !== sessionKind
+      ) {
+        shared.logger.debug(
+          `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
+        );
+        state.agentTypeFilter = sessionKind;
+      }
+    }
+
+    if (executionId) {
+      state.setExecutionId(streamTabId, executionId);
+    }
+
+    if (state.activeStream === streamTabId) {
+      shared.sendInstructionUpdate(streamTabId);
+    }
+
+    if (updater.isAvailable()) {
+      const infos: StreamTabInfo[] = buildStreamInfos(
+        state,
+        shared.streamStatus,
+        state.agentTypeFilter,
+      );
+      updater.updateStreams(infos, state.activeStream, state.agentTypeFilter);
+    }
+  };
+
+  return {
+    register(
+      bus: ProgressEventBusLike,
+      state: ProgressViewState,
+      updater: WebviewUpdater,
+    ): vscode.Disposable[] {
+      return [
+        new vscode.Disposable(
+          bus.on('setActiveStream', (payload) =>
+            withErrorBoundary('failed to handle setActiveStream', () =>
+              handleSetActiveStream(payload, state, updater),
+            ),
+          ),
+        ),
+        new vscode.Disposable(
+          bus.on('updateStreamStatus', (payload) =>
+            withErrorBoundary('failed to handle updateStreamStatus', () =>
+              shared.setStreamStatus(payload.stream, payload.status),
+            ),
+          ),
+        ),
+        new vscode.Disposable(
+          bus.on('setTaskState', (payload) =>
+            withErrorBoundary('failed to handle setTaskState', () =>
+              handleSetTaskState(payload, state, updater),
+            ),
+          ),
+        ),
+      ];
+    },
+  };
+}

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -1,0 +1,137 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - progress view
+import type { WebviewUpdater } from '../managers';
+import type { ProgressViewState } from '../state/ProgressViewState';
+import { STATUS } from '../modules/constants.js';
+
+// Local imports - events
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { TaskGroup } from '@logger/LogTypes';
+import { resolveAgentSessionMetadata } from '@agent/core/AgentDataclass';
+import type { ProgressEventBusLike } from './types';
+import { createErrorBoundary } from './errorHandling';
+
+interface TaskGroupEventsShared {
+  logger: AgentLogger;
+}
+
+export interface TaskGroupEventsModule {
+  register(
+    bus: ProgressEventBusLike,
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): vscode.Disposable[];
+}
+
+export function createTaskGroupEvents(
+  shared: TaskGroupEventsShared,
+): TaskGroupEventsModule {
+  const withErrorBoundary = createErrorBoundary(
+    shared.logger,
+    'TaskGroupEvents',
+  );
+
+  const handleAddTaskGroup = (
+    data: ProgressEventPayloads['addTaskGroup'],
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+    bus: ProgressEventBusLike,
+  ): void => {
+    withErrorBoundary('failed to handle addTaskGroup', () => {
+      const {
+        stream,
+        groupId,
+        groupName,
+        startTime,
+        status,
+        endTime,
+        parentGroupId,
+      } = data;
+
+      if (!state.streamTabs.has(stream)) {
+        shared.logger.debug(`Creating stream from addTaskGroup: ${stream}`);
+
+        const taskState = state.getTaskState(stream);
+        const metadata = taskState
+          ? resolveAgentSessionMetadata(
+              taskState.agentType,
+              taskState.agentSessionKind,
+            )
+          : resolveAgentSessionMetadata(
+              undefined,
+              state.getSessionKindHint(stream),
+            );
+
+        bus.emit('setActiveStream', {
+          stream,
+          agentType: metadata.agentType ?? null,
+          agentSessionKind: metadata.agentSessionKind,
+        });
+
+        bus.emit('updateStreamStatus', {
+          stream,
+          status: STATUS.RUNNING,
+        });
+      }
+
+      const group: TaskGroup = {
+        id: groupId,
+        name: groupName,
+        startTime,
+        endTime,
+        status,
+        parentGroupId,
+      };
+
+      state.taskGroups.addGroup(stream, groupId, group);
+
+      if (updater.isAvailable() && stream === state.activeStream) {
+        updater.addTaskGroup(stream, group);
+      }
+    });
+  };
+
+  const handleUpdateTaskGroup = (
+    data: ProgressEventPayloads['updateTaskGroup'],
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): void => {
+    withErrorBoundary('failed to handle updateTaskGroup', () => {
+      const { stream, groupId, status, endTime } = data;
+
+      state.taskGroups.updateGroup(stream, groupId, {
+        status,
+        endTime,
+      });
+
+      if (updater.isAvailable() && stream === state.activeStream) {
+        updater.updateTaskGroup(stream, groupId, status, endTime);
+      }
+    });
+  };
+
+  return {
+    register(
+      bus: ProgressEventBusLike,
+      state: ProgressViewState,
+      updater: WebviewUpdater,
+    ): vscode.Disposable[] {
+      return [
+        new vscode.Disposable(
+          bus.on('addTaskGroup', (payload) =>
+            handleAddTaskGroup(payload, state, updater, bus),
+          ),
+        ),
+        new vscode.Disposable(
+          bus.on('updateTaskGroup', (payload) =>
+            handleUpdateTaskGroup(payload, state, updater),
+          ),
+        ),
+      ];
+    },
+  };
+}

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -1,0 +1,70 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - progress view
+import type { WebviewUpdater } from '../managers';
+import type { ProgressViewState } from '../state/ProgressViewState';
+
+// Local imports - events
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ErrorBoundary, ProgressEventBusLike } from './types';
+import { createErrorBoundary } from './errorHandling';
+
+export interface UsageEventsModule {
+  register(
+    bus: ProgressEventBusLike,
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): vscode.Disposable[];
+}
+
+interface UsageEventsShared {
+  logger: AgentLogger;
+}
+
+export function createUsageEvents(
+  shared: UsageEventsShared,
+): UsageEventsModule {
+  const withErrorBoundary: ErrorBoundary = createErrorBoundary(
+    shared.logger,
+    'UsageEvents',
+  );
+
+  return {
+    register(
+      bus: ProgressEventBusLike,
+      state: ProgressViewState,
+      updater: WebviewUpdater,
+    ): vscode.Disposable[] {
+      const updateGroupUsage = bus.on(
+        'updateGroupUsage',
+        ({ stream, groupId, usage }) => {
+          withErrorBoundary('failed to handle updateGroupUsage', () => {
+            const group = state.taskGroups.getGroup(stream, groupId);
+            if (group) {
+              state.taskGroups.updateGroup(stream, groupId, { usage });
+            }
+          });
+        },
+      );
+
+      const updateStreamUsage = bus.on(
+        'updateStreamUsage',
+        ({ stream, usage }) => {
+          withErrorBoundary('failed to handle updateStreamUsage', () => {
+            state.usageStats.updateStreamUsage(stream, usage);
+            if (state.activeStream === stream && updater.isAvailable()) {
+              updater.updateUsage(usage);
+            }
+          });
+        },
+      );
+
+      return [updateGroupUsage, updateStreamUsage].map(
+        (dispose) => new vscode.Disposable(dispose),
+      );
+    },
+  };
+}

--- a/src/progressView/events/errorHandling.ts
+++ b/src/progressView/events/errorHandling.ts
@@ -1,0 +1,22 @@
+// Local imports - logger
+import type { AgentLogger } from '@logger/AgentLogger';
+
+import type { ErrorBoundary } from './types';
+
+export function createErrorBoundary(
+  logger: AgentLogger,
+  moduleName: string,
+): ErrorBoundary {
+  return (context: string, fn: () => void): void => {
+    try {
+      fn();
+    } catch (error) {
+      const details =
+        error instanceof Error
+          ? { message: error.message, stack: error.stack, error }
+          : { error };
+
+      logger.error(`[${moduleName}] ${context}`, undefined, undefined, details);
+    }
+  };
+}

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -1,0 +1,24 @@
+// Local imports - event bus
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+  StreamStatus as ProgressStreamStatus,
+  StreamStatusOrReady as ProgressStreamStatusOrReady,
+} from '@eventBus/ProgressEventBus';
+
+export interface ProgressEventBusLike {
+  on<K extends ProgressEvent>(
+    event: K,
+    listener: (payload: ProgressEventPayloads[K]) => void,
+  ): () => void;
+  emit<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void;
+}
+
+export type ErrorBoundary = (context: string, fn: () => void) => void;
+
+export type StreamStatusType = ProgressStreamStatus;
+export type StreamStatusOrReadyType = ProgressStreamStatusOrReady;
+export type StatusType = ProgressStreamStatusOrReady;

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -1,11 +1,9 @@
 // Third-party imports
-// Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports - progress view
 
-// @ts-ignore - Import JavaScript module
-import { COMMANDS } from '../modules/constants.js';
+import { COMMANDS, STATUS } from '../modules/constants.js';
 
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
@@ -22,7 +20,7 @@ import { LogMessageData } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
 
 // Type aliases for status values
-type StatusType = 'running' | 'error' | 'stopped' | 'ready' | 'waiting';
+type StatusType = (typeof STATUS)[keyof typeof STATUS];
 
 /**
  * Manages webview updates for the progress view.

--- a/src/progressView/modules/constants.d.ts
+++ b/src/progressView/modules/constants.d.ts
@@ -1,32 +1,28 @@
-declare module '@progressView/modules/constants.js' {
-  export const STATUS: {
-    RUNNING: 'running';
-    ERROR: 'error';
-    STOPPED: 'stopped';
-    READY: 'ready';
-    WAITING: 'waiting';
-    RESUMING: 'resuming';
-  };
+export declare const STATUS: {
+  readonly RUNNING: 'running';
+  readonly ERROR: 'error';
+  readonly STOPPED: 'stopped';
+  readonly READY: 'ready';
+  readonly WAITING: 'waiting';
+  readonly RESUMING: 'resuming';
+};
 
-  export const ELEMENT_IDS: Record<string, string>;
-  export const SPLIT_SIZES: { CONTENT: number; TABS: number };
-  export const MAX_HEIGHT: number;
-  export const COMMANDS: Record<string, string>;
-  export const TOOLBAR_BUTTONS: Record<string, unknown>;
-  export const ALL_TOOLBAR_BUTTON_IDS: string[];
-  export const SORT_BUTTONS: Array<{
-    id: string;
-    icon: string;
-    sort: string;
-    title: string;
-  }>;
-  export const FILTER_BUTTONS: Array<{
-    id: string;
-    label: string;
-    filter: string;
-  }>;
-}
-
-declare module '*modules/constants.js' {
-  export * from '@progressView/modules/constants.js';
-}
+export declare const ELEMENT_IDS: Record<string, string>;
+export declare const SPLIT_SIZES: { CONTENT: number; TABS: number };
+export declare const MAX_HEIGHT: number;
+export declare const COMMANDS: Record<string, string>;
+export declare const WORKFLOW_TOOLBAR: ReadonlyArray<Record<string, unknown>>;
+export declare const TOOL_USE_TOOLBAR: ReadonlyArray<Record<string, unknown>>;
+export declare const TOOLBAR_BUTTONS: Record<string, unknown>;
+export declare const ALL_TOOLBAR_BUTTON_IDS: readonly string[];
+export declare const SORT_BUTTONS: ReadonlyArray<{
+  id: string;
+  icon: string;
+  sort: string;
+  title: string;
+}>;
+export declare const FILTER_BUTTONS: ReadonlyArray<{
+  id: string;
+  label: string;
+  filter: string;
+}>;

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -1,0 +1,206 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - progress view
+import { createStreamStatusEvents } from '@progressView/events/StreamStatusEvents';
+import { createOutputEvents } from '@progressView/events/OutputEvents';
+import { createUsageEvents } from '@progressView/events/UsageEvents';
+import { createLogEvents } from '@progressView/events/LogEvents';
+import { createTaskGroupEvents } from '@progressView/events/TaskGroupEvents';
+
+import type { ProgressViewState } from '@progressView/state/ProgressViewState';
+import type { WebviewUpdater } from '@progressView/managers';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { AgentLogger } from '@logger/AgentLogger';
+
+class FakeBus {
+  public readonly events: (keyof ProgressEventPayloads)[] = [];
+  public readonly disposed: (keyof ProgressEventPayloads)[] = [];
+  public readonly listeners = new Map<
+    keyof ProgressEventPayloads,
+    (payload: ProgressEventPayloads[keyof ProgressEventPayloads]) => void
+  >();
+  public readonly emissions: {
+    event: keyof ProgressEventPayloads;
+    payload: ProgressEventPayloads[keyof ProgressEventPayloads];
+  }[] = [];
+
+  on<K extends keyof ProgressEventPayloads>(
+    event: K,
+    _listener: (payload: ProgressEventPayloads[K]) => void,
+  ): () => void {
+    this.events.push(event);
+    this.listeners.set(event, _listener as any);
+    return () => {
+      this.disposed.push(event);
+      this.listeners.delete(event);
+    };
+  }
+
+  emit<K extends keyof ProgressEventPayloads>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    this.emissions.push({ event, payload });
+  }
+
+  trigger<K extends keyof ProgressEventPayloads>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    const listener = this.listeners.get(event) as
+      | ((value: ProgressEventPayloads[K]) => void)
+      | undefined;
+    listener?.(payload);
+  }
+}
+
+describe('Progress event modules', () => {
+  const loggerStub = {
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  } as unknown as AgentLogger;
+  const stateStub = {} as ProgressViewState;
+  const updaterStub = {} as WebviewUpdater;
+
+  it('registers stream status handlers and disposes them', () => {
+    const bus = new FakeBus();
+    const module = createStreamStatusEvents({
+      logger: loggerStub,
+      streamStatus: new Map(),
+      setStreamStatus: () => {},
+      sendInstructionUpdate: () => {},
+      updateLogContentForStream: () => {},
+    });
+
+    const disposables = module.register(bus as any, stateStub, updaterStub);
+    assert.deepStrictEqual(bus.events, [
+      'setActiveStream',
+      'updateStreamStatus',
+      'setTaskState',
+    ]);
+
+    disposables.forEach((disposable) => disposable.dispose());
+    assert.deepStrictEqual(bus.disposed, bus.events);
+  });
+
+  it('registers output handlers and disposes them', () => {
+    const bus = new FakeBus();
+    const module = createOutputEvents({
+      logger: loggerStub,
+    });
+
+    const disposables = module.register(bus as any, stateStub, updaterStub);
+    assert.deepStrictEqual(bus.events, [
+      'addOutputFiles',
+      'updateMissingOutputs',
+      'clearMissingOutputs',
+      'clearOutputFiles',
+      'clearTaskOutput',
+    ]);
+
+    disposables.forEach((disposable) => disposable.dispose());
+    assert.deepStrictEqual(bus.disposed, bus.events);
+  });
+
+  it('registers usage handlers and disposes them', () => {
+    const bus = new FakeBus();
+    const module = createUsageEvents({
+      logger: loggerStub,
+    });
+
+    const disposables = module.register(bus as any, stateStub, updaterStub);
+    assert.deepStrictEqual(bus.events, [
+      'updateGroupUsage',
+      'updateStreamUsage',
+    ]);
+
+    disposables.forEach((disposable) => disposable.dispose());
+    assert.deepStrictEqual(bus.disposed, bus.events);
+  });
+
+  it('registers log handlers and disposes them', () => {
+    const bus = new FakeBus();
+    const module = createLogEvents({
+      logger: loggerStub,
+    });
+
+    const disposables = module.register(bus as any, stateStub, updaterStub);
+    assert.deepStrictEqual(bus.events, ['addLogMessage', 'updateLogMessage']);
+
+    disposables.forEach((disposable) => disposable.dispose());
+    assert.deepStrictEqual(bus.disposed, bus.events);
+  });
+
+  it('registers task group handlers and disposes them', () => {
+    const bus = new FakeBus();
+    const module = createTaskGroupEvents({
+      logger: loggerStub,
+    });
+
+    const disposables = module.register(bus as any, stateStub, updaterStub);
+    assert.deepStrictEqual(bus.events, ['addTaskGroup', 'updateTaskGroup']);
+
+    disposables.forEach((disposable) => disposable.dispose());
+    assert.deepStrictEqual(bus.disposed, bus.events);
+  });
+
+  it('emits setActiveStream when a new task group initializes a stream', () => {
+    const bus = new FakeBus();
+    const module = createTaskGroupEvents({
+      logger: loggerStub,
+    });
+
+    const state = {
+      streamTabs: {
+        has: () => false,
+        ensureStream: () => {},
+        addMessage: () => {},
+        get: () => undefined,
+        save: () => {},
+      },
+      taskGroups: {
+        addGroup: () => {},
+        updateGroup: () => {},
+      },
+      getTaskState: () => undefined,
+      getSessionKindHint: () => undefined,
+      setSessionKindHint: () => {},
+      agentTypeFilter: 'all',
+      activeStream: '',
+    } as unknown as ProgressViewState;
+    const updater = {
+      isAvailable: () => false,
+      addTaskGroup: () => {},
+    } as unknown as WebviewUpdater;
+
+    module.register(bus as any, state, updater);
+
+    bus.trigger('addTaskGroup', {
+      stream: 'stream-1',
+      groupId: 'group-1',
+      groupName: 'Group',
+      startTime: 0,
+      status: 'running',
+    });
+
+    assert.deepStrictEqual(bus.emissions, [
+      {
+        event: 'setActiveStream',
+        payload: {
+          stream: 'stream-1',
+          agentType: null,
+          agentSessionKind: 'workflow',
+        },
+      },
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          stream: 'stream-1',
+          status: 'running',
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize progress event error boundaries through a shared helper and apply them across the log, status, usage, output, and task group registrars
- ensure output event updates only touch the collections that changed while injecting logging into the module factory
- populate task-group-created streams with metadata and running status updates and align the shared bus typings and unit tests

## Testing
- npm run format
- npm run lint
- npm run compile-tests
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e781a62bbc83248df7caf049af95b0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split progress event handling into focused modules with centralized error handling, align task group/status typings, update webview/constant types, and add unit tests.
> 
> - **Progress View — Events**:
>   - Extract handlers into modules: `StreamStatusEvents`, `OutputEvents`, `UsageEvents`, `LogEvents`, `TaskGroupEvents` with a shared `createErrorBoundary` and common `types`.
>   - `ProgressEventHandler` now delegates to modules; simplifies `setStreamStatus` and centralizes stream updates.
> - **Event Bus**:
>   - Export `StreamStatus`, `StreamStatusOrReady`; add `TaskGroupStatus`; use it in `addTaskGroup`/`updateTaskGroup` payloads.
> - **Webview/Constants**:
>   - `WebviewUpdater` status type derives from `STATUS`; import `STATUS`.
>   - Refine `constants.d.ts` with readonly types and additional toolbar exports.
> - **Tests**:
>   - Add `EventModules.test.ts` covering registration/disposal and stream initialization via `addTaskGroup`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe04c514e0074e40f41ccc5d22789f3e50ea3fa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->