### PR TITLE
docs: refine changelog for 0.34.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Add Claude Haiku 4.5 (`haiku45T`, `haiku45`) to the Anthropic model catalog with pricing, reasoning capability metadata, and documentation in the model guide.
+- Add an interactive VS Code walkthrough that guides first-time users through model setup, file selection, and the progress board.
+- Expand the Anthropic catalog with Claude Haiku 4.5 (`haiku45T`, `haiku45`), including pricing, capability metadata, and updated documentation.
 
 ### Improvements
 
-- Simplify agent prompt handling by unifying initial and reflection prompts into a single `userRequest` field
-- Automatically migrate legacy `userReflect` configurations with user-friendly warnings
+- Streamline custom agent prompts by keeping all rounds in the `userRequest` list while automatically migrating older `userReflect` entries and highlighting anything that still needs attention.
+- Ensure the model picker waits for its options to load so newly enabled models reliably appear, even on slower machines.
+
+### Bug Fixes
+
+- Restore scratchpad exports to reopen the named document you selected when agents generate multiple files.
+- Repair tool-use session migration so previously saved runs load and resume without errors.
+- Improve OpenAI "thinking" summaries with clearer spacing, making reasoning traces easier to scan in the progress view.
+- Keep workflow outputs visible in the progress board when no new files were written, avoiding unnecessary refreshes.
+- Show progress board timestamps in your local timezone instead of UTC.
 
 ## [0.33.10] - 2025-10-10
 


### PR DESCRIPTION
## Summary
- highlight the new VS Code walkthrough and Claude Haiku 4.5 in the 0.34.0 changelog
- rewrite the improvements and fixes for 0.34.0 in user-facing language, including the progress board timezone fix

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68f3612dd164832494f131e07e1653cf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the 0.34.0 changelog by adding a VS Code walkthrough, expanding the Claude Haiku 4.5 entry, clarifying improvements, and listing several bug fixes.
> 
> - **Documentation** (`CHANGELOG.md`):
>   - **Features**:
>     - Add interactive VS Code walkthrough for first-time setup and progress board onboarding.
>     - Expand Anthropic entry for Claude Haiku 4.5 (`haiku45T`, `haiku45`) with pricing/capability metadata and updated docs.
>   - **Improvements**:
>     - Streamline custom agent prompts into `userRequest` rounds and auto-migrate legacy `userReflect` with highlights for remaining items.
>     - Ensure model picker waits for options to load so newly enabled models appear reliably.
>   - **Bug Fixes**:
>     - Restore scratchpad exports to reopen the chosen document when multiple files are generated.
>     - Repair tool-use session migration so saved runs resume correctly.
>     - Improve OpenAI thinking summaries spacing for clearer reasoning traces.
>     - Keep workflow outputs visible on the progress board when no new files are written.
>     - Show progress board timestamps in local timezone.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60b0c5c2acd919f2e4770483be9b0917f978541f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->