### PR TITLE
Add open file action to YAML load error prompt

### DIFF
--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -81,14 +81,24 @@ export async function loadYaml(absolutePath: string): Promise<object> {
     return parsedYaml;
   } catch (err) {
     const moreInfo = 'More Info';
-    vscode.window
+    const openFile = 'Open File';
+    void vscode.window
       .showErrorMessage(
         `Error loading YAML file ${absolutePath}: ${err instanceof Error ? err.message : String(err)}`,
         moreInfo,
+        openFile,
       )
-      .then((selection) => {
+      .then(async (selection) => {
         if (selection === moreInfo) {
           void vscode.commands.executeCommand('texra.openDoc', 'custom-agents');
+          return;
+        }
+
+        if (selection === openFile) {
+          const document = await vscode.workspace.openTextDocument(
+            vscode.Uri.file(absolutePath),
+          );
+          await vscode.window.showTextDocument(document);
         }
       });
     throw err;


### PR DESCRIPTION
## Summary
- add an "Open File" button alongside the existing "More Info" option when YAML loading fails
- open the problematic YAML document in the editor when the new action is selected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffa35b2e008324b91eaf3bc64080fa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an "Open File" option to the YAML load error dialog to open the failing file directly in the editor.
> 
> - **Runtime UX (VS Code)**:
>   - Update `src/agent/runtime/agentLoad.ts` `loadYaml` error handling:
>     - Add `"Open File"` action to error message alongside `"More Info"`.
>     - On selection, open the problematic YAML in the editor via `vscode.workspace.openTextDocument` and `vscode.window.showTextDocument`.
>     - Preserve existing `More Info` behavior (`texra.openDoc`, `custom-agents`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb91d373225bb509cc2fce65b5e8536bf87232ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->