### PR TITLE
Fix timezone handling for progress view timestamps

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -48,14 +48,23 @@ export const TaskGroupLevel = {
   ROOT: {
     name: 'root',
     formatTime: (date) => {
-      const datePart = date.toLocaleDateString('en-CA');
-      const timePart = date.toLocaleTimeString('en-US', {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: false,
-      });
-      return `${datePart} ${timePart}`;
+      try {
+        const datePart = new Intl.DateTimeFormat(undefined, {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        }).format(date);
+        const timePart = new Intl.DateTimeFormat(undefined, {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        }).format(date);
+        return `${datePart} ${timePart}`;
+      } catch (error) {
+        const isoTimestamp = date.toISOString();
+        const timePart = isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
+        return `${isoTimestamp.split('T')[0]} ${timePart}`;
+      }
     },
     showTitle: false,
     headerOrder: 'time-first', // time → bullet → usage
@@ -63,13 +72,17 @@ export const TaskGroupLevel = {
   },
   NESTED: {
     name: 'nested',
-    formatTime: (date) =>
-      date.toLocaleTimeString('en-US', {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: false,
-      }),
+    formatTime: (date) => {
+      try {
+        return new Intl.DateTimeFormat(undefined, {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        }).format(date);
+      } catch (error) {
+        return date.toISOString().split('T')[1]?.split('.')[0] ?? date.toISOString();
+      }
+    },
     showTitle: true,
     headerOrder: 'usage-first', // usage → bullet → time
     cssClass: null,

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -138,13 +138,37 @@ export class LogEntryFormatter {
    * @returns {{fullTimestamp: string, timeDisplay: string}} Formatted timestamps
    */
   _formatTimestamp(date) {
-    const fullTimestamp = date.toISOString();
-    const timeDisplay = date
-      .toISOString()
-      .split('T')[1]
-      .replace('Z', '')
-      .split('.')[0];
-    return { fullTimestamp, timeDisplay };
+    const isoTimestamp = date.toISOString();
+
+    try {
+      const timeDisplay = new Intl.DateTimeFormat(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).format(date);
+
+      const tooltipTimestamp = new Intl.DateTimeFormat(undefined, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).format(date);
+
+      return {
+        fullTimestamp: isoTimestamp,
+        timeDisplay,
+        tooltipTimestamp,
+      };
+    } catch (error) {
+      const timeDisplay = isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
+      return {
+        fullTimestamp: isoTimestamp,
+        timeDisplay,
+        tooltipTimestamp: isoTimestamp,
+      };
+    }
   }
 
   /**
@@ -303,7 +327,8 @@ export class LogEntryFormatter {
 
     const emoji = EMOJI_BY_LEVEL[level] || '•';
     const date = new Date(timestamp);
-    const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
+    const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+      this._formatTimestamp(date);
 
     // Check if we have a custom formatter for this message type
     const formatters = this._getFormatters();
@@ -360,7 +385,7 @@ export class LogEntryFormatter {
 
     const htmlMessage =
       prefix +
-      `<span class="timestamp" title="${fullTimestamp}">${emoji}${
+      `<span class="timestamp" title="${tooltipTimestamp}">${emoji}${
         verbose ? ` [${timeDisplay}]` : ''
       }</span> ` +
       levelMarkup +
@@ -677,7 +702,8 @@ export class LogEntryFormatter {
     }
 
     const date = new Date(timestamp);
-    const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
+    const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+      this._formatTimestamp(date);
 
     const bannerEntry = this._createBannerEntry({
       logId: id,
@@ -699,7 +725,7 @@ export class LogEntryFormatter {
     if (summaryElem) {
       const timestampElem = document.createElement('span');
       timestampElem.classList.add('timestamp');
-      timestampElem.title = fullTimestamp;
+      timestampElem.title = tooltipTimestamp;
       timestampElem.textContent = verbose ? `[${timeDisplay}]` : '';
       summaryElem.insertBefore(
         timestampElem,
@@ -1103,7 +1129,8 @@ export class LogEntryFormatter {
     if (!element) return null;
 
     const date = new Date(timestamp ?? Date.now());
-    const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
+    const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+      this._formatTimestamp(date);
 
     element.dataset.fullTimestamp = fullTimestamp;
     if (logId) {
@@ -1113,7 +1140,7 @@ export class LogEntryFormatter {
     const timeElem = element.querySelector('.native-status-time');
     if (timeElem) {
       timeElem.textContent = timeDisplay;
-      timeElem.title = fullTimestamp;
+      timeElem.title = tooltipTimestamp;
     }
 
     const textElem = element.querySelector('.native-status-text');
@@ -1131,12 +1158,13 @@ export class LogEntryFormatter {
     if (!element) return null;
 
     const date = new Date(timestamp);
-    const { fullTimestamp, timeDisplay } = this._formatTimestamp(date);
+    const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+      this._formatTimestamp(date);
 
     const timestampElem = element.querySelector('.user-message-timestamp');
     if (timestampElem) {
       timestampElem.textContent = timeDisplay;
-      timestampElem.title = fullTimestamp;
+      timestampElem.title = tooltipTimestamp;
     }
 
     const contentElem = element.querySelector('.user-message-content');

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -49,17 +49,14 @@ export const TaskGroupLevel = {
     name: 'root',
     formatTime: (date) => {
       try {
-        const datePart = new Intl.DateTimeFormat(undefined, {
+        return new Intl.DateTimeFormat(undefined, {
           year: 'numeric',
           month: '2-digit',
           day: '2-digit',
-        }).format(date);
-        const timePart = new Intl.DateTimeFormat(undefined, {
           hour: '2-digit',
           minute: '2-digit',
           second: '2-digit',
         }).format(date);
-        return `${datePart} ${timePart}`;
       } catch (error) {
         const isoTimestamp = date.toISOString();
         const timePart = isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -41,6 +41,24 @@ export const EMOJI_BY_LEVEL = {
   debug: '🔍',
 };
 
+// DateTimeFormat options for consistent timestamp formatting
+const DATETIME_FORMAT_OPTIONS = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+};
+
+const TIME_FORMAT_OPTIONS = {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+};
+
 /**
  * Represents different task group hierarchy levels with associated behaviors
  */
@@ -49,14 +67,7 @@ export const TaskGroupLevel = {
     name: 'root',
     formatTime: (date) => {
       try {
-        return new Intl.DateTimeFormat(undefined, {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-        }).format(date);
+        return new Intl.DateTimeFormat(undefined, DATETIME_FORMAT_OPTIONS).format(date);
       } catch (error) {
         const isoTimestamp = date.toISOString();
         const timePart = isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
@@ -71,11 +82,7 @@ export const TaskGroupLevel = {
     name: 'nested',
     formatTime: (date) => {
       try {
-        return new Intl.DateTimeFormat(undefined, {
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-        }).format(date);
+        return new Intl.DateTimeFormat(undefined, TIME_FORMAT_OPTIONS).format(date);
       } catch (error) {
         return date.toISOString().split('T')[1]?.split('.')[0] ?? date.toISOString();
       }
@@ -151,20 +158,8 @@ export class LogEntryFormatter {
     const isoTimestamp = date.toISOString();
 
     try {
-      const timeDisplay = new Intl.DateTimeFormat(undefined, {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-      }).format(date);
-
-      const tooltipTimestamp = new Intl.DateTimeFormat(undefined, {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-      }).format(date);
+      const timeDisplay = new Intl.DateTimeFormat(undefined, TIME_FORMAT_OPTIONS).format(date);
+      const tooltipTimestamp = new Intl.DateTimeFormat(undefined, DATETIME_FORMAT_OPTIONS).format(date);
 
       return {
         fullTimestamp: isoTimestamp,

--- a/src/test/progressView/Formatters.test.ts
+++ b/src/test/progressView/Formatters.test.ts
@@ -12,6 +12,32 @@ import { JSDOM } from 'jsdom';
 import { LogEntryFormatter } from '../../progressView/modules/formatters.js';
 
 describe('LogEntryFormatter DOM', () => {
+  const originalDateTimeFormat = Intl.DateTimeFormat;
+
+  function mockDateTimeFormat(
+    _locales?: Intl.LocalesArgument,
+    options?: Intl.DateTimeFormatOptions,
+  ) {
+    const prefix = options && (options.year || options.dateStyle)
+      ? 'tooltip'
+      : 'time';
+    return {
+      format(date: Date) {
+        return `${prefix}-${date.getTime()}`;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    (Intl as any).DateTimeFormat = mockDateTimeFormat as any;
+  });
+
+  afterEach(() => {
+    (Intl as any).DateTimeFormat = originalDateTimeFormat;
+    delete (global as any).document;
+    delete (global as any).window;
+  });
+
   it('creates basic log line element', () => {
     const dom = new JSDOM(`<!doctype html><html><body>
       <template id="logLineTemplate">
@@ -22,11 +48,12 @@ describe('LogEntryFormatter DOM', () => {
     global.window = dom.window as any;
 
     const formatter = new LogEntryFormatter();
+    const timestamp = Date.UTC(2023, 0, 2, 3, 4, 5);
     const el = formatter.format({
       id: '1',
       text: 'hello',
       level: 'info',
-      timestamp: Date.now(),
+      timestamp,
       groupId: null,
       messageType: 'info',
       verbose: false,
@@ -35,6 +62,14 @@ describe('LogEntryFormatter DOM', () => {
 
     assert.ok(el instanceof dom.window.HTMLElement);
     assert.equal(el.querySelector('.message')?.textContent, 'hello');
+    assert.equal(
+      el?.dataset.fullTimestamp,
+      new Date(timestamp).toISOString(),
+    );
+    assert.equal(
+      el?.querySelector('.timestamp')?.getAttribute('title'),
+      `tooltip-${timestamp}`,
+    );
   });
 
   it('renders progress status entries with native styling', () => {
@@ -50,7 +85,7 @@ describe('LogEntryFormatter DOM', () => {
     global.window = dom.window as any;
 
     const formatter = new LogEntryFormatter();
-    const timestamp = Date.now();
+    const timestamp = Date.UTC(2023, 6, 4, 12, 0, 0);
 
     const el = formatter.format({
       id: 'status-1',
@@ -70,6 +105,14 @@ describe('LogEntryFormatter DOM', () => {
       '🟢 Starting continuation #1',
     );
     assert.equal(el?.dataset.logId, 'status-1');
+    assert.equal(
+      el?.querySelector('.native-status-time')?.textContent,
+      `time-${timestamp}`,
+    );
+    assert.equal(
+      el?.querySelector('.native-status-time')?.getAttribute('title'),
+      `tooltip-${timestamp}`,
+    );
   });
 
   it('renders tool use entries from structured data', () => {

--- a/src/test/progressView/Formatters.test.ts
+++ b/src/test/progressView/Formatters.test.ts
@@ -18,6 +18,11 @@ describe('LogEntryFormatter DOM', () => {
     _locales?: Intl.LocalesArgument,
     options?: Intl.DateTimeFormatOptions,
   ) {
+    // Verify that hour12: false is set for all time formats
+    if (options && (options.hour !== undefined)) {
+      assert.equal(options.hour12, false, 'hour12 should be false for consistent 24-hour format');
+    }
+
     const prefix = options && (options.year || options.dateStyle)
       ? 'tooltip'
       : 'time';


### PR DESCRIPTION
## Summary
- format progress view timestamps with Intl APIs to reflect the local timezone and keep ISO values for data attributes
- update log entry tooltip usage to rely on localized strings while retaining ISO fallbacks
- extend formatter unit tests with deterministic Intl stubs that assert localized timestamps

## Testing
- npm run compile-tests
- npm run compile
- npm run lint
- npm test -- Formatters *(fails: vscode-test requires libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68efd6672b248324a04bb8c827a13bfa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Localizes progress view timestamps/tooltips via Intl with ISO fallbacks and updates tests to assert deterministic localized output.
> 
> - **Progress View**:
>   - **Timestamp formatting**: Use `Intl.DateTimeFormat` for localized `timeDisplay` and date; add `tooltipTimestamp`; keep ISO in `data-full-timestamp` with graceful fallbacks.
>   - **UI updates**: Switch tooltip/title attributes to use localized `tooltipTimestamp` in `format`, `modelResponse`, `progressStatus`, and `userMessage`.
>   - **Group headers**: `TaskGroupLevel.ROOT/NESTED` `formatTime` now localized with fallbacks.
> - **Tests**:
>   - Stub `Intl.DateTimeFormat` for deterministic outputs; add assertions for `data-full-timestamp`, timestamp titles, and displayed times.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2fe64899521f03222c4bf684d956fddee3605d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->