### PR TITLE
fix: remove redundant common style imports

### DIFF
--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -3,9 +3,6 @@
  * Imports all modular CSS files
  */
 
-/* Import common styles first */
-@import '../../common/styles/common.css';
-
 /* Import base styles */
 @import './base.css';
 

--- a/src/webview/styles/index.css
+++ b/src/webview/styles/index.css
@@ -3,9 +3,6 @@
  * Imports all modular CSS files
  */
 
-/* Import common styles first */
-@import '../../common/styles/common.css';
-
 /* Import base styles */
 @import './base.css';
 


### PR DESCRIPTION
## Summary
- remove the redundant common stylesheet import from the webview bundle
- remove the redundant common stylesheet import from the progress view bundle

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f90bb61654832484995fead30fc2b8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unnecessary `common.css` import from both `src/webview/styles/index.css` and `src/progressView/styles/index.css`.
> 
> - **Styles**:
>   - Remove redundant `@import '../../common/styles/common.css';` from:
>     - `src/webview/styles/index.css`
>     - `src/progressView/styles/index.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c297ca5e6d296e072dab27d6903e2b2eb83f53de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->