### PR TITLE
fix: decode HTML entities during LaTeX cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -606,6 +606,7 @@
                 "latex_xml",
                 "latex_document",
                 "unicode",
+                "html_entities",
                 "scratchpad_xml",
                 "latexdiff",
                 "gptness",
@@ -622,6 +623,7 @@
               "latex_xml",
               "latex_document",
               "unicode",
+              "html_entities",
               "scratchpad_xml",
               "latexdiff",
               "gptness"

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -31,6 +31,7 @@ import {
   CHARACTER_REPLACEMENTS,
   FONT_COMMAND_REPLACEMENTS,
   UNICODE_REPLACEMENTS,
+  HTML_ENTITY_REPLACEMENTS,
   LATEX_SPACING_REPLACEMENTS,
   LATEX_XML_REPLACEMENTS,
   LATEX_DOCUMENT_REPLACEMENTS,
@@ -108,6 +109,7 @@ const NON_REGEX_CATEGORIES: ReplacementCategory[] = [
   CHARACTER_REPLACEMENTS,
   FONT_COMMAND_REPLACEMENTS,
   UNICODE_REPLACEMENTS,
+  HTML_ENTITY_REPLACEMENTS,
   LATEX_SPACING_REPLACEMENTS,
   // XML/Structural Formatting
   LATEX_XML_REPLACEMENTS,
@@ -147,6 +149,7 @@ export function getAllReplacements(): ReplacementCategory {
     'latex_xml',
     'latex_document',
     'unicode',
+    'html_entities',
     'scratchpad_xml',
     'gptness',
     'latexdiff',

--- a/src/replacement/rules.ts
+++ b/src/replacement/rules.ts
@@ -5,6 +5,7 @@ export { default as LATEX_FORBIDDEN_REPLACEMENTS } from './rules/forbiddenComman
 export { default as CHARACTER_REPLACEMENTS } from './rules/characters';
 export { default as FONT_COMMAND_REPLACEMENTS } from './rules/fontCommands';
 export { default as UNICODE_REPLACEMENTS } from './rules/unicode';
+export { default as HTML_ENTITY_REPLACEMENTS } from './rules/htmlEntities';
 export { default as LATEX_XML_REPLACEMENTS } from './rules/latexXml';
 export { default as LATEX_DOCUMENT_REPLACEMENTS } from './rules/latexDocument';
 export { default as SCRATCHPAD_XML_REPLACEMENTS } from './rules/scratchpadXml';

--- a/src/replacement/rules/htmlEntities.ts
+++ b/src/replacement/rules/htmlEntities.ts
@@ -1,0 +1,25 @@
+// Local imports - replacement
+import { ReplacementCategory } from '../types';
+
+export const HTML_ENTITY_REPLACEMENTS: ReplacementCategory = {
+  name: 'html_entities',
+  description: 'Converts common HTML entities into LaTeX-safe equivalents',
+  isRegex: false,
+  patterns: {
+    // Angle brackets often appear when XML tags are HTML-escaped
+    '&lt;': '<',
+    '&gt;': '>',
+
+    // Ampersands should be escaped in LaTeX to avoid alignment issues
+    '&amp;': '\\&',
+
+    // Non-breaking spaces should remain non-breaking in LaTeX output
+    '&nbsp;': '~',
+
+    // Basic comparison operators frequently appear in HTML-escaped math
+    '&le;': '\\leq',
+    '&ge;': '\\geq',
+  },
+};
+
+export default HTML_ENTITY_REPLACEMENTS;

--- a/src/replacement/rules/htmlEntities.ts
+++ b/src/replacement/rules/htmlEntities.ts
@@ -13,12 +13,115 @@ export const HTML_ENTITY_REPLACEMENTS: ReplacementCategory = {
     // Ampersands should be escaped in LaTeX to avoid alignment issues
     '&amp;': '\\&',
 
-    // Non-breaking spaces should remain non-breaking in LaTeX output
+    // Quotes and spacing
+    '&quot;': '"',
+    '&apos;': '\'',
     '&nbsp;': '~',
 
     // Basic comparison operators frequently appear in HTML-escaped math
     '&le;': '\\leq',
     '&ge;': '\\geq',
+    '&ne;': '\\neq',
+
+    // Math operators and punctuation
+    '&plusmn;': '\\pm',
+    '&minus;': '-',
+    '&times;': '\\times',
+    '&divide;': '\\div',
+    '&middot;': '\\cdot',
+    '&sdot;': '\\cdot',
+    '&hellip;': '\\ldots',
+
+    // Fraction glyphs
+    '&frac12;': '\\frac{1}{2}',
+    '&frac14;': '\\frac{1}{4}',
+    '&frac34;': '\\frac{3}{4}',
+
+    // Miscellaneous glyphs
+    '&deg;': '^{\\circ}',
+    '&micro;': '\\mu',
+
+    // Lowercase Greek letters
+    '&alpha;': '\\alpha',
+    '&beta;': '\\beta',
+    '&gamma;': '\\gamma',
+    '&delta;': '\\delta',
+    '&epsilon;': '\\epsilon',
+    '&zeta;': '\\zeta',
+    '&eta;': '\\eta',
+    '&theta;': '\\theta',
+    '&iota;': '\\iota',
+    '&kappa;': '\\kappa',
+    '&lambda;': '\\lambda',
+    '&mu;': '\\mu',
+    '&nu;': '\\nu',
+    '&xi;': '\\xi',
+    '&omicron;': 'o',
+    '&pi;': '\\pi',
+    '&rho;': '\\rho',
+    '&sigmaf;': '\\sigma',
+    '&sigma;': '\\sigma',
+    '&tau;': '\\tau',
+    '&upsilon;': '\\upsilon',
+    '&phi;': '\\phi',
+    '&chi;': '\\chi',
+    '&psi;': '\\psi',
+    '&omega;': '\\omega',
+
+    // Uppercase Greek letters with LaTeX commands
+    '&Gamma;': '\\Gamma',
+    '&Delta;': '\\Delta',
+    '&Theta;': '\\Theta',
+    '&Lambda;': '\\Lambda',
+    '&Xi;': '\\Xi',
+    '&Pi;': '\\Pi',
+    '&Sigma;': '\\Sigma',
+    '&Upsilon;': '\\Upsilon',
+    '&Phi;': '\\Phi',
+    '&Psi;': '\\Psi',
+    '&Omega;': '\\Omega',
+
+    // Logical and set operators
+    '&forall;': '\\forall',
+    '&exist;': '\\exists',
+    '&nabla;': '\\nabla',
+    '&infin;': '\\infty',
+    '&and;': '\\wedge',
+    '&or;': '\\vee',
+    '&cap;': '\\cap',
+    '&cup;': '\\cup',
+    '&int;': '\\int',
+    '&sum;': '\\sum',
+    '&prod;': '\\prod',
+    '&there4;': '\\therefore',
+    '&part;': '\\partial',
+    '&prop;': '\\propto',
+
+    // Relations
+    '&isin;': '\\in',
+    '&notin;': '\\notin',
+    '&ni;': '\\ni',
+    '&sub;': '\\subset',
+    '&sup;': '\\supset',
+    '&sube;': '\\subseteq',
+    '&supe;': '\\supseteq',
+    '&oplus;': '\\oplus',
+    '&otimes;': '\\otimes',
+    '&perp;': '\\perp',
+
+    // Directional arrows
+    '&larr;': '\\leftarrow',
+    '&rarr;': '\\rightarrow',
+    '&uarr;': '\\uparrow',
+    '&darr;': '\\downarrow',
+    '&harr;': '\\leftrightarrow',
+    '&lArr;': '\\Leftarrow',
+    '&rArr;': '\\Rightarrow',
+    '&uArr;': '\\Uparrow',
+    '&dArr;': '\\Downarrow',
+    '&hArr;': '\\Leftrightarrow',
+    // Return arrow is less common; fall back to a plain left arrow
+    '&crarr;': '\\leftarrow',
   },
 };
 

--- a/src/test/replacement/htmlEntities.test.ts
+++ b/src/test/replacement/htmlEntities.test.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from 'assert';
+
+import { applyReplacements } from '@replacement/engine';
+import {
+  HTML_ENTITY_REPLACEMENTS,
+  LATEX_XML_REPLACEMENTS,
+} from '@replacement/rules';
+
+describe('html entity replacements', () => {
+  it('converts escaped xml tags into LaTeX environments', () => {
+    const input = '&lt;critique&gt;Great job&lt;/critique&gt;';
+    const expected = '\\begin{critique}Great job\\end{critique}';
+
+    const result = applyReplacements(
+      input,
+      [HTML_ENTITY_REPLACEMENTS, LATEX_XML_REPLACEMENTS],
+      { processMathUnicode: false },
+    );
+
+    assert.strictEqual(result, expected);
+  });
+
+  it('decodes common entities to LaTeX-safe output', () => {
+    const input = 'Usage&nbsp;&amp;&nbsp;limits remain &le; 10';
+    const expected = 'Usage~\\&~limits remain \\leq 10';
+
+    const result = applyReplacements(
+      input,
+      HTML_ENTITY_REPLACEMENTS,
+      { processMathUnicode: false },
+    );
+
+    assert.strictEqual(result, expected);
+  });
+});

--- a/src/test/replacement/htmlEntities.test.ts
+++ b/src/test/replacement/htmlEntities.test.ts
@@ -32,4 +32,19 @@ describe('html entity replacements', () => {
 
     assert.strictEqual(result, expected);
   });
+
+  it('covers extended math and greek entities safely', () => {
+    const input =
+      'Angles &ne; 0 &alpha;&rArr;&infin; &sum;=1 45&deg; &quot;quoted&quot; &frac12;&nbsp;items &Delta;&theta;';
+    const expected =
+      'Angles \\neq 0 \\alpha\\Rightarrow\\infty \\sum=1 45^{\\circ} "quoted" \\frac{1}{2}~items \\Delta\\theta';
+
+    const result = applyReplacements(
+      input,
+      HTML_ENTITY_REPLACEMENTS,
+      { processMathUnicode: false },
+    );
+
+    assert.strictEqual(result, expected);
+  });
 });


### PR DESCRIPTION
## Summary
- add an html entity replacement category so escaped angle brackets and symbols become eligible for LaTeX cleanup
- register the new replacements with the engine defaults and configuration schema
- cover the behavior with unit tests for escaped XML tags and inline entities

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_69021c45be288324b091595c0d0db319

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an `html_entities` replacement category, wire it into engine defaults and config, and cover with unit tests.
> 
> - **LaTeX Replacements**:
>   - **New category**: `html_entities` mapping common HTML entities (e.g., `&lt;`, `&gt;`, `&amp;`, quotes, `&nbsp;`, comparison and math operators, Greek letters, arrows, fractions) to LaTeX-safe output in `src/replacement/rules/htmlEntities.ts`.
>   - **Engine integration**: Register `HTML_ENTITY_REPLACEMENTS` in `NON_REGEX_CATEGORIES` and default-enabled list in `src/replacement/engine.ts`.
>   - **Rules export**: Export from `src/replacement/rules.ts`.
> - **Configuration**:
>   - Add `"html_entities"` to `texra.latex.enabledReplacements` enum and defaults in `package.json`.
> - **Tests**:
>   - Add `src/test/replacement/htmlEntities.test.ts` covering escaped XML tags to environments and common/extended entity decoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0261aebee2ad6323e304464cb3bfa51c41101835. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->