### PR TITLE
fix: restyle banners with toolbar buttons

### DIFF
--- a/src/test/webview/BannerManager.test.ts
+++ b/src/test/webview/BannerManager.test.ts
@@ -162,8 +162,8 @@ describe('BannerManager', () => {
     dom = new JSDOM(`<!doctype html><html><body>
       <div id="apiKeyBanner" style="display: none;">
         <span></span>
-        <button id="apiKeyBannerButton"></button>
-        <button id="apiKeyGuideButton"></button>
+        <vscode-toolbar-button id="apiKeyBannerButton"></vscode-toolbar-button>
+        <vscode-toolbar-button id="apiKeyGuideButton"></vscode-toolbar-button>
       </div>
       <div id="agentConfigBanner" style="display: none;">
         <span></span>
@@ -172,8 +172,8 @@ describe('BannerManager', () => {
       <div id="dependencyBanner" style="display: none;">
         <span class="missing-tools"></span>
         <div class="actions">
-          <button id="dependencyRecheckButton"></button>
-          <button id="dependencyDismissButton"></button>
+          <vscode-toolbar-button id="dependencyRecheckButton"></vscode-toolbar-button>
+          <vscode-toolbar-button id="dependencyDismissButton"></vscode-toolbar-button>
         </div>
       </div>
     </body></html>`);
@@ -242,6 +242,8 @@ describe('BannerManager', () => {
       assert.equal(textSpan.textContent, 'TeXRA requires an API key to run.');
       assert.equal(setButton.textContent, 'Set API Key');
       assert.equal(getButton.textContent, 'API Key Guide');
+      assert.equal(setButton.tagName, 'VSCODE-TOOLBAR-BUTTON');
+      assert.equal(getButton.tagName, 'VSCODE-TOOLBAR-BUTTON');
       assert.equal(banner.dataset.provider, undefined);
     });
 
@@ -261,6 +263,8 @@ describe('BannerManager', () => {
 
       assert.equal(setButton.textContent, 'Set Key');
       assert.equal(getButton.textContent, 'Get Key');
+      assert.equal(setButton.tagName, 'VSCODE-TOOLBAR-BUTTON');
+      assert.equal(getButton.tagName, 'VSCODE-TOOLBAR-BUTTON');
       assert.equal(banner.dataset.provider, 'openai');
     });
 
@@ -356,7 +360,8 @@ describe('BannerManager', () => {
       const items = banner.querySelectorAll('.dependency-item');
       assert.equal(items.length, 1);
       const label = items[0].querySelector('span');
-      const button = items[0].querySelector('button');
+      const button = items[0].querySelector('vscode-toolbar-button');
+      assert.equal(button.tagName, 'VSCODE-TOOLBAR-BUTTON');
       assert.equal(label.textContent, 'latex');
       assert.equal(button.textContent, 'Install');
       assert.equal(button.dataset.tool, 'latex');
@@ -407,6 +412,7 @@ describe('BannerManager', () => {
       const banner = dom.window.document.getElementById('dependencyBanner');
       manager.showBanner('dependencyBanner', { missingTools: [] });
       const recheck = banner.querySelector('#dependencyRecheckButton');
+      assert.equal(recheck.tagName, 'VSCODE-TOOLBAR-BUTTON');
       assert.equal(recheck.textContent, 'Re-check');
     });
   });

--- a/src/test/webview/BannerManager.test.ts
+++ b/src/test/webview/BannerManager.test.ts
@@ -148,7 +148,7 @@ class BannerManager {
         'vscode-toolbar-button',
       ) as ToolbarButtonElement;
       recheckButton.id = 'dependencyRecheckButton';
-      recheckButton.icon = 'refresh';
+      recheckButton.setAttribute('icon', 'refresh');
       recheckButton.textContent = 'Re-check';
       actions.insertBefore(recheckButton, actions.firstChild);
     }
@@ -166,7 +166,7 @@ class BannerManager {
     ) as ToolbarButtonElement;
     button.className = 'secondary dependency-install-button';
     button.textContent = 'Install';
-    button.icon = 'cloud-download';
+    button.setAttribute('icon', 'cloud-download');
     button.dataset.tool = tool;
 
     item.appendChild(nameSpan);

--- a/src/test/webview/BannerManager.test.ts
+++ b/src/test/webview/BannerManager.test.ts
@@ -9,6 +9,8 @@ import { JSDOM } from 'jsdom';
 // Since BannerManager uses ES6 modules with path aliases that Node.js doesn't understand,
 // we'll create a mock implementation that mirrors the actual behavior for testing purposes.
 
+type ToolbarButtonElement = HTMLElement & { icon?: string };
+
 // Mock BannerManager implementation for testing
 class BannerManager {
   private _listeners: Array<{
@@ -108,24 +110,68 @@ class BannerManager {
   }
 
   private _setupDependencyBanner(element: any, config: any) {
-    const textSpan = element.querySelector('span');
-    if (!textSpan) {
-      console.warn('[BannerManager] Dependency banner missing text element');
+    const container = element.querySelector('.missing-tools');
+    const actions = element.querySelector('.actions');
+
+    if (!(container && actions)) {
+      console.warn(
+        '[BannerManager] Dependency banner missing required elements',
+      );
       return;
     }
 
-    const missing = config?.missingTools || [];
-    const formattedTools = missing.map((tool: string) => {
-      if (tool === 'gm/magick') {
-        return 'GraphicsMagick or ImageMagick';
-      }
-      return tool;
-    });
+    container.textContent = '';
 
-    textSpan.textContent =
-      missing.length > 0
-        ? `Missing dependencies: ${formattedTools.join(', ')}`
-        : 'Missing dependencies: none';
+    const missing = config?.missingTools || [];
+    if (missing.length > 0) {
+      const intro = document.createElement('span');
+      intro.textContent = 'Missing dependencies:';
+      container.appendChild(intro);
+
+      missing.forEach((tool: string) => {
+        if (tool === 'gm/magick') {
+          this._addDependencyItem(container, 'GraphicsMagick', 'gm');
+          this._addDependencyItem(container, 'ImageMagick', 'magick');
+        } else {
+          this._addDependencyItem(container, tool, tool);
+        }
+      });
+    } else {
+      container.textContent = 'Missing dependencies: none';
+    }
+
+    let recheckButton = actions.querySelector(
+      '#dependencyRecheckButton',
+    ) as ToolbarButtonElement | null;
+    if (!recheckButton) {
+      recheckButton = document.createElement(
+        'vscode-toolbar-button',
+      ) as ToolbarButtonElement;
+      recheckButton.id = 'dependencyRecheckButton';
+      recheckButton.icon = 'refresh';
+      recheckButton.textContent = 'Re-check';
+      actions.insertBefore(recheckButton, actions.firstChild);
+    }
+  }
+
+  private _addDependencyItem(container: any, label: string, tool: string) {
+    const item = document.createElement('div');
+    item.classList.add('dependency-item');
+
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = label;
+
+    const button = document.createElement(
+      'vscode-toolbar-button',
+    ) as ToolbarButtonElement;
+    button.className = 'secondary dependency-install-button';
+    button.textContent = 'Install';
+    button.icon = 'cloud-download';
+    button.dataset.tool = tool;
+
+    item.appendChild(nameSpan);
+    item.appendChild(button);
+    container.appendChild(item);
   }
 
   addListener(

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -538,11 +538,11 @@
         <div id="apiKeyBanner" class="api-key-banner" style="display: none">
           <span>TeXRA requires an API key to run.</span>
           <div class="actions">
-            <vscode-button id="apiKeyBannerButton" icon="key"
-              >Set API Key</vscode-button
+            <vscode-toolbar-button id="apiKeyBannerButton" icon="key"
+              >Set API Key</vscode-toolbar-button
             >
-            <vscode-button id="apiKeyGuideButton" icon="book"
-              >API Key Guide</vscode-button
+            <vscode-toolbar-button id="apiKeyGuideButton" icon="book"
+              >API Key Guide</vscode-toolbar-button
             >
           </div>
         </div>
@@ -555,15 +555,15 @@
         >
           <span class="missing-tools"></span>
           <div class="actions">
-            <vscode-button id="dependencyRecheckButton" icon="refresh"
-              >Re-check</vscode-button
+            <vscode-toolbar-button id="dependencyRecheckButton" icon="refresh"
+              >Re-check</vscode-toolbar-button
             >
-            <vscode-button
+            <vscode-toolbar-button
               id="dependencyDismissButton"
               class="secondary"
               title="Dismiss (can be re-enabled in settings)"
               icon="close"
-              >Dismiss</vscode-button
+              >Dismiss</vscode-toolbar-button
             >
           </div>
         </div>

--- a/src/webview/modules/uiManagers/BannerManager.js
+++ b/src/webview/modules/uiManagers/BannerManager.js
@@ -168,7 +168,7 @@ export class BannerManager extends BaseUIManager {
     if (!recheckButton) {
       recheckButton = document.createElement('vscode-toolbar-button');
       recheckButton.id = 'dependencyRecheckButton';
-      recheckButton.icon = 'refresh';
+      recheckButton.setAttribute('icon', 'refresh');
       recheckButton.textContent = 'Re-check';
       actions.insertBefore(recheckButton, actions.firstChild);
     }
@@ -191,7 +191,7 @@ export class BannerManager extends BaseUIManager {
     const button = document.createElement('vscode-toolbar-button');
     button.className = 'secondary dependency-install-button';
     button.textContent = 'Install';
-    button.icon = 'cloud-download';
+    button.setAttribute('icon', 'cloud-download');
     button.dataset.tool = tool;
 
     item.appendChild(nameSpan);

--- a/src/webview/modules/uiManagers/BannerManager.js
+++ b/src/webview/modules/uiManagers/BannerManager.js
@@ -166,7 +166,7 @@ export class BannerManager extends BaseUIManager {
     // Ensure re-check button exists
     let recheckButton = actions.querySelector('#dependencyRecheckButton');
     if (!recheckButton) {
-      recheckButton = document.createElement('vscode-button');
+      recheckButton = document.createElement('vscode-toolbar-button');
       recheckButton.id = 'dependencyRecheckButton';
       recheckButton.icon = 'refresh';
       recheckButton.textContent = 'Re-check';
@@ -188,7 +188,7 @@ export class BannerManager extends BaseUIManager {
     const nameSpan = document.createElement('span');
     nameSpan.textContent = label;
 
-    const button = document.createElement('vscode-button');
+    const button = document.createElement('vscode-toolbar-button');
     button.className = 'secondary dependency-install-button';
     button.textContent = 'Install';
     button.icon = 'cloud-download';

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -87,6 +87,14 @@
 .agent-config-banner .actions,
 .dependency-banner .actions {
   display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.dependency-banner .dependency-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--spacing-small);
 }
 


### PR DESCRIPTION
## Summary
- replace the API key and dependency banner actions with toolbar buttons in the webview markup
- update banner manager logic and banner styles to support toolbar buttons and dependency install controls
- refresh BannerManager tests to cover the new toolbar button elements

## Testing
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_68fd4e206f2483248b663869d3d3f0ad

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch banner actions to `vscode-toolbar-button` and enhance dependency banner rendering, updating logic, markup, styles, and tests.
> 
> - **Webview UI**:
>   - Replace banner action buttons with `vscode-toolbar-button` in `src/webview/index.html` (API key and dependency banners).
>   - Update `BannerManager` (`_setupDependencyBanner`, `_addDependencyItem`) to create `vscode-toolbar-button`s and set `icon` via attributes; ensure `#dependencyRecheckButton` exists.
>   - Dependency banner now lists each missing tool with an Install toolbar button; splits `gm/magick` into separate `GraphicsMagick` and `ImageMagick` items.
>   - CSS tweaks in `styles/containers.css` to align banner actions and style dependency items.
> - **Tests**:
>   - Refresh `BannerManager.test.ts` to expect `vscode-toolbar-button` elements and new dependency banner structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95ee0283bce2afab36064f8a231b0c74b2e239db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->