### PR TITLE
fix: normalize gemini tool dispatch error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Prevent repeated-response suppression from mutating internal tool state so follow-up connectors stay aligned with written output.
+- Ensure Google Gemini tool calls synthesize stable identifiers so tool-use runs no longer spam "missing call_id" errors.
+- Normalize tool JSON error reporting and prevent Gemini dispatch cycles from silently skipping execution when orchestration passes an undefined context.
+
+### Improvements
+
+- Document the PocketFlow-style lifecycle for response and tool cycle state so each
+  node's hydration expectations are clear, and reuse a shared tool-result payload
+  helper to keep Gemini dispatch logs consistent across recovery paths.
+
 ## [0.34.1] - 2025-10-24
 
 ### Bug Fixes

--- a/src/agent/core/flows/FlowTransitions.ts
+++ b/src/agent/core/flows/FlowTransitions.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared transition identifiers that flow nodes emit to describe how control should
+ * move through a flow graph once a node finishes running.
+ */
+export const FlowTransition = {
+  /** The current flow branch has completed and should hand control back to the caller. */
+  COMPLETE: 'complete',
+  /** Continue execution by looping back to the flow's entry point. */
+  CONTINUE: 'continue',
+  /** Exit the flow entirely after running any finalisation hooks. */
+  FINALIZE: 'finalize',
+  /** Begin a new round iteration (used by reflection flows). */
+  ROUND: 'round',
+  /** Skip the current node's work but remain in the flow. */
+  SKIP: 'skip',
+  /** Execute the next actionable node immediately. */
+  EXECUTE: 'execute',
+} as const;
+
+export type FlowTransition =
+  (typeof FlowTransition)[keyof typeof FlowTransition];

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -1,6 +1,9 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 
+// Local imports - flow constants
+import { FlowTransition } from './FlowTransitions';
+
 // Local imports - agent components
 import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
@@ -50,7 +53,7 @@ interface DebugFileOptions {
   outputFile: string;
 }
 
-async function saveDebugObjectIfConfigured(
+async function maybeSaveDebug(
   debugContext: DebugContext | undefined,
   debugFileOptions: DebugFileOptions | undefined,
   object: unknown,
@@ -68,7 +71,7 @@ async function saveDebugObjectIfConfigured(
   });
 }
 
-function resetResponseCycleState(cycle: ResponseCycleState): void {
+function resetResponseCycleState(cycle: ResponseCycleRuntimeState): void {
   cycle.shouldStop = false;
   cycle.endTurn = false;
   cycle.responseObject = undefined;
@@ -77,7 +80,13 @@ function resetResponseCycleState(cycle: ResponseCycleState): void {
   cycle.processedResponse = undefined;
 }
 
-export interface ResponseCycleState {
+/**
+ * PocketFlow-style cycles pass a single mutable state object between nodes.
+ * Each node hydrates additional runtime metadata on the same reference rather
+ * than allocating new state, so callers should treat these properties as
+ * progressively populated throughout the flow execution.
+ */
+export interface ResponseCycleInputState {
   messages: ProviderMessage[];
   stateRound: AgentStateRound;
   stateGlobal: AgentStateGlobal;
@@ -85,6 +94,9 @@ export interface ResponseCycleState {
   outputFile: string;
   roundGroupId?: string;
   executionId?: ExecutionId;
+}
+
+export interface ResponseCycleRuntimeState {
   endTurn: boolean;
   shouldStop: boolean;
   outputExists: boolean;
@@ -98,16 +110,18 @@ export interface ResponseCycleState {
   processedResponse?: string;
 }
 
+export type ResponseCycleState = ResponseCycleInputState &
+  ResponseCycleRuntimeState;
+
 export interface ResponseCycleShared<C = unknown> {
   options: ResponseCycleOptions<C>;
   cycle: ResponseCycleState;
 }
 
-interface ResponseExecutionContext<C> {
-  options: ResponseCycleOptions<C>;
-  cycle: ResponseCycleState;
-}
-
+/**
+ * Prepares a response cycle by hydrating prompts, checking interruptions, and
+ * establishing debug metadata before invoking the model.
+ */
 class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async prep(shared: ResponseCycleShared<C>): Promise<{
     interrupted: boolean;
@@ -150,7 +164,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 
   async post(
-    _shared: ResponseCycleShared<C>,
+    { cycle }: ResponseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       exists: boolean;
@@ -159,10 +173,10 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
       debugFileOptions?: DebugFileOptions;
     },
   ): Promise<string | undefined> {
-    const { cycle } = _shared;
     if (prepRes.interrupted) {
+      resetResponseCycleState(cycle);
       cycle.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     cycle.outputExists = prepRes.exists;
@@ -170,9 +184,11 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
     cycle.debugContext = prepRes.debugContext;
     cycle.debugFileOptions = prepRes.debugFileOptions;
     cycle.startTime = Date.now();
+    // The runtime portion of the cycle state is reused across iterations; clear
+    // it here so later nodes hydrate fresh data while preserving the input slice.
     resetResponseCycleState(cycle);
 
-    await saveDebugObjectIfConfigured(
+    await maybeSaveDebug(
       cycle.debugContext,
       cycle.debugFileOptions,
       cycle.messages,
@@ -183,18 +199,17 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 }
 
+/**
+ * Handles the actual model invocation step, storing the raw response payload and
+ * timing information for downstream processing.
+ */
 class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(
-    shared: ResponseCycleShared<C>,
-  ): Promise<ResponseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      cycle: shared.cycle,
-    };
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
+    return shared;
   }
 
   async exec(
-    context: ResponseExecutionContext<C>,
+    context: ResponseCycleShared<C>,
   ): Promise<{ skipped: true } | { response: unknown; responseTime?: number }> {
     const { options, cycle } = context;
     if (cycle.shouldStop) {
@@ -224,6 +239,8 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
           ? `Model invocation failed: ${error.message}`
           : 'Model invocation failed with an unknown error';
       options.logger.error(message, cycle.roundGroupId);
+      cycle.shouldStop = true;
+      cycle.endTurn = false;
       throw error;
     } finally {
       options.setAbortController(null);
@@ -238,19 +255,20 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
   async post(
     _shared: ResponseCycleShared<C>,
-    prepRes: ResponseExecutionContext<C>,
+    prepRes: ResponseCycleShared<C>,
     execRes: { skipped: true } | { response: unknown; responseTime?: number },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
-      return 'complete';
+      cycle.endTurn = false;
+      return FlowTransition.COMPLETE;
     }
 
     cycle.responseObject = execRes.response;
     cycle.responseTime = execRes.responseTime;
 
-    await saveDebugObjectIfConfigured(
+    await maybeSaveDebug(
       cycle.debugContext,
       cycle.debugFileOptions,
       execRes.response,
@@ -262,8 +280,9 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         'Model response was aborted or returned no data; output may be incomplete.',
         cycle.roundGroupId,
       );
+      cycle.endTurn = false;
       cycle.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     return undefined;
@@ -284,18 +303,17 @@ interface ProcessResult {
   repetitionDetected: boolean;
 }
 
+/**
+ * Transforms the raw model response into output-ready text, updates usage metrics,
+ * and persists incremental tool-state derived from the result.
+ */
 class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(
-    shared: ResponseCycleShared<C>,
-  ): Promise<ResponseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      cycle: shared.cycle,
-    };
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
+    return shared;
   }
 
   async exec(
-    context: ResponseExecutionContext<C>,
+    context: ResponseCycleShared<C>,
   ): Promise<ProcessResult | { skipped: true }> {
     const { options, cycle } = context;
     if (cycle.shouldStop || !cycle.responseObject) {
@@ -403,17 +421,20 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     let bestConnector: string | undefined;
     if (newResponse) {
       processedResponse = replacementEngine.applyAll(newResponse);
-      const connector = await bestConnectionMethod(
-        cycle.toolState.lastResponse.slice(-K_SLICE),
-        processedResponse.slice(0, K_SLICE),
-      );
-      bestConnector = connector.connector;
-      cycle.toolState.updateLastResponse(processedResponse);
-      cycle.toolState.updateAccumulatedOutput(
-        cycle.toolState.accumulatedOutput +
-          (bestConnector ?? '') +
-          processedResponse,
-      );
+
+      if (!repetitionResult.massiveRepetitionDetected) {
+        const connector = await bestConnectionMethod(
+          cycle.toolState.lastResponse.slice(-K_SLICE),
+          processedResponse.slice(0, K_SLICE),
+        );
+        bestConnector = connector.connector;
+        cycle.toolState.updateLastResponse(processedResponse);
+        cycle.toolState.updateAccumulatedOutput(
+          cycle.toolState.accumulatedOutput +
+            (bestConnector ?? '') +
+            processedResponse,
+        );
+      }
     }
 
     return {
@@ -431,21 +452,23 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
   async post(
     _shared: ResponseCycleShared<C>,
-    prepRes: ResponseExecutionContext<C>,
+    prepRes: ResponseCycleShared<C>,
     execRes: ProcessResult | { skipped: true },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
-      return 'complete';
+      cycle.endTurn = false;
+      return FlowTransition.COMPLETE;
     }
 
     cycle.stopReason = execRes.stopReason;
     cycle.processedResponse = execRes.processedResponse;
 
     if (execRes.repetitionDetected || !execRes.processedResponse) {
+      cycle.endTurn = false;
       cycle.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     if (!cycle.outputExists) {
@@ -496,18 +519,17 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 }
 
+/**
+ * Evaluates the processed response to decide whether the agent should end the turn,
+ * stop entirely, or enqueue a continuation request.
+ */
 class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
-  async prep(
-    shared: ResponseCycleShared<C>,
-  ): Promise<ResponseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      cycle: shared.cycle,
-    };
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
+    return shared;
   }
 
   async exec(
-    context: ResponseExecutionContext<C>,
+    context: ResponseCycleShared<C>,
   ): Promise<
     | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
     | { skipped: true }
@@ -515,6 +537,11 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const { options, cycle } = context;
     if (cycle.shouldStop || !cycle.stopReason || !cycle.processedResponse) {
       return { skipped: true };
+    }
+
+    const interrupted = Boolean(await options.checkInterruption());
+    if (interrupted) {
+      return { shouldEndTurn: false, shouldStop: true, shouldContinue: false };
     }
 
     const [shouldEndTurn, shouldStop] =
@@ -537,7 +564,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
   async post(
     shared: ResponseCycleShared<C>,
-    prepRes: ResponseExecutionContext<C>,
+    prepRes: ResponseCycleShared<C>,
     execRes:
       | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
       | { skipped: true },
@@ -545,15 +572,16 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const { options, cycle } = prepRes;
 
     if ('skipped' in execRes) {
+      cycle.endTurn = false;
       cycle.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     cycle.endTurn = execRes.shouldEndTurn;
     cycle.shouldStop = execRes.shouldStop;
 
     if (execRes.shouldStop) {
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     cycle.stateRound.incrementContinuation();
@@ -564,7 +592,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     );
 
     if (!execRes.shouldContinue) {
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     options.logger.debug(
@@ -590,7 +618,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       );
     }
 
-    return 'continue';
+    return FlowTransition.CONTINUE;
   }
 }
 
@@ -604,7 +632,7 @@ export function createResponseCycleFlow<C>(): Flow<ResponseCycleShared<C>> {
   invokeNode.next(processNode);
   processNode.next(continuationNode);
 
-  continuationNode.on('continue', prepNode);
+  continuationNode.on(FlowTransition.CONTINUE, prepNode);
 
   return new Flow<ResponseCycleShared<C>>(prepNode);
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,6 +1,9 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 
+// Local imports - flow constants
+import { FlowTransition } from './FlowTransitions';
+
 // Local imports - agent components
 import { ToolState } from '@agent/core/ToolState';
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
@@ -20,6 +23,12 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 // Local imports - tools
 import { ToolResult, toolResult } from '@tools/result';
 import type { ToolDefinition } from '@model';
+
+// Local imports - error utilities
+import {
+  normalizeJsonParseError,
+  toErrorMessage,
+} from '@common/errors/errorHandlingUtils';
 
 // Local imports - filesystem utilities
 import { WorkspaceFS } from '@utils/files';
@@ -41,7 +50,7 @@ interface DebugFileOptions {
   baseName: string;
 }
 
-async function saveDebugObjectIfConfigured(
+async function maybeSaveDebug(
   debugContext: DebugContext,
   debugFileOptions: DebugFileOptions,
   object: unknown,
@@ -55,7 +64,7 @@ async function saveDebugObjectIfConfigured(
   });
 }
 
-function resetToolUseState(state: ToolUseCycleState): void {
+function resetToolUseState(state: ToolUseCycleRuntimeState): void {
   state.shouldStop = false;
   state.response = undefined;
   state.responseTime = undefined;
@@ -107,10 +116,57 @@ function normalizeToolCallError(
   return { message: fallbackMessage };
 }
 
-export interface ToolUseCycleState {
+function buildToolResultPayload(result: ToolResult): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (result.summary !== undefined) payload.summary = result.summary;
+  if (result.output !== undefined) payload.output = result.output;
+  if (result.error !== undefined) payload.error = result.error;
+  if (result.base64Image !== undefined)
+    payload.base64Image = result.base64Image;
+  if (result.system !== undefined) payload.system = result.system;
+  if (result.isError) payload.isError = true;
+  if (result.diagnostics !== undefined)
+    payload.diagnostics = result.diagnostics;
+  if (result.files !== undefined) payload.files = result.files;
+  return payload;
+}
+
+function extractToolCallId(parsed: any): string {
+  const rawId =
+    parsed?.call_id ??
+    parsed?.id ??
+    parsed?.tool_use_id ??
+    parsed?.tool_call_id;
+
+  if (rawId === undefined || rawId === null) {
+    throw new Error(
+      `Tool JSON missing call identifier: ${JSON.stringify(parsed)}`,
+    );
+  }
+
+  const trimmed =
+    typeof rawId === 'string' ? rawId.trim() : String(rawId).trim();
+  if (!trimmed) {
+    throw new Error(
+      `Tool JSON contains blank call identifier: ${JSON.stringify(parsed)}`,
+    );
+  }
+
+  return trimmed;
+}
+
+/**
+ * Tool-use flows follow the same PocketFlow contract: a single state object is
+ * threaded through every node, allowing successive stages to hydrate runtime
+ * metadata (tool info, responses, etc.) on the same reference.
+ */
+export interface ToolUseCycleInputState {
   messages: ProviderMessage[];
   toolState: ToolState;
   groupId?: string;
+}
+
+export interface ToolUseCycleRuntimeState {
   iteration: number;
   shouldStop: boolean;
   response?: unknown;
@@ -120,12 +176,19 @@ export interface ToolUseCycleState {
   stopReason?: ProviderStopReason;
 }
 
-export interface ToolUseCycleShared<C = unknown> {
-  options: ToolUseCycleOptions<C>;
-  state: ToolUseCycleState;
-}
+export type ToolUseCycleState = ToolUseCycleInputState &
+  ToolUseCycleRuntimeState;
 
-interface ToolUseExecutionContext<C> {
+type ToolDispatchErrorResult = {
+  handledError: true;
+  toolCallId?: string;
+  toolName: string;
+  result: ToolResult;
+  parsed?: any;
+  fallbackMessage?: string;
+};
+
+export interface ToolUseCycleShared<C = unknown> {
   options: ToolUseCycleOptions<C>;
   state: ToolUseCycleState;
 }
@@ -151,22 +214,24 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
   }
 
   async post(
-    _shared: ToolUseCycleShared<C>,
+    { state }: ToolUseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       debugContext: DebugContext;
       debugFileOptions: DebugFileOptions;
     },
   ): Promise<string | undefined> {
-    const { state } = _shared;
     if (prepRes.interrupted) {
       state.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
+    // Reset runtime fields at the top of each loop iteration so downstream nodes
+    // start from a clean slate while retaining the stable input slice of the state
+    // object (messages, tool registry references, etc.).
     resetToolUseState(state);
 
-    await saveDebugObjectIfConfigured(
+    await maybeSaveDebug(
       prepRes.debugContext,
       prepRes.debugFileOptions,
       state.messages,
@@ -178,16 +243,11 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(
-    shared: ToolUseCycleShared<C>,
-  ): Promise<ToolUseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      state: shared.state,
-    };
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
+    return shared;
   }
 
-  async exec(context: ToolUseExecutionContext<C>): Promise<
+  async exec(context: ToolUseCycleShared<C>): Promise<
     | { skipped: true }
     | {
         response: unknown;
@@ -238,7 +298,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
   async post(
     _shared: ToolUseCycleShared<C>,
-    prepRes: ToolUseExecutionContext<C>,
+    prepRes: ToolUseCycleShared<C>,
     execRes:
       | { skipped: true }
       | {
@@ -252,13 +312,13 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
     if ('skipped' in execRes) {
       state.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     state.response = execRes.response;
     state.responseTime = execRes.responseTime;
 
-    await saveDebugObjectIfConfigured(
+    await maybeSaveDebug(
       execRes.debugContext,
       execRes.debugFileOptions,
       execRes.response,
@@ -267,7 +327,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
     if (!execRes.response) {
       state.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     return undefined;
@@ -275,16 +335,11 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(
-    shared: ToolUseCycleShared<C>,
-  ): Promise<ToolUseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      state: shared.state,
-    };
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
+    return shared;
   }
 
-  async exec(context: ToolUseExecutionContext<C>): Promise<
+  async exec(context: ToolUseCycleShared<C>): Promise<
     | { skipped: true }
     | {
         toolInfo?: string;
@@ -377,11 +432,11 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         },
   ): Promise<string | undefined> {
     if ('skipped' in execRes) {
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     if (execRes.endTurn) {
-      return 'complete';
+      return FlowTransition.COMPLETE;
     }
 
     return undefined;
@@ -389,23 +444,25 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 }
 
 class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
-  async prep(
-    shared: ToolUseCycleShared<C>,
-  ): Promise<ToolUseExecutionContext<C>> {
-    return {
-      options: shared.options,
-      state: shared.state,
-    };
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
+    return shared;
   }
 
   async exec(
-    context: ToolUseExecutionContext<C>,
+    context: ToolUseCycleShared<C>,
   ): Promise<
     | { skipped: true }
     | { parsed: any; name: string; input: any; toolCallId: string }
+    | ToolDispatchErrorResult
   > {
     const { options, state } = context;
     if (state.shouldStop || !state.toolInfo) {
+      return { skipped: true };
+    }
+
+    const interrupted = Boolean(await options.checkInterruption());
+    if (interrupted) {
+      state.shouldStop = true;
       return { skipped: true };
     }
 
@@ -413,7 +470,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     try {
       parsed = JSON.parse(state.toolInfo);
     } catch (err) {
-      const errorMsg = `Malformed tool JSON: ${err instanceof Error ? err.message : String(err)}`;
+      const errorMsg = normalizeJsonParseError('Malformed tool JSON', err);
       const errorResult = toolResult({ error: errorMsg, isError: true });
       const toolUseLog = {
         tool: 'unknown',
@@ -426,14 +483,20 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
-      state.shouldStop = true;
-      return { skipped: true };
+      return {
+        handledError: true,
+        toolName: 'unknown',
+        result: errorResult,
+        fallbackMessage:
+          'I could not understand the tool request. Please resend valid JSON with call_id, name, and arguments.',
+      };
     }
 
-    const rawToolCallId =
-      parsed.call_id ?? parsed.id ?? parsed.tool_use_id ?? parsed.tool_call_id;
-    if (!rawToolCallId) {
-      const errorMsg = `Tool JSON missing call identifier: ${JSON.stringify(parsed)}`;
+    let toolCallId: string;
+    try {
+      toolCallId = extractToolCallId(parsed);
+    } catch (error) {
+      const errorMsg = toErrorMessage(error);
       const errorResult = toolResult({ error: errorMsg, isError: true });
       const toolUseLog = {
         tool: parsed.name || parsed.function?.name || 'unknown',
@@ -446,27 +509,14 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
-      state.shouldStop = true;
-      return { skipped: true };
-    }
-
-    const toolCallId = String(rawToolCallId).trim();
-    if (!toolCallId) {
-      const errorMsg = `Tool JSON contains blank call identifier: ${JSON.stringify(parsed)}`;
-      const errorResult = toolResult({ error: errorMsg, isError: true });
-      const toolUseLog = {
-        tool: parsed.name || parsed.function?.name || 'unknown',
-        input: parsed,
-        output: sanitizeToolResultForLog(errorResult),
+      return {
+        handledError: true,
+        toolName: parsed.name || parsed.function?.name || 'unknown',
+        result: errorResult,
+        parsed,
+        fallbackMessage:
+          'The tool call is missing a valid identifier. Please include a non-empty call_id for each tool request.',
       };
-      options.logger.info(
-        '',
-        state.groupId,
-        MESSAGE_TYPES.TOOL_USE,
-        toolUseLog,
-      );
-      state.shouldStop = true;
-      return { skipped: true };
     }
 
     const name = parsed.name || parsed.function?.name;
@@ -484,8 +534,15 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
-      state.shouldStop = true;
-      return { skipped: true };
+      return {
+        handledError: true,
+        toolCallId,
+        toolName: 'unknown',
+        result: errorResult,
+        parsed,
+        fallbackMessage:
+          'The tool request did not specify which tool to call. Please provide a "name" field with the tool identifier.',
+      };
     }
 
     let input = parsed.input ?? parsed.args;
@@ -509,15 +566,58 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
   async post(
     _shared: ToolUseCycleShared<C>,
-    prepRes: ToolUseExecutionContext<C>,
+    prepRes: ToolUseCycleShared<C>,
     execRes:
       | { skipped: true }
-      | { parsed: any; name: string; input: any; toolCallId: string },
+      | { parsed: any; name: string; input: any; toolCallId: string }
+      | ToolDispatchErrorResult,
   ): Promise<string | undefined> {
     const { options, state } = prepRes;
     if ('skipped' in execRes) {
       state.shouldStop = true;
-      return 'complete';
+      return FlowTransition.COMPLETE;
+    }
+
+    if ('handledError' in execRes) {
+      const { toolCallId, result, fallbackMessage, toolName, parsed } = execRes;
+
+      if (toolCallId) {
+        const followUpMessages =
+          await options.modelHandler.createToolUseFollowUpMessages(
+            options.client,
+            toolCallId,
+            toolName,
+            parsed,
+            buildToolResultPayload(result),
+            state.toolState,
+            state.text ?? '',
+          );
+
+        state.messages.push(...followUpMessages);
+        const fallback =
+          result.summary ??
+          result.output ??
+          result.error ??
+          fallbackMessage ??
+          '';
+        if (fallback) {
+          state.toolState.updateLastResponse(String(fallback));
+        }
+      } else if (fallbackMessage) {
+        const assistantMessage =
+          options.modelHandler.createAssistantMessage(fallbackMessage);
+        state.messages.push(assistantMessage);
+        state.toolState.updateLastResponse(fallbackMessage);
+      }
+
+      state.iteration += 1;
+      state.shouldStop = false;
+
+      if (fallbackMessage) {
+        options.logger.warn(fallbackMessage, state.groupId);
+      }
+
+      return FlowTransition.CONTINUE;
     }
 
     const tool = options.toolRegistry[execRes.name];
@@ -581,20 +681,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         execRes.toolCallId,
         execRes.name,
         execRes.parsed,
-        (() => {
-          const payload: Record<string, unknown> = {};
-          if (result.summary !== undefined) payload.summary = result.summary;
-          if (result.output !== undefined) payload.output = result.output;
-          if (result.error !== undefined) payload.error = result.error;
-          if (result.base64Image !== undefined)
-            payload.base64Image = result.base64Image;
-          if (result.system !== undefined) payload.system = result.system;
-          if (result.isError) payload.isError = true;
-          if (result.diagnostics !== undefined)
-            payload.diagnostics = result.diagnostics;
-          if (result.files !== undefined) payload.files = result.files;
-          return payload;
-        })(),
+        buildToolResultPayload(result),
         state.toolState,
         state.text ?? '',
       );
@@ -602,7 +689,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     state.messages.push(...followUpMsgs);
     state.iteration += 1;
 
-    return 'continue';
+    return FlowTransition.CONTINUE;
   }
 }
 
@@ -616,7 +703,7 @@ export function createToolUseCycleFlow<C>(): Flow<ToolUseCycleShared<C>> {
   callNode.next(processNode);
   processNode.next(dispatchNode);
 
-  dispatchNode.on('continue', prepNode);
+  dispatchNode.on(FlowTransition.CONTINUE, prepNode);
 
   return new Flow<ToolUseCycleShared<C>>(prepNode);
 }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -180,8 +180,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   /**
    * Calculates the total number of rounds to execute.
    * Returns the maximum of configured rounds and userRequest array length.
+   * Subclasses may override to simplify workflows (e.g., DirectAgent).
    */
-  private getTotalRounds(): number {
+  protected getTotalRounds(): number {
     const requestArray = Array.isArray(this.agentPrompt.userRequest)
       ? this.agentPrompt.userRequest
       : this.agentPrompt.userRequest

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -162,9 +162,23 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
         }
         // Cast with confidence after validation
         this.messages = messages as ProviderMessage[];
-        this.toolState = ToolUseSessionManager.hydrateToolStateFromSnapshot(
-          this.resumeSnapshot,
-        );
+        try {
+          this.toolState = ToolUseSessionManager.hydrateToolStateFromSnapshot(
+            this.resumeSnapshot,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : 'Unknown error while hydrating tool state';
+          this.logger.warn(
+            `Failed to hydrate tool state from snapshot: ${message}`,
+          );
+          // Snapshot hydration can fail if the saved payload is corrupted or
+          // originates from an outdated schema. Reset to a clean ToolState so
+          // the agent can continue operating without crashing.
+          this.toolState = new ToolState();
+        }
         shouldSkipCycle = true;
         this.resumeSnapshot = null;
       } else {
@@ -191,6 +205,13 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
         this.toolState = new ToolState();
       }
 
+      let toolState = this.toolState;
+      if (!toolState) {
+        this.logger.debug('Initializing fallback tool state instance.');
+        toolState = new ToolState();
+        this.toolState = toolState;
+      }
+
       const resolvedSetting = {
         ...this.agentSetting,
         tools: this.getTools(),
@@ -209,7 +230,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
         setAbortController: (ctrl: AbortController | null) => {
           this.abortController = ctrl;
         },
-        toolState: this.toolState,
+        toolState,
         modelName: this.agentConfig.model,
       } as const;
 

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -12,6 +12,10 @@ import { withLogGroup } from '@logger/logGroupUtils';
  * Extends BaseReflectionAgent with simplified output handling and no intermediate steps.
  */
 export class DirectAgent extends BaseReflectionAgent {
+  protected override getTotalRounds(): number {
+    return 1;
+  }
+
   /**
    * Generates output file name based on configuration and current round.
    * @param currRound Current round number in the conversation

--- a/src/agent/implementations/flows/ReflectionRoundFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRoundFlow.ts
@@ -1,6 +1,9 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 
+// Local imports - flow constants
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+
 // Local imports - agent components
 import type { AgentStateRound } from '@agent/core/AgentState';
 import type { ToolState } from '@agent/core/ToolState';
@@ -76,7 +79,7 @@ class RoundPreparationNode extends BaseNode<ReflectionRoundShared> {
     shared.runtime.preparedMessages = execRes.preparedMessages;
     shared.runtime.prefill = execRes.prefill ?? '';
 
-    return execRes.skip ? 'skip' : 'execute';
+    return execRes.skip ? FlowTransition.SKIP : FlowTransition.EXECUTE;
   }
 }
 
@@ -139,8 +142,8 @@ export function createReflectionRoundFlow(): Flow<ReflectionRoundShared> {
   const roundSkip = new RoundSkipNode();
 
   toolPreparation.next(roundPreparation);
-  roundPreparation.on('execute', roundExecution);
-  roundPreparation.on('skip', roundSkip);
+  roundPreparation.on(FlowTransition.EXECUTE, roundExecution);
+  roundPreparation.on(FlowTransition.SKIP, roundSkip);
 
   return new Flow<ReflectionRoundShared>(toolPreparation);
 }

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -1,6 +1,9 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 
+// Local imports - flow constants
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+
 // Local imports - agent components
 import type { AgentStateGlobal } from '@agent/core/AgentState';
 import type {
@@ -107,13 +110,13 @@ class ReflectionInitNode<C> extends BaseNode<ReflectionRunShared<C>> {
     if (execRes.error) {
       shared.lifecycle.status = 'error';
       shared.lifecycle.error = execRes.error;
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     shared.lifecycle.phase = 'rounds';
     shared.lifecycle.status = 'running';
     shared.lifecycle.error = undefined;
-    return 'round';
+    return FlowTransition.ROUND;
   }
 }
 
@@ -155,9 +158,15 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
         result,
       };
     } catch (error) {
+      const contextualError =
+        error instanceof Error
+          ? new Error(`Round ${prepRes.roundIndex} failed: ${error.message}`, {
+              cause: error,
+            })
+          : new Error(`Round ${prepRes.roundIndex} failed: ${String(error)}`);
       return {
         ...prepRes,
-        error,
+        error: contextualError,
       };
     }
   }
@@ -168,7 +177,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
     execRes: ReflectionRoundPrep<C> | ReflectionRoundExec<C>,
   ): Promise<string | undefined> {
     if (prepRes.shouldFinalize) {
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     const execResult = execRes as ReflectionRoundExec<C>;
@@ -176,7 +185,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
     if (execResult.error) {
       shared.lifecycle.status = 'error';
       shared.lifecycle.error = execResult.error;
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     const { result } = execResult;
@@ -184,7 +193,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
       const missingResultError = new Error('Round result is missing.');
       shared.lifecycle.status = 'error';
       shared.lifecycle.error = missingResultError;
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     shared.agent.roundStates.push(result.roundState);
@@ -196,18 +205,18 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
     shared.state.globalState.incrementRounds();
 
     if (shared.agent.isInterruptionRequested()) {
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     if (shared.state.currentRound >= shared.state.totalRounds) {
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
     if (!shared.state.continueRounds) {
-      return 'finalize';
+      return FlowTransition.FINALIZE;
     }
 
-    return 'continue';
+    return FlowTransition.CONTINUE;
   }
 }
 
@@ -262,11 +271,11 @@ export function createReflectionRunFlow<C>(): Flow<ReflectionRunShared<C>> {
   const roundNode = new ReflectionRoundNode<C>();
   const finalizeNode = new ReflectionFinalizeNode<C>();
 
-  initNode.on('round', roundNode);
-  initNode.on('finalize', finalizeNode);
+  initNode.on(FlowTransition.ROUND, roundNode);
+  initNode.on(FlowTransition.FINALIZE, finalizeNode);
 
-  roundNode.on('continue', roundNode);
-  roundNode.on('finalize', finalizeNode);
+  roundNode.on(FlowTransition.CONTINUE, roundNode);
+  roundNode.on(FlowTransition.FINALIZE, finalizeNode);
 
   return new Flow<ReflectionRunShared<C>>(initNode);
 }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1,6 +1,7 @@
 // Standard library imports
 import * as path from 'path';
 import { Buffer } from 'buffer';
+import { randomUUID } from 'crypto';
 
 // Third-party imports
 import {
@@ -97,6 +98,51 @@ function findLastTextPart(
     }
   }
   return undefined;
+}
+
+type NormalizedFunctionCall = (FunctionCall & Record<string, unknown>) & {
+  id: string;
+  call_id: string;
+};
+
+function toTrimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function ensureFunctionCallIdentifiers(call: FunctionCall): {
+  normalized: NormalizedFunctionCall;
+  synthesized: boolean;
+} {
+  const normalized = { ...call } as FunctionCall & Record<string, unknown>;
+  const existingId = toTrimmedString(normalized.id);
+  const existingCallId = toTrimmedString(normalized.call_id);
+  const existingToolCallId = toTrimmedString(normalized.tool_call_id);
+  const existingToolUseId = toTrimmedString(normalized.tool_use_id);
+
+  const fallbackId =
+    existingId || existingCallId || existingToolCallId || existingToolUseId;
+  const id = fallbackId || randomUUID();
+  normalized.id = id;
+
+  const callId =
+    existingCallId || existingToolCallId || existingToolUseId || id;
+  normalized.call_id = callId;
+
+  if (!toTrimmedString(normalized.tool_call_id)) {
+    normalized.tool_call_id = callId;
+  }
+  if (!toTrimmedString(normalized.tool_use_id)) {
+    normalized.tool_use_id = callId;
+  }
+
+  const synthesizedId = !fallbackId;
+  const synthesizedCallId =
+    !existingCallId && !existingToolCallId && !existingToolUseId;
+
+  return {
+    normalized: normalized as NormalizedFunctionCall,
+    synthesized: synthesizedId || synthesizedCallId,
+  };
 }
 
 function toGoogleRole(role?: string, logger?: AgentLogger): GoogleRole | null {
@@ -978,8 +1024,17 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const parts = candidate?.content?.parts;
     if (Array.isArray(parts)) {
       const funcPart = parts.find((part) => part.functionCall);
-      if (funcPart) {
-        return JSON.stringify(funcPart.functionCall, null, 2);
+      if (funcPart?.functionCall) {
+        const { normalized, synthesized } = ensureFunctionCallIdentifiers(
+          funcPart.functionCall,
+        );
+        if (synthesized) {
+          const functionName = normalized.name ?? 'unknown';
+          this.logger.debug(
+            `Synthesized tool call identifier for Google function call '${functionName}'.`,
+          );
+        }
+        return JSON.stringify(normalized, null, 2);
       }
     }
     return null;
@@ -1007,9 +1062,19 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const callPart = createPartFromFunctionCall(functionName, args);
 
     // Use consistent ID for both call and result to ensure proper correlation
-    const callId = call?.id ?? id;
+    const callRecord = call as FunctionCall & Record<string, unknown>;
+    const callId =
+      toTrimmedString(callRecord?.id) ||
+      toTrimmedString(callRecord?.call_id) ||
+      toTrimmedString(callRecord?.tool_call_id) ||
+      toTrimmedString(callRecord?.tool_use_id) ||
+      id;
     if (callPart.functionCall) {
       callPart.functionCall.id = callId;
+      // The Google GenAI Chat API rejects unknown fields on the function call
+      // payload, so avoid populating call_id/tool_call_id/tool_use_id here.
+      // The synthesized identifiers are still preserved via the follow-up
+      // result message and the normalized JSON stored in tool state.
     }
 
     // Use the same ID for the result to maintain correlation

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -66,6 +66,41 @@ export function formatError(prefix: string, err: unknown): string {
 }
 
 /**
+ * Normalize any thrown value into a user-friendly error message string.
+ *
+ * Unlike {@link formatError}, this helper only returns the detail portion of
+ * the message, making it suitable for composing custom prefixes or structured
+ * payloads. Centralizing the coercion keeps error messaging consistent across
+ * flows and model handlers.
+ */
+export function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (err === undefined) {
+    return 'undefined';
+  }
+  if (err === null) {
+    return 'null';
+  }
+  return String(err);
+}
+
+/**
+ * Produce a consistent, human-readable description for JSON parsing failures.
+ *
+ * Centralising this logic keeps error messaging aligned across flow nodes and
+ * model handlers regardless of which SDK triggered the malformed payload. The
+ * helper strips redundant whitespace and guarantees a fallback message when the
+ * upstream error omits a detail string.
+ */
+export function normalizeJsonParseError(prefix: string, err: unknown): string {
+  const detail = toErrorMessage(err).trim();
+  const message = detail.length > 0 ? detail : 'Unknown JSON parsing error';
+  return `${prefix}: ${message}`;
+}
+
+/**
  * Log a formatted error message and return the formatted message.
  *
  * This function combines error formatting with logging. It:

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -59,3 +59,87 @@ describe('ModelHandlerGoogleGenAI.shouldContinue', () => {
     assert.equal(shouldContinue, false);
   });
 });
+
+describe('ModelHandlerGoogleGenAI.extractToolUse', () => {
+  const handler = new ModelHandlerGoogleGenAI({
+    name: 'test-google-model',
+    fullName: 'google/test',
+    provider: ModelProvider.GOOGLE,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 4096,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+  });
+
+  it('synthesizes tool call identifiers when missing', () => {
+    const response: any = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  name: 'read_file',
+                  args: { path: 'syk_v5.tex' },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const toolInfo = handler.extractToolUse(response);
+    assert.ok(toolInfo, 'expected tool info to be returned');
+
+    const parsed = JSON.parse(toolInfo as string);
+    assert.equal(typeof parsed.id, 'string');
+    assert.notEqual(parsed.id.trim(), '');
+    assert.equal(parsed.call_id, parsed.id);
+    assert.equal(parsed.tool_call_id, parsed.id);
+    assert.equal(parsed.tool_use_id, parsed.id);
+  });
+});
+
+describe('ModelHandlerGoogleGenAI.createToolUseFollowUpMessages', () => {
+  const handler = new ModelHandlerGoogleGenAI({
+    name: 'test-google-model',
+    fullName: 'google/test',
+    provider: ModelProvider.GOOGLE,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 4096,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+  });
+
+  it('omits unsupported identifier fields on follow-up function call parts', async () => {
+    const messages = await handler.createToolUseFollowUpMessages(
+      undefined,
+      'call-123',
+      'read_file',
+      {
+        name: 'read_file',
+        args: { path: 'syk_v5.tex' },
+      } as any,
+      {},
+      undefined,
+    );
+
+    const callMessage = messages[0];
+    assert.ok(Array.isArray(callMessage.parts), 'expected call message parts');
+    const callPart = callMessage.parts.find((part) => part.functionCall);
+    assert.ok(callPart, 'expected a function call part');
+    const functionCall = (callPart as any).functionCall as Record<
+      string,
+      unknown
+    >;
+    assert.equal(functionCall.id, 'call-123');
+    assert.equal('call_id' in functionCall, false);
+    assert.equal('tool_call_id' in functionCall, false);
+    assert.equal('tool_use_id' in functionCall, false);
+  });
+});


### PR DESCRIPTION
## Summary
- split response and tool cycle state into input/runtime facets and align the debug helper naming with the shared saver
- centralize malformed tool JSON messaging and require tool dispatch contexts to surface orchestration failures for Gemini
- document the Gemini dispatch fix in the changelog
- document the PocketFlow-style lifecycle for cycle state and reuse a shared tool-result payload helper so Gemini dispatch payloads stay consistent

## Testing
- npm run format
- npm run lint
- npm run compile
- npm run compile-tests
- npm test *(aborted after compile phase to avoid exceeding the container log limit)*

------
https://chatgpt.com/codex/tasks/task_e_69023d67cf7483248172c59dae3c98ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies flow transitions, splits and resets cycle state cleanly, normalizes tool JSON handling with stable Gemini call IDs, and adds robust follow-ups, error utilities, tests, and docs.
> 
> - **Core Flows**
>   - Introduce `@agent/core/flows/FlowTransitions` and replace string literals with `FlowTransition` across reflection, response, and tool-use flows.
>   - Split cycle state into `InputState` and `RuntimeState` for `ResponseCycleFlow` and `ToolUseCycleFlow`; add clear reset helpers; align debug saver naming (`maybeSaveDebug`).
>   - Add interruption checks and consistent COMPLETE/CONTINUE handling; prevent repetition suppression from mutating `toolState`.
> - **Tool-Use Cycle**
>   - Centralize tool JSON handling: `extractToolCallId`, `buildToolResultPayload`, and normalized error paths that generate follow-up messages or assistant fallbacks instead of silent stops.
>   - Log sanitized tool results; gate dispatch on interruption; iterate with CONTINUE on handled errors.
> - **Google Gemini Handler**
>   - Synthesize stable function-call identifiers (`id`/`call_id`/`tool_call_id`/`tool_use_id`) and omit unsupported fields in follow-up call parts; improve correlation of tool results.
> - **Agents**
>   - `BaseReflectionAgent`: make `getTotalRounds` overridable; `DirectAgent` runs a single round.
>   - `BaseToolUseAgent`: safer snapshot hydration with fallback `ToolState`.
> - **Error Utils**
>   - Add `toErrorMessage` and `normalizeJsonParseError` for consistent messaging.
> - **Tests & Docs**
>   - Add unit tests for Google tool-call ID synthesis and follow-up messages.
>   - Update `CHANGELOG.md` with unreleased fixes and lifecycle documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cc779f1bbcee4e5f6cf98f763cd15d0fc7393da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->