### PR TITLE
feat: add workflow session selector to progress view

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -482,6 +482,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
                   streamTabId: activeStreamId,
                   executionId,
                   taskState: agentConfigToTaskState(config, metadata),
+                  taskGroupId: mainTaskGroupId,
                 });
                 logger.debug(
                   `Task state stored for stream: ${activeStreamId}`,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -652,12 +652,14 @@ export async function executeAgent(
 
 /**
  * Run merge agent to handle file merging operations.
+ * If executionId is provided, the merge will continue in the same session.
  */
 export async function executeMergeAgent(
   model: string,
   inputFile: string,
   editedFile: string,
   context: vscode.ExtensionContext,
+  executionId?: string,
 ): Promise<void> {
   const agentName = 'merge';
 
@@ -674,6 +676,6 @@ export async function executeMergeAgent(
       return { agent, agentType };
     },
     context,
-    undefined,
+    executionId,
   );
 }

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -25,8 +25,7 @@ export function registerMergeCommands(context: vscode.ExtensionContext) {
         baseFile: string,
         editedFile: string,
         executionId?: string,
-      ) =>
-        handleMerge(context, inputFile, baseFile, editedFile, executionId),
+      ) => handleMerge(context, inputFile, baseFile, editedFile, executionId),
     ),
   );
 }

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -20,8 +20,13 @@ export function registerMergeCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'texra.merge',
-      (inputFile: string, baseFile: string, editedFile: string) =>
-        handleMerge(context, inputFile, baseFile, editedFile),
+      (
+        inputFile: string,
+        baseFile: string,
+        editedFile: string,
+        executionId?: string,
+      ) =>
+        handleMerge(context, inputFile, baseFile, editedFile, executionId),
     ),
   );
 }
@@ -34,6 +39,7 @@ async function handleMerge(
   inputFile: string,
   baseFile: string,
   editedFile: string,
+  executionId?: string,
 ) {
   if (!editedFile || (!baseFile && !inputFile)) {
     await showLoggedMessageWithDocs(
@@ -49,7 +55,7 @@ async function handleMerge(
   const fileToUse = baseFile || inputFile;
 
   try {
-    await executeMergeAgent(model, fileToUse, editedFile, context);
+    await executeMergeAgent(model, fileToUse, editedFile, context, executionId);
   } catch (err) {
     // Log the error before re-throwing
     await showLoggedErrorMessage(

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -166,6 +166,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   // Task Groups
   ADD_TASK_GROUP: 'addTaskGroup',
   UPDATE_TASK_GROUP: 'updateTaskGroup',
+  SELECT_SESSION: 'selectSession',
 
   // Status and files
   UPDATE_STATUS: 'updateStatus',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -160,9 +160,13 @@ export const PROGRESS_VIEW_COMMANDS = {
   APPEND_LOG: 'appendLog',
   UPDATE_LOG: 'updateLog',
 
+  // Instruction panel
+  UPDATE_INSTRUCTION: 'updateInstruction',
+
   // Task Groups
   ADD_TASK_GROUP: 'addTaskGroup',
   UPDATE_TASK_GROUP: 'updateTaskGroup',
+  SELECT_SESSION: 'selectSession',
 
   // Status and files
   UPDATE_STATUS: 'updateStatus',

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -80,7 +80,11 @@ export interface ProgressEventPayloads {
     usage: TokenUsageStats;
   };
   clearTaskOutput: StreamTabId;
-  updateStreamUsage: { stream: StreamTabId; usage: TokenUsageStats };
+  updateStreamUsage: {
+    stream: StreamTabId;
+    groupId: string;
+    usage: TokenUsageStats;
+  };
 }
 
 export type ProgressEvent = keyof ProgressEventPayloads;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -82,8 +82,8 @@ export interface ProgressEventPayloads {
   clearTaskOutput: StreamTabId;
   updateStreamUsage: {
     stream: StreamTabId;
-    groupId: string;
     usage: TokenUsageStats;
+    groupId?: string;
   };
 }
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -53,6 +53,7 @@ interface SetTaskStatePayload {
   streamTabId: StreamTabId;
   executionId?: ExecutionId;
   taskState: TaskState;
+  taskGroupId?: TaskGroup['id'];
 }
 
 export interface ProgressEventPayloads {

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -3,8 +3,23 @@
  */
 
 // Local imports
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { TaskGroupId, LogMessageId } from './types/EntityTypes';
+
+export interface TaskGroupInstructionMetadata {
+  /** Raw instruction text associated with the task group. */
+  text: string;
+  /** Execution identifier for the run when available. */
+  executionId?: ExecutionId;
+  /** Timestamp (ms) when the instruction was last updated. */
+  updatedAt: number;
+  /** Optional presentation hints for the instruction panel. */
+  metadata?: {
+    showToggle?: boolean;
+    expanded?: boolean;
+  };
+}
 
 export interface TaskGroup {
   /** Unique identifier for the group */
@@ -21,6 +36,8 @@ export interface TaskGroup {
   parentGroupId?: TaskGroupId;
   /** Optional usage stats attached to the group */
   usage?: TokenUsageStats;
+  /** Optional instruction metadata associated with the group. */
+  instruction?: TaskGroupInstructionMetadata;
 }
 
 export interface LogMessageData {

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -36,6 +36,10 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
       key: 'instructionPanelUri',
       path: 'modules/uiManagers/InstructionPanel.js',
     },
+    {
+      key: 'sessionSelectorUri',
+      path: 'modules/uiManagers/SessionSelector.js',
+    },
   ];
 
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -68,6 +68,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       [PROGRESS_VIEW_COMMANDS.ERASE_STREAM]: this.handleEraseStream.bind(this),
       [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: this.handleDeleteAll.bind(this),
       [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: this.handleStopStream.bind(this),
+      [PROGRESS_VIEW_COMMANDS.SELECT_SESSION]:
+        this.handleSelectSession.bind(this),
 
       // Actions
       [PROGRESS_VIEW_COMMANDS.RUN_AGAIN]: this.handleRunAgain.bind(this),
@@ -118,6 +120,36 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     this.provider.setActiveStream(message.stream);
+  }
+
+  private async handleSelectSession(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const stream = message.stream as StreamTabId;
+    const sessionId = message.sessionId as string;
+
+    if (!stream || !sessionId) {
+      return;
+    }
+
+    // Update files for the selected session
+    const files =
+      this.provider.state.outputFiles.getFiles(stream, sessionId) || {};
+    this.provider.webviewUpdater.updateFiles(stream, files);
+
+    // Update missing outputs for the selected session
+    const missing =
+      this.provider.state.outputFiles.getMissingOutputs(stream, sessionId) ||
+      {};
+    this.provider.webviewUpdater.updateMissingOutputs(stream, missing);
+
+    // Update usage for the selected session
+    const usage = this.provider.state.usageStats.getSessionUsage(
+      stream,
+      sessionId,
+    );
+    this.provider.webviewUpdater.updateUsage(usage);
   }
 
   private async handleDeleteStream(
@@ -441,17 +473,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     taskState: WorkflowTaskState,
     command: 'texra.pack' | 'texra.clean',
   ): Promise<void> {
-    const generated = this.provider.state.outputFiles.getFiles(stream);
+    // Get files from all sessions for this stream
+    const streamData = this.provider.state.outputFiles.get(stream);
     const allFiles = new Set<string>(taskState.agentConfig.outputFiles || []);
-    if (generated) {
-      Object.values(generated).forEach((infos: any) =>
-        infos.forEach((info: any) => {
-          allFiles.add(info.path);
-          if (info.original) {
-            allFiles.add(info.original);
-          }
-        }),
-      );
+    if (streamData) {
+      // Iterate through all sessions
+      for (const sessionFiles of Object.values(streamData)) {
+        Object.values(sessionFiles).forEach((infos: any) =>
+          infos.forEach((info: any) => {
+            allFiles.add(info.path);
+            if (info.original) {
+              allFiles.add(info.original);
+            }
+          }),
+        );
+      }
     }
 
     const outputFilesArray = Array.from(allFiles);

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -144,53 +144,31 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
     this.logger.debug(`Switching to session ${sessionId} in stream ${stream}`);
 
-    // Update files for the selected session
-    let files =
-      this.provider.state.outputFiles.getFiles(stream, sessionId) || {};
+    const migratedFiles = this.provider.state.outputFiles.migratePlaceholders(
+      stream,
+      sessionId,
+    );
+    const migratedUsage = this.provider.state.usageStats.migratePlaceholders(
+      stream,
+      sessionId,
+    );
 
-    // One-time migration: move files from __MIGRATION__ or __DEFAULT__ to actual session
-    if (Object.keys(files).length === 0) {
-      const allSessionFiles =
-        this.provider.state.outputFiles.getAllSessionFiles(stream);
-      if (allSessionFiles) {
-        const migrationFiles = allSessionFiles['__MIGRATION__'];
-        const defaultFiles = allSessionFiles['__DEFAULT__'];
-
-        if (migrationFiles && Object.keys(migrationFiles).length > 0) {
-          this.logger.info(
-            `Migrating files from __MIGRATION__ to session ${sessionId}`,
-          );
-          // Move files to the actual session
-          this.provider.state.outputFiles.addFiles(
-            stream,
-            sessionId,
-            migrationFiles,
-          );
-          // Delete the migration placeholder
-          this.provider.state.outputFiles.clearSessionFiles(
-            stream,
-            '__MIGRATION__',
-          );
-          files = migrationFiles;
-        } else if (defaultFiles && Object.keys(defaultFiles).length > 0) {
-          this.logger.info(
-            `Migrating files from __DEFAULT__ to session ${sessionId}`,
-          );
-          // Move files to the actual session
-          this.provider.state.outputFiles.addFiles(
-            stream,
-            sessionId,
-            defaultFiles,
-          );
-          // Delete the default placeholder
-          this.provider.state.outputFiles.clearSessionFiles(
-            stream,
-            '__DEFAULT__',
-          );
-          files = defaultFiles;
-        }
-      }
+    if (migratedFiles) {
+      this.logger.info(
+        `Migrated files from placeholder sessions to ${sessionId} in stream ${stream}`,
+      );
     }
+    if (migratedUsage) {
+      this.logger.info(
+        `Migrated usage from placeholder sessions to ${sessionId} in stream ${stream}`,
+      );
+    }
+
+    this.provider.state.setSelectedTaskGroupId(stream, sessionId);
+
+    // Update files for the selected session
+    const files =
+      this.provider.state.outputFiles.getFiles(stream, sessionId) || {};
 
     this.logger.debug(
       `Files for session ${sessionId}: ${Object.keys(files).length} rounds`,
@@ -204,53 +182,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     this.provider.webviewUpdater.updateMissingOutputs(stream, missing);
 
     // Update usage for the selected session
-    let usage = this.provider.state.usageStats.getSessionUsage(
+    const usage = this.provider.state.usageStats.getSessionUsage(
       stream,
       sessionId,
     );
-
-    // One-time migration: move usage from __MIGRATION__ or __DEFAULT__ to actual session
-    if (!usage) {
-      const allSessionUsage = this.provider.state.usageStats.get(stream);
-      if (allSessionUsage) {
-        const migrationUsage = allSessionUsage['__MIGRATION__'];
-        const defaultUsage = allSessionUsage['__DEFAULT__'];
-
-        if (migrationUsage) {
-          this.logger.info(
-            `Migrating usage from __MIGRATION__ to session ${sessionId}`,
-          );
-          // Move usage to the actual session
-          this.provider.state.usageStats.updateSessionUsage(
-            stream,
-            sessionId,
-            migrationUsage,
-          );
-          // Delete the migration placeholder
-          this.provider.state.usageStats.deleteSessionUsage(
-            stream,
-            '__MIGRATION__',
-          );
-          usage = migrationUsage;
-        } else if (defaultUsage) {
-          this.logger.info(
-            `Migrating usage from __DEFAULT__ to session ${sessionId}`,
-          );
-          // Move usage to the actual session
-          this.provider.state.usageStats.updateSessionUsage(
-            stream,
-            sessionId,
-            defaultUsage,
-          );
-          // Delete the default placeholder
-          this.provider.state.usageStats.deleteSessionUsage(
-            stream,
-            '__DEFAULT__',
-          );
-          usage = defaultUsage;
-        }
-      }
-    }
 
     this.logger.debug(
       `Usage for session ${sessionId}: ${usage ? `${usage.inputTokens}/${usage.outputTokens}` : 'none'}`,

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -131,12 +131,27 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const sessionId = message.sessionId as string;
 
     if (!stream || !sessionId) {
+      this.logger.warn(
+        this.channel,
+        'handleSelectSession: missing stream or sessionId',
+        undefined,
+        undefined,
+        undefined,
+        { stream, sessionId },
+      );
       return;
     }
+
+    this.logger.debug(
+      `Switching to session ${sessionId} in stream ${stream}`,
+    );
 
     // Update files for the selected session
     const files =
       this.provider.state.outputFiles.getFiles(stream, sessionId) || {};
+    this.logger.debug(
+      `Files for session ${sessionId}: ${Object.keys(files).length} rounds`,
+    );
     this.provider.webviewUpdater.updateFiles(stream, files);
 
     // Update missing outputs for the selected session
@@ -149,6 +164,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const usage = this.provider.state.usageStats.getSessionUsage(
       stream,
       sessionId,
+    );
+    this.logger.debug(
+      `Usage for session ${sessionId}: ${usage ? `${usage.inputTokens}/${usage.outputTokens}` : 'none'}`,
     );
     this.provider.webviewUpdater.updateUsage(usage);
   }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -144,6 +144,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
     this.logger.debug(`Switching to session ${sessionId} in stream ${stream}`);
 
+    const existingGroup = this.provider.state.taskGroups.getGroup(
+      stream,
+      sessionId,
+    );
+    if (!existingGroup) {
+      this.logger.warn(
+        this.channel,
+        `handleSelectSession: group ${sessionId} not found in stream ${stream}`,
+        undefined,
+        undefined,
+        undefined,
+        { stream, sessionId },
+      );
+    }
+
     const migratedFiles = this.provider.state.outputFiles.migratePlaceholders(
       stream,
       sessionId,

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -24,6 +24,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
 interface FileCommandMessage {
   file: string;
+  stream?: string;
 }
 
 interface BaseFileCommandMessage extends FileCommandMessage {
@@ -429,11 +430,17 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       return;
     }
 
+    // Get executionId from the current stream to continue in the same session
+    const executionId = message.stream
+      ? this.provider.state.getExecutionId(message.stream)
+      : undefined;
+
     await vscode.commands.executeCommand(
       'texra.merge',
       undefined,
       message.base,
       message.file,
+      executionId,
     );
   }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -142,13 +142,56 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       return;
     }
 
-    this.logger.debug(
-      `Switching to session ${sessionId} in stream ${stream}`,
-    );
+    this.logger.debug(`Switching to session ${sessionId} in stream ${stream}`);
 
     // Update files for the selected session
-    const files =
+    let files =
       this.provider.state.outputFiles.getFiles(stream, sessionId) || {};
+
+    // One-time migration: move files from __MIGRATION__ or __DEFAULT__ to actual session
+    if (Object.keys(files).length === 0) {
+      const allSessionFiles =
+        this.provider.state.outputFiles.getAllSessionFiles(stream);
+      if (allSessionFiles) {
+        const migrationFiles = allSessionFiles['__MIGRATION__'];
+        const defaultFiles = allSessionFiles['__DEFAULT__'];
+
+        if (migrationFiles && Object.keys(migrationFiles).length > 0) {
+          this.logger.info(
+            `Migrating files from __MIGRATION__ to session ${sessionId}`,
+          );
+          // Move files to the actual session
+          this.provider.state.outputFiles.addFiles(
+            stream,
+            sessionId,
+            migrationFiles,
+          );
+          // Delete the migration placeholder
+          this.provider.state.outputFiles.clearSessionFiles(
+            stream,
+            '__MIGRATION__',
+          );
+          files = migrationFiles;
+        } else if (defaultFiles && Object.keys(defaultFiles).length > 0) {
+          this.logger.info(
+            `Migrating files from __DEFAULT__ to session ${sessionId}`,
+          );
+          // Move files to the actual session
+          this.provider.state.outputFiles.addFiles(
+            stream,
+            sessionId,
+            defaultFiles,
+          );
+          // Delete the default placeholder
+          this.provider.state.outputFiles.clearSessionFiles(
+            stream,
+            '__DEFAULT__',
+          );
+          files = defaultFiles;
+        }
+      }
+    }
+
     this.logger.debug(
       `Files for session ${sessionId}: ${Object.keys(files).length} rounds`,
     );
@@ -161,10 +204,54 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     this.provider.webviewUpdater.updateMissingOutputs(stream, missing);
 
     // Update usage for the selected session
-    const usage = this.provider.state.usageStats.getSessionUsage(
+    let usage = this.provider.state.usageStats.getSessionUsage(
       stream,
       sessionId,
     );
+
+    // One-time migration: move usage from __MIGRATION__ or __DEFAULT__ to actual session
+    if (!usage) {
+      const allSessionUsage = this.provider.state.usageStats.get(stream);
+      if (allSessionUsage) {
+        const migrationUsage = allSessionUsage['__MIGRATION__'];
+        const defaultUsage = allSessionUsage['__DEFAULT__'];
+
+        if (migrationUsage) {
+          this.logger.info(
+            `Migrating usage from __MIGRATION__ to session ${sessionId}`,
+          );
+          // Move usage to the actual session
+          this.provider.state.usageStats.updateSessionUsage(
+            stream,
+            sessionId,
+            migrationUsage,
+          );
+          // Delete the migration placeholder
+          this.provider.state.usageStats.deleteSessionUsage(
+            stream,
+            '__MIGRATION__',
+          );
+          usage = migrationUsage;
+        } else if (defaultUsage) {
+          this.logger.info(
+            `Migrating usage from __DEFAULT__ to session ${sessionId}`,
+          );
+          // Move usage to the actual session
+          this.provider.state.usageStats.updateSessionUsage(
+            stream,
+            sessionId,
+            defaultUsage,
+          );
+          // Delete the default placeholder
+          this.provider.state.usageStats.deleteSessionUsage(
+            stream,
+            '__DEFAULT__',
+          );
+          usage = defaultUsage;
+        }
+      }
+    }
+
     this.logger.debug(
       `Usage for session ${sessionId}: ${usage ? `${usage.inputTokens}/${usage.outputTokens}` : 'none'}`,
     );

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -134,10 +134,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    // Delete persisted session data when erasing stream
-    await this.deleteSessionSnapshot(message.stream);
-    this.provider.state.eraseStreamContent(message.stream);
-    this.provider.updateWebview();
+    // If a sessionId is provided and it's not the only session, delete just that session
+    if (message.sessionId) {
+      this.provider.state.deleteTaskGroup(message.stream, message.sessionId);
+      this.provider.updateWebview();
+    } else {
+      // Delete persisted session data when erasing entire stream
+      await this.deleteSessionSnapshot(message.stream);
+      this.provider.state.eraseStreamContent(message.stream);
+      this.provider.updateWebview();
+    }
   }
 
   private async handleDeleteAll(

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -59,8 +59,14 @@ const registerOutputFileListeners = (
 ): vscode.Disposable[] => {
   const addFiles = bus.on('addOutputFiles', ({ stream, filesByRound }) => {
     withErrorBoundary('failed to handle addOutputFiles', () => {
-      state.outputFiles.addFiles(stream, filesByRound);
-      const files = state.outputFiles.getFiles(stream);
+      // Get the latest task group for this stream to attribute files
+      const latestGroupId = state.getLatestTaskGroupId(stream);
+      if (!latestGroupId) {
+        // No session yet, files will be stored when session is created
+        return;
+      }
+      state.outputFiles.addFiles(stream, latestGroupId, filesByRound);
+      const files = state.outputFiles.getFiles(stream, latestGroupId);
       const updates: { files?: FilesByRound<OutputFileInfo> } = {};
       if (files !== undefined) {
         updates.files = files;
@@ -73,8 +79,12 @@ const registerOutputFileListeners = (
     'updateMissingOutputs',
     ({ stream, filesByRound }) => {
       withErrorBoundary('failed to handle updateMissingOutputs', () => {
-        state.outputFiles.updateMissingOutputs(stream, filesByRound);
-        const missing = state.outputFiles.getMissingOutputs(stream);
+        const latestGroupId = state.getLatestTaskGroupId(stream);
+        if (!latestGroupId) {
+          return;
+        }
+        state.outputFiles.updateMissingOutputs(stream, latestGroupId, filesByRound);
+        const missing = state.outputFiles.getMissingOutputs(stream, latestGroupId);
         const updates: { missing?: FilesByRound<string> } = {};
         if (missing !== undefined) {
           updates.missing = missing;

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -55,15 +55,20 @@ const registerOutputFileListeners = (
   bus: ProgressEventBusLike,
   state: ProgressViewState,
   updater: WebviewUpdater,
+  shared: OutputEventsShared,
   withErrorBoundary: ReturnType<typeof createErrorBoundary>,
 ): vscode.Disposable[] => {
   const addFiles = bus.on('addOutputFiles', ({ stream, filesByRound }) => {
     withErrorBoundary('failed to handle addOutputFiles', () => {
       // Get the latest task group for this stream to attribute files
-      const latestGroupId = state.getLatestTaskGroupId(stream);
+      let latestGroupId = state.getLatestTaskGroupId(stream);
       if (!latestGroupId) {
-        // No session yet, files will be stored when session is created
-        return;
+        // No session yet - store under __DEFAULT__ session to prevent data loss
+        // This can happen if output files arrive before task group events
+        shared.logger.warn(
+          'Received output files before session was created, storing under __DEFAULT__ session',
+        );
+        latestGroupId = '__DEFAULT__';
       }
       state.outputFiles.addFiles(stream, latestGroupId, filesByRound);
       const files = state.outputFiles.getFiles(stream, latestGroupId);
@@ -79,12 +84,23 @@ const registerOutputFileListeners = (
     'updateMissingOutputs',
     ({ stream, filesByRound }) => {
       withErrorBoundary('failed to handle updateMissingOutputs', () => {
-        const latestGroupId = state.getLatestTaskGroupId(stream);
+        let latestGroupId = state.getLatestTaskGroupId(stream);
         if (!latestGroupId) {
-          return;
+          // No session yet - store under __DEFAULT__ session to prevent data loss
+          shared.logger.warn(
+            'Received missing outputs before session was created, storing under __DEFAULT__ session',
+          );
+          latestGroupId = '__DEFAULT__';
         }
-        state.outputFiles.updateMissingOutputs(stream, latestGroupId, filesByRound);
-        const missing = state.outputFiles.getMissingOutputs(stream, latestGroupId);
+        state.outputFiles.updateMissingOutputs(
+          stream,
+          latestGroupId,
+          filesByRound,
+        );
+        const missing = state.outputFiles.getMissingOutputs(
+          stream,
+          latestGroupId,
+        );
         const updates: { missing?: FilesByRound<string> } = {};
         if (missing !== undefined) {
           updates.missing = missing;
@@ -142,6 +158,7 @@ export function createOutputEvents(
         bus,
         state,
         updater,
+        shared,
         withErrorBoundary,
       );
       disposables.push(registerClearTaskOutput(bus, state, withErrorBoundary));

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -14,6 +14,7 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createErrorBoundary } from './errorHandling';
 import type { ProgressEventBusLike } from './types';
 import type { AgentLogger } from '@logger/AgentLogger';
+import { DEFAULT_PLACEHOLDER_ID } from '../state/sessionPlaceholders';
 
 export interface OutputEventsModule {
   register(
@@ -63,12 +64,10 @@ const registerOutputFileListeners = (
       // Get the latest task group for this stream to attribute files
       let latestGroupId = state.getLatestTaskGroupId(stream);
       if (!latestGroupId) {
-        // No session yet - store under __DEFAULT__ session to prevent data loss
-        // This can happen if output files arrive before task group events
         shared.logger.warn(
           'Received output files before session was created, storing under __DEFAULT__ session',
         );
-        latestGroupId = '__DEFAULT__';
+        latestGroupId = DEFAULT_PLACEHOLDER_ID;
       }
       state.outputFiles.addFiles(stream, latestGroupId, filesByRound);
       const files = state.outputFiles.getFiles(stream, latestGroupId);
@@ -86,11 +85,10 @@ const registerOutputFileListeners = (
       withErrorBoundary('failed to handle updateMissingOutputs', () => {
         let latestGroupId = state.getLatestTaskGroupId(stream);
         if (!latestGroupId) {
-          // No session yet - store under __DEFAULT__ session to prevent data loss
           shared.logger.warn(
             'Received missing outputs before session was created, storing under __DEFAULT__ session',
           );
-          latestGroupId = '__DEFAULT__';
+          latestGroupId = DEFAULT_PLACEHOLDER_ID;
         }
         state.outputFiles.updateMissingOutputs(
           stream,

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -152,16 +152,22 @@ export class ProgressEventHandler {
     const taskGroupId = this.state.getLatestTaskGroupId(stream);
     this.webviewUpdater.updateLogContent(stream, messages, groups, taskGroupId);
 
-    // Send output files for current stream
-    const files = this.state.outputFiles.getFiles(stream) || {};
+    // Send output files for current session (latest task group)
+    const files = taskGroupId
+      ? this.state.outputFiles.getFiles(stream, taskGroupId) || {}
+      : {};
     this.webviewUpdater.updateFiles(stream, files);
 
-    // Send missing outputs for current stream
-    const missing = this.state.outputFiles.getMissingOutputs(stream) || {};
+    // Send missing outputs for current session
+    const missing = taskGroupId
+      ? this.state.outputFiles.getMissingOutputs(stream, taskGroupId) || {}
+      : {};
     this.webviewUpdater.updateMissingOutputs(stream, missing);
 
-    // Send usage for current stream
-    const usage = this.state.usageStats.getStreamUsage(stream);
+    // Send usage for current session (not total across all sessions)
+    const usage = taskGroupId
+      ? this.state.usageStats.getSessionUsage(stream, taskGroupId)
+      : undefined;
     this.webviewUpdater.updateUsage(usage);
 
     // Update status for current stream - default to STOPPED when stream exists but no status is set

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -111,17 +111,26 @@ export class ProgressEventHandler {
     }
 
     if (!stream) {
-      this.webviewUpdater.clearInstruction('');
+      this.webviewUpdater.clearInstruction('', []);
       return;
     }
 
     const taskState = this.state.getTaskState(stream);
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
+    const groups = Array.from(
+      this.state.taskGroups.getStreamGroups(stream).values(),
+    );
+    const taskGroupId = this.state.getLatestTaskGroupId(stream);
 
     if (instructionUpdate) {
-      this.webviewUpdater.updateInstruction(stream, instructionUpdate);
+      this.webviewUpdater.updateInstruction(
+        stream,
+        instructionUpdate,
+        groups,
+        taskGroupId,
+      );
     } else {
-      this.webviewUpdater.clearInstruction(stream);
+      this.webviewUpdater.clearInstruction(stream, groups, taskGroupId);
     }
   }
 
@@ -140,7 +149,8 @@ export class ProgressEventHandler {
     const groups = Array.from(
       this.state.taskGroups.getStreamGroups(stream).values(),
     );
-    this.webviewUpdater.updateLogContent(stream, messages, groups);
+    const taskGroupId = this.state.getLatestTaskGroupId(stream);
+    this.webviewUpdater.updateLogContent(stream, messages, groups, taskGroupId);
 
     // Send output files for current stream
     const files = this.state.outputFiles.getFiles(stream) || {};

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -26,7 +26,13 @@ import type { AgentLogger } from '@logger/AgentLogger';
 const INSTRUCTION_TOGGLE_LINE_THRESHOLD = 6;
 const INSTRUCTION_TOGGLE_CHAR_THRESHOLD = 600;
 
-function computeInstructionMetadata(text: string) {
+/**
+ * Compute instruction metadata based on content length.
+ * Determines whether to show a toggle for long instructions.
+ * @param text - The instruction text to analyze
+ * @returns Metadata object with showToggle hint, or undefined if no metadata needed
+ */
+export function computeInstructionMetadata(text: string): { showToggle: true } | undefined {
   const lineCount = text.split(/\r?\n/).length;
   if (lineCount > INSTRUCTION_TOGGLE_LINE_THRESHOLD || text.length > INSTRUCTION_TOGGLE_CHAR_THRESHOLD) {
     return { showToggle: true };

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -22,9 +22,13 @@ import type {
 } from './types';
 import type { AgentLogger } from '@logger/AgentLogger';
 
+// Thresholds for determining when to show instruction toggle
+const INSTRUCTION_TOGGLE_LINE_THRESHOLD = 6;
+const INSTRUCTION_TOGGLE_CHAR_THRESHOLD = 600;
+
 function computeInstructionMetadata(text: string) {
   const lineCount = text.split(/\r?\n/).length;
-  if (lineCount > 6 || text.length > 600) {
+  if (lineCount > INSTRUCTION_TOGGLE_LINE_THRESHOLD || text.length > INSTRUCTION_TOGGLE_CHAR_THRESHOLD) {
     return { showToggle: true };
   }
   return undefined;

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -32,9 +32,14 @@ const INSTRUCTION_TOGGLE_CHAR_THRESHOLD = 600;
  * @param text - The instruction text to analyze
  * @returns Metadata object with showToggle hint, or undefined if no metadata needed
  */
-export function computeInstructionMetadata(text: string): { showToggle: true } | undefined {
+export function computeInstructionMetadata(
+  text: string,
+): { showToggle: true } | undefined {
   const lineCount = text.split(/\r?\n/).length;
-  if (lineCount > INSTRUCTION_TOGGLE_LINE_THRESHOLD || text.length > INSTRUCTION_TOGGLE_CHAR_THRESHOLD) {
+  if (
+    lineCount > INSTRUCTION_TOGGLE_LINE_THRESHOLD ||
+    text.length > INSTRUCTION_TOGGLE_CHAR_THRESHOLD
+  ) {
     return { showToggle: true };
   }
   return undefined;

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -22,6 +22,14 @@ import type {
 } from './types';
 import type { AgentLogger } from '@logger/AgentLogger';
 
+function computeInstructionMetadata(text: string) {
+  const lineCount = text.split(/\r?\n/).length;
+  if (lineCount > 6 || text.length > 600) {
+    return { showToggle: true };
+  }
+  return undefined;
+}
+
 export interface StreamStatusEventShared {
   logger: AgentLogger;
   streamStatus: Map<string, StreamStatusType>;
@@ -93,7 +101,7 @@ export function createStreamStatusEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
-    const { streamTabId, executionId, taskState } = data;
+    const { streamTabId, executionId, taskState, taskGroupId } = data;
 
     state.setTaskState(streamTabId, taskState);
     state.clearSessionKindHint(streamTabId);
@@ -124,6 +132,29 @@ export function createStreamStatusEvents(
 
     if (executionId) {
       state.setExecutionId(streamTabId, executionId);
+    }
+
+    const trimmedInstruction = taskState.agentConfig?.instruction?.trim() ?? '';
+    const candidateGroupId =
+      taskGroupId ?? state.getLatestTaskGroupId(streamTabId);
+
+    if (taskGroupId) {
+      state.setLatestTaskGroupId(streamTabId, taskGroupId);
+    }
+
+    if (candidateGroupId) {
+      const instructionMetadata = trimmedInstruction
+        ? {
+            text: trimmedInstruction,
+            executionId,
+            updatedAt: Date.now(),
+            metadata: computeInstructionMetadata(trimmedInstruction),
+          }
+        : undefined;
+
+      state.taskGroups.updateGroup(streamTabId, candidateGroupId, {
+        instruction: instructionMetadata,
+      });
     }
 
     if (state.activeStream === streamTabId) {

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -49,11 +49,15 @@ export function createUsageEvents(
 
       const updateStreamUsage = bus.on(
         'updateStreamUsage',
-        ({ stream, usage }) => {
+        ({ stream, groupId, usage }) => {
           withErrorBoundary('failed to handle updateStreamUsage', () => {
-            state.usageStats.updateStreamUsage(stream, usage);
+            state.usageStats.updateSessionUsage(stream, groupId, usage);
+            // Update webview with session-specific usage if this is the active stream
             if (state.activeStream === stream && updater.isAvailable()) {
-              updater.updateUsage(usage);
+              const latestGroupId = state.getLatestTaskGroupId(stream);
+              if (latestGroupId === groupId) {
+                updater.updateUsage(usage);
+              }
             }
           });
         },

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -52,10 +52,11 @@ export function createUsageEvents(
         ({ stream, groupId, usage }) => {
           withErrorBoundary('failed to handle updateStreamUsage', () => {
             state.usageStats.updateSessionUsage(stream, groupId, usage);
-            // Update webview with session-specific usage if this is the active stream
             if (state.activeStream === stream && updater.isAvailable()) {
-              const latestGroupId = state.getLatestTaskGroupId(stream);
-              if (latestGroupId === groupId) {
+              const selectedGroupId =
+                state.getSelectedTaskGroupId(stream) ||
+                state.getLatestTaskGroupId(stream);
+              if (selectedGroupId === groupId) {
                 updater.updateUsage(usage);
               }
             }

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -51,13 +51,25 @@ export function createUsageEvents(
         'updateStreamUsage',
         ({ stream, groupId, usage }) => {
           withErrorBoundary('failed to handle updateStreamUsage', () => {
-            state.usageStats.updateSessionUsage(stream, groupId, usage);
+            const targetGroupId =
+              groupId ??
+              state.getSelectedTaskGroupId(stream) ??
+              state.getLatestTaskGroupId(stream);
+
+            if (!targetGroupId) {
+              return;
+            }
+
+            state.usageStats.updateSessionUsage(stream, targetGroupId, usage);
+
             if (state.activeStream === stream && updater.isAvailable()) {
               const selectedGroupId =
-                state.getSelectedTaskGroupId(stream) ||
-                state.getLatestTaskGroupId(stream);
-              if (selectedGroupId === groupId) {
-                updater.updateUsage(usage);
+                state.getSelectedTaskGroupId(stream) ?? targetGroupId;
+              if (selectedGroupId === targetGroupId) {
+                const latestUsage =
+                  state.usageStats.getSessionUsage(stream, targetGroupId) ||
+                  usage;
+                updater.updateUsage(latestUsage);
               }
             }
           });

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -92,9 +92,6 @@
           class="session-selector is-hidden"
           aria-hidden="true"
         >
-          <label for="sessionSelector" class="session-selector__label">
-            Session
-          </label>
           <select
             id="sessionSelector"
             class="session-selector__dropdown"

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -44,6 +44,7 @@
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
           "./modules/uiManagers/Placeholder.js": "${placeholderUri}",
           "./modules/uiManagers/InstructionPanel.js": "${instructionPanelUri}",
+          "./modules/uiManagers/SessionSelector.js": "${sessionSelectorUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
@@ -85,6 +86,20 @@
             <span id="runSummary" class="run-summary"></span>
           </div>
           <div id="toolbarContainer" class="header-actions button-group"></div>
+        </div>
+        <div
+          id="sessionSelectorContainer"
+          class="session-selector is-hidden"
+          aria-hidden="true"
+        >
+          <label for="sessionSelector" class="session-selector__label">
+            Session
+          </label>
+          <select
+            id="sessionSelector"
+            class="session-selector__dropdown"
+            aria-label="Select workflow session"
+          ></select>
         </div>
         <div
           id="instructionContainer"

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -287,9 +287,10 @@ export class OutputFilesManager extends PersistentMapManager<
     streamId: StreamTabId,
   ): Promise<{ [groupId: string]: { [key: number]: OutputFileInfo[] } }> {
     // Check if this is old format or new format
-    const obj = data as any;
+    const obj = data as Record<string, any>;
     const firstKey = Object.keys(obj)[0];
-    const isOldFormat = firstKey && !isNaN(Number(firstKey));
+    const firstValue = firstKey ? obj[firstKey] : undefined;
+    const isOldFormat = Array.isArray(firstValue);
 
     if (isOldFormat) {
       // Old format: { [round: number]: OutputFileInfo[] }
@@ -380,11 +381,7 @@ export class OutputFilesManager extends PersistentMapManager<
     sourceGroupId: string,
     targetGroupId: string,
   ): boolean {
-    if (
-      !sourceGroupId ||
-      !targetGroupId ||
-      sourceGroupId === targetGroupId
-    ) {
+    if (!sourceGroupId || !targetGroupId || sourceGroupId === targetGroupId) {
       return false;
     }
 
@@ -422,26 +419,13 @@ export class OutputFilesManager extends PersistentMapManager<
       this.saveMissingOutputs();
     }
 
-    // Remove empty placeholder entries if they had no data
-    if (streamData && streamData[sourceGroupId]) {
-      delete streamData[sourceGroupId];
-      this.add(stream, streamData);
-    }
-    if (streamMissing && streamMissing[sourceGroupId]) {
-      delete streamMissing[sourceGroupId];
-      this.saveMissingOutputs();
-    }
-
     return hasFileData || Boolean(sourceMissing);
   }
 
   /**
    * Convenience helper to migrate all known placeholder sessions to a target.
    */
-  migratePlaceholders(
-    stream: StreamTabId,
-    targetGroupId: string,
-  ): boolean {
+  migratePlaceholders(stream: StreamTabId, targetGroupId: string): boolean {
     let migrated = false;
     for (const placeholder of SESSION_PLACEHOLDER_IDS) {
       migrated =

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -7,6 +7,12 @@ import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 import { WorkspaceFS } from '@utils/files';
 
+// Local imports - state helpers
+import {
+  MIGRATION_PLACEHOLDER_ID,
+  SESSION_PLACEHOLDER_IDS,
+} from '../state/sessionPlaceholders';
+
 // Types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { OutputFileInfo } from '@agent/output/types';
@@ -76,9 +82,22 @@ export class OutputFilesManager extends PersistentMapManager<
     groupId?: string,
   ): { [key: number]: OutputFileInfo[] } | undefined {
     const streamData = this.get(stream);
-    if (!streamData) return undefined;
-    if (!groupId) return undefined;
-    return streamData[groupId];
+    if (!streamData) {
+      return undefined;
+    }
+
+    if (groupId) {
+      return streamData[groupId];
+    }
+
+    for (const placeholder of SESSION_PLACEHOLDER_IDS) {
+      const placeholderData = streamData[placeholder];
+      if (placeholderData) {
+        return placeholderData;
+      }
+    }
+
+    return undefined;
   }
 
   /** Get all sessions' files for a stream */
@@ -94,9 +113,22 @@ export class OutputFilesManager extends PersistentMapManager<
     groupId?: string,
   ): { [key: number]: string[] } | undefined {
     const streamMissing = this._missingOutputs.get(stream);
-    if (!streamMissing) return undefined;
-    if (!groupId) return undefined;
-    return streamMissing[groupId];
+    if (!streamMissing) {
+      return undefined;
+    }
+
+    if (groupId) {
+      return streamMissing[groupId];
+    }
+
+    for (const placeholder of SESSION_PLACEHOLDER_IDS) {
+      const placeholderData = streamMissing[placeholder];
+      if (placeholderData) {
+        return placeholderData;
+      }
+    }
+
+    return undefined;
   }
 
   /** Clear output files for a specific session */
@@ -206,7 +238,8 @@ export class OutputFilesManager extends PersistentMapManager<
       for (const [stream, data] of Object.entries(saved)) {
         // Check if this is old format (rounds directly) or new format (groupId -> rounds)
         const firstKey = Object.keys(data)[0];
-        const isOldFormat = firstKey && !isNaN(Number(firstKey));
+        const firstValue = firstKey ? (data as any)[firstKey] : undefined;
+        const isOldFormat = Array.isArray(firstValue);
 
         if (isOldFormat) {
           // Old format: migrate to latest session
@@ -220,7 +253,7 @@ export class OutputFilesManager extends PersistentMapManager<
             ]),
           );
           // Will be attributed to latest session by parent logic
-          processed.set(stream, { __MIGRATION__: roundMap });
+          processed.set(stream, { [MIGRATION_PLACEHOLDER_ID]: roundMap });
         } else {
           // New format: already has groupIds
           const groupMap: { [groupId: string]: { [key: number]: string[] } } =
@@ -293,7 +326,7 @@ export class OutputFilesManager extends PersistentMapManager<
       }
 
       // Return with migration marker - will be resolved by ProgressViewState
-      return { __MIGRATION__: roundMap };
+      return { [MIGRATION_PLACEHOLDER_ID]: roundMap };
     } else {
       // New format: { [groupId: string]: { [round: number]: OutputFileInfo[] } }
       const sessions = obj as {
@@ -336,5 +369,84 @@ export class OutputFilesManager extends PersistentMapManager<
 
       return result;
     }
+  }
+
+  /**
+   * Merge session-specific data from a placeholder group into the target session.
+   * Returns true when data was migrated.
+   */
+  mergeSessionData(
+    stream: StreamTabId,
+    sourceGroupId: string,
+    targetGroupId: string,
+  ): boolean {
+    if (
+      !sourceGroupId ||
+      !targetGroupId ||
+      sourceGroupId === targetGroupId
+    ) {
+      return false;
+    }
+
+    const streamData = this.get(stream);
+    const source = streamData?.[sourceGroupId];
+    const target = streamData?.[targetGroupId] || {};
+
+    const hasFileData = Boolean(source && Object.keys(source).length > 0);
+
+    if (streamData && source) {
+      const merged: { [key: number]: OutputFileInfo[] } = { ...target };
+      for (const [round, infos] of Object.entries(source)) {
+        const roundNum = Number(round);
+        const existing = merged[roundNum] ?? [];
+        merged[roundNum] = [...existing, ...infos];
+      }
+      streamData[targetGroupId] = merged;
+      delete streamData[sourceGroupId];
+      this.add(stream, streamData);
+    }
+
+    const streamMissing = this._missingOutputs.get(stream);
+    const sourceMissing = streamMissing?.[sourceGroupId];
+    if (streamMissing && sourceMissing) {
+      const targetMissing = streamMissing[targetGroupId] || {};
+      const mergedMissing: { [key: number]: string[] } = { ...targetMissing };
+      for (const [round, files] of Object.entries(sourceMissing)) {
+        const roundNum = Number(round);
+        const existing = mergedMissing[roundNum] ?? [];
+        const unique = new Set([...existing, ...files]);
+        mergedMissing[roundNum] = Array.from(unique);
+      }
+      streamMissing[targetGroupId] = mergedMissing;
+      delete streamMissing[sourceGroupId];
+      this.saveMissingOutputs();
+    }
+
+    // Remove empty placeholder entries if they had no data
+    if (streamData && streamData[sourceGroupId]) {
+      delete streamData[sourceGroupId];
+      this.add(stream, streamData);
+    }
+    if (streamMissing && streamMissing[sourceGroupId]) {
+      delete streamMissing[sourceGroupId];
+      this.saveMissingOutputs();
+    }
+
+    return hasFileData || Boolean(sourceMissing);
+  }
+
+  /**
+   * Convenience helper to migrate all known placeholder sessions to a target.
+   */
+  migratePlaceholders(
+    stream: StreamTabId,
+    targetGroupId: string,
+  ): boolean {
+    let migrated = false;
+    for (const placeholder of SESSION_PLACEHOLDER_IDS) {
+      migrated =
+        this.mergeSessionData(stream, placeholder, targetGroupId) || migrated;
+    }
+    return migrated;
   }
 }

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -13,14 +13,18 @@ import type { OutputFileInfo } from '@agent/output/types';
 
 /**
  * Manages output files collection with persistence and file existence validation.
- * Handles adding, updating, and managing output files for different streams.
+ * Handles adding, updating, and managing output files for different streams and sessions.
+ *
+ * Storage structure: Map<StreamId, { [groupId: string]: { [round: number]: OutputFileInfo[] } }>
  */
 export class OutputFilesManager extends PersistentMapManager<
   StreamTabId,
-  { [key: number]: OutputFileInfo[] }
+  { [groupId: string]: { [key: number]: OutputFileInfo[] } }
 > {
-  private _missingOutputs: Map<StreamTabId, { [key: number]: string[] }> =
-    new Map();
+  private _missingOutputs: Map<
+    StreamTabId,
+    { [groupId: string]: { [key: number]: string[] } }
+  > = new Map();
   private readonly logger: AgentLogger;
   private totalFilesProcessed = 0;
   private totalFilesRemoved = 0;
@@ -30,19 +34,23 @@ export class OutputFilesManager extends PersistentMapManager<
     this.logger = new AgentLogger('OutputFilesManager');
   }
 
-  /** Add output files for a stream and round */
+  /** Add output files for a stream, session, and round */
   addFiles(
     stream: StreamTabId,
+    groupId: string,
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): void {
     const existing = this.get(stream) || {};
-    const merged = { ...existing, ...filesByRound };
-    this.add(stream, merged);
+    const sessionFiles = existing[groupId] || {};
+    const merged = { ...sessionFiles, ...filesByRound };
+    existing[groupId] = merged;
+    this.add(stream, existing);
   }
 
-  /** Update missing outputs for a stream */
+  /** Update missing outputs for a stream and session */
   updateMissingOutputs(
     stream: StreamTabId,
+    groupId: string,
     filesByRound: { [key: number]: string[] },
   ): void {
     if (!this._missingOutputs.has(stream)) {
@@ -50,35 +58,71 @@ export class OutputFilesManager extends PersistentMapManager<
     }
 
     const streamMissing = this._missingOutputs.get(stream)!;
+    if (!streamMissing[groupId]) {
+      streamMissing[groupId] = {};
+    }
 
     for (const [round, files] of Object.entries(filesByRound)) {
       const roundNum = parseInt(round, 10);
-      streamMissing[roundNum] = files;
+      streamMissing[groupId][roundNum] = files;
     }
 
     this.saveMissingOutputs();
   }
 
-  /** Get output files for a stream */
+  /** Get output files for a stream and specific session */
   getFiles(
     stream: StreamTabId,
+    groupId?: string,
   ): { [key: number]: OutputFileInfo[] } | undefined {
+    const streamData = this.get(stream);
+    if (!streamData) return undefined;
+    if (!groupId) return undefined;
+    return streamData[groupId];
+  }
+
+  /** Get all sessions' files for a stream */
+  getAllSessionFiles(
+    stream: StreamTabId,
+  ): { [groupId: string]: { [key: number]: OutputFileInfo[] } } | undefined {
     return this.get(stream);
   }
 
-  /** Get missing outputs for a stream */
+  /** Get missing outputs for a stream and session */
   getMissingOutputs(
     stream: StreamTabId,
+    groupId?: string,
   ): { [key: number]: string[] } | undefined {
-    return this._missingOutputs.get(stream);
+    const streamMissing = this._missingOutputs.get(stream);
+    if (!streamMissing) return undefined;
+    if (!groupId) return undefined;
+    return streamMissing[groupId];
   }
 
-  /** Clear output files for a stream */
+  /** Clear output files for a specific session */
+  clearSessionFiles(stream: StreamTabId, groupId: string): void {
+    const existing = this.get(stream);
+    if (existing && existing[groupId]) {
+      delete existing[groupId];
+      this.add(stream, existing);
+    }
+  }
+
+  /** Clear missing outputs for a specific session */
+  clearSessionMissingOutputs(stream: StreamTabId, groupId: string): void {
+    const streamMissing = this._missingOutputs.get(stream);
+    if (streamMissing && streamMissing[groupId]) {
+      delete streamMissing[groupId];
+      this.saveMissingOutputs();
+    }
+  }
+
+  /** Clear output files for entire stream */
   clearFiles(stream: StreamTabId): void {
     this.delete(stream);
   }
 
-  /** Clear missing outputs for a stream */
+  /** Clear missing outputs for entire stream */
   clearMissingOutputs(stream: StreamTabId): void {
     this._missingOutputs.delete(stream);
     this.saveMissingOutputs();
@@ -99,25 +143,37 @@ export class OutputFilesManager extends PersistentMapManager<
   }
 
   /** Get all output files */
-  getAllFiles(): Map<StreamTabId, { [key: number]: OutputFileInfo[] }> {
+  getAllFiles(): Map<
+    StreamTabId,
+    { [groupId: string]: { [key: number]: OutputFileInfo[] } }
+  > {
     return this.getAll();
   }
 
   /** Get all missing outputs */
-  getAllMissingOutputs(): Map<StreamTabId, { [key: number]: string[] }> {
+  getAllMissingOutputs(): Map<
+    StreamTabId,
+    { [groupId: string]: { [key: number]: string[] } }
+  > {
     return new Map(this._missingOutputs);
   }
 
   /** Set all output files (used during loading) */
   setAllFiles(
-    files: Map<StreamTabId, { [key: number]: OutputFileInfo[] }>,
+    files: Map<
+      StreamTabId,
+      { [groupId: string]: { [key: number]: OutputFileInfo[] } }
+    >,
   ): void {
     this.setAll(files);
   }
 
   /** Set all missing outputs (used during loading) */
   setAllMissingOutputs(
-    missing: Map<StreamTabId, { [key: number]: string[] }>,
+    missing: Map<
+      StreamTabId,
+      { [groupId: string]: { [key: number]: string[] } }
+    >,
   ): void {
     this._missingOutputs = new Map(missing);
   }
@@ -138,17 +194,46 @@ export class OutputFilesManager extends PersistentMapManager<
   /** Load missing outputs from persistence */
   private async loadMissingOutputs(): Promise<void> {
     const saved = await this.persistence.load<{
-      [key: string]: { [key: number]: string[] };
+      [key: string]: any;
     }>(WorkspaceStateKey.MISSING_OUTPUTS, {});
 
     if (saved && Object.keys(saved).length > 0) {
-      const processed = new Map<StreamTabId, { [key: number]: string[] }>();
+      const processed = new Map<
+        StreamTabId,
+        { [groupId: string]: { [key: number]: string[] } }
+      >();
 
-      for (const [stream, rounds] of Object.entries(saved)) {
-        const roundMap = Object.fromEntries(
-          Object.entries(rounds).map(([r, files]) => [parseInt(r, 10), files]),
-        );
-        processed.set(stream, roundMap);
+      for (const [stream, data] of Object.entries(saved)) {
+        // Check if this is old format (rounds directly) or new format (groupId -> rounds)
+        const firstKey = Object.keys(data)[0];
+        const isOldFormat = firstKey && !isNaN(Number(firstKey));
+
+        if (isOldFormat) {
+          // Old format: migrate to latest session
+          this.logger.info(
+            `Migrating old format missing outputs for stream ${stream} to latest session`,
+          );
+          const roundMap = Object.fromEntries(
+            Object.entries(data).map(([r, files]) => [
+              parseInt(r, 10),
+              files as string[],
+            ]),
+          );
+          // Will be attributed to latest session by parent logic
+          processed.set(stream, { __MIGRATION__: roundMap });
+        } else {
+          // New format: already has groupIds
+          const groupMap: { [groupId: string]: { [key: number]: string[] } } =
+            {};
+          for (const [groupId, rounds] of Object.entries(data)) {
+            const roundMap: { [key: number]: string[] } = {};
+            for (const [r, files] of Object.entries(rounds as any)) {
+              roundMap[parseInt(r, 10)] = files as string[];
+            }
+            groupMap[groupId] = roundMap;
+          }
+          processed.set(stream, groupMap);
+        }
       }
 
       this._missingOutputs = processed;
@@ -167,51 +252,89 @@ export class OutputFilesManager extends PersistentMapManager<
   protected override async deserialize(
     data: unknown,
     streamId: StreamTabId,
-  ): Promise<{ [key: number]: OutputFileInfo[] }> {
-    const rounds = data as { [key: number]: OutputFileInfo[] };
-    const roundMap: { [key: number]: OutputFileInfo[] } = {};
-    const streamFilesProcessed = Object.values(rounds).reduce(
-      (sum, files) => sum + files.length,
-      0,
-    );
-    this.totalFilesProcessed += streamFilesProcessed;
+  ): Promise<{ [groupId: string]: { [key: number]: OutputFileInfo[] } }> {
+    // Check if this is old format or new format
+    const obj = data as any;
+    const firstKey = Object.keys(obj)[0];
+    const isOldFormat = firstKey && !isNaN(Number(firstKey));
 
-    for (const [roundStr, infos] of Object.entries(rounds)) {
-      const roundNum = parseInt(roundStr, 10);
-      this.logger.debug(
-        `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
+    if (isOldFormat) {
+      // Old format: { [round: number]: OutputFileInfo[] }
+      // Migrate to new format with __MIGRATION__ placeholder
+      this.logger.info(
+        `Migrating old format output files for stream ${streamId} to latest session`,
       );
 
-      try {
-        const filtered = await WorkspaceFS.filterExistingFiles(infos);
-        const removedCount = infos.length - filtered.length;
+      const rounds = obj as { [key: number]: OutputFileInfo[] };
+      const roundMap: { [key: number]: OutputFileInfo[] } = {};
+      const streamFilesProcessed = Object.values(rounds).reduce(
+        (sum, files) => sum + files.length,
+        0,
+      );
+      this.totalFilesProcessed += streamFilesProcessed;
 
-        if (removedCount > 0) {
-          this.logger.debug(
-            `Removed ${removedCount} missing file(s) from stream ${streamId}, round ${roundNum}`,
+      for (const [roundStr, infos] of Object.entries(rounds)) {
+        const roundNum = parseInt(roundStr, 10);
+        try {
+          const filtered = await WorkspaceFS.filterExistingFiles(infos);
+          const removedCount = infos.length - filtered.length;
+          if (removedCount > 0) {
+            this.totalFilesRemoved += removedCount;
+          }
+          if (filtered.length > 0) {
+            roundMap[roundNum] = filtered;
+          }
+        } catch (error) {
+          this.logger.warn(
+            `Error checking files in stream ${streamId}, round ${roundNum}: ${error instanceof Error ? error.message : String(error)}`,
           );
-          this.totalFilesRemoved += removedCount;
-          const removedFiles = infos.filter(
-            (info) => !filtered.find((f) => f.path === info.path),
-          );
-          removedFiles.forEach((file) => {
-            this.logger.debug(`  - Removed missing file: ${file.path}`);
-          });
+          roundMap[roundNum] = infos;
         }
-
-        if (infos.length > 0) {
-          roundMap[roundNum] = filtered;
-        }
-      } catch (error) {
-        this.logger.warn(
-          `Error checking files in stream ${streamId}, round ${roundNum}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-        roundMap[roundNum] = infos;
       }
-    }
 
-    return roundMap;
+      // Return with migration marker - will be resolved by ProgressViewState
+      return { __MIGRATION__: roundMap };
+    } else {
+      // New format: { [groupId: string]: { [round: number]: OutputFileInfo[] } }
+      const sessions = obj as {
+        [groupId: string]: { [key: number]: OutputFileInfo[] };
+      };
+      const result: { [groupId: string]: { [key: number]: OutputFileInfo[] } } =
+        {};
+
+      for (const [groupId, rounds] of Object.entries(sessions)) {
+        const roundMap: { [key: number]: OutputFileInfo[] } = {};
+        const sessionFilesProcessed = Object.values(rounds).reduce(
+          (sum, files) => sum + files.length,
+          0,
+        );
+        this.totalFilesProcessed += sessionFilesProcessed;
+
+        for (const [roundStr, infos] of Object.entries(rounds)) {
+          const roundNum = parseInt(roundStr, 10);
+          try {
+            const filtered = await WorkspaceFS.filterExistingFiles(infos);
+            const removedCount = infos.length - filtered.length;
+            if (removedCount > 0) {
+              this.totalFilesRemoved += removedCount;
+            }
+            if (filtered.length > 0) {
+              roundMap[roundNum] = filtered;
+            }
+          } catch (error) {
+            this.logger.warn(
+              `Error checking files for stream ${streamId}, session ${groupId}, round ${roundNum}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            roundMap[roundNum] = infos;
+          }
+        }
+
+        if (Object.keys(roundMap).length > 0) {
+          result[groupId] = roundMap;
+        }
+      }
+
+      return result;
+    }
   }
 }

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -121,9 +121,7 @@ export class TaskGroupManager extends PersistentMapManager<
       this.save();
       this.logger.debug(`Deleted group ${groupId} from stream ${stream}`);
     } else {
-      this.logger.warn(
-        `Group ${groupId} not found in stream ${stream}`,
-      );
+      this.logger.warn(`Group ${groupId} not found in stream ${stream}`);
     }
   }
 

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -33,7 +33,12 @@ export class TaskGroupManager extends PersistentMapManager<
     }
 
     const streamGroups = this.get(stream)!;
-    streamGroups.set(groupId, { ...group });
+    const existing = streamGroups.get(groupId);
+    const merged: TaskGroup = {
+      ...group,
+      instruction: group.instruction ?? existing?.instruction,
+    };
+    streamGroups.set(groupId, merged);
     this.save();
   }
 
@@ -53,16 +58,24 @@ export class TaskGroupManager extends PersistentMapManager<
       return;
     }
 
-    const group = streamGroups.get(groupId);
+    let group = streamGroups.get(groupId);
     if (!group) {
       this.logger.warn(
-        `Cannot update group ${groupId}: group not found in stream ${stream}`,
+        `Group ${groupId} not found in stream ${stream}, creating placeholder`,
       );
-      return;
+      group = {
+        id: groupId,
+        name: updates.name ?? groupId,
+        startTime: updates.startTime ?? Date.now(),
+        status: updates.status ?? 'running',
+        parentGroupId: updates.parentGroupId,
+        usage: updates.usage,
+        instruction: updates.instruction,
+      };
+    } else {
+      Object.assign(group, updates);
     }
 
-    // Apply updates
-    Object.assign(group, updates);
     streamGroups.set(groupId, group);
     this.save();
   }
@@ -79,7 +92,8 @@ export class TaskGroupManager extends PersistentMapManager<
    * Get all groups for a stream
    */
   getStreamGroups(stream: StreamTabId): Map<string, TaskGroup> {
-    return this.get(stream) || new Map();
+    const streamGroups = this.get(stream);
+    return streamGroups ? new Map(streamGroups) : new Map();
   }
 
   /**

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -70,10 +70,16 @@ export class TaskGroupManager extends PersistentMapManager<
         status: updates.status ?? 'running',
         parentGroupId: updates.parentGroupId,
         usage: updates.usage,
-        instruction: updates.instruction,
       };
+      if (updates.instruction !== undefined) {
+        group.instruction = updates.instruction;
+      }
     } else {
-      Object.assign(group, updates);
+      const { instruction, ...rest } = updates;
+      Object.assign(group, rest);
+      if (instruction !== undefined) {
+        group.instruction = instruction;
+      }
     }
 
     streamGroups.set(groupId, group);

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -148,6 +148,15 @@ export class TaskGroupManager extends PersistentMapManager<
               ? new Date(group.endTime).getTime()
               : group.endTime
             : undefined,
+        instruction: group.instruction
+          ? {
+              ...group.instruction,
+              updatedAt:
+                typeof group.instruction.updatedAt === 'string'
+                  ? new Date(group.instruction.updatedAt).getTime()
+                  : group.instruction.updatedAt,
+            }
+          : undefined,
       };
       map.set(id, normalized);
     }

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -83,6 +83,51 @@ export class TaskGroupManager extends PersistentMapManager<
   }
 
   /**
+   * Get all groups for a stream as an array
+   */
+  getGroupsForStream(stream: StreamTabId): TaskGroup[] {
+    const streamGroups = this.get(stream);
+    return streamGroups ? Array.from(streamGroups.values()) : [];
+  }
+
+  /**
+   * Delete a specific group from a stream
+   */
+  deleteGroup(stream: StreamTabId, groupId: string): void {
+    const streamGroups = this.get(stream);
+    if (!streamGroups) {
+      this.logger.warn(
+        `Cannot delete group ${groupId}: stream ${stream} not found`,
+      );
+      return;
+    }
+
+    // First, find and delete all child groups recursively
+    const deleteChildren = (parentId: string) => {
+      const children = Array.from(streamGroups.values()).filter(
+        (g) => g.parentGroupId === parentId,
+      );
+      children.forEach((child) => {
+        deleteChildren(child.id);
+        streamGroups.delete(child.id);
+      });
+    };
+
+    deleteChildren(groupId);
+
+    // Then delete the group itself
+    const deleted = streamGroups.delete(groupId);
+    if (deleted) {
+      this.save();
+      this.logger.debug(`Deleted group ${groupId} from stream ${stream}`);
+    } else {
+      this.logger.warn(
+        `Group ${groupId} not found in stream ${stream}`,
+      );
+    }
+  }
+
+  /**
    * Check if a stream has groups
    */
   hasStream(stream: StreamTabId): boolean {

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -11,11 +11,11 @@ import { AgentLogger } from '@logger/AgentLogger';
 
 /**
  * Manages usage statistics collection with persistence.
- * Handles tracking and updating token usage and costs for different streams.
+ * Handles tracking and updating token usage and costs for different sessions within streams.
  */
 export class UsageStatsManager extends PersistentMapManager<
   StreamTabId,
-  TokenUsageStats
+  { [groupId: string]: TokenUsageStats }
 > {
   private readonly logger: AgentLogger;
 
@@ -25,36 +25,86 @@ export class UsageStatsManager extends PersistentMapManager<
   }
 
   /**
-   * Update usage statistics for a stream
+   * Update usage statistics for a specific session within a stream
    */
-  updateStreamUsage(stream: StreamTabId, usage: TokenUsageStats): void {
-    this.add(stream, { ...usage });
+  updateSessionUsage(
+    stream: StreamTabId,
+    groupId: string,
+    usage: TokenUsageStats,
+  ): void {
+    const existing = this.get(stream) || {};
+    existing[groupId] = { ...usage };
+    this.add(stream, existing);
   }
 
   /**
-   * Add usage to existing stream statistics
+   * Add usage to existing session statistics
    */
-  addToStreamUsage(stream: StreamTabId, usage: TokenUsageStats): void {
-    const existing = this.get(stream) || {
+  addToSessionUsage(
+    stream: StreamTabId,
+    groupId: string,
+    usage: TokenUsageStats,
+  ): void {
+    const streamData = this.get(stream) || {};
+    const existing = streamData[groupId] || {
       inputTokens: 0,
       outputTokens: 0,
       cost: 0,
     };
 
-    const updated: TokenUsageStats = {
+    streamData[groupId] = {
       inputTokens: existing.inputTokens + (usage.inputTokens || 0),
       outputTokens: existing.outputTokens + (usage.outputTokens || 0),
       cost: existing.cost + (usage.cost || 0),
     };
 
-    this.add(stream, updated);
+    this.add(stream, streamData);
   }
 
   /**
-   * Get usage statistics for a stream
+   * Get usage statistics for a specific session
+   */
+  getSessionUsage(
+    stream: StreamTabId,
+    groupId: string,
+  ): TokenUsageStats | undefined {
+    const streamData = this.get(stream);
+    return streamData?.[groupId];
+  }
+
+  /**
+   * Get total usage statistics for a stream (sum of all sessions)
    */
   getStreamUsage(stream: StreamTabId): TokenUsageStats | undefined {
-    return this.get(stream);
+    const streamData = this.get(stream);
+    if (!streamData) {
+      return undefined;
+    }
+
+    const total: TokenUsageStats = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+    };
+
+    for (const sessionUsage of Object.values(streamData)) {
+      total.inputTokens += sessionUsage.inputTokens || 0;
+      total.outputTokens += sessionUsage.outputTokens || 0;
+      total.cost += sessionUsage.cost || 0;
+    }
+
+    return total;
+  }
+
+  /**
+   * Delete usage statistics for a specific session
+   */
+  deleteSessionUsage(stream: StreamTabId, groupId: string): void {
+    const streamData = this.get(stream);
+    if (streamData && streamData[groupId]) {
+      delete streamData[groupId];
+      this.add(stream, streamData);
+    }
   }
 
   /**
@@ -74,12 +124,14 @@ export class UsageStatsManager extends PersistentMapManager<
   /**
    * Set all usage statistics (used during loading)
    */
-  setAll(stats: Map<StreamTabId, TokenUsageStats>): void {
+  setAll(
+    stats: Map<StreamTabId, { [groupId: string]: TokenUsageStats }>,
+  ): void {
     super.setAll(stats);
   }
 
   /**
-   * Calculate total usage across all streams
+   * Calculate total usage across all streams and sessions
    */
   getTotalUsage(): TokenUsageStats {
     const total: TokenUsageStats = {
@@ -88,10 +140,12 @@ export class UsageStatsManager extends PersistentMapManager<
       cost: 0,
     };
 
-    for (const usage of this.items.values()) {
-      total.inputTokens += usage.inputTokens || 0;
-      total.outputTokens += usage.outputTokens || 0;
-      total.cost += usage.cost || 0;
+    for (const streamData of this.items.values()) {
+      for (const usage of Object.values(streamData)) {
+        total.inputTokens += usage.inputTokens || 0;
+        total.outputTokens += usage.outputTokens || 0;
+        total.cost += usage.cost || 0;
+      }
     }
 
     return total;
@@ -123,20 +177,41 @@ export class UsageStatsManager extends PersistentMapManager<
     }
   }
 
-  /** Normalize loaded usage records */
+  /** Normalize loaded usage records with migration support */
   protected override async deserialize(
     data: unknown,
     _key: StreamTabId,
-  ): Promise<TokenUsageStats> {
-    const usage = (data as TokenUsageStats) || {
-      inputTokens: 0,
-      outputTokens: 0,
-      cost: 0,
-    };
-    return {
-      inputTokens: usage.inputTokens || 0,
-      outputTokens: usage.outputTokens || 0,
-      cost: usage.cost || 0,
-    };
+  ): Promise<{ [groupId: string]: TokenUsageStats }> {
+    if (!data || typeof data !== 'object') {
+      return {};
+    }
+
+    const obj = data as any;
+
+    // Check if this is old format (direct TokenUsageStats) or new format (grouped by sessionId)
+    // Old format has inputTokens/outputTokens/cost at top level
+    // New format has these inside groupId objects
+    if ('inputTokens' in obj || 'outputTokens' in obj || 'cost' in obj) {
+      // Old format: migrate to __MIGRATION__ session
+      const usage: TokenUsageStats = {
+        inputTokens: obj.inputTokens || 0,
+        outputTokens: obj.outputTokens || 0,
+        cost: obj.cost || 0,
+      };
+      return { __MIGRATION__: usage };
+    }
+
+    // New format: validate and normalize each session's usage
+    const result: { [groupId: string]: TokenUsageStats } = {};
+    for (const [groupId, sessionData] of Object.entries(obj)) {
+      const usage = (sessionData as any) || {};
+      result[groupId] = {
+        inputTokens: usage.inputTokens || 0,
+        outputTokens: usage.outputTokens || 0,
+        cost: usage.cost || 0,
+      };
+    }
+
+    return result;
   }
 }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -9,6 +9,12 @@ import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 
+// Local imports - state helpers
+import {
+  SESSION_PLACEHOLDER_IDS,
+  MIGRATION_PLACEHOLDER_ID,
+} from '../state/sessionPlaceholders';
+
 /**
  * Manages usage statistics collection with persistence.
  * Handles tracking and updating token usage and costs for different sessions within streams.
@@ -198,7 +204,7 @@ export class UsageStatsManager extends PersistentMapManager<
         outputTokens: obj.outputTokens || 0,
         cost: obj.cost || 0,
       };
-      return { __MIGRATION__: usage };
+      return { [MIGRATION_PLACEHOLDER_ID]: usage };
     }
 
     // New format: validate and normalize each session's usage
@@ -213,5 +219,54 @@ export class UsageStatsManager extends PersistentMapManager<
     }
 
     return result;
+  }
+
+  /**
+   * Merge usage statistics stored under a placeholder session into the target session.
+   * Returns true when usage was migrated.
+   */
+  mergeSessionUsage(
+    stream: StreamTabId,
+    sourceGroupId: string,
+    targetGroupId: string,
+  ): boolean {
+    if (
+      !sourceGroupId ||
+      !targetGroupId ||
+      sourceGroupId === targetGroupId
+    ) {
+      return false;
+    }
+
+    const streamData = this.get(stream);
+    const source = streamData?.[sourceGroupId];
+    if (!streamData || !source) {
+      return false;
+    }
+
+    const target = streamData[targetGroupId] || {
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+    };
+
+    streamData[targetGroupId] = {
+      inputTokens: (target.inputTokens || 0) + (source.inputTokens || 0),
+      outputTokens: (target.outputTokens || 0) + (source.outputTokens || 0),
+      cost: (target.cost || 0) + (source.cost || 0),
+    };
+
+    delete streamData[sourceGroupId];
+    this.add(stream, streamData);
+    return true;
+  }
+
+  migratePlaceholders(stream: StreamTabId, targetGroupId: string): boolean {
+    let migrated = false;
+    for (const placeholder of SESSION_PLACEHOLDER_IDS) {
+      migrated =
+        this.mergeSessionUsage(stream, placeholder, targetGroupId) || migrated;
+    }
+    return migrated;
   }
 }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -230,11 +230,7 @@ export class UsageStatsManager extends PersistentMapManager<
     sourceGroupId: string,
     targetGroupId: string,
   ): boolean {
-    if (
-      !sourceGroupId ||
-      !targetGroupId ||
-      sourceGroupId === targetGroupId
-    ) {
+    if (!sourceGroupId || !targetGroupId || sourceGroupId === targetGroupId) {
       return false;
     }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -92,6 +92,7 @@ export class WebviewUpdater {
     stream: StreamTabId,
     messages: LogMessageData[],
     groups?: any[],
+    taskGroupId?: string,
   ): void {
     const webview = this.getWebview();
     if (!webview) return;
@@ -101,6 +102,7 @@ export class WebviewUpdater {
       stream,
       messages,
       groups: groups || [],
+      taskGroupId,
     });
   }
 
@@ -182,7 +184,12 @@ export class WebviewUpdater {
   /**
    * Update instruction panel content
    */
-  updateInstruction(stream: StreamTabId, instruction: InstructionUpdate): void {
+  updateInstruction(
+    stream: StreamTabId,
+    instruction: InstructionUpdate,
+    groups?: any[],
+    taskGroupId?: string,
+  ): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -190,13 +197,19 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_INSTRUCTION,
       stream,
       instruction,
+      groups: groups || [],
+      taskGroupId,
     });
   }
 
   /**
    * Clear instruction panel content
    */
-  clearInstruction(stream: StreamTabId | ''): void {
+  clearInstruction(
+    stream: StreamTabId | '',
+    groups?: any[],
+    taskGroupId?: string,
+  ): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -204,6 +217,8 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_INSTRUCTION,
       stream,
       instruction: null,
+      groups: groups || [],
+      taskGroupId,
     });
   }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - progress view
 
 import { COMMANDS, STATUS } from '../modules/constants.js';
+import { computeInstructionMetadata } from '../events/StreamStatusEvents';
 
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
@@ -47,23 +48,12 @@ export class WebviewUpdater {
       return undefined;
     }
 
-    const metadata = WebviewUpdater.computeInstructionMetadata(normalized);
+    const metadata = computeInstructionMetadata(normalized);
     const payload: InstructionUpdate = { text: normalized };
     if (metadata) {
       payload.metadata = metadata;
     }
     return payload;
-  }
-
-  private static computeInstructionMetadata(
-    text: string,
-  ): InstructionUpdate['metadata'] | undefined {
-    const lineCount = text.split(/\r?\n/).length;
-    const shouldShowToggle = lineCount > 6 || text.length > 600;
-    if (!shouldShowToggle) {
-      return undefined;
-    }
-    return { showToggle: true };
   }
 
   /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -299,16 +299,23 @@ export class WebviewUpdater {
       );
       this.updateLogContent(activeStream, messages, groups);
 
-      // Update files for active stream
-      const files = state.outputFiles.getFiles(activeStream) || {};
+      // Update files for active stream's latest session
+      const latestGroupId = state.getLatestTaskGroupId(activeStream);
+      const files = latestGroupId
+        ? state.outputFiles.getFiles(activeStream, latestGroupId) || {}
+        : {};
       this.updateFiles(activeStream, files);
 
-      // Update missing outputs for active stream
-      const missing = state.outputFiles.getMissingOutputs(activeStream) || {};
+      // Update missing outputs for active stream's latest session
+      const missing = latestGroupId
+        ? state.outputFiles.getMissingOutputs(activeStream, latestGroupId) || {}
+        : {};
       this.updateMissingOutputs(activeStream, missing);
 
-      // Update usage for active stream
-      const usage = state.usageStats.getStreamUsage(activeStream);
+      // Update usage for active stream's latest session (not total across all sessions)
+      const usage = latestGroupId
+        ? state.usageStats.getSessionUsage(activeStream, latestGroupId)
+        : undefined;
       this.updateUsage(usage);
 
       const taskState = state.getTaskState(activeStream);

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -28,6 +28,8 @@ export const ELEMENT_IDS = {
   ACTIVE_STREAM_NAME: 'activeStreamName',
   STATUS_INDICATOR: 'statusIndicator',
   RUN_SUMMARY: 'runSummary',
+  SESSION_SELECTOR_CONTAINER: 'sessionSelectorContainer',
+  SESSION_SELECTOR: 'sessionSelector',
   INSTRUCTION_CONTAINER: 'instructionContainer',
   INSTRUCTION_TEXT: 'instructionText',
   INSTRUCTION_TOGGLE_BTN: 'instructionToggleBtn',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -9,6 +9,7 @@ import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Placeholder } from './uiManagers/Placeholder.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
+import { SessionSelector } from './uiManagers/SessionSelector.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
@@ -30,6 +31,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       logEntries: new LogEntryManager(),
       events: new EventsManager(),
       placeholder: new Placeholder(),
+      sessionSelector: new SessionSelector(),
       instructionPanel: new InstructionPanel(),
     });
   }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -90,21 +90,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     const selectedId = groupId || dom.sessionSelector.getValue();
-    console.log(
-      '[Session Selection] Switching to session:',
-      selectedId,
-      'in stream:',
-      activeStream,
-    );
     state.setSelectedGroup(activeStream, selectedId || null);
     dom.taskGroups.setRootGroupVisibility(activeStream, selectedId);
     this._applyInstructionForSelection(selectedId, undefined, activeStream);
 
     // Notify extension to update files/usage for the selected session
     if (selectedId) {
-      console.log(
-        '[Session Selection] Sending SELECT_SESSION message to extension',
-      );
       vscode.postMessage({
         command: COMMANDS.SELECT_SESSION,
         stream: activeStream,

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -91,6 +91,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.setSelectedGroup(activeStream, selectedId || null);
     dom.taskGroups.setRootGroupVisibility(activeStream, selectedId);
     this._applyInstructionForSelection(selectedId, undefined, activeStream);
+
+    // Notify extension to update files/usage for the selected session
+    if (selectedId) {
+      vscode.postMessage({
+        command: COMMANDS.SELECT_SESSION,
+        stream: activeStream,
+        sessionId: selectedId,
+      });
+    }
   }
 
   _createHandlers() {
@@ -158,8 +167,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     dom.toolbar.render(sessionKind);
 
-    // Derive execution availability from message data
-    const hasExecution = Boolean(message.executionId);
+    // Derive execution availability from whether there are any sessions (task groups)
+    // Check if the active stream has any root task groups
+    const latestGroupId = activeStreamInfo
+      ? state.taskGroups.getLatestRootGroupId(message.activeStream)
+      : null;
+    const hasExecution = Boolean(latestGroupId);
     dom.status.setExecutionAvailability(hasExecution);
 
     const activeSelection = state.getSelectedGroup(message.activeStream);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -88,12 +88,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     const selectedId = groupId || dom.sessionSelector.getValue();
+    console.log('[Session Selection] Switching to session:', selectedId, 'in stream:', activeStream);
     state.setSelectedGroup(activeStream, selectedId || null);
     dom.taskGroups.setRootGroupVisibility(activeStream, selectedId);
     this._applyInstructionForSelection(selectedId, undefined, activeStream);
 
     // Notify extension to update files/usage for the selected session
     if (selectedId) {
+      console.log('[Session Selection] Sending SELECT_SESSION message to extension');
       vscode.postMessage({
         command: COMMANDS.SELECT_SESSION,
         stream: activeStream,
@@ -368,8 +370,16 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   handleUpdateFiles(message) {
+    console.log('[UPDATE_FILES] Received:', {
+      stream: message.stream,
+      activeStream: state.activeStream,
+      fileRounds: Object.keys(message.files || {}).length,
+    });
     if (message.stream === state.activeStream) {
+      console.log('[UPDATE_FILES] Updating file list with', message.files);
       dom.fileList.update(message.files);
+    } else {
+      console.log('[UPDATE_FILES] Skipping update - stream mismatch');
     }
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -117,14 +117,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateStreams(message) {
     state.activeStream = message.activeStream;
     state.agentFilter = message.agentFilter || 'all';
-    state.resetExecutionAvailability();
     message.streams.forEach((s) => {
       if (s.status) {
         state.streamStatuses.set(s.name, s.status);
       } else {
         state.streamStatuses.delete(s.name);
       }
-      state.setExecutionAvailability(s.name, Boolean(s.executionId));
+      // executionId is now tracked in ProgressViewState._executionIds (TypeScript)
+      // No need to duplicate it here
     });
     dom.streamTabs.update(message.streams, message.activeStream);
 
@@ -158,8 +158,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     dom.toolbar.render(sessionKind);
 
-    const hasExecution = state.getExecutionAvailability(message.activeStream);
-    dom.status.setExecutionAvailability(Boolean(hasExecution));
+    // Derive execution availability from message data
+    const hasExecution = Boolean(message.executionId);
+    dom.status.setExecutionAvailability(hasExecution);
 
     const activeSelection = state.getSelectedGroup(message.activeStream);
     state.setCurrentGroup(message.activeStream, activeSelection || null);
@@ -334,8 +335,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   handleUpdateStatus(message) {
-    const hasExecution = state.getExecutionAvailability(state.activeStream);
-    dom.status.setExecutionAvailability(Boolean(hasExecution));
+    // Derive execution availability from whether we have a session
+    const latestGroupId = state.taskGroups.getLatestRootGroupId(
+      state.activeStream,
+    );
+    const hasExecution = Boolean(latestGroupId);
+    dom.status.setExecutionAvailability(hasExecution);
     dom.status.update(message.status);
   }
 
@@ -439,7 +444,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleDeleteStream(message) {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
-      state.clearExecutionAvailability(message.stream);
       state.setSelectedGroup(message.stream, null);
       if (message.stream === state.activeStream) {
         const groupIds = [];
@@ -459,7 +463,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleDeleteAll() {
     state.toggleStates.clearAll();
-    state.resetExecutionAvailability();
     state.selectedGroups.clear();
     state.currentGroupIds.clear();
     dom.instructionPanel.hide();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -65,7 +65,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     stream = state.activeStream,
   ) {
     if (!groupId) {
-      dom.instructionPanel.hide();
+      const text = instructionPayload?.text?.trim();
+      if (text) {
+        dom.instructionPanel.show(text, instructionPayload.metadata || {});
+      } else {
+        dom.instructionPanel.hide();
+      }
       return;
     }
 
@@ -374,16 +379,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   handleUpdateFiles(message) {
-    console.log('[UPDATE_FILES] Received:', {
-      stream: message.stream,
-      activeStream: state.activeStream,
-      fileRounds: Object.keys(message.files || {}).length,
-    });
     if (message.stream === state.activeStream) {
-      console.log('[UPDATE_FILES] Updating file list with', message.files);
       dom.fileList.update(message.files);
-    } else {
-      console.log('[UPDATE_FILES] Skipping update - stream mismatch');
     }
   }
 
@@ -418,9 +415,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     let instructionGroupId = message.taskGroupId || null;
 
     if (instructionGroupId) {
-      const existing =
-        state.taskGroups.get(message.stream, instructionGroupId) ||
-        { id: instructionGroupId };
+      const existing = state.taskGroups.get(
+        message.stream,
+        instructionGroupId,
+      ) || { id: instructionGroupId };
       const updated = { ...existing };
       if (message.instruction) {
         updated.instruction = {
@@ -437,9 +435,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       );
       if (fallbackGroupId) {
         instructionGroupId = fallbackGroupId;
-        const existing =
-          state.taskGroups.get(message.stream, fallbackGroupId) ||
-          { id: fallbackGroupId };
+        const existing = state.taskGroups.get(
+          message.stream,
+          fallbackGroupId,
+        ) || { id: fallbackGroupId };
         const updated = { ...existing };
         updated.instruction = {
           text: message.instruction.text,
@@ -458,11 +457,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       message.stream,
     );
 
-    const shouldApplyInstruction =
-      !!message.instruction && selectedGroupId === instructionGroupId;
+    const instructionForSelection =
+      message.instruction &&
+      (!instructionGroupId || selectedGroupId === instructionGroupId)
+        ? message.instruction
+        : undefined;
     this._applyInstructionForSelection(
       selectedGroupId,
-      shouldApplyInstruction ? message.instruction : undefined,
+      instructionForSelection,
       message.stream,
     );
   }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -24,6 +24,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       ...createThemeHandlers(),
       ...this._createHandlers(),
     };
+    dom.sessionSelector.setOnChange((groupId) =>
+      this._handleSessionSelection(groupId),
+    );
   }
 
   /**
@@ -36,6 +39,52 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     } else {
       dom.placeholder.hide();
     }
+  }
+
+  _getCurrentGroups() {
+    return Array.from(state.taskGroups.getAll().values());
+  }
+
+  _syncSessionSelector(groups, preferredGroupId) {
+    const selectedId = dom.sessionSelector.update(groups, preferredGroupId);
+    const activeStream = state.activeStream;
+    if (activeStream) {
+      state.setSelectedGroup(activeStream, selectedId || null);
+    }
+    dom.taskGroups.setRootGroupVisibility(selectedId);
+    return selectedId;
+  }
+
+  _applyInstructionForSelection(groupId, instructionPayload) {
+    if (!groupId) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const group = state.taskGroups.get(groupId);
+    const text = instructionPayload?.text || group?.instruction?.text || '';
+
+    if (!text.trim()) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const metadata =
+      instructionPayload?.metadata || group?.instruction?.metadata || {};
+    dom.instructionPanel.show(text, metadata);
+  }
+
+  _handleSessionSelection(groupId) {
+    const activeStream = state.activeStream;
+    if (!activeStream) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const selectedId = groupId || dom.sessionSelector.getValue();
+    state.setSelectedGroup(activeStream, selectedId || null);
+    dom.taskGroups.setRootGroupVisibility(selectedId);
+    this._applyInstructionForSelection(selectedId);
   }
 
   _createHandlers() {
@@ -106,10 +155,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const hasExecution = state.getExecutionAvailability(message.activeStream);
     dom.status.setExecutionAvailability(Boolean(hasExecution));
 
+    const activeSelection = state.getSelectedGroup(message.activeStream);
+    state.currentGroupId = activeSelection;
+
     // Update status based on whether there's an active stream
     if (!message.activeStream) {
       dom.status.update(STATUS.READY);
       dom.instructionPanel.hide();
+      dom.sessionSelector.update([], null);
     } else {
       const streamStatus = state.streamStatuses.get(message.activeStream);
       dom.status.update(streamStatus || STATUS.STOPPED);
@@ -132,6 +185,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.add(g));
       }
+      const groups = this._getCurrentGroups();
+      const preferredGroupId =
+        message.taskGroupId || state.getSelectedGroup(message.stream);
+      const selectedGroupId = this._syncSessionSelector(
+        groups,
+        preferredGroupId,
+      );
+      this._applyInstructionForSelection(selectedGroupId);
       const sortedMessages = [...message.messages].sort(
         (a, b) => a.timestamp - b.timestamp,
       );
@@ -278,22 +339,52 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    const payload = message.instruction;
-    const text = payload?.text ?? '';
-
-    if (!text.trim()) {
-      dom.instructionPanel.hide();
-      return;
+    if (Array.isArray(message.groups)) {
+      message.groups.forEach((group) => {
+        if (group?.id) {
+          state.taskGroups.set(group.id, group);
+        }
+      });
     }
 
-    const metadata = payload?.metadata ?? {};
-    dom.instructionPanel.show(text, metadata);
+    if (message.taskGroupId) {
+      const existing = state.taskGroups.get(message.taskGroupId);
+      if (existing) {
+        const updated = { ...existing };
+        if (message.instruction) {
+          updated.instruction = {
+            ...(existing.instruction || {}),
+            text: message.instruction.text,
+            metadata: message.instruction.metadata,
+          };
+        } else {
+          updated.instruction = undefined;
+        }
+        state.taskGroups.set(message.taskGroupId, updated);
+      }
+    }
+
+    const groups = this._getCurrentGroups();
+    const preferredGroupId =
+      message.taskGroupId || state.getSelectedGroup(activeStream);
+    const selectedGroupId = this._syncSessionSelector(groups, preferredGroupId);
+
+    if (
+      message.taskGroupId &&
+      message.instruction &&
+      selectedGroupId === message.taskGroupId
+    ) {
+      this._applyInstructionForSelection(selectedGroupId, message.instruction);
+    } else {
+      this._applyInstructionForSelection(selectedGroupId);
+    }
   }
 
   handleDeleteStream(message) {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
       state.clearExecutionAvailability(message.stream);
+      state.setSelectedGroup(message.stream, null);
       if (message.stream === state.activeStream) {
         const groupIds = [];
         const headers = Array.from(
@@ -311,7 +402,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleDeleteAll() {
     state.toggleStates.clearAll();
     state.resetExecutionAvailability();
+    state.selectedGroups.clear();
+    state.currentGroupId = null;
     dom.instructionPanel.hide();
+    dom.sessionSelector.update([], null);
   }
 }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -300,6 +300,23 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       dom.taskGroups.add(message.group);
+
+      // If this is a new root group (session), switch to it automatically
+      const isRootGroup = !message.group.parentGroupId;
+      if (isRootGroup) {
+        const groups = this._getCurrentGroups(message.stream);
+        const selectedGroupId = this._syncSessionSelector(
+          groups,
+          message.group.id,
+          message.stream,
+        );
+        this._applyInstructionForSelection(
+          selectedGroupId,
+          undefined,
+          message.stream,
+        );
+      }
+
       logContent.scrollTop = logContent.scrollHeight;
     }
   }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -88,14 +88,21 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     const selectedId = groupId || dom.sessionSelector.getValue();
-    console.log('[Session Selection] Switching to session:', selectedId, 'in stream:', activeStream);
+    console.log(
+      '[Session Selection] Switching to session:',
+      selectedId,
+      'in stream:',
+      activeStream,
+    );
     state.setSelectedGroup(activeStream, selectedId || null);
     dom.taskGroups.setRootGroupVisibility(activeStream, selectedId);
     this._applyInstructionForSelection(selectedId, undefined, activeStream);
 
     // Notify extension to update files/usage for the selected session
     if (selectedId) {
-      console.log('[Session Selection] Sending SELECT_SESSION message to extension');
+      console.log(
+        '[Session Selection] Sending SELECT_SESSION message to extension',
+      );
       vscode.postMessage({
         command: COMMANDS.SELECT_SESSION,
         stream: activeStream,

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -41,27 +41,33 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
   }
 
-  _getCurrentGroups() {
-    return Array.from(state.taskGroups.getAll().values());
+  _getCurrentGroups(stream = state.activeStream) {
+    if (!stream) {
+      return [];
+    }
+    return Array.from(state.taskGroups.getAll(stream).values());
   }
 
-  _syncSessionSelector(groups, preferredGroupId) {
+  _syncSessionSelector(groups, preferredGroupId, stream = state.activeStream) {
     const selectedId = dom.sessionSelector.update(groups, preferredGroupId);
-    const activeStream = state.activeStream;
-    if (activeStream) {
-      state.setSelectedGroup(activeStream, selectedId || null);
+    if (stream) {
+      state.setSelectedGroup(stream, selectedId || null);
+      dom.taskGroups.setRootGroupVisibility(stream, selectedId);
     }
-    dom.taskGroups.setRootGroupVisibility(selectedId);
     return selectedId;
   }
 
-  _applyInstructionForSelection(groupId, instructionPayload) {
+  _applyInstructionForSelection(
+    groupId,
+    instructionPayload,
+    stream = state.activeStream,
+  ) {
     if (!groupId) {
       dom.instructionPanel.hide();
       return;
     }
 
-    const group = state.taskGroups.get(groupId);
+    const group = stream ? state.taskGroups.get(stream, groupId) : null;
     const text = instructionPayload?.text || group?.instruction?.text || '';
 
     if (!text.trim()) {
@@ -83,8 +89,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     const selectedId = groupId || dom.sessionSelector.getValue();
     state.setSelectedGroup(activeStream, selectedId || null);
-    dom.taskGroups.setRootGroupVisibility(selectedId);
-    this._applyInstructionForSelection(selectedId);
+    dom.taskGroups.setRootGroupVisibility(activeStream, selectedId);
+    this._applyInstructionForSelection(selectedId, undefined, activeStream);
   }
 
   _createHandlers() {
@@ -156,7 +162,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     dom.status.setExecutionAvailability(Boolean(hasExecution));
 
     const activeSelection = state.getSelectedGroup(message.activeStream);
-    state.currentGroupId = activeSelection;
+    state.setCurrentGroup(message.activeStream, activeSelection || null);
 
     // Update status based on whether there's an active stream
     if (!message.activeStream) {
@@ -173,7 +179,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (message.stream === state.activeStream) {
       logContent.innerHTML = '';
-      state.taskGroups.clear();
+      state.taskGroups.clear(message.stream);
+      state.setCurrentGroup(message.stream, null);
       dom.taskGroups.clear();
       if (message.groups && message.groups.length > 0) {
         const parentGroups = message.groups.filter((g) => !g.parentGroupId);
@@ -185,14 +192,19 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.add(g));
       }
-      const groups = this._getCurrentGroups();
+      const groups = this._getCurrentGroups(message.stream);
       const preferredGroupId =
         message.taskGroupId || state.getSelectedGroup(message.stream);
       const selectedGroupId = this._syncSessionSelector(
         groups,
         preferredGroupId,
+        message.stream,
       );
-      this._applyInstructionForSelection(selectedGroupId);
+      this._applyInstructionForSelection(
+        selectedGroupId,
+        undefined,
+        message.stream,
+      );
       const sortedMessages = [...message.messages].sort(
         (a, b) => a.timestamp - b.timestamp,
       );
@@ -224,7 +236,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     for (const el of headers) {
       groupIds.push(el.id.replace('group-header-', ''));
     }
-    state.taskGroups.clear();
+    const activeStream = state.activeStream;
+    state.taskGroups.clear(activeStream);
+    state.setCurrentGroup(activeStream, null);
     dom.taskGroups.clear();
     state.toggleStates.clear(groupIds);
 
@@ -292,7 +306,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleUpdateTaskGroup(message) {
     if (message.stream === state.activeStream) {
-      state.taskGroups.update(message.groupId, message.status, message.endTime);
+      state.taskGroups.update(
+        message.stream,
+        message.groupId,
+        message.status,
+        message.endTime,
+      );
       dom.taskGroups.update(message.groupId, message.status, message.endTime);
     }
   }
@@ -342,13 +361,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (Array.isArray(message.groups)) {
       message.groups.forEach((group) => {
         if (group?.id) {
-          state.taskGroups.set(group.id, group);
+          state.taskGroups.set(message.stream, group.id, group);
         }
       });
     }
 
-    if (message.taskGroupId) {
-      const existing = state.taskGroups.get(message.taskGroupId);
+    let instructionGroupId = message.taskGroupId || null;
+
+    if (instructionGroupId) {
+      const existing = state.taskGroups.get(message.stream, instructionGroupId);
       if (existing) {
         const updated = { ...existing };
         if (message.instruction) {
@@ -360,24 +381,42 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         } else {
           updated.instruction = undefined;
         }
-        state.taskGroups.set(message.taskGroupId, updated);
+        state.taskGroups.set(message.stream, instructionGroupId, updated);
+      }
+    } else if (message.instruction) {
+      const fallbackGroupId = state.taskGroups.getLatestRootGroupId(
+        message.stream,
+      );
+      if (fallbackGroupId) {
+        instructionGroupId = fallbackGroupId;
+        const existing =
+          state.taskGroups.get(message.stream, fallbackGroupId) || {};
+        const updated = { ...existing };
+        updated.instruction = {
+          ...(existing.instruction || {}),
+          text: message.instruction.text,
+          metadata: message.instruction.metadata,
+        };
+        state.taskGroups.set(message.stream, fallbackGroupId, updated);
       }
     }
 
-    const groups = this._getCurrentGroups();
+    const groups = this._getCurrentGroups(message.stream);
     const preferredGroupId =
-      message.taskGroupId || state.getSelectedGroup(activeStream);
-    const selectedGroupId = this._syncSessionSelector(groups, preferredGroupId);
+      instructionGroupId || state.getSelectedGroup(activeStream);
+    const selectedGroupId = this._syncSessionSelector(
+      groups,
+      preferredGroupId,
+      message.stream,
+    );
 
-    if (
-      message.taskGroupId &&
-      message.instruction &&
-      selectedGroupId === message.taskGroupId
-    ) {
-      this._applyInstructionForSelection(selectedGroupId, message.instruction);
-    } else {
-      this._applyInstructionForSelection(selectedGroupId);
-    }
+    const shouldApplyInstruction =
+      !!message.instruction && selectedGroupId === instructionGroupId;
+    this._applyInstructionForSelection(
+      selectedGroupId,
+      shouldApplyInstruction ? message.instruction : undefined,
+      message.stream,
+    );
   }
 
   handleDeleteStream(message) {
@@ -395,6 +434,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         }
         state.toggleStates.clear(groupIds);
         dom.instructionPanel.hide();
+        state.taskGroups.clear(message.stream);
+        state.setCurrentGroup(message.stream, null);
       }
     }
   }
@@ -403,7 +444,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.toggleStates.clearAll();
     state.resetExecutionAvailability();
     state.selectedGroups.clear();
-    state.currentGroupId = null;
+    state.currentGroupIds.clear();
     dom.instructionPanel.hide();
     dom.sessionSelector.update([], null);
   }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,3 +1,5 @@
+/* global vscode */
+
 // Local imports - progress view
 import { COMMANDS, STATUS, ELEMENT_IDS } from './constants.js';
 import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
@@ -181,7 +183,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const latestGroupId = activeStreamInfo
       ? state.taskGroups.getLatestRootGroupId(message.activeStream)
       : null;
-    const hasExecution = Boolean(latestGroupId);
+    const executionId =
+      activeStreamInfo?.executionId ??
+      activeStreamInfo?.session?.executionId ??
+      null;
+    const hasExecution = Boolean(executionId || latestGroupId);
     dom.status.setExecutionAvailability(hasExecution);
 
     const activeSelection = state.getSelectedGroup(message.activeStream);
@@ -421,20 +427,19 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     let instructionGroupId = message.taskGroupId || null;
 
     if (instructionGroupId) {
-      const existing = state.taskGroups.get(message.stream, instructionGroupId);
-      if (existing) {
-        const updated = { ...existing };
-        if (message.instruction) {
-          updated.instruction = {
-            ...(existing.instruction || {}),
-            text: message.instruction.text,
-            metadata: message.instruction.metadata,
-          };
-        } else {
-          updated.instruction = undefined;
-        }
-        state.taskGroups.set(message.stream, instructionGroupId, updated);
+      const existing =
+        state.taskGroups.get(message.stream, instructionGroupId) ||
+        { id: instructionGroupId };
+      const updated = { ...existing };
+      if (message.instruction) {
+        updated.instruction = {
+          text: message.instruction.text,
+          metadata: message.instruction.metadata,
+        };
+      } else {
+        updated.instruction = undefined;
       }
+      state.taskGroups.set(message.stream, instructionGroupId, updated);
     } else if (message.instruction) {
       const fallbackGroupId = state.taskGroups.getLatestRootGroupId(
         message.stream,
@@ -442,10 +447,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       if (fallbackGroupId) {
         instructionGroupId = fallbackGroupId;
         const existing =
-          state.taskGroups.get(message.stream, fallbackGroupId) || {};
+          state.taskGroups.get(message.stream, fallbackGroupId) ||
+          { id: fallbackGroupId };
         const updated = { ...existing };
         updated.instruction = {
-          ...(existing.instruction || {}),
           text: message.instruction.text,
           metadata: message.instruction.metadata,
         };

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -325,10 +325,11 @@ export class ProgressViewState {
     if (!stream) {
       return;
     }
-    if (groupId) {
+    if (groupId !== null && groupId !== undefined) {
       this.selectedGroups.set(stream, groupId);
       this.currentGroupIds.set(stream, groupId);
     } else {
+      // Actually delete from Maps instead of setting to null
       this.selectedGroups.delete(stream);
       this.currentGroupIds.delete(stream);
     }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -12,12 +12,14 @@ class TaskGroups {
   }
 
   _resolveStream(stream) {
+    // Use explicit undefined check to allow empty string as valid stream ID
     const resolved =
-      stream ||
-      (typeof this._getActiveStream === 'function'
-        ? this._getActiveStream()
-        : undefined);
-    if (!resolved) {
+      stream !== undefined && stream !== null
+        ? stream
+        : typeof this._getActiveStream === 'function'
+          ? this._getActiveStream()
+          : undefined;
+    if (resolved === undefined || resolved === null) {
       console.error('TaskGroups: stream id is required');
       return null;
     }
@@ -26,7 +28,7 @@ class TaskGroups {
 
   _getStreamMap(stream, { create = true } = {}) {
     const resolved = this._resolveStream(stream);
-    if (!resolved) {
+    if (resolved === null) {
       return null;
     }
 
@@ -87,13 +89,13 @@ class TaskGroups {
 
   getStreamGroups(stream) {
     const map = this._getStreamMap(stream, { create: false });
-    return map ? map : new Map();
+    return map ? new Map(map) : new Map();
   }
 
   clear(stream) {
     if (stream !== undefined && stream !== null) {
       const resolved = this._resolveStream(stream);
-      if (resolved) {
+      if (resolved !== null) {
         this._groupsByStream.delete(resolved);
       }
       return;
@@ -311,7 +313,19 @@ export class ProgressViewState {
     this.stateManager = new WebviewStateManager();
     this.activeStream = '';
     this.agentFilter = 'all';
+
+    /**
+     * Tracks the currently active group for instruction display and UI state.
+     * May differ from selectedGroups during transitions or programmatic updates.
+     * @type {Map<string, string>}
+     */
     this.currentGroupIds = new Map();
+
+    /**
+     * Tracks the user's explicit selection in the session selector dropdown.
+     * This represents the user's choice and drives the visible session.
+     * @type {Map<string, string>}
+     */
     this.selectedGroups = new Map();
 
     // Initialize managers

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -43,7 +43,8 @@ class TaskGroups {
   get(streamOrId, maybeId) {
     let stream = streamOrId;
     let id = maybeId;
-    if (maybeId === undefined) {
+    // If only one argument provided, treat it as id (old signature)
+    if (arguments.length === 1) {
       id = streamOrId;
       stream = undefined;
     }
@@ -59,7 +60,8 @@ class TaskGroups {
     let stream = streamOrId;
     let id = maybeId;
     let group = maybeGroup;
-    if (maybeGroup === undefined && typeof maybeId === 'object') {
+    // If only two arguments provided, treat as (id, group) - old signature
+    if (arguments.length === 2) {
       group = maybeId;
       id = streamOrId;
       stream = undefined;
@@ -101,26 +103,27 @@ class TaskGroups {
 
   /**
    * Update an existing log group with new status or end time.
-   * @param {string} streamId - Stream identifier for the group
-   * @param {string} groupId - ID of the group to update
-   * @param {string} status - New status
+   * Supports two signatures:
+   * - update(streamId, groupId, status, endTime) - new signature with stream
+   * - update(groupId, status, endTime) - old signature without stream
+   * @param {string} streamId - Stream identifier for the group (or groupId if 3 args)
+   * @param {string} groupId - ID of the group to update (or status if 3 args)
+   * @param {string} status - New status (or endTime if 3 args)
    * @param {number} [endTime] - Optional end time
    */
   update(streamOrGroupId, maybeGroupId, status, endTime) {
     let streamId = streamOrGroupId;
     let groupId = maybeGroupId;
-    if (
-      typeof maybeGroupId === 'string' ||
-      typeof maybeGroupId === 'number' ||
-      maybeGroupId === null
-    ) {
-      // stream provided explicitly - nothing to do
-    } else {
+    // Use argument count to distinguish between signatures
+    if (arguments.length === 3 || arguments.length === 2) {
+      // Old signature: update(groupId, status, endTime)
       endTime = status;
       status = maybeGroupId;
       groupId = streamOrGroupId;
       streamId = undefined;
     }
+    // Otherwise: new signature update(streamId, groupId, status, endTime)
+
     if (!groupId) {
       console.error('TaskGroups.update: groupId is required');
       return;

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -255,38 +255,6 @@ class StreamStatuses {
 }
 
 /**
- * Tracks whether a stream has an execution directory available.
- */
-class ExecutionAvailability {
-  constructor() {
-    this.availability = new Map();
-  }
-
-  set(stream, available) {
-    if (!stream) {
-      console.error('ExecutionAvailability.set: stream is required');
-      return;
-    }
-    this.availability.set(stream, Boolean(available));
-  }
-
-  get(stream) {
-    return this.availability.get(stream) ?? false;
-  }
-
-  delete(stream) {
-    if (!stream) {
-      return;
-    }
-    this.availability.delete(stream);
-  }
-
-  clear() {
-    this.availability.clear();
-  }
-}
-
-/**
  * Manages progress view state and handles persistence.
  */
 export class ProgressViewState {
@@ -313,7 +281,6 @@ export class ProgressViewState {
     this.taskGroups = new TaskGroups(() => this.activeStream);
     this.toggleStates = new ToggleStates(() => this.save());
     this.streamStatuses = new StreamStatuses();
-    this.executionAvailability = new ExecutionAvailability();
   }
 
   setSelectedGroup(stream, groupId) {
@@ -353,22 +320,6 @@ export class ProgressViewState {
       return null;
     }
     return this.currentGroupIds.get(stream) || null;
-  }
-
-  setExecutionAvailability(stream, available) {
-    this.executionAvailability.set(stream, available);
-  }
-
-  getExecutionAvailability(stream) {
-    return this.executionAvailability.get(stream);
-  }
-
-  clearExecutionAvailability(stream) {
-    this.executionAvailability.delete(stream);
-  }
-
-  resetExecutionAvailability() {
-    this.executionAvailability.clear();
   }
 
   /** Load saved state from VS Code storage. */

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -207,12 +207,35 @@ export class ProgressViewState {
     this.activeStream = '';
     this.agentFilter = 'all';
     this.currentGroupId = null;
+    this.selectedGroups = new Map();
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
     this.toggleStates = new ToggleStates(() => this.save());
     this.streamStatuses = new StreamStatuses();
     this.executionAvailability = new ExecutionAvailability();
+  }
+
+  setSelectedGroup(stream, groupId) {
+    if (!stream) {
+      return;
+    }
+    if (groupId) {
+      this.selectedGroups.set(stream, groupId);
+      this.currentGroupId = groupId;
+    } else {
+      this.selectedGroups.delete(stream);
+      if (this.activeStream === stream) {
+        this.currentGroupId = null;
+      }
+    }
+  }
+
+  getSelectedGroup(stream) {
+    if (!stream) {
+      return null;
+    }
+    return this.selectedGroups.get(stream) || null;
   }
 
   setExecutionAvailability(stream, available) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -6,20 +6,64 @@ import { WebviewStateManager } from '@common/webviewState.js';
  * Manages task groups in the progress view.
  */
 class TaskGroups {
-  constructor() {
-    this.groups = new Map();
-    this._cachedTotals = null;
+  constructor(getActiveStream) {
+    this._groupsByStream = new Map();
+    this._getActiveStream = getActiveStream;
   }
 
-  get(id) {
+  _resolveStream(stream) {
+    const resolved =
+      stream ||
+      (typeof this._getActiveStream === 'function'
+        ? this._getActiveStream()
+        : undefined);
+    if (!resolved) {
+      console.error('TaskGroups: stream id is required');
+      return null;
+    }
+    return resolved;
+  }
+
+  _getStreamMap(stream, { create = true } = {}) {
+    const resolved = this._resolveStream(stream);
+    if (!resolved) {
+      return null;
+    }
+
+    if (!this._groupsByStream.has(resolved)) {
+      if (!create) {
+        return null;
+      }
+      this._groupsByStream.set(resolved, new Map());
+    }
+
+    return this._groupsByStream.get(resolved) || null;
+  }
+
+  get(streamOrId, maybeId) {
+    let stream = streamOrId;
+    let id = maybeId;
+    if (maybeId === undefined) {
+      id = streamOrId;
+      stream = undefined;
+    }
     if (!id) {
       console.error('TaskGroups.get: id is required');
       return null;
     }
-    return this.groups.get(id);
+    const map = this._getStreamMap(stream, { create: false });
+    return map ? map.get(id) || null : null;
   }
 
-  set(id, group) {
+  set(streamOrId, maybeId, maybeGroup) {
+    let stream = streamOrId;
+    let id = maybeId;
+    let group = maybeGroup;
+    if (maybeGroup === undefined && typeof maybeId === 'object') {
+      group = maybeId;
+      id = streamOrId;
+      stream = undefined;
+    }
     if (!id) {
       console.error('TaskGroups.set: id is required');
       return;
@@ -28,33 +72,68 @@ class TaskGroups {
       console.error('TaskGroups.set: group must be an object');
       return;
     }
-    this.groups.set(id, group);
-    this._cachedTotals = null; // Invalidate cache
+    const map = this._getStreamMap(stream, { create: true });
+    if (map) {
+      map.set(id, group);
+    }
   }
 
-  getAll() {
-    return this.groups;
+  getAll(stream) {
+    const map = this._getStreamMap(stream, { create: false });
+    return map ? new Map(map) : new Map();
   }
 
-  clear() {
-    this.groups.clear();
-    this._cachedTotals = null; // Invalidate cache
+  getStreamGroups(stream) {
+    const map = this._getStreamMap(stream, { create: false });
+    return map ? map : new Map();
+  }
+
+  clear(stream) {
+    if (stream !== undefined && stream !== null) {
+      const resolved = this._resolveStream(stream);
+      if (resolved) {
+        this._groupsByStream.delete(resolved);
+      }
+      return;
+    }
+    this._groupsByStream.clear();
   }
 
   /**
    * Update an existing log group with new status or end time.
+   * @param {string} streamId - Stream identifier for the group
    * @param {string} groupId - ID of the group to update
    * @param {string} status - New status
    * @param {number} [endTime] - Optional end time
    */
-  update(groupId, status, endTime) {
+  update(streamOrGroupId, maybeGroupId, status, endTime) {
+    let streamId = streamOrGroupId;
+    let groupId = maybeGroupId;
+    if (
+      typeof maybeGroupId === 'string' ||
+      typeof maybeGroupId === 'number' ||
+      maybeGroupId === null
+    ) {
+      // stream provided explicitly - nothing to do
+    } else {
+      endTime = status;
+      status = maybeGroupId;
+      groupId = streamOrGroupId;
+      streamId = undefined;
+    }
     if (!groupId) {
       console.error('TaskGroups.update: groupId is required');
       return;
     }
-    const group = this.groups.get(groupId);
+    const map = this._getStreamMap(streamId, { create: false });
+    if (!map) {
+      return;
+    }
+    const group = map.get(groupId);
     if (!group) {
-      console.error(`TaskGroups.update: group not found for id ${groupId}`);
+      console.error(
+        `TaskGroups.update: group not found for id ${groupId} in stream ${streamId}`,
+      );
       return;
     }
 
@@ -65,8 +144,31 @@ class TaskGroups {
       group.endTime = endTime;
     }
 
-    this.groups.set(groupId, group);
-    this._cachedTotals = null; // Invalidate cache
+    map.set(groupId, group);
+  }
+
+  getLatestRootGroupId(streamId) {
+    const map = this._getStreamMap(streamId, { create: false });
+    if (!map) {
+      return null;
+    }
+    let latest = null;
+    for (const group of map.values()) {
+      if (group && !group.parentGroupId) {
+        if (!latest) {
+          latest = group;
+          continue;
+        }
+        const groupTime =
+          typeof group.startTime === 'number' ? group.startTime : 0;
+        const latestTime =
+          typeof latest.startTime === 'number' ? latest.startTime : 0;
+        if (groupTime >= latestTime) {
+          latest = group;
+        }
+      }
+    }
+    return latest?.id || null;
   }
 }
 
@@ -206,11 +308,11 @@ export class ProgressViewState {
     this.stateManager = new WebviewStateManager();
     this.activeStream = '';
     this.agentFilter = 'all';
-    this.currentGroupId = null;
+    this.currentGroupIds = new Map();
     this.selectedGroups = new Map();
 
     // Initialize managers
-    this.taskGroups = new TaskGroups();
+    this.taskGroups = new TaskGroups(() => this.activeStream);
     this.toggleStates = new ToggleStates(() => this.save());
     this.streamStatuses = new StreamStatuses();
     this.executionAvailability = new ExecutionAvailability();
@@ -222,12 +324,10 @@ export class ProgressViewState {
     }
     if (groupId) {
       this.selectedGroups.set(stream, groupId);
-      this.currentGroupId = groupId;
+      this.currentGroupIds.set(stream, groupId);
     } else {
       this.selectedGroups.delete(stream);
-      if (this.activeStream === stream) {
-        this.currentGroupId = null;
-      }
+      this.currentGroupIds.delete(stream);
     }
   }
 
@@ -236,6 +336,24 @@ export class ProgressViewState {
       return null;
     }
     return this.selectedGroups.get(stream) || null;
+  }
+
+  setCurrentGroup(stream, groupId) {
+    if (!stream) {
+      return;
+    }
+    if (groupId) {
+      this.currentGroupIds.set(stream, groupId);
+    } else {
+      this.currentGroupIds.delete(stream);
+    }
+  }
+
+  getCurrentGroup(stream) {
+    if (!stream) {
+      return null;
+    }
+    return this.currentGroupIds.get(stream) || null;
   }
 
   setExecutionAvailability(stream, available) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -42,14 +42,13 @@ class TaskGroups {
     return this._groupsByStream.get(resolved) || null;
   }
 
-  get(streamOrId, maybeId) {
-    let stream = streamOrId;
-    let id = maybeId;
-    // If only one argument provided, treat it as id (old signature)
-    if (arguments.length === 1) {
-      id = streamOrId;
-      stream = undefined;
-    }
+  /**
+   * Get a task group by stream and ID
+   * @param {string} stream - Stream identifier
+   * @param {string} id - Group ID
+   * @returns {Object|null} - Group object or null
+   */
+  get(stream, id) {
     if (!id) {
       console.error('TaskGroups.get: id is required');
       return null;
@@ -58,16 +57,13 @@ class TaskGroups {
     return map ? map.get(id) || null : null;
   }
 
-  set(streamOrId, maybeId, maybeGroup) {
-    let stream = streamOrId;
-    let id = maybeId;
-    let group = maybeGroup;
-    // If only two arguments provided, treat as (id, group) - old signature
-    if (arguments.length === 2) {
-      group = maybeId;
-      id = streamOrId;
-      stream = undefined;
-    }
+  /**
+   * Set a task group for a stream
+   * @param {string} stream - Stream identifier
+   * @param {string} id - Group ID
+   * @param {Object} group - Group object
+   */
+  set(stream, id, group) {
     if (!id) {
       console.error('TaskGroups.set: id is required');
       return;
@@ -104,28 +100,13 @@ class TaskGroups {
   }
 
   /**
-   * Update an existing log group with new status or end time.
-   * Supports two signatures:
-   * - update(streamId, groupId, status, endTime) - new signature with stream
-   * - update(groupId, status, endTime) - old signature without stream
-   * @param {string} streamId - Stream identifier for the group (or groupId if 3 args)
-   * @param {string} groupId - ID of the group to update (or status if 3 args)
-   * @param {string} status - New status (or endTime if 3 args)
+   * Update an existing log group with new status or end time
+   * @param {string} streamId - Stream identifier for the group
+   * @param {string} groupId - ID of the group to update
+   * @param {string} status - New status
    * @param {number} [endTime] - Optional end time
    */
-  update(streamOrGroupId, maybeGroupId, status, endTime) {
-    let streamId = streamOrGroupId;
-    let groupId = maybeGroupId;
-    // Use argument count to distinguish between signatures
-    if (arguments.length === 3 || arguments.length === 2) {
-      // Old signature: update(groupId, status, endTime)
-      endTime = status;
-      status = maybeGroupId;
-      groupId = streamOrGroupId;
-      streamId = undefined;
-    }
-    // Otherwise: new signature update(streamId, groupId, status, endTime)
-
+  update(streamId, groupId, status, endTime) {
     if (!groupId) {
       console.error('TaskGroups.update: groupId is required');
       return;

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -43,6 +43,11 @@ export class TaskGroupManager {
     }
     detailsElem.id = `group-${group.id}`;
 
+    // Add top-level class to root groups for styling
+    if (!group.parentGroupId) {
+      detailsElem.classList.add('top-level');
+    }
+
     const headerElement = this.headerFormatter.create(group);
     if (!headerElement) {
       console.error('TaskGroupManager.add: failed to create group header');

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -207,7 +207,10 @@ export class TaskGroupManager {
   findCurrentActiveGroup() {
     const activeStream = progressViewState.activeStream;
     const currentGroupId = progressViewState.getCurrentGroup(activeStream);
-    const current = progressViewState.taskGroups.get(activeStream, currentGroupId);
+    const current = progressViewState.taskGroups.get(
+      activeStream,
+      currentGroupId,
+    );
     if (current) return current.id;
 
     let latestGroup = null;

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -87,7 +87,9 @@ export class TaskGroupManager {
 
     // For top-level groups, update current group and collapse the previous active group
     if (!group.parentGroupId) {
-      progressViewState.currentGroupId = group.id;
+      if (!progressViewState.currentGroupId) {
+        progressViewState.currentGroupId = group.id;
+      }
       this.collapsePreviousActiveGroup();
     }
   }
@@ -148,6 +150,20 @@ export class TaskGroupManager {
           this.playSystemSound();
         }
       }
+    }
+  }
+
+  setRootGroupVisibility(selectedGroupId) {
+    for (const [id, element] of this.groupElements.entries()) {
+      if (!element) {
+        continue;
+      }
+      const group = progressViewState.taskGroups.get(id);
+      if (!group || group.parentGroupId) {
+        continue;
+      }
+      const shouldHide = Boolean(selectedGroupId) && id !== selectedGroupId;
+      element.classList.toggle('is-hidden', shouldHide);
     }
   }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -87,8 +87,9 @@ export class TaskGroupManager {
 
     // For top-level groups, update current group and collapse the previous active group
     if (!group.parentGroupId) {
-      if (!progressViewState.currentGroupId) {
-        progressViewState.currentGroupId = group.id;
+      const activeStream = progressViewState.activeStream;
+      if (!progressViewState.getCurrentGroup(activeStream)) {
+        progressViewState.setCurrentGroup(activeStream, group.id);
       }
       this.collapsePreviousActiveGroup();
     }
@@ -153,12 +154,12 @@ export class TaskGroupManager {
     }
   }
 
-  setRootGroupVisibility(selectedGroupId) {
+  setRootGroupVisibility(stream, selectedGroupId) {
     for (const [id, element] of this.groupElements.entries()) {
       if (!element) {
         continue;
       }
-      const group = progressViewState.taskGroups.get(id);
+      const group = progressViewState.taskGroups.get(stream, id);
       if (!group || group.parentGroupId) {
         continue;
       }
@@ -174,7 +175,10 @@ export class TaskGroupManager {
    */
   collapseGroupAndChildren(groupId) {
     // Find all child groups
-    for (const [childId, group] of progressViewState.taskGroups.getAll()) {
+    const activeStream = progressViewState.activeStream;
+    for (const [childId, group] of progressViewState.taskGroups
+      .getAll(activeStream)
+      .entries()) {
       if (group.parentGroupId === groupId) {
         this.collapseGroupAndChildren(childId);
       }
@@ -195,7 +199,7 @@ export class TaskGroupManager {
    */
   findCurrentActiveGroup() {
     const current = progressViewState.taskGroups.get(
-      progressViewState.currentGroupId,
+      progressViewState.getCurrentGroup(progressViewState.activeStream),
     );
     if (current) return current.id;
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -21,16 +21,17 @@ export class TaskGroupManager {
    * @param {Object} group - Group data
    */
   add(group) {
+    const activeStream = progressViewState.activeStream;
     const existingGroup = this.groupElements.get(group.id);
     if (existingGroup) {
-      if (!progressViewState.taskGroups.get(group.id)) {
+      if (!progressViewState.taskGroups.get(activeStream, group.id)) {
         console.warn(
           `Group ${group.id} exists in DOM but not in state - removing from DOM`,
         );
         existingGroup.remove();
         this.groupElements.delete(group.id);
       } else {
-        progressViewState.taskGroups.set(group.id, group);
+        progressViewState.taskGroups.set(activeStream, group.id, group);
         this.update(group.id, group.status, group.endTime);
         return;
       }
@@ -61,7 +62,7 @@ export class TaskGroupManager {
     }
     groupContainer.id = `group-content-${group.id}`;
 
-    progressViewState.taskGroups.set(group.id, group);
+    progressViewState.taskGroups.set(activeStream, group.id, group);
 
     const isCollapsed = progressViewState.toggleStates.get(group.id);
     detailsElem.open = isCollapsed !== true;
@@ -107,7 +108,8 @@ export class TaskGroupManager {
    * @param {string} endTime - End time (optional)
    */
   update(groupId, status, endTime) {
-    const group = progressViewState.taskGroups.get(groupId);
+    const activeStream = progressViewState.activeStream;
+    const group = progressViewState.taskGroups.get(activeStream, groupId);
     if (!group) return;
 
     group.status = status;
@@ -203,9 +205,9 @@ export class TaskGroupManager {
    * @returns {string|null} - ID of the current active group or null
    */
   findCurrentActiveGroup() {
-    const current = progressViewState.taskGroups.get(
-      progressViewState.getCurrentGroup(progressViewState.activeStream),
-    );
+    const activeStream = progressViewState.activeStream;
+    const currentGroupId = progressViewState.getCurrentGroup(activeStream);
+    const current = progressViewState.taskGroups.get(activeStream, currentGroupId);
     if (current) return current.id;
 
     let latestGroup = null;
@@ -216,7 +218,7 @@ export class TaskGroupManager {
         continue;
       }
 
-      const group = progressViewState.taskGroups.get(id);
+      const group = progressViewState.taskGroups.get(activeStream, id);
       if (!group) {
         continue;
       }

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -63,7 +63,23 @@ export class EventsManager {
       const activeStream = progressViewState.activeStream;
 
       if (activeStream) {
-        vscode.postMessage({ command, stream: activeStream });
+        const message = { command, stream: activeStream };
+
+        // For ERASE_STREAM, include the selected session if there are multiple sessions
+        if (command === COMMANDS.ERASE_STREAM) {
+          const selectedGroupId = progressViewState.getSelectedGroup(activeStream);
+          const allGroups = progressViewState.taskGroups.getAll(activeStream);
+          const rootGroups = Array.from(allGroups.values()).filter(
+            (group) => group && !group.parentGroupId
+          );
+
+          // Only include sessionId if there are multiple sessions
+          if (selectedGroupId && rootGroups.length > 1) {
+            message.sessionId = selectedGroupId;
+          }
+        }
+
+        vscode.postMessage(message);
       }
     });
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -98,6 +98,11 @@ export class EventsManager {
           if (element.dataset.file) data.file = element.dataset.file;
           if (element.dataset.base) data.base = element.dataset.base;
           if (element.dataset.prev) data.prev = element.dataset.prev;
+          // Include the active stream so merge/latexdiff can continue in the same session
+          const activeStream = progressViewState.activeStream;
+          if (activeStream) {
+            data.stream = activeStream;
+          }
           vscode.postMessage(data);
         }
       },

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -67,10 +67,11 @@ export class EventsManager {
 
         // For ERASE_STREAM, include the selected session if there are multiple sessions
         if (command === COMMANDS.ERASE_STREAM) {
-          const selectedGroupId = progressViewState.getSelectedGroup(activeStream);
+          const selectedGroupId =
+            progressViewState.getSelectedGroup(activeStream);
           const allGroups = progressViewState.taskGroups.getAll(activeStream);
           const rootGroups = Array.from(allGroups.values()).filter(
-            (group) => group && !group.parentGroupId
+            (group) => group && !group.parentGroupId,
           );
 
           // Only include sessionId if there are multiple sessions

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -10,7 +10,6 @@ function sortRootGroups(groups) {
   }
   return groups
     .filter((group) => group && !group.parentGroupId)
-    .slice()
     .sort((a, b) => (a.startTime || 0) - (b.startTime || 0));
 }
 

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -106,26 +106,18 @@ export class SessionSelector {
       return null;
     }
 
+    select.removeEventListener('change', this._boundOnChange);
     select.addEventListener('change', this._boundOnChange);
     this._elements = { container, select };
     return this._elements;
   }
 
   _handleChange(event) {
-    console.log('[SessionSelector] Change event fired:', {
-      value: event?.target?.value,
-      hasHandler: !!this._changeHandler,
-    });
     if (!this._changeHandler) {
-      console.warn('[SessionSelector] No change handler registered');
       return;
     }
     try {
       const value = event?.target?.value || '';
-      console.log(
-        '[SessionSelector] Calling change handler with value:',
-        value,
-      );
       this._changeHandler(value);
     } catch (error) {
       console.error('SessionSelector: Error in change handler:', error);

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -1,0 +1,130 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+
+// Local imports - shared helpers
+import { safeGetElementById } from '@common/domUtils.js';
+
+function sortRootGroups(groups) {
+  if (!Array.isArray(groups)) {
+    return [];
+  }
+  return groups
+    .filter((group) => group && !group.parentGroupId)
+    .slice()
+    .sort((a, b) => (a.startTime || 0) - (b.startTime || 0));
+}
+
+function formatGroupLabel(group) {
+  const baseLabel = group?.name || 'Session';
+  const timestamp = typeof group?.startTime === 'number' ? group.startTime : 0;
+
+  if (!timestamp) {
+    return baseLabel;
+  }
+
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return `${baseLabel} • ${formatter.format(new Date(timestamp))}`;
+}
+
+export class SessionSelector {
+  constructor() {
+    this._elements = null;
+    this._changeHandler = null;
+    this._boundOnChange = this._handleChange.bind(this);
+  }
+
+  _ensureElements() {
+    if (this._elements) {
+      return this._elements;
+    }
+
+    const container = safeGetElementById(
+      ELEMENT_IDS.SESSION_SELECTOR_CONTAINER,
+    );
+    const select = safeGetElementById(ELEMENT_IDS.SESSION_SELECTOR);
+
+    if (!container || !select) {
+      return null;
+    }
+
+    select.addEventListener('change', this._boundOnChange);
+    this._elements = { container, select };
+    return this._elements;
+  }
+
+  _handleChange(event) {
+    if (!this._changeHandler) {
+      return;
+    }
+    const value = event?.target?.value || '';
+    this._changeHandler(value);
+  }
+
+  setOnChange(handler) {
+    this._changeHandler = handler;
+  }
+
+  update(groups, selectedId) {
+    const elements = this._ensureElements();
+    if (!elements) {
+      return '';
+    }
+
+    const rootGroups = sortRootGroups(groups);
+    const { container, select } = elements;
+    const previousValue = select.value;
+
+    select.innerHTML = '';
+
+    for (const group of rootGroups) {
+      const option = document.createElement('option');
+      option.value = group.id;
+      option.textContent = formatGroupLabel(group);
+      select.appendChild(option);
+    }
+
+    let nextValue = '';
+    if (rootGroups.length > 0) {
+      if (
+        selectedId &&
+        rootGroups.some((group) => String(group.id) === String(selectedId))
+      ) {
+        nextValue = String(selectedId);
+      } else if (
+        previousValue &&
+        rootGroups.some((g) => g.id === previousValue)
+      ) {
+        nextValue = previousValue;
+      } else {
+        nextValue = String(rootGroups[rootGroups.length - 1].id);
+      }
+      select.value = nextValue;
+    }
+
+    const shouldHide = rootGroups.length <= 1;
+    container.classList.toggle('is-hidden', shouldHide);
+    container.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
+
+    return nextValue;
+  }
+
+  getValue() {
+    const elements = this._elements;
+    return elements?.select?.value || '';
+  }
+
+  cleanup() {
+    if (!this._elements?.select) {
+      return;
+    }
+    this._elements.select.removeEventListener('change', this._boundOnChange);
+    this._elements = null;
+  }
+}

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -38,6 +38,22 @@ function formatStatus(status) {
   return normalized.replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function formatDuration(durationMs) {
+  if (durationMs < 0) return '0s';
+  if (durationMs < 1000) return '<1s';
+
+  const seconds = Math.floor(durationMs / 1000) % 60;
+  const minutes = Math.floor(durationMs / (1000 * 60));
+
+  if (minutes === 0) {
+    return `${seconds}s`;
+  } else if (seconds === 0) {
+    return `${minutes}m`;
+  } else {
+    return `${minutes}m ${seconds}s`;
+  }
+}
+
 function formatGroupLabel(group) {
   const timestamp = typeof group?.startTime === 'number' ? group.startTime : 0;
   const statusLabel = formatStatus(group?.status);
@@ -55,6 +71,12 @@ function formatGroupLabel(group) {
   }
   if (statusLabel) {
     parts.push(statusLabel);
+  }
+
+  // Add duration if available
+  if (group?.endTime && group?.startTime) {
+    const durationMs = group.endTime - group.startTime;
+    parts.push(formatDuration(durationMs));
   }
 
   if (parts.length === 0) {

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -112,11 +112,20 @@ export class SessionSelector {
   }
 
   _handleChange(event) {
+    console.log('[SessionSelector] Change event fired:', {
+      value: event?.target?.value,
+      hasHandler: !!this._changeHandler,
+    });
     if (!this._changeHandler) {
+      console.warn('[SessionSelector] No change handler registered');
       return;
     }
     try {
       const value = event?.target?.value || '';
+      console.log(
+        '[SessionSelector] Calling change handler with value:',
+        value,
+      );
       this._changeHandler(value);
     } catch (error) {
       console.error('SessionSelector: Error in change handler:', error);

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -116,8 +116,12 @@ export class SessionSelector {
     if (!this._changeHandler) {
       return;
     }
-    const value = event?.target?.value || '';
-    this._changeHandler(value);
+    try {
+      const value = event?.target?.value || '';
+      this._changeHandler(value);
+    } catch (error) {
+      console.error('SessionSelector: Error in change handler:', error);
+    }
   }
 
   setOnChange(handler) {

--- a/src/progressView/modules/uiManagers/SessionSelector.js
+++ b/src/progressView/modules/uiManagers/SessionSelector.js
@@ -14,23 +14,54 @@ function sortRootGroups(groups) {
     .sort((a, b) => (a.startTime || 0) - (b.startTime || 0));
 }
 
-function formatGroupLabel(group) {
-  const baseLabel = group?.name || 'Session';
-  const timestamp = typeof group?.startTime === 'number' ? group.startTime : 0;
+const STATUS_OVERRIDES = new Map(
+  Object.entries({
+    succeeded: 'Completed',
+    success: 'Completed',
+    completed: 'Completed',
+    failed: 'Failed',
+    error: 'Error',
+    cancelled: 'Canceled',
+    canceled: 'Canceled',
+  }),
+);
 
-  if (!timestamp) {
-    return baseLabel;
+function formatStatus(status) {
+  if (!status) {
+    return '';
+  }
+  const lower = String(status).toLowerCase();
+  if (STATUS_OVERRIDES.has(lower)) {
+    return STATUS_OVERRIDES.get(lower);
+  }
+  const normalized = lower.replace(/[_-]+/g, ' ');
+  return normalized.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatGroupLabel(group) {
+  const timestamp = typeof group?.startTime === 'number' ? group.startTime : 0;
+  const statusLabel = formatStatus(group?.status);
+
+  const parts = [];
+  if (timestamp) {
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    parts.push(formatter.format(new Date(timestamp)));
+  }
+  if (statusLabel) {
+    parts.push(statusLabel);
   }
 
-  const formatter = new Intl.DateTimeFormat(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  if (parts.length === 0) {
+    return 'Session';
+  }
 
-  return `${baseLabel} • ${formatter.format(new Date(timestamp))}`;
+  return parts.join(' • ');
 }
 
 export class SessionSelector {
@@ -99,7 +130,7 @@ export class SessionSelector {
         nextValue = String(selectedId);
       } else if (
         previousValue &&
-        rootGroups.some((g) => g.id === previousValue)
+        rootGroups.some((g) => String(g.id) === String(previousValue))
       ) {
         nextValue = previousValue;
       } else {

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -131,7 +131,9 @@ export class UsageGroup {
   computeAggregatedUsage(parentId) {
     const activeStream = progressViewState.activeStream;
     const totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
-    for (const group of progressViewState.taskGroups.getStreamGroups(activeStream).values()) {
+    for (const group of progressViewState.taskGroups
+      .getStreamGroups(activeStream)
+      .values()) {
       if (group.parentGroupId === parentId) {
         if (group.usage) {
           totals.inputTokens += group.usage.inputTokens || 0;

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -110,10 +110,11 @@ export class UsageGroup {
     if (costEl) costEl.textContent = cost.toFixed(3);
 
     // Persist usage on the group state so the summary can be computed
-    const group = progressViewState.taskGroups.get(groupId);
+    const activeStream = progressViewState.activeStream;
+    const group = progressViewState.taskGroups.get(activeStream, groupId);
     if (group) {
       group.usage = { inputTokens, outputTokens, cost };
-      progressViewState.taskGroups.set(groupId, group);
+      progressViewState.taskGroups.set(activeStream, groupId, group);
     }
     if (!skipPropagate) {
       this.propagateUsageToParents(groupId);
@@ -128,8 +129,9 @@ export class UsageGroup {
    * @private
    */
   computeAggregatedUsage(parentId) {
+    const activeStream = progressViewState.activeStream;
     const totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
-    for (const group of progressViewState.taskGroups.getAll().values()) {
+    for (const group of progressViewState.taskGroups.getStreamGroups(activeStream).values()) {
       if (group.parentGroupId === parentId) {
         if (group.usage) {
           totals.inputTokens += group.usage.inputTokens || 0;
@@ -150,7 +152,8 @@ export class UsageGroup {
    * @private
    */
   propagateUsageToParents(groupId) {
-    const group = progressViewState.taskGroups.get(groupId);
+    const activeStream = progressViewState.activeStream;
+    const group = progressViewState.taskGroups.get(activeStream, groupId);
     if (!group) return;
 
     // If this group has a parent, update the parent with aggregated usage

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -312,9 +312,11 @@ export class ProgressViewState {
       }
     }
 
-    // NOTE: outputFiles and usageStats are not currently filtered per-session
-    // because they don't have groupId associations. This matches the behavior
-    // where these are stream-level resources that persist across sessions.
+    // Clean up session-specific output files
+    this._outputFiles.clearSessionFiles(stream, groupId);
+    this._outputFiles.clearSessionMissingOutputs(stream, groupId);
+
+    // TODO: Clean up session-specific usage stats once they become session-aware
 
     // If this was the latest group, update to the most recent remaining group
     const latestGroup = this.getLatestTaskGroupId(stream);

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -312,11 +312,10 @@ export class ProgressViewState {
       }
     }
 
-    // Clean up session-specific output files
+    // Clean up session-specific output files and usage stats
     this._outputFiles.clearSessionFiles(stream, groupId);
     this._outputFiles.clearSessionMissingOutputs(stream, groupId);
-
-    // TODO: Clean up session-specific usage stats once they become session-aware
+    this._usageStats.deleteSessionUsage(stream, groupId);
 
     // If this was the latest group, update to the most recent remaining group
     const latestGroup = this.getLatestTaskGroupId(stream);

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -18,6 +18,9 @@ import type { TaskGroup } from '@logger/LogTypes';
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
+// Local imports - session helpers
+import { isPlaceholderSessionId } from './sessionPlaceholders';
+
 // Types
 import {
   TaskState,
@@ -48,6 +51,8 @@ export class ProgressViewState {
   private readonly workflowTaskStates: WorkflowTaskStateManager;
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
   private readonly latestTaskGroupIds: Map<StreamTabId, TaskGroup['id']> =
+    new Map();
+  private readonly selectedTaskGroupIds: Map<StreamTabId, TaskGroup['id']> =
     new Map();
   /**
    * Ephemeral session-kind hints keyed by stream ID.
@@ -256,6 +261,11 @@ export class ProgressViewState {
     streamTabId: StreamTabId,
     groupId: TaskGroup['id'],
   ): void {
+    if (!groupId) {
+      return;
+    }
+
+    this.migratePlaceholderSessions(streamTabId, groupId);
     this.latestTaskGroupIds.set(streamTabId, groupId);
   }
 
@@ -265,6 +275,49 @@ export class ProgressViewState {
 
   clearLatestTaskGroupId(streamTabId: StreamTabId): void {
     this.latestTaskGroupIds.delete(streamTabId);
+  }
+
+  setSelectedTaskGroupId(
+    streamTabId: StreamTabId,
+    groupId: TaskGroup['id'] | undefined,
+  ): void {
+    if (!streamTabId) {
+      return;
+    }
+
+    if (groupId) {
+      this.selectedTaskGroupIds.set(streamTabId, groupId);
+    } else {
+      this.selectedTaskGroupIds.delete(streamTabId);
+    }
+  }
+
+  getSelectedTaskGroupId(
+    streamTabId: StreamTabId,
+  ): TaskGroup['id'] | undefined {
+    return this.selectedTaskGroupIds.get(streamTabId);
+  }
+
+  clearSelectedTaskGroupId(streamTabId: StreamTabId): void {
+    this.selectedTaskGroupIds.delete(streamTabId);
+  }
+
+  private migratePlaceholderSessions(
+    stream: StreamTabId,
+    groupId: string,
+  ): void {
+    if (!stream || isPlaceholderSessionId(groupId)) {
+      return;
+    }
+
+    const migratedFiles = this._outputFiles.migratePlaceholders(stream, groupId);
+    const migratedUsage = this._usageStats.migratePlaceholders(stream, groupId);
+
+    if (migratedFiles || migratedUsage) {
+      this.logger.debug(
+        `Migrated placeholder session data for stream ${stream} -> ${groupId}`,
+      );
+    }
   }
 
   // Stream cleanup operations
@@ -277,6 +330,7 @@ export class ProgressViewState {
     this.toolUseTaskStates.delete(stream);
     this._executionIds.delete(stream);
     this.clearLatestTaskGroupId(stream);
+    this.clearSelectedTaskGroupId(stream);
     this.clearSessionKindHint(stream);
     this.cleanupToolUseAgentRegistry();
 
@@ -328,8 +382,22 @@ export class ProgressViewState {
           (current.startTime || 0) > (latest.startTime || 0) ? current : latest,
         );
         this.setLatestTaskGroupId(stream, mostRecent.id);
+        if (this.getSelectedTaskGroupId(stream) === groupId) {
+          this.setSelectedTaskGroupId(stream, mostRecent.id);
+        }
       } else {
         this.clearLatestTaskGroupId(stream);
+        if (this.getSelectedTaskGroupId(stream) === groupId) {
+          this.clearSelectedTaskGroupId(stream);
+        }
+      }
+    } else if (this.getSelectedTaskGroupId(stream) === groupId) {
+      // If selection targeted the deleted session but latest differs, fall back to latest
+      const fallback = this.getLatestTaskGroupId(stream);
+      if (fallback) {
+        this.setSelectedTaskGroupId(stream, fallback);
+      } else {
+        this.clearSelectedTaskGroupId(stream);
       }
     }
   }
@@ -381,6 +449,7 @@ export class ProgressViewState {
     this.workflowTaskStates.clear();
     this.toolUseTaskStates.clear();
     this._executionIds.clear();
+    this.selectedTaskGroupIds.clear();
     this._sessionCategoryHints.clear();
     this._activeStream = '';
     this.saveActiveStream();

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -304,12 +304,11 @@ export class ProgressViewState {
     if (messages) {
       // Filter out messages belonging to this session (groupId) and its children
       const filtered = messages.filter(
-        msg => !msg.groupId || !allGroupIds.has(msg.groupId)
+        (msg) => !msg.groupId || !allGroupIds.has(msg.groupId),
       );
       // Only update if we actually removed messages
       if (filtered.length !== messages.length) {
-        this._streamTabs.items.set(stream, filtered);
-        this._streamTabs.save();
+        this._streamTabs.add(stream, filtered);
       }
     }
 
@@ -321,11 +320,11 @@ export class ProgressViewState {
     const latestGroup = this.getLatestTaskGroupId(stream);
     if (latestGroup === groupId) {
       const remainingGroups = this._taskGroups.getGroupsForStream(stream);
-      const rootGroups = remainingGroups.filter(g => !g.parentGroupId);
+      const rootGroups = remainingGroups.filter((g) => !g.parentGroupId);
       if (rootGroups.length > 0) {
         // Set to the most recent root group
         const mostRecent = rootGroups.reduce((latest, current) =>
-          (current.startTime || 0) > (latest.startTime || 0) ? current : latest
+          (current.startTime || 0) > (latest.startTime || 0) ? current : latest,
         );
         this.setLatestTaskGroupId(stream, mostRecent.id);
       } else {
@@ -337,7 +336,10 @@ export class ProgressViewState {
   /**
    * Collect the group ID and all its descendant group IDs recursively
    */
-  private _collectGroupAndChildren(stream: StreamTabId, groupId: string): Set<string> {
+  private _collectGroupAndChildren(
+    stream: StreamTabId,
+    groupId: string,
+  ): Set<string> {
     const result = new Set<string>();
     result.add(groupId);
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -310,7 +310,10 @@ export class ProgressViewState {
       return;
     }
 
-    const migratedFiles = this._outputFiles.migratePlaceholders(stream, groupId);
+    const migratedFiles = this._outputFiles.migratePlaceholders(
+      stream,
+      groupId,
+    );
     const migratedUsage = this._usageStats.migratePlaceholders(stream, groupId);
 
     if (migratedFiles || migratedUsage) {

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -13,6 +13,7 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { AgentFilter } from '../types';
+import type { TaskGroup } from '@logger/LogTypes';
 // Local imports - agent types
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
 import { AgentCategory } from '@agent/core/AgentDataclass';
@@ -46,6 +47,8 @@ export class ProgressViewState {
   private _agentTypeFilter: AgentFilter = 'all';
   private readonly workflowTaskStates: WorkflowTaskStateManager;
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
+  private readonly latestTaskGroupIds: Map<StreamTabId, TaskGroup['id']> =
+    new Map();
   /**
    * Ephemeral session-kind hints keyed by stream ID.
    *
@@ -249,6 +252,21 @@ export class ProgressViewState {
     this.saveExecutionIds();
   }
 
+  setLatestTaskGroupId(
+    streamTabId: StreamTabId,
+    groupId: TaskGroup['id'],
+  ): void {
+    this.latestTaskGroupIds.set(streamTabId, groupId);
+  }
+
+  getLatestTaskGroupId(streamTabId: StreamTabId): TaskGroup['id'] | undefined {
+    return this.latestTaskGroupIds.get(streamTabId);
+  }
+
+  clearLatestTaskGroupId(streamTabId: StreamTabId): void {
+    this.latestTaskGroupIds.delete(streamTabId);
+  }
+
   // Stream cleanup operations
   clearStream(stream: StreamTabId): void {
     this._streamTabs.delete(stream);
@@ -258,6 +276,7 @@ export class ProgressViewState {
     this.workflowTaskStates.delete(stream);
     this.toolUseTaskStates.delete(stream);
     this._executionIds.delete(stream);
+    this.clearLatestTaskGroupId(stream);
     this.clearSessionKindHint(stream);
     this.cleanupToolUseAgentRegistry();
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -291,6 +291,27 @@ export class ProgressViewState {
     this.saveExecutionIds();
   }
 
+  // Delete a specific task group (session) within a stream
+  deleteTaskGroup(stream: StreamTabId, groupId: string): void {
+    this._taskGroups.deleteGroup(stream, groupId);
+
+    // If this was the latest group, update to the most recent remaining group
+    const latestGroup = this.getLatestTaskGroupId(stream);
+    if (latestGroup === groupId) {
+      const remainingGroups = this._taskGroups.getGroupsForStream(stream);
+      const rootGroups = remainingGroups.filter(g => !g.parentGroupId);
+      if (rootGroups.length > 0) {
+        // Set to the most recent root group
+        const mostRecent = rootGroups.reduce((latest, current) =>
+          (current.startTime || 0) > (latest.startTime || 0) ? current : latest
+        );
+        this.setLatestTaskGroupId(stream, mostRecent.id);
+      } else {
+        this.clearLatestTaskGroupId(stream);
+      }
+    }
+  }
+
   // Stream content erasure (clear content but keep the stream tab and re-run capability)
   eraseStreamContent(stream: StreamTabId): void {
     // Clear visual content but keep the stream tab

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -293,7 +293,29 @@ export class ProgressViewState {
 
   // Delete a specific task group (session) within a stream
   deleteTaskGroup(stream: StreamTabId, groupId: string): void {
+    // Get all child group IDs before deletion
+    const allGroupIds = this._collectGroupAndChildren(stream, groupId);
+
+    // Delete the task group and its children
     this._taskGroups.deleteGroup(stream, groupId);
+
+    // Clean up session-specific logs
+    const messages = this._streamTabs.get(stream);
+    if (messages) {
+      // Filter out messages belonging to this session (groupId) and its children
+      const filtered = messages.filter(
+        msg => !msg.groupId || !allGroupIds.has(msg.groupId)
+      );
+      // Only update if we actually removed messages
+      if (filtered.length !== messages.length) {
+        this._streamTabs.items.set(stream, filtered);
+        this._streamTabs.save();
+      }
+    }
+
+    // NOTE: outputFiles and usageStats are not currently filtered per-session
+    // because they don't have groupId associations. This matches the behavior
+    // where these are stream-level resources that persist across sessions.
 
     // If this was the latest group, update to the most recent remaining group
     const latestGroup = this.getLatestTaskGroupId(stream);
@@ -310,6 +332,27 @@ export class ProgressViewState {
         this.clearLatestTaskGroupId(stream);
       }
     }
+  }
+
+  /**
+   * Collect the group ID and all its descendant group IDs recursively
+   */
+  private _collectGroupAndChildren(stream: StreamTabId, groupId: string): Set<string> {
+    const result = new Set<string>();
+    result.add(groupId);
+
+    const streamGroups = this._taskGroups.getGroupsForStream(stream);
+    const collectChildren = (parentId: string) => {
+      for (const group of streamGroups) {
+        if (group.parentGroupId === parentId) {
+          result.add(group.id);
+          collectChildren(group.id);
+        }
+      }
+    };
+
+    collectChildren(groupId);
+    return result;
   }
 
   // Stream content erasure (clear content but keep the stream tab and re-run capability)

--- a/src/progressView/state/sessionPlaceholders.ts
+++ b/src/progressView/state/sessionPlaceholders.ts
@@ -1,0 +1,13 @@
+export const MIGRATION_PLACEHOLDER_ID = '__MIGRATION__';
+export const DEFAULT_PLACEHOLDER_ID = '__DEFAULT__';
+
+export const SESSION_PLACEHOLDER_IDS = [
+  MIGRATION_PLACEHOLDER_ID,
+  DEFAULT_PLACEHOLDER_ID,
+] as const;
+
+export function isPlaceholderSessionId(
+  groupId: string | null | undefined,
+): groupId is typeof SESSION_PLACEHOLDER_IDS[number] {
+  return groupId === MIGRATION_PLACEHOLDER_ID || groupId === DEFAULT_PLACEHOLDER_ID;
+}

--- a/src/progressView/state/sessionPlaceholders.ts
+++ b/src/progressView/state/sessionPlaceholders.ts
@@ -1,13 +1,20 @@
 export const MIGRATION_PLACEHOLDER_ID = '__MIGRATION__';
 export const DEFAULT_PLACEHOLDER_ID = '__DEFAULT__';
 
+/**
+ * Placeholder identifiers appear in fallback order – prefer DEFAULT over
+ * MIGRATION so we surface the data that was queued for the active session
+ * before any legacy artifacts.
+ */
 export const SESSION_PLACEHOLDER_IDS = [
-  MIGRATION_PLACEHOLDER_ID,
   DEFAULT_PLACEHOLDER_ID,
+  MIGRATION_PLACEHOLDER_ID,
 ] as const;
 
 export function isPlaceholderSessionId(
   groupId: string | null | undefined,
-): groupId is typeof SESSION_PLACEHOLDER_IDS[number] {
-  return groupId === MIGRATION_PLACEHOLDER_ID || groupId === DEFAULT_PLACEHOLDER_ID;
+): groupId is (typeof SESSION_PLACEHOLDER_IDS)[number] {
+  return (
+    groupId === MIGRATION_PLACEHOLDER_ID || groupId === DEFAULT_PLACEHOLDER_ID
+  );
 }

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -1,6 +1,10 @@
 /**
  * Log Group styles for ProgressView
  * Styling for grouped log entries and hierarchy
+ *
+ * Note: State modifiers (is-hidden, is-visible, is-expanded) follow a common
+ * CSS pattern for state classes. BEM notation (element__subelement) is used
+ * for structural elements, while is-* classes denote dynamic states.
  */
 
 /* Log Group Styles */

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -28,7 +28,7 @@
 }
 
 /* Hide top-level task headers - we show sessions via selector instead */
-.log-group-header.top-level {
+.log-group .log-group-header.top-level {
   display: none;
 }
 

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -23,10 +23,9 @@
   border-left: var(--border-medium) solid var(--vscode-panel-border);
 }
 
-/* Minimal styling for top-level task headers */
+/* Hide top-level task headers - we show sessions via selector instead */
 .log-group-header.top-level {
-  border-left: var(--border-thin) solid var(--vscode-panel-border);
-  border-right: var(--border-thin) solid var(--vscode-panel-border);
+  display: none;
 }
 
 .log-group-header.running {
@@ -45,6 +44,21 @@
   padding-left: var(--spacing-small);
   border-left: var(--border-thin) dashed
     var(--vscode-editorGroupHeader-tabsBorder);
+}
+
+/* Remove padding/border for top-level group content since header is hidden */
+.log-group.top-level > .log-group-content {
+  padding-left: 0;
+  border-left: none;
+}
+
+/* Adjust nested group styles when inside a top-level group */
+.log-group.top-level > .log-group-content > .log-group {
+  margin-left: 0;
+}
+
+.log-group.top-level > .log-group-content > .log-group .log-group-header {
+  margin-left: 0;
 }
 
 .group-status-icon {

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -4,6 +4,14 @@
  */
 
 /* Log Group Styles */
+.log-group {
+  margin: var(--spacing-tiny) 0;
+}
+
+.log-group.is-hidden {
+  display: none;
+}
+
 .log-group-header {
   padding: var(--spacing-tiny) var(--spacing-medium);
   margin: var(--spacing-tiny) 0;

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -24,3 +24,4 @@
 @import './user-message.css';
 @import './follow-up-input.css';
 @import './instruction-panel.css';
+@import './session-selector.css';

--- a/src/progressView/styles/session-selector.css
+++ b/src/progressView/styles/session-selector.css
@@ -1,3 +1,10 @@
+/**
+ * Session Selector styles for ProgressView
+ *
+ * Follows BEM notation for structural elements (session-selector__dropdown)
+ * and common state pattern for visibility (is-hidden).
+ */
+
 .session-selector {
   display: flex;
   align-items: center;

--- a/src/progressView/styles/session-selector.css
+++ b/src/progressView/styles/session-selector.css
@@ -1,14 +1,12 @@
 /**
  * Session Selector styles for ProgressView
  *
+ * Minimalist VS Code-native dropdown for session selection.
  * Follows BEM notation for structural elements (session-selector__dropdown)
  * and common state pattern for visibility (is-hidden).
  */
 
 .session-selector {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
   margin: 0 0 0.5rem;
 }
 
@@ -16,24 +14,22 @@
   display: none;
 }
 
-.session-selector__label {
-  font-size: 0.85rem;
-  color: var(--vscode-descriptionForeground);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+.session-selector__dropdown {
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.9rem;
+  background-color: var(--vscode-dropdown-background);
+  color: var(--vscode-dropdown-foreground);
+  border: 1px solid var(--vscode-dropdown-border);
+  border-radius: 2px;
+  cursor: pointer;
 }
 
-.session-selector__dropdown {
-  flex: 1 1 auto;
-  min-width: 0;
-  padding: 0.25rem 0.5rem;
-  background-color: var(--vscode-editor-background);
-  color: var(--vscode-editor-foreground);
-  border: 1px solid var(--vscode-editorWidget-border);
-  border-radius: 2px;
+.session-selector__dropdown:hover {
+  background-color: var(--vscode-dropdown-background);
 }
 
 .session-selector__dropdown:focus {
   outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: 1px;
+  outline-offset: -1px;
 }

--- a/src/progressView/styles/session-selector.css
+++ b/src/progressView/styles/session-selector.css
@@ -1,0 +1,32 @@
+.session-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.session-selector.is-hidden {
+  display: none;
+}
+
+.session-selector__label {
+  font-size: 0.85rem;
+  color: var(--vscode-descriptionForeground);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.session-selector__dropdown {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.25rem 0.5rem;
+  background-color: var(--vscode-editor-background);
+  color: var(--vscode-editor-foreground);
+  border: 1px solid var(--vscode-editorWidget-border);
+  border-radius: 2px;
+}
+
+.session-selector__dropdown:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
+}

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -8,10 +8,13 @@ import { createUsageEvents } from '@progressView/events/UsageEvents';
 import { createLogEvents } from '@progressView/events/LogEvents';
 import { createTaskGroupEvents } from '@progressView/events/TaskGroupEvents';
 
-import type { ProgressViewState } from '@progressView/state/ProgressViewState';
+import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { AgentLogger } from '@logger/AgentLogger';
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
+import { agentConfigToTaskState } from '@utils/config';
 
 class FakeBus {
   public readonly events: (keyof ProgressEventPayloads)[] = [];
@@ -223,5 +226,80 @@ describe('Progress event modules', () => {
 
     assert.deepStrictEqual(initialized, ['stream-1']);
     assert.deepStrictEqual(bus.emissions, []);
+  });
+
+  it('attaches instruction metadata to task groups on setTaskState', () => {
+    const bus = new FakeBus();
+    const streamStatusEvents = createStreamStatusEvents({
+      logger: loggerStub,
+      streamStatus: new Map(),
+      setStreamStatus: () => {},
+      sendInstructionUpdate: () => {},
+      updateLogContentForStream: () => {},
+    });
+
+    const persistence = {
+      load: async (_key: string, defaultValue: unknown) => defaultValue,
+      save: async () => {},
+      delete: async () => {},
+      loadWithMigration: async (
+        _newKey: string,
+        _legacyKey: string,
+        defaultValue: unknown,
+      ) => defaultValue,
+    } as any;
+
+    const state = new ProgressViewState(persistence);
+
+    const updater = {
+      isAvailable: () => false,
+      updateStreams: () => {},
+    } as unknown as WebviewUpdater;
+
+    const disposables = streamStatusEvents.register(bus as any, state, updater);
+
+    const stream = 'workflow-stream';
+    const groupId = 'group-1';
+
+    state.taskGroups.addGroup(stream, groupId, {
+      id: groupId,
+      name: 'Task: example',
+      startTime: Date.now(),
+      status: 'running',
+    });
+
+    const instruction = Array.from({ length: 8 }, (_, index) => `Line ${index}`)
+      .join('\n')
+      .trim();
+
+    const config = AgentConfigSchema.parse({
+      model: 'test-model',
+      agent: 'test-agent',
+      instruction,
+      session: {
+        agentCategory: AgentCategory.Workflow,
+        agentType: AgentType.Direct,
+      },
+      inputFile: 'main.tex',
+    });
+
+    const taskState = agentConfigToTaskState(config, config.session);
+
+    bus.trigger('setTaskState', {
+      streamTabId: stream,
+      executionId: 'exec-42' as any,
+      taskState,
+      taskGroupId: groupId,
+    });
+
+    const stored = state.taskGroups.getGroup(stream, groupId);
+    assert.ok(stored?.instruction, 'instruction metadata should be stored');
+    assert.equal(stored?.instruction?.text, instruction);
+    assert.equal(stored?.instruction?.executionId, 'exec-42');
+    assert.equal(state.getLatestTaskGroupId(stream), groupId);
+    assert.equal(stored?.instruction?.metadata?.showToggle, true);
+    assert.equal(typeof stored?.instruction?.updatedAt, 'number');
+
+    disposables.forEach((disposable) => disposable.dispose());
   });
 });

--- a/src/test/progressView/modules/SessionSelector.test.ts
+++ b/src/test/progressView/modules/SessionSelector.test.ts
@@ -58,6 +58,7 @@ describe('Session selector integration', () => {
     handler = new ProgressViewMessageHandler();
     progressViewState.taskGroups.clear();
     progressViewState.selectedGroups.clear();
+    progressViewState.currentGroupIds.clear();
     progressViewState.activeStream = 'stream-1';
     progressViewDomHandler.taskGroups.clear();
   });
@@ -65,6 +66,7 @@ describe('Session selector integration', () => {
   afterEach(() => {
     progressViewState.taskGroups.clear();
     progressViewState.selectedGroups.clear();
+    progressViewState.currentGroupIds.clear();
     progressViewState.activeStream = '';
     progressViewDomHandler.taskGroups.clear();
     if (progressViewDomHandler.instructionPanel?.cleanup) {
@@ -102,10 +104,81 @@ describe('Session selector integration', () => {
       'sessionSelector',
     ) as HTMLSelectElement;
     assert.equal(selector?.value, 'group-2');
+    const optionLabels = Array.from(selector.options).map(
+      (opt) => opt.textContent,
+    );
+    assert.ok(
+      optionLabels.every((label) => label && !label.includes('Run:')),
+      'session labels should omit run prefixes',
+    );
 
     selector.value = 'group-1';
     selector.dispatchEvent(new global.window.Event('change'));
 
     assert.equal(progressViewState.getSelectedGroup('stream-1'), 'group-1');
+  });
+
+  it('keeps instructions isolated per stream even with reused group ids', () => {
+    handler.handleUpdateLogs({
+      command: 'updateLogContent',
+      stream: 'stream-1',
+      messages: [],
+      groups: [
+        {
+          id: 'group-1',
+          name: 'First run',
+          startTime: 1,
+          status: 'running',
+        },
+      ],
+      taskGroupId: 'group-1',
+    } as any);
+
+    handler.handleUpdateInstruction({
+      command: 'updateInstruction',
+      stream: 'stream-1',
+      taskGroupId: 'group-1',
+      instruction: { text: 'First instruction' },
+    } as any);
+
+    const streamOneGroup = progressViewState.taskGroups.get(
+      'stream-1',
+      'group-1',
+    );
+    assert.equal(streamOneGroup?.instruction?.text, 'First instruction');
+
+    progressViewState.activeStream = 'stream-2';
+    handler.handleUpdateLogs({
+      command: 'updateLogContent',
+      stream: 'stream-2',
+      messages: [],
+      groups: [
+        {
+          id: 'group-1',
+          name: 'Second run',
+          startTime: 2,
+          status: 'running',
+        },
+      ],
+      taskGroupId: 'group-1',
+    } as any);
+
+    handler.handleUpdateInstruction({
+      command: 'updateInstruction',
+      stream: 'stream-2',
+      taskGroupId: 'group-1',
+      instruction: { text: 'Second instruction' },
+    } as any);
+
+    const streamTwoGroup = progressViewState.taskGroups.get(
+      'stream-2',
+      'group-1',
+    );
+    assert.equal(streamTwoGroup?.instruction?.text, 'Second instruction');
+    const streamOneGroupAfter = progressViewState.taskGroups.get(
+      'stream-1',
+      'group-1',
+    );
+    assert.equal(streamOneGroupAfter?.instruction?.text, 'First instruction');
   });
 });

--- a/src/test/progressView/modules/SessionSelector.test.ts
+++ b/src/test/progressView/modules/SessionSelector.test.ts
@@ -1,0 +1,111 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+// @ts-ignore jsdom typings not available in this environment
+import { JSDOM } from 'jsdom';
+
+// Local imports - progress view
+// @ts-ignore: progress view message handler is compiled JS
+import { ProgressViewMessageHandler } from '../../../progressView/modules/messageHandlers.js';
+// @ts-ignore: progress view state is compiled JS
+import { progressViewState } from '../../../progressView/modules/progressViewState.js';
+// @ts-ignore: progress view DOM handler is compiled JS
+import { progressViewDomHandler } from '../../../progressView/modules/domHandlers.js';
+
+describe('Session selector integration', () => {
+  let handler: ProgressViewMessageHandler;
+  let originalDocument: typeof global.document;
+  let originalWindow: any;
+  let originalNavigator: any;
+
+  beforeEach(() => {
+    const dom = new JSDOM(`<!doctype html><html><body>
+      <div id="logContent"></div>
+      <div id="sessionSelectorContainer" class="session-selector">
+        <label for="sessionSelector"></label>
+        <select id="sessionSelector"></select>
+      </div>
+      <div id="instructionContainer" class="instruction-panel">
+        <div class="instruction-panel__body"></div>
+        <div id="instructionText"></div>
+        <button id="instructionToggleBtn"></button>
+        <button id="instructionCopyBtn"></button>
+      </div>
+      <template id="groupDetailsTemplate">
+        <details class="log-group">
+          <div class="log-group-content"></div>
+        </details>
+      </template>
+      <template id="groupHeaderTemplate">
+        <summary class="log-group-header">
+          <span class="group-status-icon"></span>
+          <span class="group-title"></span>
+          <span class="group-time"></span>
+        </summary>
+      </template>
+    </body></html>`);
+
+    originalDocument = global.document;
+    originalWindow = (global as any).window;
+    originalNavigator = (global as any).navigator;
+
+    global.document = dom.window.document as any;
+    (global as any).window = dom.window as any;
+    (global as any).navigator = dom.window.navigator;
+    dom.window.requestAnimationFrame = (cb: any) => cb(0);
+
+    handler = new ProgressViewMessageHandler();
+    progressViewState.taskGroups.clear();
+    progressViewState.selectedGroups.clear();
+    progressViewState.activeStream = 'stream-1';
+    progressViewDomHandler.taskGroups.clear();
+  });
+
+  afterEach(() => {
+    progressViewState.taskGroups.clear();
+    progressViewState.selectedGroups.clear();
+    progressViewState.activeStream = '';
+    progressViewDomHandler.taskGroups.clear();
+    if (progressViewDomHandler.instructionPanel?.cleanup) {
+      progressViewDomHandler.instructionPanel.cleanup();
+    }
+    global.document = originalDocument;
+    (global as any).window = originalWindow;
+    (global as any).navigator = originalNavigator;
+  });
+
+  it('selects the preferred root group and updates state', () => {
+    handler.handleUpdateLogs({
+      command: 'updateLogContent',
+      stream: 'stream-1',
+      messages: [],
+      groups: [
+        {
+          id: 'group-1',
+          name: 'First run',
+          startTime: 1,
+          status: 'running',
+        },
+        {
+          id: 'group-2',
+          name: 'Second run',
+          startTime: 2,
+          status: 'running',
+        },
+      ],
+      taskGroupId: 'group-2',
+    } as any);
+
+    assert.equal(progressViewState.getSelectedGroup('stream-1'), 'group-2');
+    const selector = global.document?.getElementById(
+      'sessionSelector',
+    ) as HTMLSelectElement;
+    assert.equal(selector?.value, 'group-2');
+
+    selector.value = 'group-1';
+    selector.dispatchEvent(new global.window.Event('change'));
+
+    assert.equal(progressViewState.getSelectedGroup('stream-1'), 'group-1');
+  });
+});


### PR DESCRIPTION
## Summary
- extend task state events with the originating task group so streams can map instructions to specific runs
- persist instruction metadata on task groups and expose the active group through webview updates
- add a session selector UI to toggle root groups and show the matching instruction text

## Testing
- npm run lint
- npm run compile
- CI=1 npm test *(fails: vscode-test requires libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68f3624435b0832485ee5b04b97e8854

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a session selector and migrate progress view to session-scoped instructions, files, and usage, with execution continuity for merge and supporting event/persistence updates.
> 
> - **Progress View UI**:
>   - Add session selector dropdown to switch root sessions and synchronize instruction display.
>   - Hide top-level group headers; new styles for session selector and groups.
> - **State & Persistence**:
>   - Track latest/selected `taskGroupId` per stream; migrate placeholder sessions (`__DEFAULT__`, `__MIGRATION__`).
>   - Make `OutputFilesManager` and `UsageStatsManager` session-scoped; add merge/migrate helpers and old-format migration.
>   - Persist instruction metadata on `TaskGroup` (text, executionId, updatedAt, UI hints).
> - **Events & Bus**:
>   - Extend `setTaskState` with optional `taskGroupId`; compute/store instruction metadata.
>   - Extend `updateStreamUsage` with optional `groupId`; usage updates target selected/latest session.
>   - Add `SELECT_SESSION` command; selectively erase a session; propagate session selection to files/usage.
> - **Webview Updater/Handlers**:
>   - Send `groups` and `taskGroupId` with log/instruction updates; update files/missing/usage for current session only.
>   - Session selector logic in JS to filter visible groups and notify extension.
> - **Merge workflow**:
>   - `executeMergeAgent` accepts optional `executionId`; wire through command and message handler to continue in same session.
> - **Misc/Tests**:
>   - New instruction toggle heuristic util; CSS additions; tests for instruction metadata and session selector.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9af6ecb59e118261e26df6d2b165a2eaddef86cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->