### PR TITLE
docs: use vscode protocol install links

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -25,8 +25,15 @@ The easiest way to install TeXRA is directly from an extension marketplace:
 
 TeXRA is available on both the official VS Code Marketplace and the Open VSX Registry:
 
-<a href="https://marketplace.visualstudio.com/items?itemName=texra-ai.texra" target="_blank" style="display: inline-block; background-color: #007ACC; color: white; padding: 8px 12px; text-decoration: none; border-radius: 4px; font-weight: bold; margin: 10px 5px 10px 0;">View on VS Code Marketplace</a>
+<a href="vscode:extension/texra-ai.texra" target="_blank" style="display: inline-block; background-color: #007ACC; color: white; padding: 8px 12px; text-decoration: none; border-radius: 4px; font-weight: bold; margin: 10px 5px 10px 0;">Open in VS Code</a>
 <a href="https://open-vsx.org/extension/texra-ai/texra" target="_blank" style="display: inline-block; background-color: #4D5D99; color: white; padding: 8px 12px; text-decoration: none; border-radius: 4px; font-weight: bold; margin: 10px 0 10px 5px;">View on Open VSX</a>
+
+You can also install TeXRA directly in your preferred editor using protocol-based links:
+
+- [Open in VS Code](vscode:extension/texra-ai.texra)
+- [Open in VS Code Insiders](vscode-insiders:extension/texra-ai.texra)
+- [Open in Cursor](cursor:extension/texra-ai.texra)
+- [Open in Windsurf](windsurf:extension/texra-ai.texra)
 
 ### From VSIX File
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ hero:
       link: /guide/
     - theme: alt
       text: Install from Marketplace
-      link: https://marketplace.visualstudio.com/items?itemName=texra-ai.texra
+      link: vscode:extension/texra-ai.texra
     - theme: alt
       text: Try it on Web
       link: /launch


### PR DESCRIPTION
## Summary
- revert the homepage hero to a single install button that opens the extension with the vscode protocol
- update the installation guide's primary button to launch the vscode protocol link directly

## Testing
- not run (docs only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f105ca06608324bdef7bb4edc2c891

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces marketplace install links with `vscode:` protocol and adds protocol-based install links; updates homepage install button accordingly.
> 
> - **Docs**:
>   - **Installation Guide (`docs/guide/installation.md`)**:
>     - Add "Open in VS Code" button using `vscode:extension/texra-ai.texra`.
>     - Add protocol-based links for VS Code Insiders (`vscode-insiders:`), Cursor (`cursor:`), and Windsurf (`windsurf:`).
>   - **Homepage (`docs/index.md`)**:
>     - Change "Install from Marketplace" action link to `vscode:extension/texra-ai.texra`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7900973c19f6de9daa4d750670964d119e991534. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->