### PR TITLE
fix: default grep tool returns content output

### DIFF
--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -182,7 +182,7 @@ For a minimal read-only configuration, see the built-in `ask` agent
 Common workspace helpers:
 
 - `glob` — Quickly list files matching a pattern, sorted by modification time.
-- `grep` — Run ripgrep searches without leaving the workspace sandbox.
+- `grep` — Run ripgrep searches without leaving the workspace sandbox. By default it returns matching content lines; switch the `output_mode` to `files_with_matches` or `count` to change the response format.
 - `ls` — Inspect directory contents with optional ignore globs.
 
 Example:

--- a/src/test/tools/grep.test.ts
+++ b/src/test/tools/grep.test.ts
@@ -1,0 +1,19 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { buildArguments, type GrepInput } from '@tools/grep';
+
+describe('buildArguments', () => {
+  const baseInput: GrepInput = { pattern: 'example' };
+
+  it('omits --files-with-matches when using content mode', () => {
+    const args = buildArguments(baseInput, 'content');
+    assert.deepEqual(args, ['--color=never']);
+  });
+
+  it('includes --files-with-matches when explicitly requested', () => {
+    const args = buildArguments(baseInput, 'files_with_matches');
+    assert.ok(args.includes('--files-with-matches'));
+  });
+});

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -35,7 +35,10 @@ export type GrepInput = z.infer<typeof GrepInputSchema>;
 
 const CHANNEL = 'GrepTool';
 
-function buildArguments(input: GrepInput, outputMode: OutputMode): string[] {
+export function buildArguments(
+  input: GrepInput,
+  outputMode: OutputMode,
+): string[] {
   const args: string[] = ['--color=never'];
 
   if (outputMode === 'files_with_matches') {
@@ -98,7 +101,7 @@ export class GrepTool extends defineTool({
   schema: GrepInputSchema,
 }) {
   protected async execute(input: GrepInput): Promise<ToolResult> {
-    const outputMode: OutputMode = input.output_mode ?? 'files_with_matches';
+    const outputMode: OutputMode = input.output_mode ?? 'content';
     const { resolved: searchPath, display } = resolveAndFormat(input.path);
     const gitignore = await getGitignoreMatcher();
     const args = buildArguments(input, outputMode);


### PR DESCRIPTION
## Summary
- default the grep tool to `content` output so ripgrep returns matching lines without extra configuration
- export the argument builder and cover it with a targeted unit test verifying the implicit mode
- document the default behavior in the custom agent guide

## Testing
- npm run lint
- npx mocha -r ts-node/register -r tsconfig-paths/register src/test/tools/grep.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f62eb5e0a483249b0b56d22beea9c3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defaults `grep` to return matching content lines, exposes `buildArguments`, adds unit tests, and updates docs to reflect output modes.
> 
> - **Tools**:
>   - **`grep`**: Default `output_mode` changed from `files_with_matches` to `content` in `GrepTool.execute`.
>   - **API**: Export `buildArguments(input, outputMode)` from `src/tools/grep.ts`.
> - **Tests**:
>   - Add `src/test/tools/grep.test.ts` covering `buildArguments` behavior for `content` vs `files_with_matches`.
> - **Docs**:
>   - Update `docs/guide/custom-agents.md` to note `grep` returns matching lines by default and document `output_mode` options (`files_with_matches`, `count`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 744a222e2ba90164db72aa081725e95737335654. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->