### PR TITLE
Refine progress view tree handling

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -137,10 +137,10 @@
               ></vscode-textarea>
             </div>
           </div>
-          <vscode-scrollable
-            id="logContent"
-            class="log-container"
-          ></vscode-scrollable>
+          <vscode-scrollable id="logContent" class="log-container">
+            <vscode-tree id="logGroupTree" class="log-group-tree"></vscode-tree>
+            <div id="logUngroupedContainer" class="log-ungrouped"></div>
+          </vscode-scrollable>
           <div id="generatedFiles" class="files-container"></div>
           <div id="followUpContainer" class="follow-up-container">
             <vscode-textarea
@@ -343,19 +343,17 @@
             </details>
           </template>
           <template id="groupDetailsTemplate">
-            <details class="log-group">
-              <div class="log-group-content"></div>
-            </details>
+            <vscode-tree-item class="log-group" branch></vscode-tree-item>
           </template>
           <template id="groupHeaderTemplate">
-            <summary class="log-group-header">
+            <div class="log-group-header">
               <span class="group-status-icon"></span>
               <span class="group-title"></span>
               <span class="group-time">
                 <span class="group-start-time"></span>
                 <span class="group-duration"></span>
               </span>
-            </summary>
+            </div>
           </template>
         </div>
         <div slot="end" class="tabs">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -22,6 +22,8 @@ export const STATUS = {
 // DOM element IDs used across the progress view
 export const ELEMENT_IDS = {
   LOG_CONTENT: 'logContent',
+  LOG_GROUP_TREE: 'logGroupTree',
+  LOG_UNGROUPED: 'logUngroupedContainer',
   LOG_PLACEHOLDER: 'logPlaceholder',
   GENERATED_FILES: 'generatedFiles',
   STREAM_TABS: 'streamTabs',

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -30,10 +30,6 @@ import {
 import { getBasename } from '@common/pathUtils.js';
 import { encodeHtml, decodeHtml } from '@common/htmlEncoding.js';
 
-// Constants
-export const BULLET_MARKUP =
-  '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
-
 export const EMOJI_BY_LEVEL = {
   error: '🔴',
   warn: '🟡',
@@ -108,31 +104,6 @@ export const TaskGroupLevel = {
  */
 export function formatTokens(tokens) {
   return tokens > 4096 ? `${Math.round(tokens / 1000)}k` : `${tokens}`;
-}
-
-/**
- * Extracts timestamps from HTML messages.
- */
-export class MessageTimestampExtractor {
-  /**
-   * Extract timestamp from a log line element
-   * @param {HTMLElement} element - Log line element
-   * @returns {string} Extracted timestamp
-   */
-  extract(element) {
-    const logLine = element.classList.contains('log-line')
-      ? element
-      : element.querySelector('.log-line');
-    if (logLine && logLine.dataset.fullTimestamp) {
-      return logLine.dataset.fullTimestamp;
-    }
-
-    const text = logLine
-      ? logLine.textContent || ''
-      : element.textContent || '';
-    const match = text.match(/\[(.*?)\]/);
-    return match ? match[1] : '';
-  }
 }
 
 /**

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -157,10 +157,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const ungroupedContainer = document.getElementById(
+      ELEMENT_IDS.LOG_UNGROUPED,
+    );
     if (message.stream === state.activeStream) {
-      logContent.innerHTML = '';
       state.taskGroups.clear();
       dom.taskGroups.clear();
+      if (ungroupedContainer) {
+        ungroupedContainer.innerHTML = '';
+      }
       if (message.groups && message.groups.length > 0) {
         const parentGroups = message.groups.filter((g) => !g.parentGroupId);
         const childGroups = message.groups.filter((g) => g.parentGroupId);
@@ -178,11 +183,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         if (msg.groupId) {
           if (!dom.logEntries.append(msg)) {
             const formatted = this._entryFormatter.format(msg);
-            appendFormatted(logContent, formatted);
+            appendFormatted(ungroupedContainer ?? logContent, formatted);
           }
         } else {
           const formatted = this._entryFormatter.format(msg);
-          appendFormatted(logContent, formatted);
+          appendFormatted(ungroupedContainer ?? logContent, formatted);
         }
       });
       logContent.scrollTop = logContent.scrollHeight;
@@ -196,12 +201,16 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleClearLogs() {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    logContent.innerHTML = '';
-    const groupIds = [];
-    const headers = Array.from(document.querySelectorAll('.log-group-header'));
-    for (const el of headers) {
-      groupIds.push(el.id.replace('group-header-', ''));
+    const ungroupedContainer = document.getElementById(
+      ELEMENT_IDS.LOG_UNGROUPED,
+    );
+    if (ungroupedContainer) {
+      ungroupedContainer.innerHTML = '';
     }
+    if (logContent) {
+      logContent.scrollTop = 0;
+    }
+    const groupIds = [...state.taskGroups.getGroupMap().keys()];
     state.taskGroups.clear();
     dom.taskGroups.clear();
     state.toggleStates.clearSelection(groupIds);
@@ -212,6 +221,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleAppendLog(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      const ungroupedContainer = document.getElementById(
+        ELEMENT_IDS.LOG_UNGROUPED,
+      );
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
         const formatted = this._entryFormatter.format(message.logMessage);
@@ -226,7 +238,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
             }
           }
         }
-        appendFormatted(logContent, formatted);
+        appendFormatted(ungroupedContainer ?? logContent, formatted);
       }
       logContent.scrollTop = logContent.scrollHeight;
     }
@@ -235,6 +247,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateLog(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      const ungroupedContainer = document.getElementById(
+        ELEMENT_IDS.LOG_UNGROUPED,
+      );
       const updated = dom.logEntries.update(message.logMessage);
       if (!updated) {
         // Fallback: append as new log with proper group placement
@@ -253,7 +268,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
               }
             }
           }
-          appendFormatted(logContent, formatted);
+          appendFormatted(ungroupedContainer ?? logContent, formatted);
         }
         logContent.scrollTop = logContent.scrollHeight;
       }
@@ -342,13 +357,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.streamStatuses.delete(message.stream);
       state.clearExecutionIdAvailability(message.stream);
       if (message.stream === state.activeStream) {
-        const groupIds = [];
-        const headers = Array.from(
-          document.querySelectorAll('.log-group-header'),
-        );
-        for (const el of headers) {
-          groupIds.push(el.id.replace('group-header-', ''));
-        }
+        const groupIds = [...state.taskGroups.getGroupMap().keys()];
+        state.taskGroups.clear();
+        dom.taskGroups.clear();
         state.toggleStates.clearSelection(groupIds);
         dom.instructionPanel.hide();
       }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -28,9 +28,7 @@ export class TaskGroupDomManager {
         console.warn(
           `Group ${group.id} exists in DOM but not in state - removing from DOM`,
         );
-        this._disconnectObserver(group.id);
-        existingGroup.remove();
-        this.groupElements.delete(group.id);
+        this.removeGroup(group.id);
       } else {
         progressViewState.taskGroups.set(group.id, group);
         this.updateGroup({
@@ -68,12 +66,9 @@ export class TaskGroupDomManager {
     progressViewState.taskGroups.set(group.id, group);
 
     const isCollapsed = progressViewState.toggleStates.get(group.id) === true;
-    treeItem.open = !isCollapsed;
-    if (treeItem.open) {
-      treeItem.setAttribute('open', '');
-    } else {
-      treeItem.removeAttribute('open');
-    }
+    const isExpanded = !isCollapsed;
+    treeItem.toggleAttribute('expanded', isExpanded);
+    treeItem.expanded = isExpanded;
 
     this._observeGroup(treeItem, group.id);
 
@@ -88,7 +83,7 @@ export class TaskGroupDomManager {
     if (group.parentGroupId) {
       const parentItem = this.groupElements.get(group.parentGroupId);
       if (parentItem instanceof HTMLElement) {
-        treeItem.slot = 'children';
+        treeItem.setAttribute('slot', 'children');
         insertChronologically({
           container: parentItem,
           element: treeItem,
@@ -143,9 +138,9 @@ export class TaskGroupDomManager {
       for (const mutation of mutations) {
         if (
           mutation.type === 'attributes' &&
-          mutation.attributeName === 'open'
+          mutation.attributeName === 'expanded'
         ) {
-          const isCollapsed = !treeItem.hasAttribute('open');
+          const isCollapsed = !treeItem.hasAttribute('expanded');
           progressViewState.toggleStates.set(groupId, isCollapsed);
         }
       }
@@ -153,7 +148,7 @@ export class TaskGroupDomManager {
 
     observer.observe(treeItem, {
       attributes: true,
-      attributeFilter: ['open'],
+      attributeFilter: ['expanded'],
     });
 
     this.groupObservers.set(groupId, observer);
@@ -164,6 +159,24 @@ export class TaskGroupDomManager {
     if (existing) {
       existing.disconnect();
       this.groupObservers.delete(groupId);
+    }
+  }
+
+  removeGroup(groupId) {
+    if (!groupId) {
+      return;
+    }
+
+    this._disconnectObserver(groupId);
+
+    const treeItem = this.groupElements.get(groupId);
+    if (treeItem instanceof HTMLElement) {
+      treeItem.remove();
+    }
+
+    this.groupElements.delete(groupId);
+    if (progressViewState.toggleStates.get(groupId) !== undefined) {
+      progressViewState.toggleStates.clearSelection([groupId]);
     }
   }
 
@@ -275,8 +288,8 @@ export class TaskGroupDomManager {
     // Collapse this group
     const treeItem = this.groupElements.get(groupId);
     if (treeItem instanceof HTMLElement) {
-      treeItem.open = false;
-      treeItem.removeAttribute('open');
+      treeItem.toggleAttribute('expanded', false);
+      treeItem.expanded = false;
       progressViewState.toggleStates.set(groupId, true);
     }
   }
@@ -296,7 +309,10 @@ export class TaskGroupDomManager {
     let latestTime = 0;
 
     for (const [id, treeItem] of this.groupElements.entries()) {
-      if (!(treeItem instanceof HTMLElement) || !treeItem.open) {
+      if (
+        !(treeItem instanceof HTMLElement) ||
+        !treeItem.hasAttribute('expanded')
+      ) {
         continue;
       }
 
@@ -359,11 +375,11 @@ export class TaskGroupDomManager {
    * Clear cached group references.
    */
   clear() {
-    this.groupElements.clear();
-    for (const observer of this.groupObservers.values()) {
-      observer.disconnect();
+    for (const groupId of [...this.groupElements.keys()]) {
+      this.removeGroup(groupId);
     }
     this.groupObservers.clear();
+    this.groupElements.clear();
     this.previousActiveGroupId = null;
 
     const treeRoot = document.getElementById(ELEMENT_IDS.LOG_GROUP_TREE);

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -14,6 +14,7 @@ export class TaskGroupDomManager {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
+    this.groupObservers = new Map();
   }
 
   /**
@@ -27,6 +28,7 @@ export class TaskGroupDomManager {
         console.warn(
           `Group ${group.id} exists in DOM but not in state - removing from DOM`,
         );
+        this._disconnectObserver(group.id);
         existingGroup.remove();
         this.groupElements.delete(group.id);
       } else {
@@ -42,14 +44,16 @@ export class TaskGroupDomManager {
       }
     }
 
-    const detailsElem = createFromTemplate('groupDetailsTemplate');
-    if (!detailsElem) {
+    const treeItem = createFromTemplate('groupDetailsTemplate');
+    if (!treeItem) {
       console.error(
         'TaskGroupDomManager.addGroup: groupDetailsTemplate not found',
       );
       return;
     }
-    detailsElem.id = `group-${group.id}`;
+    treeItem.id = `group-${group.id}`;
+    treeItem.dataset.groupId = group.id;
+    treeItem.setAttribute('branch', '');
 
     const headerElement = this.headerFormatter.create(group);
     if (!headerElement) {
@@ -59,49 +63,47 @@ export class TaskGroupDomManager {
       return;
     }
 
-    const groupContainer = detailsElem.querySelector('.log-group-content');
-    if (!groupContainer) {
-      console.error(
-        'TaskGroupDomManager.addGroup: missing group content container',
-      );
-      return;
-    }
-    groupContainer.id = `group-content-${group.id}`;
+    treeItem.appendChild(headerElement);
 
     progressViewState.taskGroups.set(group.id, group);
 
-    const isCollapsed = progressViewState.toggleStates.get(group.id);
-    detailsElem.open = isCollapsed !== true;
+    const isCollapsed = progressViewState.toggleStates.get(group.id) === true;
+    treeItem.open = !isCollapsed;
+    if (treeItem.open) {
+      treeItem.setAttribute('open', '');
+    } else {
+      treeItem.removeAttribute('open');
+    }
 
-    detailsElem.prepend(headerElement);
+    this._observeGroup(treeItem, group.id);
 
-    detailsElem.addEventListener('toggle', () => {
-      progressViewState.toggleStates.set(group.id, !detailsElem.open);
-    });
+    this.groupElements.set(group.id, treeItem);
 
-    this.groupElements.set(group.id, detailsElem);
-
-    // Insert the group at the right position in the parent
-    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const treeRoot = this._getTreeRoot();
+    if (!treeRoot) {
+      console.error('TaskGroupDomManager.addGroup: log group tree missing');
+      return;
+    }
 
     if (group.parentGroupId) {
-      const parentDetails = this.groupElements.get(group.parentGroupId);
-      const parentGroupContent =
-        parentDetails?.querySelector('.log-group-content');
-      if (parentGroupContent) {
+      const parentItem = this.groupElements.get(group.parentGroupId);
+      if (parentItem instanceof HTMLElement) {
+        treeItem.slot = 'children';
         insertChronologically({
-          container: parentGroupContent,
-          element: detailsElem,
+          container: parentItem,
+          element: treeItem,
           timestamp: group.startTime,
         });
         return;
       }
+    } else {
+      treeItem.removeAttribute('slot');
     }
 
     // For top-level groups, insert in chronological order
     insertChronologically({
-      container,
-      element: detailsElem,
+      container: treeRoot,
+      element: treeItem,
       timestamp: group.startTime,
     });
 
@@ -109,6 +111,59 @@ export class TaskGroupDomManager {
     if (!group.parentGroupId) {
       progressViewState.currentGroupId = group.id;
       this.collapsePreviousActiveGroup();
+    }
+  }
+
+  _getTreeRoot() {
+    let tree = document.getElementById(ELEMENT_IDS.LOG_GROUP_TREE);
+    if (tree) {
+      return tree;
+    }
+
+    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    if (!container) {
+      return null;
+    }
+
+    tree = document.createElement('vscode-tree');
+    tree.id = ELEMENT_IDS.LOG_GROUP_TREE;
+    tree.classList.add('log-group-tree');
+    container.prepend(tree);
+    return tree;
+  }
+
+  _observeGroup(treeItem, groupId) {
+    if (!(treeItem instanceof HTMLElement)) {
+      return;
+    }
+
+    this._disconnectObserver(groupId);
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'open'
+        ) {
+          const isCollapsed = !treeItem.hasAttribute('open');
+          progressViewState.toggleStates.set(groupId, isCollapsed);
+        }
+      }
+    });
+
+    observer.observe(treeItem, {
+      attributes: true,
+      attributeFilter: ['open'],
+    });
+
+    this.groupObservers.set(groupId, observer);
+  }
+
+  _disconnectObserver(groupId) {
+    const existing = this.groupObservers.get(groupId);
+    if (existing) {
+      existing.disconnect();
+      this.groupObservers.delete(groupId);
     }
   }
 
@@ -151,12 +206,12 @@ export class TaskGroupDomManager {
       group.endTime = updates.endTime;
     }
 
-    const detailsElem = this.groupElements.get(groupId);
-    if (!detailsElem) {
+    const treeItem = this.groupElements.get(groupId);
+    if (!(treeItem instanceof HTMLElement)) {
       return;
     }
 
-    const header = detailsElem.querySelector('.log-group-header');
+    const header = treeItem.querySelector('.log-group-header');
     if (header) {
       const level = this.headerFormatter._getGroupLevel(group);
       header.className = this.headerFormatter._getHeaderClass(group, level);
@@ -218,9 +273,10 @@ export class TaskGroupDomManager {
     }
 
     // Collapse this group
-    const detailsElem = this.groupElements.get(groupId);
-    if (detailsElem) {
-      detailsElem.open = false;
+    const treeItem = this.groupElements.get(groupId);
+    if (treeItem instanceof HTMLElement) {
+      treeItem.open = false;
+      treeItem.removeAttribute('open');
       progressViewState.toggleStates.set(groupId, true);
     }
   }
@@ -239,8 +295,8 @@ export class TaskGroupDomManager {
     let latestGroup = null;
     let latestTime = 0;
 
-    for (const [id, detailsElem] of this.groupElements.entries()) {
-      if (!detailsElem || !detailsElem.open) {
+    for (const [id, treeItem] of this.groupElements.entries()) {
+      if (!(treeItem instanceof HTMLElement) || !treeItem.open) {
         continue;
       }
 
@@ -304,7 +360,16 @@ export class TaskGroupDomManager {
    */
   clear() {
     this.groupElements.clear();
+    for (const observer of this.groupObservers.values()) {
+      observer.disconnect();
+    }
+    this.groupObservers.clear();
     this.previousActiveGroupId = null;
+
+    const treeRoot = document.getElementById(ELEMENT_IDS.LOG_GROUP_TREE);
+    if (treeRoot) {
+      treeRoot.innerHTML = '';
+    }
   }
 }
 
@@ -324,20 +389,26 @@ export class LogEntryManager {
   append(logMessage) {
     // If the message has a group ID, append it to the right group
     if (logMessage.groupId) {
-      const groupContent = document.getElementById(
-        `group-content-${logMessage.groupId}`,
+      const groupElement = document.getElementById(
+        `group-${logMessage.groupId}`,
       );
-      if (groupContent) {
+      if (groupElement instanceof HTMLElement) {
         const logLineElement = this.entryFormatter.format(logMessage);
         if (!logLineElement) {
           return true;
         }
 
+        if (!(logLineElement instanceof HTMLElement)) {
+          return false;
+        }
+
+        logLineElement.setAttribute('slot', 'children');
+
         // Extract timestamp from the message for chronological ordering
         const msgDate = new Date(logMessage.timestamp);
 
         insertChronologically({
-          container: groupContent,
+          container: groupElement,
           element: logLineElement,
           timestamp: msgDate,
         });
@@ -375,6 +446,13 @@ export class LogEntryManager {
         const toggleIcon = newEl.querySelector('.toggle-icon');
         if (toggleIcon) {
           toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
+        }
+      }
+
+      if (existing instanceof HTMLElement && newEl instanceof HTMLElement) {
+        const slotName = existing.getAttribute('slot');
+        if (slotName) {
+          newEl.setAttribute('slot', slotName);
         }
       }
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -15,95 +15,47 @@ import { vscode } from '@common/webviewContext.js';
  */
 export class EventsManager {
   /**
-   * Apply saved toggle states to any groups already in the DOM
-   */
-  applyToggleStates() {
-    const taskGroups = progressViewState.taskGroups.getGroupMap();
-    for (const [groupId] of taskGroups) {
-      const isCollapsed = progressViewState.toggleStates.get(groupId);
-      const detailsElem = document.getElementById(`group-${groupId}`);
-
-      if (detailsElem && isCollapsed !== undefined) {
-        detailsElem.open = !isCollapsed;
-      }
-    }
-  }
-
-  /**
    * Sets up all event listeners for the UI
    */
   setupEventListeners() {
-    // Debug: Listen to ALL events on the tree
-    const treeEl = document.getElementById(ELEMENT_IDS.STREAM_TABS);
-    if (treeEl) {
-      console.log('[EventsManager] Setting up tree listeners on:', treeEl);
-
-      // Try all possible event names
-      ['vsc-tree-select', 'vsc-select', 'click', 'change'].forEach(
-        (eventName) => {
-          treeEl.addEventListener(eventName, (e) => {
-            console.log(`[EventsManager] Tree event "${eventName}":`, e);
-          });
-        },
-      );
-    }
-
     // Stream tab selection handler (vscode-tree)
-    addEventListenerSafely(ELEMENT_IDS.STREAM_TABS, 'vsc-tree-select', (e) => {
-      console.log('[EventsManager] vsc-tree-select event:', e);
-      console.log('[EventsManager] event.detail:', e.detail);
-
-      // event.detail is directly an array of selected vscode-tree-item elements
-      const selectedItems = Array.isArray(e.detail) ? e.detail : [];
-      const firstItem = selectedItems[0];
-
-      console.log('[EventsManager] Selected item:', firstItem);
-      console.log('[EventsManager] Item dataset:', firstItem?.dataset);
-
-      if (firstItem?.dataset?.stream) {
-        console.log(
-          '[EventsManager] Switching to stream:',
-          firstItem.dataset.stream,
-        );
+    addEventListenerSafely(
+      ELEMENT_IDS.STREAM_TABS,
+      'vsc-tree-select',
+      (event) => {
+        const detail = event.detail;
+        const selectedItems = Array.isArray(detail)
+          ? detail
+          : Array.isArray(detail?.selection)
+            ? detail.selection
+            : [];
+        const firstItem = selectedItems[0];
+        const stream = firstItem?.dataset?.stream;
+        if (!stream) {
+          return;
+        }
         vscode.postMessage({
           command: COMMANDS.SWITCH_STREAM,
-          stream: firstItem.dataset.stream,
+          stream,
         });
-      } else {
-        console.warn(
-          '[EventsManager] No valid stream in selection:',
-          firstItem,
-        );
-      }
-    });
+      },
+    );
 
     // Stream tab delete button handler
     addEventListenerSafely(
       ELEMENT_IDS.STREAM_TABS,
       'click',
       (e) => {
-        console.log('[EventsManager] Click event:', {
-          target: e.target,
-          composedPath: e.composedPath(),
-        });
-
         // Use composedPath to handle shadow DOM clicks
         const path = e.composedPath();
         const deleteButton = path.find((el) =>
           el.classList?.contains('tab-delete'),
         );
 
-        console.log('[EventsManager] Delete button found:', deleteButton);
-
         if (deleteButton?.dataset?.stream) {
           e.preventDefault();
           e.stopPropagation();
           e.stopImmediatePropagation();
-
-          console.log(
-            '[EventsManager] Deleting stream:',
-            deleteButton.dataset.stream,
-          );
           vscode.postMessage({
             command: COMMANDS.DELETE_STREAM,
             stream: deleteButton.dataset.stream,
@@ -125,9 +77,6 @@ export class EventsManager {
         vscode.postMessage({ command, stream: activeStream });
       }
     });
-
-    // File list toggle - removed as filesToggle element doesn't exist in the HTML
-    // This appears to be orphaned code from a previous design
 
     // File list button handler
     addEventListenerSafely(

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -31,14 +31,6 @@ export class StreamTabs {
       return;
     }
 
-    console.log('[StreamTabs] Container element:', tabsContainer.tagName);
-    console.log(
-      '[StreamTabs] Updating with streams:',
-      streams.length,
-      'active:',
-      activeStream,
-    );
-
     tabsContainer.innerHTML = '';
     let activeInfo = null;
     streams.forEach((info) => {
@@ -67,7 +59,6 @@ export class StreamTabs {
       const statusEl = tabEl.querySelector('.tab-status');
       if (statusEl) {
         const status = info.status || 'stopped';
-        console.log(`[StreamTabs] Setting status for ${info.name}: ${status}`);
         statusEl.classList.add(status);
         statusEl.dataset.status =
           status.charAt(0).toUpperCase() + status.slice(1);
@@ -94,13 +85,6 @@ export class StreamTabs {
         tabEl.setAttribute('selected', '');
         activeInfo = info;
       }
-
-      console.log('[StreamTabs] Created tab element:', {
-        name: info.name,
-        dataset: tabEl.dataset,
-        hasStatusEl: !!statusEl,
-        hasDeleteBtn: !!tabEl.querySelector('.tab-delete'),
-      });
 
       tabsContainer.appendChild(tabEl);
     });

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -40,9 +40,6 @@ document.addEventListener('DOMContentLoaded', () => {
   progressViewDomHandler.events.setupEventListeners();
   progressViewDomHandler.followUpInput.setup();
 
-  // Apply saved group toggle states to any groups already in the DOM
-  progressViewDomHandler.events.applyToggleStates();
-
   // Notify extension that the webview is ready to receive messages
   vscode.postMessage({ command: COMMANDS.WEBVIEW_READY });
 });

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -43,7 +43,7 @@
   border-left-color: var(--vscode-testing-iconPassed);
 }
 
-vscode-tree-item.log-group[branch]:not([open]) > [slot='children'] {
+vscode-tree-item.log-group[branch]:not([expanded]) > [slot='children'] {
   display: none;
 }
 

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -3,8 +3,18 @@
  * Styling for grouped log entries and hierarchy
  */
 
-/* Log Group Styles */
-.log-group-header {
+/* Log Group Tree */
+.log-group-tree {
+  display: block;
+  width: 100%;
+}
+
+.log-group-tree vscode-tree-item.log-group {
+  display: block;
+  margin-bottom: var(--spacing-tiny);
+}
+
+.log-group-tree vscode-tree-item.log-group > .log-group-header {
   padding: var(--spacing-tiny) var(--spacing-medium);
   margin: var(--spacing-tiny) 0;
   border-radius: var(--border-radius-small);
@@ -16,27 +26,37 @@
 }
 
 /* Minimal styling for top-level task headers */
-.log-group-header.top-level {
+.log-group-tree vscode-tree-item.log-group > .log-group-header.top-level {
   border-left: var(--border-thin) solid var(--vscode-panel-border);
   border-right: var(--border-thin) solid var(--vscode-panel-border);
 }
 
-.log-group-header.running {
+.log-group-tree vscode-tree-item.log-group > .log-group-header.running {
   border-left-color: var(--vscode-statusBarItem-warningBackground);
 }
 
-.log-group-header.error {
+.log-group-tree vscode-tree-item.log-group > .log-group-header.error {
   border-left-color: var(--vscode-errorForeground);
 }
 
-.log-group-header.stopped {
+.log-group-tree vscode-tree-item.log-group > .log-group-header.stopped {
   border-left-color: var(--vscode-testing-iconPassed);
 }
 
-.log-group-content {
+vscode-tree-item.log-group[branch]:not([open]) > [slot='children'] {
+  display: none;
+}
+
+vscode-tree-item.log-group > [slot='children']:not(vscode-tree-item) {
+  display: block;
   padding-left: var(--spacing-small);
+  margin-left: var(--spacing-small);
   border-left: var(--border-thin) dashed
     var(--vscode-editorGroupHeader-tabsBorder);
+}
+
+.log-ungrouped {
+  margin-top: var(--spacing-small);
 }
 
 .group-status-icon {
@@ -79,39 +99,13 @@
   border-left: var(--border-medium) solid transparent;
 }
 
-/* Log group hierarchy styles */
-
-/* Child group headers have a different style to show hierarchy */
-.log-group-content .log-group-header {
-  border-left-width: var(--border-thin); /* Thinner border for child groups */
-  margin-left: var(--spacing-small);
-}
-
-/* Indent child group content */
-.log-group-content .log-group-content {
-  margin-left: var(--spacing-small);
-}
-
 /* Log lines within a group */
-.log-group-content > .log-line,
-.log-group-content > .banner-details {
+vscode-tree-item.log-group > [slot='children'].log-line,
+vscode-tree-item.log-group > [slot='children'].banner-details {
   margin-left: var(--spacing-small);
 }
 
-/* Log lines within a nested group */
-.log-group-content .log-group-content .log-line,
-.log-group-content .log-group-content .banner-details {
-  margin-left: 0; /* No extra indent for nested log lines */
-}
-
-/* Visual indicator for nested structure */
-.log-group-content .log-group-header::before {
-  content: '';
-  position: absolute;
-  left: calc(0px - var(--spacing-medium));
-  top: 50%;
-  width: var(--spacing-medium);
-  height: var(--border-thin);
-  background-color: var(--vscode-panel-border);
-  display: none; /* Start hidden, only show on advanced view option */
+/* Visual indicator for nested structure (reserved for future use) */
+vscode-tree-item.log-group > .log-group-header::before {
+  display: none;
 }


### PR DESCRIPTION
## Summary
- rely on task group state to clear toggle selections when wiping logs or removing the active stream
- streamline progress view event handlers and stream tab updates by removing debugging hooks and legacy listeners
- drop unused legacy exports from the log formatter module

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f9088cfef88324b58cabc2b7bca1b9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces log group <details> with a vscode-tree-based hierarchy (plus ungrouped area), persists expand/collapse, and streamlines handlers/styles accordingly.
> 
> - **UI/DOM structure**:
>   - Replace `details.log-group` with `vscode-tree` and `vscode-tree-item.log-group` hierarchy; introduce `#logGroupTree` and `#logUngroupedContainer` inside `#logContent`.
>   - Update templates: `groupDetailsTemplate` now a `vscode-tree-item` and `groupHeaderTemplate` uses a `div` header.
> - **Behavior/State**:
>   - Persist group expand/collapse via `MutationObserver` on `expanded` attribute; toggle states stored in `progressViewState.toggleStates`.
>   - Log appends/updates place grouped entries as `[slot='children']` under the correct tree item; ungrouped logs go to `#logUngroupedContainer`.
>   - Clearing logs and deleting active streams now derives group IDs from `state.taskGroups` and resets both tree and ungrouped areas.
> - **Event handling**:
>   - Simplify `vsc-tree-select` parsing and tab delete handling; remove debug hooks; keep toolbar/file actions and agent filter wiring.
> - **Styles**:
>   - Add tree-focused styles for `.log-group-tree` and slotted children; remove legacy `.log-group-content` rules; add `.log-ungrouped` spacing.
> - **Cleanup**:
>   - Remove unused legacy exports (e.g., timestamp extractor/bullet markup) from `formatters.js`; drop obsolete apply-toggle logic in `script.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df01e657e9f29f8ec23a8e0658086b901ea798b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->