### PR TITLE
docs: refine research positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ launch page.
 - **Reliable scientific workflow** – orchestrate literature review, drafting,
   and revision with reproducible agent runs, structured logs, and built-in
   verification tools like `latexdiff` and `texcount`.
-- **Specialized research agents** – deploy focused agents for polishing
-  arguments, fixing LaTeX, deriving intermediate results, cross-checking
-  symbolic calculations, or running code—without losing control over
-  references and context.
+- **Specialized research agents** – deploy focused agents for correcting
+  LaTeX, polishing prose, generating figures, and document transformation—without
+  losing control over references and context.
 - **Transparent reasoning loops** – inspect live reasoning, replay sessions,
   and compare outputs across models to build trust in the generated work.
 - **Model flexibility with guardrails** – connect to OpenAI, Anthropic,

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/texra-ai.texra)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
 [![License](https://img.shields.io/badge/license-Proprietary-blue)](LICENSE)
 
-TeXRA brings large language models to your academic writing workflow. The
-extension embeds AI-powered agents directly in VS Code so you can draft,
-revise, and manage LaTeX projects without leaving your editor.
+TeXRA brings large language models to rigorous scientific workflows. The
+extension embeds research-grade agents directly in VS Code so you can draft,
+review, and manage LaTeX projects without leaving your editor.
 
 See [texra.ai](https://texra.ai) or the
 [full documentation](https://texra.ai/guide/) for tutorials and a web-based
@@ -13,22 +13,18 @@ launch page.
 
 ## Why TeXRA
 
-- **AI agents for every task** – polish prose, fix LaTeX, draw TikZ, convert
-  papers to slides, perform OCR, or chat with interactive tool-use agents that
-  can run code. Follow up directly in the progress view.
-- **Transparent streaming** – watch model reasoning stream separately from
-  final responses for Claude, DeepSeek, o1, and more.
-- **Progress view** – detailed logs, clickable references, syntax-highlighted
-  code, re-run buttons, and status-bar updates. Helpful empty states guide new
-  users, and a sample project command provides a ready-made example.
-- **LaTeX-first workflow** – automatic figure extraction, PDF and image
-  conversion, indentation, word counts, diffing, and multi-file selection. The
-  extension detects TeX tools on all platforms and integrates with Overleaf and
-  LaTeX Workshop.
-- **Broad model support** – OpenAI (GPT‑5 family, GPT‑OSS), Anthropic (Claude
-  Opus 4.1 and Sonnet), Google Gemini, DeepSeek, Moonshot (Kimi K2), DashScope
-  (Qwen), GitHub Copilot, and more. Optional OpenRouter routing keeps API keys
-  flexible.
+- **Reliable scientific workflow** – orchestrate literature review, drafting,
+  and revision with reproducible agent runs, structured logs, and built-in
+  verification tools like `latexdiff` and `texcount`.
+- **Specialized research agents** – deploy focused agents for polishing
+  arguments, fixing LaTeX, deriving intermediate results, cross-checking
+  symbolic calculations, or running code—without losing control over
+  references and context.
+- **Transparent reasoning loops** – inspect live reasoning, replay sessions,
+  and compare outputs across models to build trust in the generated work.
+- **Model flexibility with guardrails** – connect to OpenAI, Anthropic,
+  DeepSeek, Gemini, Moonshot, Qwen, and custom endpoints while keeping
+  API routing and cost monitoring under your control.
 
 ## Quick Start
 

--- a/docs/guide/acknowledgments.md
+++ b/docs/guide/acknowledgments.md
@@ -23,6 +23,7 @@ TeXRA's design draws inspiration from several key concepts in AI and software de
 - **Chain-of-Thought (CoT) Reasoning [2]:** For complex agents, TeXRA employs techniques inspired by Chain-of-Thought prompting, encouraging models to "think step-by-step" (often visible in the `<scratchpad>` sections of logs) before producing a final output.
 - **Reflection & Action [3, 4]:** The automatic reflection passes, combined with the agent's ability to act (edit text, use tools), draw inspiration from frameworks like ReAct and Reflexion, allowing iterative refinement based on self-critique or environmental feedback.
 - **Structured Prompting (YAML + Jinja):** The use of YAML for structure and Jinja for templating within prompts allows for complex logic, dynamic content injection, and better maintainability, drawing inspiration from approaches seen in libraries like [Prompt Poet](https://github.com/character-ai/prompt-poet). The support for inheritance and modularity allows for a more flexible and reusable prompt design.
+- **Scientific discovery workflows [5]:** TeXRA's focus on reproducible, domain-aware assistance aligns with emerging work on language agents that support theoretical and computational physics research.
 
 We believe combining these concepts provides a robust and adaptable platform for AI-powered academic writing assistance.
 
@@ -35,3 +36,5 @@ We believe combining these concepts provides a robust and adaptable platform for
 [3] Yao, S., Zhao, J., Yu, D., Du, N., Shafran, I., Narasimhan, K., & Cao, Y. (2023). ReAct: Synergizing Reasoning and Acting in Language Models. _International Conference on Learning Representations (ICLR)_.
 
 [4] Shinn, N., Cassano, F., Gopinath, A., Narasimhan, K., & Yao, S. (2023). Reflexion: Language Agents with Verbal Reinforcement Learning. In _Advances in Neural Information Processing Systems 36 (NeurIPS 2023)_.
+
+[5] Lu, S., Jin, Z., Zhang, T. J., Kos, P., Cirac, J. I., & Schölkopf, B. (2025). Can Theoretical Physics Research Benefit from Language Agents? _arXiv preprint arXiv:2506.06214_.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ hero:
       <div class="step-number">2</div>
       <div class="step-content">
         <h3>Choose Agent/Model</h3>
-        <p>Select a specialized agent (correct, polish)</p>
+        <p>Select a specialized agent and model</p>
         <div class="step-icon">🤖</div>
       </div>
     </div>
@@ -71,7 +71,7 @@ hero:
 AI scientists need more than a chat window. TeXRA keeps research grounded in reproducible workflows and transparent reasoning:
 
 - **Reliable scientific loops** – capture every run with logs, diffs, and audit trails so collaborators can verify changes.
-- **Specialized agent roster** – summon correction, analysis, derivation, and validation agents tuned for LaTeX-heavy projects.
+- **Specialized agent roster** – summon correction, polishing, figure generation, and document transformation agents tuned for LaTeX-heavy projects.
 - **Integrated verification tools** – trigger `latexdiff`, `texcount`, compilation checks, and custom scripts directly from the agent run.
 - **Context you control** – work across multi-file projects, reference libraries, and datasets without losing track of provenance.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
   name: TeXRA
-  text: Your Intelligent Academic Research Assistant
-  tagline: AI assistance to help with your academic research in VS Code
+  text: Reliable AI Workflows for Scientific Discovery
+  tagline: Agentic research assistant for AI scientists, physicists, and research engineers
   image:
     src: /logo-1024x1024.svg
     alt: TeXRA Logo
@@ -68,12 +68,12 @@ hero:
 
 ## Why TeXRA?
 
-Standard LLM interfaces struggle with the nuances of academic work – complex formatting, precise terminology, large documents, and multi-step reasoning. TeXRA overcomes these limitations by integrating AI deeply into your workflow with:
+AI scientists need more than a chat window. TeXRA keeps research grounded in reproducible workflows and transparent reasoning:
 
-- **Agentic Design**: Specialized agents tackle specific tasks like correcting, polishing, drawing, and transforming documents.
-- **Reflection & Tool Use**: Agents can critique their own work and leverage external tools (like `latexdiff`, `texcount`) for enhanced accuracy and observability.
-- **Context Awareness**: Seamlessly handles multi-file projects and references, giving you control over the context provided to the LLM (up to its limits).
-- **Transparency & Control**: Uses a structured, customizable agent system – not a black box.
+- **Reliable scientific loops** – capture every run with logs, diffs, and audit trails so collaborators can verify changes.
+- **Specialized agent roster** – summon correction, analysis, derivation, and validation agents tuned for LaTeX-heavy projects.
+- **Integrated verification tools** – trigger `latexdiff`, `texcount`, compilation checks, and custom scripts directly from the agent run.
+- **Context you control** – work across multi-file projects, reference libraries, and datasets without losing track of provenance.
 
 ## Key Capabilities
 


### PR DESCRIPTION
## Summary
- highlight physics-oriented research assistance tasks in the README and remove unsupported model references
- align the documentation hero tagline with TeXRA's research assistant positioning and emphasize derivation/validation agents
- relocate the theoretical-physics inspiration link into the acknowledgments reference list alongside a new summary blurb

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f10e1fcefc8324a7d80bb9b51dbf26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines README and docs to emphasize scientific/reproducible workflows with specialized agents and adds a physics-oriented reference.
> 
> - **Documentation**:
>   - **`README.md`**: Rewrites intro and "Why TeXRA" to center on reliable scientific workflows, specialized research agents, transparent reasoning loops, and guarded model flexibility; highlights built-in verification tools (`latexdiff`, `texcount`).
>   - **`docs/index.md`**: Updates hero text/tagline and "Why TeXRA" to a scientific discovery focus, emphasizing reproducibility (logs/diffs), agent roster, integrated verification tools, and user-controlled context.
>   - **`docs/guide/acknowledgments.md`**: Adds a "Scientific discovery workflows" concept note and a new theoretical-physics reference `[5]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5db5dfcd10fe14714ca11dc6d31e7547d096ba47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->