### PR TITLE
Revert progress view tree migration

### DIFF
--- a/src/common/modules/RecordingButtonManager.js
+++ b/src/common/modules/RecordingButtonManager.js
@@ -61,9 +61,12 @@ export class RecordingButtonManager {
       tagName === 'vscode-button' || tagName === 'vscode-toolbar-button';
 
     if (isVsCodeButton) {
-      this.button.icon = iconName;
+      this.button.setAttribute('icon', iconName);
       if (tagName === 'vscode-button') {
         this.button.iconOnly = true;
+      }
+      if (tagName === 'vscode-toolbar-button') {
+        this.button.setAttribute('label', title);
       }
       this.button.setAttribute('aria-label', title);
       this.button.title = title;

--- a/src/common/modules/RecordingButtonManager.js
+++ b/src/common/modules/RecordingButtonManager.js
@@ -61,12 +61,9 @@ export class RecordingButtonManager {
       tagName === 'vscode-button' || tagName === 'vscode-toolbar-button';
 
     if (isVsCodeButton) {
-      this.button.setAttribute('icon', iconName);
+      this.button.icon = iconName;
       if (tagName === 'vscode-button') {
         this.button.iconOnly = true;
-      }
-      if (tagName === 'vscode-toolbar-button') {
-        this.button.setAttribute('label', title);
       }
       this.button.setAttribute('aria-label', title);
       this.button.title = title;

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -248,7 +248,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const filter: AgentTypeFilter = isAgentTypeFilter(requestedFilter)
       ? requestedFilter
       : 'all';
-    console.log(`[handleFilterStreams] Changing filter to: ${filter}`);
     this.provider.state.agentTypeFilter = filter;
     this.provider.updateWebview();
   }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -179,6 +179,18 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleDeleteAll(message: any): Promise<void> {
+    // Show confirmation dialog
+    const confirmation = await vscode.window.showWarningMessage(
+      'Are you sure you want to delete all streams? This action cannot be undone.',
+      { modal: true },
+      'Delete All',
+      'Cancel',
+    );
+
+    if (confirmation !== 'Delete All') {
+      return;
+    }
+
     // Delete all persisted session data
     const allStates = this.provider.state.getAllTaskStates();
     for (const [stream] of allStates) {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -178,7 +178,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     this.provider.updateWebview();
   }
 
-  private async handleDeleteAll(message: any): Promise<void> {
+  private async handleDeleteAll(_message: any): Promise<void> {
     // Show confirmation dialog
     const confirmation = await vscode.window.showWarningMessage(
       'Are you sure you want to delete all streams? This action cannot be undone.',
@@ -248,6 +248,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const filter: AgentTypeFilter = isAgentTypeFilter(requestedFilter)
       ? requestedFilter
       : 'all';
+    console.log(`[handleFilterStreams] Changing filter to: ${filter}`);
     this.provider.state.agentTypeFilter = filter;
     this.provider.updateWebview();
   }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -117,9 +117,15 @@ export class ProgressEventHandler {
 
     const taskState = this.state.getTaskState(stream);
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
+    const sessionKindHint = this.state.getSessionKindHint(stream);
+    const sessionKind = taskState?.session?.agentCategory ?? sessionKindHint;
 
     if (instructionUpdate) {
-      this.webviewUpdater.updateInstruction(stream, instructionUpdate);
+      this.webviewUpdater.updateInstruction(
+        stream,
+        instructionUpdate,
+        sessionKind,
+      );
     } else {
       this.webviewUpdater.clearInstruction(stream);
     }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -371,7 +371,7 @@
                 >Workflow</vscode-radio
               >
               <vscode-radio id="filterToolBtn" value="toolUse"
-                >Tool Use</vscode-radio
+                >Chat</vscode-radio
               >
             </vscode-radio-group>
             <vscode-toolbar-container id="sortButtons">

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -112,7 +112,7 @@
                   id="instructionCopyBtn"
                   class="instruction-panel__copy"
                   icon="copy"
-                  title="Copy instruction"
+                  label="Copy instruction"
                   data-default-title="Copy instruction"
                   data-success-title="Copied!"
                 ></vscode-toolbar-button>
@@ -123,7 +123,6 @@
                   aria-label="Expand instruction"
                   aria-hidden="true"
                   icon="chevron-down"
-                  title="Expand instruction"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -133,14 +132,14 @@
                 class="instruction-panel__text"
                 readonly
                 resize="none"
-                rows="8"
+                rows="6"
               ></vscode-textarea>
             </div>
           </div>
-          <vscode-scrollable id="logContent" class="log-container">
-            <vscode-tree id="logGroupTree" class="log-group-tree"></vscode-tree>
-            <div id="logUngroupedContainer" class="log-ungrouped"></div>
-          </vscode-scrollable>
+          <vscode-scrollable
+            id="logContent"
+            class="log-container"
+          ></vscode-scrollable>
           <div id="generatedFiles" class="files-container"></div>
           <div id="followUpContainer" class="follow-up-container">
             <vscode-textarea
@@ -149,28 +148,28 @@
               rows="10"
               resize="vertical"
             ></vscode-textarea>
-            <div class="follow-up-actions">
+            <vscode-toolbar-container class="follow-up-actions">
               <vscode-toolbar-button
                 id="polishFollowUpBtn"
                 icon="sparkle"
-                title="Polish follow-up with AI"
+                label="Polish follow-up with AI"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="recordFollowUpBtn"
                 icon="mic"
-                title="Record follow-up with microphone"
+                label="Record follow-up with microphone"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="clearFollowUpBtn"
                 icon="clear-all"
-                title="Clear input"
+                label="Clear input"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="sendFollowUpBtn"
                 icon="send"
-                title="Send"
+                label="Send"
               ></vscode-toolbar-button>
-            </div>
+            </vscode-toolbar-container>
           </div>
           <template id="fileItemTemplate">
             <div class="file-item">
@@ -185,27 +184,27 @@
                 <vscode-toolbar-button
                   class="compare-btn"
                   icon="diff"
-                  title="Compare with base"
+                  label="Compare with base"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   class="accept-btn"
                   icon="check"
-                  title="Accept edits"
+                  label="Accept edits"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   class="merge-btn"
                   icon="git-merge"
-                  title="Merge edits"
+                  label="Merge edits"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   class="diff-btn"
                   icon="diff-single"
-                  title="LaTeXdiff"
+                  label="LaTeXdiff"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   class="prev-btn"
                   icon="diff-added"
-                  title="Compare with previous round"
+                  label="Compare with previous round"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -224,11 +223,11 @@
             <i class="codicon codicon-circle-small-filled group-bullet"></i>
           </template>
           <template id="streamTabTemplate">
-            <vscode-tree-item data-stream="" title="">
-              <span slot="icon-leaf" class="tab-status status-indicator"></span>
-              <div class="tab-content">
+            <div class="tab-container" title="">
+              <button class="tab" data-stream="" title="">
                 <div class="tab-header">
-                  <span class="tab-title"></span>
+                  <span class="tab-status status-indicator"></span>
+                  <div class="tab-title"></div>
                 </div>
                 <div class="tab-meta">
                   <span class="model"></span>
@@ -236,14 +235,14 @@
                   <i class="agent-type"></i>
                   <i class="multi-file"></i>
                 </div>
-                <vscode-toolbar-button
-                  class="tab-delete"
-                  data-stream=""
-                  icon="close"
-                  label="Delete stream"
-                ></vscode-toolbar-button>
-              </div>
-            </vscode-tree-item>
+              </button>
+              <vscode-toolbar-button
+                class="tab-delete"
+                data-stream=""
+                icon="close"
+                label="Delete stream"
+              ></vscode-toolbar-button>
+            </div>
           </template>
           <template id="roundHeaderTemplate">
             <div class="round-group">
@@ -271,7 +270,7 @@
                 <vscode-toolbar-button
                   class="banner-content-copy"
                   icon="copy"
-                  title="Copy content"
+                  label="Copy content"
                   data-default-title="Copy content"
                   data-success-title="Copied!"
                 ></vscode-toolbar-button>
@@ -343,23 +342,25 @@
             </details>
           </template>
           <template id="groupDetailsTemplate">
-            <vscode-tree-item class="log-group" branch></vscode-tree-item>
+            <details class="log-group">
+              <div class="log-group-content"></div>
+            </details>
           </template>
           <template id="groupHeaderTemplate">
-            <div class="log-group-header">
+            <summary class="log-group-header">
               <span class="group-status-icon"></span>
               <span class="group-title"></span>
               <span class="group-time">
                 <span class="group-start-time"></span>
                 <span class="group-duration"></span>
               </span>
-            </div>
+            </summary>
           </template>
         </div>
         <div slot="end" class="tabs">
-          <vscode-tree id="streamTabs" class="tabs-content">
+          <div id="streamTabs" class="tabs-content">
             <!-- Stream tabs will be dynamically inserted here -->
-          </vscode-tree>
+          </div>
           <div class="clear-all-container">
             <vscode-radio-group
               class="agent-filter-group"
@@ -382,26 +383,26 @@
                 id="sortTimeBtn"
                 data-sort="time"
                 icon="clock"
-                title="Sort by time"
+                label="Sort by time"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 class="sort-btn"
                 id="sortFileBtn"
                 data-sort="inputFile"
                 icon="file"
-                title="Sort by file"
+                label="Sort by file"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 class="sort-btn"
                 id="sortAgentBtn"
                 data-sort="agent"
                 icon="account"
-                title="Sort by agent"
+                label="Sort by agent"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="deleteAllBtn"
                 icon="close-all"
-                title="Delete All"
+                label="Delete All"
               ></vscode-toolbar-button>
             </vscode-toolbar-container>
           </div>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -106,7 +106,7 @@
             aria-hidden="true"
           >
             <div class="instruction-panel__header">
-              <span class="instruction-panel__title">Instruction</span>
+              <span class="instruction-panel__title">Chat</span>
               <vscode-toolbar-container class="instruction-panel__actions">
                 <vscode-toolbar-button
                   id="instructionCopyBtn"
@@ -116,15 +116,6 @@
                   title="Copy instruction"
                   data-default-title="Copy instruction"
                   data-success-title="Copied!"
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="instructionToggleBtn"
-                  class="instruction-panel__toggle is-hidden"
-                  aria-expanded="false"
-                  aria-label="Expand instruction"
-                  aria-hidden="true"
-                  icon="chevron-down"
-                  title="Expand instruction"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -150,12 +141,16 @@
               rows="10"
               resize="vertical"
             ></vscode-textarea>
-            <vscode-toolbar-container class="follow-up-actions">
+            <div class="follow-up-actions">
               <vscode-toolbar-button
                 id="polishFollowUpBtn"
                 icon="sparkle"
                 label="Polish follow-up with AI"
               ></vscode-toolbar-button>
+              <vscode-progress-ring
+                id="polishFollowUpProgressContainer"
+                style="display: none; width: 16px; height: 16px"
+              ></vscode-progress-ring>
               <vscode-toolbar-button
                 id="recordFollowUpBtn"
                 icon="mic"
@@ -171,7 +166,7 @@
                 icon="send"
                 label="Send"
               ></vscode-toolbar-button>
-            </vscode-toolbar-container>
+            </div>
           </div>
           <template id="fileItemTemplate">
             <div class="file-item">

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -113,6 +113,7 @@
                   class="instruction-panel__copy"
                   icon="copy"
                   label="Copy instruction"
+                  title="Copy instruction"
                   data-default-title="Copy instruction"
                   data-success-title="Copied!"
                 ></vscode-toolbar-button>
@@ -123,6 +124,7 @@
                   aria-label="Expand instruction"
                   aria-hidden="true"
                   icon="chevron-down"
+                  title="Expand instruction"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -132,7 +134,7 @@
                 class="instruction-panel__text"
                 readonly
                 resize="none"
-                rows="6"
+                rows="8"
               ></vscode-textarea>
             </div>
           </div>

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -183,7 +183,11 @@ export class WebviewUpdater {
   /**
    * Update instruction panel content
    */
-  updateInstruction(stream: StreamTabId, instruction: InstructionUpdate): void {
+  updateInstruction(
+    stream: StreamTabId,
+    instruction: InstructionUpdate,
+    sessionKind?: string,
+  ): void {
     const webview = this.getWebview();
     if (!webview) return;
 
@@ -191,6 +195,7 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_INSTRUCTION,
       stream,
       instruction,
+      sessionKind,
     });
   }
 
@@ -302,8 +307,10 @@ export class WebviewUpdater {
       const taskState = state.getTaskState(activeStream);
       const instructionUpdate =
         WebviewUpdater.createInstructionUpdate(taskState);
+      const activeStreamInfo = streams.find((s) => s.name === activeStream);
+      const sessionKind = activeStreamInfo?.agentSessionKind;
       if (instructionUpdate) {
-        this.updateInstruction(activeStream, instructionUpdate);
+        this.updateInstruction(activeStream, instructionUpdate, sessionKind);
       } else {
         this.clearInstruction(activeStream);
       }

--- a/src/progressView/modules/constants.d.ts
+++ b/src/progressView/modules/constants.d.ts
@@ -8,6 +8,11 @@ export declare const STATUS: {
 };
 
 export declare const ELEMENT_IDS: Record<string, string>;
+export declare const GROUP_DOM_IDS: Readonly<{
+  DETAILS_PREFIX: string;
+  HEADER_PREFIX: string;
+  CONTENT_PREFIX: string;
+}>;
 export declare const MAX_HEIGHT: number;
 export declare const COMMANDS: Record<string, string>;
 export declare const WORKFLOW_TOOLBAR: ReadonlyArray<Record<string, unknown>>;

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -58,6 +58,12 @@ export const ELEMENT_IDS = {
   FILTER_TOOL_BTN: 'filterToolBtn',
 };
 
+export const GROUP_DOM_IDS = Object.freeze({
+  DETAILS_PREFIX: 'group-',
+  HEADER_PREFIX: 'group-header-',
+  CONTENT_PREFIX: 'group-content-',
+});
+
 // Constants for layout configuration
 export const MAX_HEIGHT = 400;
 

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -22,8 +22,6 @@ export const STATUS = {
 // DOM element IDs used across the progress view
 export const ELEMENT_IDS = {
   LOG_CONTENT: 'logContent',
-  LOG_GROUP_TREE: 'logGroupTree',
-  LOG_UNGROUPED: 'logUngroupedContainer',
   LOG_PLACEHOLDER: 'logPlaceholder',
   GENERATED_FILES: 'generatedFiles',
   STREAM_TABS: 'streamTabs',

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -30,6 +30,10 @@ import {
 import { getBasename } from '@common/pathUtils.js';
 import { encodeHtml, decodeHtml } from '@common/htmlEncoding.js';
 
+// Constants
+export const BULLET_MARKUP =
+  '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
+
 export const EMOJI_BY_LEVEL = {
   error: '🔴',
   warn: '🟡',
@@ -104,6 +108,31 @@ export const TaskGroupLevel = {
  */
 export function formatTokens(tokens) {
   return tokens > 4096 ? `${Math.round(tokens / 1000)}k` : `${tokens}`;
+}
+
+/**
+ * Extracts timestamps from HTML messages.
+ */
+export class MessageTimestampExtractor {
+  /**
+   * Extract timestamp from a log line element
+   * @param {HTMLElement} element - Log line element
+   * @returns {string} Extracted timestamp
+   */
+  extract(element) {
+    const logLine = element.classList.contains('log-line')
+      ? element
+      : element.querySelector('.log-line');
+    if (logLine && logLine.dataset.fullTimestamp) {
+      return logLine.dataset.fullTimestamp;
+    }
+
+    const text = logLine
+      ? logLine.textContent || ''
+      : element.textContent || '';
+    const match = text.match(/\[(.*?)\]/);
+    return match ? match[1] : '';
+  }
 }
 
 /**

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -18,7 +18,7 @@ import MarkdownIt from 'markdown-it';
 import highlight from 'markdown-it-highlightjs';
 
 // Local imports - progress view
-import { STATUS } from './constants.js';
+import { STATUS, GROUP_DOM_IDS } from './constants.js';
 
 // Local imports
 import { katexMacros } from './katexMacros.js';
@@ -1213,7 +1213,7 @@ export class TaskGroupHeaderFormatter {
     const header = createFromTemplate('groupHeaderTemplate');
     if (!header) return null;
 
-    header.id = `group-header-${group.id}`;
+    header.id = `${GROUP_DOM_IDS.HEADER_PREFIX}${group.id}`;
     header.className = this._getHeaderClass(group, level);
 
     const statusIconElem = header.querySelector('.group-status-icon');

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -87,11 +87,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateStreams(message) {
     state.activeStream = message.activeStream;
     if (
-      typeof message.agentFilter === 'string' &&
+      !state.pendingFilterUpdate &&
+      message.agentFilter !== undefined &&
       message.agentFilter !== state.agentTypeFilter
     ) {
       state.agentTypeFilter = message.agentFilter;
     }
+    state.pendingFilterUpdate = false;
     const activeFilter = state.agentTypeFilter;
     state.resetExecutionIdAvailability();
     message.streams.forEach((s) => {
@@ -175,15 +177,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    const ungroupedContainer = document.getElementById(
-      ELEMENT_IDS.LOG_UNGROUPED,
-    );
     if (message.stream === state.activeStream) {
+      logContent.innerHTML = '';
       state.taskGroups.clear();
       dom.taskGroups.clear();
-      if (ungroupedContainer) {
-        ungroupedContainer.innerHTML = '';
-      }
       if (message.groups && message.groups.length > 0) {
         const parentGroups = message.groups.filter((g) => !g.parentGroupId);
         const childGroups = message.groups.filter((g) => g.parentGroupId);
@@ -201,11 +198,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         if (msg.groupId) {
           if (!dom.logEntries.append(msg)) {
             const formatted = this._entryFormatter.format(msg);
-            appendFormatted(ungroupedContainer ?? logContent, formatted);
+            appendFormatted(logContent, formatted);
           }
         } else {
           const formatted = this._entryFormatter.format(msg);
-          appendFormatted(ungroupedContainer ?? logContent, formatted);
+          appendFormatted(logContent, formatted);
         }
       });
       scrollToBottom(logContent);
@@ -219,16 +216,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleClearLogs() {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    const ungroupedContainer = document.getElementById(
-      ELEMENT_IDS.LOG_UNGROUPED,
-    );
-    if (ungroupedContainer) {
-      ungroupedContainer.innerHTML = '';
+    logContent.innerHTML = '';
+    const groupIds = [];
+    const headers = Array.from(document.querySelectorAll('.log-group-header'));
+    for (const el of headers) {
+      groupIds.push(el.id.replace('group-header-', ''));
     }
-    if (logContent) {
-      logContent.scrollTop = 0;
-    }
-    const groupIds = [...state.taskGroups.getGroupMap().keys()];
     state.taskGroups.clear();
     dom.taskGroups.clear();
     state.toggleStates.clearSelection(groupIds);
@@ -239,9 +232,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleAppendLog(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      const ungroupedContainer = document.getElementById(
-        ELEMENT_IDS.LOG_UNGROUPED,
-      );
       const addedToGroup = dom.logEntries.append(message.logMessage);
       if (!addedToGroup) {
         const formatted = this._entryFormatter.format(message.logMessage);
@@ -256,7 +246,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
             }
           }
         }
-        appendFormatted(ungroupedContainer ?? logContent, formatted);
+        appendFormatted(logContent, formatted);
       }
       scrollToBottom(logContent);
     }
@@ -265,9 +255,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateLog(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      const ungroupedContainer = document.getElementById(
-        ELEMENT_IDS.LOG_UNGROUPED,
-      );
       const updated = dom.logEntries.update(message.logMessage);
       if (!updated) {
         // Fallback: append as new log with proper group placement
@@ -286,7 +273,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
               }
             }
           }
-          appendFormatted(ungroupedContainer ?? logContent, formatted);
+          appendFormatted(logContent, formatted);
         }
         scrollToBottom(logContent);
       }
@@ -375,9 +362,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.streamStatuses.delete(message.stream);
       state.clearExecutionIdAvailability(message.stream);
       if (message.stream === state.activeStream) {
-        const groupIds = [...state.taskGroups.getGroupMap().keys()];
-        state.taskGroups.clear();
-        dom.taskGroups.clear();
+        const groupIds = [];
+        const headers = Array.from(
+          document.querySelectorAll('.log-group-header'),
+        );
+        for (const el of headers) {
+          groupIds.push(el.id.replace('group-header-', ''));
+        }
         state.toggleStates.clearSelection(groupIds);
         dom.instructionPanel.hide();
       }
@@ -395,6 +386,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
     dom.followUpInput.applyPolishedText(message.text);
+    vscode.postMessage({
+      command: COMMANDS.SHOW_INFORMATION_MESSAGE,
+      text: 'Follow-up text has been polished!',
+    });
   }
 
   handleFollowUpTextTranscribed(message) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -97,7 +97,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     } finally {
       state.pendingFilterUpdate = false;
     }
-    const activeFilter = state.agentTypeFilter;
     state.resetExecutionIdAvailability();
     message.streams.forEach((s) => {
       if (s.status) {
@@ -107,29 +106,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
       state.setExecutionIdAvailable(s.name, Boolean(s.executionId));
     });
-    const filteredStreams = Array.isArray(message.streams)
-      ? message.streams.filter((info) => {
-          if (!info || typeof info !== 'object') {
-            return false;
-          }
-          if (activeFilter === 'all') {
-            return true;
-          }
-          const sessionKind =
-            info.agentSessionKind || info.uiTraits?.sessionKind;
-          return sessionKind === activeFilter;
-        })
-      : [];
 
-    const displayActiveStream = filteredStreams.some(
-      (s) => s.name === message.activeStream,
-    )
-      ? message.activeStream
-      : (filteredStreams[0]?.name ?? message.activeStream);
+    // Backend already sends filtered streams, no need to filter again
+    const streams = message.streams || [];
 
-    state.activeStream = displayActiveStream;
+    state.activeStream = message.activeStream;
 
-    dom.streamTabs.update(filteredStreams, displayActiveStream);
+    dom.streamTabs.update(streams, message.activeStream);
 
     // Update agent filter radio group selection
     const radioGroup = document.getElementById(
@@ -148,9 +131,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     this._updatePlaceholderVisibility();
 
-    const activeStreamInfo =
-      filteredStreams.find((s) => s.name === displayActiveStream) ??
-      message.streams.find((s) => s.name === message.activeStream);
+    const activeStreamInfo = streams.find(
+      (s) => s.name === message.activeStream,
+    );
     const sessionKind =
       activeStreamInfo?.agentSessionKind ||
       activeStreamInfo?.uiTraits?.sessionKind ||
@@ -165,7 +148,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     dom.toolbar.render(sessionKind);
 
-    const hasExecution = state.hasExecutionId(displayActiveStream);
+    const hasExecution = state.hasExecutionId(message.activeStream);
     dom.status.setExecutionIdAvailability(Boolean(hasExecution));
 
     // Update status based on whether there's an active stream

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -110,8 +110,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // Backend already sends filtered streams, no need to filter again
     const streams = message.streams || [];
 
-    state.activeStream = message.activeStream;
-
     dom.streamTabs.update(streams, message.activeStream);
 
     // Update agent filter radio group selection

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -216,12 +216,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleClearLogs() {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    logContent.innerHTML = '';
-    const groupIds = [];
-    const headers = Array.from(document.querySelectorAll('.log-group-header'));
-    for (const el of headers) {
-      groupIds.push(el.id.replace('group-header-', ''));
+    if (logContent) {
+      logContent.innerHTML = '';
     }
+    const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
     state.taskGroups.clear();
     dom.taskGroups.clear();
     state.toggleStates.clearSelection(groupIds);
@@ -362,13 +360,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.streamStatuses.delete(message.stream);
       state.clearExecutionIdAvailability(message.stream);
       if (message.stream === state.activeStream) {
-        const groupIds = [];
-        const headers = Array.from(
-          document.querySelectorAll('.log-group-header'),
-        );
-        for (const el of headers) {
-          groupIds.push(el.id.replace('group-header-', ''));
-        }
+        const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
         state.toggleStates.clearSelection(groupIds);
         dom.instructionPanel.hide();
       }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -85,15 +85,18 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   handleUpdateStreams(message) {
-    state.activeStream = message.activeStream;
-    if (
-      !state.pendingFilterUpdate &&
-      message.agentFilter !== undefined &&
-      message.agentFilter !== state.agentTypeFilter
-    ) {
-      state.agentTypeFilter = message.agentFilter;
+    try {
+      state.activeStream = message.activeStream;
+      if (
+        !state.pendingFilterUpdate &&
+        message.agentFilter !== undefined &&
+        message.agentFilter !== state.agentTypeFilter
+      ) {
+        state.agentTypeFilter = message.agentFilter;
+      }
+    } finally {
+      state.pendingFilterUpdate = false;
     }
-    state.pendingFilterUpdate = false;
     const activeFilter = state.agentTypeFilter;
     state.resetExecutionIdAvailability();
     message.streams.forEach((s) => {
@@ -178,9 +181,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (message.stream === state.activeStream) {
-      logContent.innerHTML = '';
-      state.taskGroups.clear();
       dom.taskGroups.clear();
+      state.taskGroups.clear();
+      logContent.innerHTML = '';
       if (message.groups && message.groups.length > 0) {
         const parentGroups = message.groups.filter((g) => !g.parentGroupId);
         const childGroups = message.groups.filter((g) => g.parentGroupId);
@@ -216,13 +219,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleClearLogs() {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
+    dom.taskGroups.clear();
+    state.taskGroups.clear();
+    state.toggleStates.clearSelection(groupIds);
     if (logContent) {
       logContent.innerHTML = '';
     }
-    const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
-    state.taskGroups.clear();
-    dom.taskGroups.clear();
-    state.toggleStates.clearSelection(groupIds);
 
     this._updatePlaceholderVisibility();
   }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -400,10 +400,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
     dom.followUpInput.applyPolishedText(message.text);
-    vscode.postMessage({
-      command: COMMANDS.SHOW_INFORMATION_MESSAGE,
-      text: 'Follow-up text has been polished!',
-    });
   }
 
   handleFollowUpTextTranscribed(message) {
@@ -413,10 +409,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
     dom.followUpInput.insertTranscription(message.text);
     dom.followUpInput.setRecording(false);
-    vscode.postMessage({
-      command: COMMANDS.SHOW_INFORMATION_MESSAGE,
-      text: 'Follow-up text transcribed!',
-    });
   }
 
   handleRecordingStarted() {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -354,8 +354,44 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    const metadata = payload?.metadata ?? {};
-    dom.instructionPanel.show(text, metadata);
+    const sessionKind = message.sessionKind || 'workflow';
+    const isToolUseAgent = sessionKind === 'toolUse';
+
+    if (isToolUseAgent) {
+      // For Tool Use agents, show instruction as a user message in chat
+      dom.instructionPanel.hide();
+
+      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      if (logContent) {
+        // Check if instruction message already exists
+        const existingInstruction = logContent.querySelector(
+          '.user-message-container[data-instruction="true"]',
+        );
+        if (!existingInstruction) {
+          const userMessage = this._entryFormatter.format({
+            id: `instruction-${activeStream}`,
+            messageType: 'userMessage',
+            text: text,
+            timestamp: Date.now(),
+            groupId: undefined,
+          });
+
+          if (userMessage) {
+            userMessage.dataset.instruction = 'true';
+            // Insert at the beginning of the log content
+            if (logContent.firstChild) {
+              logContent.insertBefore(userMessage, logContent.firstChild);
+            } else {
+              logContent.appendChild(userMessage);
+            }
+          }
+        }
+      }
+    } else {
+      // For Workflow agents, show in instruction panel
+      const metadata = payload?.metadata ?? {};
+      dom.instructionPanel.show(text, metadata);
+    }
   }
 
   handleDeleteStream(message) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -222,6 +222,7 @@ export class ProgressViewState {
     this.stateManager = new WebviewStateManager();
     this.activeStream = '';
     this.agentTypeFilter = 'all';
+    this.pendingFilterUpdate = false;
     this.currentGroupId = null;
 
     // Initialize managers

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -14,7 +14,6 @@ export class TaskGroupDomManager {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
-    this.groupObservers = new Map();
   }
 
   /**
@@ -28,7 +27,8 @@ export class TaskGroupDomManager {
         console.warn(
           `Group ${group.id} exists in DOM but not in state - removing from DOM`,
         );
-        this.removeGroup(group.id);
+        existingGroup.remove();
+        this.groupElements.delete(group.id);
       } else {
         progressViewState.taskGroups.set(group.id, group);
         this.updateGroup({
@@ -42,16 +42,14 @@ export class TaskGroupDomManager {
       }
     }
 
-    const treeItem = createFromTemplate('groupDetailsTemplate');
-    if (!treeItem) {
+    const detailsElem = createFromTemplate('groupDetailsTemplate');
+    if (!detailsElem) {
       console.error(
         'TaskGroupDomManager.addGroup: groupDetailsTemplate not found',
       );
       return;
     }
-    treeItem.id = `group-${group.id}`;
-    treeItem.dataset.groupId = group.id;
-    treeItem.setAttribute('branch', '');
+    detailsElem.id = `group-${group.id}`;
 
     const headerElement = this.headerFormatter.create(group);
     if (!headerElement) {
@@ -61,44 +59,49 @@ export class TaskGroupDomManager {
       return;
     }
 
-    treeItem.appendChild(headerElement);
+    const groupContainer = detailsElem.querySelector('.log-group-content');
+    if (!groupContainer) {
+      console.error(
+        'TaskGroupDomManager.addGroup: missing group content container',
+      );
+      return;
+    }
+    groupContainer.id = `group-content-${group.id}`;
 
     progressViewState.taskGroups.set(group.id, group);
 
-    const isCollapsed = progressViewState.toggleStates.get(group.id) === true;
-    const isExpanded = !isCollapsed;
-    treeItem.toggleAttribute('expanded', isExpanded);
-    treeItem.expanded = isExpanded;
+    const isCollapsed = progressViewState.toggleStates.get(group.id);
+    detailsElem.open = isCollapsed !== true;
 
-    this._observeGroup(treeItem, group.id);
+    detailsElem.prepend(headerElement);
 
-    this.groupElements.set(group.id, treeItem);
+    detailsElem.addEventListener('toggle', () => {
+      progressViewState.toggleStates.set(group.id, !detailsElem.open);
+    });
 
-    const treeRoot = this._getTreeRoot();
-    if (!treeRoot) {
-      console.error('TaskGroupDomManager.addGroup: log group tree missing');
-      return;
-    }
+    this.groupElements.set(group.id, detailsElem);
+
+    // Insert the group at the right position in the parent
+    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
 
     if (group.parentGroupId) {
-      const parentItem = this.groupElements.get(group.parentGroupId);
-      if (parentItem instanceof HTMLElement) {
-        treeItem.setAttribute('slot', 'children');
+      const parentDetails = this.groupElements.get(group.parentGroupId);
+      const parentGroupContent =
+        parentDetails?.querySelector('.log-group-content');
+      if (parentGroupContent) {
         insertChronologically({
-          container: parentItem,
-          element: treeItem,
+          container: parentGroupContent,
+          element: detailsElem,
           timestamp: group.startTime,
         });
         return;
       }
-    } else {
-      treeItem.removeAttribute('slot');
     }
 
     // For top-level groups, insert in chronological order
     insertChronologically({
-      container: treeRoot,
-      element: treeItem,
+      container,
+      element: detailsElem,
       timestamp: group.startTime,
     });
 
@@ -106,77 +109,6 @@ export class TaskGroupDomManager {
     if (!group.parentGroupId) {
       progressViewState.currentGroupId = group.id;
       this.collapsePreviousActiveGroup();
-    }
-  }
-
-  _getTreeRoot() {
-    let tree = document.getElementById(ELEMENT_IDS.LOG_GROUP_TREE);
-    if (tree) {
-      return tree;
-    }
-
-    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    if (!container) {
-      return null;
-    }
-
-    tree = document.createElement('vscode-tree');
-    tree.id = ELEMENT_IDS.LOG_GROUP_TREE;
-    tree.classList.add('log-group-tree');
-    container.prepend(tree);
-    return tree;
-  }
-
-  _observeGroup(treeItem, groupId) {
-    if (!(treeItem instanceof HTMLElement)) {
-      return;
-    }
-
-    this._disconnectObserver(groupId);
-
-    const observer = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        if (
-          mutation.type === 'attributes' &&
-          mutation.attributeName === 'expanded'
-        ) {
-          const isCollapsed = !treeItem.hasAttribute('expanded');
-          progressViewState.toggleStates.set(groupId, isCollapsed);
-        }
-      }
-    });
-
-    observer.observe(treeItem, {
-      attributes: true,
-      attributeFilter: ['expanded'],
-    });
-
-    this.groupObservers.set(groupId, observer);
-  }
-
-  _disconnectObserver(groupId) {
-    const existing = this.groupObservers.get(groupId);
-    if (existing) {
-      existing.disconnect();
-      this.groupObservers.delete(groupId);
-    }
-  }
-
-  removeGroup(groupId) {
-    if (!groupId) {
-      return;
-    }
-
-    this._disconnectObserver(groupId);
-
-    const treeItem = this.groupElements.get(groupId);
-    if (treeItem instanceof HTMLElement) {
-      treeItem.remove();
-    }
-
-    this.groupElements.delete(groupId);
-    if (progressViewState.toggleStates.get(groupId) !== undefined) {
-      progressViewState.toggleStates.clearSelection([groupId]);
     }
   }
 
@@ -219,12 +151,12 @@ export class TaskGroupDomManager {
       group.endTime = updates.endTime;
     }
 
-    const treeItem = this.groupElements.get(groupId);
-    if (!(treeItem instanceof HTMLElement)) {
+    const detailsElem = this.groupElements.get(groupId);
+    if (!detailsElem) {
       return;
     }
 
-    const header = treeItem.querySelector('.log-group-header');
+    const header = detailsElem.querySelector('.log-group-header');
     if (header) {
       const level = this.headerFormatter._getGroupLevel(group);
       header.className = this.headerFormatter._getHeaderClass(group, level);
@@ -286,10 +218,9 @@ export class TaskGroupDomManager {
     }
 
     // Collapse this group
-    const treeItem = this.groupElements.get(groupId);
-    if (treeItem instanceof HTMLElement) {
-      treeItem.toggleAttribute('expanded', false);
-      treeItem.expanded = false;
+    const detailsElem = this.groupElements.get(groupId);
+    if (detailsElem) {
+      detailsElem.open = false;
       progressViewState.toggleStates.set(groupId, true);
     }
   }
@@ -308,11 +239,8 @@ export class TaskGroupDomManager {
     let latestGroup = null;
     let latestTime = 0;
 
-    for (const [id, treeItem] of this.groupElements.entries()) {
-      if (
-        !(treeItem instanceof HTMLElement) ||
-        !treeItem.hasAttribute('expanded')
-      ) {
+    for (const [id, detailsElem] of this.groupElements.entries()) {
+      if (!detailsElem || !detailsElem.open) {
         continue;
       }
 
@@ -375,17 +303,8 @@ export class TaskGroupDomManager {
    * Clear cached group references.
    */
   clear() {
-    for (const groupId of [...this.groupElements.keys()]) {
-      this.removeGroup(groupId);
-    }
-    this.groupObservers.clear();
     this.groupElements.clear();
     this.previousActiveGroupId = null;
-
-    const treeRoot = document.getElementById(ELEMENT_IDS.LOG_GROUP_TREE);
-    if (treeRoot) {
-      treeRoot.innerHTML = '';
-    }
   }
 }
 
@@ -405,26 +324,20 @@ export class LogEntryManager {
   append(logMessage) {
     // If the message has a group ID, append it to the right group
     if (logMessage.groupId) {
-      const groupElement = document.getElementById(
-        `group-${logMessage.groupId}`,
+      const groupContent = document.getElementById(
+        `group-content-${logMessage.groupId}`,
       );
-      if (groupElement instanceof HTMLElement) {
+      if (groupContent) {
         const logLineElement = this.entryFormatter.format(logMessage);
         if (!logLineElement) {
           return true;
         }
 
-        if (!(logLineElement instanceof HTMLElement)) {
-          return false;
-        }
-
-        logLineElement.setAttribute('slot', 'children');
-
         // Extract timestamp from the message for chronological ordering
         const msgDate = new Date(logMessage.timestamp);
 
         insertChronologically({
-          container: groupElement,
+          container: groupContent,
           element: logLineElement,
           timestamp: msgDate,
         });
@@ -462,13 +375,6 @@ export class LogEntryManager {
         const toggleIcon = newEl.querySelector('.toggle-icon');
         if (toggleIcon) {
           toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
-        }
-      }
-
-      if (existing instanceof HTMLElement && newEl instanceof HTMLElement) {
-        const slotName = existing.getAttribute('slot');
-        if (slotName) {
-          newEl.setAttribute('slot', slotName);
         }
       }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,5 +1,5 @@
 // Local imports - progress view
-import { ELEMENT_IDS } from './constants.js';
+import { ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
 import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
@@ -14,6 +14,7 @@ export class TaskGroupDomManager {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
+    this.toggleListeners = new Map();
   }
 
   /**
@@ -27,6 +28,7 @@ export class TaskGroupDomManager {
         console.warn(
           `Group ${group.id} exists in DOM but not in state - removing from DOM`,
         );
+        this._removeToggleListener(group.id);
         existingGroup.remove();
         this.groupElements.delete(group.id);
       } else {
@@ -49,7 +51,7 @@ export class TaskGroupDomManager {
       );
       return;
     }
-    detailsElem.id = `group-${group.id}`;
+    detailsElem.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
 
     const headerElement = this.headerFormatter.create(group);
     if (!headerElement) {
@@ -66,7 +68,7 @@ export class TaskGroupDomManager {
       );
       return;
     }
-    groupContainer.id = `group-content-${group.id}`;
+    groupContainer.id = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;
 
     progressViewState.taskGroups.set(group.id, group);
 
@@ -75,14 +77,24 @@ export class TaskGroupDomManager {
 
     detailsElem.prepend(headerElement);
 
-    detailsElem.addEventListener('toggle', () => {
+    const toggleListener = () => {
       progressViewState.toggleStates.set(group.id, !detailsElem.open);
-    });
+    };
+    detailsElem.addEventListener('toggle', toggleListener);
+    this.toggleListeners.set(group.id, toggleListener);
 
     this.groupElements.set(group.id, detailsElem);
 
     // Insert the group at the right position in the parent
     const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    if (!container) {
+      console.error(
+        'TaskGroupDomManager.addGroup: missing log content container',
+      );
+      this._removeToggleListener(group.id);
+      this.groupElements.delete(group.id);
+      return;
+    }
 
     if (group.parentGroupId) {
       const parentDetails = this.groupElements.get(group.parentGroupId);
@@ -303,8 +315,21 @@ export class TaskGroupDomManager {
    * Clear cached group references.
    */
   clear() {
+    for (const groupId of this.groupElements.keys()) {
+      this._removeToggleListener(groupId);
+    }
     this.groupElements.clear();
+    this.toggleListeners.clear();
     this.previousActiveGroupId = null;
+  }
+
+  _removeToggleListener(groupId) {
+    const listener = this.toggleListeners.get(groupId);
+    const element = this.groupElements.get(groupId);
+    if (listener && element) {
+      element.removeEventListener('toggle', listener);
+    }
+    this.toggleListeners.delete(groupId);
   }
 }
 
@@ -324,12 +349,15 @@ export class LogEntryManager {
   append(logMessage) {
     // If the message has a group ID, append it to the right group
     if (logMessage.groupId) {
-      const groupContent = document.getElementById(
-        `group-content-${logMessage.groupId}`,
-      );
+      const groupContentId = `${GROUP_DOM_IDS.CONTENT_PREFIX}${logMessage.groupId}`;
+      const groupContent = document.getElementById(groupContentId);
       if (groupContent) {
         const logLineElement = this.entryFormatter.format(logMessage);
         if (!logLineElement) {
+          console.debug(
+            'LogEntryManager.append: formatter returned null for message',
+            logMessage,
+          );
           return true;
         }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -58,6 +58,7 @@ export class TaskGroupDomManager {
       console.error(
         'TaskGroupDomManager.addGroup: failed to create group header',
       );
+      detailsElem.remove();
       return;
     }
 
@@ -66,6 +67,7 @@ export class TaskGroupDomManager {
       console.error(
         'TaskGroupDomManager.addGroup: missing group content container',
       );
+      detailsElem.remove();
       return;
     }
     groupContainer.id = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -104,11 +104,21 @@ export class EventsManager {
     );
     if (radioGroup) {
       const attachRadioListener = () => {
-        addEventListenerSafely(radioGroup, 'change', () => {
-          const filter = radioGroup.value;
+        addEventListenerSafely(radioGroup, 'change', (event) => {
+          if (!(event?.target instanceof Element)) {
+            return;
+          }
+
+          const selectedRadio =
+            event.target.closest('vscode-radio') ||
+            radioGroup.querySelector('vscode-radio[checked]');
+          const filter =
+            selectedRadio?.value || selectedRadio?.getAttribute('value') || '';
+
           if (!filter) {
             return;
           }
+
           if (progressViewState.agentTypeFilter !== filter) {
             progressViewState.agentTypeFilter = filter;
             progressViewState.pendingFilterUpdate = true;

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -1,5 +1,5 @@
 // Local imports - progress view
-import { COMMANDS, ELEMENT_IDS } from '../constants.js';
+import { COMMANDS, ELEMENT_IDS, GROUP_DOM_IDS } from '../constants.js';
 import { progressViewState } from '../progressViewState.js';
 import { copyWithFeedback } from '../utils.js';
 
@@ -21,7 +21,9 @@ export class EventsManager {
     const taskGroups = progressViewState.taskGroups.getGroupMap();
     for (const [groupId] of taskGroups) {
       const isCollapsed = progressViewState.toggleStates.get(groupId);
-      const detailsElem = document.getElementById(`group-${groupId}`);
+      const detailsElem = document.getElementById(
+        `${GROUP_DOM_IDS.DETAILS_PREFIX}${groupId}`,
+      );
 
       if (detailsElem && isCollapsed !== undefined) {
         detailsElem.open = !isCollapsed;
@@ -63,9 +65,6 @@ export class EventsManager {
         vscode.postMessage({ command, stream: activeStream });
       }
     });
-
-    // File list toggle - removed as filesToggle element doesn't exist in the HTML
-    // This appears to be orphaned code from a previous design
 
     // File list button handler
     addEventListenerSafely(

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -15,55 +15,41 @@ import { vscode } from '@common/webviewContext.js';
  */
 export class EventsManager {
   /**
+   * Apply saved toggle states to any groups already in the DOM
+   */
+  applyToggleStates() {
+    const taskGroups = progressViewState.taskGroups.getGroupMap();
+    for (const [groupId] of taskGroups) {
+      const isCollapsed = progressViewState.toggleStates.get(groupId);
+      const detailsElem = document.getElementById(`group-${groupId}`);
+
+      if (detailsElem && isCollapsed !== undefined) {
+        detailsElem.open = !isCollapsed;
+      }
+    }
+  }
+
+  /**
    * Sets up all event listeners for the UI
    */
   setupEventListeners() {
-    // Stream tab selection handler (vscode-tree)
-    addEventListenerSafely(
-      ELEMENT_IDS.STREAM_TABS,
-      'vsc-tree-select',
-      (event) => {
-        const detail = event.detail;
-        const selectedItems = Array.isArray(detail)
-          ? detail
-          : Array.isArray(detail?.selection)
-            ? detail.selection
-            : [];
-        const firstItem = selectedItems[0];
-        const stream = firstItem?.dataset?.stream;
-        if (!stream) {
-          return;
-        }
+    // Stream tab click handler
+    addEventListenerSafely(ELEMENT_IDS.STREAM_TABS, 'click', (e) => {
+      const tabButton = e.target.closest('.tab');
+      const deleteButton = e.target.closest('.tab-delete');
+
+      if (tabButton && tabButton.dataset.stream) {
         vscode.postMessage({
           command: COMMANDS.SWITCH_STREAM,
-          stream,
+          stream: tabButton.dataset.stream,
         });
-      },
-    );
-
-    // Stream tab delete button handler
-    addEventListenerSafely(
-      ELEMENT_IDS.STREAM_TABS,
-      'click',
-      (e) => {
-        // Use composedPath to handle shadow DOM clicks
-        const path = e.composedPath();
-        const deleteButton = path.find((el) =>
-          el.classList?.contains('tab-delete'),
-        );
-
-        if (deleteButton?.dataset?.stream) {
-          e.preventDefault();
-          e.stopPropagation();
-          e.stopImmediatePropagation();
-          vscode.postMessage({
-            command: COMMANDS.DELETE_STREAM,
-            stream: deleteButton.dataset.stream,
-          });
-        }
-      },
-      true,
-    ); // Use capture phase
+      } else if (deleteButton && deleteButton.dataset.stream) {
+        vscode.postMessage({
+          command: COMMANDS.DELETE_STREAM,
+          stream: deleteButton.dataset.stream,
+        });
+      }
+    });
 
     // Toolbar click handler
     addEventListenerSafely(ELEMENT_IDS.TOOLBAR_CONTAINER, 'click', (e) => {
@@ -77,6 +63,9 @@ export class EventsManager {
         vscode.postMessage({ command, stream: activeStream });
       }
     });
+
+    // File list toggle - removed as filesToggle element doesn't exist in the HTML
+    // This appears to be orphaned code from a previous design
 
     // File list button handler
     addEventListenerSafely(
@@ -116,17 +105,14 @@ export class EventsManager {
     );
     if (radioGroup) {
       const attachRadioListener = () => {
-        addEventListenerSafely(radioGroup, 'change', (event) => {
-          const target = event?.target;
-          const filter =
-            typeof target?.value === 'string' && target.value
-              ? target.value
-              : radioGroup.value;
+        addEventListenerSafely(radioGroup, 'change', () => {
+          const filter = radioGroup.value;
           if (!filter) {
             return;
           }
           if (progressViewState.agentTypeFilter !== filter) {
             progressViewState.agentTypeFilter = filter;
+            progressViewState.pendingFilterUpdate = true;
             // Persist the new selection immediately so updates don't snap back
             vscode.postMessage({
               command: COMMANDS.FILTER_STREAMS,

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -104,6 +104,14 @@ export class FollowUpInputManager {
       return;
     }
 
+    // Show progress indicator
+    const progressContainer = document.getElementById(
+      'polishFollowUpProgressContainer',
+    );
+    if (progressContainer) {
+      progressContainer.style.display = 'block';
+    }
+
     this.vscode.postMessage({
       command: COMMANDS.POLISH_FOLLOW_UP,
       stream,
@@ -125,6 +133,14 @@ export class FollowUpInputManager {
   applyPolishedText(text) {
     if (!this.textarea || typeof text !== 'string') {
       return;
+    }
+
+    // Hide progress indicator
+    const progressContainer = document.getElementById(
+      'polishFollowUpProgressContainer',
+    );
+    if (progressContainer) {
+      progressContainer.style.display = 'none';
     }
 
     this.textarea.value = text;

--- a/src/progressView/modules/uiManagers/InstructionPanel.js
+++ b/src/progressView/modules/uiManagers/InstructionPanel.js
@@ -3,10 +3,7 @@ import { ELEMENT_IDS } from '../constants.js';
 import { copyWithFeedback } from '../utils.js';
 
 // Local imports - shared helpers
-import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
-
-const EXPAND_LABEL_COLLAPSED = 'Expand instruction';
-const EXPAND_LABEL_EXPANDED = 'Collapse instruction';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Manages the instruction panel that surfaces the active stream instruction.
@@ -15,9 +12,7 @@ export class InstructionPanel {
   constructor() {
     this._elements = null;
     this._currentText = '';
-    this._expanded = false;
 
-    this._toggleHandler = this._handleToggle.bind(this);
     this._copyHandler = this._handleCopy.bind(this);
   }
 
@@ -30,24 +25,19 @@ export class InstructionPanel {
         return null;
       }
 
-      const body = container.querySelector('.instruction-panel__body');
-      const toggle = safeGetElementById(ELEMENT_IDS.INSTRUCTION_TOGGLE_BTN);
       const copy = safeGetElementById(ELEMENT_IDS.INSTRUCTION_COPY_BTN);
 
-      if (toggle) {
-        toggle.addEventListener('click', this._toggleHandler);
-      }
       if (copy) {
         copy.addEventListener('click', this._copyHandler);
       }
 
-      this._elements = { container, body, text, toggle, copy };
+      this._elements = { container, text, copy };
     }
 
     return this._elements;
   }
 
-  show(text, metadata = {}) {
+  show(text) {
     const elements = this._getElements();
     if (!elements) {
       return;
@@ -59,7 +49,6 @@ export class InstructionPanel {
       return;
     }
 
-    const textChanged = normalized !== this._currentText;
     this._currentText = normalized;
 
     elements.text.value = normalized;
@@ -67,23 +56,6 @@ export class InstructionPanel {
     elements.container.setAttribute('aria-hidden', 'false');
 
     this._resetCopyButton(false);
-
-    if (typeof metadata?.expanded === 'boolean') {
-      this._expanded = metadata.expanded;
-    } else if (textChanged) {
-      this._expanded = false;
-    }
-
-    const schedule =
-      typeof window !== 'undefined' && window.requestAnimationFrame
-        ? window.requestAnimationFrame.bind(window)
-        : (cb) => setTimeout(cb, 0);
-
-    schedule(() => {
-      const shouldShowToggle = this._computeOverflow(metadata?.showToggle);
-      this._setToggleVisibility(shouldShowToggle);
-      this._applyExpandedState();
-    });
   }
 
   hide() {
@@ -93,78 +65,12 @@ export class InstructionPanel {
     }
 
     this._currentText = '';
-    this._expanded = false;
 
     elements.text.value = '';
-    elements.container.classList.remove('is-visible', 'is-expanded');
+    elements.container.classList.remove('is-visible');
     elements.container.setAttribute('aria-hidden', 'true');
 
     this._resetCopyButton(true);
-    this._setToggleVisibility(false);
-    this._applyExpandedState();
-  }
-
-  _computeOverflow(forceValue) {
-    if (typeof forceValue === 'boolean') {
-      return forceValue;
-    }
-
-    const elements = this._elements;
-    if (!elements?.container || !elements.text) {
-      return false;
-    }
-
-    const wasExpanded = this._expanded;
-    elements.container.classList.remove('is-expanded');
-
-    // For vscode-textarea, check the wrapped textarea element for scroll detection
-    const textareaElement =
-      elements.text.wrappedElement ||
-      elements.text.shadowRoot?.querySelector('textarea') ||
-      elements.text;
-    const hasOverflow =
-      textareaElement.scrollHeight > textareaElement.clientHeight + 1;
-
-    elements.container.classList.toggle('is-expanded', wasExpanded);
-    return hasOverflow;
-  }
-
-  _setToggleVisibility(visible) {
-    const toggle = this._elements?.toggle;
-    if (!toggle) {
-      return;
-    }
-
-    toggle.classList.toggle('is-hidden', !visible);
-    toggle.setAttribute('aria-hidden', visible ? 'false' : 'true');
-    if (!visible) {
-      toggle.setAttribute('aria-expanded', 'false');
-      toggle.setAttribute('aria-label', EXPAND_LABEL_COLLAPSED);
-      toggle.setAttribute('title', EXPAND_LABEL_COLLAPSED);
-    }
-  }
-
-  _applyExpandedState() {
-    const elements = this._elements;
-    if (!elements?.container) {
-      return;
-    }
-
-    elements.container.classList.toggle('is-expanded', this._expanded);
-
-    const toggle = elements.toggle;
-    if (!toggle) {
-      return;
-    }
-
-    const label = this._expanded
-      ? EXPAND_LABEL_EXPANDED
-      : EXPAND_LABEL_COLLAPSED;
-
-    toggle.setAttribute('aria-expanded', this._expanded ? 'true' : 'false');
-    toggle.setAttribute('aria-label', label);
-    toggle.setAttribute('title', label);
-    setChevronIcon(toggle, this._expanded);
   }
 
   _resetCopyButton(disable) {
@@ -187,11 +93,6 @@ export class InstructionPanel {
     copy.setAttribute('title', defaultTitle);
     copy.setAttribute('aria-label', defaultTitle);
     copy.disabled = Boolean(disable);
-  }
-
-  _handleToggle() {
-    this._expanded = !this._expanded;
-    this._applyExpandedState();
   }
 
   async _handleCopy(event) {
@@ -220,10 +121,7 @@ export class InstructionPanel {
       return;
     }
 
-    const { toggle, copy } = this._elements;
-    if (toggle) {
-      toggle.removeEventListener('click', this._toggleHandler);
-    }
+    const { copy } = this._elements;
     if (copy) {
       const timeoutId = copy.dataset.copyResetTimeoutId;
       if (timeoutId) {
@@ -235,6 +133,5 @@ export class InstructionPanel {
 
     this._elements = null;
     this._currentText = '';
-    this._expanded = false;
   }
 }

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -30,7 +30,6 @@ export class StreamTabs {
       console.error('StreamTabs.update: streamTabs container not found');
       return;
     }
-
     tabsContainer.innerHTML = '';
     let activeInfo = null;
     streams.forEach((info) => {
@@ -47,23 +46,21 @@ export class StreamTabs {
         },
         attributes: {
           '': { title: tooltip },
+          '.tab': { title: tooltip },
+          '.tab-delete': { title: 'Delete stream' },
         },
         dataset: {
-          '': { stream: info.name },
+          '.tab': { stream: info.name },
           '.tab-delete': { stream: info.name },
         },
       });
       if (!tabEl) return;
-
-      // Set status indicator color based on status
       const statusEl = tabEl.querySelector('.tab-status');
       if (statusEl) {
         const status = info.status || 'stopped';
         statusEl.classList.add(status);
         statusEl.dataset.status =
           status.charAt(0).toUpperCase() + status.slice(1);
-      } else {
-        console.warn('[StreamTabs] Status element not found in tab');
       }
       const agentIcon = tabEl.querySelector('.agent-type');
       if (agentIcon) {
@@ -82,10 +79,9 @@ export class StreamTabs {
         }
       }
       if (info.name === activeStream) {
-        tabEl.setAttribute('selected', '');
+        tabEl.classList.add('active');
         activeInfo = info;
       }
-
       tabsContainer.appendChild(tabEl);
     });
 

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -1,5 +1,5 @@
 // Local imports - progress view
-import { ELEMENT_IDS } from './constants.js';
+import { ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
 import { formatTokens, TaskGroupLevel } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
@@ -73,7 +73,9 @@ export class UsageGroupManager {
       return;
     }
 
-    const groupHeader = document.getElementById(`group-header-${groupId}`);
+    const groupHeader = document.getElementById(
+      `${GROUP_DOM_IDS.HEADER_PREFIX}${groupId}`,
+    );
     if (!groupHeader) {
       console.warn(
         `UsageGroupManager.update: Group header not found for ID: ${groupId}`,

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'latexdiffDetailsTemplate',
     'statisticsDetailsTemplate',
     'groupHeaderTemplate',
+    'groupDetailsTemplate',
   ]);
   progressViewDomHandler.toolbar.render('workflow');
   progressViewDomHandler.placeholder.show();

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -40,6 +40,9 @@ document.addEventListener('DOMContentLoaded', () => {
   progressViewDomHandler.events.setupEventListeners();
   progressViewDomHandler.followUpInput.setup();
 
+  // Apply saved group toggle states to any groups already in the DOM
+  progressViewDomHandler.events.applyToggleStates();
+
   // Notify extension that the webview is ready to receive messages
   vscode.postMessage({ command: COMMANDS.WEBVIEW_READY });
 });

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -65,15 +65,19 @@ export function buildStreamInfos(
     const outputs = taskState?.agentConfig.outputFiles || [];
     const inputFile = taskState?.agentConfig.inputFile || '';
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
-    const sessionCategory =
-      taskState?.session?.agentCategory ??
-      sessionKindHint ??
-      AgentCategory.Workflow; // Default to Workflow if unknown
+    let sessionCategory = taskState?.session?.agentCategory ?? sessionKindHint;
 
-    // Filter logic: check if the stream matches the current filter
-    if (!matchesAgentFilter(sessionCategory, filter)) {
+    // Filter logic: streams without category only show when filter is "all"
+    if (!sessionCategory) {
+      if (filter !== 'all') {
+        return acc;
+      }
+      // Default to Workflow for display purposes only when filter is "all"
+      sessionCategory = AgentCategory.Workflow;
+    } else if (!matchesAgentFilter(sessionCategory, filter)) {
       return acc;
     }
+
 
     const agentType =
       taskState?.session?.agentType ?? taskState?.agentConfig.agentType;

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -66,10 +66,15 @@ export function buildStreamInfos(
     const inputFile = taskState?.agentConfig.inputFile || '';
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
     const sessionCategory =
-      taskState?.session?.agentCategory ?? sessionKindHint;
-    if (!sessionCategory || !matchesAgentFilter(sessionCategory, filter)) {
+      taskState?.session?.agentCategory ??
+      sessionKindHint ??
+      AgentCategory.Workflow; // Default to Workflow if unknown
+
+    // Filter logic: check if the stream matches the current filter
+    if (!matchesAgentFilter(sessionCategory, filter)) {
       return acc;
     }
+
     const agentType =
       taskState?.session?.agentType ?? taskState?.agentConfig.agentType;
     const isToolAgent = sessionCategory === AgentCategory.ToolUse;

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -78,7 +78,6 @@ export function buildStreamInfos(
       return acc;
     }
 
-
     const agentType =
       taskState?.session?.agentType ?? taskState?.agentConfig.agentType;
     const isToolAgent = sessionCategory === AgentCategory.ToolUse;

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -32,9 +32,10 @@
   overflow-y: auto;
 }
 
-.follow-up-actions {
+.follow-up-actions,
+vscode-toolbar-container.follow-up-actions {
   display: flex;
-  flex-direction: column;
+  flex-direction: column !important;
   align-items: center;
   gap: var(--spacing-small);
 }

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -3,18 +3,8 @@
  * Styling for grouped log entries and hierarchy
  */
 
-/* Log Group Tree */
-.log-group-tree {
-  display: block;
-  width: 100%;
-}
-
-.log-group-tree vscode-tree-item.log-group {
-  display: block;
-  margin-bottom: var(--spacing-tiny);
-}
-
-.log-group-tree vscode-tree-item.log-group > .log-group-header {
+/* Log Group Styles */
+.log-group-header {
   padding: var(--spacing-tiny) var(--spacing-medium);
   margin: var(--spacing-tiny) 0;
   border-radius: var(--border-radius-small);
@@ -26,37 +16,27 @@
 }
 
 /* Minimal styling for top-level task headers */
-.log-group-tree vscode-tree-item.log-group > .log-group-header.top-level {
+.log-group-header.top-level {
   border-left: var(--border-thin) solid var(--vscode-panel-border);
   border-right: var(--border-thin) solid var(--vscode-panel-border);
 }
 
-.log-group-tree vscode-tree-item.log-group > .log-group-header.running {
+.log-group-header.running {
   border-left-color: var(--vscode-statusBarItem-warningBackground);
 }
 
-.log-group-tree vscode-tree-item.log-group > .log-group-header.error {
+.log-group-header.error {
   border-left-color: var(--vscode-errorForeground);
 }
 
-.log-group-tree vscode-tree-item.log-group > .log-group-header.stopped {
+.log-group-header.stopped {
   border-left-color: var(--vscode-testing-iconPassed);
 }
 
-vscode-tree-item.log-group[branch]:not([expanded]) > [slot='children'] {
-  display: none;
-}
-
-vscode-tree-item.log-group > [slot='children']:not(vscode-tree-item) {
-  display: block;
+.log-group-content {
   padding-left: var(--spacing-small);
-  margin-left: var(--spacing-small);
   border-left: var(--border-thin) dashed
     var(--vscode-editorGroupHeader-tabsBorder);
-}
-
-.log-ungrouped {
-  margin-top: var(--spacing-small);
 }
 
 .group-status-icon {
@@ -99,13 +79,39 @@ vscode-tree-item.log-group > [slot='children']:not(vscode-tree-item) {
   border-left: var(--border-medium) solid transparent;
 }
 
-/* Log lines within a group */
-vscode-tree-item.log-group > [slot='children'].log-line,
-vscode-tree-item.log-group > [slot='children'].banner-details {
+/* Log group hierarchy styles */
+
+/* Child group headers have a different style to show hierarchy */
+.log-group-content .log-group-header {
+  border-left-width: var(--border-thin); /* Thinner border for child groups */
   margin-left: var(--spacing-small);
 }
 
-/* Visual indicator for nested structure (reserved for future use) */
-vscode-tree-item.log-group > .log-group-header::before {
-  display: none;
+/* Indent child group content */
+.log-group-content .log-group-content {
+  margin-left: var(--spacing-small);
+}
+
+/* Log lines within a group */
+.log-group-content > .log-line,
+.log-group-content > .banner-details {
+  margin-left: var(--spacing-small);
+}
+
+/* Log lines within a nested group */
+.log-group-content .log-group-content .log-line,
+.log-group-content .log-group-content .banner-details {
+  margin-left: 0; /* No extra indent for nested log lines */
+}
+
+/* Visual indicator for nested structure */
+.log-group-content .log-group-header::before {
+  content: '';
+  position: absolute;
+  left: calc(0px - var(--spacing-medium));
+  top: 50%;
+  width: var(--spacing-medium);
+  height: var(--border-thin);
+  background-color: var(--vscode-panel-border);
+  display: none; /* Start hidden, only show on advanced view option */
 }

--- a/src/progressView/styles/instruction-panel.css
+++ b/src/progressView/styles/instruction-panel.css
@@ -6,6 +6,7 @@
   display: none;
   border-top: 1px solid var(--vscode-panel-border);
   border-bottom: 1px solid var(--vscode-panel-border);
+  background-color: var(--vscode-editor-background);
 }
 
 .instruction-panel.is-visible {

--- a/src/progressView/styles/instruction-panel.css
+++ b/src/progressView/styles/instruction-panel.css
@@ -48,10 +48,6 @@
   color: var(--vscode-testing-iconPassed, #2ea043);
 }
 
-.instruction-panel__toggle.is-hidden {
-  display: none;
-}
-
 .instruction-panel__body {
   padding: 0 var(--spacing-medium) var(--spacing-medium);
 }
@@ -62,10 +58,6 @@
   font-family: var(--vscode-editor-font-family);
   font-size: var(--vscode-editor-font-size);
   line-height: 1.45;
-}
-
-.instruction-panel.is-expanded .instruction-panel__text {
-  max-height: 30rem;
 }
 
 .instruction-panel__text::part(control) {

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -19,7 +19,6 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  --vscode-tree-indent: 0px;
 }
 
 .clear-all-container {
@@ -41,19 +40,26 @@
   flex: 0 0 auto;
 }
 
-/* vscode-tree-item content styling */
-vscode-tree-item {
+.tab-container {
+  display: flex;
+  align-items: center;
   position: relative;
+  width: 100%;
 }
 
-.tab-content {
+.tab {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  flex: 1;
+  padding: var(--spacing-small) var(--spacing-medium);
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: var(--vscode-foreground);
+  text-align: left;
+  font-family: var(--font-family);
   min-width: 0;
-  position: relative;
-  width: 100%;
 }
 
 .tab-header {
@@ -63,17 +69,9 @@ vscode-tree-item {
   width: 100%;
 }
 
-/* Status indicator in icon slot - matches main status indicators */
-.tab-status.status-indicator {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  display: inline-block;
-  margin: 3px;
-}
-
-.tab-status.status-indicator:hover::after {
-  display: none; /* Don't show tooltip in tree */
+.tab-header .tab-status {
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .tab-title {
@@ -98,21 +96,52 @@ vscode-tree-item {
   margin-left: var(--spacing-small);
 }
 
-/* Delete button visibility on hover */
-vscode-tree-item:hover .tab-delete {
-  display: flex;
-  align-items: center;
+.tab-container:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.tab-container.active {
+  background-color: var(--vscode-list-activeSelectionBackground);
+}
+
+.tab-container.active .tab {
+  color: var(--vscode-list-activeSelectionForeground);
 }
 
 .tab-delete {
   display: none;
-  position: absolute;
-  right: var(--spacing-tiny);
-  top: 50%;
-  transform: translateY(-50%);
+  padding: var(--spacing-tiny);
+  border: none;
+  background: none;
+  color: var(--vscode-foreground);
   opacity: var(--opacity-subtle);
+  cursor: pointer;
+  margin-right: var(--spacing-small);
+  font-size: var(--font-size-sm);
+  width: calc(var(--height-control) - var(--spacing-small));
+  height: calc(var(--height-control) - var(--spacing-small));
+  align-items: center;
+  justify-content: center;
+}
+
+.tab-container:hover .tab-delete {
+  display: flex;
+  align-items: center;
 }
 
 .tab-delete:hover {
   opacity: var(--opacity-full);
+  color: var(--vscode-errorForeground);
+}
+
+.tab-delete .codicon {
+  font-size: var(--font-size-sm);
+  color: var(--vscode-foreground);
+  opacity: var(--opacity-subtle);
+  margin-right: 0;
+}
+
+.tab-delete:hover .codicon {
+  opacity: var(--opacity-full);
+  color: var(--vscode-errorForeground);
 }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -72,7 +72,7 @@
                 <vscode-toolbar-button
                   id="refreshInputFileButton"
                   icon="file-code"
-                  title="Refresh input files"
+                  label="Refresh input files"
                 ></vscode-toolbar-button>
                 <label
                   for="inputFile"
@@ -84,12 +84,12 @@
                 <vscode-toolbar-button
                   id="currentInputFileButton"
                   icon="file-code"
-                  title="Set current file as input"
+                  label="Set current file as input"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyInputFileButton"
                   icon="close"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <span
                   id="toggleInputFiles"
@@ -100,17 +100,17 @@
                 <vscode-toolbar-button
                   id="addOpenedInputFilesButton"
                   icon="folder-opened"
-                  title="Add opened files as input"
+                  label="Add opened files as input"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyInputFilesButton"
                   icon="trash"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectInputFilesButton"
                   icon="add"
-                  title="Add"
+                  label="Add"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -133,7 +133,7 @@
                 <vscode-toolbar-button
                   id="refreshReferenceFileButton"
                   icon="book"
-                  title="Refresh reference files"
+                  label="Refresh reference files"
                 ></vscode-toolbar-button>
                 <label
                   for="referenceFile"
@@ -145,12 +145,12 @@
                 <vscode-toolbar-button
                   id="currentReferenceFileButton"
                   icon="file-code"
-                  title="Set current file as reference"
+                  label="Set current file as reference"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyReferenceFileButton"
                   icon="close"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <span
                   id="toggleReferenceFiles"
@@ -161,17 +161,17 @@
                 <vscode-toolbar-button
                   id="addOpenedReferenceFilesButton"
                   icon="folder-opened"
-                  title="Add opened files as reference"
+                  label="Add opened files as reference"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyReferenceFilesButton"
                   icon="trash"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectReferenceFilesButton"
                   icon="add"
-                  title="Add"
+                  label="Add"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -194,7 +194,7 @@
                 <vscode-toolbar-button
                   id="refreshAuxiliaryFileButton"
                   icon="file-add"
-                  title="Refresh auxiliary files"
+                  label="Refresh auxiliary files"
                 ></vscode-toolbar-button>
                 <label
                   for="auxiliaryFile"
@@ -206,12 +206,12 @@
                 <vscode-toolbar-button
                   id="currentAuxiliaryFileButton"
                   icon="file-code"
-                  title="Set current file as auxiliary"
+                  label="Set current file as auxiliary"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyAuxiliaryFileButton"
                   icon="close"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <span
                   id="toggleAuxiliaryFiles"
@@ -222,17 +222,17 @@
                 <vscode-toolbar-button
                   id="addOpenedAuxiliaryFilesButton"
                   icon="folder-opened"
-                  title="Add opened files as auxiliary"
+                  label="Add opened files as auxiliary"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyAuxiliaryFilesButton"
                   icon="trash"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectAuxiliaryFilesButton"
                   icon="add"
-                  title="Add"
+                  label="Add"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -255,7 +255,7 @@
                 <vscode-toolbar-button
                   id="refreshMediaFileButton"
                   icon="file-media"
-                  title="Refresh media files"
+                  label="Refresh media files"
                 ></vscode-toolbar-button>
                 <label
                   for="mediaFile"
@@ -295,7 +295,7 @@
                 <vscode-toolbar-button
                   id="emptyMediaFileButton"
                   icon="close"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <span
                   id="toggleMediaFiles"
@@ -306,12 +306,12 @@
                 <vscode-toolbar-button
                   id="emptyMediaFilesButton"
                   icon="trash"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectMediaFilesButton"
                   icon="add"
-                  title="Add"
+                  label="Add"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -347,12 +347,12 @@
                 <vscode-toolbar-button
                   id="emptyOutputFilesButton"
                   icon="trash"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectOutputFilesButton"
                   icon="add"
-                  title="Add"
+                  label="Add"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -396,19 +396,19 @@
               <vscode-toolbar-button
                 id="packButton"
                 icon="archive"
-                title="Pack the output for this agent into the History folder"
+                label="Pack the output for this agent into the History folder"
                 style="display: none"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="cleanButton"
                 icon="trash"
-                title="Clean the output for this agent"
+                label="Clean the output for this agent"
                 style="display: none"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="magicPolishButton"
                 icon="sparkle"
-                title="Polish instruction text with AI"
+                label="Polish instruction text with AI"
               ></vscode-toolbar-button>
               <div
                 id="polishProgressContainer"
@@ -424,12 +424,12 @@
               <vscode-toolbar-button
                 id="recordInstructionButton"
                 icon="mic"
-                title="Record instruction with microphone"
+                label="Record instruction with microphone"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="eraseInstructionButton"
                 icon="clear-all"
-                title="Erase Instruction"
+                label="Erase Instruction"
               ></vscode-toolbar-button>
             </vscode-toolbar-container>
           </div>
@@ -444,7 +444,7 @@
               <div class="select-group agent-select-group">
                 <i
                   id="agentSettingsButton"
-                  class="codicon codicon-robot clickable"
+                  class="codicon codicon-sparkle clickable"
                   title="Agent settings"
                 ></i>
                 <div class="agent-select-controls">
@@ -498,7 +498,7 @@
               <div class="select-group">
                 <i
                   id="modelSettingsButton"
-                  class="codicon codicon-sparkle clickable"
+                  class="codicon codicon-robot clickable"
                   title="Model settings"
                 ></i>
                 <vscode-single-select id="model">
@@ -590,12 +590,12 @@
                 <vscode-toolbar-button
                   id="currentBaseFileButton"
                   icon="file-code"
-                  title="Set current file as base"
+                  label="Set current file as base"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyBaseFileButton"
                   icon="close"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -609,7 +609,7 @@
                 <vscode-toolbar-button
                   id="refreshEditedFileButton"
                   icon="edit"
-                  title="Refresh edited files"
+                  label="Refresh edited files"
                 ></vscode-toolbar-button>
                 <label
                   for="editedFile"
@@ -621,32 +621,32 @@
                 <vscode-toolbar-button
                   id="acceptButton"
                   icon="check"
-                  title="Accept changes from edited file and overwrite base file"
+                  label="Accept changes from edited file and overwrite base file"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="compareButton"
                   icon="diff"
-                  title="Compare the selected edited file with the selected base file"
+                  label="Compare the selected edited file with the selected base file"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="mergeButton"
                   icon="merge"
-                  title="Create a new verion of the base file by merging the edits suggested by the edited file"
+                  label="Create a new verion of the base file by merging the edits suggested by the edited file"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="latexdiffButton"
                   icon="diff-single"
-                  title="LaTeXdiff the selected edited file with the selected base file"
+                  label="LaTeXdiff the selected edited file with the selected base file"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="currentEditedFileButton"
                   icon="file-code"
-                  title="Set current file as edited"
+                  label="Set current file as edited"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyEditedFileButton"
                   icon="close"
-                  title="Empty"
+                  label="Empty"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -660,7 +660,7 @@
                 <vscode-toolbar-button
                   id="refreshCommitButton"
                   icon="git-commit"
-                  title="Refresh commit list"
+                  label="Refresh commit list"
                 ></vscode-toolbar-button>
                 <label for="commit">Commit</label>
               </div>
@@ -668,17 +668,17 @@
                 <vscode-toolbar-button
                   id="latexdiffvcButton"
                   icon="diff-single"
-                  title="LaTeXdiff the selected base file with another git commit"
+                  label="LaTeXdiff the selected base file with another git commit"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="packLatexdiffvcButton"
                   icon="archive"
-                  title="Pack the latexdiff-vc output into the History folder"
+                  label="Pack the latexdiff-vc output into the History folder"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="cleanLatexdiffvcButton"
                   icon="trash"
-                  title="Clean the latexdiff-vc output"
+                  label="Clean the latexdiff-vc output"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -440,17 +440,10 @@
                 icon="sparkle"
                 label="Polish instruction text with AI"
               ></vscode-toolbar-button>
-              <div
+              <vscode-progress-ring
                 id="polishProgressContainer"
-                style="display: none; align-items: center; gap: 8px"
-              >
-                <vscode-progress-ring
-                  style="width: 16px; height: 16px"
-                ></vscode-progress-ring>
-                <span id="polishProgressText" style="font-size: 13px"
-                  >Polishing...</span
-                >
-              </div>
+                style="display: none; width: 16px; height: 16px"
+              ></vscode-progress-ring>
               <vscode-toolbar-button
                 id="recordInstructionButton"
                 icon="mic"

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -580,6 +580,10 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         progressContainer.style.display = 'none';
       }
 
+      vscode.postMessage({
+        command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
+        text: 'Instruction text has been polished!',
+      });
       mainViewState.save();
     }
     this._postHandle();

--- a/src/webview/modules/uiManagers/ActionButtonManager.js
+++ b/src/webview/modules/uiManagers/ActionButtonManager.js
@@ -36,7 +36,7 @@ export class ActionButtonManager extends BaseUIManager {
           'polishProgressContainer',
         );
         if (progressContainer) {
-          progressContainer.style.display = 'flex';
+          progressContainer.style.display = 'block';
         }
 
         this.vscode.postMessage({

--- a/src/webview/styles/dropdown.css
+++ b/src/webview/styles/dropdown.css
@@ -1,0 +1,116 @@
+/**
+ * Dropdown styles for Webview
+ * Dropdown menus, toggle buttons, and options
+ */
+
+/* Dropdown positioning */
+.dropdown-container {
+  position: relative;
+}
+
+.dropdown-left .dropdown-options {
+  left: 0;
+  right: auto;
+}
+
+/* Toggle button styling */
+.auto-toggle,
+.tool-toggle {
+  cursor: pointer;
+  user-select: none;
+  color: var(--vscode-foreground);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  padding: var(--spacing-tiny) var(--spacing-medium);
+  font-size: var(--font-size-sm);
+  border-radius: var(--border-radius);
+  background: transparent;
+  border: 1px solid var(--vscode-button-border);
+  pointer-events: auto;
+  font-weight: normal;
+}
+
+.auto-toggle.active,
+.tool-toggle.active {
+  background: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
+  border-color: var(--vscode-list-activeSelectionBackground);
+}
+
+/* Remove duplicate icon styling - use .auto-toggle/.tool-toggle .codicon instead */
+
+.auto-toggle .codicon,
+.tool-toggle .codicon {
+  font-size: var(--font-size-sm);
+  margin-left: 1px;
+  margin-right: 0;
+  color: var(--vscode-foreground);
+  position: relative;
+  top: 0;
+}
+
+/* Make dropdown toggles interactive */
+#toggleAutoExtract,
+#toggleToolConfig {
+  pointer-events: auto;
+}
+
+/* Dropdown options container */
+.dropdown-options {
+  position: absolute;
+  top: 100%;
+  z-index: 100;
+  margin-top: var(--spacing-tiny);
+  background: var(--vscode-menu-background);
+  border: 1px solid var(--vscode-menu-border);
+  border-radius: var(--border-radius);
+  box-shadow: var(--vscode-widget-shadow);
+  min-width: var(--width-dropdown);
+  display: none;
+  flex-direction: column;
+  font-size: calc(var(--vscode-editor-font-size) * 0.9);
+  padding: 1px;
+  white-space: nowrap;
+  font-weight: normal;
+}
+
+/* Dropdown option labels - special styles not covered by vscode-checkbox */
+.dropdown-options vscode-checkbox {
+  display: block;
+  width: 100%;
+  padding: 1px var(--spacing-tiny);
+  border-radius: var(--border-radius-small);
+  font-weight: normal;
+  font-size: calc(var(--vscode-editor-font-size) * 0.9);
+  line-height: 1;
+}
+
+.dropdown-options vscode-checkbox:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.dropdown-options .codicon {
+  width: var(--width-icon);
+  text-align: center;
+  font-size: calc(var(--vscode-editor-font-size) * 0.9);
+}
+
+/* Disabled option styling - shared across dropdowns */
+vscode-option.disabled-option,
+vscode-option.disabled-model,
+vscode-option.disabled-agent,
+vscode-option[data-requires-key='true'] {
+  color: var(--vscode-descriptionForeground);
+  opacity: var(--opacity-subtle);
+  font-style: italic;
+  background-color: var(--vscode-input-background);
+}
+
+vscode-option[data-multiple='true'] {
+  font-family: codicon, var(--vscode-font-family);
+}
+
+vscode-option[data-tool-use='true'] {
+  font-style: italic;
+}

--- a/src/webview/styles/file-selection.css
+++ b/src/webview/styles/file-selection.css
@@ -113,15 +113,6 @@ vscode-toolbar-container.file-select-actions {
 }
 
 /* Add this specific selector for Multiple Output Files section */
-.file-select:has(#outputFilesContainer[style*='none']) .optional-label {
-  opacity: 0.6;
-}
-
-.file-select:has(#outputFilesContainer[style*='block']) .optional-label {
-  color: var(--vscode-foreground);
-  opacity: 1;
-}
-
 .file-select:has(#outputFilesContainer[style*='none']) #emptyOutputFilesButton,
 .file-select:has(#outputFilesContainer[style*='none'])
   #selectOutputFilesButton {

--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -8,7 +8,7 @@
   display: flex;
   gap: var(--spacing-small);
   align-items: center;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   flex: 1 1 auto;
   min-width: 0;
 }


### PR DESCRIPTION
## Summary
- revert the progress view stream tab UI back to the handcrafted button layout and remove the vscode-tree dependency
- restore the original event/state handling for progress view task groups and toolbar interactions
- reinstate supporting CSS/templates plus dropdown styling that were replaced during the tree migration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6900e3e6148c8324938a64a987c77e84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the tree-based ProgressView to custom tabs and details groups, updates handlers/styles, adds delete-all confirm, chat instruction behavior, and polish progress.
> 
> - **ProgressView UI (frontend)**:
>   - **Revert tree migration**: Remove `vscode-tree` usage for stream tabs and log groups; implement custom tab buttons and `details/summary`-based groups with new templates (`streamTabTemplate`, `groupDetailsTemplate`, `groupHeaderTemplate`).
>   - **State & events**: Update `EventsManager` to handle click-based tab switching/deletion; persist and reapply group toggle states; simplify agent filter handling; remove ungrouped log container.
>   - **Instruction & chat**: Pass `sessionKind`; show workflow instructions in panel; render tool-use instructions as a user chat message; rename panel title to "Chat".
>   - **Follow-up UX**: Show/hide follow-up input for tool-use sessions; add progress ring for AI polish; tidy recording/insert behavior.
>   - **Usage & groups**: New `GROUP_DOM_IDS`; update usage insertion and header IDs; chronological insertion within nested groups; refine styles for groups/tabs.
>   - **Accessibility/UI polish**: Convert many button `title` tooltips to visible `label`s; add dropdown styles; minor template/CSS cleanups.
> - **Webview updater/events (backend glue)**:
>   - Send `sessionKind` with `UPDATE_INSTRUCTION`; streamline stream filtering; update delete-all to show confirmation modal; adjust stream info labeling for tool/chat.
>   - Minor status/usage/log updates aligned to new DOM structure and IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4965b180e799050b386e3d0c38843f5415a6f82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->