### PR TITLE
feat: add session selector to progress instructions

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -482,6 +482,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
                   streamTabId: activeStreamId,
                   executionId,
                   taskState: agentConfigToTaskState(config, metadata),
+                  taskGroupId: taskDetailsGroupId,
                 });
                 logger.debug(
                   `Task state stored for stream: ${activeStreamId}`,

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -53,6 +53,7 @@ interface SetTaskStatePayload {
   streamTabId: StreamTabId;
   executionId?: ExecutionId;
   taskState: TaskState;
+  taskGroupId?: string;
 }
 
 export interface ProgressEventPayloads {

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -6,6 +6,16 @@
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { TaskGroupId, LogMessageId } from './types/EntityTypes';
 
+export interface TaskGroupInstructionMetadata {
+  showToggle?: boolean;
+  expanded?: boolean;
+}
+
+export interface TaskGroupInstruction {
+  text: string;
+  metadata?: TaskGroupInstructionMetadata;
+}
+
 export interface TaskGroup {
   /** Unique identifier for the group */
   id: TaskGroupId;
@@ -21,6 +31,8 @@ export interface TaskGroup {
   parentGroupId?: TaskGroupId;
   /** Optional usage stats attached to the group */
   usage?: TokenUsageStats;
+  /** Optional instruction metadata captured for the group */
+  instruction?: TaskGroupInstruction;
 }
 
 export interface LogMessageData {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -111,17 +111,26 @@ export class ProgressEventHandler {
     }
 
     if (!stream) {
-      this.webviewUpdater.clearInstruction('');
+      this.webviewUpdater.clearInstruction('', []);
       return;
     }
 
     const taskState = this.state.getTaskState(stream);
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
+    const groups = Array.from(
+      this.state.taskGroups.getStreamGroups(stream).values(),
+    );
+    const taskGroupId = this.state.getLatestTaskGroup(stream);
 
     if (instructionUpdate) {
-      this.webviewUpdater.updateInstruction(stream, instructionUpdate);
+      this.webviewUpdater.updateInstruction(
+        stream,
+        instructionUpdate,
+        groups,
+        taskGroupId,
+      );
     } else {
-      this.webviewUpdater.clearInstruction(stream);
+      this.webviewUpdater.clearInstruction(stream, groups, taskGroupId);
     }
   }
 
@@ -140,7 +149,8 @@ export class ProgressEventHandler {
     const groups = Array.from(
       this.state.taskGroups.getStreamGroups(stream).values(),
     );
-    this.webviewUpdater.updateLogContent(stream, messages, groups);
+    const taskGroupId = this.state.getLatestTaskGroup(stream);
+    this.webviewUpdater.updateLogContent(stream, messages, groups, taskGroupId);
 
     // Send output files for current stream
     const files = this.state.outputFiles.getFiles(stream) || {};

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type { WebviewUpdater } from '../managers';
+import { WebviewUpdater } from '../managers';
 import { buildStreamInfos } from '../streamInfoUtils';
 import type { ProgressViewState } from '../state/ProgressViewState';
 import type { StreamTabInfo } from '../types';
@@ -93,7 +93,26 @@ export function createStreamStatusEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
-    const { streamTabId, executionId, taskState } = data;
+    const { streamTabId, executionId, taskState, taskGroupId } = data;
+
+    if (taskGroupId) {
+      state.setLatestTaskGroup(streamTabId, taskGroupId);
+    }
+
+    const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
+    const targetGroupId = taskGroupId ?? state.getLatestTaskGroup(streamTabId);
+    if (targetGroupId) {
+      const group = state.taskGroups.getGroup(streamTabId, targetGroupId);
+      if (group) {
+        state.taskGroups.updateGroup(streamTabId, targetGroupId, {
+          instruction: instructionUpdate,
+        });
+      } else {
+        shared.logger.debug(
+          `No task group ${targetGroupId} found for stream ${streamTabId} when attaching instruction`,
+        );
+      }
+    }
 
     state.setTaskState(streamTabId, taskState);
     state.clearSessionKindHint(streamTabId);

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -66,6 +66,9 @@ export function createTaskGroupEvents(
       };
 
       state.taskGroups.addGroup(stream, groupId, group);
+      if (!parentGroupId) {
+        state.setLatestTaskGroup(stream, groupId);
+      }
 
       if (updater.isAvailable() && stream === state.activeStream) {
         updater.addTaskGroup(stream, group);

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -87,6 +87,20 @@
           <div id="toolbarContainer" class="header-actions button-group"></div>
         </div>
         <div
+          id="sessionSelectorContainer"
+          class="session-selector"
+          aria-hidden="true"
+        >
+          <label class="session-selector__label" for="sessionSelector">
+            Session
+          </label>
+          <select
+            id="sessionSelector"
+            class="session-selector__select"
+            aria-label="Select session"
+          ></select>
+        </div>
+        <div
           id="instructionContainer"
           class="instruction-panel"
           aria-hidden="true"

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -125,7 +125,22 @@ export class TaskGroupManager extends PersistentMapManager<
     value: Map<string, TaskGroup>,
     _key: StreamTabId,
   ): unknown {
-    return Object.fromEntries(value.entries());
+    return Object.fromEntries(
+      Array.from(value.entries(), ([id, group]) => {
+        const serialized: TaskGroup = {
+          ...group,
+          instruction: group.instruction
+            ? {
+                text: group.instruction.text,
+                metadata: group.instruction.metadata
+                  ? { ...group.instruction.metadata }
+                  : undefined,
+              }
+            : undefined,
+        };
+        return [id, serialized];
+      }),
+    );
   }
 
   /** Normalize loaded groups */
@@ -147,6 +162,17 @@ export class TaskGroupManager extends PersistentMapManager<
             ? typeof group.endTime === 'string'
               ? new Date(group.endTime).getTime()
               : group.endTime
+            : undefined,
+        instruction:
+          group.instruction && typeof group.instruction.text === 'string'
+            ? {
+                text: group.instruction.text,
+                metadata:
+                  group.instruction.metadata &&
+                  typeof group.instruction.metadata === 'object'
+                    ? { ...group.instruction.metadata }
+                    : undefined,
+              }
             : undefined,
       };
       map.set(id, normalized);

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -16,7 +16,7 @@ import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { AgentLogger } from '@logger/AgentLogger';
-import { LogMessageData } from '@logger/LogTypes';
+import { LogMessageData, TaskGroup } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
 
 // Type aliases for status values
@@ -91,7 +91,8 @@ export class WebviewUpdater {
   updateLogContent(
     stream: StreamTabId,
     messages: LogMessageData[],
-    groups?: any[],
+    groups: TaskGroup[] = [],
+    taskGroupId?: string,
   ): void {
     const webview = this.getWebview();
     if (!webview) return;
@@ -100,7 +101,8 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_LOGS,
       stream,
       messages,
-      groups: groups || [],
+      groups,
+      taskGroupId,
     });
   }
 
@@ -182,7 +184,12 @@ export class WebviewUpdater {
   /**
    * Update instruction panel content
    */
-  updateInstruction(stream: StreamTabId, instruction: InstructionUpdate): void {
+  updateInstruction(
+    stream: StreamTabId | '',
+    instruction: InstructionUpdate | null,
+    groups: TaskGroup[],
+    taskGroupId?: string,
+  ): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -190,21 +197,20 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_INSTRUCTION,
       stream,
       instruction,
+      groups,
+      taskGroupId,
     });
   }
 
   /**
    * Clear instruction panel content
    */
-  clearInstruction(stream: StreamTabId | ''): void {
-    const webview = this.getWebview();
-    if (!webview) return;
-
-    webview.postMessage({
-      command: COMMANDS.UPDATE_INSTRUCTION,
-      stream,
-      instruction: null,
-    });
+  clearInstruction(
+    stream: StreamTabId | '',
+    groups: TaskGroup[] = [],
+    taskGroupId?: string,
+  ): void {
+    this.updateInstruction(stream, null, groups, taskGroupId);
   }
 
   /**
@@ -292,7 +298,8 @@ export class WebviewUpdater {
       const groups = Array.from(
         state.taskGroups.getStreamGroups(activeStream).values(),
       );
-      this.updateLogContent(activeStream, messages, groups);
+      const taskGroupId = state.getLatestTaskGroup(activeStream);
+      this.updateLogContent(activeStream, messages, groups, taskGroupId);
 
       // Update files for active stream
       const files = state.outputFiles.getFiles(activeStream) || {};
@@ -310,9 +317,14 @@ export class WebviewUpdater {
       const instructionUpdate =
         WebviewUpdater.createInstructionUpdate(taskState);
       if (instructionUpdate) {
-        this.updateInstruction(activeStream, instructionUpdate);
+        this.updateInstruction(
+          activeStream,
+          instructionUpdate,
+          groups,
+          taskGroupId,
+        );
       } else {
-        this.clearInstruction(activeStream);
+        this.clearInstruction(activeStream, groups, taskGroupId);
       }
     } else {
       // Clear content when no active stream

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -28,6 +28,8 @@ export const ELEMENT_IDS = {
   ACTIVE_STREAM_NAME: 'activeStreamName',
   STATUS_INDICATOR: 'statusIndicator',
   RUN_SUMMARY: 'runSummary',
+  SESSION_SELECTOR_CONTAINER: 'sessionSelectorContainer',
+  SESSION_SELECTOR_SELECT: 'sessionSelector',
   INSTRUCTION_CONTAINER: 'instructionContainer',
   INSTRUCTION_TEXT: 'instructionText',
   INSTRUCTION_TOGGLE_BTN: 'instructionToggleBtn',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -9,6 +9,7 @@ import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Placeholder } from './uiManagers/Placeholder.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
+import { SessionSelector } from './uiManagers/SessionSelector.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
@@ -31,6 +32,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       events: new EventsManager(),
       placeholder: new Placeholder(),
       instructionPanel: new InstructionPanel(),
+      sessionSelector: new SessionSelector(),
     });
   }
 }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -19,6 +19,9 @@ const dom = progressViewDomHandler;
 export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
     super();
+    dom.sessionSelector.setChangeHandler((groupId) =>
+      this._handleSessionChange(groupId),
+    );
     this._entryFormatter = new LogEntryFormatter();
     this._handlers = {
       ...createThemeHandlers(),
@@ -109,6 +112,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // Update status based on whether there's an active stream
     if (!message.activeStream) {
       dom.status.update(STATUS.READY);
+      dom.sessionSelector.hide();
       dom.instructionPanel.hide();
     } else {
       const streamStatus = state.streamStatuses.get(message.activeStream);
@@ -119,12 +123,20 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (message.stream === state.activeStream) {
+      const groups = Array.isArray(message.groups) ? message.groups : [];
+      const selectedGroupId = this._resolveSelectedGroup(
+        message.stream,
+        groups,
+        message.taskGroupId,
+      );
+
+      state.setSelectedRootGroup(message.stream, selectedGroupId);
       logContent.innerHTML = '';
       state.taskGroups.clear();
       dom.taskGroups.clear();
-      if (message.groups && message.groups.length > 0) {
-        const parentGroups = message.groups.filter((g) => !g.parentGroupId);
-        const childGroups = message.groups.filter((g) => g.parentGroupId);
+      if (groups.length > 0) {
+        const parentGroups = groups.filter((g) => !g.parentGroupId);
+        const childGroups = groups.filter((g) => g.parentGroupId);
         parentGroups
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.add(g));
@@ -132,6 +144,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.add(g));
       }
+      dom.taskGroups.setActiveRootGroup(selectedGroupId);
       const sortedMessages = [...message.messages].sort(
         (a, b) => a.timestamp - b.timestamp,
       );
@@ -150,6 +163,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
       // Recalculate cumulative usage after loading groups
       dom.usageSummary.update();
+
+      dom.sessionSelector.update(groups, selectedGroupId);
+      if (selectedGroupId) {
+        dom.sessionSelector.setSelection(selectedGroupId);
+      }
+      this._renderInstructionForGroup(message.stream, selectedGroupId);
     }
 
     this._updatePlaceholderVisibility();
@@ -166,6 +185,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.taskGroups.clear();
     dom.taskGroups.clear();
     state.toggleStates.clear(groupIds);
+    state.clearSelectedRootGroup(state.activeStream);
+    dom.sessionSelector.hide();
+    dom.instructionPanel.hide();
 
     this._updatePlaceholderVisibility();
   }
@@ -262,6 +284,96 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // State persisted server-side - no direct DOM updates needed
   }
 
+  _mergeGroups(groups) {
+    if (!Array.isArray(groups)) {
+      return;
+    }
+
+    for (const group of groups) {
+      if (!group?.id) {
+        continue;
+      }
+
+      const existing = state.taskGroups.get(group.id);
+      const merged = existing
+        ? { ...existing, ...group, id: group.id }
+        : { ...group };
+      state.taskGroups.set(group.id, merged);
+    }
+  }
+
+  _getRootGroups(groups) {
+    if (!Array.isArray(groups)) {
+      return [];
+    }
+
+    return groups
+      .filter((group) => group && !group.parentGroupId)
+      .slice()
+      .sort((a, b) => a.startTime - b.startTime);
+  }
+
+  _resolveSelectedGroup(stream, groups, preferredId) {
+    const allGroups = Array.isArray(groups) ? groups : [];
+
+    if (
+      preferredId &&
+      allGroups.some((group) => group?.id && group.id === preferredId)
+    ) {
+      return preferredId;
+    }
+
+    const stored = state.getSelectedRootGroup(stream);
+    if (stored && allGroups.some((group) => group?.id === stored)) {
+      return stored;
+    }
+
+    const rootGroups = this._getRootGroups(allGroups);
+    if (rootGroups.length === 0) {
+      return null;
+    }
+
+    return rootGroups[rootGroups.length - 1].id || null;
+  }
+
+  _renderInstructionForGroup(stream, groupId) {
+    if (!stream) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const targetGroupId = groupId || state.getSelectedRootGroup(stream);
+    if (!targetGroupId) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const group = state.taskGroups.get(targetGroupId);
+    const instruction = group?.instruction;
+    const text = instruction?.text ?? '';
+
+    if (!text.trim()) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    dom.instructionPanel.show(text, instruction?.metadata ?? {});
+  }
+
+  _handleSessionChange(groupId) {
+    const stream = state.activeStream || '';
+    if (!stream) {
+      dom.sessionSelector.hide();
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const normalized = groupId || null;
+    state.setSelectedRootGroup(stream, normalized);
+    dom.taskGroups.setActiveRootGroup(normalized);
+    this._renderInstructionForGroup(stream, normalized);
+  }
+
   /**
    * @param {{
    *   stream: string | null,
@@ -273,10 +385,31 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     if (message.stream !== activeStream) {
       if (!activeStream && !message.stream) {
+        dom.sessionSelector.hide();
         dom.instructionPanel.hide();
       }
       return;
     }
+
+    const groups = Array.isArray(message.groups) ? message.groups : [];
+    if (groups.length > 0) {
+      this._mergeGroups(groups);
+      const selectedGroupId = this._resolveSelectedGroup(
+        activeStream,
+        groups,
+        message.taskGroupId,
+      );
+      state.setSelectedRootGroup(activeStream, selectedGroupId);
+      dom.sessionSelector.update(groups, selectedGroupId);
+      if (selectedGroupId) {
+        dom.sessionSelector.setSelection(selectedGroupId);
+      }
+      dom.taskGroups.setActiveRootGroup(selectedGroupId);
+      this._renderInstructionForGroup(activeStream, selectedGroupId);
+      return;
+    }
+
+    dom.sessionSelector.hide();
 
     const payload = message.instruction;
     const text = payload?.text ?? '';
@@ -294,6 +427,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
       state.clearExecutionAvailability(message.stream);
+      state.clearSelectedRootGroup(message.stream);
       if (message.stream === state.activeStream) {
         const groupIds = [];
         const headers = Array.from(
@@ -303,6 +437,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           groupIds.push(el.id.replace('group-header-', ''));
         }
         state.toggleStates.clear(groupIds);
+        dom.sessionSelector.hide();
         dom.instructionPanel.hide();
       }
     }
@@ -311,6 +446,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleDeleteAll() {
     state.toggleStates.clearAll();
     state.resetExecutionAvailability();
+    state.clearAllSelectedRootGroups();
+    dom.sessionSelector.hide();
     dom.instructionPanel.hide();
   }
 }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -213,6 +213,7 @@ export class ProgressViewState {
     this.toggleStates = new ToggleStates(() => this.save());
     this.streamStatuses = new StreamStatuses();
     this.executionAvailability = new ExecutionAvailability();
+    this.selectedRootGroups = new Map();
   }
 
   setExecutionAvailability(stream, available) {
@@ -229,6 +230,37 @@ export class ProgressViewState {
 
   resetExecutionAvailability() {
     this.executionAvailability.clear();
+  }
+
+  setSelectedRootGroup(stream, groupId) {
+    if (!stream) {
+      return;
+    }
+
+    if (!groupId) {
+      this.selectedRootGroups.delete(stream);
+      return;
+    }
+
+    this.selectedRootGroups.set(stream, groupId);
+  }
+
+  getSelectedRootGroup(stream) {
+    if (!stream) {
+      return null;
+    }
+    return this.selectedRootGroups.get(stream) ?? null;
+  }
+
+  clearSelectedRootGroup(stream) {
+    if (!stream) {
+      return;
+    }
+    this.selectedRootGroups.delete(stream);
+  }
+
+  clearAllSelectedRootGroups() {
+    this.selectedRootGroups.clear();
   }
 
   /** Load saved state from VS Code storage. */

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -14,6 +14,7 @@ export class TaskGroupManager {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
+    this.activeRootGroupId = null;
   }
 
   /**
@@ -90,6 +91,8 @@ export class TaskGroupManager {
       progressViewState.currentGroupId = group.id;
       this.collapsePreviousActiveGroup();
     }
+
+    this._applyRootVisibility(detailsElem, group);
   }
 
   /**
@@ -224,6 +227,32 @@ export class TaskGroupManager {
     this.previousActiveGroupId = currentId;
   }
 
+  setActiveRootGroup(groupId) {
+    this.activeRootGroupId = groupId || null;
+
+    for (const [id, element] of this.groupElements.entries()) {
+      if (!element) {
+        continue;
+      }
+      const group = progressViewState.taskGroups.get(id);
+      if (!group || group.parentGroupId) {
+        continue;
+      }
+      this._applyRootVisibility(element, group);
+    }
+  }
+
+  _applyRootVisibility(element, group) {
+    if (!group || group.parentGroupId) {
+      return;
+    }
+
+    const shouldShow =
+      !this.activeRootGroupId || this.activeRootGroupId === group.id;
+    element.classList.toggle('is-hidden', !shouldShow);
+    element.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+  }
+
   /**
    * Play a short beep using the Web Audio API.
    * @private
@@ -252,6 +281,7 @@ export class TaskGroupManager {
   clear() {
     this.groupElements.clear();
     this.previousActiveGroupId = null;
+    this.activeRootGroupId = null;
   }
 }
 

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -1,0 +1,111 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+
+// Local imports - shared helpers
+import { safeGetElementById } from '@common/domUtils.js';
+
+/**
+ * Manages the session selector dropdown above the instruction panel.
+ */
+export class SessionSelector {
+  constructor() {
+    this._elements = null;
+    this._changeHandler = null;
+    this._boundOnChange = this._handleChange.bind(this);
+    this._currentSelection = '';
+  }
+
+  _ensureElements() {
+    if (!this._elements) {
+      const container = safeGetElementById(
+        ELEMENT_IDS.SESSION_SELECTOR_CONTAINER,
+      );
+      const select = safeGetElementById(ELEMENT_IDS.SESSION_SELECTOR_SELECT);
+
+      if (!container || !(select instanceof HTMLSelectElement)) {
+        return null;
+      }
+
+      select.addEventListener('change', this._boundOnChange);
+      this._elements = { container, select };
+    }
+
+    return this._elements;
+  }
+
+  setChangeHandler(handler) {
+    this._changeHandler = typeof handler === 'function' ? handler : null;
+  }
+
+  update(groups, selectedId) {
+    const elements = this._ensureElements();
+    if (!elements) {
+      return;
+    }
+
+    const rootGroups = Array.isArray(groups)
+      ? groups.filter((group) => !group.parentGroupId)
+      : [];
+    rootGroups.sort((a, b) => a.startTime - b.startTime);
+
+    elements.select.innerHTML = '';
+
+    for (const group of rootGroups) {
+      const option = document.createElement('option');
+      option.value = group.id;
+      option.textContent = group.name || group.id;
+      elements.select.appendChild(option);
+    }
+
+    const hasMultiple = rootGroups.length > 1;
+    elements.container.classList.toggle('is-visible', hasMultiple);
+    elements.container.setAttribute(
+      'aria-hidden',
+      hasMultiple ? 'false' : 'true',
+    );
+    elements.select.disabled = rootGroups.length === 0;
+
+    const defaultSelection = rootGroups.find((group) => group.id === selectedId)
+      ? selectedId
+      : rootGroups[0]?.id || '';
+
+    this._currentSelection = defaultSelection || '';
+    if (elements.select.value !== this._currentSelection) {
+      elements.select.value = this._currentSelection;
+    }
+  }
+
+  setSelection(groupId) {
+    const elements = this._ensureElements();
+    if (!elements) {
+      return;
+    }
+
+    this._currentSelection = groupId || '';
+    if (elements.select.value !== this._currentSelection) {
+      elements.select.value = this._currentSelection;
+    }
+  }
+
+  hide() {
+    const elements = this._ensureElements();
+    if (!elements) {
+      return;
+    }
+
+    elements.container.classList.remove('is-visible');
+    elements.container.setAttribute('aria-hidden', 'true');
+    elements.select.disabled = true;
+    elements.select.innerHTML = '';
+    this._currentSelection = '';
+  }
+
+  _handleChange(event) {
+    const value = event?.target?.value ?? '';
+    this._currentSelection = value;
+
+    if (this._changeHandler) {
+      this._changeHandler(value || null);
+    }
+  }
+}

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -46,6 +46,7 @@ export class ProgressViewState {
   private _agentTypeFilter: AgentFilter = 'all';
   private readonly workflowTaskStates: WorkflowTaskStateManager;
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
+  private latestTaskGroupByStream: Map<StreamTabId, string> = new Map();
   /**
    * Ephemeral session-kind hints keyed by stream ID.
    *
@@ -135,6 +136,22 @@ export class ProgressViewState {
 
   clearSessionKindHint(streamTabId: StreamTabId): void {
     this._sessionCategoryHints.delete(streamTabId);
+  }
+
+  setLatestTaskGroup(streamTabId: StreamTabId, groupId?: string): void {
+    if (!groupId) {
+      this.latestTaskGroupByStream.delete(streamTabId);
+      return;
+    }
+    this.latestTaskGroupByStream.set(streamTabId, groupId);
+  }
+
+  getLatestTaskGroup(streamTabId: StreamTabId): string | undefined {
+    return this.latestTaskGroupByStream.get(streamTabId);
+  }
+
+  clearLatestTaskGroup(streamTabId: StreamTabId): void {
+    this.latestTaskGroupByStream.delete(streamTabId);
   }
 
   /**
@@ -259,6 +276,7 @@ export class ProgressViewState {
     this.toolUseTaskStates.delete(stream);
     this._executionIds.delete(stream);
     this.clearSessionKindHint(stream);
+    this.clearLatestTaskGroup(stream);
     this.cleanupToolUseAgentRegistry();
 
     // Update active stream if necessary
@@ -281,6 +299,7 @@ export class ProgressViewState {
     this._taskGroups.deleteStream(stream);
     this._outputFiles.deleteStream(stream);
     this.clearSessionKindHint(stream);
+    this.clearLatestTaskGroup(stream);
 
     // NOTE: Preserve taskStates and executionIds - these are needed for re-run functionality
     // NOTE: Preserve usageStats - these were not cleared in original implementation
@@ -296,6 +315,7 @@ export class ProgressViewState {
     this.toolUseTaskStates.clear();
     this._executionIds.clear();
     this._sessionCategoryHints.clear();
+    this.latestTaskGroupByStream.clear();
     this._activeStream = '';
     this.saveActiveStream();
     this.saveTaskStates();

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -4,6 +4,10 @@
  */
 
 /* Log Group Styles */
+.log-group.is-hidden {
+  display: none;
+}
+
 .log-group-header {
   padding: var(--spacing-tiny) var(--spacing-medium);
   margin: var(--spacing-tiny) 0;

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -23,4 +23,5 @@
 @import './statistics.css';
 @import './user-message.css';
 @import './follow-up-input.css';
+@import './session-selector.css';
 @import './instruction-panel.css';

--- a/src/progressView/styles/session-selector.css
+++ b/src/progressView/styles/session-selector.css
@@ -1,0 +1,25 @@
+/**
+ * Session selector styles for ProgressView
+ */
+
+.session-selector {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.session-selector.is-visible {
+  display: flex;
+}
+
+.session-selector__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+}
+
+.session-selector__select {
+  flex: 1;
+  min-width: 0;
+}

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -224,4 +224,73 @@ describe('Progress event modules', () => {
     assert.deepStrictEqual(initialized, ['stream-1']);
     assert.deepStrictEqual(bus.emissions, []);
   });
+
+  it('attaches instruction metadata to task groups on setTaskState', () => {
+    const bus = new FakeBus();
+    const updates: any[] = [];
+    let latestGroup: string | undefined;
+    let storedTaskState: any;
+    let agentFilter = 'all';
+
+    const module = createStreamStatusEvents({
+      logger: loggerStub,
+      streamStatus: new Map(),
+      setStreamStatus: () => {},
+      sendInstructionUpdate: () => {},
+      updateLogContentForStream: () => {},
+    });
+
+    const state = {
+      setTaskState: (_stream: string, taskState: any) => {
+        storedTaskState = taskState;
+      },
+      clearSessionKindHint: () => {},
+      getTaskState: () => storedTaskState,
+      get agentTypeFilter() {
+        return agentFilter;
+      },
+      set agentTypeFilter(value: string) {
+        agentFilter = value;
+      },
+      activeStream: 'stream-1',
+      setExecutionId: () => {},
+      taskGroups: {
+        getGroup: () => ({ id: 'group-1' }),
+        updateGroup: (
+          _stream: string,
+          _groupId: string,
+          payload: Record<string, unknown>,
+        ) => {
+          updates.push(payload);
+        },
+      },
+      setLatestTaskGroup: (_stream: string, groupId?: string) => {
+        latestGroup = groupId;
+      },
+      getLatestTaskGroup: () => undefined,
+    } as unknown as ProgressViewState;
+
+    const updater = {
+      isAvailable: () => false,
+    } as unknown as WebviewUpdater;
+
+    module.register(bus as any, state, updater);
+
+    const payload = {
+      streamTabId: 'stream-1',
+      taskGroupId: 'group-1',
+      taskState: {
+        agentConfig: { instruction: '  Example instruction  ' },
+        session: { agentCategory: 'workflow' },
+      },
+    } as ProgressEventPayloads['setTaskState'];
+
+    bus.trigger('setTaskState', payload);
+
+    assert.equal(latestGroup, 'group-1');
+    assert.equal(updates.length, 1);
+    assert.deepStrictEqual(updates[0].instruction, {
+      text: 'Example instruction',
+    });
+  });
 });

--- a/src/test/progressView/modules/SessionSelector.test.ts
+++ b/src/test/progressView/modules/SessionSelector.test.ts
@@ -1,0 +1,73 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+// @ts-ignore: jsdom lacks ESM typings in this context
+import { JSDOM } from 'jsdom';
+
+// Local imports - progress view
+// @ts-ignore: manager is compiled JS module
+import { SessionSelector } from '../../../progressView/modules/uiManagers/SessionSelector.js';
+
+describe('SessionSelector UI manager', () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!doctype html><html><body>
+      <div id="sessionSelectorContainer" class="session-selector" aria-hidden="true">
+        <label class="session-selector__label" for="sessionSelector">Session</label>
+        <select id="sessionSelector" class="session-selector__select"></select>
+      </div>
+    </body></html>`);
+
+    global.document = dom.window.document as any;
+    global.window = dom.window as any;
+  });
+
+  afterEach(() => {
+    delete (global as any).document;
+    delete (global as any).window;
+  });
+
+  it('renders options and emits selection changes', () => {
+    const manager = new SessionSelector();
+    let selected: string | null = null;
+    manager.setChangeHandler((groupId: string | null) => {
+      selected = groupId;
+    });
+
+    manager.update(
+      [
+        { id: 'group-1', name: 'First run', startTime: 1 },
+        { id: 'group-2', name: 'Second run', startTime: 2 },
+      ],
+      'group-1',
+    );
+
+    const container = dom.window.document.getElementById(
+      'sessionSelectorContainer',
+    );
+    const select = dom.window.document.getElementById(
+      'sessionSelector',
+    ) as HTMLSelectElement;
+
+    assert.ok(container?.classList.contains('is-visible'));
+    assert.equal(select.options.length, 2);
+    assert.equal(select.value, 'group-1');
+
+    select.value = 'group-2';
+    select.dispatchEvent(new dom.window.Event('change'));
+
+    assert.equal(selected, 'group-2');
+
+    manager.update(
+      [{ id: 'group-3', name: 'Solo run', startTime: 3 }],
+      'group-3',
+    );
+    assert.equal(
+      container?.classList.contains('is-visible'),
+      false,
+      'selector hides when only one session exists',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- tag task-state events with their task group so instructions persist per session
- surface the active session in the progress view via a selector and instruction-aware log updates
- cover the new state handling and selector UI with unit tests

## Testing
- npm run lint
- npm run compile
- CI=1 npm test *(fails: missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68f3624435b0832485ee5b04b97e8854

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a session selector and ties instruction text to specific task groups, updating events, webview messaging, state, and tests.
> 
> - **UI/Progress View**:
>   - Add session selector UI with styles and DOM manager; show/hide based on multiple root groups.
>   - Instruction panel now reflects the selected session; root group visibility toggled accordingly.
> - **Events & State**:
>   - Extend `setTaskState` payload with optional `taskGroupId`; track latest group per stream.
>   - Attach normalized `instruction` to `TaskGroup` and persist/restore it; update groups on instruction changes.
>   - Update stream/log handlers to send/consume `groups` and `taskGroupId` for instruction/log rendering.
> - **Webview Messaging**:
>   - `WebviewUpdater.updateLogContent/updateInstruction/clearInstruction` now include `groups` and `taskGroupId`.
> - **Types & Persistence**:
>   - Extend `TaskGroup` with `instruction` types; add (de)serialization for instruction metadata.
> - **Agent Runtime**:
>   - Emit `setTaskState` with `taskGroupId` during task setup.
> - **Tests**:
>   - Add unit tests for attaching instructions to task groups and for the session selector UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f44e8f37cb3dbcbc5edd3cbb66597643af634ed3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->