### PR TITLE
fix: disable streaming when background responses are enabled

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -400,7 +400,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     signal?: AbortSignal,
     tools?: ToolDefinition[],
   ): Promise<Response> {
-    const useStreaming = this.getStreamingConfig();
+    const streamingToggleEnabled = this.getStreamingConfig();
     const backgroundToggleEnabled = getConfig<boolean>(
       'model.useBackgroundResponses',
       false,
@@ -412,6 +412,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
     const useBackgroundResponses =
       this.backgroundModeSupported && backgroundToggleEnabled;
+    const useStreaming = streamingToggleEnabled && !useBackgroundResponses;
+
+    if (streamingToggleEnabled && useBackgroundResponses) {
+      this.logger.debug(
+        'Background mode enabled; skipping streaming to avoid unstable behavior.',
+      );
+    }
     const newMessages = messages.slice(this.sentMessages);
 
     await this.uploadInlineInputFiles(client, newMessages);


### PR DESCRIPTION
## Summary
- prevent the OpenAI Responses handler from starting streamed runs when background mode is active
- add debug logging to clarify why streaming is skipped during background executions

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7cfaaea6c832488aedbc7b09f8682