### PR TITLE
fix: simplify model select initialization

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -123,3 +123,96 @@ export function setChevronIconHorizontal(element, expanded) {
     collapsedClass: CHEVRON_RIGHT_CLASS,
   });
 }
+
+/**
+ * Waits for a DOM element matching the provided selector.
+ *
+ * Uses a MutationObserver to watch for DOM changes until the element appears.
+ * If the element already exists, returns immediately. Supports optional timeout.
+ *
+ * @param {string} selector - CSS selector to match the desired element
+ * @param {Object} [options] - Optional configuration
+ * @param {number} [options.timeout] - Maximum time to wait in milliseconds (default: no timeout)
+ * @returns {{ promise: Promise<Element | null>, dispose: () => void }}
+ *          Returns an object with:
+ *          - promise: Resolves with the element or null if disposed/timeout
+ *          - dispose: Function to cancel the wait and clean up resources
+ *
+ * @example
+ * const { promise, dispose } = waitForElement('#model', { timeout: 5000 });
+ * const element = await promise;
+ * if (element) {
+ *   // Use the element
+ * }
+ */
+export function waitForElement(selector, options = {}) {
+  const existing = document.querySelector(selector);
+  if (existing) {
+    return {
+      promise: Promise.resolve(existing),
+      dispose: () => {},
+    };
+  }
+
+  let observer = null;
+  let resolver = null;
+  let timeoutId = null;
+
+  const promise = new Promise((resolve) => {
+    resolver = resolve;
+
+    // Set up optional timeout
+    if (options.timeout && options.timeout > 0) {
+      timeoutId = setTimeout(() => {
+        if (observer) {
+          observer.disconnect();
+          observer = null;
+        }
+        if (resolver) {
+          resolver = null;
+          resolve(null);
+        }
+      }, options.timeout);
+    }
+
+    observer = new MutationObserver(() => {
+      const element = document.querySelector(selector);
+      if (!element) {
+        return;
+      }
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+      resolver = null;
+      resolve(element);
+    });
+
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  });
+
+  const dispose = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+    if (resolver) {
+      const resolve = resolver;
+      resolver = null;
+      resolve(null);
+    }
+  };
+
+  return { promise, dispose };
+}

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -39,6 +39,59 @@ import { vscode } from '@common/webviewContext.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
 
 /**
+ * Waits for a DOM element matching the provided selector.
+ * @param {string} selector
+ * @returns {{ promise: Promise<Element | null>, dispose: () => void }}
+ */
+function waitForElement(selector) {
+  const existing = document.querySelector(selector);
+  if (existing) {
+    return {
+      promise: Promise.resolve(existing),
+      dispose: () => {},
+    };
+  }
+
+  let observer = null;
+  let resolver = null;
+
+  const promise = new Promise((resolve) => {
+    resolver = resolve;
+    observer = new MutationObserver(() => {
+      const element = document.querySelector(selector);
+      if (!element) {
+        return;
+      }
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+      resolver = null;
+      resolve(element);
+    });
+
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  });
+
+  const dispose = () => {
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+    if (resolver) {
+      const resolve = resolver;
+      resolver = null;
+      resolve(null);
+    }
+  };
+
+  return { promise, dispose };
+}
+
+/**
  * Handles messages from the extension and syncs the webview state.
  */
 export class MainViewMessageHandler extends BaseWebviewMessageHandler {
@@ -52,12 +105,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // Track file list event handlers for cleanup
     this._fileListHandlers = {};
     // Track pending model option updates until the select element is ready
-    this._latestModelOptions = null;
-    this._modelFlushScheduled = false;
-    this._isModelFlushRunning = false;
-    this._modelSelectPromise = null;
-    this._modelSelectResolver = null;
-    this._modelSelectObserver = null;
+    this._disposeModelWaiter = null;
     this._isDisposed = false;
 
     const ctx = {
@@ -87,22 +135,41 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         ),
       [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: () =>
         webviewEventBus.dispatchEvent(new CustomEvent('hideDependencyBanner')),
-      [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (m) => {
+      [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: async (m) => {
         // Validate that options are provided
         if (!m.options) {
           console.warn('SET_MODEL_OPTIONS: No options provided');
           return;
         }
 
-        const select = document.getElementById('model');
-        if (select) {
-          this._latestModelOptions = null;
-          this._applyModelOptions(select, m.options);
+        let select = document.getElementById('model');
+        if (!(select instanceof HTMLSelectElement)) {
+          const waitHandle = waitForElement('#model');
+          if (this._disposeModelWaiter) {
+            this._disposeModelWaiter();
+          }
+          const disposeHandle = () => {
+            waitHandle.dispose();
+            if (this._disposeModelWaiter === disposeHandle) {
+              this._disposeModelWaiter = null;
+            }
+          };
+          this._disposeModelWaiter = disposeHandle;
+          select = await waitHandle.promise;
+          if (this._disposeModelWaiter === disposeHandle) {
+            this._disposeModelWaiter = null;
+          }
+        }
+
+        if (this._isDisposed) {
           return;
         }
 
-        this._latestModelOptions = m.options;
-        this._enqueueModelOptionsFlush();
+        if (!(select instanceof HTMLSelectElement)) {
+          console.warn('SET_MODEL_OPTIONS: Model select element not found');
+          return;
+        }
+        this._applyModelOptions(select, m.options);
       },
       [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: (m) => {
         const optionsPayload = m.options ?? {};
@@ -267,119 +334,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     return { sessionType, select, value };
   }
 
-  _enqueueModelOptionsFlush() {
-    if (this._isDisposed) {
-      return;
-    }
-
-    if (this._modelFlushScheduled) {
-      return;
-    }
-
-    this._modelFlushScheduled = true;
-    Promise.resolve().then(() => this._drainModelOptions());
-  }
-
-  async _drainModelOptions() {
-    if (this._isDisposed) {
-      this._modelFlushScheduled = false;
-      return;
-    }
-
-    if (this._isModelFlushRunning) {
-      return;
-    }
-
-    this._isModelFlushRunning = true;
-
-    try {
-      while (!this._isDisposed && this._latestModelOptions) {
-        const select = await this._waitForModelSelect();
-        if (!select || this._isDisposed) {
-          break;
-        }
-
-        const html = this._latestModelOptions;
-        if (!html) {
-          break;
-        }
-
-        this._latestModelOptions = null;
-        this._applyModelOptions(select, html);
-      }
-    } catch (error) {
-      console.error('SET_MODEL_OPTIONS: Failed to apply options', error);
-    } finally {
-      this._isModelFlushRunning = false;
-      this._modelFlushScheduled = false;
-    }
-
-    if (!this._isDisposed && this._latestModelOptions) {
-      this._enqueueModelOptionsFlush();
-    }
-  }
-
-  _waitForModelSelect() {
-    if (this._isDisposed) {
-      return Promise.resolve(null);
-    }
-
-    const existing = document.getElementById('model');
-    if (existing) {
-      return Promise.resolve(existing);
-    }
-
-    if (this._modelSelectPromise) {
-      return this._modelSelectPromise;
-    }
-
-    this._modelSelectPromise = new Promise((resolve) => {
-      this._modelSelectResolver = resolve;
-      const observer = new MutationObserver(() => {
-        const select = document.getElementById('model');
-        if (select) {
-          this._resolveModelSelectWaiter(select);
-        }
-      });
-      observer.observe(document.documentElement, {
-        childList: true,
-        subtree: true,
-      });
-      this._modelSelectObserver = observer;
-    });
-
-    return this._modelSelectPromise;
-  }
-
-  _resolveModelSelectWaiter(result) {
-    this._disposeModelSelectObserver();
-
-    if (this._modelSelectResolver) {
-      const resolver = this._modelSelectResolver;
-      this._modelSelectResolver = null;
-      this._modelSelectPromise = null;
-      resolver(result);
-    } else {
-      this._modelSelectPromise = null;
-      this._modelSelectResolver = null;
-    }
-  }
-
-  _disposeModelSelectObserver() {
-    if (this._modelSelectObserver) {
-      this._modelSelectObserver.disconnect();
-      this._modelSelectObserver = null;
-    }
-  }
-
   /** Register handlers and optionally request initial data. */
   setup(options = {}) {
     const { requestData = true } = options;
     this._isDisposed = false;
-    this._latestModelOptions = null;
-    this._modelFlushScheduled = false;
-    this._isModelFlushRunning = false;
-    this._resolveModelSelectWaiter(null);
+    if (this._disposeModelWaiter) {
+      this._disposeModelWaiter();
+      this._disposeModelWaiter = null;
+    }
     super.setup();
     if (requestData) {
       this._initializeDataRequests();
@@ -388,11 +350,10 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
   cleanup() {
     this._isDisposed = true;
-    this._latestModelOptions = null;
-    this._modelFlushScheduled = false;
-    this._isModelFlushRunning = false;
-    this._disposeModelSelectObserver();
-    this._resolveModelSelectWaiter(null);
+    if (this._disposeModelWaiter) {
+      this._disposeModelWaiter();
+      this._disposeModelWaiter = null;
+    }
 
     super.cleanup();
     Object.values(this._fileListHandlers).forEach(({ container, handler }) => {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -40,10 +40,26 @@ import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js'
 
 /**
  * Waits for a DOM element matching the provided selector.
- * @param {string} selector
+ *
+ * Uses a MutationObserver to watch for DOM changes until the element appears.
+ * If the element already exists, returns immediately. Supports optional timeout.
+ *
+ * @param {string} selector - CSS selector to match the desired element
+ * @param {Object} [options] - Optional configuration
+ * @param {number} [options.timeout] - Maximum time to wait in milliseconds (default: no timeout)
  * @returns {{ promise: Promise<Element | null>, dispose: () => void }}
+ *          Returns an object with:
+ *          - promise: Resolves with the element or null if disposed/timeout
+ *          - dispose: Function to cancel the wait and clean up resources
+ *
+ * @example
+ * const { promise, dispose } = waitForElement('#model', { timeout: 5000 });
+ * const element = await promise;
+ * if (element) {
+ *   // Use the element
+ * }
  */
-function waitForElement(selector) {
+function waitForElement(selector, options = {}) {
   const existing = document.querySelector(selector);
   if (existing) {
     return {
@@ -54,13 +70,33 @@ function waitForElement(selector) {
 
   let observer = null;
   let resolver = null;
+  let timeoutId = null;
 
   const promise = new Promise((resolve) => {
     resolver = resolve;
+
+    // Set up optional timeout
+    if (options.timeout && options.timeout > 0) {
+      timeoutId = setTimeout(() => {
+        if (observer) {
+          observer.disconnect();
+          observer = null;
+        }
+        if (resolver) {
+          resolver = null;
+          resolve(null);
+        }
+      }, options.timeout);
+    }
+
     observer = new MutationObserver(() => {
       const element = document.querySelector(selector);
       if (!element) {
         return;
+      }
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
       }
       if (observer) {
         observer.disconnect();
@@ -77,6 +113,10 @@ function waitForElement(selector) {
   });
 
   const dispose = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
     if (observer) {
       observer.disconnect();
       observer = null;
@@ -135,6 +175,20 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         ),
       [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: () =>
         webviewEventBus.dispatchEvent(new CustomEvent('hideDependencyBanner')),
+      /**
+       * Handles SET_MODEL_OPTIONS command to update the model dropdown.
+       *
+       * Waits for the #model select element to appear in the DOM before applying options.
+       * Uses a disposer pattern to handle race conditions when multiple SET_MODEL_OPTIONS
+       * messages arrive before the element is ready.
+       *
+       * Disposer pattern explained:
+       * - Store a reference to the current disposer function in this._disposeModelWaiter
+       * - If a new wait starts before the old one finishes, dispose the old waiter
+       * - Use identity checks (disposeHandle === this._disposeModelWaiter) to detect
+       *   if this waiter was superseded by a newer one during the await
+       * - This prevents stale waiters from applying outdated model options
+       */
       [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: async (m) => {
         // Validate that options are provided
         if (!m.options) {
@@ -145,17 +199,26 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         let select = document.getElementById('model');
         if (!(select instanceof HTMLSelectElement)) {
           const waitHandle = waitForElement('#model');
+
+          // Cancel any previous waiter to prevent race conditions
           if (this._disposeModelWaiter) {
             this._disposeModelWaiter();
           }
+
+          // Create a disposer that cleans up this specific waiter
           const disposeHandle = () => {
             waitHandle.dispose();
+            // Only clear _disposeModelWaiter if this is still the active waiter
             if (this._disposeModelWaiter === disposeHandle) {
               this._disposeModelWaiter = null;
             }
           };
           this._disposeModelWaiter = disposeHandle;
+
           select = await waitHandle.promise;
+
+          // Check if this waiter is still active after the await
+          // If not, a newer waiter has taken over, so we should abort
           if (this._disposeModelWaiter === disposeHandle) {
             this._disposeModelWaiter = null;
           }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -28,6 +28,7 @@ import {
   safeSetElementValue,
   safeGetElementById,
   setChevronIcon,
+  waitForElement,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
@@ -37,99 +38,6 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - webview context
 import { vscode } from '@common/webviewContext.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
-
-/**
- * Waits for a DOM element matching the provided selector.
- *
- * Uses a MutationObserver to watch for DOM changes until the element appears.
- * If the element already exists, returns immediately. Supports optional timeout.
- *
- * @param {string} selector - CSS selector to match the desired element
- * @param {Object} [options] - Optional configuration
- * @param {number} [options.timeout] - Maximum time to wait in milliseconds (default: no timeout)
- * @returns {{ promise: Promise<Element | null>, dispose: () => void }}
- *          Returns an object with:
- *          - promise: Resolves with the element or null if disposed/timeout
- *          - dispose: Function to cancel the wait and clean up resources
- *
- * @example
- * const { promise, dispose } = waitForElement('#model', { timeout: 5000 });
- * const element = await promise;
- * if (element) {
- *   // Use the element
- * }
- */
-function waitForElement(selector, options = {}) {
-  const existing = document.querySelector(selector);
-  if (existing) {
-    return {
-      promise: Promise.resolve(existing),
-      dispose: () => {},
-    };
-  }
-
-  let observer = null;
-  let resolver = null;
-  let timeoutId = null;
-
-  const promise = new Promise((resolve) => {
-    resolver = resolve;
-
-    // Set up optional timeout
-    if (options.timeout && options.timeout > 0) {
-      timeoutId = setTimeout(() => {
-        if (observer) {
-          observer.disconnect();
-          observer = null;
-        }
-        if (resolver) {
-          resolver = null;
-          resolve(null);
-        }
-      }, options.timeout);
-    }
-
-    observer = new MutationObserver(() => {
-      const element = document.querySelector(selector);
-      if (!element) {
-        return;
-      }
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-      if (observer) {
-        observer.disconnect();
-        observer = null;
-      }
-      resolver = null;
-      resolve(element);
-    });
-
-    observer.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    });
-  });
-
-  const dispose = () => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    }
-    if (observer) {
-      observer.disconnect();
-      observer = null;
-    }
-    if (resolver) {
-      const resolve = resolver;
-      resolver = null;
-      resolve(null);
-    }
-  };
-
-  return { promise, dispose };
-}
 
 /**
  * Handles messages from the extension and syncs the webview state.
@@ -218,20 +126,26 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
           select = await waitHandle.promise;
 
           // Check if this waiter is still active after the await
-          // If not, a newer waiter has taken over, so we should abort
-          if (this._disposeModelWaiter === disposeHandle) {
-            this._disposeModelWaiter = null;
+          // If not, a newer waiter has taken over, so abort
+          if (this._disposeModelWaiter !== disposeHandle) {
+            return;
+          }
+          this._disposeModelWaiter = null;
+
+          // Check if disposed during await
+          if (this._isDisposed) {
+            return;
+          }
+
+          // Verify element was found
+          if (!(select instanceof HTMLSelectElement)) {
+            console.warn(
+              'SET_MODEL_OPTIONS: Model select element not found after waiting',
+            );
+            return;
           }
         }
 
-        if (this._isDisposed) {
-          return;
-        }
-
-        if (!(select instanceof HTMLSelectElement)) {
-          console.warn('SET_MODEL_OPTIONS: Model select element not found');
-          return;
-        }
         this._applyModelOptions(select, m.options);
       },
       [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: (m) => {


### PR DESCRIPTION
## Summary
- add a mutation-observer-based waitForElement helper to detect the model select
- simplify SET_MODEL_OPTIONS to await the element and remove custom queue bookkeeping
- ensure setup/cleanup clear any outstanding waiters via the helper disposer

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f125c5cc3c8324a7e69e9ed422a0cc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces custom queue/observer logic with a small waitForElement helper and refactors SET_MODEL_OPTIONS to await the model select, with proper disposer-based setup/cleanup.
> 
> - **Webview**:
>   - **Model select initialization**:
>     - Add `waitForElement(selector)` helper using `MutationObserver`.
>     - Refactor `SET_MODEL_OPTIONS` to `async`-await `#model`, validate `HTMLSelectElement`, and apply options directly.
>   - **Cleanup/setup**:
>     - Replace custom queue/promise machinery (`_latestModelOptions`, `_enqueueModelOptionsFlush`, `_drainModelOptions`, `_waitForModelSelect`, related resolver/observer fields) with a single `_disposeModelWaiter` disposer.
>     - Ensure `setup()` and `cleanup()` dispose any pending element waiters and respect `_isDisposed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dae308b91c9ca3d229b6c824cfbcc0d018a45a9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->