### PR TITLE
refactor: centralize agent yaml validation

### DIFF
--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -31,6 +31,41 @@ export interface ValidAgentDefinition {
   settings: AgentSetting;
 }
 
+export interface AgentYamlValidationResult extends ValidAgentDefinition {
+  prompts: AgentPrompt;
+}
+
+/**
+ * Parses a YAML string or already-parsed object and validates that it
+ * represents a full agent definition. Returns the validated name, settings,
+ * and prompts so callers can reuse consistent schema checks across string and
+ * file based workflows.
+ */
+export function validateAgentYamlContent(
+  content: string | object,
+): AgentYamlValidationResult {
+  const raw = typeof content === 'string' ? yaml.parse(content) : content;
+  const data = AgentDefinitionSchema.parse(raw);
+
+  if (!data.settings || !data.prompts) {
+    throw new Error('missing settings or prompts block');
+  }
+
+  const settingsBlock = parseAgentSetting(data.settings);
+  const promptsBlock = AgentPromptSchema.parse(data.prompts);
+  const rootName = typeof data.name === 'string' ? data.name.trim() : '';
+
+  if (!rootName) {
+    throw new Error('name is empty');
+  }
+
+  return {
+    name: rootName,
+    settings: settingsBlock,
+    prompts: promptsBlock,
+  } satisfies AgentYamlValidationResult;
+}
+
 /** Loads and parses a YAML file from an absolute path. */
 export async function loadYaml(absolutePath: string): Promise<object> {
   try {
@@ -249,31 +284,11 @@ export async function isValidAgentYaml(
 ): Promise<ValidAgentDefinition | null> {
   try {
     const rawData = await loadYaml(filePath);
-    const data = AgentDefinitionSchema.parse(rawData);
-
-    if (!data.settings || !data.prompts) {
-      logger.debug(
-        CHANNEL,
-        `isValidAgentYaml check failed for ${filePath}: missing settings or prompts block`,
-      );
-      return null;
-    }
-
-    const settingsBlock = parseAgentSetting(data.settings);
-    AgentPromptSchema.parse(data.prompts);
-    const rootName = data.name;
-
-    if (rootName === '') {
-      logger.debug(
-        CHANNEL,
-        `isValidAgentYaml check failed for ${filePath}: name is empty`,
-      );
-      return null;
-    }
+    const { name, settings } = validateAgentYamlContent(rawData);
 
     return {
-      name: rootName,
-      settings: settingsBlock,
+      name,
+      settings,
     } satisfies ValidAgentDefinition;
   } catch (err) {
     logger.debug(

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -2,14 +2,10 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { MessageCreateParams } from '@anthropic-ai/sdk/resources/messages';
 import * as vscode from 'vscode';
-import * as yaml from 'yaml';
+// Local imports - agent runtime
+import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 
 // Local imports - commands
-import {
-  AgentDefinitionSchema,
-  AgentPromptSchema,
-  parseAgentSetting,
-} from '@agent/core/AgentDataclass';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { promptToAddAgentToConfig } from '@frontend/agents/register';
 
@@ -168,16 +164,7 @@ prompts:
 
 function validateAgentYamlString(content: string): string | null {
   try {
-    const parsed = yaml.parse(content);
-    const data = AgentDefinitionSchema.parse(parsed);
-    if (!data.settings || !data.prompts) {
-      return 'missing settings or prompts block';
-    }
-    parseAgentSetting(data.settings);
-    AgentPromptSchema.parse(data.prompts);
-    if (!data.name || data.name.trim() === '') {
-      return 'name is empty';
-    }
+    validateAgentYamlContent(content);
     return null;
   } catch (err) {
     return err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- add a reusable `validateAgentYamlContent` helper that validates agent YAML definitions from parsed objects or raw strings
- update the agent creator command to use the shared helper so user-facing validation errors remain consistent
- route `isValidAgentYaml` through the helper to keep schema enforcement centralized

## Testing
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68f0185c57248324bc182fe42755734e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a shared `validateAgentYamlContent` helper and route both `isValidAgentYaml` and agent creator validation through it.
> 
> - **Runtime (`src/agent/runtime/agentLoad.ts`)**:
>   - Add `validateAgentYamlContent(content)` to parse and validate agent YAML (returns `name`, `settings`, `prompts`).
>   - Introduce `AgentYamlValidationResult` type.
>   - Refactor `isValidAgentYaml` to use `validateAgentYamlContent` and return validated `name` and `settings`.
> - **Commands (`src/commands/agent/agentCreatorCommands.ts`)**:
>   - Replace inline YAML validation in `validateAgentYamlString` with `validateAgentYamlContent` import from runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cda0e0051fb7e67838e04250e4255b48e6addb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->