### PR TITLE
Fix session toggle handling and reposition instruction controls

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -370,27 +370,57 @@
         </div>
         <div class="instruction-box">
           <div class="instruction-header">
-            <div class="dropdown-container">
-              <vscode-toolbar-button
-                id="toggleToolConfig"
-                icon="tools"
-                title="Tool configuration options"
-                toggleable
-                aria-haspopup="true"
-                aria-expanded="false"
-              >
-                <i class="codicon codicon-chevron-down"></i>
-              </vscode-toolbar-button>
-              <vscode-context-menu id="toolConfigOptions" class="dropdown-menu">
-                <div class="dropdown-menu-content">
-                  <vscode-checkbox id="attachTeXCount"
-                    >Attach TeX Count</vscode-checkbox
+            <div class="instruction-header-leading">
+              <div class="instruction-session-toggle">
+                <input type="hidden" id="sessionType" value="workflow" />
+                <vscode-radio-group
+                  id="sessionTypeToggle"
+                  aria-label="Choose the session type"
+                  orientation="horizontal"
+                  value="workflow"
+                >
+                  <vscode-radio
+                    value="workflow"
+                    data-session-type="workflow"
+                    checked
+                    title="Workflow agents automate document editing tasks"
                   >
-                  <vscode-checkbox id="attachDiagnostics"
-                    >Attach Diagnostics</vscode-checkbox
+                    Workflow
+                  </vscode-radio>
+                  <vscode-radio
+                    value="toolUse"
+                    data-session-type="toolUse"
+                    title="Tool-use agents execute commands and scripts"
                   >
-                </div>
-              </vscode-context-menu>
+                    Tool Use
+                  </vscode-radio>
+                </vscode-radio-group>
+              </div>
+              <div class="dropdown-container">
+                <vscode-toolbar-button
+                  id="toggleToolConfig"
+                  icon="tools"
+                  title="Tool configuration options"
+                  toggleable
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  <i class="codicon codicon-chevron-down"></i>
+                </vscode-toolbar-button>
+                <vscode-context-menu
+                  id="toolConfigOptions"
+                  class="dropdown-menu"
+                >
+                  <div class="dropdown-menu-content">
+                    <vscode-checkbox id="attachTeXCount"
+                      >Attach TeX Count</vscode-checkbox
+                    >
+                    <vscode-checkbox id="attachDiagnostics"
+                      >Attach Diagnostics</vscode-checkbox
+                    >
+                  </div>
+                </vscode-context-menu>
+              </div>
             </div>
             <vscode-toolbar-container class="instruction-header-actions">
               <vscode-toolbar-button
@@ -448,29 +478,6 @@
                   title="Agent settings"
                 ></i>
                 <div class="agent-select-controls">
-                  <input type="hidden" id="sessionType" value="workflow" />
-                  <vscode-radio-group
-                    id="sessionTypeToggle"
-                    aria-label="Choose the session type"
-                    orientation="horizontal"
-                    value="workflow"
-                  >
-                    <vscode-radio
-                      value="workflow"
-                      data-session-type="workflow"
-                      checked
-                      title="Workflow agents automate document editing tasks"
-                    >
-                      Workflow
-                    </vscode-radio>
-                    <vscode-radio
-                      value="toolUse"
-                      data-session-type="toolUse"
-                      title="Tool-use agents execute commands and scripts"
-                    >
-                      Tool Use
-                    </vscode-radio>
-                  </vscode-radio-group>
                   <div class="agent-select-dropdowns">
                     <vscode-single-select
                       id="workflowAgent"

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -79,6 +79,31 @@
                   title="Primary files the agent processes, such as .tex, .txt, or .md"
                   >Input</label
                 >
+                <div class="dropdown-container dropdown-left">
+                  <vscode-toolbar-button
+                    id="toggleToolConfig"
+                    icon="tools"
+                    title="Tool configuration options"
+                    toggleable
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                  >
+                    <i class="codicon codicon-chevron-down"></i>
+                  </vscode-toolbar-button>
+                  <vscode-context-menu
+                    id="toolConfigOptions"
+                    class="dropdown-menu"
+                  >
+                    <div class="dropdown-menu-content">
+                      <vscode-checkbox id="attachTeXCount"
+                        >Attach TeX Count</vscode-checkbox
+                      >
+                      <vscode-checkbox id="attachDiagnostics"
+                        >Attach Diagnostics</vscode-checkbox
+                      >
+                    </div>
+                  </vscode-context-menu>
+                </div>
               </div>
               <vscode-toolbar-container class="file-select-actions">
                 <vscode-toolbar-button
@@ -201,31 +226,6 @@
                   title="Supporting files required for correct processing, including .cls, .sty, .bib"
                   >Auxiliary</label
                 >
-                <div class="dropdown-container dropdown-left">
-                  <vscode-toolbar-button
-                    id="toggleToolConfig"
-                    icon="tools"
-                    title="Tool configuration options"
-                    toggleable
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                  >
-                    <i class="codicon codicon-chevron-down"></i>
-                  </vscode-toolbar-button>
-                  <vscode-context-menu
-                    id="toolConfigOptions"
-                    class="dropdown-menu"
-                  >
-                    <div class="dropdown-menu-content">
-                      <vscode-checkbox id="attachTeXCount"
-                        >Attach TeX Count</vscode-checkbox
-                      >
-                      <vscode-checkbox id="attachDiagnostics"
-                        >Attach Diagnostics</vscode-checkbox
-                      >
-                    </div>
-                  </vscode-context-menu>
-                </div>
               </div>
               <vscode-toolbar-container class="file-select-actions">
                 <vscode-toolbar-button

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -396,31 +396,6 @@
                   </vscode-radio>
                 </vscode-radio-group>
               </div>
-              <div class="dropdown-container">
-                <vscode-toolbar-button
-                  id="toggleToolConfig"
-                  icon="tools"
-                  title="Tool configuration options"
-                  toggleable
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                >
-                  <i class="codicon codicon-chevron-down"></i>
-                </vscode-toolbar-button>
-                <vscode-context-menu
-                  id="toolConfigOptions"
-                  class="dropdown-menu"
-                >
-                  <div class="dropdown-menu-content">
-                    <vscode-checkbox id="attachTeXCount"
-                      >Attach TeX Count</vscode-checkbox
-                    >
-                    <vscode-checkbox id="attachDiagnostics"
-                      >Attach Diagnostics</vscode-checkbox
-                    >
-                  </div>
-                </vscode-context-menu>
-              </div>
             </div>
             <vscode-toolbar-container class="instruction-header-actions">
               <vscode-toolbar-button
@@ -512,6 +487,28 @@
                   ${modelOptions}
                 </vscode-single-select>
               </div>
+            </div>
+            <div class="dropdown-container">
+              <vscode-toolbar-button
+                id="toggleToolConfig"
+                icon="tools"
+                title="Tool configuration options"
+                toggleable
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
+                <i class="codicon codicon-chevron-down"></i>
+              </vscode-toolbar-button>
+              <vscode-context-menu id="toolConfigOptions" class="dropdown-menu">
+                <div class="dropdown-menu-content">
+                  <vscode-checkbox id="attachTeXCount"
+                    >Attach TeX Count</vscode-checkbox
+                  >
+                  <vscode-checkbox id="attachDiagnostics"
+                    >Attach Diagnostics</vscode-checkbox
+                  >
+                </div>
+              </vscode-context-menu>
             </div>
             <vscode-button
               id="executeButton"

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -201,6 +201,31 @@
                   title="Supporting files required for correct processing, including .cls, .sty, .bib"
                   >Auxiliary</label
                 >
+                <div class="dropdown-container dropdown-left">
+                  <vscode-toolbar-button
+                    id="toggleToolConfig"
+                    icon="tools"
+                    title="Tool configuration options"
+                    toggleable
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                  >
+                    <i class="codicon codicon-chevron-down"></i>
+                  </vscode-toolbar-button>
+                  <vscode-context-menu
+                    id="toolConfigOptions"
+                    class="dropdown-menu"
+                  >
+                    <div class="dropdown-menu-content">
+                      <vscode-checkbox id="attachTeXCount"
+                        >Attach TeX Count</vscode-checkbox
+                      >
+                      <vscode-checkbox id="attachDiagnostics"
+                        >Attach Diagnostics</vscode-checkbox
+                      >
+                    </div>
+                  </vscode-context-menu>
+                </div>
               </div>
               <vscode-toolbar-container class="file-select-actions">
                 <vscode-toolbar-button
@@ -437,38 +462,6 @@
                 title="Erase Instruction"
               ></vscode-toolbar-button>
             </vscode-toolbar-container>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="instruction">Instruction</label>
-                <div class="dropdown-container dropdown-left">
-                  <vscode-toolbar-button
-                    id="toggleToolConfig"
-                    icon="tools"
-                    title="Tool configuration options"
-                    toggleable
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                  >
-                    <i class="codicon codicon-chevron-down"></i>
-                  </vscode-toolbar-button>
-                  <vscode-context-menu
-                    id="toolConfigOptions"
-                    class="dropdown-menu"
-                  >
-                    <div class="dropdown-menu-content">
-                      <vscode-checkbox id="attachTeXCount"
-                        >Attach TeX Count</vscode-checkbox
-                      >
-                      <vscode-checkbox id="attachDiagnostics"
-                        >Attach Diagnostics</vscode-checkbox
-                      >
-                    </div>
-                  </vscode-context-menu>
-                </div>
-              </div>
-            </div>
           </div>
           <vscode-textarea
             id="instruction"

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -438,6 +438,38 @@
               ></vscode-toolbar-button>
             </vscode-toolbar-container>
           </div>
+          <div class="file-select">
+            <div class="file-select-header">
+              <div class="file-select-label-group">
+                <label for="instruction">Instruction</label>
+                <div class="dropdown-container dropdown-left">
+                  <vscode-toolbar-button
+                    id="toggleToolConfig"
+                    icon="tools"
+                    title="Tool configuration options"
+                    toggleable
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                  >
+                    <i class="codicon codicon-chevron-down"></i>
+                  </vscode-toolbar-button>
+                  <vscode-context-menu
+                    id="toolConfigOptions"
+                    class="dropdown-menu"
+                  >
+                    <div class="dropdown-menu-content">
+                      <vscode-checkbox id="attachTeXCount"
+                        >Attach TeX Count</vscode-checkbox
+                      >
+                      <vscode-checkbox id="attachDiagnostics"
+                        >Attach Diagnostics</vscode-checkbox
+                      >
+                    </div>
+                  </vscode-context-menu>
+                </div>
+              </div>
+            </div>
+          </div>
           <vscode-textarea
             id="instruction"
             rows="10"
@@ -487,28 +519,6 @@
                   ${modelOptions}
                 </vscode-single-select>
               </div>
-            </div>
-            <div class="dropdown-container">
-              <vscode-toolbar-button
-                id="toggleToolConfig"
-                icon="tools"
-                title="Tool configuration options"
-                toggleable
-                aria-haspopup="true"
-                aria-expanded="false"
-              >
-                <i class="codicon codicon-chevron-down"></i>
-              </vscode-toolbar-button>
-              <vscode-context-menu id="toolConfigOptions" class="dropdown-menu">
-                <div class="dropdown-menu-content">
-                  <vscode-checkbox id="attachTeXCount"
-                    >Attach TeX Count</vscode-checkbox
-                  >
-                  <vscode-checkbox id="attachDiagnostics"
-                    >Attach Diagnostics</vscode-checkbox
-                  >
-                </div>
-              </vscode-context-menu>
             </div>
             <vscode-button
               id="executeButton"

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -415,9 +415,9 @@
                   <vscode-radio
                     value="toolUse"
                     data-session-type="toolUse"
-                    title="Tool-use agents execute commands and scripts"
+                    title="Chat agents execute commands and scripts"
                   >
-                    Tool Use
+                    Chat
                   </vscode-radio>
                 </vscode-radio-group>
               </div>

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -277,10 +277,6 @@ export class MainViewState {
     if (toggleContainer) {
       const radioGroup = resolveRadioGroup(toggleContainer);
       if (radioGroup instanceof HTMLElement) {
-        if (typeof radioGroup.value === 'string') {
-          radioGroup.value = normalized;
-        }
-
         const radios = radioGroup.querySelectorAll('vscode-radio');
         radios.forEach((radio) => {
           if (!(radio instanceof HTMLElement)) {

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -278,6 +278,11 @@ export class SettingsButtonManager extends BaseUIManager {
           return undefined;
         }
 
+        /**
+         * Extract session type from a radio element
+         * @param {HTMLElement} radio - The radio button element
+         * @returns {string|undefined} The session type or undefined if not found
+         */
         const findSessionType = (radio) => {
           if (!(radio instanceof HTMLElement)) {
             return undefined;
@@ -290,19 +295,18 @@ export class SettingsButtonManager extends BaseUIManager {
             : undefined;
         };
 
-        const checkedRadio =
-          radios.find((radio) => {
-            if (!(radio instanceof HTMLElement)) {
-              return false;
-            }
-            const hasCheckedProperty =
-              'checked' in radio && Boolean(radio.checked);
-            return (
-              hasCheckedProperty ||
-              radio.hasAttribute('checked') ||
-              radio.getAttribute('aria-checked') === 'true'
-            );
-          }) ?? null;
+        const checkedRadio = radios.find((radio) => {
+          if (!(radio instanceof HTMLElement)) {
+            return false;
+          }
+          const hasCheckedProperty =
+            'checked' in radio && Boolean(radio.checked);
+          return (
+            hasCheckedProperty ||
+            radio.hasAttribute('checked') ||
+            radio.getAttribute('aria-checked') === 'true'
+          );
+        });
 
         if (checkedRadio) {
           return findSessionType(checkedRadio);

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -269,14 +269,46 @@ export class SettingsButtonManager extends BaseUIManager {
        * @returns {string|undefined} The session type, or undefined if not found
        */
       const getSessionTypeFromGroup = (group) => {
-        if (
-          !(group instanceof HTMLElement) ||
-          typeof group.value !== 'string' ||
-          group.value.length === 0
-        ) {
+        if (!(group instanceof HTMLElement)) {
           return undefined;
         }
-        return group.value;
+
+        const radios = Array.from(group.querySelectorAll('vscode-radio'));
+        if (radios.length === 0) {
+          return undefined;
+        }
+
+        const findSessionType = (radio) => {
+          if (!(radio instanceof HTMLElement)) {
+            return undefined;
+          }
+
+          const sessionType =
+            radio.dataset.sessionType || radio.getAttribute('value');
+          return sessionType && sessionType.length > 0
+            ? sessionType
+            : undefined;
+        };
+
+        const checkedRadio =
+          radios.find((radio) => {
+            if (!(radio instanceof HTMLElement)) {
+              return false;
+            }
+            const hasCheckedProperty =
+              'checked' in radio && Boolean(radio.checked);
+            return (
+              hasCheckedProperty ||
+              radio.hasAttribute('checked') ||
+              radio.getAttribute('aria-checked') === 'true'
+            );
+          }) ?? null;
+
+        if (checkedRadio) {
+          return findSessionType(checkedRadio);
+        }
+
+        return findSessionType(radios[0]);
       };
 
       const radioGroup = resolveRadioGroup(toggleContainer);
@@ -290,8 +322,20 @@ export class SettingsButtonManager extends BaseUIManager {
           );
         }
 
-        this.addListener(radioGroup, 'change', () => {
-          const sessionType = getSessionTypeFromGroup(radioGroup);
+        this.addListener(radioGroup, 'change', (event) => {
+          let sessionType;
+          const target = event?.target;
+          if (target instanceof HTMLElement) {
+            const isRadio = target.tagName.toLowerCase() === 'vscode-radio';
+            if (isRadio) {
+              sessionType =
+                target.dataset.sessionType || target.getAttribute('value');
+            }
+          }
+
+          if (!sessionType) {
+            sessionType = getSessionTypeFromGroup(radioGroup);
+          }
           if (!sessionType) {
             return;
           }

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -24,8 +24,8 @@
   align-items: center;
   gap: var(--spacing-small);
   flex: 0 1 auto;
-  min-width: 10rem;
-  max-width: 14rem;
+  min-width: 8rem;
+  max-width: 12rem;
 }
 
 .agent-select-dropdowns {
@@ -40,8 +40,8 @@
 
 .model-selection-footer .select-group select,
 .model-selection-footer .select-group vscode-single-select {
-  min-width: 6.4rem;
-  max-width: 9.6rem;
+  min-width: 5rem;
+  max-width: 8rem;
 }
 
 .agent-select--hidden {

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -25,7 +25,7 @@
   gap: var(--spacing-small);
   flex: 1;
   min-width: 10rem;
-  max-width: 18rem;
+  max-width: 16rem;
 }
 
 .agent-select-dropdowns {
@@ -40,8 +40,8 @@
 
 .model-selection-footer .select-group select,
 .model-selection-footer .select-group vscode-single-select {
-  min-width: 8rem;
-  max-width: 18rem;
+  min-width: 6.4rem;
+  max-width: 9.6rem;
 }
 
 .agent-select--hidden {

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -6,56 +6,42 @@
 /* Model Selection Footer styles */
 .model-selection-footer {
   display: flex;
-  flex-direction: column;
   gap: var(--spacing-small);
-  align-items: flex-start;
-  flex-wrap: nowrap;
-  flex: 1 1 auto;
-  min-width: 0;
+  flex: 1;
 }
 
-.model-selection-footer .select-group {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  flex: 1 1 100%;
-  min-width: 0;
-}
-
+.model-selection-footer .select-group,
 .model-selection-footer .agent-select-group {
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 1 1 100%;
-  min-width: 0;
+  flex: 1;
 }
 
-.agent-select-controls {
+.agent-select-controls,
+.agent-select-dropdowns {
   display: flex;
-  flex-direction: row;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 1 1 100%;
-  min-width: 0;
+  flex: 1;
+  min-width: 10rem;
+  max-width: 18rem;
 }
 
 .agent-select-dropdowns {
   position: relative;
-  flex: 1 1 auto;
-  min-width: 10rem;
-  max-width: 18rem;
-  width: 100%;
 }
 
 .agent-select-dropdowns select,
-.agent-select-dropdowns vscode-single-select {
-  width: 100%;
-  min-width: 0;
-}
-
+.agent-select-dropdowns vscode-single-select,
 .agent-select {
   width: 100%;
-  min-width: 0;
+}
+
+.model-selection-footer .select-group select,
+.model-selection-footer .select-group vscode-single-select {
+  min-width: 8rem;
+  max-width: 18rem;
 }
 
 .agent-select--hidden {
@@ -67,20 +53,4 @@
 
 .agent-select--active {
   position: relative;
-  visibility: visible;
-}
-
-.model-selection-footer .select-group select,
-.model-selection-footer .select-group vscode-single-select {
-  flex: 1 1 auto;
-  width: 100%;
-  min-width: 6.4rem;
-  max-width: 18rem;
-  height: var(--height-control);
-  font-size: var(--font-size);
-  padding: var(--spacing-tiny) var(--spacing-small);
-}
-
-.model-selection-footer .codicon {
-  margin-right: var(--spacing-small);
 }

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -6,8 +6,9 @@
 /* Model Selection Footer styles */
 .model-selection-footer {
   display: flex;
+  flex-direction: column;
   gap: var(--spacing-small);
-  align-items: center;
+  align-items: flex-start;
   flex-wrap: nowrap;
   flex: 1 1 auto;
   min-width: 0;
@@ -17,7 +18,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 0 1 auto;
+  flex: 1 1 100%;
   min-width: 0;
 }
 
@@ -25,7 +26,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 1 1 auto;
+  flex: 1 1 100%;
   min-width: 0;
 }
 
@@ -34,15 +35,16 @@
   flex-direction: row;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 0 0 auto;
+  flex: 1 1 100%;
   min-width: 0;
 }
 
 .agent-select-dropdowns {
   position: relative;
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   min-width: 10rem;
-  max-width: 16rem;
+  max-width: 18rem;
+  width: 100%;
 }
 
 .agent-select-dropdowns select,
@@ -70,10 +72,10 @@
 
 .model-selection-footer .select-group select,
 .model-selection-footer .select-group vscode-single-select {
-  flex: 0 1 auto;
-  width: auto;
+  flex: 1 1 auto;
+  width: 100%;
   min-width: 6.4rem;
-  max-width: 9.6rem;
+  max-width: 18rem;
   height: var(--height-control);
   font-size: var(--font-size);
   padding: var(--spacing-tiny) var(--spacing-small);

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -19,6 +19,12 @@
   flex: 0 1 auto;
 }
 
+.model-selection-footer .codicon {
+  display: flex;
+  align-items: center;
+  line-height: 1;
+}
+
 .agent-select-controls,
 .agent-select-dropdowns {
   display: flex;

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -6,6 +6,7 @@
 /* Model Selection Footer styles */
 .model-selection-footer {
   display: flex;
+  align-items: center;
   gap: var(--spacing-small);
   flex: 0 1 auto;
 }

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -7,7 +7,7 @@
 .model-selection-footer {
   display: flex;
   gap: var(--spacing-small);
-  flex: 1;
+  flex: 0 1 auto;
 }
 
 .model-selection-footer .select-group,
@@ -15,7 +15,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 1;
+  flex: 0 1 auto;
 }
 
 .agent-select-controls,
@@ -23,9 +23,9 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-small);
-  flex: 1;
+  flex: 0 1 auto;
   min-width: 10rem;
-  max-width: 16rem;
+  max-width: 14rem;
 }
 
 .agent-select-dropdowns {

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -23,7 +23,7 @@
 
 .instruction-controls {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: var(--spacing-small);
   flex-wrap: wrap;

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -23,19 +23,39 @@
 
 .instruction-controls {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
   gap: var(--spacing-small);
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   width: 100%;
 }
 
 .instruction-header {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
+  gap: var(--spacing-medium);
   margin-bottom: var(--spacing-small);
   line-height: 1.5;
+  flex-wrap: wrap;
+}
+
+.instruction-header-leading {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-medium);
+  flex-wrap: wrap;
+}
+
+.instruction-session-toggle {
+  display: flex;
+  align-items: center;
+}
+
+.instruction-session-toggle vscode-radio-group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-small);
 }
 
 #executeButton {

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -63,6 +63,7 @@
   margin-left: var(--spacing-small);
   flex-shrink: 0;
   min-width: 3rem;
+  align-self: center;
 }
 
 /* Recording button states - icon change is enough, no red background needed */


### PR DESCRIPTION
## Summary
- update the session type radio handling to read the checked element from the native vscode-radio-group so changes fire correctly
- move the session type selector into the instruction header, relocate the agent/model selectors to the footer, and refresh the accompanying layout styles

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6900cb0ca68c8324a0e29806bfc504cf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Repositions the session selector to the instruction header, moves agent/model pickers to the footer, adds a tool-config dropdown to Input, and fixes radio-group change handling with layout/style tweaks.
> 
> - **UI layout**:
>   - Move `sessionTypeToggle` radios into instruction header; relocate agent and model selectors to the footer area.
>   - Add tool configuration dropdown (`toggleToolConfig` + `toolConfigOptions`) near `Input` with checkboxes `attachTeXCount` and `attachDiagnostics`.
> - **Behavior**:
>   - Update session handling to derive the checked radio from `vscode-radio-group` and events; set per-radio `checked`/`aria-checked` instead of using `value`.
>   - Improve session selection change logic in `SettingsButtonManager` and `mainViewState.applySessionType`, including fallback resolution and accessibility attributes.
> - **Styles**:
>   - Adjust `instruction-box.css` and `footer.css` for wrapping, spacing, and widths of controls; align `executeButton` and agent/model dropdowns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 710920deaa4918a93cdcae3d40bea1a30a9d01ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->