### PR TITLE
refactor: centralize active editor guard checks

### DIFF
--- a/src/commands/latex/figCommands.ts
+++ b/src/commands/latex/figCommands.ts
@@ -11,7 +11,7 @@ import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import {
   getActiveEditorWithGuards,
-  type ActiveFileGuardFailureReason,
+  logGuardFailure,
 } from '@utils/editor/activeFileGuards';
 
 // Local imports - latex utils
@@ -46,7 +46,7 @@ async function handleExtractFigurePaths(): Promise<void> {
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('extract figure paths', guardResult.status);
+      logGuardFailure(CHANNEL, 'extract figure paths', guardResult.status, 'LaTeX');
       return;
     }
 
@@ -89,7 +89,7 @@ async function handleExtractTikzFigures(): Promise<void> {
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('extract TikZ figures', guardResult.status);
+      logGuardFailure(CHANNEL, 'extract TikZ figures', guardResult.status, 'LaTeX');
       return;
     }
 
@@ -145,7 +145,7 @@ async function handleCompileTikzFigures(): Promise<void> {
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('compile TikZ figures', guardResult.status);
+      logGuardFailure(CHANNEL, 'compile TikZ figures', guardResult.status, 'LaTeX');
       return;
     }
 
@@ -208,29 +208,6 @@ async function handleCompileTikzFigures(): Promise<void> {
       `Error in compileTikzFigures command: ${err instanceof Error ? err.message : String(err)}`,
     );
     vscode.window.showErrorMessage('Error compiling TikZ figures');
-  }
-}
-
-function logGuardFailure(
-  action: string,
-  reason: ActiveFileGuardFailureReason,
-): void {
-  switch (reason) {
-    case 'noEditor':
-      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
-      break;
-    case 'unsupportedExtension':
-      logger.warn(
-        CHANNEL,
-        `Cannot ${action}: active document is not a LaTeX file.`,
-      );
-      break;
-    case 'saveFailed':
-      logger.error(
-        CHANNEL,
-        `Cannot ${action}: failed to save LaTeX document before running command.`,
-      );
-      break;
   }
 }
 

--- a/src/commands/latex/figCommands.ts
+++ b/src/commands/latex/figCommands.ts
@@ -9,6 +9,10 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { WorkspaceFS } from '@utils/files';
+import {
+  getActiveEditorWithGuards,
+  type ActiveFileGuardFailureReason,
+} from '@utils/editor/activeFileGuards';
 
 // Local imports - latex utils
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
@@ -36,22 +40,17 @@ export function registerFigureCommands(context: vscode.ExtensionContext) {
 
 async function handleExtractFigurePaths(): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showWarningMessage('Please open a LaTeX file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('extract figure paths', guardResult.status);
       return;
     }
 
-    // Check if it's a LaTeX file
-    if (!editor.document.fileName.toLowerCase().endsWith('.tex')) {
-      vscode.window.showWarningMessage(
-        'This command only works with LaTeX files',
-      );
-      return;
-    }
-
-    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
+    const { relativePath: filePath } = guardResult;
     logger.debug(CHANNEL, `Processing LaTeX file: ${filePath}`);
 
     // Extract figure paths
@@ -84,22 +83,17 @@ async function handleExtractFigurePaths(): Promise<void> {
 
 async function handleExtractTikzFigures(): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showWarningMessage('Please open a LaTeX file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('extract TikZ figures', guardResult.status);
       return;
     }
 
-    // Check if it's a LaTeX file
-    if (!editor.document.fileName.toLowerCase().endsWith('.tex')) {
-      vscode.window.showWarningMessage(
-        'This command only works with LaTeX files',
-      );
-      return;
-    }
-
-    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
+    const { relativePath: filePath } = guardResult;
     logger.debug(
       CHANNEL,
       `Processing LaTeX file for TikZ figures: ${filePath}`,
@@ -145,22 +139,17 @@ async function handleExtractTikzFigures(): Promise<void> {
 
 async function handleCompileTikzFigures(): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showWarningMessage('Please open a LaTeX file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('compile TikZ figures', guardResult.status);
       return;
     }
 
-    // Check if it's a LaTeX file
-    if (!editor.document.fileName.toLowerCase().endsWith('.tex')) {
-      vscode.window.showWarningMessage(
-        'This command only works with LaTeX files',
-      );
-      return;
-    }
-
-    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
+    const { relativePath: filePath } = guardResult;
     logger.debug(
       CHANNEL,
       `Processing LaTeX file for TikZ compilation: ${filePath}`,
@@ -219,6 +208,29 @@ async function handleCompileTikzFigures(): Promise<void> {
       `Error in compileTikzFigures command: ${err instanceof Error ? err.message : String(err)}`,
     );
     vscode.window.showErrorMessage('Error compiling TikZ figures');
+  }
+}
+
+function logGuardFailure(
+  action: string,
+  reason: ActiveFileGuardFailureReason,
+): void {
+  switch (reason) {
+    case 'noEditor':
+      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
+      break;
+    case 'unsupportedExtension':
+      logger.warn(
+        CHANNEL,
+        `Cannot ${action}: active document is not a LaTeX file.`,
+      );
+      break;
+    case 'saveFailed':
+      logger.error(
+        CHANNEL,
+        `Cannot ${action}: failed to save LaTeX document before running command.`,
+      );
+      break;
   }
 }
 

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -8,14 +8,15 @@ import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { sleep } from '@utils/helpers';
 import replacementEngine from '@replacement/engine';
+import {
+  getActiveEditorWithGuards,
+  type ActiveFileGuardFailureReason,
+} from '@utils/editor/activeFileGuards';
 
 // Local imports - latex utils
 import { runLatexFormatter } from '@latex/texFormatter';
 import { getTeXCount, type TexcountMode } from '@latex/texcount';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
-
-// Local imports - commands
-import { fileSelectionCommands } from '../files/fileSelectionCommands';
 
 // Local imports - housekeeping
 import { runIndentTeX } from '@housekeeping';
@@ -40,17 +41,18 @@ export function registerLatexCommands(context: vscode.ExtensionContext) {
 
 async function handleApplyReplacements(): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showWarningMessage('No active text editor found');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+      saveDocument: true,
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('apply replacements', guardResult.status);
       return;
     }
-    if (editor?.document.isDirty) {
-      await editor.document.save();
-    }
 
-    // Get document content
+    const { editor } = guardResult;
     const document = editor.document;
     const text = document.getText();
 
@@ -81,26 +83,20 @@ async function handleApplyReplacements(): Promise<void> {
 
 async function handleIndentCurrentTeX(): Promise<void> {
   try {
-    const relativePath = await fileSelectionCommands.getCurrentFile();
-    if (!relativePath) {
-      vscode.window.showWarningMessage('No active text editor found');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+      saveDocument: true,
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('indent LaTeX document', guardResult.status);
       return;
     }
 
-    if (!relativePath.endsWith('.tex')) {
-      vscode.window.showWarningMessage(
-        'Active file is not a LaTeX document (.tex)',
-      );
-      return;
-    }
+    const { relativePath } = guardResult;
 
     logger.debug(CHANNEL, `Indenting LaTeX file: ${relativePath}`);
-
-    // Save any unsaved changes
-    const editor = vscode.window.activeTextEditor;
-    if (editor?.document.isDirty) {
-      await editor.document.save();
-    }
 
     // Run the indent operation with relative path
     const success = await runLatexFormatter(relativePath);
@@ -115,6 +111,29 @@ async function handleIndentCurrentTeX(): Promise<void> {
     }
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error in indentTeX command', err);
+  }
+}
+
+function logGuardFailure(
+  action: string,
+  reason: ActiveFileGuardFailureReason,
+): void {
+  switch (reason) {
+    case 'noEditor':
+      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
+      break;
+    case 'unsupportedExtension':
+      logger.warn(
+        CHANNEL,
+        `Cannot ${action}: active document is not a LaTeX file.`,
+      );
+      break;
+    case 'saveFailed':
+      logger.error(
+        CHANNEL,
+        `Cannot ${action}: failed to save LaTeX document before running command.`,
+      );
+      break;
   }
 }
 

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -10,7 +10,7 @@ import { sleep } from '@utils/helpers';
 import replacementEngine from '@replacement/engine';
 import {
   getActiveEditorWithGuards,
-  type ActiveFileGuardFailureReason,
+  logGuardFailure,
 } from '@utils/editor/activeFileGuards';
 
 // Local imports - latex utils
@@ -48,7 +48,7 @@ async function handleApplyReplacements(): Promise<void> {
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('apply replacements', guardResult.status);
+      logGuardFailure(CHANNEL, 'apply replacements', guardResult.status, 'LaTeX');
       return;
     }
 
@@ -90,7 +90,7 @@ async function handleIndentCurrentTeX(): Promise<void> {
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('indent LaTeX document', guardResult.status);
+      logGuardFailure(CHANNEL, 'indent LaTeX document', guardResult.status, 'LaTeX');
       return;
     }
 
@@ -114,47 +114,19 @@ async function handleIndentCurrentTeX(): Promise<void> {
   }
 }
 
-function logGuardFailure(
-  action: string,
-  reason: ActiveFileGuardFailureReason,
-): void {
-  switch (reason) {
-    case 'noEditor':
-      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
-      break;
-    case 'unsupportedExtension':
-      logger.warn(
-        CHANNEL,
-        `Cannot ${action}: active document is not a LaTeX file.`,
-      );
-      break;
-    case 'saveFailed':
-      logger.error(
-        CHANNEL,
-        `Cannot ${action}: failed to save LaTeX document before running command.`,
-      );
-      break;
-  }
-}
-
 async function handleGetTeXCount(): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showWarningMessage('Please open a LaTeX file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure(CHANNEL, 'get TeX count', guardResult.status, 'LaTeX');
       return;
     }
 
-    // Check if it's a LaTeX file
-    if (!editor.document.fileName.toLowerCase().endsWith('.tex')) {
-      vscode.window.showWarningMessage(
-        'This command only works with LaTeX files',
-      );
-      return;
-    }
-
-    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
+    const { relativePath: filePath } = guardResult;
     logger.debug(CHANNEL, `Getting tex count for: ${filePath}`);
 
     // Ask if user wants to merge included files

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -12,7 +12,7 @@ import {
 } from '@frontend/latex/linter';
 import {
   getActiveEditorWithGuards,
-  type ActiveFileGuardFailureReason,
+  logGuardFailure,
 } from '@utils/editor/activeFileGuards';
 
 // Local imports - core
@@ -38,7 +38,7 @@ export async function handleShowLinterMessages(): Promise<void> {
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('show linter messages', guardResult.status);
+      logGuardFailure(CHANNEL, 'show linter messages', guardResult.status, 'LaTeX');
       return;
     }
 
@@ -92,7 +92,7 @@ export async function handleCountLinterMessages(): Promise<void> {
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('count linter messages', guardResult.status);
+      logGuardFailure(CHANNEL, 'count linter messages', guardResult.status, 'LaTeX');
       return;
     }
 
@@ -140,7 +140,7 @@ export async function handleFixLinterIssues(
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('fix linter issues', guardResult.status);
+      logGuardFailure(CHANNEL, 'fix linter issues', guardResult.status, 'LaTeX');
       return;
     }
 
@@ -178,29 +178,6 @@ export async function handleFixLinterIssues(
     vscode.window.showErrorMessage(
       `Error fixing linter issues: ${String(err)}`,
     );
-  }
-}
-
-function logGuardFailure(
-  action: string,
-  reason: ActiveFileGuardFailureReason,
-): void {
-  switch (reason) {
-    case 'noEditor':
-      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
-      break;
-    case 'unsupportedExtension':
-      logger.warn(
-        CHANNEL,
-        `Cannot ${action}: active document is not a LaTeX file.`,
-      );
-      break;
-    case 'saveFailed':
-      logger.error(
-        CHANNEL,
-        `Cannot ${action}: failed to save LaTeX document before running command.`,
-      );
-      break;
   }
 }
 

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -10,7 +10,10 @@ import {
   getSeverityString,
   countDiagnosticsBySeverity,
 } from '@frontend/latex/linter';
-import { WorkspaceFS } from '@utils/files';
+import {
+  getActiveEditorWithGuards,
+  type ActiveFileGuardFailureReason,
+} from '@utils/editor/activeFileGuards';
 
 // Local imports - core
 import { executeAgent } from '@agent/runtime/executeAgent';
@@ -29,17 +32,17 @@ export const linterCommands = {
  */
 export async function handleShowLinterMessages(): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      logger.warn(CHANNEL, 'No active editor found');
-      vscode.window.showWarningMessage('Please open a file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('show linter messages', guardResult.status);
       return;
     }
 
-    // Convert absolute file path to workspace-relative path
-    const absolutePath = editor.document.fileName;
-    const relativePath = WorkspaceFS.relativePath(absolutePath);
+    const { relativePath } = guardResult;
     logger.debug(CHANNEL, `Getting linter messages for ${relativePath}`);
 
     // Get linter messages
@@ -83,17 +86,17 @@ export async function handleShowLinterMessages(): Promise<void> {
  */
 export async function handleCountLinterMessages(): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      logger.warn(CHANNEL, 'No active editor found');
-      vscode.window.showWarningMessage('Please open a file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('count linter messages', guardResult.status);
       return;
     }
 
-    // Convert absolute file path to workspace-relative path
-    const absolutePath = editor.document.fileName;
-    const relativePath = WorkspaceFS.relativePath(absolutePath);
+    const { relativePath } = guardResult;
     logger.debug(CHANNEL, `Counting linter messages for ${relativePath}`);
 
     // Get linter messages - now uses the async version to ensure build is triggered
@@ -130,22 +133,18 @@ export async function handleFixLinterIssues(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      logger.warn(CHANNEL, 'No active editor found');
-      vscode.window.showWarningMessage('Please open a file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+      saveDocument: true,
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('fix linter issues', guardResult.status);
       return;
     }
 
-    // Save any unsaved changes before attempting to fix
-    if (editor.document.isDirty) {
-      await editor.document.save();
-    }
-
-    // Convert absolute file path to workspace-relative path
-    const absolutePath = editor.document.fileName;
-    const relativePath = WorkspaceFS.relativePath(absolutePath);
+    const { relativePath } = guardResult;
     logger.debug(CHANNEL, `Fixing linter issues for ${relativePath}`);
 
     // Check if there are any linter issues
@@ -179,6 +178,29 @@ export async function handleFixLinterIssues(
     vscode.window.showErrorMessage(
       `Error fixing linter issues: ${String(err)}`,
     );
+  }
+}
+
+function logGuardFailure(
+  action: string,
+  reason: ActiveFileGuardFailureReason,
+): void {
+  switch (reason) {
+    case 'noEditor':
+      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
+      break;
+    case 'unsupportedExtension':
+      logger.warn(
+        CHANNEL,
+        `Cannot ${action}: active document is not a LaTeX file.`,
+      );
+      break;
+    case 'saveFailed':
+      logger.error(
+        CHANNEL,
+        `Cannot ${action}: failed to save LaTeX document before running command.`,
+      );
+      break;
   }
 }
 

--- a/src/commands/system/xmlCommands.ts
+++ b/src/commands/system/xmlCommands.ts
@@ -9,7 +9,10 @@ import * as logger from '@logger/logUtils';
 import { executeAgent } from '@agent/runtime/executeAgent';
 
 // Local imports - utils
-import { WorkspaceFS } from '@utils/files';
+import {
+  getActiveEditorWithGuards,
+  type ActiveFileGuardFailureReason,
+} from '@utils/editor/activeFileGuards';
 
 const CHANNEL = 'XmlCommands';
 logger.initialize(CHANNEL);
@@ -21,26 +24,17 @@ export const xmlCommands = {
 
 export async function handleParseXml(): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      logger.warn(CHANNEL, 'No active editor found');
-      vscode.window.showWarningMessage('Please open an XML file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.xml'],
+      resourceName: 'XML',
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('parse XML', guardResult.status);
       return;
     }
 
-    // Check if it's an XML file
-    if (!editor.document.fileName.toLowerCase().endsWith('.xml')) {
-      logger.warn(
-        CHANNEL,
-        `File ${editor.document.fileName} is not an XML file`,
-      );
-      vscode.window.showWarningMessage(
-        'This command only works with XML files',
-      );
-      return;
-    }
-
+    const { editor } = guardResult;
     const content = editor.document.getText();
     logger.debug(
       CHANNEL,
@@ -87,28 +81,18 @@ export async function handleValidateAndFixXml(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showWarningMessage('Please open an XML file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.xml'],
+      resourceName: 'XML',
+      saveDocument: true,
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('validate XML', guardResult.status);
       return;
     }
 
-    // Check if it's an XML file
-    if (!editor.document.fileName.toLowerCase().endsWith('.xml')) {
-      logger.warn(
-        CHANNEL,
-        `File ${editor.document.fileName} is not an XML file`,
-      );
-      vscode.window.showWarningMessage(
-        'This command only works with XML files',
-      );
-      return;
-    }
-
-    await editor.document.save();
-
-    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
+    const { relativePath: filePath } = guardResult;
 
     logger.info(CHANNEL, `Starting XML validation for ${filePath}`);
 
@@ -126,6 +110,29 @@ export async function handleValidateAndFixXml(
       `Error in validateAndFixXml command: ${err instanceof Error ? err.message : String(err)}`,
     );
     vscode.window.showErrorMessage(`Error validating XML: ${String(err)}`);
+  }
+}
+
+function logGuardFailure(
+  action: string,
+  reason: ActiveFileGuardFailureReason,
+): void {
+  switch (reason) {
+    case 'noEditor':
+      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
+      break;
+    case 'unsupportedExtension':
+      logger.warn(
+        CHANNEL,
+        `Cannot ${action}: active document is not an XML file.`,
+      );
+      break;
+    case 'saveFailed':
+      logger.error(
+        CHANNEL,
+        `Cannot ${action}: failed to save XML document before running command.`,
+      );
+      break;
   }
 }
 

--- a/src/commands/system/xmlCommands.ts
+++ b/src/commands/system/xmlCommands.ts
@@ -11,7 +11,7 @@ import { executeAgent } from '@agent/runtime/executeAgent';
 // Local imports - utils
 import {
   getActiveEditorWithGuards,
-  type ActiveFileGuardFailureReason,
+  logGuardFailure,
 } from '@utils/editor/activeFileGuards';
 
 const CHANNEL = 'XmlCommands';
@@ -30,7 +30,7 @@ export async function handleParseXml(): Promise<void> {
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('parse XML', guardResult.status);
+      logGuardFailure(CHANNEL, 'parse XML', guardResult.status, 'XML');
       return;
     }
 
@@ -88,7 +88,7 @@ export async function handleValidateAndFixXml(
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('validate XML', guardResult.status);
+      logGuardFailure(CHANNEL, 'validate XML', guardResult.status, 'XML');
       return;
     }
 
@@ -110,29 +110,6 @@ export async function handleValidateAndFixXml(
       `Error in validateAndFixXml command: ${err instanceof Error ? err.message : String(err)}`,
     );
     vscode.window.showErrorMessage(`Error validating XML: ${String(err)}`);
-  }
-}
-
-function logGuardFailure(
-  action: string,
-  reason: ActiveFileGuardFailureReason,
-): void {
-  switch (reason) {
-    case 'noEditor':
-      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
-      break;
-    case 'unsupportedExtension':
-      logger.warn(
-        CHANNEL,
-        `Cannot ${action}: active document is not an XML file.`,
-      );
-      break;
-    case 'saveFailed':
-      logger.error(
-        CHANNEL,
-        `Cannot ${action}: failed to save XML document before running command.`,
-      );
-      break;
   }
 }
 

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -15,7 +15,7 @@ import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { GlobalStorageFS, StorageFS } from '@utils/files';
 import {
   getActiveEditorWithGuards,
-  type ActiveFileGuardFailureReason,
+  logGuardFailure,
 } from '@utils/editor/activeFileGuards';
 
 const CHANNEL = 'TestCommands';
@@ -215,7 +215,7 @@ export async function handleParseYaml(
     });
 
     if (guardResult.status !== 'ok') {
-      logGuardFailure('parse YAML', guardResult.status);
+      logGuardFailure(CHANNEL, 'parse YAML', guardResult.status, 'YAML');
       return;
     }
 
@@ -252,29 +252,6 @@ export async function handleParseYaml(
       `Error in parseYaml command: ${err instanceof Error ? err.message : String(err)}`,
     );
     vscode.window.showErrorMessage('Error parsing YAML');
-  }
-}
-
-function logGuardFailure(
-  action: string,
-  reason: ActiveFileGuardFailureReason,
-): void {
-  switch (reason) {
-    case 'noEditor':
-      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
-      break;
-    case 'unsupportedExtension':
-      logger.warn(
-        CHANNEL,
-        `Cannot ${action}: active document is not a YAML file.`,
-      );
-      break;
-    case 'saveFailed':
-      logger.error(
-        CHANNEL,
-        `Cannot ${action}: failed to save YAML document before running command.`,
-      );
-      break;
   }
 }
 

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -13,6 +13,10 @@ import { getAgentPath } from '@agent/runtime/executeAgent';
 import { AgentType } from '@agent/core/AgentDataclass';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { GlobalStorageFS, StorageFS } from '@utils/files';
+import {
+  getActiveEditorWithGuards,
+  type ActiveFileGuardFailureReason,
+} from '@utils/editor/activeFileGuards';
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);
@@ -205,29 +209,17 @@ export async function handleParseYaml(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   try {
-    // Get active editor
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      logger.warn(CHANNEL, 'No active editor found');
-      vscode.window.showWarningMessage('Please open a YAML file first');
+    const guardResult = await getActiveEditorWithGuards({
+      allowedExtensions: ['.yaml', '.yml'],
+      resourceName: 'YAML',
+    });
+
+    if (guardResult.status !== 'ok') {
+      logGuardFailure('parse YAML', guardResult.status);
       return;
     }
 
-    // Check if it's a YAML file
-    if (
-      !editor.document.fileName.toLowerCase().endsWith('.yaml') &&
-      !editor.document.fileName.toLowerCase().endsWith('.yml')
-    ) {
-      logger.warn(
-        CHANNEL,
-        `File ${editor.document.fileName} is not a YAML file`,
-      );
-      vscode.window.showWarningMessage(
-        'This command only works with YAML files',
-      );
-      return;
-    }
-
+    const { editor } = guardResult;
     const content = editor.document.getText();
     logger.debug(
       CHANNEL,
@@ -260,6 +252,29 @@ export async function handleParseYaml(
       `Error in parseYaml command: ${err instanceof Error ? err.message : String(err)}`,
     );
     vscode.window.showErrorMessage('Error parsing YAML');
+  }
+}
+
+function logGuardFailure(
+  action: string,
+  reason: ActiveFileGuardFailureReason,
+): void {
+  switch (reason) {
+    case 'noEditor':
+      logger.warn(CHANNEL, `Cannot ${action}: no active editor found.`);
+      break;
+    case 'unsupportedExtension':
+      logger.warn(
+        CHANNEL,
+        `Cannot ${action}: active document is not a YAML file.`,
+      );
+      break;
+    case 'saveFailed':
+      logger.error(
+        CHANNEL,
+        `Cannot ${action}: failed to save YAML document before running command.`,
+      );
+      break;
   }
 }
 

--- a/src/test/utils/editor/activeFileGuards.test.ts
+++ b/src/test/utils/editor/activeFileGuards.test.ts
@@ -10,29 +10,36 @@ import {
   type ActiveFileGuardResult,
 } from '@utils/editor/activeFileGuards';
 
+// Mock messageUtils before importing it
+let warningMessages: string[] = [];
+let errorMessages: string[] = [];
+
+// Import and mock messageUtils
+import * as messageUtils from '@frontend/ui/messageUtils';
+
 suite('Active File Guards', () => {
   let originalActiveTextEditor: vscode.TextEditor | undefined;
   let originalWorkspaceFolders:
     | readonly vscode.WorkspaceFolder[]
     | undefined;
-  let warningMessages: string[];
-  let errorMessages: string[];
-
-  const originalShowWarningMessage = vscode.window.showWarningMessage;
-  const originalShowErrorMessage = vscode.window.showErrorMessage;
+  let originalShowWarningMessage: typeof messageUtils.showWarningMessage;
+  let originalShowErrorMessage: typeof messageUtils.showErrorMessage;
 
   beforeEach(() => {
     originalActiveTextEditor = vscode.window.activeTextEditor;
     originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+    originalShowWarningMessage = messageUtils.showWarningMessage;
+    originalShowErrorMessage = messageUtils.showErrorMessage;
     warningMessages = [];
     errorMessages = [];
 
-    (vscode.window as any).showWarningMessage = (message: string) => {
+    // Mock the messageUtils exports
+    (messageUtils as any).showWarningMessage = (message: string) => {
       warningMessages.push(message);
       return Promise.resolve(undefined);
     };
 
-    (vscode.window as any).showErrorMessage = (message: string) => {
+    (messageUtils as any).showErrorMessage = (message: string) => {
       errorMessages.push(message);
       return Promise.resolve(undefined);
     };
@@ -47,8 +54,8 @@ suite('Active File Guards', () => {
   afterEach(() => {
     (vscode.window as any).activeTextEditor = originalActiveTextEditor;
     (vscode.workspace as any).workspaceFolders = originalWorkspaceFolders;
-    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
-    (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+    (messageUtils as any).showWarningMessage = originalShowWarningMessage;
+    (messageUtils as any).showErrorMessage = originalShowErrorMessage;
   });
 
   test('returns noEditor when there is no active editor', async () => {

--- a/src/test/utils/editor/activeFileGuards.test.ts
+++ b/src/test/utils/editor/activeFileGuards.test.ts
@@ -1,0 +1,127 @@
+// Standard library imports
+import * as assert from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - utils
+import {
+  getActiveEditorWithGuards,
+  type ActiveFileGuardResult,
+} from '@utils/editor/activeFileGuards';
+
+suite('Active File Guards', () => {
+  let originalActiveTextEditor: vscode.TextEditor | undefined;
+  let originalWorkspaceFolders:
+    | readonly vscode.WorkspaceFolder[]
+    | undefined;
+  let warningMessages: string[];
+  let errorMessages: string[];
+
+  const originalShowWarningMessage = vscode.window.showWarningMessage;
+  const originalShowErrorMessage = vscode.window.showErrorMessage;
+
+  beforeEach(() => {
+    originalActiveTextEditor = vscode.window.activeTextEditor;
+    originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+    warningMessages = [];
+    errorMessages = [];
+
+    (vscode.window as any).showWarningMessage = (message: string) => {
+      warningMessages.push(message);
+      return Promise.resolve(undefined);
+    };
+
+    (vscode.window as any).showErrorMessage = (message: string) => {
+      errorMessages.push(message);
+      return Promise.resolve(undefined);
+    };
+
+    (vscode.workspace as any).workspaceFolders = [
+      { uri: vscode.Uri.file('/workspace/project') },
+    ];
+
+    (vscode.window as any).activeTextEditor = undefined;
+  });
+
+  afterEach(() => {
+    (vscode.window as any).activeTextEditor = originalActiveTextEditor;
+    (vscode.workspace as any).workspaceFolders = originalWorkspaceFolders;
+    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+  });
+
+  test('returns noEditor when there is no active editor', async () => {
+    const result = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+    });
+
+    assert.strictEqual(result.status, 'noEditor');
+    assert.strictEqual(warningMessages.length, 1);
+    assert.ok(warningMessages[0].includes('No active editor found'));
+  });
+
+  test('returns unsupportedExtension when active document does not match', async () => {
+    const mockEditor = createEditor('/workspace/project/notes/sample.txt');
+    (vscode.window as any).activeTextEditor = mockEditor;
+
+    const result = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+    });
+
+    assert.strictEqual(result.status, 'unsupportedExtension');
+    assert.strictEqual(warningMessages.length, 1);
+    assert.ok(warningMessages[0].includes('LaTeX'));
+  });
+
+  test('saves dirty document when requested and returns editor data', async () => {
+    const mockEditor = createEditor('/workspace/project/main.tex', true);
+    (vscode.window as any).activeTextEditor = mockEditor;
+
+    const result = await getActiveEditorWithGuards({
+      allowedExtensions: ['.tex'],
+      resourceName: 'LaTeX',
+      saveDocument: true,
+    });
+
+    assert.strictEqual(result.status, 'ok');
+    const successResult = result as Extract<ActiveFileGuardResult, { status: 'ok' }>;
+    assert.strictEqual(successResult.relativePath, 'main.tex');
+    assert.strictEqual(mockEditor.document.save.callCount, 1);
+    assert.deepStrictEqual(errorMessages, []);
+    assert.deepStrictEqual(warningMessages, []);
+  });
+
+  function createEditor(
+    fileName: string,
+    isDirty = false,
+  ): vscode.TextEditor & {
+    document: {
+      fileName: string;
+      isDirty: boolean;
+      save: (() => Promise<boolean>) & { callCount: number };
+    };
+  } {
+    const saveStub = Object.assign(
+      () => {
+        saveStub.callCount += 1;
+        return Promise.resolve(true);
+      },
+      { callCount: 0 },
+    );
+
+    const document = {
+      fileName,
+      isDirty,
+      save: saveStub,
+    } as any;
+
+    return {
+      document,
+    } as vscode.TextEditor & {
+      document: typeof document;
+    };
+  }
+});

--- a/src/utils/editor/activeFileGuards.ts
+++ b/src/utils/editor/activeFileGuards.ts
@@ -8,6 +8,9 @@ import {
   showWarningMessage,
 } from '@frontend/ui/messageUtils';
 
+// Local imports - log
+import * as logger from '@logger/logUtils';
+
 export type ActiveFileGuardFailureReason =
   | 'noEditor'
   | 'unsupportedExtension'
@@ -96,4 +99,42 @@ export async function getActiveEditorWithGuards(
     editor,
     relativePath,
   };
+}
+
+/**
+ * Log guard failure with standardized messages.
+ * @param channel - Logger channel name
+ * @param action - Description of the action being performed (e.g., "parse XML", "indent LaTeX document")
+ * @param reason - Reason for guard failure
+ * @param resourceType - Optional resource type (e.g., "LaTeX", "XML", "YAML") for unsupported extension messages
+ */
+export function logGuardFailure(
+  channel: string,
+  action: string,
+  reason: ActiveFileGuardFailureReason,
+  resourceType?: string,
+): void {
+  switch (reason) {
+    case 'noEditor':
+      logger.warn(channel, `Cannot ${action}: no active editor found.`);
+      break;
+    case 'unsupportedExtension': {
+      const typeDescription = resourceType
+        ? ` ${resourceType} file`
+        : ' file with the expected extension';
+      logger.warn(
+        channel,
+        `Cannot ${action}: active document is not a${typeDescription}.`,
+      );
+      break;
+    }
+    case 'saveFailed': {
+      const typeDescription = resourceType ? ` ${resourceType}` : '';
+      logger.error(
+        channel,
+        `Cannot ${action}: failed to save${typeDescription} document before running command.`,
+      );
+      break;
+    }
+  }
 }

--- a/src/utils/editor/activeFileGuards.ts
+++ b/src/utils/editor/activeFileGuards.ts
@@ -1,0 +1,99 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - utils
+import { WorkspaceFS } from '@utils/files';
+import {
+  showErrorMessage,
+  showWarningMessage,
+} from '@frontend/ui/messageUtils';
+
+export type ActiveFileGuardFailureReason =
+  | 'noEditor'
+  | 'unsupportedExtension'
+  | 'saveFailed';
+
+export interface ActiveFileGuardOptions {
+  allowedExtensions: string[];
+  resourceName?: string;
+  saveDocument?: boolean;
+}
+
+export type ActiveFileGuardResult =
+  | {
+      status: 'ok';
+      editor: vscode.TextEditor;
+      relativePath: string;
+    }
+  | {
+      status: ActiveFileGuardFailureReason;
+    };
+
+const ensureLeadingDot = (extension: string): string =>
+  extension.startsWith('.') ? extension : `.${extension}`;
+
+const toLowerCase = (value: string): string => value.toLowerCase();
+
+const formatExtensionList = (extensions: string[]): string =>
+  extensions.length > 0 ? extensions.join(', ') : '';
+
+/**
+ * Retrieve the active text editor when available and ensure the document
+ * matches the required extension list. Optionally saves dirty documents.
+ */
+export async function getActiveEditorWithGuards(
+  options: ActiveFileGuardOptions,
+): Promise<ActiveFileGuardResult> {
+  const {
+    allowedExtensions,
+    resourceName,
+    saveDocument = false,
+  } = options;
+
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    const fileDescription = resourceName
+      ? `${resourceName} file`
+      : 'supported file';
+    await showWarningMessage(
+      `No active editor found. Open a ${fileDescription} in the editor and try again.`,
+    );
+    return { status: 'noEditor' };
+  }
+
+  const extensionsForDisplay = allowedExtensions.map(ensureLeadingDot);
+  const normalizedExtensions = extensionsForDisplay.map(toLowerCase);
+  const fileName = editor.document.fileName.toLowerCase();
+
+  if (
+    normalizedExtensions.length > 0 &&
+    !normalizedExtensions.some((extension) => fileName.endsWith(extension))
+  ) {
+    const resourceLabel = resourceName
+      ? `${resourceName} files`
+      : 'files with the supported extensions';
+    const extensionList = formatExtensionList(extensionsForDisplay);
+    await showWarningMessage(
+      `This command only works with ${resourceLabel} (${extensionList}).`,
+    );
+    return { status: 'unsupportedExtension' };
+  }
+
+  if (saveDocument && editor.document.isDirty) {
+    const saved = await editor.document.save();
+    if (!saved) {
+      await showErrorMessage(
+        'Could not save the current file. Please save and try again.',
+      );
+      return { status: 'saveFailed' };
+    }
+  }
+
+  const relativePath = WorkspaceFS.relativePath(editor.document.fileName);
+
+  return {
+    status: 'ok',
+    editor,
+    relativePath,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable `getActiveEditorWithGuards` helper that validates the active editor, normalizes warnings, and optionally saves dirty documents
- refactor LaTeX, XML, and YAML command handlers to use the shared guard logic for consistent messaging and logging
- add unit coverage for missing-editor, unsupported extension, and dirty document flows

## Testing
- npm run lint
- npm test -- --grep "Active File Guards" *(fails: vscode-test cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f01729ad9483248668dc252360e199

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds shared `getActiveEditorWithGuards` and refactors LaTeX/XML/YAML commands to use it, with unified messaging/logging and new tests.
> 
> - **Utilities**:
>   - Add `src/utils/editor/activeFileGuards.ts` providing `getActiveEditorWithGuards` with extension checks, optional save, and normalized messages.
> - **Command Handlers**:
>   - Refactor LaTeX commands (`src/commands/latex/figCommands.ts`, `latexCommands.ts`, `linterCommands.ts`) to use `getActiveEditorWithGuards`; add `logGuardFailure` helpers; remove ad-hoc editor/extension checks and inline saving; use returned `relativePath`/`editor`.
>   - Refactor system commands (`src/commands/system/xmlCommands.ts`, `yamlCommands.ts`) to use `getActiveEditorWithGuards` for `.xml`/`.yaml|.yml`; add `logGuardFailure`; remove direct `WorkspaceFS`/editor checks where replaced.
> - **Tests**:
>   - Add `src/test/utils/editor/activeFileGuards.test.ts` covering no editor, unsupported extension, and dirty document save flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a64a127969ae5120173b45a5b83382d565a38fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->