### PR TITLE
Refactor manager APIs to reuse active webview context

### DIFF
--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -24,13 +24,11 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
 
   constructor(
     private workspaceRoot: string | undefined,
-    private context?: vscode.ExtensionContext,
+    _context?: vscode.ExtensionContext,
   ) {
-    if (this.context) {
-      agentDirectories.builtIn(this.context).then((p) => {
-        this.builtInAgentsPath = p;
-      });
-    }
+    agentDirectories.builtIn().then((p) => {
+      this.builtInAgentsPath = p;
+    });
   }
 
   refresh(): void {
@@ -55,21 +53,14 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
   }
 
   async getChildren(element?: FileItem): Promise<FileItem[]> {
-    if (!this.context) {
-      logger.error(CHANNEL, 'Extension context not available');
-      return [];
-    }
-
     try {
       if (element) {
         return this.getFilesInDirectory(element.resourceUri.fsPath);
       }
 
       const items: FileItem[] = [];
-      const builtInPath = await agentDirectories.builtIn(this.context);
-      const builtInToolUsePath = await agentDirectories.builtInToolUse(
-        this.context,
-      );
+      const builtInPath = await agentDirectories.builtIn();
+      const builtInToolUsePath = await agentDirectories.builtInToolUse();
       items.push(
         new FileItem(
           'Built-in Agents',
@@ -85,7 +76,7 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
         ),
       );
 
-      const customPath = await agentDirectories.custom(this.context);
+      const customPath = await agentDirectories.custom();
       if (customPath) {
         items.push(
           new FileItem(

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -1,6 +1,3 @@
-// Third-party imports
-import * as vscode from 'vscode';
-
 // Local imports - agent utilities
 import {
   buildAgentOptionsPayload,
@@ -23,9 +20,7 @@ export interface AgentNameBuckets {
   defaultWorkflowAgent: string;
 }
 
-export async function getAllAgents(
-  context: vscode.ExtensionContext,
-): Promise<AgentNameBuckets> {
+export async function getAllAgents(): Promise<AgentNameBuckets> {
   const configuredWorkflowAgents = getConfig<string[]>('agents', []);
   const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
 
@@ -50,13 +45,11 @@ export async function getAllAgents(
 /**
  * Get all agent directories.
  */
-async function getAgentDirectories(
-  context: vscode.ExtensionContext,
-): Promise<AgentDirectoryMap> {
+async function getAgentDirectories(): Promise<AgentDirectoryMap> {
   return {
-    custom: await agentDirectories.custom(context),
-    builtIn: await agentDirectories.builtIn(context),
-    builtInToolUse: await agentDirectories.builtInToolUse(context),
+    custom: await agentDirectories.custom(),
+    builtIn: await agentDirectories.builtIn(),
+    builtInToolUse: await agentDirectories.builtInToolUse(),
   };
 }
 
@@ -66,12 +59,10 @@ async function getAgentDirectories(
  * A codicon indicator is added via data-multiple when either the agent declares
  * `isMultipleOutput: true` or a sibling `_multiple.yaml` definition exists.
  */
-export async function computeAgentOptions(
-  context: vscode.ExtensionContext,
-): Promise<AgentOptionsPayload> {
+export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
   const { allAgents, toolUseAgents, defaultWorkflowAgent } =
-    await getAllAgents(context);
-  const dirs = await getAgentDirectories(context);
+    await getAllAgents();
+  const dirs = await getAgentDirectories();
 
   return buildAgentOptionsPayload(allAgents, dirs, toolUseAgents, {
     workflowAgent: defaultWorkflowAgent,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -87,13 +87,12 @@ type AgentConstructor = {
  */
 export async function getAgentPath(
   agentName: string,
-  context: vscode.ExtensionContext,
 ): Promise<AgentPathResolution> {
   try {
     const [customDir, builtInDir, builtInToolUseDir] = await Promise.all([
-      agentDirectories.custom(context),
-      agentDirectories.builtIn(context),
-      agentDirectories.builtInToolUse(context),
+      agentDirectories.custom(),
+      agentDirectories.builtIn(),
+      agentDirectories.builtInToolUse(),
     ]);
 
     const candidateDirectories = [
@@ -181,8 +180,6 @@ interface PrepareAgentInstanceParams {
   agentName: string;
   /** Partial agent configuration to merge with defaults */
   configPayload: Partial<AgentConfig>;
-  /** VS Code extension context for resource access */
-  context: vscode.ExtensionContext;
   /** Optional execution ID for tracking and logging */
   executionId?: ExecutionId;
   /** Optional agent class to use instead of automatic selection based on agent type */
@@ -229,8 +226,7 @@ interface PrepareAgentInstanceParams {
 export async function prepareAgentInstance<T extends IAgent = IAgent>(
   params: PrepareAgentInstanceParams,
 ): Promise<{ agent: T; agentType: AgentType }> {
-  const { agentName, configPayload, context, executionId, agentClassOverride } =
-    params;
+  const { agentName, configPayload, executionId, agentClassOverride } = params;
 
   const configInput: Partial<AgentConfig> = {
     agent: agentName,
@@ -246,11 +242,11 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
 
   let agentPathInfo: AgentPathResolution;
   try {
-    agentPathInfo = await getAgentPath(resolvedAgentName, context);
+    agentPathInfo = await getAgentPath(resolvedAgentName);
   } catch (err) {
     if (resolvedAgentName !== originalAgentName) {
       resolvedAgentName = originalAgentName;
-      agentPathInfo = await getAgentPath(originalAgentName, context);
+      agentPathInfo = await getAgentPath(originalAgentName);
     } else {
       throw err;
     }
@@ -328,7 +324,6 @@ interface ExecuteAgentOptions {
 export async function executeAgentWithLogging<T extends IAgent>(
   agentName: string,
   createAgentFn: () => Promise<{ agent: T; agentType?: AgentType }>,
-  context: vscode.ExtensionContext,
   executionId?: ExecutionId,
   options?: ExecuteAgentOptions,
 ): Promise<void> {
@@ -606,7 +601,6 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
 export async function executeAgent(
   agentConfig: Partial<AgentConfig>,
-  context: vscode.ExtensionContext,
   executionId?: ExecutionId,
 ): Promise<void> {
   // Ensure required fields
@@ -626,7 +620,6 @@ export async function executeAgent(
       const { agent, agentType } = await prepareAgentInstance({
         agentName: requestedAgentName,
         configPayload: agentConfig,
-        context,
         executionId,
       });
 
@@ -643,7 +636,6 @@ export async function executeAgent(
 
       return { agent, agentType };
     },
-    context,
     executionId,
     { resume: false },
   );
@@ -656,7 +648,6 @@ export async function executeMergeAgent(
   model: string,
   inputFile: string,
   editedFile: string,
-  context: vscode.ExtensionContext,
 ): Promise<void> {
   const agentName = 'merge';
 
@@ -666,13 +657,11 @@ export async function executeMergeAgent(
       const { agent, agentType } = await prepareAgentInstance<MergeAgent>({
         agentName,
         configPayload: { agent: agentName, model, inputFile, editedFile },
-        context,
         agentClassOverride: MergeAgent,
       });
 
       return { agent, agentType };
     },
-    context,
     undefined,
   );
 }

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -187,7 +187,7 @@ export function registerAgentCreatorCommands(context: vscode.ExtensionContext) {
   return agentCreatorCommands;
 }
 
-async function handleCreateAgentWithAI(context: vscode.ExtensionContext) {
+async function handleCreateAgentWithAI(_context: vscode.ExtensionContext) {
   try {
     const agentName = await vscode.window.showInputBox({
       prompt: 'Enter a name for the new agent (without .yaml)',
@@ -230,7 +230,7 @@ async function handleCreateAgentWithAI(context: vscode.ExtensionContext) {
       outputFilesYaml = files.map((f) => `    - ${f}`).join('\n');
     }
 
-    const targetDir = await agentDirectories.custom(context);
+    const targetDir = await agentDirectories.custom();
 
     const filePath = vscode.Uri.file(`${targetDir}/${agentName}.yaml`);
 

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -29,7 +29,7 @@ export const executeCommand = {
         await AgentHistoryManager.addToHistory(config);
 
       // Run the agent directly, passing through the execution ID
-      await executeAgent(config, context, executionId);
+      await executeAgent(config, executionId);
     } catch (err) {
       throw err;
     }

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -49,7 +49,7 @@ async function handleMerge(
   const fileToUse = baseFile || inputFile;
 
   try {
-    await executeMergeAgent(model, fileToUse, editedFile, context);
+    await executeMergeAgent(model, fileToUse, editedFile);
   } catch (err) {
     // Log the error before re-throwing
     await showLoggedErrorMessage(

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -21,7 +21,7 @@ import { logErrorMessage } from '@common/errors/errorHandlingUtils';
 
 async function buildToolUseAgent(
   snapshot: ToolUseSessionSnapshot,
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
 ): Promise<{ agent: BaseToolUseAgent; agentType: AgentType }> {
   const provider = ProgressViewProvider.getInstance();
   if (!provider) {
@@ -41,7 +41,6 @@ async function buildToolUseAgent(
   const { agent, agentType } = await prepareAgentInstance<BaseToolUseAgent>({
     agentName: fullConfig.agent,
     configPayload: fullConfig,
-    context,
     executionId: snapshot.executionId as ExecutionId,
   });
 
@@ -121,7 +120,6 @@ export function registerResumeAgentCommand(
             agent,
             agentType,
           }),
-          context,
           executionId,
           { resume: true },
         );

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -140,7 +140,7 @@ export async function handleCountLinterMessages(): Promise<void> {
  * Fix linter issues in the current file using Claude
  */
 export async function handleFixLinterIssues(
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
 ): Promise<void> {
   try {
     const guardResult = await getActiveEditorWithGuards({
@@ -177,14 +177,11 @@ export async function handleFixLinterIssues(
       `Found ${issues.length} linter issues in ${relativePath}`,
     );
 
-    await executeAgent(
-      {
-        agent: 'tex_linter_fix',
-        model: 'claude-3-7-sonnet-latest',
-        inputFile: relativePath,
-      },
-      context,
-    );
+    await executeAgent({
+      agent: 'tex_linter_fix',
+      model: 'claude-3-7-sonnet-latest',
+      inputFile: relativePath,
+    });
   } catch (err) {
     logger.error(
       CHANNEL,

--- a/src/commands/system/xmlCommands.ts
+++ b/src/commands/system/xmlCommands.ts
@@ -78,7 +78,7 @@ export async function handleParseXml(): Promise<void> {
  * Validate and fix XML errors using Claude
  */
 export async function handleValidateAndFixXml(
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
 ): Promise<void> {
   try {
     const guardResult = await getActiveEditorWithGuards({
@@ -96,14 +96,11 @@ export async function handleValidateAndFixXml(
 
     logger.info(CHANNEL, `Starting XML validation for ${filePath}`);
 
-    await executeAgent(
-      {
-        agent: 'xml_validator',
-        model: 'claude-3-7-sonnet-latest',
-        inputFile: filePath,
-      },
-      context,
-    );
+    await executeAgent({
+      agent: 'xml_validator',
+      model: 'claude-3-7-sonnet-latest',
+      inputFile: filePath,
+    });
   } catch (err) {
     logger.error(
       CHANNEL,

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -149,7 +149,7 @@ export async function handleTestAgentLoading(
 }
 
 export async function handleLoadSpecificAgent(
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
 ): Promise<void> {
   try {
     // Get agent name from user
@@ -166,7 +166,7 @@ export async function handleLoadSpecificAgent(
     logger.info(CHANNEL, `Testing loading of agent: ${agentName}`);
 
     // Use getAgentPath to find the agent's directory
-    const agentPath = await getAgentPath(agentName, context);
+    const agentPath = await getAgentPath(agentName);
     logger.info(CHANNEL, `Loading from path: ${agentPath.directory}`);
 
     // Load and display the agent configuration

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -58,17 +58,15 @@ export class ExplorerOperations {
 
   constructor(
     private workspaceRoot: string | undefined,
-    private context: vscode.ExtensionContext | undefined,
+    _context: vscode.ExtensionContext | undefined,
     private refresh: () => void,
   ) {
-    if (this.context) {
-      agentDirectories.builtIn(this.context).then((p) => {
-        this.builtInAgentsPath = p;
-      });
-      agentDirectories.builtInToolUse(this.context).then((p) => {
-        this.builtInToolUsePath = p;
-      });
-    }
+    agentDirectories.builtIn().then((p) => {
+      this.builtInAgentsPath = p;
+    });
+    agentDirectories.builtInToolUse().then((p) => {
+      this.builtInToolUsePath = p;
+    });
   }
 
   async open(uri: vscode.Uri) {
@@ -108,7 +106,7 @@ export class ExplorerOperations {
 
   private async createCustomCopy(uri: vscode.Uri) {
     try {
-      const customPath = await agentDirectories.custom(this.context);
+      const customPath = await agentDirectories.custom();
 
       const base = uri.fsPath.startsWith(this.builtInToolUsePath)
         ? this.builtInToolUsePath
@@ -136,7 +134,7 @@ export class ExplorerOperations {
 
   async create(node: FileItem | undefined, isFolder: boolean) {
     try {
-      const customBase = await agentDirectories.custom(this.context);
+      const customBase = await agentDirectories.custom();
 
       let parentPath = node?.resourceUri.fsPath || customBase;
 

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -42,11 +42,9 @@ export class WatcherManager {
 
       this.dispose();
 
-      const builtInAgentsPath = await agentDirectories.builtIn(this.context);
-      const builtInToolUsePath = await agentDirectories.builtInToolUse(
-        this.context,
-      );
-      const customAgentsPath = await agentDirectories.custom(this.context);
+      const builtInAgentsPath = await agentDirectories.builtIn();
+      const builtInToolUsePath = await agentDirectories.builtInToolUse();
+      const customAgentsPath = await agentDirectories.custom();
 
       const pathsToWatch = [builtInAgentsPath, builtInToolUsePath];
       if (customAgentsPath) {

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -22,15 +22,9 @@ export class AgentDirectoryManager {
   /**
    * Ensure a built-in agents directory exists and return its path.
    */
-  private async ensureBuiltInDir(
-    context: vscode.ExtensionContext,
-    dirName: string,
-  ): Promise<string> {
-    if (!context) {
-      throw new Error('Extension context required for built-in agents');
-    }
+  private async ensureBuiltInDir(dirName: string): Promise<string> {
+    this.ensureInitialized();
 
-    StorageFS.initialize(context);
     await GlobalStorageFS.ensureDir(dirName);
 
     const basePath = GlobalStorageFS.fullPath(dirName);
@@ -45,7 +39,7 @@ export class AgentDirectoryManager {
     StorageFS.initialize(context);
   }
 
-  private ensureInitialized(): void {
+  private ensureInitialized(): vscode.ExtensionContext {
     if (!this.context) {
       throw new Error(
         'Agent directories not initialized. Call agentDirectories.initialize(context) first.',
@@ -53,14 +47,15 @@ export class AgentDirectoryManager {
     }
 
     StorageFS.initialize(this.context);
+    return this.context;
   }
 
-  async builtIn(context: vscode.ExtensionContext): Promise<string> {
-    return this.ensureBuiltInDir(context, 'agents');
+  async builtIn(): Promise<string> {
+    return this.ensureBuiltInDir('agents');
   }
 
-  async builtInToolUse(context: vscode.ExtensionContext): Promise<string> {
-    return this.ensureBuiltInDir(context, 'tool_use_agents');
+  async builtInToolUse(): Promise<string> {
+    return this.ensureBuiltInDir('tool_use_agents');
   }
 
   private async ensureDefaultCustomDir(): Promise<string> {
@@ -132,11 +127,8 @@ export class AgentDirectoryManager {
     return configuredPath;
   }
 
-  async custom(context?: vscode.ExtensionContext): Promise<string> {
-    if (context) {
-      this.context = context;
-    }
-
+  async custom(): Promise<string> {
+    this.ensureInitialized();
     const configuredPath = getConfig<string>(
       'explorer.agentsDirectory',
       '',

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -45,6 +45,7 @@ interface CompareMessage extends BaseFileCommandMessage {
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;
+  private activeView: vscode.WebviewView | undefined;
 
   constructor(
     private readonly provider: ProgressViewProvider,
@@ -57,6 +58,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       transcriptionCommand: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED,
       progressTitle: 'Transcribing follow-up message',
     });
+  }
+
+  public override async handleMessage(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    this.activeView = webviewView;
+    await super.handleMessage(message, webviewView);
+  }
+
+  private getActiveView(): vscode.WebviewView | undefined {
+    if (!this.activeView) {
+      this.logger.warn(this.channel, 'No active progress view available');
+      return undefined;
+    }
+
+    return this.activeView;
   }
 
   private async deleteSessionSnapshot(stream: StreamTabId): Promise<void> {
@@ -134,44 +152,33 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
    * This allows the provider to process any pending updates that
    * were queued while the webview was initializing.
    */
-  protected override async handleWebviewReady(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  protected override async handleWebviewReady(message: any): Promise<void> {
+    const webviewView = this.getActiveView();
+    if (webviewView) {
+      await super.handleWebviewReady(message, webviewView);
+    }
     this.provider.markWebviewReady();
   }
 
-  private async handleSwitchStream(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleSwitchStream(message: any): Promise<void> {
     this.provider.setActiveStream(message.stream);
   }
 
-  private async handleDeleteStream(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleDeleteStream(message: any): Promise<void> {
     // Delete persisted session data if any
     await this.deleteSessionSnapshot(message.stream);
     this.provider.state.clearStream(message.stream);
     this.provider.updateWebview();
   }
 
-  private async handleEraseStream(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleEraseStream(message: any): Promise<void> {
     // Delete persisted session data when erasing stream
     await this.deleteSessionSnapshot(message.stream);
     this.provider.state.eraseStreamContent(message.stream);
     this.provider.updateWebview();
   }
 
-  private async handleDeleteAll(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleDeleteAll(message: any): Promise<void> {
     // Delete all persisted session data
     const allStates = this.provider.state.getAllTaskStates();
     for (const [stream] of allStates) {
@@ -182,17 +189,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     this.provider.updateWebview();
   }
 
-  private async handleStopStream(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleStopStream(message: any): Promise<void> {
     await vscode.commands.executeCommand('texra.stopAgent', message.stream);
   }
 
-  private async handleRunAgain(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleRunAgain(message: any): Promise<void> {
     await this.withToolbarTaskState(message.stream, async (taskState) => {
       await vscode.commands.executeCommand(
         'texra.execute',
@@ -201,10 +202,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
-  private async handleDiffStream(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleDiffStream(message: any): Promise<void> {
     await this.withToolbarTaskState(message.stream, async (taskState) => {
       await vscode.commands.executeCommand('texra.runLatexdiff', {
         agent: taskState.agentConfig.agent,
@@ -216,36 +214,24 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
-  private async handlePackStream(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handlePackStream(message: any): Promise<void> {
     await this.withToolbarTaskState(message.stream, async (taskState) => {
       await this.handleFileOperation(message.stream, taskState, 'texra.pack');
     });
   }
 
-  private async handleCleanStream(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleCleanStream(message: any): Promise<void> {
     await this.withToolbarTaskState(message.stream, async (taskState) => {
       await this.handleFileOperation(message.stream, taskState, 'texra.clean');
     });
   }
 
-  private async handleSortStreams(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleSortStreams(message: any): Promise<void> {
     this.provider.state.streamSortOrder = message.sortBy ?? 'time';
     this.provider.updateWebview();
   }
 
-  private async handleFilterStreams(
-    message: any,
-    _webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleFilterStreams(message: any): Promise<void> {
     const requestedFilter = message.filter;
     const filter: AgentTypeFilter = isAgentTypeFilter(requestedFilter)
       ? requestedFilter
@@ -254,30 +240,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     this.provider.updateWebview();
   }
 
-  private async handleRestoreState(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleRestoreState(message: any): Promise<void> {
     const taskState = this.provider.state.getTaskState(message.stream);
     if (taskState) {
       await vscode.commands.executeCommand('texra.restoreState', taskState);
     }
   }
 
-  private async handleSendFollowUp(
-    message: any,
-    _webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleSendFollowUp(message: any): Promise<void> {
     await vscode.commands.executeCommand('texra.sendFollowUp', {
       stream: message.stream,
       text: message.text,
     });
   }
 
-  private async handlePolishFollowUp(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handlePolishFollowUp(message: any): Promise<void> {
     const stream = message.stream as StreamTabId | undefined;
     const text = typeof message.text === 'string' ? message.text.trim() : '';
     if (!stream || !text) {
@@ -309,7 +286,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
           progress.report({ message: 'Applying changes...', increment: 60 });
 
           if (result.success) {
-            webviewView.webview.postMessage({
+            const view = this.getActiveView();
+            view?.webview.postMessage({
               command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISHED,
               text: result.text,
             });
@@ -340,10 +318,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     await vscode.window.showInformationMessage(text);
   }
 
-  private async handleOpenTaskStorage(
-    message: any,
-    _webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleOpenTaskStorage(message: any): Promise<void> {
     const stream = message.stream as StreamTabId | undefined;
     if (!stream) {
       await vscode.window.showInformationMessage(
@@ -384,23 +359,18 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     }
   }
 
-  private async handleOpenFile(
-    message: FileCommandMessage,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleOpenFile(message: FileCommandMessage): Promise<void> {
     await vscode.commands.executeCommand('texra.openFile', message.file);
   }
 
   private async handleOpenFileCompile(
     message: FileCommandMessage,
-    webviewView: vscode.WebviewView,
   ): Promise<void> {
     await vscode.commands.executeCommand('texra.openFileCompile', message.file);
   }
 
   private async handleCompareOriginal(
     message: BaseFileCommandMessage,
-    webviewView: vscode.WebviewView,
   ): Promise<void> {
     if (!message.base) {
       this.logger.warn(
@@ -422,10 +392,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     );
   }
 
-  private async handleComparePrevious(
-    message: CompareMessage,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleComparePrevious(message: CompareMessage): Promise<void> {
     const previousFile = message.prev || message.base;
 
     if (previousFile) {
@@ -447,7 +414,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleAcceptFile(
     message: BaseFileCommandMessage,
-    webviewView: vscode.WebviewView,
   ): Promise<void> {
     if (!message.base) {
       this.logger.warn(
@@ -471,7 +437,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleMergeFile(
     message: BaseFileCommandMessage,
-    webviewView: vscode.WebviewView,
   ): Promise<void> {
     if (!message.base) {
       this.logger.warn(
@@ -495,7 +460,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleLatexdiffFile(
     message: BaseFileCommandMessage,
-    webviewView: vscode.WebviewView,
   ): Promise<void> {
     if (!message.base) {
       this.logger.warn(
@@ -517,10 +481,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     );
   }
 
-  private async handleOpenLabel(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleOpenLabel(message: any): Promise<void> {
     await vscode.commands.executeCommand('texra.openLabel', message.label);
   }
 

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -38,6 +38,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly executionManager: ExecutionManager;
   private readonly diffManager: DiffManager;
   private readonly instructionManager: InstructionManager;
+  private activeView: vscode.WebviewView | undefined;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     super('MainView');
@@ -52,6 +53,26 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     this.executionManager = new ExecutionManager();
     this.diffManager = new DiffManager();
     this.instructionManager = new InstructionManager(context);
+  }
+
+  public override async handleMessage(
+    message: any,
+    webviewView: vscode.WebviewView,
+  ): Promise<void> {
+    this.activeView = webviewView;
+    this.fileManager.attachWebview(webviewView);
+    this.instructionManager.attachWebview(webviewView);
+
+    await super.handleMessage(message, webviewView);
+  }
+
+  private getActiveView(): vscode.WebviewView | undefined {
+    if (!this.activeView) {
+      this.logger.warn(this.channel, 'No active webview available');
+      return undefined;
+    }
+
+    return this.activeView;
   }
 
   protected createHandlers(): Record<
@@ -80,20 +101,20 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
 
       // Delegate to managers for specific functionality
       // File selection commands
-      [MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE]: async (m, w) =>
-        this.fileManager.handleFileSelection(m, w),
-      [MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE]: async (m, w) =>
-        this.fileManager.handleFileSelection(m, w),
-      [MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE]: async (m, w) =>
-        this.fileManager.handleFileSelection(m, w),
-      [MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE]: async (m, w) =>
-        this.fileManager.handleFileSelection(m, w),
-      [MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE]: async (_m, w) =>
-        this.fileManager.handleEditedFileSelection(w),
+      [MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE]: async (m) =>
+        this.fileManager.handleFileSelection(m),
+      [MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE]: async (m) =>
+        this.fileManager.handleFileSelection(m),
+      [MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE]: async (m) =>
+        this.fileManager.handleFileSelection(m),
+      [MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE]: async (m) =>
+        this.fileManager.handleFileSelection(m),
+      [MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE]: async () =>
+        this.fileManager.handleEditedFileSelection(),
 
       // File selected commands
-      [MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED]: async (m, w) =>
-        this.fileManager.handleInputFileSelected(m, w),
+      [MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED]: async (m) =>
+        this.fileManager.handleInputFileSelected(m),
       [MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED]: async (m) =>
         this.fileManager.handleGenericFileSelected(m),
       [MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED]: async (m) =>
@@ -104,38 +125,38 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleGenericFileSelected(m),
 
       // Request file commands
-      [MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE]: async (m, w) =>
-        this.fileManager.handleRequestInputFile(m, w),
-      [MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE]: async (m, w) =>
-        this.fileManager.handleRequestFile(m, w),
-      [MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE]: async (m, w) =>
-        this.fileManager.handleRequestFile(m, w),
-      [MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE]: async (m, w) =>
-        this.fileManager.handleRequestFile(m, w),
-      [MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE]: async (m, w) =>
-        this.fileManager.handleRequestEditedFile(m, w),
-      [MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE]: async (m, w) =>
-        this.fileManager.handleRequestBaseFile(m, w),
-      [MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES]: async (m, w) =>
-        this.fileManager.handleRequestDefaultOutputFiles(m, w),
+      [MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE]: async (m) =>
+        this.fileManager.handleRequestInputFile(m),
+      [MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE]: async (m) =>
+        this.fileManager.handleRequestFile(m),
+      [MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE]: async (m) =>
+        this.fileManager.handleRequestFile(m),
+      [MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE]: async (m) =>
+        this.fileManager.handleRequestFile(m),
+      [MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE]: async (m) =>
+        this.fileManager.handleRequestEditedFile(m),
+      [MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE]: async (m) =>
+        this.fileManager.handleRequestBaseFile(m),
+      [MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES]: async (m) =>
+        this.fileManager.handleRequestDefaultOutputFiles(m),
 
       // Multiple file operations
-      [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: async (m, w) =>
-        this.fileManager.handleSetMultipleFiles(m, w),
-      [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES]: async (m, w) =>
-        this.fileManager.handleSetMultipleFiles(m, w),
-      [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES]: async (m, w) =>
-        this.fileManager.handleSetMultipleFiles(m, w),
-      [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: async (m, w) =>
-        this.fileManager.handleSetMultipleFiles(m, w),
-      [MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES]: async (m, w) =>
-        this.fileManager.handleSelectMultipleFiles(m, w),
+      [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: async (m) =>
+        this.fileManager.handleSetMultipleFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES]: async (m) =>
+        this.fileManager.handleSetMultipleFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES]: async (m) =>
+        this.fileManager.handleSetMultipleFiles(m),
+      [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: async (m) =>
+        this.fileManager.handleSetMultipleFiles(m),
+      [MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES]: async (m) =>
+        this.fileManager.handleSelectMultipleFiles(m),
 
       // Other file operations
-      [MAIN_VIEW_COMMANDS.GET_CURRENT_FILE]: async (m, w) =>
-        this.fileManager.handleGetCurrentFile(m, w),
-      [MAIN_VIEW_COMMANDS.ADD_OPENED_FILES]: async (m, w) =>
-        this.fileManager.handleAddOpenedFiles(m.fileType, w),
+      [MAIN_VIEW_COMMANDS.GET_CURRENT_FILE]: async (m) =>
+        this.fileManager.handleGetCurrentFile(m),
+      [MAIN_VIEW_COMMANDS.ADD_OPENED_FILES]: async (m) =>
+        this.fileManager.handleAddOpenedFiles(m.fileType),
 
       // Execution commands
       [MAIN_VIEW_COMMANDS.MERGE]: async (m) =>
@@ -152,7 +173,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.settingsManager.openSettings(SETTINGS_QUERY.MODELS),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {
         if (m?.customDirSet) {
-          const dir = await agentDirectories.custom(this.context);
+          const dir = await agentDirectories.custom();
           if (dir) {
             await vscode.commands.executeCommand(
               'revealFileInOS',
@@ -173,12 +194,12 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         safeExecuteCommand('texra.openDoc', ['installation'], this.viewName),
 
       // Instruction commands
-      [MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT]: async (m, w) =>
-        this.instructionManager.handlePolishInstructionText(m, w),
-      [MAIN_VIEW_COMMANDS.TRANSCRIBE_INSTRUCTION]: async (_m, w) =>
-        this.instructionManager.handleTranscribeInstruction(w),
-      [MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE]: async (m, w) =>
-        this.instructionManager.handleClipboardImage(m, w),
+      [MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT]: async (m) =>
+        this.instructionManager.handlePolishInstructionText(m),
+      [MAIN_VIEW_COMMANDS.TRANSCRIBE_INSTRUCTION]: async () =>
+        this.instructionManager.handleTranscribeInstruction(),
+      [MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE]: async (m) =>
+        this.instructionManager.handleClipboardImage(m),
       [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: async () =>
         safeExecuteCommand('texra.setApiKey'),
       [MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY]: async (m) => {
@@ -203,29 +224,35 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
           ),
         );
       },
-      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: async (m, w) => {
+      [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: async (m) => {
         /* Banner handled client-side */
-        w.webview.postMessage(m);
+        const view = this.getActiveView();
+        view?.webview.postMessage(m);
       },
-      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: async (m, w) => {
+      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: async (m) => {
         /* Banner handled client-side */
-        w.webview.postMessage(m);
+        const view = this.getActiveView();
+        view?.webview.postMessage(m);
       },
-      [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: async (m, w) => {
+      [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: async (m) => {
         /* Banner handled client-side */
-        w.webview.postMessage(m);
+        const view = this.getActiveView();
+        view?.webview.postMessage(m);
       },
-      [MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER]: async (m, w) => {
+      [MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER]: async (m) => {
         /* Banner handled client-side */
-        w.webview.postMessage(m);
+        const view = this.getActiveView();
+        view?.webview.postMessage(m);
       },
-      [MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER]: async (m, w) => {
+      [MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER]: async (m) => {
         /* Banner handled client-side */
-        w.webview.postMessage(m);
+        const view = this.getActiveView();
+        view?.webview.postMessage(m);
       },
-      [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: async (m, w) => {
+      [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: async (m) => {
         /* Banner handled client-side */
-        w.webview.postMessage(m);
+        const view = this.getActiveView();
+        view?.webview.postMessage(m);
       },
       [MAIN_VIEW_COMMANDS.UPDATE_DEPENDENCY_REMINDER_SETTING]: async (m) => {
         await setConfig('ui.showDependencyReminders', m.value);
@@ -237,15 +264,19 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
           await safeExecuteCommand(command, args);
         }
       },
-      [MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES]: async (_m, w) => {
+      [MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES]: async () => {
+        const view = this.getActiveView();
+        if (!view) {
+          return;
+        }
         const missingTools = await checkCoreDependencies(true);
         if (missingTools.length > 0) {
-          w.webview.postMessage({
+          view.webview.postMessage({
             command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
             missingTools,
           });
         } else {
-          w.webview.postMessage({
+          view.webview.postMessage({
             command: MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER,
           });
         }
@@ -258,24 +289,34 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.recordingManager.stop(w),
 
       // File refresh and update operations
-      [MAIN_VIEW_COMMANDS.REFRESH_ALL_FILES]: async (_m, w) =>
-        this.fileManager.handleRefreshAllFiles(w),
-      [MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES]: async (m, w) =>
-        this.fileManager.handleUpdateFiles(m, w),
-      [MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES]: async (m, w) =>
-        this.fileManager.handleUpdateFiles(m, w),
-      [MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES]: async (m, w) =>
-        this.fileManager.handleUpdateFiles(m, w),
-      [MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES]: async (m, w) =>
-        this.fileManager.handleUpdateFiles(m, w),
-      [MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES]: async (m, w) =>
-        this.fileManager.handleUpdateFiles(m, w),
+      [MAIN_VIEW_COMMANDS.REFRESH_ALL_FILES]: async () =>
+        this.fileManager.handleRefreshAllFiles(),
+      [MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES]: async (m) =>
+        this.fileManager.handleUpdateFiles(m),
+      [MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES]: async (m) =>
+        this.fileManager.handleUpdateFiles(m),
+      [MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES]: async (m) =>
+        this.fileManager.handleUpdateFiles(m),
+      [MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES]: async (m) =>
+        this.fileManager.handleUpdateFiles(m),
+      [MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES]: async (m) =>
+        this.fileManager.handleUpdateFiles(m),
 
       // Git/diff operations
-      [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: async (m, w) =>
-        this.diffManager.handleRequestRecentCommits(m, w),
-      [MAIN_VIEW_COMMANDS.REFRESH_COMMITS]: async (_m, w) =>
-        this.diffManager.handleRefreshCommits(w),
+      [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: async (m) => {
+        const view = this.getActiveView();
+        if (!view) {
+          return;
+        }
+        await this.diffManager.handleRequestRecentCommits(m, view);
+      },
+      [MAIN_VIEW_COMMANDS.REFRESH_COMMITS]: async () => {
+        const view = this.getActiveView();
+        if (!view) {
+          return;
+        }
+        await this.diffManager.handleRefreshCommits(view);
+      },
       [MAIN_VIEW_COMMANDS.LATEXDIFF]: async (m) =>
         this.diffManager.handleLatexdiff(m),
       [MAIN_VIEW_COMMANDS.LATEXDIFFVC]: async (m) =>
@@ -308,18 +349,16 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   }
 
   // Implement handler methods
-  private async handleInfoMessage(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleInfoMessage(message: any): Promise<void> {
     vscode.window.showInformationMessage(message.text);
     this.logger.debug(`Information message: ${message.text}`);
   }
 
-  private async handleThemeRequest(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleThemeRequest(message: any): Promise<void> {
+    const webviewView = this.getActiveView();
+    if (!webviewView) {
+      return;
+    }
     const theme =
       vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
         ? 'dark'
@@ -330,10 +369,11 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
-  private async handleDebugModeRequest(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleDebugModeRequest(message: any): Promise<void> {
+    const webviewView = this.getActiveView();
+    if (!webviewView) {
+      return;
+    }
     const debugMode = getConfig<boolean>('logger.debugMode', false);
     webviewView.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
@@ -341,10 +381,11 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
-  private async handleModelSelection(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleModelSelection(message: any): Promise<void> {
+    const webviewView = this.getActiveView();
+    if (!webviewView) {
+      return;
+    }
     if (message.model) {
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
@@ -353,17 +394,15 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     }
   }
 
-  private async handleShowAgentHistory(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async handleShowAgentHistory(message: any): Promise<void> {
     await safeExecuteCommand('texra.showAgentHistory', [], this.viewName);
   }
 
-  protected async handleWebviewReady(
-    _message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  protected async handleWebviewReady(_message: any): Promise<void> {
+    const webviewView = this.getActiveView();
+    if (!webviewView) {
+      return;
+    }
     await super.handleWebviewReady(_message, webviewView);
     try {
       const modelOptions = await computeModelOptions();
@@ -382,7 +421,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         }
       }
 
-      const agentOptions = await computeAgentOptions(this.context);
+      const agentOptions = await computeAgentOptions();
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
         options: agentOptions,

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -35,12 +35,28 @@ type FileUpdateOptions = {
 };
 
 export class FileManager {
-  constructor(private readonly context: vscode.ExtensionContext) {}
+  private webview: vscode.WebviewView | undefined;
 
-  async handleFileSelection(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  constructor(_context: vscode.ExtensionContext) {}
+
+  attachWebview(webviewView: vscode.WebviewView): void {
+    this.webview = webviewView;
+  }
+
+  private getWebview(): vscode.WebviewView | undefined {
+    if (!this.webview) {
+      logger.warn(CHANNEL, 'Webview not attached for FileManager operation');
+      return undefined;
+    }
+
+    return this.webview;
+  }
+
+  async handleFileSelection(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const singleFileType = message.command.replace('select', '');
     logger.debug(CHANNEL, `Selecting ${singleFileType}`);
 
@@ -56,9 +72,11 @@ export class FileManager {
     }
   }
 
-  async handleEditedFileSelection(
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleEditedFileSelection(): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const editedFile = await vscode.commands.executeCommand<string>(
       'texra.selectEditedFile',
     );
@@ -70,40 +88,39 @@ export class FileManager {
     }
   }
 
-  async handleInputFileSelected(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleInputFileSelected(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const baseFileNameForInput = path.basename(
       message.filePath,
       path.extname(message.filePath),
     );
     const filteredEditedFiles =
       await fileLister.listEditedFiles(baseFileNameForInput);
-    this.postFileUpdate(webviewView, 'Edited', filteredEditedFiles);
+    this.postFileUpdate('Edited', filteredEditedFiles);
   }
 
   handleGenericFileSelected(message: any): void {
     logger.debug(CHANNEL, `${message.command}: ${message.filePath}`);
   }
 
-  async handleRequestInputFile(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleRequestInputFile(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const refreshedInputFiles =
       (await vscode.commands.executeCommand<string[]>(
         'texra.refreshInputFiles',
       )) || [];
-    await this.postFileUpdate(webviewView, 'Input', refreshedInputFiles, {
+    await this.postFileUpdate('Input', refreshedInputFiles, {
       notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
     });
   }
 
-  async handleRequestFile(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleRequestFile(message: any): Promise<void> {
     const fileType = message.command.replace('request', '').replace('File', '');
     const files = await (async () => {
       switch (fileType) {
@@ -117,15 +134,12 @@ export class FileManager {
           return [];
       }
     })();
-    await this.postFileUpdate(webviewView, fileType, files, {
+    await this.postFileUpdate(fileType, files, {
       notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
     });
   }
 
-  async handleRequestEditedFile(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleRequestEditedFile(message: any): Promise<void> {
     let allEditedFiles: string[] = [];
     if (message.baseFile) {
       const baseFileNameForEdited = path.basename(
@@ -134,17 +148,14 @@ export class FileManager {
       );
       allEditedFiles = await fileLister.listEditedFiles(baseFileNameForEdited);
     }
-    await this.postFileUpdate(webviewView, 'Edited', allEditedFiles, {
+    await this.postFileUpdate('Edited', allEditedFiles, {
       notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
     });
   }
 
-  async handleRequestBaseFile(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleRequestBaseFile(message: any): Promise<void> {
     const files = await fileLister.list('input');
-    await this.postFileUpdate(webviewView, 'Base', files, {
+    await this.postFileUpdate('Base', files, {
       notifyWhenEmpty: Boolean(message?.notifyWhenEmpty),
       additionalPayload: message?.preserveBaseFile
         ? { preserveBaseFile: true }
@@ -152,10 +163,11 @@ export class FileManager {
     });
   }
 
-  async handleRequestDefaultOutputFiles(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleRequestDefaultOutputFiles(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const agent = message.agent;
     if (!agent) {
       webviewView.webview.postMessage({
@@ -166,7 +178,7 @@ export class FileManager {
     }
 
     try {
-      const agentPath = await getAgentPath(agent, this.context);
+      const agentPath = await getAgentPath(agent);
       const [settings] = await loadAgentSettingAndPrompts(agentPath, agent);
       const files = Array.isArray(settings?.defaultOutputFiles)
         ? settings.defaultOutputFiles
@@ -187,7 +199,11 @@ export class FileManager {
     }
   }
 
-  handleSetMultipleFiles(message: any, webviewView: vscode.WebviewView): void {
+  handleSetMultipleFiles(message: any): void {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     if (message.files?.length > 0) {
       webviewView.webview.postMessage({
         command: message.command,
@@ -196,10 +212,11 @@ export class FileManager {
     }
   }
 
-  async handleSelectMultipleFiles(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleSelectMultipleFiles(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const fileType = message.fileType;
     let selectedFiles: string[] | null = null;
 
@@ -239,7 +256,7 @@ export class FileManager {
     }
   }
 
-  async handleRefreshAllFiles(webviewView: vscode.WebviewView): Promise<void> {
+  async handleRefreshAllFiles(): Promise<void> {
     const refreshedFiles = {
       input: await fileLister.list('input'),
       reference: await fileLister.list('reference'),
@@ -248,20 +265,17 @@ export class FileManager {
     };
 
     Object.entries(refreshedFiles).forEach(([type, files]) => {
-      this.postFileUpdate(
-        webviewView,
-        type.charAt(0).toUpperCase() + type.slice(1),
-        files,
-      );
+      this.postFileUpdate(type.charAt(0).toUpperCase() + type.slice(1), files);
     });
 
-    await this.updateBaseFileSelect(webviewView);
+    await this.updateBaseFileSelect();
   }
 
-  async handleGetCurrentFile(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleGetCurrentFile(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const fileType = message.fileType || 'input';
     const currentOpenFile = await vscode.commands.executeCommand<string>(
       'texra.getCurrentFile',
@@ -304,10 +318,7 @@ export class FileManager {
           if (derivedBaseFile) {
             const baseExists = await WorkspaceFS.exists(derivedBaseFile);
             if (baseExists) {
-              await this.handleRequestBaseFile(
-                { preserveBaseFile: true },
-                webviewView,
-              );
+              await this.handleRequestBaseFile({ preserveBaseFile: true });
               filePathToSelect = derivedBaseFile;
             } else {
               logger.info(
@@ -329,7 +340,7 @@ export class FileManager {
         commitCheckFile = currentOpenFile;
       }
       if (commitCheckFile) {
-        await this._maybeSelectCommitFromDiffFile(commitCheckFile, webviewView);
+        await this._maybeSelectCommitFromDiffFile(commitCheckFile);
       }
     } else {
       vscode.window.showInformationMessage(
@@ -340,8 +351,11 @@ export class FileManager {
 
   private async _maybeSelectCommitFromDiffFile(
     filePath: string,
-    webviewView: vscode.WebviewView,
   ): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const fileName = path.basename(filePath);
     const latexDiffMetadata = this._parseLatexDiffMetadata(filePath);
     if (!latexDiffMetadata) {
@@ -371,10 +385,11 @@ export class FileManager {
     }
   }
 
-  async handleAddOpenedFiles(
-    fileType: string,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleAddOpenedFiles(fileType: string): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const openedFiles = await this.getOpenedFiles();
     webviewView.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_OPENED_FILES,
@@ -384,10 +399,11 @@ export class FileManager {
     });
   }
 
-  async handleUpdateFiles(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleUpdateFiles(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const command = message.command;
     const fileType = command.replace('update', '');
     const files = message.files || [];
@@ -474,11 +490,14 @@ export class FileManager {
   }
 
   private async postFileUpdate(
-    webviewView: vscode.WebviewView,
     fileType: string,
     files: string[],
     options: FileUpdateOptions = {},
   ): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     if (options.notifyWhenEmpty && files.length === 0) {
       logger.debug(
         CHANNEL,
@@ -493,9 +512,11 @@ export class FileManager {
     });
   }
 
-  private async updateBaseFileSelect(
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  private async updateBaseFileSelect(): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     const baseFiles = await fileLister.list('input');
     webviewView.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_BASE_FILE,

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -24,6 +24,8 @@ const CHANNEL = 'InstructionManager';
 logger.initialize(CHANNEL);
 
 export class InstructionManager {
+  private webview: vscode.WebviewView | undefined;
+
   constructor(private readonly _context: vscode.ExtensionContext) {
     setTimeout(() => {
       StorageFS.ensureDir(PASTED_DIR)
@@ -35,6 +37,19 @@ export class InstructionManager {
           ),
         );
     }, 100);
+  }
+
+  attachWebview(webviewView: vscode.WebviewView): void {
+    this.webview = webviewView;
+  }
+
+  private getWebview(): vscode.WebviewView | undefined {
+    if (!this.webview) {
+      logger.warn(CHANNEL, 'Webview not attached for InstructionManager');
+      return undefined;
+    }
+
+    return this.webview;
   }
 
   /**
@@ -71,10 +86,11 @@ export class InstructionManager {
     }
   }
 
-  async handlePolishInstructionText(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handlePolishInstructionText(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     try {
       const fileContext: FileContext = { agent: message.agent || undefined };
 
@@ -163,16 +179,17 @@ export class InstructionManager {
     }
   }
 
-  handleTranscribeInstruction(_view: vscode.WebviewView): void {
+  handleTranscribeInstruction(): void {
     vscode.window.showInformationMessage(
       'Please use the new recording interface with start/stop controls.',
     );
   }
 
-  async handleClipboardImage(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
+  async handleClipboardImage(message: any): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
     try {
       const { base64, mediaType, fileName } = message;
       if (!base64 || !mediaType || !fileName) {


### PR DESCRIPTION
## Summary
- cache the active WebviewView in the main and progress message handlers so callbacks no longer need to thread the view around
- let FileManager and InstructionManager attach to the current webview and drop the repetitive webview parameters
- reuse the stored extension context in AgentDirectoryManager and update downstream utilities and commands accordingly

## Testing
- npm run format
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5f5308b5083248df1e6ebe330b68c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches active webviews and removes explicit VS Code context plumbing across agent and directory APIs, updating handlers and runtime to use centralized managers.
> 
> - **Webview handlers**:
>   - Cache active `WebviewView` in `MainViewMessageHandler` and `ProgressViewMessageHandler`; handlers no longer pass `webviewView` around and post via stored view.
>   - `FileManager` and `InstructionManager` now `attachWebview(...)` and use internal accessors; all call sites drop `webviewView` params.
>   - Updated command-to-handler mappings to new no-webview signatures; banner/commit/dependency updates post via the active view.
> - **Agent directory/context API**:
>   - `AgentDirectoryManager`: stores extension context once; `builtIn()`, `builtInToolUse()`, `custom()` no longer take a context; added stronger initialization checks.
>   - Updated all callers (`FolderExplorer`/`ExplorerOperations`/`WatcherManager`, commands) to use context-free `agentDirectories.*()`.
> - **Agent runtime**:
>   - Removed explicit `vscode.ExtensionContext` parameters from `getAgentPath`, `computeAgentOptions` flow, `prepareAgentInstance`, `executeAgent`, `executeMergeAgent`, `executeAgentWithLogging`; updated all usages accordingly.
> - **Misc**:
>   - Adjusted function signatures (unused params prefixed with `_`), streamlined posting/logging, and minor guard/warning additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ec4242499f533635bd69df09c984c4d70edaaff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->