### PR TITLE
refactor: unify webview file list restoration

### DIFF
--- a/src/test/webview/MessageHandlersRestore.test.ts
+++ b/src/test/webview/MessageHandlersRestore.test.ts
@@ -1,0 +1,432 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vm from 'vm';
+
+// Third-party imports
+// @ts-ignore: jsdom lacks ESM typings in this context
+import { JSDOM } from 'jsdom';
+
+function loadFileListModule(dom: JSDOM) {
+  const filePath = path.resolve(
+    __dirname,
+    '../../webview/modules/uiManagers/FileList.js',
+  );
+  let code = fs.readFileSync(filePath, 'utf8');
+
+  code = code.replace(/^import .*;$/gm, '');
+  code = code.replace('export class FileList', 'class FileList');
+  code = code.replace(
+    'export const fileList = new FileList();',
+    'const fileList = new FileList();\nmodule.exports = { FileList, fileList };',
+  );
+
+  const iconCalls: Array<{ elementId: string | null; isVisible: boolean }> = [];
+
+  const context = {
+    module: { exports: {} },
+    exports: {},
+    document: dom.window.document,
+    window: dom.window,
+    console,
+    addEventListenerSafely: (
+      el: Element,
+      event: string,
+      handler: EventListener,
+    ) => {
+      el.addEventListener(event, handler);
+    },
+    safeGetElementById: (id: string) => dom.window.document.getElementById(id),
+    setChevronIcon: (element: HTMLElement | null, isVisible: boolean) => {
+      iconCalls.push({ elementId: element?.id ?? null, isVisible });
+    },
+    createFromTemplate: (
+      _templateId: string,
+      config: { text?: Record<string, string>; dataset?: Record<string, any> },
+    ) => {
+      const item = dom.window.document.createElement('div');
+      item.className = 'file-item';
+      const pathValue = config.dataset?.['']?.path ?? '';
+      item.dataset.path = pathValue;
+
+      const nameSpan = dom.window.document.createElement('span');
+      nameSpan.className = 'file-name';
+      nameSpan.textContent = config.text?.['.file-name'] ?? pathValue;
+      item.appendChild(nameSpan);
+
+      const removeButton = dom.window.document.createElement('button');
+      removeButton.className = 'remove-button';
+      removeButton.type = 'button';
+      removeButton.textContent = 'remove';
+      item.appendChild(removeButton);
+
+      return item;
+    },
+    capitalize: (value: string) =>
+      value.charAt(0).toUpperCase() + value.slice(1),
+  } as unknown as vm.Context;
+
+  (context as any).globalThis = context;
+  (context as any).HTMLElement = dom.window.HTMLElement;
+  (context as any).Node = dom.window.Node;
+  (context as any).Event = dom.window.Event;
+
+  vm.createContext(context);
+  vm.runInContext(code, context, { filename: 'FileList.js' });
+
+  return {
+    FileList: (context.module as any).exports.FileList as any,
+    iconCalls,
+  };
+}
+
+function loadMessageHandlerModule(dom: JSDOM) {
+  const filePath = path.resolve(
+    __dirname,
+    '../../webview/modules/messageHandlers.js',
+  );
+  let code = fs.readFileSync(filePath, 'utf8');
+
+  const importMap: Record<string, string> = {
+    './constants.js': 'constants',
+    './eventBus.js': 'eventBus',
+    './handlers/fileHandlers.js': 'fileHandlers',
+    './handlers/recordingHandlers.js': 'recordingHandlers',
+    './handlers/themeHandlers.js': 'themeHandlers',
+    './mainViewState.js': 'mainViewState',
+    './uiManagers/FileSelect.js': 'fileSelect',
+    './uiManagers/BannerManager.js': 'bannerManager',
+    './uiManagers/FileList.js': 'fileListModule',
+    '@common/domUtils.js': 'domUtils',
+    '@common/stringUtils.js': 'stringUtils',
+    '@common/webview/commands.js': 'commands',
+    '@common/webviewContext.js': 'webviewContext',
+    '@common/BaseWebviewMessageHandler.js': 'baseHandler',
+  };
+
+  code = code.replace(
+    /import\s+{\s*([^}]+)\s*}\s+from\s+'([^']+)';/g,
+    (_match, imports, specifier) => {
+      const key = importMap[specifier];
+      if (!key) {
+        throw new Error(`Missing mock for ${specifier}`);
+      }
+      return `const { ${imports.trim()} } = __mocks.${key};`;
+    },
+  );
+
+  code = code.replace(
+    'export class MainViewMessageHandler',
+    'class MainViewMessageHandler',
+  );
+  code = code.replace(
+    /const handler = new MainViewMessageHandler\(\);[\s\S]*?export const cleanup = handler.cleanup.bind\(handler\);/m,
+    '',
+  );
+  code += '\nmodule.exports = { MainViewMessageHandler };';
+
+  const fileListAddCalls: Array<{ listId: string; file: string }> = [];
+  const fileListRemoveCallbacks = new Map<string, (files: string[]) => void>();
+  const vscodeMessages: any[] = [];
+  const mainViewStateSetCalls: any[] = [];
+  const mainViewStateUpdateCalls: any[] = [];
+  const setChevronCalls: Array<{
+    elementId: string | null;
+    isVisible: boolean;
+  }> = [];
+  let restoreCalled = false;
+
+  const constantsMock = {
+    FILE_TYPES: ['input', 'reference', 'auxiliary', 'media', 'output'],
+    INPUT_FILE: 'inputFile',
+    REFERENCE_FILE: 'referenceFile',
+    AUXILIARY_FILE: 'auxiliaryFile',
+    MEDIA_FILE: 'mediaFile',
+    EDITED_FILE: 'editedFile',
+    BASE_FILE: 'baseFile',
+    ELEMENT_IDS: {
+      OUTPUT_FILES: 'outputFiles',
+      OUTPUT_FILES_CONTAINER: 'outputFilesContainer',
+      TOGGLE_OUTPUT_FILES: 'toggleOutputFiles',
+      SESSION_TYPE_TOGGLE: 'sessionTypeToggle',
+      LATEXDIFFS_CONTENT: 'latexdiffsContent',
+      TOGGLE_LATEXDIFFS: 'toggleLatexdiffs',
+      TOGGLE_TOOL_CONFIG: 'toggleToolConfig',
+      TOOL_CONFIG_OPTIONS: 'toolConfigOptions',
+      TOGGLE_AUTO_EXTRACT: 'toggleAutoExtract',
+      AUTO_EXTRACT_OPTIONS: 'autoExtractOptions',
+      API_KEY_BANNER: 'apiKeyBanner',
+      AGENT_CONFIG_BANNER: 'agentConfigBanner',
+    },
+    SESSION_TYPES: { WORKFLOW: 'workflow', TOOL_USE: 'toolUse' },
+    SESSION_TYPE_INPUT: 'sessionType',
+    AGENT_SELECT_IDS: {
+      workflow: 'workflowAgentSelect',
+      toolUse: 'toolUseAgentSelect',
+    },
+    AGENT_SELECT_LIST: ['workflowAgentSelect', 'toolUseAgentSelect'],
+  };
+
+  const domUtilsMock = {
+    safeSetElementValue: (id: string, value: string) => {
+      const element = dom.window.document.getElementById(
+        id,
+      ) as HTMLInputElement | null;
+      if (element) {
+        (element as any).value = value;
+      }
+    },
+    safeGetElementById: (id: string) => dom.window.document.getElementById(id),
+    setChevronIcon: (element: HTMLElement | null, isVisible: boolean) => {
+      setChevronCalls.push({ elementId: element?.id ?? null, isVisible });
+    },
+  };
+
+  const __mocks = {
+    constants: constantsMock,
+    eventBus: { webviewEventBus: { dispatchEvent: () => {} } },
+    fileHandlers: { createFileHandlers: () => ({}) },
+    recordingHandlers: { createRecordingHandlers: () => ({}) },
+    themeHandlers: { createThemeHandlers: () => ({}) },
+    mainViewState: {
+      mainViewState: {
+        set: (state: any) => {
+          mainViewStateSetCalls.push(state);
+        },
+        restore: () => {
+          restoreCalled = true;
+        },
+        update: (update: any) => {
+          mainViewStateUpdateCalls.push(update);
+        },
+        get: () => ({}),
+      },
+    },
+    fileSelect: {
+      fileSelect: {
+        update: () => {},
+        updateEdited: () => {},
+        setAgentDefaultOutputFiles: () => {},
+        handleRecentCommits: () => {},
+        handleSetCurrentFile: () => {},
+        handleSetSelectedCommit: () => {},
+      },
+    },
+    bannerManager: {
+      bannerManager: {
+        showBanner: () => {},
+        hideBanner: () => {},
+      },
+    },
+    fileListModule: {
+      fileList: {
+        add: (listId: string, file: string) => {
+          fileListAddCalls.push({ listId, file });
+        },
+        setRemoveCallback: (
+          listId: string,
+          callback: (files: string[]) => void,
+        ) => {
+          fileListRemoveCallbacks.set(listId, callback);
+        },
+      },
+    },
+    domUtils: domUtilsMock,
+    stringUtils: {
+      capitalize: (value: string) =>
+        value.charAt(0).toUpperCase() + value.slice(1),
+      uncapitalize: (value: string) =>
+        value.charAt(0).toLowerCase() + value.slice(1),
+    },
+    commands: {
+      MAIN_VIEW_COMMANDS: {
+        UPDATE_INPUT_FILES: 'updateInputFiles',
+        UPDATE_REFERENCE_FILES: 'updateReferenceFiles',
+        UPDATE_AUXILIARY_FILES: 'updateAuxiliaryFiles',
+        UPDATE_MEDIA_FILES: 'updateMediaFiles',
+        UPDATE_OUTPUT_FILES: 'updateOutputFiles',
+        SHOW_API_KEY_BANNER: 'showApiKeyBanner',
+        HIDE_API_KEY_BANNER: 'hideApiKeyBanner',
+        SHOW_AGENT_CONFIG_BANNER: 'showAgentConfigBanner',
+        HIDE_AGENT_CONFIG_BANNER: 'hideAgentConfigBanner',
+        SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',
+        HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
+        SET_MODEL_OPTIONS: 'setModelOptions',
+        SET_AGENT_OPTIONS: 'setAgentOptions',
+        SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
+        REQUEST_DEFAULT_OUTPUT_FILES: 'requestDefaultOutputFiles',
+        STATE_RESTORE: 'stateRestore',
+        CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',
+      },
+    },
+    webviewContext: {
+      vscode: {
+        postMessage: (message: any) => {
+          vscodeMessages.push(message);
+        },
+      },
+    },
+    baseHandler: {
+      BaseWebviewMessageHandler: class {
+        setup() {}
+        cleanup() {}
+      },
+    },
+  };
+
+  const context = {
+    __mocks,
+    module: { exports: {} },
+    exports: {},
+    document: dom.window.document,
+    window: dom.window,
+    console,
+  } as unknown as vm.Context;
+
+  (context as any).globalThis = context;
+  (context as any).HTMLElement = dom.window.HTMLElement;
+  (context as any).HTMLSelectElement = dom.window.HTMLSelectElement;
+  (context as any).Event = dom.window.Event;
+  (context as any).CustomEvent = dom.window.CustomEvent;
+
+  vm.createContext(context);
+  vm.runInContext(code, context, { filename: 'messageHandlers.js' });
+
+  return {
+    MainViewMessageHandler: (context.module as any).exports
+      .MainViewMessageHandler as any,
+    mocks: {
+      fileListAddCalls,
+      fileListRemoveCallbacks,
+      vscodeMessages,
+      mainViewStateSetCalls,
+      mainViewStateUpdateCalls,
+      setChevronCalls,
+      restoreCalled: () => restoreCalled,
+      constants: constantsMock,
+    },
+  };
+}
+
+describe('FileList remove callbacks', () => {
+  it('invokes registered callbacks and hides the container when empty', () => {
+    const dom = new JSDOM(`
+      <div id="inputFilesContainer" style="display: block;">
+        <div id="inputFiles"></div>
+      </div>
+      <div id="toggleInputFiles"></div>
+    `);
+
+    const { FileList, iconCalls } = loadFileListModule(dom);
+    let saveCount = 0;
+    let lastRemoved: string[] | null = null;
+    const list = new FileList(() => {
+      saveCount += 1;
+    });
+    list.setRemoveCallback('inputFiles', (files: string[]) => {
+      lastRemoved = files;
+    });
+
+    list.add('inputFiles', 'alpha.tex');
+    list.add('inputFiles', 'beta.tex');
+
+    const firstRemove = dom.window.document.querySelector(
+      '#inputFiles .remove-button',
+    ) as HTMLElement;
+    firstRemove.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+    assert.deepEqual(lastRemoved, ['beta.tex']);
+    assert.strictEqual(saveCount, 1);
+
+    const secondRemove = dom.window.document.querySelector(
+      '#inputFiles .remove-button',
+    ) as HTMLElement;
+    secondRemove.dispatchEvent(
+      new dom.window.Event('click', { bubbles: true }),
+    );
+    assert.deepEqual(lastRemoved, []);
+    assert.strictEqual(
+      dom.window.document.getElementById('inputFilesContainer')?.style.display,
+      'none',
+    );
+    assert(
+      iconCalls.some(
+        (call) =>
+          call.elementId === 'toggleInputFiles' && call.isVisible === false,
+      ),
+      'expected toggle icon to be updated when the list becomes empty',
+    );
+    assert.strictEqual(saveCount, 3);
+  });
+});
+
+describe('MainViewMessageHandler state restoration', () => {
+  it('hydrates lists through FileList and wires removal callbacks', () => {
+    const dom = new JSDOM(`
+      <select id="sessionType"></select>
+      <select id="workflowAgentSelect"></select>
+      <select id="toolUseAgentSelect"></select>
+      <input id="model" />
+      <textarea id="instruction"></textarea>
+      <input id="inputFile" />
+      <input id="referenceFile" />
+      <input id="auxiliaryFile" />
+      <input id="mediaFile" />
+      <div id="sessionTypeToggle">
+        <button data-session-type="workflow"></button>
+        <button data-session-type="toolUse"></button>
+      </div>
+      <div id="inputFilesContainer" style="display: none;">
+        <div id="inputFiles"></div>
+      </div>
+      <div id="toggleInputFiles"></div>
+    `);
+
+    const { MainViewMessageHandler, mocks } = loadMessageHandlerModule(dom);
+    const handler = new MainViewMessageHandler();
+
+    handler._handleStateRestoration({
+      agentConfig: {
+        sessionType: 'workflow',
+        workflowAgent: 'agent-a',
+        inputFiles: ['alpha.tex', 'beta.tex'],
+        inputFilesActive: true,
+      },
+      activeFiles: { input: true },
+    });
+
+    assert.deepEqual(mocks.fileListAddCalls, [
+      { listId: 'inputFiles', file: 'alpha.tex' },
+      { listId: 'inputFiles', file: 'beta.tex' },
+    ]);
+
+    assert.strictEqual(mocks.mainViewStateSetCalls.length, 1);
+    assert.deepEqual(mocks.mainViewStateSetCalls[0].inputFiles, [
+      'alpha.tex',
+      'beta.tex',
+    ]);
+    assert.strictEqual(mocks.mainViewStateSetCalls[0].inputFilesActive, true);
+    assert.strictEqual(mocks.restoreCalled(), true);
+
+    const container = dom.window.document.getElementById('inputFilesContainer');
+    assert.strictEqual(container?.style.display, 'block');
+    assert(
+      mocks.setChevronCalls.some(
+        (call) =>
+          call.elementId === 'toggleInputFiles' && call.isVisible === true,
+      ),
+      'expected toggle icon to be expanded when restoring visible list',
+    );
+
+    const removeCallback = mocks.fileListRemoveCallbacks.get('inputFiles');
+    assert(removeCallback, 'expected removal callback to be registered');
+    removeCallback!(['beta.tex']);
+    assert.deepEqual(mocks.vscodeMessages.pop(), {
+      command: 'updateInputFiles',
+      files: ['beta.tex'],
+    });
+    assert.deepEqual(mocks.mainViewStateUpdateCalls.pop(), {
+      inputFiles: ['beta.tex'],
+    });
+  });
+});

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -19,10 +19,9 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
  * @param {Function} ctx.postHandle
  * @param {Function} ctx.getElement
  * @param {Function} ctx.setToggleIcon
- * @param {Function} ctx.setupFileListHandler
  */
 export function createFileHandlers(ctx) {
-  const { postHandle, getElement, setToggleIcon, setupFileListHandler } = ctx;
+  const { postHandle, getElement, setToggleIcon } = ctx;
   const createSetFileHandler = (fileType, domId) => (message) => {
     fileSelect.update(domId, message.files);
     postHandle();
@@ -35,10 +34,6 @@ export function createFileHandlers(ctx) {
 
   const createSetFilesHandler = (fileType, listId, toggleId) => (message) => {
     fileList.update(listId, toggleId, message.files);
-    const listEl = getElement(listId);
-    if (listEl) {
-      setupFileListHandler(fileType, listEl);
-    }
     postHandle();
   };
 
@@ -80,10 +75,6 @@ export function createFileHandlers(ctx) {
       ...existingFiles,
       message.file,
     ]);
-    if (listDiv) {
-      setupFileListHandler('media', listDiv);
-    }
-
     const container = getElement('mediaFilesContainer');
     if (container && container.style.display === 'none') {
       container.style.display = 'block';

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -582,9 +582,11 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         }
 
         if (filesArray.length > 0 && multipleFiles) {
+          fileList._batchMode = true;
           filesArray.forEach((file) => {
             fileList.add(multipleFilesId, file);
           });
+          fileList._batchMode = false;
         }
       }
     }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -24,13 +24,13 @@ import { mainViewState } from './mainViewState.js';
 // Local imports - UI managers
 import { fileSelect } from './uiManagers/FileSelect.js';
 import { bannerManager } from './uiManagers/BannerManager.js';
+import { fileList } from './uiManagers/FileList.js';
 import {
   safeSetElementValue,
   safeGetElementById,
   setChevronIcon,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { createFromTemplate } from '@common/templateUtils.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -49,8 +49,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // Cached DOM elements
     this._instructionEl = null;
     this._elementCache = new Map();
-    // Track file list event handlers for cleanup
-    this._fileListHandlers = {};
     // Track pending model option updates until the select element is ready
     this._latestModelOptions = null;
     this._modelFlushScheduled = false;
@@ -64,8 +62,9 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       postHandle: this._postHandle.bind(this),
       getElement: this._getElement.bind(this),
       setToggleIcon: this._setToggleIcon.bind(this),
-      setupFileListHandler: this._setupFileListHandler.bind(this),
     };
+
+    this._registerFileListCallbacks();
 
     this._handlers = {
       ...createThemeHandlers({ postHandle: ctx.postHandle }),
@@ -395,10 +394,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     this._resolveModelSelectWaiter(null);
 
     super.cleanup();
-    Object.values(this._fileListHandlers).forEach(({ container, handler }) => {
-      container.removeEventListener('click', handler);
-    });
-    this._fileListHandlers = {};
     this._instructionEl = null;
     this._elementCache.clear();
   }
@@ -409,61 +404,27 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     setChevronIcon(element, isVisible);
   }
 
-  _createFileItem(file) {
-    const element = createFromTemplate('fileListEntryTemplate', {
-      text: { '.file-name': file },
-      dataset: { '': { path: file } },
-    });
-    if (element) return element;
-
-    const fileItem = document.createElement('div');
-    fileItem.className = 'file-item';
-    fileItem.dataset.path = file;
-
-    const nameSpan = document.createElement('span');
-    nameSpan.className = 'file-name';
-    nameSpan.textContent = file;
-    fileItem.appendChild(nameSpan);
-
-    const removeButton = document.createElement('span');
-    removeButton.className = 'remove-button';
-    removeButton.textContent = '-';
-    fileItem.appendChild(removeButton);
-
-    return fileItem;
-  }
-
-  _setupFileListHandler(fileType, container) {
-    if (!container || this._fileListHandlers[fileType]) return;
-    const handler = (e) => {
-      if (
-        e.target instanceof HTMLElement &&
-        e.target.classList.contains('remove-button')
-      ) {
-        e.stopPropagation();
-        const item = e.target.closest('.file-item');
-        if (item) {
-          item.remove();
-          const updated = Array.from(
-            container.querySelectorAll('.file-item'),
-          ).map((el) => el.dataset.path);
-          const updateCommands = {
-            input: MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES,
-            reference: MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES,
-            auxiliary: MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES,
-            media: MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES,
-            output: MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES,
-          };
-          vscode.postMessage({
-            command: updateCommands[fileType],
-            files: updated,
-          });
-          mainViewState.update({ [`${fileType}Files`]: updated });
-        }
-      }
+  _registerFileListCallbacks() {
+    const updateCommands = {
+      input: MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES,
+      reference: MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES,
+      auxiliary: MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES,
+      media: MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES,
+      output: MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES,
     };
-    container.addEventListener('click', handler);
-    this._fileListHandlers[fileType] = { container, handler };
+
+    FILE_TYPES.forEach((fileType) => {
+      const listId =
+        fileType === 'output' ? ELEMENT_IDS.OUTPUT_FILES : `${fileType}Files`;
+
+      fileList.setRemoveCallback(listId, (files) => {
+        const command = updateCommands[fileType];
+        if (command) {
+          vscode.postMessage({ command, files });
+        }
+        mainViewState.update({ [`${fileType}Files`]: files });
+      });
+    });
   }
 
   _getElement(id) {
@@ -616,12 +577,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         const toggleElement = this._getElement(toggleId);
         this._setToggleIcon(toggleElement, isVisible);
 
-        if (filesArray.length > 0 && multipleFiles) {
+        if (multipleFiles) {
           multipleFiles.innerHTML = '';
+        }
+
+        if (filesArray.length > 0 && multipleFiles) {
           filesArray.forEach((file) => {
-            multipleFiles.appendChild(this._createFileItem(file));
+            fileList.add(multipleFilesId, file);
           });
-          this._setupFileListHandler(fileType, multipleFiles);
         }
       }
     }

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -13,11 +13,24 @@ import { createFromTemplate } from '@common/templateUtils.js';
 export class FileList {
   constructor(saveFn = () => {}) {
     this._saveFn = saveFn;
+    this._removeCallbacks = new Map();
   }
 
   /** Set the callback used to persist state */
   setSaveFn(saveFn) {
     this._saveFn = typeof saveFn === 'function' ? saveFn : () => {};
+  }
+
+  /** Register a callback fired when entries are removed from a list */
+  setRemoveCallback(containerId, callback) {
+    if (!containerId) {
+      return;
+    }
+    if (typeof callback === 'function') {
+      this._removeCallbacks.set(containerId, callback);
+    } else {
+      this._removeCallbacks.delete(containerId);
+    }
   }
   /**
    * Add a file entry to a list container
@@ -47,9 +60,17 @@ export class FileList {
         if (container.contains(fileElement)) {
           container.removeChild(fileElement);
         }
+
+        const remaining = this.getSelected(container);
+        const removeCallback = this._removeCallbacks.get(containerId);
+        if (removeCallback) {
+          removeCallback(remaining);
+        }
+
         if (container.children.length === 0) {
           this.empty(containerId, `toggle${capitalize(containerId)}`);
         }
+
         this._saveFn();
       });
     }

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -14,6 +14,7 @@ export class FileList {
   constructor(saveFn = () => {}) {
     this._saveFn = saveFn;
     this._removeCallbacks = new Map();
+    this._batchMode = false;
   }
 
   /** Set the callback used to persist state */
@@ -30,6 +31,13 @@ export class FileList {
       this._removeCallbacks.set(containerId, callback);
     } else {
       this._removeCallbacks.delete(containerId);
+    }
+  }
+
+  /** Save state unless in batch mode */
+  _save() {
+    if (!this._batchMode) {
+      this._saveFn();
     }
   }
   /**
@@ -68,10 +76,10 @@ export class FileList {
         }
 
         if (container.children.length === 0) {
-          this.empty(containerId, `toggle${capitalize(containerId)}`);
+          this.empty(containerId, `toggle${capitalize(containerId)}`, false);
+        } else {
+          this._save();
         }
-
-        this._saveFn();
       });
     }
     container.appendChild(fileElement);
@@ -87,7 +95,10 @@ export class FileList {
     const newFiles = files.filter((f) => !existing.includes(f));
 
     if (newFiles.length > 0) {
+      this._batchMode = true;
       newFiles.forEach((file) => this.add(listId, file));
+      this._batchMode = false;
+
       listDiv.style.display = 'block';
       setChevronIcon(toggleIcon, true);
 
@@ -96,7 +107,7 @@ export class FileList {
         container.style.display = 'block';
       }
     }
-    this._saveFn();
+    this._save();
   }
 
   /** Return an array of selected file paths */
@@ -120,11 +131,11 @@ export class FileList {
     if (!container) return;
     const isVisible = container.style.display !== 'none';
     this.setVisibility(containerId, toggleId, !isVisible);
-    this._saveFn();
+    this._save();
   }
 
   /** Empty all files from a container and hide it */
-  empty(containerId, toggleId) {
+  empty(containerId, toggleId, shouldSave = true) {
     const listDiv = safeGetElementById(containerId);
     const container = safeGetElementById(`${containerId}Container`);
     if (!listDiv || !container) return;
@@ -135,7 +146,9 @@ export class FileList {
     if (toggleIconDiv) {
       setChevronIcon(toggleIconDiv, false);
     }
-    this._saveFn();
+    if (shouldSave) {
+      this._save();
+    }
   }
 
   /** Hide empty lists from the provided id array */


### PR DESCRIPTION
## Summary
- reuse the shared FileList manager during state restoration and route removal updates through its callbacks
- simplify multi-file handlers now that FileList owns remove wiring
- add jsdom-based tests that exercise restored list hydration and removal persistence

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68f1275b014c8324804c725073f78b7c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route file list hydration and removal through the shared FileList manager, simplify handlers, and add jsdom tests for restoration and removal callbacks.
> 
> - **Webview**:
>   - **State restoration & removal**: `MainViewMessageHandler` now uses `fileList` for hydrating lists (`fileList.add`) and registers per-list removal callbacks that post `UPDATE_*_FILES` and update `mainViewState`.
>   - **Simplified handlers**: Removed manual DOM item creation and `_setupFileListHandler`; dropped `createFromTemplate` usage and related cleanup logic.
>   - **Visibility/chevron**: Maintains container visibility and chevron state during restore via existing helpers.
> - **File handlers**:
>   - Use `fileList.update` without wiring remove handlers; simplify media add flow; remove `setupFileListHandler` dependence.
> - **UI Manager (`FileList`)**:
>   - Add `setRemoveCallback(containerId, callback)`; invoke callback with remaining files on item removal; ensure empty list hides container and updates chevron; persist via `_saveFn`.
> - **Tests**:
>   - Add `MessageHandlersRestore.test.ts` using jsdom to verify removal callbacks, container visibility/chevron updates, state hydration, and VS Code message/state updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ac353298ecf51a1f1bf354c37b4b8af4f9b0959. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->