### PR TITLE
Fix duplicate Gemini file logging

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -244,7 +244,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       }
     }
 
-    this.logMediaResults(uploadSummaries);
+    if (uploadSummaries.some((summary) => !summary.ok)) {
+      this.logger.warn(
+        'Some media files failed to upload via Google GenAI SDK',
+      );
+    }
     return uploadedParts;
   }
 

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -138,6 +138,44 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
     ]);
   });
 
+  it('does not emit duplicate fileList logs while uploading media', async () => {
+    const clientStub = {
+      files: {
+        upload: async (params: UploadFileParameters) => {
+          return {
+            name: 'files/test-file',
+            uri: 'files/test-file',
+            mimeType: params.config?.mimeType ?? 'application/pdf',
+            displayName: params.config?.displayName ?? 'test.pdf',
+          } satisfies Partial<File> as File;
+        },
+      },
+    };
+
+    const handler = new GoogleHandlerTestDouble(
+      buildGoogleConfig(),
+      clientStub,
+    );
+    const { logger, stub } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const entry: MediaEntry = {
+      file_name: 'sample.pdf',
+      data: Buffer.from('%PDF-1.7').toString('base64'),
+      media_type: 'application/pdf',
+      media_category: 'image',
+      source_path: '/tmp/sample.pdf',
+    };
+
+    await handler.invokeUpload([entry]);
+
+    assert.equal(
+      stub.fileListEntries.length,
+      0,
+      'uploadMediaEntries should not emit fileList logs',
+    );
+  });
+
   it('prefers binary payloads when provided on media entries', async () => {
     let uploadInvocationCount = 0;
     const clientStub = {


### PR DESCRIPTION
## Summary
- remove the redundant fileList logging from the Gemini upload path
- add a guard to only warn when uploads fail without duplicating success logs
- cover the regression with a unit test that ensures uploads do not emit fileList logs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6902188825048324bef6535c7cca945b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes redundant media file logging in Google GenAI uploads and adds a single warning when any upload fails, with a unit test ensuring no duplicate logs.
> 
> - **Google GenAI handler (`src/agent/modelHandlers/modelHandlerGoogleGenAI.ts`)**:
>   - Remove `logMediaResults` call after uploads to avoid duplicate `fileList` logs.
>   - Add conditional warn when any `uploadSummaries` item has `ok=false`.
> - **Tests (`src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts`)**:
>   - Add test verifying no duplicate `fileList` logs during media upload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc08cda44a95e04b49ac3b095c9146ce72a88ad6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->