### PR TITLE
feat: add claude haiku 4.5 model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.34.1] - 2025-10-15
+## [0.34.0] - 2025-10-15
 
 ### Features
 
-- Add Claude Haiku 4.5 (`haiku45`) to the Anthropic model catalog with pricing and capability metadata, and document the option in the model guide.
+- Add Claude Haiku 4.5 (`haiku45`) to the Anthropic model catalog with pricing, reasoning capability metadata, and documentation in the model guide.
 
 ## [0.33.10] - 2025-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Add Claude Haiku 4.5 (`haiku45`) to the Anthropic model catalog with pricing, reasoning capability metadata, and documentation in the model guide.
+- Add Claude Haiku 4.5 (`haiku45T`, `haiku45`) to the Anthropic model catalog with pricing, reasoning capability metadata, and documentation in the model guide.
 
 ## [0.33.10] - 2025-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.34.1] - 2025-10-15
+
+### Features
+
+- Add Claude Haiku 4.5 (`haiku45`) to the Anthropic model catalog with pricing and capability metadata, and document the option in the model guide.
+
 ## [0.33.10] - 2025-10-10
 
 ### Features

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -35,6 +35,7 @@ Known for strong instruction following and context handling.
 | `sonnet37T` | `sonnet37` with explicit reasoning steps    | $$$           | Medium         | Good for math, complex logic    |
 | `sonnet37`  | Strong all-rounder, good context            | $$$           | Medium         |                                 |
 | `sonnet35`  | Good balance of quality/cost (older Sonnet) | $$$           | Medium         |                                 |
+| `haiku45`   | Fast Claude 4.5 responses                   | $$            | Fast           | Claude 4.5 Haiku                |
 
 #### Sonnet 4 / 4.5 1M Context (Beta)
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -35,7 +35,8 @@ Known for strong instruction following and context handling.
 | `sonnet37T` | `sonnet37` with explicit reasoning steps    | $$$           | Medium         | Good for math, complex logic    |
 | `sonnet37`  | Strong all-rounder, good context            | $$$           | Medium         |                                 |
 | `sonnet35`  | Good balance of quality/cost (older Sonnet) | $$$           | Medium         |                                 |
-| `haiku45`   | Fast Claude 4.5 responses with reasoning    | $$            | Fast           | Claude 4.5 Haiku                |
+| `haiku45T`  | Fast Claude 4.5 with explicit reasoning     | $$            | Fast           | Claude 4.5 Haiku with thinking  |
+| `haiku45`   | Fast Claude 4.5 responses                   | $$            | Fast           | Claude 4.5 Haiku                |
 
 #### Sonnet 4 / 4.5 1M Context (Beta)
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -35,7 +35,7 @@ Known for strong instruction following and context handling.
 | `sonnet37T` | `sonnet37` with explicit reasoning steps    | $$$           | Medium         | Good for math, complex logic    |
 | `sonnet37`  | Strong all-rounder, good context            | $$$           | Medium         |                                 |
 | `sonnet35`  | Good balance of quality/cost (older Sonnet) | $$$           | Medium         |                                 |
-| `haiku45`   | Fast Claude 4.5 responses                   | $$            | Fast           | Claude 4.5 Haiku                |
+| `haiku45`   | Fast Claude 4.5 responses with reasoning    | $$            | Fast           | Claude 4.5 Haiku                |
 
 #### Sonnet 4 / 4.5 1M Context (Beta)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.99.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.34.1",
+  "version": "0.34.0",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.99.3"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
                 "opus4",
                 "sonnet45T",
                 "sonnet45",
+                "haiku45T",
+                "haiku45",
                 "sonnet4T",
                 "sonnet4",
                 "sonnet37T",
@@ -116,7 +118,7 @@
               "qwen3max",
               "grok4"
             ],
-            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet45T/sonnet45 (Claude Sonnet 4.5 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5pro/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Pro/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
+            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet45T/sonnet45 (Claude Sonnet 4.5 Thinking/Regular), haiku45T/haiku45 (Claude Haiku 4.5 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt5/gpt5pro/gpt5-/gpt5--/gpt41/gpt4o (GPT-5/5 Pro/5 Mini/5 Nano/4.1/4O), gemini25p/gemini25f/gemini2fT (Gemini 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2turbo (Kimi Thinking/Vision/K2/K2 Turbo)",
             "scope": "resource"
           }
         }
@@ -247,6 +249,8 @@
               "opus4",
               "sonnet45T",
               "sonnet45",
+              "haiku45T",
+              "haiku45",
               "sonnet4T",
               "sonnet4",
               "sonnet37T",

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -146,8 +146,8 @@ export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
     provider: ModelProvider.ANTHROPIC,
     maxOutputTokens: 64000, // Official Claude Haiku 4.5 limit - streaming recommended for large outputs
     contextWindow: 200000,
-    inputPrice: 0.8,
-    outputPrice: 4.0,
+    inputPrice: 1.0,
+    outputPrice: 5.0,
     capabilities: {
       ...ANTHROPIC_DEFAULT_CAPABILITIES,
       supportsNativeWebSearch: true,
@@ -165,14 +165,14 @@ export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
     provider: ModelProvider.ANTHROPIC,
     maxOutputTokens: 64000, // Official Claude Haiku 4.5 limit - streaming recommended for large outputs
     contextWindow: 200000,
-    inputPrice: 0.8,
-    outputPrice: 4.0,
+    inputPrice: 1.0,
+    outputPrice: 5.0,
     capabilities: {
       ...ANTHROPIC_DEFAULT_CAPABILITIES,
       supportsNativeWebSearch: true,
       supportsNativeCodeExecution: true,
       supportsAssistantPrefill: true,
-      supportsReasoning: true,
+      supportsReasoning: false,
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -153,7 +153,7 @@ export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
       supportsNativeWebSearch: true,
       supportsNativeCodeExecution: true,
       supportsAssistantPrefill: true,
-      supportsReasoning: false,
+      supportsReasoning: true,
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -139,6 +139,25 @@ export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
+  haiku45T: {
+    name: 'haiku45T',
+    fullName: 'claude-haiku-4-5-20251001',
+    openrouterFullName: 'anthropic/claude-haiku-4.5:thinking',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 64000, // Official Claude Haiku 4.5 limit - streaming recommended for large outputs
+    contextWindow: 200000,
+    inputPrice: 0.8,
+    outputPrice: 4.0,
+    capabilities: {
+      ...ANTHROPIC_DEFAULT_CAPABILITIES,
+      supportsNativeWebSearch: true,
+      supportsNativeCodeExecution: true,
+      supportsAssistantPrefill: false,
+      supportsReasoning: true,
+      supportsInterleavedThinking: true,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
   haiku45: {
     name: 'haiku45',
     fullName: 'claude-haiku-4-5-20251001',

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -139,6 +139,24 @@ export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
+  haiku45: {
+    name: 'haiku45',
+    fullName: 'claude-haiku-4-5-20251001',
+    openrouterFullName: 'anthropic/claude-haiku-4.5',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 64000, // Official Claude Haiku 4.5 limit - streaming recommended for large outputs
+    contextWindow: 200000,
+    inputPrice: 0.8,
+    outputPrice: 4.0,
+    capabilities: {
+      ...ANTHROPIC_DEFAULT_CAPABILITIES,
+      supportsNativeWebSearch: true,
+      supportsNativeCodeExecution: true,
+      supportsAssistantPrefill: true,
+      supportsReasoning: false,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
   sonnet4T: {
     name: 'sonnet4T',
     fullName: 'claude-sonnet-4-20250514',


### PR DESCRIPTION
## Summary
- add Claude Haiku 4.5 configuration to the Anthropic model registry
- note the new Haiku option in the Anthropic models guide

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68efd636a1e88324b62b328a78cb486b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Claude Haiku 4.5 (`haiku45T`, `haiku45`) with pricing/capabilities, updates settings enums/descriptions, docs, and changelog.
> 
> - **Models**:
>   - Add `haiku45T` and `haiku45` to `ANTRHOPIC_MODELS` with IDs, OpenRouter names, 200k context, 64k max output, pricing (0.8/4.0), and capabilities (reasoning; interleaved thinking on `haiku45T`).
> - **Settings (package.json)**:
>   - Extend `texra.models` and `texra.model.instructionPolishModel` enums to include `haiku45T`, `haiku45`.
>   - Update model codes description to mention `haiku45T/haiku45`.
> - **Docs**:
>   - Insert `haiku45T` and `haiku45` in Anthropic models table in `docs/guide/models.md`.
> - **Changelog**:
>   - Add 0.34.0 entry noting Claude Haiku 4.5 addition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f138da602ca21a2343608ddb8b6353f2ed81355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->