### PR TITLE
Refactor progress view naming for DOM and state parity

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -68,7 +68,7 @@ export class ProgressViewProvider
     super(context);
     this._extensionUri = context.extensionUri;
     this._viewTitle = title;
-    this.logger = new AgentLogger('ProgressViewProviderNew');
+    this.logger = new AgentLogger('ProgressViewProvider');
 
     // Initialize new modular architecture
     const persistenceManager = new StatePersistenceManager(

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -2,7 +2,7 @@
 import { LogEntryFormatter } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { TaskGroupManager, LogEntryManager } from './taskManagers.js';
+import { TaskGroupDomManager, LogEntryManager } from './taskManagers.js';
 import { EventsManager } from './uiManagers/EventsManager.js';
 import { FileList } from './uiManagers/FileList.js';
 import { Status } from './uiManagers/Status.js';
@@ -11,7 +11,7 @@ import { Placeholder } from './uiManagers/Placeholder.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
 import { FollowUpInputManager } from './uiManagers/FollowUpInputManager.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
-import { UsageSummary, UsageGroup } from './usageManagers.js';
+import { UsageSummary, UsageGroupManager } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -26,9 +26,9 @@ class ProgressViewDomHandler extends BaseDomHandler {
       toolbar: new Toolbar(),
       status: new Status(),
       usageSummary,
-      usageGroup: new UsageGroup(usageSummary),
+      usageGroup: new UsageGroupManager(usageSummary),
       fileList: new FileList(usageSummary),
-      taskGroups: new TaskGroupManager(),
+      taskGroups: new TaskGroupDomManager(),
       logEntries: new LogEntryManager(),
       events: new EventsManager(),
       placeholder: new Placeholder(),

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -68,15 +68,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleUpdateStreams(message) {
     state.activeStream = message.activeStream;
-    state.agentFilter = message.agentFilter || 'all';
-    state.resetExecutionAvailability();
+    state.agentTypeFilter = message.agentFilter || 'all';
+    state.resetExecutionIdAvailability();
     message.streams.forEach((s) => {
       if (s.status) {
         state.streamStatuses.set(s.name, s.status);
       } else {
         state.streamStatuses.delete(s.name);
       }
-      state.setExecutionAvailability(s.name, Boolean(s.executionId));
+      state.setExecutionIdAvailable(s.name, Boolean(s.executionId));
     });
     dom.streamTabs.update(message.streams, message.activeStream);
 
@@ -85,7 +85,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     );
     if (filterContainer) {
       filterContainer.querySelectorAll('button[data-filter]').forEach((btn) => {
-        const isActive = btn.dataset.filter === state.agentFilter;
+        const isActive = btn.dataset.filter === state.agentTypeFilter;
         btn.classList.toggle('toggled', isActive);
         btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
       });
@@ -110,8 +110,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     dom.toolbar.render(sessionKind);
 
-    const hasExecution = state.getExecutionAvailability(message.activeStream);
-    dom.status.setExecutionAvailability(Boolean(hasExecution));
+    const hasExecution = state.hasExecutionId(message.activeStream);
+    dom.status.setExecutionIdAvailability(Boolean(hasExecution));
 
     // Update status based on whether there's an active stream
     if (!message.activeStream) {
@@ -134,10 +134,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         const childGroups = message.groups.filter((g) => g.parentGroupId);
         parentGroups
           .sort((a, b) => a.startTime - b.startTime)
-          .forEach((g) => dom.taskGroups.add(g));
+          .forEach((g) => dom.taskGroups.addGroup(g));
         childGroups
           .sort((a, b) => a.startTime - b.startTime)
-          .forEach((g) => dom.taskGroups.add(g));
+          .forEach((g) => dom.taskGroups.addGroup(g));
       }
       const sortedMessages = [...message.messages].sort(
         (a, b) => a.timestamp - b.timestamp,
@@ -172,7 +172,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
     state.taskGroups.clear();
     dom.taskGroups.clear();
-    state.toggleStates.clear(groupIds);
+    state.toggleStates.clearSelection(groupIds);
 
     this._updatePlaceholderVisibility();
   }
@@ -231,7 +231,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleAddTaskGroup(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      dom.taskGroups.add(message.group);
+      dom.taskGroups.addGroup(message.group);
       logContent.scrollTop = logContent.scrollHeight;
     }
   }
@@ -239,13 +239,17 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateTaskGroup(message) {
     if (message.stream === state.activeStream) {
       state.taskGroups.update(message.groupId, message.status, message.endTime);
-      dom.taskGroups.update(message.groupId, message.status, message.endTime);
+      dom.taskGroups.updateGroup(
+        message.groupId,
+        message.status,
+        message.endTime,
+      );
     }
   }
 
   handleUpdateStatus(message) {
-    const hasExecution = state.getExecutionAvailability(state.activeStream);
-    dom.status.setExecutionAvailability(Boolean(hasExecution));
+    const hasExecution = state.hasExecutionId(state.activeStream);
+    dom.status.setExecutionIdAvailability(Boolean(hasExecution));
     dom.status.update(message.status);
   }
 
@@ -300,7 +304,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleDeleteStream(message) {
     if (message.stream) {
       state.streamStatuses.delete(message.stream);
-      state.clearExecutionAvailability(message.stream);
+      state.clearExecutionIdAvailability(message.stream);
       if (message.stream === state.activeStream) {
         const groupIds = [];
         const headers = Array.from(
@@ -309,7 +313,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         for (const el of headers) {
           groupIds.push(el.id.replace('group-header-', ''));
         }
-        state.toggleStates.clear(groupIds);
+        state.toggleStates.clearSelection(groupIds);
         dom.instructionPanel.hide();
       }
     }
@@ -317,7 +321,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleDeleteAll() {
     state.toggleStates.clearAll();
-    state.resetExecutionAvailability();
+    state.resetExecutionIdAvailability();
     dom.instructionPanel.hide();
   }
 

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -32,7 +32,7 @@ class TaskGroups {
     this._cachedTotals = null; // Invalidate cache
   }
 
-  getAll() {
+  getGroupMap() {
     return this.groups;
   }
 
@@ -98,9 +98,9 @@ class ToggleStates {
     return this.states.get(id);
   }
 
-  clear(ids) {
+  clearSelection(ids) {
     if (!Array.isArray(ids)) {
-      console.error('ToggleStates.clear: ids must be an array');
+      console.error('ToggleStates.clearSelection: ids must be an array');
       return;
     }
     ids.forEach((id) => {
@@ -169,20 +169,20 @@ class StreamStatuses {
 /**
  * Tracks whether a stream has an execution directory available.
  */
-class ExecutionAvailability {
+class ExecutionIdAvailability {
   constructor() {
     this.availability = new Map();
   }
 
-  set(stream, available) {
+  setAvailable(stream, hasExecutionId) {
     if (!stream) {
-      console.error('ExecutionAvailability.set: stream is required');
+      console.error('ExecutionIdAvailability.setAvailable: stream is required');
       return;
     }
-    this.availability.set(stream, Boolean(available));
+    this.availability.set(stream, Boolean(hasExecutionId));
   }
 
-  get(stream) {
+  hasExecutionId(stream) {
     return this.availability.get(stream) ?? false;
   }
 
@@ -205,34 +205,34 @@ export class ProgressViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
     this.activeStream = '';
-    this.agentFilter = 'all';
+    this.agentTypeFilter = 'all';
     this.currentGroupId = null;
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
-    this.toggleStates = new ToggleStates(() => this.save());
+    this.toggleStates = new ToggleStates(() => this.saveToggleStates());
     this.streamStatuses = new StreamStatuses();
-    this.executionAvailability = new ExecutionAvailability();
+    this.executionIdAvailability = new ExecutionIdAvailability();
   }
 
-  setExecutionAvailability(stream, available) {
-    this.executionAvailability.set(stream, available);
+  setExecutionIdAvailable(stream, hasExecutionId) {
+    this.executionIdAvailability.setAvailable(stream, hasExecutionId);
   }
 
-  getExecutionAvailability(stream) {
-    return this.executionAvailability.get(stream);
+  hasExecutionId(stream) {
+    return this.executionIdAvailability.hasExecutionId(stream);
   }
 
-  clearExecutionAvailability(stream) {
-    this.executionAvailability.delete(stream);
+  clearExecutionIdAvailability(stream) {
+    this.executionIdAvailability.delete(stream);
   }
 
-  resetExecutionAvailability() {
-    this.executionAvailability.clear();
+  resetExecutionIdAvailability() {
+    this.executionIdAvailability.clear();
   }
 
   /** Load saved state from VS Code storage. */
-  initialize() {
+  load() {
     const previous = this.stateManager.getState();
     if (previous.groupToggleStates) {
       let data = previous.groupToggleStates;
@@ -283,7 +283,7 @@ export class ProgressViewState {
   }
 
   /** Persist the current group toggle states. */
-  save() {
+  saveToggleStates() {
     try {
       this.stateManager.update({
         groupToggleStates: this.toggleStates.entries(),

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -9,7 +9,7 @@ import { createFromTemplate } from '@common/templateUtils.js';
 /**
  * Manages task group DOM operations.
  */
-export class TaskGroupManager {
+export class TaskGroupDomManager {
   constructor() {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
@@ -20,7 +20,7 @@ export class TaskGroupManager {
    * Adds a log group to the DOM
    * @param {Object} group - Group data
    */
-  add(group) {
+  addGroup(group) {
     const existingGroup = this.groupElements.get(group.id);
     if (existingGroup) {
       if (!progressViewState.taskGroups.get(group.id)) {
@@ -31,27 +31,33 @@ export class TaskGroupManager {
         this.groupElements.delete(group.id);
       } else {
         progressViewState.taskGroups.set(group.id, group);
-        this.update(group.id, group.status, group.endTime);
+        this.updateGroup(group.id, group.status, group.endTime);
         return;
       }
     }
 
     const detailsElem = createFromTemplate('groupDetailsTemplate');
     if (!detailsElem) {
-      console.error('TaskGroupManager.add: groupDetailsTemplate not found');
+      console.error(
+        'TaskGroupDomManager.addGroup: groupDetailsTemplate not found',
+      );
       return;
     }
     detailsElem.id = `group-${group.id}`;
 
     const headerElement = this.headerFormatter.create(group);
     if (!headerElement) {
-      console.error('TaskGroupManager.add: failed to create group header');
+      console.error(
+        'TaskGroupDomManager.addGroup: failed to create group header',
+      );
       return;
     }
 
     const groupContainer = detailsElem.querySelector('.log-group-content');
     if (!groupContainer) {
-      console.error('TaskGroupManager.add: missing group content container');
+      console.error(
+        'TaskGroupDomManager.addGroup: missing group content container',
+      );
       return;
     }
     groupContainer.id = `group-content-${group.id}`;
@@ -98,7 +104,7 @@ export class TaskGroupManager {
    * @param {string} status - New status
    * @param {string} endTime - End time (optional)
    */
-  update(groupId, status, endTime) {
+  updateGroup(groupId, status, endTime) {
     const group = progressViewState.taskGroups.get(groupId);
     if (!group) return;
 
@@ -157,8 +163,9 @@ export class TaskGroupManager {
    * @param {string} groupId - ID of the group to collapse
    */
   collapseGroupAndChildren(groupId) {
-    // Find all child groups
-    for (const [childId, group] of progressViewState.taskGroups.getAll()) {
+    const taskGroups = progressViewState.taskGroups.getGroupMap();
+
+    for (const [childId, group] of taskGroups.entries()) {
       if (group.parentGroupId === groupId) {
         this.collapseGroupAndChildren(childId);
       }

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -21,8 +21,8 @@ export class EventsManager {
    * Apply saved toggle states to any groups already in the DOM
    */
   applyToggleStates() {
-    const taskGroups = progressViewState.taskGroups.getAll();
-    for (const [groupId, _] of taskGroups) {
+    const taskGroups = progressViewState.taskGroups.getGroupMap();
+    for (const [groupId] of taskGroups) {
       const isCollapsed = progressViewState.toggleStates.get(groupId);
       const detailsElem = document.getElementById(`group-${groupId}`);
 

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -71,7 +71,7 @@ export class Status {
     this._executionAvailable = false;
   }
 
-  setExecutionAvailability(hasExecution) {
+  setExecutionIdAvailability(hasExecution) {
     this._executionAvailable = Boolean(hasExecution);
     this._applyExecutionAvailability();
   }

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -37,7 +37,8 @@ export class UsageSummary {
    */
   computeTotal() {
     const totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
-    for (const group of progressViewState.taskGroups.getAll().values()) {
+    const taskGroups = progressViewState.taskGroups.getGroupMap();
+    for (const group of taskGroups.values()) {
       if (group.usage) {
         totals.inputTokens += group.usage.inputTokens || 0;
         totals.outputTokens += group.usage.outputTokens || 0;
@@ -51,7 +52,7 @@ export class UsageSummary {
 /**
  * Manages usage display for individual groups.
  */
-export class UsageGroup {
+export class UsageGroupManager {
   constructor(usageSummary) {
     this.usageSummary = usageSummary; // Use the shared instance
   }
@@ -64,14 +65,14 @@ export class UsageGroup {
    */
   update(groupId, usage, skipPropagate = false) {
     if (!groupId) {
-      console.error('UsageGroup.update: groupId is required');
+      console.error('UsageGroupManager.update: groupId is required');
       return;
     }
 
     const groupHeader = document.getElementById(`group-header-${groupId}`);
     if (!groupHeader) {
       console.warn(
-        `UsageGroup.update: Group header not found for ID: ${groupId}`,
+        `UsageGroupManager.update: Group header not found for ID: ${groupId}`,
       );
       return;
     }
@@ -81,7 +82,7 @@ export class UsageGroup {
     if (!usageElem) {
       usageElem = createFromTemplate('usageTemplate');
       if (!usageElem) {
-        console.error('UsageGroup.update: usageTemplate not found');
+        console.error('UsageGroupManager.update: usageTemplate not found');
         return;
       }
       // Determine the group level by checking for the 'top-level' class
@@ -129,7 +130,8 @@ export class UsageGroup {
    */
   computeAggregatedUsage(parentId) {
     const totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
-    for (const group of progressViewState.taskGroups.getAll().values()) {
+    const taskGroups = progressViewState.taskGroups.getGroupMap();
+    for (const group of taskGroups.values()) {
       if (group.parentGroupId === parentId) {
         if (group.usage) {
           totals.inputTokens += group.usage.inputTokens || 0;

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -8,7 +8,7 @@ import { validateTemplates } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
 
 // Initialize the state when the window loads
-progressViewState.initialize();
+progressViewState.load();
 
 // Register handlers for VSCode messages
 messageHandler.setup();

--- a/src/test/progressView/ProgressViewMessageHandler.test.ts
+++ b/src/test/progressView/ProgressViewMessageHandler.test.ts
@@ -38,7 +38,9 @@ describe('ProgressViewMessageHandler.handleFileOperation', () => {
       return undefined;
     };
 
-    const malformedEntry = { path: 'should-be-array' } as unknown as OutputFileInfo[];
+    const malformedEntry = {
+      path: 'should-be-array',
+    } as unknown as OutputFileInfo[];
 
     const providerStub = {
       state: {
@@ -61,7 +63,10 @@ describe('ProgressViewMessageHandler.handleFileOperation', () => {
       },
     } as unknown as ProgressViewProvider;
 
-    const handler = new ProgressViewMessageHandler(providerStub, extensionContext);
+    const handler = new ProgressViewMessageHandler(
+      providerStub,
+      extensionContext,
+    );
 
     const taskState = {
       agentConfig: {
@@ -74,7 +79,11 @@ describe('ProgressViewMessageHandler.handleFileOperation', () => {
       session: { agentCategory: AgentCategory.Workflow },
     } as unknown as WorkflowTaskState;
 
-    await (handler as any).handleFileOperation('stream-123', taskState, 'texra.pack');
+    await (handler as any).handleFileOperation(
+      'stream-123',
+      taskState,
+      'texra.pack',
+    );
 
     assert.strictEqual(commandCalls.length, 1);
     const [{ command, payload }] = commandCalls;


### PR DESCRIPTION
## Summary
- rename the progress view DOM task group manager and usage manager to avoid backend naming collisions while aligning message handler calls
- standardize progress view state APIs around agent filters, execution ID availability, and toggle persistence terminology
- update status handling, event wiring, initialization, and the provider logger label to adopt the new naming

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f573ccc524832482c05f6716847b80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames DOM managers and standardizes state/status APIs (executionId availability, agent type filter, toggle persistence), updating message handling, events, script init, and provider logger label.
> 
> - **Progress View (Webview JS)**:
>   - **DOM/Managers**:
>     - Rename `TaskGroupManager` → `TaskGroupDomManager` (`add` → `addGroup`, `update` → `updateGroup`).
>     - Rename `UsageGroup` → `UsageGroupManager`.
>   - **State API** (`modules/progressViewState.js`):
>     - `agentFilter` → `agentTypeFilter`.
>     - `ExecutionAvailability` → `ExecutionIdAvailability` with methods `setAvailable`, `hasExecutionId`, and corresponding `setExecutionIdAvailable`, `hasExecutionId`, `clearExecutionIdAvailability`, `resetExecutionIdAvailability` on `ProgressViewState`.
>     - Rename `getAll()` → `getGroupMap()`; `ToggleStates.clear()` → `clearSelection()`.
>     - Lifecycle: `initialize()` → `load()`; `save()` → `saveToggleStates()`.
>   - **UI/Status**: `setExecutionAvailability()` → `setExecutionIdAvailability()`.
>   - **Message/Events**:
>     - Update handlers to use new state/status API and renamed DOM manager methods.
>     - Update filter button toggling to use `agentTypeFilter`.
>   - **Script init**: call `progressViewState.load()` instead of `initialize()`.
> - **Provider (TS)**:
>   - Logger label changed to `ProgressViewProvider`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 663b4755bf6ef3d65b0453c8d9f8ca590a3503b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->