### PR TITLE
refactor: centralize main view context retrieval

### DIFF
--- a/src/test/webview/currentContextHelper.test.ts
+++ b/src/test/webview/currentContextHelper.test.ts
@@ -1,0 +1,167 @@
+// @ts-nocheck
+/* eslint-env mocha */
+
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+// @ts-ignore: jsdom lacks ESM typings in this context
+import { JSDOM } from 'jsdom';
+
+// Local imports - webview
+// Webview modules are authored in JavaScript without type declarations.
+// @ts-ignore
+import {
+  MULTIPLE_SELECTIONS,
+  CHECK_BOXES,
+  ELEMENT_IDS,
+} from '../../webview/modules/constants.js';
+// Helper module is authored in JavaScript as well.
+// @ts-ignore
+import { collectCurrentContext } from '../../webview/modules/state/currentContext.js';
+
+function createSelect(id: string, value: string) {
+  const select = document.createElement('select');
+  select.id = id;
+  const option = document.createElement('option');
+  option.value = value;
+  option.textContent = value;
+  option.selected = true;
+  select.appendChild(option);
+  document.body.appendChild(select);
+  return select;
+}
+
+function createInput(id: string, value: string) {
+  const input = document.createElement('input');
+  input.id = id;
+  input.value = value;
+  document.body.appendChild(input);
+  return input;
+}
+
+function createCheckbox(id: string, checked: boolean) {
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.id = id;
+  checkbox.checked = checked;
+  document.body.appendChild(checkbox);
+  return checkbox;
+}
+
+function createFileList(
+  id: string,
+  display: 'block' | 'none',
+  files: string[],
+) {
+  const container = document.createElement('div');
+  container.id = `${id}Container`;
+  container.style.display = display;
+  document.body.appendChild(container);
+
+  const list = document.createElement('div');
+  list.id = id;
+  container.appendChild(list);
+
+  files.forEach((file) => {
+    const item = document.createElement('div');
+    item.className = 'file-item';
+    item.dataset.path = file;
+    list.appendChild(item);
+  });
+
+  return { container, list };
+}
+
+describe('collectCurrentContext', () => {
+  let dom: any;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+    (globalThis as any).window = dom.window;
+    (globalThis as any).document = dom.window.document;
+    (globalThis as any).HTMLElement = dom.window.HTMLElement;
+    (globalThis as any).HTMLInputElement = dom.window.HTMLInputElement;
+    (globalThis as any).HTMLSelectElement = dom.window.HTMLSelectElement;
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+    delete (globalThis as any).HTMLElement;
+    delete (globalThis as any).HTMLInputElement;
+    delete (globalThis as any).HTMLSelectElement;
+  });
+
+  function bootstrapDom(sessionType: 'workflow' | 'toolUse') {
+    createInput('sessionType', sessionType);
+    createSelect('workflowAgent', 'workflowAgentValue');
+    createSelect('toolUseAgent', 'toolUseAgentValue');
+
+    createInput('inputFile', 'main.tex');
+    createInput('referenceFile', 'references.bib');
+    createInput('auxiliaryFile', 'aux.log');
+    createInput('mediaFile', 'figure.png');
+
+    MULTIPLE_SELECTIONS.forEach((id: string) => {
+      if (id === ELEMENT_IDS.OUTPUT_FILES) {
+        createFileList(id, 'block', ['output.pdf']);
+        return;
+      }
+      if (id === 'inputFiles') {
+        createFileList(id, 'block', ['main.tex', 'chapter1.tex']);
+        return;
+      }
+      createFileList(id, 'none', []);
+    });
+
+    CHECK_BOXES.forEach((id: string, index: number) => {
+      createCheckbox(id, index % 2 === 0);
+    });
+  }
+
+  it('aggregates workflow context including filtered single selections', () => {
+    bootstrapDom('workflow');
+
+    const context = collectCurrentContext();
+
+    assert.equal(context.sessionType, 'workflow');
+    assert.equal(context.agent, 'workflowAgentValue');
+    assert.equal(context.isToolUseAgent, false);
+
+    assert.deepEqual(context.singleFileSelections, {
+      inputFile: 'main.tex',
+      referenceFile: 'references.bib',
+      auxiliaryFile: 'aux.log',
+      mediaFile: 'figure.png',
+    });
+
+    assert.deepEqual(context.multipleFileSelections.inputFiles, [
+      'chapter1.tex',
+    ]);
+    assert.equal(context.multipleFileSelections.inputFilesActive, true);
+
+    assert.deepEqual(context.multipleFileSelections.outputFiles, [
+      'output.pdf',
+    ]);
+    assert.equal(context.multipleFileSelections.outputFilesActive, true);
+
+    CHECK_BOXES.forEach((id: string, index: number) => {
+      assert.equal(context.checkboxValues[id], index % 2 === 0);
+    });
+  });
+
+  it('uses tool-use agent selection and respects inactive lists', () => {
+    bootstrapDom('toolUse');
+
+    const context = collectCurrentContext();
+
+    assert.equal(context.sessionType, 'toolUse');
+    assert.equal(context.agent, 'toolUseAgentValue');
+    assert.equal(context.isToolUseAgent, true);
+
+    assert.equal(context.multipleFileSelections.referenceFilesActive, false);
+    assert.deepEqual(context.multipleFileSelections.referenceFiles, []);
+  });
+});

--- a/src/webview/modules/state/currentContext.js
+++ b/src/webview/modules/state/currentContext.js
@@ -1,0 +1,107 @@
+// Local imports - webview
+import {
+  MULTIPLE_SELECTIONS,
+  CHECK_BOXES,
+  ELEMENT_IDS,
+  SESSION_TYPES,
+  SESSION_TYPE_INPUT,
+  AGENT_SELECT_IDS,
+} from '../constants.js';
+import { fileList as defaultFileList } from '../uiManagers/FileList.js';
+import {
+  safeGetElementById,
+  safeGetElementValue,
+  safeGetElementChecked,
+} from '@common/domUtils.js';
+
+const DEFAULT_SINGLE_FILE_TYPES = ['input', 'reference', 'auxiliary', 'media'];
+
+function getSessionType() {
+  const sessionTypeElement = safeGetElementById(SESSION_TYPE_INPUT);
+  if (
+    sessionTypeElement instanceof HTMLInputElement &&
+    sessionTypeElement.value
+  ) {
+    return sessionTypeElement.value;
+  }
+  return SESSION_TYPES.WORKFLOW;
+}
+
+function getAgent(sessionType) {
+  const selectId =
+    AGENT_SELECT_IDS[sessionType] ?? AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW];
+  const selectElement = safeGetElementById(selectId);
+  if (selectElement instanceof HTMLSelectElement && selectElement.value) {
+    return selectElement.value;
+  }
+  return '';
+}
+
+function collectSingleFileSelections(singleFileTypes) {
+  const selections = {};
+  singleFileTypes.forEach((type) => {
+    const elementId = `${type}File`;
+    selections[elementId] = safeGetElementValue(elementId);
+  });
+  return selections;
+}
+
+function collectMultipleFileSelections(singleFiles, fileList) {
+  const selections = {};
+  MULTIPLE_SELECTIONS.forEach((id) => {
+    const container = safeGetElementById(`${id}Container`);
+    const isActive = container?.style.display !== 'none';
+    selections[`${id}Active`] = isActive;
+
+    const filesDiv = safeGetElementById(id);
+    const files = isActive && filesDiv ? fileList.getSelected(filesDiv) : [];
+
+    const singleFileKey = id.replace('Files', 'File');
+    const singleFileSelection = singleFiles[singleFileKey];
+    selections[id] =
+      id !== ELEMENT_IDS.OUTPUT_FILES && singleFileSelection
+        ? files.filter((file) => file !== singleFileSelection)
+        : files;
+  });
+  return selections;
+}
+
+function collectCheckboxValues() {
+  const values = {};
+  CHECK_BOXES.forEach((id) => {
+    values[id] = safeGetElementChecked(id);
+  });
+  return values;
+}
+
+/**
+ * Collect the current main view context from the DOM.
+ *
+ * @param {{
+ *   fileList?: import('../uiManagers/FileList.js').FileList,
+ *   singleFileTypes?: string[],
+ * }} [options]
+ */
+export function collectCurrentContext(options = {}) {
+  const {
+    fileList = defaultFileList,
+    singleFileTypes = DEFAULT_SINGLE_FILE_TYPES,
+  } = options;
+  const sessionType = getSessionType();
+  const agent = getAgent(sessionType);
+  const singleFileSelections = collectSingleFileSelections(singleFileTypes);
+  const multipleFileSelections = collectMultipleFileSelections(
+    singleFileSelections,
+    fileList,
+  );
+  const checkboxValues = collectCheckboxValues();
+
+  return {
+    agent,
+    sessionType,
+    isToolUseAgent: sessionType === SESSION_TYPES.TOOL_USE,
+    singleFileSelections,
+    multipleFileSelections,
+    checkboxValues,
+  };
+}

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -1,20 +1,8 @@
 // Local imports - webview
-import {
-  CHECK_BOXES,
-  MULTIPLE_SELECTIONS,
-  ELEMENT_IDS,
-  BASE_FILE,
-  EDITED_FILE,
-  SESSION_TYPES,
-  SESSION_TYPE_INPUT,
-  AGENT_SELECT_IDS,
-} from '../constants.js';
+import { ELEMENT_IDS, BASE_FILE, EDITED_FILE } from '../constants.js';
 import { BaseUIManager } from './BaseUIManager.js';
-import {
-  safeGetElementById,
-  safeGetElementValue,
-  safeGetElementChecked,
-} from '@common/domUtils.js';
+import { collectCurrentContext } from '../state/currentContext.js';
+import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
@@ -26,38 +14,6 @@ export class ActionButtonManager extends BaseUIManager {
     this.fileList = fileList;
     this.state = state;
     this.instructionManager = instructionMgr;
-    this._sessionTypeInput = null;
-    this._agentSelectCache = new Map();
-  }
-
-  _getSingleFileData(fileTypes = ['input', 'reference', 'auxiliary', 'media']) {
-    const data = {};
-    fileTypes.forEach((type) => {
-      data[`${type}File`] = safeGetElementValue(`${type}File`);
-    });
-    return data;
-  }
-
-  _getMultipleFileData(singleFiles = {}) {
-    const multipleFilesData = {};
-    MULTIPLE_SELECTIONS.forEach((id) => {
-      const container = safeGetElementById(`${id}Container`);
-      const isActive = container?.style.display !== 'none';
-      multipleFilesData[`${id}Active`] = isActive;
-
-      const singleFileKey = id.replace('Files', 'File');
-      const singleFile = singleFiles[singleFileKey];
-
-      const filesDiv = safeGetElementById(id);
-      const files =
-        isActive && filesDiv ? this.fileList.getSelected(filesDiv) : [];
-
-      multipleFilesData[id] =
-        id !== ELEMENT_IDS.OUTPUT_FILES && singleFile
-          ? files.filter((file) => file !== singleFile)
-          : files;
-    });
-    return multipleFilesData;
   }
 
   _setupInstructionButtons() {
@@ -73,18 +29,17 @@ export class ActionButtonManager extends BaseUIManager {
     this.addListener(ELEMENT_IDS.MAGIC_POLISH_BUTTON, 'click', () => {
       const instruction = safeGetElementById(ELEMENT_IDS.INSTRUCTION);
       if (instruction && instruction.value.trim()) {
-        const { agent } = this._getActiveAgentSelection();
+        const { agent, singleFileSelections, multipleFileSelections } =
+          collectCurrentContext({ fileList: this.fileList });
         const model = safeGetElementValue('model');
-        const singleFiles = this._getSingleFileData();
-        const multipleFilesData = this._getMultipleFileData(singleFiles);
 
         this.vscode.postMessage({
           command: MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT,
           text: instruction.value,
           agent,
           model,
-          ...singleFiles,
-          ...multipleFilesData,
+          ...singleFileSelections,
+          ...multipleFileSelections,
         });
       }
     });
@@ -92,17 +47,15 @@ export class ActionButtonManager extends BaseUIManager {
 
   _setupExecuteButtons() {
     this.addListener(ELEMENT_IDS.EXECUTE_BUTTON, 'click', () => {
-      const { agent, sessionType } = this._getActiveAgentSelection();
+      const {
+        agent,
+        isToolUseAgent,
+        singleFileSelections,
+        multipleFileSelections,
+        checkboxValues,
+      } = collectCurrentContext({ fileList: this.fileList });
       const model = safeGetElementValue('model');
       const instruction = safeGetElementValue(ELEMENT_IDS.INSTRUCTION);
-      const isToolUseAgent = sessionType === SESSION_TYPES.TOOL_USE;
-      const singleFiles = this._getSingleFileData();
-      const multipleFilesData = this._getMultipleFileData(singleFiles);
-
-      const checkboxValues = {};
-      CHECK_BOXES.forEach((id) => {
-        checkboxValues[id] = safeGetElementChecked(id);
-      });
 
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.EXECUTE,
@@ -110,14 +63,18 @@ export class ActionButtonManager extends BaseUIManager {
         model,
         instruction,
         isToolUseAgent,
-        ...singleFiles,
-        ...multipleFilesData,
+        ...singleFileSelections,
+        ...multipleFileSelections,
         ...checkboxValues,
       });
     });
 
     this.addListener(ELEMENT_IDS.MERGE_BUTTON, 'click', () => {
-      const { inputFile } = this._getSingleFileData(['input']);
+      const { singleFileSelections } = collectCurrentContext({
+        fileList: this.fileList,
+        singleFileTypes: ['input'],
+      });
+      const { inputFile } = singleFileSelections;
       const editedFile = safeGetElementValue(EDITED_FILE);
 
       this.vscode.postMessage({
@@ -137,20 +94,18 @@ export class ActionButtonManager extends BaseUIManager {
       { id: ELEMENT_IDS.CLEAN_BUTTON, action: 'clean' },
     ].forEach(({ id, action }) => {
       this.addListener(id, 'click', () => {
-        const { inputFile } = this._getSingleFileData(['input']);
-        const { agent } = this._getActiveAgentSelection();
+        const { agent, singleFileSelections, multipleFileSelections } =
+          collectCurrentContext({
+            fileList: this.fileList,
+            singleFileTypes: ['input'],
+          });
+        const { inputFile } = singleFileSelections;
         const model = safeGetElementValue('model');
-
-        const outputFiles = this.fileList.getSelected(
-          safeGetElementById(ELEMENT_IDS.OUTPUT_FILES),
-        );
-        const container = safeGetElementById(
-          ELEMENT_IDS.OUTPUT_FILES_CONTAINER,
-        );
-        const useMultiple =
-          container &&
-          container.style.display !== 'none' &&
-          outputFiles.length > 0;
+        const outputFiles =
+          multipleFileSelections[ELEMENT_IDS.OUTPUT_FILES] ?? [];
+        const outputFilesActive =
+          multipleFileSelections[`${ELEMENT_IDS.OUTPUT_FILES}Active`] ?? false;
+        const useMultiple = outputFilesActive && outputFiles.length > 0;
 
         if (useMultiple) {
           const multipleCommand =
@@ -200,7 +155,11 @@ export class ActionButtonManager extends BaseUIManager {
 
   _setupLatexdiffButtons() {
     this.addListener(ELEMENT_IDS.LATEXDIFF_BUTTON, 'click', () => {
-      const { inputFile } = this._getSingleFileData(['input']);
+      const { singleFileSelections } = collectCurrentContext({
+        fileList: this.fileList,
+        singleFileTypes: ['input'],
+      });
+      const { inputFile } = singleFileSelections;
       const baseFile = safeGetElementValue(BASE_FILE);
       const editedFile = safeGetElementValue(EDITED_FILE);
 
@@ -218,7 +177,11 @@ export class ActionButtonManager extends BaseUIManager {
     });
 
     this.addListener(ELEMENT_IDS.LATEXDIFF_VC_BUTTON, 'click', () => {
-      const { inputFile } = this._getSingleFileData(['input']);
+      const { singleFileSelections } = collectCurrentContext({
+        fileList: this.fileList,
+        singleFileTypes: ['input'],
+      });
+      const { inputFile } = singleFileSelections;
       const baseFile = safeGetElementValue(BASE_FILE);
       const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
 
@@ -240,7 +203,11 @@ export class ActionButtonManager extends BaseUIManager {
       { id: ELEMENT_IDS.CLEAN_LATEXDIFF_VC_BUTTON, action: 'clean' },
     ].forEach(({ id, action }) => {
       this.addListener(id, 'click', () => {
-        const { inputFile } = this._getSingleFileData(['input']);
+        const { singleFileSelections } = collectCurrentContext({
+          fileList: this.fileList,
+          singleFileTypes: ['input'],
+        });
+        const { inputFile } = singleFileSelections;
         const baseFile = safeGetElementValue(BASE_FILE);
         const commitHash = safeGetElementValue(ELEMENT_IDS.COMMIT_SELECT);
 
@@ -301,50 +268,9 @@ export class ActionButtonManager extends BaseUIManager {
   }
 
   setup() {
-    this._sessionTypeInput = null;
-    this._agentSelectCache.clear();
     this._setupInstructionButtons();
     this._setupExecuteButtons();
     this._setupLatexdiffButtons();
     this._setupCompareButtons();
-  }
-
-  _getSessionTypeInput() {
-    if (!this._sessionTypeInput) {
-      const element = safeGetElementById(SESSION_TYPE_INPUT);
-      this._sessionTypeInput =
-        element instanceof HTMLInputElement ? element : null;
-    }
-    return this._sessionTypeInput;
-  }
-
-  _getAgentSelect(sessionType) {
-    const selectId = AGENT_SELECT_IDS[sessionType];
-    if (!selectId) {
-      return null;
-    }
-
-    if (!this._agentSelectCache.has(selectId)) {
-      const element = safeGetElementById(selectId);
-      this._agentSelectCache.set(
-        selectId,
-        element instanceof HTMLSelectElement ? element : null,
-      );
-    }
-
-    return this._agentSelectCache.get(selectId) || null;
-  }
-
-  _getActiveAgentSelection() {
-    const sessionTypeInput = this._getSessionTypeInput();
-    const rawSessionType = sessionTypeInput?.value;
-    const sessionType = rawSessionType || SESSION_TYPES.WORKFLOW;
-    const selectElement = this._getAgentSelect(sessionType);
-    const agent = selectElement?.value ?? '';
-    return {
-      agent,
-      sessionType,
-      selectElement,
-    };
   }
 }


### PR DESCRIPTION
## Summary
- add a shared `collectCurrentContext` helper that aggregates agent, file selection, and checkbox state
- refactor `ActionButtonManager` to rely on the helper instead of duplicating DOM queries
- add mocha coverage around the helper to lock down the aggregated payload structure

## Testing
- npm run lint
- npm run compile-tests
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68f017a41d908324a1c6b37c6d76ba8d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce shared `collectCurrentContext` for aggregating agent/file/checkbox state, refactor `ActionButtonManager` to use it, and add JSDOM tests.
> 
> - **Webview State**:
>   - **New helper**: `modules/state/currentContext.js` adds `collectCurrentContext` to aggregate `sessionType`, `agent`, `singleFileSelections`, `multipleFileSelections` (with Active flags and filtering), and `checkboxValues` using `domUtils` and `FileList`.
> - **UI**:
>   - **Refactor**: `uiManagers/ActionButtonManager.js` now consumes `collectCurrentContext` for polish/execute/pack/clean/merge/latexdiff flows.
>   - Removes internal DOM-parsing helpers and agent/session caching; simplifies output files handling via `multipleFileSelections` and `isToolUseAgent`.
> - **Tests**:
>   - Add `currentContextHelper.test.ts` (Mocha + JSDOM) covering workflow vs toolUse, single/multiple selections, active flags, and filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cfd3f28d60ebb3445cd87038670af12a79d0876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->