### PR TITLE
Refactor PDF selection helper in image commands

### DIFF
--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -5,7 +5,8 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
-import { selectFile } from '@utils/dialogs';
+import * as dialogUtils from '@utils/dialogs';
+import { WorkspaceFS } from '@utils/files';
 import {
   countPdfPages,
   getBase64EncodedMedia,
@@ -15,6 +16,38 @@ import {
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);
+
+interface PdfSelectionResult {
+  relativePath: string;
+  absolutePath: string;
+}
+
+/**
+ * Prompts the user to select a PDF file within the current workspace.
+ * Returns both the workspace-relative and absolute paths for downstream
+ * consumers. Returns null when the workspace is unavailable or the user
+ * cancels the dialog.
+ */
+export async function selectPdfFileFromWorkspace(): Promise<PdfSelectionResult | null> {
+  if (!WorkspaceFS.getPath()) {
+    vscode.window.showErrorMessage('No workspace folder open');
+    return null;
+  }
+
+  const relativePath = await dialogUtils.selectFile({
+    openLabel: 'Select PDF file',
+    filters: {
+      'PDF files': ['pdf'],
+    },
+  });
+
+  if (!relativePath) {
+    return null;
+  }
+
+  const absolutePath = WorkspaceFS.fullPath(relativePath);
+  return { relativePath, absolutePath };
+}
 
 export function registerImageCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -36,20 +69,17 @@ export function registerImageCommands(context: vscode.ExtensionContext) {
 
 async function handleCountPdfPages(): Promise<void> {
   try {
-    const selectedFile = await selectFile({
-      openLabel: 'Select PDF file',
-      filters: {
-        'PDF files': ['pdf'],
-      },
-    });
-
-    if (!selectedFile) {
+    const selection = await selectPdfFileFromWorkspace();
+    if (!selection) {
       return;
     }
 
-    logger.debug(CHANNEL, `Processing PDF file: ${selectedFile}`);
+    logger.debug(
+      CHANNEL,
+      `Processing PDF file: ${selection.relativePath} (resolved: ${selection.absolutePath})`,
+    );
 
-    const pageCount = await countPdfPages(selectedFile);
+    const pageCount = await countPdfPages(selection.relativePath);
     if (pageCount > 0) {
       vscode.window.showInformationMessage(`The PDF has ${pageCount} pages`);
     } else {
@@ -66,7 +96,7 @@ async function handleCountPdfPages(): Promise<void> {
 
 async function handleEncodeImageToBase64(): Promise<string | undefined> {
   try {
-    const selectedFile = await selectFile({
+    const selectedFile = await dialogUtils.selectFile({
       openLabel: 'Select file',
       filters: {
         'Image files': ['png', 'jpg', 'jpeg', 'gif', 'heic', 'heif', 'webp'],
@@ -104,18 +134,15 @@ async function handleConvertPdfToImages(): Promise<
   string[] | string | undefined
 > {
   try {
-    const selectedFile = await selectFile({
-      openLabel: 'Select PDF file',
-      filters: {
-        'PDF files': ['pdf'],
-      },
-    });
-
-    if (!selectedFile) {
+    const selection = await selectPdfFileFromWorkspace();
+    if (!selection) {
       return undefined;
     }
 
-    logger.debug(CHANNEL, `Processing PDF file: ${selectedFile}`);
+    logger.debug(
+      CHANNEL,
+      `Processing PDF file: ${selection.relativePath} (resolved: ${selection.absolutePath})`,
+    );
 
     // Get quality from user
     const quality = await vscode.window.showInputBox({
@@ -146,7 +173,7 @@ async function handleConvertPdfToImages(): Promise<
     });
 
     const result = await processPdf2Png(
-      selectedFile,
+      selection.relativePath,
       maxPages ? parseInt(maxPages) : undefined,
       parseInt(quality),
     );
@@ -172,18 +199,15 @@ async function handleConvertPdfToImages(): Promise<
 
 async function handleTestPdfToImage(): Promise<string | undefined> {
   try {
-    const selectedFile = await selectFile({
-      openLabel: 'Select PDF file',
-      filters: {
-        'PDF files': ['pdf'],
-      },
-    });
-
-    if (!selectedFile) {
+    const selection = await selectPdfFileFromWorkspace();
+    if (!selection) {
       return undefined;
     }
 
-    logger.debug(CHANNEL, `Testing PDF to PNG conversion for: ${selectedFile}`);
+    logger.debug(
+      CHANNEL,
+      `Testing PDF to PNG conversion for: ${selection.relativePath} (resolved: ${selection.absolutePath})`,
+    );
 
     // Get page number from user
     const pageNum = await vscode.window.showInputBox({
@@ -201,7 +225,7 @@ async function handleTestPdfToImage(): Promise<string | undefined> {
 
     // Convert single page
     const base64String = await singlePagePdf2Png(
-      selectedFile,
+      selection.relativePath,
       parseInt(pageNum),
       300,
       [1024, 1024],
@@ -215,7 +239,7 @@ async function handleTestPdfToImage(): Promise<string | undefined> {
     );
 
     vscode.window.showInformationMessage(
-      `Successfully converted page ${pageNum} of ${selectedFile} to PNG`,
+      `Successfully converted page ${pageNum} of ${selection.relativePath} to PNG`,
     );
 
     return base64String;

--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -6,7 +6,6 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import * as dialogUtils from '@utils/dialogs';
-import { WorkspaceFS } from '@utils/files';
 import {
   countPdfPages,
   getBase64EncodedMedia,
@@ -16,38 +15,6 @@ import {
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);
-
-interface PdfSelectionResult {
-  relativePath: string;
-  absolutePath: string;
-}
-
-/**
- * Prompts the user to select a PDF file within the current workspace.
- * Returns both the workspace-relative and absolute paths for downstream
- * consumers. Returns null when the workspace is unavailable or the user
- * cancels the dialog.
- */
-export async function selectPdfFileFromWorkspace(): Promise<PdfSelectionResult | null> {
-  if (!WorkspaceFS.getPath()) {
-    vscode.window.showErrorMessage('No workspace folder open');
-    return null;
-  }
-
-  const relativePath = await dialogUtils.selectFile({
-    openLabel: 'Select PDF file',
-    filters: {
-      'PDF files': ['pdf'],
-    },
-  });
-
-  if (!relativePath) {
-    return null;
-  }
-
-  const absolutePath = WorkspaceFS.fullPath(relativePath);
-  return { relativePath, absolutePath };
-}
 
 export function registerImageCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -69,7 +36,12 @@ export function registerImageCommands(context: vscode.ExtensionContext) {
 
 async function handleCountPdfPages(): Promise<void> {
   try {
-    const selection = await selectPdfFileFromWorkspace();
+    const selection = await dialogUtils.selectFileFromWorkspace({
+      openLabel: 'Select PDF file',
+      filters: {
+        'PDF files': ['pdf'],
+      },
+    });
     if (!selection) {
       return;
     }
@@ -96,7 +68,7 @@ async function handleCountPdfPages(): Promise<void> {
 
 async function handleEncodeImageToBase64(): Promise<string | undefined> {
   try {
-    const selectedFile = await dialogUtils.selectFile({
+    const selection = await dialogUtils.selectFileFromWorkspace({
       openLabel: 'Select file',
       filters: {
         'Image files': ['png', 'jpg', 'jpeg', 'gif', 'heic', 'heif', 'webp'],
@@ -104,13 +76,16 @@ async function handleEncodeImageToBase64(): Promise<string | undefined> {
       },
     });
 
-    if (!selectedFile) {
+    if (!selection) {
       return undefined;
     }
 
-    logger.debug(CHANNEL, `Processing image file: ${selectedFile}`);
+    logger.debug(
+      CHANNEL,
+      `Processing image file: ${selection.relativePath} (resolved: ${selection.absolutePath})`,
+    );
 
-    const base64String = await getBase64EncodedMedia(selectedFile);
+    const base64String = await getBase64EncodedMedia(selection.relativePath);
 
     // Also show a truncated version in the debug log for quick verification
     const truncatedString = base64String.substring(0, 100) + '...';
@@ -134,7 +109,12 @@ async function handleConvertPdfToImages(): Promise<
   string[] | string | undefined
 > {
   try {
-    const selection = await selectPdfFileFromWorkspace();
+    const selection = await dialogUtils.selectFileFromWorkspace({
+      openLabel: 'Select PDF file',
+      filters: {
+        'PDF files': ['pdf'],
+      },
+    });
     if (!selection) {
       return undefined;
     }
@@ -199,7 +179,12 @@ async function handleConvertPdfToImages(): Promise<
 
 async function handleTestPdfToImage(): Promise<string | undefined> {
   try {
-    const selection = await selectPdfFileFromWorkspace();
+    const selection = await dialogUtils.selectFileFromWorkspace({
+      openLabel: 'Select PDF file',
+      filters: {
+        'PDF files': ['pdf'],
+      },
+    });
     if (!selection) {
       return undefined;
     }

--- a/src/test/commands/latex/imageCommands.test.ts
+++ b/src/test/commands/latex/imageCommands.test.ts
@@ -1,0 +1,98 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - commands
+import { selectPdfFileFromWorkspace } from '@commands/latex/imageCommands';
+
+// Local imports - utilities
+import * as dialogUtils from '@utils/dialogs';
+import { WorkspaceFS } from '@utils/files';
+
+describe('imageCommands.selectPdfFileFromWorkspace', () => {
+  type DialogUtilsMutable = {
+    selectFile: typeof dialogUtils.selectFile;
+  };
+
+  type WorkspaceFsMutable = {
+    getPath: typeof WorkspaceFS.getPath;
+    fullPath: typeof WorkspaceFS.fullPath;
+  };
+
+  const dialogs = dialogUtils as unknown as DialogUtilsMutable;
+  const workspaceFs = WorkspaceFS as unknown as WorkspaceFsMutable;
+
+  const originalSelectFile = dialogs.selectFile;
+  const originalGetPath = workspaceFs.getPath;
+  const originalFullPath = workspaceFs.fullPath;
+  const originalShowErrorMessage = vscode.window.showErrorMessage;
+
+  let errorMessages: string[];
+  let selectFileCalls: number;
+
+  beforeEach(() => {
+    errorMessages = [];
+    selectFileCalls = 0;
+
+    dialogs.selectFile = async () => {
+      selectFileCalls += 1;
+      return null;
+    };
+
+    workspaceFs.getPath = () => '/mock/workspace';
+    workspaceFs.fullPath = (relativePath: string) =>
+      `/mock/workspace/${relativePath}`;
+
+    (vscode.window as any).showErrorMessage = (message: string) => {
+      errorMessages.push(message);
+      return Promise.resolve(undefined);
+    };
+  });
+
+  afterEach(() => {
+    dialogs.selectFile = originalSelectFile;
+    workspaceFs.getPath = originalGetPath;
+    workspaceFs.fullPath = originalFullPath;
+    (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+  });
+
+  it('returns null when the user cancels the picker', async () => {
+    dialogs.selectFile = async () => {
+      selectFileCalls += 1;
+      return null;
+    };
+
+    const result = await selectPdfFileFromWorkspace();
+
+    assert.strictEqual(result, null);
+    assert.strictEqual(selectFileCalls, 1);
+    assert.deepStrictEqual(errorMessages, []);
+  });
+
+  it('returns selection with relative and absolute paths when available', async () => {
+    dialogs.selectFile = async () => {
+      selectFileCalls += 1;
+      return 'docs/sample.pdf';
+    };
+
+    const result = await selectPdfFileFromWorkspace();
+
+    assert.ok(result);
+    assert.strictEqual(result?.relativePath, 'docs/sample.pdf');
+    assert.strictEqual(result?.absolutePath, '/mock/workspace/docs/sample.pdf');
+    assert.strictEqual(selectFileCalls, 1);
+    assert.deepStrictEqual(errorMessages, []);
+  });
+
+  it('returns null and shows an error when no workspace is open', async () => {
+    workspaceFs.getPath = () => undefined;
+
+    const result = await selectPdfFileFromWorkspace();
+
+    assert.strictEqual(result, null);
+    assert.strictEqual(selectFileCalls, 0);
+    assert.deepStrictEqual(errorMessages, ['No workspace folder open']);
+  });
+});

--- a/src/test/commands/latex/imageCommands.test.ts
+++ b/src/test/commands/latex/imageCommands.test.ts
@@ -4,14 +4,11 @@ import { strict as assert } from 'assert';
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - commands
-import { selectPdfFileFromWorkspace } from '@commands/latex/imageCommands';
-
 // Local imports - utilities
 import * as dialogUtils from '@utils/dialogs';
 import { WorkspaceFS } from '@utils/files';
 
-describe('imageCommands.selectPdfFileFromWorkspace', () => {
+describe('dialogs.selectFileFromWorkspace', () => {
   type DialogUtilsMutable = {
     selectFile: typeof dialogUtils.selectFile;
   };
@@ -64,7 +61,10 @@ describe('imageCommands.selectPdfFileFromWorkspace', () => {
       return null;
     };
 
-    const result = await selectPdfFileFromWorkspace();
+    const result = await dialogUtils.selectFileFromWorkspace({
+      openLabel: 'Select file',
+      filters: { 'PDF files': ['pdf'] },
+    });
 
     assert.strictEqual(result, null);
     assert.strictEqual(selectFileCalls, 1);
@@ -77,9 +77,12 @@ describe('imageCommands.selectPdfFileFromWorkspace', () => {
       return 'docs/sample.pdf';
     };
 
-    const result = await selectPdfFileFromWorkspace();
+    const result = await dialogUtils.selectFileFromWorkspace({
+      openLabel: 'Select file',
+      filters: { 'PDF files': ['pdf'] },
+    });
 
-    assert.ok(result);
+    assert.ok(result, 'Expected result to be defined');
     assert.strictEqual(result?.relativePath, 'docs/sample.pdf');
     assert.strictEqual(result?.absolutePath, '/mock/workspace/docs/sample.pdf');
     assert.strictEqual(selectFileCalls, 1);
@@ -89,7 +92,10 @@ describe('imageCommands.selectPdfFileFromWorkspace', () => {
   it('returns null and shows an error when no workspace is open', async () => {
     workspaceFs.getPath = () => undefined;
 
-    const result = await selectPdfFileFromWorkspace();
+    const result = await dialogUtils.selectFileFromWorkspace({
+      openLabel: 'Select file',
+      filters: { 'PDF files': ['pdf'] },
+    });
 
     assert.strictEqual(result, null);
     assert.strictEqual(selectFileCalls, 0);

--- a/src/utils/dialogs.ts
+++ b/src/utils/dialogs.ts
@@ -69,3 +69,32 @@ export async function selectFile(
   const paths = await selectFiles({ ...options, allowMany: false });
   return paths ? paths[0] : null;
 }
+
+export interface FileSelectionResult {
+  relativePath: string;
+  absolutePath: string;
+}
+
+/**
+ * Prompts the user to select a file within the current workspace.
+ * Returns both the workspace-relative and absolute paths for downstream
+ * consumers. Returns null when the workspace is unavailable or the user
+ * cancels the dialog.
+ */
+export async function selectFileFromWorkspace(
+  options: FileDialogOptions,
+): Promise<FileSelectionResult | null> {
+  if (!WorkspaceFS.getPath()) {
+    vscode.window.showErrorMessage('No workspace folder open');
+    return null;
+  }
+
+  const relativePath = await selectFile(options);
+
+  if (!relativePath) {
+    return null;
+  }
+
+  const absolutePath = WorkspaceFS.fullPath(relativePath);
+  return { relativePath, absolutePath };
+}


### PR DESCRIPTION
## Summary
- add a selectPdfFileFromWorkspace helper that wraps the PDF picker and returns relative/absolute paths
- reuse the helper inside the PDF commands to remove the duplicated selection logic
- add unit tests covering the helper behavior for success, cancellation, and missing workspace cases

## Testing
- npm run lint
- npm run compile-tests
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68f017621ad08324a3100b272a2a11b6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `selectPdfFileFromWorkspace` to return relative/absolute paths and refactor PDF commands to use it, with new unit tests.
> 
> - **LaTeX image commands**:
>   - **Helper**: Add `selectPdfFileFromWorkspace` using `dialogUtils.selectFile` and `WorkspaceFS` to return both `relativePath` and `absolutePath`.
>   - **Refactor commands**: Update `handleCountPdfPages`, `handleConvertPdfToImages`, and `handleTestPdfToImage` to use the helper, pass `relativePath` to processing functions, and improve debug logging with resolved paths.
>   - Switch `handleEncodeImageToBase64` to `dialogUtils.selectFile`.
> - **Tests**:
>   - Add `src/test/commands/latex/imageCommands.test.ts` covering helper success, cancellation, and missing workspace cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fac8ed3a2b7d4f72a5df41d27cd19e2743e813a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->