### PR TITLE
fix: rename workflow instructions header

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -106,7 +106,7 @@
             aria-hidden="true"
           >
             <div class="instruction-panel__header">
-              <span class="instruction-panel__title">Chat</span>
+              <span class="instruction-panel__title">Instructions</span>
               <vscode-toolbar-container class="instruction-panel__actions">
                 <vscode-toolbar-button
                   id="instructionCopyBtn"


### PR DESCRIPTION
## Summary
- update the workflow instruction panel header to read "Instructions" instead of "Chat"

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69028a8e9e388324b2d2c00fc531495b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the instruction panel header in `src/progressView/index.html` from "Chat" to "Instructions".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f7ef4b68d747144c9c8aa023068c4d42eec21d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->