### PR TITLE
fix: ensure round pipeline receives prefill string

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -494,14 +494,18 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     return this.withRoundGroup(`r${currRound}`, async (roundGroupId) => {
       await this.prepareToolState(currRound, toolState, roundGroupId);
 
-      const { stateRound, preparedMessages, prefill, skip } =
-        await this.prepareRoundContext(
-          currRound,
-          stateGlobal,
-          messages,
-          toolState,
-          roundGroupId,
-        );
+      const {
+        stateRound,
+        preparedMessages,
+        prefill = '',
+        skip,
+      } = await this.prepareRoundContext(
+        currRound,
+        stateGlobal,
+        messages,
+        toolState,
+        roundGroupId,
+      );
 
       if (skip) {
         return [stateRound, stateGlobal, messages, true, toolState];


### PR DESCRIPTION
## Summary
- default the round prefill to an empty string when prepareRoundContext omits it
- keep the run pipeline invocation using a plain string to satisfy model handler expectations

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f548fa569c8324b0c76eff1c3c7fee

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `runRoundPipeline` always receives a string by defaulting `prefill` to `''` when `prepareRoundContext` omits it.
> 
> - **Agent**:
>   - In `src/agent/implementations/BaseReflectionAgent.ts` `executeRound`, destructuring now defaults `prefill = ''` from `prepareRoundContext`.
>   - Guarantees `runRoundPipeline` and model handler receive a string `prefill`, avoiding `undefined` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 954b1fc3399ef409f8784b03534ce33db198f64c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->