### PR TITLE
refactor: centralize message content handling

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -27,6 +27,7 @@ import {
   describeAttachments,
   extractToolAttachments,
 } from './utils/toolAttachmentUtils';
+import { appendTextContent } from './utils/messageContentUtils';
 import { toOpenAITools } from './toolConversion';
 import {
   normalizeOpenAIMessageContent,
@@ -495,67 +496,44 @@ export class ModelHandlerOpenAI extends ModelHandler<
       }
     }
 
-    // Create content list for the user message
     const userMessageContent: ChatCompletionContentPart[] = [
       { type: 'text', text: userPrefix },
     ];
 
-    // Add media if provided
     if (
       mediaFiles &&
       (this.config.capabilities.supportsVision ||
         this.config.capabilities.supportsNativeAudio)
     ) {
-      // createMediaMessage returns an array of objects formatted by createMediaContent
       const formattedMediaContent = await this.createMediaMessage(mediaFiles);
       userMessageContent.push(...formattedMediaContent);
     }
 
-    // Append the formatted content to the correct message
-    let lastRole = messages.length > 0 ? messages.at(-1).role : null;
-    if (lastRole === 'system' || messages.length === 0) {
-      messages.push({ role: 'user', content: userMessageContent });
-    } else if (lastRole === 'user') {
-      messages.at(-1).content.push(...userMessageContent);
-    } else {
-      // Fallback: Should not happen with current logic but good to handle
-      messages.push({ role: 'user', content: userMessageContent });
+    const lastMessageBeforeUser = messages.at(-1);
+    if (
+      lastMessageBeforeUser &&
+      lastMessageBeforeUser.role !== 'system' &&
+      lastMessageBeforeUser.role !== 'user'
+    ) {
       this.logger.warn(
         'Unexpected message structure, adding new user message.',
       );
     }
 
-    // Add final user request
+    appendTextContent(messages, 'user', userMessageContent);
+
     const requestRole = this.config.capabilities.supportsIntermDevMsgs
       ? 'system'
       : 'user';
-    lastRole = messages.length > 0 ? messages.at(-1)?.role : null;
 
-    if (requestRole === 'system') {
-      messages.push({
-        role: requestRole,
-        content: [{ type: 'text', text: userRequest }],
-      });
-    } else if (requestRole === 'user' && lastRole === 'user') {
-      const lastMessage = messages.at(-1);
-      if (lastMessage && Array.isArray(lastMessage.content)) {
-        lastMessage.content.push({
-          type: 'text',
-          text: userRequest,
-        });
-      } else if (lastMessage && typeof lastMessage.content === 'string') {
-        // Convert string content to array format
-        lastMessage.content = [
-          { type: 'text', text: lastMessage.content },
-          { type: 'text', text: userRequest },
-        ];
-      }
-    } else {
-      messages.push({
-        role: requestRole,
-        content: [{ type: 'text', text: userRequest }],
-      });
-    }
+    appendTextContent(
+      messages,
+      requestRole,
+      [{ type: 'text', text: userRequest }],
+      requestRole === 'system'
+        ? { alwaysCreateNewMessage: true }
+        : undefined,
+    );
 
     return messages;
   }
@@ -596,7 +574,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
     }
     roundContent.push({ type: 'text', text: userMessage });
 
-    messages.push({ role, content: roundContent });
+    appendTextContent(messages, role, roundContent, {
+      alwaysCreateNewMessage: true,
+    });
     return messages;
   }
 
@@ -829,16 +809,17 @@ export class ModelHandlerOpenAI extends ModelHandler<
     if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
       const PseudoPrefillMsgContentString = `Organize your response with xml tags. Start your response with:\n${prefill}`;
       const lastMessage = messages.at(-1);
-      if (lastMessage && Array.isArray(lastMessage.content)) {
-        lastMessage.content.push({
-          type: 'text',
-          text: PseudoPrefillMsgContentString,
-        });
-      } else if (lastMessage && typeof lastMessage.content === 'string') {
-        lastMessage.content = [
-          { type: 'text', text: lastMessage.content },
+      if (lastMessage) {
+        appendTextContent(messages, lastMessage.role, [
           { type: 'text', text: PseudoPrefillMsgContentString },
-        ];
+        ]);
+      } else {
+        appendTextContent(
+          messages,
+          'user',
+          [{ type: 'text', text: PseudoPrefillMsgContentString }],
+          { alwaysCreateNewMessage: true },
+        );
       }
       this.logger.debug(
         `Added pseudo prefill message to messages:\n${PseudoPrefillMsgContentString}`,
@@ -862,32 +843,23 @@ export class ModelHandlerOpenAI extends ModelHandler<
     // Write file content to output file
     await WorkspaceFS.write(outputFile, fileContent);
 
-    messages.push({
-      role: 'assistant',
-      content: [
-        {
-          type: 'text',
-          text: fileContent,
-        },
-      ],
-    });
+    appendTextContent(
+      messages,
+      'assistant',
+      [{ type: 'text', text: fileContent }],
+      { alwaysCreateNewMessage: true },
+    );
 
     const lastMessage = messages.at(-1);
     if (hasEndTag(agentSetting, fileContent)) {
       this.logger.debug('End tag detected - skipping continuation');
-      if (lastMessage && Array.isArray(lastMessage.content)) {
-        // this is suspicious, because the two conflicts!!!
-        const lastPart = lastMessage.content[lastMessage.content.length - 1];
-        if (lastPart && 'text' in lastPart) {
-          lastPart.text = fileContent;
-        }
-      } else if (lastMessage) {
-        lastMessage.content = [
-          {
-            type: 'text',
-            text: fileContent,
-          },
-        ];
+      if (lastMessage) {
+        appendTextContent(
+          messages,
+          lastMessage.role,
+          [fileContent],
+          { replaceExistingText: true },
+        );
       }
       endTurn = true;
       return [endTurn, messages];
@@ -1003,31 +975,29 @@ export class ModelHandlerOpenAI extends ModelHandler<
 
     const lastMessage = messages.at(-1);
 
-    if (lastMessage.role === 'assistant') {
-      if (Array.isArray(lastMessage.content)) {
-        const newMessage = {
-          type: 'text',
-          text: bestConnector + newResponse,
-        };
-        lastMessage.content.push(newMessage);
-      } else {
-        lastMessage.content = [
-          {
-            type: 'text',
-            text: toolState.accumulatedOutput,
-          },
-        ];
-      }
-    } else if (lastMessage.role === 'user' || lastMessage.role === 'system') {
+    if (lastMessage?.role === 'assistant') {
+      const hasStringContent = typeof lastMessage.content === 'string';
+
+      appendTextContent(
+        messages,
+        'assistant',
+        hasStringContent
+          ? [toolState.accumulatedOutput]
+          : [{ type: 'text', text: `${bestConnector}${newResponse}` }],
+        hasStringContent ? { replaceExistingText: true } : undefined,
+      );
+      return;
+    }
+
+    if (lastMessage?.role === 'user' || lastMessage?.role === 'system') {
       this.logger.debug(
         ' Last message is a user or system message - unexpected format',
       );
-      // Add a new assistant message
-      messages.push({
-        role: 'assistant',
-        content: [{ type: 'text', text: bestConnector + newResponse }],
-      });
     }
+
+    appendTextContent(messages, 'assistant', [
+      { type: 'text', text: `${bestConnector}${newResponse}` },
+    ]);
   }
 
   /** Updates message content for models without prefill support. */
@@ -1063,40 +1033,39 @@ export class ModelHandlerOpenAI extends ModelHandler<
       // Then the last message is a user message
       // So the second last message must be an assistant message
       if (secondLastMessage && secondLastMessage.role === 'assistant') {
-        // we get gradually get rid if this kind of isArray conditioning since now we are consistently using the content array
-        // but why do the following two differ?
-        if (Array.isArray(secondLastMessage.content)) {
-          secondLastMessage.content.push({
-            type: 'text',
-            text: bestConnector + newResponse,
-          } as any);
-        } else {
+        const hasArrayContent = Array.isArray(secondLastMessage.content);
+        if (!hasArrayContent) {
           this.logger.error('Second last message content is not a list');
-          secondLastMessage.content = [
-            {
-              type: 'text',
-              text: toolState.accumulatedOutput,
-            },
-          ];
         }
 
-        // Remove the user continuation prompt to keep the conversation clean
         if (messages.at(-1)?.role === 'user') {
           messages.pop();
         } else {
           this.logger.error(
             'Last message is not a user message - unexpected format',
           );
+          return;
         }
+
+        appendTextContent(
+          messages,
+          'assistant',
+          hasArrayContent
+            ? [{ type: 'text', text: `${bestConnector}${newResponse}` }]
+            : [toolState.accumulatedOutput],
+          hasArrayContent ? undefined : { replaceExistingText: true },
+        );
       }
     } else {
       this.logger.debug(
         'Last message is a request message rather than a ask to continue after cut off',
       );
-      messages.push({
-        role: 'assistant',
-        content: [{ type: 'text', text: toolState.accumulatedOutput }],
-      });
+      appendTextContent(
+        messages,
+        'assistant',
+        [{ type: 'text', text: toolState.accumulatedOutput }],
+        { alwaysCreateNewMessage: true },
+      );
     }
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -981,9 +981,14 @@ export class ModelHandlerOpenAI extends ModelHandler<
       appendTextContent(
         messages,
         'assistant',
-        hasStringContent
-          ? [toolState.accumulatedOutput]
-          : [{ type: 'text', text: `${bestConnector}${newResponse}` }],
+        [
+          {
+            type: 'text',
+            text: hasStringContent
+              ? toolState.accumulatedOutput
+              : `${bestConnector}${newResponse}`,
+          },
+        ],
         hasStringContent ? { replaceExistingText: true } : undefined,
       );
       return;
@@ -1019,8 +1024,14 @@ export class ModelHandlerOpenAI extends ModelHandler<
       !lastMessage ||
       (lastMessage.role !== 'user' && lastMessage.role !== 'system')
     ) {
-      this.logger.error(
-        'Last message is not a user or system message - unexpected format',
+      this.logger.warn(
+        'Last message is not a user or system message - unexpected format, appending assistant message anyway',
+      );
+      appendTextContent(
+        messages,
+        'assistant',
+        [{ type: 'text', text: toolState.accumulatedOutput }],
+        { alwaysCreateNewMessage: true },
       );
       return;
     }

--- a/src/agent/modelHandlers/utils/messageContentUtils.ts
+++ b/src/agent/modelHandlers/utils/messageContentUtils.ts
@@ -1,0 +1,127 @@
+// Third-party imports
+import type { ChatCompletionContentPart } from 'openai/resources/chat/completions';
+
+export type MessageWithContent<T extends ChatCompletionContentPart = ChatCompletionContentPart> = {
+  role: string;
+  content?: string | T[];
+  [key: string]: unknown;
+};
+
+type AppendablePart<T extends ChatCompletionContentPart> =
+  | string
+  | T
+  | T[]
+  | undefined
+  | null;
+
+export interface AppendTextContentOptions {
+  /**
+   * When true, any existing string content on the target message is discarded
+   * before appending new parts. This mirrors legacy behaviour that replaced
+   * assistant prefill strings with the accumulated tool output.
+   */
+  replaceExistingText?: boolean;
+  /**
+   * When true, the helper always creates a new message even if the last entry
+   * already matches the requested role.
+   */
+  alwaysCreateNewMessage?: boolean;
+}
+
+function createTextPart<T extends ChatCompletionContentPart>(text: string): T {
+  return { type: 'text', text } as T;
+}
+
+function ensureContentArray<T extends ChatCompletionContentPart>(
+  message: MessageWithContent<T>,
+  replaceExistingText: boolean,
+): T[] {
+  const { content } = message;
+
+  if (Array.isArray(content)) {
+    if (replaceExistingText) {
+      message.content = [];
+      return message.content as T[];
+    }
+    return content;
+  }
+
+  const normalized: T[] = [];
+
+  if (!replaceExistingText && typeof content === 'string') {
+    normalized.push(createTextPart<T>(content));
+  }
+
+  message.content = normalized;
+  return normalized;
+}
+
+function normalizeParts<T extends ChatCompletionContentPart>(
+  parts: AppendablePart<T>[],
+): T[] {
+  return parts.flatMap((part) => {
+    if (part === null || part === undefined) {
+      return [];
+    }
+    if (typeof part === 'string') {
+      return [createTextPart<T>(part)];
+    }
+    if (Array.isArray(part)) {
+      return part as T[];
+    }
+    return [part as T];
+  });
+}
+
+/**
+ * Appends text or media content to the trailing message with the provided role.
+ * The helper normalises string content into OpenAI's array-based format so
+ * callers can avoid repeated Array checks and coercion.
+ *
+ * @returns Object describing the mutated message and whether the helper
+ *          appended to an existing entry.
+ */
+export function appendTextContent<
+  T extends ChatCompletionContentPart = ChatCompletionContentPart,
+>(
+  messages: MessageWithContent<T>[],
+  role: string,
+  parts: AppendablePart<T>[],
+  options: AppendTextContentOptions = {},
+): { message: MessageWithContent<T>; appendedToExisting: boolean } {
+  const normalizedParts = normalizeParts(parts);
+  const {
+    replaceExistingText = false,
+    alwaysCreateNewMessage = false,
+  } = options;
+
+  const lastMessage = messages.at(-1);
+  const shouldAppendToLast =
+    !alwaysCreateNewMessage &&
+    lastMessage !== undefined &&
+    lastMessage.role === role;
+
+  if (normalizedParts.length === 0) {
+    if (shouldAppendToLast) {
+      ensureContentArray(lastMessage, replaceExistingText);
+      return { message: lastMessage, appendedToExisting: true };
+    }
+
+    const emptyMessage: MessageWithContent<T> = { role, content: [] };
+    messages.push(emptyMessage);
+    return { message: emptyMessage, appendedToExisting: false };
+  }
+
+  if (!shouldAppendToLast) {
+    const newMessage: MessageWithContent<T> = {
+      role,
+      content: [...normalizedParts],
+    };
+    messages.push(newMessage);
+    return { message: newMessage, appendedToExisting: false };
+  }
+
+  const contentArray = ensureContentArray(lastMessage, replaceExistingText);
+  contentArray.push(...normalizedParts);
+  return { message: lastMessage, appendedToExisting: true };
+}

--- a/src/test/agent/modelHandlers/utils/messageContentUtils.test.ts
+++ b/src/test/agent/modelHandlers/utils/messageContentUtils.test.ts
@@ -1,0 +1,69 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import type { ChatCompletionContentPart } from 'openai/resources/chat/completions';
+
+// Local imports - agent utilities
+import {
+  appendTextContent,
+  type MessageWithContent,
+} from '@agent/modelHandlers/utils/messageContentUtils';
+
+describe('appendTextContent', () => {
+  it('promotes string content to array when appending text', () => {
+    const messages = [
+      { role: 'assistant', content: 'previous response' },
+    ];
+
+    appendTextContent(messages, 'assistant', [
+      { type: 'text', text: 'new output' } as ChatCompletionContentPart,
+    ]);
+
+    const [assistantMessage] = messages;
+    assert.ok(
+      Array.isArray(assistantMessage.content),
+      'expected helper to normalise string content into an array',
+    );
+    const content = assistantMessage
+      .content as ChatCompletionContentPart[];
+    assert.equal(content.length, 2);
+    assert.deepEqual(content[0], {
+      type: 'text',
+      text: 'previous response',
+    });
+    assert.deepEqual(content[1], {
+      type: 'text',
+      text: 'new output',
+    });
+  });
+
+  it('adds media parts when creating a new user message', () => {
+    const messages: MessageWithContent[] = [];
+    const mediaPart = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/image.png' },
+    } as ChatCompletionContentPart;
+
+    appendTextContent(
+      messages,
+      'user',
+      [
+        { type: 'text', text: 'prefix' } as ChatCompletionContentPart,
+        mediaPart,
+      ],
+      { alwaysCreateNewMessage: true },
+    );
+
+    assert.equal(messages.length, 1);
+    const [userMessage] = messages;
+    assert.ok(
+      Array.isArray(userMessage.content),
+      'expected new message content to be an array',
+    );
+    assert.deepEqual(userMessage.content, [
+      { type: 'text', text: 'prefix' },
+      mediaPart,
+    ]);
+  });
+});

--- a/src/test/agent/modelHandlers/utils/messageContentUtils.test.ts
+++ b/src/test/agent/modelHandlers/utils/messageContentUtils.test.ts
@@ -66,4 +66,157 @@ describe('appendTextContent', () => {
       mediaPart,
     ]);
   });
+
+  it('replaces existing string content when replaceExistingText is true', () => {
+    const messages = [{ role: 'assistant', content: 'old text' }];
+    appendTextContent(
+      messages,
+      'assistant',
+      [{ type: 'text', text: 'new text' } as ChatCompletionContentPart],
+      { replaceExistingText: true },
+    );
+
+    const content = messages[0].content as ChatCompletionContentPart[];
+    assert.ok(Array.isArray(content));
+    assert.equal(content.length, 1);
+    assert.deepEqual(content[0], { type: 'text', text: 'new text' });
+  });
+
+  it('replaces existing array content when replaceExistingText is true', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'old text 1' },
+          { type: 'text', text: 'old text 2' },
+        ] as ChatCompletionContentPart[],
+      },
+    ];
+    appendTextContent(
+      messages,
+      'assistant',
+      [{ type: 'text', text: 'replacement' } as ChatCompletionContentPart],
+      { replaceExistingText: true },
+    );
+
+    const content = messages[0].content as ChatCompletionContentPart[];
+    assert.equal(content.length, 1);
+    assert.deepEqual(content[0], { type: 'text', text: 'replacement' });
+  });
+
+  it('creates new message when alwaysCreateNewMessage is true despite matching role', () => {
+    const messages = [{ role: 'user', content: 'first' }];
+    appendTextContent(
+      messages,
+      'user',
+      [{ type: 'text', text: 'second' } as ChatCompletionContentPart],
+      { alwaysCreateNewMessage: true },
+    );
+
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0].content, 'first');
+    const secondContent = messages[1].content as ChatCompletionContentPart[];
+    assert.deepEqual(secondContent[0], { type: 'text', text: 'second' });
+  });
+
+  it('appends to existing array content', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'first part' },
+        ] as ChatCompletionContentPart[],
+      },
+    ];
+    appendTextContent(messages, 'user', [
+      { type: 'text', text: 'second part' } as ChatCompletionContentPart,
+    ]);
+
+    const content = messages[0].content as ChatCompletionContentPart[];
+    assert.equal(content.length, 2);
+    assert.deepEqual(content[0], { type: 'text', text: 'first part' });
+    assert.deepEqual(content[1], { type: 'text', text: 'second part' });
+  });
+
+  it('filters out null and undefined parts', () => {
+    const messages: MessageWithContent[] = [];
+    appendTextContent(messages, 'user', [
+      null,
+      { type: 'text', text: 'valid text' } as ChatCompletionContentPart,
+      undefined,
+    ]);
+
+    const content = messages[0].content as ChatCompletionContentPart[];
+    assert.equal(content.length, 1);
+    assert.deepEqual(content[0], { type: 'text', text: 'valid text' });
+  });
+
+  it('handles empty parts array when appending to existing message', () => {
+    const messages = [{ role: 'assistant', content: 'existing' }];
+    appendTextContent(messages, 'assistant', []);
+
+    assert.equal(messages.length, 1);
+    const content = messages[0].content as ChatCompletionContentPart[];
+    assert.ok(Array.isArray(content));
+    assert.equal(content.length, 1);
+    assert.deepEqual(content[0], { type: 'text', text: 'existing' });
+  });
+
+  it('creates empty message when parts array is empty and no existing message', () => {
+    const messages: MessageWithContent[] = [];
+    appendTextContent(messages, 'user', []);
+
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].role, 'user');
+    assert.deepEqual(messages[0].content, []);
+  });
+
+  it('converts string parts to text objects', () => {
+    const messages: MessageWithContent[] = [];
+    appendTextContent(messages, 'user', ['simple string']);
+
+    const content = messages[0].content as ChatCompletionContentPart[];
+    assert.equal(content.length, 1);
+    assert.deepEqual(content[0], { type: 'text', text: 'simple string' });
+  });
+
+  it('handles mixed string and object parts', () => {
+    const messages: MessageWithContent[] = [];
+    appendTextContent(messages, 'user', [
+      'text string',
+      { type: 'text', text: 'text object' } as ChatCompletionContentPart,
+    ]);
+
+    const content = messages[0].content as ChatCompletionContentPart[];
+    assert.equal(content.length, 2);
+    assert.deepEqual(content[0], { type: 'text', text: 'text string' });
+    assert.deepEqual(content[1], { type: 'text', text: 'text object' });
+  });
+
+  it('creates new message when messages array is empty', () => {
+    const messages: MessageWithContent[] = [];
+    appendTextContent(messages, 'user', [
+      { type: 'text', text: 'first message' } as ChatCompletionContentPart,
+    ]);
+
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].role, 'user');
+    const content = messages[0].content as ChatCompletionContentPart[];
+    assert.deepEqual(content[0], { type: 'text', text: 'first message' });
+  });
+
+  it('creates new message when last message has different role', () => {
+    const messages = [{ role: 'user', content: 'user message' }];
+    appendTextContent(messages, 'assistant', [
+      { type: 'text', text: 'assistant message' } as ChatCompletionContentPart,
+    ]);
+
+    assert.equal(messages.length, 2);
+    const assistantContent = messages[1]
+      .content as ChatCompletionContentPart[];
+    assert.deepEqual(assistantContent[0], {
+      type: 'text',
+      text: 'assistant message',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add a shared appendTextContent helper for OpenAI-style messages that normalizes string content and supports media parts
- refactor OpenAI message assembly and update flows to use the helper for consistent behavior
- cover helper behavior with targeted tests for string promotion and media insertion

## Testing
- npm run lint
- npm test -- ToolUseCycleOpenAIResponse.test.ts *(fails: vscode-test requires libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f13254f0048324935bd3154870fa66

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce appendTextContent helper and refactor OpenAI message assembly/update flows to use it; add targeted tests.
> 
> - **Utils**:
>   - Add `utils/messageContentUtils.ts` with `appendTextContent` to normalize `content` (promote strings, append/replace parts, force new messages) for OpenAI-style messages.
> - **ModelHandlerOpenAI**:
>   - Replace ad-hoc message mutations with `appendTextContent` in `initializeMessages`, `createRoundMessages`, `initializeOutputAndPrefill`, `updateMessageContentWithPrefill`, and `updateMessageContentWithoutPrefill`.
>   - Simplify logic for appending user/system/assistant parts, handling media, replacing existing text, and continuation/cutoff flows; add warning for unexpected last message role before user insert.
> - **Tests**:
>   - Add `messageContentUtils.test.ts` covering string-to-array promotion and media part insertion when creating new user messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44eac47bd55a81c981c2aa44825542da9c5ae41d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->