### PR TITLE
Normalize blank lines around math environments

### DIFF
--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -5,6 +5,9 @@ import {
   FENCED_LATEX_BLOCK_PATTERN_MULTILINE,
 } from './constants';
 
+const EQUATION_ENVIRONMENT_PATTERN =
+  '(?:align\\*?|aligned\\*?|alignat\\*?|gather\\*?|multline\\*?|equation\\*?)';
+
 const convertFencedLatexBlock: ReplacementFunction = (
   match,
   leadingBreak,
@@ -273,6 +276,10 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
   isRegex: true,
   flags: 'g',
   patterns: {
+    // Collapse repeated blank lines after \begin for common equation environments
+    [String.raw`([ \t]*\\begin{${EQUATION_ENVIRONMENT_PATTERN}}[ \t]*\r?\n)(?:[ \t]*\r?\n)+`]: '$1',
+    // Collapse repeated blank lines before \end for common equation environments
+    [String.raw`([ \t]*\r?\n)(?:[ \t]*\r?\n)+([ \t]*\\end{${EQUATION_ENVIRONMENT_PATTERN}})`]: '$1$2',
     // Swap order of superscript and subscript in integrals/sums/products to ensure subscript comes first
     // Example: \int^{x}_{t} -> \int_{t}^{x}
     '(\\\\int|\\\\sum|\\\\prod)\\^\\{([^{}]+|\\{[^{}]*\\})\\}_\\{([^{}]+|\\{[^{}]*\\})\\}':

--- a/src/test/replacement/equationEnvironmentBlankLines.test.ts
+++ b/src/test/replacement/equationEnvironmentBlankLines.test.ts
@@ -1,0 +1,52 @@
+import { strict as assert } from 'assert';
+
+import { applyReplacements } from '@replacement/engine';
+import { EQUATION_STYLE_REPLACEMENTS } from '@replacement/rulesRegex';
+
+function normalize(input: string): string {
+  return applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+    processMathUnicode: false,
+  });
+}
+
+describe('EQUATION_STYLE_REPLACEMENTS - blank line normalization', () => {
+  it('collapses extra blank lines after equation begins', () => {
+    const environments = [
+      'align',
+      'align*',
+      'aligned',
+      'aligned*',
+      'alignat',
+      'alignat*',
+      'gather',
+      'gather*',
+      'multline',
+      'multline*',
+      'equation',
+      'equation*',
+    ];
+
+    for (const env of environments) {
+      const input = String.raw`\begin{${env}}\n\n\nbody\n\end{${env}}`;
+      const expected = String.raw`\begin{${env}}\nbody\n\end{${env}}`;
+      assert.strictEqual(normalize(input), expected, `Failed for ${env}`);
+    }
+  });
+
+  it('collapses extra blank lines before equation ends', () => {
+    const input = String.raw`\begin{gather}\nbody\n\n\n\end{gather}`;
+    const expected = String.raw`\begin{gather}\nbody\n\end{gather}`;
+    assert.strictEqual(normalize(input), expected);
+  });
+
+  it('preserves indentation and CRLF line endings', () => {
+    const input = String.raw`  \begin{aligned}\r\n\r\n\r\n  content\r\n\r\n  \end{aligned}`;
+    const expected = String.raw`  \begin{aligned}\r\n  content\r\n  \end{aligned}`;
+    assert.strictEqual(normalize(input), expected);
+  });
+
+  it('leaves single blank lines untouched', () => {
+    const input = String.raw`\begin{equation}\n\nx\n\n\end{equation}`;
+    assert.strictEqual(normalize(input), input);
+  });
+});


### PR DESCRIPTION
## Summary
- collapse repeated blank lines immediately after `\begin{…}` and before `\end{…}` for common math environments in the regex replacement suite
- add regression coverage ensuring the new normalization works for multiple environments and CRLF line endings

## Testing
- `npm test` *(hangs during `vscode-test`; terminated after ~7 minutes without completing)*

------
https://chatgpt.com/codex/tasks/task_e_69028bb92b388324a67ca5903a76c455

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize repeated blank lines around common LaTeX equation environments and add targeted tests for behavior and CRLF handling.
> 
> - **Replacement rules (`src/replacement/rulesRegex.ts`)**:
>   - Add `EQUATION_ENVIRONMENT_PATTERN` for common math environments.
>   - In `EQUATION_STYLE_REPLACEMENTS`, add regexes to collapse repeated blank lines:
>     - After `\begin{...}` lines.
>     - Before `\end{...}` lines.
> - **Tests (`src/test/replacement/equationEnvironmentBlankLines.test.ts`)**:
>   - Add coverage across multiple environments, verify CRLF handling and indentation preservation, and ensure single blank lines remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 332f7a8f33ba67740727606effc6c0faf25a7537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->