### PR TITLE
Clean up webview UI layout and styling

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -381,10 +381,7 @@
         </div>
         <div class="instruction-box">
           <div class="instruction-header">
-            <div class="instruction-header-left">
-              <label for="instruction"
-                ><i class="codicon codicon-edit"></i> Instruction</label
-              >
+            <div class="instruction-header-actions button-group">
               <div class="dropdown-container dropdown-left">
                 <span
                   id="toggleToolConfig"
@@ -411,8 +408,6 @@
                   >
                 </div>
               </div>
-            </div>
-            <div class="instruction-header-actions button-group">
               <button
                 id="packButton"
                 class="vscode-button"

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -337,7 +337,8 @@ export class MainViewState {
     // Disable Tool Config dropdown for tool use sessions
     const toggleToolConfig = safeGetElementById(ELEMENT_IDS.TOGGLE_TOOL_CONFIG);
     if (toggleToolConfig instanceof HTMLElement) {
-      toggleToolConfig.style.opacity = isToolUseSession ? '0.5' : '';
+      toggleToolConfig.style.opacity = isToolUseSession ? '0.6' : '';
+      toggleToolConfig.style.filter = isToolUseSession ? 'grayscale(0.3)' : '';
       toggleToolConfig.style.pointerEvents = isToolUseSession ? 'none' : '';
       toggleToolConfig.style.cursor = isToolUseSession ? 'not-allowed' : '';
     }

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -334,6 +334,14 @@ export class MainViewState {
 
     setFileSelectionGroupDisabled(isToolUseSession);
 
+    // Disable Tool Config dropdown for tool use sessions
+    const toggleToolConfig = safeGetElementById(ELEMENT_IDS.TOGGLE_TOOL_CONFIG);
+    if (toggleToolConfig instanceof HTMLElement) {
+      toggleToolConfig.style.opacity = isToolUseSession ? '0.5' : '';
+      toggleToolConfig.style.pointerEvents = isToolUseSession ? 'none' : '';
+      toggleToolConfig.style.cursor = isToolUseSession ? 'not-allowed' : '';
+    }
+
     if (!skipSave) {
       this.save();
     }

--- a/src/webview/styles/file-selection.css
+++ b/src/webview/styles/file-selection.css
@@ -22,7 +22,6 @@
 }
 
 .file-select-header label {
-  font-weight: bold;
   margin-right: var(--spacing-small);
   display: flex;
   align-items: center;

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -105,8 +105,8 @@
 .model-selection-footer .select-group select {
   flex: 0 0 auto;
   width: auto;
-  min-width: 8rem;
-  max-width: 11rem;
+  min-width: 6.4rem;
+  max-width: 8.8rem;
   height: var(--height-control);
   font-size: var(--font-size);
   padding: var(--spacing-tiny) var(--spacing-small);

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -40,7 +40,7 @@
 
 .instruction-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   margin-bottom: var(--spacing-small);
   line-height: 1.5;

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -13,12 +13,6 @@
   padding: var(--spacing-medium);
 }
 
-.instruction-box label {
-  display: block;
-  margin-bottom: var(--spacing-tiny);
-  font-size: var(--font-size);
-}
-
 #instruction {
   min-height: var(--height-medium);
   max-height: var(--height-xlarge);
@@ -44,25 +38,6 @@
   align-items: center;
   margin-bottom: var(--spacing-small);
   line-height: 1.5;
-}
-
-.instruction-header-left {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-medium);
-}
-
-.instruction-header label {
-  font-size: var(--font-size);
-  font-weight: bold;
-  display: flex;
-  align-items: center;
-}
-
-.instruction-header label .codicon {
-  margin-right: var(--spacing-small);
-  color: var(--icon-color);
-  opacity: var(--opacity-subtle);
 }
 
 #executeButton {


### PR DESCRIPTION
## Summary

This PR cleans up the webview UI to improve visual clarity and usability:

- Remove bold styling from file selection labels (Input, Reference, Auxiliary, Media) for a cleaner appearance
- Remove redundant "Instruction" label and icon from instruction box header - the purpose is clear without it
- Move Tool Config dropdown (Attach TeX Count/Diagnostics) to the right-aligned button group for better organization
- Reduce model dropdown minimum width by 20% (from 8rem to 6.4rem, max from 11rem to 8.8rem) for better space efficiency
- Disable Tool Config dropdown when tool use agent is selected, as these options only apply to workflow agents

## Test plan

- [ ] Verify file selection labels no longer appear bold
- [ ] Verify instruction box no longer shows "Instruction" label/icon
- [ ] Verify Tool Config dropdown appears in the right-aligned button group
- [ ] Verify model dropdown has appropriate width
- [ ] Verify Tool Config dropdown is disabled (grayed out) when switching to tool use agent
- [ ] Verify Tool Config dropdown is enabled when switching back to workflow agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the webview by removing the Instruction label, moving Tool Config into the right-aligned action group and disabling it for tool-use sessions, de-bolding file labels, and narrowing the model dropdown.
> 
> - **Webview UI**:
>   - **Instruction Header**: Remove the `Instruction` label; right-align actions; move `Tool Config` dropdown into the actions group.
>   - **Tool Config Behavior**: Disable/grey out `#toggleToolConfig` during tool-use sessions.
>   - **File Selection Labels**: Remove bold styling for `.file-select-header label`.
>   - **Model Select**: Reduce `#model` dropdown width (`min-width` 6.4rem, `max-width` 8.8rem).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4f19def2fd8afed2cd2f2d3dc48ff0efb16777a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->