### PR TITLE
refactor: simplify log group nesting

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -372,34 +372,29 @@ export async function executeAgentWithLogging<T extends IAgent>(
     await withLogGroup(
       logger,
       `Task: ${agentName}@${config.model}`,
-      async (mainTaskGroupId) => {
+      async (mainTaskGroup) => {
+        const mainTaskLog = mainTaskGroup?.logger ?? logger;
         try {
           await withLogGroup(
             logger,
             `Task Details`,
-            async (taskDetailsGroupId) => {
-              if (!isResume && taskDetailsGroupId) {
-                logger.info(
+            async (taskDetailsGroup) => {
+              const taskDetailsLog = taskDetailsGroup?.logger ?? mainTaskLog;
+              if (!isResume && taskDetailsGroup) {
+                taskDetailsLog.info(
                   `Starting task execution for ${activeStreamId}`,
-                  taskDetailsGroupId,
                 );
-                logger.info(
-                  `Input file: ${config.inputFile}`,
-                  taskDetailsGroupId,
-                );
+                taskDetailsLog.info(`Input file: ${config.inputFile}`);
               }
 
-              logger.debug(
+              taskDetailsLog.debug(
                 `Creating stream with ID: ${activeStreamId}`,
-                taskDetailsGroupId,
               );
-              logger.debug(
+              taskDetailsLog.debug(
                 `Agent name: ${agentName}, Model: ${config.model}, Input file: ${config.inputFile}`,
-                taskDetailsGroupId,
               );
-              logger.debug(
+              taskDetailsLog.debug(
                 `Config has output files: ${!!config.outputFiles}, Number of output files: ${config.outputFiles?.length || 0}, useMultipleOutputs: ${config.useMultipleOutputs}`,
-                taskDetailsGroupId,
               );
 
               // Switch to this stream and set its status to running
@@ -462,13 +457,11 @@ export async function executeAgentWithLogging<T extends IAgent>(
                 }
 
                 // Store taskState
-                logger.debug(
+                taskDetailsLog.debug(
                   `Storing taskState for stream: ${activeStreamId}`,
-                  taskDetailsGroupId,
                 );
-                logger.debug(
+                taskDetailsLog.debug(
                   `Config for taskState: ${JSON.stringify(config)}`,
-                  taskDetailsGroupId,
                 );
 
                 // Convert AgentConfig to TaskState using utility function
@@ -477,28 +470,23 @@ export async function executeAgentWithLogging<T extends IAgent>(
                   executionId,
                   taskState: agentConfigToTaskState(config, metadata),
                 });
-                logger.debug(
+                mainTaskLog.debug(
                   `Task state stored for stream: ${activeStreamId}`,
-                  mainTaskGroupId,
                 );
               }
             },
-            { parentGroupId: mainTaskGroupId, skip: isResume },
+            { skip: isResume },
           );
         } catch (err) {
-          logger.error(
+          mainTaskLog.error(
             `Task initialization failed: ${err instanceof Error ? err.message : String(err)}`,
-            mainTaskGroupId,
           );
           throw err;
         }
 
         try {
           // Run the agent
-          logger.info(
-            `Executing ${agentName} with model ${config.model}`,
-            mainTaskGroupId,
-          );
+          mainTaskLog.info(`Executing ${agentName} with model ${config.model}`);
           if (!agent) {
             throw new Error('Agent instance was not initialized');
           }
@@ -506,7 +494,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           await agent.run();
           // await checkExpectedOutputs(config.outputFiles, agent);
           // Mark the task as completed successfully
-          logger.debug(`Task completed successfully`, mainTaskGroupId);
+          mainTaskLog.debug(`Task completed successfully`);
           // Update status to stopped on successful completion
           bus.emit('updateStreamStatus', {
             stream: activeStreamId,
@@ -514,9 +502,8 @@ export async function executeAgentWithLogging<T extends IAgent>(
           });
         } catch (err) {
           // Mark the task as failed
-          logger.error(
+          mainTaskLog.error(
             `Task failed: ${err instanceof Error ? err.message : String(err)}`,
-            mainTaskGroupId,
           );
           // Update status to error if agent run fails
           bus.emit('updateStreamStatus', {

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -16,6 +16,69 @@ import { SHORT_SLEEP_MS } from '@utils/config';
  * Encapsulates logging functionality for agents with a dedicated channel.
  * Uses the updated consolidated logger system.
  */
+export class GroupScopedLogger {
+  constructor(
+    private readonly baseLogger: AgentLogger,
+    public readonly groupId: string,
+  ) {}
+
+  debug(
+    message: string,
+    groupId?: string,
+    messageType?: MessageType,
+    data?: unknown,
+  ): void {
+    this.baseLogger.debug(message, groupId ?? this.groupId, messageType, data);
+  }
+
+  info(
+    message: string,
+    groupId?: string,
+    messageType?: MessageType,
+    data?: unknown,
+  ): void {
+    this.baseLogger.info(message, groupId ?? this.groupId, messageType, data);
+  }
+
+  warn(
+    message: string,
+    groupId?: string,
+    messageType?: MessageType,
+    data?: unknown,
+  ): void {
+    this.baseLogger.warn(message, groupId ?? this.groupId, messageType, data);
+  }
+
+  error(
+    message: string,
+    groupId?: string,
+    messageType?: MessageType,
+    data?: unknown,
+  ): void {
+    this.baseLogger.error(message, groupId ?? this.groupId, messageType, data);
+  }
+
+  fileList(files: unknown[], groupId?: string): void {
+    this.baseLogger.fileList(files, groupId ?? this.groupId);
+  }
+
+  missingOutputs(info: unknown, groupId?: string): void {
+    this.baseLogger.missingOutputs(info, groupId ?? this.groupId);
+  }
+
+  latexDiff(results: unknown[], groupId?: string): void {
+    this.baseLogger.latexDiff(results, groupId ?? this.groupId);
+  }
+
+  statistics(stats: ExtendedTokenUsageStats, groupId?: string): void {
+    this.baseLogger.statistics(stats, groupId ?? this.groupId);
+  }
+
+  userMessage(message: string, groupId?: string): void {
+    this.baseLogger.userMessage(message, groupId ?? this.groupId);
+  }
+}
+
 export class AgentLogger {
   public readonly isAgentLogger: boolean;
 
@@ -179,5 +242,9 @@ export class AgentLogger {
    */
   setActiveGroupId(groupId: string | undefined): void {
     logger.setActiveGroupId(this.channelId, groupId);
+  }
+
+  createGroupLogger(groupId: string): GroupScopedLogger {
+    return new GroupScopedLogger(this, groupId);
   }
 }

--- a/src/logger/logGroupUtils.ts
+++ b/src/logger/logGroupUtils.ts
@@ -1,5 +1,5 @@
 // Local imports - log
-import type { AgentLogger } from './AgentLogger';
+import type { AgentLogger, GroupScopedLogger } from './AgentLogger';
 
 type GroupStatus = Parameters<AgentLogger['endGroup']>[1];
 
@@ -10,17 +10,21 @@ interface WithLogGroupOptions {
   errorStatus?: GroupStatus;
 }
 
+export interface LogGroupContext {
+  groupId: string;
+  logger: GroupScopedLogger;
+}
+
 /**
  * Utility helper to start a log group, run a function, and automatically end the group.
  */
 export async function withLogGroup<T>(
   logger: AgentLogger,
   groupName: string,
-  fn: (groupId?: string) => Promise<T>,
+  fn: (context: LogGroupContext | undefined) => Promise<T>,
   options: WithLogGroupOptions = {},
 ): Promise<T> {
   const {
-    parentGroupId,
     skip = false,
     successStatus = 'stopped',
     errorStatus = 'error',
@@ -30,14 +34,28 @@ export async function withLogGroup<T>(
     return fn(undefined);
   }
 
-  const groupId = await logger.startGroup(groupName, undefined, parentGroupId);
+  const previousGroupId = logger.getActiveGroupId();
+  const resolvedParentGroupId =
+    options.parentGroupId === undefined
+      ? previousGroupId
+      : options.parentGroupId;
+  const groupId = await logger.startGroup(
+    groupName,
+    undefined,
+    resolvedParentGroupId,
+  );
+  const groupLogger = logger.createGroupLogger(groupId);
+
+  logger.setActiveGroupId(groupId);
 
   try {
-    const result = await fn(groupId);
+    const result = await fn({ groupId, logger: groupLogger });
     logger.endGroup(groupId, successStatus);
     return result;
   } catch (error) {
     logger.endGroup(groupId, errorStatus);
     throw error;
+  } finally {
+    logger.setActiveGroupId(previousGroupId);
   }
 }


### PR DESCRIPTION
## Summary
- default `withLogGroup` to nest groups using the previously active group when no parent is supplied
- simplify `executeAgentWithLogging` to rely on the scoped logger context instead of threading group IDs

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6900ff5ab3a08324bed3fccfcec77d1f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `GroupScopedLogger` and updates `withLogGroup` to auto-nest using the active group, refactoring agent execution to use scoped loggers instead of passing group IDs.
> 
> - **Logger**:
>   - **`GroupScopedLogger`**: New wrapper providing group-bound `debug/info/warn/error` and structured methods.
>   - **`withLogGroup`**: Now returns `{ groupId, logger }` context; implicitly nests under the previously active group when `parentGroupId` is unspecified; sets/restores active group automatically.
>   - **`AgentLogger`**: Adds `createGroupLogger(groupId)`; minor integrations with active group management.
> - **Runtime**:
>   - **`executeAgent.ts`**: Refactors logging to use scoped logger context (`mainTaskLog`/`taskDetailsLog`) instead of threading group IDs; consolidates log calls accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c2f10a5ebfba1912fc8a3fb47371b191b5bb381. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->