### PR TITLE
Adopt vscode collapsibles for file selection lists

### DIFF
--- a/src/test/webview/MessageHandlersRestore.test.ts
+++ b/src/test/webview/MessageHandlersRestore.test.ts
@@ -186,8 +186,6 @@ function loadFileListModule(dom: JSDOM) {
     'const fileList = new FileList();\nmodule.exports = { FileList, fileList };',
   );
 
-  const iconCalls: Array<{ elementId: string | null; isVisible: boolean }> = [];
-
   const context = {
     module: { exports: {} },
     exports: {},
@@ -202,9 +200,6 @@ function loadFileListModule(dom: JSDOM) {
       el.addEventListener(event, handler);
     },
     safeGetElementById: (id: string) => dom.window.document.getElementById(id),
-    setChevronIcon: (element: HTMLElement | null, isVisible: boolean) => {
-      iconCalls.push({ elementId: element?.id ?? null, isVisible });
-    },
     createFromTemplate: (
       _templateId: string,
       config: { text?: Record<string, string>; dataset?: Record<string, any> },
@@ -227,8 +222,6 @@ function loadFileListModule(dom: JSDOM) {
 
       return item;
     },
-    capitalize: (value: string) =>
-      value.charAt(0).toUpperCase() + value.slice(1),
   } as unknown as vm.Context;
 
   (context as any).globalThis = context;
@@ -241,7 +234,6 @@ function loadFileListModule(dom: JSDOM) {
 
   return {
     FileList: (context.module as any).exports.FileList as any,
-    iconCalls,
   };
 }
 
@@ -295,10 +287,6 @@ function loadMessageHandlerModule(dom: JSDOM) {
   const vscodeMessages: any[] = [];
   const mainViewStateSetCalls: any[] = [];
   const mainViewStateUpdateCalls: any[] = [];
-  const setChevronCalls: Array<{
-    elementId: string | null;
-    isVisible: boolean;
-  }> = [];
   let restoreCalled = false;
 
   const constantsMock = {
@@ -312,7 +300,6 @@ function loadMessageHandlerModule(dom: JSDOM) {
     ELEMENT_IDS: {
       OUTPUT_FILES: 'outputFiles',
       OUTPUT_FILES_CONTAINER: 'outputFilesContainer',
-      TOGGLE_OUTPUT_FILES: 'toggleOutputFiles',
       SESSION_TYPE_TOGGLE: 'sessionTypeToggle',
       LATEXDIFFS_CONTENT: 'latexdiffsContent',
       TOGGLE_LATEXDIFFS: 'toggleLatexdiffs',
@@ -342,9 +329,6 @@ function loadMessageHandlerModule(dom: JSDOM) {
       }
     },
     safeGetElementById: (id: string) => dom.window.document.getElementById(id),
-    setChevronIcon: (element: HTMLElement | null, isVisible: boolean) => {
-      setChevronCalls.push({ elementId: element?.id ?? null, isVisible });
-    },
   };
 
   const __mocks = {
@@ -466,7 +450,6 @@ function loadMessageHandlerModule(dom: JSDOM) {
       vscodeMessages,
       mainViewStateSetCalls,
       mainViewStateUpdateCalls,
-      setChevronCalls,
       restoreCalled: () => restoreCalled,
       constants: constantsMock,
     },
@@ -476,13 +459,12 @@ function loadMessageHandlerModule(dom: JSDOM) {
 describe('FileList remove callbacks', () => {
   it('invokes registered callbacks and hides the container when empty', () => {
     const dom = createTestDom(`
-      <div id="inputFilesContainer" style="display: block;">
+      <vscode-collapsible id="inputFilesContainer" open>
         <div id="inputFiles"></div>
-      </div>
-      <div id="toggleInputFiles"></div>
+      </vscode-collapsible>
     `);
 
-    const { FileList, iconCalls } = loadFileListModule(dom);
+    const { FileList } = loadFileListModule(dom);
     let saveCount = 0;
     let lastRemoved: string[] | null = null;
     const list = new FileList(() => {
@@ -502,6 +484,12 @@ describe('FileList remove callbacks', () => {
     assert.deepEqual(lastRemoved, ['beta.tex']);
     assert.strictEqual(saveCount, 1);
 
+    const container = dom.window.document.getElementById('inputFilesContainer');
+    let toggleCount = 0;
+    container?.addEventListener('toggle', () => {
+      toggleCount += 1;
+    });
+
     const secondRemove = dom.window.document.querySelector(
       '#inputFiles .remove-button',
     ) as HTMLElement;
@@ -509,17 +497,8 @@ describe('FileList remove callbacks', () => {
       new dom.window.Event('click', { bubbles: true }),
     );
     assert.deepEqual(lastRemoved, []);
-    assert.strictEqual(
-      dom.window.document.getElementById('inputFilesContainer')?.style.display,
-      'none',
-    );
-    assert(
-      iconCalls.some(
-        (call) =>
-          call.elementId === 'toggleInputFiles' && call.isVisible === false,
-      ),
-      'expected toggle icon to be updated when the list becomes empty',
-    );
+    assert.strictEqual(container?.hasAttribute('open'), false);
+    assert.strictEqual(toggleCount > 0, true);
     assert.strictEqual(saveCount, 3);
   });
 });
@@ -549,10 +528,9 @@ describe('MainViewMessageHandler state restoration', () => {
         <vscode-radio data-session-type="workflow" value="workflow"></vscode-radio>
         <vscode-radio data-session-type="toolUse" value="toolUse"></vscode-radio>
       </vscode-radio-group>
-      <div id="inputFilesContainer" style="display: none;">
+      <vscode-collapsible id="inputFilesContainer">
         <div id="inputFiles"></div>
-      </div>
-      <div id="toggleInputFiles"></div>
+      </vscode-collapsible>
     `);
 
     const { MainViewMessageHandler, mocks } = loadMessageHandlerModule(dom);
@@ -582,14 +560,7 @@ describe('MainViewMessageHandler state restoration', () => {
     assert.strictEqual(mocks.restoreCalled(), true);
 
     const container = dom.window.document.getElementById('inputFilesContainer');
-    assert.strictEqual(container?.style.display, 'block');
-    assert(
-      mocks.setChevronCalls.some(
-        (call) =>
-          call.elementId === 'toggleInputFiles' && call.isVisible === true,
-      ),
-      'expected toggle icon to be expanded when restoring visible list',
-    );
+    assert.strictEqual(container?.hasAttribute('open'), true);
 
     const removeCallback = mocks.fileListRemoveCallbacks.get('inputFiles');
     assert(removeCallback, 'expected removal callback to be registered');

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -92,41 +92,43 @@
                   icon="close"
                   title="Empty"
                 ></vscode-toolbar-button>
-                <span
-                  id="toggleInputFiles"
-                  class="toggle-icon"
-                  title="Show or hide additional input files"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <vscode-toolbar-button
-                  id="addOpenedInputFilesButton"
-                  icon="folder-opened"
-                  title="Add opened files as input"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="emptyInputFilesButton"
-                  icon="trash"
-                  title="Empty"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="selectInputFilesButton"
-                  icon="add"
-                  title="Add"
-                ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
             <vscode-single-select id="inputFile">
               <vscode-option value="">None</vscode-option>
             </vscode-single-select>
-            <div
+            <vscode-collapsible
               id="inputFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
+              class="multiple-files-collapsible"
             >
-              <div class="multiple-files-content">
-                <div id="inputFiles" class="multiple-files-list"></div>
+              <div slot="header" class="multiple-files-header">
+                <span class="multiple-files-label">Additional Input Files</span>
+                <vscode-toolbar-container
+                  class="file-select-actions file-select-actions--multiple"
+                >
+                  <vscode-toolbar-button
+                    id="addOpenedInputFilesButton"
+                    icon="folder-opened"
+                    title="Add opened files as input"
+                  ></vscode-toolbar-button>
+                  <vscode-toolbar-button
+                    id="emptyInputFilesButton"
+                    icon="trash"
+                    title="Empty"
+                  ></vscode-toolbar-button>
+                  <vscode-toolbar-button
+                    id="selectInputFilesButton"
+                    icon="add"
+                    title="Add"
+                  ></vscode-toolbar-button>
+                </vscode-toolbar-container>
               </div>
-            </div>
+              <div class="multiple-files-container">
+                <div class="multiple-files-content">
+                  <div id="inputFiles" class="multiple-files-list"></div>
+                </div>
+              </div>
+            </vscode-collapsible>
           </div>
           <div class="file-select">
             <div class="file-select-header">
@@ -153,41 +155,45 @@
                   icon="close"
                   title="Empty"
                 ></vscode-toolbar-button>
-                <span
-                  id="toggleReferenceFiles"
-                  class="toggle-icon"
-                  title="Show or hide additional reference files"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <vscode-toolbar-button
-                  id="addOpenedReferenceFilesButton"
-                  icon="folder-opened"
-                  title="Add opened files as reference"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="emptyReferenceFilesButton"
-                  icon="trash"
-                  title="Empty"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="selectReferenceFilesButton"
-                  icon="add"
-                  title="Add"
-                ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
             <vscode-single-select id="referenceFile">
               <vscode-option value="">None</vscode-option>
             </vscode-single-select>
-            <div
+            <vscode-collapsible
               id="referenceFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
+              class="multiple-files-collapsible"
             >
-              <div class="multiple-files-content">
-                <div id="referenceFiles" class="multiple-files-list"></div>
+              <div slot="header" class="multiple-files-header">
+                <span class="multiple-files-label"
+                  >Additional Reference Files</span
+                >
+                <vscode-toolbar-container
+                  class="file-select-actions file-select-actions--multiple"
+                >
+                  <vscode-toolbar-button
+                    id="addOpenedReferenceFilesButton"
+                    icon="folder-opened"
+                    title="Add opened files as reference"
+                  ></vscode-toolbar-button>
+                  <vscode-toolbar-button
+                    id="emptyReferenceFilesButton"
+                    icon="trash"
+                    title="Empty"
+                  ></vscode-toolbar-button>
+                  <vscode-toolbar-button
+                    id="selectReferenceFilesButton"
+                    icon="add"
+                    title="Add"
+                  ></vscode-toolbar-button>
+                </vscode-toolbar-container>
               </div>
-            </div>
+              <div class="multiple-files-container">
+                <div class="multiple-files-content">
+                  <div id="referenceFiles" class="multiple-files-list"></div>
+                </div>
+              </div>
+            </vscode-collapsible>
           </div>
           <div class="file-select">
             <div class="file-select-header">
@@ -214,41 +220,45 @@
                   icon="close"
                   title="Empty"
                 ></vscode-toolbar-button>
-                <span
-                  id="toggleAuxiliaryFiles"
-                  class="toggle-icon"
-                  title="Show or hide additional auxiliary files"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <vscode-toolbar-button
-                  id="addOpenedAuxiliaryFilesButton"
-                  icon="folder-opened"
-                  title="Add opened files as auxiliary"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="emptyAuxiliaryFilesButton"
-                  icon="trash"
-                  title="Empty"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="selectAuxiliaryFilesButton"
-                  icon="add"
-                  title="Add"
-                ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
             <vscode-single-select id="auxiliaryFile">
               <vscode-option value="">None</vscode-option>
             </vscode-single-select>
-            <div
+            <vscode-collapsible
               id="auxiliaryFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
+              class="multiple-files-collapsible"
             >
-              <div class="multiple-files-content">
-                <div id="auxiliaryFiles" class="multiple-files-list"></div>
+              <div slot="header" class="multiple-files-header">
+                <span class="multiple-files-label"
+                  >Additional Auxiliary Files</span
+                >
+                <vscode-toolbar-container
+                  class="file-select-actions file-select-actions--multiple"
+                >
+                  <vscode-toolbar-button
+                    id="addOpenedAuxiliaryFilesButton"
+                    icon="folder-opened"
+                    title="Add opened files as auxiliary"
+                  ></vscode-toolbar-button>
+                  <vscode-toolbar-button
+                    id="emptyAuxiliaryFilesButton"
+                    icon="trash"
+                    title="Empty"
+                  ></vscode-toolbar-button>
+                  <vscode-toolbar-button
+                    id="selectAuxiliaryFilesButton"
+                    icon="add"
+                    title="Add"
+                  ></vscode-toolbar-button>
+                </vscode-toolbar-container>
               </div>
-            </div>
+              <div class="multiple-files-container">
+                <div class="multiple-files-content">
+                  <div id="auxiliaryFiles" class="multiple-files-list"></div>
+                </div>
+              </div>
+            </vscode-collapsible>
           </div>
           <div class="file-select">
             <div class="file-select-header">
@@ -295,75 +305,74 @@
                   icon="close"
                   title="Empty"
                 ></vscode-toolbar-button>
-                <span
-                  id="toggleMediaFiles"
-                  class="toggle-icon"
-                  title="Show or hide additional media files"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <vscode-toolbar-button
-                  id="emptyMediaFilesButton"
-                  icon="trash"
-                  title="Empty"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="selectMediaFilesButton"
-                  icon="add"
-                  title="Add"
-                ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
             <vscode-single-select id="mediaFile">
               <vscode-option value="">None</vscode-option>
             </vscode-single-select>
-            <div
+            <vscode-collapsible
               id="mediaFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
+              class="multiple-files-collapsible"
             >
-              <div class="multiple-files-content">
-                <div id="mediaFiles" class="multiple-files-list"></div>
+              <div slot="header" class="multiple-files-header">
+                <span class="multiple-files-label">Additional Media Files</span>
+                <vscode-toolbar-container
+                  class="file-select-actions file-select-actions--multiple"
+                >
+                  <vscode-toolbar-button
+                    id="emptyMediaFilesButton"
+                    icon="trash"
+                    title="Empty"
+                  ></vscode-toolbar-button>
+                  <vscode-toolbar-button
+                    id="selectMediaFilesButton"
+                    icon="add"
+                    title="Add"
+                  ></vscode-toolbar-button>
+                </vscode-toolbar-container>
               </div>
-            </div>
+              <div class="multiple-files-container">
+                <div class="multiple-files-content">
+                  <div id="mediaFiles" class="multiple-files-list"></div>
+                </div>
+              </div>
+            </vscode-collapsible>
           </div>
           <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <span
-                  id="toggleOutputFiles"
-                  class="toggle-icon"
-                  title="Show or hide additional files for the agent’s output"
-                  ><i class="codicon codicon-chevron-down"></i
-                ></span>
-                <span
-                  class="optional-label"
-                  title="List the files that should receive the agent’s output"
-                  >Multiple Outputs</span
-                >
-              </div>
-              <vscode-toolbar-container class="file-select-actions">
-                <vscode-toolbar-button
-                  id="emptyOutputFilesButton"
-                  icon="trash"
-                  title="Empty"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="selectOutputFilesButton"
-                  icon="add"
-                  title="Add"
-                ></vscode-toolbar-button>
-              </vscode-toolbar-container>
-            </div>
-            <div
+            <vscode-collapsible
               id="outputFilesContainer"
-              class="multiple-files-container"
-              style="display: none"
+              class="multiple-files-collapsible"
             >
-              <div class="multiple-files-content">
-                <div id="outputFiles" class="multiple-files-list"></div>
-                <!-- Output filename override removed -->
+              <div slot="header" class="file-select-header">
+                <div class="file-select-label-group">
+                  <span
+                    class="optional-label"
+                    title="List the files that should receive the agent’s output"
+                    >Multiple Outputs</span
+                  >
+                </div>
+                <vscode-toolbar-container
+                  class="file-select-actions file-select-actions--multiple"
+                >
+                  <vscode-toolbar-button
+                    id="emptyOutputFilesButton"
+                    icon="trash"
+                    title="Empty"
+                  ></vscode-toolbar-button>
+                  <vscode-toolbar-button
+                    id="selectOutputFilesButton"
+                    icon="add"
+                    title="Add"
+                  ></vscode-toolbar-button>
+                </vscode-toolbar-container>
               </div>
-            </div>
+              <div class="multiple-files-container">
+                <div class="multiple-files-content">
+                  <div id="outputFiles" class="multiple-files-list"></div>
+                  <!-- Output filename override removed -->
+                </div>
+              </div>
+            </vscode-collapsible>
           </div>
         </div>
         <div class="instruction-box">

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -94,7 +94,6 @@ export const ELEMENT_IDS = {
   COMMIT_SELECT: 'commit',
   OUTPUT_FILES: 'outputFiles',
   OUTPUT_FILES_CONTAINER: 'outputFilesContainer',
-  TOGGLE_OUTPUT_FILES: 'toggleOutputFiles',
   INSTRUCTION: 'instruction',
   API_KEY_BANNER: 'apiKeyBanner',
   API_KEY_BANNER_BUTTON: 'apiKeyBannerButton',

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -9,7 +9,7 @@ import { mainViewState } from '../mainViewState.js';
 import { fileList } from '../uiManagers/FileList.js';
 import { fileSelect } from '../uiManagers/FileSelect.js';
 import { safeSetElementValue } from '@common/domUtils.js';
-import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { uncapitalize } from '@common/stringUtils.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - utilities
 
@@ -18,10 +18,9 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
  * @param {Object} ctx
  * @param {Function} ctx.postHandle
  * @param {Function} ctx.getElement
- * @param {Function} ctx.setToggleIcon
  */
 export function createFileHandlers(ctx) {
-  const { postHandle, getElement, setToggleIcon } = ctx;
+  const { postHandle, getElement } = ctx;
   const createSetFileHandler = (fileType, domId) => (message) => {
     fileSelect.update(domId, message.files);
     postHandle();
@@ -44,8 +43,8 @@ export function createFileHandlers(ctx) {
       fileType === 'output' ? ELEMENT_IDS.OUTPUT_FILES : `${fileType}Files`;
     const toggleId =
       fileType === 'output'
-        ? ELEMENT_IDS.TOGGLE_OUTPUT_FILES
-        : `toggle${capitalize(fileType)}Files`;
+        ? ELEMENT_IDS.OUTPUT_FILES_CONTAINER
+        : `${fileType}FilesContainer`;
 
     handlers[MAIN_VIEW_COMMANDS[`SET_${fileType.toUpperCase()}_FILES`]] =
       createSetFilesHandler(fileType, listId, toggleId);
@@ -71,15 +70,14 @@ export function createFileHandlers(ctx) {
   function handleAddMediaFile(message) {
     const listDiv = getElement('mediaFiles');
     const existingFiles = listDiv ? fileList.getSelected(listDiv) : [];
-    fileList.update('mediaFiles', 'toggleMediaFiles', [
+    fileList.update('mediaFiles', 'mediaFilesContainer', [
       ...existingFiles,
       message.file,
     ]);
     const container = getElement('mediaFilesContainer');
-    if (container && container.style.display === 'none') {
-      container.style.display = 'block';
-      const toggleIcon = getElement('toggleMediaFiles');
-      setToggleIcon(toggleIcon, true);
+    if (container && !container.hasAttribute('open')) {
+      container.setAttribute('open', '');
+      container.dispatchEvent(new Event('toggle', { bubbles: true }));
     }
 
     postHandle();
@@ -116,7 +114,7 @@ export function createFileHandlers(ctx) {
       const fileType = message.fileType.replace('Files', '');
       const singleFileId = `${uncapitalize(fileType)}File`;
       const multipleFileId = `${uncapitalize(fileType)}Files`;
-      const toggleId = `toggle${capitalize(fileType)}Files`;
+      const toggleId = `${uncapitalize(fileType)}FilesContainer`;
 
       let filesToAdd = message.files ?? [];
       if (message.shouldFilter) {

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -25,7 +25,6 @@ import {
   isSelectLikeElement,
   getSelectOptionElements,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
 import { CHEVRON_DOWN_CLASS } from '@common/iconConstants.js';
 import { WebviewStateManager } from '@common/webviewState.js';
 
@@ -115,8 +114,8 @@ export class MainViewState {
     }
 
     MULTIPLE_SELECTIONS.forEach((id) => {
-      const toggleId = `toggle${capitalize(id)}`;
-      fileList.setVisibility(id, toggleId, false);
+      const collapsibleId = `${id}Container`;
+      fileList.setVisibility(id, collapsibleId, false);
       const listDiv = safeGetElementById(id);
       if (listDiv) {
         listDiv.innerHTML = '';
@@ -202,7 +201,7 @@ export class MainViewState {
       // Tool config multi-select is initialized by loadState
 
       MULTIPLE_SELECTIONS.forEach((id) => {
-        const toggleId = `toggle${capitalize(id)}`;
+        const collapsibleId = `${id}Container`;
         const selectDiv = safeGetElementById(id);
         if (!selectDiv) {
           console.warn(`Element with id '${id}' not found`);
@@ -211,19 +210,22 @@ export class MainViewState {
         selectDiv.innerHTML = '';
 
         const filesArray = previousState[id] ?? [];
-        const isVisible = previousState[`${id}Visible`];
+        const storedOpen =
+          previousState[`${id}Open`] ??
+          previousState[`${id}Active`] ??
+          previousState[`${id}Visible`];
+        const isOpen =
+          storedOpen !== undefined
+            ? Boolean(storedOpen)
+            : filesArray.length > 0;
 
         if (filesArray && filesArray.length > 0) {
           filesArray.forEach((file) => {
             fileList.add(id, file);
           });
-          fileList.setVisibility(
-            id,
-            toggleId,
-            isVisible !== undefined ? isVisible : true,
-          );
+          fileList.setVisibility(id, collapsibleId, isOpen);
         } else {
-          fileList.setVisibility(id, toggleId, false);
+          fileList.setVisibility(id, collapsibleId, false);
         }
       });
 
@@ -274,8 +276,9 @@ export class MainViewState {
       const elementDiv = safeGetElementById(id);
       if (!elementDiv) return;
       const containerDiv = safeGetElementById(`${id}Container`);
-      state[`${id}Visible`] =
-        containerDiv && containerDiv.style.display === 'block';
+      const isOpen = containerDiv?.hasAttribute('open') ?? false;
+      state[`${id}Active`] = isOpen;
+      state[`${id}Open`] = isOpen;
       state[id] = fileList.getSelected(elementDiv);
     });
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -29,7 +29,6 @@ import { fileList } from './uiManagers/FileList.js';
 import {
   safeSetElementValue,
   safeGetElementById,
-  setChevronIcon,
   waitForElement,
   isSelectLikeElement,
   getSelectOptionElements,
@@ -61,7 +60,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     const ctx = {
       postHandle: this._postHandle.bind(this),
       getElement: this._getElement.bind(this),
-      setToggleIcon: this._setToggleIcon.bind(this),
     };
 
     this._registerFileListCallbacks();
@@ -349,11 +347,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /* ---------- Private helpers ---------- */
-  _setToggleIcon(element, isVisible) {
-    if (!element) return;
-    setChevronIcon(element, isVisible);
-  }
-
   _registerFileListCallbacks() {
     const updateCommands = {
       input: MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES,
@@ -515,28 +508,30 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
       const multipleFilesId = `${fileType}Files`;
       const multipleFiles = this._getElement(multipleFilesId);
-      if (filesArray.length > 0 || isVisible) {
-        const containerId = `${fileType}FilesContainer`;
-        const toggleId = `toggle${capitalize(fileType)}Files`;
+      const collapsibleId = `${fileType}FilesContainer`;
+      const collapsible = this._getElement(collapsibleId);
 
-        const container = this._getElement(containerId);
-        if (container) {
-          container.style.display = isVisible ? 'block' : 'none';
+      if (multipleFiles) {
+        multipleFiles.innerHTML = '';
+      }
+
+      if (filesArray.length > 0 && multipleFiles) {
+        fileList._batchMode = true;
+        filesArray.forEach((file) => {
+          fileList.add(multipleFilesId, file);
+        });
+        fileList._batchMode = false;
+      }
+
+      if (collapsible) {
+        const wasOpen = collapsible.hasAttribute('open');
+        if (isVisible) {
+          collapsible.setAttribute('open', '');
+        } else {
+          collapsible.removeAttribute('open');
         }
-
-        const toggleElement = this._getElement(toggleId);
-        this._setToggleIcon(toggleElement, isVisible);
-
-        if (multipleFiles) {
-          multipleFiles.innerHTML = '';
-        }
-
-        if (filesArray.length > 0 && multipleFiles) {
-          fileList._batchMode = true;
-          filesArray.forEach((file) => {
-            fileList.add(multipleFilesId, file);
-          });
-          fileList._batchMode = false;
+        if (wasOpen !== isVisible) {
+          collapsible.dispatchEvent(new Event('toggle', { bubbles: true }));
         }
       }
     }

--- a/src/webview/modules/state/currentContext.js
+++ b/src/webview/modules/state/currentContext.js
@@ -52,7 +52,7 @@ function collectMultipleFileSelections(singleFiles, fileList) {
   const selections = {};
   MULTIPLE_SELECTIONS.forEach((id) => {
     const container = safeGetElementById(`${id}Container`);
-    const isActive = container?.style.display !== 'none';
+    const isActive = container?.hasAttribute('open') ?? false;
     selections[`${id}Active`] = isActive;
 
     const filesDiv = safeGetElementById(id);

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -6,6 +6,7 @@ import {
   MULTIPLE_SELECTIONS,
   FILE_TYPES,
   ELEMENTS_TO_SAVE,
+  ELEMENT_IDS,
   INPUT_FILE,
   REFERENCE_FILE,
   AUXILIARY_FILE,
@@ -46,13 +47,14 @@ export class FileInputManager extends BaseUIManager {
       singleId: `${type}File`,
       emptySingleId: `empty${cap}FileButton`,
       listId: `${type}Files`,
-      toggleId: `toggle${cap}Files`,
+      toggleId: `${type}FilesContainer`,
       emptyListId: `empty${cap}FilesButton`,
     };
 
     if (type === 'output') {
       ids.singleId = undefined;
       ids.emptySingleId = undefined;
+      ids.toggleId = ELEMENT_IDS.OUTPUT_FILES_CONTAINER;
     }
 
     if (type === 'base' || type === 'edited') {
@@ -200,12 +202,13 @@ export class FileInputManager extends BaseUIManager {
       }
 
       if (toggleId) {
-        this.addListener(toggleId, 'click', () => {
-          if (type === 'output') {
-            this.outputFilesManager.toggleOutputFiles();
-          } else {
-            this.fileList.toggle(listId, toggleId);
+        this.addListener(toggleId, 'toggle', () => {
+          const collapsible = safeGetElementById(toggleId);
+          const isOpen = collapsible?.hasAttribute('open');
+          if (type === 'output' && isOpen) {
+            this.outputFilesManager.initializeOutputFiles();
           }
+          this.state.save();
         });
       }
     });

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -2,9 +2,7 @@
 import {
   addEventListenerSafely,
   safeGetElementById,
-  setChevronIcon,
 } from '@common/domUtils.js';
-import { capitalize } from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
@@ -15,6 +13,31 @@ export class FileList {
     this._saveFn = saveFn;
     this._removeCallbacks = new Map();
     this._batchMode = false;
+  }
+
+  _getCollapsible(containerId, toggleId) {
+    if (toggleId) {
+      const toggleElement = safeGetElementById(toggleId);
+      if (toggleElement) {
+        return toggleElement;
+      }
+    }
+    return safeGetElementById(`${containerId}Container`);
+  }
+
+  _setOpen(collapsible, isOpen, emitEvent = true) {
+    if (!collapsible) {
+      return;
+    }
+    const wasOpen = collapsible.hasAttribute('open');
+    if (isOpen) {
+      collapsible.setAttribute('open', '');
+    } else {
+      collapsible.removeAttribute('open');
+    }
+    if (emitEvent && wasOpen !== isOpen) {
+      collapsible.dispatchEvent(new Event('toggle', { bubbles: true }));
+    }
   }
 
   /** Set the callback used to persist state */
@@ -47,8 +70,8 @@ export class FileList {
    */
   add(containerId, file) {
     const container = safeGetElementById(containerId);
-    const toggleIcon = safeGetElementById(`toggle${capitalize(containerId)}`);
-    if (!container || !toggleIcon) return;
+    const collapsible = this._getCollapsible(containerId);
+    if (!container || !collapsible) return;
 
     const placeholder = container.querySelector('.file-list-placeholder');
     if (placeholder) {
@@ -76,7 +99,7 @@ export class FileList {
         }
 
         if (container.children.length === 0) {
-          this.empty(containerId, `toggle${capitalize(containerId)}`, false);
+          this.empty(containerId, undefined, false);
         } else {
           this._save();
         }
@@ -88,8 +111,8 @@ export class FileList {
   /** Update a multi-file list, showing the toggle when files exist */
   update(listId, toggleId, files) {
     const listDiv = safeGetElementById(listId);
-    const toggleIcon = safeGetElementById(toggleId);
-    if (!listDiv || !toggleIcon) return;
+    const collapsible = this._getCollapsible(listId, toggleId);
+    if (!listDiv || !collapsible) return;
 
     const existing = this.getSelected(listDiv);
     const newFiles = files.filter((f) => !existing.includes(f));
@@ -99,13 +122,7 @@ export class FileList {
       newFiles.forEach((file) => this.add(listId, file));
       this._batchMode = false;
 
-      listDiv.style.display = 'block';
-      setChevronIcon(toggleIcon, true);
-
-      const container = safeGetElementById(`${listId}Container`);
-      if (container) {
-        container.style.display = 'block';
-      }
+      this._setOpen(collapsible, true);
     }
     this._save();
   }
@@ -118,18 +135,16 @@ export class FileList {
 
   /** Show or hide a file list container */
   setVisibility(containerId, toggleId, isVisible) {
-    const container = safeGetElementById(`${containerId}Container`);
-    const toggleIcon = safeGetElementById(toggleId);
-    if (!container || !toggleIcon) return;
-    container.style.display = isVisible ? 'block' : 'none';
-    setChevronIcon(toggleIcon, isVisible);
+    const collapsible = this._getCollapsible(containerId, toggleId);
+    if (!collapsible) return;
+    this._setOpen(collapsible, isVisible);
   }
 
   /** Toggle visibility of a file list container */
   toggle(containerId, toggleId) {
-    const container = safeGetElementById(`${containerId}Container`);
-    if (!container) return;
-    const isVisible = container.style.display !== 'none';
+    const collapsible = this._getCollapsible(containerId, toggleId);
+    if (!collapsible) return;
+    const isVisible = collapsible.hasAttribute('open');
     this.setVisibility(containerId, toggleId, !isVisible);
     this._save();
   }
@@ -137,15 +152,11 @@ export class FileList {
   /** Empty all files from a container and hide it */
   empty(containerId, toggleId, shouldSave = true) {
     const listDiv = safeGetElementById(containerId);
-    const container = safeGetElementById(`${containerId}Container`);
-    if (!listDiv || !container) return;
+    const collapsible = this._getCollapsible(containerId, toggleId);
+    if (!listDiv || !collapsible) return;
 
     listDiv.innerHTML = '';
-    container.style.display = 'none';
-    const toggleIconDiv = safeGetElementById(toggleId);
-    if (toggleIconDiv) {
-      setChevronIcon(toggleIconDiv, false);
-    }
+    this._setOpen(collapsible, false);
     if (shouldSave) {
       this._save();
     }
@@ -156,9 +167,8 @@ export class FileList {
     ids.forEach((id) => {
       const selectDiv = safeGetElementById(id);
       if (!selectDiv) return;
-      const toggleId = `toggle${capitalize(id)}`;
       if (selectDiv.children.length === 0) {
-        this.setVisibility(id, toggleId, false);
+        this.setVisibility(id, undefined, false);
       }
     });
   }

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -3,12 +3,11 @@ import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
-import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 const INPUT_FILE_ID = INPUT_FILE;
 const OUTPUT_FILES_ID = ELEMENT_IDS.OUTPUT_FILES;
 const OUTPUT_FILES_CONTAINER_ID = ELEMENT_IDS.OUTPUT_FILES_CONTAINER;
-const TOGGLE_OUTPUT_FILES_ID = ELEMENT_IDS.TOGGLE_OUTPUT_FILES;
 
 /**
  * Manages output files UI logic.
@@ -70,31 +69,18 @@ export class OutputFilesManager {
     this.state.save();
   }
 
-  /** Toggle visibility of the output files container */
-  toggleOutputFiles() {
-    const container = safeGetElementById(OUTPUT_FILES_CONTAINER_ID);
-    if (!container) return;
-
-    const containerVisible = container.style.display !== 'none';
-
-    if (!containerVisible) {
-      this.initializeOutputFiles();
-    }
-
-    this.fileList.toggle(OUTPUT_FILES_ID, TOGGLE_OUTPUT_FILES_ID);
-  }
-
   /** Initialize the output files container based on state */
   initializeOutputContainer() {
     const container = safeGetElementById(OUTPUT_FILES_CONTAINER_ID);
-    const toggleIcon = safeGetElementById(TOGGLE_OUTPUT_FILES_ID);
+    if (!container) return;
 
-    if (container && toggleIcon) {
-      const state = this.state.get();
-      const shouldShow = state && state.outputFilesActive;
+    const state = this.state.get();
+    const shouldShow = Boolean(state && state.outputFilesActive);
 
-      container.style.display = shouldShow ? 'block' : 'none';
-      setChevronIcon(toggleIcon, shouldShow);
+    if (shouldShow) {
+      container.setAttribute('open', '');
+    } else {
+      container.removeAttribute('open');
     }
   }
 }

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -204,7 +204,7 @@ export class SettingsButtonManager extends BaseUIManager {
         const initialSessionType = getSessionTypeFromGroup(radioGroup);
         if (initialSessionType) {
           this._setLastRadioSessionType(
-            normalizeSessionType(initialSessionType)
+            normalizeSessionType(initialSessionType),
           );
         }
 

--- a/src/webview/styles/file-selection.css
+++ b/src/webview/styles/file-selection.css
@@ -68,6 +68,11 @@ vscode-toolbar-container.file-select-actions {
   opacity: 1;
 }
 
+.file-select-actions--multiple {
+  flex-direction: row !important;
+  gap: var(--spacing-small);
+}
+
 .file-select label {
   display: block;
   margin-bottom: var(--spacing-tiny);
@@ -102,60 +107,43 @@ vscode-toolbar-container.file-select-actions {
   height: var(--height-control);
 }
 
-/* When toggled (input is visible), make the label more prominent */
+/* When inputs are active, make the labels more prominent */
 .file-select-label-group:has(vscode-textfield[style*='inline-block'])
   .optional-label,
 .file-select-label-group:has(vscode-textfield[style*='inline-block'])
   .toggle-icon,
-.file-select:has(.multiple-files-container[style*='block']) .optional-label,
-.file-select:has(.multiple-files-container[style*='block']) .toggle-icon {
+.multiple-files-collapsible[open] .multiple-files-label,
+.multiple-files-collapsible[open] .optional-label {
   color: var(--vscode-foreground);
 }
 
-/* Add this specific selector for Multiple Output Files section */
-.file-select:has(#outputFilesContainer[style*='none']) .optional-label {
+.multiple-files-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-small);
+  padding: 0 var(--spacing-small);
+}
+
+.multiple-files-label {
+  color: var(--text-color);
+  font-size: var(--font-size);
+  display: flex;
+  align-items: center;
+  height: var(--height-control);
+  white-space: nowrap;
+}
+
+.multiple-files-collapsible {
+  margin-top: var(--spacing-small);
+}
+
+.multiple-files-collapsible:not([open]) .optional-label,
+.multiple-files-collapsible:not([open]) .multiple-files-label {
   opacity: 0.6;
 }
 
-.file-select:has(#outputFilesContainer[style*='block']) .optional-label {
-  color: var(--vscode-foreground);
-  opacity: 1;
-}
-
-.file-select:has(#outputFilesContainer[style*='none']) #emptyOutputFilesButton,
-.file-select:has(#outputFilesContainer[style*='none'])
-  #selectOutputFilesButton {
-  display: none;
-}
-
-/* Hide multiple file operation buttons when containers are not toggled */
-.file-select:has(#inputFilesContainer[style*='none']) #emptyInputFilesButton,
-.file-select:has(#inputFilesContainer[style*='none']) #selectInputFilesButton,
-.file-select:has(#inputFilesContainer[style*='none'])
-  #addOpenedInputFilesButton {
-  display: none;
-}
-
-.file-select:has(#referenceFilesContainer[style*='none'])
-  #emptyReferenceFilesButton,
-.file-select:has(#referenceFilesContainer[style*='none'])
-  #selectReferenceFilesButton,
-.file-select:has(#referenceFilesContainer[style*='none'])
-  #addOpenedReferenceFilesButton {
-  display: none;
-}
-
-.file-select:has(#auxiliaryFilesContainer[style*='none'])
-  #emptyAuxiliaryFilesButton,
-.file-select:has(#auxiliaryFilesContainer[style*='none'])
-  #selectAuxiliaryFilesButton,
-.file-select:has(#auxiliaryFilesContainer[style*='none'])
-  #addOpenedAuxiliaryFilesButton {
-  display: none;
-}
-
-.file-select:has(#mediaFilesContainer[style*='none']) #emptyMediaFilesButton,
-.file-select:has(#mediaFilesContainer[style*='none']) #selectMediaFilesButton {
+.multiple-files-collapsible:not([open]) .file-select-actions--multiple {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- replace manual multi-file toggles in the main webview with vscode-collapsible sections that host the existing toolbar controls
- update file list, state management, and handlers to drive the collapsible open attribute, persist state, and react to toggle events
- refresh styling and tests to target the new collapsible elements

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68ffad61e0088324ae017067970f50d3