### PR TITLE
Fix: open workflow outputs per round

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -26,6 +26,7 @@ import {
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { bus } from '@eventBus/ProgressEventBus';
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 
 // Local imports - utilities
@@ -57,6 +58,7 @@ export class OutputHandler implements IOutputHandler {
   public readonly xmlManager: XmlOutputManager;
   public readonly diffManager: LatexDiffManager;
   private diffStatsManager: DiffStatsManager;
+  private readonly openedOutputs: Set<string>;
 
   constructor(
     agentSetting: AgentSetting,
@@ -88,6 +90,7 @@ export class OutputHandler implements IOutputHandler {
       this.channel,
     );
     this.diffStatsManager = new DiffStatsManager();
+    this.openedOutputs = new Set();
   }
 
   /**
@@ -370,6 +373,24 @@ export class OutputHandler implements IOutputHandler {
       stream: this.channel,
       filesByRound: { [currRound]: fileInfos },
     });
+
+    for (const { path: filePath } of fileInfos) {
+      if (this.openedOutputs.has(filePath)) {
+        continue;
+      }
+
+      try {
+        await openBuildDisplayIfTex(filePath, { preserveFocus: true });
+        this.openedOutputs.add(filePath);
+      } catch (error) {
+        this.logger.error(
+          `Failed to open output file ${filePath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          groupId,
+        );
+      }
+    }
   }
 
   /**

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -36,7 +36,6 @@ import {
 
 // Local imports - utilities
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
 import { withLogGroup } from '@logger/logGroupUtils';
@@ -513,18 +512,6 @@ export async function executeAgentWithLogging<T extends IAgent>(
             stream: activeStreamId,
             status: 'stopped',
           });
-
-          const generated = Object.values(
-            (agent as any).outputHandler?.outputFiles || {},
-          )
-            .flat()
-            .filter(
-              (file): file is string =>
-                typeof file === 'string' && file.trim().length > 0,
-            );
-          for (const out of generated) {
-            await openBuildDisplayIfTex(out, { preserveFocus: true });
-          }
         } catch (err) {
           // Mark the task as failed
           logger.error(


### PR DESCRIPTION
## Summary
- open each workflow output as soon as the round finalizes and avoid reopening the same file
- remove the post-run output opening logic from executeAgent now that per-round handling owns it

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ff92a5e89c8324a23443b22649cc12