### PR TITLE
Fix clean command multi-output detection

### DIFF
--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -141,23 +141,8 @@ export async function handleClean(config: {
   const declaredOutputFiles = Array.isArray(config.outputFiles)
     ? config.outputFiles
     : [];
-  const legacyActiveFlag =
-    typeof config.activeFiles?.output === 'boolean'
-      ? config.activeFiles.output
-      : undefined;
   const useMultipleOutputs =
-    typeof config.useMultipleOutputs === 'boolean'
-      ? config.useMultipleOutputs
-      : typeof legacyActiveFlag === 'boolean'
-        ? legacyActiveFlag
-        : declaredOutputFiles.length > 1;
-
-  if (declaredOutputFiles.length > 1 && !useMultipleOutputs) {
-    logger.warn(
-      CHANNEL,
-      'Clean command received multiple output files but multi-output mode is disabled. Verify stored task state.',
-    );
-  }
+    config.useMultipleOutputs ?? (declaredOutputFiles.length > 1);
 
   const outputFiles = useMultipleOutputs ? declaredOutputFiles : [];
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -450,16 +450,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
     const outputFilesArray = Array.from(allFiles);
     const useMultipleOutputs =
-      taskState.agentConfig.useMultipleOutputs || taskState.activeFiles.output;
+      taskState.agentConfig.useMultipleOutputs ??
+      taskState.activeFiles.output ??
+      (outputFilesArray.length > 1);
     await vscode.commands.executeCommand(command, {
       streamId: stream,
       agent: taskState.agentConfig.agent,
       model: taskState.agentConfig.model,
       inputFile: taskState.agentConfig.inputFile,
       outputFiles: useMultipleOutputs ? outputFilesArray : [],
-      activeFiles: {
-        output: useMultipleOutputs,
-      },
       useMultipleOutputs,
     });
   }


### PR DESCRIPTION
## Summary
- rely on declared output file count when multi-output config is missing during clean
- stop sending legacy activeFiles output flags from progress view toolbar commands

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f3d2e50c1c832484ea838482555ae5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize multi-output detection using config or output file count and stop sending legacy activeFiles flags from progress view.
> 
> - **Housekeeping (`src/commands/housekeeping/cleanCommands.ts`)**:
>   - Compute `useMultipleOutputs` via `config.useMultipleOutputs ?? (declaredOutputFiles.length > 1)`.
>   - Remove legacy `activeFiles.output` handling and the warning tied to mixed states.
> - **Progress View (`src/progressView/ProgressViewMessageHandler.ts`)**:
>   - Determine `useMultipleOutputs` via `taskState.agentConfig.useMultipleOutputs ?? taskState.activeFiles.output ?? (outputFilesArray.length > 1)`.
>   - Stop including legacy `activeFiles` in command payload; conditionally pass `outputFiles` based on `useMultipleOutputs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8604a141fa9b174cf25bd6493013d4c62f026f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->