### PR TITLE
feat: add session selector to progress view

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -481,6 +481,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
                 bus.emit('setTaskState', {
                   streamTabId: activeStreamId,
                   executionId,
+                  taskGroupId: mainTaskGroupId,
                   taskState: agentConfigToTaskState(config, metadata),
                 });
                 logger.debug(

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -14,6 +14,7 @@ import type {
   TaskGroup,
 } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
+import type { TaskGroupId } from '@logger/types/EntityTypes';
 
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
@@ -53,6 +54,7 @@ interface SetTaskStatePayload {
   streamTabId: StreamTabId;
   executionId?: ExecutionId;
   taskState: TaskState;
+  taskGroupId?: TaskGroupId;
 }
 
 export interface ProgressEventPayloads {

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -6,6 +6,16 @@
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { TaskGroupId, LogMessageId } from './types/EntityTypes';
 
+export interface TaskGroupInstructionMetadata {
+  showToggle?: boolean;
+  expanded?: boolean;
+}
+
+export interface TaskGroupInstruction {
+  text: string;
+  metadata?: TaskGroupInstructionMetadata;
+}
+
 export interface TaskGroup {
   /** Unique identifier for the group */
   id: TaskGroupId;
@@ -21,6 +31,8 @@ export interface TaskGroup {
   parentGroupId?: TaskGroupId;
   /** Optional usage stats attached to the group */
   usage?: TokenUsageStats;
+  /** Optional instruction metadata for this task group */
+  instruction?: TaskGroupInstruction;
 }
 
 export interface LogMessageData {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -319,7 +319,13 @@ export class ProgressViewProvider
     const groups = Array.from(
       this.state.taskGroups.getStreamGroups(stream).values(),
     );
-    this.webviewUpdater.updateLogContent(stream, messages, groups);
+    const latestGroupId = this.state.getLatestSessionGroup(stream);
+    this.webviewUpdater.updateLogContent(
+      stream,
+      messages,
+      groups,
+      latestGroupId,
+    );
   }
 
   /**

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -117,11 +117,20 @@ export class ProgressEventHandler {
 
     const taskState = this.state.getTaskState(stream);
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
+    const taskGroupId = this.state.getLatestSessionGroup(stream);
+    const groups = Array.from(
+      this.state.taskGroups.getStreamGroups(stream).values(),
+    );
 
     if (instructionUpdate) {
-      this.webviewUpdater.updateInstruction(stream, instructionUpdate);
+      this.webviewUpdater.updateInstruction(
+        stream,
+        instructionUpdate,
+        taskGroupId,
+        groups,
+      );
     } else {
-      this.webviewUpdater.clearInstruction(stream);
+      this.webviewUpdater.clearInstruction(stream, taskGroupId, groups);
     }
   }
 
@@ -140,7 +149,13 @@ export class ProgressEventHandler {
     const groups = Array.from(
       this.state.taskGroups.getStreamGroups(stream).values(),
     );
-    this.webviewUpdater.updateLogContent(stream, messages, groups);
+    const latestGroupId = this.state.getLatestSessionGroup(stream);
+    this.webviewUpdater.updateLogContent(
+      stream,
+      messages,
+      groups,
+      latestGroupId,
+    );
 
     // Send output files for current stream
     const files = this.state.outputFiles.getFiles(stream) || {};

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type { WebviewUpdater } from '../managers';
+import { WebviewUpdater } from '../managers';
 import { buildStreamInfos } from '../streamInfoUtils';
 import type { ProgressViewState } from '../state/ProgressViewState';
 import type { StreamTabInfo } from '../types';
@@ -93,7 +93,23 @@ export function createStreamStatusEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
-    const { streamTabId, executionId, taskState } = data;
+    const { streamTabId, executionId, taskState, taskGroupId } = data;
+
+    const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
+    const targetGroupId =
+      taskGroupId ?? state.getLatestSessionGroup(streamTabId);
+
+    if (targetGroupId) {
+      state.setLatestSessionGroup(streamTabId, targetGroupId);
+      state.taskGroups.updateGroup(streamTabId, targetGroupId, {
+        instruction: instructionUpdate
+          ? {
+              text: instructionUpdate.text,
+              metadata: instructionUpdate.metadata,
+            }
+          : undefined,
+      });
+    }
 
     state.setTaskState(streamTabId, taskState);
     state.clearSessionKindHint(streamTabId);

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -66,6 +66,9 @@ export function createTaskGroupEvents(
       };
 
       state.taskGroups.addGroup(stream, groupId, group);
+      if (!parentGroupId) {
+        state.setLatestSessionGroup(stream, groupId);
+      }
 
       if (updater.isAvailable() && stream === state.activeStream) {
         updater.addTaskGroup(stream, group);

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -91,6 +91,23 @@
           class="instruction-panel"
           aria-hidden="true"
         >
+          <div
+            id="sessionSelectorContainer"
+            class="session-selector"
+            aria-hidden="true"
+          >
+            <label
+              id="sessionSelectorLabel"
+              class="session-selector__label"
+              for="sessionSelector"
+              >Session</label
+            >
+            <select
+              id="sessionSelector"
+              class="session-selector__dropdown"
+              aria-label="Select session"
+            ></select>
+          </div>
           <div class="instruction-panel__header">
             <span class="instruction-panel__title">Instruction</span>
             <div class="instruction-panel__actions button-group">

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -149,6 +149,29 @@ export class TaskGroupManager extends PersistentMapManager<
               : group.endTime
             : undefined,
       };
+
+      if (group.instruction && typeof group.instruction.text === 'string') {
+        const metadata = group.instruction.metadata;
+        const normalizedMetadata =
+          metadata && typeof metadata === 'object'
+            ? {
+                ...(typeof metadata.showToggle === 'boolean'
+                  ? { showToggle: metadata.showToggle }
+                  : {}),
+                ...(typeof metadata.expanded === 'boolean'
+                  ? { expanded: metadata.expanded }
+                  : {}),
+              }
+            : undefined;
+
+        normalized.instruction = {
+          text: group.instruction.text,
+          ...(normalizedMetadata && Object.keys(normalizedMetadata).length > 0
+            ? { metadata: normalizedMetadata }
+            : {}),
+        };
+      }
+
       map.set(id, normalized);
     }
     return map;

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -16,7 +16,7 @@ import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { AgentLogger } from '@logger/AgentLogger';
-import { LogMessageData } from '@logger/LogTypes';
+import type { LogMessageData, TaskGroup } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
 
 // Type aliases for status values
@@ -91,7 +91,8 @@ export class WebviewUpdater {
   updateLogContent(
     stream: StreamTabId,
     messages: LogMessageData[],
-    groups?: any[],
+    groups: TaskGroup[] = [],
+    taskGroupId?: string,
   ): void {
     const webview = this.getWebview();
     if (!webview) return;
@@ -100,7 +101,8 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_LOGS,
       stream,
       messages,
-      groups: groups || [],
+      groups,
+      taskGroupId,
     });
   }
 
@@ -182,7 +184,12 @@ export class WebviewUpdater {
   /**
    * Update instruction panel content
    */
-  updateInstruction(stream: StreamTabId, instruction: InstructionUpdate): void {
+  updateInstruction(
+    stream: StreamTabId,
+    instruction: InstructionUpdate,
+    taskGroupId?: string,
+    groups: TaskGroup[] = [],
+  ): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -190,13 +197,19 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_INSTRUCTION,
       stream,
       instruction,
+      taskGroupId,
+      groups,
     });
   }
 
   /**
    * Clear instruction panel content
    */
-  clearInstruction(stream: StreamTabId | ''): void {
+  clearInstruction(
+    stream: StreamTabId | '',
+    taskGroupId?: string,
+    groups: TaskGroup[] = [],
+  ): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -204,6 +217,8 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_INSTRUCTION,
       stream,
       instruction: null,
+      taskGroupId,
+      groups,
     });
   }
 

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -28,6 +28,8 @@ export const ELEMENT_IDS = {
   ACTIVE_STREAM_NAME: 'activeStreamName',
   STATUS_INDICATOR: 'statusIndicator',
   RUN_SUMMARY: 'runSummary',
+  SESSION_SELECTOR_CONTAINER: 'sessionSelectorContainer',
+  SESSION_SELECTOR: 'sessionSelector',
   INSTRUCTION_CONTAINER: 'instructionContainer',
   INSTRUCTION_TEXT: 'instructionText',
   INSTRUCTION_TOGGLE_BTN: 'instructionToggleBtn',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -9,6 +9,7 @@ import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Placeholder } from './uiManagers/Placeholder.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
+import { SessionSelector } from './uiManagers/SessionSelector.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
@@ -31,6 +32,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       events: new EventsManager(),
       placeholder: new Placeholder(),
       instructionPanel: new InstructionPanel(),
+      sessionSelector: new SessionSelector(),
     });
   }
 }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -14,6 +14,62 @@ import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js'
 const state = progressViewState;
 const dom = progressViewDomHandler;
 
+const updateInstructionPanelForSelection = (selectionId) => {
+  const activeStream = state.activeStream;
+  if (!activeStream) {
+    dom.instructionPanel.hide();
+    return;
+  }
+
+  const targetId = selectionId ?? state.getSelectedRootGroup(activeStream);
+  if (!targetId) {
+    dom.instructionPanel.hide();
+    return;
+  }
+
+  const group = state.taskGroups.get(targetId);
+  const instruction = group?.instruction;
+
+  if (instruction?.text) {
+    dom.instructionPanel.show(instruction.text, instruction.metadata);
+  } else {
+    dom.instructionPanel.hide();
+  }
+};
+
+const updateSessionSelector = (groups, preferredId) => {
+  const selected = dom.sessionSelector.updateOptions(groups, preferredId);
+  const activeStream = state.activeStream;
+
+  if (activeStream) {
+    if (selected) {
+      state.setSelectedRootGroup(activeStream, selected);
+    } else {
+      state.clearSelectedRootGroup(activeStream);
+    }
+  }
+
+  dom.taskGroups.setVisibleRootGroup(selected);
+  updateInstructionPanelForSelection(selected);
+  return selected;
+};
+
+dom.sessionSelector.setOnChange((groupId) => {
+  const activeStream = state.activeStream;
+  if (!activeStream) {
+    return;
+  }
+
+  if (groupId) {
+    state.setSelectedRootGroup(activeStream, groupId);
+  } else {
+    state.clearSelectedRootGroup(activeStream);
+  }
+
+  dom.taskGroups.setVisibleRootGroup(groupId);
+  updateInstructionPanelForSelection(groupId);
+});
+
 // Create formatter instances
 
 export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
@@ -119,12 +175,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (message.stream === state.activeStream) {
+      const previousSelection = state.getSelectedRootGroup(message.stream);
       logContent.innerHTML = '';
       state.taskGroups.clear();
       dom.taskGroups.clear();
-      if (message.groups && message.groups.length > 0) {
-        const parentGroups = message.groups.filter((g) => !g.parentGroupId);
-        const childGroups = message.groups.filter((g) => g.parentGroupId);
+      const groups = Array.isArray(message.groups) ? message.groups : [];
+      if (groups.length > 0) {
+        const parentGroups = groups.filter((g) => !g.parentGroupId);
+        const childGroups = groups.filter((g) => g.parentGroupId);
         parentGroups
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.add(g));
@@ -150,6 +208,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
       // Recalculate cumulative usage after loading groups
       dom.usageSummary.update();
+
+      const preferredGroupId = message.taskGroupId || previousSelection || null;
+      updateSessionSelector(groups, preferredGroupId);
     }
 
     this._updatePlaceholderVisibility();
@@ -165,6 +226,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
     state.taskGroups.clear();
     dom.taskGroups.clear();
+    state.clearSelectedRootGroup(state.activeStream);
+    dom.sessionSelector.clear();
+    updateInstructionPanelForSelection(null);
     state.toggleStates.clear(groupIds);
 
     this._updatePlaceholderVisibility();
@@ -269,25 +333,44 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * }} message
    */
   handleUpdateInstruction(message) {
+    const { stream, instruction, taskGroupId } = message;
     const activeStream = state.activeStream || '';
 
-    if (message.stream !== activeStream) {
-      if (!activeStream && !message.stream) {
-        dom.instructionPanel.hide();
+    if (!stream || stream !== activeStream) {
+      return;
+    }
+
+    const groups = Array.isArray(message.groups) ? message.groups : [];
+    if (groups.length > 0) {
+      groups.forEach((group) => {
+        if (group?.id) {
+          state.taskGroups.set(group.id, group);
+        }
+      });
+    }
+
+    if (typeof taskGroupId === 'string') {
+      const existingGroup = state.taskGroups.get(taskGroupId);
+      if (existingGroup) {
+        state.taskGroups.set(taskGroupId, {
+          ...existingGroup,
+          instruction: instruction ? { ...instruction } : undefined,
+        });
       }
-      return;
     }
 
-    const payload = message.instruction;
-    const text = payload?.text ?? '';
+    const preferredGroupId =
+      taskGroupId || state.getSelectedRootGroup(stream) || null;
 
-    if (!text.trim()) {
-      dom.instructionPanel.hide();
-      return;
+    if (groups.length > 0) {
+      updateSessionSelector(groups, preferredGroupId);
+    } else if (taskGroupId && !state.getSelectedRootGroup(stream)) {
+      state.setSelectedRootGroup(stream, taskGroupId);
+      dom.taskGroups.setVisibleRootGroup(taskGroupId);
     }
 
-    const metadata = payload?.metadata ?? {};
-    dom.instructionPanel.show(text, metadata);
+    const selection = state.getSelectedRootGroup(stream) || taskGroupId || null;
+    updateInstructionPanelForSelection(selection);
   }
 
   handleDeleteStream(message) {
@@ -303,6 +386,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           groupIds.push(el.id.replace('group-header-', ''));
         }
         state.toggleStates.clear(groupIds);
+        state.clearSelectedRootGroup(message.stream);
+        dom.sessionSelector.clear();
         dom.instructionPanel.hide();
       }
     }
@@ -311,6 +396,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleDeleteAll() {
     state.toggleStates.clearAll();
     state.resetExecutionAvailability();
+    state.clearSelectedRootGroup(state.activeStream);
+    dom.sessionSelector.clear();
     dom.instructionPanel.hide();
   }
 }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -207,6 +207,7 @@ export class ProgressViewState {
     this.activeStream = '';
     this.agentFilter = 'all';
     this.currentGroupId = null;
+    this.selectedRootGroups = new Map();
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
@@ -229,6 +230,35 @@ export class ProgressViewState {
 
   resetExecutionAvailability() {
     this.executionAvailability.clear();
+  }
+
+  setSelectedRootGroup(stream, groupId) {
+    if (!stream) {
+      return;
+    }
+
+    if (!groupId) {
+      this.selectedRootGroups.delete(stream);
+      return;
+    }
+
+    this.selectedRootGroups.set(stream, groupId);
+  }
+
+  getSelectedRootGroup(stream) {
+    if (!stream) {
+      return null;
+    }
+
+    return this.selectedRootGroups.get(stream) ?? null;
+  }
+
+  clearSelectedRootGroup(stream) {
+    if (!stream) {
+      return;
+    }
+
+    this.selectedRootGroups.delete(stream);
   }
 
   /** Load saved state from VS Code storage. */

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -253,6 +253,25 @@ export class TaskGroupManager {
     this.groupElements.clear();
     this.previousActiveGroupId = null;
   }
+
+  setVisibleRootGroup(groupId) {
+    for (const [id, element] of this.groupElements.entries()) {
+      if (!element) {
+        continue;
+      }
+
+      const group = progressViewState.taskGroups.get(id);
+      if (!group || group.parentGroupId) {
+        continue;
+      }
+
+      if (!groupId || groupId === id) {
+        element.style.removeProperty('display');
+      } else {
+        element.style.display = 'none';
+      }
+    }
+  }
 }
 
 /**

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -1,0 +1,174 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+
+// Local imports - shared helpers
+import { safeGetElementById } from '@common/domUtils.js';
+
+function formatSessionLabel(group) {
+  const date = group?.startTime ? new Date(group.startTime) : null;
+  const timeLabel = date
+    ? date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : '';
+  if (timeLabel) {
+    return `${timeLabel} • ${group.name}`;
+  }
+  return group?.name ?? '';
+}
+
+export class SessionSelector {
+  constructor() {
+    this._elements = null;
+    this._onChange = null;
+    this._selected = null;
+
+    this._handleChange = this._handleChange.bind(this);
+  }
+
+  _getElements() {
+    if (!this._elements) {
+      const container = safeGetElementById(
+        ELEMENT_IDS.SESSION_SELECTOR_CONTAINER,
+      );
+      const dropdown = safeGetElementById(ELEMENT_IDS.SESSION_SELECTOR);
+
+      if (!container || !dropdown) {
+        return null;
+      }
+
+      dropdown.addEventListener('change', this._handleChange);
+      this._elements = { container, dropdown };
+    }
+
+    return this._elements;
+  }
+
+  setOnChange(handler) {
+    this._onChange = typeof handler === 'function' ? handler : null;
+  }
+
+  updateOptions(groups, preferredId) {
+    const elements = this._getElements();
+    if (!elements) {
+      return null;
+    }
+
+    const rootGroups = Array.isArray(groups)
+      ? groups.filter((group) => group && !group.parentGroupId)
+      : [];
+
+    const hasMultiple = rootGroups.length > 1;
+    this._setVisibility(hasMultiple);
+
+    const dropdown = elements.dropdown;
+    dropdown.innerHTML = '';
+
+    if (rootGroups.length === 0) {
+      this._selected = null;
+      elements.container.setAttribute('aria-hidden', 'true');
+      return null;
+    }
+
+    const sortedGroups = [...rootGroups].sort(
+      (a, b) => b.startTime - a.startTime,
+    );
+
+    const fragment = document.createDocumentFragment();
+    let nextSelected = null;
+
+    for (const group of sortedGroups) {
+      const option = document.createElement('option');
+      option.value = group.id;
+      option.textContent = formatSessionLabel(group);
+      fragment.appendChild(option);
+    }
+
+    dropdown.appendChild(fragment);
+
+    const preferredExists = sortedGroups.some(
+      (group) => group.id === preferredId,
+    );
+    if (preferredExists) {
+      nextSelected = preferredId;
+    } else {
+      nextSelected = sortedGroups[0]?.id ?? null;
+    }
+
+    dropdown.value = nextSelected ?? '';
+    this._selected = nextSelected;
+    elements.container.setAttribute(
+      'aria-hidden',
+      hasMultiple ? 'false' : 'true',
+    );
+
+    return this._selected;
+  }
+
+  setSelected(groupId) {
+    const elements = this._elements;
+    if (!elements) {
+      return;
+    }
+
+    const dropdown = elements.dropdown;
+    if (!dropdown) {
+      return;
+    }
+
+    if (groupId && dropdown.value === groupId) {
+      return;
+    }
+
+    const hasOption = Array.from(dropdown.options).some(
+      (option) => option.value === groupId,
+    );
+
+    if (!hasOption) {
+      return;
+    }
+
+    dropdown.value = groupId;
+    this._selected = groupId;
+    this._notifyChange();
+  }
+
+  getSelected() {
+    return this._selected;
+  }
+
+  clear() {
+    const elements = this._elements;
+    if (!elements) {
+      return;
+    }
+
+    elements.dropdown.innerHTML = '';
+    elements.container.classList.remove('is-visible');
+    elements.container.setAttribute('aria-hidden', 'true');
+    this._selected = null;
+  }
+
+  _setVisibility(visible) {
+    const elements = this._elements;
+    if (!elements) {
+      return;
+    }
+
+    elements.container.classList.toggle('is-visible', Boolean(visible));
+  }
+
+  _handleChange(event) {
+    const dropdown = event?.currentTarget;
+    if (!dropdown) {
+      return;
+    }
+
+    this._selected = dropdown.value || null;
+    this._notifyChange();
+  }
+
+  _notifyChange() {
+    if (this._onChange) {
+      this._onChange(this._selected);
+    }
+  }
+}

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -46,6 +46,7 @@ export class ProgressViewState {
   private _agentTypeFilter: AgentFilter = 'all';
   private readonly workflowTaskStates: WorkflowTaskStateManager;
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
+  private latestSessionGroupByStream: Map<StreamTabId, string> = new Map();
   /**
    * Ephemeral session-kind hints keyed by stream ID.
    *
@@ -249,6 +250,18 @@ export class ProgressViewState {
     this.saveExecutionIds();
   }
 
+  setLatestSessionGroup(stream: StreamTabId, groupId: string): void {
+    this.latestSessionGroupByStream.set(stream, groupId);
+  }
+
+  getLatestSessionGroup(stream: StreamTabId): string | undefined {
+    return this.latestSessionGroupByStream.get(stream);
+  }
+
+  clearLatestSessionGroup(stream: StreamTabId): void {
+    this.latestSessionGroupByStream.delete(stream);
+  }
+
   // Stream cleanup operations
   clearStream(stream: StreamTabId): void {
     this._streamTabs.delete(stream);
@@ -258,6 +271,7 @@ export class ProgressViewState {
     this.workflowTaskStates.delete(stream);
     this.toolUseTaskStates.delete(stream);
     this._executionIds.delete(stream);
+    this.clearLatestSessionGroup(stream);
     this.clearSessionKindHint(stream);
     this.cleanupToolUseAgentRegistry();
 

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -23,4 +23,5 @@
 @import './statistics.css';
 @import './user-message.css';
 @import './follow-up-input.css';
+@import './session-selector.css';
 @import './instruction-panel.css';

--- a/src/progressView/styles/session-selector.css
+++ b/src/progressView/styles/session-selector.css
@@ -1,0 +1,33 @@
+.session-selector {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.session-selector.is-visible {
+  display: flex;
+}
+
+.session-selector__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vscode-descriptionForeground);
+}
+
+.session-selector__dropdown {
+  flex: 1;
+  min-width: 0;
+  padding: 0.25rem 0.5rem;
+  font-size: 12px;
+  background-color: var(--vscode-dropdown-background);
+  color: var(--vscode-dropdown-foreground);
+  border: 1px solid var(--vscode-dropdown-border);
+  border-radius: 4px;
+}
+
+.session-selector__dropdown:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
+}

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -12,6 +12,7 @@ import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { AgentLogger } from '@logger/AgentLogger';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 class FakeBus {
   public readonly events: (keyof ProgressEventPayloads)[] = [];
@@ -223,5 +224,126 @@ describe('Progress event modules', () => {
 
     assert.deepStrictEqual(initialized, ['stream-1']);
     assert.deepStrictEqual(bus.emissions, []);
+  });
+
+  it('records the latest session group when adding a root task group', () => {
+    const bus = new FakeBus();
+    const recorded: { stream: string; groupId: string }[] = [];
+    const module = createTaskGroupEvents({
+      logger: loggerStub,
+      initializeStreamForTaskGroup: () => {},
+    });
+
+    const state = {
+      streamTabs: {
+        has: () => true,
+        ensureStream: () => {},
+      },
+      taskGroups: {
+        addGroup: () => {},
+      },
+      setLatestSessionGroup: (stream: string, groupId: string) => {
+        recorded.push({ stream, groupId });
+      },
+    } as unknown as ProgressViewState;
+    const updater = {
+      isAvailable: () => false,
+    } as unknown as WebviewUpdater;
+
+    module.register(bus as any, state, updater);
+
+    bus.trigger('addTaskGroup', {
+      stream: 'stream-xyz',
+      groupId: 'group-123',
+      groupName: 'Task',
+      startTime: 123,
+      status: 'running',
+      parentGroupId: undefined,
+    });
+
+    assert.deepStrictEqual(recorded, [
+      { stream: 'stream-xyz', groupId: 'group-123' },
+    ]);
+  });
+
+  it('attaches instruction metadata to the matching task group', () => {
+    const bus = new FakeBus();
+    const shared = {
+      logger: loggerStub,
+      streamStatus: new Map(),
+      setStreamStatus: () => {},
+      sendInstructionUpdate: () => {},
+      updateLogContentForStream: () => {},
+    };
+    const module = createStreamStatusEvents(shared);
+
+    const updates: Array<{
+      stream: string;
+      groupId: string;
+      update: Record<string, unknown>;
+    }> = [];
+    const latestSessions: Array<{ stream: string; groupId: string }> = [];
+    let agentFilter = 'all';
+
+    const state = {
+      setTaskState: () => {},
+      clearSessionKindHint: () => {},
+      getTaskState: () => ({
+        session: { agentCategory: AgentCategory.Workflow },
+        agentConfig: { instruction: 'Focus on the main file' },
+      }),
+      get activeStream() {
+        return 'stream-42';
+      },
+      get agentTypeFilter() {
+        return agentFilter;
+      },
+      set agentTypeFilter(value) {
+        agentFilter = value;
+      },
+      setExecutionId: () => {},
+      setLatestSessionGroup: (stream: string, groupId: string) => {
+        latestSessions.push({ stream, groupId });
+      },
+      getLatestSessionGroup: () => undefined,
+      taskGroups: {
+        updateGroup: (
+          stream: string,
+          groupId: string,
+          update: Record<string, unknown>,
+        ) => {
+          updates.push({ stream, groupId, update });
+        },
+      },
+    } as unknown as ProgressViewState;
+    const updater = {
+      isAvailable: () => false,
+    } as unknown as WebviewUpdater;
+
+    module.register(bus as any, state, updater);
+
+    bus.trigger('setTaskState', {
+      streamTabId: 'stream-42',
+      executionId: undefined,
+      taskState: {
+        agentConfig: { instruction: 'Focus on the main file' },
+        session: { agentCategory: AgentCategory.Workflow },
+      } as any,
+      taskGroupId: 'group-alpha',
+    });
+
+    assert.deepStrictEqual(latestSessions, [
+      { stream: 'stream-42', groupId: 'group-alpha' },
+    ]);
+    assert.equal(updates.length, 1);
+    assert.deepStrictEqual(updates[0], {
+      stream: 'stream-42',
+      groupId: 'group-alpha',
+      update: {
+        instruction: {
+          text: 'Focus on the main file',
+        },
+      },
+    });
   });
 });

--- a/src/test/progressView/managers/TaskGroupManager.test.ts
+++ b/src/test/progressView/managers/TaskGroupManager.test.ts
@@ -1,0 +1,64 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import type { Memento } from 'vscode';
+
+// Local imports - progress view
+import { TaskGroupManager } from '@progressView/managers/TaskGroupManager';
+import { StatePersistenceManager } from '@progressView/persistence/StatePersistenceManager';
+
+class MemoryMemento implements Memento {
+  private readonly store = new Map<string, unknown>();
+
+  keys(): readonly string[] {
+    return [...this.store.keys()];
+  }
+
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+    return defaultValue;
+  }
+
+  update(key: string, value: any): Thenable<void> {
+    if (value === undefined) {
+      this.store.delete(key);
+    } else {
+      this.store.set(key, value);
+    }
+    return Promise.resolve();
+  }
+}
+
+describe('TaskGroupManager', () => {
+  it('preserves instruction metadata during deserialization', async () => {
+    const memento = new MemoryMemento();
+    const persistence = new StatePersistenceManager(memento);
+    const manager = new TaskGroupManager(persistence);
+
+    const serialized = {
+      'group-1': {
+        id: 'group-1',
+        name: 'Task',
+        startTime: '2024-01-01T00:00:00.000Z',
+        status: 'running',
+        instruction: {
+          text: 'Review the introduction',
+          metadata: { showToggle: true, expanded: true },
+        },
+      },
+    } as unknown;
+
+    const map = await (manager as any).deserialize(serialized, 'stream-1');
+    const group = map.get('group-1');
+
+    assert.ok(group);
+    assert.equal(typeof group?.startTime, 'number');
+    assert.deepStrictEqual(group?.instruction, {
+      text: 'Review the introduction',
+      metadata: { showToggle: true, expanded: true },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- tag task-state progress events with their originating task group and persist instruction metadata
- surface session-aware instructions and log groups through the progress view, adding a dropdown selector
- update webview handling and unit tests to cover instruction persistence and selector behavior

## Testing
- npm run lint
- npm run compile
- npm test *(fails: libatk-1.0.so.0 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3624435b0832485ee5b04b97e8854

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a session selector to the Progress View and propagates `taskGroupId` + instruction metadata through events/state/UI for session-aware instructions and logs.
> 
> - **Progress View UI**:
>   - Add session selector dropdown in `progressView/index.html` with styles in `styles/session-selector.css` and DOM manager `uiManagers/SessionSelector.js`.
>   - Show instruction text per selected session; update log rendering to filter/top-level visibility based on selection.
> - **Webview updates/handlers**:
>   - Extend `WebviewUpdater.updateLogContent`/`updateInstruction`/`clearInstruction` to include `groups` and optional `taskGroupId`.
>   - Update `ProgressViewProvider`, `ProgressEventHandler`, and message handlers to pass `latestGroupId`/`taskGroupId`, rebuild groups, and manage selection.
> - **State and persistence**:
>   - Track latest session group per stream in `state/ProgressViewState.ts`; add selected-root-group tracking in webview `progressViewState.js`.
>   - Preserve `TaskGroup.instruction` metadata on (de)serialization in `TaskGroupManager`.
> - **Events and bus**:
>   - Add optional `taskGroupId` to `setTaskState` payload (`ProgressEventBus`); emit it from `executeAgent.ts`.
>   - Attach instruction metadata to task groups on `setTaskState`; mark latest session group on root group creation.
> - **Types**:
>   - Extend `LogTypes.TaskGroup` with `instruction` and metadata types.
> - **Tests**:
>   - Update/add tests for latest-session tracking and instruction metadata persistence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8bc7b1d076e2d7b5579ab70431b065f8f7856fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->