### PR TITLE
fix: guard agent execution when initialization fails

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -499,6 +499,10 @@ export async function executeAgentWithLogging<T extends IAgent>(
             `Executing ${agentName} with model ${config.model}`,
             mainTaskGroupId,
           );
+          if (!agent) {
+            throw new Error('Agent instance was not initialized');
+          }
+
           await agent.run();
           // await checkExpectedOutputs(config.outputFiles, agent);
           // Mark the task as completed successfully


### PR DESCRIPTION
## Summary
- add a defensive guard that aborts execution when the agent instance fails to initialize

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e8149634ec8324b3fc02547686fbaa