### PR TITLE
Adjust arXiv download staging path

### DIFF
--- a/package.json
+++ b/package.json
@@ -374,9 +374,7 @@
             "items": {
               "type": "string"
             },
-            "default": [
-              "PapersEx"
-            ],
+            "default": [],
             "description": "Additional directories to ignore when listing input and edited files",
             "editPresentation": "multilineText",
             "order": 11

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -164,25 +164,24 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    const papersExDir = 'PapersEx';
-    if (!(await WorkspaceFS.exists(papersExDir))) {
-      await WorkspaceFS.createDir(papersExDir);
-    }
-
-    const paperDirRelative = path.join(papersExDir, id.replace(/\//g, '_'));
+    const sanitizedId = id.replace(/\//g, '_');
+    const paperDirRelative = sanitizedId;
     if (!(await WorkspaceFS.exists(paperDirRelative))) {
       await WorkspaceFS.createDir(paperDirRelative);
     }
 
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
-    const basePath = path.join(paperDirFull, id.replace(/\//g, '_'));
+    const downloadBasePath = path.join(paperDirFull, 'download');
 
     if (progressCallback) {
       progressCallback(`Downloading arXiv source for ${id}...`, 20);
     }
 
     const downloadUrl = `https://arxiv.org/src/${id}`;
-    const downloadedPath = await this.downloadFile(downloadUrl, basePath);
+    const downloadedPath = await this.downloadFile(
+      downloadUrl,
+      downloadBasePath,
+    );
 
     const isArchive =
       downloadedPath.endsWith('.tar') ||

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -72,7 +72,7 @@ export class ArxivSourceProcessor {
       if (disposition) {
         const match = /filename="?([^";]+)"?/i.exec(disposition);
         if (match) {
-          destPath = path.join(path.dirname(destBasePath), match[1]);
+          destPath = destBasePath + '_' + match[1];
         }
       } else {
         const contentType = response.headers['content-type'];

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -72,7 +72,8 @@ export class ArxivSourceProcessor {
       if (disposition) {
         const match = /filename="?([^";]+)"?/i.exec(disposition);
         if (match) {
-          destPath = path.join(path.dirname(destBasePath), match[1]);
+          // Keep file in the same directory as destBasePath
+          destPath = path.join(path.dirname(destBasePath), path.basename(match[1]));
         }
       } else {
         const contentType = response.headers['content-type'];
@@ -214,12 +215,25 @@ export class ArxivSourceProcessor {
         progressCallback('Cleaning up...', 80);
       }
 
+      // Delete the archive and then the download directory
       await AbsoluteFS.delete(downloadedPath);
+      try {
+        await AbsoluteFS.delete(downloadDirFull);
+      } catch {
+        // Ignore errors if directory is not empty or doesn't exist
+      }
     } else {
+      // For non-archive files, move to paper root and clean up download directory
       const downloadedRel = WorkspaceFS.relativePath(downloadedPath);
       const targetRel = path.join(paperDirRelative, 'main.tex');
       if (path.basename(downloadedPath) !== 'main.tex') {
         await WorkspaceFS.rename(downloadedRel, targetRel);
+      }
+      // Clean up the download directory
+      try {
+        await AbsoluteFS.delete(downloadDirFull);
+      } catch {
+        // Ignore errors if directory is not empty or doesn't exist
       }
     }
 

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -72,7 +72,7 @@ export class ArxivSourceProcessor {
       if (disposition) {
         const match = /filename="?([^";]+)"?/i.exec(disposition);
         if (match) {
-          destPath = destBasePath + '_' + match[1];
+          destPath = path.join(path.dirname(destBasePath), match[1]);
         }
       } else {
         const contentType = response.headers['content-type'];
@@ -171,7 +171,12 @@ export class ArxivSourceProcessor {
     }
 
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
-    const downloadBasePath = path.join(paperDirFull, 'download');
+    const downloadDirRelative = path.join(paperDirRelative, 'download');
+    if (!(await WorkspaceFS.exists(downloadDirRelative))) {
+      await WorkspaceFS.createDir(downloadDirRelative);
+    }
+    const downloadDirFull = path.join(paperDirFull, 'download');
+    const downloadBasePath = path.join(downloadDirFull, 'source');
 
     if (progressCallback) {
       progressCallback(`Downloading arXiv source for ${id}...`, 20);

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -67,12 +67,12 @@ export class ArxivSourceProcessor {
         throw new Error(`Failed to download: HTTP ${response.status}`);
       }
 
-      // Determine filename from headers
+      // Extract filename from Content-Disposition header if available
       const disposition = response.headers['content-disposition'];
       if (disposition) {
         const match = /filename="?([^";]+)"?/i.exec(disposition);
         if (match) {
-          // Keep file in the same directory as destBasePath
+          // Place file in download directory using basename to prevent path traversal
           destPath = path.join(path.dirname(destBasePath), path.basename(match[1]));
         }
       } else {
@@ -165,17 +165,16 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
+    // Create project directory for the arXiv paper (sanitize ID to avoid path issues)
     const sanitizedId = id.replace(/\//g, '_');
     const paperDirRelative = sanitizedId;
-    if (!(await WorkspaceFS.exists(paperDirRelative))) {
-      await WorkspaceFS.createDir(paperDirRelative);
-    }
+    await WorkspaceFS.ensureDir(paperDirRelative);
 
+    // Create temporary download subdirectory for staging the archive
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
     const downloadDirRelative = path.join(paperDirRelative, 'download');
-    if (!(await WorkspaceFS.exists(downloadDirRelative))) {
-      await WorkspaceFS.createDir(downloadDirRelative);
-    }
+    await WorkspaceFS.ensureDir(downloadDirRelative);
+
     const downloadDirFull = path.join(paperDirFull, 'download');
     const downloadBasePath = path.join(downloadDirFull, 'source');
 
@@ -215,25 +214,26 @@ export class ArxivSourceProcessor {
         progressCallback('Cleaning up...', 80);
       }
 
-      // Delete the archive and then the download directory
+      // Remove the downloaded archive file
       await AbsoluteFS.delete(downloadedPath);
+      // Remove the temporary download directory (files are now in paper root)
       try {
         await AbsoluteFS.delete(downloadDirFull);
       } catch {
-        // Ignore errors if directory is not empty or doesn't exist
+        // Ignore cleanup errors (directory may not be empty or may not exist)
       }
     } else {
-      // For non-archive files, move to paper root and clean up download directory
+      // For non-archive files, rename to main.tex and move to paper root
       const downloadedRel = WorkspaceFS.relativePath(downloadedPath);
       const targetRel = path.join(paperDirRelative, 'main.tex');
       if (path.basename(downloadedPath) !== 'main.tex') {
         await WorkspaceFS.rename(downloadedRel, targetRel);
       }
-      // Clean up the download directory
+      // Remove the temporary download directory (file is now in paper root)
       try {
         await AbsoluteFS.delete(downloadDirFull);
       } catch {
-        // Ignore errors if directory is not empty or doesn't exist
+        // Ignore cleanup errors (directory may not be empty or may not exist)
       }
     }
 

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -218,22 +218,29 @@ export class ArxivSourceProcessor {
       await AbsoluteFS.delete(downloadedPath);
       // Remove the temporary download directory (files are now in paper root)
       try {
-        await AbsoluteFS.delete(downloadDirFull);
-      } catch {
-        // Ignore cleanup errors (directory may not be empty or may not exist)
+        await AbsoluteFS.delete(downloadDirFull, { recursive: true });
+      } catch (err) {
+        logger.debug(
+          this.channel,
+          `Could not remove download directory: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     } else {
       // For non-archive files, rename to main.tex and move to paper root
       const downloadedRel = WorkspaceFS.relativePath(downloadedPath);
       const targetRel = path.join(paperDirRelative, 'main.tex');
-      if (path.basename(downloadedPath) !== 'main.tex') {
+      // Always move the file to paper root, even if already named main.tex
+      if (downloadedRel !== targetRel) {
         await WorkspaceFS.rename(downloadedRel, targetRel);
       }
       // Remove the temporary download directory (file is now in paper root)
       try {
-        await AbsoluteFS.delete(downloadDirFull);
-      } catch {
-        // Ignore cleanup errors (directory may not be empty or may not exist)
+        await AbsoluteFS.delete(downloadDirFull, { recursive: true });
+      } catch (err) {
+        logger.debug(
+          this.channel,
+          `Could not remove download directory: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
 

--- a/src/progressView/modules/uiManagers/Placeholder.js
+++ b/src/progressView/modules/uiManagers/Placeholder.js
@@ -23,9 +23,11 @@ export class Placeholder {
       this._element.className = 'log-placeholder';
       const sampleLink =
         '<a href="command:texra.createSampleProject">create a sample project</a>';
+      const arxivLink =
+        '<a href="command:texra.downloadArXivSource">download an arXiv source</a>';
       const guideArgs = encodeURIComponent(JSON.stringify(['quick-start']));
       const guideLink = `<a href="command:texra.openDoc?${guideArgs}">user guide</a>`;
-      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${sampleLink} or read the ${guideLink}.`;
+      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${sampleLink}, ${arxivLink}, or read the ${guideLink}.`;
     }
 
     container.innerHTML = '';

--- a/src/test/tools/ArxivDownloadTool.test.ts
+++ b/src/test/tools/ArxivDownloadTool.test.ts
@@ -72,14 +72,14 @@ suite('ArxivDownloadTool', () => {
     ).downloadSource = async (id, _progress, autoIndent) => {
       receivedId = id;
       receivedAutoIndent = autoIndent;
-      return '/workspace/project/PapersEx/sample';
+      return '/workspace/project/sample';
     };
 
     (
       WorkspaceFS as unknown as {
         relativePath: typeof originalRelativePath;
       }
-    ).relativePath = () => 'PapersEx/sample';
+    ).relativePath = () => 'sample';
 
     (
       LsTool.prototype as unknown as {
@@ -87,7 +87,7 @@ suite('ArxivDownloadTool', () => {
       }
     ).call = async () =>
       toolResult({
-        summary: 'Listing for PapersEx/sample',
+        summary: 'Listing for sample',
         output: 'dir src\nfile main.tex',
       });
 
@@ -97,11 +97,8 @@ suite('ArxivDownloadTool', () => {
     assert.strictEqual(validateCalls, 1);
     assert.strictEqual(receivedId, '2401.12345v2');
     assert.strictEqual(receivedAutoIndent, false);
-    assert.strictEqual(
-      result.summary,
-      'Downloaded arXiv source to PapersEx/sample',
-    );
-    assert.ok(result.output?.includes('Listing for PapersEx/sample'));
+    assert.strictEqual(result.summary, 'Downloaded arXiv source to sample');
+    assert.ok(result.output?.includes('Listing for sample'));
     assert.ok(result.output?.includes('file main.tex'));
   });
 });


### PR DESCRIPTION
## Summary
- adjust the arXiv source download staging path to avoid creating nested folders when saving archives

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e8d229c070832498669b9f6a1e87f0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Flattens arXiv download paths (remove PapersEx, stage archives under `download`), updates UI placeholder and tests, and clears default ignored input directories.
> 
> - **ArXiv download**:
>   - Use sanitized ID as the project folder (remove `PapersEx` parent) and write archive to `download` subpath.
>   - Adjust `downloadFile` base path accordingly.
> - **Config**:
>   - Set `texra.files.ignored.inputDirectories` default to `[]` (was `['PapersEx']`).
> - **UI**:
>   - Add “download an arXiv source” link to the empty-state placeholder.
> - **Tests**:
>   - Update `ArxivDownloadTool` expectations and paths from `PapersEx/sample` to `sample`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b1e98681aa88c499e2084c2cedbce673c762e25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->