### PR TITLE
Refactor latexdiff mapping caching

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -7,10 +7,9 @@ import { LaTeXdiffService, LaTeXdiffResult } from '@latex/latexdiff';
 import { compileLatex2Pdf } from '@latex/texTools';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { createFileMapping } from '@utils/files';
 import { getConfig } from '@utils/config';
 import { checkToolInstalled } from '@utils/system';
-import { objectToLogString } from '@utils/text/stringUtils';
+import type { RoundOutputMapping } from './types';
 
 export class LatexDiffManager {
   private readonly latexdiffService: LaTeXdiffService;
@@ -54,6 +53,7 @@ export class LatexDiffManager {
 
   async handleLatexdiffofOutput(
     currRound: number,
+    mapping: RoundOutputMapping,
     groupId?: string,
   ): Promise<void> {
     const diffProcessGroupId = groupId ?? this.logger.getActiveGroupId();
@@ -93,16 +93,42 @@ export class LatexDiffManager {
         diffProcessGroupId,
       );
 
-      const baseToOutputMap = createFileMapping(
-        this.baseFiles,
-        outputFiles,
-        'contains',
-      );
+      const processDiffPair = async (
+        baseFile: string,
+        revisedFile: string,
+        runner: () => Promise<LaTeXdiffResult>,
+        operation: 'round-diff' | 'between-rounds-diff',
+      ): Promise<void> => {
+        const result = await runner();
+        this.logLatexdiffResult(result, operation, diffProcessGroupId);
+        aggregated.push({
+          base: baseFile,
+          revised: revisedFile,
+          output: result.diffFileName
+            ? path.join(path.dirname(baseFile), result.diffFileName)
+            : '',
+          status: result.success ? 'success' : 'error',
+          message: result.success ? undefined : result.message,
+        });
+        if (result.success && result.diffFileName) {
+          const diffPath = path.join(
+            path.dirname(baseFile),
+            result.diffFileName,
+          );
+          const buildDir = path.join(path.dirname(diffPath), 'build');
+          await compileLatex2Pdf(
+            diffPath,
+            this.channel,
+            buildDir,
+            true, // prefer latexmk when available
+          );
+        }
+      };
+
+      const basePairs = Array.from(mapping.baseToOutput.entries());
 
       this.logger.debug(
-        `Matched base files to output files: ${Array.from(
-          baseToOutputMap.entries(),
-        )
+        `Matched base files to output files: ${basePairs
           .map(
             ([base, output]) =>
               `${path.basename(base)} -> ${path.basename(output)}`,
@@ -116,35 +142,18 @@ export class LatexDiffManager {
           'Running round-based latexdiff operations',
           diffProcessGroupId,
         );
-        for (const [baseFile, outputFile] of baseToOutputMap.entries()) {
-          const result = await this.latexdiffService.runDiffForRound(
+        for (const [baseFile, outputFile] of basePairs) {
+          await processDiffPair(
             baseFile,
             outputFile,
-            currRound,
+            () =>
+              this.latexdiffService.runDiffForRound(
+                baseFile,
+                outputFile,
+                currRound,
+              ),
+            'round-diff',
           );
-          this.logLatexdiffResult(result, 'round-diff', diffProcessGroupId);
-          aggregated.push({
-            base: baseFile,
-            revised: outputFile,
-            output: result.diffFileName
-              ? path.join(path.dirname(baseFile), result.diffFileName)
-              : '',
-            status: result.success ? 'success' : 'error',
-            message: result.success ? undefined : result.message,
-          });
-          if (result.success && result.diffFileName) {
-            const diffPath = path.join(
-              path.dirname(baseFile),
-              result.diffFileName,
-            );
-            const buildDir = path.join(path.dirname(diffPath), 'build');
-            await compileLatex2Pdf(
-              diffPath,
-              this.channel,
-              buildDir,
-              true, // prefer latexmk when available
-            );
-          }
         }
       }
 
@@ -153,18 +162,10 @@ export class LatexDiffManager {
           'Running between-rounds latexdiff operations',
           diffProcessGroupId,
         );
-        const prevOutputFiles = this.outputFiles[currRound - 1] || [];
-        const prevToCurrentMap = createFileMapping(
-          prevOutputFiles,
-          outputFiles,
-          'basename',
-          true,
-        );
+        const prevPairs = Array.from(mapping.prevToCurrent.entries());
 
         this.logger.debug(
-          `Matched previous round files to current round files: ${Array.from(
-            prevToCurrentMap.entries(),
-          )
+          `Matched previous round files to current round files: ${prevPairs
             .map(
               ([prev, curr]) =>
                 `${path.basename(prev)} -> ${path.basename(curr)}`,
@@ -173,41 +174,17 @@ export class LatexDiffManager {
           diffProcessGroupId,
         );
 
-        for (const [
-          prevOutputFile,
-          currOutputFile,
-        ] of prevToCurrentMap.entries()) {
-          const result = await this.latexdiffService.runDiffBetweenRounds(
+        for (const [prevOutputFile, currOutputFile] of prevPairs) {
+          await processDiffPair(
             prevOutputFile,
             currOutputFile,
-          );
-          this.logLatexdiffResult(
-            result,
+            () =>
+              this.latexdiffService.runDiffBetweenRounds(
+                prevOutputFile,
+                currOutputFile,
+              ),
             'between-rounds-diff',
-            diffProcessGroupId,
           );
-          aggregated.push({
-            base: prevOutputFile,
-            revised: currOutputFile,
-            output: result.diffFileName
-              ? path.join(path.dirname(prevOutputFile), result.diffFileName)
-              : '',
-            status: result.success ? 'success' : 'error',
-            message: result.success ? undefined : result.message,
-          });
-          if (result.success && result.diffFileName) {
-            const diffPath = path.join(
-              path.dirname(prevOutputFile),
-              result.diffFileName,
-            );
-            const buildDir = path.join(path.dirname(diffPath), 'build');
-            await compileLatex2Pdf(
-              diffPath,
-              this.channel,
-              buildDir,
-              true, // prefer latexmk when available
-            );
-          }
         }
       } else if (!generateBetweenRoundDiffs) {
         this.logger.debug(

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -8,7 +8,11 @@ import * as vscode from 'vscode';
 import { DiffStatsManager } from './DiffStatsManager';
 import type { IOutputHandler } from './IOutputHandler';
 import { LatexDiffManager } from './LatexDiffManager';
-import type { NamedOutputFile, OutputFileInfo } from './types';
+import type {
+  NamedOutputFile,
+  OutputFileInfo,
+  RoundOutputMapping,
+} from './types';
 import { XmlOutputManager } from './XmlOutputManager';
 
 // Local imports - agent components
@@ -52,6 +56,10 @@ export class OutputHandler implements IOutputHandler {
   public readonly xmlManager: XmlOutputManager;
   private diffManager: LatexDiffManager;
   private diffStatsManager: DiffStatsManager;
+  private readonly roundMappings: Record<
+    number,
+    RoundOutputMapping | undefined
+  >;
 
   constructor(
     agentSetting: AgentSetting,
@@ -82,6 +90,7 @@ export class OutputHandler implements IOutputHandler {
       this.channel,
     );
     this.diffStatsManager = new DiffStatsManager();
+    this.roundMappings = {};
   }
 
   private ensureRound(round: number): void {
@@ -91,6 +100,43 @@ export class OutputHandler implements IOutputHandler {
     if (!this.outputMappings[round]) {
       this.outputMappings[round] = [];
     }
+  }
+
+  private invalidateRoundMapping(round: number): void {
+    delete this.roundMappings[round];
+  }
+
+  public getRoundFileMapping(round: number): RoundOutputMapping {
+    this.ensureRound(round);
+
+    if (!this.roundMappings[round]) {
+      const roundOutputs = this.outputFiles[round] || [];
+      const baseToOutput = createFileMapping(
+        this.baseFiles,
+        roundOutputs,
+        'contains',
+      );
+      const prevToCurrent =
+        round > 0
+          ? createFileMapping(
+              this.outputFiles[round - 1] || [],
+              roundOutputs,
+              'basename',
+              true,
+            )
+          : new Map<string, string>();
+      const outputToOrigin = new Map(
+        (this.outputMappings[round] || []).map((p) => [p.path, p.source]),
+      );
+
+      this.roundMappings[round] = {
+        baseToOutput,
+        prevToCurrent,
+        outputToOrigin,
+      };
+    }
+
+    return this.roundMappings[round]!;
   }
 
   /**
@@ -174,7 +220,8 @@ export class OutputHandler implements IOutputHandler {
     groupId?: string,
   ): Promise<void> {
     this.ensureRound(currRound);
-    await this.diffManager.handleLatexdiffofOutput(currRound, groupId);
+    const mapping = this.getRoundFileMapping(currRound);
+    await this.diffManager.handleLatexdiffofOutput(currRound, mapping, groupId);
   }
 
   /**
@@ -185,29 +232,21 @@ export class OutputHandler implements IOutputHandler {
   ): Promise<OutputFileInfo[]> {
     this.ensureRound(currRound);
     const roundOutputs = this.outputFiles[currRound];
-    const baseMap = createFileMapping(this.baseFiles, roundOutputs, 'contains');
-    const prevMap =
-      currRound > 0
-        ? createFileMapping(
-            this.outputFiles[currRound - 1] || [],
-            roundOutputs,
-            'basename',
-            true,
-          )
-        : new Map<string, string>();
-    const originMap = new Map(
-      (this.outputMappings[currRound] || []).map((p) => [p.path, p.source]),
-    );
+    const mapping = this.getRoundFileMapping(currRound);
+    const outputToBase = new Map<string, string>();
+    for (const [base, output] of mapping.baseToOutput.entries()) {
+      outputToBase.set(output, base);
+    }
+    const currentToPrev = new Map<string, string>();
+    for (const [prev, curr] of mapping.prevToCurrent.entries()) {
+      currentToPrev.set(curr, prev);
+    }
 
     const infos: OutputFileInfo[] = [];
     for (const file of roundOutputs) {
-      const baseFile =
-        Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
-        null;
-      const prevFile =
-        Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
-        null;
-      const originalFile = originMap.get(file) || null;
+      const baseFile = outputToBase.get(file) ?? null;
+      const prevFile = currentToPrev.get(file) ?? null;
+      const originalFile = mapping.outputToOrigin.get(file) ?? null;
       const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
       const stats = await this.diffStatsManager.computeDiffStats(
         diffBase,
@@ -358,6 +397,7 @@ export class OutputHandler implements IOutputHandler {
 
           this.outputFiles[currRound] = processedFiles;
           this.outputMappings[currRound] = processedPairs;
+          this.invalidateRoundMapping(currRound);
 
           if (this.baseFiles && this.baseFiles.length > 0) {
             await replaceInputCommands(
@@ -373,6 +413,7 @@ export class OutputHandler implements IOutputHandler {
           );
           this.outputFiles[currRound] = [];
           this.outputMappings[currRound] = [];
+          this.invalidateRoundMapping(currRound);
         }
       } catch (err) {
         this.logger.debug(
@@ -382,6 +423,7 @@ export class OutputHandler implements IOutputHandler {
         );
         this.outputFiles[currRound] = [];
         this.outputMappings[currRound] = [];
+        this.invalidateRoundMapping(currRound);
       }
     } else {
       // Single output file case
@@ -417,6 +459,7 @@ export class OutputHandler implements IOutputHandler {
 
           this.outputFiles[currRound] = [processed.path];
           this.outputMappings[currRound] = [processed];
+          this.invalidateRoundMapping(currRound);
         } else {
           this.logger.debug(
             `No processed file was generated from ${outputFile}`,
@@ -424,6 +467,7 @@ export class OutputHandler implements IOutputHandler {
           );
           this.outputFiles[currRound] = [];
           this.outputMappings[currRound] = [];
+          this.invalidateRoundMapping(currRound);
         }
       } catch (err) {
         this.logger.debug(
@@ -443,6 +487,7 @@ export class OutputHandler implements IOutputHandler {
         });
         this.outputFiles[currRound] = [];
         this.outputMappings[currRound] = [];
+        this.invalidateRoundMapping(currRound);
       }
     }
   }

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -12,3 +12,9 @@ export interface OutputFileInfo extends DiffStats {
   prev?: string | null;
   original?: string | null;
 }
+
+export interface RoundOutputMapping {
+  baseToOutput: Map<string, string>;
+  prevToCurrent: Map<string, string>;
+  outputToOrigin: Map<string, string>;
+}

--- a/src/test/output/LatexDiffManager.test.ts
+++ b/src/test/output/LatexDiffManager.test.ts
@@ -1,0 +1,239 @@
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports - agent
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import {
+  AgentCategory,
+  AgentSetting,
+  AgentType,
+} from '@agent/core/AgentDataclass';
+import { OutputHandler } from '@agent/output';
+import { LatexDiffManager } from '@agent/output/LatexDiffManager';
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - utilities
+import * as systemModule from '@utils/system';
+import * as configModule from '@utils/config';
+import * as texToolsModule from '@latex/texTools';
+
+type CheckToolInstalled = typeof systemModule.checkToolInstalled;
+type GetConfig = typeof configModule.getConfig;
+type CompileLatex2Pdf = typeof texToolsModule.compileLatex2Pdf;
+
+describe('LatexDiffManager.handleLatexdiffofOutput', () => {
+  const originalCheckToolInstalled = systemModule.checkToolInstalled;
+  const originalGetConfig = configModule.getConfig;
+  const originalCompileLatex2Pdf = texToolsModule.compileLatex2Pdf;
+
+  const createSetting = (): AgentSetting => ({
+    agentType: AgentType.CoT,
+    agentCategory: AgentCategory.Workflow,
+    documentTag: 'document',
+    temperature: 0,
+    isRewrite: true,
+    rounds: 2,
+    prefills: [],
+    outputExt: 'tex',
+    endTag: '</latex_document>',
+    requiredFiles: {},
+    requiredFilesInternal: {},
+    defaultOutputFiles: [],
+    isMultipleOutput: false,
+    filePatternsContain: [],
+    tools: [],
+  });
+
+  const config: AgentConfig = {
+    model: 'test',
+    agent: 'a',
+    instruction: '',
+    useMultipleOutputs: false,
+    inputFile: 'input.tex',
+    inputFiles: null,
+    referenceFile: null,
+    referenceFiles: null,
+    auxiliaryFile: null,
+    auxiliaryFiles: null,
+    mediaFile: null,
+    mediaFiles: null,
+    outputFiles: null,
+    editedFile: null,
+    toolConfig: {
+      autoExtractFigure: false,
+      autoExtractTikzFigure: false,
+      attachTeXCount: false,
+      attachDiagnostics: false,
+      autoCompileInputPdf: false,
+    },
+  };
+
+  afterEach(() => {
+    (
+      systemModule as { checkToolInstalled: CheckToolInstalled }
+    ).checkToolInstalled = originalCheckToolInstalled;
+    (configModule as { getConfig: GetConfig }).getConfig = originalGetConfig;
+    (
+      texToolsModule as { compileLatex2Pdf: CompileLatex2Pdf }
+    ).compileLatex2Pdf = originalCompileLatex2Pdf;
+  });
+
+  it('executes round diffs using provided mapping', async () => {
+    (
+      systemModule as { checkToolInstalled: CheckToolInstalled }
+    ).checkToolInstalled = async () => true;
+    (configModule as { getConfig: GetConfig }).getConfig = (<T>() =>
+      false as unknown as T) as GetConfig;
+
+    const compileCalls: Array<{ diffPath: string; buildDir: string }> = [];
+    (
+      texToolsModule as { compileLatex2Pdf: CompileLatex2Pdf }
+    ).compileLatex2Pdf = async (
+      diffPath,
+      _channel,
+      buildDir,
+      _preferLatexmk,
+    ) => {
+      compileCalls.push({ diffPath, buildDir: buildDir ?? '' });
+      return true;
+    };
+
+    const baseFile = path.join('workspace', 'base', 'ch1.tex');
+    const outputFile = path.join('workspace', 'output', 'ch1.tex');
+
+    const handler = new OutputHandler(
+      createSetting(),
+      config,
+      0,
+      [baseFile],
+      new AgentLogger('TestLatexDiffManager'),
+    );
+    handler.outputFiles[0] = [outputFile];
+    handler.outputMappings[0] = [
+      { source: path.join('workspace', 'xml', 'ch1.tex'), path: outputFile },
+    ];
+
+    const mapping = handler.getRoundFileMapping(0);
+
+    const manager = new LatexDiffManager(
+      handler.agentSetting,
+      handler.outputFiles,
+      handler.baseFiles,
+      new AgentLogger('TestLatexDiffManager'),
+      'test-channel',
+    );
+
+    const roundCalls: Array<{ base: string; revised: string; round: number }> =
+      [];
+    (manager as any).latexdiffService = {
+      runDiffForRound: async (base: string, revised: string, round: number) => {
+        roundCalls.push({ base, revised, round });
+        return { success: true, diffFileName: 'diff.tex' } as const;
+      },
+      runDiffBetweenRounds: async () => {
+        throw new assert.AssertionError({
+          message: 'between-round diff should not execute',
+        });
+      },
+    };
+
+    await manager.handleLatexdiffofOutput(0, mapping);
+
+    assert.deepStrictEqual(roundCalls, [
+      { base: baseFile, revised: outputFile, round: 0 },
+    ]);
+    assert.deepStrictEqual(compileCalls, [
+      {
+        diffPath: path.join(path.dirname(baseFile), 'diff.tex'),
+        buildDir: path.join('workspace', 'base', 'build'),
+      },
+    ]);
+  });
+
+  it('executes between-round diffs using shared mapping', async () => {
+    (
+      systemModule as { checkToolInstalled: CheckToolInstalled }
+    ).checkToolInstalled = async () => true;
+    (configModule as { getConfig: GetConfig }).getConfig = (<T>() =>
+      true as unknown as T) as GetConfig;
+
+    const compileCalls: Array<{ diffPath: string; buildDir: string }> = [];
+    (
+      texToolsModule as { compileLatex2Pdf: CompileLatex2Pdf }
+    ).compileLatex2Pdf = async (
+      diffPath,
+      _channel,
+      buildDir,
+      _preferLatexmk,
+    ) => {
+      compileCalls.push({ diffPath, buildDir: buildDir ?? '' });
+      return true;
+    };
+
+    const baseFile = path.join('workspace', 'base', 'ch2.tex');
+    const prevOutput = path.join('workspace', 'round0', 'ch2.tex');
+    const currOutput = path.join('workspace', 'round1', 'ch2.tex');
+
+    const handler = new OutputHandler(
+      createSetting(),
+      config,
+      0,
+      [baseFile],
+      new AgentLogger('TestLatexDiffManager'),
+    );
+    handler.agentSetting.isRewrite = false;
+    handler.outputFiles[0] = [prevOutput];
+    handler.outputMappings[0] = [
+      {
+        source: path.join('workspace', 'xml', 'round0', 'ch2.tex'),
+        path: prevOutput,
+      },
+    ];
+    handler.outputFiles[1] = [currOutput];
+    handler.outputMappings[1] = [
+      {
+        source: path.join('workspace', 'xml', 'round1', 'ch2.tex'),
+        path: currOutput,
+      },
+    ];
+
+    const mapping = handler.getRoundFileMapping(1);
+
+    const manager = new LatexDiffManager(
+      handler.agentSetting,
+      handler.outputFiles,
+      handler.baseFiles,
+      new AgentLogger('TestLatexDiffManager'),
+      'test-channel',
+    );
+
+    const roundCalls: Array<{ base: string; revised: string; round: number }> =
+      [];
+    const betweenCalls: Array<{ prev: string; curr: string }> = [];
+    (manager as any).latexdiffService = {
+      runDiffForRound: async (base: string, revised: string, round: number) => {
+        roundCalls.push({ base, revised, round });
+        return { success: true, diffFileName: 'round.tex' } as const;
+      },
+      runDiffBetweenRounds: async (prev: string, curr: string) => {
+        betweenCalls.push({ prev, curr });
+        return { success: true, diffFileName: 'between.tex' } as const;
+      },
+    };
+
+    await manager.handleLatexdiffofOutput(1, mapping);
+
+    assert.deepStrictEqual(roundCalls, []);
+    assert.deepStrictEqual(betweenCalls, [
+      { prev: prevOutput, curr: currOutput },
+    ]);
+    assert.deepStrictEqual(compileCalls, [
+      {
+        diffPath: path.join(path.dirname(prevOutput), 'between.tex'),
+        buildDir: path.join('workspace', 'round0', 'build'),
+      },
+    ]);
+  });
+});

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -115,3 +115,111 @@ describe('OutputHandler.finalizeRound', () => {
     dispose();
   });
 });
+
+describe('OutputHandler.getRoundFileMapping', () => {
+  const setting: AgentSetting = {
+    agentType: AgentType.CoT,
+    agentCategory: AgentCategory.Workflow,
+    documentTag: 'document',
+    temperature: 0,
+    isRewrite: true,
+    rounds: 2,
+    prefills: [],
+    outputExt: 'tex',
+    endTag: '</latex_document>',
+    requiredFiles: {},
+    requiredFilesInternal: {},
+    defaultOutputFiles: [],
+    isMultipleOutput: false,
+    filePatternsContain: [],
+    tools: [],
+  };
+
+  const config: AgentConfig = {
+    model: 'test',
+    agent: 'a',
+    instruction: '',
+    useMultipleOutputs: false,
+    inputFile: 'input.tex',
+    inputFiles: null,
+    referenceFile: null,
+    referenceFiles: null,
+    auxiliaryFile: null,
+    auxiliaryFiles: null,
+    mediaFile: null,
+    mediaFiles: null,
+    outputFiles: null,
+    editedFile: null,
+    toolConfig: {
+      autoExtractFigure: false,
+      autoExtractTikzFigure: false,
+      attachTeXCount: false,
+      attachDiagnostics: false,
+      autoCompileInputPdf: false,
+    },
+  };
+
+  it('caches mapping per round and exposes origin data', () => {
+    const handler = new OutputHandler(
+      setting,
+      config,
+      0,
+      ['workspace/base/ch1.tex'],
+      new AgentLogger('TestOutputHandler'),
+    );
+
+    handler.outputFiles[0] = ['workspace/output/ch1.tex'];
+    handler.outputMappings[0] = [
+      { source: 'workspace/xml/ch1.tex', path: 'workspace/output/ch1.tex' },
+    ];
+
+    const first = handler.getRoundFileMapping(0);
+    const second = handler.getRoundFileMapping(0);
+
+    assert.strictEqual(first, second);
+    assert.strictEqual(
+      first.baseToOutput.get('workspace/base/ch1.tex'),
+      'workspace/output/ch1.tex',
+    );
+    assert.strictEqual(
+      first.outputToOrigin.get('workspace/output/ch1.tex'),
+      'workspace/xml/ch1.tex',
+    );
+  });
+
+  it('includes previous round relationships when available', () => {
+    const handler = new OutputHandler(
+      setting,
+      config,
+      0,
+      ['workspace/base/ch1.tex'],
+      new AgentLogger('TestOutputHandler'),
+    );
+
+    handler.outputFiles[0] = ['workspace/round0/ch1.tex'];
+    handler.outputMappings[0] = [
+      {
+        source: 'workspace/xml/round0/ch1.tex',
+        path: 'workspace/round0/ch1.tex',
+      },
+    ];
+    handler.outputFiles[1] = ['workspace/round1/ch1.tex'];
+    handler.outputMappings[1] = [
+      {
+        source: 'workspace/xml/round1/ch1.tex',
+        path: 'workspace/round1/ch1.tex',
+      },
+    ];
+
+    const mapping = handler.getRoundFileMapping(1);
+
+    assert.strictEqual(
+      mapping.prevToCurrent.get('workspace/round0/ch1.tex'),
+      'workspace/round1/ch1.tex',
+    );
+    assert.strictEqual(
+      mapping.outputToOrigin.get('workspace/round1/ch1.tex'),
+      'workspace/xml/round1/ch1.tex',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- cache base, previous, and origin mappings per round within OutputHandler and expose a shared accessor
- update LatexDiffManager to consume the cached mapping, consolidating diff iteration and logging
- add regression tests covering mapping reuse plus round and between-round latexdiff pairings

## Testing
- npm run compile-tests
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68f10b9309708324887dc89eeef82fe7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches per-round base/prev/origin mappings in `OutputHandler` and updates `LatexDiffManager` to use them, consolidating diff pairing/processing with new tests.
> 
> - **Output handling**:
>   - Introduces cached `RoundOutputMapping` (maps: `baseToOutput`, `prevToCurrent`, `outputToOrigin`) in `OutputHandler` with accessor `getRoundFileMapping` and invalidation on updates.
>   - Uses shared mapping in `handleLatexdiffofOutput` and `gatherOutputFileInfo` to derive base/prev/origin relationships.
> - **Latexdiff**:
>   - `LatexDiffManager.handleLatexdiffofOutput` now accepts `RoundOutputMapping` and iterates over `baseToOutput` and `prevToCurrent` pairs.
>   - Consolidates diff execution/logging via a helper and compiles generated diffs to PDF.
> - **Tests**:
>   - Adds `src/test/output/LatexDiffManager.test.ts` covering round and between-round diffs using shared mapping.
>   - Extends `src/test/output/OutputHandler.test.ts` to verify mapping caching and reuse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4124e216c91478d2d30d3e4df6d4416e6134a32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->