### PR TITLE
refactor: unify agent session descriptor handling

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -22,6 +22,15 @@ export const validateOutputFiles = (cfg: Record<string, any>): boolean => {
   return true;
 };
 
+/**
+ * Session descriptor schema for AgentConfig.
+ * The session field is the canonical source of truth for agent classification.
+ */
+const SessionDescriptorSchema = z.object({
+  agentType: z.enum(AgentType).optional(),
+  agentCategory: z.enum(AgentCategory),
+});
+
 /** Zod schema for validating AgentConfig objects */
 export const AgentConfigSchema = z
   .object({
@@ -30,13 +39,10 @@ export const AgentConfigSchema = z
     instruction: z.string().prefault(''),
     useMultipleOutputs: z.boolean().prefault(false),
 
+    // Legacy field for backward compatibility - prefer session.agentType
     agentType: z.enum(AgentType).optional(),
-    session: z
-      .object({
-        agentType: z.enum(AgentType).optional(),
-        agentCategory: z.enum(AgentCategory),
-      })
-      .optional(),
+    // Canonical session descriptor - single source of truth
+    session: SessionDescriptorSchema.optional(),
 
     inputFile: z.string().prefault(''),
     inputFiles: z.array(z.string()).nullable().prefault(null),
@@ -57,6 +63,4 @@ export const AgentConfigSchema = z
       'Number of output files must not be greater than the number of input files.',
   });
 
-export type AgentConfig = z.infer<typeof AgentConfigSchema> & {
-  session?: AgentSessionDescriptor;
-};
+export type AgentConfig = z.infer<typeof AgentConfigSchema>;

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 
 // Local imports - agent
 // Local imports - agent components
-import { AgentSessionKind, AgentType } from './AgentDataclass';
+import {
+  AgentCategory,
+  AgentType,
+  type AgentSessionDescriptor,
+} from './AgentDataclass';
 import { DEFAULT_TOOL_CONFIG, ToolConfigSchema } from './ToolConfig';
 
 /**
@@ -27,7 +31,12 @@ export const AgentConfigSchema = z
     useMultipleOutputs: z.boolean().prefault(false),
 
     agentType: z.enum(AgentType).optional(),
-    agentSessionKind: z.enum(AgentSessionKind).optional(),
+    session: z
+      .object({
+        agentType: z.enum(AgentType).optional(),
+        agentCategory: z.enum(AgentCategory),
+      })
+      .optional(),
 
     inputFile: z.string().prefault(''),
     inputFiles: z.array(z.string()).nullable().prefault(null),
@@ -48,4 +57,6 @@ export const AgentConfigSchema = z
       'Number of output files must not be greater than the number of input files.',
   });
 
-export type AgentConfig = z.infer<typeof AgentConfigSchema>;
+export type AgentConfig = z.infer<typeof AgentConfigSchema> & {
+  session?: AgentSessionDescriptor;
+};

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -17,11 +17,11 @@ export enum AgentType {
 }
 
 /**
- * Canonical session groupings used throughout the extension UI.
+ * Canonical session categories used throughout the extension UI.
  * Workflow sessions represent traditional direct/CoT executions while
  * toolUse isolates interactive tool panels.
  */
-export enum AgentSessionKind {
+export enum AgentCategory {
   Workflow = 'workflow',
   ToolUse = 'toolUse',
 }
@@ -29,36 +29,36 @@ export enum AgentSessionKind {
 /**
  * Shared metadata describing how an agent session should be classified.
  */
-export interface AgentSessionMetadata {
+export interface AgentSessionDescriptor {
   /** Specific agent implementation type if known. */
   agentType?: AgentType;
   /** Canonical grouping used by the UI to filter sessions. */
-  agentSessionKind: AgentSessionKind;
+  agentCategory: AgentCategory;
 }
 
 /**
- * Derive the canonical {@link AgentSessionKind} from a specific agent type.
- * Defaults to {@link AgentSessionKind.Workflow} when the type is unknown.
+ * Derive the canonical {@link AgentCategory} from a specific agent type.
+ * Defaults to {@link AgentCategory.Workflow} when the type is unknown.
  */
-export function deriveAgentSessionKind(
+export function deriveAgentCategory(
   agentType?: AgentType | null,
-): AgentSessionKind {
+): AgentCategory {
   return agentType === AgentType.ToolUse
-    ? AgentSessionKind.ToolUse
-    : AgentSessionKind.Workflow;
+    ? AgentCategory.ToolUse
+    : AgentCategory.Workflow;
 }
 
 /**
  * Resolve canonical session metadata from optional hints.
  */
-export function resolveAgentSessionMetadata(
+export function resolveAgentSessionDescriptor(
   agentType?: AgentType | null,
-  sessionKindHint?: AgentSessionKind | null,
-): AgentSessionMetadata {
-  const agentSessionKind = sessionKindHint ?? deriveAgentSessionKind(agentType);
+  categoryHint?: AgentCategory | null,
+): AgentSessionDescriptor {
+  const agentCategory = categoryHint ?? deriveAgentCategory(agentType);
   return {
     agentType: agentType ?? undefined,
-    agentSessionKind,
+    agentCategory,
   };
 }
 
@@ -68,6 +68,7 @@ export function resolveAgentSessionMetadata(
  */
 export const AgentSettingBaseSchema = z.strictObject({
   agentType: z.enum(AgentType).prefault(AgentType.CoT),
+  agentCategory: z.enum(AgentCategory).prefault(AgentCategory.Workflow),
   documentTag: z
     .string()
     .min(1, 'documentTag cannot be empty')
@@ -114,11 +115,22 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
         'Workflow agent settings cannot use the toolUse agent type. Use the tool-use schema instead.',
     });
   }
+  if (data.agentCategory === AgentCategory.ToolUse) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['agentCategory'],
+      message:
+        'Workflow agent settings must use the workflow category. Use the tool-use schema instead.',
+    });
+  }
 });
 
 /** Tool-use agents never expose workflow-specific flags. */
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
   agentType: z.literal(AgentType.ToolUse).prefault(AgentType.ToolUse),
+  agentCategory: z
+    .literal(AgentCategory.ToolUse)
+    .prefault(AgentCategory.ToolUse),
 });
 
 /**
@@ -132,6 +144,18 @@ export const AgentSettingSchema = z.union([
 export type AgentWorkflowSetting = z.infer<typeof AgentWorkflowSettingSchema>;
 export type AgentToolUseSetting = z.infer<typeof AgentToolUseSettingSchema>;
 export type AgentSetting = z.infer<typeof AgentSettingSchema>;
+
+/**
+ * Return the canonical session descriptor for a fully-materialized agent setting.
+ */
+export function getAgentSessionDescriptor(
+  setting: AgentSetting,
+): Required<AgentSessionDescriptor> {
+  return {
+    agentType: setting.agentType,
+    agentCategory: setting.agentCategory,
+  };
+}
 
 /** Narrow an {@link AgentSetting} to the workflow variant. */
 export function requireWorkflowSetting(

--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -1,7 +1,7 @@
 // Local imports - agent
 import type { AgentConfig } from './AgentConfig';
 // Local imports - agent components
-import type { AgentSessionMetadata } from './AgentDataclass';
+import type { AgentSessionDescriptor } from './AgentDataclass';
 // Local imports - agent types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
@@ -37,7 +37,7 @@ export interface IAgent {
   /**
    * Report how the agent identifies its session for logging and UI purposes.
    */
-  getSessionMetadata(): AgentSessionMetadata;
+  getSessionMetadata(): AgentSessionDescriptor;
 
   /**
    * Return the most recent run group identifier for logging fallbacks.

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -3,8 +3,8 @@ import type { AgentConfig } from '../core/AgentConfig';
 import {
   AgentPrompt,
   AgentSetting,
-  AgentSessionMetadata,
-  resolveAgentSessionMetadata,
+  type AgentSessionDescriptor,
+  resolveAgentSessionDescriptor,
 } from '../core/AgentDataclass';
 import { AgentStateGlobal } from '../core/AgentState';
 import { IAgent } from '../core/IAgent';
@@ -47,10 +47,13 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     return this.agentConfig;
   }
 
-  public getSessionMetadata(): AgentSessionMetadata {
-    return resolveAgentSessionMetadata(
+  public getSessionMetadata(): AgentSessionDescriptor {
+    if (this.agentConfig.session) {
+      return this.agentConfig.session;
+    }
+
+    return resolveAgentSessionDescriptor(
       this.agentConfig.agentType ?? this.agentSetting.agentType,
-      this.agentConfig.agentSessionKind,
     );
   }
 

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -2,10 +2,10 @@
 import type { AgentConfig } from '../core/AgentConfig';
 import {
   AgentPrompt,
-  AgentSessionKind,
   AgentSetting,
   AgentType,
-  resolveAgentSessionMetadata,
+  AgentCategory,
+  resolveAgentSessionDescriptor,
 } from '../core/AgentDataclass';
 import { ToolState } from '../core/ToolState';
 import { runToolUseCycle } from '../core/ToolUseCycle';
@@ -73,10 +73,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
   }
 
   public override getSessionMetadata() {
-    return resolveAgentSessionMetadata(
-      AgentType.ToolUse,
-      AgentSessionKind.ToolUse,
-    );
+    return resolveAgentSessionDescriptor(AgentType.ToolUse, AgentCategory.ToolUse);
   }
 
   private getTools(): ToolDefinition[] {
@@ -266,7 +263,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
             streamId: stream,
             agentName: this.agentConfig.agent,
             model: this.agentConfig.model,
-            agentSessionKind: AgentSessionKind.ToolUse,
+            session: this.getSessionMetadata(),
             messages: this.messages,
             toolState: state,
           });

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -520,7 +520,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           });
 
           const generated = Object.values(
-            (activeAgent as any).outputHandler?.outputFiles || {},
+            (agent as any).outputHandler?.outputFiles || {},
           )
             .flat()
             .filter(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -12,7 +12,8 @@ import {
   AgentSetting,
   AgentPrompt,
   AgentType,
-  resolveAgentSessionMetadata,
+  resolveAgentSessionDescriptor,
+  getAgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
 import { IAgent } from '@agent/core/IAgent';
 import {
@@ -261,9 +262,18 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
     { preferMultiple: fullConfig.useMultipleOutputs },
   );
 
+  const agentSetting = ensureAgentTypeForSource(
+    loadedAgentSetting,
+    agentPathInfo.source,
+  );
+
+  const sessionDescriptor = getAgentSessionDescriptor(agentSetting);
+
   const agentConfig: AgentConfig = {
     ...fullConfig,
     agent: originalAgentName,
+    agentType: sessionDescriptor.agentType,
+    session: sessionDescriptor,
   };
 
   const modelName = agentConfig.model;
@@ -292,11 +302,6 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
   };
 
   const modelHandler = ModelFactory.createHandler(modelConfig);
-
-  const agentSetting = ensureAgentTypeForSource(
-    loadedAgentSetting,
-    agentPathInfo.source,
-  );
 
   const AgentClass = (agentClassOverride ??
     getAgentClass(agentSetting)) as AgentConstructor;
@@ -344,10 +349,12 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
     // Get the full stream tab ID
     const config = agent.config;
-    const metadata = resolveAgentSessionMetadata(
-      config.agentType ?? agentType ?? sessionMetadata.agentType,
-      config.agentSessionKind ?? sessionMetadata.agentSessionKind,
-    );
+    const metadata =
+      config.session ??
+      resolveAgentSessionDescriptor(
+        config.agentType ?? agentType ?? sessionMetadata.agentType,
+        sessionMetadata.agentCategory,
+      );
 
     streamTabId = agent.getStreamTabId();
 
@@ -404,8 +411,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
               // Switch to this stream and set its status to running
               bus.emit('setActiveStream', {
                 stream: activeStreamId,
-                agentType: metadata.agentType ?? null,
-                agentSessionKind: metadata.agentSessionKind ?? null,
+                session: metadata,
               });
               bus.emit('updateStreamStatus', {
                 stream: activeStreamId,
@@ -499,7 +505,11 @@ export async function executeAgentWithLogging<T extends IAgent>(
             `Executing ${agentName} with model ${config.model}`,
             mainTaskGroupId,
           );
-          await agent.run();
+          const activeAgent = agent;
+          if (!activeAgent) {
+            throw new Error('Agent instance is not initialized.');
+          }
+          await activeAgent.run();
           // await checkExpectedOutputs(config.outputFiles, agent);
           // Mark the task as completed successfully
           logger.debug(`Task completed successfully`, mainTaskGroupId);
@@ -510,7 +520,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           });
 
           const generated = Object.values(
-            (agent as any).outputHandler?.outputFiles || {},
+            (activeAgent as any).outputHandler?.outputFiles || {},
           )
             .flat()
             .filter(

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -305,18 +305,17 @@ export class ToolUseSessionManager {
     }
 
     try {
-      const normalizedSession = {
-        agentType: payload.session.agentType ?? AgentType.ToolUse,
-        agentCategory: payload.session.agentCategory,
-      } as Required<AgentSessionDescriptor>;
-
+      // Store only what's necessary - session is the canonical descriptor
       const snapshot: ToolUseSessionSnapshot = {
         version: SNAPSHOT_VERSION,
         executionId: payload.executionId,
         streamId: payload.streamId,
         agentName: payload.agentName,
         model: payload.model,
-        session: normalizedSession,
+        session: {
+          agentType: payload.session.agentType ?? AgentType.ToolUse,
+          agentCategory: payload.session.agentCategory,
+        },
         messages: structuredClone(payload.messages),
         toolState: toToolStateSnapshot(payload.toolState),
         lastUpdated: Date.now(),

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -6,7 +6,11 @@ import { z } from 'zod';
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import {
+  AgentCategory,
+  AgentType,
+  type AgentSessionDescriptor,
+} from '@agent/core/AgentDataclass';
 import { ToolState } from '@agent/core/ToolState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
@@ -37,28 +41,36 @@ const ToolStateSnapshotSchema = z.object({
   thinkingAdded: z.boolean(),
 });
 
+const SessionDescriptorSchema = z.strictObject({
+  agentType: z.enum(AgentType).optional(),
+  agentCategory: z.enum(AgentCategory),
+});
+
 const ToolUseSessionSnapshotSchema = z.strictObject({
   version: z.literal(SNAPSHOT_VERSION),
   executionId: z.string(),
   streamId: z.string(),
   agentName: z.string(),
   model: z.string(),
-  agentSessionKind: z.enum(AgentSessionKind),
+  agentSessionKind: z.enum(AgentCategory),
+  session: SessionDescriptorSchema.optional(),
   messages: z.array(z.unknown()),
   toolState: ToolStateSnapshotSchema,
   lastUpdated: z.number(),
 });
 
-export type ToolUseSessionSnapshot = z.infer<
-  typeof ToolUseSessionSnapshotSchema
->;
+type ToolUseSessionSnapshotParsed = z.infer<typeof ToolUseSessionSnapshotSchema>;
+
+export type ToolUseSessionSnapshot = ToolUseSessionSnapshotParsed & {
+  session: Required<AgentSessionDescriptor>;
+};
 
 interface SavePayload {
   executionId: ExecutionId;
   streamId: StreamTabId;
   agentName: string;
   model: string;
-  agentSessionKind: AgentSessionKind;
+  session: AgentSessionDescriptor;
   messages: ProviderMessage[];
   toolState: ToolState;
 }
@@ -105,6 +117,22 @@ function getSnapshotPath(executionId: ExecutionId): string {
 
 interface ResumingSessionState {
   queuedFollowUps: string[];
+}
+
+function normalizeSnapshot(
+  snapshot: ToolUseSessionSnapshotParsed,
+): ToolUseSessionSnapshot {
+  const agentCategory = snapshot.session?.agentCategory ?? snapshot.agentSessionKind;
+  const agentType = snapshot.session?.agentType ?? AgentType.ToolUse;
+
+  return {
+    ...snapshot,
+    agentSessionKind: agentCategory,
+    session: {
+      agentType,
+      agentCategory,
+    },
+  };
 }
 
 export class ToolUseSessionManager {
@@ -271,13 +299,19 @@ export class ToolUseSessionManager {
     }
 
     try {
+      const normalizedSession = {
+        agentType: payload.session.agentType ?? AgentType.ToolUse,
+        agentCategory: payload.session.agentCategory,
+      } as Required<AgentSessionDescriptor>;
+
       const snapshot: ToolUseSessionSnapshot = {
         version: SNAPSHOT_VERSION,
         executionId: payload.executionId,
         streamId: payload.streamId,
         agentName: payload.agentName,
         model: payload.model,
-        agentSessionKind: payload.agentSessionKind,
+        agentSessionKind: normalizedSession.agentCategory,
+        session: normalizedSession,
         messages: structuredClone(payload.messages),
         toolState: toToolStateSnapshot(payload.toolState),
         lastUpdated: Date.now(),
@@ -311,7 +345,8 @@ export class ToolUseSessionManager {
       );
       const normalized =
         typeof stored === 'string' ? JSON.parse(stored) : stored;
-      return ToolUseSessionSnapshotSchema.parse(normalized);
+      const parsed = ToolUseSessionSnapshotSchema.parse(normalized);
+      return normalizeSnapshot(parsed);
     } catch (error) {
       if (
         error instanceof vscode.FileSystemError &&
@@ -327,7 +362,8 @@ export class ToolUseSessionManager {
           typeof fallbackParsed === 'string'
             ? JSON.parse(fallbackParsed)
             : fallbackParsed;
-        return ToolUseSessionSnapshotSchema.parse(normalized);
+        const parsed = ToolUseSessionSnapshotSchema.parse(normalized);
+        return normalizeSnapshot(parsed);
       } catch (fallbackError) {
         if (
           fallbackError instanceof vscode.FileSystemError &&

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -126,9 +126,14 @@ interface ResumingSessionState {
 function normalizeSnapshot(
   snapshot: ToolUseSessionSnapshotParsed,
 ): ToolUseSessionSnapshot {
+  // If already normalized (has session, no legacy fields), trust it
+  if (snapshot.session && !snapshot.agentSessionKind) {
+    return snapshot as ToolUseSessionSnapshot;
+  }
+
+  // Legacy path: derive descriptor and create new normalized object
   const descriptor = snapshot.session
-    ? snapshot.session
-    : resolveAgentSessionDescriptor(AgentType.ToolUse, snapshot.agentSessionKind);
+    ?? resolveAgentSessionDescriptor(AgentType.ToolUse, snapshot.agentSessionKind);
 
   const { agentSessionKind: _legacyKind, session: _legacySession, ...rest } = snapshot;
 

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import {
   AgentCategory,
   AgentType,
+  resolveAgentSessionDescriptor,
   type AgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
 import { ToolState } from '@agent/core/ToolState';
@@ -52,7 +53,7 @@ const ToolUseSessionSnapshotSchema = z.strictObject({
   streamId: z.string(),
   agentName: z.string(),
   model: z.string(),
-  agentSessionKind: z.enum(AgentCategory),
+  agentSessionKind: z.enum(AgentCategory).optional(),
   session: SessionDescriptorSchema.optional(),
   messages: z.array(z.unknown()),
   toolState: ToolStateSnapshotSchema,
@@ -61,7 +62,10 @@ const ToolUseSessionSnapshotSchema = z.strictObject({
 
 type ToolUseSessionSnapshotParsed = z.infer<typeof ToolUseSessionSnapshotSchema>;
 
-export type ToolUseSessionSnapshot = ToolUseSessionSnapshotParsed & {
+export type ToolUseSessionSnapshot = Omit<
+  ToolUseSessionSnapshotParsed,
+  'agentSessionKind' | 'session'
+> & {
   session: Required<AgentSessionDescriptor>;
 };
 
@@ -122,15 +126,17 @@ interface ResumingSessionState {
 function normalizeSnapshot(
   snapshot: ToolUseSessionSnapshotParsed,
 ): ToolUseSessionSnapshot {
-  const agentCategory = snapshot.session?.agentCategory ?? snapshot.agentSessionKind;
-  const agentType = snapshot.session?.agentType ?? AgentType.ToolUse;
+  const descriptor = snapshot.session
+    ? snapshot.session
+    : resolveAgentSessionDescriptor(AgentType.ToolUse, snapshot.agentSessionKind);
+
+  const { agentSessionKind: _legacyKind, session: _legacySession, ...rest } = snapshot;
 
   return {
-    ...snapshot,
-    agentSessionKind: agentCategory,
+    ...rest,
     session: {
-      agentType,
-      agentCategory,
+      agentType: descriptor.agentType ?? AgentType.ToolUse,
+      agentCategory: descriptor.agentCategory,
     },
   };
 }
@@ -310,7 +316,6 @@ export class ToolUseSessionManager {
         streamId: payload.streamId,
         agentName: payload.agentName,
         model: payload.model,
-        agentSessionKind: normalizedSession.agentCategory,
         session: normalizedSession,
         messages: structuredClone(payload.messages),
         toolState: toToolStateSnapshot(payload.toolState),

--- a/src/agent/types/AgentStreamTypes.ts
+++ b/src/agent/types/AgentStreamTypes.ts
@@ -1,12 +1,12 @@
 // Local types - agent
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 /**
  * Allowed filter values for agent streams in the ProgressBoard.
  * "workflow" groups traditional direct/CoT agents while
  * "toolUse" isolates interactive tool sessions.
  */
-export type AgentTypeFilter = 'all' | AgentSessionKind;
+export type AgentTypeFilter = 'all' | AgentCategory;
 
 /**
  * Type guard ensuring a value is a valid {@link AgentTypeFilter}.
@@ -14,7 +14,7 @@ export type AgentTypeFilter = 'all' | AgentSessionKind;
 export function isAgentTypeFilter(value: unknown): value is AgentTypeFilter {
   return (
     value === 'all' ||
-    value === AgentSessionKind.Workflow ||
-    value === AgentSessionKind.ToolUse
+    value === AgentCategory.Workflow ||
+    value === AgentCategory.ToolUse
   );
 }

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -2,7 +2,7 @@
 import { EventEmitter } from 'events';
 
 // Local imports - agent
-import type { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
+import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
@@ -46,8 +46,7 @@ interface UpdateTaskGroupPayload {
 
 interface SetActiveStreamPayload {
   stream: StreamTabId | null;
-  agentType?: AgentType | null;
-  agentSessionKind?: AgentSessionKind | null;
+  session?: AgentSessionDescriptor | null;
 }
 
 interface SetTaskStatePayload {

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -90,7 +90,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
       if (historyItem) {
         const taskState = agentConfigToTaskState(
           historyItem.config,
-          historyItem.session ?? historyItem.agentType,
+          historyItem.session,
         );
         await vscode.commands.executeCommand('texra.restoreState', taskState);
       } else {

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode';
 
 // Local imports - agent commands
 import { executeCommand } from '@commands/agent/executeCommand';
-import { resolveAgentSessionMetadata } from '@agent/core/AgentDataclass';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 
 // Local imports - history view
@@ -89,11 +88,10 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
       const historyItem =
         await AgentHistoryManager.getHistoryItemById(historyId);
       if (historyItem) {
-        const metadata = resolveAgentSessionMetadata(
-          historyItem.agentType,
-          historyItem.agentSessionKind,
+        const taskState = agentConfigToTaskState(
+          historyItem.config,
+          historyItem.session ?? historyItem.agentType,
         );
-        const taskState = agentConfigToTaskState(historyItem.config, metadata);
         await vscode.commands.executeCommand('texra.restoreState', taskState);
       } else {
         await vscode.window.showErrorMessage('History item not found');

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -38,14 +38,13 @@ export class AgentHistoryManager {
    * Add a new agent execution to history
    */
   public static async addToHistory(config: AgentConfig): Promise<string> {
-    // Ensure config has session set (single source of truth)
-    const session =
-      config.session ?? resolveAgentSessionDescriptor(config.agentType);
+    // Trust that config already has session (internal data from runtime)
+    const session = config.session ?? resolveAgentSessionDescriptor(config.agentType);
 
     const historyItem: AgentHistoryItem = {
       id: randomUUID(),
       timestamp: new Date().toISOString(),
-      config: config.session ? config : { ...config, session },
+      config,
       session,
     };
 
@@ -104,7 +103,7 @@ export class AgentHistoryManager {
     }
 
     // Derive session from the most canonical source available
-    const descriptor =
+    const session =
       candidate.session ??
       candidate.config.session ??
       resolveAgentSessionDescriptor(
@@ -115,10 +114,8 @@ export class AgentHistoryManager {
     return {
       id: candidate.id,
       timestamp: candidate.timestamp,
-      config: candidate.config.session
-        ? candidate.config
-        : { ...candidate.config, session: descriptor },
-      session: descriptor,
+      config: candidate.config,
+      session,
     };
   }
 

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -24,9 +24,7 @@ export interface AgentHistoryItem {
   id: ExecutionId;
   timestamp: string;
   config: AgentConfig;
-  agentType?: AgentType;
-  agentSessionKind?: AgentCategory;
-  session?: AgentSessionDescriptor;
+  session: AgentSessionDescriptor;
 }
 
 /**
@@ -52,8 +50,6 @@ export class AgentHistoryManager {
       id: randomUUID(),
       timestamp: new Date().toISOString(),
       config: normalizedConfig,
-      agentType: session.agentType,
-      agentSessionKind: session.agentCategory,
       session,
     };
 
@@ -79,8 +75,14 @@ export class AgentHistoryManager {
    */
   public static async getHistory(): Promise<AgentHistoryItem[]> {
     const storageKey = this.getWorkspaceStorageKey();
-    const history = workspaceSM.get<AgentHistoryItem[]>(storageKey, []);
-    return history.map((item) => this.normalizeHistoryItem(item));
+    const history = workspaceSM.get<unknown[]>(storageKey, []);
+    return history.reduce<AgentHistoryItem[]>((acc, item) => {
+      const normalized = this.normalizeHistoryItem(item);
+      if (normalized) {
+        acc.push(normalized);
+      }
+      return acc;
+    }, []);
   }
 
   /**
@@ -91,28 +93,42 @@ export class AgentHistoryManager {
     await workspaceSM.update(storageKey, history);
   }
 
-  private static normalizeHistoryItem(
-    item: AgentHistoryItem,
-  ): AgentHistoryItem {
-    const session =
-      item.session ??
-      resolveAgentSessionDescriptor(
-        item.agentType ?? item.config.agentType,
-        item.agentSessionKind ?? item.config.session?.agentCategory,
-      );
+  private static normalizeHistoryItem(item: unknown): AgentHistoryItem | null {
+    const candidate = item as Partial<{
+      id: ExecutionId;
+      timestamp: string;
+      config: AgentConfig;
+      session?: AgentSessionDescriptor;
+      agentType?: AgentType;
+      agentSessionKind?: AgentCategory;
+    }>;
+
+    if (!candidate.id || !candidate.timestamp || !candidate.config) {
+      return null;
+    }
+
+    const baseSession = candidate.session ?? candidate.config.session;
+    const descriptor = baseSession
+      ? resolveAgentSessionDescriptor(
+          baseSession.agentType ?? candidate.config.agentType,
+          baseSession.agentCategory,
+        )
+      : resolveAgentSessionDescriptor(
+          candidate.agentType ?? candidate.config.agentType,
+          candidate.agentSessionKind ?? candidate.config.session?.agentCategory,
+        );
 
     const normalizedConfig: AgentConfig = {
-      ...item.config,
-      agentType: session.agentType,
-      session,
+      ...candidate.config,
+      agentType: descriptor.agentType,
+      session: descriptor,
     };
 
     return {
-      ...item,
+      id: candidate.id,
+      timestamp: candidate.timestamp,
       config: normalizedConfig,
-      agentType: session.agentType,
-      agentSessionKind: session.agentCategory,
-      session,
+      session: descriptor,
     };
   }
 

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -38,18 +38,14 @@ export class AgentHistoryManager {
    * Add a new agent execution to history
    */
   public static async addToHistory(config: AgentConfig): Promise<string> {
+    // Ensure config has session set (single source of truth)
     const session =
       config.session ?? resolveAgentSessionDescriptor(config.agentType);
-    const normalizedConfig: AgentConfig = {
-      ...config,
-      agentType: session.agentType,
-      session,
-    };
 
     const historyItem: AgentHistoryItem = {
       id: randomUUID(),
       timestamp: new Date().toISOString(),
-      config: normalizedConfig,
+      config: config.session ? config : { ...config, session },
       session,
     };
 
@@ -107,27 +103,21 @@ export class AgentHistoryManager {
       return null;
     }
 
-    const baseSession = candidate.session ?? candidate.config.session;
-    const descriptor = baseSession
-      ? resolveAgentSessionDescriptor(
-          baseSession.agentType ?? candidate.config.agentType,
-          baseSession.agentCategory,
-        )
-      : resolveAgentSessionDescriptor(
-          candidate.agentType ?? candidate.config.agentType,
-          candidate.agentSessionKind ?? candidate.config.session?.agentCategory,
-        );
-
-    const normalizedConfig: AgentConfig = {
-      ...candidate.config,
-      agentType: descriptor.agentType,
-      session: descriptor,
-    };
+    // Derive session from the most canonical source available
+    const descriptor =
+      candidate.session ??
+      candidate.config.session ??
+      resolveAgentSessionDescriptor(
+        candidate.agentType ?? candidate.config.agentType,
+        candidate.agentSessionKind,
+      );
 
     return {
       id: candidate.id,
       timestamp: candidate.timestamp,
-      config: normalizedConfig,
+      config: candidate.config.session
+        ? candidate.config
+        : { ...candidate.config, session: descriptor },
       session: descriptor,
     };
   }

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -7,9 +7,10 @@ import * as vscode from 'vscode';
 // Local imports - agent metadata
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import {
-  AgentSessionKind,
+  AgentCategory,
   AgentType,
-  resolveAgentSessionMetadata,
+  type AgentSessionDescriptor,
+  resolveAgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
@@ -24,7 +25,8 @@ export interface AgentHistoryItem {
   timestamp: string;
   config: AgentConfig;
   agentType?: AgentType;
-  agentSessionKind?: AgentSessionKind;
+  agentSessionKind?: AgentCategory;
+  session?: AgentSessionDescriptor;
 }
 
 /**
@@ -38,22 +40,21 @@ export class AgentHistoryManager {
    * Add a new agent execution to history
    */
   public static async addToHistory(config: AgentConfig): Promise<string> {
-    const metadata = resolveAgentSessionMetadata(
-      config.agentType,
-      config.agentSessionKind,
-    );
+    const session =
+      config.session ?? resolveAgentSessionDescriptor(config.agentType);
     const normalizedConfig: AgentConfig = {
       ...config,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType: session.agentType,
+      session,
     };
 
     const historyItem: AgentHistoryItem = {
       id: randomUUID(),
       timestamp: new Date().toISOString(),
       config: normalizedConfig,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType: session.agentType,
+      agentSessionKind: session.agentCategory,
+      session,
     };
 
     // Get current workspace-specific history
@@ -93,22 +94,25 @@ export class AgentHistoryManager {
   private static normalizeHistoryItem(
     item: AgentHistoryItem,
   ): AgentHistoryItem {
-    const metadata = resolveAgentSessionMetadata(
-      item.agentType ?? item.config.agentType,
-      item.agentSessionKind ?? item.config.agentSessionKind,
-    );
+    const session =
+      item.session ??
+      resolveAgentSessionDescriptor(
+        item.agentType ?? item.config.agentType,
+        item.agentSessionKind ?? item.config.session?.agentCategory,
+      );
 
     const normalizedConfig: AgentConfig = {
       ...item.config,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType: session.agentType,
+      session,
     };
 
     return {
       ...item,
       config: normalizedConfig,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType: session.agentType,
+      agentSessionKind: session.agentCategory,
+      session,
     };
   }
 

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -1,21 +1,22 @@
 // Local imports
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
-import type { AgentType } from '@agent/core/AgentDataclass';
+import {
+  AgentCategory,
+  type AgentSessionDescriptor,
+} from '@agent/core/AgentDataclass';
 import type { FileType } from '@utils/config';
 
 /** Shared properties for all task state variants. */
 interface BaseTaskState {
   agentConfig: AgentConfig;
-  agentType?: AgentType;
-  agentSessionKind: AgentSessionKind;
+  session: AgentSessionDescriptor;
 }
 
 /**
  * Workflow task state stores file visibility information for toolbar actions.
  */
 export interface WorkflowTaskState extends BaseTaskState {
-  agentSessionKind: AgentSessionKind.Workflow;
+  session: AgentSessionDescriptor & { agentCategory: AgentCategory.Workflow };
   activeFiles: Record<FileType, boolean>;
 }
 
@@ -27,7 +28,7 @@ export interface ToolSessionState {
 }
 
 export interface ToolUseTaskState extends BaseTaskState {
-  agentSessionKind: AgentSessionKind.ToolUse;
+  session: AgentSessionDescriptor & { agentCategory: AgentCategory.ToolUse };
   toolSessionState?: ToolSessionState;
 }
 
@@ -36,11 +37,11 @@ export type TaskState = WorkflowTaskState | ToolUseTaskState;
 export function isWorkflowTaskState(
   taskState: TaskState,
 ): taskState is WorkflowTaskState {
-  return taskState.agentSessionKind === AgentSessionKind.Workflow;
+  return taskState.session.agentCategory === AgentCategory.Workflow;
 }
 
 export function isToolUseTaskState(
   taskState: TaskState,
 ): taskState is ToolUseTaskState {
-  return taskState.agentSessionKind === AgentSessionKind.ToolUse;
+  return taskState.session.agentCategory === AgentCategory.ToolUse;
 }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -12,7 +12,7 @@ import { buildStreamInfos } from '../streamInfoUtils';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports - agent
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Types
 import { bus } from '@eventBus/ProgressEventBus';
@@ -219,11 +219,11 @@ export class ProgressEventHandler {
       this.setStreamStatus(stream, STATUS.RUNNING);
     }
 
-    this.state.setSessionKindHint(stream, AgentSessionKind.Workflow);
+    this.state.setSessionKindHint(stream, AgentCategory.Workflow);
 
     const currentFilter = this.state.agentTypeFilter;
-    if (currentFilter !== 'all' && currentFilter !== AgentSessionKind.Workflow) {
-      this.state.agentTypeFilter = AgentSessionKind.Workflow;
+    if (currentFilter !== 'all' && currentFilter !== AgentCategory.Workflow) {
+      this.state.agentTypeFilter = AgentCategory.Workflow;
     }
 
     this.state.activeStream = stream;

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -10,10 +10,6 @@ import type { StreamTabInfo } from '../types';
 import { STATUS } from '../modules/constants.js';
 
 // Local imports - agent
-import {
-  AgentType,
-  resolveAgentSessionMetadata,
-} from '@agent/core/AgentDataclass';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - events
@@ -58,7 +54,7 @@ export function createStreamStatusEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
-    const { stream, agentType, agentSessionKind } = payload;
+    const { stream, session } = payload;
 
     if (!stream) {
       return;
@@ -66,15 +62,14 @@ export function createStreamStatusEvents(
 
     state.streamTabs.ensureStream(stream);
 
-    const metadata = resolveAgentSessionMetadata(agentType, agentSessionKind);
-    state.setSessionKindHint(stream, metadata.agentSessionKind);
+    if (session) {
+      state.setSessionKindHint(stream, session.agentCategory);
+    }
 
     const currentFilter = state.agentTypeFilter;
-    if (
-      currentFilter !== 'all' &&
-      currentFilter !== metadata.agentSessionKind
-    ) {
-      state.agentTypeFilter = metadata.agentSessionKind;
+    const targetCategory = session?.agentCategory;
+    if (targetCategory && currentFilter !== 'all' && currentFilter !== targetCategory) {
+      state.agentTypeFilter = targetCategory;
     }
 
     state.activeStream = stream;
@@ -106,10 +101,7 @@ export function createStreamStatusEvents(
         `Received setTaskState for ${streamTabId} but no state was stored`,
       );
     } else {
-      const sessionKind = resolveAgentSessionMetadata(
-        normalizedState.agentType,
-        normalizedState.agentSessionKind,
-      ).agentSessionKind;
+      const sessionKind = normalizedState.session.agentCategory;
       const currentFilter = state.agentTypeFilter;
       const activeStream = state.activeStream;
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -15,10 +15,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import type { AgentFilter } from '../types';
 // Local imports - agent types
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
-import {
-  AgentSessionKind,
-  resolveAgentSessionMetadata,
-} from '@agent/core/AgentDataclass';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Types
 import {
@@ -57,7 +54,7 @@ export class ProgressViewState {
    * tab as workflow vs. tool-use. Once canonical metadata is stored the entry
    * is cleared, so there is no need to persist these hints across sessions.
    */
-  private _sessionKindHints: Map<StreamTabId, AgentSessionKind> = new Map();
+  private _sessionCategoryHints: Map<StreamTabId, AgentCategory> = new Map();
   private readonly toolUseTaskStates: ToolUseTaskStateManager;
   private readonly persistence: StatePersistenceManager;
   private readonly logger: AgentLogger;
@@ -127,28 +124,24 @@ export class ProgressViewState {
   // Session kind hint management (non-persistent)
   setSessionKindHint(
     streamTabId: StreamTabId,
-    sessionKind: AgentSessionKind,
+    sessionCategory: AgentCategory,
   ): void {
-    this._sessionKindHints.set(streamTabId, sessionKind);
+    this._sessionCategoryHints.set(streamTabId, sessionCategory);
   }
 
-  getSessionKindHint(streamTabId: StreamTabId): AgentSessionKind | undefined {
-    return this._sessionKindHints.get(streamTabId);
+  getSessionKindHint(streamTabId: StreamTabId): AgentCategory | undefined {
+    return this._sessionCategoryHints.get(streamTabId);
   }
 
   clearSessionKindHint(streamTabId: StreamTabId): void {
-    this._sessionKindHints.delete(streamTabId);
+    this._sessionCategoryHints.delete(streamTabId);
   }
 
   // Task state management
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
-    const metadata = resolveAgentSessionMetadata(
-      taskState.agentType,
-      taskState.agentSessionKind,
-    );
     const normalizedState = agentConfigToTaskState(
       taskState.agentConfig,
-      metadata,
+      taskState.session,
     );
 
     if (
@@ -262,7 +255,7 @@ export class ProgressViewState {
     this.workflowTaskStates.clear();
     this.toolUseTaskStates.clear();
     this._executionIds.clear();
-    this._sessionKindHints.clear();
+    this._sessionCategoryHints.clear();
     this._activeStream = '';
     this.saveActiveStream();
     this.saveTaskStates();

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -69,7 +69,7 @@ export function buildStreamInfos(
     if (!sessionCategory || !matchesAgentFilter(sessionCategory, filter)) {
       return acc;
     }
-    const agentType = taskState?.session.agentType ?? taskState?.agentConfig.agentType;
+    const agentType = taskState?.session?.agentType ?? taskState?.agentConfig.agentType;
     const isToolAgent = sessionCategory === AgentCategory.ToolUse;
     const executionId = state.getExecutionId(id);
     const label = buildStreamLabel(agentName, inputFile, sessionCategory);

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -5,10 +5,7 @@ import * as path from 'path';
 import type { ProgressViewState } from './state/ProgressViewState';
 import type { AgentFilter, StreamTabInfo } from './types';
 // Local imports - agent types
-import {
-  AgentSessionKind,
-  resolveAgentSessionMetadata,
-} from '@agent/core/AgentDataclass';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 const sortComparators = {
   time: (a: StreamTabInfo, b: StreamTabInfo) =>
@@ -21,16 +18,16 @@ const sortComparators = {
 } as const;
 
 function matchesAgentFilter(
-  sessionKind: AgentSessionKind,
+  sessionCategory: AgentCategory,
   filter: AgentFilter,
 ): boolean {
   switch (filter) {
     case 'all':
       return true;
     case 'toolUse':
-      return sessionKind === AgentSessionKind.ToolUse;
+      return sessionCategory === AgentCategory.ToolUse;
     case 'workflow':
-      return sessionKind === AgentSessionKind.Workflow;
+      return sessionCategory === AgentCategory.Workflow;
     default:
       return true;
   }
@@ -39,9 +36,9 @@ function matchesAgentFilter(
 function buildStreamLabel(
   agentName: string,
   inputFile: string,
-  sessionKind: AgentSessionKind,
+  sessionCategory: AgentCategory,
 ): string {
-  if (sessionKind === AgentSessionKind.ToolUse) {
+  if (sessionCategory === AgentCategory.ToolUse) {
     return agentName;
   }
 
@@ -68,27 +65,23 @@ export function buildStreamInfos(
     const outputs = taskState?.agentConfig.outputFiles || [];
     const inputFile = taskState?.agentConfig.inputFile || '';
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
-    const metadata = resolveAgentSessionMetadata(
-      taskState?.agentType,
-      taskState?.agentSessionKind ?? sessionKindHint,
-    );
-    const agentType = metadata.agentType ?? taskState?.agentType;
-    const agentSessionKind = metadata.agentSessionKind;
-    if (!matchesAgentFilter(agentSessionKind, filter)) {
+    const sessionCategory = taskState?.session.agentCategory ?? sessionKindHint;
+    if (!sessionCategory || !matchesAgentFilter(sessionCategory, filter)) {
       return acc;
     }
-    const isToolAgent = agentSessionKind === AgentSessionKind.ToolUse;
+    const agentType = taskState?.session.agentType ?? taskState?.agentConfig.agentType;
+    const isToolAgent = sessionCategory === AgentCategory.ToolUse;
     const executionId = state.getExecutionId(id);
-    const label = buildStreamLabel(agentName, inputFile, agentSessionKind);
+    const label = buildStreamLabel(agentName, inputFile, sessionCategory);
     acc.push({
       name: id,
       label,
       model: taskState?.agentConfig.model,
       agent: taskState?.agentConfig.agent,
       agentType,
-      agentSessionKind,
+      agentSessionKind: sessionCategory,
       uiTraits: {
-        sessionKind: agentSessionKind,
+        sessionKind: sessionCategory,
         isToolAgent,
       },
       hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -65,7 +65,7 @@ export function buildStreamInfos(
     const outputs = taskState?.agentConfig.outputFiles || [];
     const inputFile = taskState?.agentConfig.inputFile || '';
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
-    const sessionCategory = taskState?.session.agentCategory ?? sessionKindHint;
+    const sessionCategory = taskState?.session?.agentCategory ?? sessionKindHint;
     if (!sessionCategory || !matchesAgentFilter(sessionCategory, filter)) {
       return acc;
     }

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,11 +1,11 @@
 // Local imports - agent types
-import type { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
+import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
 export interface StreamUITraits {
   /** Canonical session grouping for the stream. */
-  sessionKind: AgentSessionKind;
+  sessionKind: AgentCategory;
   /** Indicates whether the associated agent is a tool-use session. */
   isToolAgent: boolean;
 }
@@ -17,7 +17,7 @@ export interface StreamTabInfo {
   model?: string;
   agent?: string;
   agentType?: AgentType;
-  agentSessionKind: AgentSessionKind;
+  agentSessionKind: AgentCategory;
   uiTraits: StreamUITraits;
   hasMultipleOutputs?: boolean;
   lastTimestamp?: number;

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -3,13 +3,14 @@ import { strict as assert } from 'assert';
 
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { AgentSetting, AgentType, AgentCategory } from '@agent/core/AgentDataclass';
 import type { AgentPrompt } from '@agent/core/AgentDataclass';
 import { getToolFlags } from '@agent/utils/userVars';
 import * as configModule from '@utils/config';
 
 const baseSetting: AgentSetting = {
   agentType: AgentType.CoT,
+  agentCategory: AgentCategory.Workflow,
   documentTag: 'document',
   temperature: 0,
   isRewrite: true,

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -282,7 +282,6 @@ describe('followUpCommand', () => {
       streamId,
       agentName: 'demo-agent',
       model: 'demo-model',
-      agentSessionKind: AgentCategory.ToolUse,
       session: { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse },
       messages: [],
       toolState: {

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 // Local imports - agent
 import type { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import {
   registerToolUseAgent,
   clearToolUseAgents,
@@ -282,7 +282,8 @@ describe('followUpCommand', () => {
       streamId,
       agentName: 'demo-agent',
       model: 'demo-model',
-      agentSessionKind: AgentSessionKind.ToolUse,
+      agentSessionKind: AgentCategory.ToolUse,
+      session: { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse },
       messages: [],
       toolState: {
         texcountStats: null,

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -3,7 +3,7 @@ import { strict as assert } from 'assert';
 
 // Local imports - test
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { AgentSetting, AgentType, AgentCategory } from '@agent/core/AgentDataclass';
 import { OutputHandler } from '@agent/output';
 
 // Local imports
@@ -42,6 +42,7 @@ class MockOutputHandler extends OutputHandler {
 describe('OutputHandler.finalizeRound', () => {
   const setting: AgentSetting = {
     agentType: AgentType.CoT,
+    agentCategory: AgentCategory.Workflow,
     documentTag: 'document',
     temperature: 0,
     isRewrite: true,

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -5,7 +5,7 @@ import { strict as assert } from 'assert';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 
 // Local imports
-import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import { AgentSetting, AgentType, AgentCategory } from '@agent/core/AgentDataclass';
 import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import { AgentLogger } from '@logger/AgentLogger';
 import { WorkspaceFS } from '@utils/files';
@@ -13,6 +13,7 @@ import { WorkspaceFS } from '@utils/files';
 describe('XmlOutputManager markdown fallback', () => {
   const setting: AgentSetting = {
     agentType: AgentType.CoT,
+    agentCategory: AgentCategory.Workflow,
     documentTag: 'latex_document',
     temperature: 0,
     isRewrite: true,

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -7,6 +7,7 @@ import {
   AgentSetting,
   AgentPrompt,
   AgentType,
+  AgentCategory,
 } from '@agent/core/AgentDataclass';
 import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
@@ -115,6 +116,7 @@ describe('BaseToolUseAgent follow-up loop', () => {
     const handler = new DummyHandler();
     const setting: AgentSetting = {
       agentType: AgentType.ToolUse,
+      agentCategory: AgentCategory.ToolUse,
       documentTag: 'doc',
       temperature: 0,
       endTag: '</doc>',

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -9,6 +9,7 @@ import {
   AgentSetting,
   AgentType,
   AgentPrompt,
+  AgentCategory,
 } from '@agent/core/AgentDataclass';
 import { ToolState } from '@agent/core/ToolState';
 import { runToolUseCycle } from '@agent/core/ToolUseCycle';
@@ -98,6 +99,7 @@ describe('runToolUseCycle DeepSeek', () => {
     const toolRegistry = { echo: new EchoTool() };
     const setting: AgentSetting = {
       agentType: AgentType.ToolUse,
+      agentCategory: AgentCategory.ToolUse,
       documentTag: 'doc',
       temperature: 0,
       endTag: '</doc>',

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -9,6 +9,7 @@ import {
   AgentSetting,
   AgentType,
   AgentPrompt,
+  AgentCategory,
 } from '@agent/core/AgentDataclass';
 import { ToolState } from '@agent/core/ToolState';
 import { runToolUseCycle } from '@agent/core/ToolUseCycle';
@@ -110,6 +111,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
     const toolRegistry = { echo: new EchoTool() };
     const setting: AgentSetting = {
       agentType: AgentType.ToolUse,
+      agentCategory: AgentCategory.ToolUse,
       documentTag: 'doc',
       temperature: 0,
       endTag: '</doc>',

--- a/src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts
+++ b/src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts
@@ -5,14 +5,11 @@ import { promises as fs } from 'fs';
 
 import * as vscode from 'vscode';
 
-import { AgentSessionKind } from '@agent/core/AgentDataclass';
+import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import { ToolState } from '@agent/core/ToolState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
-import {
-  ToolUseSessionManager,
-  type ToolUseSessionSnapshot,
-} from '@agent/toolUse/ToolUseSessionManager';
+import { ToolUseSessionManager } from '@agent/toolUse/ToolUseSessionManager';
 import StorageFS from '@utils/files/storageFS';
 
 const STORAGE_DIR = path.join(os.tmpdir(), 'texra-tooluse-snapshot-tests');
@@ -61,20 +58,20 @@ suite('ToolUseSessionManager snapshot compatibility', () => {
       streamId: 'stream-id',
       agentName: 'demo-agent',
       model: 'demo-model',
-      agentSessionKind: AgentSessionKind.ToolUse,
+      session: { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse },
       messages: [] as ProviderMessage[],
       toolState,
     };
   }
 
-  function buildSnapshot(executionId: ExecutionId): ToolUseSessionSnapshot {
+  function buildLegacySnapshot(executionId: ExecutionId) {
     return {
       version: 1,
       executionId,
       streamId: 'stream-id',
       agentName: 'demo-agent',
       model: 'demo-model',
-      agentSessionKind: AgentSessionKind.ToolUse,
+      agentSessionKind: AgentCategory.ToolUse,
       messages: [],
       toolState: {
         texcountStats: null,
@@ -102,7 +99,7 @@ suite('ToolUseSessionManager snapshot compatibility', () => {
 
   test('loadSnapshot reads snapshots saved before helper migration', async () => {
     const executionId = 'legacy-snapshot' as ExecutionId;
-    const snapshot = buildSnapshot(executionId);
+    const snapshot = buildLegacySnapshot(executionId);
 
     await StorageFS.ensureDir('toolUseSessions');
     await StorageFS.write(
@@ -118,7 +115,7 @@ suite('ToolUseSessionManager snapshot compatibility', () => {
 
   test('loadSnapshot falls back to raw JSON parsing when helper fails', async () => {
     const executionId = 'fallback-snapshot' as ExecutionId;
-    const snapshot = buildSnapshot(executionId);
+    const snapshot = buildLegacySnapshot(executionId);
 
     await StorageFS.ensureDir('toolUseSessions');
     await StorageFS.write(

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -9,10 +9,10 @@ import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { TaskState, isWorkflowTaskState } from '@logger/TaskState';
 import {
-  AgentSessionKind,
+  AgentCategory,
   type AgentType,
-  type AgentSessionMetadata,
-  resolveAgentSessionMetadata,
+  type AgentSessionDescriptor,
+  resolveAgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
 
 import { FILE_TYPES, type FileType } from './constants';
@@ -40,6 +40,25 @@ function createActiveFilesFromArrays(
   return active;
 }
 
+function createDescriptorFromLegacy(
+  obj: Record<string, any>,
+): AgentSessionDescriptor | undefined {
+  const category = obj.agentSessionKind as AgentCategory | undefined;
+  if (!category) {
+    return undefined;
+  }
+
+  if (category !== AgentCategory.Workflow && category !== AgentCategory.ToolUse) {
+    return undefined;
+  }
+
+  const agentType = obj.agentType as AgentType | undefined;
+  return {
+    agentType,
+    agentCategory: category,
+  };
+}
+
 /**
  * Converts an AgentConfig object to a TaskState object
  *
@@ -48,49 +67,52 @@ function createActiveFilesFromArrays(
  */
 export function agentConfigToTaskState(
   config: AgentConfig,
-  metadata?: AgentSessionMetadata | AgentType,
+  session?: AgentSessionDescriptor | AgentType,
 ): TaskState {
-  const configMetadata = resolveAgentSessionMetadata(
-    config.agentType,
-    config.agentSessionKind,
-  );
+  const resolvedSession = (() => {
+    if (!session && config.session) {
+      return config.session;
+    }
 
-  const providedMetadata =
-    typeof metadata === 'object' && metadata !== null
-      ? resolveAgentSessionMetadata(
-          metadata.agentType,
-          metadata.agentSessionKind,
-        )
-      : metadata !== undefined
-        ? resolveAgentSessionMetadata(metadata)
-        : null;
+    if (typeof session === 'string') {
+      return resolveAgentSessionDescriptor(session);
+    }
 
-  const resolvedMetadata = providedMetadata
-    ? resolveAgentSessionMetadata(
-        providedMetadata.agentType ?? configMetadata.agentType,
-        providedMetadata.agentSessionKind ?? configMetadata.agentSessionKind,
-      )
-    : configMetadata;
+    if (session) {
+      return session;
+    }
+
+    return resolveAgentSessionDescriptor(config.agentType);
+  })();
+
+  const normalizedSession: AgentSessionDescriptor = {
+    agentType: resolvedSession.agentType ?? config.agentType,
+    agentCategory: resolvedSession.agentCategory,
+  };
 
   const normalizedConfig: AgentConfig = {
     ...config,
-    agentType: resolvedMetadata.agentType,
-    agentSessionKind: resolvedMetadata.agentSessionKind,
+    agentType: normalizedSession.agentType,
+    session: normalizedSession,
   };
 
-  if (resolvedMetadata.agentSessionKind === AgentSessionKind.ToolUse) {
+  if (normalizedSession.agentCategory === AgentCategory.ToolUse) {
     return {
       agentConfig: normalizedConfig,
-      agentType: resolvedMetadata.agentType,
-      agentSessionKind: AgentSessionKind.ToolUse,
+      session: {
+        agentType: normalizedSession.agentType,
+        agentCategory: AgentCategory.ToolUse,
+      },
       toolSessionState: {},
     };
   }
 
   return {
     agentConfig: normalizedConfig,
-    agentType: resolvedMetadata.agentType,
-    agentSessionKind: AgentSessionKind.Workflow,
+    session: {
+      agentType: normalizedSession.agentType,
+      agentCategory: AgentCategory.Workflow,
+    },
     activeFiles: createActiveFilesFromArrays(normalizedConfig),
   };
 }
@@ -105,12 +127,12 @@ export function agentConfigToTaskState(
 export function objectToTaskState(obj: Record<string, any>): TaskState {
   // Check if this is already in the new format with nested agentConfig
   if (obj.agentConfig && typeof obj.agentConfig === 'object') {
-    const agentType = obj.agentType as AgentType | undefined;
-    const sessionKind = normalizeSessionKind(obj.agentSessionKind);
-    const metadata = resolveAgentSessionMetadata(agentType, sessionKind);
+    const sessionDescriptor =
+      (obj.session as AgentSessionDescriptor | undefined) ??
+      createDescriptorFromLegacy(obj);
     const state = agentConfigToTaskState(
       AgentConfigSchema.parse(obj.agentConfig),
-      metadata,
+      sessionDescriptor,
     );
 
     if (isWorkflowTaskState(state)) {
@@ -196,10 +218,10 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   // Parse only AgentConfig-compatible fields
   try {
     const normalized = AgentConfigSchema.parse(agentConfigData);
-    const agentType = obj.agentType as AgentType | undefined;
-    const sessionKind = normalizeSessionKind(obj.agentSessionKind);
-    const metadata = resolveAgentSessionMetadata(agentType, sessionKind);
-    const taskState = agentConfigToTaskState(normalized, metadata);
+    const sessionDescriptor =
+      (obj.session as AgentSessionDescriptor | undefined) ??
+      createDescriptorFromLegacy(obj);
+    const taskState = agentConfigToTaskState(normalized, sessionDescriptor);
 
     if (isWorkflowTaskState(taskState)) {
       if (activeFiles) {
@@ -215,8 +237,7 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
     console.error('Failed to parse task state, using defaults:', error);
     const defaultConfig = AgentConfigSchema.parse({});
     const agentType = obj.agentType as AgentType | undefined;
-    const metadata = resolveAgentSessionMetadata(agentType);
-    const taskState = agentConfigToTaskState(defaultConfig, metadata);
+    const taskState = agentConfigToTaskState(defaultConfig, agentType);
 
     if (isWorkflowTaskState(taskState) && activeFiles) {
       taskState.activeFiles = activeFiles;
@@ -233,12 +254,4 @@ export function objectToTaskState(obj: Record<string, any>): TaskState {
   }
 }
 
-function normalizeSessionKind(value: unknown): AgentSessionKind | undefined {
-  if (
-    value === AgentSessionKind.Workflow ||
-    value === AgentSessionKind.ToolUse
-  ) {
-    return value;
-  }
-  return undefined;
-}
+// normalizeSessionKind removed – canonical descriptor is now provided directly.

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -69,51 +69,28 @@ export function agentConfigToTaskState(
   config: AgentConfig,
   session?: AgentSessionDescriptor | AgentType,
 ): TaskState {
-  const resolvedSession = (() => {
-    if (!session && config.session) {
-      return config.session;
-    }
+  // Single source of truth: prefer config.session, then provided session, then derive
+  const resolvedSession =
+    config.session ??
+    (typeof session === 'string'
+      ? resolveAgentSessionDescriptor(session)
+      : session ?? resolveAgentSessionDescriptor(config.agentType));
 
-    if (typeof session === 'string') {
-      return resolveAgentSessionDescriptor(session);
-    }
+  // Ensure config has session - mutate only if needed to avoid unnecessary copying
+  const finalConfig = config.session ? config : { ...config, session: resolvedSession };
 
-    if (session) {
-      return session;
-    }
-
-    return resolveAgentSessionDescriptor(config.agentType);
-  })();
-
-  const normalizedSession: AgentSessionDescriptor = {
-    agentType: resolvedSession.agentType ?? config.agentType,
-    agentCategory: resolvedSession.agentCategory,
-  };
-
-  const normalizedConfig: AgentConfig = {
-    ...config,
-    agentType: normalizedSession.agentType,
-    session: normalizedSession,
-  };
-
-  if (normalizedSession.agentCategory === AgentCategory.ToolUse) {
+  if (resolvedSession.agentCategory === AgentCategory.ToolUse) {
     return {
-      agentConfig: normalizedConfig,
-      session: {
-        agentType: normalizedSession.agentType,
-        agentCategory: AgentCategory.ToolUse,
-      },
+      agentConfig: finalConfig,
+      session: resolvedSession,
       toolSessionState: {},
     };
   }
 
   return {
-    agentConfig: normalizedConfig,
-    session: {
-      agentType: normalizedSession.agentType,
-      agentCategory: AgentCategory.Workflow,
-    },
-    activeFiles: createActiveFilesFromArrays(normalizedConfig),
+    agentConfig: finalConfig,
+    session: resolvedSession,
+    activeFiles: createActiveFilesFromArrays(finalConfig),
   };
 }
 

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -76,21 +76,18 @@ export function agentConfigToTaskState(
       ? resolveAgentSessionDescriptor(session)
       : session ?? resolveAgentSessionDescriptor(config.agentType));
 
-  // Ensure config has session - mutate only if needed to avoid unnecessary copying
-  const finalConfig = config.session ? config : { ...config, session: resolvedSession };
-
   if (resolvedSession.agentCategory === AgentCategory.ToolUse) {
     return {
-      agentConfig: finalConfig,
+      agentConfig: config,
       session: resolvedSession,
       toolSessionState: {},
     };
   }
 
   return {
-    agentConfig: finalConfig,
+    agentConfig: config,
     session: resolvedSession,
-    activeFiles: createActiveFilesFromArrays(finalConfig),
+    activeFiles: createActiveFilesFromArrays(config),
   };
 }
 

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 
 // Local imports - agent
-import { AgentSessionKind, AgentType } from '@agent/core/AgentDataclass';
+import { AgentCategory, AgentType, type AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import { ToolConfig } from '@agent/core/ToolConfig';
 
 // Local imports - utils
@@ -61,20 +61,20 @@ export class ExecutionManager {
     }
 
     return this.composeAgentConfig(message, {
-      agentSessionKind: AgentSessionKind.Workflow,
+      agentCategory: AgentCategory.Workflow,
     });
   }
 
   private buildToolUseCommandPayload(message: any): AgentConfig {
     return this.composeAgentConfig(message, {
       agentType: AgentType.ToolUse,
-      agentSessionKind: AgentSessionKind.ToolUse,
+      agentCategory: AgentCategory.ToolUse,
     });
   }
 
   private composeAgentConfig(
     message: any,
-    metadata: { agentType?: AgentType; agentSessionKind: AgentSessionKind },
+    session: AgentSessionDescriptor,
   ): AgentConfig {
     const toolConfig: ToolConfig = {
       autoExtractFigure: message.autoExtractFigure,
@@ -120,8 +120,8 @@ export class ExecutionManager {
       outputFiles,
       editedFile: null,
       toolConfig,
-      agentType: metadata.agentType,
-      agentSessionKind: metadata.agentSessionKind,
+      agentType: session.agentType,
+      session,
     };
   }
 


### PR DESCRIPTION
## Summary
- add an explicit `agentCategory` to agent settings, expose `getAgentSessionDescriptor`, and persist the descriptor on agent configs, history items, and tool-use snapshots for later use
- rework task-state/config conversion, the event bus, and progress/history tooling to consume the canonical descriptor, simplifying downstream filters and removing legacy session-kind inference
- update runtime helpers, execution manager payloads, and related tests to pass the descriptor through UI and tool-use flows

## Testing
- CI=1 npm test -- --runTestsByPath src/test/commands/agent/followUpCommand.test.ts src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts *(fails: vscode-test requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8157815808324ba2e820e739c99a3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace legacy session kind/type fields with a canonical AgentSessionDescriptor (agentType + agentCategory), updating schemas, runtime, persistence, event bus, views, and tests.
> 
> - **Core types/schemas**:
>   - Introduce `AgentCategory` and `AgentSessionDescriptor`; replace `AgentSessionKind` and related helpers with `deriveAgentCategory`/`resolveAgentSessionDescriptor`.
>   - Extend `AgentConfig` to carry `session` and adjust `AgentConfigSchema`; add `getAgentSessionDescriptor`.
>   - Update `AgentSetting*` schemas to include/validate `agentCategory`.
> - **Runtime/agents**:
>   - `BaseAgent`/`BaseToolUseAgent` now return/use `AgentSessionDescriptor`; prefer `config.session` when present.
>   - `executeAgent` and preparation flow compute and propagate `session`; event bus `setActiveStream` now carries `session` instead of separate fields.
> - **Persistence/history**:
>   - Tool-use snapshots store `session` (with legacy normalization); `ToolUseSessionManager` reads/writes normalized descriptors.
>   - History items persist `session`; normalization/backfill for legacy entries.
> - **Progress/Views**:
>   - Replace filters/hints and stream metadata to use `AgentCategory` and `session` throughout Progress view and event handlers.
>   - Update `TaskState` to store `session`; converters in `configConversion` consume/produce descriptors and migrate legacy fields.
> - **Tests**:
>   - Adjust tests to new schemas/descriptors and snapshot format; add compatibility paths for legacy data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb7cd87b2b691e8cbb6f9ef6ebb0f918ac8d03bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->