### PR TITLE
Fix agent initialization guard before execution

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -499,7 +499,11 @@ export async function executeAgentWithLogging<T extends IAgent>(
             `Executing ${agentName} with model ${config.model}`,
             mainTaskGroupId,
           );
-          await agent.run();
+          const initializedAgent = agent;
+          if (!initializedAgent) {
+            throw new Error('Agent instance was not initialized');
+          }
+          await initializedAgent.run();
           // await checkExpectedOutputs(config.outputFiles, agent);
           // Mark the task as completed successfully
           logger.debug(`Task completed successfully`, mainTaskGroupId);
@@ -510,7 +514,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           });
 
           const generated = Object.values(
-            (agent as any).outputHandler?.outputFiles || {},
+            (initializedAgent as any).outputHandler?.outputFiles || {},
           )
             .flat()
             .filter(


### PR DESCRIPTION
## Summary
- ensure executeAgentWithLogging validates that the agent instance exists before running
- reuse the validated agent reference when accessing generated outputs to avoid undefined checks

## Testing
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e8149634ec8324b3fc02547686fbaa