### PR TITLE
fix: narrow task session typing

### DIFF
--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -7,7 +7,7 @@
 // Local imports - models
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
-import { TaskState, isWorkflowTaskState } from '@logger/TaskState';
+import { type TaskState, isWorkflowTaskState } from '@logger/TaskState';
 import {
   AgentCategory,
   type AgentType,
@@ -80,16 +80,29 @@ export function agentConfigToTaskState(
       : (session ?? resolveAgentSessionDescriptor(config.agentType)));
 
   if (resolvedSession.agentCategory === AgentCategory.ToolUse) {
+    const toolUseSession: AgentSessionDescriptor & {
+      agentCategory: AgentCategory.ToolUse;
+    } = {
+      ...resolvedSession,
+      agentCategory: AgentCategory.ToolUse,
+    };
     return {
       agentConfig: config,
-      session: resolvedSession,
+      session: toolUseSession,
       toolSessionState: {},
     };
   }
 
+  const workflowSession: AgentSessionDescriptor & {
+    agentCategory: AgentCategory.Workflow;
+  } = {
+    ...resolvedSession,
+    agentCategory: AgentCategory.Workflow,
+  };
+
   return {
     agentConfig: config,
-    session: resolvedSession,
+    session: workflowSession,
     activeFiles: createActiveFilesFromArrays(config),
   };
 }


### PR DESCRIPTION
## Summary
- ensure agentConfigToTaskState returns tool-use and workflow sessions with narrowed categories to satisfy TaskState typing
- continue deriving active files and tool session state without altering existing behavior

## Testing
- npm run format
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e902b2f8f08324a709c03930123637

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Narrow `TaskState` session typing by explicitly constructing `ToolUse` and `Workflow` session descriptors; minor type-only import tweak.
> 
> - **Types**:
>   - Narrow `session` in `agentConfigToTaskState` by constructing explicit `toolUseSession` (`AgentCategory.ToolUse`) and `workflowSession` (`AgentCategory.Workflow`).
> - **Refinement**:
>   - Use type-only import for `TaskState` in `src/utils/config/configConversion.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff6acc7d29c51b79d9580b29db4c34493d9682a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->