### PR TITLE
fix: align progress tree groups with vscode-tree behavior

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -354,7 +354,7 @@
                 class="group-status-icon"
                 aria-hidden="true"
               ></span>
-              <span slot="content" class="log-group-header">
+              <span class="log-group-header">
                 <span class="group-title"></span>
                 <span class="group-meta">
                   <span class="group-usage"></span>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -343,17 +343,32 @@
             </details>
           </template>
           <template id="groupDetailsTemplate">
-            <vscode-tree-item class="log-group" branch></vscode-tree-item>
-          </template>
-          <template id="groupHeaderTemplate">
-            <div class="log-group-header">
-              <span class="group-status-icon"></span>
-              <span class="group-title"></span>
-              <span class="group-time">
-                <span class="group-start-time"></span>
-                <span class="group-duration"></span>
+            <vscode-tree-item class="log-group" branch>
+              <span
+                slot="icon-branch"
+                class="group-status-icon"
+                aria-hidden="true"
+              ></span>
+              <span
+                slot="icon-branch-opened"
+                class="group-status-icon"
+                aria-hidden="true"
+              ></span>
+              <span slot="content" class="log-group-header">
+                <span class="group-title"></span>
+                <span class="group-meta">
+                  <span class="group-usage"></span>
+                  <i
+                    class="codicon codicon-circle-small-filled group-bullet"
+                    aria-hidden="true"
+                  ></i>
+                  <span class="group-time">
+                    <span class="group-start-time"></span>
+                    <span class="group-duration"></span>
+                  </span>
+                </span>
               </span>
-            </div>
+            </vscode-tree-item>
           </template>
         </div>
         <div slot="end" class="tabs">

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -370,6 +370,23 @@
               </span>
             </vscode-tree-item>
           </template>
+          <template id="contentTreeItemTemplate">
+            <vscode-tree-item class="content-item" branch>
+              <span slot="icon-branch" class="content-icon"></span>
+              <span slot="icon-branch-opened" class="content-icon"></span>
+              <span class="content-label">
+                <span class="content-title"></span>
+                <vscode-toolbar-button
+                  class="content-copy"
+                  icon="copy"
+                  title="Copy content"
+                  data-default-title="Copy content"
+                  data-success-title="Copied!"
+                ></vscode-toolbar-button>
+              </span>
+              <div slot="children" class="content-body markdown-content"></div>
+            </vscode-tree-item>
+          </template>
         </div>
         <div slot="end" class="tabs">
           <vscode-tree id="streamTabs" class="tabs-content">

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -21,14 +21,15 @@ import { vscode } from '@common/webviewContext.js';
 class ProgressViewDomHandler extends BaseDomHandler {
   constructor() {
     const usageSummary = new UsageSummary();
+    const taskGroups = new TaskGroupDomManager();
     super({
       streamTabs: new StreamTabs(),
       toolbar: new Toolbar(),
       status: new Status(),
       usageSummary,
-      usageGroup: new UsageGroupManager(usageSummary),
+      taskGroups,
+      usageGroup: new UsageGroupManager(usageSummary, taskGroups),
       fileList: new FileList(usageSummary),
-      taskGroups: new TaskGroupDomManager(),
       logEntries: new LogEntryManager(),
       events: new EventsManager(),
       placeholder: new Placeholder(),

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -56,46 +56,24 @@ const TIME_FORMAT_OPTIONS = {
 };
 
 /**
- * Represents different task group hierarchy levels with associated behaviors
+ * Format timestamp based on group level
+ * @param {Date} date - Date to format
+ * @param {boolean} isNested - Whether this is a nested group
+ * @returns {string} Formatted timestamp
  */
-export const TaskGroupLevel = {
-  ROOT: {
-    name: 'root',
-    formatTime: (date) => {
-      try {
-        return new Intl.DateTimeFormat(
-          undefined,
-          DATETIME_FORMAT_OPTIONS,
-        ).format(date);
-      } catch (error) {
-        const isoTimestamp = date.toISOString();
-        const timePart =
-          isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
-        return `${isoTimestamp.split('T')[0]} ${timePart}`;
-      }
-    },
-    showTitle: false,
-    headerOrder: 'time-first', // time → bullet → usage
-    cssClass: 'top-level',
-  },
-  NESTED: {
-    name: 'nested',
-    formatTime: (date) => {
-      try {
-        return new Intl.DateTimeFormat(undefined, TIME_FORMAT_OPTIONS).format(
-          date,
-        );
-      } catch (error) {
-        return (
-          date.toISOString().split('T')[1]?.split('.')[0] ?? date.toISOString()
-        );
-      }
-    },
-    showTitle: true,
-    headerOrder: 'usage-first', // usage → bullet → time
-    cssClass: null,
-  },
-};
+function formatGroupTime(date, isNested) {
+  try {
+    const options = isNested ? TIME_FORMAT_OPTIONS : DATETIME_FORMAT_OPTIONS;
+    return new Intl.DateTimeFormat(undefined, options).format(date);
+  } catch (error) {
+    const isoTimestamp = date.toISOString();
+    if (isNested) {
+      return isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
+    }
+    const timePart = isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
+    return `${isoTimestamp.split('T')[0]} ${timePart}`;
+  }
+}
 
 /**
  * Format token counts, displaying values in "k" units when exceeding 4096.
@@ -1168,13 +1146,9 @@ export class LogEntryFormatter {
 }
 
 /**
- * Formats task group headers.
+ * Formats task group headers - simplified implementation
  */
 export class TaskGroupHeaderFormatter {
-  constructor() {
-    this._statusClasses = new Set(Object.values(STATUS));
-  }
-
   /**
    * Render a group header inside the provided tree item element.
    * @param {HTMLElement} treeItem - The tree item hosting the group.
@@ -1190,23 +1164,66 @@ export class TaskGroupHeaderFormatter {
       return;
     }
 
-    const startDate = new Date(group.startTime);
-    const level = this._getGroupLevel(group);
-    const formattedStartTime = level.formatTime(startDate);
+    const isNested = Boolean(group.parentGroupId);
 
-    this._applyLevelClasses(treeItem, header, level);
-    this._updateStatus(treeItem, group.status);
-    this._updateTitle(header, level, group.name);
-    this._updateStartTime(header, group.startTime, formattedStartTime);
-    this._updateDuration(header, group.startTime, group.endTime);
-    this._updateUsage(header, level, group.usage);
+    // Set data attributes for CSS styling
+    treeItem.dataset.status = group.status || '';
+    if (isNested) {
+      treeItem.dataset.parent = group.parentGroupId;
+    } else {
+      delete treeItem.dataset.parent;
+    }
+
+    // Query all elements once
+    const titleElem = header.querySelector('.group-title');
+    const startTimeElem = header.querySelector('.group-start-time');
+    const durationElem = header.querySelector('.group-duration');
+    const usageElem = header.querySelector('.group-usage');
+
+    // Update title
+    if (titleElem) {
+      titleElem.textContent = group.name || '';
+    }
+
+    // Update start time
+    if (startTimeElem) {
+      const startDate = new Date(group.startTime);
+      const formattedTime = formatGroupTime(startDate, isNested);
+      startTimeElem.dataset.start = String(group.startTime);
+      startTimeElem.innerHTML = `<i class="codicon codicon-clock"></i> ${formattedTime}`;
+    }
+
+    // Update duration (only if group has ended)
+    if (durationElem) {
+      if (group.endTime !== undefined && group.endTime !== null) {
+        const durationMs = group.endTime - group.startTime;
+        durationElem.textContent = this._formatDuration(durationMs);
+      } else {
+        durationElem.textContent = '';
+      }
+    }
+
+    // Update usage
+    if (usageElem) {
+      if (group.usage) {
+        const { inputTokens = 0, outputTokens = 0, cost = 0 } = group.usage;
+        usageElem.innerHTML =
+          `<i class="codicon codicon-arrow-up"></i> ${formatTokens(inputTokens)}, ` +
+          `<i class="codicon codicon-arrow-down"></i> ${formatTokens(outputTokens)}, ` +
+          `$${cost.toFixed(3)}`;
+      } else {
+        usageElem.textContent = '';
+      }
+    }
+
+    // Update status icons
     this._updateStatusIcons(treeItem, group.status);
   }
 
-  _getGroupLevel(group) {
-    return group.parentGroupId ? TaskGroupLevel.NESTED : TaskGroupLevel.ROOT;
-  }
-
+  /**
+   * Get status icon HTML for a given status
+   * @private
+   */
   _getStatusIcon(status) {
     switch (status) {
       case STATUS.RUNNING:
@@ -1220,98 +1237,15 @@ export class TaskGroupHeaderFormatter {
       case STATUS.RESUMING:
         return '<i class="codicon codicon-debug-step-over"></i>';
       case STATUS.READY:
-        return '<i class="codicon codicon-circle-outline"></i>';
       default:
         return '<i class="codicon codicon-circle-outline"></i>';
     }
   }
 
-  _applyLevelClasses(treeItem, header, level) {
-    const isRoot = level === TaskGroupLevel.ROOT;
-    treeItem.classList.toggle('top-level', isRoot);
-    treeItem.classList.toggle('nested', !isRoot);
-    header.classList.toggle('top-level', isRoot);
-    header.classList.toggle('nested', !isRoot);
-  }
-
-  _updateStatus(treeItem, status) {
-    this._statusClasses.forEach((statusClass) => {
-      treeItem.classList.remove(statusClass);
-    });
-    if (status) {
-      treeItem.classList.add(status);
-    }
-
-    if (status) {
-      treeItem.dataset.status = status;
-    } else {
-      delete treeItem.dataset.status;
-    }
-  }
-
-  _updateTitle(header, level, name) {
-    const titleElem = header.querySelector('.group-title');
-    if (!titleElem) {
-      return;
-    }
-
-    if (level.showTitle && name) {
-      titleElem.textContent = name;
-      titleElem.removeAttribute('hidden');
-    } else {
-      titleElem.textContent = '';
-      titleElem.setAttribute('hidden', '');
-    }
-  }
-
-  _updateStartTime(header, startTime, formattedStartTime) {
-    const startTimeElem = header.querySelector('.group-start-time');
-    if (!startTimeElem) {
-      return;
-    }
-
-    startTimeElem.dataset.start = String(startTime);
-    startTimeElem.innerHTML = `<i class="codicon codicon-clock"></i> ${formattedStartTime}`;
-  }
-
-  _updateDuration(header, startTime, endTime) {
-    const durationElem = header.querySelector('.group-duration');
-    if (!durationElem) {
-      return;
-    }
-
-    if (endTime !== undefined && endTime !== null) {
-      const durationMs = endTime - startTime;
-      durationElem.textContent = this._formatDuration(durationMs);
-      durationElem.classList.remove('is-hidden');
-    } else {
-      durationElem.textContent = '';
-      durationElem.classList.add('is-hidden');
-    }
-  }
-
-  _updateUsage(header, level, usage) {
-    const usageElem = header.querySelector('.group-usage');
-    const bulletElem = header.querySelector('.group-bullet');
-    if (!usageElem || !bulletElem) {
-      return;
-    }
-
-    if (usage) {
-      const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
-      usageElem.innerHTML =
-        `<i class="codicon codicon-arrow-up"></i> ${formatTokens(inputTokens)}, ` +
-        `<i class="codicon codicon-arrow-down"></i> ${formatTokens(outputTokens)}, ` +
-        `$${cost.toFixed(3)}`;
-      usageElem.classList.remove('is-hidden');
-      bulletElem.classList.remove('is-hidden');
-    } else {
-      usageElem.textContent = '';
-      usageElem.classList.add('is-hidden');
-      bulletElem.classList.add('is-hidden');
-    }
-  }
-
+  /**
+   * Update status icons in branch icon slots
+   * @private
+   */
   _updateStatusIcons(treeItem, status) {
     const iconMarkup = this._getStatusIcon(status);
     const icons = treeItem.querySelectorAll(
@@ -1322,14 +1256,13 @@ export class TaskGroupHeaderFormatter {
     });
   }
 
+  /**
+   * Format duration in milliseconds to human-readable string
+   * @private
+   */
   _formatDuration(durationMs) {
-    // Handle edge cases
     if (durationMs < 0) return '0s';
-
-    // For very short durations, show under a second
-    if (durationMs < 1000) {
-      return '<1s';
-    }
+    if (durationMs < 1000) return '<1s';
 
     const seconds = Math.floor(durationMs / 1000) % 60;
     const minutes = Math.floor(durationMs / (1000 * 60));

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -373,27 +373,33 @@ export class LogEntryFormatter {
 
     const parsedMarkdown = this._processMarkdownContent(decodedContent, false);
     const isThinking = contentType.includes('Thinking');
-    const bannerEntry = this._createBannerEntry({
+
+    // Create tree item instead of details element
+    const treeItem = this._createContentTreeItem({
       logId,
       groupId,
       timestamp,
       iconClass: isThinking ? 'codicon-lightbulb' : 'codicon-pencil',
-      labelText: isThinking ? 'Thinking' : 'Scratchpad',
+      title: isThinking ? 'Thinking' : 'Scratchpad',
       copyTitle: isThinking ? 'Copy thinking' : 'Copy scratchpad',
-      contentClass: isThinking
-        ? 'banner-content--thinking'
-        : 'banner-content--scratchpad',
       open: false,
     });
 
-    if (!bannerEntry || !bannerEntry.contentElem) {
-      return bannerEntry ? bannerEntry.element : null;
+    if (!treeItem || !treeItem.contentElem) {
+      return treeItem ? treeItem.element : null;
     }
 
-    bannerEntry.contentElem.dataset.rawContent = decodedContent;
-    bannerEntry.contentElem.innerHTML = parsedMarkdown;
+    // Add specific class for styling
+    if (isThinking) {
+      treeItem.element.classList.add('thinking-item');
+    } else {
+      treeItem.element.classList.add('scratchpad-item');
+    }
 
-    return bannerEntry.element;
+    treeItem.contentElem.dataset.rawContent = decodedContent;
+    treeItem.contentElem.innerHTML = parsedMarkdown;
+
+    return treeItem.element;
   }
 
   _formatToolUse(content, structuredData, logId, groupId, timestamp) {
@@ -780,20 +786,98 @@ export class LogEntryFormatter {
     };
   }
 
-  _formatFileList(content, data, logId) {
-    const element = createFromTemplate('fileListDetailsTemplate');
+  /**
+   * Creates a tree item for collapsible content (Thinking, Scratchpad, Files, etc.)
+   * @param {Object} options - Configuration for the tree item
+   * @returns {Object} Object containing the tree item element and content container
+   */
+  _createContentTreeItem({
+    logId,
+    groupId,
+    timestamp,
+    iconClass,
+    title,
+    copyTitle,
+    open = false,
+  }) {
+    const element = createFromTemplate('contentTreeItemTemplate');
     if (!element) return null;
-    const contentElem = element.querySelector('.file-list-content');
-    const summaryElem = element.querySelector('.summary-text');
-    const toggleIcon = element.querySelector('.toggle-icon');
-    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
 
+    // Set data attributes
+    if (logId) element.dataset.logId = logId;
+    if (groupId) element.dataset.groupId = groupId;
+    if (timestamp) element.dataset.fullTimestamp = timestamp;
+
+    // Set open state
+    if (open) {
+      element.setAttribute('open', '');
+      element.open = true;
+    }
+
+    // Set up icons
+    const icons = element.querySelectorAll('.content-icon');
+    icons.forEach((icon) => {
+      icon.innerHTML = `<i class="codicon ${iconClass}"></i>`;
+    });
+
+    // Set title
+    const titleElem = element.querySelector('.content-title');
+    if (titleElem) {
+      titleElem.textContent = title;
+    }
+
+    // Set up copy button
+    const copyButton = element.querySelector('.content-copy');
+    if (copyButton) {
+      const defaultTitle = copyTitle || `Copy ${title.toLowerCase()}`;
+      copyButton.dataset.defaultTitle = defaultTitle;
+      copyButton.dataset.successTitle = 'Copied!';
+      copyButton.setAttribute('title', defaultTitle);
+      copyButton.setAttribute('aria-label', defaultTitle);
+    }
+
+    // Get content container
+    const contentElem = element.querySelector('.content-body');
+
+    return {
+      element,
+      contentElem,
+      copyButton,
+    };
+  }
+
+  _formatFileList(content, data, logId) {
     const parsed = data ?? JSON.parse(decodeHtml(content));
 
     if (!Array.isArray(parsed)) {
       console.warn('Missing structured data for file list log entry');
       return null;
     }
+
+    const totalFiles = parsed.length;
+    const loadedFiles = parsed.filter((f) => f.ok).length;
+    const failedFiles = totalFiles - loadedFiles;
+
+    let title = `Files (${loadedFiles}/${totalFiles} loaded`;
+    if (failedFiles > 0) {
+      title += `, ${failedFiles} not found`;
+    }
+    title += ')';
+
+    // Create tree item
+    const treeItem = this._createContentTreeItem({
+      logId,
+      iconClass: 'codicon-list-tree',
+      title,
+      copyTitle: 'Copy file list',
+      open: false,
+    });
+
+    if (!treeItem || !treeItem.contentElem) {
+      return treeItem ? treeItem.element : null;
+    }
+
+    treeItem.element.classList.add('file-list-item');
 
     // Group files by source for better organization
     const filesBySource = {};
@@ -838,23 +922,11 @@ export class LogEntryFormatter {
       });
     });
 
-    const totalFiles = parsed.length;
-    const loadedFiles = parsed.filter((f) => f.ok).length;
-    const failedFiles = totalFiles - loadedFiles;
+    // Wrap items in a list
+    treeItem.contentElem.innerHTML = `<ul class="file-list-content detail-content detail-list">${items}</ul>`;
+    if (logId) treeItem.contentElem.dataset.logId = logId;
 
-    let summary = `Files (${loadedFiles}/${totalFiles} loaded`;
-    if (failedFiles > 0) {
-      summary += `, ${failedFiles} not found`;
-    }
-    summary += ')';
-
-    if (summaryElem) summaryElem.textContent = summary;
-    if (contentElem) {
-      contentElem.innerHTML = items;
-      if (logId) contentElem.dataset.logId = logId;
-    }
-
-    return element;
+    return treeItem.element;
   }
 
   _formatMissingOutputs(content, data, logId) {
@@ -945,13 +1017,6 @@ export class LogEntryFormatter {
   }
 
   _formatLatexdiff(content, data, logId) {
-    const element = createFromTemplate('latexdiffDetailsTemplate');
-    if (!element) return null;
-    const contentElem = element.querySelector('.latexdiff-content');
-    const summaryElem = element.querySelector('.summary-text');
-    const toggleIcon = element.querySelector('.toggle-icon');
-    if (toggleIcon) toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
-
     const parsed = data ?? JSON.parse(decodeHtml(content));
     const entries = Array.isArray(parsed)
       ? parsed
@@ -962,6 +1027,26 @@ export class LogEntryFormatter {
     if (entries.length === 0) {
       return null;
     }
+
+    const title =
+      entries.length === 1
+        ? 'Latexdiff result'
+        : `Latexdiff results (${entries.length})`;
+
+    // Create tree item
+    const treeItem = this._createContentTreeItem({
+      logId,
+      iconClass: 'codicon-diff',
+      title,
+      copyTitle: 'Copy latexdiff results',
+      open: true,
+    });
+
+    if (!treeItem || !treeItem.contentElem) {
+      return treeItem ? treeItem.element : null;
+    }
+
+    treeItem.element.classList.add('latexdiff-item');
 
     let items = '';
     entries.forEach((d) => {
@@ -993,18 +1078,11 @@ export class LogEntryFormatter {
       )}</span> (<span class="file-link clickable-link" data-file="${outputEsc}">diff</span>)</li>`;
     });
 
-    const summary =
-      entries.length === 1
-        ? 'Latexdiff result'
-        : `Latexdiff results (${entries.length})`;
+    // Wrap items in a list
+    treeItem.contentElem.innerHTML = `<ul class="latexdiff-content detail-content detail-list">${items}</ul>`;
+    if (logId) treeItem.contentElem.dataset.logId = logId;
 
-    if (summaryElem) summaryElem.textContent = summary;
-    if (contentElem) {
-      contentElem.innerHTML = items;
-      if (logId) contentElem.dataset.logId = logId;
-    }
-
-    return element;
+    return treeItem.element;
   }
 
   _formatStatistics(content, data, logId) {

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1171,95 +1171,40 @@ export class LogEntryFormatter {
  * Formats task group headers.
  */
 export class TaskGroupHeaderFormatter {
+  constructor() {
+    this._statusClasses = new Set(Object.values(STATUS));
+  }
+
   /**
-   * Create a group header element
-   * @param {Object} group - Task group data
-   * @returns {HTMLElement|null} Header element or null if template creation fails
+   * Render a group header inside the provided tree item element.
+   * @param {HTMLElement} treeItem - The tree item hosting the group.
+   * @param {Object} group - Task group data.
    */
-  create(group) {
+  render(treeItem, group) {
+    if (!(treeItem instanceof HTMLElement)) {
+      return;
+    }
+
+    const header = treeItem.querySelector('.log-group-header');
+    if (!header) {
+      return;
+    }
+
     const startDate = new Date(group.startTime);
     const level = this._getGroupLevel(group);
     const formattedStartTime = level.formatTime(startDate);
 
-    const header = createFromTemplate('groupHeaderTemplate');
-    if (!header) return null;
-
-    header.id = `group-header-${group.id}`;
-    header.className = this._getHeaderClass(group, level);
-
-    const statusIconElem = header.querySelector('.group-status-icon');
-    if (statusIconElem) {
-      statusIconElem.innerHTML = this._getStatusIcon(group.status);
-    }
-
-    const titleElem = header.querySelector('.group-title');
-    if (titleElem) {
-      if (level.showTitle) {
-        titleElem.textContent = group.name;
-      } else {
-        titleElem.remove();
-      }
-    }
-
-    const startTimeElem = header.querySelector('.group-start-time');
-    if (startTimeElem) {
-      startTimeElem.dataset.start = String(group.startTime);
-      startTimeElem.innerHTML = `<i class="codicon codicon-clock"></i> ${formattedStartTime}`;
-    }
-
-    const durationElem = header.querySelector('.group-duration');
-    if (durationElem) {
-      if (group.endTime) {
-        const durationMs = group.endTime - group.startTime;
-        durationElem.textContent = this._formatDuration(durationMs);
-      } else {
-        durationElem.remove();
-      }
-    }
-
-    // Add usage information if available
-    if (group.usage) {
-      const { inputTokens = 0, outputTokens = 0, cost = 0 } = group.usage;
-      const usageDisplay =
-        `<span class="group-usage"><i class="codicon codicon-arrow-up"></i> ${formatTokens(inputTokens)}, ` +
-        `<i class="codicon codicon-arrow-down"></i> ${formatTokens(outputTokens)}, ` +
-        `$${cost.toFixed(3)}</span>`;
-
-      const bulletMarkup =
-        '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
-
-      // Add usage and bullet based on level
-      const timeSpan = header.querySelector('.group-time');
-      if (timeSpan) {
-        if (level.headerOrder === 'time-first') {
-          // For root level: time → bullet → usage
-          timeSpan.insertAdjacentHTML(
-            'afterend',
-            usageDisplay ? `${bulletMarkup}${usageDisplay}` : '',
-          );
-        } else {
-          // For nested level: usage → bullet → time
-          timeSpan.insertAdjacentHTML(
-            'beforebegin',
-            usageDisplay ? `${usageDisplay}${bulletMarkup}` : '',
-          );
-        }
-      }
-    }
-
-    return header;
+    this._applyLevelClasses(treeItem, header, level);
+    this._updateStatus(treeItem, group.status);
+    this._updateTitle(header, level, group.name);
+    this._updateStartTime(header, group.startTime, formattedStartTime);
+    this._updateDuration(header, group.startTime, group.endTime);
+    this._updateUsage(header, level, group.usage);
+    this._updateStatusIcons(treeItem, group.status);
   }
 
   _getGroupLevel(group) {
     return group.parentGroupId ? TaskGroupLevel.NESTED : TaskGroupLevel.ROOT;
-  }
-
-  _getHeaderClass(group, level) {
-    const classes = ['log-group-header', group.status];
-    if (level.cssClass) {
-      classes.push(level.cssClass);
-    }
-    return classes.join(' ');
   }
 
   _getStatusIcon(status) {
@@ -1270,9 +1215,111 @@ export class TaskGroupHeaderFormatter {
         return '<i class="codicon codicon-error"></i>';
       case STATUS.STOPPED:
         return '<i class="codicon codicon-check"></i>';
+      case STATUS.WAITING:
+        return '<i class="codicon codicon-clock"></i>';
+      case STATUS.RESUMING:
+        return '<i class="codicon codicon-debug-step-over"></i>';
+      case STATUS.READY:
+        return '<i class="codicon codicon-circle-outline"></i>';
       default:
         return '<i class="codicon codicon-circle-outline"></i>';
     }
+  }
+
+  _applyLevelClasses(treeItem, header, level) {
+    const isRoot = level === TaskGroupLevel.ROOT;
+    treeItem.classList.toggle('top-level', isRoot);
+    treeItem.classList.toggle('nested', !isRoot);
+    header.classList.toggle('top-level', isRoot);
+    header.classList.toggle('nested', !isRoot);
+  }
+
+  _updateStatus(treeItem, status) {
+    this._statusClasses.forEach((statusClass) => {
+      treeItem.classList.remove(statusClass);
+    });
+    if (status) {
+      treeItem.classList.add(status);
+    }
+
+    if (status) {
+      treeItem.dataset.status = status;
+    } else {
+      delete treeItem.dataset.status;
+    }
+  }
+
+  _updateTitle(header, level, name) {
+    const titleElem = header.querySelector('.group-title');
+    if (!titleElem) {
+      return;
+    }
+
+    if (level.showTitle && name) {
+      titleElem.textContent = name;
+      titleElem.removeAttribute('hidden');
+    } else {
+      titleElem.textContent = '';
+      titleElem.setAttribute('hidden', '');
+    }
+  }
+
+  _updateStartTime(header, startTime, formattedStartTime) {
+    const startTimeElem = header.querySelector('.group-start-time');
+    if (!startTimeElem) {
+      return;
+    }
+
+    startTimeElem.dataset.start = String(startTime);
+    startTimeElem.innerHTML = `<i class="codicon codicon-clock"></i> ${formattedStartTime}`;
+  }
+
+  _updateDuration(header, startTime, endTime) {
+    const durationElem = header.querySelector('.group-duration');
+    if (!durationElem) {
+      return;
+    }
+
+    if (endTime !== undefined && endTime !== null) {
+      const durationMs = endTime - startTime;
+      durationElem.textContent = this._formatDuration(durationMs);
+      durationElem.classList.remove('is-hidden');
+    } else {
+      durationElem.textContent = '';
+      durationElem.classList.add('is-hidden');
+    }
+  }
+
+  _updateUsage(header, level, usage) {
+    const usageElem = header.querySelector('.group-usage');
+    const bulletElem = header.querySelector('.group-bullet');
+    if (!usageElem || !bulletElem) {
+      return;
+    }
+
+    if (usage) {
+      const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
+      usageElem.innerHTML =
+        `<i class="codicon codicon-arrow-up"></i> ${formatTokens(inputTokens)}, ` +
+        `<i class="codicon codicon-arrow-down"></i> ${formatTokens(outputTokens)}, ` +
+        `$${cost.toFixed(3)}`;
+      usageElem.classList.remove('is-hidden');
+      bulletElem.classList.remove('is-hidden');
+    } else {
+      usageElem.textContent = '';
+      usageElem.classList.add('is-hidden');
+      bulletElem.classList.add('is-hidden');
+    }
+  }
+
+  _updateStatusIcons(treeItem, status) {
+    const iconMarkup = this._getStatusIcon(status);
+    const icons = treeItem.querySelectorAll(
+      '[slot="icon-branch"], [slot="icon-branch-opened"]',
+    );
+    icons.forEach((icon) => {
+      icon.innerHTML = iconMarkup;
+    });
   }
 
   _formatDuration(durationMs) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -244,15 +244,31 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       );
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
+        console.warn(
+          `handleNewLog: Failed to add to group, adding to root. MessageType: ${message.logMessage.messageType}, GroupId: ${message.logMessage.groupId}`,
+        );
         const formatted = this._entryFormatter.format(message.logMessage);
         if (formatted instanceof HTMLElement) {
+          // Set level 0 for tree items at root
+          if (formatted.tagName.toLowerCase() === 'vscode-tree-item') {
+            formatted.level = 0;
+          }
+
           // For thinking and scratchpad, auto-expand when live streaming
           const messageType = message.logMessage.messageType;
           if (messageType === 'thinking' || messageType === 'scratchpad') {
-            formatted.setAttribute('open', '');
-            const toggleIcon = formatted.querySelector('.toggle-icon');
-            if (toggleIcon) {
-              toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
+            // Handle tree items (vscode-tree-item)
+            if (formatted.tagName.toLowerCase() === 'vscode-tree-item') {
+              formatted.setAttribute('open', '');
+              formatted.open = true;
+            } else {
+              // Handle legacy details elements
+              formatted.setAttribute('open', '');
+              const toggleIcon = formatted.querySelector('.toggle-icon');
+              if (toggleIcon) {
+                toggleIcon.className =
+                  'codicon codicon-chevron-down toggle-icon';
+              }
             }
           }
         }
@@ -273,16 +289,31 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         // Fallback: append as new log with proper group placement
         const addedToGroup = dom.logEntries.append(message.logMessage);
         if (!addedToGroup) {
+          console.warn(
+            `handleUpdateLog: Failed to add to group, adding to root. MessageType: ${message.logMessage.messageType}, GroupId: ${message.logMessage.groupId}`,
+          );
           const formatted = this._entryFormatter.format(message.logMessage);
           if (formatted instanceof HTMLElement) {
+            // Set level 0 for tree items at root
+            if (formatted.tagName.toLowerCase() === 'vscode-tree-item') {
+              formatted.level = 0;
+            }
+
             // For thinking and scratchpad, auto-expand when live streaming
             const messageType = message.logMessage.messageType;
             if (messageType === 'thinking' || messageType === 'scratchpad') {
-              formatted.setAttribute('open', '');
-              const toggleIcon = formatted.querySelector('.toggle-icon');
-              if (toggleIcon) {
-                toggleIcon.className =
-                  'codicon codicon-chevron-down toggle-icon';
+              // Handle tree items (vscode-tree-item)
+              if (formatted.tagName.toLowerCase() === 'vscode-tree-item') {
+                formatted.setAttribute('open', '');
+                formatted.open = true;
+              } else {
+                // Handle legacy details elements
+                formatted.setAttribute('open', '');
+                const toggleIcon = formatted.querySelector('.toggle-icon');
+                if (toggleIcon) {
+                  toggleIcon.className =
+                    'codicon codicon-chevron-down toggle-icon';
+                }
               }
             }
           }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -79,9 +79,8 @@ export class TaskGroupDomManager {
     if (group.parentGroupId) {
       const parentItem = this.groupElements.get(group.parentGroupId);
       if (parentItem instanceof HTMLElement) {
-        // Child tree items go in the default slot (no slot attribute)
-        // Only non-tree-item children like log lines use slot="children"
-        treeItem.removeAttribute('slot');
+        // Child tree items use slot="children" for proper hierarchy
+        treeItem.setAttribute('slot', 'children');
         insertChronologically({
           container: parentItem,
           element: treeItem,

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -86,10 +86,20 @@ export class TaskGroupDomManager {
           element: treeItem,
           timestamp: group.startTime,
         });
+
+        // Manually set the level based on parent's level
+        // The vscode-tree-item should do this automatically via slotchange,
+        // but we ensure it's set immediately for dynamically added items
+        if (typeof parentItem.level === 'number') {
+          treeItem.level = parentItem.level + 1;
+        }
+
         return;
       }
     } else {
       treeItem.removeAttribute('slot');
+      // Top-level items are at level 0
+      treeItem.level = 0;
     }
 
     // For top-level groups, insert in chronological order

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -79,7 +79,9 @@ export class TaskGroupDomManager {
     if (group.parentGroupId) {
       const parentItem = this.groupElements.get(group.parentGroupId);
       if (parentItem instanceof HTMLElement) {
-        treeItem.setAttribute('slot', 'children');
+        // Child tree items go in the default slot (no slot attribute)
+        // Only non-tree-item children like log lines use slot="children"
+        treeItem.removeAttribute('slot');
         insertChronologically({
           container: parentItem,
           element: treeItem,

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -53,22 +53,18 @@ export class TaskGroupDomManager {
     treeItem.dataset.groupId = group.id;
     treeItem.setAttribute('branch', '');
 
-    const headerElement = this.headerFormatter.create(group);
-    if (!headerElement) {
-      console.error(
-        'TaskGroupDomManager.addGroup: failed to create group header',
-      );
-      return;
-    }
-
-    treeItem.appendChild(headerElement);
-
     progressViewState.taskGroups.set(group.id, group);
 
     const isCollapsed = progressViewState.toggleStates.get(group.id) === true;
     const isExpanded = !isCollapsed;
-    treeItem.toggleAttribute('expanded', isExpanded);
-    treeItem.expanded = isExpanded;
+    treeItem.open = isExpanded;
+    if (isExpanded) {
+      treeItem.setAttribute('open', '');
+    } else {
+      treeItem.removeAttribute('open');
+    }
+
+    this.headerFormatter.render(treeItem, group);
 
     this._observeGroup(treeItem, group.id);
 
@@ -123,6 +119,12 @@ export class TaskGroupDomManager {
     tree = document.createElement('vscode-tree');
     tree.id = ELEMENT_IDS.LOG_GROUP_TREE;
     tree.classList.add('log-group-tree');
+    tree.setAttribute('indent-guides', 'always');
+    try {
+      tree.indentGuides = 'always';
+    } catch (error) {
+      // Ignore assignment failures in environments without property reflection
+    }
     container.prepend(tree);
     return tree;
   }
@@ -138,9 +140,9 @@ export class TaskGroupDomManager {
       for (const mutation of mutations) {
         if (
           mutation.type === 'attributes' &&
-          mutation.attributeName === 'expanded'
+          mutation.attributeName === 'open'
         ) {
-          const isCollapsed = !treeItem.hasAttribute('expanded');
+          const isCollapsed = !treeItem.hasAttribute('open');
           progressViewState.toggleStates.set(groupId, isCollapsed);
         }
       }
@@ -148,7 +150,7 @@ export class TaskGroupDomManager {
 
     observer.observe(treeItem, {
       attributes: true,
-      attributeFilter: ['expanded'],
+      attributeFilter: ['open'],
     });
 
     this.groupObservers.set(groupId, observer);
@@ -224,48 +226,15 @@ export class TaskGroupDomManager {
       return;
     }
 
-    const header = treeItem.querySelector('.log-group-header');
-    if (header) {
-      const level = this.headerFormatter._getGroupLevel(group);
-      header.className = this.headerFormatter._getHeaderClass(group, level);
+    this.headerFormatter.render(treeItem, group);
 
-      // Update the status icon
-      const statusIconElem = header.querySelector('.group-status-icon');
-      if (statusIconElem) {
-        statusIconElem.innerHTML = this.headerFormatter._getStatusIcon(
-          group.status,
-        );
-      }
-
-      // Update or add the duration display when the group finishes
-      const timeContainer = header.querySelector('.group-time');
-
-      if (
-        hasEndTimeUpdate &&
-        group.endTime !== undefined &&
-        group.endTime !== null
-      ) {
-        const endDate = group.endTime;
-        const startDate = group.startTime;
-        const durationMs = endDate - startDate;
-
-        // Update or create duration element
-        const durationElem = header.querySelector('.group-duration');
-        if (durationElem) {
-          durationElem.textContent = `${this.headerFormatter._formatDuration(durationMs)}`;
-          durationElem.style.display = 'inline';
-        } else if (timeContainer) {
-          const durationSpan = document.createElement('span');
-          durationSpan.className = 'group-duration';
-          durationSpan.textContent = `${this.headerFormatter._formatDuration(durationMs)}`;
-          durationSpan.style.display = 'inline';
-          timeContainer.appendChild(durationSpan);
-        }
-
-        if (/^r\d+$/.test(group.name)) {
-          this.playSystemSound();
-        }
-      }
+    if (
+      hasEndTimeUpdate &&
+      group.endTime !== undefined &&
+      group.endTime !== null &&
+      /^r\d+$/.test(group.name)
+    ) {
+      this.playSystemSound();
     }
 
     progressViewState.taskGroups.set(groupId, group);
@@ -288,8 +257,8 @@ export class TaskGroupDomManager {
     // Collapse this group
     const treeItem = this.groupElements.get(groupId);
     if (treeItem instanceof HTMLElement) {
-      treeItem.toggleAttribute('expanded', false);
-      treeItem.expanded = false;
+      treeItem.open = false;
+      treeItem.removeAttribute('open');
       progressViewState.toggleStates.set(groupId, true);
     }
   }
@@ -311,7 +280,7 @@ export class TaskGroupDomManager {
     for (const [id, treeItem] of this.groupElements.entries()) {
       if (
         !(treeItem instanceof HTMLElement) ||
-        !treeItem.hasAttribute('expanded')
+        !treeItem.hasAttribute('open')
       ) {
         continue;
       }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -388,6 +388,13 @@ export class LogEntryManager {
       const groupElement = document.getElementById(
         `group-${logMessage.groupId}`,
       );
+      if (!groupElement) {
+        console.warn(
+          `LogEntryManager.append: Group not found for ID: ${logMessage.groupId}, messageType: ${logMessage.messageType}`,
+        );
+        return false;
+      }
+
       if (groupElement instanceof HTMLElement) {
         const logLineElement = this.entryFormatter.format(logMessage);
         if (!logLineElement) {

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -400,6 +400,14 @@ export class LogEntryManager {
 
         logLineElement.setAttribute('slot', 'children');
 
+        // Set level for content tree items
+        if (
+          logLineElement.classList.contains('content-item') &&
+          typeof groupElement.level === 'number'
+        ) {
+          logLineElement.level = groupElement.level + 1;
+        }
+
         // Extract timestamp from the message for chronological ordering
         const msgDate = new Date(logMessage.timestamp);
 

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -1,9 +1,7 @@
 // Local imports - progress view
 import { ELEMENT_IDS } from './constants.js';
-import { formatTokens, TaskGroupLevel } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
-import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Manages usage summary display.
@@ -53,8 +51,9 @@ export class UsageSummary {
  * Manages usage display for individual groups.
  */
 export class UsageGroupManager {
-  constructor(usageSummary) {
+  constructor(usageSummary, taskGroupDomManager) {
     this.usageSummary = usageSummary; // Use the shared instance
+    this.taskGroups = taskGroupDomManager;
   }
 
   /**
@@ -73,53 +72,28 @@ export class UsageGroupManager {
       return;
     }
 
-    const groupHeader = document.getElementById(`group-header-${groupId}`);
-    if (!groupHeader) {
+    const group = progressViewState.taskGroups.get(groupId);
+    if (!group) {
       console.warn(
-        `UsageGroupManager.update: Group header not found for ID: ${groupId}`,
+        `UsageGroupManager.update: Group not found for ID: ${groupId}`,
       );
       return;
     }
 
-    // Find or create usage display element in the group header
-    let usageElem = groupHeader.querySelector('.group-usage');
-    if (!usageElem) {
-      usageElem = createFromTemplate('usageTemplate');
-      if (!usageElem) {
-        console.error('UsageGroupManager.update: usageTemplate not found');
-        return;
-      }
-      // Determine the group level by checking for the 'top-level' class
-      const level = groupHeader.classList.contains('top-level')
-        ? TaskGroupLevel.ROOT
-        : TaskGroupLevel.NESTED;
-      this.insertUsageElement(groupHeader, usageElem, level);
-    }
-
-    if (!usageElem) return;
-
-    const inputEl = usageElem.querySelector('.usage-input');
-    const outputEl = usageElem.querySelector('.usage-output');
-    const costEl = usageElem.querySelector('.usage-cost');
-
-    if (!usage) {
-      if (inputEl) inputEl.textContent = '';
-      if (outputEl) outputEl.textContent = '';
-      if (costEl) costEl.textContent = '';
-      return;
-    }
-
-    const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
-    if (inputEl) inputEl.textContent = formatTokens(inputTokens);
-    if (outputEl) outputEl.textContent = formatTokens(outputTokens);
-    if (costEl) costEl.textContent = cost.toFixed(3);
-
-    // Persist usage on the group state so the summary can be computed
-    const group = progressViewState.taskGroups.get(groupId);
-    if (group) {
+    if (usage) {
+      const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
       group.usage = { inputTokens, outputTokens, cost };
-      progressViewState.taskGroups.set(groupId, group);
+    } else {
+      delete group.usage;
     }
+
+    progressViewState.taskGroups.set(groupId, group);
+
+    const treeItem = this.taskGroups?.groupElements?.get(groupId);
+    if (treeItem instanceof HTMLElement) {
+      this.taskGroups.headerFormatter.render(treeItem, group);
+    }
+
     if (!skipPropagate) {
       this.propagateUsageToParents(groupId);
     }
@@ -161,9 +135,7 @@ export class UsageGroupManager {
 
     // If this group has a parent, update the parent with aggregated usage
     if (group.parentGroupId) {
-      const totals = {
-        ...this.computeAggregatedUsage(group.parentGroupId),
-      };
+      const totals = this.computeAggregatedUsage(group.parentGroupId);
       this.update({
         groupId: group.parentGroupId,
         usage: totals,
@@ -172,56 +144,8 @@ export class UsageGroupManager {
       this.propagateUsageToParents(group.parentGroupId);
     } else {
       // This is a top-level group, update it with aggregated usage from its children
-      const totals = {
-        ...this.computeAggregatedUsage(groupId),
-      };
+      const totals = this.computeAggregatedUsage(groupId);
       this.update({ groupId, usage: totals, skipPropagate: true });
-    }
-  }
-
-  /**
-   * Determines where to insert a usage element based on group level and existing elements
-   * @private
-   * @param {HTMLElement} groupHeader - The group header element
-   * @param {HTMLElement} usageElem - The usage element to insert
-   * @param {Object} level - The task group level configuration
-   */
-  insertUsageElement(groupHeader, usageElem, level) {
-    const timeContainer = groupHeader.querySelector('.group-time');
-
-    let bulletElem = groupHeader.querySelector('.group-bullet');
-    if (!bulletElem) {
-      bulletElem = createFromTemplate('bulletTemplate');
-    }
-
-    // If bullet template is missing, skip adding it
-    const hasBullet = !!bulletElem;
-
-    if (timeContainer) {
-      if (level.headerOrder === 'time-first') {
-        // For root level groups: time comes first, then usage
-        if (hasBullet) {
-          timeContainer.parentNode.insertBefore(
-            bulletElem,
-            timeContainer.nextSibling,
-          );
-        }
-        timeContainer.parentNode.insertBefore(
-          usageElem,
-          hasBullet ? bulletElem.nextSibling : timeContainer.nextSibling,
-        );
-      } else {
-        // For nested groups: usage comes first, then time
-        groupHeader.insertBefore(usageElem, timeContainer);
-        if (hasBullet) {
-          groupHeader.insertBefore(bulletElem, timeContainer);
-        }
-      }
-    } else {
-      groupHeader.appendChild(usageElem);
-      if (hasBullet) {
-        groupHeader.appendChild(bulletElem);
-      }
     }
   }
 }

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -49,16 +49,17 @@ export class UsageSummary {
 
 /**
  * Manages usage display for individual groups.
+ * Simplified implementation that stores usage per group and computes aggregates on-demand.
  */
 export class UsageGroupManager {
   constructor(usageSummary, taskGroupDomManager) {
-    this.usageSummary = usageSummary; // Use the shared instance
+    this.usageSummary = usageSummary;
     this.taskGroups = taskGroupDomManager;
   }
 
   /**
    * Update token and cost usage for a specific group
-   * @param {{ groupId: string, usage?: Object, skipPropagate?: boolean }} payload
+   * @param {{ groupId: string, usage?: Object }} payload
    */
   update(payload) {
     if (!payload || typeof payload !== 'object') {
@@ -66,7 +67,7 @@ export class UsageGroupManager {
       return;
     }
 
-    const { groupId, usage, skipPropagate = false } = payload;
+    const { groupId, usage } = payload;
     if (!groupId) {
       console.error('UsageGroupManager.update: groupId is required');
       return;
@@ -80,6 +81,7 @@ export class UsageGroupManager {
       return;
     }
 
+    // Store usage for this group
     if (usage) {
       const { inputTokens = 0, outputTokens = 0, cost = 0 } = usage;
       group.usage = { inputTokens, outputTokens, cost };
@@ -89,63 +91,91 @@ export class UsageGroupManager {
 
     progressViewState.taskGroups.set(groupId, group);
 
-    const treeItem = this.taskGroups?.groupElements?.get(groupId);
-    if (treeItem instanceof HTMLElement) {
-      this.taskGroups.headerFormatter.render(treeItem, group);
-    }
+    // Update all affected groups in a single pass
+    this._updateAffectedGroups(groupId);
 
-    if (!skipPropagate) {
-      this.propagateUsageToParents(groupId);
-    }
-
-    // Refresh the cumulative summary displayed in the header
+    // Refresh the cumulative summary
     this.usageSummary.update();
   }
 
   /**
-   * Compute aggregated usage for all children of a parent group
+   * Update the UI for this group and all its ancestors
    * @private
    */
-  computeAggregatedUsage(parentId) {
-    const totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
-    const taskGroups = progressViewState.taskGroups.getGroupMap();
-    for (const group of taskGroups.values()) {
-      if (group.parentGroupId === parentId) {
-        if (group.usage) {
-          totals.inputTokens += group.usage.inputTokens || 0;
-          totals.outputTokens += group.usage.outputTokens || 0;
-          totals.cost += group.usage.cost || 0;
-        }
-        const childTotals = this.computeAggregatedUsage(group.id);
-        totals.inputTokens += childTotals.inputTokens;
-        totals.outputTokens += childTotals.outputTokens;
-        totals.cost += childTotals.cost;
-      }
-    }
-    return totals;
-  }
-
-  /**
-   * Propagate usage updates to parent groups
-   * @private
-   */
-  propagateUsageToParents(groupId) {
+  _updateAffectedGroups(groupId) {
     const group = progressViewState.taskGroups.get(groupId);
     if (!group) return;
 
-    // If this group has a parent, update the parent with aggregated usage
-    if (group.parentGroupId) {
-      const totals = this.computeAggregatedUsage(group.parentGroupId);
-      this.update({
-        groupId: group.parentGroupId,
-        usage: totals,
-        skipPropagate: true,
-      });
-      this.propagateUsageToParents(group.parentGroupId);
-    } else {
-      // This is a top-level group, update it with aggregated usage from its children
-      const totals = this.computeAggregatedUsage(groupId);
-      this.update({ groupId, usage: totals, skipPropagate: true });
+    // Get all groups that need updating (this group and all ancestors)
+    const groupsToUpdate = [groupId];
+    let currentId = group.parentGroupId;
+    while (currentId) {
+      groupsToUpdate.push(currentId);
+      const parent = progressViewState.taskGroups.get(currentId);
+      currentId = parent?.parentGroupId;
     }
+
+    // Update each group's display with its computed usage
+    for (const id of groupsToUpdate) {
+      const groupToUpdate = progressViewState.taskGroups.get(id);
+      if (!groupToUpdate) continue;
+
+      // Compute aggregated usage for this group (includes own + all descendants)
+      const aggregatedUsage = this._computeGroupUsage(id);
+
+      // Update the display with aggregated usage
+      const treeItem = this.taskGroups?.groupElements?.get(id);
+      if (treeItem instanceof HTMLElement) {
+        // Temporarily set aggregated usage for rendering
+        const originalUsage = groupToUpdate.usage;
+        groupToUpdate.usage = aggregatedUsage;
+        this.taskGroups.headerFormatter.render(treeItem, groupToUpdate);
+        groupToUpdate.usage = originalUsage; // Restore original
+      }
+    }
+  }
+
+  /**
+   * Compute total usage for a group and all its descendants
+   * @private
+   */
+  _computeGroupUsage(groupId) {
+    const totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
+    const group = progressViewState.taskGroups.get(groupId);
+
+    // Add this group's usage
+    if (group?.usage) {
+      totals.inputTokens += group.usage.inputTokens || 0;
+      totals.outputTokens += group.usage.outputTokens || 0;
+      totals.cost += group.usage.cost || 0;
+    }
+
+    // Add all descendants' usage in a single pass
+    const taskGroups = progressViewState.taskGroups.getGroupMap();
+    const descendants = new Set();
+
+    // Find all descendants
+    const findDescendants = (parentId) => {
+      for (const [id, g] of taskGroups.entries()) {
+        if (g.parentGroupId === parentId && !descendants.has(id)) {
+          descendants.add(id);
+          findDescendants(id);
+        }
+      }
+    };
+
+    findDescendants(groupId);
+
+    // Sum up usage from all descendants
+    for (const descendantId of descendants) {
+      const descendant = taskGroups.get(descendantId);
+      if (descendant?.usage) {
+        totals.inputTokens += descendant.usage.inputTokens || 0;
+        totals.outputTokens += descendant.usage.outputTokens || 0;
+        totals.cost += descendant.usage.cost || 0;
+      }
+    }
+
+    return totals;
   }
 }

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -32,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'missingOutputsDetailsTemplate',
     'latexdiffDetailsTemplate',
     'statisticsDetailsTemplate',
-    'groupHeaderTemplate',
+    'groupDetailsTemplate',
   ]);
   progressViewDomHandler.toolbar.render('workflow');
   progressViewDomHandler.placeholder.show();

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -131,9 +131,17 @@ vscode-tree-item.log-group[branch]:not([open])
   display: none;
 }
 
-/* Spacing for child log entries - let native tree handle indentation */
+/* Indentation for non-tree-item children to match tree hierarchy */
+vscode-tree-item.log-group > [slot='children']:not(vscode-tree-item) {
+  display: block;
+  padding-left: var(--spacing-small);
+  margin-left: var(--spacing-small);
+  border-left: var(--border-thin) dashed
+    var(--vscode-editorGroupHeader-tabsBorder);
+}
+
+/* Spacing for child log entries */
 vscode-tree-item.log-group > [slot='children'].log-line,
 vscode-tree-item.log-group > [slot='children'].banner-details {
-  margin-left: var(--spacing-small);
   margin-bottom: var(--spacing-tiny);
 }

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -7,6 +7,10 @@
 .log-group-tree {
   display: block;
   width: 100%;
+  --vscode-tree-inactiveIndentGuidesStroke: var(
+    --vscode-tree-indentGuidesStroke,
+    var(--vscode-panel-border)
+  );
 }
 
 .log-group-tree vscode-tree-item.log-group {
@@ -14,78 +18,119 @@
   margin-bottom: var(--spacing-tiny);
 }
 
-.log-group-tree vscode-tree-item.log-group > .log-group-header {
-  padding: var(--spacing-tiny) var(--spacing-medium);
-  margin: var(--spacing-tiny) 0;
-  border-radius: var(--border-radius-small);
-  cursor: pointer;
+.log-group-tree vscode-tree-item.log-group::part(content) {
   display: flex;
   align-items: center;
-  background-color: transparent;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) var(--spacing-medium);
+  border-radius: var(--border-radius-small);
   border-left: var(--border-medium) solid var(--vscode-panel-border);
+  background-color: transparent;
+  transition: border-color 120ms ease;
 }
 
-/* Minimal styling for top-level task headers */
-.log-group-tree vscode-tree-item.log-group > .log-group-header.top-level {
-  border-left: var(--border-thin) solid var(--vscode-panel-border);
-  border-right: var(--border-thin) solid var(--vscode-panel-border);
+.log-group-tree vscode-tree-item.log-group.nested::part(content) {
+  border-left-width: var(--border-thin);
 }
 
-.log-group-tree vscode-tree-item.log-group > .log-group-header.running {
+.log-group-tree vscode-tree-item.log-group.running::part(content) {
   border-left-color: var(--vscode-statusBarItem-warningBackground);
 }
 
-.log-group-tree vscode-tree-item.log-group > .log-group-header.error {
+.log-group-tree vscode-tree-item.log-group.error::part(content) {
   border-left-color: var(--vscode-errorForeground);
 }
 
-.log-group-tree vscode-tree-item.log-group > .log-group-header.stopped {
+.log-group-tree vscode-tree-item.log-group.stopped::part(content) {
   border-left-color: var(--vscode-testing-iconPassed);
 }
 
-vscode-tree-item.log-group[branch]:not([expanded]) > [slot='children'] {
-  display: none;
+.log-group-tree vscode-tree-item.log-group.waiting::part(content),
+.log-group-tree vscode-tree-item.log-group.resuming::part(content) {
+  border-left-color: var(
+    --vscode-progressBar-background,
+    var(--vscode-panel-border)
+  );
 }
 
-vscode-tree-item.log-group > [slot='children']:not(vscode-tree-item) {
-  display: block;
-  padding-left: var(--spacing-small);
-  margin-left: var(--spacing-small);
-  border-left: var(--border-thin) dashed
-    var(--vscode-editorGroupHeader-tabsBorder);
+/* Header layout */
+.log-group-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  width: 100%;
+  min-width: 0;
+  --group-usage-order: 1;
+  --group-bullet-order: 2;
+  --group-time-order: 3;
 }
 
-.log-ungrouped {
-  margin-top: var(--spacing-small);
+.log-group-header.top-level {
+  --group-time-order: 1;
+  --group-bullet-order: 2;
+  --group-usage-order: 3;
+  gap: var(--spacing-medium);
 }
 
 .group-status-icon {
-  margin-right: var(--spacing-small);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.group-status-icon .codicon {
+  font-size: 16px;
 }
 
 .group-title {
-  font-weight: bold;
-  flex-grow: 1;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
 }
 
-.group-time {
-  font-size: var(--font-size-sm);
-  opacity: var(--opacity-subtle);
-  margin-left: var(--spacing-small);
+.log-group-header.top-level .group-title {
+  display: none;
 }
 
-.log-group-header.top-level .group-time {
-  flex-grow: 1;
-  margin-left: 0;
+.group-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  margin-left: auto;
 }
 
-.group-start-time,
-.group-duration {
-  margin-right: var(--spacing-small);
+.group-usage {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  order: var(--group-usage-order);
+  white-space: nowrap;
+}
+
+.group-usage i {
+  font-size: inherit;
 }
 
 .group-bullet {
+  order: var(--group-bullet-order);
   margin: 0 var(--spacing-tiny);
+}
+
+.group-time {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  order: var(--group-time-order);
+  font-size: var(--font-size-sm);
+  opacity: var(--opacity-subtle);
+}
+
+.group-duration.is-hidden,
+.group-usage.is-hidden,
+.group-bullet.is-hidden {
+  display: none !important;
 }
 
 /* Use the spin animation defined in base.css */
@@ -93,10 +138,8 @@ vscode-tree-item.log-group > [slot='children']:not(vscode-tree-item) {
   animation: spin 2s linear infinite;
 }
 
-/* Make sure log lines in groups are associated */
-.log-line[data-group-id],
-.banner-details[data-group-id] {
-  border-left: var(--border-medium) solid transparent;
+.log-ungrouped {
+  margin-top: var(--spacing-small);
 }
 
 /* Log lines within a group */
@@ -105,7 +148,7 @@ vscode-tree-item.log-group > [slot='children'].banner-details {
   margin-left: var(--spacing-small);
 }
 
-/* Visual indicator for nested structure (reserved for future use) */
-vscode-tree-item.log-group > .log-group-header::before {
-  display: none;
+.log-line[data-group-id],
+.banner-details[data-group-id] {
+  border-left: var(--border-medium) solid transparent;
 }

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -3,14 +3,10 @@
  * Styling for grouped log entries and hierarchy
  */
 
-/* Log Group Tree */
+/* Log Group Tree - use native indent guides */
 .log-group-tree {
   display: block;
   width: 100%;
-  --vscode-tree-inactiveIndentGuidesStroke: var(
-    --vscode-tree-indentGuidesStroke,
-    var(--vscode-panel-border)
-  );
 }
 
 .log-group-tree vscode-tree-item.log-group {
@@ -18,137 +14,126 @@
   margin-bottom: var(--spacing-tiny);
 }
 
+/* Group content styling using native ::part(content) */
 .log-group-tree vscode-tree-item.log-group::part(content) {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
   padding: var(--spacing-tiny) var(--spacing-medium);
   border-radius: var(--border-radius-small);
-  border-left: var(--border-medium) solid var(--vscode-panel-border);
-  background-color: transparent;
+  border-left: var(--border-medium) solid
+    var(--group-status-color, var(--vscode-panel-border));
   transition: border-color 120ms ease;
 }
 
-.log-group-tree vscode-tree-item.log-group.nested::part(content) {
+/* Nested groups have thinner border */
+.log-group-tree vscode-tree-item.log-group[data-parent]::part(content) {
   border-left-width: var(--border-thin);
 }
 
-.log-group-tree vscode-tree-item.log-group.running::part(content) {
-  border-left-color: var(--vscode-statusBarItem-warningBackground);
+/* Status colors via data attributes */
+.log-group-tree vscode-tree-item.log-group[data-status='running'] {
+  --group-status-color: var(--vscode-statusBarItem-warningBackground);
 }
 
-.log-group-tree vscode-tree-item.log-group.error::part(content) {
-  border-left-color: var(--vscode-errorForeground);
+.log-group-tree vscode-tree-item.log-group[data-status='error'] {
+  --group-status-color: var(--vscode-errorForeground);
 }
 
-.log-group-tree vscode-tree-item.log-group.stopped::part(content) {
-  border-left-color: var(--vscode-testing-iconPassed);
+.log-group-tree vscode-tree-item.log-group[data-status='stopped'] {
+  --group-status-color: var(--vscode-testing-iconPassed);
 }
 
-.log-group-tree vscode-tree-item.log-group.waiting::part(content),
-.log-group-tree vscode-tree-item.log-group.resuming::part(content) {
-  border-left-color: var(
+.log-group-tree vscode-tree-item.log-group[data-status='waiting'],
+.log-group-tree vscode-tree-item.log-group[data-status='resuming'] {
+  --group-status-color: var(
     --vscode-progressBar-background,
     var(--vscode-panel-border)
   );
 }
 
-/* Header layout */
+/* Header layout - simplified with minimal customization */
 .log-group-header {
   display: flex;
   align-items: center;
-  gap: var(--spacing-small);
+  gap: var(--spacing-medium);
   width: 100%;
   min-width: 0;
-  --group-usage-order: 1;
-  --group-bullet-order: 2;
-  --group-time-order: 3;
 }
 
-.log-group-header.top-level {
-  --group-time-order: 1;
-  --group-bullet-order: 2;
-  --group-usage-order: 3;
-  gap: var(--spacing-medium);
-}
-
-.group-status-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-}
-
-.group-status-icon .codicon {
-  font-size: 16px;
-}
-
+/* Title takes available space */
 .group-title {
   font-weight: 600;
   flex: 1;
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.log-group-header.top-level .group-title {
+/* Hide empty titles */
+.group-title:empty {
   display: none;
 }
 
+/* Right-aligned metadata group */
 .group-meta {
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  margin-left: auto;
+  flex-shrink: 0;
 }
 
+/* Usage display */
 .group-usage {
   display: flex;
   align-items: center;
   gap: var(--spacing-tiny);
-  order: var(--group-usage-order);
   white-space: nowrap;
+  font-size: var(--font-size-sm);
 }
 
-.group-usage i {
-  font-size: inherit;
-}
-
+/* Bullet separator */
 .group-bullet {
-  order: var(--group-bullet-order);
   margin: 0 var(--spacing-tiny);
+  opacity: var(--opacity-subtle);
 }
 
+/* Time display */
 .group-time {
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  order: var(--group-time-order);
   font-size: var(--font-size-sm);
   opacity: var(--opacity-subtle);
 }
 
-.group-duration.is-hidden,
-.group-usage.is-hidden,
-.group-bullet.is-hidden {
-  display: none !important;
+/* Hide empty elements */
+.group-duration:empty,
+.group-usage:empty {
+  display: none;
 }
 
-/* Use the spin animation defined in base.css */
+.group-usage:empty + .group-bullet {
+  display: none;
+}
+
+/* Spin animation for status icons */
 .spin {
   animation: spin 2s linear infinite;
 }
 
+/* Ungrouped logs container */
 .log-ungrouped {
   margin-top: var(--spacing-small);
 }
 
-/* Log lines within a group */
+/* Collapse/expand behavior for non-tree-item children (log lines, banners, etc) */
+vscode-tree-item.log-group[branch]:not([open])
+  > [slot='children']:not(vscode-tree-item) {
+  display: none;
+}
+
+/* Spacing for child log entries - let native tree handle indentation */
 vscode-tree-item.log-group > [slot='children'].log-line,
 vscode-tree-item.log-group > [slot='children'].banner-details {
   margin-left: var(--spacing-small);
-}
-
-.log-line[data-group-id],
-.banner-details[data-group-id] {
-  border-left: var(--border-medium) solid transparent;
+  margin-bottom: var(--spacing-tiny);
 }

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -145,3 +145,50 @@ vscode-tree-item.log-group > [slot='children'].log-line,
 vscode-tree-item.log-group > [slot='children'].banner-details {
   margin-bottom: var(--spacing-tiny);
 }
+
+/* Content tree items (Thinking, Scratchpad, Files, Latexdiff) */
+vscode-tree-item.content-item {
+  display: block;
+  margin-bottom: var(--spacing-tiny);
+}
+
+.content-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  width: 100%;
+}
+
+.content-title {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+}
+
+.content-copy {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.content-copy:hover {
+  opacity: 1;
+}
+
+/* Content body styling */
+.content-body {
+  padding: var(--spacing-small);
+  margin-top: var(--spacing-tiny);
+}
+
+.content-body ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.content-body .detail-item {
+  padding: var(--spacing-tiny) 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}

--- a/src/test/replacement/latexForbiddenCommands.test.ts
+++ b/src/test/replacement/latexForbiddenCommands.test.ts
@@ -70,7 +70,8 @@ describe('latex forbidden commands replacements', () => {
   });
 
   it('handles multiple invalid endings in one document', () => {
-    const input = '\\section{A}\n\\end{section}\nText\n\\section{B}\n\\end{section}';
+    const input =
+      '\\section{A}\n\\end{section}\nText\n\\section{B}\n\\end{section}';
     const expected = '\\section{A}\n\nText\n\\section{B}\n';
     const result = applyReplacements(input, LATEX_FORBIDDEN_REPLACEMENTS, {
       processMathUnicode: false,


### PR DESCRIPTION
## Summary
- refactor the progress tree templates to use vscode-tree slots, native indent guides, and refreshed header markup
- update task group rendering to rely on the tree item's `open` state and shared formatter logic for status, timing, and usage
- simplify usage aggregation updates and restyle the log group rows to match the new structure

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_690097b8a4a483249029eb5c928f2f8c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns progress groups with native vscode-tree behavior, converts content (Thinking/Scratchpad/Files/Latexdiff) to tree items, and simplifies usage aggregation and header rendering.
> 
> - **UI/Templates**:
>   - Replace legacy group header with `vscode-tree-item`-based `groupDetailsTemplate`; add `contentTreeItemTemplate` for collapsible content (Thinking/Scratchpad/Files/Latexdiff).
>   - Update `script.js` template validation to include `groupDetailsTemplate`.
> - **Rendering/Formatters**:
>   - Remove `TaskGroupLevel`; add `formatGroupTime` and new `TaskGroupHeaderFormatter.render(...)` to set title, time, duration, usage, and status icons in tree item slots.
>   - Render Thinking/Scratchpad/File list/Latexdiff as `vscode-tree-item.content-item` with copy actions; keep others as details where applicable.
> - **State/Managers**:
>   - `TaskGroupDomManager`: use tree item `open` state, track indent guides/levels, observe `open` attribute, and insert children via `slot="children"` chronologically.
>   - `UsageGroupManager`: store per-group usage and compute aggregated usage on-demand for a group and its ancestors; re-render headers via shared formatter.
>   - `MessageHandlers`: adapt append/update flows for tree items (auto-expand thinking/scratchpad, set root level), add debug warnings.
>   - `DomHandlers`: wire `UsageGroupManager` with `TaskGroupDomManager`.
> - **Styles**:
>   - Refresh group row styles using `::part(content)`, data-status colors, native indent guides, and new content-item layout.
> - **Tests**:
>   - Minor formatting change in LaTeX forbidden commands test input string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57849d84e0949604a1aece3cf954839bfa2cb6b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->