### PR TITLE
Fix task state session descriptor typing

### DIFF
--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -21,6 +21,20 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function withSessionCategory<T extends AgentCategory>(
+  descriptor: AgentSessionDescriptor,
+  category: T,
+): AgentSessionDescriptor & { agentCategory: T } {
+  if (descriptor.agentCategory === category) {
+    return descriptor as AgentSessionDescriptor & { agentCategory: T };
+  }
+
+  return {
+    ...descriptor,
+    agentCategory: category,
+  } as AgentSessionDescriptor & { agentCategory: T };
+}
+
 function createActiveFilesFromArrays(
   src: Record<string, any>,
 ): Record<FileType, boolean> {
@@ -82,14 +96,14 @@ export function agentConfigToTaskState(
   if (resolvedSession.agentCategory === AgentCategory.ToolUse) {
     return {
       agentConfig: config,
-      session: resolvedSession,
+      session: withSessionCategory(resolvedSession, AgentCategory.ToolUse),
       toolSessionState: {},
     };
   }
 
   return {
     agentConfig: config,
-    session: resolvedSession,
+    session: withSessionCategory(resolvedSession, AgentCategory.Workflow),
     activeFiles: createActiveFilesFromArrays(config),
   };
 }


### PR DESCRIPTION
## Summary
- ensure session descriptors returned from config conversion carry category-specific typing
- reuse a helper to coerce descriptors into workflow or tool-use variants before returning TaskState

## Testing
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e902b2f8f08324a709c03930123637

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `TaskState.session` carries the correct category-specific type by coercing session descriptors for workflow and tool-use paths.
> 
> - **Config Conversion (`src/utils/config/configConversion.ts`)**:
>   - Add `withSessionCategory` helper to coerce `AgentSessionDescriptor` to a specific `agentCategory` type.
>   - Use the helper in `agentConfigToTaskState` to return category-specific `session` for `ToolUse` and `Workflow` branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e76362b0a06a60ff6aac9c1e4bd2062df0b422b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->