### PR TITLE
fix: wait for latex diagnostics events

### DIFF
--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -4,10 +4,52 @@ import * as vscode from 'vscode';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
-import { sleep } from '@utils/helpers';
 
 const CHANNEL = 'LinterUtils';
 logger.initialize(CHANNEL);
+
+const DIAGNOSTIC_UPDATE_TIMEOUT_MS = 7500;
+
+async function waitForDiagnosticsUpdate(
+  targetUri: vscode.Uri,
+  timeoutMs: number = DIAGNOSTIC_UPDATE_TIMEOUT_MS,
+): Promise<void> {
+  if (timeoutMs <= 0) {
+    return;
+  }
+
+  const targetKey = targetUri.toString();
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+
+    const diagnosticsDisposable = vscode.languages.onDidChangeDiagnostics(
+      (event) => {
+        if (event.uris.some((uri) => uri.toString() === targetKey)) {
+          finish();
+        }
+      },
+    );
+
+    const timeoutHandle = setTimeout(() => {
+      logger.debug(
+        CHANNEL,
+        `Timed out waiting for diagnostics update for ${targetUri.fsPath}`,
+      );
+      finish();
+    }, timeoutMs);
+
+    function finish(): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutHandle);
+      diagnosticsDisposable.dispose();
+      resolve();
+    }
+  });
+}
 
 /**
  * Trigger a LaTeX build for a specific file
@@ -60,21 +102,16 @@ export async function triggerLaTeXBuild(filePath: string): Promise<void> {
       `Triggering LaTeX build for ${filePath} to refresh linter diagnostics`,
     );
 
-    // Trigger the build
-    await vscode.commands.executeCommand('latex-workshop.build', fileUri);
+    let diagnosticsWait: Promise<void> | undefined;
 
-    // Wait for the build and diagnostics to complete
-    await sleep(2500);
-
-    // Try to trigger diagnostics refresh explicitly if the editor is available
-    if (editor) {
-      // Save the file again after build to ensure diagnostics are refreshed
-      await editor.document.save();
-      logger.debug(CHANNEL, `Saved file after build: ${filePath}`);
+    try {
+      diagnosticsWait = waitForDiagnosticsUpdate(fileUri);
+      await vscode.commands.executeCommand('latex-workshop.build', fileUri);
+    } finally {
+      if (diagnosticsWait) {
+        await diagnosticsWait;
+      }
     }
-
-    // Wait a bit more for diagnostics to be updated
-    await sleep(500);
   } catch (buildErr) {
     logger.warn(
       CHANNEL,

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -102,15 +102,15 @@ export async function triggerLaTeXBuild(filePath: string): Promise<void> {
       `Triggering LaTeX build for ${filePath} to refresh linter diagnostics`,
     );
 
-    let diagnosticsWait: Promise<void> | undefined;
+    // Start listening for diagnostics updates before triggering the build
+    // to ensure we don't miss the event if the build completes quickly
+    const diagnosticsWait = waitForDiagnosticsUpdate(fileUri);
 
     try {
-      diagnosticsWait = waitForDiagnosticsUpdate(fileUri);
       await vscode.commands.executeCommand('latex-workshop.build', fileUri);
     } finally {
-      if (diagnosticsWait) {
-        await diagnosticsWait;
-      }
+      // Wait for diagnostics to update (or timeout)
+      await diagnosticsWait;
     }
   } catch (buildErr) {
     logger.warn(

--- a/src/test/frontend/latex/linter.test.ts
+++ b/src/test/frontend/latex/linter.test.ts
@@ -1,0 +1,274 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - filesystem
+import { WorkspaceFS } from '@utils/files';
+
+// Local imports - latex
+import { getLinterMessages } from '@frontend/latex/linter';
+
+describe('latex linter diagnostics', () => {
+  type MutableWorkspaceFs = {
+    fullPath: typeof WorkspaceFS.fullPath;
+  };
+
+  type MutableCommands = {
+    executeCommand: typeof vscode.commands.executeCommand;
+  };
+
+  type MutableLanguages = {
+    getDiagnostics: typeof vscode.languages.getDiagnostics;
+    onDidChangeDiagnostics: typeof vscode.languages.onDidChangeDiagnostics;
+    createDiagnosticCollection: typeof vscode.languages.createDiagnosticCollection;
+  };
+
+  type MutableWorkspace = {
+    openTextDocument: typeof vscode.workspace.openTextDocument;
+  };
+
+  type MutableWindow = {
+    showTextDocument: typeof vscode.window.showTextDocument;
+  };
+
+  const workspaceFs = WorkspaceFS as unknown as MutableWorkspaceFs;
+  const commands = vscode.commands as unknown as MutableCommands;
+  const languages = vscode.languages as unknown as MutableLanguages;
+  const workspace = vscode.workspace as unknown as MutableWorkspace;
+  const window = vscode.window as unknown as MutableWindow & {
+    visibleTextEditors: vscode.TextEditor[];
+  };
+
+  const originalFullPath = workspaceFs.fullPath;
+  const originalExecuteCommand = commands.executeCommand;
+  const originalGetDiagnostics = languages.getDiagnostics;
+  const originalOnDidChangeDiagnostics = languages.onDidChangeDiagnostics;
+  const originalCreateDiagnosticCollection =
+    languages.createDiagnosticCollection;
+  const originalOpenTextDocument = workspace.openTextDocument;
+  const originalShowTextDocument = window.showTextDocument;
+  const originalVisibleEditorsDescriptor = Object.getOwnPropertyDescriptor(
+    vscode.window,
+    'visibleTextEditors',
+  );
+
+  let diagnosticsByUri: Map<string, vscode.Diagnostic[]>;
+  let recordedCommands: { command: string; args: unknown[] }[];
+  let activeListener:
+    | ((event: vscode.DiagnosticChangeEvent) => void)
+    | undefined;
+  let visibleEditors: vscode.TextEditor[];
+
+  beforeEach(() => {
+    diagnosticsByUri = new Map();
+    recordedCommands = [];
+    activeListener = undefined;
+    visibleEditors = [];
+
+    workspaceFs.fullPath = (relativePath: string) =>
+      `/mock/workspace/${relativePath}`;
+
+    commands.executeCommand = ((command: string, ...args: unknown[]) => {
+      recordedCommands.push({ command, args });
+      return Promise.resolve(undefined);
+    }) as typeof commands.executeCommand;
+
+    languages.getDiagnostics = ((uri?: vscode.Uri) => {
+      if (!uri) {
+        return Array.from(diagnosticsByUri.entries()).map(
+          ([uriPath, diagnostics]) =>
+            [vscode.Uri.file(uriPath), diagnostics] as [
+              vscode.Uri,
+              vscode.Diagnostic[],
+            ],
+        );
+      }
+      return diagnosticsByUri.get(uri.fsPath) ?? [];
+    }) as typeof languages.getDiagnostics;
+
+    languages.onDidChangeDiagnostics = (listener) => {
+      activeListener = listener;
+      return new vscode.Disposable(() => {
+        activeListener = undefined;
+      });
+    };
+
+    languages.createDiagnosticCollection = () => {
+      const collection = {
+        name: 'test-diagnostics',
+        set: (
+          uri:
+            | vscode.Uri
+            | Iterable<[vscode.Uri, readonly vscode.Diagnostic[]]>
+            | readonly [vscode.Uri, readonly vscode.Diagnostic[] | undefined][],
+          diagnostics?: readonly vscode.Diagnostic[] | undefined,
+        ) => {
+          const entries: Iterable<
+            [vscode.Uri, readonly vscode.Diagnostic[] | undefined]
+          > =
+            uri instanceof vscode.Uri
+              ? ([
+                  [uri, diagnostics] as [
+                    vscode.Uri,
+                    readonly vscode.Diagnostic[] | undefined,
+                  ],
+                ] as const)
+              : (uri as Iterable<
+                  [vscode.Uri, readonly vscode.Diagnostic[] | undefined]
+                >);
+
+          const uris: vscode.Uri[] = [];
+
+          for (const [entryUri, entryDiagnostics] of entries) {
+            if (entryDiagnostics && entryDiagnostics.length > 0) {
+              diagnosticsByUri.set(entryUri.fsPath, [...entryDiagnostics]);
+            } else {
+              diagnosticsByUri.delete(entryUri.fsPath);
+            }
+            uris.push(entryUri);
+          }
+
+          if (uris.length > 0 && activeListener) {
+            activeListener({ uris });
+          }
+        },
+        clear: () => {
+          diagnosticsByUri.clear();
+        },
+        delete: (uri: vscode.Uri) => {
+          diagnosticsByUri.delete(uri.fsPath);
+        },
+        dispose: () => {
+          diagnosticsByUri.clear();
+        },
+        forEach: (
+          callback: (
+            uri: vscode.Uri,
+            diagnostics: readonly vscode.Diagnostic[],
+            collection: vscode.DiagnosticCollection,
+          ) => unknown,
+          thisArg?: unknown,
+        ) => {
+          for (const [uriPath, diagnostics] of diagnosticsByUri.entries()) {
+            callback.call(
+              thisArg,
+              vscode.Uri.file(uriPath),
+              diagnostics,
+              collection as vscode.DiagnosticCollection,
+            );
+          }
+        },
+        get: (uri: vscode.Uri) => diagnosticsByUri.get(uri.fsPath),
+        has: (uri: vscode.Uri) => diagnosticsByUri.has(uri.fsPath),
+        [Symbol.iterator]: function* () {
+          for (const [uriPath, diagnostics] of diagnosticsByUri.entries()) {
+            yield [vscode.Uri.file(uriPath), diagnostics] as [
+              vscode.Uri,
+              vscode.Diagnostic[],
+            ];
+          }
+        },
+      } satisfies Partial<vscode.DiagnosticCollection> & { name: string };
+
+      return collection as unknown as vscode.DiagnosticCollection;
+    };
+
+    workspace.openTextDocument = async () => {
+      throw new Error('openTextDocument should not be called in this test');
+    };
+
+    window.showTextDocument = async () => {
+      throw new Error('showTextDocument should not be called in this test');
+    };
+
+    Object.defineProperty(vscode.window, 'visibleTextEditors', {
+      configurable: true,
+      get: () => visibleEditors,
+    });
+  });
+
+  afterEach(() => {
+    workspaceFs.fullPath = originalFullPath;
+    commands.executeCommand = originalExecuteCommand;
+    languages.getDiagnostics = originalGetDiagnostics;
+    languages.onDidChangeDiagnostics = originalOnDidChangeDiagnostics;
+    languages.createDiagnosticCollection = originalCreateDiagnosticCollection;
+    workspace.openTextDocument = originalOpenTextDocument;
+    window.showTextDocument = originalShowTextDocument;
+    diagnosticsByUri.clear();
+    recordedCommands = [];
+    activeListener = undefined;
+
+    if (originalVisibleEditorsDescriptor) {
+      Object.defineProperty(
+        vscode.window,
+        'visibleTextEditors',
+        originalVisibleEditorsDescriptor,
+      );
+    } else {
+      delete (
+        vscode.window as unknown as { visibleTextEditors?: vscode.TextEditor[] }
+      ).visibleTextEditors;
+    }
+  });
+
+  it('waits for diagnostics change events before returning results', async () => {
+    const relativePath = 'main.tex';
+    const targetUri = vscode.Uri.file(`/mock/workspace/${relativePath}`);
+
+    const mockDocument = {
+      uri: targetUri,
+      isDirty: false,
+      save: async () => undefined,
+    } as unknown as vscode.TextDocument;
+
+    const mockEditor = {
+      document: mockDocument,
+    } as unknown as vscode.TextEditor;
+
+    visibleEditors.push(mockEditor);
+
+    const collection = vscode.languages.createDiagnosticCollection('test');
+    diagnosticsByUri.set(targetUri.fsPath, []);
+
+    const diagnosticsPromise = getLinterMessages(relativePath);
+
+    const raceResult = await Promise.race([
+      diagnosticsPromise.then(() => 'resolved'),
+      new Promise<'pending'>((resolve) =>
+        setTimeout(() => resolve('pending'), 25),
+      ),
+    ]);
+
+    assert.strictEqual(
+      raceResult,
+      'pending',
+      'Expected getLinterMessages to wait for diagnostics updates',
+    );
+
+    const diagnostic = new vscode.Diagnostic(
+      new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 5)),
+      'Example diagnostic',
+      vscode.DiagnosticSeverity.Error,
+    );
+
+    collection.set(targetUri, [diagnostic]);
+
+    const diagnostics = await diagnosticsPromise;
+
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].message, 'Example diagnostic');
+    assert.deepStrictEqual(recordedCommands, [
+      { command: 'latex-workshop.build', args: [targetUri] },
+    ]);
+    assert.strictEqual(
+      activeListener,
+      undefined,
+      'Expected diagnostics listener to be disposed after resolving',
+    );
+
+    collection.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- wait for VS Code diagnostic change events instead of fixed sleeps after LaTeX builds
- add a frontend test that simulates diagnostic updates and verifies getLinterMessages blocks on the change notification

## Testing
- npm run format
- npm run lint
- CI=1 npm test *(fails: vscode-test exits with libatk-1.0.so.0 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fdeb33919483248df3341f359b5b1f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wait for VS Code diagnostics change events after LaTeX builds and add a test that verifies `getLinterMessages` blocks until diagnostics update.
> 
> - **LaTeX linter (`src/frontend/latex/linter.ts`)**:
>   - Introduce `waitForDiagnosticsUpdate(uri, timeoutMs)` with a 7.5s timeout and use it around `vscode.commands.executeCommand('latex-workshop.build', uri)`.
>   - Remove fixed sleeps and rely on diagnostics change events; ensure listener is disposed on completion/timeout.
> - **Tests (`src/test/frontend/latex/linter.test.ts`)**:
>   - Add test that simulates diagnostics updates and asserts `getLinterMessages` waits for change, triggers `latex-workshop.build`, and disposes the listener.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73dd56ab881dd0c861e77d1a44761b8c1fdfb3bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->