### PR TITLE
fix: align LaTeX command error handling

### DIFF
--- a/src/commands/latex/figCommands.ts
+++ b/src/commands/latex/figCommands.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - errors
+import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
@@ -74,11 +77,11 @@ async function handleExtractFigurePaths(): Promise<void> {
       );
     }
   } catch (err) {
-    logger.error(
+    await showLoggedErrorMessage(
       CHANNEL,
-      `Error in extractFigurePaths command: ${err instanceof Error ? err.message : String(err)}`,
+      'extractFigurePaths command failed',
+      err,
     );
-    vscode.window.showErrorMessage('Error extracting figure paths');
   }
 }
 
@@ -135,11 +138,11 @@ async function handleExtractTikzFigures(): Promise<void> {
       );
     }
   } catch (err) {
-    logger.error(
+    await showLoggedErrorMessage(
       CHANNEL,
-      `Error in extractTikzFigures command: ${err instanceof Error ? err.message : String(err)}`,
+      'extractTikzFigures command failed',
+      err,
     );
-    vscode.window.showErrorMessage('Error extracting TikZ figures');
   }
 }
 
@@ -214,11 +217,11 @@ async function handleCompileTikzFigures(): Promise<void> {
       },
     );
   } catch (err) {
-    logger.error(
+    await showLoggedErrorMessage(
       CHANNEL,
-      `Error in compileTikzFigures command: ${err instanceof Error ? err.message : String(err)}`,
+      'compileTikzFigures command failed',
+      err,
     );
-    vscode.window.showErrorMessage('Error compiling TikZ figures');
   }
 }
 

--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - errors
+import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
@@ -56,11 +59,11 @@ async function handleCountPdfPages(): Promise<void> {
       vscode.window.showErrorMessage('Could not count pages in the PDF');
     }
   } catch (err) {
-    logger.error(
+    await showLoggedErrorMessage(
       CHANNEL,
-      `Error in countPdfPages command: ${err instanceof Error ? err.message : String(err)}`,
+      'countPdfPages command failed',
+      err,
     );
-    vscode.window.showErrorMessage('Error counting PDF pages');
   }
 }
 
@@ -91,11 +94,11 @@ async function handleEncodeImageToBase64(): Promise<string | undefined> {
 
     return base64String;
   } catch (err) {
-    logger.error(
+    await showLoggedErrorMessage(
       CHANNEL,
-      `Error in encodeImageToBase64 command: ${err instanceof Error ? err.message : String(err)}`,
+      'encodeImageToBase64 command failed',
+      err,
     );
-    vscode.window.showErrorMessage('Error encoding image to base64');
     return undefined;
   }
 }
@@ -161,11 +164,11 @@ async function handleConvertPdfToImages(): Promise<
       return undefined;
     }
   } catch (err) {
-    logger.error(
+    await showLoggedErrorMessage(
       CHANNEL,
-      `Error in convertPdfToImages command: ${err instanceof Error ? err.message : String(err)}`,
+      'convertPdfToImages command failed',
+      err,
     );
-    vscode.window.showErrorMessage('Error converting PDF to images');
     return undefined;
   }
 }
@@ -220,29 +223,28 @@ async function handleTestPdfToImage(): Promise<string | undefined> {
 
     return base64String;
   } catch (err) {
-    if (err instanceof Error) {
-      logger.error(CHANNEL, `Error in testPdfToImage command: ${err.message}`);
-      logger.error(CHANNEL, `Error stack: ${err.stack}`); // Print stack trace
-    } else {
-      logger.error(CHANNEL, `Error in testPdfToImage command: ${String(err)}`);
-    }
+    await showLoggedErrorMessage(
+      CHANNEL,
+      'testPdfToImage command failed',
+      err,
+    );
 
-    // Show a more detailed error message if it's about missing dependencies
     if (
       err instanceof Error &&
       err.message.includes('GraphicsMagick/ImageMagick is not installed')
     ) {
-      vscode.window
-        .showErrorMessage(err.message, 'More Info')
+      void vscode.window
+        .showInformationMessage(
+          'GraphicsMagick/ImageMagick is required for PDF conversion. Open the download page?',
+          'Open Download Page',
+        )
         .then((selection) => {
-          if (selection === 'More Info') {
-            vscode.env.openExternal(
+          if (selection === 'Open Download Page') {
+            void vscode.env.openExternal(
               vscode.Uri.parse('http://www.graphicsmagick.org/download.html'),
             );
           }
         });
-    } else {
-      vscode.window.showErrorMessage('Error converting PDF to PNG');
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary
- replace manual logging in LaTeX figure commands with showLoggedErrorMessage for consistent telemetry
- update LaTeX image commands to use logged error helpers and provide an informational GraphicsMagick prompt

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f01753271c8324b5390e04134a5cdb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace ad-hoc logging with `showLoggedErrorMessage` in LaTeX figure/image commands and refine the GraphicsMagick dependency prompt.
> 
> - **Error handling**:
>   - Replace manual `logger.error` + `showErrorMessage` with `await showLoggedErrorMessage(...)` in:
>     - `src/commands/latex/figCommands.ts`: `handleExtractFigurePaths`, `handleExtractTikzFigures`, `handleCompileTikzFigures`.
>     - `src/commands/latex/imageCommands.ts`: `handleCountPdfPages`, `handleEncodeImageToBase64`, `handleConvertPdfToImages`, `handleTestPdfToImage`.
> - **User messaging**:
>   - In `handleTestPdfToImage`, switch dependency notice to `showInformationMessage` with "Open Download Page" action and keep external link to GraphicsMagick download.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5230bedd714c4e99ef3306ef9d8185a8a9a4e09b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->