### PR TITLE
fix: drop temperature for haiku thinking requests

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -295,6 +295,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         this.config.fullName.includes('claude-opus-4') ||
         this.config.fullName.includes('claude-sonnet-4-5') ||
         this.config.fullName.includes('claude-sonnet-4') ||
+        this.config.fullName.includes('claude-haiku-4-5') ||
         this.config.fullName.includes('claude-3-7-sonnet')
       ) {
         delete options.temperature;


### PR DESCRIPTION
## Summary
- extend the Anthropic temperature guard to cover Claude Haiku 4.5 thinking so the API accepts requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f905d22b2883248317e84ae2cbc03e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends the temperature removal guard to `claude-haiku-4-5` for thinking-enabled requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c4883d681867b626039f2dd618932ae7c1fceb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->