### PR TITLE
Refactor latex compare commands validation

### DIFF
--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -11,9 +11,83 @@ import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import { DIFF_REGISTRATION_DELAY_MS } from '@utils/config';
+import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 
 const CHANNEL = 'CompareCommands';
 logger.initialize(CHANNEL);
+
+type CompareValidationErrorCode =
+  | 'MISSING_SELECTION'
+  | 'BASE_FILE_NOT_FOUND'
+  | 'EDITED_FILE_NOT_FOUND';
+
+export class CompareCommandValidationError extends Error {
+  constructor(
+    public readonly code: CompareValidationErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'CompareCommandValidationError';
+  }
+}
+
+interface DiffValidationResult {
+  baseRelativePath: string;
+  editedRelativePath: string;
+  baseUri: vscode.Uri;
+  editedUri: vscode.Uri;
+  baseFileName: string;
+  editedFileName: string;
+}
+
+const VALIDATION_ERROR_PREFIX = 'Unable to prepare files for diff';
+
+export async function validateDiffFiles(
+  inputFile: string,
+  baseFile: string,
+  editedFile: string,
+): Promise<DiffValidationResult> {
+  const baseRelativePath = baseFile || inputFile;
+
+  if (!baseRelativePath || !editedFile) {
+    const error = new CompareCommandValidationError(
+      'MISSING_SELECTION',
+      'Both base file and edited file must be selected.',
+    );
+    await showLoggedErrorMessage(CHANNEL, VALIDATION_ERROR_PREFIX, error);
+    throw error;
+  }
+
+  if (!(await WorkspaceFS.exists(baseRelativePath))) {
+    const error = new CompareCommandValidationError(
+      'BASE_FILE_NOT_FOUND',
+      `Base file not found: ${baseRelativePath}`,
+    );
+    await showLoggedErrorMessage(CHANNEL, VALIDATION_ERROR_PREFIX, error);
+    throw error;
+  }
+
+  if (!(await WorkspaceFS.exists(editedFile))) {
+    const error = new CompareCommandValidationError(
+      'EDITED_FILE_NOT_FOUND',
+      `Edited file not found: ${editedFile}`,
+    );
+    await showLoggedErrorMessage(CHANNEL, VALIDATION_ERROR_PREFIX, error);
+    throw error;
+  }
+
+  const normalizedBasePath = path.normalize(baseRelativePath);
+  const normalizedEditedPath = path.normalize(editedFile);
+
+  return {
+    baseRelativePath: normalizedBasePath,
+    editedRelativePath: normalizedEditedPath,
+    baseUri: vscode.Uri.file(WorkspaceFS.fullPath(normalizedBasePath)),
+    editedUri: vscode.Uri.file(WorkspaceFS.fullPath(normalizedEditedPath)),
+    baseFileName: path.basename(normalizedBasePath),
+    editedFileName: path.basename(normalizedEditedPath),
+  };
+}
 
 /**
  * Register comparison related commands
@@ -34,32 +108,9 @@ async function handleCompare(
   editedFile: string,
 ) {
   try {
-    const fileToUse = baseFile || inputFile;
-    if (!fileToUse || !editedFile) {
-      vscode.window.showErrorMessage(
-        'Both base file and edited file must be selected for comparison',
-      );
-      return;
-    }
+    const { baseUri, editedUri, baseFileName, editedFileName } =
+      await validateDiffFiles(inputFile, baseFile, editedFile);
 
-    // Create URIs for both files
-    const baseUri = vscode.Uri.file(WorkspaceFS.fullPath(fileToUse));
-    const editedUri = vscode.Uri.file(WorkspaceFS.fullPath(editedFile));
-
-    // Verify both files exist
-    if (!(await WorkspaceFS.exists(fileToUse))) {
-      vscode.window.showErrorMessage(`Base file not found: ${fileToUse}`);
-      return;
-    }
-
-    if (!(await WorkspaceFS.exists(editedFile))) {
-      vscode.window.showErrorMessage(`Edited file not found: ${editedFile}`);
-      return;
-    }
-
-    // Create title for the diff editor
-    const baseFileName = path.basename(fileToUse);
-    const editedFileName = path.basename(editedFile);
     const title = `Compare: ${editedFileName} ↔ ${baseFileName}`;
     // const title = `Compare: ${baseFileName} ↔ ${editedFileName}`;
 
@@ -106,13 +157,10 @@ async function handleCompare(
       `Opened diff comparison between ${baseFileName} and ${editedFileName}`,
     );
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error comparing files: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    logger.error(
-      CHANNEL,
-      `Error in handleCompare: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    if (err instanceof CompareCommandValidationError) {
+      return;
+    }
+    await showLoggedErrorMessage(CHANNEL, 'Error comparing files', err);
   }
 }
 
@@ -125,31 +173,15 @@ async function handleAcceptEdited(
   editedFile: string,
 ) {
   try {
-    const fileToUse = baseFile || inputFile;
-    if (!fileToUse || !editedFile) {
-      vscode.window.showErrorMessage(
-        'Both base file and edited file must be selected to accept changes',
-      );
-      return;
-    }
-
-    // Verify both files exist
-    if (!(await WorkspaceFS.exists(fileToUse))) {
-      vscode.window.showErrorMessage(`Base file not found: ${fileToUse}`);
-      return;
-    }
-
-    if (!(await WorkspaceFS.exists(editedFile))) {
-      vscode.window.showErrorMessage(`Edited file not found: ${editedFile}`);
-      return;
-    }
+    const {
+      baseRelativePath,
+      editedRelativePath,
+      baseFileName,
+      editedFileName,
+    } = await validateDiffFiles(inputFile, baseFile, editedFile);
 
     // Read content from edited file using workspace utilities
-    const editedContent = await WorkspaceFS.read(editedFile);
-
-    // Confirm with user
-    const baseFileName = path.basename(fileToUse);
-    const editedFileName = path.basename(editedFile);
+    const editedContent = await WorkspaceFS.read(editedRelativePath);
 
     const answer = await vscode.window.showWarningMessage(
       `This will overwrite '${baseFileName}' with content from '${editedFileName}'. Are you sure?`,
@@ -163,7 +195,7 @@ async function handleAcceptEdited(
     }
 
     // Write content to base file using workspace utilities
-    await WorkspaceFS.write(fileToUse, editedContent);
+    await WorkspaceFS.write(baseRelativePath, editedContent);
 
     vscode.window.showInformationMessage(
       `Successfully replaced '${baseFileName}' with content from '${editedFileName}'`,
@@ -174,13 +206,10 @@ async function handleAcceptEdited(
       `Copied content from ${editedFileName} to ${baseFileName}`,
     );
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error accepting changes: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    logger.error(
-      CHANNEL,
-      `Error in handleAcceptEdited: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    if (err instanceof CompareCommandValidationError) {
+      return;
+    }
+    await showLoggedErrorMessage(CHANNEL, 'Error accepting changes', err);
   }
 }
 

--- a/src/test/commands/latex/compareCommands.test.ts
+++ b/src/test/commands/latex/compareCommands.test.ts
@@ -1,0 +1,190 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - commands
+import {
+  compareCommands,
+  CompareCommandValidationError,
+  validateDiffFiles,
+} from '@commands/latex/compareCommands';
+
+// Local imports - utils
+import { WorkspaceFS } from '@utils/files';
+import * as errorHandlingUtils from '@common/errors/errorHandlingUtils';
+
+describe('compareCommands validation', () => {
+  let originalExists: typeof WorkspaceFS.exists;
+  let originalFullPath: typeof WorkspaceFS.fullPath;
+  let originalRead: typeof WorkspaceFS.read;
+  let originalWrite: typeof WorkspaceFS.write;
+  let originalShowErrorMessage: typeof vscode.window.showErrorMessage;
+  let originalShowInformationMessage: typeof vscode.window.showInformationMessage;
+  let originalShowWarningMessage: typeof vscode.window.showWarningMessage;
+  let originalShowLoggedErrorMessage: typeof errorHandlingUtils.showLoggedErrorMessage;
+
+  let recordedErrors: { channel: string; prefix: string; message: string }[];
+  let windowErrors: string[];
+
+  beforeEach(() => {
+    originalExists = WorkspaceFS.exists;
+    originalFullPath = WorkspaceFS.fullPath;
+    originalRead = WorkspaceFS.read;
+    originalWrite = WorkspaceFS.write;
+    originalShowErrorMessage = vscode.window.showErrorMessage;
+    originalShowInformationMessage = vscode.window.showInformationMessage;
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    originalShowLoggedErrorMessage = errorHandlingUtils.showLoggedErrorMessage;
+
+    recordedErrors = [];
+    windowErrors = [];
+
+    (WorkspaceFS.fullPath as any) = (relativePath: string) =>
+      path.join('/workspace', path.normalize(relativePath));
+    (WorkspaceFS.read as any) = async () => {
+      throw new Error('read should not be called in this test');
+    };
+    (WorkspaceFS.write as any) = async () => {
+      throw new Error('write should not be called in this test');
+    };
+
+    (vscode.window as any).showErrorMessage = (message: string) => {
+      windowErrors.push(message);
+      return Promise.resolve(message);
+    };
+    (vscode.window as any).showInformationMessage = () => Promise.resolve();
+    (vscode.window as any).showWarningMessage = () => Promise.resolve('Yes');
+
+    (errorHandlingUtils as any).showLoggedErrorMessage = async (
+      channel: string,
+      prefix: string,
+      err: unknown,
+    ) => {
+      const message = err instanceof Error ? err.message : String(err);
+      recordedErrors.push({ channel, prefix, message });
+      return `${prefix}: ${message}`;
+    };
+  });
+
+  afterEach(() => {
+    (WorkspaceFS.exists as any) = originalExists;
+    (WorkspaceFS.fullPath as any) = originalFullPath;
+    (WorkspaceFS.read as any) = originalRead;
+    (WorkspaceFS.write as any) = originalWrite;
+    (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+    (vscode.window as any).showInformationMessage = originalShowInformationMessage;
+    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    (errorHandlingUtils as any).showLoggedErrorMessage =
+      originalShowLoggedErrorMessage;
+  });
+
+  describe('validateDiffFiles', () => {
+    it('resolves base file fallback and returns normalized URIs', async () => {
+      (WorkspaceFS.exists as any) = async () => true;
+
+      const result = await validateDiffFiles(
+        'input/main.tex',
+        '',
+        'edited/main.tex',
+      );
+
+      assert.strictEqual(result.baseRelativePath, path.normalize('input/main.tex'));
+      assert.strictEqual(
+        result.editedRelativePath,
+        path.normalize('edited/main.tex'),
+      );
+      assert.strictEqual(
+        result.baseUri.fsPath,
+        path.join('/workspace', path.normalize('input/main.tex')),
+      );
+      assert.strictEqual(
+        result.editedUri.fsPath,
+        path.join('/workspace', path.normalize('edited/main.tex')),
+      );
+      assert.strictEqual(result.baseFileName, 'main.tex');
+      assert.strictEqual(result.editedFileName, 'main.tex');
+      assert.strictEqual(recordedErrors.length, 0);
+    });
+
+    it('throws when base file is missing', async () => {
+      (WorkspaceFS.exists as any) = async (filePath: string) =>
+        filePath !== 'input/base.tex';
+
+      await assert.rejects(
+        validateDiffFiles('input/base.tex', '', 'edited/main.tex'),
+        (err: unknown) => {
+          assert.ok(err instanceof CompareCommandValidationError);
+          assert.strictEqual(err.code, 'BASE_FILE_NOT_FOUND');
+          assert.strictEqual(
+            err.message,
+            'Base file not found: input/base.tex',
+          );
+          return true;
+        },
+      );
+
+      assert.strictEqual(recordedErrors.length, 1);
+      assert.deepStrictEqual(recordedErrors[0], {
+        channel: 'CompareCommands',
+        prefix: 'Unable to prepare files for diff',
+        message: 'Base file not found: input/base.tex',
+      });
+    });
+
+    it('throws when edited file is missing', async () => {
+      (WorkspaceFS.exists as any) = async (filePath: string) =>
+        filePath === 'input/base.tex';
+
+      await assert.rejects(
+        validateDiffFiles('input/base.tex', '', 'edited/main.tex'),
+        (err: unknown) => {
+          assert.ok(err instanceof CompareCommandValidationError);
+          assert.strictEqual(err.code, 'EDITED_FILE_NOT_FOUND');
+          assert.strictEqual(
+            err.message,
+            'Edited file not found: edited/main.tex',
+          );
+          return true;
+        },
+      );
+
+      assert.strictEqual(recordedErrors.length, 1);
+      assert.deepStrictEqual(recordedErrors[0], {
+        channel: 'CompareCommands',
+        prefix: 'Unable to prepare files for diff',
+        message: 'Edited file not found: edited/main.tex',
+      });
+    });
+  });
+
+  describe('command guard path reuse', () => {
+    it('uses shared validation for compare and accept commands', async () => {
+      (WorkspaceFS.exists as any) = async (filePath: string) =>
+        filePath !== 'input/base.tex';
+
+      await compareCommands.handleCompare(
+        'input/base.tex',
+        '',
+        'edited/main.tex',
+      );
+      await compareCommands.handleAcceptEdited(
+        'input/base.tex',
+        '',
+        'edited/main.tex',
+      );
+
+      assert.strictEqual(recordedErrors.length, 2);
+      for (const entry of recordedErrors) {
+        assert.deepStrictEqual(entry, {
+          channel: 'CompareCommands',
+          prefix: 'Unable to prepare files for diff',
+          message: 'Base file not found: input/base.tex',
+        });
+      }
+      assert.strictEqual(windowErrors.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract a shared `validateDiffFiles` helper for LaTeX compare commands
- surface validation errors through `showLoggedErrorMessage` and reuse the guard path for compare/accept flows
- add unit tests covering missing base and edited files for both commands

## Testing
- npm run compile-tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0174002648324ac6aa27e2d1d6707

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts `validateDiffFiles` with typed errors, refactors `compare`/`acceptEdited` to use it with centralized logged error handling, and adds unit tests.
> 
> - **Latex compare commands**:
>   - **Shared validation**: Introduces `validateDiffFiles` to resolve paths, verify existence, normalize, and return URIs/file names.
>   - **Typed errors**: Adds `CompareCommandValidationError` with specific codes and routes errors via `showLoggedErrorMessage`.
>   - **Refactor commands**: `handleCompare` and `handleAcceptEdited` now use shared validation; remove inline checks; reuse normalized paths; early-return on validation errors.
> - **Tests**:
>   - Adds `src/test/commands/latex/compareCommands.test.ts` covering path normalization, missing base/edited files, and shared guard path reuse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0a5e25acc4d3cff76357daa685a1d1e06561708. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->