### PR TITLE
feat: unify follow-up input controls

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -513,7 +513,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         stateGlobal,
         toolState,
         preparedMessages,
-        prefill,
+        prefill ?? '',
         this.outputFile[currRound],
         roundGroupId,
       );

--- a/src/common/modules/recordingButtonManager.js
+++ b/src/common/modules/recordingButtonManager.js
@@ -1,0 +1,90 @@
+// Local imports - common
+import { addEventListenerSafely, safeGetElementById } from './domUtils.js';
+import { createCodicon } from './templateUtils.js';
+
+const DEFAULT_IDLE_ICON = 'mic';
+const DEFAULT_RECORDING_ICON = 'stop-circle';
+const RECORDING_EVENT = 'recordingUIUpdate';
+
+/**
+ * Lightweight controller for a recording toggle button shared across webviews.
+ */
+export class RecordingButtonManager {
+  constructor({
+    buttonId,
+    vscode,
+    startCommand,
+    stopCommand,
+    eventTarget,
+    idleIcon = DEFAULT_IDLE_ICON,
+    recordingIcon = DEFAULT_RECORDING_ICON,
+    idleTitle = 'Record with microphone',
+    recordingTitle = 'Stop recording',
+    recordingClass = 'recording',
+  }) {
+    this.buttonId = buttonId;
+    this.vscode = vscode;
+    this.startCommand = startCommand;
+    this.stopCommand = stopCommand;
+    this.eventTarget = eventTarget;
+    this.idleIcon = idleIcon;
+    this.recordingIcon = recordingIcon;
+    this.idleTitle = idleTitle;
+    this.recordingTitle = recordingTitle;
+    this.recordingClass = recordingClass;
+    this.isRecording = false;
+  }
+
+  setup() {
+    const button = safeGetElementById(this.buttonId);
+    if (!button) {
+      return;
+    }
+
+    this._render();
+
+    addEventListenerSafely(this.buttonId, 'click', () => {
+      const nextState = !this.isRecording;
+      this.vscode.postMessage({
+        command: nextState ? this.startCommand : this.stopCommand,
+      });
+      this._emitRecordingState(nextState);
+    });
+
+    if (this.eventTarget) {
+      this.eventTarget.addEventListener(RECORDING_EVENT, (event) => {
+        const recording = Boolean(event?.detail?.recording);
+        this.setRecording(recording);
+      });
+    }
+  }
+
+  setRecording(recording) {
+    this.isRecording = Boolean(recording);
+    this._render();
+  }
+
+  _emitRecordingState(recording) {
+    this.setRecording(recording);
+    if (this.eventTarget) {
+      this.eventTarget.dispatchEvent(
+        new CustomEvent(RECORDING_EVENT, { detail: { recording } }),
+      );
+    }
+  }
+
+  _render() {
+    const button = safeGetElementById(this.buttonId);
+    if (!button) {
+      return;
+    }
+    button.innerHTML = '';
+    const iconName = this.isRecording ? this.recordingIcon : this.idleIcon;
+    const icon = createCodicon(iconName);
+    if (icon) {
+      button.appendChild(icon);
+    }
+    button.title = this.isRecording ? this.recordingTitle : this.idleTitle;
+    button.classList.toggle(this.recordingClass, this.isRecording);
+  }
+}

--- a/src/common/modules/textareaUtils.js
+++ b/src/common/modules/textareaUtils.js
@@ -1,0 +1,65 @@
+// Local imports - common
+import { safeGetElementById } from './domUtils.js';
+
+const DEFAULT_MAX_HEIGHT = 400;
+
+/**
+ * Automatically resize a textarea to fit its content while respecting a max height.
+ * @param {HTMLTextAreaElement|string|null} textareaOrId - Textarea element or its id.
+ * @param {number} [maxHeight=DEFAULT_MAX_HEIGHT] - Maximum height in pixels.
+ */
+export function autoResizeTextarea(
+  textareaOrId,
+  maxHeight = DEFAULT_MAX_HEIGHT,
+) {
+  const textarea =
+    typeof textareaOrId === 'string'
+      ? safeGetElementById(textareaOrId)
+      : textareaOrId;
+  if (!textarea) {
+    return;
+  }
+  textarea.style.height = 'auto';
+  const boundedHeight = Math.min(textarea.scrollHeight, maxHeight);
+  textarea.style.height = `${boundedHeight}px`;
+  textarea.style.overflowY =
+    textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+}
+
+/**
+ * Insert text at the current cursor position of the textarea.
+ * @param {HTMLTextAreaElement|string|null} textareaOrId - Textarea element or its id.
+ * @param {string} text - Text to insert at the cursor.
+ */
+export function insertTextAtCursor(textareaOrId, text) {
+  const textarea =
+    typeof textareaOrId === 'string'
+      ? safeGetElementById(textareaOrId)
+      : textareaOrId;
+  if (!textarea) {
+    return;
+  }
+  const start = textarea.selectionStart ?? textarea.value.length;
+  const end = textarea.selectionEnd ?? textarea.value.length;
+  const original = textarea.value;
+  textarea.value = original.slice(0, start) + text + original.slice(end);
+  const cursor = start + text.length;
+  textarea.selectionStart = cursor;
+  textarea.selectionEnd = cursor;
+}
+
+/**
+ * Reset textarea sizing styles so the element can shrink back to its base height.
+ * @param {HTMLTextAreaElement|string|null} textareaOrId - Textarea element or its id.
+ */
+export function resetTextareaHeight(textareaOrId) {
+  const textarea =
+    typeof textareaOrId === 'string'
+      ? safeGetElementById(textareaOrId)
+      : textareaOrId;
+  if (!textarea) {
+    return;
+  }
+  textarea.style.height = '';
+  textarea.style.overflowY = '';
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -172,6 +172,11 @@ export abstract class BaseViewContentProvider {
       ),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
       pathUtilsUri: this.getCommonUri(webview, 'modules/pathUtils.js'),
+      textareaUtilsUri: this.getCommonUri(webview, 'modules/textareaUtils.js'),
+      recordingButtonManagerUri: this.getCommonUri(
+        webview,
+        'modules/recordingButtonManager.js',
+      ),
       codiconUri: this.getNodeModulesUri(
         webview,
         '@vscode/codicons/dist/codicon.css',

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -185,6 +185,14 @@ export const PROGRESS_VIEW_COMMANDS = {
   FILTER_STREAMS: 'filterStreams',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
+  POLISH_FOLLOW_UP: 'polishFollowUp',
+  START_RECORDING: 'startRecording',
+  STOP_RECORDING: 'stopRecording',
+  RECORDING_STARTED: 'recordingStarted',
+  RECORDING_ERROR: 'recordingError',
+  FOLLOW_UP_TEXT_TRANSCRIBED: 'instructionTextTranscribed',
+  FOLLOW_UP_TEXT_POLISHED: 'instructionTextPolished',
+  SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
 
   // File operations

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -182,6 +182,14 @@ export const PROGRESS_VIEW_COMMANDS = {
   FILTER_STREAMS: 'filterStreams',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
+  POLISH_FOLLOW_UP: 'polishFollowUp',
+  START_RECORDING: 'startRecording',
+  STOP_RECORDING: 'stopRecording',
+  RECORDING_STARTED: 'recordingStarted',
+  RECORDING_ERROR: 'recordingError',
+  FOLLOW_UP_TEXT_TRANSCRIBED: 'instructionTextTranscribed',
+  FOLLOW_UP_TEXT_POLISHED: 'instructionTextPolished',
+  SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
 
   // File operations

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -36,6 +36,10 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
       key: 'instructionPanelUri',
       path: 'modules/uiManagers/InstructionPanel.js',
     },
+    {
+      key: 'followUpInputUri',
+      path: 'modules/uiManagers/FollowUpInputManager.js',
+    },
   ];
 
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,12 +12,21 @@ import {
   AgentTypeFilter,
   isAgentTypeFilter,
 } from '@agent/types/AgentStreamTypes';
-import { isWorkflowTaskState, type WorkflowTaskState } from '@logger/TaskState';
+import {
+  isWorkflowTaskState,
+  type WorkflowTaskState,
+  type TaskState,
+} from '@logger/TaskState';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - storage
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
 // Local imports - commands
 import { safeExecuteCommand } from '@utils/system/commandUtils';
+import { RecordingManager } from '@webview/managers/RecordingManager';
+import {
+  polishTextWithAI,
+  type FileContext,
+} from '@utils/text/textEnhancementUtils';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -35,8 +44,11 @@ interface CompareMessage extends BaseFileCommandMessage {
 }
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
+  private readonly recordingManager: RecordingManager;
+
   constructor(private readonly provider: ProgressViewProvider) {
     super('ProgressView');
+    this.recordingManager = new RecordingManager(provider.extensionContext);
   }
 
   private async deleteSessionSnapshot(stream: StreamTabId): Promise<void> {
@@ -81,6 +93,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         this.handleRestoreState.bind(this),
       [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]:
         this.handleSendFollowUp.bind(this),
+      [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]:
+        this.handlePolishFollowUp.bind(this),
+      [PROGRESS_VIEW_COMMANDS.START_RECORDING]:
+        this.handleStartRecording.bind(this),
+      [PROGRESS_VIEW_COMMANDS.STOP_RECORDING]:
+        this.handleStopRecording.bind(this),
+      [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]:
+        this.handleShowInformationMessage.bind(this),
       [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]:
         this.handleOpenTaskStorage.bind(this),
 
@@ -244,6 +264,78 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       stream: message.stream,
       text: message.text,
     });
+  }
+
+  private async handlePolishFollowUp(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const stream = message.stream as StreamTabId | undefined;
+    const text = typeof message.text === 'string' ? message.text.trim() : '';
+    if (!stream || !text) {
+      return;
+    }
+
+    const taskState = this.provider.state.getTaskState(stream);
+    const fileContext = this.buildFileContext(taskState);
+
+    try {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Polishing follow-up message',
+          cancellable: false,
+        },
+        async (progress) => {
+          progress.report({ message: 'Sending to AI for polishing...' });
+          const result = await polishTextWithAI(text, fileContext);
+          if (result.success) {
+            webviewView.webview.postMessage({
+              command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISHED,
+              text: result.text,
+            });
+          } else {
+            const fallbackError =
+              result.error || 'Error polishing follow-up text';
+            await vscode.window.showErrorMessage(fallbackError);
+          }
+        },
+      );
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        this.channel,
+        `Error polishing follow-up text: ${errorMessage}`,
+      );
+      await vscode.window.showErrorMessage(
+        `Error polishing follow-up text: ${errorMessage}`,
+      );
+    }
+  }
+
+  private async handleStartRecording(
+    _message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    await this.recordingManager.start(webviewView);
+  }
+
+  private async handleStopRecording(
+    _message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    await this.recordingManager.stop(webviewView);
+  }
+
+  private async handleShowInformationMessage(
+    message: any,
+    _webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const text = typeof message?.text === 'string' ? message.text.trim() : '';
+    if (text) {
+      await vscode.window.showInformationMessage(text);
+    }
   }
 
   private async handleOpenTaskStorage(
@@ -479,5 +571,47 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     }
 
     await action(taskState);
+  }
+
+  private buildFileContext(taskState?: TaskState): FileContext | undefined {
+    if (!taskState) {
+      return undefined;
+    }
+
+    const context: FileContext = {};
+    const { agentConfig } = taskState;
+
+    const setString = (key: keyof FileContext, value?: string | null): void => {
+      if (typeof value === 'string' && value.trim().length > 0) {
+        (context as Record<string, unknown>)[key] = value;
+      }
+    };
+
+    const setArray = (
+      key: keyof FileContext,
+      value?: string[] | null,
+    ): void => {
+      if (Array.isArray(value)) {
+        const filtered = value.filter(
+          (item) => typeof item === 'string' && item.trim().length > 0,
+        );
+        if (filtered.length > 0) {
+          (context as Record<string, unknown>)[key] = filtered;
+        }
+      }
+    };
+
+    setString('agent', agentConfig.agent);
+    setString('inputFile', agentConfig.inputFile);
+    setArray('inputFiles', agentConfig.inputFiles);
+    setString('referenceFile', agentConfig.referenceFile);
+    setArray('referenceFiles', agentConfig.referenceFiles);
+    setString('auxiliaryFile', agentConfig.auxiliaryFile);
+    setArray('auxiliaryFiles', agentConfig.auxiliaryFiles);
+    setString('mediaFile', agentConfig.mediaFile);
+    setArray('mediaFiles', agentConfig.mediaFiles);
+    setArray('outputFiles', agentConfig.outputFiles);
+
+    return context;
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -115,6 +115,10 @@ export class ProgressViewProvider
     return this._instance;
   }
 
+  public get extensionContext(): vscode.ExtensionContext {
+    return this.context;
+  }
+
   protected override cleanupView(): void {
     super.cleanupView();
     this._webviewReady = false;

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -44,6 +44,7 @@
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
           "./modules/uiManagers/Placeholder.js": "${placeholderUri}",
           "./modules/uiManagers/InstructionPanel.js": "${instructionPanelUri}",
+          "./modules/uiManagers/FollowUpInputManager.js": "${followUpInputUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
@@ -57,6 +58,8 @@
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/pathUtils.js": "${pathUtilsUri}",
+          "@common/textareaUtils.js": "${textareaUtilsUri}",
+          "@common/recordingButtonManager.js": "${recordingButtonManagerUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "he": "https://esm.sh/he@1.2.0",
@@ -126,18 +129,36 @@
         </div>
         <div id="logContent" class="log-container"></div>
         <div id="generatedFiles" class="files-container"></div>
-        <div id="followUpContainer" class="follow-up-container">
+        <div
+          id="followUpContainer"
+          class="follow-up-container"
+          aria-hidden="true"
+        >
           <textarea
             id="followUpInput"
             class="vscode-textarea"
             placeholder="Send follow-up message"
           ></textarea>
-          <button
-            id="sendFollowUpBtn"
-            class="vscode-button"
-            title="Send"
-            data-icon="send"
-          ></button>
+          <div class="follow-up-actions button-group">
+            <button
+              id="polishFollowUpBtn"
+              class="vscode-button"
+              title="Polish follow-up with AI"
+              data-icon="sparkle"
+            ></button>
+            <button
+              id="recordFollowUpBtn"
+              class="vscode-button"
+              title="Record follow-up with microphone"
+              data-icon="mic"
+            ></button>
+            <button
+              id="sendFollowUpBtn"
+              class="vscode-button"
+              title="Send"
+              data-icon="send"
+            ></button>
+          </div>
         </div>
         <template id="fileItemTemplate">
           <div class="file-item">

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -15,12 +15,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 
 const LEGACY_MESSAGE_TYPES: ReadonlySet<LogMessageData['messageType']> =
-  new Set([
-    'fileList',
-    'missingOutputs',
-    'latexdiff',
-    'statistics',
-  ]);
+  new Set(['fileList', 'missingOutputs', 'latexdiff', 'statistics']);
 
 /**
  * Manages stream tabs collection with persistence.

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -48,6 +48,8 @@ export const ELEMENT_IDS = {
   ERASE_STREAM_BTN: 'eraseStreamBtn',
   FOLLOW_UP_CONTAINER: 'followUpContainer',
   FOLLOW_UP_INPUT: 'followUpInput',
+  POLISH_FOLLOW_UP_BTN: 'polishFollowUpBtn',
+  RECORD_FOLLOW_UP_BTN: 'recordFollowUpBtn',
   SEND_FOLLOW_UP_BTN: 'sendFollowUpBtn',
   AGENT_FILTER_CONTAINER: 'agentFilterButtons',
   FILTER_ALL_BTN: 'filterAllBtn',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -10,8 +10,10 @@ import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Placeholder } from './uiManagers/Placeholder.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
+import { FollowUpInputManager } from './uiManagers/FollowUpInputManager.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
+import { vscode } from '@common/webviewContext.js';
 
 /**
  * Manages all DOM operations for the progress view.
@@ -31,6 +33,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       events: new EventsManager(),
       placeholder: new Placeholder(),
       instructionPanel: new InstructionPanel(),
+      followUpInput: new FollowUpInputManager(vscode),
     });
   }
 }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -56,6 +56,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       [COMMANDS.UPDATE_INSTRUCTION]: (m) => this.handleUpdateInstruction(m),
       [COMMANDS.DELETE_STREAM]: (m) => this.handleDeleteStream(m),
       [COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
+      [COMMANDS.FOLLOW_UP_TEXT_POLISHED]: (m) =>
+        this.handleFollowUpTextPolished(m),
+      [COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED]: (m) =>
+        this.handleFollowUpTextTranscribed(m),
+      [COMMANDS.RECORDING_STARTED]: () => this.handleRecordingState(true),
+      [COMMANDS.RECORDING_ERROR]: () => this.handleRecordingError(),
     };
   }
 
@@ -99,6 +105,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (container) {
       container.classList.toggle('is-visible', isToolAgent);
       container.setAttribute('aria-hidden', isToolAgent ? 'false' : 'true');
+    }
+
+    if (!isToolAgent) {
+      dom.followUpInput?.setRecording(false);
     }
 
     dom.toolbar.render(sessionKind);
@@ -256,6 +266,28 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream === state.activeStream) {
       dom.fileList.update(message.files);
     }
+  }
+
+  handleFollowUpTextPolished(message) {
+    if (!message?.text || !dom.followUpInput) {
+      return;
+    }
+    dom.followUpInput.applyPolishedText(message.text);
+  }
+
+  handleFollowUpTextTranscribed(message) {
+    if (!message?.text || !dom.followUpInput) {
+      return;
+    }
+    dom.followUpInput.appendTranscription(message.text);
+  }
+
+  handleRecordingState(recording) {
+    dom.followUpInput?.setRecording(recording);
+  }
+
+  handleRecordingError() {
+    dom.followUpInput?.handleRecordingError();
   }
 
   handleUpdateMissingOutputs(message) {

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -112,32 +112,6 @@ export class EventsManager {
       }
     });
 
-    // Follow-up input handler
-    const sendFollowUp = () => {
-      const followInput = document.getElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
-      if (!followInput) return;
-      const text = followInput.value.trim();
-      if (!text) return;
-      vscode.postMessage({
-        command: COMMANDS.SEND_FOLLOW_UP,
-        stream: progressViewState.activeStream,
-        text,
-      });
-      followInput.value = '';
-    };
-    addEventListenerSafely(
-      ELEMENT_IDS.SEND_FOLLOW_UP_BTN,
-      'click',
-      sendFollowUp,
-    );
-    addEventListenerSafely(ELEMENT_IDS.FOLLOW_UP_INPUT, 'keydown', (e) => {
-      // Enter sends, Shift+Enter adds new line
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        sendFollowUp();
-      }
-    });
-
     // Initialize split view
     Split(['.content-area', '.tabs'], {
       sizes: [SPLIT_SIZES.CONTENT, SPLIT_SIZES.TABS],

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -1,0 +1,145 @@
+// Local imports - progress view
+import { COMMANDS, ELEMENT_IDS, MAX_HEIGHT } from '../constants.js';
+import { progressViewState } from '../progressViewState.js';
+
+// Local imports - common
+import {
+  addEventListenerSafely,
+  safeGetElementById,
+} from '@common/domUtils.js';
+import {
+  autoResizeTextarea,
+  insertTextAtCursor,
+  resetTextareaHeight,
+} from '@common/textareaUtils.js';
+import { RecordingButtonManager } from '@common/recordingButtonManager.js';
+import { vscode } from '@common/webviewContext.js';
+
+const POLISH_SUCCESS_MESSAGE = 'Follow-up text has been polished!';
+const TRANSCRIBE_SUCCESS_MESSAGE = 'Follow-up text transcribed!';
+
+export class FollowUpInputManager {
+  constructor(vscodeInstance = vscode) {
+    this.vscode = vscodeInstance;
+    this._textarea = null;
+    this._recordingButton = new RecordingButtonManager({
+      buttonId: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,
+      vscode: this.vscode,
+      startCommand: COMMANDS.START_RECORDING,
+      stopCommand: COMMANDS.STOP_RECORDING,
+      idleTitle: 'Record follow-up with microphone',
+      recordingTitle: 'Stop recording',
+    });
+  }
+
+  setup() {
+    this._textarea = safeGetElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
+    if (!this._textarea) {
+      return;
+    }
+
+    autoResizeTextarea(this._textarea, MAX_HEIGHT);
+
+    addEventListenerSafely(this._textarea, 'input', () => {
+      autoResizeTextarea(this._textarea, MAX_HEIGHT);
+    });
+
+    addEventListenerSafely(this._textarea, 'keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        this.sendFollowUp();
+      }
+    });
+
+    addEventListenerSafely(ELEMENT_IDS.SEND_FOLLOW_UP_BTN, 'click', () => {
+      this.sendFollowUp();
+    });
+
+    addEventListenerSafely(ELEMENT_IDS.POLISH_FOLLOW_UP_BTN, 'click', () => {
+      this.requestPolish();
+    });
+
+    this._recordingButton.setup();
+  }
+
+  sendFollowUp() {
+    if (!this._textarea) {
+      return;
+    }
+    const text = this._textarea.value.trim();
+    const stream = progressViewState.activeStream;
+    if (!text || !stream) {
+      return;
+    }
+    this.vscode.postMessage({
+      command: COMMANDS.SEND_FOLLOW_UP,
+      stream,
+      text,
+    });
+    this.clear();
+  }
+
+  requestPolish() {
+    if (!this._textarea) {
+      return;
+    }
+    const text = this._textarea.value.trim();
+    const stream = progressViewState.activeStream;
+    if (!text || !stream) {
+      return;
+    }
+    this.vscode.postMessage({
+      command: COMMANDS.POLISH_FOLLOW_UP,
+      stream,
+      text,
+    });
+  }
+
+  clear() {
+    if (!this._textarea) {
+      return;
+    }
+    this._textarea.value = '';
+    resetTextareaHeight(this._textarea);
+    autoResizeTextarea(this._textarea, MAX_HEIGHT);
+  }
+
+  setRecording(recording) {
+    this._recordingButton.setRecording(recording);
+  }
+
+  handleRecordingError() {
+    this._recordingButton.setRecording(false);
+  }
+
+  applyPolishedText(text) {
+    if (!this._textarea || typeof text !== 'string') {
+      return;
+    }
+    this._textarea.value = text;
+    autoResizeTextarea(this._textarea, MAX_HEIGHT);
+    this._textarea.focus();
+    this._notifyInfo(POLISH_SUCCESS_MESSAGE);
+  }
+
+  appendTranscription(text) {
+    if (!this._textarea || typeof text !== 'string') {
+      return;
+    }
+    insertTextAtCursor(this._textarea, text);
+    autoResizeTextarea(this._textarea, MAX_HEIGHT);
+    this._textarea.focus();
+    this._recordingButton.setRecording(false);
+    this._notifyInfo(TRANSCRIBE_SUCCESS_MESSAGE);
+  }
+
+  _notifyInfo(message) {
+    if (!message) {
+      return;
+    }
+    this.vscode.postMessage({
+      command: COMMANDS.SHOW_INFORMATION_MESSAGE,
+      text: message,
+    });
+  }
+}

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initializeIconButtons();
   progressViewDomHandler.toolbar.render('workflow');
   progressViewDomHandler.placeholder.show();
+  progressViewDomHandler.followUpInput.setup();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();
 

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -19,14 +19,43 @@
 /* Style the textarea for multi-line input */
 #followUpInput {
   min-height: 36px;
-  max-height: 200px;
+  max-height: 400px;
   resize: none;
   flex: 1;
-  overflow-y: auto;
+  overflow-y: hidden;
   line-height: 1.4;
 }
 
-/* Align send button to bottom */
-#sendFollowUpBtn {
-  margin-bottom: var(--spacing-tiny);
+.follow-up-actions {
+  display: flex;
+  gap: var(--spacing-small);
+}
+
+.follow-up-actions .vscode-button {
+  align-self: flex-end;
+}
+
+#recordFollowUpBtn.recording {
+  background-color: var(--vscode-statusBarItem-errorBackground, #d32f2f);
+  color: var(--vscode-statusBarItem-errorForeground, #ffffff);
+}
+
+#recordFollowUpBtn.recording:hover {
+  background-color: var(--vscode-statusBarItem-errorBackground, #b71c1c);
+}
+
+#recordFollowUpBtn.recording .codicon-stop-circle {
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 1;
+  }
 }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -42,6 +42,8 @@
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/textareaUtils.js": "${textareaUtilsUri}",
+          "@common/recordingButtonManager.js": "${recordingButtonManagerUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "sortablejs": "https://cdn.skypack.dev/sortablejs",

--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -1,6 +1,10 @@
 // Local imports - webview
 import { setupPasteListener } from '../pasteHandler.js';
 import { safeGetElementById } from '@common/domUtils.js';
+import {
+  autoResizeTextarea as resizeTextarea,
+  insertTextAtCursor as insertAtCursor,
+} from '@common/textareaUtils.js';
 
 export class InstructionManager {
   constructor(textareaId, vscode, state) {
@@ -10,20 +14,11 @@ export class InstructionManager {
   }
 
   autoResizeTextarea(textarea) {
-    textarea.style.height = 'auto';
-    const maxHeight = 400;
-    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
-    textarea.style.height = `${newHeight}px`;
-    textarea.style.overflowY =
-      textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    resizeTextarea(textarea);
   }
 
   insertTextAtCursor(textarea, text) {
-    const start = textarea.selectionStart;
-    const end = textarea.selectionEnd;
-    const original = textarea.value;
-    textarea.value = original.slice(0, start) + text + original.slice(end);
-    textarea.selectionStart = textarea.selectionEnd = start + text.length;
+    insertAtCursor(textarea, text);
   }
 
   setup() {
@@ -35,19 +30,19 @@ export class InstructionManager {
       return;
     }
 
-    this.autoResizeTextarea(textarea);
+    resizeTextarea(textarea);
 
     textarea.addEventListener('input', () => {
-      this.autoResizeTextarea(textarea);
+      resizeTextarea(textarea);
       this.state?.save();
     });
 
     setupPasteListener(
       textarea,
       this.vscode,
-      (ta) => this.autoResizeTextarea(ta),
+      (ta) => resizeTextarea(ta),
       () => this.state?.save(),
-      (ta, text) => this.insertTextAtCursor(ta, text),
+      (ta, text) => insertAtCursor(ta, text),
     );
   }
 }

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -1,58 +1,27 @@
 // Local imports - webview
 import { ELEMENT_IDS } from '../constants.js';
 import { webviewEventBus } from '../eventBus.js';
-import {
-  addEventListenerSafely,
-  safeGetElementById,
-} from '@common/domUtils.js';
-import { createCodicon } from '@common/templateUtils.js';
+import { RecordingButtonManager } from '@common/recordingButtonManager.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class RecordingManager {
   constructor(vscode, eventBus = webviewEventBus) {
-    this.vscode = vscode;
-    this.eventBus = eventBus;
-    this.isRecording = false;
+    this._controller = new RecordingButtonManager({
+      buttonId: ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON,
+      vscode,
+      startCommand: MAIN_VIEW_COMMANDS.START_RECORDING,
+      stopCommand: MAIN_VIEW_COMMANDS.STOP_RECORDING,
+      eventTarget: eventBus,
+      idleTitle: 'Record instruction with microphone',
+      recordingTitle: 'Stop recording',
+    });
   }
 
   updateRecordingUI(recording) {
-    this.isRecording = recording;
-    const recordButton = safeGetElementById(
-      ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON,
-    );
-    if (recordButton) {
-      recordButton.innerHTML = '';
-      const iconName = recording ? 'stop-circle' : 'mic';
-      const icon = createCodicon(iconName);
-      if (icon) recordButton.appendChild(icon);
-      recordButton.title = recording
-        ? 'Stop recording'
-        : 'Record instruction with microphone';
-      recordButton.classList.toggle('recording', recording);
-    }
+    this._controller.setRecording(recording);
   }
 
   setupRecordButton() {
-    const buttonId = ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON;
-    const button = safeGetElementById(buttonId);
-    if (!button) return;
-
-    addEventListenerSafely(buttonId, 'click', () => {
-      const nextState = !this.isRecording;
-      this.vscode.postMessage({
-        command: nextState
-          ? MAIN_VIEW_COMMANDS.START_RECORDING
-          : MAIN_VIEW_COMMANDS.STOP_RECORDING,
-      });
-      this.eventBus.dispatchEvent(
-        new CustomEvent('recordingUIUpdate', {
-          detail: { recording: nextState },
-        }),
-      );
-    });
-
-    this.eventBus.addEventListener('recordingUIUpdate', (e) => {
-      this.updateRecordingUI(e.detail.recording);
-    });
+    this._controller.setup();
   }
 }


### PR DESCRIPTION
## Summary
- add shared textarea sizing and recording button utilities for webviews
- update the main view instruction and recording managers to use the shared helpers
- enhance the progress view follow-up UI with polishing, recording, and auto-resize support backed by new commands

## Testing
- npm run format
- npm run lint
- npm run compile *(fails: BaseReflectionAgent.ts argument type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68f53e3c44148324b45375d213562cd6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces shared textarea sizing and recording button utilities, migrates main/progress views to them, and enhances progress follow-up with AI polish, recording, and related commands/messages.
> 
> - **Webviews/UI**:
>   - **Shared utilities**: Add `@common/textareaUtils.js` and `@common/recordingButtonManager.js`; wire into import maps for `progressView` and main `webview`.
>   - **Progress View follow-up**:
>     - New `FollowUpInputManager` managing send, AI polish, recording, auto-resize; updates HTML (`follow-up` container with polish/record/send buttons) and CSS (larger max height, recording styles).
>     - Message handling: handle `FOLLOW_UP_TEXT_POLISHED`, `FOLLOW_UP_TEXT_TRANSCRIBED`, and recording state/errors; show/hide input for tool-use sessions.
>   - **Main View**: `InstructionManager` and `RecordingManager` refactored to use shared textarea/recording helpers.
> - **Commands/IPC**:
>   - Add progress-view actions/events: `POLISH_FOLLOW_UP`, `START_RECORDING`, `STOP_RECORDING`, `RECORDING_STARTED`, `RECORDING_ERROR`, `FOLLOW_UP_TEXT_TRANSCRIBED`, `FOLLOW_UP_TEXT_POLISHED`, `SHOW_INFORMATION_MESSAGE`.
> - **Extension backend**:
>   - `ProgressViewMessageHandler`: implement polish flow via `polishTextWithAI`, start/stop recording via `RecordingManager`, info message handler, and file-context builder; minor type additions.
>   - `ProgressViewProvider`: expose `extensionContext` getter.
> - **Agent**:
>   - `BaseReflectionAgent`: ensure `prefill` passed as string with `prefill ?? ''`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e1f04a8e4e6cac1a9e52961d23f53e70d788ec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->