### PR TITLE
Refactor progress detail styling

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -66,6 +66,7 @@
   /* Opacity levels */
   --opacity-disabled: 0.5;
   --opacity-subtle: 0.7;
+  --opacity-normal: 0.85;
   --opacity-full: 1;
 }
 
@@ -234,6 +235,26 @@ select:focus {
 .clickable-link:hover {
   color: var(--vscode-textLink-activeForeground);
   text-decoration: underline;
+}
+
+/* Shared layout for expandable detail sections */
+.detail-section {
+  margin: var(--spacing-small) 0;
+}
+
+.detail-content {
+  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
+}
+
+.detail-list {
+  list-style: none;
+  margin: 0;
+}
+
+.detail-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
 }
 
 /* Shared styling for expandable summary blocks */

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -296,43 +296,43 @@
           </div>
         </template>
         <template id="fileListDetailsTemplate">
-          <details class="file-list-details">
+          <details class="file-list-details detail-section">
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-list-tree"></i>
               <span class="summary-text"></span>
             </summary>
-            <ul class="file-list-content"></ul>
+            <ul class="file-list-content detail-content detail-list"></ul>
           </details>
         </template>
         <template id="missingOutputsDetailsTemplate">
-          <details class="file-list-details">
+          <details class="file-list-details detail-section">
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-warning"></i>
               <span class="summary-text"></span>
             </summary>
-            <ul class="file-list-content"></ul>
+            <ul class="file-list-content detail-content detail-list"></ul>
           </details>
         </template>
         <template id="latexdiffDetailsTemplate">
-          <details class="latexdiff-details" open>
+          <details class="latexdiff-details detail-section" open>
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-diff"></i>
               <span class="summary-text"></span>
             </summary>
-            <ul class="latexdiff-content"></ul>
+            <ul class="latexdiff-content detail-content detail-list"></ul>
           </details>
         </template>
         <template id="statisticsDetailsTemplate">
-          <details class="statistics-details" open>
+          <details class="statistics-details detail-section" open>
             <summary class="details-summary">
               <i class="toggle-icon"></i>
               <i class="codicon codicon-dashboard"></i>
               <span>Statistics</span>
             </summary>
-            <div class="statistics-content"></div>
+            <div class="statistics-content detail-content"></div>
           </details>
         </template>
         <template id="groupDetailsTemplate">

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -630,7 +630,7 @@ export class LogEntryFormatter {
               <span class="tool-use-sublabel">Output:</span>
               <pre class="tool-output-preview">${preview}</pre>
               <details class="tool-output-details">
-                <summary>Show full output</summary>
+                <summary class="details-summary">Show full output</summary>
                 <pre class="tool-output-full">${encodedOutput}</pre>
               </details>
             </div>
@@ -885,7 +885,7 @@ export class LogEntryFormatter {
           }
         }
 
-        items += `<li title="${escaped}"><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span> ${metadata}</li>`;
+        items += `<li class="detail-item" title="${escaped}"><i class="codicon ${icon}"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span> ${metadata}</li>`;
       });
     });
 
@@ -942,7 +942,7 @@ export class LogEntryFormatter {
         const escaped = encodeHtml(filePath);
         const fileName = getBasename(filePath);
         const fileNameEscaped = encodeHtml(fileName);
-        return `<li title="${escaped}"><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span></li>`;
+        return `<li class="detail-item" title="${escaped}"><i class="codicon codicon-warning"></i> <span class="file-link clickable-link" data-file="${escaped}">${fileNameEscaped}</span></li>`;
       })
       .join('');
 
@@ -1037,7 +1037,7 @@ export class LogEntryFormatter {
 
       const titleAttr = msg ? ` title="${encodeHtml(msg)}"` : '';
 
-      items += `<li><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
+      items += `<li class="detail-item"><i class="codicon ${icon}"${titleAttr}></i> <span class="file-link clickable-link" data-file="${baseEsc}">${encodeHtml(
         baseName,
       )}</span> <span class="arrow">&rarr;</span> <span class="file-link clickable-link" data-file="${revisedEsc}">${encodeHtml(
         revisedName,
@@ -1073,7 +1073,7 @@ export class LogEntryFormatter {
     const items = [];
     const pushItem = (icon, label, value, suffix = '') => {
       items.push(
-        `<span class="stat-item" title="${label}"><i class="codicon ${icon}"></i> ${value}${suffix}</span>`,
+        `<span class="stat-item detail-item" title="${label}"><i class="codicon ${icon}"></i> ${value}${suffix}</span>`,
       );
     };
 

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -3,21 +3,6 @@
  * Styling for file list entries and file tree display
  */
 
-/* File list block styling */
-.file-list-details {
-  margin: var(--spacing-small) 0;
-}
-.file-list-content {
-  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
-  list-style: none;
-}
-
-.file-list-content li {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-}
-
 /* File metadata styling */
 .file-list-content .file-var {
   color: var(--vscode-descriptionForeground);

--- a/src/progressView/styles/latexdiff.css
+++ b/src/progressView/styles/latexdiff.css
@@ -2,18 +2,7 @@
  * Latexdiff log styles for ProgressView
  */
 
-.latexdiff-details {
-  margin: var(--spacing-small) 0;
-}
-.latexdiff-content {
-  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
-  list-style: none;
-}
-
-.latexdiff-content li {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
+.latexdiff-content .detail-item {
   flex-wrap: wrap;
 }
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -348,7 +348,7 @@
     gap: var(--spacing-small);
   }
 
-  .follow-up-container input {
+  .follow-up-container textarea {
     flex: 1;
   }
 }

--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -192,10 +192,6 @@
   margin-bottom: 0;
 }
 
-.markdown-content p:last-child {
-  margin-bottom: 0;
-}
-
 /* Scratchpad reflection patterns */
 .banner-content--scratchpad p:has(strong:first-child) {
   border-left: calc(var(--spacing-small) - 1px) solid

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -47,7 +47,7 @@
 }
 
 .tool-output-full {
-  max-height: 240px;
+  max-height: var(--height-large);
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
@@ -55,15 +55,4 @@
 
 .tool-output-details {
   margin-top: var(--spacing-tiny);
-}
-
-.tool-output-details summary {
-  cursor: pointer;
-  color: var(--vscode-textLink-foreground);
-  font-size: var(--font-size-sm);
-}
-
-.tool-output-full {
-  max-height: 20rem;
-  overflow: auto;
 }

--- a/src/progressView/styles/statistics.css
+++ b/src/progressView/styles/statistics.css
@@ -2,20 +2,8 @@
  * Statistics log styles for ProgressView
  */
 
-.statistics-details {
-  margin: var(--spacing-small) 0;
-}
-
 .statistics-content {
-  padding: var(--spacing-tiny) 0 var(--spacing-small) var(--spacing-large);
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-large);
-  list-style: none;
-}
-
-.stat-item {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
 }

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -22,10 +22,9 @@
 /* LaTeX diffs section */
 .latexdiffs-section {
   margin-top: auto;
-  padding-top: var(--spacing-large);
+  padding: var(--spacing-large) 0 0;
   background-color: transparent;
   border: none;
-  padding: 0;
   margin-bottom: var(--spacing-large);
 }
 


### PR DESCRIPTION
## Summary
- add a shared opacity token and reusable detail section classes in `common.css`
- update progress view templates, CSS modules, and formatters to use the shared classes
- streamline tool output summary styling and tidy duplicate/legacy selectors across the stylesheets

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: VS Code test runner is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f80dca94b883249cf9cfa705f47daa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds shared detail layout classes and applies them across progress view templates/formatters while cleaning up redundant CSS and tweaking tool output and layout.
> 
> - **Styles (shared)**:
>   - Add `--opacity-normal` and reusable `detail-*` classes: `detail-section`, `detail-content`, `detail-list`, `detail-item` in `src/common/styles/common.css`; set `details-summary` opacity to `var(--opacity-normal)`.
> - **Progress View templates**:
>   - Apply shared classes to details blocks in `index.html` (`fileListDetailsTemplate`, `missingOutputsDetailsTemplate`, `latexdiffDetailsTemplate`, `statisticsDetailsTemplate`).
> - **Formatters**:
>   - Use `details-summary` on tool output expander; emit list/stat items with `detail-item` (`formatters.js`).
> - **Styles (module cleanup)**:
>   - Remove per-module margins/paddings and list item flex from `file-list.css`, `latexdiff.css`, `statistics.css`; rely on shared classes. Adjust latexdiff item wrapping.
>   - Increase `.tool-output-full` max height to `var(--height-large)` and drop duplicate rules in `scratchpad.css`.
>   - Responsive fix: target `.follow-up-container textarea` (was `input`) in `logs.css`.
>   - Tweak `.latexdiffs-section` padding in `webview/styles/containers.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25b3790b6bb195297c7c94c882184c20cbbdad2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->