### PR TITLE
fix: keep selected files when refreshing lists

### DIFF
--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -34,20 +34,22 @@ export class FileSelect {
       return;
     }
     const previousValue = selectDiv.value;
-    selectDiv.innerHTML = '';
-    this.addOption(selectDiv, '', 'None');
-    files.forEach((f) => this.addOption(selectDiv, f, f));
-    if (
+    const normalizedFiles = Array.isArray(files) ? files : [];
+    const shouldPreserveValue =
       previousValue !== undefined &&
       previousValue !== null &&
-      previousValue !== ''
-    ) {
-      const hasPreviousOption = Array.from(
-        selectDiv.querySelectorAll('vscode-option'),
-      ).some((option) => option.value === previousValue);
-      if (hasPreviousOption) {
-        safeSetElementValue(id, previousValue);
+      previousValue !== '';
+
+    selectDiv.innerHTML = '';
+    this.addOption(selectDiv, '', 'None');
+    normalizedFiles.forEach((f) => this.addOption(selectDiv, f, f));
+
+    if (shouldPreserveValue) {
+      const hasPreviousOption = normalizedFiles.includes(previousValue);
+      if (!hasPreviousOption) {
+        this.addOption(selectDiv, previousValue, previousValue);
       }
+      safeSetElementValue(id, previousValue);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure single-file dropdowns retain their current value after refresh requests even if the option is not returned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6900a4c9c2148324826e184c13e542f8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures single-file dropdowns retain the previous selection across refreshes, even if the option isn’t in the new list.
> 
> - **Webview UI** (`src/webview/modules/uiManagers/FileSelect.js`):
>   - **File dropdown update**: Normalize `files` input, rebuild options, and preserve previous selection.
>     - If previous value isn’t in refreshed options, add it back before setting value.
>     - Always add base `None` option and safely set selected value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd25a97362dcf8feb9faff97d8a2a652f7dd0528. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->