### PR TITLE
fix: prioritize named document extraction

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -156,6 +156,29 @@ export class XmlOutputManager {
     outputContent = xmlUtils.addCdataToTags(outputContent, tagsToWrap);
 
     try {
+      const filename = path.basename(this.agentConfig.inputFile);
+      const namedDocuments = xmlUtils.extractMultipleTextFromTag(
+        outputContent,
+        documentTag,
+      );
+      const matchingDocument = namedDocuments.find((doc) => {
+        const documentName = doc.name?.trim();
+        if (!documentName) {
+          return false;
+        }
+        return path.basename(documentName) === filename;
+      });
+
+      if (matchingDocument?.content) {
+        this.logger.info(
+          `Recovered ${documentTag} from named document ${filename}`,
+          undefined,
+          MESSAGE_TYPES.INTERNAL,
+        );
+        await WorkspaceFS.write(texFile, matchingDocument.content);
+        return texFile;
+      }
+
       const parser = new XMLParser({
         ignoreAttributes: false,
         parseTagValue: true,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -155,30 +155,17 @@ export class XmlOutputManager {
     const tagsToWrap = [documentTag, thinkingTag];
     outputContent = xmlUtils.addCdataToTags(outputContent, tagsToWrap);
 
+    // First, try to extract named document matching input file (prioritized)
+    const namedDocumentContent = this.extractDocumentbyRegex(
+      outputContent,
+      documentTag,
+    );
+    if (namedDocumentContent) {
+      await WorkspaceFS.write(texFile, namedDocumentContent);
+      return texFile;
+    }
+
     try {
-      const filename = path.basename(this.agentConfig.inputFile);
-      const namedDocuments = xmlUtils.extractMultipleTextFromTag(
-        outputContent,
-        documentTag,
-      );
-      const matchingDocument = namedDocuments.find((doc) => {
-        const documentName = doc.name?.trim();
-        if (!documentName) {
-          return false;
-        }
-        return path.basename(documentName) === filename;
-      });
-
-      if (matchingDocument?.content) {
-        this.logger.info(
-          `Recovered ${documentTag} from named document ${filename}`,
-          undefined,
-          MESSAGE_TYPES.INTERNAL,
-        );
-        await WorkspaceFS.write(texFile, matchingDocument.content);
-        return texFile;
-      }
-
       const parser = new XMLParser({
         ignoreAttributes: false,
         parseTagValue: true,
@@ -197,36 +184,10 @@ export class XmlOutputManager {
         await WorkspaceFS.write(texFile, latexDocument);
         return texFile;
       }
-      this.logger.debug(
-        `No ${documentTag} found in parsed XML, attempting fallback extraction...`,
-        undefined,
-        MESSAGE_TYPES.INTERNAL,
-      );
-      const fallbackContent = this.extractDocumentbyRegex(
-        outputContent,
-        documentTag,
-      );
-      if (fallbackContent) {
-        await WorkspaceFS.write(texFile, fallbackContent);
-        return texFile;
-      }
       throw new Error(
         `Failed to extract <${documentTag}> from ${path.basename(outputFile)}`,
       );
     } catch (err) {
-      this.logger.debug(
-        `Failed to parse XML content: ${err instanceof Error ? err.message : String(err)}, attempting fallback extraction...`,
-        undefined,
-        MESSAGE_TYPES.INTERNAL,
-      );
-      const fallbackContent = this.extractDocumentbyRegex(
-        outputContent,
-        documentTag,
-      );
-      if (fallbackContent) {
-        await WorkspaceFS.write(texFile, fallbackContent);
-        return texFile;
-      }
       throw err;
     }
   }

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -104,9 +104,11 @@ describe('XmlOutputManager markdown fallback', () => {
     const logger = new AgentLogger('TestXmlOutput');
     const manager = new XmlOutputManager(setting, config, logger);
     const outputXml = 'both_tags.xml';
-    const xmlContent =
-      '<latex_document><![CDATA[\\begin{document}wrong\\end{document}]]></latex_document>' +
-      '<document name="input.tex"><![CDATA[\\begin{document}right\\end{document}]]></document><';
+    const xmlContent = `<?xml version="1.0"?>
+<latex_document>
+  <![CDATA[\\begin{document}wrong\\end{document}]]>
+  <document name="input.tex"><![CDATA[\\begin{document}right\\end{document}]]></document>
+</latex_document>`;
 
     await WorkspaceFS.write(outputXml, xmlContent);
 


### PR DESCRIPTION
## Summary
- prefer named <document> entries that match the input file when splitting XML output
- add a valid XML fixture to ensure named documents override container content

## Testing
- CI=1 npm test -- --runTestsByPath src/test/output/XmlOutputManager.test.ts *(fails: VS Code binary requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f17b4886748324acafb763366eda00

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes extraction of a named `document` matching the input filename before parsing `latex_document`, and updates the test with a valid XML fixture to assert precedence.
> 
> - **Xml extraction priority (`src/agent/output/XmlOutputManager.ts`)**:
>   - Before XML parsing, extract multiple `document` entries and select the one whose `name` basename matches the input file; write it directly to the `.tex` output.
>   - Adds info log on successful recovery from named document; otherwise falls back to XML parsing and existing regex-based fallbacks.
> - **Tests (`src/test/output/XmlOutputManager.test.ts`)**:
>   - Update fixture to valid XML and assert that the named `document` overrides `latex_document` content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af5a8669eb6993e314710f6cc915c80069a5caa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->