### PR TITLE
fix: default grep tool emits matches

### DIFF
--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -182,7 +182,7 @@ For a minimal read-only configuration, see the built-in `ask` agent
 Common workspace helpers:
 
 - `glob` — Quickly list files matching a pattern, sorted by modification time.
-- `grep` — Run ripgrep searches without leaving the workspace sandbox.
+- `grep` — Run ripgrep searches without leaving the workspace sandbox. By default it returns the matching lines so you can see the context immediately.
 - `ls` — Inspect directory contents with optional ignore globs.
 
 Example:

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -98,7 +98,7 @@ export class GrepTool extends defineTool({
   schema: GrepInputSchema,
 }) {
   protected async execute(input: GrepInput): Promise<ToolResult> {
-    const outputMode: OutputMode = input.output_mode ?? 'files_with_matches';
+    const outputMode: OutputMode = input.output_mode ?? 'content';
     const { resolved: searchPath, display } = resolveAndFormat(input.path);
     const gitignore = await getGitignoreMatcher();
     const args = buildArguments(input, outputMode);


### PR DESCRIPTION
## Summary
- default the grep tool to the content output mode so matched lines are shown without extra configuration
- document the updated default so agent authors know the tool emits match content automatically

## Testing
- npm run lint
- NODE_PATH=out node <<'NODE'
const path = require('path');
const fs = require('fs');
const { spawnSync } = require('child_process');
const Module = require('module');
const baseOut = path.resolve(__dirname, 'out');
const workspacePath = process.cwd();
const stubDir = path.join(baseOut, '__stubs__');
fs.mkdirSync(stubDir, { recursive: true });
const stubDefinitions = new Map([
  ['@tools/result', {
    ToolError: class ToolError extends Error {},
    toolResult: (data) => data,
    cliResult: (data) => data,
  }],
  ['@tools/gitignore', {
    async getGitignoreMatcher() {
      return { hasRules: false, ignores: () => false, ignoreFiles: [] };
    },
    clearGitignoreCache() {},
  }],
  ['@tools/utils', {
    resolveAndFormat(targetPath) {
      const trimmed = targetPath && targetPath.trim().length > 0 ? targetPath : '.';
      const absolute = path.resolve(workspacePath, trimmed);
      const relative = path.relative(workspacePath, absolute) || '.';
      const display = relative.split(path.sep).join('/');
      return { resolved: { relative, absolute }, display };
    },
  }],
  ['@utils/system/execUtils', {
    async executeCommand(command) {
      const result = spawnSync(command[0], command.slice(1), {
        cwd: workspacePath,
        encoding: 'utf8',
      });
      const format = (value) => {
        if (typeof value !== 'string') {
          return null;
        }
        const trimmed = value.trim();
        return trimmed.length > 0 ? trimmed : null;
      };
      return {
        success: result.status === 0,
        stdout: format(result.stdout),
        stderr: format(result.stderr),
        timedOut: false,
      };
    },
  }],
]);
const stubPaths = new Map();
for (const [name, exportsObj] of stubDefinitions.entries()) {
  const safeName = name.replace(/[^a-zA-Z0-9_]/g, '_');
  const stubPath = path.join(stubDir, `${safeName}.js`);
  stubPaths.set(name, stubPath);
  require.cache[stubPath] = {
    id: stubPath,
    filename: stubPath,
    loaded: true,
    exports: exportsObj,
  };
}
const originalResolveFilename = Module._resolveFilename;
Module._resolveFilename = function(request, parent, isMain, options) {
  if (stubPaths.has(request)) {
    return stubPaths.get(request);
  }
  return originalResolveFilename.call(this, request, parent, isMain, options);
};
const { GrepTool } = require(path.join(baseOut, 'tools/grep.js'));
(async () => {
  const tool = new GrepTool();
  const result = await tool.call({ pattern: 'class GrepTool', path: 'src/tools/grep.ts' });
  console.log(JSON.stringify(result, null, 2));
})();
NODE

------
https://chatgpt.com/codex/tasks/task_e_68f62eb5e0a483249b0b56d22beea9c3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default `grep` to return matching lines (content) and update docs to reflect the new default.
> 
> - **Tools**:
>   - **`src/tools/grep.ts`**: Change default `output_mode` from `files_with_matches` to `content` so `grep` returns matching lines by default.
> - **Docs**:
>   - **`docs/guide/custom-agents.md`**: Update `grep` description to note it returns matching lines by default for immediate context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 806bf427c9363681f249af3a127ae711e46006b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->