### PR TITLE
refactor: hydrate main view state via managers

### DIFF
--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -138,6 +138,11 @@ class MainViewDomHandler extends BaseDomHandler {
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS,
       });
     });
+
+    latexdiffManager.hydrate(mainViewState.get());
+    outputFilesManager.hydrate(mainViewState.get(), {
+      fallbackToAgentDefaults: true,
+    });
   }
 
   cleanupUI() {

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -18,9 +18,7 @@ import {
   safeGetElementChecked,
   safeSetElementValue,
   safeSetElementChecked,
-  setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
 import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { WebviewStateManager } from '@common/webviewState.js';
 
@@ -46,6 +44,8 @@ function getSelectDefaultValue(selectId, fallback) {
 export class MainViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
+    this._latexdiffManager = null;
+    this._outputFilesManager = null;
   }
 
   get() {
@@ -58,6 +58,14 @@ export class MainViewState {
 
   update(partial) {
     this.stateManager.update(partial);
+  }
+
+  registerLatexdiffManager(manager) {
+    this._latexdiffManager = manager;
+  }
+
+  registerOutputFilesManager(manager) {
+    this._outputFilesManager = manager;
   }
 
   /** Initialize UI with default state */
@@ -77,22 +85,14 @@ export class MainViewState {
     }
 
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const toggleId = `toggle${capitalize(id)}`;
-      fileList.setVisibility(id, toggleId, false);
-      const listDiv = safeGetElementById(id);
-      if (listDiv) {
-        listDiv.innerHTML = '';
-      }
+      fileList.hydrate(id, { files: [], visible: false });
     });
 
-    const latexdiffsContent = safeGetElementById(
-      ELEMENT_IDS.LATEXDIFFS_CONTENT,
+    this._latexdiffManager?.hydrate({ latexdiffsVisible: false });
+    this._outputFilesManager?.hydrate(
+      { outputFiles: [], outputFilesActive: false, inputFiles: [] },
+      { visible: false, fallbackToAgentDefaults: false },
     );
-    const toggleLatexdiffs = safeGetElementById(ELEMENT_IDS.TOGGLE_LATEXDIFFS);
-    if (latexdiffsContent && toggleLatexdiffs) {
-      latexdiffsContent.style.display = 'none';
-      setChevronIcon(toggleLatexdiffs, false);
-    }
 
     this.save();
   }
@@ -176,42 +176,18 @@ export class MainViewState {
       }
 
       MULTIPLE_SELECTIONS.forEach((id) => {
-        const toggleId = `toggle${capitalize(id)}`;
-        const selectDiv = safeGetElementById(id);
-        if (!selectDiv) {
-          console.warn(`Element with id '${id}' not found`);
-          return;
-        }
-        selectDiv.innerHTML = '';
-
-        const filesArray = previousState[id] ?? [];
-        const isVisible = previousState[`${id}Visible`];
-
-        if (filesArray && filesArray.length > 0) {
-          filesArray.forEach((file) => {
-            fileList.add(id, file);
-          });
-          fileList.setVisibility(
-            id,
-            toggleId,
-            isVisible !== undefined ? isVisible : true,
-          );
-        } else {
-          fileList.setVisibility(id, toggleId, false);
-        }
+        const filesArray = Array.isArray(previousState[id])
+          ? previousState[id]
+          : [];
+        const visible =
+          previousState[`${id}Active`] ??
+          previousState[`${id}Visible`] ??
+          (filesArray.length > 0 ? true : false);
+        fileList.hydrate(id, { files: filesArray, visible });
       });
 
-      const latexdiffsContent = safeGetElementById(
-        ELEMENT_IDS.LATEXDIFFS_CONTENT,
-      );
-      const toggleLatexdiffs = safeGetElementById(
-        ELEMENT_IDS.TOGGLE_LATEXDIFFS,
-      );
-      if (latexdiffsContent && toggleLatexdiffs) {
-        const visible = previousState.latexdiffsVisible ?? false;
-        latexdiffsContent.style.display = visible ? 'block' : 'none';
-        setChevronIcon(toggleLatexdiffs, visible);
-      }
+      this._latexdiffManager?.hydrate(previousState);
+      this._outputFilesManager?.hydrate(previousState);
 
       this.applySessionType(
         normalizedValues.sessionType ?? defaults.sessionType,
@@ -222,6 +198,10 @@ export class MainViewState {
     }
 
     fileList.hideEmpty(MULTIPLE_SELECTIONS);
+
+    if (previousState) {
+      this.save();
+    }
   }
 
   /** Persist current UI state */
@@ -247,8 +227,9 @@ export class MainViewState {
       const elementDiv = safeGetElementById(id);
       if (!elementDiv) return;
       const containerDiv = safeGetElementById(`${id}Container`);
-      state[`${id}Visible`] =
-        containerDiv && containerDiv.style.display === 'block';
+      const isVisible = containerDiv && containerDiv.style.display === 'block';
+      state[`${id}Visible`] = isVisible;
+      state[`${id}Active`] = isVisible;
       state[id] = fileList.getSelected(elementDiv);
     });
 

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -15,6 +15,35 @@ export class FileList {
     this._saveFn = saveFn;
   }
 
+  /**
+   * Hydrate a list container with the provided files and visibility state.
+   * @param {string} containerId - The list element ID
+   * @param {object} options - Hydration options
+   * @param {string[]} options.files - Files to render inside the list
+   * @param {boolean} [options.visible] - Optional visibility override
+   * @param {string} [options.placeholder] - Placeholder text when list is empty
+   */
+  hydrate(containerId, { files = [], visible, placeholder } = {}) {
+    const listDiv = safeGetElementById(containerId);
+    if (!listDiv) return;
+
+    listDiv.innerHTML = '';
+
+    if (Array.isArray(files) && files.length > 0) {
+      files.forEach((file) => this.add(containerId, file));
+    } else if (placeholder) {
+      const placeholderEl = document.createElement('div');
+      placeholderEl.className = 'file-list-placeholder';
+      placeholderEl.textContent = placeholder;
+      listDiv.appendChild(placeholderEl);
+    }
+
+    if (typeof visible === 'boolean') {
+      const toggleId = `toggle${capitalize(containerId)}`;
+      this.setVisibility(containerId, toggleId, visible);
+    }
+  }
+
   /** Set the callback used to persist state */
   setSaveFn(saveFn) {
     this._saveFn = typeof saveFn === 'function' ? saveFn : () => {};

--- a/src/webview/modules/uiManagers/LatexdiffManager.js
+++ b/src/webview/modules/uiManagers/LatexdiffManager.js
@@ -14,18 +14,15 @@ export class LatexdiffManager {
     this.state = state;
   }
 
-  /** Initialize the LaTeX diffs section based on stored state */
-  initializeLatexdiffsSection() {
+  /** Hydrate the LaTeX diffs section based on persisted state */
+  hydrate(persistedState = this.state.get()) {
     const container = safeGetElementById(LATEXDIFF_CONTENT_ID);
     const toggleIcon = safeGetElementById(TOGGLE_LATEXDIFFS_ID);
+    if (!container || !toggleIcon) return;
 
-    if (container && toggleIcon) {
-      const state = this.state.get();
-      const shouldShow = state && state.latexdiffsVisible;
-
-      container.style.display = shouldShow ? 'block' : 'none';
-      setChevronIcon(toggleIcon, shouldShow);
-    }
+    const shouldShow = Boolean(persistedState?.latexdiffsVisible);
+    container.style.display = shouldShow ? 'block' : 'none';
+    setChevronIcon(toggleIcon, shouldShow);
   }
 
   /** Toggle the LaTeX diffs section */
@@ -44,3 +41,4 @@ export class LatexdiffManager {
 }
 
 export const latexdiffManager = new LatexdiffManager(mainViewState);
+mainViewState.registerLatexdiffManager(latexdiffManager);

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -3,7 +3,7 @@ import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
-import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 const INPUT_FILE_ID = INPUT_FILE;
 const OUTPUT_FILES_ID = ELEMENT_IDS.OUTPUT_FILES;
@@ -20,54 +20,73 @@ export class OutputFilesManager {
     this.fileSelect = select;
   }
 
-  /** Initialize the output files list with the input file */
-  initializeOutputFiles() {
-    const state = this.state.get();
+  /** Hydrate the output files list and container from persisted state */
+  hydrate(persistedState = this.state.get() ?? {}, options = {}) {
+    const { fallbackToAgentDefaults = true, visible } = options;
+
     const inputFileDiv = safeGetElementById(INPUT_FILE_ID);
     const outputFilesDiv = safeGetElementById(OUTPUT_FILES_ID);
     if (!outputFilesDiv) return;
 
-    outputFilesDiv.innerHTML = '';
     const inputFile = inputFileDiv?.value;
+    const stateOutputs = Array.isArray(persistedState.outputFiles)
+      ? persistedState.outputFiles.filter(Boolean)
+      : [];
 
-    if (inputFile) {
-      if (state.outputFiles && state.outputFiles.length > 0) {
-        state.outputFiles.forEach((file) => {
-          this.fileList.add(OUTPUT_FILES_ID, file);
-        });
-      } else if (
-        this.fileSelect.getAgentDefaultOutputFiles().length > 0 &&
-        (!state.outputFiles || state.outputFiles.length === 0)
-      ) {
-        this.fileSelect.getAgentDefaultOutputFiles().forEach((file) => {
-          this.fileList.add(OUTPUT_FILES_ID, file);
+    const derivedOutputs = [...stateOutputs];
+
+    if (derivedOutputs.length === 0 && fallbackToAgentDefaults && inputFile) {
+      const agentDefaults = this.fileSelect.getAgentDefaultOutputFiles();
+      if (agentDefaults.length > 0) {
+        agentDefaults.forEach((file) => {
+          if (!derivedOutputs.includes(file)) {
+            derivedOutputs.push(file);
+          }
         });
       } else {
-        this.fileList.add(OUTPUT_FILES_ID, inputFileDiv?.value);
-        if (state.inputFiles && state.inputFiles.length > 0) {
-          state.inputFiles.forEach((file) => {
-            if (file !== inputFile) {
-              this.fileList.add(OUTPUT_FILES_ID, file);
-            }
-          });
-        }
+        derivedOutputs.push(inputFile);
+        const additionalInputs = Array.isArray(persistedState.inputFiles)
+          ? persistedState.inputFiles
+          : [];
+        additionalInputs.forEach((file) => {
+          if (file && file !== inputFile && !derivedOutputs.includes(file)) {
+            derivedOutputs.push(file);
+          }
+        });
       }
     }
 
-    const openedFiles = this.state.get()?.openedFiles ?? [];
+    const openedFiles = Array.isArray(persistedState.openedFiles)
+      ? persistedState.openedFiles
+      : [];
     openedFiles.forEach((file) => {
-      this.fileList.add(OUTPUT_FILES_ID, file);
+      if (file && !derivedOutputs.includes(file)) {
+        derivedOutputs.push(file);
+      }
     });
 
-    if (outputFilesDiv.children.length === 0) {
-      const placeholder = document.createElement('div');
-      placeholder.className = 'file-list-placeholder';
-      placeholder.textContent =
-        'No extra outputs selected. Click "Add" to choose files.';
-      outputFilesDiv.appendChild(placeholder);
-    }
+    const visibility =
+      typeof visible === 'boolean'
+        ? visible
+        : Boolean(
+            persistedState.outputFilesActive ??
+              persistedState.outputFilesVisible,
+          );
 
-    this.state.save();
+    this.fileList.hydrate(OUTPUT_FILES_ID, {
+      files: derivedOutputs,
+      visible: visibility,
+      placeholder: 'No extra outputs selected. Click "Add" to choose files.',
+    });
+
+    const listDiv = safeGetElementById(OUTPUT_FILES_ID);
+    if (listDiv) {
+      const resolvedOutputs = this.fileList.getSelected(listDiv);
+      this.state.update({
+        outputFiles: resolvedOutputs,
+        outputFilesActive: visibility,
+      });
+    }
   }
 
   /** Toggle visibility of the output files container */
@@ -78,24 +97,10 @@ export class OutputFilesManager {
     const containerVisible = container.style.display !== 'none';
 
     if (!containerVisible) {
-      this.initializeOutputFiles();
+      this.hydrate(this.state.get(), { fallbackToAgentDefaults: true });
     }
 
     this.fileList.toggle(OUTPUT_FILES_ID, TOGGLE_OUTPUT_FILES_ID);
-  }
-
-  /** Initialize the output files container based on state */
-  initializeOutputContainer() {
-    const container = safeGetElementById(OUTPUT_FILES_CONTAINER_ID);
-    const toggleIcon = safeGetElementById(TOGGLE_OUTPUT_FILES_ID);
-
-    if (container && toggleIcon) {
-      const state = this.state.get();
-      const shouldShow = state && state.outputFilesActive;
-
-      container.style.display = shouldShow ? 'block' : 'none';
-      setChevronIcon(toggleIcon, shouldShow);
-    }
   }
 }
 
@@ -104,3 +109,4 @@ export const outputFilesManager = new OutputFilesManager(
   fileList,
   fileSelect,
 );
+mainViewState.registerOutputFilesManager(outputFilesManager);


### PR DESCRIPTION
## Summary
- add hydration helpers to the file list, LaTeX diff, and output file managers so they can rebuild their DOM state from persisted data
- refactor `MainViewState` and startup flows to delegate UI restoration to these managers instead of manipulating DOM nodes directly

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f0179367a88324ae9fe285b7301099

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce hydrate methods for `FileList`, `LatexdiffManager`, and `OutputFilesManager` and refactor `MainViewState`/startup to use them, persisting visibility/active flags.
> 
> - **Webview State & Restoration**:
>   - `MainViewState`: adds manager registration (`registerLatexdiffManager`, `registerOutputFilesManager`), uses manager/file list `hydrate` in `setDefaults` and `restore`, and saves both `...Visible` and `...Active` flags.
>   - Updates visibility logic to derive `...Active`/`...Visible` and persist them on save.
> - **UI Managers**:
>   - `FileList`: new `hydrate(containerId, { files, visible, placeholder })` to rebuild lists and set visibility.
>   - `LatexdiffManager`: replaces `initializeLatexdiffsSection` with `hydrate(persistedState)`; registers with `MainViewState`.
>   - `OutputFilesManager`: new `hydrate(persistedState, { fallbackToAgentDefaults, visible })` to build output files from state/agent defaults/input/opened files; updates `toggleOutputFiles` to call `hydrate`; removes `initializeOutputContainer`; registers with `MainViewState`.
> - **Startup**:
>   - `domHandlers`: hydrates LaTeX diffs and output files on init (with agent-default fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a20eeda9dff43681d252d24a18a00ae6bb0cb9b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->