### PR TITLE
refactor: clean up progress view css

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -66,6 +66,7 @@
   /* Opacity levels */
   --opacity-disabled: 0.5;
   --opacity-subtle: 0.7;
+  --opacity-normal: 0.85;
   --opacity-full: 1;
 }
 
@@ -222,6 +223,26 @@ select:focus {
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+/* Shared layout for collapsible detail sections */
+.detail-section {
+  margin: var(--spacing-small) 0;
+}
+
+.detail-content {
+  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
+}
+
+.detail-list {
+  list-style: none;
+  margin: 0;
+}
+
+.detail-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
 }
 
 /* Common clickable link style (actually used in progressView) */

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -296,43 +296,43 @@
           </div>
         </template>
         <template id="fileListDetailsTemplate">
-          <details class="file-list-details">
+          <details class="detail-section file-list-details">
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-list-tree"></i>
               <span class="summary-text"></span>
             </summary>
-            <ul class="file-list-content"></ul>
+            <ul class="detail-content detail-list file-list-content"></ul>
           </details>
         </template>
         <template id="missingOutputsDetailsTemplate">
-          <details class="file-list-details">
+          <details class="detail-section file-list-details">
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-warning"></i>
               <span class="summary-text"></span>
             </summary>
-            <ul class="file-list-content"></ul>
+            <ul class="detail-content detail-list file-list-content"></ul>
           </details>
         </template>
         <template id="latexdiffDetailsTemplate">
-          <details class="latexdiff-details" open>
+          <details class="detail-section latexdiff-details" open>
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-diff"></i>
               <span class="summary-text"></span>
             </summary>
-            <ul class="latexdiff-content"></ul>
+            <ul class="detail-content detail-list latexdiff-content"></ul>
           </details>
         </template>
         <template id="statisticsDetailsTemplate">
-          <details class="statistics-details" open>
+          <details class="detail-section statistics-details" open>
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-dashboard"></i>
               <span>Statistics</span>
             </summary>
-            <div class="statistics-content"></div>
+            <div class="detail-content statistics-content"></div>
           </details>
         </template>
         <template id="groupDetailsTemplate">

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -630,7 +630,7 @@ export class LogEntryFormatter {
               <span class="tool-use-sublabel">Output:</span>
               <pre class="tool-output-preview">${preview}</pre>
               <details class="tool-output-details">
-                <summary>Show full output</summary>
+                <summary class="details-summary"><i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i><span>Show full output</span></summary>
                 <pre class="tool-output-full">${encodedOutput}</pre>
               </details>
             </div>
@@ -885,7 +885,7 @@ export class LogEntryFormatter {
           }
         }
 
-        items += `<li title="${escaped}"><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span> ${metadata}</li>`;
+        items += `<li class="detail-item" title="${escaped}"><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span> ${metadata}</li>`;
       });
     });
 
@@ -942,7 +942,7 @@ export class LogEntryFormatter {
         const escaped = encodeHtml(filePath);
         const fileName = getBasename(filePath);
         const fileNameEscaped = encodeHtml(fileName);
-        return `<li title="${escaped}"><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span></li>`;
+        return `<li class="detail-item" title="${escaped}"><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span></li>`;
       })
       .join('');
 
@@ -1037,7 +1037,7 @@ export class LogEntryFormatter {
 
       const titleAttr = msg ? ` title="${encodeHtml(msg)}"` : '';
 
-      items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
+      items += `<li class="detail-item"><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
         baseName,
       )}</span> <span class="arrow">&rarr;</span> <span class="file-link clickable-link" data-file="${revisedEsc}">${encodeHtml(
         revisedName,

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -129,7 +129,8 @@ export class EventsManager {
           (e.target.classList.contains('banner-details') ||
             e.target.classList.contains('file-list-details') ||
             e.target.classList.contains('latexdiff-details') ||
-            e.target.classList.contains('statistics-details'))
+            e.target.classList.contains('statistics-details') ||
+            e.target.classList.contains('tool-output-details'))
         ) {
           const toggleIcon = e.target.querySelector('.toggle-icon');
           if (toggleIcon) {

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -3,21 +3,6 @@
  * Styling for file list entries and file tree display
  */
 
-/* File list block styling */
-.file-list-details {
-  margin: var(--spacing-small) 0;
-}
-.file-list-content {
-  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
-  list-style: none;
-}
-
-.file-list-content li {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-}
-
 /* File metadata styling */
 .file-list-content .file-var {
   color: var(--vscode-descriptionForeground);

--- a/src/progressView/styles/latexdiff.css
+++ b/src/progressView/styles/latexdiff.css
@@ -2,18 +2,7 @@
  * Latexdiff log styles for ProgressView
  */
 
-.latexdiff-details {
-  margin: var(--spacing-small) 0;
-}
-.latexdiff-content {
-  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
-  list-style: none;
-}
-
-.latexdiff-content li {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
+.latexdiff-content .detail-item {
   flex-wrap: wrap;
 }
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -348,7 +348,7 @@
     gap: var(--spacing-small);
   }
 
-  .follow-up-container input {
+  .follow-up-container :is(textarea, input) {
     flex: 1;
   }
 }

--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -192,10 +192,6 @@
   margin-bottom: 0;
 }
 
-.markdown-content p:last-child {
-  margin-bottom: 0;
-}
-
 /* Scratchpad reflection patterns */
 .banner-content--scratchpad p:has(strong:first-child) {
   border-left: calc(var(--spacing-small) - 1px) solid

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -47,7 +47,7 @@
 }
 
 .tool-output-full {
-  max-height: 240px;
+  max-height: var(--height-xlarge);
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
@@ -55,15 +55,4 @@
 
 .tool-output-details {
   margin-top: var(--spacing-tiny);
-}
-
-.tool-output-details summary {
-  cursor: pointer;
-  color: var(--vscode-textLink-foreground);
-  font-size: var(--font-size-sm);
-}
-
-.tool-output-full {
-  max-height: 20rem;
-  overflow: auto;
 }

--- a/src/progressView/styles/statistics.css
+++ b/src/progressView/styles/statistics.css
@@ -2,16 +2,10 @@
  * Statistics log styles for ProgressView
  */
 
-.statistics-details {
-  margin: var(--spacing-small) 0;
-}
-
 .statistics-content {
-  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-large);
-  list-style: none;
 }
 
 .stat-item {

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -22,10 +22,9 @@
 /* LaTeX diffs section */
 .latexdiffs-section {
   margin-top: auto;
-  padding-top: var(--spacing-large);
+  padding: var(--spacing-large) 0 0;
   background-color: transparent;
   border: none;
-  padding: 0;
   margin-bottom: var(--spacing-large);
 }
 


### PR DESCRIPTION
## Summary
- add the missing --opacity-normal token and shared detail section utility classes used across progress-view templates
- refactor file list, latex diff, statistics, and markdown styles to reuse the shared utilities and correct responsive selectors
- consolidate tool output styling and toggle behaviour while tidying the latex diffs webview padding override

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f80dca94b883249cf9cfa705f47daa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces shared detail-section utilities, applies them across ProgressView templates/formatters, refines tool-output toggles, and consolidates related CSS.
> 
> - **Common styles**:
>   - Add `--opacity-normal` token.
>   - Introduce shared detail utilities: `detail-section`, `detail-content`, `detail-list`, `detail-item`; enhance `details-summary` styling.
> - **ProgressView templates**:
>   - Apply shared detail classes to `fileList`, `missingOutputs`, `latexdiff`, and `statistics` sections in `index.html`.
> - **Formatters**:
>   - Use `details-summary` with chevron icon for tool output; support toggle via `tool-output-details`.
>   - Render list entries with `detail-item` in file lists, missing outputs, and latexdiff.
> - **Events**:
>   - Toggle handler now updates chevrons for `tool-output-details`.
> - **CSS refactors**:
>   - Remove per-section margins/padding/list-style in `file-list.css`, `latexdiff.css`, `statistics.css` in favor of shared utilities; adjust latexdiff wrapping selector.
>   - Use `:is(textarea, input)` in responsive `.follow-up-container` input rule.
>   - Set `.tool-output-full` max-height to `var(--height-xlarge)` and drop redundant summary styles.
>   - Tidy `webview` LaTeX diffs section padding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b68160b65ed2c1c18250bbe162db682ab0a71345. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->