### PR TITLE
fix: improve anthropic prompt caching management

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -109,6 +109,22 @@ const INTERLEAVED_THINKING_BETA: AnthropicBeta =
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
+type CacheControlBlock = (ContentBlockParam | ContentBlock) & {
+  type: 'text' | 'tool_result';
+  cache_control?: { type: 'ephemeral' };
+};
+
+const isCacheControlEligibleBlock = (
+  block: ContentBlockParam | ContentBlock | undefined,
+): block is CacheControlBlock => {
+  if (!block || typeof block !== 'object') {
+    return false;
+  }
+
+  const blockType = (block as { type?: string }).type;
+  return blockType === 'text' || blockType === 'tool_result';
+};
+
 export class ModelHandlerAnthropic extends ModelHandler<
   MessageParam,
   AnthropicUsage,
@@ -116,7 +132,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   ToolUseBlock,
   Anthropic
 > {
-  private cacheControlledBlock?: ContentBlockParam | ContentBlock;
+  private cacheControlledBlock?: CacheControlBlock;
 
   protected override get supportsToolFileOutputs(): boolean {
     return true;
@@ -126,25 +142,21 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return true;
   }
 
-  private setCacheControlTarget(
-    block: ContentBlockParam | ContentBlock,
-  ): void {
+  private setCacheControlTarget(block: ContentBlockParam | ContentBlock): void {
     if (!this.capabilities.supportsPromptCaching) {
       return;
     }
 
-    if (
-      this.cacheControlledBlock &&
-      this.cacheControlledBlock !== block &&
-      typeof this.cacheControlledBlock === 'object'
-    ) {
-      delete (this.cacheControlledBlock as any).cache_control;
+    if (!isCacheControlEligibleBlock(block)) {
+      return;
     }
 
-    if (block && typeof block === 'object') {
-      (block as any).cache_control = { type: 'ephemeral' as const };
-      this.cacheControlledBlock = block;
+    if (this.cacheControlledBlock && this.cacheControlledBlock !== block) {
+      delete this.cacheControlledBlock.cache_control;
     }
+
+    block.cache_control = { type: 'ephemeral' };
+    this.cacheControlledBlock = block;
   }
 
   private clearCacheControlTarget(): void {
@@ -153,10 +165,45 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return;
     }
 
-    if (this.cacheControlledBlock && typeof this.cacheControlledBlock === 'object') {
-      delete (this.cacheControlledBlock as any).cache_control;
+    if (this.cacheControlledBlock) {
+      delete this.cacheControlledBlock.cache_control;
     }
     this.cacheControlledBlock = undefined;
+  }
+
+  private findCacheControlCandidate(
+    content: (ContentBlockParam | ContentBlock)[] | undefined,
+  ): CacheControlBlock | undefined {
+    if (!Array.isArray(content) || content.length === 0) {
+      return undefined;
+    }
+
+    for (let idx = content.length - 1; idx >= 0; idx -= 1) {
+      const candidate = content[idx];
+      if (isCacheControlEligibleBlock(candidate)) {
+        return candidate;
+      }
+    }
+
+    return undefined;
+  }
+
+  private assignCacheControlToLatest(
+    content: (ContentBlockParam | ContentBlock)[] | undefined,
+  ): void {
+    if (!this.capabilities.supportsPromptCaching) {
+      return;
+    }
+
+    const target = this.findCacheControlCandidate(content);
+    if (target) {
+      this.setCacheControlTarget(target);
+    } else if (Array.isArray(content) && content.length > 0) {
+      this.logger.debug(
+        'No eligible content block available for Anthropic cache control marker',
+      );
+      this.clearCacheControlTarget();
+    }
   }
 
   async getClient(): Promise<Anthropic> {
@@ -662,6 +709,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
       throw new Error(errMsg);
     }
 
+    this.clearCacheControlTarget();
+
     // Create content list for the user message
     const userMessageContent: ContentBlockParam[] = [];
 
@@ -694,10 +743,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       { role: 'user', content: userMessageContent },
     ];
 
-    const cacheTarget = userMessageContent.at(-1);
-    if (cacheTarget) {
-      this.setCacheControlTarget(cacheTarget);
-    }
+    this.assignCacheControlToLatest(userMessageContent);
 
     return messages;
   }
@@ -750,10 +796,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     messages.push({ role: 'user', content: roundContent });
 
-    const cacheTarget = roundContent.at(-1);
-    if (cacheTarget) {
-      this.setCacheControlTarget(cacheTarget);
-    }
+    this.assignCacheControlToLatest(roundContent);
 
     return messages;
   }
@@ -776,10 +819,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     const lastMessage = messages.at(-1);
     if (lastMessage && Array.isArray(lastMessage.content)) {
-      const cacheTarget = lastMessage.content.at(-1);
-      if (cacheTarget) {
-        this.setCacheControlTarget(cacheTarget);
-      }
+      this.assignCacheControlToLatest(lastMessage.content);
     }
 
     return messages;
@@ -966,10 +1006,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     const lastMessage = messages.at(-1);
     if (lastMessage && Array.isArray(lastMessage.content)) {
-      const continuationTarget = lastMessage.content.at(-1);
-      if (continuationTarget) {
-        this.setCacheControlTarget(continuationTarget);
-      }
+      this.assignCacheControlToLatest(lastMessage.content);
     }
   }
 
@@ -1079,10 +1116,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     this.logger.debug(`Using existing content as prefill: ${outputFile}`);
     messages.push({ role: 'assistant', content });
 
-    const cacheTarget = content.at(-1);
-    if (cacheTarget) {
-      this.setCacheControlTarget(cacheTarget);
-    }
+    this.assignCacheControlToLatest(content);
 
     if (!this.capabilities.supportsAssistantPrefill) {
       // For models that don't support assistant prefill, we need to:
@@ -1182,11 +1216,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
         ];
       }
 
-      const lastContentItem = Array.isArray(lastMessage.content)
-        ? lastMessage.content.at(-1)
-        : undefined;
-      if (lastContentItem) {
-        this.setCacheControlTarget(lastContentItem);
+      if (Array.isArray(lastMessage.content)) {
+        this.assignCacheControlToLatest(lastMessage.content);
       }
     }
     return;
@@ -1285,11 +1316,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
           // secondLastMessage.content = newContent;
         }
 
-        const lastContentItem = Array.isArray(secondLastMessage.content)
-          ? secondLastMessage.content.at(-1)
-          : undefined;
-        if (lastContentItem) {
-          this.setCacheControlTarget(lastContentItem);
+        if (Array.isArray(secondLastMessage.content)) {
+          this.assignCacheControlToLatest(secondLastMessage.content);
         }
 
         // Remove the user continuation prompt to keep the conversation clean
@@ -1333,11 +1361,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
       messages.push(assistantMessage);
 
-      const lastContentItem = Array.isArray(assistantMessage.content)
-        ? assistantMessage.content.at(-1)
-        : undefined;
-      if (lastContentItem) {
-        this.setCacheControlTarget(lastContentItem);
+      if (Array.isArray(assistantMessage.content)) {
+        this.assignCacheControlToLatest(assistantMessage.content);
       }
 
       this.logger.debug('Added a new assistant message');

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -116,12 +116,47 @@ export class ModelHandlerAnthropic extends ModelHandler<
   ToolUseBlock,
   Anthropic
 > {
+  private cacheControlledBlock?: ContentBlockParam | ContentBlock;
+
   protected override get supportsToolFileOutputs(): boolean {
     return true;
   }
 
   protected override get supportsInlineToolImages(): boolean {
     return true;
+  }
+
+  private setCacheControlTarget(
+    block: ContentBlockParam | ContentBlock,
+  ): void {
+    if (!this.capabilities.supportsPromptCaching) {
+      return;
+    }
+
+    if (
+      this.cacheControlledBlock &&
+      this.cacheControlledBlock !== block &&
+      typeof this.cacheControlledBlock === 'object'
+    ) {
+      delete (this.cacheControlledBlock as any).cache_control;
+    }
+
+    if (block && typeof block === 'object') {
+      (block as any).cache_control = { type: 'ephemeral' as const };
+      this.cacheControlledBlock = block;
+    }
+  }
+
+  private clearCacheControlTarget(): void {
+    if (!this.capabilities.supportsPromptCaching) {
+      this.cacheControlledBlock = undefined;
+      return;
+    }
+
+    if (this.cacheControlledBlock && typeof this.cacheControlledBlock === 'object') {
+      delete (this.cacheControlledBlock as any).cache_control;
+    }
+    this.cacheControlledBlock = undefined;
   }
 
   async getClient(): Promise<Anthropic> {
@@ -650,9 +685,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         type: 'text',
         text: trimmedRequest,
         citations: null,
-        ...(this.capabilities.supportsPromptCaching
-          ? { cache_control: { type: 'ephemeral' } }
-          : {}),
       };
       userMessageContent.push(requestBlock);
     }
@@ -661,23 +693,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const messages: MessageParam[] = [
       { role: 'user', content: userMessageContent },
     ];
-    return messages;
-  }
 
-  public removeCacheControl(content: ContentBlock[] | ContentBlockParam[]) {
-    // With the updated Anthropic prompt caching, we should ensure we never exceed
-    // Anthropic's limit of 4 cache_control blocks across the entire conversation
-
-    // Complete removal approach - remove all cache_control properties
-    // This ensures we don't accumulate too many cache points over time
-    if (Array.isArray(content) && content.length > 0) {
-      for (let i = 0; i < content.length; i++) {
-        const item = content[i] as any;
-        if (typeof item === 'object' && item?.cache_control) {
-          delete item.cache_control;
-        }
-      }
+    const cacheTarget = userMessageContent.at(-1);
+    if (cacheTarget) {
+      this.setCacheControlTarget(cacheTarget);
     }
+
+    return messages;
   }
 
   /** Creates message array for subsequent rounds, managing cache control and image content. */
@@ -715,9 +737,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         type: 'text',
         text: trimmedMessage,
         citations: null,
-        ...(this.capabilities.supportsPromptCaching
-          ? { cache_control: { type: 'ephemeral' } }
-          : {}),
       };
       roundContent.push(messageBlock);
     }
@@ -729,17 +748,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       throw new Error(errMsg);
     }
 
-    // We need to ensure we don't exceed Anthropic's limit of 4 cache_control blocks
-    // Remove cache_control from ALL previous message contents
-    if (this.capabilities.supportsPromptCaching) {
-      for (const msg of messages) {
-        if (Array.isArray(msg.content)) {
-          this.removeCacheControl(msg.content);
-        }
-      }
+    messages.push({ role: 'user', content: roundContent });
+
+    const cacheTarget = roundContent.at(-1);
+    if (cacheTarget) {
+      this.setCacheControlTarget(cacheTarget);
     }
 
-    messages.push({ role: 'user', content: roundContent });
     return messages;
   }
 
@@ -758,6 +773,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
       role: 'user',
       content: [{ type: 'text', text: trimmedMessage, citations: null }],
     });
+
+    const lastMessage = messages.at(-1);
+    if (lastMessage && Array.isArray(lastMessage.content)) {
+      const cacheTarget = lastMessage.content.at(-1);
+      if (cacheTarget) {
+        this.setCacheControlTarget(cacheTarget);
+      }
+    }
+
     return messages;
   }
 
@@ -938,9 +962,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
     messages.push({
       role: 'user',
       content: [{ type: 'text', text: userMessageContinuation }],
-      // cache_control: { type: 'ephemeral' },
-      // if we keep removing this userContinuation message, then the cache_control will be removed too!
     });
+
+    const lastMessage = messages.at(-1);
+    if (lastMessage && Array.isArray(lastMessage.content)) {
+      const continuationTarget = lastMessage.content.at(-1);
+      if (continuationTarget) {
+        this.setCacheControlTarget(continuationTarget);
+      }
+    }
   }
 
   /** Initializes output file and handles prefill content, returning [isComplete, updatedMessages]. */
@@ -1027,10 +1057,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         ];
       }
 
-      const lastMsgContent = messages.at(-1)?.content;
-      if (lastMsgContent && Array.isArray(lastMsgContent)) {
-        this.removeCacheControl(lastMsgContent);
-      }
+      this.clearCacheControlTarget();
 
       endTurn = true;
       return [endTurn, messages];
@@ -1047,13 +1074,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
       {
         type: 'text' as const,
         text: fileContent,
-        ...(this.capabilities.supportsPromptCaching
-          ? { cache_control: { type: 'ephemeral' as const } }
-          : {}),
       },
     ];
     this.logger.debug(`Using existing content as prefill: ${outputFile}`);
     messages.push({ role: 'assistant', content });
+
+    const cacheTarget = content.at(-1);
+    if (cacheTarget) {
+      this.setCacheControlTarget(cacheTarget);
+    }
 
     if (!this.capabilities.supportsAssistantPrefill) {
       // For models that don't support assistant prefill, we need to:
@@ -1153,27 +1182,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
         ];
       }
 
-      if (this.capabilities.supportsPromptCaching) {
-        // First remove all cache_control from all previous messages to stay under the limit
-        for (let i = 0; i < messages.length - 1; i++) {
-          const msg = messages[i];
-          if (Array.isArray(msg.content)) {
-            this.removeCacheControl(msg.content);
-          }
-        }
-
-        // Then ensure the current message has at most one cache_control
-        if (Array.isArray(lastMessage.content)) {
-          // Remove all existing cache_control
-          this.removeCacheControl(lastMessage.content);
-
-          const lastContentItem = lastMessage.content.at(-1);
-          if (lastContentItem && typeof lastContentItem === 'object') {
-            (lastContentItem as any).cache_control = {
-              type: 'ephemeral',
-            };
-          }
-        }
+      const lastContentItem = Array.isArray(lastMessage.content)
+        ? lastMessage.content.at(-1)
+        : undefined;
+      if (lastContentItem) {
+        this.setCacheControlTarget(lastContentItem);
       }
     }
     return;
@@ -1272,14 +1285,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
           // secondLastMessage.content = newContent;
         }
 
-        // Remove cache_control from previous messages if needed
-        if (this.capabilities.supportsPromptCaching) {
-          for (let i = 0; i < messages.length - 1; i++) {
-            const msg = messages[i];
-            if (Array.isArray(msg.content)) {
-              this.removeCacheControl(msg.content);
-            }
-          }
+        const lastContentItem = Array.isArray(secondLastMessage.content)
+          ? secondLastMessage.content.at(-1)
+          : undefined;
+        if (lastContentItem) {
+          this.setCacheControlTarget(lastContentItem);
         }
 
         // Remove the user continuation prompt to keep the conversation clean
@@ -1322,6 +1332,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
 
       messages.push(assistantMessage);
+
+      const lastContentItem = Array.isArray(assistantMessage.content)
+        ? assistantMessage.content.at(-1)
+        : undefined;
+      if (lastContentItem) {
+        this.setCacheControlTarget(lastContentItem);
+      }
+
       this.logger.debug('Added a new assistant message');
     }
   }
@@ -1616,6 +1634,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
         },
       ],
     };
+
+    const toolResultBlock = Array.isArray(resultMsg.content)
+      ? resultMsg.content.at(-1)
+      : undefined;
+    if (toolResultBlock) {
+      this.setCacheControlTarget(toolResultBlock);
+    }
+
     return [callMsg, resultMsg];
   }
 }

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -6,6 +6,7 @@ import type {
   ContentBlock,
   ContentBlockParam,
   MessageParam,
+  ToolUseBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
 // Local imports - agent
@@ -63,6 +64,16 @@ function assertSingleTextBlock(content: ContentBlock[]): TextBlock {
     'expected exactly one text block in Anthropic message content',
   );
   return textBlocks[0];
+}
+
+function getCacheMarker(
+  block?: ContentBlockParam | ContentBlock,
+): unknown {
+  if (!block) {
+    return undefined;
+  }
+
+  return (block as { cache_control?: unknown }).cache_control;
 }
 
 class PdfStubAnthropicHandler extends ModelHandlerAnthropic {
@@ -173,6 +184,97 @@ describe('ModelHandlerAnthropic message guards', () => {
         assert.match(err.message, /non-empty content block/i);
         return true;
       },
+    );
+  });
+
+  it('moves the cache control marker to the newest message block', async () => {
+    const handler = createAnthropicHandler();
+    const baseMessages = await handler.initializeMessages('prefix', 'initial request');
+    const initialContent = baseMessages[0].content as ContentBlockParam[];
+    const initialBlock = initialContent.at(-1);
+    const initialMarker = getCacheMarker(initialBlock);
+
+    assert.ok(
+      initialMarker,
+      'expected the initial request to include a cache control marker',
+    );
+
+    const updated = await handler.createRoundMessages(
+      [...baseMessages],
+      'next follow up',
+    );
+    const followUp = updated[updated.length - 1];
+    const followUpContent = followUp.content as ContentBlockParam[];
+    const followUpBlock = followUpContent.at(-1);
+    const followUpMarker = getCacheMarker(followUpBlock);
+
+    assert.ok(
+      followUpMarker,
+      'expected the newest message block to keep the cache marker',
+    );
+    assert.equal(
+      getCacheMarker(initialBlock),
+      undefined,
+      'previous message should have its cache marker removed',
+    );
+  });
+
+  it('applies cache control to tool result follow-ups when supported', async () => {
+    const handler = createAnthropicHandler();
+    const call: ToolUseBlock = {
+      id: 'tool-call',
+      type: 'tool_use',
+      name: 'demo',
+      input: {},
+    } as ToolUseBlock;
+
+    const [, resultMsg] = await handler.createToolUseFollowUpMessages(
+      undefined,
+      'tool-call',
+      'demo',
+      call,
+      { output: 'ok' },
+    );
+
+    const toolResultBlock = (resultMsg.content as ContentBlockParam[])[0];
+    assert.ok(
+      getCacheMarker(toolResultBlock),
+      'tool result block should include cache control metadata',
+    );
+  });
+
+  it('skips cache control when prompt caching is disabled', async () => {
+    const handler = createAnthropicHandler({ supportsPromptCaching: false });
+    const call: ToolUseBlock = {
+      id: 'tool-call',
+      type: 'tool_use',
+      name: 'demo',
+      input: {},
+    } as ToolUseBlock;
+
+    const baseMessages = await handler.initializeMessages('prefix', 'request');
+    const initialContent = baseMessages[0].content as ContentBlockParam[];
+    const initialBlock = initialContent.at(-1);
+
+    assert.equal(
+      getCacheMarker(initialBlock),
+      undefined,
+      'initial message should not include cache metadata when disabled',
+    );
+
+    const [, resultMsg] = await handler.createToolUseFollowUpMessages(
+      undefined,
+      'tool-call',
+      'demo',
+      call,
+      { output: 'ok' },
+    );
+
+    const toolResultBlock = (resultMsg.content as ContentBlockParam[])[0];
+    assert.equal(
+      getCacheMarker(toolResultBlock),
+      undefined,
+      'tool result block should remain untouched when caching disabled',
     );
   });
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -66,9 +66,7 @@ function assertSingleTextBlock(content: ContentBlock[]): TextBlock {
   return textBlocks[0];
 }
 
-function getCacheMarker(
-  block?: ContentBlockParam | ContentBlock,
-): unknown {
+function getCacheMarker(block?: ContentBlockParam | ContentBlock): unknown {
   if (!block) {
     return undefined;
   }
@@ -189,7 +187,10 @@ describe('ModelHandlerAnthropic message guards', () => {
 
   it('moves the cache control marker to the newest message block', async () => {
     const handler = createAnthropicHandler();
-    const baseMessages = await handler.initializeMessages('prefix', 'initial request');
+    const baseMessages = await handler.initializeMessages(
+      'prefix',
+      'initial request',
+    );
     const initialContent = baseMessages[0].content as ContentBlockParam[];
     const initialBlock = initialContent.at(-1);
     const initialMarker = getCacheMarker(initialBlock);
@@ -216,6 +217,53 @@ describe('ModelHandlerAnthropic message guards', () => {
       getCacheMarker(initialBlock),
       undefined,
       'previous message should have its cache marker removed',
+    );
+  });
+
+  it('avoids assigning cache control to non-text media blocks', async () => {
+    const handler = new PdfStubAnthropicHandler(
+      buildAnthropicConfig({ supportsVision: true }),
+    );
+
+    handler.setMediaContent([
+      { type: 'text', text: 'Image: diagram.png', citations: null },
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: 'ZHVtbXk=',
+        },
+      },
+    ] as ContentBlockParam[]);
+
+    const messages = await handler.initializeMessages('prefix text', '', [
+      'diagram.png',
+    ]);
+
+    const content = messages[0].content as ContentBlockParam[];
+    const finalBlock = content.at(-1);
+    assert.equal(
+      finalBlock?.type,
+      'image',
+      'expected the final block to be an image',
+    );
+    assert.equal(
+      getCacheMarker(finalBlock),
+      undefined,
+      'image block should not carry cache control metadata',
+    );
+
+    const lastTextBlock = [...content]
+      .reverse()
+      .find((block) => block.type === 'text');
+    assert.ok(
+      lastTextBlock,
+      'expected at least one text block in the message content',
+    );
+    assert.ok(
+      getCacheMarker(lastTextBlock),
+      'last eligible text block should include cache control metadata',
     );
   });
 


### PR DESCRIPTION
## Summary
- centralize Anthropic cache_control marker management and reuse it across initialization, follow-ups, prefill flows, and continuation prompts
- tag tool-use follow-ups with cache control metadata when Anthropic prompt caching is available
- add regression tests that cover cache marker rotation and capability gating for tool results

## Testing
- npm run lint
- npm run compile-tests
- npm test *(hangs during vscode-test, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68f7a8d2d4c88324b74efeb7af39634f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes Anthropic prompt caching, moving a single ephemeral cache_control marker to the latest eligible block and tagging tool_result follow-ups when supported.
> 
> - **Anthropic handler**:
>   - **Centralized cache control**:
>     - Introduces `CacheControlBlock` and helpers (`isCacheControlEligibleBlock`, `setCacheControlTarget`, `clearCacheControlTarget`, `assignCacheControlToLatest`).
>     - Moves a single `cache_control: { type: 'ephemeral' }` marker to the latest eligible `text`/`tool_result` block; removes scattered inline cache markers.
>     - Integrates marker management into `initializeMessages`, `createRoundMessages`, `createUserFollowUpMessages`, continuation flows, and prefill/update paths.
>   - **Tool results**:
>     - Applies cache marker to `tool_result` follow-ups when prompt caching is enabled.
> - **Tests**:
>   - Add coverage for marker rotation to newest block, skipping non-text (e.g., `image`), applying to `tool_result`, and capability gating when caching disabled.
>   - Minor test scaffolding updates (e.g., `ToolUseBlock` import, media stubs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b081be3114d413e2d5c2a4c6e27a68de1c7b60c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->