### PR TITLE
Fix redundant arXiv download base path

### DIFF
--- a/package.json
+++ b/package.json
@@ -374,9 +374,7 @@
             "items": {
               "type": "string"
             },
-            "default": [
-              "PapersEx"
-            ],
+            "default": [],
             "description": "Additional directories to ignore when listing input and edited files",
             "editPresentation": "multilineText",
             "order": 11

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -164,25 +164,26 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    const papersExDir = 'PapersEx';
-    if (!(await WorkspaceFS.exists(papersExDir))) {
-      await WorkspaceFS.createDir(papersExDir);
-    }
-
-    const paperDirRelative = path.join(papersExDir, id.replace(/\//g, '_'));
+    const sanitizedId = id.replace(/\//g, '_');
+    const paperDirRelative = sanitizedId;
     if (!(await WorkspaceFS.exists(paperDirRelative))) {
       await WorkspaceFS.createDir(paperDirRelative);
     }
 
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
-    const basePath = path.join(paperDirFull, id.replace(/\//g, '_'));
+    const downloadBasePath = path.join(paperDirFull, 'source');
+    // Store the temporary download next to the extracted files without nesting
+    // another sanitized-id directory (e.g., <id>/<id>.tar).
 
     if (progressCallback) {
       progressCallback(`Downloading arXiv source for ${id}...`, 20);
     }
 
     const downloadUrl = `https://arxiv.org/src/${id}`;
-    const downloadedPath = await this.downloadFile(downloadUrl, basePath);
+    const downloadedPath = await this.downloadFile(
+      downloadUrl,
+      downloadBasePath,
+    );
 
     const isArchive =
       downloadedPath.endsWith('.tar') ||

--- a/src/progressView/modules/uiManagers/Placeholder.js
+++ b/src/progressView/modules/uiManagers/Placeholder.js
@@ -23,9 +23,11 @@ export class Placeholder {
       this._element.className = 'log-placeholder';
       const sampleLink =
         '<a href="command:texra.createSampleProject">create a sample project</a>';
+      const arxivLink =
+        '<a href="command:texra.downloadArXivSource">download an arXiv source</a>';
       const guideArgs = encodeURIComponent(JSON.stringify(['quick-start']));
       const guideLink = `<a href="command:texra.openDoc?${guideArgs}">user guide</a>`;
-      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${sampleLink} or read the ${guideLink}.`;
+      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${sampleLink}, ${arxivLink}, or read the ${guideLink}.`;
     }
 
     container.innerHTML = '';

--- a/src/test/tools/ArxivDownloadTool.test.ts
+++ b/src/test/tools/ArxivDownloadTool.test.ts
@@ -72,14 +72,14 @@ suite('ArxivDownloadTool', () => {
     ).downloadSource = async (id, _progress, autoIndent) => {
       receivedId = id;
       receivedAutoIndent = autoIndent;
-      return '/workspace/project/PapersEx/sample';
+      return '/workspace/project/sample';
     };
 
     (
       WorkspaceFS as unknown as {
         relativePath: typeof originalRelativePath;
       }
-    ).relativePath = () => 'PapersEx/sample';
+    ).relativePath = () => 'sample';
 
     (
       LsTool.prototype as unknown as {
@@ -87,7 +87,7 @@ suite('ArxivDownloadTool', () => {
       }
     ).call = async () =>
       toolResult({
-        summary: 'Listing for PapersEx/sample',
+        summary: 'Listing for sample',
         output: 'dir src\nfile main.tex',
       });
 
@@ -97,11 +97,8 @@ suite('ArxivDownloadTool', () => {
     assert.strictEqual(validateCalls, 1);
     assert.strictEqual(receivedId, '2401.12345v2');
     assert.strictEqual(receivedAutoIndent, false);
-    assert.strictEqual(
-      result.summary,
-      'Downloaded arXiv source to PapersEx/sample',
-    );
-    assert.ok(result.output?.includes('Listing for PapersEx/sample'));
+    assert.strictEqual(result.summary, 'Downloaded arXiv source to sample');
+    assert.ok(result.output?.includes('Listing for sample'));
     assert.ok(result.output?.includes('file main.tex'));
   });
 });


### PR DESCRIPTION
## Summary
- write temporary arXiv archives to `<id>/source` so the extracted folder no longer contains a duplicate sanitized segment
- document the intent to keep the flattened workspace layout when storing the download

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e8d229c070832498669b9f6a1e87f0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Flattens arXiv source download paths (no `PapersEx` nesting, temporary archive in `<id>/source`), updates UI placeholder and tests, and clears default ignored input directories.
> 
> - **LaTeX / arXiv processing**:
>   - Flatten download layout: use sanitized `id` as the project directory (remove `PapersEx` nesting).
>   - Save temporary archive to `/<id>/source` next to extracted files; avoid duplicate sanitized subfolder.
> - **UI**:
>   - Placeholder adds link to `command:texra.downloadArXivSource`.
> - **Tests**:
>   - Update `ArxivDownloadTool` expectations and paths from `PapersEx/sample` to `sample`.
> - **Config**:
>   - `texra.files.ignored.inputDirectories` default changed to `[]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3126faa4fd25531183151ac463e659d2f85a017a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->