### PR TITLE
fix: preserve dropdown selection on refresh

### DIFF
--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -1,5 +1,6 @@
 // Local imports - webview
 import { ELEMENT_IDS, EDITED_FILE } from '../constants.js';
+import { mainViewState } from '../mainViewState.js';
 import {
   safeGetElementById,
   safeSetElementValue,
@@ -50,6 +51,7 @@ export class FileSelect {
         this.addOption(selectDiv, previousValue, previousValue);
       }
       safeSetElementValue(id, previousValue);
+      mainViewState.update({ [id]: previousValue });
     }
   }
 


### PR DESCRIPTION
## Summary
- keep the previous single-file selection when refreshing dropdown options
- sync the restored value back into the saved main view state to avoid wiping it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6900ffefda888324be8db9800a1dc64f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves previous single-file dropdown selection on refresh and persists the restored value to `mainViewState`.
> 
> - **Webview UI**:
>   - **`FileSelect.update`**: When repopulating options, preserves the prior selection and syncs it via `mainViewState.update({ [id]: previousValue })`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf875187a17db875ac8f412e4a5cce1c8a505776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->