### PR TITLE
Fix clean command multi-output detection

### DIFF
--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -141,23 +141,8 @@ export async function handleClean(config: {
   const declaredOutputFiles = Array.isArray(config.outputFiles)
     ? config.outputFiles
     : [];
-  const legacyActiveFlag =
-    typeof config.activeFiles?.output === 'boolean'
-      ? config.activeFiles.output
-      : undefined;
   const useMultipleOutputs =
-    typeof config.useMultipleOutputs === 'boolean'
-      ? config.useMultipleOutputs
-      : typeof legacyActiveFlag === 'boolean'
-        ? legacyActiveFlag
-        : declaredOutputFiles.length > 1;
-
-  if (declaredOutputFiles.length > 1 && !useMultipleOutputs) {
-    logger.warn(
-      CHANNEL,
-      'Clean command received multiple output files but multi-output mode is disabled. Verify stored task state.',
-    );
-  }
+    config.useMultipleOutputs ?? (declaredOutputFiles.length > 1);
 
   const outputFiles = useMultipleOutputs ? declaredOutputFiles : [];
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -450,16 +450,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
     const outputFilesArray = Array.from(allFiles);
     const useMultipleOutputs =
-      taskState.agentConfig.useMultipleOutputs || taskState.activeFiles.output;
+      taskState.agentConfig.useMultipleOutputs ??
+      taskState.activeFiles.output ??
+      (outputFilesArray.length > 1);
     await vscode.commands.executeCommand(command, {
       streamId: stream,
       agent: taskState.agentConfig.agent,
       model: taskState.agentConfig.model,
       inputFile: taskState.agentConfig.inputFile,
       outputFiles: useMultipleOutputs ? outputFilesArray : [],
-      activeFiles: {
-        output: useMultipleOutputs,
-      },
       useMultipleOutputs,
     });
   }


### PR DESCRIPTION
## Summary
- rely on declared output file count when multi-output config is missing during clean
- stop sending legacy activeFiles output flags from progress view toolbar commands

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f3d2e50c1c832484ea838482555ae5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default multi-output to output file count when unset and stop sending legacy activeFiles flags from progress view file operations.
> 
> - **Housekeeping**:
>   - **`src/commands/housekeeping/cleanCommands.ts`**: Determine `useMultipleOutputs` via `config.useMultipleOutputs ?? (declaredOutputFiles.length > 1)` and use it to gate `outputFiles`; removes legacy `activeFiles` handling/warning.
> - **Progress View**:
>   - **`src/progressView/ProgressViewMessageHandler.ts`**: Compute `useMultipleOutputs` via `agentConfig.useMultipleOutputs ?? activeFiles.output ?? (outputFilesArray.length > 1)`; stop sending legacy `activeFiles` in command payload; continue passing `useMultipleOutputs` and conditional `outputFiles`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dc439bf10b187c55950441fa390111a61cce892. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->