### PR TITLE
Fix progress view agent filter and reposition session controls

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -131,13 +131,22 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       ELEMENT_IDS.AGENT_FILTER_CONTAINER,
     );
     if (radioGroup) {
-      radioGroup.value = state.agentTypeFilter;
+      if (typeof radioGroup.value === 'string') {
+        radioGroup.value = state.agentTypeFilter;
+      }
       // Also update the checked state on individual radio buttons
       radioGroup.querySelectorAll('vscode-radio').forEach((radio) => {
-        const isActive = radio.value === state.agentTypeFilter;
-        radio.checked = isActive;
-        radio.setAttribute('aria-checked', isActive ? 'true' : 'false');
+        if (!(radio instanceof HTMLElement)) {
+          return;
+        }
+        const radioValue =
+          radio.getAttribute('value') || radio.value || radio.dataset?.value;
+        const isActive = radioValue === state.agentTypeFilter;
+        if ('checked' in radio) {
+          radio.checked = isActive;
+        }
         radio.toggleAttribute('checked', isActive);
+        radio.setAttribute('aria-checked', isActive ? 'true' : 'false');
       });
     }
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -117,14 +117,33 @@ export class EventsManager {
     if (radioGroup) {
       const attachRadioListener = () => {
         addEventListenerSafely(radioGroup, 'change', (event) => {
-          const target = event?.target;
-          const filter =
-            typeof target?.value === 'string' && target.value
-              ? target.value
-              : radioGroup.value;
+          const composedPath =
+            typeof event?.composedPath === 'function'
+              ? event.composedPath()
+              : [];
+          /** @type {HTMLElement | undefined} */
+          const radioFromPath = composedPath.find(
+            (el) => el?.tagName?.toLowerCase?.() === 'vscode-radio',
+          );
+          const fallbackRadio = radioGroup.querySelector(
+            'vscode-radio[checked]',
+          );
+          const selectedRadio = radioFromPath || fallbackRadio;
+
+          let filter = '';
+          if (selectedRadio instanceof HTMLElement) {
+            filter =
+              selectedRadio.getAttribute('value') || selectedRadio.value || '';
+          }
+
+          if (!filter && typeof radioGroup.value === 'string') {
+            filter = radioGroup.value;
+          }
+
           if (!filter) {
             return;
           }
+
           if (progressViewState.agentTypeFilter !== filter) {
             progressViewState.agentTypeFilter = filter;
             // Persist the new selection immediately so updates don't snap back

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -368,25 +368,52 @@
         </div>
         <div class="instruction-box">
           <div class="instruction-header">
-            <div class="dropdown-container">
-              <span
-                id="toggleToolConfig"
-                class="tool-toggle"
-                title="Tool configuration options"
-              >
-                <i class="codicon codicon-chevron-down"></i>
-              </span>
-              <div
-                id="toolConfigOptions"
-                class="dropdown-options"
-                style="display: none"
-              >
-                <vscode-checkbox id="attachTeXCount"
-                  >Attach TeX Count</vscode-checkbox
+            <div class="instruction-header-left">
+              <div class="dropdown-container">
+                <span
+                  id="toggleToolConfig"
+                  class="tool-toggle"
+                  title="Tool configuration options"
                 >
-                <vscode-checkbox id="attachDiagnostics"
-                  >Attach Diagnostics</vscode-checkbox
+                  <i class="codicon codicon-chevron-down"></i>
+                </span>
+                <div
+                  id="toolConfigOptions"
+                  class="dropdown-options"
+                  style="display: none"
                 >
+                  <vscode-checkbox id="attachTeXCount"
+                    >Attach TeX Count</vscode-checkbox
+                  >
+                  <vscode-checkbox id="attachDiagnostics"
+                    >Attach Diagnostics</vscode-checkbox
+                  >
+                </div>
+              </div>
+              <div class="session-type-toggle">
+                <input type="hidden" id="sessionType" value="workflow" />
+                <vscode-radio-group
+                  id="sessionTypeToggle"
+                  aria-label="Choose the session type"
+                  orientation="horizontal"
+                  value="workflow"
+                >
+                  <vscode-radio
+                    value="workflow"
+                    data-session-type="workflow"
+                    checked
+                    title="Workflow agents automate document editing tasks"
+                  >
+                    Workflow
+                  </vscode-radio>
+                  <vscode-radio
+                    value="toolUse"
+                    data-session-type="toolUse"
+                    title="Tool-use agents execute commands and scripts"
+                  >
+                    Tool Use
+                  </vscode-radio>
+                </vscode-radio-group>
               </div>
             </div>
             <vscode-toolbar-container class="instruction-header-actions">
@@ -445,29 +472,6 @@
                   title="Agent settings"
                 ></i>
                 <div class="agent-select-controls">
-                  <input type="hidden" id="sessionType" value="workflow" />
-                  <vscode-radio-group
-                    id="sessionTypeToggle"
-                    aria-label="Choose the session type"
-                    orientation="horizontal"
-                    value="workflow"
-                  >
-                    <vscode-radio
-                      value="workflow"
-                      data-session-type="workflow"
-                      checked
-                      title="Workflow agents automate document editing tasks"
-                    >
-                      Workflow
-                    </vscode-radio>
-                    <vscode-radio
-                      value="toolUse"
-                      data-session-type="toolUse"
-                      title="Tool-use agents execute commands and scripts"
-                    >
-                      Tool Use
-                    </vscode-radio>
-                  </vscode-radio-group>
                   <div class="agent-select-dropdowns">
                     <vscode-single-select
                       id="workflowAgent"

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -6,9 +6,9 @@
 /* Model Selection Footer styles */
 .model-selection-footer {
   display: flex;
+  flex-direction: column;
   gap: var(--spacing-small);
-  align-items: center;
-  flex-wrap: nowrap;
+  align-items: flex-start;
   flex: 1 1 auto;
   min-width: 0;
 }
@@ -17,32 +17,31 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 0 1 auto;
-  min-width: 0;
-}
-
-.model-selection-footer .agent-select-group {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
   flex: 1 1 auto;
   min-width: 0;
 }
 
+.model-selection-footer .agent-select-group {
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  gap: var(--spacing-small);
+}
+
 .agent-select-controls {
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: var(--spacing-small);
-  flex: 0 0 auto;
+  width: 100%;
   min-width: 0;
 }
 
 .agent-select-dropdowns {
   position: relative;
-  flex: 0 1 auto;
-  min-width: 10rem;
-  max-width: 16rem;
+  width: 100%;
+  min-width: 0;
+  max-width: 20rem;
 }
 
 .agent-select-dropdowns select,
@@ -70,10 +69,10 @@
 
 .model-selection-footer .select-group select,
 .model-selection-footer .select-group vscode-single-select {
-  flex: 0 1 auto;
-  width: auto;
-  min-width: 6.4rem;
-  max-width: 9.6rem;
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  max-width: 20rem;
   height: var(--height-control);
   font-size: var(--font-size);
   padding: var(--spacing-tiny) var(--spacing-small);

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -23,19 +23,34 @@
 
 .instruction-controls {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: var(--spacing-small);
-  flex-wrap: nowrap;
+  gap: var(--spacing-medium);
+  flex-wrap: wrap;
   width: 100%;
 }
 
 .instruction-header {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
+  gap: var(--spacing-medium);
   margin-bottom: var(--spacing-small);
   line-height: 1.5;
+  flex-wrap: wrap;
+}
+
+.instruction-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  flex-wrap: wrap;
+}
+
+.session-type-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
 }
 
 #executeButton {


### PR DESCRIPTION
## Summary
- restore the progress view agent filter change handling to work with native `vscode-radio` events
- keep the radio buttons in sync when the extension updates the active filter selection
- move the session type toggle into the instruction header and stack the agent/model selectors along the lower-left edge of the instruction box

## Testing
- npm run lint
- npm run compile
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_6900a302b2348324b35fe0a27df5ced3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores functional agent filter radio handling and moves the session type toggle into the instruction header with updated responsive layout.
> 
> - **Progress View**:
>   - **Agent Filter**: Reworks `vscode-radio` change handling to use `composedPath()` and correctly derive selected values; syncs radio group and individual `vscode-radio` states (including `checked`/`aria-checked`) in `messageHandlers.js` and `EventsManager.js`.
>   - **Active Stream Display**: Chooses a valid `activeStream` from filtered streams before updating tabs and status.
> - **UI/Layout**:
>   - **Session Controls**: Moves `sessionTypeToggle` from footer controls into the instruction header (`index.html`), introducing `.instruction-header-left` and `.session-type-toggle` wrappers.
>   - **Styling**: Updates `footer.css` and `instruction-box.css` to stack agent/model selectors vertically, improve wrapping, and align elements for responsive layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18e4e8e716e7cc263be7450f801404a87198878b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->