### PR TITLE
fix: clarify ts-ignore usage in webview test

### DIFF
--- a/src/test/webview/currentContextHelper.test.ts
+++ b/src/test/webview/currentContextHelper.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /* eslint-env mocha */
 
 // Standard library imports
@@ -9,15 +8,14 @@ import { strict as assert } from 'assert';
 import { JSDOM } from 'jsdom';
 
 // Local imports - webview
-// Webview modules are authored in JavaScript without type declarations.
-// @ts-ignore
+// @ts-ignore: Webview modules are authored in JavaScript without type declarations.
 import {
   MULTIPLE_SELECTIONS,
   CHECK_BOXES,
   ELEMENT_IDS,
 } from '../../webview/modules/constants.js';
 // Helper module is authored in JavaScript as well.
-// @ts-ignore
+// @ts-ignore: collectCurrentContext is defined in a JavaScript module without typings.
 import { collectCurrentContext } from '../../webview/modules/state/currentContext.js';
 
 function createSelect(id: string, value: string) {


### PR DESCRIPTION
## Summary
- remove the @ts-nocheck directive from currentContextHelper webview test
- document the remaining @ts-ignore directives with clear justifications

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0f833b25c8324aa4e9bdfefaec350

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the global `@ts-nocheck` and adds explicit justifications to remaining `@ts-ignore` directives in `src/test/webview/currentContextHelper.test.ts`.
> 
> - **Tests**:
>   - Update `src/test/webview/currentContextHelper.test.ts`:
>     - Remove top-level `@ts-nocheck`.
>     - Add explicit rationale to `@ts-ignore` import lines (jsdom ESM typings; untyped webview modules).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1829394ecfadc641b9f34640f4bbfc13d1658b04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->