### PR TITLE
Remove legacy log parsing helper

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 import * as winston from 'winston';
 import Transport from 'winston-transport';
-import { encode as encodeHtml, decode as decodeHtml } from 'he';
+import { encode as encodeHtml } from 'he';
 import { randomUUID } from 'crypto';
 
 // Local imports - progressView
@@ -415,49 +415,6 @@ export const error = (
 ): void => {
   logWithGroup(channel, 'error', message, groupId, messageType, isAgent, data);
 };
-
-/**
- * Parse legacy JSON content from the log message text when structured data is
- * missing. Parsed results are stored back into the log object so that future
- * lookups don't require re-parsing.
- */
-export function parseLegacyLogData(
-  logMessage: LogMessageData,
-  logger?: AgentLogger,
-  forceParse = false,
-): unknown | undefined {
-  if (!forceParse && logMessage.data !== undefined) {
-    return logMessage.data;
-  }
-
-  const type = logMessage.messageType;
-  const legacyTypes = new Set<string>([
-    MESSAGE_TYPES.FILE_LIST,
-    MESSAGE_TYPES.MISSING_OUTPUTS,
-    MESSAGE_TYPES.LATEXDIFF,
-    MESSAGE_TYPES.STATISTICS,
-  ]);
-
-  if (type && legacyTypes.has(type) && logMessage.text) {
-    try {
-      const decoded = decodeHtml(logMessage.text);
-      const parsed = JSON.parse(decoded);
-
-      if (typeof parsed === 'object' && parsed !== null) {
-        logMessage.data = parsed;
-        return parsed;
-      }
-    } catch (err) {
-      logger?.warn(
-        `Failed to parse legacy log data: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
-  }
-
-  return undefined;
-}
 
 function getOrCreateLogger(channel: string, isAgent = false): winston.Logger {
   if (!channelLoggers.has(channel)) {

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -11,8 +11,7 @@ import { createErrorBoundary } from './errorHandling';
 import type { ProgressEventBusLike } from './types';
 
 // Local imports - logger
-import { parseLegacyLogData } from '@logger/logUtils';
-import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
+import type { LogMessageUpdate } from '@logger/LogTypes';
 import { getConfig } from '@utils/config';
 
 import type { AgentLogger } from '@logger/AgentLogger';
@@ -32,15 +31,6 @@ export interface LogEventsModule {
 export function createLogEvents(shared: LogEventsShared): LogEventsModule {
   const withErrorBoundary = createErrorBoundary(shared.logger, 'LogEvents');
 
-  const safelyParseLegacyLogData = (
-    data: LogMessageData,
-    isUpdate = false,
-  ): void => {
-    withErrorBoundary('failed to parse legacy log data', () => {
-      parseLegacyLogData(data, shared.logger, isUpdate);
-    });
-  };
-
   const handleAddLogMessage = (
     data: ProgressEventPayloads['addLogMessage'],
     state: ProgressViewState,
@@ -48,8 +38,6 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
   ): void => {
     withErrorBoundary('failed to handle addLogMessage', () => {
       const { stream, logMessage } = data;
-
-      safelyParseLegacyLogData(logMessage);
 
       if (
         logMessage.level === 'debug' &&
@@ -97,8 +85,6 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
       }
       if (logMessage.data !== undefined) {
         existing.data = logMessage.data;
-      } else {
-        safelyParseLegacyLogData(existing, true);
       }
 
       state.streamTabs.save();

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -1,6 +1,9 @@
 // Standard library imports
 import { randomUUID } from 'crypto';
 
+// Third-party imports
+import { decode as decodeHtml } from 'he';
+
 // Local imports - persistence
 import { PersistentMapManager } from '../persistence/PersistentMapManager';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
@@ -10,7 +13,14 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
-import { parseLegacyLogData } from '@logger/logUtils';
+
+const LEGACY_MESSAGE_TYPES: ReadonlySet<LogMessageData['messageType']> =
+  new Set([
+    'fileList',
+    'missingOutputs',
+    'latexdiff',
+    'statistics',
+  ]);
 
 /**
  * Manages stream tabs collection with persistence.
@@ -135,7 +145,21 @@ export class StreamTabsManager extends PersistentMapManager<
         msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
       }
       const log = msg as LogMessageData;
-      parseLegacyLogData(log, this.logger);
+      if (log.data === undefined && typeof log.text === 'string') {
+        if (log.messageType && LEGACY_MESSAGE_TYPES.has(log.messageType)) {
+          try {
+            const decoded = decodeHtml(log.text);
+            const parsed = JSON.parse(decoded);
+            if (typeof parsed === 'object' && parsed !== null) {
+              log.data = parsed;
+            }
+          } catch (error) {
+            const reason =
+              error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Failed to parse legacy log data: ${reason}`);
+          }
+        }
+      }
       if (!log.messageType) {
         log.messageType = 'default';
       }


### PR DESCRIPTION
## Summary
- remove the legacy `parseLegacyLogData` helper and rely on structured payloads in progress view handlers
- migrate legacy serialized log payloads as part of stream tab deserialization so data is hydrated once on load

## Testing
- npm test -- --runTestsByPath src/test/logger/errorData.test.ts *(fails: VS Code binary requires libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d2f3a48c83248367e1fddb15ed08

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `parseLegacyLogData` and shifts legacy payload parsing to `StreamTabsManager` deserialization, eliminating parsing in progress view event handlers.
> 
> - **Logging**:
>   - Delete `parseLegacyLogData` and its usage; drop `decodeHtml` import from `src/logger/logUtils.ts`.
> - **Progress View (events)**:
>   - Remove legacy parsing in `LogEvents` (`safelyParseLegacyLogData` and related calls) for add/update handlers.
> - **Progress View (persistence)**:
>   - Add legacy payload migration in `StreamTabsManager.deserialize`:
>     - Parse legacy JSON from `text` for `messageType` in `{fileList, missingOutputs, latexdiff, statistics}` using `he.decode`.
>     - Log warning on parse failure; ensure `messageType` defaults to `default`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f1af02fe5318244ae65064ed2007c7f64f6ad97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->