### PR TITLE
Refactor latexdiff commands to share helper utilities

### DIFF
--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -45,11 +45,27 @@ logger.initialize(CHANNEL);
 
 const service = new LaTeXdiffService(CHANNEL);
 
+type LatexdiffTool = 'latexdiff' | 'latexdiff-vc';
+
+/**
+ * Ensures the required latexdiff tool is installed before running a command.
+ * @param tool The tool name to verify.
+ * @returns True when the tool is available, false otherwise.
+ */
+async function ensureLatexdiffToolInstalled(tool: LatexdiffTool): Promise<boolean> {
+  if (await checkToolInstalled(tool)) {
+    return true;
+  }
+
+  logger.warn(CHANNEL, `${tool} is not installed; command will not run.`);
+  return false;
+}
+
 /**
  * Prompts the user to select a math markup granularity for latexdiff operations.
  * @returns The selected math markup option, or undefined if the user cancels.
  */
-async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
+async function promptForLatexdiffMathMarkup(): Promise<MathMarkupOption | undefined> {
   const configuredMode = getConfig<string>(
     'latexdiff.mathMarkup',
     DEFAULT_MATH_MARKUP,
@@ -73,6 +89,33 @@ async function promptForMathMarkup(): Promise<MathMarkupOption | undefined> {
   });
 
   return selection?.value;
+}
+
+/**
+ * Opens a generated latexdiff result in the LaTeX build preview after verifying it exists.
+ * @param basePath The base file (or directory) used when generating the diff.
+ * @param diffFileName The generated diff file name returned by the service.
+ * @returns True when the diff file exists and is opened successfully.
+ */
+async function openLatexdiffResult(
+  basePath: string,
+  diffFileName: string,
+): Promise<string | undefined> {
+  const baseDirectory = path.extname(basePath)
+    ? path.dirname(basePath)
+    : basePath;
+  const diffFilePath = path.join(baseDirectory, diffFileName);
+
+  if (!(await WorkspaceFS.exists(diffFilePath))) {
+    await showLoggedMessage(
+      CHANNEL,
+      `Diff file could not be found. Expected path: ${diffFilePath}`,
+    );
+    return undefined;
+  }
+
+  await openBuildDisplayIfTex(diffFilePath, { preserveFocus: true });
+  return diffFilePath;
 }
 
 // Removed showLatexdiffError wrapper - using showLoggedMessageWithDocs directly
@@ -127,12 +170,11 @@ async function handleLatexdiff(
 
   const fileToUse = baseFile || inputFile;
   try {
-    // Check if latexdiff is installed
-    if (!(await checkToolInstalled('latexdiff'))) {
+    if (!(await ensureLatexdiffToolInstalled('latexdiff'))) {
       return;
     }
 
-    const mathMarkup = await promptForMathMarkup();
+    const mathMarkup = await promptForLatexdiffMathMarkup();
     if (!mathMarkup) {
       logger.debug(CHANNEL, 'Math markup selection cancelled by user');
       return;
@@ -155,20 +197,7 @@ async function handleLatexdiff(
       throw new Error(result.message || 'Failed to generate diff file');
     }
 
-    // Verify the file exists using fileExists utility
-    const filePathRelative = path.join(
-      path.dirname(fileToUse),
-      result.diffFileName,
-    );
-    if (!(await WorkspaceFS.exists(filePathRelative))) {
-      await showLoggedMessage(
-        CHANNEL,
-        `Diff file could not be found. Expected path: ${filePathRelative}`,
-      );
-      return;
-    }
-
-    await openBuildDisplayIfTex(filePathRelative, { preserveFocus: true });
+    await openLatexdiffResult(fileToUse, result.diffFileName);
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error creating LaTeX diff', err);
   }
@@ -181,12 +210,11 @@ async function handleLatexdiffvc(
 ) {
   const fileToUse = baseFile || inputFile;
   try {
-    // Check if latexdiff-vc is installed
-    if (!(await checkToolInstalled('latexdiff-vc'))) {
+    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
     }
 
-    const mathMarkup = await promptForMathMarkup();
+    const mathMarkup = await promptForLatexdiffMathMarkup();
     if (!mathMarkup) {
       logger.debug(CHANNEL, 'Math markup selection cancelled by user');
       return;
@@ -203,20 +231,7 @@ async function handleLatexdiffvc(
       throw new Error(result.message || 'Failed to generate diff file');
     }
 
-    // Verify the file exists using fileExists utility
-    const filePathRelative = path.join(
-      path.dirname(fileToUse),
-      result.diffFileName,
-    );
-    if (!(await WorkspaceFS.exists(filePathRelative))) {
-      await showLoggedMessage(
-        CHANNEL,
-        `Diff file could not be found. Expected path: ${filePathRelative}`,
-      );
-      return;
-    }
-
-    await openBuildDisplayIfTex(filePathRelative, { preserveFocus: true });
+    await openLatexdiffResult(fileToUse, result.diffFileName);
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error creating LaTeX diff', err);
   }
@@ -229,8 +244,7 @@ async function handlePackLatexdiffvc(
   clean: boolean,
 ) {
   try {
-    // Check if latexdiff-vc is installed
-    if (!(await checkToolInstalled('latexdiff-vc'))) {
+    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -251,8 +265,7 @@ async function handlePackLatexdiffvcMultiple(
   clean: boolean,
 ) {
   try {
-    // Check if latexdiff-vc is installed
-    if (!(await checkToolInstalled('latexdiff-vc'))) {
+    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -273,8 +286,7 @@ async function handleCleanLatexdiffvc(
   commitHash: string,
 ) {
   try {
-    // Check if latexdiff-vc is installed
-    if (!(await checkToolInstalled('latexdiff-vc'))) {
+    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -294,8 +306,7 @@ async function handleCleanLatexdiffvcMultiple(
   commitHash: string,
 ) {
   try {
-    // Check if latexdiff-vc is installed
-    if (!(await checkToolInstalled('latexdiff-vc'))) {
+    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
     }
 
@@ -318,8 +329,7 @@ async function handleRunLatexdiff(config: any) {
       `Command called with config: ${JSON.stringify(config)}`,
     );
 
-    // Check if latexdiff is installed
-    if (!(await checkToolInstalled('latexdiff'))) {
+    if (!(await ensureLatexdiffToolInstalled('latexdiff'))) {
       return;
     }
 
@@ -334,7 +344,7 @@ async function handleRunLatexdiff(config: any) {
       return;
     }
 
-    const mathMarkup = await promptForMathMarkup();
+    const mathMarkup = await promptForLatexdiffMathMarkup();
     if (!mathMarkup) {
       logger.debug(CHANNEL, 'Math markup selection cancelled by user');
       return;
@@ -482,7 +492,8 @@ async function handleRunLatexdiff(config: any) {
         const results: Array<{
           success: boolean;
           message?: string;
-          diffFile?: string;
+          basePath?: string;
+          diffFileName?: string;
         }> = [];
 
         // Process each input file and its outputs
@@ -515,9 +526,8 @@ async function handleRunLatexdiff(config: any) {
             results.push({
               success: result.success,
               message: result.message,
-              diffFile: result.diffFileName
-                ? path.join(path.dirname(inputFile), result.diffFileName)
-                : undefined,
+              basePath: inputFile,
+              diffFileName: result.diffFileName,
             });
 
             completedOperations++;
@@ -551,9 +561,8 @@ async function handleRunLatexdiff(config: any) {
               results.push({
                 success: result.success,
                 message: result.message,
-                diffFile: result.diffFileName
-                  ? path.join(path.dirname(currentFile), result.diffFileName)
-                  : undefined,
+                basePath: currentFile,
+                diffFileName: result.diffFileName,
               });
 
               completedOperations++;
@@ -585,14 +594,17 @@ async function handleRunLatexdiff(config: any) {
 
         // Log detailed results
         for (const result of results) {
-          if (result.success && result.diffFile) {
-            logger.debug(
-              CHANNEL,
-              `Successfully generated diff: ${result.diffFile}`,
+          if (result.success && result.basePath && result.diffFileName) {
+            const diffFilePath = await openLatexdiffResult(
+              result.basePath,
+              result.diffFileName,
             );
-            await openBuildDisplayIfTex(result.diffFile, {
-              preserveFocus: true,
-            });
+            if (diffFilePath) {
+              logger.debug(
+                CHANNEL,
+                `Successfully generated diff: ${diffFilePath}`,
+              );
+            }
           } else {
             logger.warn(CHANNEL, `Failed to generate diff: ${result.message}`);
           }
@@ -612,4 +624,10 @@ export const latexdiffCommands = {
   handleCleanLatexdiffvc,
   handleCleanLatexdiffvcMultiple,
   handleRunLatexdiff,
+};
+
+export const latexdiffHelpers = {
+  ensureLatexdiffToolInstalled,
+  promptForLatexdiffMathMarkup,
+  openLatexdiffResult,
 };

--- a/src/test/commands/latex/latexdiffCommands.test.ts
+++ b/src/test/commands/latex/latexdiffCommands.test.ts
@@ -1,0 +1,151 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - commands
+import { latexdiffHelpers } from '@commands/latex/latexdiffCommands';
+
+// Local imports - utilities
+import * as systemModule from '@utils/system';
+import * as configModule from '@utils/config';
+import { WorkspaceFS } from '@utils/files';
+import * as openBuildModule from '@frontend/latex/openBuild';
+
+// Local imports - errors
+import * as errorHandlingModule from '@common/errors/errorHandlingUtils';
+
+const {
+  ensureLatexdiffToolInstalled,
+  promptForLatexdiffMathMarkup,
+  openLatexdiffResult,
+} = latexdiffHelpers;
+
+type CheckToolInstalled = typeof systemModule.checkToolInstalled;
+type GetConfig = typeof configModule.getConfig;
+type WorkspaceExists = typeof WorkspaceFS.exists;
+type OpenBuildDisplayIfTex = typeof openBuildModule.openBuildDisplayIfTex;
+type ShowLoggedMessage = typeof errorHandlingModule.showLoggedMessage;
+
+suite('Latexdiff command helpers', () => {
+  const originalCheckToolInstalled = systemModule.checkToolInstalled;
+  const originalGetConfig = configModule.getConfig;
+  const originalShowQuickPick = vscode.window.showQuickPick;
+  const originalWorkspaceExists = WorkspaceFS.exists;
+  const originalOpenBuildDisplayIfTex = openBuildModule.openBuildDisplayIfTex;
+  const originalShowLoggedMessage = errorHandlingModule.showLoggedMessage;
+
+  teardown(() => {
+    (systemModule as { checkToolInstalled: CheckToolInstalled }).checkToolInstalled =
+      originalCheckToolInstalled;
+    (configModule as { getConfig: GetConfig }).getConfig = originalGetConfig;
+    (vscode.window as { showQuickPick: typeof originalShowQuickPick }).showQuickPick =
+      originalShowQuickPick;
+    (WorkspaceFS as { exists: WorkspaceExists }).exists = originalWorkspaceExists;
+    (openBuildModule as { openBuildDisplayIfTex: OpenBuildDisplayIfTex }).openBuildDisplayIfTex =
+      originalOpenBuildDisplayIfTex;
+    (errorHandlingModule as { showLoggedMessage: ShowLoggedMessage }).showLoggedMessage =
+      originalShowLoggedMessage;
+  });
+
+  test('ensureLatexdiffToolInstalled returns boolean status from tool check', async () => {
+    const calls: string[] = [];
+    (systemModule as { checkToolInstalled: CheckToolInstalled }).checkToolInstalled =
+      async (toolOrConfig, _showError) => {
+        const normalized =
+          typeof toolOrConfig === 'string'
+            ? toolOrConfig
+            : Array.isArray(toolOrConfig.command)
+              ? toolOrConfig.command[0]
+              : toolOrConfig.command ?? 'unknown';
+        const toolName = typeof normalized === 'string' ? normalized : String(normalized);
+        calls.push(toolName);
+        return toolName === 'latexdiff';
+      };
+
+    const available = await ensureLatexdiffToolInstalled('latexdiff');
+    const missing = await ensureLatexdiffToolInstalled('latexdiff-vc');
+
+    assert.deepStrictEqual(calls, ['latexdiff', 'latexdiff-vc']);
+    assert.strictEqual(available, true);
+    assert.strictEqual(missing, false);
+  });
+
+  test('promptForLatexdiffMathMarkup prioritizes configured option and returns selection', async () => {
+    (configModule as { getConfig: GetConfig }).getConfig = (<T>() =>
+      'Scope' as unknown as T) as GetConfig;
+
+    let receivedItems: Array<vscode.QuickPickItem & { value: string }> = [];
+    const stubQuickPick = ((items: unknown) => {
+      receivedItems = items as Array<vscode.QuickPickItem & { value: string }>;
+      return Promise.resolve(receivedItems[1] as vscode.QuickPickItem);
+    }) as unknown as typeof originalShowQuickPick;
+    (vscode.window as { showQuickPick: typeof originalShowQuickPick }).showQuickPick =
+      stubQuickPick;
+
+    const selection = await promptForLatexdiffMathMarkup();
+
+    assert.ok(receivedItems.length > 1, 'Quick pick items should be provided');
+    assert.strictEqual(receivedItems[0].label, 'Scope');
+    assert.strictEqual(receivedItems[0].picked, true);
+    assert.strictEqual(selection, receivedItems[1].value);
+  });
+
+  test('openLatexdiffResult resolves and opens single-file diff output', async () => {
+    const existsCalls: string[] = [];
+    (WorkspaceFS as { exists: WorkspaceExists }).exists = async (filePath) => {
+      existsCalls.push(filePath);
+      return true;
+    };
+
+    let openedPath: string | undefined;
+    (openBuildModule as { openBuildDisplayIfTex: OpenBuildDisplayIfTex }).openBuildDisplayIfTex =
+      async (filePath) => {
+        openedPath = filePath;
+      };
+
+    const diffPath = await openLatexdiffResult('chapters/ch1.tex', 'ch1_diff.tex');
+
+    assert.strictEqual(diffPath, 'chapters/ch1_diff.tex');
+    assert.deepStrictEqual(existsCalls, ['chapters/ch1_diff.tex']);
+    assert.strictEqual(openedPath, 'chapters/ch1_diff.tex');
+  });
+
+  test('openLatexdiffResult resolves diff inside directory for multi-file flows', async () => {
+    let checkedPath: string | undefined;
+    (WorkspaceFS as { exists: WorkspaceExists }).exists = async (filePath) => {
+      checkedPath = filePath;
+      return true;
+    };
+
+    (openBuildModule as { openBuildDisplayIfTex: OpenBuildDisplayIfTex }).openBuildDisplayIfTex =
+      async () => {
+        /* no-op for test */
+      };
+
+    const diffPath = await openLatexdiffResult('chapters', 'rounds/ch2_diff.tex');
+
+    assert.strictEqual(checkedPath, path.join('chapters', 'rounds/ch2_diff.tex'));
+    assert.strictEqual(diffPath, path.join('chapters', 'rounds/ch2_diff.tex'));
+  });
+
+  test('openLatexdiffResult shows message when diff file missing', async () => {
+    (WorkspaceFS as { exists: WorkspaceExists }).exists = async () => false;
+
+    let message: string | undefined;
+    (errorHandlingModule as { showLoggedMessage: ShowLoggedMessage }).showLoggedMessage =
+      async (_channel, content: string) => {
+        message = content;
+        return content;
+      };
+
+    const diffPath = await openLatexdiffResult('main.tex', 'missing_diff.tex');
+
+    assert.strictEqual(diffPath, undefined);
+    assert.ok(
+      message?.includes('missing_diff.tex'),
+      'Expected missing diff message to include file name',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extract latexdiff helper utilities for tool checks, math markup prompting, and diff opening
- refactor latexdiff command handlers to use the shared helpers
- add unit tests covering helper behaviors for both single-file and multi-file scenarios

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68f018741e808324a5a5593a5241a67c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts shared latexdiff helpers, refactors command handlers to use them, and adds unit tests covering helper behaviors.
> 
> - **Latexdiff commands**:
>   - **Helpers**: Add `ensureLatexdiffToolInstalled`, `promptForLatexdiffMathMarkup`, and `openLatexdiffResult`; export via `latexdiffHelpers`.
>   - **Refactor handlers**: Update `handleLatexdiff*` and `handleRunLatexdiff` to use helpers; rename `promptForMathMarkup` to `promptForLatexdiffMathMarkup`; centralize diff file resolution/opening.
>   - **Result handling**: In `handleRunLatexdiff`, store `basePath`/`diffFileName` instead of a pre-joined `diffFile`, and open via `openLatexdiffResult`.
> - **Tests**:
>   - Add `src/test/commands/latex/latexdiffCommands.test.ts` covering tool checks, math markup quick-pick prioritization, diff opening for single/multi-file, and missing-file messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 262f8a044e5c59b6ad7061f3396108b6c90f97bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->