### PR TITLE
refactor: rely on ambient log groups

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -40,6 +40,7 @@ export interface ResponseCycleOptions<C = unknown> {
   userVars: Record<string, any>;
   logger: AgentLogger;
   client: C;
+  executionId?: ExecutionId;
   checkInterruption: () => Promise<boolean> | boolean;
   setAbortController: (ctrl: AbortController | null) => void;
 }
@@ -55,8 +56,6 @@ export async function runResponseCycle<C = unknown>(
   stateGlobal: AgentStateGlobal,
   toolState: ToolState,
   outputFile: string,
-  roundGroupId?: string,
-  executionId?: ExecutionId,
 ): Promise<[AgentStateRound, AgentStateGlobal, ToolState, boolean]> {
   const {
     modelHandler,
@@ -66,11 +65,10 @@ export async function runResponseCycle<C = unknown>(
     userVars,
     logger,
     client,
+    executionId,
     checkInterruption,
     setAbortController,
   } = options;
-
-  const taskGroupId = roundGroupId;
 
   let endTurn = false;
   while (!endTurn) {
@@ -90,7 +88,6 @@ export async function runResponseCycle<C = unknown>(
       logger,
       modelName: agentConfig.model,
       executionId,
-      groupId: taskGroupId,
     };
     const debugFileOptions = {
       continuationCount: stateRound.continuationCount,
@@ -129,43 +126,35 @@ export async function runResponseCycle<C = unknown>(
       });
       setAbortController(null);
     }
-    await maybeSaveDebugObject({
-      object: responseObject,
-      objectType: 'response',
-      context: debugContext,
-      fileOptions: debugFileOptions,
-    });
     if (!responseObject) {
       logger.warn(
         'Model response was aborted or returned no data; output may be incomplete.',
-        taskGroupId,
       );
       break;
     }
     const responseTime = (Date.now() - startTime) / 1000;
     stateRound.updateResponseTime(responseTime);
-    logger.debug(`Response time: ${responseTime.toFixed(2)}s`, taskGroupId);
+    logger.debug(`Response time: ${responseTime.toFixed(2)}s`);
 
     const [newResponse, responseUsage, stopReason] =
       modelHandler.extractResponse(responseObject, agentSetting.endTag);
 
-    logger.debug(`Stop reason: ${stopReason}`, taskGroupId);
-    logger.debug(`Token usage: ${JSON.stringify(responseUsage)}`, taskGroupId);
+    logger.debug(`Stop reason: ${stopReason}`);
+    logger.debug(`Token usage: ${JSON.stringify(responseUsage)}`);
 
     const thinkingContent = modelHandler.processThinkingBlock(
       responseObject,
-      taskGroupId,
       toolState,
     );
     const useStreaming = modelHandler.getStreamingConfig();
 
     if (newResponse) {
-      logger.debug(`Model response: ${newResponse.slice(0, 100)}`, taskGroupId);
+      logger.debug(`Model response: ${newResponse.slice(0, 100)}`);
       if (!useStreaming) {
         const formattedResponse = await xmlUtils.formatContent(newResponse);
         logger.info(
           formattedResponse,
-          taskGroupId,
+          undefined,
           // Workflow agents should not surface final completions in the progress view,
           // so mark the response as INTERNAL while still writing it to the output channel.
           MESSAGE_TYPES.INTERNAL,
@@ -178,7 +167,7 @@ export async function runResponseCycle<C = unknown>(
     // so we avoid duplicate logging here
     if (thinkingContent && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinkingContent);
-      logger.info(formatted, taskGroupId, MESSAGE_TYPES.THINKING);
+      logger.info(formatted, undefined, MESSAGE_TYPES.THINKING);
     }
 
     const scratchpad = await xmlUtils.extractScratchpad(
@@ -186,7 +175,7 @@ export async function runResponseCycle<C = unknown>(
       'scratchpad',
     );
     if (scratchpad) {
-      logger.info(scratchpad, taskGroupId, MESSAGE_TYPES.SCRATCHPAD);
+      logger.info(scratchpad, undefined, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     const APIUsage = modelHandler.computeResponseUsage(
@@ -203,17 +192,10 @@ export async function runResponseCycle<C = unknown>(
     if (repetitionResult.massiveRepetitionDetected) {
       logger.error(
         `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-        taskGroupId,
       );
-      logger.error(
-        'Massive repetition detected - skipping this response',
-        taskGroupId,
-      );
-      logger.error('Message structure when repetition detected:', taskGroupId);
-      logger.error(
-        JSON.stringify(messageToSkeleton(messages), null, 2),
-        taskGroupId,
-      );
+      logger.error('Massive repetition detected - skipping this response');
+      logger.error('Message structure when repetition detected:');
+      logger.error(JSON.stringify(messageToSkeleton(messages), null, 2));
       break;
     }
 
@@ -231,24 +213,22 @@ export async function runResponseCycle<C = unknown>(
     );
 
     if (!exists) {
-      logger.debug(`Creating new file: ${outputFile}`, taskGroupId);
+      logger.debug(`Creating new file: ${outputFile}`);
       await WorkspaceFS.write(outputFile, processedResponse);
     } else {
-      logger.debug(`Appending to existing file: ${outputFile}`, taskGroupId);
+      logger.debug(`Appending to existing file: ${outputFile}`);
       await WorkspaceFS.appendFile(
         outputFile,
         bestConnector + processedResponse,
       );
     }
 
-    logger.debug('Response preview:', taskGroupId);
+    logger.debug('Response preview:');
     logger.debug(
       `First ${K_SLICE} chars:\n${processedResponse.slice(0, K_SLICE)}`,
-      taskGroupId,
     );
     logger.debug(
       `Last ${K_SLICE} chars:\n${processedResponse.slice(-K_SLICE)}`,
-      taskGroupId,
     );
 
     if (modelHandler.capabilities.supportsAssistantPrefill) {
@@ -282,7 +262,7 @@ export async function runResponseCycle<C = unknown>(
     stateRound.incrementContinuation();
     logger.info(
       `Starting continuation #${stateRound.continuationCount}`,
-      taskGroupId,
+      undefined,
       MESSAGE_TYPES.PROGRESS_STATUS,
     );
 
@@ -291,7 +271,6 @@ export async function runResponseCycle<C = unknown>(
     ) {
       logger.debug(
         'Should continue - adding continuation message to conversation',
-        taskGroupId,
       );
       if (modelHandler.capabilities.supportsAssistantPrefill) {
         modelHandler.addContinueMessageWithPrefill(

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -53,7 +53,6 @@ export interface ToolUseCycleOptions<C = unknown> {
 export async function runToolUseCycle<C = unknown>(
   options: ToolUseCycleOptions<C>,
   messages: ProviderMessage[],
-  groupId?: string,
 ): Promise<void> {
   const {
     modelHandler,
@@ -80,7 +79,6 @@ export async function runToolUseCycle<C = unknown>(
       context: {
         logger,
         modelName,
-        groupId,
       },
       fileOptions: {
         continuationCount: iteration,
@@ -112,7 +110,6 @@ export async function runToolUseCycle<C = unknown>(
       context: {
         logger,
         modelName,
-        groupId,
       },
       fileOptions: {
         continuationCount: iteration,
@@ -124,16 +121,12 @@ export async function runToolUseCycle<C = unknown>(
       break;
     }
 
-    const thinking = modelHandler.processThinkingBlock(
-      response,
-      groupId,
-      toolState,
-    );
+    const thinking = modelHandler.processThinkingBlock(response, toolState);
     const useStreaming = modelHandler.getStreamingConfig();
     if (thinking && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinking);
       if (formatted.trim().length > 0) {
-        logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
+        logger.info(formatted, undefined, MESSAGE_TYPES.THINKING);
       }
     }
 
@@ -146,10 +139,10 @@ export async function runToolUseCycle<C = unknown>(
       '',
     );
     if (text) {
-      logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
+      logger.debug(`Model response: ${text.slice(0, 100)}`);
       if (!useStreaming) {
         const formatted = await xmlUtils.formatContent(text);
-        logger.info(formatted, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
+        logger.info(formatted, undefined, MESSAGE_TYPES.MODEL_RESPONSE);
       }
     }
     if (usage) {
@@ -160,7 +153,7 @@ export async function runToolUseCycle<C = unknown>(
         cost: normalized.cost,
         elapsedTime: normalized.responseTime,
       };
-      logger.statistics(stats, groupId);
+      logger.statistics(stats);
     }
 
     const endTurn = modelHandler.isEndTurnStop(stopReason);
@@ -186,7 +179,7 @@ export async function runToolUseCycle<C = unknown>(
         input: toolInfo,
         output: sanitizeToolResultForLog(errorResult),
       };
-      logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      logger.info('', undefined, MESSAGE_TYPES.TOOL_USE, toolUseLog);
       break;
     }
 
@@ -203,7 +196,7 @@ export async function runToolUseCycle<C = unknown>(
         input: parsed,
         output: sanitizeToolResultForLog(errorResult),
       };
-      logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      logger.info('', undefined, MESSAGE_TYPES.TOOL_USE, toolUseLog);
       break;
     }
     let input = parsed.input ?? parsed.args;
@@ -280,7 +273,7 @@ export async function runToolUseCycle<C = unknown>(
       output: sanitizeToolResultForLog(result),
     };
 
-    logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+    logger.info('', undefined, MESSAGE_TYPES.TOOL_USE, toolUseLog);
 
     // Build provider-specific message containing the tool result
     const resultObj: Record<string, unknown> = {};

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -196,9 +196,8 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
 
   protected async trackRoundUsage(
     stateGlobal: AgentStateGlobal,
-    groupId?: string,
   ): Promise<void> {
-    await this.usageMonitor.recordUsage(stateGlobal, groupId);
+    await this.usageMonitor.recordUsage(stateGlobal);
   }
 
   /**

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -38,12 +38,10 @@ import { WorkspaceFS } from '@utils/files';
  *
  * @property outputFile - The path to the file where the round's output will be saved.
  * @property endTurn - A flag indicating whether the current turn should be ended after processing.
- * @property processGroupId - (Optional) An identifier for grouping related processes, useful for tracking or managing outputs.
  */
 export interface RoundOutputOptions {
   outputFile: string;
   endTurn: boolean;
-  processGroupId?: string;
 }
 
 /**
@@ -160,24 +158,23 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<void> {
-    const { outputFile, endTurn, processGroupId } = options;
+    const { outputFile, endTurn } = options;
     try {
       // Instead of creating a new group, use the round group directly
       // this.logger.debug(
       //   `State global: ${JSON.stringify(stateGlobal)}`,
-      //   processGroupId,
+      //   this.logger.getActiveGroupId(),
       // );
 
       await this.handleOutput(currRound, stateRound, stateGlobal, options);
 
-      this.logger.debug(`Completed round ${currRound}`, processGroupId);
+      this.logger.debug(`Completed round ${currRound}`);
     } catch (error) {
       throw error;
     }
 
     await this.outputHandler.finalizeRound(outputFile, currRound, {
       endTurn,
-      groupId: processGroupId,
     });
   }
 
@@ -197,9 +194,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
+    const { outputFile, endTurn } = options;
     // Record usage statistics at the end of each round
-    await this.trackRoundUsage(stateGlobal, processGroupId);
+    await this.trackRoundUsage(stateGlobal);
 
     // If this is the end of a turn, handle latexdiff operations as a separate step
     if (endTurn && this.outputHandler.hasRoundOutputs(currRound)) {
@@ -213,12 +210,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         await this.outputHandler.diffManager.handleLatexdiffofOutput(
           currRound,
           mapping,
-          processGroupId,
         );
       } else {
         this.logger.debug(
           `Skipping latexdiff for round ${currRound} - base files missing`,
-          processGroupId,
         );
       }
     }
@@ -238,7 +233,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * @param preparedMessages - Messages prepared for the model before execution.
    * @param prefill - Initial text inserted into the model response buffer.
    * @param outputPath - Filesystem path where model output for this round is stored.
-   * @param roundGroupId - Identifier for grouping related log and output operations.
    * @returns Updated round/global state, messages, completion flag, and tool state after execution.
    */
   private async runRoundPipeline(
@@ -249,7 +243,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     preparedMessages: any[],
     prefill: string,
     outputPath: string,
-    roundGroupId: string,
   ): Promise<[AgentStateRound, AgentStateGlobal, any[], boolean, ToolState]> {
     const [endTurn, updatedMessages] =
       await this.modelHandler.initializeOutputAndPrefill(
@@ -259,7 +252,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         toolState,
         outputPath,
         prefill,
-        roundGroupId,
       );
 
     if (!endTurn) {
@@ -272,6 +264,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         userVars: this.userVars,
         logger: this.logger,
         client,
+        executionId: this.executionId,
         checkInterruption: () => this.checkInterruption(),
         setAbortController: (ctrl) => {
           this.abortController = ctrl;
@@ -290,8 +283,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         stateGlobal,
         toolState,
         outputPath,
-        roundGroupId,
-        this.executionId,
       );
 
       // The round state is forwarded to handleRoundCompletion so subclasses can
@@ -303,15 +294,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         {
           outputFile: outputPath,
           endTurn: newEndTurn,
-          processGroupId: roundGroupId,
         },
       );
 
       if (currRound === 0) {
-        this.logger.debug(
-          `stateGlobal: ${JSON.stringify(updatedStateGlobal)}`,
-          roundGroupId,
-        );
+        this.logger.debug(`stateGlobal: ${JSON.stringify(updatedStateGlobal)}`);
       }
 
       return [
@@ -326,7 +313,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     await this.handleRoundCompletion(currRound, stateRound, stateGlobal, {
       outputFile: outputPath,
       endTurn,
-      processGroupId: roundGroupId,
     });
 
     return [stateRound, stateGlobal, updatedMessages, endTurn, toolState];
@@ -337,7 +323,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     _stateGlobal: AgentStateGlobal,
     messages: any[],
     toolState: ToolState,
-    roundGroupId: string,
   ): Promise<{
     stateRound: AgentStateRound;
     preparedMessages: any[];
@@ -371,7 +356,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         );
         this.logger.info(
           `Saved input prompt to ${promptPath}`,
-          roundGroupId,
+          undefined,
           MESSAGE_TYPES.DEFAULT,
         );
       }
@@ -428,7 +413,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   private async prepareToolState(
     currRound: number,
     toolState: ToolState,
-    roundGroupId: string,
   ): Promise<void> {
     if (currRound === 0) {
       const inputFiles = [
@@ -455,7 +439,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         this.agentConfig.toolConfig,
         this.modelHandler.capabilities.supportsVision,
         extraMedia,
-        roundGroupId,
       );
       return;
     }
@@ -479,7 +462,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       toolState,
       this.agentConfig.toolConfig,
       this.modelHandler.capabilities.supportsVision,
-      roundGroupId,
     );
   }
 
@@ -491,8 +473,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     this.logger.debug(`Processing round ${currRound}`);
     const toolState = new ToolState();
 
-    return this.withRoundGroup(`r${currRound}`, async (roundGroupId) => {
-      await this.prepareToolState(currRound, toolState, roundGroupId);
+    return this.withRoundGroup(`r${currRound}`, async () => {
+      await this.prepareToolState(currRound, toolState);
 
       const {
         stateRound,
@@ -504,7 +486,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         stateGlobal,
         messages,
         toolState,
-        roundGroupId,
       );
 
       if (skip) {
@@ -519,7 +500,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         preparedMessages,
         prefill,
         this.outputFile[currRound],
-        roundGroupId,
       );
     });
   }

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -42,54 +42,37 @@ export class CoTAgent extends BaseReflectionAgent {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
-
-    const runOutputHandling = async (groupId?: string): Promise<string[]> => {
-      const effectiveGroupId = groupId ?? this.logger.getActiveGroupId();
-
-      try {
-        this.outputHandler.ensureRound(currRound);
-
-        if (endTurn) {
-          this.logger.debug(
-            `Processing output for round ${currRound}`,
-            effectiveGroupId,
-          );
-
-          await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-            outputFile,
-            this.agentSetting.documentTag,
-          );
-
-          await this.outputHandler.processOutputFiles(
-            outputFile,
-            currRound,
-            effectiveGroupId,
-          );
-        }
-
-        return super.handleOutput(currRound, stateRound, stateGlobal, {
-          outputFile,
-          endTurn,
-          processGroupId: effectiveGroupId,
-        });
-      } catch (error) {
-        this.logger.error(
-          `Error in handleOutput for round ${currRound}: ${error}`,
-          effectiveGroupId,
-        );
-        throw error;
-      }
-    };
-
-    if (processGroupId) {
-      return runOutputHandling(processGroupId);
-    }
+    const { outputFile, endTurn } = options;
 
     return withLogGroup(
       this.logger,
       `OutputProcessing-Round${currRound}`,
-      runOutputHandling,
+      async () => {
+        try {
+          this.outputHandler.ensureRound(currRound);
+
+          if (endTurn) {
+            this.logger.debug(`Processing output for round ${currRound}`);
+
+            await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
+              outputFile,
+              this.agentSetting.documentTag,
+            );
+
+            await this.outputHandler.processOutputFiles(outputFile, currRound);
+          }
+
+          return super.handleOutput(currRound, stateRound, stateGlobal, {
+            outputFile,
+            endTurn,
+          });
+        } catch (error) {
+          this.logger.error(
+            `Error in handleOutput for round ${currRound}: ${error}`,
+          );
+          throw error;
+        }
+      },
       { parentGroupId: this.logger.getActiveGroupId() },
     );
   }

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -39,60 +39,38 @@ export class DirectAgent extends BaseReflectionAgent {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
-
-    const runOutputHandling = async (groupId?: string): Promise<string[]> => {
-      const effectiveGroupId = groupId ?? this.logger.getActiveGroupId();
-
-      try {
-        this.outputHandler.ensureRound(currRound);
-
-        if (endTurn) {
-          this.logger.debug(
-            `Processing output for round ${currRound}`,
-            effectiveGroupId,
-          );
-
-          if (this.useScratchpad) {
-            await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-              outputFile,
-              this.agentSetting.documentTag,
-            );
-          }
-
-          await this.outputHandler.processOutputFiles(
-            outputFile,
-            currRound,
-            effectiveGroupId,
-          );
-          this.logger.debug(
-            `Output files processed for round ${currRound}`,
-            effectiveGroupId,
-          );
-        }
-
-        return super.handleOutput(currRound, stateRound, stateGlobal, {
-          outputFile,
-          endTurn,
-          processGroupId: effectiveGroupId,
-        });
-      } catch (error) {
-        this.logger.error(
-          `Error in DirectAgent.handleOutput: ${error}`,
-          effectiveGroupId,
-        );
-        throw error;
-      }
-    };
-
-    if (processGroupId) {
-      return runOutputHandling(processGroupId);
-    }
+    const { outputFile, endTurn } = options;
 
     return withLogGroup(
       this.logger,
       `OutputProcessing-Round${currRound}`,
-      runOutputHandling,
+      async () => {
+        try {
+          this.outputHandler.ensureRound(currRound);
+
+          if (endTurn) {
+            this.logger.debug(`Processing output for round ${currRound}`);
+
+            if (this.useScratchpad) {
+              await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
+                outputFile,
+                this.agentSetting.documentTag,
+              );
+            }
+
+            await this.outputHandler.processOutputFiles(outputFile, currRound);
+            this.logger.debug(`Output files processed for round ${currRound}`);
+          }
+
+          return super.handleOutput(currRound, stateRound, stateGlobal, {
+            outputFile,
+            endTurn,
+          });
+        } catch (error) {
+          this.logger.error(`Error in DirectAgent.handleOutput: ${error}`);
+          throw error;
+        }
+      },
       { parentGroupId: this.logger.getActiveGroupId() },
     );
   }

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -143,12 +143,9 @@ export class MergeAgent extends DirectAgent {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
+    const { outputFile, endTurn } = options;
     if (endTurn) {
-      this.logger.debug(
-        `Processing merge output for round ${currRound}`,
-        processGroupId,
-      );
+      this.logger.debug(`Processing merge output for round ${currRound}`);
       const files = await super.handleOutput(
         currRound,
         stateRound,
@@ -156,10 +153,9 @@ export class MergeAgent extends DirectAgent {
         {
           outputFile,
           endTurn,
-          processGroupId,
         },
       );
-      this.logger.info(`Merge output file: ${outputFile}`, processGroupId);
+      this.logger.info(`Merge output file: ${outputFile}`);
       return files;
     }
     return [];

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -181,14 +181,14 @@ export abstract class ModelHandler<
    * Creates a log stream for progressive updates to the Progress view.
    *
    * @param type Message type for the stream.
-   * @param groupId Optional log group identifier.
    * @returns Object with `append` and `finalize` helpers.
    */
-  protected createLogStream(type: MessageType, groupId?: string) {
+  protected createLogStream(type: MessageType) {
     const streamId = this.logger.channelId;
     const id = randomUUID();
     let buffer = '';
     let isFirstUpdate = true;
+    const groupId = this.logger.getActiveGroupId();
 
     return {
       append: (text: string) => {
@@ -269,15 +269,15 @@ export abstract class ModelHandler<
   /**
    * Convenience wrapper for thinking streams.
    */
-  protected createThinkingStream(groupId?: string) {
-    return this.createLogStream(MESSAGE_TYPES.THINKING, groupId);
+  protected createThinkingStream() {
+    return this.createLogStream(MESSAGE_TYPES.THINKING);
   }
 
   /**
    * Convenience wrapper for output streams.
    */
-  protected createOutputStream(groupId?: string) {
-    return this.createLogStream(MESSAGE_TYPES.MODEL_RESPONSE, groupId);
+  protected createOutputStream() {
+    return this.createLogStream(MESSAGE_TYPES.MODEL_RESPONSE);
   }
 
   /**
@@ -966,7 +966,6 @@ export abstract class ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, M[]]>;
 
   /**
@@ -1016,13 +1015,11 @@ export abstract class ModelHandler<
   /**
    * Extracts thinking content from model responses
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted thinking content string or null if no thinking content is available
    */
   abstract processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null;
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -465,9 +465,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
         try {
           const groupId = this.logger.getActiveGroupId();
-          const thinking = this.createThinkingStream(groupId);
+          const thinking = this.createThinkingStream();
           const output = this.isOutputStreamingEnabled()
-            ? this.createOutputStream(groupId)
+            ? this.createOutputStream()
             : undefined;
           stream.on('thinking', (delta: string) => {
             thinking.append(delta);
@@ -1048,10 +1048,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, MessageParam[]]> {
     const workflowSetting = requireWorkflowSetting(agentSetting);
     let endTurn = false;
+    const logGroupId = this.logger.getActiveGroupId();
 
     if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
       if (this.capabilities.supportsAssistantPrefill) {
@@ -1097,7 +1097,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      this.logger.info(scratchpad, logGroupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     await WorkspaceFS.write(outputFile, fileContent);
@@ -1441,7 +1441,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /**
    * Process thinking blocks for Anthropic models
    * @param responseObject The response object from Anthropic API
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking blocks
    * @returns The extracted thinking content (or null if none)
    * This preserves the full thinking objects including signature which is required
@@ -1449,7 +1448,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
    */
   processThinkingBlock(
     responseObject: BetaMessage,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -1459,6 +1457,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Extract all thinking blocks from the response
     const thinkingBlocks = [];
     let regularThinkingContent = null;
+    const logGroupId = this.logger.getActiveGroupId();
 
     try {
       if (responseObject.content && Array.isArray(responseObject.content)) {
@@ -1478,7 +1477,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     } catch (e) {
       this.logger.error(
         `Error extracting thinking blocks: ${getSdkErrorMessage(e)}`,
-        groupId,
+        logGroupId,
         undefined,
         e,
       );
@@ -1491,7 +1490,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     this.logger.debug(
       `Found ${thinkingBlocks.length} thinking blocks`,
-      groupId,
+      logGroupId,
     );
 
     // If toolState is provided, update it with all thinking blocks
@@ -1506,12 +1505,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
         toolState.thinkingAdded = true;
         this.logger.debug(
           `Added ${thinkingBlocks.length} thinking blocks to toolState`,
-          groupId,
+          logGroupId,
         );
       } else {
         this.logger.debug(
           `Skipping adding thinking blocks to toolState because of cut off message`,
-          groupId,
+          logGroupId,
         );
       }
     }

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -64,13 +64,11 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for DeepSeek models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -94,7 +92,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
         reasoningContent = message.reasoning_content;
         this.logger.debug(
           'Found reasoning_content in choices[0].message.reasoning_content',
-          groupId,
+          this.logger.getActiveGroupId(),
         );
 
         // If toolState is provided and we have reasoning content,
@@ -108,7 +106,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
 
           toolState.thinkingBlocks = [thinkingBlock];
           toolState.thinkingAdded = true;
-          // this.logger.debug('Added reasoning content to toolState', groupId);
+          // this.logger.debug('Added reasoning content to toolState');
         }
         // For deepseek mode thinking content should not be attached back to the message as a content item.
         // Nevertheless one can include one in a bare way...
@@ -121,7 +119,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     // Log preview of thinking content (assuming it's a string)
     this.logger.debug(
       `DeepSeek reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
+      this.logger.getActiveGroupId(),
     );
 
     // Return the reasoning content (already a string for DeepSeek)

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -436,9 +436,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         const stream = await chat.sendMessageStream(streamParams);
 
         const groupId = this.logger.getActiveGroupId();
-        const thinking = this.createThinkingStream(groupId);
+        const thinking = this.createThinkingStream();
         const output = this.isOutputStreamingEnabled()
-          ? this.createOutputStream(groupId)
+          ? this.createOutputStream()
           : undefined;
         const fullParts: Part[] = [];
         let lastCandidate: Candidate | undefined;
@@ -819,9 +819,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, Content[]]> {
     let endTurn = false;
+    const logGroupId = this.logger.getActiveGroupId();
     this.logger.debug(
       `Initializing output and prefill for ${outputFile}. Prefill content: "${prefill.slice(0, 100)}..."`,
     );
@@ -862,7 +862,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      this.logger.info(scratchpad, logGroupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     await WorkspaceFS.write(outputFile, fileContent);
@@ -923,7 +923,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   processThinkingBlock(
     responseObject: GenerateContentResponse,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (
@@ -964,9 +963,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     }
 
     if (thoughtContent) {
+      const logGroupId = this.logger.getActiveGroupId();
       this.logger.debug(
         `Google GenAI thought summary preview: ${thoughtContent.substring(0, K_SLICE)}...`,
-        groupId,
+        logGroupId,
       );
     }
 

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -31,13 +31,11 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for Moonshot models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -59,7 +57,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         reasoningContent = message.thinking_content;
         this.logger.debug(
           'Found thinking_content in choices[0].message.thinking_content',
-          groupId,
+          this.logger.getActiveGroupId(),
         );
 
         // If toolState is provided and we have reasoning content,
@@ -84,7 +82,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     // Log preview of thinking content
     this.logger.debug(
       `Kimi thinking content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
+      this.logger.getActiveGroupId(),
     );
 
     return reasoningContent;

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -177,9 +177,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
           signal,
         });
         const groupId = this.logger.getActiveGroupId();
-        const thinking = this.createThinkingStream(groupId);
+        const thinking = this.createThinkingStream();
         const output = this.isOutputStreamingEnabled()
-          ? this.createOutputStream(groupId)
+          ? this.createOutputStream()
           : undefined;
 
         if (this.config.fullName.includes('deepseek')) {
@@ -822,9 +822,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, any[]]> {
     let endTurn = false;
+    const logGroupId = this.logger.getActiveGroupId();
 
     if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
       const PseudoPrefillMsgContentString = `Organize your response with xml tags. Start your response with:\n${prefill}`;
@@ -856,7 +856,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      this.logger.info(scratchpad, logGroupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     // Write file content to output file
@@ -1115,13 +1115,11 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /**
    * Processes thinking blocks from API response. OpenAI models do not support thinking blocks.
    * @param responseObject The response object from the OpenAI API
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with thinking blocks
    * @returns Always returns null as OpenAI doesn't support thinking blocks
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     const reasoning = responseObject?.choices?.[0]?.message?.reasoning_content;
@@ -1134,9 +1132,11 @@ export class ModelHandlerOpenAI extends ModelHandler<
       toolState.thinkingAdded = true;
     }
 
+    const logGroupId = this.logger.getActiveGroupId();
+
     this.logger.debug(
       `OpenAI reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
-      groupId,
+      logGroupId,
     );
     return reasoning;
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -521,9 +521,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const streamParams: ResponseStreamParams = { ...rest, stream: true };
       const stream = client.responses.stream(streamParams, { signal });
       const groupId = this.logger.getActiveGroupId();
-      const thinking = this.createThinkingStream(groupId);
+      const thinking = this.createThinkingStream();
       const output = this.isOutputStreamingEnabled()
-        ? this.createOutputStream(groupId)
+        ? this.createOutputStream()
         : undefined;
       const responseStream: AsyncIterable<ResponseStreamEvent> = stream;
       for await (const event of responseStream) {
@@ -1039,9 +1039,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, ResponseInputItem[]]> {
     let endTurn = false;
+    const logGroupId = this.logger.getActiveGroupId();
 
     if (!(await WorkspaceFS.existsAndNonTrivial(outputFile))) {
       const pseudoPrefill = `Organize your response with xml tags. Start your response with:\n${prefill}`;
@@ -1071,7 +1071,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      this.logger.info(scratchpad, logGroupId, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     await WorkspaceFS.write(outputFile, fileContent);
@@ -1197,7 +1197,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Process reasoning summaries from the Responses API. */
   processThinkingBlock(
     responseObject: Response,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     const outputArr = responseObject?.output;
@@ -1223,9 +1222,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     if (thoughtContent) {
+      const logGroupId = this.logger.getActiveGroupId();
       this.logger.debug(
         `OpenAI Responses reasoning preview: ${thoughtContent.substring(0, K_SLICE)}...`,
-        groupId,
+        logGroupId,
       );
     }
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -67,9 +67,9 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
       const stream = client.chat.completions.stream(kwargs, { signal });
       const groupId = this.logger.getActiveGroupId();
-      const thinking = this.createThinkingStream(groupId);
+      const thinking = this.createThinkingStream();
       const output = this.isOutputStreamingEnabled()
-        ? this.createOutputStream(groupId)
+        ? this.createOutputStream()
         : undefined;
       for await (const chunk of stream) {
         const reasoningDelta =
@@ -95,7 +95,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   // Implementation for processing thinking blocks in OpenRouter responses
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -110,13 +109,14 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       responseObject.choices[0].message.reasoning
     ) {
       const reasoning = responseObject.choices[0].message.reasoning;
-      this.logger.debug(`OpenRouter reasoning found`, groupId);
+      const logGroupId = this.logger.getActiveGroupId();
+      this.logger.debug(`OpenRouter reasoning found`, logGroupId);
 
       // Log preview of reasoning content
       if (typeof reasoning === 'string') {
         this.logger.debug(
           `Reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
-          groupId,
+          logGroupId,
         );
         return reasoning;
       } else {
@@ -124,7 +124,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
         const reasoningStr = JSON.stringify(reasoning);
         this.logger.debug(
           `Reasoning preview: ${reasoningStr.substring(0, K_SLICE)}...`,
-          groupId,
+          logGroupId,
         );
         return reasoningStr;
       }

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -18,13 +18,11 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for xAI models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -50,7 +48,7 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
         reasoningContent = message.reasoning_content;
         this.logger.debug(
           'Found reasoning_content in choices[0].message.reasoning_content',
-          groupId,
+          this.logger.getActiveGroupId(),
         );
 
         // If toolState is provided and we have reasoning content,
@@ -75,7 +73,7 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
     // Log preview of thinking content
     this.logger.debug(
       `xAI reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
+      this.logger.getActiveGroupId(),
     );
 
     return reasoningContent;

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -138,7 +138,6 @@ export interface IModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, M[]]>;
 
   /** Compute the cost for a response. */
@@ -185,7 +184,6 @@ export interface IModelHandler<
   /** Extract intermediate "thinking" content from a response. */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null;
 

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -32,11 +32,7 @@ export interface IOutputHandler {
   indentLatexFiles(filePaths: string[]): Promise<void>;
 
   /** Process output files from XML or direct input. */
-  processOutputFiles(
-    outputFile: string,
-    currRound: number,
-    groupId?: string,
-  ): Promise<void>;
+  processOutputFiles(outputFile: string, currRound: number): Promise<void>;
 
   /** Gather mapping and diff stats for output files of a round. */
   gatherOutputFileInfo(currRound: number): Promise<OutputFileInfo[]>;
@@ -45,11 +41,7 @@ export interface IOutputHandler {
   getRoundMapping(currRound: number): RoundFileMapping;
 
   /** Validate expected output files for the given round. */
-  validateExpectedOutputs(
-    outputFile: string,
-    currRound: number,
-    groupId?: string,
-  ): Promise<void>;
+  validateExpectedOutputs(outputFile: string, currRound: number): Promise<void>;
 
   /** Finalize processing for a round. */
   finalizeRound(
@@ -57,7 +49,6 @@ export interface IOutputHandler {
     currRound: number,
     options: {
       endTurn: boolean;
-      groupId?: string;
     },
   ): Promise<void>;
 }

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -42,24 +42,20 @@ export class LatexDiffManager {
   private logLatexdiffResult(
     result: LaTeXdiffResult,
     operation: string = 'latexdiff',
-    groupId?: string,
   ): void {
     if (result.success) {
       this.logger.debug(
         `Successfully generated ${operation} file: ${result.diffFileName}`,
-        groupId,
       );
     } else {
       if (result.message && result.message.includes('document environment')) {
         this.logger.debug(
           `Skipping ${operation}: ${result.message}`,
-          groupId,
           MESSAGE_TYPES.INTERNAL,
         );
       } else {
         this.logger.warn(
           `Failed to generate ${operation}: ${result.message}`,
-          groupId,
           MESSAGE_TYPES.INTERNAL,
         );
       }
@@ -69,9 +65,7 @@ export class LatexDiffManager {
   async handleLatexdiffofOutput(
     currRound: number,
     mapping: RoundFileMapping,
-    groupId?: string,
   ): Promise<void> {
-    const diffProcessGroupId = groupId ?? this.logger.getActiveGroupId();
     const generateBetweenRoundDiffs = this.dependencies.getConfig<boolean>(
       'latexdiff.generateBetweenRoundDiffs',
       false,
@@ -88,7 +82,6 @@ export class LatexDiffManager {
       if (!(await this.dependencies.checkToolInstalled('latexdiff'))) {
         this.logger.warn(
           'Skipping latexdiff operations - latexdiff not installed',
-          diffProcessGroupId,
         );
         return;
       }
@@ -97,16 +90,12 @@ export class LatexDiffManager {
       if (outputFiles.length === 0) {
         this.logger.warn(
           `No output files found for round ${currRound}, skipping latexdiff operations`,
-          diffProcessGroupId,
         );
         return;
       }
 
-      this.logger.debug(`Base files: ${this.baseFiles}`, diffProcessGroupId);
-      this.logger.debug(
-        `r${currRound} output files: ${outputFiles}`,
-        diffProcessGroupId,
-      );
+      this.logger.debug(`Base files: ${this.baseFiles}`);
+      this.logger.debug(`r${currRound} output files: ${outputFiles}`);
 
       const basePairs = Array.from(mapping.baseToOutput.entries());
       if (basePairs.length > 0) {
@@ -117,27 +106,22 @@ export class LatexDiffManager {
                 `${path.basename(base)} -> ${path.basename(output)}`,
             )
             .join(', ')}`,
-          diffProcessGroupId,
         );
       } else if (this.baseFiles.length > 0) {
         this.logger.debug(
           'No base file mappings found for current round outputs',
-          diffProcessGroupId,
         );
       }
 
       if (this.agentSetting.isRewrite) {
-        this.logger.debug(
-          'Running round-based latexdiff operations',
-          diffProcessGroupId,
-        );
+        this.logger.debug('Running round-based latexdiff operations');
         for (const [baseFile, outputFile] of basePairs) {
           const result = await this.latexdiffService.runDiffForRound(
             baseFile,
             outputFile,
             currRound,
           );
-          this.logLatexdiffResult(result, 'round-diff', diffProcessGroupId);
+          this.logLatexdiffResult(result, 'round-diff');
           aggregated.push({
             base: baseFile,
             revised: outputFile,
@@ -164,10 +148,7 @@ export class LatexDiffManager {
       }
 
       if (generateBetweenRoundDiffs && currRound > 0) {
-        this.logger.debug(
-          'Running between-rounds latexdiff operations',
-          diffProcessGroupId,
-        );
+        this.logger.debug('Running between-rounds latexdiff operations');
         const prevPairs = Array.from(mapping.prevToOutput.entries());
 
         if (prevPairs.length > 0) {
@@ -178,12 +159,10 @@ export class LatexDiffManager {
                   `${path.basename(prev)} -> ${path.basename(curr)}`,
               )
               .join(', ')}`,
-            diffProcessGroupId,
           );
         } else {
           this.logger.debug(
             'No previous round mappings found for current round outputs',
-            diffProcessGroupId,
           );
         }
 
@@ -192,11 +171,7 @@ export class LatexDiffManager {
             prevOutputFile,
             currOutputFile,
           );
-          this.logLatexdiffResult(
-            result,
-            'between-rounds-diff',
-            diffProcessGroupId,
-          );
+          this.logLatexdiffResult(result, 'between-rounds-diff');
           aggregated.push({
             base: prevOutputFile,
             revised: currOutputFile,
@@ -223,19 +198,17 @@ export class LatexDiffManager {
       } else if (!generateBetweenRoundDiffs) {
         this.logger.debug(
           'Skipping between-round latexdiff operations: disabled in settings',
-          diffProcessGroupId,
         );
       }
 
       if (aggregated.length > 0) {
-        this.logger.latexDiff(aggregated, diffProcessGroupId);
+        this.logger.latexDiff(aggregated);
       } else {
-        this.logger.debug('No latexdiff results to report', diffProcessGroupId);
+        this.logger.debug('No latexdiff results to report');
       }
     } catch (err) {
       this.logger.error(
         `Error during latexdiff processing: ${err instanceof Error ? err.message : String(err)}`,
-        diffProcessGroupId,
       );
     }
   }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -52,7 +52,6 @@ export class OutputHandler implements IOutputHandler {
   public outputMappings: { [key: number]: NamedOutputFile[] };
   private roundMappings: { [key: number]: RoundFileMapping };
   public baseFiles: string[];
-  public processGroupId?: string;
   protected logger: AgentLogger;
   protected channel: string;
   public readonly xmlManager: XmlOutputManager;
@@ -151,10 +150,6 @@ export class OutputHandler implements IOutputHandler {
   ): void {
     if (groupId) {
       this.logger.endGroup(groupId, status);
-    } else if (this.processGroupId) {
-      // this.logger.info(`Completed output processing`, this.processGroupId);
-      this.logger.endGroup(this.processGroupId, status);
-      this.processGroupId = undefined;
     }
   }
 
@@ -279,7 +274,6 @@ export class OutputHandler implements IOutputHandler {
   public async validateExpectedOutputs(
     outputFile: string,
     currRound: number,
-    groupId?: string,
   ): Promise<void> {
     const expected = this.agentConfig.outputFiles;
     if (!expected || expected.length === 0) {
@@ -329,7 +323,7 @@ export class OutputHandler implements IOutputHandler {
         documentTag: this.agentSetting.documentTag,
       };
 
-      this.logger.missingOutputs(missingOutputsData, groupId);
+      this.logger.missingOutputs(missingOutputsData);
     }
 
     bus.emit('updateMissingOutputs', {
@@ -346,25 +340,21 @@ export class OutputHandler implements IOutputHandler {
   public async finalizeRound(
     outputFile: string,
     currRound: number,
-    options: { endTurn: boolean; groupId?: string },
+    options: { endTurn: boolean },
   ): Promise<void> {
-    const { endTurn, groupId } = options;
+    const { endTurn } = options;
     this.ensureRound(currRound);
     const fileInfos = await this.gatherOutputFileInfo(currRound);
 
     if (endTurn) {
       try {
-        await this.validateExpectedOutputs(outputFile, currRound, groupId);
-        this.logger.debug(
-          `Expected outputs validated for round ${currRound}`,
-          groupId,
-        );
+        await this.validateExpectedOutputs(outputFile, currRound);
+        this.logger.debug(`Expected outputs validated for round ${currRound}`);
       } catch (error) {
         this.logger.error(
           `Expected output validation failed after round ${currRound}: ${
             error instanceof Error ? error.message : String(error)
           }`,
-          groupId,
         );
       }
     }
@@ -387,7 +377,6 @@ export class OutputHandler implements IOutputHandler {
           `Failed to open output file ${filePath}: ${
             error instanceof Error ? error.message : String(error)
           }`,
-          groupId,
         );
       }
     }
@@ -399,9 +388,7 @@ export class OutputHandler implements IOutputHandler {
   public async processOutputFiles(
     outputFile: string,
     currRound: number,
-    groupId?: string,
   ): Promise<void> {
-    const activeGroupId = groupId || this.logger.getActiveGroupId();
     this.ensureRound(currRound);
 
     if (
@@ -411,7 +398,6 @@ export class OutputHandler implements IOutputHandler {
       // Multiple output files case
       this.logger.debug(
         `Processing multiple outputs for ${outputFile}; outputFiles: ${this.agentConfig.outputFiles}`,
-        activeGroupId,
       );
 
       try {
@@ -423,7 +409,6 @@ export class OutputHandler implements IOutputHandler {
           await this.indentLatexFiles(processedFiles);
           this.logger.debug(
             `Indented multiple output files: ${processedFiles.join(',')}`,
-            activeGroupId,
           );
 
           this.setRoundOutputs(currRound, processedFiles, processedPairs);
@@ -438,24 +423,20 @@ export class OutputHandler implements IOutputHandler {
         } else {
           this.logger.debug(
             `No processed files were generated from ${outputFile}`,
-            activeGroupId,
           );
           this.setRoundOutputs(currRound, [], []);
         }
       } catch (err) {
         this.logger.debug(
           `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
-          activeGroupId,
+          undefined,
           MESSAGE_TYPES.INTERNAL,
         );
         this.setRoundOutputs(currRound, [], []);
       }
     } else {
       // Single output file case
-      this.logger.debug(
-        `Processing single output for ${outputFile}`,
-        activeGroupId,
-      );
+      this.logger.debug(`Processing single output for ${outputFile}`);
 
       try {
         let processed: NamedOutputFile = {
@@ -477,23 +458,19 @@ export class OutputHandler implements IOutputHandler {
 
         if (processed && processed.path) {
           await this.indentLatexFile(processed.path);
-          this.logger.debug(
-            `Indented single output file: ${processed.path}`,
-            activeGroupId,
-          );
+          this.logger.debug(`Indented single output file: ${processed.path}`);
 
           this.setRoundOutputs(currRound, [processed.path], [processed]);
         } else {
           this.logger.debug(
             `No processed file was generated from ${outputFile}`,
-            activeGroupId,
           );
           this.setRoundOutputs(currRound, [], []);
         }
       } catch (err) {
         this.logger.debug(
           `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
-          activeGroupId,
+          undefined,
           MESSAGE_TYPES.INTERNAL,
         );
         const missingOutputsData = {
@@ -501,7 +478,7 @@ export class OutputHandler implements IOutputHandler {
           xmlFile: outputFile,
           documentTag: this.agentSetting.documentTag,
         };
-        this.logger.missingOutputs(missingOutputsData, activeGroupId);
+        this.logger.missingOutputs(missingOutputsData);
         bus.emit('updateMissingOutputs', {
           stream: this.channel,
           filesByRound: { [currRound]: [] },

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -28,11 +28,8 @@ export class UsageMonitor {
     private readonly logger: AgentLogger,
   ) {}
 
-  async recordUsage(
-    stateGlobal: AgentStateGlobal,
-    groupId?: string,
-  ): Promise<void> {
-    const statsGroupId = groupId ?? this.logger.getActiveGroupId();
+  async recordUsage(stateGlobal: AgentStateGlobal): Promise<void> {
+    const statsGroupId = this.logger.getActiveGroupId();
 
     try {
       let responseUsage:
@@ -156,9 +153,9 @@ export class UsageMonitor {
         }),
       };
 
-      this.logger.statistics(payload, statsGroupId);
+      this.logger.statistics(payload);
     } catch (error) {
-      this.logger.error(`Error printing statistics: ${error}`, statsGroupId);
+      this.logger.error(`Error printing statistics: ${error}`);
     }
   }
 }

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -75,6 +75,7 @@ export async function maybeSaveDebugObject({
   }
 
   const { logger, modelName, executionId, groupId } = context;
+  const resolvedGroupId = groupId ?? logger.getActiveGroupId();
   const { outputFile, baseName = objectType, continuationCount } = fileOptions;
 
   const fileBase =
@@ -99,8 +100,14 @@ export async function maybeSaveDebugObject({
         object,
       );
     }
-    logger.info(`Saved ${objectType} object to ${debugFilePath}`, groupId);
+    logger.info(
+      `Saved ${objectType} object to ${debugFilePath}`,
+      resolvedGroupId,
+    );
   } catch (error) {
-    logger.error(`Failed to save ${objectType} object: ${error}`, groupId);
+    logger.error(
+      `Failed to save ${objectType} object: ${error}`,
+      resolvedGroupId,
+    );
   }
 }

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -37,7 +37,6 @@ export class LatexMediaManager {
   private async compilePdfs(
     files: string[],
     toolState: ToolState,
-    groupId?: string,
   ): Promise<void> {
     const texFiles = files.filter((file) =>
       file.toLowerCase().endsWith('.tex'),
@@ -63,7 +62,6 @@ export class LatexMediaManager {
               if (stats.size === 0) {
                 this.logger.warn(
                   `Compiled PDF is empty for ${file}: ${pdfFile}`,
-                  groupId,
                 );
                 return undefined;
               }
@@ -71,12 +69,11 @@ export class LatexMediaManager {
               const message = err instanceof Error ? err.message : String(err);
               this.logger.error(
                 `Failed to stat compiled PDF ${pdfFile}: ${message}`,
-                groupId,
               );
               return undefined;
             }
 
-            this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
+            this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`);
             return pdfFile;
           }
         }
@@ -93,7 +90,6 @@ export class LatexMediaManager {
   private async extractFiguresFromFiles(
     files: string[],
     toolState: ToolState,
-    groupId?: string,
   ): Promise<void> {
     const figureResults = await Promise.allSettled(
       files.map((file) => extractFigurePathsFromLatex(file)),
@@ -107,7 +103,6 @@ export class LatexMediaManager {
         const file = files[idx];
         this.logger.debug(
           `Extracted ${result.value.length} figures from ${file}`,
-          groupId,
         );
         toolState.addMediaFiles(result.value);
       }
@@ -118,7 +113,6 @@ export class LatexMediaManager {
     files: string[],
     toolState: ToolState,
     logSummary: boolean,
-    groupId?: string,
   ): Promise<void> {
     const tikzResults = await Promise.allSettled(
       files.map((file) => tikzPictureManager.compile(file)),
@@ -133,10 +127,7 @@ export class LatexMediaManager {
       }
     });
     if (logSummary) {
-      this.logger.debug(
-        `Extracted ${tikzResults.length} TikZ figures`,
-        groupId,
-      );
+      this.logger.debug(`Extracted ${tikzResults.length} TikZ figures`);
     }
   }
 
@@ -151,14 +142,12 @@ export class LatexMediaManager {
       includePdfCompilation,
       extraMediaFiles = [],
       logTikzSummary = false,
-      groupId,
     }: {
       includeFigureExtraction: boolean;
       includeTikzCompilation: boolean;
       includePdfCompilation: boolean;
       extraMediaFiles?: string[];
       logTikzSummary?: boolean;
-      groupId?: string;
     },
   ): Promise<void> {
     if (!files || files.length === 0) {
@@ -190,20 +179,15 @@ export class LatexMediaManager {
     }
 
     if (includeFigureExtraction && cfg.autoExtractFigure) {
-      await this.extractFiguresFromFiles(existingFiles, toolState, groupId);
+      await this.extractFiguresFromFiles(existingFiles, toolState);
     }
 
     if (includeTikzCompilation && cfg.autoExtractTikzFigure) {
-      await this.compileTikzFigures(
-        existingFiles,
-        toolState,
-        logTikzSummary,
-        groupId,
-      );
+      await this.compileTikzFigures(existingFiles, toolState, logTikzSummary);
     }
 
     if (includePdfCompilation && cfg.autoCompileInputPdf) {
-      await this.compilePdfs(existingFiles, toolState, groupId);
+      await this.compilePdfs(existingFiles, toolState);
     }
   }
 
@@ -217,7 +201,6 @@ export class LatexMediaManager {
     cfg: ToolConfig,
     supportsVision: boolean,
     extraMediaFiles: string[] = [],
-    groupId?: string,
   ): Promise<void> {
     await this.processFiles(inputFiles, toolState, cfg, supportsVision, {
       includeFigureExtraction: true,
@@ -225,7 +208,6 @@ export class LatexMediaManager {
       includePdfCompilation: true,
       extraMediaFiles,
       logTikzSummary: true,
-      groupId,
     });
   }
 
@@ -237,13 +219,11 @@ export class LatexMediaManager {
     toolState: ToolState,
     cfg: ToolConfig,
     supportsVision: boolean,
-    groupId?: string,
   ): Promise<void> {
     await this.processFiles(outputFiles, toolState, cfg, supportsVision, {
       includeFigureExtraction: false,
       includeTikzCompilation: true,
       includePdfCompilation: true,
-      groupId,
     });
   }
 }

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -246,6 +246,7 @@ describe('ResponseCycle background reasoning logs', () => {
 
   it('logs reasoning content when background responses disable streaming', async () => {
     const loggedEvents: LoggedEvent[] = [];
+    let activeGroupId: string | undefined = 'group';
     const loggerStub = {
       channelId: 'test',
       isAgentLogger: true,
@@ -264,8 +265,10 @@ describe('ResponseCycle background reasoning logs', () => {
       userMessage() {},
       startGroup: async () => 'group',
       endGroup() {},
-      getActiveGroupId: () => undefined,
-      setActiveGroupId() {},
+      getActiveGroupId: () => activeGroupId,
+      setActiveGroupId(value?: string) {
+        activeGroupId = value;
+      },
     } as unknown as AgentLogger;
 
     const handlerConfig: ModelConfig = {
@@ -381,6 +384,7 @@ describe('ResponseCycle background reasoning logs', () => {
     configValues.set('texra.model.useStreamingOpenai', true);
     configValues.set('texra.model.useBackgroundResponses', false);
 
+    let activeGroupId: string | undefined = 'group';
     const loggerStub = {
       channelId: 'test',
       isAgentLogger: true,
@@ -395,8 +399,10 @@ describe('ResponseCycle background reasoning logs', () => {
       userMessage() {},
       startGroup: async () => 'group',
       endGroup() {},
-      getActiveGroupId: () => undefined,
-      setActiveGroupId() {},
+      getActiveGroupId: () => activeGroupId,
+      setActiveGroupId(value?: string) {
+        activeGroupId = value;
+      },
     } as unknown as AgentLogger;
 
     const handlerConfig: ModelConfig = {


### PR DESCRIPTION
## Summary
- derive the response and tool-use cycles' logging scope from the ambient AgentLogger context instead of threading explicit group identifiers
- refactor the reflection pipeline and agent subclasses to stop plumbing round group IDs while keeping round processing behaviour unchanged
- update output-handling utilities to fetch their own logging context, simplifying interfaces like `IOutputHandler`, the latex diff/media managers, and usage monitoring

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69010900ec748324920557527450887f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates explicit groupId parameters across agents, handlers, and output utilities by using the logger’s active group, and updates cycles, interfaces, and tests accordingly (plus adds executionId to ResponseCycle options).
> 
> - **Core**:
>   - `runResponseCycle`/`runToolUseCycle`: drop `groupId` args; log via ambient `AgentLogger`; add `executionId` to `ResponseCycleOptions`; streamline response/debug logging.
> - **Agents**:
>   - `BaseReflectionAgent`/`CoTAgent`/`DirectAgent`/`MergeAgent`: stop passing round group IDs; use `withLogGroup` and ambient context; unchanged round logic.
>   - `BaseAgent.trackRoundUsage`: remove `groupId` param.
> - **Model Handlers**:
>   - `ModelHandler`: `createLogStream`, `createThinkingStream`, `createOutputStream` use `getActiveGroupId()` internally.
>   - Remove `groupId` from `processThinkingBlock` and `initializeOutputAndPrefill` signatures across implementations (Anthropic, OpenAI, Google, OpenRouter, DeepSeek, Kimi, xAI, Responses); update streaming/logging accordingly.
> - **Output**:
>   - `IOutputHandler`/`OutputHandler`/`LatexDiffManager`: remove `groupId` from APIs; logs derive context; keep behavior; minor log text tweaks.
> - **LaTeX Media**:
>   - `LatexMediaManager`: remove `groupId` params; logs use ambient context.
> - **Utils**:
>   - `UsageMonitor.recordUsage`: no `groupId` arg; uses active group.
>   - `debugMessageSaver`: resolve `groupId` from logger when absent.
> - **Tests**:
>   - Update stubs to implement `getActiveGroupId`/`setActiveGroupId`; validate background reasoning logs with ambient groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 989b764005ac49bf2b0173c46bf0eed52e30b7ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->