### PR TITLE
docs: broaden unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file.
 
 - Add OpenAI GPT-5 Pro (`gpt5pro`) to the model catalog with updated pricing and documentation.
 - Add interactive prompt to select latexdiff math markup granularity before each run.
+- Add one-click **Generate diff** controls in the Progress Board so you can launch round-by-round `latexdiff` comparisons without leaving the view.
+- Add copy buttons to Progress Board model responses and special log sections, plus native status styling that makes continuation updates easier to scan.
+
+### Bug Fixes
+
+- Keep agent error logs grouped with their most recent run so failures stay visible in the Progress Board timeline.
+- Turn off streaming automatically whenever background responses are enabled to avoid unstable background replies.
+- Stop launching agent runs when initialization fails, preventing follow-up crashes from uninitialized sessions.
+- Stabilize Progress Board event handling to prevent duplicate task groups, stale status badges, and other glitches while sessions stream updates.
+- Hide workflow-only model responses from the Progress Board so tool logs stay focused on user-visible activity.
+- Ensure progress compare actions run `latexdiff` before opening previous-round diffs and close conflicting panels when needed, keeping the VS Code diff view reliable.
+- Improve LaTeX fenced-block parsing and OpenAI response handling so inline math, whitespace, and multi-part summaries render without mangling formatting.
 
 ## [0.33.9] - 2025-10-03
 


### PR DESCRIPTION
## Summary
- expand the unreleased changelog with recent Progress Board features like one-click latexdiff actions and copy controls
- note additional bug fixes since 0.33.9, covering Progress Board stability, diff reliability, and LaTeX formatting improvements

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e8178bb3c48324b439caee2a1e0695

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `CHANGELOG.md` Unreleased with new Progress Board features and multiple stability/formatting fixes.
> 
> - **Documentation**:
>   - Update `CHANGELOG.md` Unreleased:
>     - **Features**: one-click Generate diff in Progress Board; copy buttons for model responses/logs with improved status styling.
>     - **Bug Fixes**: keep agent error logs with latest run; auto-disable streaming with background responses; prevent runs after init failures; stabilize Progress Board events (no dup groups/stale badges); hide workflow-only model responses; ensure `latexdiff` runs before compare and close conflicting panels; improve LaTeX fenced-block parsing and OpenAI response handling for inline math/whitespace/multi-part summaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bc808a7a3debe1e03ea61673e0bcf97b8da3f80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->