### PR TITLE
refactor: centralize agent output group management

### DIFF
--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -3,6 +3,9 @@ import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
 
+// Local imports - logging
+import { withLogGroup } from '@logger/logGroupUtils';
+
 /**
  * Chain of Thought (CoT) agent implementation that extends BaseReflectionAgent.
  * Adds XML structure validation and specialized output handling for multi-step reasoning.
@@ -40,76 +43,54 @@ export class CoTAgent extends BaseReflectionAgent {
     options: RoundOutputOptions,
   ): Promise<string[]> {
     const { outputFile, endTurn, processGroupId } = options;
-    // Declare the process group ID at the function scope level
-    // Initialize with processGroupId if provided, otherwise it will be set in the try block
-    let outputProcessGroupId: string = processGroupId || '';
 
-    try {
-      // Start a main output processing group if none provided
-      if (!processGroupId) {
-        outputProcessGroupId = await this.logger.startGroup(
-          `OutputProcessing-Round${currRound}`,
-          undefined,
-          this.logger.getActiveGroupId(),
-        );
-      }
+    const runOutputHandling = async (groupId?: string): Promise<string[]> => {
+      const effectiveGroupId = groupId ?? this.logger.getActiveGroupId();
 
-      // Initialize output files array if needed
-      this.outputHandler.ensureRound(currRound);
+      try {
+        this.outputHandler.ensureRound(currRound);
 
-      if (endTurn) {
-        this.logger.debug(
-          `Processing output for round ${currRound}`,
-          outputProcessGroupId,
-        );
+        if (endTurn) {
+          this.logger.debug(
+            `Processing output for round ${currRound}`,
+            effectiveGroupId,
+          );
 
-        // First fix XML structure
-        await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-          outputFile,
-          this.agentSetting.documentTag,
-        );
+          await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
+            outputFile,
+            this.agentSetting.documentTag,
+          );
 
-        // Then process output files using the output handler
-        await this.outputHandler.processOutputFiles(
-          outputFile,
-          currRound,
-          outputProcessGroupId,
-        );
+          await this.outputHandler.processOutputFiles(
+            outputFile,
+            currRound,
+            effectiveGroupId,
+          );
+        }
 
-        // Note: latexdiff processing is now handled in the parent class's handleOutput method
-      }
-
-      // Finally handle statistics in base class (but pass our group ID)
-      const result = await super.handleOutput(
-        currRound,
-        stateRound,
-        stateGlobal,
-        {
+        return super.handleOutput(currRound, stateRound, stateGlobal, {
           outputFile,
           endTurn,
-          processGroupId: outputProcessGroupId,
-        },
-      );
-
-      // Only end the processing group if we created it
-      // Maybe this kind of setup is more graceful to do a withGroup kind of function?
-      if (!processGroupId) {
-        this.logger.endGroup(outputProcessGroupId, 'stopped');
+          processGroupId: effectiveGroupId,
+        });
+      } catch (error) {
+        this.logger.error(
+          `Error in handleOutput for round ${currRound}: ${error}`,
+          effectiveGroupId,
+        );
+        throw error;
       }
+    };
 
-      return result;
-    } catch (err) {
-      this.logger.error(
-        `Error in handleOutput for round ${currRound}: ${err}`,
-        processGroupId,
-      );
-
-      // Only end the processing group if we created it and we have a valid outputProcessGroupId
-      if (!processGroupId && outputProcessGroupId) {
-        this.logger.endGroup(outputProcessGroupId, 'error');
-      }
-
-      throw err; // Re-throw to maintain error propagation
+    if (processGroupId) {
+      return runOutputHandling(processGroupId);
     }
+
+    return withLogGroup(
+      this.logger,
+      `OutputProcessing-Round${currRound}`,
+      runOutputHandling,
+      { parentGroupId: this.logger.getActiveGroupId() },
+    );
   }
 }

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -4,6 +4,9 @@ import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
 
+// Local imports - logging
+import { withLogGroup } from '@logger/logGroupUtils';
+
 /**
  * Direct agent implementation that processes requests in a single pass.
  * Extends BaseReflectionAgent with simplified output handling and no intermediate steps.
@@ -37,83 +40,60 @@ export class DirectAgent extends BaseReflectionAgent {
     options: RoundOutputOptions,
   ): Promise<string[]> {
     const { outputFile, endTurn, processGroupId } = options;
-    // Declare the process group ID at the function scope level
-    // Initialize with processGroupId if provided, otherwise it will be set in the try block
-    let outputProcessGroupId: string = processGroupId || '';
 
-    // These groups needs to be made consistent with the @BaseReflectionAgent.handleOutput method
-    try {
-      // Start a main output processing group if none provided
-      if (!processGroupId) {
-        outputProcessGroupId = await this.logger.startGroup(
-          `OutputProcessing-Round${currRound}`,
-          undefined,
-          this.logger.getActiveGroupId(),
-        );
-      }
+    const runOutputHandling = async (groupId?: string): Promise<string[]> => {
+      const effectiveGroupId = groupId ?? this.logger.getActiveGroupId();
 
-      // Initialize output files array if needed
-      this.outputHandler.ensureRound(currRound);
+      try {
+        this.outputHandler.ensureRound(currRound);
 
-      if (endTurn) {
-        this.logger.debug(
-          `Processing output for round ${currRound}`,
-          outputProcessGroupId,
-        );
+        if (endTurn) {
+          this.logger.debug(
+            `Processing output for round ${currRound}`,
+            effectiveGroupId,
+          );
 
-        // I do not think DirectAgent should ever use scratchpad;
-        if (this.useScratchpad) {
-          await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
+          if (this.useScratchpad) {
+            await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
+              outputFile,
+              this.agentSetting.documentTag,
+            );
+          }
+
+          await this.outputHandler.processOutputFiles(
             outputFile,
-            this.agentSetting.documentTag,
+            currRound,
+            effectiveGroupId,
+          );
+          this.logger.debug(
+            `Output files processed for round ${currRound}`,
+            effectiveGroupId,
           );
         }
 
-        // Process output files using the output handler
-        await this.outputHandler.processOutputFiles(
-          outputFile,
-          currRound,
-          outputProcessGroupId,
-        );
-        this.logger.debug(
-          `Output files processed for round ${currRound}`,
-          outputProcessGroupId,
-        );
-
-        // Note: latexdiff processing is now handled in the parent class's handleOutput method
-      }
-
-      // Finally handle statistics in base class (but pass our group ID)
-      const result = await super.handleOutput(
-        currRound,
-        stateRound,
-        stateGlobal,
-        {
+        return super.handleOutput(currRound, stateRound, stateGlobal, {
           outputFile,
           endTurn,
-          processGroupId: outputProcessGroupId,
-        },
-      );
-
-      // Only end the processing group if we created it
-      // Maybe this kind of setup is more graceful to do a withGroup kind of function?
-      if (!processGroupId) {
-        this.logger.endGroup(outputProcessGroupId, 'stopped');
+          processGroupId: effectiveGroupId,
+        });
+      } catch (error) {
+        this.logger.error(
+          `Error in DirectAgent.handleOutput: ${error}`,
+          effectiveGroupId,
+        );
+        throw error;
       }
+    };
 
-      return result;
-    } catch (error) {
-      this.logger.error(
-        `Error in DirectAgent.handleOutput: ${error}`,
-        processGroupId,
-      );
-
-      // Only end the processing group if we created it and we have a valid outputProcessGroupId
-      if (!processGroupId && outputProcessGroupId) {
-        this.logger.endGroup(outputProcessGroupId, 'error');
-      }
-
-      throw error;
+    if (processGroupId) {
+      return runOutputHandling(processGroupId);
     }
+
+    return withLogGroup(
+      this.logger,
+      `OutputProcessing-Round${currRound}`,
+      runOutputHandling,
+      { parentGroupId: this.logger.getActiveGroupId() },
+    );
   }
 }


### PR DESCRIPTION
## Summary
- use `withLogGroup` to manage output processing groups in CoTAgent and DirectAgent
- share the output handling flow through a helper that reuses the active group context

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690100d59b50832498ffdf02f6d996d3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces manual logger group management with withLogGroup and a shared runOutputHandling flow in CoTAgent and DirectAgent.
> 
> - **Agents**:
>   - **CoTAgent**:
>     - Refactors `handleOutput` to use `withLogGroup` and a `runOutputHandling` helper with `effectiveGroupId`.
>     - Keeps XML validation before processing and delegates to base `handleOutput` with the active group.
>   - **DirectAgent**:
>     - Mirrors the same `withLogGroup`-based `handleOutput` refactor with `runOutputHandling`.
>     - Conditionally performs XML structure fix when `useScratchpad` is enabled; then processes outputs and delegates to base.
> - **Logging**:
>   - Centralizes output group lifecycle management; removes manual start/end and standardizes error logging with the active group context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b271cdf84400120f18ec30d0807ba2cea7083728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->