### PR TITLE
fix: preserve media dropdown selection when refreshing options

### DIFF
--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -33,9 +33,22 @@ export class FileSelect {
       console.warn(`[FileSelect] Element with id '${id}' not found`);
       return;
     }
+    const previousValue = selectDiv.value;
     selectDiv.innerHTML = '';
     this.addOption(selectDiv, '', 'None');
     files.forEach((f) => this.addOption(selectDiv, f, f));
+    if (
+      previousValue !== undefined &&
+      previousValue !== null &&
+      previousValue !== ''
+    ) {
+      const hasPreviousOption = Array.from(
+        selectDiv.querySelectorAll('vscode-option'),
+      ).some((option) => option.value === previousValue);
+      if (hasPreviousOption) {
+        safeSetElementValue(id, previousValue);
+      }
+    }
   }
 
   updateEdited(baseFile) {


### PR DESCRIPTION
## Summary
- keep the previously selected option when rebuilding file dropdowns so media selections persist across agent changes

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68ff43789f208324a2ab966836fba828

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves the previously selected file in the dropdown after rebuilding options, if the option still exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03c0706ed4aaaccbdf1f81667f48d1f631525e2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->