### PR TITLE
Disable file selection UI during tool-use sessions

### DIFF
--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -27,6 +27,33 @@ import { WebviewStateManager } from '@common/webviewState.js';
 const DEFAULT_WORKFLOW_AGENT = 'correct';
 const DEFAULT_TOOL_USE_AGENT = 'chat';
 
+function setFileSelectionGroupDisabled(isDisabled) {
+  const container = document.querySelector('.file-selection-group');
+  if (!(container instanceof HTMLElement)) {
+    return;
+  }
+
+  container.classList.toggle('file-selection-group--disabled', isDisabled);
+  if (isDisabled) {
+    container.setAttribute('aria-disabled', 'true');
+  } else {
+    container.removeAttribute('aria-disabled');
+  }
+
+  const interactiveElements = container.querySelectorAll(
+    'select, button, input',
+  );
+  interactiveElements.forEach((element) => {
+    if (
+      element instanceof HTMLButtonElement ||
+      element instanceof HTMLSelectElement ||
+      element instanceof HTMLInputElement
+    ) {
+      element.disabled = isDisabled;
+    }
+  });
+}
+
 function getSelectDefaultValue(selectId, fallback) {
   const element = safeGetElementById(selectId);
   if (element instanceof HTMLSelectElement) {
@@ -273,6 +300,7 @@ export class MainViewState {
       sessionType === SESSION_TYPES.TOOL_USE
         ? SESSION_TYPES.TOOL_USE
         : SESSION_TYPES.WORKFLOW;
+    const isToolUseSession = normalized === SESSION_TYPES.TOOL_USE;
 
     const sessionInput = safeGetElementById(SESSION_TYPE_INPUT);
     if (sessionInput) {
@@ -303,6 +331,8 @@ export class MainViewState {
       selectEl.setAttribute('aria-hidden', isActive ? 'false' : 'true');
       selectEl.tabIndex = isActive ? 0 : -1;
     });
+
+    setFileSelectionGroupDisabled(isToolUseSession);
 
     if (!skipSave) {
       this.save();

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -13,6 +13,12 @@
   overflow: hidden;
 }
 
+.file-selection-group--disabled {
+  opacity: 0.6;
+  filter: grayscale(0.3);
+  pointer-events: none;
+}
+
 /* LaTeX diffs section */
 .latexdiffs-section {
   margin-top: auto;


### PR DESCRIPTION
## Summary
- add a helper in the main view state to toggle the file selection panel when tool-use sessions are active
- disable interactive controls inside the file selection group during tool-use sessions and restore them for workflow mode
- add styling for the disabled state so the panel appears inactive while tool-use is selected

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f78e55f5c48324bbb006407cbcad28

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the file selection UI and its controls during tool-use sessions, adding disabled styling and aria attributes.
> 
> - **Webview Logic (`src/webview/modules/mainViewState.js`)**
>   - Add `setFileSelectionGroupDisabled(isDisabled)` to toggle disabled state on `.file-selection-group`, set `aria-disabled`, and disable `select/button/input` children.
>   - Update `applySessionType` to detect tool-use sessions and call `setFileSelectionGroupDisabled(true/false)`.
> - **Styles (`src/webview/styles/containers.css`)**
>   - Add `.file-selection-group--disabled` with reduced opacity, slight grayscale, and `pointer-events: none`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5f79477a1c39e3d23e63dc2dbfd220748d588c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->