### PR TITLE
Refactor: remove unused legacy styling hooks

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -10,16 +10,8 @@
   /* Colors */
   --background-color: var(--vscode-sideBar-background);
   --text-color: var(--vscode-sideBar-foreground);
-  --button-background: var(--vscode-button-background);
-  --button-foreground: var(--vscode-button-foreground);
   --button-hover-background: var(--vscode-button-hoverBackground);
-  --input-background: var(--vscode-input-background);
-  --input-foreground: var(--vscode-input-foreground);
-  --input-border: var(--vscode-input-border);
-  --dropdown-background: var(--vscode-dropdown-background);
-  --dropdown-foreground: var(--vscode-dropdown-foreground);
   --dropdown-border: var(--vscode-dropdown-border);
-  --icon-color: var(--vscode-textLink-foreground);
   --focus-border: var(--vscode-focusBorder);
 
   /* Typography */
@@ -48,20 +40,17 @@
   --height-medium: 200px;
   --height-large: 300px;
   --height-xlarge: 400px;
-  --height-xxlarge: 500px;
   --height-max: 1000px;
 
   /* Widths */
   --width-icon: 16px;
   --width-button-min: 80px;
-  --width-sidebar: 120px;
   --width-dropdown: 160px;
 
   /* Borders */
   --border-thin: 1px;
   --border-medium: 2px;
   --border-thick: 3px;
-  --border-xlarge: 4px;
 
   /* Opacity levels */
   --opacity-disabled: 0.5;
@@ -80,13 +69,6 @@
   align-items: center;
   position: relative;
   top: 0;
-}
-
-/* Generic button group container */
-.button-group {
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 
 /* VSCode Elements toolbar styling */

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -28,10 +28,6 @@
   padding: var(--spacing-small);
 }
 
-.clear-all-container .button-group {
-  justify-content: space-between;
-}
-
 .agent-filter-group {
   display: flex;
   justify-content: flex-start;

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -215,7 +215,6 @@ export class FileInputManager extends BaseUIManager {
     const refreshConfigs = [
       {
         buttonIds: ['refreshInputFileButton'],
-        iconClass: 'codicon-file-code',
         getRequests: () => [
           {
             command: MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE,
@@ -227,7 +226,6 @@ export class FileInputManager extends BaseUIManager {
       },
       {
         buttonIds: ['refreshReferenceFileButton'],
-        iconClass: 'codicon-book',
         getRequests: () => [
           {
             command: MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE,
@@ -239,7 +237,6 @@ export class FileInputManager extends BaseUIManager {
       },
       {
         buttonIds: ['refreshAuxiliaryFileButton'],
-        iconClass: 'codicon-file-add',
         getRequests: () => [
           {
             command: MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE,
@@ -251,7 +248,6 @@ export class FileInputManager extends BaseUIManager {
       },
       {
         buttonIds: ['refreshMediaFileButton'],
-        iconClass: 'codicon-file-media',
         getRequests: () => [
           {
             command: MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
@@ -263,7 +259,6 @@ export class FileInputManager extends BaseUIManager {
       },
       {
         buttonIds: ['refreshEditedFileButton'],
-        iconClass: 'codicon-edit',
         getRequests: () => {
           const baseFile = safeGetElementValue(BASE_FILE);
           return [
@@ -286,7 +281,6 @@ export class FileInputManager extends BaseUIManager {
       },
       {
         buttonIds: ['refreshCommitButton'],
-        iconClass: 'codicon-git-commit',
         getRequests: () => [
           {
             command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
@@ -322,18 +316,6 @@ export class FileInputManager extends BaseUIManager {
         const element = document.getElementById(id);
         registerElement(element, handler);
       });
-
-      if (config.iconClass) {
-        const selectors = [
-          `.file-select-header label .${config.iconClass}`,
-          `.file-select-header label .codicon.${config.iconClass}`,
-        ];
-        selectors.forEach((selector) => {
-          document.querySelectorAll(selector).forEach((element) => {
-            registerElement(element, handler);
-          });
-        });
-      }
     });
   }
 

--- a/src/webview/styles/file-selection.css
+++ b/src/webview/styles/file-selection.css
@@ -159,13 +159,6 @@ vscode-toolbar-container.file-select-actions {
   display: none;
 }
 
-/* Update icon styles */
-.file-select-header label .codicon {
-  margin-right: var(--spacing-small);
-  color: var(--icon-color);
-  vertical-align: text-bottom;
-}
-
 /* LaTeX diffs section header styling */
 .latexdiffs-section .file-select-header {
   margin-bottom: 0;


### PR DESCRIPTION
## Summary
- remove unused shared CSS custom properties and dead button-group styles
- drop obsolete label codicon styling from the file selection webview
- simplify FileInputManager refresh wiring to rely on the new toolbar buttons

## Testing
- npm run lint
- npm run compile
- CI=1 npm test *(fails: VS Code binary requires libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f908c68c948324ad8f8e0f7e7b2280

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused legacy CSS vars/styles and simplify FileInputManager refresh to use toolbar buttons only.
> 
> - **UI/Styling**:
>   - Remove unused CSS custom properties from `src/common/styles/common.css` (various `--button-*`, `--input-*`, `--dropdown-*`, `--icon-color`, sizing/border vars).
>   - Delete legacy `.button-group` styles and related layout usage (`tabs.css` rule removed).
>   - Drop codicon label icon styling from `src/webview/styles/file-selection.css`.
> - **Webview (FileInputManager)**:
>   - Simplify refresh wiring to rely on toolbar buttons only: remove `iconClass` configs and label/icon query bindings; keep `buttonIds` handlers for refresh actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0294ac3e32904281487b8002fb6fd39eeb82752e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->