### PR TITLE
fix: stabilize round output path access

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -507,6 +507,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         return [stateRound, stateGlobal, messages, true, toolState];
       }
 
+      const outputPath = this.outputFile[currRound] ?? this.getOutputFile(currRound);
+      this.outputFile[currRound] = outputPath;
+
       return this.runRoundPipeline(
         currRound,
         stateRound,
@@ -514,7 +517,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         toolState,
         preparedMessages,
         prefill,
-        this.outputFile[currRound],
+        outputPath,
         roundGroupId,
       );
     });


### PR DESCRIPTION
## Summary
- ensure each round reuses a guaranteed output path before invoking the round pipeline

## Testing
- npm run compile *(fails: webpack command hung in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f548fa569c8324b0c76eff1c3c7fee

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cache and reuse the per-round output path, passing a stable `outputPath` to the round pipeline.
> 
> - **Agent core** (`src/agent/implementations/BaseReflectionAgent.ts`):
>   - Cache per-round output path via `const outputPath = this.outputFile[currRound] ?? this.getOutputFile(currRound)` and store back to `this.outputFile[currRound]`.
>   - Pass the stable `outputPath` to `runRoundPipeline` to ensure consistent file handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2df2b5c425472ca18e4780cb411328082d29ebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->