### PR TITLE
fix: relax caption spacing normalization

### DIFF
--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -35,6 +35,49 @@ const convertFencedLatexBlock: ReplacementFunction = (
   return `${safeLeadingBreak}${safeIndent}\\begin{${safeEnvironment}}${newline}${emptyBodyPadding}${bodyWithTrailingBreak}${safeIndent}\\end{${safeEnvironment}}`;
 };
 
+const hasBalancedBraces = (value: string): boolean => {
+  let depth = 0;
+
+  for (const char of value) {
+    if (char === '{') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === '}') {
+      if (depth === 0) {
+        return false;
+      }
+
+      depth -= 1;
+    }
+  }
+
+  return depth === 0;
+};
+
+const createCaptionTrimmer = (
+  command: '\\caption' | '\\caption*',
+): ReplacementFunction => {
+  return (match, content) => {
+    if (typeof content !== 'string') {
+      return match;
+    }
+
+    if (!hasBalancedBraces(content) || /[\r\n]/.test(content)) {
+      return match;
+    }
+
+    const trimmed = content.replace(/^[\t ]+/, '').replace(/[\t ]+$/, '');
+
+    if (trimmed === content) {
+      return match;
+    }
+
+    return `${command}{${trimmed}}`;
+  };
+};
+
 // ===== Regex replacements =====
 
 export const FENCED_LATEX_BLOCK_REPLACEMENTS: ReplacementCategory = {
@@ -337,9 +380,9 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
     '\\\\underbrace\\{\\s+([^}]*)\\s+\\}': '\\underbrace{$1}',
     // Remove spaces inside label
     '\\\\label\\{\\s+([^}]*)\\s+\\}': '\\label{$1}',
-    // Remove spaces inside caption
-    '\\\\caption\\{[\\t ]+([^}]*)[\\t ]+\\}': '\\caption{$1}',
+    // Remove spaces inside caption (only horizontal whitespace, preserving newlines for multi-line captions)
+    '\\\\caption\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\}': createCaptionTrimmer('\\caption'),
     // Remove spaces inside caption*
-    '\\\\caption\\*\\{[\\t ]+([^}]*)[\\t ]+\\}': '\\caption*{$1}',
+    '\\\\caption\\*\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\}': createCaptionTrimmer('\\caption*'),
   },
 };

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -317,7 +317,7 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
       '$1\n\n$3',
 
     // Remove spaces inside formatting
-    '\\\\(?:textbf|textit|emph|underline|overbrace|underbrace|label|caption(?:\\*)?)\\{\\s+([^}]*)\\s+\\}':
+    '\\\\(?:textbf|textit|emph|underline|overbrace|underbrace|label)\\{\\s+([^}]*)\\s+\\}':
       '\\$1{$2}',
 
     // Fix space before closing braces in commands (nearly universal style)
@@ -338,8 +338,8 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
     // Remove spaces inside label
     '\\\\label\\{\\s+([^}]*)\\s+\\}': '\\label{$1}',
     // Remove spaces inside caption
-    '\\\\caption\\{\\s+([^}]*)\\s+\\}': '\\caption{$1}',
+    '\\\\caption\\{[\\t ]+([^}]*)[\\t ]+\\}': '\\caption{$1}',
     // Remove spaces inside caption*
-    '\\\\caption\\*\\{\\s+([^}]*)\\s+\\}': '\\caption*{$1}',
+    '\\\\caption\\*\\{[\\t ]+([^}]*)[\\t ]+\\}': '\\caption*{$1}',
   },
 };

--- a/src/test/replacement/captionSpacing.test.ts
+++ b/src/test/replacement/captionSpacing.test.ts
@@ -1,0 +1,69 @@
+import { strict as assert } from 'assert';
+
+import { applyReplacements } from '@replacement/engine';
+import { EQUATION_STYLE_REPLACEMENTS } from '@replacement/rulesRegex';
+
+describe('caption spacing normalization', () => {
+  it('trims tabs in single-line caption', () => {
+    const input = '\\caption{\tMy caption\t}';
+    const expected = '\\caption{My caption}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('trims spaces in single-line caption', () => {
+    const input = '\\caption{  My caption  }';
+    const expected = '\\caption{My caption}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('trims mixed spaces and tabs in single-line caption', () => {
+    const input = '\\caption{ \tMy caption\t }';
+    const expected = '\\caption{My caption}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('preserves multi-line captions', () => {
+    const input = ['\\caption{', '  This is a long caption', '  that spans multiple lines', '}'].join('\n');
+    const expected = input;
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('trims caption* variants', () => {
+    const input = '\\caption*{\tSpecial caption\t}';
+    const expected = '\\caption*{Special caption}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('preserves nested braces within captions', () => {
+    const input = '\\caption{  Text with {nested braces}  }';
+    const expected = '\\caption{Text with {nested braces}}';
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+
+  it('keeps captions with embedded newlines unchanged even with surrounding spaces', () => {
+    const input = ['\\caption{  ', '  First line', '  Second line', '  }'].join('\n');
+    const expected = input;
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+    assert.strictEqual(result, expected);
+  });
+});


### PR DESCRIPTION
## Summary
- stop the shared formatting regex from normalizing captions
- only trim spaces around captions when they are on a single line

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690290833abc8324ad7f29d59add5e27

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Trim spaces/tabs in single-line `\caption`/`\caption*` while preserving multi-line or unbalanced content; add targeted tests.
> 
> - **Replacement rules (`src/replacement/rulesRegex.ts`)**
>   - Add `hasBalancedBraces` and `createCaptionTrimmer` to safely trim caption content.
>   - Remove `caption` commands from generic spacing regex group.
>   - Replace caption patterns to use trimmer for `\caption{...}` and `\caption*{...}`, trimming only horizontal whitespace on single-line, balanced content; preserve multi-line/nested braces.
> - **Tests (`src/test/replacement/captionSpacing.test.ts`)**
>   - Add tests covering trimming tabs/spaces/mixed on single-line captions and `\caption*`.
>   - Verify preservation of multi-line captions and nested braces; unchanged when newlines present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8147df6bb47df46c805c16393921587d54ea4ba8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->