### PR TITLE
Fix tool-use snapshot migration handling

### DIFF
--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -33,9 +33,6 @@ const logger = new AgentLogger(CHANNEL);
 const STORAGE_DIR = 'toolUseSessions';
 const SNAPSHOT_VERSION = 1;
 
-let legacySnapshotMigrationPromise: Promise<void> | null = null;
-let legacySnapshotMigrationCompleted = false;
-
 const ToolStateSnapshotSchema = z.object({
   texcountStats: z.string().nullable(),
   lastResponse: z.string(),
@@ -128,65 +125,6 @@ interface ResumingSessionState {
   queuedFollowUps: string[];
 }
 
-async function migrateLegacySnapshotsOnDisk(): Promise<void> {
-  if (!(await ensureStorageDir())) {
-    return;
-  }
-
-  let entries: [string, vscode.FileType][];
-  try {
-    entries = await StorageFS.readDir(STORAGE_DIR);
-  } catch (error) {
-    logger.debug(
-      `Unable to enumerate tool-use snapshots for migration: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return;
-  }
-
-  for (const [name, type] of entries) {
-    if (type !== vscode.FileType.File || !name.endsWith('.json')) {
-      continue;
-    }
-
-    const relativePath = path.join(STORAGE_DIR, name);
-
-    try {
-      const stored = await StorageFS.readJson<unknown>(relativePath);
-      if (typeof stored !== 'string') {
-        continue;
-      }
-
-      let normalized: unknown;
-      try {
-        normalized = JSON.parse(stored);
-      } catch (parseError) {
-        logger.debug(
-          `Skipping migration for ${name}: unable to parse legacy payload (${parseError instanceof Error ? parseError.message : String(parseError)})`,
-        );
-        continue;
-      }
-
-      const parsed = ToolUseSessionSnapshotSchema.safeParse(normalized);
-      if (!parsed.success) {
-        logger.debug(
-          `Skipping migration for ${name}: legacy payload failed validation (${parsed.error.message})`,
-        );
-        continue;
-      }
-
-      await StorageFS.writeJson(relativePath, parsed.data);
-      logger.debug(`Migrated legacy tool-use snapshot ${name}.`);
-    } catch (error) {
-      logger.debug(
-        `Failed migrating tool-use snapshot ${name}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
-  }
-}
 
 function normalizeSnapshot(
   snapshot: ToolUseSessionSnapshotParsed,
@@ -225,6 +163,8 @@ export class ToolUseSessionManager {
     StreamTabId,
     ResumingSessionState
   >();
+  private static migrationPromise: Promise<void> | null = null;
+  private static migrationCompleted = false;
 
   /**
    * Determines whether the provided stream is currently marked as resuming.
@@ -396,9 +336,18 @@ export class ToolUseSessionManager {
         lastUpdated: Date.now(),
       };
 
-      ToolUseSessionSnapshotSchema.parse(snapshot);
+      const validationResult = ToolUseSessionSnapshotSchema.safeParse(snapshot);
+      if (!validationResult.success) {
+        logger.warn(
+          `Snapshot validation failed before save: ${validationResult.error.message}`,
+        );
+        return;
+      }
 
-      await StorageFS.writeJson(getSnapshotPath(payload.executionId), snapshot);
+      await StorageFS.writeJson(
+        getSnapshotPath(payload.executionId),
+        validationResult.data,
+      );
     } catch (error) {
       logger.warn(
         `Failed to save tool-use session snapshot: ${error instanceof Error ? error.message : String(error)}`,
@@ -551,14 +500,65 @@ export class ToolUseSessionManager {
   }
 
   public static async migrateLegacySnapshots(): Promise<void> {
-    if (legacySnapshotMigrationCompleted) {
+    if (this.migrationCompleted) {
       return;
     }
 
-    if (!legacySnapshotMigrationPromise) {
-      legacySnapshotMigrationPromise = (async () => {
+    if (!this.migrationPromise) {
+      this.migrationPromise = (async () => {
         try {
-          await migrateLegacySnapshotsOnDisk();
+          if (!(await ensureStorageDir())) {
+            return;
+          }
+
+          const entries = await StorageFS.readDir(STORAGE_DIR).catch(
+            (error) => {
+              logger.debug(
+                `Unable to enumerate tool-use snapshots for migration: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+              return null;
+            },
+          );
+
+          if (!entries) {
+            return;
+          }
+
+          for (const [name, type] of entries) {
+            if (type !== vscode.FileType.File || !name.endsWith('.json')) {
+              continue;
+            }
+
+            const relativePath = path.join(STORAGE_DIR, name);
+
+            try {
+              const stored = await StorageFS.readJson<unknown>(relativePath);
+              if (typeof stored !== 'string') {
+                continue;
+              }
+
+              const normalized = JSON.parse(stored);
+              const parsed = ToolUseSessionSnapshotSchema.safeParse(normalized);
+
+              if (!parsed.success) {
+                logger.debug(
+                  `Skipping migration for ${name}: validation failed (${parsed.error.message})`,
+                );
+                continue;
+              }
+
+              await StorageFS.writeJson(relativePath, parsed.data);
+              logger.debug(`Migrated legacy snapshot ${name}`);
+            } catch (error) {
+              logger.debug(
+                `Skipping migration for ${name}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+            }
+          }
         } catch (error) {
           logger.debug(
             `Legacy snapshot migration failed: ${
@@ -566,11 +566,11 @@ export class ToolUseSessionManager {
             }`,
           );
         } finally {
-          legacySnapshotMigrationCompleted = true;
+          this.migrationCompleted = true;
         }
       })();
     }
 
-    await legacySnapshotMigrationPromise;
+    await this.migrationPromise;
   }
 }

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -33,6 +33,9 @@ const logger = new AgentLogger(CHANNEL);
 const STORAGE_DIR = 'toolUseSessions';
 const SNAPSHOT_VERSION = 1;
 
+let legacySnapshotMigrationPromise: Promise<void> | null = null;
+let legacySnapshotMigrationCompleted = false;
+
 const ToolStateSnapshotSchema = z.object({
   texcountStats: z.string().nullable(),
   lastResponse: z.string(),
@@ -123,6 +126,66 @@ function getSnapshotPath(executionId: ExecutionId): string {
 
 interface ResumingSessionState {
   queuedFollowUps: string[];
+}
+
+async function migrateLegacySnapshotsOnDisk(): Promise<void> {
+  if (!(await ensureStorageDir())) {
+    return;
+  }
+
+  let entries: [string, vscode.FileType][];
+  try {
+    entries = await StorageFS.readDir(STORAGE_DIR);
+  } catch (error) {
+    logger.debug(
+      `Unable to enumerate tool-use snapshots for migration: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return;
+  }
+
+  for (const [name, type] of entries) {
+    if (type !== vscode.FileType.File || !name.endsWith('.json')) {
+      continue;
+    }
+
+    const relativePath = path.join(STORAGE_DIR, name);
+
+    try {
+      const stored = await StorageFS.readJson<unknown>(relativePath);
+      if (typeof stored !== 'string') {
+        continue;
+      }
+
+      let normalized: unknown;
+      try {
+        normalized = JSON.parse(stored);
+      } catch (parseError) {
+        logger.debug(
+          `Skipping migration for ${name}: unable to parse legacy payload (${parseError instanceof Error ? parseError.message : String(parseError)})`,
+        );
+        continue;
+      }
+
+      const parsed = ToolUseSessionSnapshotSchema.safeParse(normalized);
+      if (!parsed.success) {
+        logger.debug(
+          `Skipping migration for ${name}: legacy payload failed validation (${parsed.error.message})`,
+        );
+        continue;
+      }
+
+      await StorageFS.writeJson(relativePath, parsed.data);
+      logger.debug(`Migrated legacy tool-use snapshot ${name}.`);
+    } catch (error) {
+      logger.debug(
+        `Failed migrating tool-use snapshot ${name}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
 }
 
 function normalizeSnapshot(
@@ -333,6 +396,8 @@ export class ToolUseSessionManager {
         lastUpdated: Date.now(),
       };
 
+      ToolUseSessionSnapshotSchema.parse(snapshot);
+
       await StorageFS.writeJson(getSnapshotPath(payload.executionId), snapshot);
     } catch (error) {
       logger.warn(
@@ -356,13 +421,17 @@ export class ToolUseSessionManager {
     const snapshotPath = getSnapshotPath(executionId);
 
     try {
-      const stored = await StorageFS.readJson<ToolUseSessionSnapshot | string>(
+      const stored = await StorageFS.readJson<ToolUseSessionSnapshot>(
         snapshotPath,
       );
-      const normalized =
-        typeof stored === 'string' ? JSON.parse(stored) : stored;
-      const parsed = ToolUseSessionSnapshotSchema.parse(normalized);
-      return normalizeSnapshot(parsed);
+      const parsed = ToolUseSessionSnapshotSchema.safeParse(stored);
+      if (!parsed.success) {
+        logger.warn(
+          `Failed to parse tool-use session snapshot ${executionId}: ${parsed.error.message}`,
+        );
+        return null;
+      }
+      return normalizeSnapshot(parsed.data);
     } catch (error) {
       if (
         error instanceof vscode.FileSystemError &&
@@ -370,36 +439,12 @@ export class ToolUseSessionManager {
       ) {
         return null;
       }
-
-      try {
-        const raw = await StorageFS.read(snapshotPath);
-        const fallbackParsed = JSON.parse(raw);
-        const normalized =
-          typeof fallbackParsed === 'string'
-            ? JSON.parse(fallbackParsed)
-            : fallbackParsed;
-        const parsed = ToolUseSessionSnapshotSchema.parse(normalized);
-        return normalizeSnapshot(parsed);
-      } catch (fallbackError) {
-        if (
-          fallbackError instanceof vscode.FileSystemError &&
-          fallbackError.code === 'FileNotFound'
-        ) {
-          return null;
-        }
-
-        const originalMessage =
-          error instanceof Error ? error.message : String(error);
-        const fallbackMessage =
-          fallbackError instanceof Error
-            ? fallbackError.message
-            : String(fallbackError);
-
-        logger.warn(
-          `Failed to load tool-use session snapshot: original=${originalMessage}; fallback=${fallbackMessage}`,
-        );
-        return null;
-      }
+      logger.warn(
+        `Failed to load tool-use session snapshot ${executionId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
     }
   }
 
@@ -503,5 +548,29 @@ export class ToolUseSessionManager {
         `Failed to delete all snapshots: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
+  }
+
+  public static async migrateLegacySnapshots(): Promise<void> {
+    if (legacySnapshotMigrationCompleted) {
+      return;
+    }
+
+    if (!legacySnapshotMigrationPromise) {
+      legacySnapshotMigrationPromise = (async () => {
+        try {
+          await migrateLegacySnapshotsOnDisk();
+        } catch (error) {
+          logger.debug(
+            `Legacy snapshot migration failed: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        } finally {
+          legacySnapshotMigrationCompleted = true;
+        }
+      })();
+    }
+
+    await legacySnapshotMigrationPromise;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,7 +99,12 @@ export async function activate(context: vscode.ExtensionContext) {
   const progressViewProvider = new ProgressViewProvider(context);
   await progressViewProvider.initialize();
 
-  const persistedToolUseSessions = ToolUseSessionManager.isPersistenceEnabled()
+  const toolUsePersistenceEnabled = ToolUseSessionManager.isPersistenceEnabled();
+  if (toolUsePersistenceEnabled) {
+    await ToolUseSessionManager.migrateLegacySnapshots();
+  }
+
+  const persistedToolUseSessions = toolUsePersistenceEnabled
     ? await ToolUseSessionManager.listSnapshots()
     : [];
   ToolUseSessionManager.registerPendingSnapshots(persistedToolUseSessions);

--- a/src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts
+++ b/src/test/toolUse/ToolUseSessionManagerSnapshot.test.ts
@@ -100,52 +100,34 @@ suite('ToolUseSessionManager snapshot compatibility', () => {
     assert.strictEqual(loaded?.toolState.lastResponse, 'response');
   });
 
-  test('loadSnapshot reads snapshots saved before helper migration', async () => {
+  test('migrateLegacySnapshots rewrites stringified snapshots before load', async () => {
     const executionId = 'legacy-snapshot' as ExecutionId;
     const snapshot = buildLegacySnapshot(executionId);
 
     await StorageFS.ensureDir('toolUseSessions');
     await StorageFS.write(
       path.join('toolUseSessions', `${executionId}.json`),
-      JSON.stringify(snapshot, null, 2),
+      JSON.stringify(JSON.stringify(snapshot)),
     );
 
+    await ToolUseSessionManager.migrateLegacySnapshots();
     const loaded = await ToolUseSessionManager.loadSnapshot(executionId);
 
-    assert.ok(loaded, 'expected legacy snapshot to load');
+    assert.ok(loaded, 'expected legacy snapshot to load after migration');
     assert.strictEqual(loaded?.executionId, executionId);
   });
 
-  test('loadSnapshot falls back to raw JSON parsing when helper fails', async () => {
-    const executionId = 'fallback-snapshot' as ExecutionId;
-    const snapshot = buildLegacySnapshot(executionId);
+  test('loadSnapshot returns null when snapshot fails validation', async () => {
+    const executionId = 'invalid-snapshot' as ExecutionId;
 
     await StorageFS.ensureDir('toolUseSessions');
     await StorageFS.write(
       path.join('toolUseSessions', `${executionId}.json`),
-      JSON.stringify(snapshot, null, 2),
+      JSON.stringify({ version: 1 }),
     );
 
-    const originalReadJson = StorageFS.readJson;
+    const loaded = await ToolUseSessionManager.loadSnapshot(executionId);
 
-    (
-      StorageFS as typeof StorageFS & {
-        readJson: typeof StorageFS.readJson;
-      }
-    ).readJson = async () => {
-      throw new SyntaxError('forced failure');
-    };
-
-    try {
-      const loaded = await ToolUseSessionManager.loadSnapshot(executionId);
-      assert.ok(loaded, 'expected fallback parsing to succeed');
-      assert.strictEqual(loaded?.executionId, executionId);
-    } finally {
-      (
-        StorageFS as typeof StorageFS & {
-          readJson: typeof StorageFS.readJson;
-        }
-      ).readJson = originalReadJson;
-    }
+    assert.strictEqual(loaded, null, 'expected invalid snapshot to be ignored');
   });
 });


### PR DESCRIPTION
## Summary
- add a one-time migration to normalize legacy stringified tool-use snapshots
- rely on schema validation when reading/writing tool-use snapshots and simplify error handling
- invoke migration during activation and update snapshot compatibility tests

## Testing
- npm run lint
- npm run compile-tests
- CI=1 npm test -- ToolUseSessionManagerSnapshot *(fails: VS Code binary missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68f1260eb72883248f3d2f52263126c3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds one-time migration for legacy stringified tool-use snapshots, enforces schema validation on read/write, simplifies loading/error handling, and updates activation/tests accordingly.
> 
> - **Tool-use session persistence**:
>   - **Migration**: Add `migrateLegacySnapshots()` with single-flight control to rewrite legacy stringified snapshots in `toolUseSessions/*.json` to normalized JSON.
>   - **Read/Write Validation**: Use `ToolUseSessionSnapshotSchema.safeParse` before saving and when loading; drop fallback raw JSON parsing and simplify error handling/logging.
>   - **Normalization**: Continue to `normalizeSnapshot` after validated load.
> - **Extension activation**:
>   - Invoke `migrateLegacySnapshots()` when persistence is enabled before listing snapshots.
> - **Tests**:
>   - Update tests to cover migration of stringified snapshots and invalid snapshot rejection; remove fallback parsing case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 941581b046fabffcaf6878c820fe7b33dac73439. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->