### PR TITLE
feat: coordinate main view restore via event bus

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -154,6 +154,13 @@ export class MainViewProvider
       return;
     }
 
+    const fallbackPayload: ProgressEventPayloads['restoreStateRequest'] = {
+      taskState: payload.taskState,
+      streamId: payload.streamId,
+      source: payload.source,
+      metadata: payload.metadata,
+    };
+
     await vscode.commands.executeCommand(
       'setContext',
       'texra.hasStateToRestore',
@@ -162,7 +169,7 @@ export class MainViewProvider
     await vscode.commands.executeCommand(
       'setContext',
       'texra.stateToRestore',
-      payload.taskState,
+      fallbackPayload,
     );
   };
 
@@ -261,11 +268,42 @@ export class MainViewProvider
           }
         }
 
+        let restorePayload:
+          | ProgressEventPayloads['restoreStateRequest']
+          | undefined;
+
         if (state && typeof state === 'object' && !Array.isArray(state)) {
+          const payloadCandidate = state as Record<string, unknown>;
+          if ('taskState' in payloadCandidate) {
+            restorePayload = {
+              taskState:
+                payloadCandidate.taskState as ProgressEventPayloads['restoreStateRequest']['taskState'],
+              streamId: payloadCandidate.streamId as
+                | ProgressEventPayloads['restoreStateRequest']['streamId']
+                | undefined,
+              source: payloadCandidate.source as
+                | ProgressEventPayloads['restoreStateRequest']['source']
+                | undefined,
+              metadata: payloadCandidate.metadata as
+                | ProgressEventPayloads['restoreStateRequest']['metadata']
+                | undefined,
+            };
+          } else {
+            restorePayload = {
+              taskState:
+                state as ProgressEventPayloads['restoreStateRequest']['taskState'],
+            };
+          }
+        }
+
+        if (restorePayload) {
           // Send the state to the webview
           webviewView.webview.postMessage({
             command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-            state,
+            state: restorePayload.taskState,
+            streamId: restorePayload.streamId,
+            source: restorePayload.source,
+            metadata: restorePayload.metadata,
           });
 
           console.log('Restored state from context');

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -10,6 +10,8 @@ import { MainViewContentProvider } from './webview/MainViewContentProvider';
 import { watchConfig, getConfig } from '@utils/config';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
+import { bus } from './eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from './eventBus/ProgressEventBus';
 
 export class MainViewProvider
   extends BaseWebviewProvider
@@ -29,6 +31,7 @@ export class MainViewProvider
     this.setupFileWatcher();
     this.setupConfigurationWatcher();
     this.registerCommandHandlers();
+    this.registerRestoreStateListener();
   }
 
   private registerCommandHandlers() {
@@ -112,6 +115,56 @@ export class MainViewProvider
     // Dispose watcher when extension is deactivated
     this.context.subscriptions.push(this.fileWatcher);
   }
+
+  private registerRestoreStateListener() {
+    const dispose = bus.on(
+      'restoreStateRequest',
+      (payload) => void this.handleRestoreStateRequest(payload),
+    );
+
+    this.context.subscriptions.push({ dispose });
+  }
+
+  private readonly handleRestoreStateRequest = async (
+    payload: ProgressEventPayloads['restoreStateRequest'],
+  ): Promise<void> => {
+    try {
+      await vscode.commands.executeCommand('texra.mainView.focus');
+    } catch (error) {
+      console.warn('Failed to focus main view before restore:', error);
+    }
+
+    if (this._view) {
+      const view = this._view;
+      if ('show' in view && typeof view.show === 'function') {
+        try {
+          view.show(true);
+        } catch (error) {
+          console.warn('Failed to reveal main view before restore:', error);
+        }
+      }
+
+      await view.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+        state: payload.taskState,
+        streamId: payload.streamId,
+        source: payload.source,
+        metadata: payload.metadata,
+      });
+      return;
+    }
+
+    await vscode.commands.executeCommand(
+      'setContext',
+      'texra.hasStateToRestore',
+      true,
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      'texra.stateToRestore',
+      payload.taskState,
+    );
+  };
 
   private async refreshFiles() {
     if (this._view) {

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 import { objectToTaskState } from '@utils/config';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { bus } from '@eventBus/ProgressEventBus';
 
 const CHANNEL = 'stateRestoreCommand';
 logger.initialize(CHANNEL);
@@ -31,71 +32,12 @@ async function restoreState(config: any) {
   );
 
   try {
-    // Focus the webview panel first to make sure it's visible
-    // Use the specific view ID instead of the extension to avoid sidebar switching issues
-    await vscode.commands.executeCommand('texra.mainView.focus');
-
     // Create a complete state object from the task state using utility function
     const taskState = objectToTaskState(config);
-    // TaskState already has toolConfig as a nested object
-    const stateToRestore = taskState;
-
-    // Try to get the webview directly using our safe command
-    try {
-      const webviewView =
-        await vscode.commands.executeCommand<vscode.WebviewView>(
-          'texra.getWebviewView',
-        );
-
-      if (webviewView) {
-        // Send the state directly to the webview
-        webviewView.webview.postMessage({
-          command: 'restoreState',
-          state: stateToRestore,
-        });
-
-        logger.info(CHANNEL, 'State restored using direct webview access');
-      } else {
-        // Fallback to context storage method
-        await vscode.commands.executeCommand(
-          'setContext',
-          'texra.hasStateToRestore',
-          true,
-        );
-        await vscode.commands.executeCommand(
-          'setContext',
-          'texra.stateToRestore',
-          stateToRestore,
-        );
-
-        // Try to focus the main view to trigger its activation
-        // Use the specific view ID to avoid sidebar switching issues
-        await vscode.commands.executeCommand('texra.mainView.focus');
-        logger.info(CHANNEL, 'State stored in context for later restoration');
-      }
-    } catch (error) {
-      logger.warn(
-        CHANNEL,
-        `Could not access webview directly: ${error instanceof Error ? error.message : String(error)}`,
-      );
-
-      // Fallback to context storage method
-      await vscode.commands.executeCommand(
-        'setContext',
-        'texra.hasStateToRestore',
-        true,
-      );
-      await vscode.commands.executeCommand(
-        'setContext',
-        'texra.stateToRestore',
-        stateToRestore,
-      );
-
-      // Try to focus the main view to trigger its activation
-      // Use the specific view ID to avoid sidebar switching issues
-      await vscode.commands.executeCommand('texra.mainView.focus');
-      logger.info(CHANNEL, 'State stored in context for later restoration');
-    }
+    bus.emit('restoreStateRequest', {
+      taskState,
+      source: CHANNEL,
+    });
 
     logger.info(CHANNEL, 'Main webview state restoration requested');
     // vscode.window.showInformationMessage('Configuration restored to main view');

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -55,6 +55,13 @@ interface SetTaskStatePayload {
   taskState: TaskState;
 }
 
+interface RestoreStateRequestPayload {
+  taskState: TaskState;
+  streamId?: StreamTabId;
+  source?: string;
+  metadata?: Record<string, unknown>;
+}
+
 export interface ProgressEventPayloads {
   addLogMessage: { stream: StreamTabId; logMessage: LogMessageData };
   updateLogMessage: { stream: StreamTabId; logMessage: LogMessageUpdate };
@@ -80,6 +87,7 @@ export interface ProgressEventPayloads {
   };
   clearTaskOutput: StreamTabId;
   updateStreamUsage: { stream: StreamTabId; usage: TokenUsageStats };
+  restoreStateRequest: RestoreStateRequestPayload;
 }
 
 export type ProgressEvent = keyof ProgressEventPayloads;

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - agent commands
 import { executeCommand } from '@commands/agent/executeCommand';
 import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - history view
 import { AgentHistoryManager } from '@historyView/managers';
@@ -92,7 +93,11 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
           historyItem.config,
           historyItem.session,
         );
-        await vscode.commands.executeCommand('texra.restoreState', taskState);
+        bus.emit('restoreStateRequest', {
+          taskState,
+          source: 'historyView',
+          metadata: { historyId },
+        });
       } else {
         await vscode.window.showErrorMessage('History item not found');
       }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -27,6 +27,7 @@ import {
   buildFileContextFromTaskState,
   polishTextWithAI,
 } from '@utils/text/textEnhancementUtils';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // @ts-ignore - Import JavaScript module
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -256,11 +257,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleRestoreState(
     message: any,
-    webviewView: vscode.WebviewView,
+    _webviewView: vscode.WebviewView,
   ): Promise<void> {
     const taskState = this.provider.state.getTaskState(message.stream);
     if (taskState) {
-      await vscode.commands.executeCommand('texra.restoreState', taskState);
+      bus.emit('restoreStateRequest', {
+        taskState,
+        streamId: message.stream,
+        source: 'progressView',
+      });
     }
   }
 

--- a/src/test/mainView/MainViewProviderRestore.test.ts
+++ b/src/test/mainView/MainViewProviderRestore.test.ts
@@ -1,0 +1,177 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { MainViewProvider } from '@/MainViewProvider';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { bus } from '@eventBus/ProgressEventBus';
+import * as configUtils from '@utils/config';
+import * as toolUtils from '@utils/system/toolUtils';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { DEFAULT_TOOL_CONFIG } from '@agent/core/ToolConfig';
+import type { TaskState } from '@logger/TaskState';
+import type { FileType } from '@utils/config';
+
+describe('MainViewProvider restore handling', () => {
+  const originalWatchConfig = configUtils.watchConfig;
+  const originalGetConfig = configUtils.getConfig;
+  const originalCheckCoreDependencies = toolUtils.checkCoreDependencies;
+  const originalCreateFileSystemWatcher =
+    vscode.workspace.createFileSystemWatcher;
+  const originalOnDidChangeActiveTextEditor =
+    vscode.window.onDidChangeActiveTextEditor;
+  const originalRegisterCommand = vscode.commands.registerCommand;
+  const originalGetCommands = vscode.commands.getCommands;
+  const originalExecuteCommand = vscode.commands.executeCommand;
+
+  let context: vscode.ExtensionContext;
+  let provider: MainViewProvider | undefined;
+  let contextStore: Map<string, unknown>;
+  let commandCalls: Array<{ command: string; args: unknown[] }>;
+  let postMessageCalls: any[];
+
+  beforeEach(() => {
+    context = {
+      subscriptions: [],
+      extensionUri: vscode.Uri.parse('file:///texra-test'),
+    } as unknown as vscode.ExtensionContext;
+
+    contextStore = new Map();
+    commandCalls = [];
+    postMessageCalls = [];
+
+    (configUtils as any).watchConfig = () => {};
+    (configUtils as any).getConfig = <T>(_key: string, defaultValue: T) => {
+      if (_key === 'ui.showDependencyReminders') {
+        return false as T;
+      }
+      return defaultValue;
+    };
+    (toolUtils as any).checkCoreDependencies = async () => [];
+
+    (vscode.workspace as any).createFileSystemWatcher = () => ({
+      onDidCreate: () => ({ dispose: () => {} }),
+      onDidDelete: () => ({ dispose: () => {} }),
+      dispose: () => {},
+    });
+
+    (vscode.window as any).onDidChangeActiveTextEditor = () => ({
+      dispose: () => {},
+    });
+
+    (vscode.commands as any).registerCommand = (
+      _command: string,
+      _callback: (...args: unknown[]) => unknown,
+    ) => ({ dispose: () => {} });
+
+    (vscode.commands as any).getCommands = async () => [];
+
+    (vscode.commands as any).executeCommand = async (
+      command: string,
+      ...args: unknown[]
+    ) => {
+      commandCalls.push({ command, args });
+      if (command === 'setContext') {
+        const [key, value] = args as [string, unknown];
+        contextStore.set(key, value);
+        return undefined;
+      }
+      if (command === 'getContext') {
+        const [key] = args as [string];
+        return contextStore.get(key);
+      }
+      return undefined;
+    };
+  });
+
+  afterEach(() => {
+    provider?.dispose();
+    provider = undefined;
+
+    (configUtils as any).watchConfig = originalWatchConfig;
+    (configUtils as any).getConfig = originalGetConfig;
+    (toolUtils as any).checkCoreDependencies = originalCheckCoreDependencies;
+    (vscode.workspace as any).createFileSystemWatcher =
+      originalCreateFileSystemWatcher;
+    (vscode.window as any).onDidChangeActiveTextEditor =
+      originalOnDidChangeActiveTextEditor;
+    (vscode.commands as any).registerCommand = originalRegisterCommand;
+    (vscode.commands as any).getCommands = originalGetCommands;
+    (vscode.commands as any).executeCommand = originalExecuteCommand;
+  });
+
+  it('replays buffered restore requests once the view becomes available', async () => {
+    const taskState = {
+      agentConfig: {
+        model: 'test-model',
+        agent: 'test-agent',
+        instruction: 'Restore me',
+        useMultipleOutputs: false,
+        inputFile: 'main.tex',
+        inputFiles: null,
+        referenceFile: null,
+        referenceFiles: null,
+        auxiliaryFile: null,
+        auxiliaryFiles: null,
+        mediaFile: null,
+        mediaFiles: null,
+        outputFiles: null,
+        editedFile: null,
+        toolConfig: DEFAULT_TOOL_CONFIG,
+        session: { agentCategory: AgentCategory.Workflow },
+      },
+      session: { agentCategory: AgentCategory.Workflow },
+      activeFiles: {} as Record<FileType, boolean>,
+    } as TaskState;
+
+    bus.emit('restoreStateRequest', {
+      taskState,
+      source: 'test-suite',
+      metadata: { case: 'buffered' },
+    });
+
+    provider = new MainViewProvider(context);
+
+    assert.strictEqual(contextStore.get('texra.hasStateToRestore'), true);
+    assert.deepStrictEqual(contextStore.get('texra.stateToRestore'), taskState);
+
+    const mockWebviewView = {
+      webview: {
+        options: {},
+        postMessage: async (message: any) => {
+          postMessageCalls.push(message);
+          return true;
+        },
+        onDidReceiveMessage: () => ({ dispose: () => {} }),
+        get html() {
+          return '';
+        },
+        set html(_value: string) {},
+      },
+      onDidDispose: () => ({ dispose: () => {} }),
+      show: () => {},
+    } as unknown as vscode.WebviewView;
+
+    provider.resolveWebviewView(mockWebviewView);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const restoreMessage = postMessageCalls.find(
+      (message) => message.command === MAIN_VIEW_COMMANDS.STATE_RESTORE,
+    );
+
+    assert.ok(restoreMessage, 'Expected restore message to be posted');
+    assert.deepStrictEqual(restoreMessage.state, taskState);
+    assert.deepStrictEqual(restoreMessage.source, 'test-suite');
+
+    assert.strictEqual(contextStore.get('texra.hasStateToRestore'), false);
+    assert.strictEqual(contextStore.get('texra.stateToRestore'), undefined);
+
+    const focusCalls = commandCalls.filter(
+      (call) => call.command === 'texra.mainView.focus',
+    );
+    assert.ok(focusCalls.length >= 1, 'Expected focus command to run');
+  });
+});

--- a/src/test/mainView/MainViewProviderRestore.test.ts
+++ b/src/test/mainView/MainViewProviderRestore.test.ts
@@ -127,16 +127,22 @@ describe('MainViewProvider restore handling', () => {
       activeFiles: {} as Record<FileType, boolean>,
     } as TaskState;
 
-    bus.emit('restoreStateRequest', {
+    const bufferedPayload = {
       taskState,
       source: 'test-suite',
       metadata: { case: 'buffered' },
-    });
+      streamId: 'test-stream',
+    };
+
+    bus.emit('restoreStateRequest', bufferedPayload);
 
     provider = new MainViewProvider(context);
 
     assert.strictEqual(contextStore.get('texra.hasStateToRestore'), true);
-    assert.deepStrictEqual(contextStore.get('texra.stateToRestore'), taskState);
+    assert.deepStrictEqual(
+      contextStore.get('texra.stateToRestore'),
+      bufferedPayload,
+    );
 
     const mockWebviewView = {
       webview: {
@@ -165,6 +171,8 @@ describe('MainViewProvider restore handling', () => {
     assert.ok(restoreMessage, 'Expected restore message to be posted');
     assert.deepStrictEqual(restoreMessage.state, taskState);
     assert.deepStrictEqual(restoreMessage.source, 'test-suite');
+    assert.deepStrictEqual(restoreMessage.streamId, 'test-stream');
+    assert.deepStrictEqual(restoreMessage.metadata, { case: 'buffered' });
 
     assert.strictEqual(contextStore.get('texra.hasStateToRestore'), false);
     assert.strictEqual(contextStore.get('texra.stateToRestore'), undefined);

--- a/src/test/progressView/ProgressViewMessageHandler.test.ts
+++ b/src/test/progressView/ProgressViewMessageHandler.test.ts
@@ -38,7 +38,9 @@ describe('ProgressViewMessageHandler.handleFileOperation', () => {
       return undefined;
     };
 
-    const malformedEntry = { path: 'should-be-array' } as unknown as OutputFileInfo[];
+    const malformedEntry = {
+      path: 'should-be-array',
+    } as unknown as OutputFileInfo[];
 
     const providerStub = {
       state: {
@@ -61,7 +63,10 @@ describe('ProgressViewMessageHandler.handleFileOperation', () => {
       },
     } as unknown as ProgressViewProvider;
 
-    const handler = new ProgressViewMessageHandler(providerStub, extensionContext);
+    const handler = new ProgressViewMessageHandler(
+      providerStub,
+      extensionContext,
+    );
 
     const taskState = {
       agentConfig: {
@@ -74,7 +79,11 @@ describe('ProgressViewMessageHandler.handleFileOperation', () => {
       session: { agentCategory: AgentCategory.Workflow },
     } as unknown as WorkflowTaskState;
 
-    await (handler as any).handleFileOperation('stream-123', taskState, 'texra.pack');
+    await (handler as any).handleFileOperation(
+      'stream-123',
+      taskState,
+      'texra.pack',
+    );
 
     assert.strictEqual(commandCalls.length, 1);
     const [{ command, payload }] = commandCalls;


### PR DESCRIPTION
## Summary
- add a typed restoreStateRequest event to the progress event bus so state restores can buffer across listeners
- have the main view provider listen for restoreStateRequest to focus the panel, post STATE_RESTORE when ready, or fall back to context storage
- refactor restore entry points to emit the new bus event and add a regression test covering buffered restore delivery

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f572cb46808324b98369741923d0c6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route state restoration through a typed ProgressEventBus event, handled by MainViewProvider with focus/reveal and buffered delivery; update callers and add tests.
> 
> - **Event Bus**:
>   - Add typed `restoreStateRequest` to `eventBus/ProgressEventBus` with buffering.
> - **Main View**:
>   - Listen for `restoreStateRequest`; focus/reveal `texra.mainView` and post `MAIN_VIEW_COMMANDS.STATE_RESTORE` with `state`, `streamId`, `source`, `metadata`.
>   - Fallback to context flags `texra.hasStateToRestore`/`texra.stateToRestore` when view not ready.
> - **Command/View Emitters**:
>   - `commands/history/stateRestoreCommand`: emit `restoreStateRequest` with `taskState` instead of direct restore logic.
>   - `historyView/HistoryViewMessageHandler`: emit `restoreStateRequest` with `source=historyView` and `historyId` metadata.
>   - `progressView/ProgressViewMessageHandler`: emit `restoreStateRequest` with `streamId` for RESTORE_STATE.
> - **Tests**:
>   - Add `test/mainView/MainViewProviderRestore.test.ts` to verify buffered restore delivery and context clearing.
>   - Minor test formatting updates in `progressView` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e950894cf0a5d0051c76f70da4f59096796d5972. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->