### PR TITLE
refactor: align agent cycles with flow nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Prevent repeated-response suppression from mutating internal tool state so follow-up connectors stay aligned with written output.
+
 ## [0.34.1] - 2025-10-24
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Prevent repeated-response suppression from mutating internal tool state so follow-up connectors stay aligned with written output.
+- Ensure Google Gemini tool calls synthesize stable identifiers so tool-use runs no longer spam "missing call_id" errors.
 
 ## [0.34.1] - 2025-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Prevent repeated-response suppression from mutating internal tool state so follow-up connectors stay aligned with written output.
 - Ensure Google Gemini tool calls synthesize stable identifiers so tool-use runs no longer spam "missing call_id" errors.
+- Strip unsupported Gemini tool-call identifiers from follow-up history and tighten tool dispatch context handling to prevent silent failures during tool runs.
 
 ## [0.34.1] - 2025-10-24
 

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -1,37 +1,30 @@
 // Local imports - agent components
-import type { AgentConfig } from './AgentConfig';
-import type { AgentSetting, AgentPrompt } from './AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from './AgentState';
+import { AgentStateGlobal, AgentStateRound } from './AgentState';
 import { ToolState } from './ToolState';
 
-// Local imports - agent utilities
-import type { IModelHandler } from '@agent/modelHandlers';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
-import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
-import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
-import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
-import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
+// Local imports - flow orchestration
+import {
+  createResponseCycleFlow,
+  type ResponseCycleShared,
+  type ResponseCycleState,
+} from './flows/ResponseCycleFlow';
 
-// Local imports - latex utilities
-import { bestConnectionMethod } from '@latex';
+// Local imports - model handler types
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+// Local imports - identifier types
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - logging
-import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import replacementEngine from '@replacement/engine';
+import type { AgentLogger } from '@logger/AgentLogger';
 
-// Shared constants
-import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
+// Local imports - model handlers
+import type { IModelHandler } from '@agent/modelHandlers';
 
-// Local imports - filesystem utilities
-import { WorkspaceFS } from '@utils/files';
-import { getRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
-import xmlUtils from '@utils/text/xmlUtils';
+// Local imports - agent configuration
+import type { AgentConfig } from './AgentConfig';
+import type { AgentPrompt, AgentSetting } from './AgentDataclass';
 
-/**
- * Options required to run a single response cycle.
- */
 export interface ResponseCycleOptions<C = unknown> {
   modelHandler: IModelHandler<any, any, any, any, C>;
   agentSetting: AgentSetting;
@@ -44,276 +37,58 @@ export interface ResponseCycleOptions<C = unknown> {
   setAbortController: (ctrl: AbortController | null) => void;
 }
 
-/**
- * Executes a response cycle.
- * @returns Tuple of [round state, global state, tool state, completion flag]
- */
+export interface ResponseCycleContext<C = unknown> {
+  options: ResponseCycleOptions<C>;
+  messages: ProviderMessage[];
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  outputFile: string;
+  roundGroupId?: string;
+  executionId?: ExecutionId;
+}
+
+export interface ResponseCycleResult {
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  endTurn: boolean;
+}
+
 export async function runResponseCycle<C = unknown>(
-  options: ResponseCycleOptions<C>,
-  messages: ProviderMessage[],
-  stateRound: AgentStateRound,
-  stateGlobal: AgentStateGlobal,
-  toolState: ToolState,
-  outputFile: string,
-  roundGroupId?: string,
-  executionId?: ExecutionId,
-): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
-  const {
-    modelHandler,
-    agentSetting,
-    agentConfig,
-    agentPrompt,
-    userVars,
-    logger,
-    client,
-    checkInterruption,
-    setAbortController,
-  } = options;
+  context: ResponseCycleContext<C>,
+): Promise<ResponseCycleResult> {
+  const shared: ResponseCycleShared<C> = {
+    options: context.options,
+    cycle: {
+      messages: context.messages,
+      stateRound: context.stateRound,
+      stateGlobal: context.stateGlobal,
+      toolState: context.toolState,
+      outputFile: context.outputFile,
+      roundGroupId: context.roundGroupId,
+      executionId: context.executionId,
+      endTurn: false,
+      shouldStop: false,
+      outputExists: false,
+      systemPrompt: undefined,
+      debugContext: undefined,
+      debugFileOptions: undefined,
+      startTime: undefined,
+      responseObject: undefined,
+      responseTime: undefined,
+      stopReason: undefined,
+      processedResponse: undefined,
+    } satisfies ResponseCycleState,
+  };
 
-  const taskGroupId = roundGroupId;
+  const flow = createResponseCycleFlow<C>();
+  await flow.run(shared);
 
-  let endTurn = false;
-  while (!endTurn) {
-    if (await checkInterruption()) {
-      break;
-    }
-
-    const exists = await WorkspaceFS.exists(outputFile);
-    const startTime = Date.now();
-    const systemPrompt = await getSystemPromptWithRules(
-      agentPrompt.systemPrompt,
-      userVars,
-    );
-
-    // Common debug save parameters
-    const debugContext = {
-      logger,
-      modelName: agentConfig.model,
-      executionId,
-      groupId: taskGroupId,
-    };
-    const debugFileOptions = {
-      continuationCount: stateRound.continuationCount,
-      outputFile,
-    };
-
-    await maybeSaveDebugObject({
-      object: messages,
-      objectType: 'messages',
-      context: debugContext,
-      fileOptions: debugFileOptions,
-    });
-
-    const abortController = new AbortController();
-    setAbortController(abortController);
-    modelHandler.setOutputStreaming(false);
-    let responseObject;
-    try {
-      responseObject = await modelHandler.createResponse(
-        client,
-        messages,
-        agentSetting.temperature || 0.0,
-        systemPrompt,
-        agentSetting.endTag,
-        abortController.signal,
-        modelHandler.capabilities.supportsFunctionCalling
-          ? agentSetting.tools
-          : undefined,
-      );
-    } finally {
-      await maybeSaveDebugObject({
-        object: responseObject,
-        objectType: 'response',
-        context: debugContext,
-        fileOptions: debugFileOptions,
-      });
-      setAbortController(null);
-    }
-    await maybeSaveDebugObject({
-      object: responseObject,
-      objectType: 'response',
-      context: debugContext,
-      fileOptions: debugFileOptions,
-    });
-    if (!responseObject) {
-      logger.warn(
-        'Model response was aborted or returned no data; output may be incomplete.',
-        taskGroupId,
-      );
-      break;
-    }
-    const responseTime = (Date.now() - startTime) / 1000;
-    stateRound.updateResponseTime(responseTime);
-    logger.debug(`Response time: ${responseTime.toFixed(2)}s`, taskGroupId);
-
-    const [newResponse, responseUsage, stopReason] =
-      modelHandler.extractResponse(responseObject, agentSetting.endTag);
-
-    logger.debug(`Stop reason: ${stopReason}`, taskGroupId);
-    logger.debug(`Token usage: ${JSON.stringify(responseUsage)}`, taskGroupId);
-
-    const thinkingContent = modelHandler.processThinkingBlock(
-      responseObject,
-      taskGroupId,
-      toolState,
-    );
-    const useStreaming = modelHandler.getStreamingConfig();
-
-    if (newResponse) {
-      logger.debug(`Model response: ${newResponse.slice(0, 100)}`, taskGroupId);
-      if (!useStreaming) {
-        const formattedResponse = await xmlUtils.formatContent(newResponse);
-        logger.info(
-          formattedResponse,
-          taskGroupId,
-          // Workflow agents should not surface final completions in the progress view,
-          // so mark the response as INTERNAL while still writing it to the output channel.
-          MESSAGE_TYPES.INTERNAL,
-        );
-      }
-    }
-
-    // Only log thinking content for non-streaming responses
-    // Streaming responses display thinking content progressively via createThinkingStream()
-    // so we avoid duplicate logging here
-    if (thinkingContent && !useStreaming) {
-      const formatted = await xmlUtils.formatContent(thinkingContent);
-      logger.info(formatted, taskGroupId, MESSAGE_TYPES.THINKING);
-    }
-
-    const scratchpad = await xmlUtils.extractScratchpad(
-      newResponse,
-      'scratchpad',
-    );
-    if (scratchpad) {
-      logger.info(scratchpad, taskGroupId, MESSAGE_TYPES.SCRATCHPAD);
-    }
-
-    const APIUsage = modelHandler.computeResponseUsage(
-      responseUsage,
-      responseTime,
-    );
-    stateRound.updateTokenCounts(APIUsage);
-    stateGlobal.updateFromCurrRound(stateRound);
-
-    const repetitionResult = checkForMassiveRepetition(
-      toolState.lastResponse,
-      newResponse,
-    );
-    if (repetitionResult.massiveRepetitionDetected) {
-      logger.error(
-        `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-        taskGroupId,
-      );
-      logger.error(
-        'Massive repetition detected - skipping this response',
-        taskGroupId,
-      );
-      logger.error('Message structure when repetition detected:', taskGroupId);
-      logger.error(
-        JSON.stringify(messageToSkeleton(messages), null, 2),
-        taskGroupId,
-      );
-      break;
-    }
-
-    const processedResponse = replacementEngine.applyAll(newResponse);
-    toolState.updateLastResponse(processedResponse);
-
-    const result = await bestConnectionMethod(
-      toolState.lastResponse.slice(-K_SLICE),
-      processedResponse.slice(0, K_SLICE),
-    );
-    const bestConnector = result.connector;
-
-    toolState.updateAccumulatedOutput(
-      toolState.accumulatedOutput + bestConnector + processedResponse,
-    );
-
-    if (!exists) {
-      logger.debug(`Creating new file: ${outputFile}`, taskGroupId);
-      await WorkspaceFS.write(outputFile, processedResponse);
-    } else {
-      logger.debug(`Appending to existing file: ${outputFile}`, taskGroupId);
-      await WorkspaceFS.appendFile(
-        outputFile,
-        bestConnector + processedResponse,
-      );
-    }
-
-    logger.debug('Response preview:', taskGroupId);
-    logger.debug(
-      `First ${K_SLICE} chars:\n${processedResponse.slice(0, K_SLICE)}`,
-      taskGroupId,
-    );
-    logger.debug(
-      `Last ${K_SLICE} chars:\n${processedResponse.slice(-K_SLICE)}`,
-      taskGroupId,
-    );
-
-    if (modelHandler.capabilities.supportsAssistantPrefill) {
-      modelHandler.updateMessageContentWithPrefill(
-        messages,
-        bestConnector,
-        processedResponse,
-        toolState,
-      );
-    } else {
-      modelHandler.updateMessageContentWithoutPrefill(
-        messages,
-        bestConnector,
-        processedResponse,
-        toolState,
-      );
-    }
-
-    const [shouldEndTurn, shouldStop] = modelHandler.checkStopConditions(
-      stopReason,
-      processedResponse,
-      stateRound,
-      stateGlobal,
-      agentSetting,
-    );
-    endTurn = shouldEndTurn;
-    if (shouldStop) {
-      break;
-    }
-
-    stateRound.incrementContinuation();
-    logger.info(
-      `Starting continuation #${stateRound.continuationCount}`,
-      taskGroupId,
-      MESSAGE_TYPES.PROGRESS_STATUS,
-    );
-
-    if (
-      modelHandler.shouldContinue(stopReason, processedResponse, agentSetting)
-    ) {
-      logger.debug(
-        'Should continue - adding continuation message to conversation',
-        taskGroupId,
-      );
-      if (modelHandler.capabilities.supportsAssistantPrefill) {
-        modelHandler.addContinueMessageWithPrefill(
-          messages,
-          stateRound,
-          toolState,
-          agentSetting,
-          agentConfig,
-        );
-        continue;
-      } else {
-        modelHandler.addContinueMessageWithoutPrefill(
-          messages,
-          stateRound,
-          toolState,
-          agentSetting,
-          agentConfig,
-        );
-        continue;
-      }
-    }
-  }
-
-  return [stateRound, stateGlobal, toolState, endTurn];
+  return {
+    stateRound: shared.cycle.stateRound,
+    stateGlobal: shared.cycle.stateGlobal,
+    toolState: shared.cycle.toolState,
+    endTurn: shared.cycle.endTurn,
+  };
 }

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -34,7 +34,7 @@ export interface ToolUseCycleOptions<C = unknown> {
   toolRegistry: Record<string, BaseTool<any>>;
   checkInterruption: () => Promise<boolean> | boolean;
   setAbortController: (ctrl: AbortController | null) => void;
-  toolState?: ToolState | null;
+  toolState: ToolState;
   modelName?: string;
   executionId?: ExecutionId;
 }
@@ -52,7 +52,7 @@ export async function runToolUseCycle<C = unknown>(
     options: context.options,
     state: {
       messages: context.messages,
-      toolState: context.options.toolState ?? null,
+      toolState: context.options.toolState,
       groupId: context.groupId,
       iteration: 0,
       shouldStop: false,

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -1,336 +1,69 @@
-// Local imports - agent
-import type { IModelHandler } from '../modelHandlers';
-import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
-
 // Local imports - agent components
-import type { AgentSetting, AgentPrompt } from './AgentDataclass';
 import { ToolState } from './ToolState';
-import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
-import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
-// Utility to run iterative tool-use cycles
 
-// Third-party imports
+// Local imports - flow orchestration
+import {
+  createToolUseCycleFlow,
+  type ToolUseCycleShared,
+  type ToolUseCycleState,
+} from './flows/ToolUseCycleFlow';
 
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import type { ToolDefinition } from '@model';
-import { BaseTool } from '@tools/core/base';
-import { ToolResult, toolResult } from '@tools/result';
-import { sanitizeToolResultForLog } from '@agent/modelHandlers/utils/toolAttachmentUtils';
-import { WorkspaceFS } from '@utils/files';
-import xmlUtils from '@utils/text/xmlUtils';
+// Local imports - agent configuration
+import type { AgentPrompt, AgentSetting } from './AgentDataclass';
+
+// Local imports - logging
+import type { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - model handlers
+import type { IModelHandler } from '@agent/modelHandlers';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+// Local imports - tools
+import type { BaseTool } from '@tools/core/base';
+
+// Local imports - usage
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 export interface ToolUseCycleOptions<C = unknown> {
-  /** Model handler for API interactions */
   modelHandler: IModelHandler<any, any, any, any, C>;
-  /** Agent settings with tool configuration */
   agentSetting: AgentSetting;
-  /** Prompt configuration for the agent */
   agentPrompt: AgentPrompt;
-  /** User variables resolved from YAML */
   userVars: Record<string, any>;
-  /** Logger instance for progress output */
   logger: AgentLogger;
-  /** Provider client object */
   client: C;
-  /** Registry mapping tool names to implementations */
   toolRegistry: Record<string, BaseTool<any>>;
-  /** Check if the agent run has been interrupted */
   checkInterruption: () => Promise<boolean> | boolean;
-  /** Pass abort controllers back to the agent */
   setAbortController: (ctrl: AbortController | null) => void;
-  /** Runtime state tracking for tools */
-  toolState?: ToolState;
-  /** Name of the model used for this run */
+  toolState?: ToolState | null;
   modelName?: string;
+  executionId?: ExecutionId;
 }
 
-/**
- * Execute a tool-use interaction loop until the model returns no tool calls or
- * signals end of turn.
- */
+export interface ToolUseCycleContext<C = unknown> {
+  options: ToolUseCycleOptions<C>;
+  messages: ProviderMessage[];
+  groupId?: string;
+}
+
 export async function runToolUseCycle<C = unknown>(
-  options: ToolUseCycleOptions<C>,
-  messages: ProviderMessage[],
-  groupId?: string,
+  context: ToolUseCycleContext<C>,
 ): Promise<void> {
-  const {
-    modelHandler,
-    agentSetting,
-    logger,
-    client,
-    toolRegistry,
-    checkInterruption,
-    setAbortController,
-    toolState,
-    modelName,
-  } = options;
+  const shared: ToolUseCycleShared<C> = {
+    options: context.options,
+    state: {
+      messages: context.messages,
+      toolState: context.options.toolState ?? null,
+      groupId: context.groupId,
+      iteration: 0,
+      shouldStop: false,
+      response: undefined,
+      responseTime: undefined,
+      toolInfo: undefined,
+      text: undefined,
+      stopReason: undefined,
+    } satisfies ToolUseCycleState,
+  };
 
-  let iteration = 0;
-
-  while (true) {
-    if (await checkInterruption()) {
-      break;
-    }
-
-    await maybeSaveDebugObject({
-      object: messages,
-      objectType: 'messages',
-      context: {
-        logger,
-        modelName,
-        groupId,
-      },
-      fileOptions: {
-        continuationCount: iteration,
-        baseName: 'tooluse',
-      },
-    });
-
-    const abortController = new AbortController();
-    setAbortController(abortController);
-    let response: any;
-    const startTime = Date.now();
-    try {
-      modelHandler.setOutputStreaming(true);
-      response = await modelHandler.createResponse(
-        client,
-        messages,
-        agentSetting.temperature ?? 0,
-        undefined, // endTag - not used in tool use scenarios
-        undefined,
-        abortController.signal,
-        agentSetting.tools as ToolDefinition[],
-      );
-    } finally {
-      setAbortController(null);
-    }
-    await maybeSaveDebugObject({
-      object: response,
-      objectType: 'response',
-      context: {
-        logger,
-        modelName,
-        groupId,
-      },
-      fileOptions: {
-        continuationCount: iteration,
-        baseName: 'tooluse_response',
-      },
-    });
-    const responseTime = (Date.now() - startTime) / 1000;
-    if (!response) {
-      break;
-    }
-
-    const thinking = modelHandler.processThinkingBlock(
-      response,
-      groupId,
-      toolState,
-    );
-    const useStreaming = modelHandler.getStreamingConfig();
-    if (thinking && !useStreaming) {
-      const formatted = await xmlUtils.formatContent(thinking);
-      if (formatted.trim().length > 0) {
-        logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
-      }
-    }
-
-    const toolInfo = modelHandler.extractToolUse(response);
-    // Note: We pass empty string for endTag because model responses in tool use
-    // scenarios should not have custom end tags - they're part of the natural
-    // conversation flow (not specialized content like thinking/scratchpad)
-    const [text, usage, stopReason] = modelHandler.extractResponse(
-      response,
-      '',
-    );
-    if (text) {
-      logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
-      if (!useStreaming) {
-        const formatted = await xmlUtils.formatContent(text);
-        logger.info(formatted, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
-      }
-    }
-    if (usage) {
-      const normalized = modelHandler.computeResponseUsage(usage, responseTime);
-      const stats: ExtendedTokenUsageStats = {
-        inputTokens: normalized.totalInputTokens,
-        outputTokens: normalized.totalOutputTokens,
-        cost: normalized.cost,
-        elapsedTime: normalized.responseTime,
-      };
-      logger.statistics(stats, groupId);
-    }
-
-    const endTurn = modelHandler.isEndTurnStop(stopReason);
-    if (!toolInfo || endTurn) {
-      if (text) {
-        messages.push(modelHandler.createAssistantMessage(text));
-        toolState?.updateLastResponse(text);
-      }
-      break;
-    }
-
-    // Parse tool info first before logging
-    let parsed: any;
-    try {
-      parsed = JSON.parse(toolInfo);
-    } catch (err) {
-      const errorMsg = `Malformed tool JSON: ${err instanceof Error ? err.message : String(err)}`;
-
-      // Log the failed tool use attempt
-      const errorResult = toolResult({ error: errorMsg, isError: true });
-      const toolUseLog = {
-        tool: 'unknown',
-        input: toolInfo,
-        output: sanitizeToolResultForLog(errorResult),
-      };
-      logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
-      break;
-    }
-
-    const id =
-      parsed.call_id || parsed.id || parsed.tool_use_id || parsed.tool_call_id;
-    const name = parsed.name || parsed.function?.name;
-    if (!name) {
-      const errorMsg = `Tool JSON missing name: ${JSON.stringify(parsed)}`;
-
-      // Log the failed tool use attempt with available info
-      const errorResult = toolResult({ error: errorMsg, isError: true });
-      const toolUseLog = {
-        tool: 'unknown',
-        input: parsed,
-        output: sanitizeToolResultForLog(errorResult),
-      };
-      logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
-      break;
-    }
-    let input = parsed.input ?? parsed.args;
-    if (!input && parsed.arguments) {
-      try {
-        input = JSON.parse(parsed.arguments);
-      } catch {
-        input = parsed.arguments;
-      }
-    }
-    if (!input && parsed.function?.arguments) {
-      try {
-        input = JSON.parse(parsed.function.arguments);
-      } catch {
-        input = parsed.function.arguments;
-      }
-    }
-
-    const tool = toolRegistry[name];
-    let result: ToolResult;
-    if (!tool) {
-      result = toolResult({ error: `Unknown tool ${name}`, isError: true });
-    } else {
-      try {
-        result = await tool.call(input);
-      } catch (err) {
-        // Prepare both user-friendly error and detailed diagnostics
-        let errorMessage: string;
-        let diagnostics: any;
-
-        if (err && typeof err === 'object' && 'issues' in err) {
-          // This is a Zod validation error
-          const zodError = err as any;
-          // Simple message for the model/user
-          errorMessage = `${name}: Invalid parameters provided`;
-          // Detailed diagnostics for debugging
-          diagnostics = {
-            type: 'validation_error',
-            issues: zodError.issues,
-            formatted: zodError.issues?.map((issue: any) => ({
-              path: issue.path.join('.'),
-              message: issue.message,
-              expected: issue.expected,
-              received: issue.received,
-              code: issue.code,
-            })),
-          };
-        } else {
-          errorMessage =
-            err instanceof Error
-              ? `${name}: ${err.message}`
-              : `${name}: ${String(err)}`;
-        }
-
-        result = toolResult({
-          error: errorMessage,
-          isError: true,
-          diagnostics,
-        });
-      }
-    }
-
-    // Combine tool input and output into a single log entry
-    // Extract just the arguments/input based on provider format
-    let toolInput = input; // Default to the already extracted input
-    if (!toolInput) {
-      // Fallback to the raw parsed object if input extraction failed
-      toolInput = parsed;
-    }
-
-    const toolUseLog = {
-      tool: name,
-      input: toolInput,
-      output: sanitizeToolResultForLog(result),
-    };
-
-    logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
-
-    // Build provider-specific message containing the tool result
-    const resultObj: Record<string, unknown> = {};
-    if (result.summary !== undefined) resultObj.summary = result.summary;
-    if (result.output !== undefined) resultObj.output = result.output;
-    if (result.error !== undefined) resultObj.error = result.error;
-    if (result.base64Image !== undefined)
-      resultObj.base64Image = result.base64Image;
-    if (result.system !== undefined) resultObj.system = result.system;
-    if (result.isError) resultObj.isError = true;
-    if (result.diagnostics !== undefined)
-      resultObj.diagnostics = result.diagnostics;
-    if (result.files !== undefined) resultObj.files = result.files;
-
-    if (result.files && result.files.length > 0 && toolState) {
-      const existing = toolState.mediaFiles;
-      const toAdd: string[] = [];
-      for (const attachment of result.files) {
-        const candidate = attachment.path;
-        if (typeof candidate !== 'string' || candidate.trim() === '') {
-          continue;
-        }
-        if (existing.includes(candidate) || toAdd.includes(candidate)) {
-          continue;
-        }
-        try {
-          const exists = await WorkspaceFS.exists(candidate);
-          if (exists) {
-            toAdd.push(candidate);
-          }
-        } catch {
-          // Ignore errors when checking existence; attachment metadata may still be useful
-        }
-      }
-      if (toAdd.length > 0) {
-        toolState.addMediaFiles(toAdd);
-      }
-    }
-
-    const followUpMsgs = await modelHandler.createToolUseFollowUpMessages(
-      client,
-      id,
-      name,
-      parsed,
-      resultObj,
-      toolState,
-      text,
-    );
-    messages.push(...followUpMsgs);
-
-    iteration++;
-  }
+  const flow = createToolUseCycleFlow<C>();
+  await flow.run(shared);
 }

--- a/src/agent/core/flows/FlowTransitions.ts
+++ b/src/agent/core/flows/FlowTransitions.ts
@@ -1,9 +1,19 @@
+/**
+ * Shared transition identifiers that flow nodes emit to describe how control should
+ * move through a flow graph once a node finishes running.
+ */
 export const FlowTransition = {
+  /** The current flow branch has completed and should hand control back to the caller. */
   COMPLETE: 'complete',
+  /** Continue execution by looping back to the flow's entry point. */
   CONTINUE: 'continue',
+  /** Exit the flow entirely after running any finalisation hooks. */
   FINALIZE: 'finalize',
+  /** Begin a new round iteration (used by reflection flows). */
   ROUND: 'round',
+  /** Skip the current node's work but remain in the flow. */
   SKIP: 'skip',
+  /** Execute the next actionable node immediately. */
   EXECUTE: 'execute',
 } as const;
 

--- a/src/agent/core/flows/FlowTransitions.ts
+++ b/src/agent/core/flows/FlowTransitions.ts
@@ -1,0 +1,11 @@
+export const FlowTransition = {
+  COMPLETE: 'complete',
+  CONTINUE: 'continue',
+  FINALIZE: 'finalize',
+  ROUND: 'round',
+  SKIP: 'skip',
+  EXECUTE: 'execute',
+} as const;
+
+export type FlowTransition =
+  (typeof FlowTransition)[keyof typeof FlowTransition];

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -12,6 +12,7 @@ import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage
 
 // Local imports - utilities
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+import type { DebugObjectType } from '@agent/utils/debugMessageSaver';
 import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
 import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
@@ -47,6 +48,33 @@ interface DebugContext {
 interface DebugFileOptions {
   continuationCount: number;
   outputFile: string;
+}
+
+async function saveDebugObjectIfConfigured(
+  debugContext: DebugContext | undefined,
+  debugFileOptions: DebugFileOptions | undefined,
+  object: unknown,
+  objectType: DebugObjectType,
+): Promise<void> {
+  if (!debugContext || !debugFileOptions) {
+    return;
+  }
+
+  await maybeSaveDebugObject({
+    object,
+    objectType,
+    context: debugContext,
+    fileOptions: debugFileOptions,
+  });
+}
+
+function resetResponseCycleState(cycle: ResponseCycleState): void {
+  cycle.shouldStop = false;
+  cycle.endTurn = false;
+  cycle.responseObject = undefined;
+  cycle.responseTime = undefined;
+  cycle.stopReason = undefined;
+  cycle.processedResponse = undefined;
 }
 
 export interface ResponseCycleState {
@@ -137,26 +165,19 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
       return 'complete';
     }
 
-    cycle.shouldStop = false;
     cycle.outputExists = prepRes.exists;
     cycle.systemPrompt = prepRes.systemPrompt;
     cycle.debugContext = prepRes.debugContext;
     cycle.debugFileOptions = prepRes.debugFileOptions;
     cycle.startTime = Date.now();
-    cycle.endTurn = false;
-    cycle.responseObject = undefined;
-    cycle.responseTime = undefined;
-    cycle.stopReason = undefined;
-    cycle.processedResponse = undefined;
+    resetResponseCycleState(cycle);
 
-    if (prepRes.debugContext && prepRes.debugFileOptions) {
-      await maybeSaveDebugObject({
-        object: cycle.messages,
-        objectType: 'messages',
-        context: prepRes.debugContext,
-        fileOptions: prepRes.debugFileOptions,
-      });
-    }
+    await saveDebugObjectIfConfigured(
+      cycle.debugContext,
+      cycle.debugFileOptions,
+      cycle.messages,
+      'messages',
+    );
 
     return undefined;
   }
@@ -227,14 +248,12 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     cycle.responseObject = execRes.response;
     cycle.responseTime = execRes.responseTime;
 
-    if (cycle.debugContext && cycle.debugFileOptions) {
-      await maybeSaveDebugObject({
-        object: execRes.response,
-        objectType: 'response',
-        context: cycle.debugContext,
-        fileOptions: cycle.debugFileOptions,
-      });
-    }
+    await saveDebugObjectIfConfigured(
+      cycle.debugContext,
+      cycle.debugFileOptions,
+      execRes.response,
+      'response',
+    );
 
     if (!execRes.response) {
       options.logger.warn(

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -106,6 +106,10 @@ export interface ResponseCycleShared<C = unknown> {
   cycle: ResponseCycleState;
 }
 
+/**
+ * Prepares a response cycle by hydrating prompts, checking interruptions, and
+ * establishing debug metadata before invoking the model.
+ */
 class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async prep(shared: ResponseCycleShared<C>): Promise<{
     interrupted: boolean;
@@ -181,6 +185,10 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 }
 
+/**
+ * Handles the actual model invocation step, storing the raw response payload and
+ * timing information for downstream processing.
+ */
 class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
     return shared;
@@ -281,6 +289,10 @@ interface ProcessResult {
   repetitionDetected: boolean;
 }
 
+/**
+ * Transforms the raw model response into output-ready text, updates usage metrics,
+ * and persists incremental tool-state derived from the result.
+ */
 class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
     return shared;
@@ -395,17 +407,20 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     let bestConnector: string | undefined;
     if (newResponse) {
       processedResponse = replacementEngine.applyAll(newResponse);
-      const connector = await bestConnectionMethod(
-        cycle.toolState.lastResponse.slice(-K_SLICE),
-        processedResponse.slice(0, K_SLICE),
-      );
-      bestConnector = connector.connector;
-      cycle.toolState.updateLastResponse(processedResponse);
-      cycle.toolState.updateAccumulatedOutput(
-        cycle.toolState.accumulatedOutput +
-          (bestConnector ?? '') +
-          processedResponse,
-      );
+
+      if (!repetitionResult.massiveRepetitionDetected) {
+        const connector = await bestConnectionMethod(
+          cycle.toolState.lastResponse.slice(-K_SLICE),
+          processedResponse.slice(0, K_SLICE),
+        );
+        bestConnector = connector.connector;
+        cycle.toolState.updateLastResponse(processedResponse);
+        cycle.toolState.updateAccumulatedOutput(
+          cycle.toolState.accumulatedOutput +
+            (bestConnector ?? '') +
+            processedResponse,
+        );
+      }
     }
 
     return {
@@ -490,6 +505,10 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 }
 
+/**
+ * Evaluates the processed response to decide whether the agent should end the turn,
+ * stop entirely, or enqueue a continuation request.
+ */
 class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
     return shared;

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -75,6 +75,11 @@ export interface ResponseCycleShared<C = unknown> {
   cycle: ResponseCycleState;
 }
 
+interface ResponseExecutionContext<C> {
+  options: ResponseCycleOptions<C>;
+  cycle: ResponseCycleState;
+}
+
 class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async prep(shared: ResponseCycleShared<C>): Promise<{
     interrupted: boolean;
@@ -117,7 +122,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 
   async post(
-    shared: ResponseCycleShared<C>,
+    _shared: ResponseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       exists: boolean;
@@ -126,7 +131,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
       debugFileOptions?: DebugFileOptions;
     },
   ): Promise<string | undefined> {
-    const { cycle } = shared;
+    const { cycle } = _shared;
     if (prepRes.interrupted) {
       cycle.shouldStop = true;
       return 'complete';
@@ -158,10 +163,17 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
 }
 
 class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseExecutionContext<C>> {
+    return {
+      options: shared.options,
+      cycle: shared.cycle,
+    };
+  }
+
   async exec(
-    shared: ResponseCycleShared<C>,
+    context: ResponseExecutionContext<C>,
   ): Promise<{ skipped: true } | { response: unknown; responseTime?: number }> {
-    const { options, cycle } = shared;
+    const { options, cycle } = context;
     if (cycle.shouldStop) {
       return { skipped: true };
     }
@@ -202,11 +214,11 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 
   async post(
-    shared: ResponseCycleShared<C>,
-    _prepRes: unknown,
+    _shared: ResponseCycleShared<C>,
+    prepRes: ResponseExecutionContext<C>,
     execRes: { skipped: true } | { response: unknown; responseTime?: number },
   ): Promise<string | undefined> {
-    const { options, cycle } = shared;
+    const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
       return 'complete';
@@ -252,10 +264,17 @@ interface ProcessResult {
 }
 
 class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseExecutionContext<C>> {
+    return {
+      options: shared.options,
+      cycle: shared.cycle,
+    };
+  }
+
   async exec(
-    shared: ResponseCycleShared<C>,
+    context: ResponseExecutionContext<C>,
   ): Promise<ProcessResult | { skipped: true }> {
-    const { options, cycle } = shared;
+    const { options, cycle } = context;
     if (cycle.shouldStop || !cycle.responseObject) {
       return { skipped: true };
     }
@@ -388,11 +407,11 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 
   async post(
-    shared: ResponseCycleShared<C>,
-    _prepRes: unknown,
+    _shared: ResponseCycleShared<C>,
+    prepRes: ResponseExecutionContext<C>,
     execRes: ProcessResult | { skipped: true },
   ): Promise<string | undefined> {
-    const { options, cycle } = shared;
+    const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
       return 'complete';
@@ -455,13 +474,20 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 }
 
 class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseExecutionContext<C>> {
+    return {
+      options: shared.options,
+      cycle: shared.cycle,
+    };
+  }
+
   async exec(
-    shared: ResponseCycleShared<C>,
+    context: ResponseExecutionContext<C>,
   ): Promise<
     | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
     | { skipped: true }
   > {
-    const { options, cycle } = shared;
+    const { options, cycle } = context;
     if (cycle.shouldStop || !cycle.stopReason || !cycle.processedResponse) {
       return { skipped: true };
     }
@@ -486,12 +512,12 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
   async post(
     shared: ResponseCycleShared<C>,
-    _prepRes: unknown,
+    prepRes: ResponseExecutionContext<C>,
     execRes:
       | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
       | { skipped: true },
   ): Promise<string | undefined> {
-    const { options, cycle } = shared;
+    const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
       cycle.shouldStop = true;

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -128,7 +128,6 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   ): Promise<string | undefined> {
     const { cycle } = shared;
     if (prepRes.interrupted) {
-      cycle.endTurn = true;
       cycle.shouldStop = true;
       return 'complete';
     }
@@ -184,6 +183,13 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
           ? options.agentSetting.tools
           : undefined,
       );
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? `Model invocation failed: ${error.message}`
+          : 'Model invocation failed with an unknown error';
+      options.logger.error(message, cycle.roundGroupId);
+      throw error;
     } finally {
       options.setAbortController(null);
     }
@@ -223,7 +229,6 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         'Model response was aborted or returned no data; output may be incomplete.',
         cycle.roundGroupId,
       );
-      cycle.endTurn = true;
       cycle.shouldStop = true;
       return 'complete';
     }
@@ -397,7 +402,6 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     cycle.processedResponse = execRes.processedResponse;
 
     if (execRes.repetitionDetected || !execRes.processedResponse) {
-      cycle.endTurn = true;
       cycle.shouldStop = true;
       return 'complete';
     }
@@ -490,7 +494,6 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const { options, cycle } = shared;
 
     if ('skipped' in execRes) {
-      cycle.endTurn = true;
       cycle.shouldStop = true;
       return 'complete';
     }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -1,0 +1,556 @@
+// Local imports - core flow primitives
+import { BaseNode, Flow } from '@agent/node';
+
+// Local imports - agent components
+import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
+import { ToolState } from '@agent/core/ToolState';
+import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
+import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
+
+// Local imports - model handler types
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+// Local imports - utilities
+import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
+import { getSystemPromptWithRules } from '@agent/utils/promptHelpers';
+import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
+
+// Local imports - latex utilities
+import { bestConnectionMethod } from '@latex';
+
+// Local imports - logging
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+// Local imports - replacement engine
+import replacementEngine from '@replacement/engine';
+
+// Local imports - configuration/constants
+import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
+
+// Local imports - filesystem utilities
+import { WorkspaceFS } from '@utils/files';
+
+// Local imports - text utilities
+import xmlUtils from '@utils/text/xmlUtils';
+
+// Local imports - identifier types
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+
+interface DebugContext {
+  logger: ResponseCycleOptions['logger'];
+  modelName: string;
+  executionId?: ExecutionId;
+  groupId?: string;
+}
+
+interface DebugFileOptions {
+  continuationCount: number;
+  outputFile: string;
+}
+
+export interface ResponseCycleState {
+  messages: ProviderMessage[];
+  stateRound: AgentStateRound;
+  stateGlobal: AgentStateGlobal;
+  toolState: ToolState;
+  outputFile: string;
+  roundGroupId?: string;
+  executionId?: ExecutionId;
+  endTurn: boolean;
+  shouldStop: boolean;
+  outputExists: boolean;
+  systemPrompt?: string;
+  debugContext?: DebugContext;
+  debugFileOptions?: DebugFileOptions;
+  startTime?: number;
+  responseObject?: unknown;
+  responseTime?: number;
+  stopReason?: ProviderStopReason;
+  processedResponse?: string;
+}
+
+export interface ResponseCycleShared<C = unknown> {
+  options: ResponseCycleOptions<C>;
+  cycle: ResponseCycleState;
+}
+
+class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
+  async prep(shared: ResponseCycleShared<C>): Promise<{
+    interrupted: boolean;
+    exists: boolean;
+    systemPrompt?: string;
+    debugContext?: DebugContext;
+    debugFileOptions?: DebugFileOptions;
+  }> {
+    const { options, cycle } = shared;
+    const { agentPrompt, userVars, logger, agentConfig } = options;
+    const interrupted = Boolean(await options.checkInterruption());
+    const exists = await WorkspaceFS.exists(cycle.outputFile);
+    const systemPrompt = interrupted
+      ? undefined
+      : await getSystemPromptWithRules(agentPrompt.systemPrompt, userVars);
+
+    const debugContext: DebugContext | undefined = interrupted
+      ? undefined
+      : {
+          logger,
+          modelName: agentConfig.model,
+          executionId: cycle.executionId,
+          groupId: cycle.roundGroupId,
+        };
+
+    const debugFileOptions: DebugFileOptions | undefined = interrupted
+      ? undefined
+      : {
+          continuationCount: cycle.stateRound.continuationCount,
+          outputFile: cycle.outputFile,
+        };
+
+    return {
+      interrupted,
+      exists,
+      systemPrompt,
+      debugContext,
+      debugFileOptions,
+    };
+  }
+
+  async post(
+    shared: ResponseCycleShared<C>,
+    prepRes: {
+      interrupted: boolean;
+      exists: boolean;
+      systemPrompt?: string;
+      debugContext?: DebugContext;
+      debugFileOptions?: DebugFileOptions;
+    },
+  ): Promise<string | undefined> {
+    const { cycle } = shared;
+    if (prepRes.interrupted) {
+      cycle.endTurn = true;
+      cycle.shouldStop = true;
+      return 'complete';
+    }
+
+    cycle.shouldStop = false;
+    cycle.outputExists = prepRes.exists;
+    cycle.systemPrompt = prepRes.systemPrompt;
+    cycle.debugContext = prepRes.debugContext;
+    cycle.debugFileOptions = prepRes.debugFileOptions;
+    cycle.startTime = Date.now();
+    cycle.endTurn = false;
+    cycle.responseObject = undefined;
+    cycle.responseTime = undefined;
+    cycle.stopReason = undefined;
+    cycle.processedResponse = undefined;
+
+    if (prepRes.debugContext && prepRes.debugFileOptions) {
+      await maybeSaveDebugObject({
+        object: cycle.messages,
+        objectType: 'messages',
+        context: prepRes.debugContext,
+        fileOptions: prepRes.debugFileOptions,
+      });
+    }
+
+    return undefined;
+  }
+}
+
+class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
+  async exec(
+    shared: ResponseCycleShared<C>,
+  ): Promise<{ skipped: true } | { response: unknown; responseTime?: number }> {
+    const { options, cycle } = shared;
+    if (cycle.shouldStop) {
+      return { skipped: true };
+    }
+
+    const abortController = new AbortController();
+    options.setAbortController(abortController);
+    options.modelHandler.setOutputStreaming(false);
+
+    let response: unknown;
+    try {
+      response = await options.modelHandler.createResponse(
+        options.client,
+        cycle.messages,
+        options.agentSetting.temperature || 0.0,
+        cycle.systemPrompt,
+        options.agentSetting.endTag,
+        abortController.signal,
+        options.modelHandler.capabilities.supportsFunctionCalling
+          ? options.agentSetting.tools
+          : undefined,
+      );
+    } finally {
+      options.setAbortController(null);
+    }
+
+    const responseTime = cycle.startTime
+      ? (Date.now() - cycle.startTime) / 1000
+      : undefined;
+
+    return { response, responseTime };
+  }
+
+  async post(
+    shared: ResponseCycleShared<C>,
+    _prepRes: unknown,
+    execRes: { skipped: true } | { response: unknown; responseTime?: number },
+  ): Promise<string | undefined> {
+    const { options, cycle } = shared;
+
+    if ('skipped' in execRes) {
+      return 'complete';
+    }
+
+    cycle.responseObject = execRes.response;
+    cycle.responseTime = execRes.responseTime;
+
+    if (cycle.debugContext && cycle.debugFileOptions) {
+      await maybeSaveDebugObject({
+        object: execRes.response,
+        objectType: 'response',
+        context: cycle.debugContext,
+        fileOptions: cycle.debugFileOptions,
+      });
+    }
+
+    if (!execRes.response) {
+      options.logger.warn(
+        'Model response was aborted or returned no data; output may be incomplete.',
+        cycle.roundGroupId,
+      );
+      cycle.endTurn = true;
+      cycle.shouldStop = true;
+      return 'complete';
+    }
+
+    return undefined;
+  }
+}
+
+interface ProcessResult {
+  stopReason: ProviderStopReason;
+  newResponse?: string;
+  processedResponse?: string;
+  bestConnector?: string;
+  thinkingContent?: string | null;
+  useStreaming: boolean;
+  responseUsage: any;
+  apiUsage: ReturnType<
+    ResponseCycleOptions['modelHandler']['computeResponseUsage']
+  >;
+  repetitionDetected: boolean;
+}
+
+class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
+  async exec(
+    shared: ResponseCycleShared<C>,
+  ): Promise<ProcessResult | { skipped: true }> {
+    const { options, cycle } = shared;
+    if (cycle.shouldStop || !cycle.responseObject) {
+      return { skipped: true };
+    }
+
+    const [newResponse, responseUsage, stopReason] =
+      options.modelHandler.extractResponse(
+        cycle.responseObject,
+        options.agentSetting.endTag,
+      );
+
+    if (newResponse) {
+      options.logger.debug(
+        `Model response: ${newResponse.slice(0, 100)}`,
+        cycle.roundGroupId,
+      );
+    }
+
+    if (cycle.responseTime !== undefined) {
+      cycle.stateRound.updateResponseTime(cycle.responseTime);
+      options.logger.debug(
+        `Response time: ${cycle.responseTime.toFixed(2)}s`,
+        cycle.roundGroupId,
+      );
+    }
+
+    options.logger.debug(`Stop reason: ${stopReason}`, cycle.roundGroupId);
+    options.logger.debug(
+      `Token usage: ${JSON.stringify(responseUsage)}`,
+      cycle.roundGroupId,
+    );
+
+    const thinkingContent = options.modelHandler.processThinkingBlock(
+      cycle.responseObject,
+      cycle.roundGroupId,
+      cycle.toolState,
+    );
+    const useStreaming = options.modelHandler.getStreamingConfig();
+
+    if (thinkingContent && !useStreaming) {
+      const formatted = await xmlUtils.formatContent(thinkingContent);
+      if (formatted.trim().length > 0) {
+        options.logger.info(
+          formatted,
+          cycle.roundGroupId,
+          MESSAGE_TYPES.THINKING,
+        );
+      }
+    }
+
+    const scratchpad = await xmlUtils.extractScratchpad(
+      newResponse,
+      'scratchpad',
+    );
+    if (scratchpad) {
+      options.logger.info(
+        scratchpad,
+        cycle.roundGroupId,
+        MESSAGE_TYPES.SCRATCHPAD,
+      );
+    }
+
+    if (newResponse && !useStreaming) {
+      const formattedResponse = await xmlUtils.formatContent(newResponse);
+      options.logger.info(
+        formattedResponse,
+        cycle.roundGroupId,
+        MESSAGE_TYPES.INTERNAL,
+      );
+    }
+
+    const apiUsage = options.modelHandler.computeResponseUsage(
+      responseUsage,
+      cycle.responseTime ?? 0,
+    );
+    cycle.stateRound.updateTokenCounts(apiUsage);
+    cycle.stateGlobal.updateFromCurrRound(cycle.stateRound);
+
+    const repetitionResult = checkForMassiveRepetition(
+      cycle.toolState.lastResponse,
+      newResponse,
+    );
+
+    if (repetitionResult.massiveRepetitionDetected && newResponse) {
+      options.logger.error(
+        `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
+        cycle.roundGroupId,
+      );
+      options.logger.error(
+        'Massive repetition detected - skipping this response',
+        cycle.roundGroupId,
+      );
+      options.logger.error(
+        'Message structure when repetition detected:',
+        cycle.roundGroupId,
+      );
+      options.logger.error(
+        JSON.stringify(messageToSkeleton(cycle.messages), null, 2),
+        cycle.roundGroupId,
+      );
+    }
+
+    let processedResponse: string | undefined;
+    let bestConnector: string | undefined;
+    if (newResponse) {
+      processedResponse = replacementEngine.applyAll(newResponse);
+      const connector = await bestConnectionMethod(
+        cycle.toolState.lastResponse.slice(-K_SLICE),
+        processedResponse.slice(0, K_SLICE),
+      );
+      bestConnector = connector.connector;
+      cycle.toolState.updateLastResponse(processedResponse);
+      cycle.toolState.updateAccumulatedOutput(
+        cycle.toolState.accumulatedOutput +
+          (bestConnector ?? '') +
+          processedResponse,
+      );
+    }
+
+    return {
+      stopReason,
+      newResponse,
+      processedResponse,
+      bestConnector,
+      thinkingContent,
+      useStreaming,
+      responseUsage,
+      apiUsage,
+      repetitionDetected: repetitionResult.massiveRepetitionDetected,
+    };
+  }
+
+  async post(
+    shared: ResponseCycleShared<C>,
+    _prepRes: unknown,
+    execRes: ProcessResult | { skipped: true },
+  ): Promise<string | undefined> {
+    const { options, cycle } = shared;
+
+    if ('skipped' in execRes) {
+      return 'complete';
+    }
+
+    cycle.stopReason = execRes.stopReason;
+    cycle.processedResponse = execRes.processedResponse;
+
+    if (execRes.repetitionDetected || !execRes.processedResponse) {
+      cycle.endTurn = true;
+      cycle.shouldStop = true;
+      return 'complete';
+    }
+
+    if (!cycle.outputExists) {
+      options.logger.debug(
+        `Creating new file: ${cycle.outputFile}`,
+        cycle.roundGroupId,
+      );
+      await WorkspaceFS.write(cycle.outputFile, execRes.processedResponse);
+      cycle.outputExists = true;
+    } else {
+      options.logger.debug(
+        `Appending to existing file: ${cycle.outputFile}`,
+        cycle.roundGroupId,
+      );
+      await WorkspaceFS.appendFile(
+        cycle.outputFile,
+        (execRes.bestConnector ?? '') + execRes.processedResponse,
+      );
+    }
+
+    options.logger.debug('Response preview:', cycle.roundGroupId);
+    options.logger.debug(
+      `First ${K_SLICE} chars:\n${execRes.processedResponse.slice(0, K_SLICE)}`,
+      cycle.roundGroupId,
+    );
+    options.logger.debug(
+      `Last ${K_SLICE} chars:\n${execRes.processedResponse.slice(-K_SLICE)}`,
+      cycle.roundGroupId,
+    );
+
+    if (options.modelHandler.capabilities.supportsAssistantPrefill) {
+      options.modelHandler.updateMessageContentWithPrefill(
+        cycle.messages,
+        execRes.bestConnector ?? '',
+        execRes.processedResponse,
+        cycle.toolState,
+      );
+    } else {
+      options.modelHandler.updateMessageContentWithoutPrefill(
+        cycle.messages,
+        execRes.bestConnector ?? '',
+        execRes.processedResponse,
+        cycle.toolState,
+      );
+    }
+
+    return undefined;
+  }
+}
+
+class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
+  async exec(
+    shared: ResponseCycleShared<C>,
+  ): Promise<
+    | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
+    | { skipped: true }
+  > {
+    const { options, cycle } = shared;
+    if (cycle.shouldStop || !cycle.stopReason || !cycle.processedResponse) {
+      return { skipped: true };
+    }
+
+    const [shouldEndTurn, shouldStop] =
+      options.modelHandler.checkStopConditions(
+        cycle.stopReason,
+        cycle.processedResponse,
+        cycle.stateRound,
+        cycle.stateGlobal,
+        options.agentSetting,
+      );
+
+    const shouldContinue = options.modelHandler.shouldContinue(
+      cycle.stopReason,
+      cycle.processedResponse,
+      options.agentSetting,
+    );
+
+    return { shouldEndTurn, shouldStop, shouldContinue };
+  }
+
+  async post(
+    shared: ResponseCycleShared<C>,
+    _prepRes: unknown,
+    execRes:
+      | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
+      | { skipped: true },
+  ): Promise<string | undefined> {
+    const { options, cycle } = shared;
+
+    if ('skipped' in execRes) {
+      cycle.endTurn = true;
+      cycle.shouldStop = true;
+      return 'complete';
+    }
+
+    cycle.endTurn = execRes.shouldEndTurn;
+    cycle.shouldStop = execRes.shouldStop;
+
+    if (execRes.shouldStop) {
+      return 'complete';
+    }
+
+    cycle.stateRound.incrementContinuation();
+    options.logger.info(
+      `Starting continuation #${cycle.stateRound.continuationCount}`,
+      cycle.roundGroupId,
+      MESSAGE_TYPES.PROGRESS_STATUS,
+    );
+
+    if (!execRes.shouldContinue) {
+      return 'complete';
+    }
+
+    options.logger.debug(
+      'Should continue - adding continuation message to conversation',
+      cycle.roundGroupId,
+    );
+
+    if (options.modelHandler.capabilities.supportsAssistantPrefill) {
+      options.modelHandler.addContinueMessageWithPrefill(
+        cycle.messages,
+        cycle.stateRound,
+        cycle.toolState,
+        options.agentSetting,
+        options.agentConfig,
+      );
+    } else {
+      options.modelHandler.addContinueMessageWithoutPrefill(
+        cycle.messages,
+        cycle.stateRound,
+        cycle.toolState,
+        options.agentSetting,
+        options.agentConfig,
+      );
+    }
+
+    return 'continue';
+  }
+}
+
+export function createResponseCycleFlow<C>(): Flow<ResponseCycleShared<C>> {
+  const prepNode = new ResponsePrepNode<C>();
+  const invokeNode = new ResponseModelInvocationNode<C>();
+  const processNode = new ResponseProcessNode<C>();
+  const continuationNode = new ResponseContinuationNode<C>();
+
+  prepNode.next(invokeNode);
+  invokeNode.next(processNode);
+  processNode.next(continuationNode);
+
+  continuationNode.on('continue', prepNode);
+
+  return new Flow<ResponseCycleShared<C>>(prepNode);
+}

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -161,6 +161,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   ): Promise<string | undefined> {
     const { cycle } = _shared;
     if (prepRes.interrupted) {
+      resetResponseCycleState(cycle);
       cycle.shouldStop = true;
       return 'complete';
     }
@@ -244,6 +245,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
+      cycle.endTurn = false;
       return 'complete';
     }
 
@@ -262,6 +264,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         'Model response was aborted or returned no data; output may be incomplete.',
         cycle.roundGroupId,
       );
+      cycle.endTurn = false;
       cycle.shouldStop = true;
       return 'complete';
     }
@@ -437,6 +440,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
+      cycle.endTurn = false;
       return 'complete';
     }
 
@@ -444,6 +448,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     cycle.processedResponse = execRes.processedResponse;
 
     if (execRes.repetitionDetected || !execRes.processedResponse) {
+      cycle.endTurn = false;
       cycle.shouldStop = true;
       return 'complete';
     }
@@ -545,6 +550,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
+      cycle.endTurn = false;
       cycle.shouldStop = true;
       return 'complete';
     }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -150,7 +150,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 
   async post(
-    _shared: ResponseCycleShared<C>,
+    { cycle }: ResponseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       exists: boolean;
@@ -159,7 +159,6 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
       debugFileOptions?: DebugFileOptions;
     },
   ): Promise<string | undefined> {
-    const { cycle } = _shared;
     if (prepRes.interrupted) {
       resetResponseCycleState(cycle);
       cycle.shouldStop = true;
@@ -225,6 +224,8 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
           ? `Model invocation failed: ${error.message}`
           : 'Model invocation failed with an unknown error';
       options.logger.error(message, cycle.roundGroupId);
+      cycle.shouldStop = true;
+      cycle.endTurn = false;
       throw error;
     } finally {
       options.setAbortController(null);
@@ -520,6 +521,11 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const { options, cycle } = context;
     if (cycle.shouldStop || !cycle.stopReason || !cycle.processedResponse) {
       return { skipped: true };
+    }
+
+    const interrupted = Boolean(await options.checkInterruption());
+    if (interrupted) {
+      return { shouldEndTurn: false, shouldStop: true, shouldContinue: false };
     }
 
     const [shouldEndTurn, shouldStop] =

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -184,7 +184,9 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
 }
 
 class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(shared: ResponseCycleShared<C>): Promise<ResponseExecutionContext<C>> {
+  async prep(
+    shared: ResponseCycleShared<C>,
+  ): Promise<ResponseExecutionContext<C>> {
     return {
       options: shared.options,
       cycle: shared.cycle,
@@ -283,7 +285,9 @@ interface ProcessResult {
 }
 
 class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(shared: ResponseCycleShared<C>): Promise<ResponseExecutionContext<C>> {
+  async prep(
+    shared: ResponseCycleShared<C>,
+  ): Promise<ResponseExecutionContext<C>> {
     return {
       options: shared.options,
       cycle: shared.cycle,
@@ -493,7 +497,9 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 }
 
 class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(shared: ResponseCycleShared<C>): Promise<ResponseExecutionContext<C>> {
+  async prep(
+    shared: ResponseCycleShared<C>,
+  ): Promise<ResponseExecutionContext<C>> {
     return {
       options: shared.options,
       cycle: shared.cycle,

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -103,11 +103,6 @@ export interface ResponseCycleShared<C = unknown> {
   cycle: ResponseCycleState;
 }
 
-interface ResponseExecutionContext<C> {
-  options: ResponseCycleOptions<C>;
-  cycle: ResponseCycleState;
-}
-
 class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async prep(shared: ResponseCycleShared<C>): Promise<{
     interrupted: boolean;
@@ -184,17 +179,12 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
 }
 
 class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(
-    shared: ResponseCycleShared<C>,
-  ): Promise<ResponseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      cycle: shared.cycle,
-    };
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
+    return shared;
   }
 
   async exec(
-    context: ResponseExecutionContext<C>,
+    context: ResponseCycleShared<C>,
   ): Promise<{ skipped: true } | { response: unknown; responseTime?: number }> {
     const { options, cycle } = context;
     if (cycle.shouldStop) {
@@ -240,7 +230,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
   async post(
     _shared: ResponseCycleShared<C>,
-    prepRes: ResponseExecutionContext<C>,
+    prepRes: ResponseCycleShared<C>,
     execRes: { skipped: true } | { response: unknown; responseTime?: number },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
@@ -289,17 +279,12 @@ interface ProcessResult {
 }
 
 class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(
-    shared: ResponseCycleShared<C>,
-  ): Promise<ResponseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      cycle: shared.cycle,
-    };
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
+    return shared;
   }
 
   async exec(
-    context: ResponseExecutionContext<C>,
+    context: ResponseCycleShared<C>,
   ): Promise<ProcessResult | { skipped: true }> {
     const { options, cycle } = context;
     if (cycle.shouldStop || !cycle.responseObject) {
@@ -435,7 +420,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
   async post(
     _shared: ResponseCycleShared<C>,
-    prepRes: ResponseExecutionContext<C>,
+    prepRes: ResponseCycleShared<C>,
     execRes: ProcessResult | { skipped: true },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
@@ -503,17 +488,12 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 }
 
 class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(
-    shared: ResponseCycleShared<C>,
-  ): Promise<ResponseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      cycle: shared.cycle,
-    };
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
+    return shared;
   }
 
   async exec(
-    context: ResponseExecutionContext<C>,
+    context: ResponseCycleShared<C>,
   ): Promise<
     | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
     | { skipped: true }
@@ -548,7 +528,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
   async post(
     shared: ResponseCycleShared<C>,
-    prepRes: ResponseExecutionContext<C>,
+    prepRes: ResponseCycleShared<C>,
     execRes:
       | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
       | { skipped: true },

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -53,7 +53,7 @@ interface DebugFileOptions {
   outputFile: string;
 }
 
-async function saveDebugObjectIfConfigured(
+async function maybeSaveDebug(
   debugContext: DebugContext | undefined,
   debugFileOptions: DebugFileOptions | undefined,
   object: unknown,
@@ -71,16 +71,7 @@ async function saveDebugObjectIfConfigured(
   });
 }
 
-function resetResponseCycleState(cycle: ResponseCycleState): void {
-  cycle.shouldStop = false;
-  cycle.endTurn = false;
-  cycle.responseObject = undefined;
-  cycle.responseTime = undefined;
-  cycle.stopReason = undefined;
-  cycle.processedResponse = undefined;
-}
-
-export interface ResponseCycleState {
+export interface ResponseCycleInputState {
   messages: ProviderMessage[];
   stateRound: AgentStateRound;
   stateGlobal: AgentStateGlobal;
@@ -88,6 +79,9 @@ export interface ResponseCycleState {
   outputFile: string;
   roundGroupId?: string;
   executionId?: ExecutionId;
+}
+
+export interface ResponseCycleRuntimeState {
   endTurn: boolean;
   shouldStop: boolean;
   outputExists: boolean;
@@ -99,6 +93,18 @@ export interface ResponseCycleState {
   responseTime?: number;
   stopReason?: ProviderStopReason;
   processedResponse?: string;
+}
+
+export type ResponseCycleState = ResponseCycleInputState &
+  ResponseCycleRuntimeState;
+
+function resetResponseCycleState(cycle: ResponseCycleRuntimeState): void {
+  cycle.shouldStop = false;
+  cycle.endTurn = false;
+  cycle.responseObject = undefined;
+  cycle.responseTime = undefined;
+  cycle.stopReason = undefined;
+  cycle.processedResponse = undefined;
 }
 
 export interface ResponseCycleShared<C = unknown> {
@@ -174,7 +180,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
     cycle.startTime = Date.now();
     resetResponseCycleState(cycle);
 
-    await saveDebugObjectIfConfigured(
+    await maybeSaveDebug(
       cycle.debugContext,
       cycle.debugFileOptions,
       cycle.messages,
@@ -254,7 +260,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     cycle.responseObject = execRes.response;
     cycle.responseTime = execRes.responseTime;
 
-    await saveDebugObjectIfConfigured(
+    await maybeSaveDebug(
       cycle.debugContext,
       cycle.debugFileOptions,
       execRes.response,

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -1,6 +1,9 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 
+// Local imports - flow constants
+import { FlowTransition } from './FlowTransitions';
+
 // Local imports - agent components
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
@@ -157,7 +160,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (prepRes.interrupted) {
       resetResponseCycleState(cycle);
       cycle.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     cycle.outputExists = prepRes.exists;
@@ -237,7 +240,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     if ('skipped' in execRes) {
       cycle.endTurn = false;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     cycle.responseObject = execRes.response;
@@ -257,7 +260,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       );
       cycle.endTurn = false;
       cycle.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     return undefined;
@@ -427,7 +430,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     if ('skipped' in execRes) {
       cycle.endTurn = false;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     cycle.stopReason = execRes.stopReason;
@@ -436,7 +439,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (execRes.repetitionDetected || !execRes.processedResponse) {
       cycle.endTurn = false;
       cycle.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     if (!cycle.outputExists) {
@@ -538,14 +541,14 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if ('skipped' in execRes) {
       cycle.endTurn = false;
       cycle.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     cycle.endTurn = execRes.shouldEndTurn;
     cycle.shouldStop = execRes.shouldStop;
 
     if (execRes.shouldStop) {
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     cycle.stateRound.incrementContinuation();
@@ -556,7 +559,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     );
 
     if (!execRes.shouldContinue) {
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     options.logger.debug(
@@ -582,7 +585,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       );
     }
 
-    return 'continue';
+    return FlowTransition.CONTINUE;
   }
 }
 
@@ -596,7 +599,7 @@ export function createResponseCycleFlow<C>(): Flow<ResponseCycleShared<C>> {
   invokeNode.next(processNode);
   processNode.next(continuationNode);
 
-  continuationNode.on('continue', prepNode);
+  continuationNode.on(FlowTransition.CONTINUE, prepNode);
 
   return new Flow<ResponseCycleShared<C>>(prepNode);
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -101,6 +101,11 @@ export interface ToolUseCycleShared<C = unknown> {
   state: ToolUseCycleState;
 }
 
+interface ToolUseExecutionContext<C> {
+  options: ToolUseCycleOptions<C>;
+  state: ToolUseCycleState;
+}
+
 class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   async prep(shared: ToolUseCycleShared<C>): Promise<{
     interrupted: boolean;
@@ -122,14 +127,14 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   }
 
   async post(
-    shared: ToolUseCycleShared<C>,
+    _shared: ToolUseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       debugContext: DebugContext;
       debugFileOptions: DebugFileOptions;
     },
   ): Promise<string | undefined> {
-    const { state } = shared;
+    const { state } = _shared;
     if (prepRes.interrupted) {
       state.shouldStop = true;
       return 'complete';
@@ -154,8 +159,15 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseExecutionContext<C>> {
+    return {
+      options: shared.options,
+      state: shared.state,
+    };
+  }
+
   async exec(
-    shared: ToolUseCycleShared<C>,
+    context: ToolUseExecutionContext<C>,
   ): Promise<
     | { skipped: true }
     | {
@@ -165,7 +177,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         debugFileOptions: DebugFileOptions;
       }
   > {
-    const { options, state } = shared;
+    const { options, state } = context;
     if (state.shouldStop) {
       return { skipped: true };
     }
@@ -206,8 +218,8 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   }
 
   async post(
-    shared: ToolUseCycleShared<C>,
-    _prepRes: unknown,
+    _shared: ToolUseCycleShared<C>,
+    prepRes: ToolUseExecutionContext<C>,
     execRes:
       | { skipped: true }
       | {
@@ -215,9 +227,9 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
           responseTime?: number;
           debugContext: DebugContext;
           debugFileOptions: DebugFileOptions;
-        },
+      },
   ): Promise<string | undefined> {
-    const { options, state } = shared;
+    const { options, state } = prepRes;
 
     if ('skipped' in execRes) {
       state.shouldStop = true;
@@ -244,8 +256,15 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseExecutionContext<C>> {
+    return {
+      options: shared.options,
+      state: shared.state,
+    };
+  }
+
   async exec(
-    shared: ToolUseCycleShared<C>,
+    context: ToolUseExecutionContext<C>,
   ): Promise<
     | { skipped: true }
     | {
@@ -255,7 +274,7 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         endTurn: boolean;
       }
   > {
-    const { options, state } = shared;
+    const { options, state } = context;
     if (state.shouldStop || !state.response) {
       return { skipped: true };
     }
@@ -327,7 +346,7 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   }
 
   async post(
-    shared: ToolUseCycleShared<C>,
+    _shared: ToolUseCycleShared<C>,
     _prepRes: unknown,
     execRes:
       | { skipped: true }
@@ -352,12 +371,12 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
 class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   async exec(
-    shared: ToolUseCycleShared<C>,
+    context: ToolUseExecutionContext<C>,
   ): Promise<
     | { skipped: true }
     | { parsed: any; name: string; input: any; toolCallId: string }
   > {
-    const { options, state } = shared;
+    const { options, state } = context;
     if (state.shouldStop || !state.toolInfo) {
       return { skipped: true };
     }
@@ -439,13 +458,13 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   }
 
   async post(
-    shared: ToolUseCycleShared<C>,
-    _prepRes: unknown,
+    _shared: ToolUseCycleShared<C>,
+    prepRes: ToolUseExecutionContext<C>,
     execRes:
       | { skipped: true }
       | { parsed: any; name: string; input: any; toolCallId: string },
   ): Promise<string | undefined> {
-    const { options, state } = shared;
+    const { options, state } = prepRes;
     if ('skipped' in execRes) {
       state.shouldStop = true;
       return 'complete';

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,6 +1,9 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 
+// Local imports - flow constants
+import { FlowTransition } from './FlowTransitions';
+
 // Local imports - agent components
 import { ToolState } from '@agent/core/ToolState';
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
@@ -120,7 +123,8 @@ function extractToolCallId(parsed: any): string {
     );
   }
 
-  const trimmed = String(rawId).trim();
+  const trimmed =
+    typeof rawId === 'string' ? rawId.trim() : String(rawId).trim();
   if (!trimmed) {
     throw new Error(
       `Tool JSON contains blank call identifier: ${JSON.stringify(parsed)}`,
@@ -129,6 +133,15 @@ function extractToolCallId(parsed: any): string {
 
   return trimmed;
 }
+
+type ToolDispatchErrorResult = {
+  handledError: true;
+  toolCallId?: string;
+  toolName: string;
+  result: ToolResult;
+  parsed?: any;
+  fallbackMessage?: string;
+};
 
 export interface ToolUseCycleState {
   messages: ProviderMessage[];
@@ -183,7 +196,7 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   ): Promise<string | undefined> {
     if (prepRes.interrupted) {
       state.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     resetToolUseState(state);
@@ -274,7 +287,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
     if ('skipped' in execRes) {
       state.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     state.response = execRes.response;
@@ -289,7 +302,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
     if (!execRes.response) {
       state.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     return undefined;
@@ -399,11 +412,11 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         },
   ): Promise<string | undefined> {
     if ('skipped' in execRes) {
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     if (execRes.endTurn) {
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     return undefined;
@@ -425,6 +438,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   ): Promise<
     | { skipped: true }
     | { parsed: any; name: string; input: any; toolCallId: string }
+    | ToolDispatchErrorResult
   > {
     if (!context) {
       return { skipped: true };
@@ -445,7 +459,9 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     try {
       parsed = JSON.parse(state.toolInfo);
     } catch (err) {
-      const errorMsg = `Malformed tool JSON: ${err instanceof Error ? err.message : String(err)}`;
+      const errorMsg = `Malformed tool JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
       const errorResult = toolResult({ error: errorMsg, isError: true });
       const toolUseLog = {
         tool: 'unknown',
@@ -458,8 +474,13 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
-      state.shouldStop = true;
-      return { skipped: true };
+      return {
+        handledError: true,
+        toolName: 'unknown',
+        result: errorResult,
+        fallbackMessage:
+          'I could not understand the tool request. Please resend valid JSON with call_id, name, and arguments.',
+      };
     }
 
     let toolCallId: string;
@@ -479,8 +500,14 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
-      state.shouldStop = true;
-      return { skipped: true };
+      return {
+        handledError: true,
+        toolName: parsed.name || parsed.function?.name || 'unknown',
+        result: errorResult,
+        parsed,
+        fallbackMessage:
+          'The tool call is missing a valid identifier. Please include a non-empty call_id for each tool request.',
+      };
     }
 
     const name = parsed.name || parsed.function?.name;
@@ -498,8 +525,15 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
-      state.shouldStop = true;
-      return { skipped: true };
+      return {
+        handledError: true,
+        toolCallId,
+        toolName: 'unknown',
+        result: errorResult,
+        parsed,
+        fallbackMessage:
+          'The tool request did not specify which tool to call. Please provide a "name" field with the tool identifier.',
+      };
     }
 
     let input = parsed.input ?? parsed.args;
@@ -526,12 +560,69 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     prepRes: ToolUseExecutionContext<C>,
     execRes:
       | { skipped: true }
-      | { parsed: any; name: string; input: any; toolCallId: string },
+      | { parsed: any; name: string; input: any; toolCallId: string }
+      | ToolDispatchErrorResult,
   ): Promise<string | undefined> {
     const { options, state } = prepRes;
     if ('skipped' in execRes) {
       state.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
+    }
+
+    if ('handledError' in execRes) {
+      const { toolCallId, result, fallbackMessage, toolName, parsed } = execRes;
+
+      if (toolCallId) {
+        const followUpMessages =
+          await options.modelHandler.createToolUseFollowUpMessages(
+            options.client,
+            toolCallId,
+            toolName,
+            parsed,
+            (() => {
+              const payload: Record<string, unknown> = {};
+              if (result.summary !== undefined)
+                payload.summary = result.summary;
+              if (result.output !== undefined) payload.output = result.output;
+              if (result.error !== undefined) payload.error = result.error;
+              if (result.base64Image !== undefined)
+                payload.base64Image = result.base64Image;
+              if (result.system !== undefined) payload.system = result.system;
+              if (result.isError) payload.isError = true;
+              if (result.diagnostics !== undefined)
+                payload.diagnostics = result.diagnostics;
+              if (result.files !== undefined) payload.files = result.files;
+              return payload;
+            })(),
+            state.toolState,
+            state.text ?? '',
+          );
+
+        state.messages.push(...followUpMessages);
+        const fallback =
+          result.summary ??
+          result.output ??
+          result.error ??
+          fallbackMessage ??
+          '';
+        if (fallback) {
+          state.toolState.updateLastResponse(String(fallback));
+        }
+      } else if (fallbackMessage) {
+        const assistantMessage =
+          options.modelHandler.createAssistantMessage(fallbackMessage);
+        state.messages.push(assistantMessage);
+        state.toolState.updateLastResponse(fallbackMessage);
+      }
+
+      state.iteration += 1;
+      state.shouldStop = false;
+
+      if (fallbackMessage) {
+        options.logger.warn(fallbackMessage, state.groupId);
+      }
+
+      return FlowTransition.CONTINUE;
     }
 
     const tool = options.toolRegistry[execRes.name];
@@ -616,7 +707,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     state.messages.push(...followUpMsgs);
     state.iteration += 1;
 
-    return 'continue';
+    return FlowTransition.CONTINUE;
   }
 }
 
@@ -630,7 +721,7 @@ export function createToolUseCycleFlow<C>(): Flow<ToolUseCycleShared<C>> {
   callNode.next(processNode);
   processNode.next(dispatchNode);
 
-  dispatchNode.on('continue', prepNode);
+  dispatchNode.on(FlowTransition.CONTINUE, prepNode);
 
   return new Flow<ToolUseCycleShared<C>>(prepNode);
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -107,6 +107,29 @@ function normalizeToolCallError(
   return { message: fallbackMessage };
 }
 
+function extractToolCallId(parsed: any): { id: string } | { error: string } {
+  const rawId =
+    parsed?.call_id ??
+    parsed?.id ??
+    parsed?.tool_use_id ??
+    parsed?.tool_call_id;
+
+  if (rawId === undefined || rawId === null) {
+    return {
+      error: `Tool JSON missing call identifier: ${JSON.stringify(parsed)}`,
+    };
+  }
+
+  const trimmed = String(rawId).trim();
+  if (!trimmed) {
+    return {
+      error: `Tool JSON contains blank call identifier: ${JSON.stringify(parsed)}`,
+    };
+  }
+
+  return { id: trimmed };
+}
+
 export interface ToolUseCycleState {
   messages: ProviderMessage[];
   toolState: ToolState;
@@ -151,14 +174,13 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   }
 
   async post(
-    _shared: ToolUseCycleShared<C>,
+    { state }: ToolUseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       debugContext: DebugContext;
       debugFileOptions: DebugFileOptions;
     },
   ): Promise<string | undefined> {
-    const { state } = _shared;
     if (prepRes.interrupted) {
       state.shouldStop = true;
       return 'complete';
@@ -413,6 +435,12 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       return { skipped: true };
     }
 
+    const interrupted = Boolean(await options.checkInterruption());
+    if (interrupted) {
+      state.shouldStop = true;
+      return { skipped: true };
+    }
+
     let parsed: any;
     try {
       parsed = JSON.parse(state.toolInfo);
@@ -434,29 +462,9 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       return { skipped: true };
     }
 
-    const rawToolCallId =
-      parsed.call_id ?? parsed.id ?? parsed.tool_use_id ?? parsed.tool_call_id;
-    if (!rawToolCallId) {
-      const errorMsg = `Tool JSON missing call identifier: ${JSON.stringify(parsed)}`;
-      const errorResult = toolResult({ error: errorMsg, isError: true });
-      const toolUseLog = {
-        tool: parsed.name || parsed.function?.name || 'unknown',
-        input: parsed,
-        output: sanitizeToolResultForLog(errorResult),
-      };
-      options.logger.info(
-        '',
-        state.groupId,
-        MESSAGE_TYPES.TOOL_USE,
-        toolUseLog,
-      );
-      state.shouldStop = true;
-      return { skipped: true };
-    }
-
-    const toolCallId = String(rawToolCallId).trim();
-    if (!toolCallId) {
-      const errorMsg = `Tool JSON contains blank call identifier: ${JSON.stringify(parsed)}`;
+    const toolCallIdResult = extractToolCallId(parsed);
+    if ('error' in toolCallIdResult) {
+      const errorMsg = toolCallIdResult.error;
       const errorResult = toolResult({ error: errorMsg, isError: true });
       const toolUseLog = {
         tool: parsed.name || parsed.function?.name || 'unknown',
@@ -508,7 +516,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       }
     }
 
-    return { parsed, name, input, toolCallId };
+    return { parsed, name, input, toolCallId: toolCallIdResult.id };
   }
 
   async post(

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -47,7 +47,7 @@ interface DebugFileOptions {
   baseName: string;
 }
 
-async function saveDebugObjectIfConfigured(
+async function maybeSaveDebug(
   debugContext: DebugContext,
   debugFileOptions: DebugFileOptions,
   object: unknown,
@@ -59,15 +59,6 @@ async function saveDebugObjectIfConfigured(
     context: debugContext,
     fileOptions: debugFileOptions,
   });
-}
-
-function resetToolUseState(state: ToolUseCycleState): void {
-  state.shouldStop = false;
-  state.response = undefined;
-  state.responseTime = undefined;
-  state.toolInfo = undefined;
-  state.text = undefined;
-  state.stopReason = undefined;
 }
 
 interface ToolValidationDiagnostics {
@@ -146,17 +137,32 @@ type ToolDispatchErrorResult = {
   fallbackMessage?: string;
 };
 
-export interface ToolUseCycleState {
+export interface ToolUseCycleInputState {
   messages: ProviderMessage[];
   toolState: ToolState;
   groupId?: string;
   iteration: number;
+}
+
+export interface ToolUseCycleRuntimeState {
   shouldStop: boolean;
   response?: unknown;
   responseTime?: number;
   toolInfo?: string;
   text?: string;
   stopReason?: ProviderStopReason;
+}
+
+export type ToolUseCycleState = ToolUseCycleInputState &
+  ToolUseCycleRuntimeState;
+
+function resetToolUseState(state: ToolUseCycleRuntimeState): void {
+  state.shouldStop = false;
+  state.response = undefined;
+  state.responseTime = undefined;
+  state.toolInfo = undefined;
+  state.text = undefined;
+  state.stopReason = undefined;
 }
 
 export interface ToolUseCycleShared<C = unknown> {
@@ -199,7 +205,7 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
     resetToolUseState(state);
 
-    await saveDebugObjectIfConfigured(
+    await maybeSaveDebug(
       prepRes.debugContext,
       prepRes.debugFileOptions,
       state.messages,
@@ -286,7 +292,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     state.response = execRes.response;
     state.responseTime = execRes.responseTime;
 
-    await saveDebugObjectIfConfigured(
+    await maybeSaveDebug(
       execRes.debugContext,
       execRes.debugFileOptions,
       execRes.response,
@@ -417,14 +423,14 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   }
 
   async exec(
-    context: ToolUseCycleShared<C> | undefined,
+    context: ToolUseCycleShared<C>,
   ): Promise<
     | { skipped: true }
     | { parsed: any; name: string; input: any; toolCallId: string }
     | ToolDispatchErrorResult
   > {
     if (!context) {
-      return { skipped: true };
+      throw new Error('ToolUseDispatchNode requires shared cycle context.');
     }
 
     const { options, state } = context;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -178,16 +178,16 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseExecutionContext<C>> {
+  async prep(
+    shared: ToolUseCycleShared<C>,
+  ): Promise<ToolUseExecutionContext<C>> {
     return {
       options: shared.options,
       state: shared.state,
     };
   }
 
-  async exec(
-    context: ToolUseExecutionContext<C>,
-  ): Promise<
+  async exec(context: ToolUseExecutionContext<C>): Promise<
     | { skipped: true }
     | {
         response: unknown;
@@ -246,7 +246,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
           responseTime?: number;
           debugContext: DebugContext;
           debugFileOptions: DebugFileOptions;
-      },
+        },
   ): Promise<string | undefined> {
     const { options, state } = prepRes;
 
@@ -275,16 +275,16 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseExecutionContext<C>> {
+  async prep(
+    shared: ToolUseCycleShared<C>,
+  ): Promise<ToolUseExecutionContext<C>> {
     return {
       options: shared.options,
       state: shared.state,
     };
   }
 
-  async exec(
-    context: ToolUseExecutionContext<C>,
-  ): Promise<
+  async exec(context: ToolUseExecutionContext<C>): Promise<
     | { skipped: true }
     | {
         toolInfo?: string;
@@ -389,7 +389,9 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseExecutionContext<C>> {
+  async prep(
+    shared: ToolUseCycleShared<C>,
+  ): Promise<ToolUseExecutionContext<C>> {
     return {
       options: shared.options,
       state: shared.state,
@@ -438,7 +440,12 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         input: parsed,
         output: sanitizeToolResultForLog(errorResult),
       };
-      options.logger.info('', state.groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      options.logger.info(
+        '',
+        state.groupId,
+        MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
+      );
       state.shouldStop = true;
       return { skipped: true };
     }
@@ -452,7 +459,12 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         input: parsed,
         output: sanitizeToolResultForLog(errorResult),
       };
-      options.logger.info('', state.groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      options.logger.info(
+        '',
+        state.groupId,
+        MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
+      );
       state.shouldStop = true;
       return { skipped: true };
     }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -11,6 +11,7 @@ import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTy
 
 // Local imports - utilities
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+import type { DebugObjectType } from '@agent/utils/debugMessageSaver';
 import { sanitizeToolResultForLog } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 
 // Local imports - logging
@@ -38,6 +39,29 @@ interface DebugContext {
 interface DebugFileOptions {
   continuationCount: number;
   baseName: string;
+}
+
+async function saveDebugObjectIfConfigured(
+  debugContext: DebugContext,
+  debugFileOptions: DebugFileOptions,
+  object: unknown,
+  objectType: DebugObjectType,
+): Promise<void> {
+  await maybeSaveDebugObject({
+    object,
+    objectType,
+    context: debugContext,
+    fileOptions: debugFileOptions,
+  });
+}
+
+function resetToolUseState(state: ToolUseCycleState): void {
+  state.shouldStop = false;
+  state.response = undefined;
+  state.responseTime = undefined;
+  state.toolInfo = undefined;
+  state.text = undefined;
+  state.stopReason = undefined;
 }
 
 interface ToolValidationDiagnostics {
@@ -140,19 +164,14 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       return 'complete';
     }
 
-    state.shouldStop = false;
-    state.response = undefined;
-    state.responseTime = undefined;
-    state.toolInfo = undefined;
-    state.text = undefined;
-    state.stopReason = undefined;
+    resetToolUseState(state);
 
-    await maybeSaveDebugObject({
-      object: state.messages,
-      objectType: 'messages',
-      context: prepRes.debugContext,
-      fileOptions: prepRes.debugFileOptions,
-    });
+    await saveDebugObjectIfConfigured(
+      prepRes.debugContext,
+      prepRes.debugFileOptions,
+      state.messages,
+      'messages',
+    );
 
     return undefined;
   }
@@ -239,12 +258,12 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     state.response = execRes.response;
     state.responseTime = execRes.responseTime;
 
-    await maybeSaveDebugObject({
-      object: execRes.response,
-      objectType: 'response',
-      context: execRes.debugContext,
-      fileOptions: execRes.debugFileOptions,
-    });
+    await saveDebugObjectIfConfigured(
+      execRes.debugContext,
+      execRes.debugFileOptions,
+      execRes.response,
+      'response',
+    );
 
     if (!execRes.response) {
       state.shouldStop = true;
@@ -370,6 +389,13 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseExecutionContext<C>> {
+    return {
+      options: shared.options,
+      state: shared.state,
+    };
+  }
+
   async exec(
     context: ToolUseExecutionContext<C>,
   ): Promise<
@@ -417,7 +443,19 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       return { skipped: true };
     }
 
-    const toolCallId = String(rawToolCallId);
+    const toolCallId = String(rawToolCallId).trim();
+    if (!toolCallId) {
+      const errorMsg = `Tool JSON contains blank call identifier: ${JSON.stringify(parsed)}`;
+      const errorResult = toolResult({ error: errorMsg, isError: true });
+      const toolUseLog = {
+        tool: parsed.name || parsed.function?.name || 'unknown',
+        input: parsed,
+        output: sanitizeToolResultForLog(errorResult),
+      };
+      options.logger.info('', state.groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      state.shouldStop = true;
+      return { skipped: true };
+    }
 
     const name = parsed.name || parsed.function?.name;
     if (!name) {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -399,11 +399,15 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   }
 
   async exec(
-    context: ToolUseExecutionContext<C>,
+    context: ToolUseExecutionContext<C> | undefined,
   ): Promise<
     | { skipped: true }
     | { parsed: any; name: string; input: any; toolCallId: string }
   > {
+    if (!context) {
+      return { skipped: true };
+    }
+
     const { options, state } = context;
     if (state.shouldStop || !state.toolInfo) {
       return { skipped: true };

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -40,9 +40,52 @@ interface DebugFileOptions {
   baseName: string;
 }
 
+interface ToolValidationDiagnostics {
+  type: 'validation_error';
+  issues: any;
+  formatted: Array<{
+    path: string;
+    message: string;
+    expected?: unknown;
+    received?: unknown;
+    code?: string;
+  }>;
+}
+
+function normalizeToolCallError(
+  toolName: string,
+  error: unknown,
+): { message: string; diagnostics?: ToolValidationDiagnostics } {
+  if (error && typeof error === 'object' && 'issues' in error) {
+    const zodError = error as { issues?: any[] };
+    const issues = Array.isArray(zodError.issues) ? zodError.issues : [];
+    return {
+      message: `${toolName}: Invalid parameters provided`,
+      diagnostics: {
+        type: 'validation_error',
+        issues,
+        formatted: issues.map((issue) => ({
+          path: Array.isArray(issue.path) ? issue.path.join('.') : '',
+          message: issue.message,
+          expected: issue.expected,
+          received: issue.received,
+          code: issue.code,
+        })),
+      },
+    };
+  }
+
+  const fallbackMessage =
+    error instanceof Error
+      ? `${toolName}: ${error.message}`
+      : `${toolName}: ${String(error)}`;
+
+  return { message: fallbackMessage };
+}
+
 export interface ToolUseCycleState {
   messages: ProviderMessage[];
-  toolState?: ToolState | null;
+  toolState: ToolState;
   groupId?: string;
   iteration: number;
   shouldStop: boolean;
@@ -220,7 +263,7 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     const thinking = options.modelHandler.processThinkingBlock(
       state.response,
       state.groupId,
-      state.toolState ?? undefined,
+      state.toolState,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
     if (thinking && !useStreaming) {
@@ -270,7 +313,7 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     if (!toolInfo || endTurn) {
       if (text) {
         state.messages.push(options.modelHandler.createAssistantMessage(text));
-        state.toolState?.updateLastResponse(text);
+        state.toolState.updateLastResponse(text);
       }
       state.shouldStop = true;
       return { stopReason, text, endTurn: true };
@@ -310,7 +353,10 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   async exec(
     shared: ToolUseCycleShared<C>,
-  ): Promise<{ skipped: true } | { parsed: any; name: string; input: any }> {
+  ): Promise<
+    | { skipped: true }
+    | { parsed: any; name: string; input: any; toolCallId: string }
+  > {
     const { options, state } = shared;
     if (state.shouldStop || !state.toolInfo) {
       return { skipped: true };
@@ -337,8 +383,23 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       return { skipped: true };
     }
 
-    const id =
-      parsed.call_id || parsed.id || parsed.tool_use_id || parsed.tool_call_id;
+    const rawToolCallId =
+      parsed.call_id ?? parsed.id ?? parsed.tool_use_id ?? parsed.tool_call_id;
+    if (!rawToolCallId) {
+      const errorMsg = `Tool JSON missing call identifier: ${JSON.stringify(parsed)}`;
+      const errorResult = toolResult({ error: errorMsg, isError: true });
+      const toolUseLog = {
+        tool: parsed.name || parsed.function?.name || 'unknown',
+        input: parsed,
+        output: sanitizeToolResultForLog(errorResult),
+      };
+      options.logger.info('', state.groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      state.shouldStop = true;
+      return { skipped: true };
+    }
+
+    const toolCallId = String(rawToolCallId);
+
     const name = parsed.name || parsed.function?.name;
     if (!name) {
       const errorMsg = `Tool JSON missing name: ${JSON.stringify(parsed)}`;
@@ -374,13 +435,15 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       }
     }
 
-    return { parsed, name, input };
+    return { parsed, name, input, toolCallId };
   }
 
   async post(
     shared: ToolUseCycleShared<C>,
     _prepRes: unknown,
-    execRes: { skipped: true } | { parsed: any; name: string; input: any },
+    execRes:
+      | { skipped: true }
+      | { parsed: any; name: string; input: any; toolCallId: string },
   ): Promise<string | undefined> {
     const { options, state } = shared;
     if ('skipped' in execRes) {
@@ -399,31 +462,12 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       try {
         result = await tool.call(execRes.input);
       } catch (err) {
-        let errorMessage: string;
-        let diagnostics: any;
-        if (err && typeof err === 'object' && 'issues' in err) {
-          const zodError = err as any;
-          errorMessage = `${execRes.name}: Invalid parameters provided`;
-          diagnostics = {
-            type: 'validation_error',
-            issues: zodError.issues,
-            formatted: zodError.issues?.map((issue: any) => ({
-              path: issue.path.join('.'),
-              message: issue.message,
-              expected: issue.expected,
-              received: issue.received,
-              code: issue.code,
-            })),
-          };
-        } else {
-          errorMessage =
-            err instanceof Error
-              ? `${execRes.name}: ${err.message}`
-              : `${execRes.name}: ${String(err)}`;
-        }
-
+        const { message, diagnostics } = normalizeToolCallError(
+          execRes.name,
+          err,
+        );
         result = toolResult({
-          error: errorMessage,
+          error: message,
           isError: true,
           diagnostics,
         });
@@ -437,7 +481,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     };
     options.logger.info('', state.groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
 
-    if (result.files && result.files.length > 0 && state.toolState) {
+    if (result.files && result.files.length > 0) {
       const existing = state.toolState.mediaFiles;
       const toAdd: string[] = [];
       for (const attachment of result.files) {
@@ -465,10 +509,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     const followUpMsgs =
       await options.modelHandler.createToolUseFollowUpMessages(
         options.client,
-        execRes.parsed.call_id ||
-          execRes.parsed.id ||
-          execRes.parsed.tool_use_id ||
-          execRes.parsed.tool_call_id,
+        execRes.toolCallId,
         execRes.name,
         execRes.parsed,
         (() => {
@@ -485,7 +526,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
           if (result.files !== undefined) payload.files = result.files;
           return payload;
         })(),
-        state.toolState ?? undefined,
+        state.toolState,
         state.text ?? '',
       );
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,0 +1,512 @@
+// Local imports - core flow primitives
+import { BaseNode, Flow } from '@agent/node';
+
+// Local imports - agent components
+import { ToolState } from '@agent/core/ToolState';
+import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
+
+// Local imports - model handler types
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
+
+// Local imports - utilities
+import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+import { sanitizeToolResultForLog } from '@agent/modelHandlers/utils/toolAttachmentUtils';
+
+// Local imports - logging
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+// Local imports - tools
+import { ToolResult, toolResult } from '@tools/result';
+import type { ToolDefinition } from '@model';
+
+// Local imports - filesystem utilities
+import { WorkspaceFS } from '@utils/files';
+
+// Local imports - text utilities
+import xmlUtils from '@utils/text/xmlUtils';
+
+// Local imports - usage types
+import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
+
+interface DebugContext {
+  logger: ToolUseCycleOptions['logger'];
+  modelName?: string;
+  groupId?: string;
+}
+
+interface DebugFileOptions {
+  continuationCount: number;
+  baseName: string;
+}
+
+export interface ToolUseCycleState {
+  messages: ProviderMessage[];
+  toolState?: ToolState | null;
+  groupId?: string;
+  iteration: number;
+  shouldStop: boolean;
+  response?: unknown;
+  responseTime?: number;
+  toolInfo?: string;
+  text?: string;
+  stopReason?: ProviderStopReason;
+}
+
+export interface ToolUseCycleShared<C = unknown> {
+  options: ToolUseCycleOptions<C>;
+  state: ToolUseCycleState;
+}
+
+class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
+  async prep(shared: ToolUseCycleShared<C>): Promise<{
+    interrupted: boolean;
+    debugContext: DebugContext;
+    debugFileOptions: DebugFileOptions;
+  }> {
+    const { options, state } = shared;
+    const interrupted = Boolean(await options.checkInterruption());
+    const debugContext: DebugContext = {
+      logger: options.logger,
+      modelName: options.modelName,
+      groupId: state.groupId,
+    };
+    const debugFileOptions: DebugFileOptions = {
+      continuationCount: state.iteration,
+      baseName: 'tooluse',
+    };
+    return { interrupted, debugContext, debugFileOptions };
+  }
+
+  async post(
+    shared: ToolUseCycleShared<C>,
+    prepRes: {
+      interrupted: boolean;
+      debugContext: DebugContext;
+      debugFileOptions: DebugFileOptions;
+    },
+  ): Promise<string | undefined> {
+    const { state } = shared;
+    if (prepRes.interrupted) {
+      state.shouldStop = true;
+      return 'complete';
+    }
+
+    state.shouldStop = false;
+    state.response = undefined;
+    state.responseTime = undefined;
+    state.toolInfo = undefined;
+    state.text = undefined;
+    state.stopReason = undefined;
+
+    await maybeSaveDebugObject({
+      object: state.messages,
+      objectType: 'messages',
+      context: prepRes.debugContext,
+      fileOptions: prepRes.debugFileOptions,
+    });
+
+    return undefined;
+  }
+}
+
+class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
+  async exec(
+    shared: ToolUseCycleShared<C>,
+  ): Promise<
+    | { skipped: true }
+    | {
+        response: unknown;
+        responseTime?: number;
+        debugContext: DebugContext;
+        debugFileOptions: DebugFileOptions;
+      }
+  > {
+    const { options, state } = shared;
+    if (state.shouldStop) {
+      return { skipped: true };
+    }
+
+    const debugContext: DebugContext = {
+      logger: options.logger,
+      modelName: options.modelName,
+      groupId: state.groupId,
+    };
+    const debugFileOptions: DebugFileOptions = {
+      continuationCount: state.iteration,
+      baseName: 'tooluse_response',
+    };
+
+    const abortController = new AbortController();
+    options.setAbortController(abortController);
+
+    let response: unknown;
+    const start = Date.now();
+    try {
+      options.modelHandler.setOutputStreaming(true);
+      response = await options.modelHandler.createResponse(
+        options.client,
+        state.messages,
+        options.agentSetting.temperature ?? 0,
+        undefined,
+        undefined,
+        abortController.signal,
+        options.agentSetting.tools as ToolDefinition[] | undefined,
+      );
+    } finally {
+      options.setAbortController(null);
+    }
+
+    const responseTime = (Date.now() - start) / 1000;
+
+    return { response, responseTime, debugContext, debugFileOptions };
+  }
+
+  async post(
+    shared: ToolUseCycleShared<C>,
+    _prepRes: unknown,
+    execRes:
+      | { skipped: true }
+      | {
+          response: unknown;
+          responseTime?: number;
+          debugContext: DebugContext;
+          debugFileOptions: DebugFileOptions;
+        },
+  ): Promise<string | undefined> {
+    const { options, state } = shared;
+
+    if ('skipped' in execRes) {
+      state.shouldStop = true;
+      return 'complete';
+    }
+
+    state.response = execRes.response;
+    state.responseTime = execRes.responseTime;
+
+    await maybeSaveDebugObject({
+      object: execRes.response,
+      objectType: 'response',
+      context: execRes.debugContext,
+      fileOptions: execRes.debugFileOptions,
+    });
+
+    if (!execRes.response) {
+      state.shouldStop = true;
+      return 'complete';
+    }
+
+    return undefined;
+  }
+}
+
+class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
+  async exec(
+    shared: ToolUseCycleShared<C>,
+  ): Promise<
+    | { skipped: true }
+    | {
+        toolInfo?: string;
+        stopReason: ProviderStopReason;
+        text?: string;
+        endTurn: boolean;
+      }
+  > {
+    const { options, state } = shared;
+    if (state.shouldStop || !state.response) {
+      return { skipped: true };
+    }
+
+    const thinking = options.modelHandler.processThinkingBlock(
+      state.response,
+      state.groupId,
+      state.toolState ?? undefined,
+    );
+    const useStreaming = options.modelHandler.getStreamingConfig();
+    if (thinking && !useStreaming) {
+      const formatted = await xmlUtils.formatContent(thinking);
+      if (formatted.trim().length > 0) {
+        options.logger.info(formatted, state.groupId, MESSAGE_TYPES.THINKING);
+      }
+    }
+
+    const toolInfo = options.modelHandler.extractToolUse(state.response);
+    const [text, usage, stopReason] = options.modelHandler.extractResponse(
+      state.response,
+      '',
+    );
+
+    if (text) {
+      options.logger.debug(
+        `Model response: ${text.slice(0, 100)}`,
+        state.groupId,
+      );
+      if (!useStreaming) {
+        const formatted = await xmlUtils.formatContent(text);
+        options.logger.info(
+          formatted,
+          state.groupId,
+          MESSAGE_TYPES.MODEL_RESPONSE,
+        );
+      }
+    }
+
+    if (usage) {
+      const normalized = options.modelHandler.computeResponseUsage(
+        usage,
+        state.responseTime ?? 0,
+      );
+      const stats: ExtendedTokenUsageStats = {
+        inputTokens: normalized.totalInputTokens,
+        outputTokens: normalized.totalOutputTokens,
+        cost: normalized.cost,
+        elapsedTime: normalized.responseTime,
+      };
+      options.logger.statistics(stats, state.groupId);
+    }
+
+    const endTurn = options.modelHandler.isEndTurnStop(stopReason);
+
+    if (!toolInfo || endTurn) {
+      if (text) {
+        state.messages.push(options.modelHandler.createAssistantMessage(text));
+        state.toolState?.updateLastResponse(text);
+      }
+      state.shouldStop = true;
+      return { stopReason, text, endTurn: true };
+    }
+
+    state.toolInfo = toolInfo;
+    state.text = text ?? undefined;
+    state.stopReason = stopReason;
+
+    return { toolInfo, stopReason, text: text ?? undefined, endTurn: false };
+  }
+
+  async post(
+    shared: ToolUseCycleShared<C>,
+    _prepRes: unknown,
+    execRes:
+      | { skipped: true }
+      | {
+          toolInfo?: string;
+          stopReason: ProviderStopReason;
+          text?: string;
+          endTurn: boolean;
+        },
+  ): Promise<string | undefined> {
+    if ('skipped' in execRes) {
+      return 'complete';
+    }
+
+    if (execRes.endTurn) {
+      return 'complete';
+    }
+
+    return undefined;
+  }
+}
+
+class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
+  async exec(
+    shared: ToolUseCycleShared<C>,
+  ): Promise<{ skipped: true } | { parsed: any; name: string; input: any }> {
+    const { options, state } = shared;
+    if (state.shouldStop || !state.toolInfo) {
+      return { skipped: true };
+    }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(state.toolInfo);
+    } catch (err) {
+      const errorMsg = `Malformed tool JSON: ${err instanceof Error ? err.message : String(err)}`;
+      const errorResult = toolResult({ error: errorMsg, isError: true });
+      const toolUseLog = {
+        tool: 'unknown',
+        input: state.toolInfo,
+        output: sanitizeToolResultForLog(errorResult),
+      };
+      options.logger.info(
+        '',
+        state.groupId,
+        MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
+      );
+      state.shouldStop = true;
+      return { skipped: true };
+    }
+
+    const id =
+      parsed.call_id || parsed.id || parsed.tool_use_id || parsed.tool_call_id;
+    const name = parsed.name || parsed.function?.name;
+    if (!name) {
+      const errorMsg = `Tool JSON missing name: ${JSON.stringify(parsed)}`;
+      const errorResult = toolResult({ error: errorMsg, isError: true });
+      const toolUseLog = {
+        tool: 'unknown',
+        input: parsed,
+        output: sanitizeToolResultForLog(errorResult),
+      };
+      options.logger.info(
+        '',
+        state.groupId,
+        MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
+      );
+      state.shouldStop = true;
+      return { skipped: true };
+    }
+
+    let input = parsed.input ?? parsed.args;
+    if (!input && parsed.arguments) {
+      try {
+        input = JSON.parse(parsed.arguments);
+      } catch {
+        input = parsed.arguments;
+      }
+    }
+    if (!input && parsed.function?.arguments) {
+      try {
+        input = JSON.parse(parsed.function.arguments);
+      } catch {
+        input = parsed.function.arguments;
+      }
+    }
+
+    return { parsed, name, input };
+  }
+
+  async post(
+    shared: ToolUseCycleShared<C>,
+    _prepRes: unknown,
+    execRes: { skipped: true } | { parsed: any; name: string; input: any },
+  ): Promise<string | undefined> {
+    const { options, state } = shared;
+    if ('skipped' in execRes) {
+      state.shouldStop = true;
+      return 'complete';
+    }
+
+    const tool = options.toolRegistry[execRes.name];
+    let result: ToolResult;
+    if (!tool) {
+      result = toolResult({
+        error: `Unknown tool ${execRes.name}`,
+        isError: true,
+      });
+    } else {
+      try {
+        result = await tool.call(execRes.input);
+      } catch (err) {
+        let errorMessage: string;
+        let diagnostics: any;
+        if (err && typeof err === 'object' && 'issues' in err) {
+          const zodError = err as any;
+          errorMessage = `${execRes.name}: Invalid parameters provided`;
+          diagnostics = {
+            type: 'validation_error',
+            issues: zodError.issues,
+            formatted: zodError.issues?.map((issue: any) => ({
+              path: issue.path.join('.'),
+              message: issue.message,
+              expected: issue.expected,
+              received: issue.received,
+              code: issue.code,
+            })),
+          };
+        } else {
+          errorMessage =
+            err instanceof Error
+              ? `${execRes.name}: ${err.message}`
+              : `${execRes.name}: ${String(err)}`;
+        }
+
+        result = toolResult({
+          error: errorMessage,
+          isError: true,
+          diagnostics,
+        });
+      }
+    }
+
+    const toolUseLog = {
+      tool: execRes.name,
+      input: execRes.input ?? execRes.parsed,
+      output: sanitizeToolResultForLog(result),
+    };
+    options.logger.info('', state.groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+
+    if (result.files && result.files.length > 0 && state.toolState) {
+      const existing = state.toolState.mediaFiles;
+      const toAdd: string[] = [];
+      for (const attachment of result.files) {
+        const candidate = attachment.path;
+        if (typeof candidate !== 'string' || candidate.trim() === '') {
+          continue;
+        }
+        if (existing.includes(candidate) || toAdd.includes(candidate)) {
+          continue;
+        }
+        try {
+          const exists = await WorkspaceFS.exists(candidate);
+          if (exists) {
+            toAdd.push(candidate);
+          }
+        } catch {
+          // Ignore errors when checking existence
+        }
+      }
+      if (toAdd.length > 0) {
+        state.toolState.addMediaFiles(toAdd);
+      }
+    }
+
+    const followUpMsgs =
+      await options.modelHandler.createToolUseFollowUpMessages(
+        options.client,
+        execRes.parsed.call_id ||
+          execRes.parsed.id ||
+          execRes.parsed.tool_use_id ||
+          execRes.parsed.tool_call_id,
+        execRes.name,
+        execRes.parsed,
+        (() => {
+          const payload: Record<string, unknown> = {};
+          if (result.summary !== undefined) payload.summary = result.summary;
+          if (result.output !== undefined) payload.output = result.output;
+          if (result.error !== undefined) payload.error = result.error;
+          if (result.base64Image !== undefined)
+            payload.base64Image = result.base64Image;
+          if (result.system !== undefined) payload.system = result.system;
+          if (result.isError) payload.isError = true;
+          if (result.diagnostics !== undefined)
+            payload.diagnostics = result.diagnostics;
+          if (result.files !== undefined) payload.files = result.files;
+          return payload;
+        })(),
+        state.toolState ?? undefined,
+        state.text ?? '',
+      );
+
+    state.messages.push(...followUpMsgs);
+    state.iteration += 1;
+
+    return 'continue';
+  }
+}
+
+export function createToolUseCycleFlow<C>(): Flow<ToolUseCycleShared<C>> {
+  const prepNode = new ToolUsePrepNode<C>();
+  const callNode = new ToolUseCallNode<C>();
+  const processNode = new ToolUseProcessNode<C>();
+  const dispatchNode = new ToolUseDispatchNode<C>();
+
+  prepNode.next(callNode);
+  callNode.next(processNode);
+  processNode.next(dispatchNode);
+
+  dispatchNode.on('continue', prepNode);
+
+  return new Flow<ToolUseCycleShared<C>>(prepNode);
+}

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -24,6 +24,9 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { ToolResult, toolResult } from '@tools/result';
 import type { ToolDefinition } from '@model';
 
+// Local imports - error utilities
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - filesystem utilities
 import { WorkspaceFS } from '@utils/files';
 
@@ -161,11 +164,6 @@ export interface ToolUseCycleShared<C = unknown> {
   state: ToolUseCycleState;
 }
 
-interface ToolUseExecutionContext<C> {
-  options: ToolUseCycleOptions<C>;
-  state: ToolUseCycleState;
-}
-
 class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   async prep(shared: ToolUseCycleShared<C>): Promise<{
     interrupted: boolean;
@@ -213,16 +211,11 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(
-    shared: ToolUseCycleShared<C>,
-  ): Promise<ToolUseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      state: shared.state,
-    };
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
+    return shared;
   }
 
-  async exec(context: ToolUseExecutionContext<C>): Promise<
+  async exec(context: ToolUseCycleShared<C>): Promise<
     | { skipped: true }
     | {
         response: unknown;
@@ -273,7 +266,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
   async post(
     _shared: ToolUseCycleShared<C>,
-    prepRes: ToolUseExecutionContext<C>,
+    prepRes: ToolUseCycleShared<C>,
     execRes:
       | { skipped: true }
       | {
@@ -310,16 +303,11 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(
-    shared: ToolUseCycleShared<C>,
-  ): Promise<ToolUseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      state: shared.state,
-    };
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
+    return shared;
   }
 
-  async exec(context: ToolUseExecutionContext<C>): Promise<
+  async exec(context: ToolUseCycleShared<C>): Promise<
     | { skipped: true }
     | {
         toolInfo?: string;
@@ -424,17 +412,12 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(
-    shared: ToolUseCycleShared<C>,
-  ): Promise<ToolUseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      state: shared.state,
-    };
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
+    return shared;
   }
 
   async exec(
-    context: ToolUseExecutionContext<C> | undefined,
+    context: ToolUseCycleShared<C> | undefined,
   ): Promise<
     | { skipped: true }
     | { parsed: any; name: string; input: any; toolCallId: string }
@@ -459,9 +442,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     try {
       parsed = JSON.parse(state.toolInfo);
     } catch (err) {
-      const errorMsg = `Malformed tool JSON: ${
-        err instanceof Error ? err.message : String(err)
-      }`;
+      const errorMsg = `Malformed tool JSON: ${toErrorMessage(err)}`;
       const errorResult = toolResult({ error: errorMsg, isError: true });
       const toolUseLog = {
         tool: 'unknown',
@@ -487,7 +468,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     try {
       toolCallId = extractToolCallId(parsed);
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = toErrorMessage(error);
       const errorResult = toolResult({ error: errorMsg, isError: true });
       const toolUseLog = {
         tool: parsed.name || parsed.function?.name || 'unknown',
@@ -557,7 +538,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
   async post(
     _shared: ToolUseCycleShared<C>,
-    prepRes: ToolUseExecutionContext<C>,
+    prepRes: ToolUseCycleShared<C>,
     execRes:
       | { skipped: true }
       | { parsed: any; name: string; input: any; toolCallId: string }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -107,7 +107,7 @@ function normalizeToolCallError(
   return { message: fallbackMessage };
 }
 
-function extractToolCallId(parsed: any): { id: string } | { error: string } {
+function extractToolCallId(parsed: any): string {
   const rawId =
     parsed?.call_id ??
     parsed?.id ??
@@ -115,19 +115,19 @@ function extractToolCallId(parsed: any): { id: string } | { error: string } {
     parsed?.tool_call_id;
 
   if (rawId === undefined || rawId === null) {
-    return {
-      error: `Tool JSON missing call identifier: ${JSON.stringify(parsed)}`,
-    };
+    throw new Error(
+      `Tool JSON missing call identifier: ${JSON.stringify(parsed)}`,
+    );
   }
 
   const trimmed = String(rawId).trim();
   if (!trimmed) {
-    return {
-      error: `Tool JSON contains blank call identifier: ${JSON.stringify(parsed)}`,
-    };
+    throw new Error(
+      `Tool JSON contains blank call identifier: ${JSON.stringify(parsed)}`,
+    );
   }
 
-  return { id: trimmed };
+  return trimmed;
 }
 
 export interface ToolUseCycleState {
@@ -462,9 +462,11 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       return { skipped: true };
     }
 
-    const toolCallIdResult = extractToolCallId(parsed);
-    if ('error' in toolCallIdResult) {
-      const errorMsg = toolCallIdResult.error;
+    let toolCallId: string;
+    try {
+      toolCallId = extractToolCallId(parsed);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
       const errorResult = toolResult({ error: errorMsg, isError: true });
       const toolUseLog = {
         tool: parsed.name || parsed.function?.name || 'unknown',
@@ -516,7 +518,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       }
     }
 
-    return { parsed, name, input, toolCallId: toolCallIdResult.id };
+    return { parsed, name, input, toolCallId };
   }
 
   async post(

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -186,6 +186,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     return false;
   }
 
+  public isInterruptionRequested(): boolean {
+    return this.isInterrupted;
+  }
+
   public setExecutionId(id: ExecutionId): void {
     this.executionId = id;
   }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -180,8 +180,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   /**
    * Calculates the total number of rounds to execute.
    * Returns the maximum of configured rounds and userRequest array length.
+   * Subclasses may override to simplify workflows (e.g., DirectAgent).
    */
-  private getTotalRounds(): number {
+  protected getTotalRounds(): number {
     const requestArray = Array.isArray(this.agentPrompt.userRequest)
       ? this.agentPrompt.userRequest
       : this.agentPrompt.userRequest

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -11,6 +11,11 @@ import { runResponseCycle } from '@agent/core/ResponseCycle';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 import { ToolState } from '@agent/core/ToolState';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
+import {
+  createReflectionRunFlow,
+  type ReflectionRunShared,
+  type ReflectionRunState,
+} from '@agent/implementations/flows/ReflectionRunFlow';
 import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
@@ -44,6 +49,31 @@ export interface RoundOutputOptions {
   outputFile: string;
   endTurn: boolean;
   processGroupId?: string;
+}
+
+export interface ReflectionRoundContext {
+  roundIndex: number;
+  globalState: AgentStateGlobal;
+  messages: any[];
+}
+
+export interface ReflectionRoundResult {
+  roundState: AgentStateRound;
+  globalState: AgentStateGlobal;
+  messages: any[];
+  shouldContinue: boolean;
+  toolState: ToolState;
+}
+
+interface RoundPipelineContext {
+  roundIndex: number;
+  roundState: AgentStateRound;
+  globalState: AgentStateGlobal;
+  toolState: ToolState;
+  preparedMessages: any[];
+  prefill: string;
+  outputPath: string;
+  roundGroupId: string;
 }
 
 /**
@@ -131,6 +161,14 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     }
 
     return this.promptBuilder;
+  }
+
+  protected resetPromptBuilder(): void {
+    this.promptBuilder = undefined;
+  }
+
+  public setCurrentRound(roundIndex: number): void {
+    this.userVars.CURRENT_ROUND = roundIndex;
   }
 
   /**
@@ -241,16 +279,16 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * @param roundGroupId - Identifier for grouping related log and output operations.
    * @returns Updated round/global state, messages, completion flag, and tool state after execution.
    */
-  private async runRoundPipeline(
-    currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
-    toolState: ToolState,
-    preparedMessages: any[],
-    prefill: string,
-    outputPath: string,
-    roundGroupId: string,
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
+  private async runRoundPipeline({
+    roundIndex,
+    roundState,
+    globalState,
+    toolState,
+    preparedMessages,
+    prefill,
+    outputPath,
+    roundGroupId,
+  }: RoundPipelineContext): Promise<ReflectionRoundResult> {
     const [endTurn, updatedMessages] =
       await this.modelHandler.initializeOutputAndPrefill(
         this.agentConfig,
@@ -263,73 +301,74 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       );
 
     if (!endTurn) {
-      const client = this.getClientInstance();
-      const options: ResponseCycleOptions<C> = {
-        modelHandler: this.modelHandler,
-        agentSetting: this.agentSetting,
-        agentConfig: this.agentConfig,
-        agentPrompt: this.agentPrompt,
-        userVars: this.userVars,
-        logger: this.logger,
-        client,
-        checkInterruption: () => this.checkInterruption(),
-        setAbortController: (ctrl) => {
-          this.abortController = ctrl;
-        },
-      };
-
-      const [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedToolState,
-        newEndTurn,
-      ] = await runResponseCycle(
-        options,
-        updatedMessages,
-        stateRound,
-        stateGlobal,
+      const cycleResult = await runResponseCycle({
+        options: this.createResponseCycleOptions(),
+        messages: updatedMessages,
+        stateRound: roundState,
+        stateGlobal: globalState,
         toolState,
-        outputPath,
+        outputFile: outputPath,
         roundGroupId,
-        this.executionId,
-      );
+        executionId: this.executionId,
+      });
 
-      // The round state is forwarded to handleRoundCompletion so subclasses can
-      // maintain a consistent signature even when this helper doesn't mutate it directly.
       await this.handleRoundCompletion(
-        currRound,
-        updatedStateRound,
-        updatedStateGlobal,
+        roundIndex,
+        cycleResult.stateRound,
+        cycleResult.stateGlobal,
         {
           outputFile: outputPath,
-          endTurn: newEndTurn,
+          endTurn: cycleResult.endTurn,
           processGroupId: roundGroupId,
         },
       );
 
-      if (currRound === 0) {
+      if (roundIndex === 0) {
         this.logger.debug(
-          `stateGlobal: ${JSON.stringify(updatedStateGlobal)}`,
+          `stateGlobal: ${JSON.stringify(cycleResult.stateGlobal)}`,
           roundGroupId,
         );
       }
 
-      return [
-        updatedStateRound,
-        updatedStateGlobal,
-        updatedMessages,
-        newEndTurn,
-        updatedToolState,
-      ];
+      return {
+        roundState: cycleResult.stateRound,
+        globalState: cycleResult.stateGlobal,
+        messages: updatedMessages,
+        shouldContinue: cycleResult.endTurn,
+        toolState: cycleResult.toolState,
+      };
     }
 
-    await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
+    await this.handleRoundCompletion(roundIndex, roundState, globalState, {
       outputFile: outputPath,
       endTurn,
       processGroupId: roundGroupId,
     });
 
-    return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
+    return {
+      roundState,
+      globalState,
+      messages: updatedMessages,
+      shouldContinue: endTurn,
+      toolState,
+    };
+  }
+
+  private createResponseCycleOptions(): ResponseCycleOptions<C> {
+    const client = this.getClientInstance();
+    return {
+      modelHandler: this.modelHandler,
+      agentSetting: this.agentSetting,
+      agentConfig: this.agentConfig,
+      agentPrompt: this.agentPrompt,
+      userVars: this.userVars,
+      logger: this.logger,
+      client,
+      checkInterruption: () => this.checkInterruption(),
+      setAbortController: (ctrl) => {
+        this.abortController = ctrl;
+      },
+    } as const;
   }
 
   private async prepareRoundContext(
@@ -483,16 +522,16 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     );
   }
 
-  private async executeRound(
-    currRound: number,
-    stateGlobal: AgentStateGlobal,
-    messages: any[],
-  ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
-    this.logger.debug(`Processing round ${currRound}`);
+  public async runReflectionRound({
+    roundIndex,
+    globalState,
+    messages,
+  }: ReflectionRoundContext): Promise<ReflectionRoundResult> {
+    this.logger.debug(`Processing round ${roundIndex}`);
     const toolState = new ToolState();
 
-    return this.withRoundGroup(`r${currRound}`, async (roundGroupId) => {
-      await this.prepareToolState(currRound, toolState, roundGroupId);
+    return this.withRoundGroup(`r${roundIndex}`, async (roundGroupId) => {
+      await this.prepareToolState(roundIndex, toolState, roundGroupId);
 
       const {
         stateRound,
@@ -500,27 +539,33 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         prefill = '',
         skip,
       } = await this.prepareRoundContext(
-        currRound,
-        stateGlobal,
+        roundIndex,
+        globalState,
         messages,
         toolState,
         roundGroupId,
       );
 
       if (skip) {
-        return [stateRound, stateGlobal, messages, true, toolState];
+        return {
+          roundState: stateRound,
+          globalState,
+          messages,
+          shouldContinue: true,
+          toolState,
+        };
       }
 
-      return this.runRoundPipeline(
-        currRound,
-        stateRound,
-        stateGlobal,
+      return this.runRoundPipeline({
+        roundIndex,
+        roundState: stateRound,
+        globalState,
         toolState,
         preparedMessages,
         prefill,
-        this.outputFile[currRound],
+        outputPath: this.outputFile[roundIndex],
         roundGroupId,
-      );
+      });
     });
   }
 
@@ -532,33 +577,23 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
     try {
       await this.init(this.runGroupId, { createGroup: true });
-      this.promptBuilder = undefined;
+      this.resetPromptBuilder();
       await this.initializeClient();
 
-      let stateGlobal = new AgentStateGlobal();
-      let messages: any[] = [];
-      let continueRounds = true;
-
       const totalRounds = this.getTotalRounds();
-      for (let currRound = 0; currRound < totalRounds; currRound++) {
-        if (this.isInterrupted) {
-          break;
-        }
+      const shared: ReflectionRunShared<C> = {
+        agent: this,
+        state: {
+          totalRounds,
+          currentRound: 0,
+          continueRounds: true,
+          messages: [],
+          globalState: new AgentStateGlobal(),
+        } satisfies ReflectionRunState,
+      };
 
-        if (currRound > 0 && !continueRounds) {
-          break;
-        }
-
-        this.userVars.CURRENT_ROUND = currRound;
-        const [stateRound, updatedGlobal, newMessages, endTurn, usedToolState] =
-          await this.executeRound(currRound, stateGlobal, messages);
-        this.roundStates.push(stateRound);
-        this.toolStates.push(usedToolState);
-        stateGlobal = updatedGlobal;
-        messages = newMessages;
-        continueRounds = endTurn;
-        stateGlobal.incrementRounds();
-      }
+      const flow = createReflectionRunFlow<C>();
+      await flow.run(shared);
 
       this.endRunGroup('stopped');
     } catch (error) {

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -13,9 +13,15 @@ import { ToolState } from '@agent/core/ToolState';
 import { BaseAgent } from '@agent/implementations/BaseAgent';
 import {
   createReflectionRunFlow,
+  type ReflectionRunHooks,
+  type ReflectionRunLifecycle,
   type ReflectionRunShared,
   type ReflectionRunState,
 } from '@agent/implementations/flows/ReflectionRunFlow';
+import {
+  createReflectionRoundFlow,
+  type ReflectionRoundShared,
+} from '@agent/implementations/flows/ReflectionRoundFlow';
 import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
@@ -531,41 +537,50 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     const toolState = new ToolState();
 
     return this.withRoundGroup(`r${roundIndex}`, async (roundGroupId) => {
-      await this.prepareToolState(roundIndex, toolState, roundGroupId);
-
-      const {
-        stateRound,
-        preparedMessages,
-        prefill = '',
-        skip,
-      } = await this.prepareRoundContext(
-        roundIndex,
-        globalState,
-        messages,
-        toolState,
-        roundGroupId,
-      );
-
-      if (skip) {
-        return {
-          roundState: stateRound,
-          globalState,
-          messages,
-          shouldContinue: true,
+      const shared: ReflectionRoundShared = {
+        runtime: {
           toolState,
-        };
+        },
+        hooks: {
+          prepareToolState: () =>
+            this.prepareToolState(roundIndex, toolState, roundGroupId),
+          prepareRoundContext: () =>
+            this.prepareRoundContext(
+              roundIndex,
+              globalState,
+              messages,
+              toolState,
+              roundGroupId,
+            ),
+          runRoundPipeline: ({ stateRound, preparedMessages, prefill }) =>
+            this.runRoundPipeline({
+              roundIndex,
+              roundState: stateRound,
+              globalState,
+              toolState,
+              preparedMessages,
+              prefill,
+              outputPath: this.outputFile[roundIndex],
+              roundGroupId,
+            }),
+          createSkipResult: (stateRound) => ({
+            roundState: stateRound,
+            globalState,
+            messages,
+            shouldContinue: true,
+            toolState,
+          }),
+        },
+      };
+
+      const flow = createReflectionRoundFlow();
+      await flow.run(shared);
+
+      if (!shared.runtime.result) {
+        throw new Error('Reflection round did not produce a result.');
       }
 
-      return this.runRoundPipeline({
-        roundIndex,
-        roundState: stateRound,
-        globalState,
-        toolState,
-        preparedMessages,
-        prefill,
-        outputPath: this.outputFile[roundIndex],
-        roundGroupId,
-      });
+      return shared.runtime.result;
     });
   }
 
@@ -573,34 +588,40 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * Main execution method that processes inputs and generates outputs.
    */
   public async run(): Promise<void> {
-    await this.startRunGroup();
+    const lifecycle: ReflectionRunLifecycle = {
+      phase: 'idle',
+      status: 'pending',
+      error: undefined,
+    };
 
-    try {
-      await this.init(this.runGroupId, { createGroup: true });
-      this.resetPromptBuilder();
-      await this.initializeClient();
+    const hooks: ReflectionRunHooks = {
+      start: () => this.startRunGroup(),
+      init: (runGroupId) => this.init(runGroupId, { createGroup: true }),
+      resetPromptBuilder: () => this.resetPromptBuilder(),
+      initializeClient: () => this.initializeClient(),
+      end: (status) => this.endRunGroup(status),
+      cleanup: () => this.cleanup(),
+    };
 
-      const totalRounds = this.getTotalRounds();
-      const shared: ReflectionRunShared<C> = {
-        agent: this,
-        state: {
-          totalRounds,
-          currentRound: 0,
-          continueRounds: true,
-          messages: [],
-          globalState: new AgentStateGlobal(),
-        } satisfies ReflectionRunState,
-      };
+    const totalRounds = this.getTotalRounds();
+    const shared: ReflectionRunShared<C> = {
+      agent: this,
+      state: {
+        totalRounds,
+        currentRound: 0,
+        continueRounds: true,
+        messages: [],
+        globalState: new AgentStateGlobal(),
+      } satisfies ReflectionRunState,
+      lifecycle,
+      hooks,
+    };
 
-      const flow = createReflectionRunFlow<C>();
-      await flow.run(shared);
+    const flow = createReflectionRunFlow<C>();
+    await flow.run(shared);
 
-      this.endRunGroup('stopped');
-    } catch (error) {
-      this.endRunGroup('error');
-      throw error;
-    } finally {
-      this.cleanup();
+    if (shared.lifecycle.error) {
+      throw shared.lifecycle.error;
     }
   }
 }

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -215,7 +215,10 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
 
       while (true) {
         if (!shouldSkipCycle) {
-          await runToolUseCycle(cycleOptions, this.messages);
+          await runToolUseCycle({
+            options: cycleOptions,
+            messages: this.messages,
+          });
         } else {
           shouldSkipCycle = false;
         }

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -174,6 +174,9 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
           this.logger.warn(
             `Failed to hydrate tool state from snapshot: ${message}`,
           );
+          // Snapshot hydration can fail if the saved payload is corrupted or
+          // originates from an outdated schema. Reset to a clean ToolState so
+          // the agent can continue operating without crashing.
           this.toolState = new ToolState();
         }
         shouldSkipCycle = true;

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -162,9 +162,20 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
         }
         // Cast with confidence after validation
         this.messages = messages as ProviderMessage[];
-        this.toolState = ToolUseSessionManager.hydrateToolStateFromSnapshot(
-          this.resumeSnapshot,
-        );
+        try {
+          this.toolState = ToolUseSessionManager.hydrateToolStateFromSnapshot(
+            this.resumeSnapshot,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : 'Unknown error while hydrating tool state';
+          this.logger.warn(
+            `Failed to hydrate tool state from snapshot: ${message}`,
+          );
+          this.toolState = new ToolState();
+        }
         shouldSkipCycle = true;
         this.resumeSnapshot = null;
       } else {
@@ -191,6 +202,13 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
         this.toolState = new ToolState();
       }
 
+      let toolState = this.toolState;
+      if (!toolState) {
+        this.logger.debug('Initializing fallback tool state instance.');
+        toolState = new ToolState();
+        this.toolState = toolState;
+      }
+
       const resolvedSetting = {
         ...this.agentSetting,
         tools: this.getTools(),
@@ -209,7 +227,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
         setAbortController: (ctrl: AbortController | null) => {
           this.abortController = ctrl;
         },
-        toolState: this.toolState,
+        toolState,
         modelName: this.agentConfig.model,
       } as const;
 

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -12,6 +12,10 @@ import { withLogGroup } from '@logger/logGroupUtils';
  * Extends BaseReflectionAgent with simplified output handling and no intermediate steps.
  */
 export class DirectAgent extends BaseReflectionAgent {
+  protected override getTotalRounds(): number {
+    return 1;
+  }
+
   /**
    * Generates output file name based on configuration and current round.
    * @param currRound Current round number in the conversation

--- a/src/agent/implementations/flows/ReflectionRoundFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRoundFlow.ts
@@ -1,0 +1,146 @@
+// Local imports - core flow primitives
+import { BaseNode, Flow } from '@agent/node';
+
+// Local imports - agent components
+import type { AgentStateRound } from '@agent/core/AgentState';
+import type { ToolState } from '@agent/core/ToolState';
+import type { ReflectionRoundResult } from '../BaseReflectionAgent';
+
+interface RoundPreparationResult {
+  stateRound: AgentStateRound;
+  preparedMessages: any[];
+  prefill?: string;
+  skip: boolean;
+}
+
+interface ReflectionRoundPipelineInput {
+  stateRound: AgentStateRound;
+  preparedMessages: any[];
+  prefill: string;
+}
+
+export interface ReflectionRoundHooks {
+  prepareToolState(): Promise<void>;
+  prepareRoundContext(): Promise<RoundPreparationResult>;
+  runRoundPipeline(
+    input: ReflectionRoundPipelineInput,
+  ): Promise<ReflectionRoundResult>;
+  createSkipResult(stateRound: AgentStateRound): ReflectionRoundResult;
+}
+
+export interface ReflectionRoundRuntime {
+  toolState: ToolState;
+  roundState?: AgentStateRound;
+  preparedMessages?: any[];
+  prefill?: string;
+  result?: ReflectionRoundResult;
+}
+
+export interface ReflectionRoundShared {
+  runtime: ReflectionRoundRuntime;
+  hooks: ReflectionRoundHooks;
+}
+
+class ToolPreparationNode extends BaseNode<ReflectionRoundShared> {
+  async prep(shared: ReflectionRoundShared): Promise<ReflectionRoundHooks> {
+    return shared.hooks;
+  }
+
+  async exec(hooks: ReflectionRoundHooks): Promise<void> {
+    await hooks.prepareToolState();
+  }
+}
+
+interface RoundPreparationExec {
+  stateRound: AgentStateRound;
+  preparedMessages: any[];
+  prefill?: string;
+  skip: boolean;
+}
+
+class RoundPreparationNode extends BaseNode<ReflectionRoundShared> {
+  async prep(shared: ReflectionRoundShared): Promise<ReflectionRoundHooks> {
+    return shared.hooks;
+  }
+
+  async exec(hooks: ReflectionRoundHooks): Promise<RoundPreparationExec> {
+    return await hooks.prepareRoundContext();
+  }
+
+  async post(
+    shared: ReflectionRoundShared,
+    _prepRes: ReflectionRoundHooks,
+    execRes: RoundPreparationExec,
+  ): Promise<string | undefined> {
+    shared.runtime.roundState = execRes.stateRound;
+    shared.runtime.preparedMessages = execRes.preparedMessages;
+    shared.runtime.prefill = execRes.prefill ?? '';
+
+    return execRes.skip ? 'skip' : 'execute';
+  }
+}
+
+class RoundExecutionNode extends BaseNode<ReflectionRoundShared> {
+  async prep(shared: ReflectionRoundShared): Promise<ReflectionRoundShared> {
+    return shared;
+  }
+
+  async exec(shared: ReflectionRoundShared): Promise<ReflectionRoundResult> {
+    const { runtime, hooks } = shared;
+    if (!runtime.roundState || !runtime.preparedMessages) {
+      throw new Error('Round execution requires prepared round data.');
+    }
+
+    return await hooks.runRoundPipeline({
+      stateRound: runtime.roundState,
+      preparedMessages: runtime.preparedMessages,
+      prefill: runtime.prefill ?? '',
+    });
+  }
+
+  async post(
+    shared: ReflectionRoundShared,
+    _prepRes: ReflectionRoundShared,
+    execRes: ReflectionRoundResult,
+  ): Promise<string | undefined> {
+    shared.runtime.result = execRes;
+    return undefined;
+  }
+}
+
+class RoundSkipNode extends BaseNode<ReflectionRoundShared> {
+  async prep(shared: ReflectionRoundShared): Promise<ReflectionRoundShared> {
+    return shared;
+  }
+
+  async exec(shared: ReflectionRoundShared): Promise<ReflectionRoundResult> {
+    const { runtime, hooks } = shared;
+    if (!runtime.roundState) {
+      throw new Error('Skip handling requires the current round state.');
+    }
+
+    return hooks.createSkipResult(runtime.roundState);
+  }
+
+  async post(
+    shared: ReflectionRoundShared,
+    _prepRes: ReflectionRoundShared,
+    execRes: ReflectionRoundResult,
+  ): Promise<string | undefined> {
+    shared.runtime.result = execRes;
+    return undefined;
+  }
+}
+
+export function createReflectionRoundFlow(): Flow<ReflectionRoundShared> {
+  const toolPreparation = new ToolPreparationNode();
+  const roundPreparation = new RoundPreparationNode();
+  const roundExecution = new RoundExecutionNode();
+  const roundSkip = new RoundSkipNode();
+
+  toolPreparation.next(roundPreparation);
+  roundPreparation.on('execute', roundExecution);
+  roundPreparation.on('skip', roundSkip);
+
+  return new Flow<ReflectionRoundShared>(toolPreparation);
+}

--- a/src/agent/implementations/flows/ReflectionRoundFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRoundFlow.ts
@@ -1,6 +1,9 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 
+// Local imports - flow constants
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+
 // Local imports - agent components
 import type { AgentStateRound } from '@agent/core/AgentState';
 import type { ToolState } from '@agent/core/ToolState';
@@ -76,7 +79,7 @@ class RoundPreparationNode extends BaseNode<ReflectionRoundShared> {
     shared.runtime.preparedMessages = execRes.preparedMessages;
     shared.runtime.prefill = execRes.prefill ?? '';
 
-    return execRes.skip ? 'skip' : 'execute';
+    return execRes.skip ? FlowTransition.SKIP : FlowTransition.EXECUTE;
   }
 }
 
@@ -139,8 +142,8 @@ export function createReflectionRoundFlow(): Flow<ReflectionRoundShared> {
   const roundSkip = new RoundSkipNode();
 
   toolPreparation.next(roundPreparation);
-  roundPreparation.on('execute', roundExecution);
-  roundPreparation.on('skip', roundSkip);
+  roundPreparation.on(FlowTransition.EXECUTE, roundExecution);
+  roundPreparation.on(FlowTransition.SKIP, roundSkip);
 
   return new Flow<ReflectionRoundShared>(toolPreparation);
 }

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -220,9 +220,7 @@ class ReflectionFinalizeNode<C> extends BaseNode<ReflectionRunShared<C>> {
     };
   }
 
-  async exec(
-    prepRes: ReflectionFinalizePrep,
-  ): Promise<ReflectionFinalizeExec> {
+  async exec(prepRes: ReflectionFinalizePrep): Promise<ReflectionFinalizeExec> {
     const status = prepRes.lifecycle.error ? 'error' : 'stopped';
     try {
       await Promise.resolve(prepRes.hooks.end(status));

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -5,9 +5,27 @@ import { BaseNode, Flow } from '@agent/node';
 import type { AgentStateGlobal } from '@agent/core/AgentState';
 import type {
   BaseReflectionAgent,
-  ReflectionRoundResult,
   ReflectionRoundContext,
+  ReflectionRoundResult,
 } from '../BaseReflectionAgent';
+
+type RunPhase = 'idle' | 'init' | 'rounds' | 'finalize';
+type RunStatus = 'pending' | 'running' | 'error' | 'completed';
+
+export interface ReflectionRunLifecycle {
+  phase: RunPhase;
+  status: RunStatus;
+  error?: unknown;
+}
+
+export interface ReflectionRunHooks {
+  start(): Promise<string>;
+  init(runGroupId: string): Promise<void>;
+  resetPromptBuilder(): void;
+  initializeClient(): Promise<void>;
+  end(status: 'stopped' | 'error'): void | Promise<void>;
+  cleanup(): void | Promise<void>;
+}
 
 export interface ReflectionRunState {
   totalRounds: number;
@@ -20,6 +38,18 @@ export interface ReflectionRunState {
 export interface ReflectionRunShared<C = unknown> {
   agent: BaseReflectionAgent<C>;
   state: ReflectionRunState;
+  lifecycle: ReflectionRunLifecycle;
+  hooks: ReflectionRunHooks;
+}
+
+interface ReflectionInitPrep<C> {
+  agent: BaseReflectionAgent<C>;
+  hooks: ReflectionRunHooks;
+  lifecycle: ReflectionRunLifecycle;
+}
+
+interface ReflectionInitExec {
+  error?: unknown;
 }
 
 interface ReflectionRoundPrep<C> {
@@ -32,7 +62,59 @@ interface ReflectionRoundPrep<C> {
 }
 
 interface ReflectionRoundExec<C> extends ReflectionRoundPrep<C> {
-  result: ReflectionRoundResult;
+  result?: ReflectionRoundResult;
+  error?: unknown;
+}
+
+interface ReflectionFinalizePrep {
+  hooks: ReflectionRunHooks;
+  lifecycle: ReflectionRunLifecycle;
+}
+
+interface ReflectionFinalizeExec {
+  endError?: unknown;
+}
+
+class ReflectionInitNode<C> extends BaseNode<ReflectionRunShared<C>> {
+  async prep(shared: ReflectionRunShared<C>): Promise<ReflectionInitPrep<C>> {
+    shared.lifecycle.phase = 'init';
+    shared.lifecycle.status = 'running';
+    shared.lifecycle.error = undefined;
+    return {
+      agent: shared.agent,
+      hooks: shared.hooks,
+      lifecycle: shared.lifecycle,
+    };
+  }
+
+  async exec(prepRes: ReflectionInitPrep<C>): Promise<ReflectionInitExec> {
+    try {
+      const runGroupId = await prepRes.hooks.start();
+      await prepRes.hooks.init(runGroupId);
+      prepRes.hooks.resetPromptBuilder();
+      await prepRes.hooks.initializeClient();
+      return {};
+    } catch (error) {
+      return { error };
+    }
+  }
+
+  async post(
+    shared: ReflectionRunShared<C>,
+    _prepRes: ReflectionInitPrep<C>,
+    execRes: ReflectionInitExec,
+  ): Promise<string | undefined> {
+    if (execRes.error) {
+      shared.lifecycle.status = 'error';
+      shared.lifecycle.error = execRes.error;
+      return 'finalize';
+    }
+
+    shared.lifecycle.phase = 'rounds';
+    shared.lifecycle.status = 'running';
+    shared.lifecycle.error = undefined;
+    return 'round';
+  }
 }
 
 class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
@@ -60,18 +142,24 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
       return prepRes;
     }
 
-    prepRes.agent.setCurrentRound(prepRes.roundIndex);
+    try {
+      prepRes.agent.setCurrentRound(prepRes.roundIndex);
+      const result = await prepRes.agent.runReflectionRound({
+        roundIndex: prepRes.roundIndex,
+        globalState: prepRes.state.globalState,
+        messages: prepRes.state.messages,
+      } satisfies ReflectionRoundContext);
 
-    const result = await prepRes.agent.runReflectionRound({
-      roundIndex: prepRes.roundIndex,
-      globalState: prepRes.state.globalState,
-      messages: prepRes.state.messages,
-    } satisfies ReflectionRoundContext);
-
-    return {
-      ...prepRes,
-      result,
-    };
+      return {
+        ...prepRes,
+        result,
+      };
+    } catch (error) {
+      return {
+        ...prepRes,
+        error,
+      };
+    }
   }
 
   async post(
@@ -83,7 +171,22 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
       return 'finalize';
     }
 
-    const { result } = execRes as ReflectionRoundExec<C>;
+    const execResult = execRes as ReflectionRoundExec<C>;
+
+    if (execResult.error) {
+      shared.lifecycle.status = 'error';
+      shared.lifecycle.error = execResult.error;
+      return 'finalize';
+    }
+
+    const { result } = execResult;
+    if (!result) {
+      const missingResultError = new Error('Round result is missing.');
+      shared.lifecycle.status = 'error';
+      shared.lifecycle.error = missingResultError;
+      return 'finalize';
+    }
+
     shared.agent.roundStates.push(result.roundState);
     shared.agent.toolStates.push(result.toolState);
     shared.state.globalState = result.globalState;
@@ -108,14 +211,64 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
   }
 }
 
-class ReflectionFinalizeNode<C> extends BaseNode<ReflectionRunShared<C>> {}
+class ReflectionFinalizeNode<C> extends BaseNode<ReflectionRunShared<C>> {
+  async prep(shared: ReflectionRunShared<C>): Promise<ReflectionFinalizePrep> {
+    shared.lifecycle.phase = 'finalize';
+    return {
+      hooks: shared.hooks,
+      lifecycle: shared.lifecycle,
+    };
+  }
+
+  async exec(
+    prepRes: ReflectionFinalizePrep,
+  ): Promise<ReflectionFinalizeExec> {
+    const status = prepRes.lifecycle.error ? 'error' : 'stopped';
+    try {
+      await Promise.resolve(prepRes.hooks.end(status));
+      return {};
+    } catch (error) {
+      return { endError: error };
+    }
+  }
+
+  async post(
+    shared: ReflectionRunShared<C>,
+    prepRes: ReflectionFinalizePrep,
+    execRes: ReflectionFinalizeExec,
+  ): Promise<string | undefined> {
+    let error = shared.lifecycle.error ?? execRes.endError;
+
+    try {
+      await Promise.resolve(prepRes.hooks.cleanup());
+    } catch (cleanupError) {
+      if (!error) {
+        error = cleanupError;
+      }
+    }
+
+    if (error) {
+      shared.lifecycle.status = 'error';
+      shared.lifecycle.error = error;
+    } else {
+      shared.lifecycle.status = 'completed';
+      shared.lifecycle.error = undefined;
+    }
+
+    return undefined;
+  }
+}
 
 export function createReflectionRunFlow<C>(): Flow<ReflectionRunShared<C>> {
+  const initNode = new ReflectionInitNode<C>();
   const roundNode = new ReflectionRoundNode<C>();
   const finalizeNode = new ReflectionFinalizeNode<C>();
 
-  roundNode.on('finalize', finalizeNode);
-  roundNode.on('continue', roundNode);
+  initNode.on('round', roundNode);
+  initNode.on('finalize', finalizeNode);
 
-  return new Flow<ReflectionRunShared<C>>(roundNode);
+  roundNode.on('continue', roundNode);
+  roundNode.on('finalize', finalizeNode);
+
+  return new Flow<ReflectionRunShared<C>>(initNode);
 }

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -1,6 +1,9 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 
+// Local imports - flow constants
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+
 // Local imports - agent components
 import type { AgentStateGlobal } from '@agent/core/AgentState';
 import type {
@@ -107,13 +110,13 @@ class ReflectionInitNode<C> extends BaseNode<ReflectionRunShared<C>> {
     if (execRes.error) {
       shared.lifecycle.status = 'error';
       shared.lifecycle.error = execRes.error;
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     shared.lifecycle.phase = 'rounds';
     shared.lifecycle.status = 'running';
     shared.lifecycle.error = undefined;
-    return 'round';
+    return FlowTransition.ROUND;
   }
 }
 
@@ -174,7 +177,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
     execRes: ReflectionRoundPrep<C> | ReflectionRoundExec<C>,
   ): Promise<string | undefined> {
     if (prepRes.shouldFinalize) {
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     const execResult = execRes as ReflectionRoundExec<C>;
@@ -182,7 +185,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
     if (execResult.error) {
       shared.lifecycle.status = 'error';
       shared.lifecycle.error = execResult.error;
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     const { result } = execResult;
@@ -190,7 +193,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
       const missingResultError = new Error('Round result is missing.');
       shared.lifecycle.status = 'error';
       shared.lifecycle.error = missingResultError;
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     shared.agent.roundStates.push(result.roundState);
@@ -202,18 +205,18 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
     shared.state.globalState.incrementRounds();
 
     if (shared.agent.isInterruptionRequested()) {
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     if (shared.state.currentRound >= shared.state.totalRounds) {
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     if (!shared.state.continueRounds) {
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
-    return 'continue';
+    return FlowTransition.CONTINUE;
   }
 }
 
@@ -268,11 +271,11 @@ export function createReflectionRunFlow<C>(): Flow<ReflectionRunShared<C>> {
   const roundNode = new ReflectionRoundNode<C>();
   const finalizeNode = new ReflectionFinalizeNode<C>();
 
-  initNode.on('round', roundNode);
-  initNode.on('finalize', finalizeNode);
+  initNode.on(FlowTransition.ROUND, roundNode);
+  initNode.on(FlowTransition.FINALIZE, finalizeNode);
 
-  roundNode.on('continue', roundNode);
-  roundNode.on('finalize', finalizeNode);
+  roundNode.on(FlowTransition.CONTINUE, roundNode);
+  roundNode.on(FlowTransition.FINALIZE, finalizeNode);
 
   return new Flow<ReflectionRunShared<C>>(initNode);
 }

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -1,0 +1,121 @@
+// Local imports - core flow primitives
+import { BaseNode, Flow } from '@agent/node';
+
+// Local imports - agent components
+import type { AgentStateGlobal } from '@agent/core/AgentState';
+import type {
+  BaseReflectionAgent,
+  ReflectionRoundResult,
+  ReflectionRoundContext,
+} from '../BaseReflectionAgent';
+
+export interface ReflectionRunState {
+  totalRounds: number;
+  currentRound: number;
+  continueRounds: boolean;
+  messages: any[];
+  globalState: AgentStateGlobal;
+}
+
+export interface ReflectionRunShared<C = unknown> {
+  agent: BaseReflectionAgent<C>;
+  state: ReflectionRunState;
+}
+
+interface ReflectionRoundPrep<C> {
+  agent: BaseReflectionAgent<C>;
+  state: ReflectionRunState;
+  shouldFinalize: boolean;
+  roundIndex: number;
+  messages: any[];
+  globalState: AgentStateGlobal;
+}
+
+interface ReflectionRoundExec<C> extends ReflectionRoundPrep<C> {
+  result: ReflectionRoundResult;
+}
+
+class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
+  async prep(shared: ReflectionRunShared<C>): Promise<ReflectionRoundPrep<C>> {
+    const { agent, state } = shared;
+    const shouldFinalize =
+      state.currentRound >= state.totalRounds ||
+      (state.currentRound > 0 && !state.continueRounds) ||
+      agent.isInterruptionRequested();
+
+    return {
+      agent,
+      state,
+      shouldFinalize,
+      roundIndex: state.currentRound,
+      messages: state.messages,
+      globalState: state.globalState,
+    };
+  }
+
+  async exec(
+    prepRes: ReflectionRoundPrep<C>,
+  ): Promise<ReflectionRoundPrep<C> | ReflectionRoundExec<C>> {
+    if (prepRes.shouldFinalize) {
+      return prepRes;
+    }
+
+    prepRes.agent.setCurrentRound(prepRes.roundIndex);
+
+    const result = await prepRes.agent.runReflectionRound({
+      roundIndex: prepRes.roundIndex,
+      globalState: prepRes.state.globalState,
+      messages: prepRes.state.messages,
+    } satisfies ReflectionRoundContext);
+
+    return {
+      ...prepRes,
+      result,
+    };
+  }
+
+  async post(
+    shared: ReflectionRunShared<C>,
+    prepRes: ReflectionRoundPrep<C>,
+    execRes: ReflectionRoundPrep<C> | ReflectionRoundExec<C>,
+  ): Promise<string | undefined> {
+    if (prepRes.shouldFinalize) {
+      return 'finalize';
+    }
+
+    const { result } = execRes as ReflectionRoundExec<C>;
+    shared.agent.roundStates.push(result.roundState);
+    shared.agent.toolStates.push(result.toolState);
+    shared.state.globalState = result.globalState;
+    shared.state.messages = result.messages;
+    shared.state.continueRounds = result.shouldContinue;
+    shared.state.currentRound += 1;
+    shared.state.globalState.incrementRounds();
+
+    if (shared.agent.isInterruptionRequested()) {
+      return 'finalize';
+    }
+
+    if (shared.state.currentRound >= shared.state.totalRounds) {
+      return 'finalize';
+    }
+
+    if (!shared.state.continueRounds) {
+      return 'finalize';
+    }
+
+    return 'continue';
+  }
+}
+
+class ReflectionFinalizeNode<C> extends BaseNode<ReflectionRunShared<C>> {}
+
+export function createReflectionRunFlow<C>(): Flow<ReflectionRunShared<C>> {
+  const roundNode = new ReflectionRoundNode<C>();
+  const finalizeNode = new ReflectionFinalizeNode<C>();
+
+  roundNode.on('finalize', finalizeNode);
+  roundNode.on('continue', roundNode);
+
+  return new Flow<ReflectionRunShared<C>>(roundNode);
+}

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -155,9 +155,15 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
         result,
       };
     } catch (error) {
+      const contextualError =
+        error instanceof Error
+          ? new Error(`Round ${prepRes.roundIndex} failed: ${error.message}`, {
+              cause: error,
+            })
+          : new Error(`Round ${prepRes.roundIndex} failed: ${String(error)}`);
       return {
         ...prepRes,
-        error,
+        error: contextualError,
       };
     }
   }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1071,16 +1071,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       id;
     if (callPart.functionCall) {
       callPart.functionCall.id = callId;
-      const partRecord = callPart.functionCall as Record<string, unknown>;
-      if (!toTrimmedString(partRecord.call_id)) {
-        partRecord.call_id = callId;
-      }
-      if (!toTrimmedString(partRecord.tool_call_id)) {
-        partRecord.tool_call_id = callId;
-      }
-      if (!toTrimmedString(partRecord.tool_use_id)) {
-        partRecord.tool_use_id = callId;
-      }
+      // The Google GenAI Chat API rejects unknown fields on the function call
+      // payload, so avoid populating call_id/tool_call_id/tool_use_id here.
+      // The synthesized identifiers are still preserved via the follow-up
+      // result message and the normalized JSON stored in tool state.
     }
 
     // Use the same ID for the result to maintain correlation

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -100,6 +100,49 @@ function findLastTextPart(
   return undefined;
 }
 
+const UNSUPPORTED_FUNCTION_CALL_KEYS = [
+  'call_id',
+  'tool_call_id',
+  'tool_use_id',
+];
+
+function sanitizeFunctionCallPart(part: Part): Part {
+  if (!part || typeof part !== 'object') {
+    return part;
+  }
+
+  const candidate = part as Part & {
+    functionCall?: Record<string, unknown>;
+  };
+
+  if (!candidate.functionCall) {
+    return part;
+  }
+
+  const sanitizedCall = {
+    ...candidate.functionCall,
+  } as Record<string, unknown>;
+
+  for (const key of UNSUPPORTED_FUNCTION_CALL_KEYS) {
+    if (key in sanitizedCall) {
+      delete sanitizedCall[key];
+    }
+  }
+
+  return {
+    ...candidate,
+    functionCall: sanitizedCall as Part['functionCall'],
+  };
+}
+
+function sanitizeFunctionCallParts(parts?: Part[]): Part[] {
+  if (!Array.isArray(parts)) {
+    return [];
+  }
+
+  return parts.map((part) => sanitizeFunctionCallPart(part));
+}
+
 type NormalizedFunctionCall = (FunctionCall & Record<string, unknown>) & {
   id: string;
   call_id: string;
@@ -179,18 +222,19 @@ function convertMessagesToGoogleContentHistory(
     }
 
     const parts = Array.isArray(message.parts) ? message.parts : [];
+    const sanitizedParts = sanitizeFunctionCallParts(parts);
     if (parts.length === 0) {
       return;
     }
 
     if (role === currentRole) {
-      currentParts.push(...parts);
+      currentParts.push(...sanitizedParts);
     } else {
       if (currentRole && currentParts.length > 0) {
         history.push({ role: currentRole, parts: [...currentParts] });
       }
       currentRole = role;
-      currentParts = [...parts];
+      currentParts = [...sanitizedParts];
     }
   });
 
@@ -374,7 +418,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       this.logger,
     );
 
-    const lastMessageParts = lastMessage?.parts ? [...lastMessage.parts] : [];
+    const lastMessageParts = sanitizeFunctionCallParts(lastMessage?.parts);
     if (lastMessageParts.length === 0) {
       this.logger.error('Could not extract valid parts from the last message.');
       throw new Error('Last message conversion resulted in empty parts.');
@@ -1095,7 +1139,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       callParts.push(createPartFromText(text));
     }
     callParts.push(callPart);
-    const callMsg: Content = { role: 'model', parts: callParts };
+    const callMsg: Content = {
+      role: 'model',
+      parts: sanitizeFunctionCallParts(callParts),
+    };
     const resultMsg: Content = { role: 'user', parts: [resultPart] };
     return [callMsg, resultMsg];
   }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1,6 +1,7 @@
 // Standard library imports
 import * as path from 'path';
 import { Buffer } from 'buffer';
+import { randomUUID } from 'crypto';
 
 // Third-party imports
 import {
@@ -97,6 +98,51 @@ function findLastTextPart(
     }
   }
   return undefined;
+}
+
+type NormalizedFunctionCall = (FunctionCall & Record<string, unknown>) & {
+  id: string;
+  call_id: string;
+};
+
+function toTrimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function ensureFunctionCallIdentifiers(call: FunctionCall): {
+  normalized: NormalizedFunctionCall;
+  synthesized: boolean;
+} {
+  const normalized = { ...call } as FunctionCall & Record<string, unknown>;
+  const existingId = toTrimmedString(normalized.id);
+  const existingCallId = toTrimmedString(normalized.call_id);
+  const existingToolCallId = toTrimmedString(normalized.tool_call_id);
+  const existingToolUseId = toTrimmedString(normalized.tool_use_id);
+
+  const fallbackId =
+    existingId || existingCallId || existingToolCallId || existingToolUseId;
+  const id = fallbackId || randomUUID();
+  normalized.id = id;
+
+  const callId =
+    existingCallId || existingToolCallId || existingToolUseId || id;
+  normalized.call_id = callId;
+
+  if (!toTrimmedString(normalized.tool_call_id)) {
+    normalized.tool_call_id = callId;
+  }
+  if (!toTrimmedString(normalized.tool_use_id)) {
+    normalized.tool_use_id = callId;
+  }
+
+  const synthesizedId = !fallbackId;
+  const synthesizedCallId =
+    !existingCallId && !existingToolCallId && !existingToolUseId;
+
+  return {
+    normalized: normalized as NormalizedFunctionCall,
+    synthesized: synthesizedId || synthesizedCallId,
+  };
 }
 
 function toGoogleRole(role?: string, logger?: AgentLogger): GoogleRole | null {
@@ -978,8 +1024,17 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const parts = candidate?.content?.parts;
     if (Array.isArray(parts)) {
       const funcPart = parts.find((part) => part.functionCall);
-      if (funcPart) {
-        return JSON.stringify(funcPart.functionCall, null, 2);
+      if (funcPart?.functionCall) {
+        const { normalized, synthesized } = ensureFunctionCallIdentifiers(
+          funcPart.functionCall,
+        );
+        if (synthesized) {
+          const functionName = normalized.name ?? 'unknown';
+          this.logger.debug(
+            `Synthesized tool call identifier for Google function call '${functionName}'.`,
+          );
+        }
+        return JSON.stringify(normalized, null, 2);
       }
     }
     return null;
@@ -1007,9 +1062,25 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const callPart = createPartFromFunctionCall(functionName, args);
 
     // Use consistent ID for both call and result to ensure proper correlation
-    const callId = call?.id ?? id;
+    const callRecord = call as FunctionCall & Record<string, unknown>;
+    const callId =
+      toTrimmedString(callRecord?.id) ||
+      toTrimmedString(callRecord?.call_id) ||
+      toTrimmedString(callRecord?.tool_call_id) ||
+      toTrimmedString(callRecord?.tool_use_id) ||
+      id;
     if (callPart.functionCall) {
       callPart.functionCall.id = callId;
+      const partRecord = callPart.functionCall as Record<string, unknown>;
+      if (!toTrimmedString(partRecord.call_id)) {
+        partRecord.call_id = callId;
+      }
+      if (!toTrimmedString(partRecord.tool_call_id)) {
+        partRecord.tool_call_id = callId;
+      }
+      if (!toTrimmedString(partRecord.tool_use_id)) {
+        partRecord.tool_use_id = callId;
+      }
     }
 
     // Use the same ID for the result to maintain correlation

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -66,6 +66,27 @@ export function formatError(prefix: string, err: unknown): string {
 }
 
 /**
+ * Normalize any thrown value into a user-friendly error message string.
+ *
+ * Unlike {@link formatError}, this helper only returns the detail portion of
+ * the message, making it suitable for composing custom prefixes or structured
+ * payloads. Centralizing the coercion keeps error messaging consistent across
+ * flows and model handlers.
+ */
+export function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (err === undefined) {
+    return 'undefined';
+  }
+  if (err === null) {
+    return 'null';
+  }
+  return String(err);
+}
+
+/**
  * Log a formatted error message and return the formatted message.
  *
  * This function combines error formatting with logging. It:

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -341,8 +341,8 @@ describe('ResponseCycle background reasoning logs', () => {
     const stateGlobal = new AgentStateGlobal();
     const toolState = new ToolState();
 
-    await runResponseCycle(
-      {
+    await runResponseCycle({
+      options: {
         modelHandler: handler,
         agentSetting,
         agentConfig,
@@ -357,8 +357,8 @@ describe('ResponseCycle background reasoning logs', () => {
       stateRound,
       stateGlobal,
       toolState,
-      'output.txt',
-    );
+      outputFile: 'output.txt',
+    });
 
     const thinkingLogs = loggedEvents.filter(
       (event) =>

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -2,7 +2,12 @@
 import { strict as assert } from 'assert';
 
 // Third-party imports
-import { FinishReason } from '@google/genai';
+import {
+  FinishReason,
+  GenerateContentResponse,
+  createPartFromText,
+} from '@google/genai';
+import type { Content } from '@google/genai';
 
 // Local imports - agent
 import type { AgentSetting } from '@agent/core/AgentDataclass';
@@ -138,6 +143,89 @@ describe('ModelHandlerGoogleGenAI.createToolUseFollowUpMessages', () => {
       unknown
     >;
     assert.equal(functionCall.id, 'call-123');
+    assert.equal('call_id' in functionCall, false);
+    assert.equal('tool_call_id' in functionCall, false);
+    assert.equal('tool_use_id' in functionCall, false);
+  });
+});
+
+describe('ModelHandlerGoogleGenAI.createResponse', () => {
+  it('strips unsupported identifier fields before issuing chat history', async () => {
+    const handler = new ModelHandlerGoogleGenAI({
+      name: 'test-google-model',
+      fullName: 'google/test',
+      provider: ModelProvider.GOOGLE,
+      maxOutputTokens: 1024,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 4096,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    });
+
+    (handler as any).capabilities.supportsTokenCounting = false;
+    (handler as any).logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      statistics: () => {},
+      getActiveGroupId: () => undefined,
+    };
+    (handler as any).getStreamingConfig = () => false;
+
+    const capturedHistory: Content[][] = [];
+    const fakeClient = {
+      chats: {
+        create: (params: any) => {
+          capturedHistory.push(params.history);
+          return {
+            sendMessage: async () => new GenerateContentResponse(),
+            sendMessageStream: async () => {
+              throw new Error('streaming not expected in unit test');
+            },
+          };
+        },
+      },
+      models: {},
+    } as any;
+
+    const messages: Content[] = [
+      { role: 'user', parts: [createPartFromText('Hello')] },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'ls',
+              args: {},
+              call_id: 'abc',
+              tool_call_id: 'abc',
+              tool_use_id: 'abc',
+            } as any,
+          },
+        ],
+      },
+      { role: 'user', parts: [createPartFromText('Continue?')] },
+    ];
+
+    await handler.createResponse(fakeClient, messages, 0);
+
+    assert.equal(
+      capturedHistory.length,
+      1,
+      'expected one chat history payload',
+    );
+    const history = capturedHistory[0];
+    assert.ok(Array.isArray(history), 'expected captured history array');
+    const modelEntry = history[1];
+    assert.ok(modelEntry, 'expected model entry in history');
+    assert.ok(Array.isArray(modelEntry.parts), 'expected parts array on model entry');
+    const callPart = (modelEntry.parts as any[]).find(
+      (part) => part && typeof part === 'object' && 'functionCall' in part,
+    );
+    assert.ok(callPart, 'expected function call part in model entry');
+    const functionCall = (callPart as any).functionCall as Record<string, unknown>;
     assert.equal('call_id' in functionCall, false);
     assert.equal('tool_call_id' in functionCall, false);
     assert.equal('tool_use_id' in functionCall, false);

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -59,3 +59,46 @@ describe('ModelHandlerGoogleGenAI.shouldContinue', () => {
     assert.equal(shouldContinue, false);
   });
 });
+
+describe('ModelHandlerGoogleGenAI.extractToolUse', () => {
+  const handler = new ModelHandlerGoogleGenAI({
+    name: 'test-google-model',
+    fullName: 'google/test',
+    provider: ModelProvider.GOOGLE,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 4096,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+  });
+
+  it('synthesizes tool call identifiers when missing', () => {
+    const response: any = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  name: 'read_file',
+                  args: { path: 'syk_v5.tex' },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const toolInfo = handler.extractToolUse(response);
+    assert.ok(toolInfo, 'expected tool info to be returned');
+
+    const parsed = JSON.parse(toolInfo as string);
+    assert.equal(typeof parsed.id, 'string');
+    assert.notEqual(parsed.id.trim(), '');
+    assert.equal(parsed.call_id, parsed.id);
+    assert.equal(parsed.tool_call_id, parsed.id);
+    assert.equal(parsed.tool_use_id, parsed.id);
+  });
+});

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -102,3 +102,44 @@ describe('ModelHandlerGoogleGenAI.extractToolUse', () => {
     assert.equal(parsed.tool_use_id, parsed.id);
   });
 });
+
+describe('ModelHandlerGoogleGenAI.createToolUseFollowUpMessages', () => {
+  const handler = new ModelHandlerGoogleGenAI({
+    name: 'test-google-model',
+    fullName: 'google/test',
+    provider: ModelProvider.GOOGLE,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 4096,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+  });
+
+  it('omits unsupported identifier fields on follow-up function call parts', async () => {
+    const messages = await handler.createToolUseFollowUpMessages(
+      undefined,
+      'call-123',
+      'read_file',
+      {
+        name: 'read_file',
+        args: { path: 'syk_v5.tex' },
+      } as any,
+      {},
+      undefined,
+    );
+
+    const callMessage = messages[0];
+    assert.ok(Array.isArray(callMessage.parts), 'expected call message parts');
+    const callPart = callMessage.parts.find((part) => part.functionCall);
+    assert.ok(callPart, 'expected a function call part');
+    const functionCall = (callPart as any).functionCall as Record<
+      string,
+      unknown
+    >;
+    assert.equal(functionCall.id, 'call-123');
+    assert.equal('call_id' in functionCall, false);
+    assert.equal('tool_call_id' in functionCall, false);
+    assert.equal('tool_use_id' in functionCall, false);
+  });
+});

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -132,7 +132,7 @@ describe('runToolUseCycle DeepSeek', () => {
     const dispose = bus.on('addLogMessage', (e) => events.push(e));
     const messages: ProviderMessage[] = [];
 
-    await runToolUseCycle(options, messages);
+    await runToolUseCycle({ options, messages });
     dispose();
 
     const toolEvents = events.filter(

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -144,7 +144,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
     const dispose = bus.on('addLogMessage', (e) => events.push(e));
     const messages: ProviderMessage[] = [];
 
-    await runToolUseCycle(options, messages);
+    await runToolUseCycle({ options, messages });
     dispose();
 
     const toolEvents = events.filter(


### PR DESCRIPTION
## Summary
- refactor the reflection agent to orchestrate rounds through a new ReflectionRunFlow
- split the response and tool-use loops into dedicated PocketFlow nodes with shared cycle contexts
- update agent implementations and tests to use the new cycle context interfaces

## Testing
- npm run lint
- npm run compile
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_6901076af81483249d62dca89e521fcc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces response/tool-use loops with flow-based orchestration and updates reflection agents, while sanitizing/synthesizing Google Gemini tool-call IDs and tightening tool-use error handling.
> 
> - **Core Flows**:
>   - Introduce `FlowTransition` and new flow graphs `createResponseCycleFlow` and `createToolUseCycleFlow`.
>   - Rewrite `runResponseCycle` and `runToolUseCycle` to accept context objects (`ResponseCycleContext`, `ToolUseCycleContext`) and drive execution via flow nodes.
> - **Reflection Agents**:
>   - Add `ReflectionRunFlow` and `ReflectionRoundFlow`; refactor `BaseReflectionAgent.run()` and round execution to use these flows.
>   - Expose helpers (`setCurrentRound`, `resetPromptBuilder`, `createResponseCycleOptions`) and return structured `ReflectionRoundResult`.
>   - `DirectAgent` forces a single round via overridden `getTotalRounds()`.
>   - `BaseAgent`: add `isInterruptionRequested()`.
> - **Tool-Use Agent**:
>   - Switch to new `runToolUseCycle` context API; add robust snapshot hydration with fallback `ToolState` and safer persistence.
> - **Google GenAI Handler**:
>   - Sanitize function-call parts in history and follow-ups; synthesize stable IDs (`id`/`call_id`) when missing; omit unsupported fields in payloads.
> - **Error Utils**:
>   - Add `toErrorMessage()` for consistent error strings.
> - **Bug Fixes/Behavior**:
>   - Prevent repetition-suppression from corrupting `ToolState` connectors.
>   - Harden tool dispatch: strict call-id extraction and clearer fallback messages.
> - **Tests**:
>   - Update tests to new contexts and Google tool-call ID behavior; add coverage for history sanitization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82e5ebd4b25c972a23d5628da45b552899909e4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->