### PR TITLE
Add shared follow-up controls to progress view

### DIFF
--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -142,7 +142,7 @@ export async function handleClean(config: {
     ? config.outputFiles
     : [];
   const useMultipleOutputs =
-    config.useMultipleOutputs ?? (declaredOutputFiles.length > 1);
+    config.useMultipleOutputs ?? declaredOutputFiles.length > 1;
 
   const outputFiles = useMultipleOutputs ? declaredOutputFiles : [];
 

--- a/src/common/modules/RecordingButtonManager.js
+++ b/src/common/modules/RecordingButtonManager.js
@@ -37,7 +37,7 @@ export class RecordingButtonManager {
       this.vscode.postMessage({
         command: nextState ? this.startCommand : this.stopCommand,
       });
-      this.setRecording(nextState);
+      // Don't update state optimistically - wait for backend confirmation
     });
   }
 
@@ -47,18 +47,23 @@ export class RecordingButtonManager {
   }
 
   _updateButton() {
-    const button = this.button || safeGetElementById(this.buttonId);
-    if (!button) {
+    if (!this.button) {
       return;
     }
 
-    button.innerHTML = '';
+    this.button.innerHTML = '';
     const iconName = this.isRecording ? this.stopIcon : this.startIcon;
     const icon = createCodicon(iconName);
     if (icon) {
-      button.appendChild(icon);
+      this.button.appendChild(icon);
     }
-    button.title = this.isRecording ? this.stopTitle : this.startTitle;
-    button.classList.toggle(this.recordingClass, this.isRecording);
+    this.button.title = this.isRecording ? this.stopTitle : this.startTitle;
+    this.button.classList.toggle(this.recordingClass, this.isRecording);
+  }
+
+  dispose() {
+    // Event listeners added via addEventListenerSafely are automatically managed
+    // Just clear the button reference
+    this.button = null;
   }
 }

--- a/src/common/modules/RecordingButtonManager.js
+++ b/src/common/modules/RecordingButtonManager.js
@@ -1,0 +1,64 @@
+// Local imports - DOM helpers
+import {
+  addEventListenerSafely,
+  safeGetElementById,
+} from '@common/domUtils.js';
+import { createCodicon } from '@common/templateUtils.js';
+
+/**
+ * Manages a recording toggle button shared across webviews.
+ */
+export class RecordingButtonManager {
+  constructor(vscode, config) {
+    this.vscode = vscode;
+    this.buttonId = config.buttonId;
+    this.startCommand = config.startCommand;
+    this.stopCommand = config.stopCommand;
+    this.startTitle = config.startTitle || 'Record with microphone';
+    this.stopTitle = config.stopTitle || 'Stop recording';
+    this.startIcon = config.startIcon || 'mic';
+    this.stopIcon = config.stopIcon || 'stop-circle';
+    this.recordingClass = config.recordingClass || 'recording';
+    this.isRecording = false;
+    this.button = null;
+  }
+
+  setup() {
+    const button = safeGetElementById(this.buttonId);
+    if (!button) {
+      return;
+    }
+
+    this.button = button;
+    this._updateButton();
+
+    addEventListenerSafely(this.buttonId, 'click', () => {
+      const nextState = !this.isRecording;
+      this.vscode.postMessage({
+        command: nextState ? this.startCommand : this.stopCommand,
+      });
+      this.setRecording(nextState);
+    });
+  }
+
+  setRecording(recording) {
+    this.isRecording = Boolean(recording);
+    this._updateButton();
+  }
+
+  _updateButton() {
+    const button = this.button || safeGetElementById(this.buttonId);
+    if (!button) {
+      return;
+    }
+
+    button.innerHTML = '';
+    const iconName = this.isRecording ? this.stopIcon : this.startIcon;
+    const icon = createCodicon(iconName);
+    if (icon) {
+      button.appendChild(icon);
+    }
+    button.title = this.isRecording ? this.stopTitle : this.startTitle;
+    button.classList.toggle(this.recordingClass, this.isRecording);
+  }
+}

--- a/src/common/modules/textareaUtils.js
+++ b/src/common/modules/textareaUtils.js
@@ -1,0 +1,49 @@
+const DEFAULT_MAX_HEIGHT = 400;
+
+/**
+ * Automatically resize a textarea based on its scroll height.
+ * @param {HTMLTextAreaElement} textarea
+ * @param {number} [maxHeight]
+ */
+export function autoResizeTextarea(textarea, maxHeight = DEFAULT_MAX_HEIGHT) {
+  if (!(textarea instanceof HTMLTextAreaElement)) {
+    return;
+  }
+
+  textarea.style.height = 'auto';
+  const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+  textarea.style.height = `${newHeight}px`;
+  textarea.style.overflowY =
+    textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+}
+
+/**
+ * Insert text at the current cursor position in a textarea.
+ * @param {HTMLTextAreaElement} textarea
+ * @param {string} text
+ */
+export function insertTextAtCursor(textarea, text) {
+  if (!(textarea instanceof HTMLTextAreaElement) || typeof text !== 'string') {
+    return;
+  }
+
+  const start = textarea.selectionStart ?? textarea.value.length;
+  const end = textarea.selectionEnd ?? textarea.value.length;
+  const original = textarea.value;
+  textarea.value = original.slice(0, start) + text + original.slice(end);
+  const newCursorPos = start + text.length;
+  textarea.selectionStart = textarea.selectionEnd = newCursorPos;
+}
+
+/**
+ * Reset the height styles applied during auto-resize.
+ * @param {HTMLTextAreaElement} textarea
+ */
+export function resetTextareaHeight(textarea) {
+  if (!(textarea instanceof HTMLTextAreaElement)) {
+    return;
+  }
+
+  textarea.style.height = '';
+  textarea.style.overflowY = '';
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -159,6 +159,11 @@ export abstract class BaseViewContentProvider {
         webview,
         'modules/iconButtonInitializer.js',
       ),
+      recordingButtonManagerUri: this.getCommonUri(
+        webview,
+        'modules/RecordingButtonManager.js',
+      ),
+      textareaUtilsUri: this.getCommonUri(webview, 'modules/textareaUtils.js'),
       htmlEncodingUri: this.getCommonUri(webview, 'modules/htmlEncoding.js'),
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       baseWebviewMessageHandlerUri: this.getCommonUri(

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -185,6 +185,14 @@ export const PROGRESS_VIEW_COMMANDS = {
   FILTER_STREAMS: 'filterStreams',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
+  POLISH_FOLLOW_UP: 'polishFollowUp',
+  FOLLOW_UP_TEXT_POLISHED: 'followUpTextPolished',
+  FOLLOW_UP_TEXT_TRANSCRIBED: 'followUpTextTranscribed',
+  START_RECORDING: 'startRecording',
+  STOP_RECORDING: 'stopRecording',
+  RECORDING_STARTED: 'recordingStarted',
+  RECORDING_ERROR: 'recordingError',
+  SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
 
   // File operations

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -182,6 +182,14 @@ export const PROGRESS_VIEW_COMMANDS = {
   FILTER_STREAMS: 'filterStreams',
   RESTORE_STATE: 'restoreState',
   SEND_FOLLOW_UP: 'sendFollowUp',
+  POLISH_FOLLOW_UP: 'polishFollowUp',
+  FOLLOW_UP_TEXT_POLISHED: 'followUpTextPolished',
+  FOLLOW_UP_TEXT_TRANSCRIBED: 'followUpTextTranscribed',
+  START_RECORDING: 'startRecording',
+  STOP_RECORDING: 'stopRecording',
+  RECORDING_STARTED: 'recordingStarted',
+  RECORDING_ERROR: 'recordingError',
+  SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
 
   // File operations

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -36,6 +36,10 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
       key: 'instructionPanelUri',
       path: 'modules/uiManagers/InstructionPanel.js',
     },
+    {
+      key: 'followUpInputManagerUri',
+      path: 'modules/uiManagers/FollowUpInputManager.js',
+    },
   ];
 
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -22,7 +22,6 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
 // Local imports - commands
 import { safeExecuteCommand } from '@utils/system/commandUtils';
-import { sleep } from '@utils/helpers';
 import { RecordingManager } from '@webview/managers/RecordingManager';
 import {
   buildFileContextFromTaskState,
@@ -302,15 +301,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       },
       async (progress) => {
         try {
-          progress.report({ message: 'Preparing text and context...' });
-          await sleep(300);
           progress.report({
             message: 'Sending to AI for polishing...',
             increment: 30,
           });
           const result = await polishTextWithAI(text, fileContext);
           progress.report({ message: 'Applying changes...', increment: 60 });
-          await sleep(200);
 
           if (result.success) {
             webviewView.webview.postMessage({

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,12 +12,22 @@ import {
   AgentTypeFilter,
   isAgentTypeFilter,
 } from '@agent/types/AgentStreamTypes';
-import { isWorkflowTaskState, type WorkflowTaskState } from '@logger/TaskState';
+import {
+  isWorkflowTaskState,
+  type WorkflowTaskState,
+  type TaskState,
+} from '@logger/TaskState';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - storage
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
 // Local imports - commands
 import { safeExecuteCommand } from '@utils/system/commandUtils';
+import { sleep } from '@utils/helpers';
+import { RecordingManager } from '@webview/managers/RecordingManager';
+import {
+  buildFileContextFromTaskState,
+  polishTextWithAI,
+} from '@utils/text/textEnhancementUtils';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -35,8 +45,19 @@ interface CompareMessage extends BaseFileCommandMessage {
 }
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
-  constructor(private readonly provider: ProgressViewProvider) {
+  private readonly recordingManager: RecordingManager;
+
+  constructor(
+    private readonly provider: ProgressViewProvider,
+    context: vscode.ExtensionContext,
+  ) {
     super('ProgressView');
+    this.recordingManager = new RecordingManager(context, {
+      recordingStartedCommand: PROGRESS_VIEW_COMMANDS.RECORDING_STARTED,
+      recordingErrorCommand: PROGRESS_VIEW_COMMANDS.RECORDING_ERROR,
+      transcriptionCommand: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED,
+      progressTitle: 'Transcribing follow-up message',
+    });
   }
 
   private async deleteSessionSnapshot(stream: StreamTabId): Promise<void> {
@@ -83,6 +104,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         this.handleSendFollowUp.bind(this),
       [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]:
         this.handleOpenTaskStorage.bind(this),
+      [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]:
+        this.handlePolishFollowUp.bind(this),
+      [PROGRESS_VIEW_COMMANDS.START_RECORDING]: async (_m, w) =>
+        this.recordingManager.start(w),
+      [PROGRESS_VIEW_COMMANDS.STOP_RECORDING]: async (_m, w) =>
+        this.recordingManager.stop(w),
+      [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]:
+        this.handleShowInformationMessage.bind(this),
 
       // File operations
       [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: this.handleOpenFile.bind(this),
@@ -244,6 +273,75 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       stream: message.stream,
       text: message.text,
     });
+  }
+
+  private async handlePolishFollowUp(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    const stream = message.stream as StreamTabId | undefined;
+    const text = typeof message.text === 'string' ? message.text.trim() : '';
+    if (!stream || !text) {
+      return;
+    }
+
+    const taskState = this.provider.state.getTaskState(stream) as
+      | TaskState
+      | undefined;
+    if (!taskState) {
+      return;
+    }
+
+    const fileContext = buildFileContextFromTaskState(taskState);
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Polishing follow-up message',
+        cancellable: false,
+      },
+      async (progress) => {
+        try {
+          progress.report({ message: 'Preparing text and context...' });
+          await sleep(300);
+          progress.report({
+            message: 'Sending to AI for polishing...',
+            increment: 30,
+          });
+          const result = await polishTextWithAI(text, fileContext);
+          progress.report({ message: 'Applying changes...', increment: 60 });
+          await sleep(200);
+
+          if (result.success) {
+            webviewView.webview.postMessage({
+              command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISHED,
+              text: result.text,
+            });
+          } else if (result.error) {
+            await vscode.window.showErrorMessage(result.error);
+          }
+        } catch (error) {
+          const messageText =
+            error instanceof Error ? error.message : 'Unknown error';
+          await vscode.window.showErrorMessage(
+            `Error polishing follow-up: ${messageText}`,
+          );
+          this.logger.error(
+            this.channel,
+            `Error polishing follow-up: ${messageText}`,
+            error instanceof Error ? error : undefined,
+          );
+        }
+      },
+    );
+  }
+
+  private async handleShowInformationMessage(message: any): Promise<void> {
+    const text = typeof message?.text === 'string' ? message.text.trim() : '';
+    if (!text) {
+      return;
+    }
+    await vscode.window.showInformationMessage(text);
   }
 
   private async handleOpenTaskStorage(

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -550,7 +550,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const useMultipleOutputs =
       taskState.agentConfig.useMultipleOutputs ??
       taskState.activeFiles.output ??
-      (outputFilesArray.length > 1);
+      outputFilesArray.length > 1;
     await vscode.commands.executeCommand(command, {
       streamId: stream,
       agent: taskState.agentConfig.agent,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -83,7 +83,7 @@ export class ProgressViewProvider
 
     // Initialize existing components
     this.contentProvider = new ProgressViewContentProvider(context);
-    this.messageHandler = new ProgressViewMessageHandler(this);
+    this.messageHandler = new ProgressViewMessageHandler(this, context);
 
     // Set instance
     ProgressViewProvider._instance = this;

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -149,6 +149,12 @@
               data-icon="mic"
             ></button>
             <button
+              id="clearFollowUpBtn"
+              class="vscode-button"
+              title="Clear input"
+              data-icon="trash"
+            ></button>
+            <button
               id="sendFollowUpBtn"
               class="vscode-button"
               title="Send"

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -420,5 +420,8 @@
         <i class="codicon"></i>
       </button>
     </template>
+    <template id="codiconTemplate">
+      <i class="codicon"></i>
+    </template>
   </body>
 </html>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -152,7 +152,7 @@
               id="clearFollowUpBtn"
               class="vscode-button"
               title="Clear input"
-              data-icon="trash"
+              data-icon="clear-all"
             ></button>
             <button
               id="sendFollowUpBtn"

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -44,6 +44,7 @@
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
           "./modules/uiManagers/Placeholder.js": "${placeholderUri}",
           "./modules/uiManagers/InstructionPanel.js": "${instructionPanelUri}",
+          "./modules/uiManagers/FollowUpInputManager.js": "${followUpInputManagerUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
@@ -51,6 +52,8 @@
           "@common/webview/themeHandlers.js": "${webviewThemeHandlersUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
+          "@common/RecordingButtonManager.js": "${recordingButtonManagerUri}",
+          "@common/textareaUtils.js": "${textareaUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/domUtils.js": "${domUtilsUri}",
@@ -132,12 +135,26 @@
             class="vscode-textarea"
             placeholder="Send follow-up message"
           ></textarea>
-          <button
-            id="sendFollowUpBtn"
-            class="vscode-button"
-            title="Send"
-            data-icon="send"
-          ></button>
+          <div class="follow-up-actions button-group">
+            <button
+              id="polishFollowUpBtn"
+              class="vscode-button"
+              title="Polish follow-up with AI"
+              data-icon="sparkle"
+            ></button>
+            <button
+              id="recordFollowUpBtn"
+              class="vscode-button"
+              title="Record follow-up with microphone"
+              data-icon="mic"
+            ></button>
+            <button
+              id="sendFollowUpBtn"
+              class="vscode-button"
+              title="Send"
+              data-icon="send"
+            ></button>
+          </div>
         </div>
         <template id="fileItemTemplate">
           <div class="file-item">

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -15,12 +15,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 
 const LEGACY_MESSAGE_TYPES: ReadonlySet<LogMessageData['messageType']> =
-  new Set([
-    'fileList',
-    'missingOutputs',
-    'latexdiff',
-    'statistics',
-  ]);
+  new Set(['fileList', 'missingOutputs', 'latexdiff', 'statistics']);
 
 /**
  * Manages stream tabs collection with persistence.

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -50,6 +50,7 @@ export const ELEMENT_IDS = {
   FOLLOW_UP_INPUT: 'followUpInput',
   RECORD_FOLLOW_UP_BTN: 'recordFollowUpBtn',
   POLISH_FOLLOW_UP_BTN: 'polishFollowUpBtn',
+  CLEAR_FOLLOW_UP_BTN: 'clearFollowUpBtn',
   SEND_FOLLOW_UP_BTN: 'sendFollowUpBtn',
   AGENT_FILTER_CONTAINER: 'agentFilterButtons',
   FILTER_ALL_BTN: 'filterAllBtn',

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -48,6 +48,8 @@ export const ELEMENT_IDS = {
   ERASE_STREAM_BTN: 'eraseStreamBtn',
   FOLLOW_UP_CONTAINER: 'followUpContainer',
   FOLLOW_UP_INPUT: 'followUpInput',
+  RECORD_FOLLOW_UP_BTN: 'recordFollowUpBtn',
+  POLISH_FOLLOW_UP_BTN: 'polishFollowUpBtn',
   SEND_FOLLOW_UP_BTN: 'sendFollowUpBtn',
   AGENT_FILTER_CONTAINER: 'agentFilterButtons',
   FILTER_ALL_BTN: 'filterAllBtn',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -9,9 +9,11 @@ import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Placeholder } from './uiManagers/Placeholder.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
+import { FollowUpInputManager } from './uiManagers/FollowUpInputManager.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { UsageSummary, UsageGroup } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
+import { vscode } from '@common/webviewContext.js';
 
 /**
  * Manages all DOM operations for the progress view.
@@ -31,6 +33,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       events: new EventsManager(),
       placeholder: new Placeholder(),
       instructionPanel: new InstructionPanel(),
+      followUpInput: new FollowUpInputManager(vscode),
     });
   }
 }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -276,10 +276,7 @@ export class LogEntryFormatter {
           'tool use',
         ),
       modelResponse: (params) =>
-        this._safeFormat(
-          () => this._formatModelResponse(params),
-          'Assistant',
-        ),
+        this._safeFormat(() => this._formatModelResponse(params), 'Assistant'),
       fileList: (text, data, id) =>
         this._safeFormat(
           () => this._formatFileList(text, data, id),

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -278,7 +278,7 @@ export class LogEntryFormatter {
       modelResponse: (params) =>
         this._safeFormat(
           () => this._formatModelResponse(params),
-          'model response',
+          'Assistant',
         ),
       fileList: (text, data, id) =>
         this._safeFormat(
@@ -730,7 +730,7 @@ export class LogEntryFormatter {
       groupId,
       timestamp: fullTimestamp,
       iconClass: 'codicon-sparkle',
-      labelText: 'Model response',
+      labelText: 'Assistant',
       copyTitle: 'Copy model output',
       contentClass: 'banner-content--model',
       open: true,

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -6,6 +6,7 @@ import { appendFormatted } from './utils.js';
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
+import { vscode } from '@common/webviewContext.js';
 
 // Session kind values match TypeScript AgentSessionKind enum
 // No need to duplicate - we use the actual values from messages
@@ -56,6 +57,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       [COMMANDS.UPDATE_INSTRUCTION]: (m) => this.handleUpdateInstruction(m),
       [COMMANDS.DELETE_STREAM]: (m) => this.handleDeleteStream(m),
       [COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
+      [COMMANDS.FOLLOW_UP_TEXT_POLISHED]: (m) =>
+        this.handleFollowUpTextPolished(m),
+      [COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED]: (m) =>
+        this.handleFollowUpTextTranscribed(m),
+      [COMMANDS.RECORDING_STARTED]: () => this.handleRecordingStarted(),
+      [COMMANDS.RECORDING_ERROR]: () => this.handleRecordingError(),
     };
   }
 
@@ -312,6 +319,38 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.toggleStates.clearAll();
     state.resetExecutionAvailability();
     dom.instructionPanel.hide();
+  }
+
+  handleFollowUpTextPolished(message) {
+    if (typeof message.text !== 'string') {
+      return;
+    }
+    dom.followUpInput.applyPolishedText(message.text);
+    vscode.postMessage({
+      command: COMMANDS.SHOW_INFORMATION_MESSAGE,
+      text: 'Follow-up text has been polished!',
+    });
+  }
+
+  handleFollowUpTextTranscribed(message) {
+    if (typeof message.text !== 'string') {
+      dom.followUpInput.setRecording(false);
+      return;
+    }
+    dom.followUpInput.insertTranscription(message.text);
+    dom.followUpInput.setRecording(false);
+    vscode.postMessage({
+      command: COMMANDS.SHOW_INFORMATION_MESSAGE,
+      text: 'Follow-up text transcribed!',
+    });
+  }
+
+  handleRecordingStarted() {
+    dom.followUpInput.setRecording(true);
+  }
+
+  handleRecordingError() {
+    dom.followUpInput.setRecording(false);
   }
 }
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -112,32 +112,6 @@ export class EventsManager {
       }
     });
 
-    // Follow-up input handler
-    const sendFollowUp = () => {
-      const followInput = document.getElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
-      if (!followInput) return;
-      const text = followInput.value.trim();
-      if (!text) return;
-      vscode.postMessage({
-        command: COMMANDS.SEND_FOLLOW_UP,
-        stream: progressViewState.activeStream,
-        text,
-      });
-      followInput.value = '';
-    };
-    addEventListenerSafely(
-      ELEMENT_IDS.SEND_FOLLOW_UP_BTN,
-      'click',
-      sendFollowUp,
-    );
-    addEventListenerSafely(ELEMENT_IDS.FOLLOW_UP_INPUT, 'keydown', (e) => {
-      // Enter sends, Shift+Enter adds new line
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        sendFollowUp();
-      }
-    });
-
     // Initialize split view
     Split(['.content-area', '.tabs'], {
       sizes: [SPLIT_SIZES.CONTENT, SPLIT_SIZES.TABS],

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -85,7 +85,17 @@ export class FileList {
 
     rounds.forEach((round) => {
       const files = filesByRound[round];
-      if (!files || files.length === 0) return;
+      if (!Array.isArray(files)) {
+        if (files !== undefined) {
+          console.warn(
+            `FileList.update: Expected array for round ${round}, got:`,
+            typeof files,
+            files,
+          );
+        }
+        return;
+      }
+      if (files.length === 0) return;
 
       const roundGroup = createFromTemplate('roundHeaderTemplate');
       if (!roundGroup) return;

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -102,7 +102,6 @@ export class FollowUpInputManager {
 
     this.textarea.value = '';
     resetTextareaHeight(this.textarea);
-    autoResizeTextarea(this.textarea);
     this.textarea.focus();
   }
 

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -78,7 +78,6 @@ export class FollowUpInputManager {
 
     this.textarea.value = '';
     resetTextareaHeight(this.textarea);
-    autoResizeTextarea(this.textarea);
   }
 
   _polishFollowUp() {

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -1,0 +1,119 @@
+// Local imports - progress view
+import { COMMANDS, ELEMENT_IDS } from '../constants.js';
+import { progressViewState } from '../progressViewState.js';
+
+// Local imports - common helpers
+import {
+  autoResizeTextarea,
+  insertTextAtCursor,
+  resetTextareaHeight,
+} from '@common/textareaUtils.js';
+import {
+  addEventListenerSafely,
+  safeGetElementById,
+} from '@common/domUtils.js';
+import { RecordingButtonManager } from '@common/RecordingButtonManager.js';
+
+export class FollowUpInputManager {
+  constructor(vscode) {
+    this.vscode = vscode;
+    this.textarea = null;
+    this.recordingButton = new RecordingButtonManager(vscode, {
+      buttonId: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,
+      startCommand: COMMANDS.START_RECORDING,
+      stopCommand: COMMANDS.STOP_RECORDING,
+      startTitle: 'Record follow-up with microphone',
+      stopTitle: 'Stop recording',
+    });
+  }
+
+  setup() {
+    this.textarea = safeGetElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
+    if (!this.textarea) {
+      return;
+    }
+
+    autoResizeTextarea(this.textarea);
+
+    addEventListenerSafely(ELEMENT_IDS.FOLLOW_UP_INPUT, 'input', () => {
+      autoResizeTextarea(this.textarea);
+    });
+
+    addEventListenerSafely(ELEMENT_IDS.SEND_FOLLOW_UP_BTN, 'click', () => {
+      this._sendFollowUp();
+    });
+
+    addEventListenerSafely(ELEMENT_IDS.FOLLOW_UP_INPUT, 'keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        this._sendFollowUp();
+      }
+    });
+
+    addEventListenerSafely(ELEMENT_IDS.POLISH_FOLLOW_UP_BTN, 'click', () => {
+      this._polishFollowUp();
+    });
+
+    this.recordingButton.setup();
+  }
+
+  _sendFollowUp() {
+    if (!this.textarea) return;
+
+    const text = this.textarea.value.trim();
+    const stream = progressViewState.activeStream;
+    if (!text || !stream) {
+      return;
+    }
+
+    this.vscode.postMessage({
+      command: COMMANDS.SEND_FOLLOW_UP,
+      stream,
+      text,
+    });
+
+    this.textarea.value = '';
+    resetTextareaHeight(this.textarea);
+    autoResizeTextarea(this.textarea);
+  }
+
+  _polishFollowUp() {
+    if (!this.textarea) return;
+
+    const text = this.textarea.value.trim();
+    const stream = progressViewState.activeStream;
+    if (!text || !stream) {
+      return;
+    }
+
+    this.vscode.postMessage({
+      command: COMMANDS.POLISH_FOLLOW_UP,
+      stream,
+      text,
+    });
+  }
+
+  setRecording(recording) {
+    this.recordingButton.setRecording(recording);
+  }
+
+  applyPolishedText(text) {
+    if (!this.textarea || typeof text !== 'string') {
+      return;
+    }
+
+    this.textarea.value = text;
+    autoResizeTextarea(this.textarea);
+    this.textarea.focus();
+  }
+
+  insertTranscription(text) {
+    if (!this.textarea || typeof text !== 'string') {
+      return;
+    }
+
+    insertTextAtCursor(this.textarea, text);
+    autoResizeTextarea(this.textarea);
+    this.textarea.focus();
+  }
+}

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -54,6 +54,10 @@ export class FollowUpInputManager {
       this._polishFollowUp();
     });
 
+    addEventListenerSafely(ELEMENT_IDS.CLEAR_FOLLOW_UP_BTN, 'click', () => {
+      this._clearFollowUp();
+    });
+
     this.recordingButton.setup();
   }
 
@@ -91,6 +95,15 @@ export class FollowUpInputManager {
       stream,
       text,
     });
+  }
+
+  _clearFollowUp() {
+    if (!this.textarea) return;
+
+    this.textarea.value = '';
+    resetTextareaHeight(this.textarea);
+    autoResizeTextarea(this.textarea);
+    this.textarea.focus();
   }
 
   setRecording(recording) {

--- a/src/progressView/modules/uiManagers/Toolbar.js
+++ b/src/progressView/modules/uiManagers/Toolbar.js
@@ -30,7 +30,10 @@ export class Toolbar {
         if (btn) {
           container.appendChild(btn);
         } else {
-          console.error('Toolbar.render: button creation returned null:', def.id);
+          console.error(
+            'Toolbar.render: button creation returned null:',
+            def.id,
+          );
         }
       } catch (error) {
         console.error('Toolbar.render: error creating button:', def.id, error);

--- a/src/progressView/modules/uiManagers/Toolbar.js
+++ b/src/progressView/modules/uiManagers/Toolbar.js
@@ -27,7 +27,11 @@ export class Toolbar {
           disabled: def.disabled,
           dataset,
         });
-        container.appendChild(btn);
+        if (btn) {
+          container.appendChild(btn);
+        } else {
+          console.error('Toolbar.render: button creation returned null:', def.id);
+        }
       } catch (error) {
         console.error('Toolbar.render: error creating button:', def.id, error);
       }

--- a/src/progressView/modules/utils.js
+++ b/src/progressView/modules/utils.js
@@ -82,6 +82,9 @@ export function insertChronologically(
  * @returns {number|null} The timestamp in ms or null if not applicable
  */
 function defaultChildTimestamp(child) {
+  if (!child || !child.classList) {
+    return null;
+  }
   if (child.classList.contains('log-group')) {
     const startElem = child.querySelector('.group-start-time');
     const start = startElem?.dataset.start;

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -41,6 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
   progressViewDomHandler.placeholder.show();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();
+  progressViewDomHandler.followUpInput.setup();
 
   // Apply saved group toggle states to any groups already in the DOM
   progressViewDomHandler.events.applyToggleStates();

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -19,14 +19,19 @@
 /* Style the textarea for multi-line input */
 #followUpInput {
   min-height: 36px;
-  max-height: 200px;
+  max-height: 400px;
   resize: none;
   flex: 1;
-  overflow-y: auto;
+  overflow-y: hidden;
   line-height: 1.4;
 }
 
-/* Align send button to bottom */
-#sendFollowUpBtn {
+.follow-up-actions {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-small);
+}
+
+.follow-up-actions .vscode-button {
   margin-bottom: var(--spacing-tiny);
 }

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -18,7 +18,7 @@
 
 /* Style the textarea for multi-line input */
 #followUpInput {
-  min-height: 80px;
+  min-height: 106px;
   max-height: 400px;
   resize: vertical;
   flex: 1;

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -18,9 +18,9 @@
 
 /* Style the textarea for multi-line input */
 #followUpInput {
-  min-height: 36px;
+  min-height: 80px;
   max-height: 400px;
-  resize: none;
+  resize: vertical;
   flex: 1;
   overflow-y: hidden;
   line-height: 1.4;
@@ -28,10 +28,11 @@
 
 .follow-up-actions {
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: center;
   gap: var(--spacing-small);
 }
 
 .follow-up-actions .vscode-button {
-  margin-bottom: var(--spacing-tiny);
+  /* Remove margin-bottom since we're using gap in flex column */
 }

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -17,6 +17,7 @@ import { getConfig } from '../config';
 // Local imports - agent runtime
 import { ModelFactory } from '@agent/runtime/ModelFactory';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import type { TaskState } from '@logger/TaskState';
 
 // Local imports - model configs
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
@@ -52,6 +53,50 @@ export interface FileContext {
   mediaFile?: string;
   mediaFiles?: string[];
   outputFiles?: string[];
+}
+
+/**
+ * Derive a FileContext from a stored task state.
+ */
+export function buildFileContextFromTaskState(
+  taskState: TaskState,
+): FileContext {
+  const context: FileContext = {};
+  const { agentConfig } = taskState;
+
+  if (agentConfig.agent) {
+    context.agent = agentConfig.agent;
+  }
+
+  const assignString = (
+    value: string | null | undefined,
+    key: keyof FileContext,
+  ) => {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      context[key] = value;
+    }
+  };
+
+  const assignArray = (
+    value: string[] | null | undefined,
+    key: keyof FileContext,
+  ) => {
+    if (Array.isArray(value) && value.length > 0) {
+      context[key] = value;
+    }
+  };
+
+  assignString(agentConfig.inputFile, 'inputFile');
+  assignArray(agentConfig.inputFiles ?? undefined, 'inputFiles');
+  assignString(agentConfig.referenceFile, 'referenceFile');
+  assignArray(agentConfig.referenceFiles ?? undefined, 'referenceFiles');
+  assignString(agentConfig.auxiliaryFile, 'auxiliaryFile');
+  assignArray(agentConfig.auxiliaryFiles ?? undefined, 'auxiliaryFiles');
+  assignString(agentConfig.mediaFile, 'mediaFile');
+  assignArray(agentConfig.mediaFiles ?? undefined, 'mediaFiles');
+  assignArray(agentConfig.outputFiles ?? undefined, 'outputFiles');
+
+  return context;
 }
 
 /**

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -73,7 +73,7 @@ export function buildFileContextFromTaskState(
     key: keyof FileContext,
   ) => {
     if (typeof value === 'string' && value.trim().length > 0) {
-      context[key] = value;
+      (context[key] as string) = value;
     }
   };
 
@@ -82,7 +82,7 @@ export function buildFileContextFromTaskState(
     key: keyof FileContext,
   ) => {
     if (Array.isArray(value) && value.length > 0) {
-      context[key] = value;
+      (context[key] as string[]) = value;
     }
   };
 

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -42,7 +42,12 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   constructor(private readonly context: vscode.ExtensionContext) {
     super('MainView');
     this.settingsManager = new SettingsManager();
-    this.recordingManager = new RecordingManager(context);
+    this.recordingManager = new RecordingManager(context, {
+      recordingStartedCommand: MAIN_VIEW_COMMANDS.RECORDING_STARTED,
+      recordingErrorCommand: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+      transcriptionCommand: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED,
+      progressTitle: 'Transcribing instruction',
+    });
     this.fileManager = new FileManager(context);
     this.executionManager = new ExecutionManager();
     this.diffManager = new DiffManager();

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -38,6 +38,8 @@
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webview/themeHandlers.js": "${webviewThemeHandlersUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
+          "@common/RecordingButtonManager.js": "${recordingButtonManagerUri}",
+          "@common/textareaUtils.js": "${textareaUtilsUri}",
           "@common/iconButtonInitializer.js": "${iconButtonInitializerUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",

--- a/src/webview/managers/RecordingManager.ts
+++ b/src/webview/managers/RecordingManager.ts
@@ -1,9 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
-
 // Local imports - media utilities
 import {
   startRecording,
@@ -16,20 +13,30 @@ import * as logger from '@logger/logUtils';
 const CHANNEL = 'RecordingManager';
 logger.initialize(CHANNEL);
 
+export interface RecordingManagerConfig {
+  recordingStartedCommand: string;
+  recordingErrorCommand: string;
+  transcriptionCommand: string;
+  progressTitle?: string;
+}
+
 export class RecordingManager {
-  constructor(private readonly context: vscode.ExtensionContext) {}
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly commandConfig: RecordingManagerConfig,
+  ) {}
 
   async start(webviewView: vscode.WebviewView): Promise<void> {
     try {
       const result = await startRecording(this.context);
       if (result.success) {
         webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.RECORDING_STARTED,
+          command: this.commandConfig.recordingStartedCommand,
         });
       } else if (result.error) {
         vscode.window.showErrorMessage(result.error);
         webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+          command: this.commandConfig.recordingErrorCommand,
           error: result.error,
         });
       }
@@ -42,7 +49,7 @@ export class RecordingManager {
         `Error in start: ${error instanceof Error ? error.message : String(error)}`,
       );
       webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+        command: this.commandConfig.recordingErrorCommand,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }
@@ -53,20 +60,20 @@ export class RecordingManager {
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: 'Transcribing instruction',
+          title: this.commandConfig.progressTitle ?? 'Transcribing recording',
           cancellable: false,
         },
         async () => {
           const result = await stopRecordingAndTranscribe(this.context);
           if (result.success) {
             webviewView.webview.postMessage({
-              command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED,
+              command: this.commandConfig.transcriptionCommand,
               text: result.text,
             });
           } else if (result.error) {
             vscode.window.showErrorMessage(result.error);
             webviewView.webview.postMessage({
-              command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+              command: this.commandConfig.recordingErrorCommand,
               error: result.error,
             });
           }
@@ -81,7 +88,7 @@ export class RecordingManager {
         `Error in stop: ${error instanceof Error ? error.message : String(error)}`,
       );
       webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+        command: this.commandConfig.recordingErrorCommand,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -22,7 +22,7 @@ export const instructionManager = new InstructionManager(
   mainViewState,
 );
 export const toggleManager = new ToggleManager();
-export const recordingManager = new RecordingManager(vscode, webviewEventBus);
+export const recordingManager = new RecordingManager(vscode);
 
 /**
  * Coordinates UI managers for the main webview.

--- a/src/webview/modules/handlers/recordingHandlers.js
+++ b/src/webview/modules/handlers/recordingHandlers.js
@@ -1,5 +1,5 @@
 // Local imports - webview
-import { webviewEventBus } from '../eventBus.js';
+import { recordingManager } from '../domHandlers.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 /**
@@ -9,16 +9,12 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
  */
 export function createRecordingHandlers({ postHandle }) {
   function handleRecordingStarted() {
-    webviewEventBus.dispatchEvent(
-      new CustomEvent('recordingUIUpdate', { detail: { recording: true } }),
-    );
+    recordingManager.setRecording(true);
     postHandle();
   }
 
   function handleRecordingError() {
-    webviewEventBus.dispatchEvent(
-      new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
-    );
+    recordingManager.setRecording(false);
     postHandle();
   }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -16,6 +16,7 @@ import {
 import { webviewEventBus } from './eventBus.js';
 import { createFileHandlers } from './handlers/fileHandlers.js';
 import { createRecordingHandlers } from './handlers/recordingHandlers.js';
+import { recordingManager } from './domHandlers.js';
 
 // Handler submodules
 import { createThemeHandlers } from './handlers/themeHandlers.js';
@@ -585,9 +586,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       });
       mainViewState.save();
     }
-    webviewEventBus.dispatchEvent(
-      new CustomEvent('recordingUIUpdate', { detail: { recording: false } }),
-    );
+    recordingManager.setRecording(false);
     this._postHandle();
   }
 }

--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -1,29 +1,16 @@
 // Local imports - webview
 import { setupPasteListener } from '../pasteHandler.js';
 import { safeGetElementById } from '@common/domUtils.js';
+import {
+  autoResizeTextarea,
+  insertTextAtCursor,
+} from '@common/textareaUtils.js';
 
 export class InstructionManager {
   constructor(textareaId, vscode, state) {
     this.textareaId = textareaId;
     this.vscode = vscode;
     this.state = state;
-  }
-
-  autoResizeTextarea(textarea) {
-    textarea.style.height = 'auto';
-    const maxHeight = 400;
-    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
-    textarea.style.height = `${newHeight}px`;
-    textarea.style.overflowY =
-      textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
-  }
-
-  insertTextAtCursor(textarea, text) {
-    const start = textarea.selectionStart;
-    const end = textarea.selectionEnd;
-    const original = textarea.value;
-    textarea.value = original.slice(0, start) + text + original.slice(end);
-    textarea.selectionStart = textarea.selectionEnd = start + text.length;
   }
 
   setup() {
@@ -35,19 +22,19 @@ export class InstructionManager {
       return;
     }
 
-    this.autoResizeTextarea(textarea);
+    autoResizeTextarea(textarea);
 
     textarea.addEventListener('input', () => {
-      this.autoResizeTextarea(textarea);
+      autoResizeTextarea(textarea);
       this.state?.save();
     });
 
     setupPasteListener(
       textarea,
       this.vscode,
-      (ta) => this.autoResizeTextarea(ta),
+      (ta) => autoResizeTextarea(ta),
       () => this.state?.save(),
-      (ta, text) => this.insertTextAtCursor(ta, text),
+      (ta, text) => insertTextAtCursor(ta, text),
     );
   }
 }

--- a/src/webview/modules/uiManagers/RecordingManager.js
+++ b/src/webview/modules/uiManagers/RecordingManager.js
@@ -1,58 +1,24 @@
 // Local imports - webview
 import { ELEMENT_IDS } from '../constants.js';
-import { webviewEventBus } from '../eventBus.js';
-import {
-  addEventListenerSafely,
-  safeGetElementById,
-} from '@common/domUtils.js';
-import { createCodicon } from '@common/templateUtils.js';
+import { RecordingButtonManager } from '@common/RecordingButtonManager.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 
 export class RecordingManager {
-  constructor(vscode, eventBus = webviewEventBus) {
-    this.vscode = vscode;
-    this.eventBus = eventBus;
-    this.isRecording = false;
-  }
-
-  updateRecordingUI(recording) {
-    this.isRecording = recording;
-    const recordButton = safeGetElementById(
-      ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON,
-    );
-    if (recordButton) {
-      recordButton.innerHTML = '';
-      const iconName = recording ? 'stop-circle' : 'mic';
-      const icon = createCodicon(iconName);
-      if (icon) recordButton.appendChild(icon);
-      recordButton.title = recording
-        ? 'Stop recording'
-        : 'Record instruction with microphone';
-      recordButton.classList.toggle('recording', recording);
-    }
+  constructor(vscode) {
+    this.buttonManager = new RecordingButtonManager(vscode, {
+      buttonId: ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON,
+      startCommand: MAIN_VIEW_COMMANDS.START_RECORDING,
+      stopCommand: MAIN_VIEW_COMMANDS.STOP_RECORDING,
+      startTitle: 'Record instruction with microphone',
+      stopTitle: 'Stop recording',
+    });
   }
 
   setupRecordButton() {
-    const buttonId = ELEMENT_IDS.RECORD_INSTRUCTION_BUTTON;
-    const button = safeGetElementById(buttonId);
-    if (!button) return;
+    this.buttonManager.setup();
+  }
 
-    addEventListenerSafely(buttonId, 'click', () => {
-      const nextState = !this.isRecording;
-      this.vscode.postMessage({
-        command: nextState
-          ? MAIN_VIEW_COMMANDS.START_RECORDING
-          : MAIN_VIEW_COMMANDS.STOP_RECORDING,
-      });
-      this.eventBus.dispatchEvent(
-        new CustomEvent('recordingUIUpdate', {
-          detail: { recording: nextState },
-        }),
-      );
-    });
-
-    this.eventBus.addEventListener('recordingUIUpdate', (e) => {
-      this.updateRecordingUI(e.detail.recording);
-    });
+  setRecording(recording) {
+    this.buttonManager.setRecording(recording);
   }
 }

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -71,16 +71,7 @@
   flex-shrink: 0;
 }
 
-/* Recording button states */
-#recordInstructionButton.recording {
-  background-color: var(--vscode-statusBarItem-errorBackground, #d32f2f);
-  color: var(--vscode-statusBarItem-errorForeground, #ffffff);
-}
-
-#recordInstructionButton.recording:hover {
-  background-color: var(--vscode-statusBarItem-errorBackground, #b71c1c);
-}
-
+/* Recording button states - icon change is enough, no red background needed */
 #recordInstructionButton.recording .codicon-stop-circle {
   animation: pulse 1.5s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary
- share textarea auto-resize and recording button helpers so both views reuse the same UI primitives
- add a dedicated progress view follow-up manager with Magic Polish and microphone controls plus auto-growing textarea
- extend progress view commands and handlers to polish or transcribe follow-ups and keep the recording UI in sync

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f53e3c44148324b45375d213562cd6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce shared recording/textarea modules and add a follow-up input in Progress View with AI polish and microphone recording, plus refactor recording flow and minor robustness fixes.
> 
> - **Progress View**:
>   - **Follow-up input**: Add `FollowUpInputManager` with actions to polish, record, clear, and send; auto-resizing textarea; new UI elements and styles.
>   - **Recording integration**: Wire start/stop recording, transcription, and UI sync via `RecordingManager`; handle `RECORDING_STARTED/ERROR`, `FOLLOW_UP_TEXT_TRANSCRIBED`, and `FOLLOW_UP_TEXT_POLISHED` messages.
>   - **Polish flow**: Implement `POLISH_FOLLOW_UP` handler using `polishTextWithAI` and `buildFileContextFromTaskState`; show info/error messages with progress UI.
>   - **Formatting**: Rename model response banner label to "Assistant".
> - **Common**:
>   - Add `modules/RecordingButtonManager.js` and `modules/textareaUtils.js`; expose URIs in `BaseViewContentProvider` and import maps.
> - **Main View**:
>   - Refactor `RecordingManager` to accept command config; update message/DOM handlers to use shared `RecordingButtonManager` and direct `setRecording` calls.
> - **Utilities/Robustness**:
>   - Add `buildFileContextFromTaskState` in `textEnhancementUtils`; improve null checks and error handling in FileList, utils, toolbar.
>   - Fix `useMultipleOutputs` precedence in clean operations (`cleanCommands.ts`, file-op path).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 702a15a5bd3b0eca58861fb8c26b91cfb98cb07c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->