### PR TITLE
Refactor OutputHandler mapping for latexdiff

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -183,7 +183,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * Processes output files for current round.
    * This method orchestrates the overall output processing flow with clear separation of concerns:
    * 1. Usage tracking via trackRoundUsage
-   * 2. LaTeX diff operations via handleLatexdiffofOutput (only when endTurn is true)
+   * 2. LaTeX diff operations via diffManager.handleLatexdiffofOutput (only when endTurn is true)
    *
    * The actual file processing is handled separately in processOutputFiles.
    *
@@ -207,8 +207,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
       if (existingBase.some((e) => e)) {
         // Pass the process group ID to maintain proper nesting in the log hierarchy
-        await this.outputHandler.handleLatexdiffofOutput(
+        const mapping = this.outputHandler.getRoundMapping(currRound);
+        await this.outputHandler.diffManager.handleLatexdiffofOutput(
           currRound,
+          mapping,
           processGroupId,
         );
       } else {

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -26,9 +26,6 @@ export interface IOutputHandler {
   /** Indent multiple LaTeX files for readability. */
   indentLatexFiles(filePaths: string[]): Promise<void>;
 
-  /** Run latexdiff comparisons for the current round. */
-  handleLatexdiffofOutput(currRound: number, groupId?: string): Promise<void>;
-
   /** Process output files from XML or direct input. */
   processOutputFiles(
     outputFile: string,

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,7 +1,9 @@
 // Local imports - agent
+import { LatexDiffManager } from './LatexDiffManager';
+import { XmlOutputManager } from './XmlOutputManager';
+
 // Local imports - types
 import { NamedOutputFile, OutputFileInfo, RoundFileMapping } from './types';
-import { XmlOutputManager } from './XmlOutputManager';
 
 /** Interface describing OutputHandler behavior used by agents. */
 export interface IOutputHandler {
@@ -13,6 +15,9 @@ export interface IOutputHandler {
 
   /** XML manager for parsing and splitting outputs. */
   xmlManager: XmlOutputManager;
+
+  /** Manager responsible for orchestrating latexdiff operations. */
+  readonly diffManager: LatexDiffManager;
 
   /** Ensure storage for a round and return its outputs. */
   ensureRound(round: number): string[];

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,6 +1,6 @@
 // Local imports - agent
 // Local imports - types
-import { NamedOutputFile, OutputFileInfo } from './types';
+import { NamedOutputFile, OutputFileInfo, RoundFileMapping } from './types';
 import { XmlOutputManager } from './XmlOutputManager';
 
 /** Interface describing OutputHandler behavior used by agents. */
@@ -38,6 +38,9 @@ export interface IOutputHandler {
 
   /** Gather mapping and diff stats for output files of a round. */
   gatherOutputFileInfo(currRound: number): Promise<OutputFileInfo[]>;
+
+  /** Retrieve the cached mapping metadata for a round. */
+  getRoundMapping(currRound: number): RoundFileMapping;
 
   /** Validate expected output files for the given round. */
   validateExpectedOutputs(

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -7,10 +7,23 @@ import { LaTeXdiffService, LaTeXdiffResult } from '@latex/latexdiff';
 import { compileLatex2Pdf } from '@latex/texTools';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { createFileMapping } from '@utils/files';
 import { getConfig } from '@utils/config';
 import { checkToolInstalled } from '@utils/system';
-import { objectToLogString } from '@utils/text/stringUtils';
+
+// Local imports - types
+import type { RoundFileMapping } from './types';
+
+interface LatexDiffDependencies {
+  checkToolInstalled: typeof checkToolInstalled;
+  compileLatex2Pdf: typeof compileLatex2Pdf;
+  getConfig: typeof getConfig;
+}
+
+const defaultLatexDiffDependencies: LatexDiffDependencies = {
+  checkToolInstalled,
+  compileLatex2Pdf,
+  getConfig,
+};
 
 export class LatexDiffManager {
   private readonly latexdiffService: LaTeXdiffService;
@@ -21,6 +34,7 @@ export class LatexDiffManager {
     private readonly baseFiles: string[],
     private readonly logger: AgentLogger,
     private readonly channel: string,
+    private readonly dependencies: LatexDiffDependencies = defaultLatexDiffDependencies,
   ) {
     this.latexdiffService = new LaTeXdiffService(channel);
   }
@@ -54,10 +68,11 @@ export class LatexDiffManager {
 
   async handleLatexdiffofOutput(
     currRound: number,
+    mapping: RoundFileMapping,
     groupId?: string,
   ): Promise<void> {
     const diffProcessGroupId = groupId ?? this.logger.getActiveGroupId();
-    const generateBetweenRoundDiffs = getConfig<boolean>(
+    const generateBetweenRoundDiffs = this.dependencies.getConfig<boolean>(
       'latexdiff.generateBetweenRoundDiffs',
       false,
     );
@@ -70,7 +85,7 @@ export class LatexDiffManager {
     }> = [];
 
     try {
-      if (!(await checkToolInstalled('latexdiff'))) {
+      if (!(await this.dependencies.checkToolInstalled('latexdiff'))) {
         this.logger.warn(
           'Skipping latexdiff operations - latexdiff not installed',
           diffProcessGroupId,
@@ -93,30 +108,30 @@ export class LatexDiffManager {
         diffProcessGroupId,
       );
 
-      const baseToOutputMap = createFileMapping(
-        this.baseFiles,
-        outputFiles,
-        'contains',
-      );
-
-      this.logger.debug(
-        `Matched base files to output files: ${Array.from(
-          baseToOutputMap.entries(),
-        )
-          .map(
-            ([base, output]) =>
-              `${path.basename(base)} -> ${path.basename(output)}`,
-          )
-          .join(', ')}`,
-        diffProcessGroupId,
-      );
+      const basePairs = Array.from(mapping.baseToOutput.entries());
+      if (basePairs.length > 0) {
+        this.logger.debug(
+          `Matched base files to output files: ${basePairs
+            .map(
+              ([base, output]) =>
+                `${path.basename(base)} -> ${path.basename(output)}`,
+            )
+            .join(', ')}`,
+          diffProcessGroupId,
+        );
+      } else if (this.baseFiles.length > 0) {
+        this.logger.debug(
+          'No base file mappings found for current round outputs',
+          diffProcessGroupId,
+        );
+      }
 
       if (this.agentSetting.isRewrite) {
         this.logger.debug(
           'Running round-based latexdiff operations',
           diffProcessGroupId,
         );
-        for (const [baseFile, outputFile] of baseToOutputMap.entries()) {
+        for (const [baseFile, outputFile] of basePairs) {
           const result = await this.latexdiffService.runDiffForRound(
             baseFile,
             outputFile,
@@ -138,7 +153,7 @@ export class LatexDiffManager {
               result.diffFileName,
             );
             const buildDir = path.join(path.dirname(diffPath), 'build');
-            await compileLatex2Pdf(
+            await this.dependencies.compileLatex2Pdf(
               diffPath,
               this.channel,
               buildDir,
@@ -153,30 +168,26 @@ export class LatexDiffManager {
           'Running between-rounds latexdiff operations',
           diffProcessGroupId,
         );
-        const prevOutputFiles = this.outputFiles[currRound - 1] || [];
-        const prevToCurrentMap = createFileMapping(
-          prevOutputFiles,
-          outputFiles,
-          'basename',
-          true,
-        );
+        const prevPairs = Array.from(mapping.prevToOutput.entries());
 
-        this.logger.debug(
-          `Matched previous round files to current round files: ${Array.from(
-            prevToCurrentMap.entries(),
-          )
-            .map(
-              ([prev, curr]) =>
-                `${path.basename(prev)} -> ${path.basename(curr)}`,
-            )
-            .join(', ')}`,
-          diffProcessGroupId,
-        );
+        if (prevPairs.length > 0) {
+          this.logger.debug(
+            `Matched previous round files to current round files: ${prevPairs
+              .map(
+                ([prev, curr]) =>
+                  `${path.basename(prev)} -> ${path.basename(curr)}`,
+              )
+              .join(', ')}`,
+            diffProcessGroupId,
+          );
+        } else {
+          this.logger.debug(
+            'No previous round mappings found for current round outputs',
+            diffProcessGroupId,
+          );
+        }
 
-        for (const [
-          prevOutputFile,
-          currOutputFile,
-        ] of prevToCurrentMap.entries()) {
+        for (const [prevOutputFile, currOutputFile] of prevPairs) {
           const result = await this.latexdiffService.runDiffBetweenRounds(
             prevOutputFile,
             currOutputFile,
@@ -201,7 +212,7 @@ export class LatexDiffManager {
               result.diffFileName,
             );
             const buildDir = path.join(path.dirname(diffPath), 'build');
-            await compileLatex2Pdf(
+            await this.dependencies.compileLatex2Pdf(
               diffPath,
               this.channel,
               buildDir,

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -55,7 +55,7 @@ export class OutputHandler implements IOutputHandler {
   protected logger: AgentLogger;
   protected channel: string;
   public readonly xmlManager: XmlOutputManager;
-  private diffManager: LatexDiffManager;
+  public readonly diffManager: LatexDiffManager;
   private diffStatsManager: DiffStatsManager;
 
   constructor(
@@ -175,34 +175,6 @@ export class OutputHandler implements IOutputHandler {
     }
   }
 
-  /**
-   * Helper method to log latexdiff results with appropriate level
-   * @param result The result of a latexdiff operation
-   * @param operation Description of the operation being performed
-   * @param groupId The group ID for logging context
-   */
-
-  /**
-   * Runs all latexdiff comparisons for the current round.
-   * This is the ONLY place where latexdiff operations should be performed.
-   *
-   * Generates two types of diffs:
-   * 1. Round diffs: Between original input and current output (when in rewrite mode)
-   * 2. Between-rounds diffs: Comparing previous round to current round (when applicable)
-   *
-   */
-  public async handleLatexdiffofOutput(
-    currRound: number,
-    groupId?: string,
-  ): Promise<void> {
-    this.ensureRound(currRound);
-    const mapping = this.getRoundMapping(currRound);
-    await this.diffManager.handleLatexdiffofOutput(
-      currRound,
-      mapping,
-      groupId,
-    );
-  }
 
   /**
    * Gather mapping and diff statistics for output files of a round.
@@ -279,6 +251,11 @@ export class OutputHandler implements IOutputHandler {
 
   private invalidateRoundMapping(round: number): void {
     delete this.roundMappings[round];
+  }
+
+  private invalidateMappingsFromRound(round: number): void {
+    this.invalidateRoundMapping(round);
+    this.invalidateRoundMapping(round + 1);
   }
 
   public async validateExpectedOutputs(
@@ -415,8 +392,7 @@ export class OutputHandler implements IOutputHandler {
 
           this.outputFiles[currRound] = processedFiles;
           this.outputMappings[currRound] = processedPairs;
-          this.invalidateRoundMapping(currRound);
-          this.invalidateRoundMapping(currRound + 1);
+          this.invalidateMappingsFromRound(currRound);
 
           if (this.baseFiles && this.baseFiles.length > 0) {
             await replaceInputCommands(
@@ -432,8 +408,7 @@ export class OutputHandler implements IOutputHandler {
           );
           this.outputFiles[currRound] = [];
           this.outputMappings[currRound] = [];
-          this.invalidateRoundMapping(currRound);
-          this.invalidateRoundMapping(currRound + 1);
+          this.invalidateMappingsFromRound(currRound);
         }
       } catch (err) {
         this.logger.debug(
@@ -443,8 +418,7 @@ export class OutputHandler implements IOutputHandler {
         );
         this.outputFiles[currRound] = [];
         this.outputMappings[currRound] = [];
-        this.invalidateRoundMapping(currRound);
-        this.invalidateRoundMapping(currRound + 1);
+        this.invalidateMappingsFromRound(currRound);
       }
     } else {
       // Single output file case
@@ -480,8 +454,7 @@ export class OutputHandler implements IOutputHandler {
 
           this.outputFiles[currRound] = [processed.path];
           this.outputMappings[currRound] = [processed];
-          this.invalidateRoundMapping(currRound);
-          this.invalidateRoundMapping(currRound + 1);
+          this.invalidateMappingsFromRound(currRound);
         } else {
           this.logger.debug(
             `No processed file was generated from ${outputFile}`,
@@ -489,8 +462,7 @@ export class OutputHandler implements IOutputHandler {
           );
           this.outputFiles[currRound] = [];
           this.outputMappings[currRound] = [];
-          this.invalidateRoundMapping(currRound);
-          this.invalidateRoundMapping(currRound + 1);
+          this.invalidateMappingsFromRound(currRound);
         }
       } catch (err) {
         this.logger.debug(
@@ -510,8 +482,7 @@ export class OutputHandler implements IOutputHandler {
         });
         this.outputFiles[currRound] = [];
         this.outputMappings[currRound] = [];
-        this.invalidateRoundMapping(currRound);
-        this.invalidateRoundMapping(currRound + 1);
+        this.invalidateMappingsFromRound(currRound);
       }
     }
   }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -258,6 +258,22 @@ export class OutputHandler implements IOutputHandler {
     this.invalidateRoundMapping(round + 1);
   }
 
+  /**
+   * Set output files and mappings for a round, invalidating the cache.
+   * @param round The round number
+   * @param files The output file paths
+   * @param mappings The named output file mappings
+   */
+  private setRoundOutputs(
+    round: number,
+    files: string[],
+    mappings: NamedOutputFile[],
+  ): void {
+    this.outputFiles[round] = files;
+    this.outputMappings[round] = mappings;
+    this.invalidateMappingsFromRound(round);
+  }
+
   public async validateExpectedOutputs(
     outputFile: string,
     currRound: number,
@@ -390,9 +406,7 @@ export class OutputHandler implements IOutputHandler {
             activeGroupId,
           );
 
-          this.outputFiles[currRound] = processedFiles;
-          this.outputMappings[currRound] = processedPairs;
-          this.invalidateMappingsFromRound(currRound);
+          this.setRoundOutputs(currRound, processedFiles, processedPairs);
 
           if (this.baseFiles && this.baseFiles.length > 0) {
             await replaceInputCommands(
@@ -406,9 +420,7 @@ export class OutputHandler implements IOutputHandler {
             `No processed files were generated from ${outputFile}`,
             activeGroupId,
           );
-          this.outputFiles[currRound] = [];
-          this.outputMappings[currRound] = [];
-          this.invalidateMappingsFromRound(currRound);
+          this.setRoundOutputs(currRound, [], []);
         }
       } catch (err) {
         this.logger.debug(
@@ -416,9 +428,7 @@ export class OutputHandler implements IOutputHandler {
           activeGroupId,
           MESSAGE_TYPES.INTERNAL,
         );
-        this.outputFiles[currRound] = [];
-        this.outputMappings[currRound] = [];
-        this.invalidateMappingsFromRound(currRound);
+        this.setRoundOutputs(currRound, [], []);
       }
     } else {
       // Single output file case
@@ -452,17 +462,13 @@ export class OutputHandler implements IOutputHandler {
             activeGroupId,
           );
 
-          this.outputFiles[currRound] = [processed.path];
-          this.outputMappings[currRound] = [processed];
-          this.invalidateMappingsFromRound(currRound);
+          this.setRoundOutputs(currRound, [processed.path], [processed]);
         } else {
           this.logger.debug(
             `No processed file was generated from ${outputFile}`,
             activeGroupId,
           );
-          this.outputFiles[currRound] = [];
-          this.outputMappings[currRound] = [];
-          this.invalidateMappingsFromRound(currRound);
+          this.setRoundOutputs(currRound, [], []);
         }
       } catch (err) {
         this.logger.debug(
@@ -480,9 +486,7 @@ export class OutputHandler implements IOutputHandler {
           stream: this.channel,
           filesByRound: { [currRound]: [] },
         });
-        this.outputFiles[currRound] = [];
-        this.outputMappings[currRound] = [];
-        this.invalidateMappingsFromRound(currRound);
+        this.setRoundOutputs(currRound, [], []);
       }
     }
   }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -8,7 +8,11 @@ import * as vscode from 'vscode';
 import { DiffStatsManager } from './DiffStatsManager';
 import type { IOutputHandler } from './IOutputHandler';
 import { LatexDiffManager } from './LatexDiffManager';
-import type { NamedOutputFile, OutputFileInfo } from './types';
+import type {
+  NamedOutputFile,
+  OutputFileInfo,
+  RoundFileMapping,
+} from './types';
 import { XmlOutputManager } from './XmlOutputManager';
 
 // Local imports - agent components
@@ -45,6 +49,7 @@ export class OutputHandler implements IOutputHandler {
   public logId: number;
   public outputFiles: { [key: number]: string[] };
   public outputMappings: { [key: number]: NamedOutputFile[] };
+  private roundMappings: { [key: number]: RoundFileMapping };
   public baseFiles: string[];
   public processGroupId?: string;
   protected logger: AgentLogger;
@@ -65,6 +70,7 @@ export class OutputHandler implements IOutputHandler {
     this.logId = logId;
     this.outputFiles = {};
     this.outputMappings = {};
+    this.roundMappings = {};
     this.baseFiles = baseFiles;
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
@@ -190,7 +196,12 @@ export class OutputHandler implements IOutputHandler {
     groupId?: string,
   ): Promise<void> {
     this.ensureRound(currRound);
-    await this.diffManager.handleLatexdiffofOutput(currRound, groupId);
+    const mapping = this.getRoundMapping(currRound);
+    await this.diffManager.handleLatexdiffofOutput(
+      currRound,
+      mapping,
+      groupId,
+    );
   }
 
   /**
@@ -200,29 +211,19 @@ export class OutputHandler implements IOutputHandler {
     currRound: number,
   ): Promise<OutputFileInfo[]> {
     const roundOutputs = this.ensureRound(currRound);
-    const baseMap = createFileMapping(this.baseFiles, roundOutputs, 'contains');
-    const prevMap =
-      currRound > 0
-        ? createFileMapping(
-            this.ensureRound(currRound - 1),
-            roundOutputs,
-            'basename',
-            true,
-          )
-        : new Map<string, string>();
-    const originMap = new Map(
-      (this.outputMappings[currRound] || []).map((p) => [p.path, p.source]),
-    );
+    const mapping = this.getRoundMapping(currRound);
 
     const infos: OutputFileInfo[] = [];
     for (const file of roundOutputs) {
       const baseFile =
-        Array.from(baseMap.entries()).find(([, out]) => out === file)?.[0] ||
-        null;
+        Array.from(mapping.baseToOutput.entries()).find(
+          ([, out]) => out === file,
+        )?.[0] || null;
       const prevFile =
-        Array.from(prevMap.entries()).find(([, out]) => out === file)?.[0] ||
-        null;
-      const originalFile = originMap.get(file) || null;
+        Array.from(mapping.prevToOutput.entries()).find(
+          ([, out]) => out === file,
+        )?.[0] || null;
+      const originalFile = mapping.originByOutput.get(file) || null;
       const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
       const stats = await this.diffStatsManager.computeDiffStats(
         diffBase,
@@ -237,6 +238,47 @@ export class OutputHandler implements IOutputHandler {
       });
     }
     return infos;
+  }
+
+  /**
+   * Retrieve the cached mapping metadata for a round, computing it if needed.
+   */
+  public getRoundMapping(currRound: number): RoundFileMapping {
+    const existing = this.roundMappings[currRound];
+    if (existing) {
+      return existing;
+    }
+
+    const roundOutputs = this.ensureRound(currRound);
+    const baseToOutput = createFileMapping(
+      this.baseFiles,
+      roundOutputs,
+      'contains',
+    );
+    const prevToOutput =
+      currRound > 0
+        ? createFileMapping(
+            this.ensureRound(currRound - 1),
+            roundOutputs,
+            'basename',
+            true,
+          )
+        : new Map<string, string>();
+    const originByOutput = new Map(
+      (this.outputMappings[currRound] || []).map((p) => [p.path, p.source]),
+    );
+
+    const mapping: RoundFileMapping = {
+      baseToOutput,
+      prevToOutput,
+      originByOutput,
+    };
+    this.roundMappings[currRound] = mapping;
+    return mapping;
+  }
+
+  private invalidateRoundMapping(round: number): void {
+    delete this.roundMappings[round];
   }
 
   public async validateExpectedOutputs(
@@ -373,6 +415,8 @@ export class OutputHandler implements IOutputHandler {
 
           this.outputFiles[currRound] = processedFiles;
           this.outputMappings[currRound] = processedPairs;
+          this.invalidateRoundMapping(currRound);
+          this.invalidateRoundMapping(currRound + 1);
 
           if (this.baseFiles && this.baseFiles.length > 0) {
             await replaceInputCommands(
@@ -388,6 +432,8 @@ export class OutputHandler implements IOutputHandler {
           );
           this.outputFiles[currRound] = [];
           this.outputMappings[currRound] = [];
+          this.invalidateRoundMapping(currRound);
+          this.invalidateRoundMapping(currRound + 1);
         }
       } catch (err) {
         this.logger.debug(
@@ -397,6 +443,8 @@ export class OutputHandler implements IOutputHandler {
         );
         this.outputFiles[currRound] = [];
         this.outputMappings[currRound] = [];
+        this.invalidateRoundMapping(currRound);
+        this.invalidateRoundMapping(currRound + 1);
       }
     } else {
       // Single output file case
@@ -432,6 +480,8 @@ export class OutputHandler implements IOutputHandler {
 
           this.outputFiles[currRound] = [processed.path];
           this.outputMappings[currRound] = [processed];
+          this.invalidateRoundMapping(currRound);
+          this.invalidateRoundMapping(currRound + 1);
         } else {
           this.logger.debug(
             `No processed file was generated from ${outputFile}`,
@@ -439,6 +489,8 @@ export class OutputHandler implements IOutputHandler {
           );
           this.outputFiles[currRound] = [];
           this.outputMappings[currRound] = [];
+          this.invalidateRoundMapping(currRound);
+          this.invalidateRoundMapping(currRound + 1);
         }
       } catch (err) {
         this.logger.debug(
@@ -458,6 +510,8 @@ export class OutputHandler implements IOutputHandler {
         });
         this.outputFiles[currRound] = [];
         this.outputMappings[currRound] = [];
+        this.invalidateRoundMapping(currRound);
+        this.invalidateRoundMapping(currRound + 1);
       }
     }
   }

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -12,3 +12,9 @@ export interface OutputFileInfo extends DiffStats {
   prev?: string | null;
   original?: string | null;
 }
+
+export interface RoundFileMapping {
+  baseToOutput: Map<string, string>;
+  prevToOutput: Map<string, string>;
+  originByOutput: Map<string, string | undefined>;
+}

--- a/src/test/output/LatexDiffManager.test.ts
+++ b/src/test/output/LatexDiffManager.test.ts
@@ -1,0 +1,197 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports - agent
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import {
+  AgentCategory,
+  AgentSetting,
+  AgentType,
+} from '@agent/core/AgentDataclass';
+import { OutputHandler } from '@agent/output';
+import { LatexDiffManager } from '@agent/output/LatexDiffManager';
+
+// Local imports - log
+import { AgentLogger } from '@logger/AgentLogger';
+
+describe('LatexDiffManager mapping reuse', () => {
+  const baseSetting: AgentSetting = {
+    agentType: AgentType.CoT,
+    agentCategory: AgentCategory.Workflow,
+    documentTag: 'document',
+    temperature: 0,
+    isRewrite: true,
+    rounds: 3,
+    prefills: [],
+    outputExt: 'tex',
+    endTag: '</latex_document>',
+    requiredFiles: {},
+    requiredFilesInternal: {},
+    defaultOutputFiles: [],
+    isMultipleOutput: false,
+    filePatternsContain: [],
+    tools: [],
+  };
+
+  const baseConfig: AgentConfig = {
+    model: 'test',
+    agent: 'agent',
+    instruction: '',
+    useMultipleOutputs: false,
+    inputFile: 'input.tex',
+    inputFiles: null,
+    referenceFile: null,
+    referenceFiles: null,
+    auxiliaryFile: null,
+    auxiliaryFiles: null,
+    mediaFile: null,
+    mediaFiles: null,
+    outputFiles: null,
+    editedFile: null,
+    toolConfig: {
+      autoExtractFigure: false,
+      autoExtractTikzFigure: false,
+      attachTeXCount: false,
+      attachDiagnostics: false,
+      autoCompileInputPdf: false,
+    },
+  };
+
+  function createLogger(): AgentLogger {
+    const logger = new AgentLogger('LatexDiffManagerTest');
+    const noop = () => {};
+    (logger as any).debug = noop;
+    (logger as any).info = noop;
+    (logger as any).warn = noop;
+    (logger as any).error = noop;
+    (logger as any).latexDiff = noop;
+    return logger;
+  }
+
+  it('uses shared base mapping for round diffs', async () => {
+    const logger = createLogger();
+    const baseFiles = [path.join('workspace', 'chapter.tex')];
+    const handler = new OutputHandler(baseSetting, baseConfig, 0, baseFiles, logger);
+
+    handler.outputFiles[0] = [path.join('workspace', 'chapter_r0.tex')];
+    handler.outputMappings[0] = [
+      {
+        source: path.join('workspace', 'chapter_r0.tex'),
+        path: path.join('workspace', 'chapter_r0.tex'),
+      },
+    ];
+
+    const mapping = handler.getRoundMapping(0);
+
+    const roundPairs: Array<{ base: string; revised: string; round: number }> = [];
+    const aggregated: unknown[][] = [];
+
+    const testLogger = createLogger();
+    (testLogger as any).latexDiff = (entries: unknown[]) => aggregated.push(entries);
+
+    const manager = new LatexDiffManager(
+      handler.agentSetting,
+      handler.outputFiles,
+      baseFiles,
+      testLogger,
+      'channel',
+      {
+        checkToolInstalled: async () => true,
+        compileLatex2Pdf: async () => true,
+        getConfig: <T>(_: string, defaultValue?: T) => defaultValue as T,
+      },
+    );
+
+    (manager as any).latexdiffService = {
+      runDiffForRound: async (base: string, revised: string, round: number) => {
+        roundPairs.push({ base, revised, round });
+        return { success: true };
+      },
+      runDiffBetweenRounds: async () => ({ success: true }),
+    };
+
+    await manager.handleLatexdiffofOutput(0, mapping, 'group');
+
+    assert.deepEqual(roundPairs, [
+      {
+        base: path.join('workspace', 'chapter.tex'),
+        revised: path.join('workspace', 'chapter_r0.tex'),
+        round: 0,
+      },
+    ]);
+    assert.equal(aggregated.length, 1);
+    assert.equal(aggregated[0].length, 1);
+  });
+
+  it('uses shared previous mapping for between-round diffs', async () => {
+    const logger = createLogger();
+    const baseFiles = [path.join('workspace', 'paper.tex')];
+    const handler = new OutputHandler(baseSetting, baseConfig, 0, baseFiles, logger);
+
+    handler.outputFiles[0] = [path.join('workspace', 'paper_r0.tex')];
+    handler.outputMappings[0] = [
+      {
+        source: path.join('workspace', 'paper_r0.tex'),
+        path: path.join('workspace', 'paper_r0.tex'),
+      },
+    ];
+    handler.outputFiles[1] = [path.join('workspace', 'paper_r1.tex')];
+    handler.outputMappings[1] = [
+      {
+        source: path.join('workspace', 'paper_r1.tex'),
+        path: path.join('workspace', 'paper_r1.tex'),
+      },
+    ];
+
+    const mapping = handler.getRoundMapping(1);
+
+    const roundPairs: Array<{ base: string; revised: string; round: number }> = [];
+    const betweenPairs: Array<{ previous: string; current: string }> = [];
+
+    const testLogger = createLogger();
+
+    const manager = new LatexDiffManager(
+      handler.agentSetting,
+      handler.outputFiles,
+      baseFiles,
+      testLogger,
+      'channel',
+      {
+        checkToolInstalled: async () => true,
+        compileLatex2Pdf: async () => true,
+        getConfig: <T>(key: string, defaultValue?: T) =>
+          (key === 'latexdiff.generateBetweenRoundDiffs'
+            ? (true as T)
+            : (defaultValue as T)),
+      },
+    );
+
+    (manager as any).latexdiffService = {
+      runDiffForRound: async (base: string, revised: string, round: number) => {
+        roundPairs.push({ base, revised, round });
+        return { success: true };
+      },
+      runDiffBetweenRounds: async (prev: string, curr: string) => {
+        betweenPairs.push({ previous: prev, current: curr });
+        return { success: true };
+      },
+    };
+
+    await manager.handleLatexdiffofOutput(1, mapping, 'group');
+
+    assert.deepEqual(roundPairs, [
+      {
+        base: path.join('workspace', 'paper.tex'),
+        revised: path.join('workspace', 'paper_r1.tex'),
+        round: 1,
+      },
+    ]);
+    assert.deepEqual(betweenPairs, [
+      {
+        previous: path.join('workspace', 'paper_r0.tex'),
+        current: path.join('workspace', 'paper_r1.tex'),
+      },
+    ]);
+  });
+});

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -1,5 +1,6 @@
 // Standard library imports
 import { strict as assert } from 'assert';
+import * as path from 'path';
 
 // Local imports - test
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -135,6 +136,42 @@ describe('OutputHandler round helpers', () => {
 
     // Verify reference equality (returns the actual array, not a copy)
     assert.strictEqual(outputs, handler.outputFiles[2]);
+  });
+});
+
+describe('OutputHandler.getRoundMapping', () => {
+  it('caches computed mappings until invalidated', () => {
+    const handler = new OutputHandler(
+      baseSetting,
+      baseConfig,
+      0,
+      [path.join('workspace', 'chapter.tex')],
+      new AgentLogger('TestOutputHandlerMapping'),
+    );
+
+    handler.outputFiles[0] = [path.join('workspace', 'chapter_r0.tex')];
+    handler.outputMappings[0] = [
+      {
+        source: path.join('workspace', 'chapter_r0.tex'),
+        path: path.join('workspace', 'chapter_r0.tex'),
+      },
+    ];
+
+    const first = handler.getRoundMapping(0);
+    const second = handler.getRoundMapping(0);
+
+    assert.strictEqual(second, first, 'expected mapping to be cached');
+
+    handler.outputFiles[0].push(path.join('workspace', 'chapter_appendix_r0.tex'));
+    (handler as any).invalidateRoundMapping(0);
+
+    const third = handler.getRoundMapping(0);
+
+    assert.notStrictEqual(
+      third,
+      first,
+      'expected mapping to refresh after invalidation',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- cache round mapping metadata in OutputHandler and reuse it when gathering info or running latexdiff
- update LatexDiffManager to accept prepared mappings and provide injectable helpers for testing
- add regression coverage for mapping caching, round diffs, and between-round diffs

## Testing
- npm run compile-tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f110785be88324baac91d6e8c3afb9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches per-round file mappings in `OutputHandler` and reworks `LatexDiffManager` to consume these mappings with injectable dependencies, updating agents and tests accordingly.
> 
> - **Output processing**:
>   - Introduce cached round mapping via `OutputHandler.getRoundMapping` with invalidation on updates; `gatherOutputFileInfo` now uses this mapping.
>   - Expose `diffManager` on `OutputHandler`; remove `handleLatexdiffofOutput` from `IOutputHandler`.
>   - Update `processOutputFiles` to use `setRoundOutputs` and invalidate mapping cache.
> - **LaTeX diff**:
>   - `LatexDiffManager.handleLatexdiffofOutput(currRound, mapping, ...)` now consumes a provided `RoundFileMapping` and uses injected helpers (`checkToolInstalled`, `compileLatex2Pdf`, `getConfig`).
>   - Adjust logging and operations to use prepared base and previous-round pairs.
> - **Agent integration**:
>   - `BaseReflectionAgent` calls `outputHandler.diffManager.handleLatexdiffofOutput` with `getRoundMapping(currRound)`.
> - **Types**:
>   - Add `RoundFileMapping` type and `diffManager` to `IOutputHandler`.
> - **Tests**:
>   - Add `LatexDiffManager` tests for mapping reuse and between-round diffs.
>   - Extend `OutputHandler` tests for mapping caching behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ee01026972cc37aabeb4e2c8a993fc971e97d15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->