### PR TITLE
Refactor progress task group updates to use structured payloads

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -272,9 +272,13 @@ export class ProgressViewProvider
           if (group.status === STATUS.RUNNING) {
             // Update the group to ERROR status with current end time
             const endTime = Date.now();
-            this.state.taskGroups.updateGroup(streamId, groupId, {
-              status: STATUS.ERROR,
-              endTime,
+            this.state.taskGroups.updateGroup({
+              stream: streamId,
+              groupId,
+              updates: {
+                status: STATUS.ERROR,
+                endTime,
+              },
             });
 
             this.logger.debug(

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -29,15 +29,22 @@ interface OutputEventsShared {
 
 type FilesByRound<T> = { [key: number]: T[] };
 
-const updateActiveStreamOutputs = (
-  state: ProgressViewState,
-  updater: WebviewUpdater,
-  stream: string,
+interface ActiveStreamOutputUpdate {
+  state: ProgressViewState;
+  updater: WebviewUpdater;
+  stream: string;
   updates: {
     files?: FilesByRound<OutputFileInfo> | undefined;
     missing?: FilesByRound<string> | undefined;
-  },
-): void => {
+  };
+}
+
+const updateActiveStreamOutputs = ({
+  state,
+  updater,
+  stream,
+  updates,
+}: ActiveStreamOutputUpdate): void => {
   if (state.activeStream !== stream || !updater.isAvailable()) {
     return;
   }
@@ -65,7 +72,7 @@ const registerOutputFileListeners = (
       if (files !== undefined) {
         updates.files = files;
       }
-      updateActiveStreamOutputs(state, updater, stream, updates);
+      updateActiveStreamOutputs({ state, updater, stream, updates });
     });
   });
 
@@ -79,7 +86,7 @@ const registerOutputFileListeners = (
         if (missing !== undefined) {
           updates.missing = missing;
         }
-        updateActiveStreamOutputs(state, updater, stream, updates);
+        updateActiveStreamOutputs({ state, updater, stream, updates });
       });
     },
   );
@@ -87,14 +94,24 @@ const registerOutputFileListeners = (
   const clearMissing = bus.on('clearMissingOutputs', (stream) => {
     withErrorBoundary('failed to handle clearMissingOutputs', () => {
       state.outputFiles.clearMissingOutputs(stream);
-      updateActiveStreamOutputs(state, updater, stream, { missing: {} });
+      updateActiveStreamOutputs({
+        state,
+        updater,
+        stream,
+        updates: { missing: {} },
+      });
     });
   });
 
   const clearFiles = bus.on('clearOutputFiles', (stream) => {
     withErrorBoundary('failed to handle clearOutputFiles', () => {
       state.outputFiles.clearFiles(stream);
-      updateActiveStreamOutputs(state, updater, stream, { files: {} });
+      updateActiveStreamOutputs({
+        state,
+        updater,
+        stream,
+        updates: { files: {} },
+      });
     });
   });
 

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type { WebviewUpdater } from '../managers';
+import type { TaskGroupUpdatePayload, WebviewUpdater } from '../managers';
 import type { ProgressViewState } from '../state/ProgressViewState';
 
 // Local imports - events
@@ -79,15 +79,19 @@ export function createTaskGroupEvents(
     updater: WebviewUpdater,
   ): void => {
     withErrorBoundary('failed to handle updateTaskGroup', () => {
-      const { stream, groupId, status, endTime } = data;
+      const update: TaskGroupUpdatePayload = {
+        stream: data.stream,
+        groupId: data.groupId,
+        updates: {
+          status: data.status,
+          endTime: data.endTime,
+        },
+      };
 
-      state.taskGroups.updateGroup(stream, groupId, {
-        status,
-        endTime,
-      });
+      state.taskGroups.updateGroup(update);
 
-      if (updater.isAvailable() && stream === state.activeStream) {
-        updater.updateTaskGroup(stream, groupId, status, endTime);
+      if (updater.isAvailable() && data.stream === state.activeStream) {
+        updater.updateTaskGroup(update);
       }
     });
   };

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type { WebviewUpdater } from '../managers';
+import type { TaskGroupUpdatePayload, WebviewUpdater } from '../managers';
 import type { ProgressViewState } from '../state/ProgressViewState';
 
 // Local imports - events
@@ -41,7 +41,12 @@ export function createUsageEvents(
           withErrorBoundary('failed to handle updateGroupUsage', () => {
             const group = state.taskGroups.getGroup(stream, groupId);
             if (group) {
-              state.taskGroups.updateGroup(stream, groupId, { usage });
+              const update: TaskGroupUpdatePayload = {
+                stream,
+                groupId,
+                updates: { usage },
+              };
+              state.taskGroups.updateGroup(update);
             }
           });
         },

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -9,6 +9,12 @@ import { AgentLogger } from '@logger/AgentLogger';
 // Types
 import { TaskGroup } from '@logger/LogTypes';
 
+export interface TaskGroupUpdatePayload {
+  stream: StreamTabId;
+  groupId: string;
+  updates: Partial<TaskGroup>;
+}
+
 /**
  * Manages task groups collection with persistence.
  * Handles adding, updating, and managing task groups for different streams.
@@ -40,11 +46,7 @@ export class TaskGroupManager extends PersistentMapManager<
   /**
    * Update an existing task group
    */
-  updateGroup(
-    stream: StreamTabId,
-    groupId: string,
-    updates: Partial<TaskGroup>,
-  ): void {
+  updateGroup({ stream, groupId, updates }: TaskGroupUpdatePayload): void {
     const streamGroups = this.get(stream);
     if (!streamGroups) {
       this.logger.warn(

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -7,6 +7,7 @@ import { COMMANDS, STATUS } from '../modules/constants.js';
 
 // Local imports
 import { ProgressViewState } from '../state/ProgressViewState';
+import type { TaskGroupUpdatePayload } from './TaskGroupManager';
 import { buildStreamInfos } from '../streamInfoUtils';
 import type { InstructionUpdate, StreamTabInfo } from '../types';
 import type { OutputFileInfo } from '@agent/output/types';
@@ -250,21 +251,13 @@ export class WebviewUpdater {
   /**
    * Update a task group in the webview
    */
-  updateTaskGroup(
-    stream: StreamTabId,
-    groupId: string,
-    status: StatusType,
-    endTime?: number,
-  ): void {
+  updateTaskGroup(update: TaskGroupUpdatePayload): void {
     const webview = this.getWebview();
     if (!webview) return;
 
     webview.postMessage({
       command: COMMANDS.UPDATE_TASK_GROUP,
-      stream,
-      groupId,
-      status,
-      endTime,
+      update,
     });
   }
 

--- a/src/progressView/managers/index.ts
+++ b/src/progressView/managers/index.ts
@@ -1,6 +1,7 @@
 export { OutputFilesManager } from './OutputFilesManager';
 export { StreamTabsManager } from './StreamTabsManager';
 export { TaskGroupManager } from './TaskGroupManager';
+export type { TaskGroupUpdatePayload } from './TaskGroupManager';
 export { ToolUseTaskStateManager } from './ToolUseTaskStateManager';
 export { UsageStatsManager } from './UsageStatsManager';
 export { WebviewUpdater } from './WebviewUpdater';

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -237,13 +237,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   handleUpdateTaskGroup(message) {
-    if (message.stream === state.activeStream) {
-      state.taskGroups.update(message.groupId, message.status, message.endTime);
-      dom.taskGroups.updateGroup(
-        message.groupId,
-        message.status,
-        message.endTime,
-      );
+    const update = message?.update;
+    if (!update) {
+      return;
+    }
+
+    if (update.stream === state.activeStream) {
+      state.taskGroups.update(update);
+      dom.taskGroups.updateGroup(update);
     }
   }
 
@@ -259,7 +260,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleUpdateGroupUsage(message) {
     if (message.stream === state.activeStream) {
-      dom.usageGroup.update(message.groupId, message.usage);
+      dom.usageGroup.update({
+        groupId: message.groupId,
+        usage: message.usage,
+      });
     }
   }
 

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -63,7 +63,11 @@ class TaskGroups {
       return;
     }
 
-    if (Object.prototype.hasOwnProperty.call(updates, 'status')) {
+    const hasStatusUpdate = Object.prototype.hasOwnProperty.call(
+      updates,
+      'status',
+    );
+    if (hasStatusUpdate && updates.status) {
       group.status = updates.status;
     }
     if (

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -42,27 +42,39 @@ class TaskGroups {
   }
 
   /**
-   * Update an existing log group with new status or end time.
-   * @param {string} groupId - ID of the group to update
-   * @param {string} status - New status
-   * @param {number} [endTime] - Optional end time
+   * Update an existing log group with a structured payload.
+   * @param {{ groupId: string, updates?: Object }} payload
    */
-  update(groupId, status, endTime) {
+  update(payload) {
+    if (!payload || typeof payload !== 'object') {
+      console.error('TaskGroups.update: payload must be an object');
+      return;
+    }
+
+    const { groupId, updates = {} } = payload;
     if (!groupId) {
       console.error('TaskGroups.update: groupId is required');
       return;
     }
+
     const group = this.groups.get(groupId);
     if (!group) {
       console.error(`TaskGroups.update: group not found for id ${groupId}`);
       return;
     }
 
-    if (status) {
-      group.status = status;
+    if (Object.prototype.hasOwnProperty.call(updates, 'status')) {
+      group.status = updates.status;
     }
-    if (endTime !== undefined && endTime !== null) {
-      group.endTime = endTime;
+    if (
+      Object.prototype.hasOwnProperty.call(updates, 'endTime') &&
+      updates.endTime !== undefined &&
+      updates.endTime !== null
+    ) {
+      group.endTime = updates.endTime;
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'usage')) {
+      group.usage = updates.usage;
     }
 
     this.groups.set(groupId, group);

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -31,7 +31,13 @@ export class TaskGroupDomManager {
         this.groupElements.delete(group.id);
       } else {
         progressViewState.taskGroups.set(group.id, group);
-        this.updateGroup(group.id, group.status, group.endTime);
+        this.updateGroup({
+          groupId: group.id,
+          updates: {
+            status: group.status,
+            endTime: group.endTime,
+          },
+        });
         return;
       }
     }
@@ -83,13 +89,21 @@ export class TaskGroupDomManager {
       const parentGroupContent =
         parentDetails?.querySelector('.log-group-content');
       if (parentGroupContent) {
-        insertChronologically(parentGroupContent, detailsElem, group.startTime);
+        insertChronologically({
+          container: parentGroupContent,
+          element: detailsElem,
+          timestamp: group.startTime,
+        });
         return;
       }
     }
 
     // For top-level groups, insert in chronological order
-    insertChronologically(container, detailsElem, group.startTime);
+    insertChronologically({
+      container,
+      element: detailsElem,
+      timestamp: group.startTime,
+    });
 
     // For top-level groups, update current group and collapse the previous active group
     if (!group.parentGroupId) {
@@ -104,13 +118,33 @@ export class TaskGroupDomManager {
    * @param {string} status - New status
    * @param {string} endTime - End time (optional)
    */
-  updateGroup(groupId, status, endTime) {
+  updateGroup(update) {
+    if (!update || typeof update !== 'object') {
+      return;
+    }
+
+    const { groupId, updates = {} } = update;
+    if (!groupId) {
+      return;
+    }
+
     const group = progressViewState.taskGroups.get(groupId);
     if (!group) return;
 
-    group.status = status;
-    if (endTime) {
-      group.endTime = endTime;
+    const hasStatusUpdate = Object.prototype.hasOwnProperty.call(
+      updates,
+      'status',
+    );
+    const hasEndTimeUpdate = Object.prototype.hasOwnProperty.call(
+      updates,
+      'endTime',
+    );
+
+    if (hasStatusUpdate) {
+      group.status = updates.status;
+    }
+    if (hasEndTimeUpdate && updates.endTime) {
+      group.endTime = updates.endTime;
     }
 
     const detailsElem = this.groupElements.get(groupId);
@@ -126,14 +160,16 @@ export class TaskGroupDomManager {
       // Update the status icon
       const statusIconElem = header.querySelector('.group-status-icon');
       if (statusIconElem) {
-        statusIconElem.innerHTML = this.headerFormatter._getStatusIcon(status);
+        statusIconElem.innerHTML = this.headerFormatter._getStatusIcon(
+          group.status,
+        );
       }
 
       // Update or add the duration display when the group finishes
       const timeContainer = header.querySelector('.group-time');
 
-      if (endTime) {
-        const endDate = endTime;
+      if (hasEndTimeUpdate && group.endTime) {
+        const endDate = group.endTime;
         const startDate = group.startTime;
         const durationMs = endDate - startDate;
 
@@ -155,6 +191,8 @@ export class TaskGroupDomManager {
         }
       }
     }
+
+    progressViewState.taskGroups.set(groupId, group);
   }
 
   /**
@@ -290,7 +328,11 @@ export class LogEntryManager {
         // Extract timestamp from the message for chronological ordering
         const msgDate = new Date(logMessage.timestamp);
 
-        insertChronologically(groupContent, logLineElement, msgDate);
+        insertChronologically({
+          container: groupContent,
+          element: logLineElement,
+          timestamp: msgDate,
+        });
 
         return true;
       }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -140,10 +140,14 @@ export class TaskGroupDomManager {
       'endTime',
     );
 
-    if (hasStatusUpdate) {
+    if (hasStatusUpdate && updates.status) {
       group.status = updates.status;
     }
-    if (hasEndTimeUpdate && updates.endTime) {
+    if (
+      hasEndTimeUpdate &&
+      updates.endTime !== undefined &&
+      updates.endTime !== null
+    ) {
       group.endTime = updates.endTime;
     }
 
@@ -168,7 +172,11 @@ export class TaskGroupDomManager {
       // Update or add the duration display when the group finishes
       const timeContainer = header.querySelector('.group-time');
 
-      if (hasEndTimeUpdate && group.endTime) {
+      if (
+        hasEndTimeUpdate &&
+        group.endTime !== undefined &&
+        group.endTime !== null
+      ) {
         const endDate = group.endTime;
         const startDate = group.startTime;
         const durationMs = endDate - startDate;

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -59,11 +59,15 @@ export class UsageGroupManager {
 
   /**
    * Update token and cost usage for a specific group
-   * @param {string} groupId - ID of the group to update
-   * @param {Object} usage - Usage data with inputTokens, outputTokens, cost
-   * @param {boolean} skipPropagate - Whether to skip propagating to parents
+   * @param {{ groupId: string, usage?: Object, skipPropagate?: boolean }} payload
    */
-  update(groupId, usage, skipPropagate = false) {
+  update(payload) {
+    if (!payload || typeof payload !== 'object') {
+      console.error('UsageGroupManager.update: payload must be an object');
+      return;
+    }
+
+    const { groupId, usage, skipPropagate = false } = payload;
     if (!groupId) {
       console.error('UsageGroupManager.update: groupId is required');
       return;
@@ -160,14 +164,18 @@ export class UsageGroupManager {
       const totals = {
         ...this.computeAggregatedUsage(group.parentGroupId),
       };
-      this.update(group.parentGroupId, totals, true);
+      this.update({
+        groupId: group.parentGroupId,
+        usage: totals,
+        skipPropagate: true,
+      });
       this.propagateUsageToParents(group.parentGroupId);
     } else {
       // This is a top-level group, update it with aggregated usage from its children
       const totals = {
         ...this.computeAggregatedUsage(groupId),
       };
-      this.update(groupId, totals, true);
+      this.update({ groupId, usage: totals, skipPropagate: true });
     }
   }
 

--- a/src/progressView/modules/utils.js
+++ b/src/progressView/modules/utils.js
@@ -54,12 +54,16 @@ export function appendFormatted(container, formatted) {
  *   callback to extract a timestamp from each child. Should return milliseconds
  *   since epoch or null if the child should be ignored.
  */
-export function insertChronologically(
+export function insertChronologically({
   container,
   element,
   timestamp,
   getChildTimestamp,
-) {
+}) {
+  if (!container || !element || timestamp === undefined || timestamp === null) {
+    return;
+  }
+
   const targetTime =
     timestamp instanceof Date ? timestamp.getTime() : timestamp;
   const children = Array.from(container.children);


### PR DESCRIPTION
## Summary
- refactor TaskGroupManager and related event handlers to accept object-based updates and propagate them through the webview bridge
- update progress view DOM, state, and usage managers to consume structured update payloads and shared insertion helpers
- replace positional helper signatures with descriptive objects for output updates and chronological insertion ordering

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: vscode-test binary missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f80d4c97088324b9fb26e5566bbb7f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch APIs to object-based update payloads across task group/state/webview/DOM and unify chronological insertion via a single object param.
> 
> - **Progress View Core**:
>   - **Task Groups**:
>     - Introduce `TaskGroupUpdatePayload`; change `TaskGroupManager.updateGroup(...)` to `updateGroup({ stream, groupId, updates })`.
>     - Update `WebviewUpdater.updateTaskGroup(...)` to accept `{ update }` payload; export `TaskGroupUpdatePayload` from `managers/index.ts`.
>     - Refactor event handlers in `events/TaskGroupEvents.ts` and `events/UsageEvents.ts` to build and pass structured updates; propagate to webview.
>   - **Outputs**:
>     - Replace positional helper with `updateActiveStreamOutputs({ state, updater, stream, updates })` in `events/OutputEvents.ts`.
> - **Webview (Frontend)**:
>   - **Message handling & state**:
>     - `modules/messageHandlers.js`: `handleUpdateTaskGroup` consumes `message.update` and forwards structured updates to state/DOM; `handleUpdateGroupUsage` uses object payload.
>     - `modules/progressViewState.js`: `taskGroups.update(payload)` accepts `{ groupId, updates }` and supports `status`, `endTime`, `usage`.
>   - **DOM managers**:
>     - `modules/taskManagers.js`: `updateGroup({ groupId, updates })`; use `group.status/endTime` when rendering; update insert calls to new helper signature.
>     - `modules/usageManagers.js`: `UsageGroupManager.update({ groupId, usage, skipPropagate })`; propagate with structured payloads.
>   - **Utilities**:
>     - `modules/utils.js`: `insertChronologically({ container, element, timestamp, getChildTimestamp })`; update all call sites accordingly.
> - **Provider cleanup**:
>   - Adjust `ProgressViewProvider.ts` group updates to new `TaskGroupManager.updateGroup({ ... })` API (incl. webview reload error handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90aa08117f09ff5b2182b15c8ace8add6834745e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->