### PR TITLE
fix: allow TypeScript to consume webview JS modules

### DIFF
--- a/src/test/webview/currentContextHelper.test.ts
+++ b/src/test/webview/currentContextHelper.test.ts
@@ -8,15 +8,31 @@ import { strict as assert } from 'assert';
 import { JSDOM } from 'jsdom';
 
 // Local imports - webview
-// @ts-ignore: Webview modules are authored in JavaScript without type declarations.
 import {
   MULTIPLE_SELECTIONS,
   CHECK_BOXES,
   ELEMENT_IDS,
 } from '../../webview/modules/constants.js';
-// Helper module is authored in JavaScript as well.
-// @ts-ignore: collectCurrentContext is defined in a JavaScript module without typings.
 import { collectCurrentContext } from '../../webview/modules/state/currentContext.js';
+
+type MultipleSelections = {
+  [key: string]: string[] | boolean;
+  inputFiles: string[];
+  inputFilesActive: boolean;
+  referenceFiles: string[];
+  referenceFilesActive: boolean;
+  outputFiles: string[];
+  outputFilesActive: boolean;
+};
+
+type WebviewContext = {
+  agent: string;
+  sessionType: 'workflow' | 'toolUse';
+  isToolUseAgent: boolean;
+  singleFileSelections: Record<string, string>;
+  multipleFileSelections: MultipleSelections;
+  checkboxValues: Record<string, boolean>;
+};
 
 function createSelect(id: string, value: string) {
   const select = document.createElement('select');
@@ -122,7 +138,7 @@ describe('collectCurrentContext', () => {
   it('aggregates workflow context including filtered single selections', () => {
     bootstrapDom('workflow');
 
-    const context = collectCurrentContext();
+    const context = collectCurrentContext() as WebviewContext;
 
     assert.equal(context.sessionType, 'workflow');
     assert.equal(context.agent, 'workflowAgentValue');
@@ -153,7 +169,7 @@ describe('collectCurrentContext', () => {
   it('uses tool-use agent selection and respects inactive lists', () => {
     bootstrapDom('toolUse');
 
-    const context = collectCurrentContext();
+    const context = collectCurrentContext() as WebviewContext;
 
     assert.equal(context.sessionType, 'toolUse');
     assert.equal(context.agent, 'toolUseAgentValue');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "@eventBus/*": ["src/eventBus/*"]
     },
     "moduleResolution": "node",
+    "allowJs": true,
     "strict": true /* enable all strict type-checking options */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules */
     /* Additional Checks */
@@ -37,5 +38,6 @@
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
   },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.js"],
   "exclude": ["node_modules", "prototypes"]
 }


### PR DESCRIPTION
## Summary
- enable `allowJs` and scope the TypeScript project to `src` so JavaScript webview modules resolve without hand-written declarations
- remove the fragile `constants.d.ts` shim and add a focused context type inside the webview test

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f104a5c72c8324840ffa7f69d7e2e3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable TS to consume webview JS modules and add explicit context types/casts in the webview test.
> 
> - **Build/TypeScript Config**:
>   - Enable `allowJs` and include `src/**/*.js` in project to resolve webview JavaScript modules.
> - **Tests (`src/test/webview/currentContextHelper.test.ts`)**:
>   - Add `MultipleSelections` and `WebviewContext` types and cast `collectCurrentContext()` to `WebviewContext`.
>   - Minor typing of iteration params and cleanup of ignore comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3d83d791c9b06e4e8c07e2164b0688cb36299a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->