### PR TITLE
fix: harden progress follow-up shared helpers

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -507,6 +507,14 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         return [stateRound, stateGlobal, messages, true, toolState];
       }
 
+      const outputPath = this.outputFile[currRound];
+      if (outputPath === undefined) {
+        throw new Error(`Missing output file path for round ${currRound}`);
+      }
+      if (typeof prefill !== 'string') {
+        throw new Error(`Missing prefill text for round ${currRound}`);
+      }
+
       return this.runRoundPipeline(
         currRound,
         stateRound,
@@ -514,7 +522,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         toolState,
         preparedMessages,
         prefill,
-        this.outputFile[currRound],
+        outputPath,
         roundGroupId,
       );
     });

--- a/src/common/modules/RecordingButtonManager.js
+++ b/src/common/modules/RecordingButtonManager.js
@@ -1,0 +1,134 @@
+// Local imports - common
+import { addEventListenerSafely, safeGetElementById } from './domUtils.js';
+import { createCodicon } from './templateUtils.js';
+
+/**
+ * Lightweight controller for a recording toggle button shared across webviews.
+ */
+export class RecordingButtonManager {
+  constructor({
+    vscode,
+    buttonId,
+    startCommand,
+    stopCommand,
+    idleTitle = 'Record with microphone',
+    recordingTitle = 'Stop recording',
+    idleIcon = 'mic',
+    recordingIcon = 'stop-circle',
+    recordingClass = 'recording',
+    eventBus = null,
+    eventName = 'recordingUIUpdate',
+    createMessagePayload = () => ({}),
+  }) {
+    this.vscode = vscode;
+    this.buttonId = buttonId;
+    this.startCommand = startCommand;
+    this.stopCommand = stopCommand;
+    this.idleTitle = idleTitle;
+    this.recordingTitle = recordingTitle;
+    this.idleIcon = idleIcon;
+    this.recordingIcon = recordingIcon;
+    this.recordingClass = recordingClass;
+    this.eventBus = eventBus;
+    this.eventName = eventName;
+    this.createMessagePayload = createMessagePayload;
+    this.isRecording = false;
+  }
+
+  /**
+   * Initialize the button by wiring up event listeners and syncing UI state.
+   */
+  setup() {
+    const button = safeGetElementById(this.buttonId);
+    if (!button) {
+      return;
+    }
+
+    this._render(button);
+
+    addEventListenerSafely(this.buttonId, 'click', () => {
+      const target = safeGetElementById(this.buttonId);
+      if (target?.disabled) {
+        return;
+      }
+      if (this.isRecording) {
+        this.stopRecording();
+      } else {
+        this.startRecording();
+      }
+    });
+
+    if (this.eventBus) {
+      this.eventBus.addEventListener(this.eventName, (event) => {
+        const recording = Boolean(event?.detail?.recording);
+        this.setRecording(recording);
+      });
+    }
+  }
+
+  /** Start recording and notify the extension. */
+  startRecording() {
+    if (this.isRecording) {
+      return;
+    }
+    this.isRecording = true;
+    this.vscode.postMessage({
+      command: this.startCommand,
+      ...this.createMessagePayload(),
+    });
+    this._render();
+    this._dispatchEvent(true);
+  }
+
+  /** Stop recording and notify the extension. */
+  stopRecording() {
+    if (!this.isRecording) {
+      return;
+    }
+    this.isRecording = false;
+    this.vscode.postMessage({
+      command: this.stopCommand,
+      ...this.createMessagePayload(),
+    });
+    this._render();
+    this._dispatchEvent(false);
+  }
+
+  /** Update UI state without posting messages. */
+  setRecording(recording) {
+    this.isRecording = Boolean(recording);
+    this._render();
+  }
+
+  /** Returns whether the button is currently marked as recording. */
+  isRecordingActive() {
+    return this.isRecording;
+  }
+
+  _dispatchEvent(recording) {
+    if (!this.eventBus) {
+      return;
+    }
+    this.eventBus.dispatchEvent(
+      new CustomEvent(this.eventName, { detail: { recording } }),
+    );
+  }
+
+  _render(buttonElement) {
+    const button = buttonElement || safeGetElementById(this.buttonId);
+    if (!button) {
+      return;
+    }
+
+    button.innerHTML = '';
+    const icon = createCodicon(
+      this.isRecording ? this.recordingIcon : this.idleIcon,
+    );
+    if (icon) {
+      button.appendChild(icon);
+    }
+    button.title = this.isRecording ? this.recordingTitle : this.idleTitle;
+    button.classList.toggle(this.recordingClass, this.isRecording);
+    button.setAttribute('aria-pressed', this.isRecording ? 'true' : 'false');
+  }
+}

--- a/src/common/modules/textareaUtils.js
+++ b/src/common/modules/textareaUtils.js
@@ -1,0 +1,38 @@
+// Utility helpers for managing textarea interactions across webviews.
+
+/**
+ * Automatically resize a textarea based on its scroll height while capping the
+ * maximum height to maintain layout stability.
+ *
+ * @param {HTMLTextAreaElement} textarea - The textarea to resize.
+ * @param {number} [maxHeight=400] - Maximum height in pixels.
+ */
+export function autoResizeTextarea(textarea, maxHeight = 400) {
+  if (!textarea) return;
+
+  textarea.style.height = 'auto';
+  const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+  textarea.style.height = `${newHeight}px`;
+  textarea.style.overflowY =
+    textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+}
+
+/**
+ * Insert text at the cursor position of a textarea, replacing any selected text.
+ *
+ * @param {HTMLTextAreaElement} textarea - Target textarea.
+ * @param {string} text - Text to insert.
+ */
+export function insertTextAtCursor(textarea, text) {
+  if (!textarea || typeof text !== 'string') {
+    return;
+  }
+
+  const start = textarea.selectionStart ?? textarea.value.length;
+  const end = textarea.selectionEnd ?? textarea.value.length;
+  const original = textarea.value;
+  textarea.value = `${original.slice(0, start)}${text}${original.slice(end)}`;
+  const cursor = start + text.length;
+  textarea.selectionStart = cursor;
+  textarea.selectionEnd = cursor;
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -159,6 +159,10 @@ export abstract class BaseViewContentProvider {
         webview,
         'modules/iconButtonInitializer.js',
       ),
+      recordingButtonManagerUri: this.getCommonUri(
+        webview,
+        'modules/RecordingButtonManager.js',
+      ),
       htmlEncodingUri: this.getCommonUri(webview, 'modules/htmlEncoding.js'),
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       baseWebviewMessageHandlerUri: this.getCommonUri(
@@ -170,6 +174,7 @@ export abstract class BaseViewContentProvider {
         webview,
         'modules/BaseDomHandler.js',
       ),
+      textareaUtilsUri: this.getCommonUri(webview, 'modules/textareaUtils.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
       pathUtilsUri: this.getCommonUri(webview, 'modules/pathUtils.js'),
       codiconUri: this.getNodeModulesUri(

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -185,6 +185,14 @@ export const PROGRESS_VIEW_COMMANDS = {
   FILTER_STREAMS: 'filterStreams',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
+  POLISH_FOLLOW_UP: 'polishFollowUp',
+  FOLLOW_UP_TEXT_POLISHED: 'followUpTextPolished',
+  START_RECORDING: 'startRecording',
+  STOP_RECORDING: 'stopRecording',
+  RECORDING_STARTED: 'recordingStarted',
+  RECORDING_ERROR: 'recordingError',
+  FOLLOW_UP_TEXT_TRANSCRIBED: 'followUpTextTranscribed',
+  SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
 
   // File operations

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -182,6 +182,14 @@ export const PROGRESS_VIEW_COMMANDS = {
   FILTER_STREAMS: 'filterStreams',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
+  POLISH_FOLLOW_UP: 'polishFollowUp',
+  FOLLOW_UP_TEXT_POLISHED: 'followUpTextPolished',
+  START_RECORDING: 'startRecording',
+  STOP_RECORDING: 'stopRecording',
+  RECORDING_STARTED: 'recordingStarted',
+  RECORDING_ERROR: 'recordingError',
+  FOLLOW_UP_TEXT_TRANSCRIBED: 'followUpTextTranscribed',
+  SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
 
   // File operations

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -36,6 +36,10 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
       key: 'instructionPanelUri',
       path: 'modules/uiManagers/InstructionPanel.js',
     },
+    {
+      key: 'followUpInputUri',
+      path: 'modules/uiManagers/FollowUpInputManager.js',
+    },
   ];
 
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,12 +12,21 @@ import {
   AgentTypeFilter,
   isAgentTypeFilter,
 } from '@agent/types/AgentStreamTypes';
-import { isWorkflowTaskState, type WorkflowTaskState } from '@logger/TaskState';
+import {
+  isWorkflowTaskState,
+  type WorkflowTaskState,
+  type TaskState,
+} from '@logger/TaskState';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - storage
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
 // Local imports - commands
 import { safeExecuteCommand } from '@utils/system/commandUtils';
+import { RecordingManager } from '@webview/managers/RecordingManager';
+import {
+  polishTextWithAI,
+  type FileContext,
+} from '@utils/text/textEnhancementUtils';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -35,8 +44,20 @@ interface CompareMessage extends BaseFileCommandMessage {
 }
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
-  constructor(private readonly provider: ProgressViewProvider) {
+  private readonly recordingManager: RecordingManager;
+
+  constructor(
+    private readonly provider: ProgressViewProvider,
+    private readonly extensionContext: vscode.ExtensionContext,
+  ) {
     super('ProgressView');
+    this.recordingManager = new RecordingManager(extensionContext, {
+      startRecording: PROGRESS_VIEW_COMMANDS.START_RECORDING,
+      stopRecording: PROGRESS_VIEW_COMMANDS.STOP_RECORDING,
+      recordingStarted: PROGRESS_VIEW_COMMANDS.RECORDING_STARTED,
+      recordingError: PROGRESS_VIEW_COMMANDS.RECORDING_ERROR,
+      transcription: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED,
+    });
   }
 
   private async deleteSessionSnapshot(stream: StreamTabId): Promise<void> {
@@ -81,6 +102,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         this.handleRestoreState.bind(this),
       [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]:
         this.handleSendFollowUp.bind(this),
+      [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]:
+        this.handlePolishFollowUp.bind(this),
+      [PROGRESS_VIEW_COMMANDS.START_RECORDING]:
+        this.handleStartRecording.bind(this),
+      [PROGRESS_VIEW_COMMANDS.STOP_RECORDING]:
+        this.handleStopRecording.bind(this),
+      [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]:
+        this.handleShowInformationMessage.bind(this),
       [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]:
         this.handleOpenTaskStorage.bind(this),
 
@@ -244,6 +273,77 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       stream: message.stream,
       text: message.text,
     });
+  }
+
+  private async handlePolishFollowUp(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const text = typeof message?.text === 'string' ? message.text.trim() : '';
+    if (!text) {
+      return;
+    }
+
+    const stream = message.stream as StreamTabId | undefined;
+    const taskState = stream
+      ? this.provider.state.getTaskState(stream)
+      : undefined;
+    const fileContext = this.buildFileContext(taskState);
+
+    try {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Polishing follow-up text',
+          cancellable: false,
+        },
+        async () => {
+          const result = await polishTextWithAI(text, fileContext);
+          if (result.success) {
+            webviewView.webview.postMessage({
+              command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISHED,
+              text: result.text,
+            });
+            await vscode.window.showInformationMessage(
+              'Follow-up text polished!',
+            );
+          } else if (result.error) {
+            await vscode.window.showErrorMessage(result.error);
+          }
+        },
+      );
+    } catch (error) {
+      const messageText =
+        error instanceof Error ? error.message : String(error);
+      await vscode.window.showErrorMessage(
+        `Error polishing follow-up: ${messageText}`,
+      );
+      this.logger.error(
+        this.channel,
+        `Error polishing follow-up: ${messageText}`,
+      );
+    }
+  }
+
+  private async handleStartRecording(
+    _message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    await this.recordingManager.start(webviewView);
+  }
+
+  private async handleStopRecording(
+    _message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    await this.recordingManager.stop(webviewView);
+  }
+
+  private async handleShowInformationMessage(message: any): Promise<void> {
+    const text = typeof message?.text === 'string' ? message.text.trim() : '';
+    if (text) {
+      await vscode.window.showInformationMessage(text);
+    }
   }
 
   private async handleOpenTaskStorage(
@@ -479,5 +579,60 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     }
 
     await action(taskState);
+  }
+
+  private buildFileContext(
+    taskState?: TaskState | null,
+  ): FileContext | undefined {
+    if (!taskState) {
+      return undefined;
+    }
+
+    const context: FileContext = {};
+    const { agentConfig } = taskState;
+
+    type SingleFileContextKey =
+      | 'agent'
+      | 'inputFile'
+      | 'referenceFile'
+      | 'auxiliaryFile'
+      | 'mediaFile';
+    type ArrayFileContextKey =
+      | 'inputFiles'
+      | 'referenceFiles'
+      | 'auxiliaryFiles'
+      | 'mediaFiles'
+      | 'outputFiles';
+
+    const assignSingle = (
+      value: string | null | undefined,
+      key: SingleFileContextKey,
+    ) => {
+      if (value && value !== 'None') {
+        context[key] = value;
+      }
+    };
+
+    const assignArray = (
+      value: string[] | null | undefined,
+      key: ArrayFileContextKey,
+    ) => {
+      if (Array.isArray(value) && value.length > 0) {
+        context[key] = value;
+      }
+    };
+
+    assignSingle(agentConfig.agent, 'agent');
+    assignSingle(agentConfig.inputFile, 'inputFile');
+    assignArray(agentConfig.inputFiles ?? undefined, 'inputFiles');
+    assignSingle(agentConfig.referenceFile ?? undefined, 'referenceFile');
+    assignArray(agentConfig.referenceFiles ?? undefined, 'referenceFiles');
+    assignSingle(agentConfig.auxiliaryFile ?? undefined, 'auxiliaryFile');
+    assignArray(agentConfig.auxiliaryFiles ?? undefined, 'auxiliaryFiles');
+    assignSingle(agentConfig.mediaFile ?? undefined, 'mediaFile');
+    assignArray(agentConfig.mediaFiles ?? undefined, 'mediaFiles');
+    assignArray(agentConfig.outputFiles ?? undefined, 'outputFiles');
+
+    return context;
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -83,7 +83,7 @@ export class ProgressViewProvider
 
     // Initialize existing components
     this.contentProvider = new ProgressViewContentProvider(context);
-    this.messageHandler = new ProgressViewMessageHandler(this);
+    this.messageHandler = new ProgressViewMessageHandler(this, context);
 
     // Set instance
     ProgressViewProvider._instance = this;

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -44,6 +44,7 @@
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
           "./modules/uiManagers/Placeholder.js": "${placeholderUri}",
           "./modules/uiManagers/InstructionPanel.js": "${instructionPanelUri}",
+          "./modules/uiManagers/FollowUpInputManager.js": "${followUpInputUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
@@ -52,6 +53,8 @@
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/modules/RecordingButtonManager.js": "${recordingButtonManagerUri}",
+          "@common/modules/textareaUtils.js": "${textareaUtilsUri}",
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
@@ -132,12 +135,26 @@
             class="vscode-textarea"
             placeholder="Send follow-up message"
           ></textarea>
-          <button
-            id="sendFollowUpBtn"
-            class="vscode-button"
-            title="Send"
-            data-icon="send"
-          ></button>
+          <div class="follow-up-actions button-group">
+            <button
+              id="polishFollowUpBtn"
+              class="vscode-button"
+              title="Polish follow-up text"
+              data-icon="sparkle"
+            ></button>
+            <button
+              id="recordFollowUpBtn"
+              class="vscode-button"
+              title="Record follow-up with microphone"
+              data-icon="mic"
+            ></button>
+            <button
+              id="sendFollowUpBtn"
+              class="vscode-button"
+              title="Send"
+              data-icon="send"
+            ></button>
+          </div>
         </div>
         <template id="fileItemTemplate">
           <div class="file-item">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -49,6 +49,8 @@ export const ELEMENT_IDS = {
   FOLLOW_UP_CONTAINER: 'followUpContainer',
   FOLLOW_UP_INPUT: 'followUpInput',
   SEND_FOLLOW_UP_BTN: 'sendFollowUpBtn',
+  POLISH_FOLLOW_UP_BUTTON: 'polishFollowUpBtn',
+  RECORD_FOLLOW_UP_BUTTON: 'recordFollowUpBtn',
   AGENT_FILTER_CONTAINER: 'agentFilterButtons',
   FILTER_ALL_BTN: 'filterAllBtn',
   FILTER_WORKFLOW_BTN: 'filterWorkflowBtn',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -9,6 +9,7 @@ import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Placeholder } from './uiManagers/Placeholder.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
+import { FollowUpInputManager } from './uiManagers/FollowUpInputManager.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
@@ -19,6 +20,7 @@ import { BaseDomHandler } from '@common/BaseDomHandler.js';
 class ProgressViewDomHandler extends BaseDomHandler {
   constructor() {
     const usageSummary = new UsageSummary();
+    const followUpInput = new FollowUpInputManager();
     super({
       streamTabs: new StreamTabs(),
       toolbar: new Toolbar(),
@@ -31,6 +33,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       events: new EventsManager(),
       placeholder: new Placeholder(),
       instructionPanel: new InstructionPanel(),
+      followUpInput,
     });
   }
 }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -6,6 +6,7 @@ import { appendFormatted } from './utils.js';
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
+import { vscode } from '@common/webviewContext.js';
 
 // Session kind values match TypeScript AgentSessionKind enum
 // No need to duplicate - we use the actual values from messages
@@ -56,6 +57,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       [COMMANDS.UPDATE_INSTRUCTION]: (m) => this.handleUpdateInstruction(m),
       [COMMANDS.DELETE_STREAM]: (m) => this.handleDeleteStream(m),
       [COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
+      [COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED]: (m) =>
+        this.handleFollowUpTextTranscribed(m),
+      [COMMANDS.FOLLOW_UP_TEXT_POLISHED]: (m) =>
+        this.handleFollowUpTextPolished(m),
+      [COMMANDS.RECORDING_STARTED]: () => this.handleRecordingStarted(),
+      [COMMANDS.RECORDING_ERROR]: (m) => this.handleRecordingError(m),
     };
   }
 
@@ -100,6 +107,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       container.classList.toggle('is-visible', isToolAgent);
       container.setAttribute('aria-hidden', isToolAgent ? 'false' : 'true');
     }
+
+    dom.followUpInput.setEnabled(isToolAgent && Boolean(message.activeStream));
 
     dom.toolbar.render(sessionKind);
 
@@ -250,6 +259,31 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream === state.activeStream) {
       dom.usageGroup.update(message.groupId, message.usage);
     }
+  }
+
+  handleFollowUpTextTranscribed(message) {
+    if (message?.text) {
+      dom.followUpInput.insertTranscription(message.text);
+      vscode.postMessage({
+        command: COMMANDS.SHOW_INFORMATION_MESSAGE,
+        text: 'Follow-up text transcribed!',
+      });
+    }
+    dom.followUpInput.setRecording(false);
+  }
+
+  handleFollowUpTextPolished(message) {
+    if (message?.text) {
+      dom.followUpInput.applyPolishedText(message.text);
+    }
+  }
+
+  handleRecordingStarted() {
+    dom.followUpInput.setRecording(true);
+  }
+
+  handleRecordingError() {
+    dom.followUpInput.setRecording(false);
   }
 
   handleUpdateFiles(message) {

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -112,32 +112,6 @@ export class EventsManager {
       }
     });
 
-    // Follow-up input handler
-    const sendFollowUp = () => {
-      const followInput = document.getElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
-      if (!followInput) return;
-      const text = followInput.value.trim();
-      if (!text) return;
-      vscode.postMessage({
-        command: COMMANDS.SEND_FOLLOW_UP,
-        stream: progressViewState.activeStream,
-        text,
-      });
-      followInput.value = '';
-    };
-    addEventListenerSafely(
-      ELEMENT_IDS.SEND_FOLLOW_UP_BTN,
-      'click',
-      sendFollowUp,
-    );
-    addEventListenerSafely(ELEMENT_IDS.FOLLOW_UP_INPUT, 'keydown', (e) => {
-      // Enter sends, Shift+Enter adds new line
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        sendFollowUp();
-      }
-    });
-
     // Initialize split view
     Split(['.content-area', '.tabs'], {
       sizes: [SPLIT_SIZES.CONTENT, SPLIT_SIZES.TABS],

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -1,0 +1,187 @@
+// Local imports - progress view
+import { COMMANDS, ELEMENT_IDS } from '../constants.js';
+import { progressViewState } from '../progressViewState.js';
+import { RecordingButtonManager } from '@common/modules/RecordingButtonManager.js';
+import {
+  autoResizeTextarea,
+  insertTextAtCursor,
+} from '@common/modules/textareaUtils.js';
+import {
+  addEventListenerSafely,
+  safeGetElementById,
+} from '@common/domUtils.js';
+import { vscode } from '@common/webviewContext.js';
+
+export class FollowUpInputManager {
+  constructor(vscodeInstance = vscode, state = progressViewState) {
+    this.vscode = vscodeInstance;
+    this.state = state;
+    this.textarea = null;
+    this.sendButton = null;
+    this.polishButton = null;
+    this.container = null;
+    this.enabled = false;
+    this.pendingRecordingState = undefined;
+    this.recordingButtonInitialized = false;
+    this.recordingButton = new RecordingButtonManager({
+      vscode: this.vscode,
+      buttonId: ELEMENT_IDS.RECORD_FOLLOW_UP_BUTTON,
+      startCommand: COMMANDS.START_RECORDING,
+      stopCommand: COMMANDS.STOP_RECORDING,
+      idleTitle: 'Record follow-up with microphone',
+      recordingTitle: 'Stop recording',
+      createMessagePayload: () => ({ stream: this.state.activeStream }),
+    });
+  }
+
+  setup() {
+    this.textarea = safeGetElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
+    this.sendButton = safeGetElementById(ELEMENT_IDS.SEND_FOLLOW_UP_BTN);
+    this.polishButton = safeGetElementById(ELEMENT_IDS.POLISH_FOLLOW_UP_BUTTON);
+    this.container = safeGetElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
+
+    if (!this.textarea) {
+      return;
+    }
+
+    autoResizeTextarea(this.textarea);
+    addEventListenerSafely(ELEMENT_IDS.FOLLOW_UP_INPUT, 'input', () => {
+      autoResizeTextarea(this.textarea);
+    });
+
+    addEventListenerSafely(ELEMENT_IDS.FOLLOW_UP_INPUT, 'keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        this.sendFollowUp();
+      }
+    });
+
+    addEventListenerSafely(ELEMENT_IDS.SEND_FOLLOW_UP_BTN, 'click', () => {
+      this.sendFollowUp();
+    });
+
+    addEventListenerSafely(ELEMENT_IDS.POLISH_FOLLOW_UP_BUTTON, 'click', () => {
+      this.requestPolish();
+    });
+
+    this.recordingButton.setup();
+    this.recordingButtonInitialized = true;
+    if (this.pendingRecordingState !== undefined) {
+      this.recordingButton.setRecording(this.pendingRecordingState);
+      this.pendingRecordingState = undefined;
+    }
+
+    this._applyEnabledState();
+  }
+
+  setEnabled(enabled) {
+    this.enabled = Boolean(enabled);
+    this._applyEnabledState();
+    if (!this.enabled && this.recordingButtonInitialized) {
+      if (this.recordingButton.isRecordingActive()) {
+        this.recordingButton.stopRecording();
+      }
+      this.clear();
+    }
+  }
+
+  sendFollowUp() {
+    if (!this.enabled || !this.textarea) {
+      return;
+    }
+    const stream = this.state.activeStream;
+    const text = this.textarea.value.trim();
+    if (!stream || !text) {
+      return;
+    }
+    this.vscode.postMessage({
+      command: COMMANDS.SEND_FOLLOW_UP,
+      stream,
+      text,
+    });
+    this.clear();
+  }
+
+  requestPolish() {
+    if (!this.enabled || !this.textarea) {
+      return;
+    }
+    const stream = this.state.activeStream;
+    const text = this.textarea.value.trim();
+    if (!stream || !text) {
+      return;
+    }
+    this.vscode.postMessage({
+      command: COMMANDS.POLISH_FOLLOW_UP,
+      stream,
+      text,
+    });
+  }
+
+  insertTranscription(text) {
+    if (!this.textarea) {
+      return;
+    }
+    insertTextAtCursor(this.textarea, text);
+    autoResizeTextarea(this.textarea);
+    this.textarea.focus();
+  }
+
+  applyPolishedText(text) {
+    if (!this.textarea) {
+      return;
+    }
+    this.textarea.value = text;
+    autoResizeTextarea(this.textarea);
+    const end = this.textarea.value.length;
+    this.textarea.setSelectionRange(end, end);
+    this.textarea.focus();
+  }
+
+  setRecording(recording) {
+    if (!this.recordingButtonInitialized) {
+      this.pendingRecordingState = recording;
+      return;
+    }
+    this.recordingButton.setRecording(recording);
+  }
+
+  stopRecording() {
+    if (!this.recordingButtonInitialized) {
+      this.pendingRecordingState = false;
+      return;
+    }
+    if (this.recordingButton.isRecordingActive()) {
+      this.recordingButton.stopRecording();
+    } else {
+      this.recordingButton.setRecording(false);
+    }
+  }
+
+  clear() {
+    if (!this.textarea) {
+      return;
+    }
+    this.textarea.value = '';
+    autoResizeTextarea(this.textarea);
+  }
+
+  _applyEnabledState() {
+    const disabled = !this.enabled;
+    if (this.textarea) {
+      this.textarea.disabled = disabled;
+    }
+    if (this.sendButton) {
+      this.sendButton.disabled = disabled;
+    }
+    if (this.polishButton) {
+      this.polishButton.disabled = disabled;
+    }
+    const recordButton = safeGetElementById(
+      ELEMENT_IDS.RECORD_FOLLOW_UP_BUTTON,
+    );
+    if (recordButton) {
+      recordButton.disabled = disabled;
+    }
+  }
+}

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initializeIconButtons();
   progressViewDomHandler.toolbar.render('workflow');
   progressViewDomHandler.placeholder.show();
+  progressViewDomHandler.followUpInput.setup();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();
 

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -19,14 +19,19 @@
 /* Style the textarea for multi-line input */
 #followUpInput {
   min-height: 36px;
-  max-height: 200px;
+  max-height: 400px;
   resize: none;
   flex: 1;
-  overflow-y: auto;
+  overflow-y: hidden;
   line-height: 1.4;
 }
 
-/* Align send button to bottom */
-#sendFollowUpBtn {
-  margin-bottom: var(--spacing-tiny);
+.follow-up-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+}
+
+.follow-up-actions .vscode-button {
+  margin: 0;
 }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -39,6 +39,8 @@
           "@common/webview/themeHandlers.js": "${webviewThemeHandlersUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
+          "@common/modules/RecordingButtonManager.js": "${recordingButtonManagerUri}",
+          "@common/modules/textareaUtils.js": "${textareaUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",

--- a/src/webview/managers/RecordingManager.ts
+++ b/src/webview/managers/RecordingManager.ts
@@ -16,20 +16,47 @@ import * as logger from '@logger/logUtils';
 const CHANNEL = 'RecordingManager';
 logger.initialize(CHANNEL);
 
+interface RecordingCommandOverrides {
+  startRecording?: string;
+  stopRecording?: string;
+  recordingStarted?: string;
+  recordingError?: string;
+  transcription?: string;
+}
+
 export class RecordingManager {
-  constructor(private readonly context: vscode.ExtensionContext) {}
+  private readonly commands: Required<RecordingCommandOverrides>;
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    overrides: RecordingCommandOverrides = {},
+  ) {
+    this.commands = {
+      startRecording:
+        overrides.startRecording ?? MAIN_VIEW_COMMANDS.START_RECORDING,
+      stopRecording:
+        overrides.stopRecording ?? MAIN_VIEW_COMMANDS.STOP_RECORDING,
+      recordingStarted:
+        overrides.recordingStarted ?? MAIN_VIEW_COMMANDS.RECORDING_STARTED,
+      recordingError:
+        overrides.recordingError ?? MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+      transcription:
+        overrides.transcription ??
+        MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED,
+    };
+  }
 
   async start(webviewView: vscode.WebviewView): Promise<void> {
     try {
       const result = await startRecording(this.context);
       if (result.success) {
         webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.RECORDING_STARTED,
+          command: this.commands.recordingStarted,
         });
       } else if (result.error) {
         vscode.window.showErrorMessage(result.error);
         webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+          command: this.commands.recordingError,
           error: result.error,
         });
       }
@@ -42,7 +69,7 @@ export class RecordingManager {
         `Error in start: ${error instanceof Error ? error.message : String(error)}`,
       );
       webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+        command: this.commands.recordingError,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }
@@ -60,13 +87,13 @@ export class RecordingManager {
           const result = await stopRecordingAndTranscribe(this.context);
           if (result.success) {
             webviewView.webview.postMessage({
-              command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED,
+              command: this.commands.transcription,
               text: result.text,
             });
           } else if (result.error) {
             vscode.window.showErrorMessage(result.error);
             webviewView.webview.postMessage({
-              command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+              command: this.commands.recordingError,
               error: result.error,
             });
           }
@@ -81,7 +108,7 @@ export class RecordingManager {
         `Error in stop: ${error instanceof Error ? error.message : String(error)}`,
       );
       webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+        command: this.commands.recordingError,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }

--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -1,6 +1,10 @@
 // Local imports - webview
 import { setupPasteListener } from '../pasteHandler.js';
 import { safeGetElementById } from '@common/domUtils.js';
+import {
+  autoResizeTextarea as resizeTextarea,
+  insertTextAtCursor as insertAtCursor,
+} from '@common/modules/textareaUtils.js';
 
 export class InstructionManager {
   constructor(textareaId, vscode, state) {
@@ -10,20 +14,11 @@ export class InstructionManager {
   }
 
   autoResizeTextarea(textarea) {
-    textarea.style.height = 'auto';
-    const maxHeight = 400;
-    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
-    textarea.style.height = `${newHeight}px`;
-    textarea.style.overflowY =
-      textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    resizeTextarea(textarea);
   }
 
   insertTextAtCursor(textarea, text) {
-    const start = textarea.selectionStart;
-    const end = textarea.selectionEnd;
-    const original = textarea.value;
-    textarea.value = original.slice(0, start) + text + original.slice(end);
-    textarea.selectionStart = textarea.selectionEnd = start + text.length;
+    insertAtCursor(textarea, text);
   }
 
   setup() {

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -1,58 +1,27 @@
 // Local imports - webview
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
-import {
-  addEventListenerSafely,
-  safeGetElementById,
-} from '@common/domUtils.js';
-import { createCodicon } from '@common/templateUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { RecordingButtonManager } from '@common/modules/RecordingButtonManager.js';
 
-export class RecordingManager {
+export class RecordingManager extends RecordingButtonManager {
   constructor(vscode, eventBus = webviewEventBus) {
-    this.vscode = vscode;
-    this.eventBus = eventBus;
-    this.isRecording = false;
+    super({
+      vscode,
+      buttonId: ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON,
+      startCommand: MAIN_VIEW_COMMANDS.START_RECORDING,
+      stopCommand: MAIN_VIEW_COMMANDS.STOP_RECORDING,
+      idleTitle: 'Record instruction with microphone',
+      recordingTitle: 'Stop recording',
+      eventBus,
+    });
   }
 
   updateRecordingUI(recording) {
-    this.isRecording = recording;
-    const recordButton = safeGetElementById(
-      ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON,
-    );
-    if (recordButton) {
-      recordButton.innerHTML = '';
-      const iconName = recording ? 'stop-circle' : 'mic';
-      const icon = createCodicon(iconName);
-      if (icon) recordButton.appendChild(icon);
-      recordButton.title = recording
-        ? 'Stop recording'
-        : 'Record instruction with microphone';
-      recordButton.classList.toggle('recording', recording);
-    }
+    this.setRecording(recording);
   }
 
   setupRecordButton() {
-    const buttonId = ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON;
-    const button = safeGetElementById(buttonId);
-    if (!button) return;
-
-    addEventListenerSafely(buttonId, 'click', () => {
-      const nextState = !this.isRecording;
-      this.vscode.postMessage({
-        command: nextState
-          ? MAIN_VIEW_COMMANDS.START_RECORDING
-          : MAIN_VIEW_COMMANDS.STOP_RECORDING,
-      });
-      this.eventBus.dispatchEvent(
-        new CustomEvent('recordingUIUpdate', {
-          detail: { recording: nextState },
-        }),
-      );
-    });
-
-    this.eventBus.addEventListener('recordingUIUpdate', (e) => {
-      this.updateRecordingUI(e.detail.recording);
-    });
+    this.setup();
   }
 }


### PR DESCRIPTION
## Summary
- ensure reflection agent rounds throw when missing output paths or prefill text before invoking the shared pipeline
- narrow follow-up polishing file-context helpers to explicit key unions to satisfy TypeScript strictness

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: `/workspace/TeXRA/.vscode-test/vscode-linux-x64-1.105.1/code: error while loading shared libraries: libatk-1.0.so.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68f53e3c44148324b45375d213562cd6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds polish-and-record follow-up UX to Progress View using shared button/textarea utils, integrates recording/transcription pipeline, and validates output/prefill before reflection rounds.
> 
> - **Progress View (UI/UX)**:
>   - **Follow-up input**: Adds polish (`sparkle`) and microphone record controls alongside send; introduces `FollowUpInputManager` to handle send/polish/record, auto-resize, and text insertion.
>   - **Message handling**: New handlers for polishing results, transcription, recording started/error; enables input only for tool-use sessions.
>   - **HTML/CSS**: Updates import map and layout; styles follow-up actions; increases textarea max height.
> - **Extension/Backend**:
>   - **Recording**: Generalizes `RecordingManager` to accept command overrides; wires start/stop + transcription to Progress View; adds info/error notifications.
>   - **Polish**: Implements `polishFollowUp` command using `polishTextWithAI` with narrowed `FileContext` builder.
> - **Common Modules**:
>   - Adds `RecordingButtonManager` and `textareaUtils` and exposes them to webviews.
> - **Main View**:
>   - Refactors instruction textarea to use shared `textareaUtils` and recording UI to extend `RecordingButtonManager`.
> - **Agent**:
>   - Validates `outputPath` and `prefill` in `BaseReflectionAgent.executeRound` before running the round pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15465e67fd84627595279288e1de7806133e19cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->