### PR TITLE
fix: restore toolbar disablement and progress log autoscroll

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -96,16 +96,37 @@ export function safeGetElementChecked(id) {
   return element.checked;
 }
 
+export function setElementDisabled(element, disabled) {
+  if (!element) {
+    return;
+  }
+
+  if ('disabled' in element) {
+    try {
+      element.disabled = disabled;
+    } catch (error) {
+      // Ignore assignment errors from custom elements without writable props
+    }
+  }
+
+  if (element instanceof Element) {
+    element.toggleAttribute('disabled', Boolean(disabled));
+  }
+}
+
 export function setElementsDisabled(idsOrElements, disabled) {
   const elements = Array.isArray(idsOrElements)
     ? idsOrElements
     : [idsOrElements];
+
   elements.forEach((el) => {
     if (typeof el === 'string') {
       const elem = document.getElementById(el);
-      if (elem) elem.disabled = disabled;
-    } else if (el) {
-      el.disabled = disabled;
+      if (elem) {
+        setElementDisabled(elem, disabled);
+      }
+    } else {
+      setElementDisabled(el, disabled);
     }
   });
 }

--- a/src/common/modules/templateUtils.js
+++ b/src/common/modules/templateUtils.js
@@ -1,3 +1,6 @@
+// Local imports - common
+import { setElementDisabled } from './domUtils.js';
+
 export function renderTemplate(templateId) {
   const template = document.getElementById(templateId);
   if (!template) {
@@ -73,7 +76,7 @@ export function createIconButton({
     element.setAttribute('label', title);
     element.setAttribute('aria-label', title);
   }
-  element.disabled = disabled;
+  setElementDisabled(element, disabled);
   Object.entries(dataset).forEach(([key, value]) => {
     element.dataset[key] = value;
   });

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -15,6 +15,24 @@ import { vscode } from '@common/webviewContext.js';
 const state = progressViewState;
 const dom = progressViewDomHandler;
 
+function scrollToBottom(element) {
+  if (!element) {
+    return;
+  }
+
+  if (
+    typeof element.scrollPos === 'number' &&
+    typeof element.scrollMax === 'number'
+  ) {
+    element.scrollPos = element.scrollMax;
+    return;
+  }
+
+  if ('scrollTop' in element && 'scrollHeight' in element) {
+    element.scrollTop = element.scrollHeight;
+  }
+}
+
 // Create formatter instances
 
 export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
@@ -185,7 +203,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           appendFormatted(logContent, formatted);
         }
       });
-      logContent.scrollTop = logContent.scrollHeight;
+      scrollToBottom(logContent);
 
       // Recalculate cumulative usage after loading groups
       dom.usageSummary.update();
@@ -228,7 +246,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         }
         appendFormatted(logContent, formatted);
       }
-      logContent.scrollTop = logContent.scrollHeight;
+      scrollToBottom(logContent);
     }
   }
 
@@ -255,7 +273,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           }
           appendFormatted(logContent, formatted);
         }
-        logContent.scrollTop = logContent.scrollHeight;
+        scrollToBottom(logContent);
       }
     }
   }
@@ -264,7 +282,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       dom.taskGroups.addGroup(message.group);
-      logContent.scrollTop = logContent.scrollHeight;
+      scrollToBottom(logContent);
     }
   }
 

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -19,6 +19,7 @@ import {
   safeSetElementValue,
   safeSetElementChecked,
   setChevronIcon,
+  setElementDisabled,
   isSelectLikeElement,
   getSelectOptionElements,
 } from '@common/domUtils.js';
@@ -57,9 +58,7 @@ function setFileSelectionGroupDisabled(isDisabled) {
     ].join(', '),
   );
   interactiveElements.forEach((element) => {
-    if (element instanceof HTMLElement && 'disabled' in element) {
-      element.disabled = isDisabled;
-    }
+    setElementDisabled(element, isDisabled);
   });
 }
 


### PR DESCRIPTION
## Summary
- add a shared `setElementDisabled` helper so VS Code toolbar controls honor disabled state
- update main view and template utilities to use the helper when toggling interactivity
- restore progress log auto-scroll by targeting the `vscode-scrollable` API with DOM fallbacks

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: VS Code binary requires libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f9093aa1948324aac70bc8541aa2b1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a shared `setElementDisabled` helper and replaces manual disabling across the UI; restores progress log auto-scroll via a `scrollToBottom` util that supports VS Code `vscode-scrollable`.
> 
> - **Common utilities (`src/common/modules/domUtils.js`)**
>   - Add `setElementDisabled(element, disabled)` to robustly apply disabled state (handles custom elements and `disabled` attribute).
>   - Update `setElementsDisabled` to use `setElementDisabled`.
> - **Template utilities (`src/common/modules/templateUtils.js`)**
>   - `createIconButton` now uses `setElementDisabled` instead of direct `disabled` assignment.
> - **Progress view (`src/progressView/modules/messageHandlers.js`)**
>   - Add `scrollToBottom(element)` supporting `vscode-scrollable` (`scrollPos`/`scrollMax`) with DOM fallbacks.
>   - Replace direct `scrollTop` updates with `scrollToBottom` to restore log auto-scroll in multiple handlers.
> - **Main webview (`src/webview/modules/mainViewState.js`)**
>   - Import and use `setElementDisabled` in `setFileSelectionGroupDisabled` to uniformly disable interactive controls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f879ceb8e91a59208c6752fd3e11887bc49d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->