### PR TITLE
fix: prevent malformed progress view output metadata from breaking pack/clean

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -532,14 +532,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const generated = this.provider.state.outputFiles.getFiles(stream);
     const allFiles = new Set<string>(taskState.agentConfig.outputFiles || []);
     if (generated) {
-      Object.values(generated).forEach((infos: any) =>
-        infos.forEach((info: any) => {
+      for (const [round, infos] of Object.entries(generated)) {
+        if (!Array.isArray(infos)) {
+          this.logger.warn(
+            `Skipping invalid output metadata for stream ${stream}, round ${round}`,
+          );
+          continue;
+        }
+
+        for (const info of infos) {
           allFiles.add(info.path);
           if (info.original) {
             allFiles.add(info.original);
           }
-        }),
-      );
+        }
+      }
     }
 
     const outputFilesArray = Array.from(allFiles);

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -168,16 +168,43 @@ export class OutputFilesManager extends PersistentMapManager<
     data: unknown,
     streamId: StreamTabId,
   ): Promise<{ [key: number]: OutputFileInfo[] }> {
-    const rounds = data as { [key: number]: OutputFileInfo[] };
+    if (!data || typeof data !== 'object') {
+      this.logger.warn(
+        `Invalid output files payload for stream ${streamId}; resetting entry`,
+      );
+      return {};
+    }
+
+    const rounds = data as Record<string, unknown>;
     const roundMap: { [key: number]: OutputFileInfo[] } = {};
-    const streamFilesProcessed = Object.values(rounds).reduce(
-      (sum, files) => sum + files.length,
+    const streamFilesProcessed = Object.values(rounds).reduce<number>(
+      (sum, value) => {
+        if (Array.isArray(value)) {
+          return sum + value.length;
+        }
+        return sum;
+      },
       0,
     );
     this.totalFilesProcessed += streamFilesProcessed;
 
-    for (const [roundStr, infos] of Object.entries(rounds)) {
+    for (const [roundStr, value] of Object.entries(rounds)) {
       const roundNum = parseInt(roundStr, 10);
+      if (Number.isNaN(roundNum)) {
+        this.logger.warn(
+          `Skipping non-numeric round key "${roundStr}" for stream ${streamId}`,
+        );
+        continue;
+      }
+
+      if (!Array.isArray(value)) {
+        this.logger.warn(
+          `Skipping invalid output metadata for stream ${streamId}, round ${roundNum}`,
+        );
+        continue;
+      }
+
+      const infos = value as OutputFileInfo[];
       this.logger.debug(
         `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
       );

--- a/src/test/progressView/ProgressViewMessageHandler.test.ts
+++ b/src/test/progressView/ProgressViewMessageHandler.test.ts
@@ -1,0 +1,89 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - progress view
+import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
+
+// Types
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { OutputFileInfo } from '@agent/output/types';
+import type { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import type { WorkflowTaskState } from '@logger/TaskState';
+
+describe('ProgressViewMessageHandler.handleFileOperation', () => {
+  const extensionContext = {
+    extensionUri: vscode.Uri.file('/tmp/texra'),
+  } as unknown as vscode.ExtensionContext;
+
+  let originalExecuteCommand: typeof vscode.commands.executeCommand;
+
+  before(() => {
+    originalExecuteCommand = vscode.commands.executeCommand;
+  });
+
+  afterEach(() => {
+    (vscode.commands as any).executeCommand = originalExecuteCommand;
+  });
+
+  it('ignores malformed output metadata when collecting files for toolbar commands', async () => {
+    const commandCalls: Array<{ command: string; payload: any }> = [];
+    (vscode.commands as any).executeCommand = async (
+      command: string,
+      payload: any,
+    ) => {
+      commandCalls.push({ command, payload });
+      return undefined;
+    };
+
+    const malformedEntry = { path: 'should-be-array' } as unknown as OutputFileInfo[];
+
+    const providerStub = {
+      state: {
+        outputFiles: {
+          getFiles: () => ({
+            0: [
+              {
+                path: 'generated/output.txt',
+                original: 'source/output.tex',
+              },
+            ],
+            1: malformedEntry,
+            round: [
+              {
+                path: 'ignored.txt',
+              },
+            ],
+          }),
+        },
+      },
+    } as unknown as ProgressViewProvider;
+
+    const handler = new ProgressViewMessageHandler(providerStub, extensionContext);
+
+    const taskState = {
+      agentConfig: {
+        agent: 'test-agent',
+        model: 'test-model',
+        inputFile: 'main.tex',
+        outputFiles: ['config/output.tex'],
+      },
+      activeFiles: { output: false },
+      session: { agentCategory: AgentCategory.Workflow },
+    } as unknown as WorkflowTaskState;
+
+    await (handler as any).handleFileOperation('stream-123', taskState, 'texra.pack');
+
+    assert.strictEqual(commandCalls.length, 1);
+    const [{ command, payload }] = commandCalls;
+    assert.strictEqual(command, 'texra.pack');
+    assert.strictEqual(payload.streamId, 'stream-123');
+    assert.deepStrictEqual(
+      payload.outputFiles.sort(),
+      ['config/output.tex', 'generated/output.txt', 'source/output.tex'].sort(),
+    );
+    assert.strictEqual(payload.useMultipleOutputs, true);
+  });
+});


### PR DESCRIPTION
## Summary
- guard pack/clean file collection against malformed progress view metadata
- ignore invalid persisted output entries while deserializing saved streams
- add regression coverage for malformed output metadata

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68f557b26a2483249b7e154871e0799d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden progress view file collection and deserialization to skip invalid output metadata and add regression test.
> 
> - **Progress View**:
>   - **`ProgressViewMessageHandler.handleFileOperation`**: Iterate rounds safely; validate entries are arrays; warn and skip invalid rounds; collect `path`/`original` into `outputFiles` before executing `texra.pack`/`texra.clean`.
> - **Persistence**:
>   - **`OutputFilesManager.deserialize`**: Validate payload object; compute counts only from array values; skip non-numeric round keys and non-array entries with warnings; continue filtering existing files; update processed/removed totals.
> - **Tests**:
>   - **`src/test/progressView/ProgressViewMessageHandler.test.ts`**: Add regression test ensuring malformed output metadata is ignored when invoking `texra.pack`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3797b81ef024293dcbeba4a6eccc032fdb9c2a60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->