### PR TITLE
Refactor progress output clearing into shared state helper

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -24,7 +24,6 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
-import { TaskState, isWorkflowTaskState } from '@logger/TaskState';
 
 // Type aliases for status values
 type StreamStatusType =
@@ -229,16 +228,10 @@ export class ProgressViewProvider
    * Clear task output (legacy compatibility)
    */
   public clearTaskOutput(streamTabId: StreamTabId): void {
-    const taskState = this.state.getTaskState(streamTabId);
-    if (!taskState || !isWorkflowTaskState(taskState)) {
-      return;
+    const didUpdate = this.state.clearOutputState(streamTabId);
+    if (didUpdate) {
+      this.updateWebview();
     }
-
-    // Only clear output-related fields, preserve other task state data
-    taskState.agentConfig.outputFiles = [];
-    taskState.agentConfig.useMultipleOutputs = false;
-    taskState.activeFiles.output = false;
-    this.state.setTaskState(streamTabId, taskState);
   }
 
   /**

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -13,8 +13,6 @@ import type { OutputFileInfo } from '@agent/output/types';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createErrorBoundary } from './errorHandling';
 import type { ProgressEventBusLike } from './types';
-import { isWorkflowTaskState } from '@logger/TaskState';
-
 import type { AgentLogger } from '@logger/AgentLogger';
 
 export interface OutputEventsModule {
@@ -113,15 +111,7 @@ const registerClearTaskOutput = (
   return new vscode.Disposable(
     bus.on('clearTaskOutput', (streamTabId: StreamTabId) => {
       withErrorBoundary('failed to handle clearTaskOutput', () => {
-        const taskState = state.getTaskState(streamTabId);
-        if (!taskState || !isWorkflowTaskState(taskState)) {
-          return;
-        }
-
-        taskState.agentConfig.outputFiles = [];
-        taskState.agentConfig.useMultipleOutputs = false;
-        taskState.activeFiles.output = false;
-        state.setTaskState(streamTabId, taskState);
+        state.clearOutputState(streamTabId);
       });
     }),
   );

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -140,9 +140,9 @@ export class ProgressViewState {
   /**
    * Reset workflow output metadata for the provided stream.
    *
-   * This keeps the state update logic centralized so commands and
-   * progress events remain consistent. Returns `true` when a stored
-   * workflow task was updated and persisted.
+   * Clears outputFiles, useMultipleOutputs, and the output flag.
+   * Returns true when state was modified and persisted, false when
+   * already cleared or not a workflow task.
    */
   clearOutputState(streamTabId: StreamTabId): boolean {
     const taskState = this.getTaskState(streamTabId);
@@ -151,7 +151,7 @@ export class ProgressViewState {
     }
 
     const hasPersistedOutputs =
-      !Array.isArray(taskState.agentConfig.outputFiles) ||
+      Array.isArray(taskState.agentConfig.outputFiles) &&
       taskState.agentConfig.outputFiles.length > 0;
     const usesMultipleOutputs = taskState.agentConfig.useMultipleOutputs;
     const outputFlagEnabled = taskState.activeFiles.output;

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -137,6 +137,46 @@ export class ProgressViewState {
     this._sessionCategoryHints.delete(streamTabId);
   }
 
+  /**
+   * Reset workflow output metadata for the provided stream.
+   *
+   * This keeps the state update logic centralized so commands and
+   * progress events remain consistent. Returns `true` when a stored
+   * workflow task was updated and persisted.
+   */
+  clearOutputState(streamTabId: StreamTabId): boolean {
+    const taskState = this.getTaskState(streamTabId);
+    if (!taskState || !isWorkflowTaskState(taskState)) {
+      return false;
+    }
+
+    const hasPersistedOutputs =
+      !Array.isArray(taskState.agentConfig.outputFiles) ||
+      taskState.agentConfig.outputFiles.length > 0;
+    const usesMultipleOutputs = taskState.agentConfig.useMultipleOutputs;
+    const outputFlagEnabled = taskState.activeFiles.output;
+
+    if (!hasPersistedOutputs && !usesMultipleOutputs && !outputFlagEnabled) {
+      return false;
+    }
+
+    const updatedState = {
+      ...taskState,
+      agentConfig: {
+        ...taskState.agentConfig,
+        outputFiles: [],
+        useMultipleOutputs: false,
+      },
+      activeFiles: {
+        ...taskState.activeFiles,
+        output: false,
+      },
+    };
+
+    this.setTaskState(streamTabId, updatedState);
+    return true;
+  }
+
   // Task state management
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
     const normalizedState = agentConfigToTaskState(

--- a/src/test/progressView/ProgressViewProvider.test.ts
+++ b/src/test/progressView/ProgressViewProvider.test.ts
@@ -1,0 +1,53 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - progress view
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+
+// Local imports - agent
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+
+describe('ProgressViewProvider.clearTaskOutput', () => {
+  it('delegates to ProgressViewState.clearOutputState and refreshes the webview', () => {
+    const calls: StreamTabId[] = [];
+    let updateCount = 0;
+    const provider = {
+      state: {
+        clearOutputState: (stream: StreamTabId) => {
+          calls.push(stream);
+          return true;
+        },
+      },
+      updateWebview: () => {
+        updateCount += 1;
+      },
+    } as unknown as ProgressViewProvider;
+
+    ProgressViewProvider.prototype.clearTaskOutput.call(
+      provider,
+      'stream-1' as StreamTabId,
+    );
+
+    assert.deepStrictEqual(calls, ['stream-1']);
+    assert.equal(updateCount, 1);
+  });
+
+  it('skips the webview update when no state change occurs', () => {
+    let updateCount = 0;
+    const provider = {
+      state: {
+        clearOutputState: () => false,
+      },
+      updateWebview: () => {
+        updateCount += 1;
+      },
+    } as unknown as ProgressViewProvider;
+
+    ProgressViewProvider.prototype.clearTaskOutput.call(
+      provider,
+      'stream-2' as StreamTabId,
+    );
+
+    assert.equal(updateCount, 0);
+  });
+});

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -104,6 +104,39 @@ describe('Progress event modules', () => {
     assert.deepStrictEqual(bus.disposed, bus.events);
   });
 
+  it('delegates clearTaskOutput to ProgressViewState.clearOutputState', () => {
+    const bus = new FakeBus();
+    const module = createOutputEvents({
+      logger: loggerStub,
+    });
+
+    const calls: string[] = [];
+    const state = {
+      outputFiles: {
+        addFiles: () => {},
+        getFiles: () => undefined,
+        updateMissingOutputs: () => {},
+        getMissingOutputs: () => undefined,
+        clearMissingOutputs: () => {},
+        clearFiles: () => {},
+      },
+      clearOutputState: (stream: string) => {
+        calls.push(stream);
+      },
+      activeStream: '',
+    } as unknown as ProgressViewState;
+    const updater = {
+      isAvailable: () => false,
+      updateFiles: () => {},
+      updateMissingOutputs: () => {},
+    } as unknown as WebviewUpdater;
+
+    module.register(bus as any, state, updater);
+    bus.trigger('clearTaskOutput', 'stream-42');
+
+    assert.deepStrictEqual(calls, ['stream-42']);
+  });
+
   it('registers usage handlers and disposes them', () => {
     const bus = new FakeBus();
     const module = createUsageEvents({

--- a/src/test/progressView/state/ProgressViewState.test.ts
+++ b/src/test/progressView/state/ProgressViewState.test.ts
@@ -107,4 +107,33 @@ describe('ProgressViewState.clearOutputState', () => {
     assert.equal(didUpdate, false);
     assert.deepStrictEqual(persistence.saved, []);
   });
+
+  it('avoids persisting when outputFiles is undefined', () => {
+    const persistence = new FakePersistence();
+    const state = new ProgressViewState(
+      persistence as unknown as StatePersistenceManager,
+    );
+
+    const config = AgentConfigSchema.parse({
+      model: 'test-model',
+      agent: 'test-agent',
+      instruction: 'Test instruction',
+      session: {
+        agentCategory: AgentCategory.Workflow,
+        agentType: AgentType.Direct,
+      },
+      inputFile: 'main.tex',
+      outputFiles: undefined,
+    });
+
+    const workflowState = agentConfigToTaskState(config, config.session);
+    const streamId = 'stream-3';
+    state.setTaskState(streamId, workflowState);
+
+    persistence.saved.length = 0;
+
+    const didUpdate = state.clearOutputState(streamId);
+    assert.equal(didUpdate, false);
+    assert.deepStrictEqual(persistence.saved, []);
+  });
 });

--- a/src/test/progressView/state/ProgressViewState.test.ts
+++ b/src/test/progressView/state/ProgressViewState.test.ts
@@ -1,0 +1,110 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - progress view
+import { ProgressViewState } from '@progressView/state/ProgressViewState';
+import type { StatePersistenceManager } from '@progressView/persistence/StatePersistenceManager';
+import { WorkspaceStateKey } from '@common/state/stateManager';
+
+// Local imports - agent
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
+
+// Local imports - utils
+import { agentConfigToTaskState } from '@utils/config';
+
+class FakePersistence {
+  public readonly saved: { key: string; value: unknown }[] = [];
+
+  async load<T>(_key: string, defaultValue: T): Promise<T> {
+    return defaultValue;
+  }
+
+  async save<T>(key: string, value: T): Promise<void> {
+    this.saved.push({ key, value });
+  }
+
+  async delete(): Promise<void> {
+    // no-op
+  }
+
+  async loadWithMigration<T>(
+    _newKey: string,
+    _legacyKey: string,
+    defaultValue: T,
+  ): Promise<T> {
+    return defaultValue;
+  }
+}
+
+describe('ProgressViewState.clearOutputState', () => {
+  it('resets workflow output metadata and persists the change', () => {
+    const persistence = new FakePersistence();
+    const state = new ProgressViewState(
+      persistence as unknown as StatePersistenceManager,
+    );
+
+    const config = AgentConfigSchema.parse({
+      model: 'test-model',
+      agent: 'test-agent',
+      instruction: 'Test instruction',
+      session: {
+        agentCategory: AgentCategory.Workflow,
+        agentType: AgentType.Direct,
+      },
+      inputFile: 'main.tex',
+      outputFiles: ['out.pdf'],
+      useMultipleOutputs: true,
+    });
+
+    const workflowState = agentConfigToTaskState(config, config.session);
+    const streamId = 'stream-1';
+    state.setTaskState(streamId, workflowState);
+
+    const savesBeforeClear = persistence.saved.length;
+
+    const didUpdate = state.clearOutputState(streamId);
+    assert.equal(didUpdate, true);
+
+    assert.equal(persistence.saved.length, savesBeforeClear + 1);
+    const lastSave = persistence.saved[persistence.saved.length - 1];
+    assert.equal(lastSave.key, WorkspaceStateKey.TASK_STATES);
+
+    const savedState = lastSave.value as {
+      workflow: Record<string, any>;
+    };
+    const storedWorkflow = savedState.workflow[streamId];
+    assert.deepStrictEqual(storedWorkflow.agentConfig.outputFiles, []);
+    assert.equal(storedWorkflow.agentConfig.useMultipleOutputs, false);
+    assert.equal(storedWorkflow.activeFiles.output, false);
+  });
+
+  it('avoids persisting when output metadata is already cleared', () => {
+    const persistence = new FakePersistence();
+    const state = new ProgressViewState(
+      persistence as unknown as StatePersistenceManager,
+    );
+
+    const config = AgentConfigSchema.parse({
+      model: 'test-model',
+      agent: 'test-agent',
+      instruction: 'Test instruction',
+      session: {
+        agentCategory: AgentCategory.Workflow,
+        agentType: AgentType.Direct,
+      },
+      inputFile: 'main.tex',
+    });
+
+    const workflowState = agentConfigToTaskState(config, config.session);
+    const streamId = 'stream-2';
+    state.setTaskState(streamId, workflowState);
+
+    // Initial save happens when setting the state
+    persistence.saved.length = 0;
+
+    const didUpdate = state.clearOutputState(streamId);
+    assert.equal(didUpdate, false);
+    assert.deepStrictEqual(persistence.saved, []);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated ProgressViewState.clearOutputState helper and reuse it from the event handler and provider entry points
- refresh the progress view after command-driven clears to keep the UI in sync
- add regression tests covering the new helper and provider/event delegation

## Testing
- npm run compile-tests
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f126e207488324894e79c9271d285e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes workflow output clearing in `ProgressViewState.clearOutputState`, updates provider/event handlers to delegate to it with conditional webview refresh, and adds targeted tests.
> 
> - **State**:
>   - Add `ProgressViewState.clearOutputState(streamTabId)` to reset workflow output metadata; returns boolean and persists only when changed.
> - **Provider**:
>   - Update `ProgressViewProvider.clearTaskOutput` to delegate to `state.clearOutputState` and refresh the webview only if state changed.
> - **Events**:
>   - Update `clearTaskOutput` handler in `events/OutputEvents` to call `state.clearOutputState`.
> - **Tests**:
>   - Add tests for `ProgressViewState.clearOutputState` persistence behavior.
>   - Add tests verifying provider and event delegation to the new helper and conditional webview refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 977bc74c26e688006cb375e15dc613e6decd524f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->