### PR TITLE
Expose arXiv download option and flatten extracted sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -374,9 +374,7 @@
             "items": {
               "type": "string"
             },
-            "default": [
-              "PapersEx"
-            ],
+            "default": [],
             "description": "Additional directories to ignore when listing input and edited files",
             "editPresentation": "multilineText",
             "order": 11

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -164,18 +164,14 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    const papersExDir = 'PapersEx';
-    if (!(await WorkspaceFS.exists(papersExDir))) {
-      await WorkspaceFS.createDir(papersExDir);
-    }
-
-    const paperDirRelative = path.join(papersExDir, id.replace(/\//g, '_'));
+    const sanitizedId = id.replace(/\//g, '_');
+    const paperDirRelative = sanitizedId;
     if (!(await WorkspaceFS.exists(paperDirRelative))) {
       await WorkspaceFS.createDir(paperDirRelative);
     }
 
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
-    const basePath = path.join(paperDirFull, id.replace(/\//g, '_'));
+    const basePath = path.join(paperDirFull, sanitizedId);
 
     if (progressCallback) {
       progressCallback(`Downloading arXiv source for ${id}...`, 20);

--- a/src/progressView/modules/uiManagers/Placeholder.js
+++ b/src/progressView/modules/uiManagers/Placeholder.js
@@ -23,9 +23,11 @@ export class Placeholder {
       this._element.className = 'log-placeholder';
       const sampleLink =
         '<a href="command:texra.createSampleProject">create a sample project</a>';
+      const arxivLink =
+        '<a href="command:texra.downloadArXivSource">download an arXiv source</a>';
       const guideArgs = encodeURIComponent(JSON.stringify(['quick-start']));
       const guideLink = `<a href="command:texra.openDoc?${guideArgs}">user guide</a>`;
-      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${sampleLink} or read the ${guideLink}.`;
+      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${sampleLink}, ${arxivLink}, or read the ${guideLink}.`;
     }
 
     container.innerHTML = '';

--- a/src/test/tools/ArxivDownloadTool.test.ts
+++ b/src/test/tools/ArxivDownloadTool.test.ts
@@ -72,14 +72,14 @@ suite('ArxivDownloadTool', () => {
     ).downloadSource = async (id, _progress, autoIndent) => {
       receivedId = id;
       receivedAutoIndent = autoIndent;
-      return '/workspace/project/PapersEx/sample';
+      return '/workspace/project/2401.12345v2';
     };
 
     (
       WorkspaceFS as unknown as {
         relativePath: typeof originalRelativePath;
       }
-    ).relativePath = () => 'PapersEx/sample';
+    ).relativePath = () => '2401.12345v2';
 
     (
       LsTool.prototype as unknown as {
@@ -87,7 +87,7 @@ suite('ArxivDownloadTool', () => {
       }
     ).call = async () =>
       toolResult({
-        summary: 'Listing for PapersEx/sample',
+        summary: 'Listing for 2401.12345v2',
         output: 'dir src\nfile main.tex',
       });
 
@@ -99,9 +99,9 @@ suite('ArxivDownloadTool', () => {
     assert.strictEqual(receivedAutoIndent, false);
     assert.strictEqual(
       result.summary,
-      'Downloaded arXiv source to PapersEx/sample',
+      'Downloaded arXiv source to 2401.12345v2',
     );
-    assert.ok(result.output?.includes('Listing for PapersEx/sample'));
+    assert.ok(result.output?.includes('Listing for 2401.12345v2'));
     assert.ok(result.output?.includes('file main.tex'));
   });
 });


### PR DESCRIPTION
## Summary
- surface the arXiv source downloader alongside the sample project and guide links in the progress view placeholder
- unpack downloaded arXiv sources directly into a sanitized top-level workspace folder and drop the PapersEx nesting
- update configuration defaults and tests that assumed the PapersEx directory

## Testing
- npm run lint
- npm run compile
- CI=1 npm test *(fails: vscode-test cannot load libatk-1.0.so.0 in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68e8d229c070832498669b9f6a1e87f0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an arXiv download link in the progress view and extracts arXiv sources into top-level sanitized folders (removes PapersEx), updating config and tests.
> 
> - **Backend (LaTeX)**:
>   - **Flatten extraction path**: Unpack arXiv sources directly into a top-level sanitized folder (`src/latex/arxivProcessor.ts`), removing `PapersEx` nesting and adjusting `basePath`.
> - **UI**:
>   - **Progress placeholder**: Add link to `command:texra.downloadArXivSource` (`src/progressView/modules/uiManagers/Placeholder.js`).
> - **Config**:
>   - **Defaults**: Set `texra.files.ignored.inputDirectories` default to `[]` (remove `PapersEx`) in `package.json`.
> - **Tests**:
>   - Update expected paths/summaries from `PapersEx/sample` to `2401.12345v2` in `src/test/tools/ArxivDownloadTool.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d28b91c01c93bdf2628b50cd4efb897d1e14feb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->