### PR TITLE
feat: streamline workflow session navigation

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -117,7 +117,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    this.provider.setActiveStream(message.stream);
+    this.provider.setActiveStream(message.stream, message.workflowRunId);
   }
 
   private async handleDeleteStream(

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -325,8 +325,14 @@ export class ProgressViewProvider
   /**
    * Set active stream (used by message handler)
    */
-  public setActiveStream(stream: string): void {
+  public setActiveStream(stream: string, workflowRunId?: string): void {
     this.state.activeStream = stream;
+    if (workflowRunId !== undefined) {
+      this.state.setActiveWorkflowGroup(
+        stream,
+        workflowRunId ? workflowRunId : undefined,
+      );
+    }
     this.updateWebview();
   }
 }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -76,6 +76,7 @@ export class ProgressEventHandler {
       logger: this.logger,
       initializeStreamForTaskGroup: (stream) =>
         this.initializeStreamForTaskGroup(stream),
+      getStreamStatuses: () => new Map(this._streamStatus),
     });
   }
 

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -4,11 +4,12 @@ import * as vscode from 'vscode';
 // Local imports - progress view
 import type { WebviewUpdater } from '../managers';
 import type { ProgressViewState } from '../state/ProgressViewState';
+import { buildStreamInfos } from '../streamInfoUtils';
 
 // Local imports - events
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createErrorBoundary } from './errorHandling';
-import type { ProgressEventBusLike } from './types';
+import type { ProgressEventBusLike, StreamStatusType } from './types';
 
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { TaskGroup } from '@logger/LogTypes';
@@ -16,6 +17,7 @@ import type { TaskGroup } from '@logger/LogTypes';
 interface TaskGroupEventsShared {
   logger: AgentLogger;
   initializeStreamForTaskGroup(stream: string): void;
+  getStreamStatuses(): Map<string, StreamStatusType>;
 }
 
 export interface TaskGroupEventsModule {
@@ -66,9 +68,22 @@ export function createTaskGroupEvents(
       };
 
       state.taskGroups.addGroup(stream, groupId, group);
+      if (!parentGroupId) {
+        state.setActiveWorkflowGroup(stream, groupId);
+      }
 
       if (updater.isAvailable() && stream === state.activeStream) {
         updater.addTaskGroup(stream, group);
+      }
+
+      if (updater.isAvailable()) {
+        const statuses = shared.getStreamStatuses();
+        const infos = buildStreamInfos(
+          state,
+          statuses,
+          state.agentTypeFilter,
+        );
+        updater.updateStreams(infos, state.activeStream, state.agentTypeFilter);
       }
     });
   };
@@ -86,8 +101,29 @@ export function createTaskGroupEvents(
         endTime,
       });
 
+      const group = state.taskGroups.getGroup(stream, groupId);
+      if (group && !group.parentGroupId) {
+        if (status === 'running' || endTime === undefined) {
+          state.setActiveWorkflowGroup(stream, groupId);
+        } else if (state.getActiveWorkflowGroup(stream) === groupId) {
+          const latestActive =
+            state.taskGroups.findLatestActiveRootGroup(stream);
+          state.setActiveWorkflowGroup(stream, latestActive?.id);
+        }
+      }
+
       if (updater.isAvailable() && stream === state.activeStream) {
         updater.updateTaskGroup(stream, groupId, status, endTime);
+      }
+
+      if (updater.isAvailable()) {
+        const statuses = shared.getStreamStatuses();
+        const infos = buildStreamInfos(
+          state,
+          statuses,
+          state.agentTypeFilter,
+        );
+        updater.updateStreams(infos, state.activeStream, state.agentTypeFilter);
       }
     });
   };

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -330,6 +330,15 @@
       </div>
       <div class="tabs split">
         <div id="streamTabs" class="tabs-content">
+          <div id="workflowSelectorContainer" class="workflow-selector">
+            <label class="workflow-selector__label" for="workflowSelector"
+              >Workflow sessions</label
+            >
+            <select
+              id="workflowSelector"
+              class="workflow-selector__control vscode-select"
+            ></select>
+          </div>
           <!-- Stream tabs will be dynamically inserted here -->
         </div>
         <div class="clear-all-container">

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -83,6 +83,27 @@ export class TaskGroupManager extends PersistentMapManager<
   }
 
   /**
+   * Return the list of root-level task groups ordered by newest first.
+   */
+  getRootGroups(stream: StreamTabId): TaskGroup[] {
+    const groups = this.getStreamGroups(stream);
+    const rootGroups = Array.from(groups.values()).filter(
+      (group) => !group.parentGroupId,
+    );
+
+    return rootGroups.sort((a, b) => (b.startTime ?? 0) - (a.startTime ?? 0));
+  }
+
+  /**
+   * Find the most recent root group that is still considered active.
+   */
+  findLatestActiveRootGroup(stream: StreamTabId): TaskGroup | undefined {
+    return this.getRootGroups(stream).find(
+      (group) => group.status === 'running' || group.endTime === undefined,
+    );
+  }
+
+  /**
    * Check if a stream has groups
    */
   hasStream(stream: StreamTabId): boolean {

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -25,6 +25,8 @@ export const ELEMENT_IDS = {
   LOG_PLACEHOLDER: 'logPlaceholder',
   GENERATED_FILES: 'generatedFiles',
   STREAM_TABS: 'streamTabs',
+  WORKFLOW_SELECTOR_CONTAINER: 'workflowSelectorContainer',
+  WORKFLOW_SELECTOR: 'workflowSelector',
   ACTIVE_STREAM_NAME: 'activeStreamName',
   STATUS_INDICATOR: 'statusIndicator',
   RUN_SUMMARY: 'runSummary',

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -63,6 +63,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.activeStream = message.activeStream;
     state.agentFilter = message.agentFilter || 'all';
     state.resetExecutionAvailability();
+    state.clearAllWorkflowRuns();
     message.streams.forEach((s) => {
       if (s.status) {
         state.streamStatuses.set(s.name, s.status);
@@ -70,8 +71,20 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         state.streamStatuses.delete(s.name);
       }
       state.setExecutionAvailability(s.name, Boolean(s.executionId));
+      if (s.agentSessionKind === 'workflow') {
+        state.setWorkflowRuns(s.name, s.workflowRuns || []);
+        state.setActiveWorkflowRunId(s.name, s.activeWorkflowRunId || null);
+      }
     });
+    const hasWorkflowStreams = message.streams.some(
+      (stream) => stream.agentSessionKind === 'workflow',
+    );
+    state.setWorkflowSelectorActive(hasWorkflowStreams);
+
     dom.streamTabs.update(message.streams, message.activeStream);
+    dom.taskGroups.setActiveRunId(
+      state.getActiveWorkflowRunId(message.activeStream),
+    );
 
     const filterContainer = document.getElementById(
       ELEMENT_IDS.AGENT_FILTER_CONTAINER,
@@ -222,17 +235,52 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   handleAddTaskGroup(message) {
-    if (message.stream === state.activeStream) {
+    const { stream, group } = message;
+    if (!group) {
+      return;
+    }
+
+    if (!group.parentGroupId) {
+      state.upsertWorkflowRun(stream, group);
+      if (group.status === 'running' || group.endTime === undefined) {
+        state.setActiveWorkflowRunId(stream, group.id);
+      }
+    }
+
+    if (stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      dom.taskGroups.add(message.group);
+      dom.taskGroups.add(group);
+      dom.taskGroups.setActiveRunId(
+        state.getActiveWorkflowRunId(state.activeStream),
+      );
       logContent.scrollTop = logContent.scrollHeight;
     }
   }
 
   handleUpdateTaskGroup(message) {
-    if (message.stream === state.activeStream) {
-      state.taskGroups.update(message.groupId, message.status, message.endTime);
-      dom.taskGroups.update(message.groupId, message.status, message.endTime);
+    const { stream, groupId, status, endTime } = message;
+
+    state.taskGroups.update(groupId, status, endTime);
+    const group = state.taskGroups.get(groupId);
+
+    if (group && !group.parentGroupId) {
+      state.upsertWorkflowRun(stream, {
+        id: group.id,
+        name: group.name,
+        startTime: group.startTime,
+        endTime: endTime ?? group.endTime,
+        status: status ?? group.status,
+      });
+      if (status === 'running' || endTime === undefined) {
+        state.setActiveWorkflowRunId(stream, group.id);
+      }
+    }
+
+    if (stream === state.activeStream) {
+      dom.taskGroups.update(groupId, status, endTime);
+      dom.taskGroups.setActiveRunId(
+        state.getActiveWorkflowRunId(state.activeStream),
+      );
     }
   }
 
@@ -294,6 +342,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
       state.clearExecutionAvailability(message.stream);
+      state.clearWorkflowRuns(message.stream);
       if (message.stream === state.activeStream) {
         const groupIds = [];
         const headers = Array.from(
@@ -311,6 +360,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleDeleteAll() {
     state.toggleStates.clearAll();
     state.resetExecutionAvailability();
+    state.clearAllWorkflowRuns();
+    dom.taskGroups.setActiveRunId(null);
     dom.instructionPanel.hide();
   }
 }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -207,12 +207,134 @@ export class ProgressViewState {
     this.activeStream = '';
     this.agentFilter = 'all';
     this.currentGroupId = null;
+    this.workflowRuns = new Map();
+    this.activeWorkflowRunIds = new Map();
+    this.workflowSelectorActive = false;
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
     this.toggleStates = new ToggleStates(() => this.save());
     this.streamStatuses = new StreamStatuses();
     this.executionAvailability = new ExecutionAvailability();
+  }
+
+  setWorkflowRuns(stream, runs) {
+    if (!stream) {
+      return;
+    }
+    if (!Array.isArray(runs)) {
+      this.workflowRuns.set(stream, []);
+      return;
+    }
+    const normalized = runs
+      .map((run) => this._normalizeWorkflowRun(run))
+      .filter(Boolean);
+    this.workflowRuns.set(stream, normalized);
+  }
+
+  getWorkflowRuns(stream) {
+    return this.workflowRuns.get(stream) || [];
+  }
+
+  upsertWorkflowRun(stream, run) {
+    if (!stream || !run || !run.id) {
+      return;
+    }
+
+    const existing = this.getWorkflowRuns(stream);
+    const normalized = this._normalizeWorkflowRun(run);
+    if (!normalized) {
+      return;
+    }
+
+    const updated = [...existing];
+    const index = updated.findIndex((item) => item.id === normalized.id);
+    if (index >= 0) {
+      updated[index] = { ...updated[index], ...normalized };
+    } else {
+      updated.push(normalized);
+    }
+
+    updated.sort(
+      (a, b) => (b.startTime ?? 0) - (a.startTime ?? 0),
+    );
+
+    this.workflowRuns.set(stream, updated);
+  }
+
+  clearWorkflowRuns(stream) {
+    if (!stream) {
+      return;
+    }
+    this.workflowRuns.delete(stream);
+    this.activeWorkflowRunIds.delete(stream);
+  }
+
+  clearAllWorkflowRuns() {
+    this.workflowRuns.clear();
+    this.activeWorkflowRunIds.clear();
+  }
+
+  setActiveWorkflowRunId(stream, runId) {
+    if (!stream) {
+      return;
+    }
+    if (runId) {
+      this.activeWorkflowRunIds.set(stream, runId);
+    } else {
+      this.activeWorkflowRunIds.delete(stream);
+    }
+  }
+
+  getActiveWorkflowRunId(stream) {
+    return this.activeWorkflowRunIds.get(stream) || null;
+  }
+
+  setWorkflowSelectorActive(isActive) {
+    this.workflowSelectorActive = Boolean(isActive);
+  }
+
+  isWorkflowSelectorActive() {
+    return this.workflowSelectorActive;
+  }
+
+  _normalizeWorkflowRun(run) {
+    if (!run || typeof run !== 'object') {
+      return null;
+    }
+
+    const { id } = run;
+    if (!id) {
+      return null;
+    }
+
+    let startTime = run.startTime;
+    if (startTime instanceof Date) {
+      startTime = startTime.getTime();
+    }
+
+    if (typeof startTime === 'string') {
+      const parsed = Date.parse(startTime);
+      startTime = Number.isNaN(parsed) ? undefined : parsed;
+    }
+
+    let endTime = run.endTime;
+    if (endTime instanceof Date) {
+      endTime = endTime.getTime();
+    }
+
+    if (typeof endTime === 'string') {
+      const parsed = Date.parse(endTime);
+      endTime = Number.isNaN(parsed) ? undefined : parsed;
+    }
+
+    return {
+      id,
+      name: run.name ?? '',
+      startTime: typeof startTime === 'number' ? startTime : undefined,
+      endTime: typeof endTime === 'number' ? endTime : undefined,
+      status: run.status,
+    };
   }
 
   setExecutionAvailability(stream, available) {

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -6,6 +6,8 @@ import { progressViewState } from './progressViewState.js';
 import { insertChronologically } from './utils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
+const ACTIVE_RUN_CLASS = 'log-group--active-run';
+
 /**
  * Manages task group DOM operations.
  */
@@ -13,7 +15,8 @@ export class TaskGroupManager {
   constructor() {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
-    this.groupElements = new Map();
+    this.groupNodes = new Map();
+    this.activeRunId = null;
   }
 
   /**
@@ -21,14 +24,14 @@ export class TaskGroupManager {
    * @param {Object} group - Group data
    */
   add(group) {
-    const existingGroup = this.groupElements.get(group.id);
-    if (existingGroup) {
+    const existingNode = this.groupNodes.get(group.id);
+    if (existingNode) {
       if (!progressViewState.taskGroups.get(group.id)) {
         console.warn(
           `Group ${group.id} exists in DOM but not in state - removing from DOM`,
         );
-        existingGroup.remove();
-        this.groupElements.delete(group.id);
+        existingNode.wrapper?.remove();
+        this.groupNodes.delete(group.id);
       } else {
         progressViewState.taskGroups.set(group.id, group);
         this.update(group.id, group.status, group.endTime);
@@ -36,27 +39,72 @@ export class TaskGroupManager {
       }
     }
 
+    const isRoot = !group.parentGroupId;
+    const shouldFlattenRoot =
+      isRoot && progressViewState.isWorkflowSelectorActive();
+
+    const node = shouldFlattenRoot
+      ? this._createFlattenedGroupNode(group)
+      : this._createStandardGroupNode(group);
+
+    if (!node) {
+      return;
+    }
+
+    progressViewState.taskGroups.set(group.id, group);
+    this.groupNodes.set(group.id, {
+      ...node,
+      isRoot,
+      isFlattened: shouldFlattenRoot,
+    });
+
+    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    if (!container) {
+      console.error('TaskGroupManager.add: log container not found');
+      return;
+    }
+
+    if (group.parentGroupId) {
+      const parentNode = this.groupNodes.get(group.parentGroupId);
+      const parentContent = parentNode?.content;
+      if (parentContent) {
+        insertChronologically(parentContent, node.wrapper, group.startTime);
+        return;
+      }
+    }
+
+    insertChronologically(container, node.wrapper, group.startTime);
+
+    if (isRoot) {
+      progressViewState.currentGroupId = group.id;
+      if (!shouldFlattenRoot) {
+        this.collapsePreviousActiveGroup();
+      }
+      this._applyActiveRunClass(group.id);
+    }
+  }
+
+  _createStandardGroupNode(group) {
     const detailsElem = createFromTemplate('groupDetailsTemplate');
     if (!detailsElem) {
       console.error('TaskGroupManager.add: groupDetailsTemplate not found');
-      return;
+      return null;
     }
     detailsElem.id = `group-${group.id}`;
+    detailsElem.dataset.start = `${group.startTime ?? Date.now()}`;
 
     const headerElement = this.headerFormatter.create(group);
     if (!headerElement) {
       console.error('TaskGroupManager.add: failed to create group header');
-      return;
+      return null;
     }
 
     const groupContainer = detailsElem.querySelector('.log-group-content');
     if (!groupContainer) {
       console.error('TaskGroupManager.add: missing group content container');
-      return;
+      return null;
     }
     groupContainer.id = `group-content-${group.id}`;
-
-    progressViewState.taskGroups.set(group.id, group);
 
     const isCollapsed = progressViewState.toggleStates.get(group.id);
     detailsElem.open = isCollapsed !== true;
@@ -67,29 +115,21 @@ export class TaskGroupManager {
       progressViewState.toggleStates.set(group.id, !detailsElem.open);
     });
 
-    this.groupElements.set(group.id, detailsElem);
+    return { wrapper: detailsElem, content: groupContainer };
+  }
 
-    // Insert the group at the right position in the parent
-    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+  _createFlattenedGroupNode(group) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'log-group log-group--flattened';
+    wrapper.id = `group-${group.id}`;
+    wrapper.dataset.start = `${group.startTime ?? Date.now()}`;
 
-    if (group.parentGroupId) {
-      const parentDetails = this.groupElements.get(group.parentGroupId);
-      const parentGroupContent =
-        parentDetails?.querySelector('.log-group-content');
-      if (parentGroupContent) {
-        insertChronologically(parentGroupContent, detailsElem, group.startTime);
-        return;
-      }
-    }
+    const content = document.createElement('div');
+    content.className = 'log-group-content';
+    content.id = `group-content-${group.id}`;
+    wrapper.appendChild(content);
 
-    // For top-level groups, insert in chronological order
-    insertChronologically(container, detailsElem, group.startTime);
-
-    // For top-level groups, update current group and collapse the previous active group
-    if (!group.parentGroupId) {
-      progressViewState.currentGroupId = group.id;
-      this.collapsePreviousActiveGroup();
-    }
+    return { wrapper, content };
   }
 
   /**
@@ -107,23 +147,22 @@ export class TaskGroupManager {
       group.endTime = endTime;
     }
 
-    const detailsElem = this.groupElements.get(groupId);
-    if (!detailsElem) {
+    const node = this.groupNodes.get(groupId);
+    const wrapper = node?.wrapper;
+    if (!(wrapper instanceof HTMLDetailsElement)) {
       return;
     }
 
-    const header = detailsElem.querySelector('.log-group-header');
+    const header = wrapper.querySelector('.log-group-header');
     if (header) {
       const level = this.headerFormatter._getGroupLevel(group);
       header.className = this.headerFormatter._getHeaderClass(group, level);
 
-      // Update the status icon
       const statusIconElem = header.querySelector('.group-status-icon');
       if (statusIconElem) {
         statusIconElem.innerHTML = this.headerFormatter._getStatusIcon(status);
       }
 
-      // Update or add the duration display when the group finishes
       const timeContainer = header.querySelector('.group-time');
 
       if (endTime) {
@@ -131,7 +170,6 @@ export class TaskGroupManager {
         const startDate = group.startTime;
         const durationMs = endDate - startDate;
 
-        // Update or create duration element
         const durationElem = header.querySelector('.group-duration');
         if (durationElem) {
           durationElem.textContent = `${this.headerFormatter._formatDuration(durationMs)}`;
@@ -151,23 +189,59 @@ export class TaskGroupManager {
     }
   }
 
+  setActiveRunId(runId) {
+    this.activeRunId = runId || null;
+    for (const [groupId, node] of this.groupNodes.entries()) {
+      if (!node.isRoot) {
+        continue;
+      }
+      this._toggleActiveRunClass(node, groupId === this.activeRunId);
+    }
+  }
+
+  _applyActiveRunClass(groupId) {
+    const node = this.groupNodes.get(groupId);
+    if (!node || !node.isRoot) {
+      return;
+    }
+    this._toggleActiveRunClass(node, groupId === this.activeRunId);
+  }
+
+  _toggleActiveRunClass(node, isActive) {
+    const { wrapper, isFlattened } = node;
+    if (!wrapper) {
+      return;
+    }
+    if (isActive) {
+      wrapper.classList.add(ACTIVE_RUN_CLASS);
+      if (!isFlattened && wrapper instanceof HTMLDetailsElement) {
+        wrapper.open = true;
+        progressViewState.toggleStates.set(
+          wrapper.id.replace('group-', ''),
+          false,
+        );
+      }
+    } else {
+      wrapper.classList.remove(ACTIVE_RUN_CLASS);
+    }
+  }
+
   /**
    * Collapse a group and all of its child groups recursively
    * @private
    * @param {string} groupId - ID of the group to collapse
    */
   collapseGroupAndChildren(groupId) {
-    // Find all child groups
     for (const [childId, group] of progressViewState.taskGroups.getAll()) {
       if (group.parentGroupId === groupId) {
         this.collapseGroupAndChildren(childId);
       }
     }
 
-    // Collapse this group
-    const detailsElem = this.groupElements.get(groupId);
-    if (detailsElem) {
-      detailsElem.open = false;
+    const node = this.groupNodes.get(groupId);
+    const wrapper = node?.wrapper;
+    if (wrapper instanceof HTMLDetailsElement) {
+      wrapper.open = false;
       progressViewState.toggleStates.set(groupId, true);
     }
   }
@@ -186,8 +260,9 @@ export class TaskGroupManager {
     let latestGroup = null;
     let latestTime = 0;
 
-    for (const [id, detailsElem] of this.groupElements.entries()) {
-      if (!detailsElem || !detailsElem.open) {
+    for (const [id, node] of this.groupNodes.entries()) {
+      const wrapper = node.wrapper;
+      if (!(wrapper instanceof HTMLDetailsElement) || !wrapper.open) {
         continue;
       }
 
@@ -212,7 +287,6 @@ export class TaskGroupManager {
   collapsePreviousActiveGroup() {
     const currentId = this.findCurrentActiveGroup();
 
-    // Collapse the previous group if it's different from current
     if (
       this.previousActiveGroupId &&
       this.previousActiveGroupId !== currentId
@@ -220,7 +294,6 @@ export class TaskGroupManager {
       this.collapseGroupAndChildren(this.previousActiveGroupId);
     }
 
-    // Update the previous ID to current for next time
     this.previousActiveGroupId = currentId;
   }
 
@@ -250,8 +323,9 @@ export class TaskGroupManager {
    * Clear cached group references.
    */
   clear() {
-    this.groupElements.clear();
+    this.groupNodes.clear();
     this.previousActiveGroupId = null;
+    this.activeRunId = null;
   }
 }
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -54,6 +54,34 @@ export class EventsManager {
       }
     });
 
+    addEventListenerSafely(ELEMENT_IDS.WORKFLOW_SELECTOR, 'change', (e) => {
+      const select = e.target;
+      if (!(select instanceof HTMLSelectElement)) {
+        return;
+      }
+
+      const option = select.selectedOptions[0];
+      if (!option) {
+        return;
+      }
+
+      const stream = option.dataset.stream;
+      if (!stream) {
+        return;
+      }
+
+      const runId = option.dataset.runId || '';
+
+      progressViewState.activeStream = stream;
+      progressViewState.setActiveWorkflowRunId(stream, runId || null);
+
+      vscode.postMessage({
+        command: COMMANDS.SWITCH_STREAM,
+        stream,
+        workflowRunId: runId || undefined,
+      });
+    });
+
     // Toolbar click handler
     addEventListenerSafely(ELEMENT_IDS.TOOLBAR_CONTAINER, 'click', (e) => {
       const button = e.target.closest('button[data-command]');

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -31,13 +31,67 @@ export class StreamTabs {
       console.error('StreamTabs.update: streamTabs container not found');
       return;
     }
-    tabsContainer.innerHTML = '';
+    const workflowSelectorContainer = document.getElementById(
+      ELEMENT_IDS.WORKFLOW_SELECTOR_CONTAINER,
+    );
+    const workflowSelector = document.getElementById(
+      ELEMENT_IDS.WORKFLOW_SELECTOR,
+    );
+
+    tabsContainer
+      .querySelectorAll('.tab-container')
+      .forEach((node) => node.remove());
+
+    const workflowEntries = [];
+    const toolStreams = [];
     let activeInfo = null;
-    streams.forEach((info) => {
+    for (const info of streams) {
       if (!info || typeof info !== 'object') {
         console.warn('StreamTabs.update: invalid stream value:', info);
-        return;
+        continue;
       }
+      if (info.agentSessionKind === 'workflow') {
+        const runs = Array.isArray(info.workflowRuns)
+          ? [...info.workflowRuns]
+          : [];
+        workflowEntries.push({
+          info,
+          runs: runs.sort(
+            (a, b) => (b?.startTime ?? 0) - (a?.startTime ?? 0),
+          ),
+          activeRunId: info.activeWorkflowRunId || null,
+        });
+      } else {
+        toolStreams.push(info);
+      }
+      if (info.name === activeStream) {
+        activeInfo = info;
+      }
+    }
+
+    const shouldShowWorkflowSelector = workflowEntries.length > 0;
+    if (workflowSelectorContainer && workflowSelector) {
+      if (shouldShowWorkflowSelector) {
+        workflowSelectorContainer.classList.add('visible');
+        workflowSelector.innerHTML = '';
+        const options = this._createWorkflowOptions(workflowEntries);
+        options.forEach((option) => workflowSelector.appendChild(option));
+
+        this._selectWorkflowOption(
+          workflowSelector,
+          activeStream,
+          activeInfo?.activeWorkflowRunId ?? null,
+        );
+
+        workflowSelector.disabled = options.length === 0;
+      } else {
+        workflowSelectorContainer.classList.remove('visible');
+        workflowSelector.innerHTML = '';
+        workflowSelector.disabled = true;
+      }
+    }
+
+    toolStreams.forEach((info) => {
       const tooltip = this._buildTooltip(info);
       const tabEl = createFromTemplate('streamTabTemplate', {
         text: {
@@ -55,7 +109,9 @@ export class StreamTabs {
           '.tab-delete': { stream: info.name },
         },
       });
-      if (!tabEl) return;
+      if (!tabEl) {
+        return;
+      }
       initializeIconButtons(tabEl);
       const statusEl = tabEl.querySelector('.tab-status');
       if (statusEl) {
@@ -82,7 +138,6 @@ export class StreamTabs {
       }
       if (info.name === activeStream) {
         tabEl.classList.add('active');
-        activeInfo = info;
       }
       tabsContainer.appendChild(tabEl);
     });
@@ -103,6 +158,38 @@ export class StreamTabs {
         delete streamNameElem.dataset.stream;
       }
     }
+
+    this._updateActiveRunSummary(activeInfo);
+  }
+
+  _createWorkflowOptions(entries) {
+    const sorted = entries
+      .slice()
+      .sort((a, b) => this._compareWorkflowStreams(a.info, b.info));
+
+    const options = [];
+    sorted.forEach((entry) => {
+      const { info, runs, activeRunId } = entry;
+      const effectiveRuns = runs.length > 0
+        ? runs
+        : [this._createSyntheticRun(info)];
+
+      effectiveRuns.forEach((run, index) => {
+        const option = document.createElement('option');
+        option.value = this._composeWorkflowOptionValue(
+          info.name,
+          run.id,
+          index,
+        );
+        option.dataset.stream = info.name;
+        option.dataset.runId = run.id || '';
+        option.textContent = this._buildWorkflowOptionLabel(info, run);
+        option.title = this._buildWorkflowRunTooltip(info, run, activeRunId);
+        options.push(option);
+      });
+    });
+
+    return options;
   }
 
   _buildTooltip(info) {
@@ -117,6 +204,175 @@ export class StreamTabs {
       parts.push(`Input: ${info.inputFile}`);
     }
     return parts.filter(Boolean).join(' • ');
+  }
+
+  _composeWorkflowOptionValue(streamId, runId, index) {
+    if (runId) {
+      return `${streamId}::${runId}`;
+    }
+    return `${streamId}::idx${index}`;
+  }
+
+  _selectWorkflowOption(selectEl, streamId, runId) {
+    if (!(selectEl instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    const options = Array.from(selectEl.options);
+    let matched = false;
+    let fallback = null;
+
+    options.forEach((option) => {
+      option.selected = false;
+      if (option.dataset.stream === streamId) {
+        if (!fallback) {
+          fallback = option;
+        }
+        if (runId && option.dataset.runId === runId) {
+          option.selected = true;
+          matched = true;
+        }
+      }
+    });
+
+    if (!matched) {
+      const target = fallback || options[0];
+      if (target) {
+        target.selected = true;
+        matched = true;
+      }
+    }
+
+    if (matched && selectEl.selectedIndex === -1) {
+      const newIndex = options.findIndex((option) => option.selected);
+      if (newIndex >= 0) {
+        selectEl.selectedIndex = newIndex;
+      }
+    }
+  }
+
+  _compareWorkflowStreams(a, b) {
+    const aTime = a.lastTimestamp ?? a.creationTimestamp ?? 0;
+    const bTime = b.lastTimestamp ?? b.creationTimestamp ?? 0;
+    return bTime - aTime;
+  }
+
+  _createSyntheticRun(info) {
+    return {
+      id: '',
+      name: info.label || info.name,
+      startTime: info.lastTimestamp ?? info.creationTimestamp,
+      endTime: info.lastTimestamp,
+      status: info.status,
+    };
+  }
+
+  _buildWorkflowOptionLabel(info, run) {
+    const baseLabel = info.label || info.name;
+    const runLabel = this._normalizeRunLabel(run?.name);
+    const timestamp = formatRelativeTime(
+      run?.endTime ??
+        run?.startTime ??
+        info.lastTimestamp ??
+        info.creationTimestamp,
+    );
+    const descriptors = [];
+    if (runLabel) {
+      descriptors.push(runLabel);
+    }
+    if (timestamp) {
+      descriptors.push(timestamp);
+    }
+    if (descriptors.length === 0) {
+      return baseLabel;
+    }
+    return `${baseLabel} • ${descriptors.join(' • ')}`;
+  }
+
+  _buildWorkflowRunTooltip(info, run, activeRunId) {
+    const tooltipParts = [this._buildTooltip(info)];
+    const runLabel = this._normalizeRunLabel(run?.name);
+    if (runLabel) {
+      tooltipParts.push(`Run: ${runLabel}`);
+    }
+    if (run?.status) {
+      tooltipParts.push(`Status: ${run.status}`);
+    }
+    if (run?.startTime) {
+      const startText = new Date(run.startTime).toLocaleString();
+      tooltipParts.push(`Started: ${startText}`);
+    }
+    if (run?.endTime) {
+      const endText = new Date(run.endTime).toLocaleString();
+      tooltipParts.push(`Finished: ${endText}`);
+    }
+    if (run?.id && run.id === activeRunId) {
+      tooltipParts.push('Currently active');
+    }
+    return tooltipParts.filter(Boolean).join('\n');
+  }
+
+  _normalizeRunLabel(label) {
+    if (!label) {
+      return '';
+    }
+    return label.replace(/^Run:\s*/i, '').trim();
+  }
+
+  _updateActiveRunSummary(activeInfo) {
+    const summary = document.getElementById(ELEMENT_IDS.RUN_SUMMARY);
+    if (!summary) {
+      return;
+    }
+
+    if (!activeInfo || activeInfo.agentSessionKind !== 'workflow') {
+      summary.textContent = '';
+      return;
+    }
+
+    const activeRun = this._findActiveRun(activeInfo);
+    if (!activeRun) {
+      summary.textContent = '';
+      return;
+    }
+
+    const parts = [];
+    const runLabel = this._normalizeRunLabel(activeRun.name);
+    if (runLabel) {
+      parts.push(runLabel);
+    }
+
+    if (activeRun.status) {
+      parts.push(activeRun.status);
+    }
+
+    const timestamp = formatRelativeTime(
+      activeRun.endTime ??
+        activeRun.startTime ??
+        activeInfo.lastTimestamp ??
+        activeInfo.creationTimestamp,
+    );
+    if (timestamp) {
+      parts.push(timestamp);
+    }
+
+    summary.textContent = parts.filter(Boolean).join(' • ');
+  }
+
+  _findActiveRun(info) {
+    const runs = Array.isArray(info.workflowRuns) ? info.workflowRuns : [];
+    if (!runs.length) {
+      return null;
+    }
+
+    if (info.activeWorkflowRunId) {
+      const matching = runs.find((run) => run.id === info.activeWorkflowRunId);
+      if (matching) {
+        return matching;
+      }
+    }
+
+    return runs[0];
   }
 
   _buildActiveTitle(info) {

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -27,8 +27,10 @@ export class UsageSummary {
     // If usage is not provided, compute it from existing log groups
     const totals = usage ?? this.computeTotal();
 
-    // Clear the summary - we're showing total usage in the files section now
-    this._summaryElem.textContent = '';
+    if (!progressViewState.isWorkflowSelectorActive()) {
+      // Clear the summary - we're showing total usage in the files section now
+      this._summaryElem.textContent = '';
+    }
   }
 
   /**

--- a/src/progressView/modules/utils.js
+++ b/src/progressView/modules/utils.js
@@ -83,6 +83,12 @@ export function insertChronologically(
  */
 function defaultChildTimestamp(child) {
   if (child.classList.contains('log-group')) {
+    if (child.dataset.start) {
+      const parsed = parseInt(child.dataset.start, DECIMAL_RADIX);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
     const startElem = child.querySelector('.group-start-time');
     const start = startElem?.dataset.start;
     return start ? parseInt(start, DECIMAL_RADIX) : null;

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -46,6 +46,8 @@ export class ProgressViewState {
   private _agentTypeFilter: AgentFilter = 'all';
   private readonly workflowTaskStates: WorkflowTaskStateManager;
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
+  private readonly _activeWorkflowGroupIds: Map<StreamTabId, string> =
+    new Map();
   /**
    * Ephemeral session-kind hints keyed by stream ID.
    *
@@ -135,6 +137,25 @@ export class ProgressViewState {
 
   clearSessionKindHint(streamTabId: StreamTabId): void {
     this._sessionCategoryHints.delete(streamTabId);
+  }
+
+  setActiveWorkflowGroup(
+    streamTabId: StreamTabId,
+    groupId: string | undefined,
+  ): void {
+    if (!groupId) {
+      this._activeWorkflowGroupIds.delete(streamTabId);
+      return;
+    }
+    this._activeWorkflowGroupIds.set(streamTabId, groupId);
+  }
+
+  getActiveWorkflowGroup(streamTabId: StreamTabId): string | undefined {
+    return this._activeWorkflowGroupIds.get(streamTabId);
+  }
+
+  clearActiveWorkflowGroup(streamTabId: StreamTabId): void {
+    this._activeWorkflowGroupIds.delete(streamTabId);
   }
 
   /**
@@ -259,6 +280,7 @@ export class ProgressViewState {
     this.toolUseTaskStates.delete(stream);
     this._executionIds.delete(stream);
     this.clearSessionKindHint(stream);
+    this.clearActiveWorkflowGroup(stream);
     this.cleanupToolUseAgentRegistry();
 
     // Update active stream if necessary
@@ -281,6 +303,7 @@ export class ProgressViewState {
     this._taskGroups.deleteStream(stream);
     this._outputFiles.deleteStream(stream);
     this.clearSessionKindHint(stream);
+    this.clearActiveWorkflowGroup(stream);
 
     // NOTE: Preserve taskStates and executionIds - these are needed for re-run functionality
     // NOTE: Preserve usageStats - these were not cleared in original implementation
@@ -296,6 +319,7 @@ export class ProgressViewState {
     this.toolUseTaskStates.clear();
     this._executionIds.clear();
     this._sessionCategoryHints.clear();
+    this._activeWorkflowGroupIds.clear();
     this._activeStream = '';
     this.saveActiveStream();
     this.saveTaskStates();

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 // Local imports - progress view
 import type { ProgressViewState } from './state/ProgressViewState';
-import type { AgentFilter, StreamTabInfo } from './types';
+import type { AgentFilter, StreamTabInfo, WorkflowRunInfo } from './types';
 // Local imports - agent types
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
@@ -75,6 +75,19 @@ export function buildStreamInfos(
     const isToolAgent = sessionCategory === AgentCategory.ToolUse;
     const executionId = state.getExecutionId(id);
     const label = buildStreamLabel(agentName, inputFile, sessionCategory);
+    let workflowRuns: WorkflowRunInfo[] | undefined;
+    let activeWorkflowRunId: string | undefined;
+
+    if (sessionCategory === AgentCategory.Workflow) {
+      workflowRuns = state.taskGroups.getRootGroups(id).map((group) => ({
+        id: group.id,
+        name: group.name,
+        startTime: group.startTime ?? 0,
+        endTime: group.endTime,
+        status: group.status,
+      }));
+      activeWorkflowRunId = state.getActiveWorkflowGroup(id);
+    }
     acc.push({
       name: id,
       label,
@@ -92,6 +105,8 @@ export function buildStreamInfos(
       creationTimestamp,
       status: statuses?.get(id),
       executionId,
+      workflowRuns,
+      activeWorkflowRunId,
     });
     return acc;
   }, []);

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -39,6 +39,31 @@
     var(--vscode-editorGroupHeader-tabsBorder);
 }
 
+.log-group--flattened {
+  margin: var(--spacing-small) 0;
+  padding: var(--spacing-small) var(--spacing-medium);
+  border-radius: var(--border-radius-small);
+  border: var(--border-thin) solid transparent;
+}
+
+.log-group--flattened .log-group-content {
+  border-left: none;
+  padding-left: 0;
+}
+
+.log-group--active-run {
+  outline: var(--border-thin) solid var(--vscode-focusBorder);
+  outline-offset: var(--spacing-tiny);
+}
+
+.log-group--flattened.log-group--active-run {
+  background-color: color-mix(
+    in srgb,
+    var(--vscode-focusBorder) 12%,
+    transparent
+  );
+}
+
 .group-status-icon {
   margin-right: var(--spacing-small);
 }

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -22,6 +22,28 @@
   min-height: 0;
 }
 
+.workflow-selector {
+  display: none;
+  flex-direction: column;
+  gap: var(--spacing-small);
+  padding: var(--spacing-small) var(--spacing-medium);
+  border-bottom: var(--border-thin) solid var(--vscode-panel-border);
+}
+
+.workflow-selector.visible {
+  display: flex;
+}
+
+.workflow-selector__label {
+  font-size: var(--font-size-sm);
+  color: var(--vscode-foreground);
+  opacity: var(--opacity-subtle);
+}
+
+.workflow-selector__control {
+  width: 100%;
+}
+
 .clear-all-container {
   flex-shrink: 0;
   border-top: var(--border-thin) solid var(--vscode-panel-border);

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -10,6 +10,14 @@ export interface StreamUITraits {
   isToolAgent: boolean;
 }
 
+export interface WorkflowRunInfo {
+  id: string;
+  name: string;
+  startTime: number;
+  endTime?: number;
+  status?: string;
+}
+
 export interface StreamTabInfo {
   name: string;
   /** Short label displayed in the tab UI */
@@ -25,6 +33,10 @@ export interface StreamTabInfo {
   creationTimestamp?: number;
   status?: string;
   executionId?: ExecutionId;
+  /** List of top-level workflow runs associated with this stream. */
+  workflowRuns?: WorkflowRunInfo[];
+  /** Identifier of the active workflow run when available. */
+  activeWorkflowRunId?: string;
 }
 
 export type AgentFilter = AgentTypeFilter;

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -171,6 +171,7 @@ describe('Progress event modules', () => {
     const module = createTaskGroupEvents({
       logger: loggerStub,
       initializeStreamForTaskGroup: () => {},
+      getStreamStatuses: () => new Map(),
     });
 
     const disposables = module.register(bus as any, stateStub, updaterStub);
@@ -188,6 +189,7 @@ describe('Progress event modules', () => {
       initializeStreamForTaskGroup: (stream) => {
         initialized.push(stream);
       },
+      getStreamStatuses: () => new Map(),
     });
 
     const state = {
@@ -201,8 +203,12 @@ describe('Progress event modules', () => {
       taskGroups: {
         addGroup: () => {},
         updateGroup: () => {},
+        getGroup: () => undefined,
+        findLatestActiveRootGroup: () => undefined,
       },
       setSessionKindHint: () => {},
+      setActiveWorkflowGroup: () => {},
+      getActiveWorkflowGroup: () => undefined,
       agentTypeFilter: 'all',
       activeStream: '',
     } as unknown as ProgressViewState;

--- a/src/test/progressView/state/ProgressViewState.test.ts
+++ b/src/test/progressView/state/ProgressViewState.test.ts
@@ -5,6 +5,7 @@ import { strict as assert } from 'assert';
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { StatePersistenceManager } from '@progressView/persistence/StatePersistenceManager';
 import { WorkspaceStateKey } from '@common/state/stateManager';
+import { buildStreamInfos } from '@progressView/streamInfoUtils';
 
 // Local imports - agent
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
@@ -135,5 +136,67 @@ describe('ProgressViewState.clearOutputState', () => {
     const didUpdate = state.clearOutputState(streamId);
     assert.equal(didUpdate, false);
     assert.deepStrictEqual(persistence.saved, []);
+  });
+});
+
+describe('ProgressViewState workflow run tracking', () => {
+  it('tracks and clears active workflow group identifiers', () => {
+    const persistence = new FakePersistence();
+    const state = new ProgressViewState(
+      persistence as unknown as StatePersistenceManager,
+    );
+
+    const streamId = 'stream-99';
+    state.setActiveWorkflowGroup(streamId, 'run-1');
+    assert.equal(state.getActiveWorkflowGroup(streamId), 'run-1');
+
+    state.setActiveWorkflowGroup(streamId, undefined);
+    assert.equal(state.getActiveWorkflowGroup(streamId), undefined);
+
+    state.streamTabs.ensureStream(streamId);
+    state.setActiveWorkflowGroup(streamId, 'run-2');
+    state.clearStream(streamId);
+    assert.equal(state.getActiveWorkflowGroup(streamId), undefined);
+  });
+});
+
+describe('buildStreamInfos workflow metadata', () => {
+  it('includes workflow run details and active identifiers', () => {
+    const persistence = new FakePersistence();
+    const state = new ProgressViewState(
+      persistence as unknown as StatePersistenceManager,
+    );
+
+    const config = AgentConfigSchema.parse({
+      model: 'test-model',
+      agent: 'test-agent',
+      instruction: 'Test instruction',
+      session: {
+        agentCategory: AgentCategory.Workflow,
+        agentType: AgentType.Direct,
+      },
+      inputFile: 'main.tex',
+    });
+
+    const streamId = 'stream-workflow';
+    state.streamTabs.ensureStream(streamId);
+    const workflowState = agentConfigToTaskState(config, config.session);
+    state.setTaskState(streamId, workflowState);
+
+    const group = {
+      id: 'run-123',
+      name: 'Run: test',
+      startTime: 1000,
+      status: 'running',
+    } as any;
+    state.taskGroups.addGroup(streamId, group.id, group);
+    state.setActiveWorkflowGroup(streamId, group.id);
+
+    const infos = buildStreamInfos(state, undefined, 'all');
+    const info = infos.find((entry) => entry.name === streamId);
+    assert.ok(info);
+    assert.equal(info?.activeWorkflowRunId, 'run-123');
+    assert.ok(Array.isArray(info?.workflowRuns));
+    assert.equal(info?.workflowRuns?.[0]?.id, 'run-123');
   });
 });


### PR DESCRIPTION
## Summary
- group workflow workflows into a dropdown that favors the active run and flattens its log banner
- surface workflow run metadata across the state, events, and UI handlers so the selector and logs stay in sync
- keep the usage header compatible with the new run summary and extend the task-group event tests accordingly

## Testing
- CI=1 npm test -- --runInBand *(fails: vscode-test needs libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68f11a06ba7c8324a447b1ad419c5578

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a workflow run selector and active-run tracking, wiring workflow run metadata through state, events, and UI with updated rendering and styles.
> 
> - **UI/UX**:
>   - Add workflow run selector (`index.html`, `StreamTabs.js`, `EventsManager.js`) with option generation, selection handling, and active run summary.
>   - Flatten top-level workflow groups when selector is active; highlight active run (`taskManagers.js`, `groups.css`).
>   - Update tabs to show only tool streams; workflow sessions moved to selector (`StreamTabs.js`).
> - **State & Types**:
>   - Track workflow runs and active run IDs in webview state (`progressViewState.js`).
>   - Track active workflow group per stream in extension state (`ProgressViewState.ts`).
>   - Extend `StreamTabInfo` with `workflowRuns` and `activeWorkflowRunId`; add `WorkflowRunInfo` (`types.ts`).
>   - Expose root/active workflow groups (`TaskGroupManager.ts`).
> - **Events & Data Flow**:
>   - Populate stream info with workflow runs and active group (`streamInfoUtils.ts`).
>   - Update task-group events to set/advance active workflow group and refresh streams; inject `getStreamStatuses` (`TaskGroupEvents.ts`, `ProgressEventHandler.ts`).
> - **Provider & Messaging**:
>   - Support switching streams with `workflowRunId`; set active workflow group (`ProgressViewProvider.ts`, `ProgressViewMessageHandler.ts`).
> - **DOM/Handlers**:
>   - Sync workflow runs in webview state and DOM updates (`messageHandlers.js`, `usageManagers.js`, `utils.js`).
> - **Styles**:
>   - Add styles for workflow selector and active/flattened groups (`tabs.css`, `groups.css`).
> - **Tests**:
>   - Extend tests for task-group events and workflow metadata (`EventModules.test.ts`, `ProgressViewState.test.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df5a61c4e2d03352643777d5cc2aa46e8f978ba0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->