### PR TITLE
Switch session type toggle to VS Code radio group

### DIFF
--- a/src/test/webview/MessageHandlersRestore.test.ts
+++ b/src/test/webview/MessageHandlersRestore.test.ts
@@ -372,12 +372,10 @@ describe('MainViewMessageHandler state restoration', () => {
       <input id="referenceFile" />
       <input id="auxiliaryFile" />
       <input id="mediaFile" />
-      <div id="sessionTypeToggle">
-        <vscode-radio-group>
-          <vscode-radio data-session-type="workflow" value="workflow"></vscode-radio>
-          <vscode-radio data-session-type="toolUse" value="toolUse"></vscode-radio>
-        </vscode-radio-group>
-      </div>
+      <vscode-radio-group id="sessionTypeToggle">
+        <vscode-radio data-session-type="workflow" value="workflow"></vscode-radio>
+        <vscode-radio data-session-type="toolUse" value="toolUse"></vscode-radio>
+      </vscode-radio-group>
       <div id="inputFilesContainer" style="display: none;">
         <div id="inputFiles"></div>
       </div>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -446,31 +446,28 @@
                 ></i>
                 <div class="agent-select-controls">
                   <input type="hidden" id="sessionType" value="workflow" />
-                  <div
+                  <vscode-radio-group
                     id="sessionTypeToggle"
-                    class="session-toggle"
-                    role="radiogroup"
                     aria-label="Choose the session type"
+                    orientation="horizontal"
+                    value="workflow"
                   >
-                    <button
-                      type="button"
-                      class="session-toggle__option active"
+                    <vscode-radio
+                      value="workflow"
                       data-session-type="workflow"
-                      aria-pressed="true"
+                      checked
                       title="Workflow agents automate document editing tasks"
                     >
                       Workflow
-                    </button>
-                    <button
-                      type="button"
-                      class="session-toggle__option"
+                    </vscode-radio>
+                    <vscode-radio
+                      value="toolUse"
                       data-session-type="toolUse"
-                      aria-pressed="false"
                       title="Tool-use agents execute commands and scripts"
                     >
                       Tool Use
-                    </button>
-                  </div>
+                    </vscode-radio>
+                  </vscode-radio-group>
                   <div class="agent-select-dropdowns">
                     <vscode-single-select
                       id="workflowAgent"

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -124,3 +124,14 @@ export const AGENT_SELECT_IDS = {
 };
 
 export const AGENT_SELECT_LIST = Object.values(AGENT_SELECT_IDS);
+
+/**
+ * Normalizes a session type value to ensure it's a valid SESSION_TYPE.
+ * @param {string} sessionType - The session type to normalize
+ * @returns {string} Either SESSION_TYPES.TOOL_USE or SESSION_TYPES.WORKFLOW
+ */
+export function normalizeSessionType(sessionType) {
+  return sessionType === SESSION_TYPES.TOOL_USE
+    ? SESSION_TYPES.TOOL_USE
+    : SESSION_TYPES.WORKFLOW;
+}

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -126,6 +126,11 @@ export const AGENT_SELECT_IDS = {
 export const AGENT_SELECT_LIST = Object.values(AGENT_SELECT_IDS);
 
 /**
+ * Tag name constant for VS Code radio group web component
+ */
+export const VSCODE_RADIO_GROUP_TAG = 'VSCODE-RADIO-GROUP';
+
+/**
  * Normalizes a session type value to ensure it's a valid SESSION_TYPE.
  * @param {string} sessionType - The session type to normalize
  * @returns {string} Either SESSION_TYPES.TOOL_USE or SESSION_TYPES.WORKFLOW
@@ -147,7 +152,7 @@ export function resolveRadioGroup(element) {
   if (!element) {
     return null;
   }
-  if (element.tagName === 'VSCODE-RADIO-GROUP') {
+  if (element.tagName === VSCODE_RADIO_GROUP_TAG) {
     return element;
   }
   const radioGroup = element.querySelector('vscode-radio-group');

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -135,3 +135,21 @@ export function normalizeSessionType(sessionType) {
     ? SESSION_TYPES.TOOL_USE
     : SESSION_TYPES.WORKFLOW;
 }
+
+/**
+ * Resolves a vscode-radio-group element from a container element.
+ * If the element itself is a radio group, returns it directly.
+ * Otherwise, searches for a radio group child element.
+ * @param {HTMLElement|null|undefined} element - The container element
+ * @returns {HTMLElement|null} The radio group element, or null if not found
+ */
+export function resolveRadioGroup(element) {
+  if (!element) {
+    return null;
+  }
+  if (element.tagName === 'VSCODE-RADIO-GROUP') {
+    return element;
+  }
+  const radioGroup = element.querySelector('vscode-radio-group');
+  return radioGroup instanceof HTMLElement ? radioGroup : null;
+}

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -305,10 +305,11 @@ export class MainViewState {
     if (toggleContainer) {
       const radioGroup = resolveRadioGroup(toggleContainer);
       if (radioGroup instanceof HTMLElement) {
-        if (typeof radioGroup.value === 'string') {
+        // Set both attribute and property for proper web component synchronization
+        // The attribute ensures immediate DOM reflection, property ensures component state
+        radioGroup.setAttribute('value', normalized);
+        if ('value' in radioGroup) {
           radioGroup.value = normalized;
-        } else {
-          radioGroup.setAttribute('value', normalized);
         }
 
         const radios = radioGroup.querySelectorAll('vscode-radio');

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -11,6 +11,7 @@ import {
   AGENT_SELECT_IDS,
   AGENT_SELECT_LIST,
   normalizeSessionType,
+  resolveRadioGroup,
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
@@ -302,10 +303,7 @@ export class MainViewState {
 
     const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
     if (toggleContainer) {
-      const radioGroup =
-        toggleContainer.tagName === 'VSCODE-RADIO-GROUP'
-          ? toggleContainer
-          : toggleContainer.querySelector('vscode-radio-group');
+      const radioGroup = resolveRadioGroup(toggleContainer);
       if (radioGroup instanceof HTMLElement) {
         if (typeof radioGroup.value === 'string') {
           radioGroup.value = normalized;

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -10,6 +10,7 @@ import {
   SESSION_TYPE_INPUT,
   AGENT_SELECT_IDS,
   AGENT_SELECT_LIST,
+  normalizeSessionType,
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
@@ -279,10 +280,7 @@ export class MainViewState {
 
     const sessionTypeValue =
       state.sessionType ?? safeGetElementValue(SESSION_TYPE_INPUT);
-    const normalizedSessionType =
-      sessionTypeValue === SESSION_TYPES.TOOL_USE
-        ? SESSION_TYPES.TOOL_USE
-        : SESSION_TYPES.WORKFLOW;
+    const normalizedSessionType = normalizeSessionType(sessionTypeValue);
     const activeSelectId = AGENT_SELECT_IDS[normalizedSessionType];
     if (activeSelectId) {
       state.agent = safeGetElementValue(activeSelectId) ?? '';
@@ -294,10 +292,7 @@ export class MainViewState {
 
   applySessionType(sessionType, options = {}) {
     const { skipSave = false } = options;
-    const normalized =
-      sessionType === SESSION_TYPES.TOOL_USE
-        ? SESSION_TYPES.TOOL_USE
-        : SESSION_TYPES.WORKFLOW;
+    const normalized = normalizeSessionType(sessionType);
     const isToolUseSession = normalized === SESSION_TYPES.TOOL_USE;
 
     const sessionInput = safeGetElementById(SESSION_TYPE_INPUT);

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -308,8 +308,17 @@ export class MainViewState {
 
     const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
     if (toggleContainer) {
-      const radioGroup = toggleContainer.querySelector('vscode-radio-group');
-      if (radioGroup) {
+      const radioGroup =
+        toggleContainer.tagName === 'VSCODE-RADIO-GROUP'
+          ? toggleContainer
+          : toggleContainer.querySelector('vscode-radio-group');
+      if (radioGroup instanceof HTMLElement) {
+        if (typeof radioGroup.value === 'string') {
+          radioGroup.value = normalized;
+        } else {
+          radioGroup.setAttribute('value', normalized);
+        }
+
         const radios = radioGroup.querySelectorAll('vscode-radio');
         radios.forEach((radio) => {
           if (!(radio instanceof HTMLElement)) {

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -305,10 +305,7 @@ export class MainViewState {
     if (toggleContainer) {
       const radioGroup = resolveRadioGroup(toggleContainer);
       if (radioGroup instanceof HTMLElement) {
-        // Set both attribute and property for proper web component synchronization
-        // The attribute ensures immediate DOM reflection, property ensures component state
-        radioGroup.setAttribute('value', normalized);
-        if ('value' in radioGroup) {
+        if (typeof radioGroup.value === 'string') {
           radioGroup.value = normalized;
         }
 

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -181,6 +181,15 @@ export class SettingsButtonManager extends BaseUIManager {
         }
       };
 
+      /**
+       * Gets the current session type from a vscode-radio-group element.
+       * Uses multiple fallback strategies to ensure compatibility:
+       * 1. Check group's value property (web component API)
+       * 2. Check group's value attribute (fallback for delayed property sync)
+       * 3. Query for checked radio and extract its session type
+       * @param {HTMLElement} group - The radio group element
+       * @returns {string|undefined} The session type, or undefined if not found
+       */
       const getSessionTypeFromGroup = (group) => {
         if (!(group instanceof HTMLElement)) {
           return undefined;
@@ -207,10 +216,19 @@ export class SettingsButtonManager extends BaseUIManager {
 
       const radioGroup = resolveRadioGroup(toggleContainer);
       if (radioGroup) {
-        this._setLastRadioSessionType(getSessionTypeFromGroup(radioGroup));
+        // Initialize last session type from radio group
+        // Only set if we can determine a valid initial value to avoid masking the first user interaction
+        const initialSessionType = getSessionTypeFromGroup(radioGroup);
+        if (initialSessionType) {
+          this._setLastRadioSessionType(initialSessionType);
+        } else {
+          console.warn('Radio group has no initial session type value');
+        }
+
         this.addListener(radioGroup, 'change', () => {
           const sessionType = getSessionTypeFromGroup(radioGroup);
           if (!sessionType) {
+            console.warn('Could not determine session type from radio group');
             return;
           }
           const normalized = normalizeSessionType(sessionType);

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -37,6 +37,7 @@ export class SettingsButtonManager extends BaseUIManager {
     this.state = state;
     this.eventBus = eventBus;
     this._dependencyInstallListeners = [];
+    this._lastRadioSessionType = undefined;
   }
 
   _setupToggles() {
@@ -161,7 +162,8 @@ export class SettingsButtonManager extends BaseUIManager {
     const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
     if (toggleContainer) {
       const handleSessionTypeSelection = (sessionType) => {
-        const normalized = sessionType ?? SESSION_TYPES.WORKFLOW;
+        const normalized = this._normalizeSessionType(sessionType);
+        this._setLastRadioSessionType(normalized);
         this.state.applySessionType(normalized);
         const selectId =
           AGENT_SELECT_IDS[normalized] ??
@@ -214,14 +216,17 @@ export class SettingsButtonManager extends BaseUIManager {
 
       const radioGroup = resolveRadioGroup(toggleContainer);
       if (radioGroup) {
-        let lastSessionType = getSessionTypeFromGroup(radioGroup);
+        this._setLastRadioSessionType(getSessionTypeFromGroup(radioGroup));
         this.addListener(radioGroup, 'change', () => {
           const sessionType = getSessionTypeFromGroup(radioGroup);
-          if (!sessionType || sessionType === lastSessionType) {
+          if (!sessionType) {
             return;
           }
-          lastSessionType = sessionType;
-          handleSessionTypeSelection(sessionType);
+          const normalized = this._normalizeSessionType(sessionType);
+          if (normalized === this._lastRadioSessionType) {
+            return;
+          }
+          handleSessionTypeSelection(normalized);
         });
       } else {
         const buttons = toggleContainer.querySelectorAll('[data-session-type]');
@@ -332,7 +337,9 @@ export class SettingsButtonManager extends BaseUIManager {
 
     const sessionType =
       selectElement.dataset.sessionType || SESSION_TYPES.WORKFLOW;
-    this.state.applySessionType(sessionType, { skipSave: true });
+    const normalized = this._normalizeSessionType(sessionType);
+    this._setLastRadioSessionType(normalized);
+    this.state.applySessionType(normalized, { skipSave: true });
 
     const selectedAgent = selectElement.value;
     const selectedOption = getSelectedOptionElement(selectElement);
@@ -363,5 +370,15 @@ export class SettingsButtonManager extends BaseUIManager {
     }
 
     this.state.save();
+  }
+
+  _normalizeSessionType(sessionType) {
+    return sessionType === SESSION_TYPES.TOOL_USE
+      ? SESSION_TYPES.TOOL_USE
+      : SESSION_TYPES.WORKFLOW;
+  }
+
+  _setLastRadioSessionType(sessionType) {
+    this._lastRadioSessionType = this._normalizeSessionType(sessionType);
   }
 }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -183,35 +183,18 @@ export class SettingsButtonManager extends BaseUIManager {
 
       /**
        * Gets the current session type from a vscode-radio-group element.
-       * Uses multiple fallback strategies to ensure compatibility:
-       * 1. Check group's value property (web component API)
-       * 2. Check group's value attribute (fallback for delayed property sync)
-       * 3. Query for checked radio and extract its session type
        * @param {HTMLElement} group - The radio group element
        * @returns {string|undefined} The session type, or undefined if not found
        */
       const getSessionTypeFromGroup = (group) => {
-        if (!(group instanceof HTMLElement)) {
+        if (
+          !(group instanceof HTMLElement) ||
+          typeof group.value !== 'string' ||
+          group.value.length === 0
+        ) {
           return undefined;
         }
-        const groupValue =
-          typeof group.value === 'string' && group.value.length > 0
-            ? group.value
-            : group.getAttribute('value');
-        if (typeof groupValue === 'string' && groupValue.length > 0) {
-          return groupValue;
-        }
-        const checkedRadio = group.querySelector(
-          'vscode-radio[aria-checked="true"], vscode-radio[checked]'
-        );
-        if (checkedRadio instanceof HTMLElement) {
-          return (
-            checkedRadio.dataset.sessionType ??
-            checkedRadio.getAttribute('value') ??
-            undefined
-          );
-        }
-        return undefined;
+        return group.value;
       };
 
       const radioGroup = resolveRadioGroup(toggleContainer);
@@ -220,15 +203,14 @@ export class SettingsButtonManager extends BaseUIManager {
         // Only set if we can determine a valid initial value to avoid masking the first user interaction
         const initialSessionType = getSessionTypeFromGroup(radioGroup);
         if (initialSessionType) {
-          this._setLastRadioSessionType(initialSessionType);
-        } else {
-          console.warn('Radio group has no initial session type value');
+          this._setLastRadioSessionType(
+            normalizeSessionType(initialSessionType)
+          );
         }
 
         this.addListener(radioGroup, 'change', () => {
           const sessionType = getSessionTypeFromGroup(radioGroup);
           if (!sessionType) {
-            console.warn('Could not determine session type from radio group');
             return;
           }
           const normalized = normalizeSessionType(sessionType);
@@ -382,6 +364,6 @@ export class SettingsButtonManager extends BaseUIManager {
   }
 
   _setLastRadioSessionType(sessionType) {
-    this._lastRadioSessionType = normalizeSessionType(sessionType);
+    this._lastRadioSessionType = sessionType;
   }
 }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -195,9 +195,9 @@ export class SettingsButtonManager extends BaseUIManager {
           return undefined;
         }
         const groupValue =
-          (typeof group.value === 'string' && group.value.length > 0
+          typeof group.value === 'string' && group.value.length > 0
             ? group.value
-            : null) ?? group.getAttribute('value');
+            : group.getAttribute('value');
         if (typeof groupValue === 'string' && groupValue.length > 0) {
           return groupValue;
         }
@@ -366,7 +366,7 @@ export class SettingsButtonManager extends BaseUIManager {
 
     const sessionInput = safeGetElementById(SESSION_TYPE_INPUT);
     if (sessionInput) {
-      sessionInput.value = sessionType;
+      sessionInput.value = normalized;
     }
 
     this.state.save();

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -9,6 +9,7 @@ import {
   AGENT_SELECT_IDS,
   AGENT_SELECT_LIST,
   normalizeSessionType,
+  resolveRadioGroup,
 } from '../constants.js';
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
@@ -178,17 +179,6 @@ export class SettingsButtonManager extends BaseUIManager {
         } else {
           this.state.save();
         }
-      };
-
-      const resolveRadioGroup = (element) => {
-        if (!element) {
-          return null;
-        }
-        if (element.tagName === 'VSCODE-RADIO-GROUP') {
-          return element;
-        }
-        const radioGroup = element.querySelector('vscode-radio-group');
-        return radioGroup instanceof HTMLElement ? radioGroup : null;
       };
 
       const getSessionTypeFromGroup = (group) => {

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -8,6 +8,7 @@ import {
   SESSION_TYPE_INPUT,
   AGENT_SELECT_IDS,
   AGENT_SELECT_LIST,
+  normalizeSessionType,
 } from '../constants.js';
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
@@ -162,7 +163,7 @@ export class SettingsButtonManager extends BaseUIManager {
     const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
     if (toggleContainer) {
       const handleSessionTypeSelection = (sessionType) => {
-        const normalized = this._normalizeSessionType(sessionType);
+        const normalized = normalizeSessionType(sessionType);
         this._setLastRadioSessionType(normalized);
         this.state.applySessionType(normalized);
         const selectId =
@@ -222,7 +223,7 @@ export class SettingsButtonManager extends BaseUIManager {
           if (!sessionType) {
             return;
           }
-          const normalized = this._normalizeSessionType(sessionType);
+          const normalized = normalizeSessionType(sessionType);
           if (normalized === this._lastRadioSessionType) {
             return;
           }
@@ -337,7 +338,7 @@ export class SettingsButtonManager extends BaseUIManager {
 
     const sessionType =
       selectElement.dataset.sessionType || SESSION_TYPES.WORKFLOW;
-    const normalized = this._normalizeSessionType(sessionType);
+    const normalized = normalizeSessionType(sessionType);
     this._setLastRadioSessionType(normalized);
     this.state.applySessionType(normalized, { skipSave: true });
 
@@ -372,13 +373,7 @@ export class SettingsButtonManager extends BaseUIManager {
     this.state.save();
   }
 
-  _normalizeSessionType(sessionType) {
-    return sessionType === SESSION_TYPES.TOOL_USE
-      ? SESSION_TYPES.TOOL_USE
-      : SESSION_TYPES.WORKFLOW;
-  }
-
   _setLastRadioSessionType(sessionType) {
-    this._lastRadioSessionType = this._normalizeSessionType(sessionType);
+    this._lastRadioSessionType = normalizeSessionType(sessionType);
   }
 }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -177,22 +177,69 @@ export class SettingsButtonManager extends BaseUIManager {
         }
       };
 
-      const buttons = toggleContainer.querySelectorAll('[data-session-type]');
-      buttons.forEach((button) => {
-        this.addListener(button, 'click', () => {
-          if (!(button instanceof HTMLElement)) {
+      const resolveRadioGroup = (element) => {
+        if (!element) {
+          return null;
+        }
+        if (element.tagName === 'VSCODE-RADIO-GROUP') {
+          return element;
+        }
+        const radioGroup = element.querySelector('vscode-radio-group');
+        return radioGroup instanceof HTMLElement ? radioGroup : null;
+      };
+
+      const getSessionTypeFromGroup = (group) => {
+        if (!(group instanceof HTMLElement)) {
+          return undefined;
+        }
+        const groupValue =
+          (typeof group.value === 'string' && group.value.length > 0
+            ? group.value
+            : null) ?? group.getAttribute('value');
+        if (typeof groupValue === 'string' && groupValue.length > 0) {
+          return groupValue;
+        }
+        const checkedRadio = group.querySelector(
+          'vscode-radio[aria-checked="true"], vscode-radio[checked]'
+        );
+        if (checkedRadio instanceof HTMLElement) {
+          return (
+            checkedRadio.dataset.sessionType ??
+            checkedRadio.getAttribute('value') ??
+            undefined
+          );
+        }
+        return undefined;
+      };
+
+      const radioGroup = resolveRadioGroup(toggleContainer);
+      if (radioGroup) {
+        let lastSessionType = getSessionTypeFromGroup(radioGroup);
+        this.addListener(radioGroup, 'change', () => {
+          const sessionType = getSessionTypeFromGroup(radioGroup);
+          if (!sessionType || sessionType === lastSessionType) {
             return;
           }
-          const sessionType = button.dataset.sessionType;
-          if (!sessionType) {
-            return;
-          }
-          // Update active state on toggle buttons
-          buttons.forEach((btn) => btn.classList.remove('active'));
-          button.classList.add('active');
+          lastSessionType = sessionType;
           handleSessionTypeSelection(sessionType);
         });
-      });
+      } else {
+        const buttons = toggleContainer.querySelectorAll('[data-session-type]');
+        buttons.forEach((button) => {
+          this.addListener(button, 'click', () => {
+            if (!(button instanceof HTMLElement)) {
+              return;
+            }
+            const sessionType = button.dataset.sessionType;
+            if (!sessionType) {
+              return;
+            }
+            buttons.forEach((btn) => btn.classList.remove('active'));
+            button.classList.add('active');
+            handleSessionTypeSelection(sessionType);
+          });
+        });
+      }
     }
 
     AGENT_SELECT_LIST.forEach((id) => {

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -51,42 +51,6 @@
   min-width: 0;
 }
 
-.session-toggle {
-  display: inline-flex;
-  border: 1px solid var(--vscode-button-border);
-  border-radius: var(--border-radius);
-  overflow: hidden;
-  background: var(--vscode-input-background);
-}
-
-.session-toggle__option {
-  flex: 1 1 50%;
-  padding: var(--spacing-tiny) var(--spacing-small);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  background: transparent;
-  border: none;
-  color: var(--vscode-foreground);
-  transition:
-    background 0.12s ease,
-    color 0.12s ease;
-}
-
-.session-toggle__option:hover,
-.session-toggle__option:focus {
-  background: var(--vscode-list-hoverBackground);
-}
-
-.session-toggle__option.active {
-  background: var(--vscode-list-activeSelectionBackground);
-  color: var(--vscode-list-activeSelectionForeground);
-}
-
-.session-toggle__option:focus-visible {
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: 1px;
-}
-
 .agent-select {
   width: 100%;
   min-width: 0;


### PR DESCRIPTION
## Summary
- replace the workflow/tool-use toggle buttons with a segmented `vscode-radio-group`
- drop the custom `.session-toggle` styles in favor of the native control appearance
- listen for radio group changes in the settings manager and update affected tests

## Testing
- npm run lint
- npm run compile-tests
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68f90b9b07a88324b29bfaa69b5ae1d2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the workflow/tool-use toggle to a vscode-radio-group and updates state handling, settings interactions, tests, and styles accordingly.
> 
> - **UI (index.html)**:
>   - Replace custom session type toggle buttons with `vscode-radio-group` and `vscode-radio` in `#sessionTypeToggle`; set horizontal orientation and default `workflow` value.
> - **State management (`modules`)**:
>   - `constants.js`: add `VSCODE_RADIO_GROUP_TAG`, `normalizeSessionType(sessionType)`, and `resolveRadioGroup(element)` utilities.
>   - `mainViewState.js`: use `normalizeSessionType` and `resolveRadioGroup`; set radio group `value` and `checked` states; maintain fallback for old button-based toggles; save normalized session type and active agent.
>   - `SettingsButtonManager.js`: listen to radio group `change`, track last selection to prevent redundant updates, normalize session type across handlers, and sync hidden `sessionType` input.
> - **Tests**:
>   - Update `MessageHandlersRestore.test.ts` HTML fixture to include `vscode-radio-group` for `#sessionTypeToggle`.
> - **Styles**:
>   - Remove custom `.session-toggle` and related button styles; rely on native control appearance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5229f7edcb69a6d7c64940864d28ae9d2db4a289. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->