### PR TITLE
Enable context management for Anthropic tool-use agents

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -75,6 +75,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     const streamTabId = this.getStreamTabId();
     this.logger = new AgentLogger(streamTabId, true);
     this.modelHandler.setLogger(this.logger);
+    this.modelHandler.setAgentType(this.agentSetting.agentType);
     this.usageMonitor = new UsageMonitor(
       this.modelHandler,
       this.logger.channelId,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -9,7 +9,7 @@ import { encode as encodeHtml } from 'he';
 
 // Local imports - agent components
 import type { AgentConfig } from '../core/AgentConfig';
-import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
+import { AgentSetting, AgentType, hasEndTag } from '../core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { ToolState } from '../core/ToolState';
 import type { IModelHandler } from './types/IModelHandler';
@@ -106,6 +106,7 @@ export abstract class ModelHandler<
   protected outputStreaming = false;
   protected backgroundModeSupported = false;
   protected progressViewEnabled = true;
+  protected agentType?: AgentType;
 
   protected get supportsToolFileOutputs(): boolean {
     return false;
@@ -139,6 +140,20 @@ export abstract class ModelHandler<
    */
   public setLogger(logger: AgentLogger): void {
     this.logger = logger;
+  }
+
+  /**
+   * Records the active agent type so provider handlers can adjust behaviour per session.
+   */
+  public setAgentType(agentType?: AgentType | null): void {
+    this.agentType = agentType ?? undefined;
+  }
+
+  /**
+   * Returns the agent type that is currently driving the handler, if any.
+   */
+  public getAgentType(): AgentType | undefined {
+    return this.agentType;
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -6,6 +6,7 @@ import { basename } from 'node:path';
 import { Anthropic, toFile } from '@anthropic-ai/sdk';
 import type {
   BetaBase64ImageSource,
+  BetaContextManagementConfig,
   BetaImageBlockParam,
   BetaMessage,
   BetaRequestDocumentBlock,
@@ -56,6 +57,7 @@ import { ANTHROPIC_STOP } from './types/StopReasonTypes';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import {
   AgentSetting,
+  AgentType,
   hasEndTag,
   requireWorkflowSetting,
 } from '@agent/core/AgentDataclass';
@@ -96,9 +98,11 @@ import xmlUtils from '@utils/text/xmlUtils';
 // The new implicit prompt caching is worth checking out (can eliminate many controls of previous caching)
 type BetaMessageCreateParams = MessageCreateParams & {
   betas?: AnthropicBeta[];
+  context_management?: BetaContextManagementConfig | null;
 };
 type BetaMessageCountTokensParams = MessageCountTokensParams & {
   betas?: AnthropicBeta[];
+  context_management?: BetaContextManagementConfig | null;
 };
 
 const CONTEXT_1M_BETA: AnthropicBeta = 'context-1m-2025-08-07';
@@ -106,6 +110,7 @@ const FILES_API_BETA: AnthropicBeta = 'files-api-2025-04-14';
 const SONNET_37_OUTPUT_BETA: AnthropicBeta = 'output-128k-2025-02-19';
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
+const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -315,6 +320,30 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (!existingBetas.includes(FILES_API_BETA)) {
         options.betas = [...existingBetas, FILES_API_BETA];
       }
+    }
+
+    if (this.agentType === AgentType.ToolUse) {
+      const existingBetas = options.betas ?? [];
+      if (!existingBetas.includes(CONTEXT_MANAGEMENT_BETA)) {
+        options.betas = [...existingBetas, CONTEXT_MANAGEMENT_BETA];
+      }
+
+      const contextManagementEdits = [
+        ...(options.context_management?.edits ?? []),
+      ];
+
+      if (
+        !contextManagementEdits.some(
+          (edit) => edit.type === 'clear_tool_uses_20250919',
+        )
+      ) {
+        contextManagementEdits.push({ type: 'clear_tool_uses_20250919' });
+      }
+
+      options.context_management = {
+        ...(options.context_management ?? {}),
+        edits: contextManagementEdits,
+      } satisfies BetaContextManagementConfig;
     }
 
     // this.logger.debug(

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -1,6 +1,6 @@
 // Local imports - agent components
 import type { AgentConfig } from '../../core/AgentConfig';
-import { AgentSetting } from '../../core/AgentDataclass';
+import { AgentSetting, AgentType } from '../../core/AgentDataclass';
 import { AgentStateRound, AgentStateGlobal } from '../../core/AgentState';
 import { ToolState } from '../../core/ToolState';
 import type { MediaEntry } from '../../utils/mediaTypes';
@@ -59,6 +59,12 @@ export interface IModelHandler<
 
   /** Set the logger instance for the handler. */
   setLogger(logger: AgentLogger): void;
+
+  /** Inform the handler about the active agent type. */
+  setAgentType(agentType?: AgentType | null): void;
+
+  /** Retrieve the agent type currently associated with the handler, if any. */
+  getAgentType(): AgentType | undefined;
 
   /** Retrieve an authenticated client instance. */
   getClient(): Promise<C>;


### PR DESCRIPTION
## Summary
- track the active agent type on model handlers so providers can tailor requests
- propagate tool-use sessions to Anthropic handlers and opt into the context-management beta
- attach the clear_tool_uses context-management strategy for Anthropic tool-use conversations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f644504f18832480ffcb48b13d3ef9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track agent type on model handlers and enable Anthropic context-management (with clear_tool_uses) for tool-use conversations.
> 
> - **Model Handlers**:
>   - Track active agent type: add `agentType` with `setAgentType`/`getAgentType` in `src/agent/modelHandlers/ModelHandler.ts` and expose in `IModelHandler`.
>   - `BaseAgent` now informs handlers of the active agent type via `modelHandler.setAgentType(...)` in `src/agent/implementations/BaseAgent.ts`.
> - **Anthropic Provider** (`src/agent/modelHandlers/modelHandlerAnthropic.ts`):
>   - Opt into context-management beta (`CONTEXT_MANAGEMENT_BETA`) when `agentType === AgentType.ToolUse`.
>   - Attach `context_management.edits` with `clear_tool_uses_20250919` to requests.
>   - Extend message param types to carry `context_management` and betas for relevant calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0180c8e9b1d59bcd685fc46671c572308adef03f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->