### PR TITLE
Normalize equation environment linebreaks

### DIFF
--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -5,6 +5,9 @@ import {
   FENCED_LATEX_BLOCK_PATTERN_MULTILINE,
 } from './constants';
 
+const EQUATION_ENVIRONMENT_PATTERN =
+  '(?:align\\*?|aligned\\*?|alignat\\*?|flalign\\*?|gather\\*?|multline\\*?|equation\\*?|split\\*?)';
+
 const convertFencedLatexBlock: ReplacementFunction = (
   match,
   leadingBreak,
@@ -311,6 +314,14 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
     '(\\\\(?:cre[f]|re[f]|eqre[f])\\{[^{}]*?)\\\\(_)': '$1$2',
     // Pass 5: Using redundant grouping
     '(\\\\(?:(?:cref)|(?:ref)|(?:eqref))\\{[^{}]*?)\\\\(_)': '$1$2',
+
+    // Normalize blank lines immediately after equation environments begin
+    [`\\\\begin\\{(${EQUATION_ENVIRONMENT_PATTERN})\\}([ \t]*\\r?\\n)(?:[ \t]*\\r?\\n)+`]:
+      '\\begin{$1}$2',
+
+    // Normalize blank lines immediately before equation environments end
+    [`(\\r?\\n)(?:[ \t]*\\r?\\n)+([ \t]*\\\\end\\{(${EQUATION_ENVIRONMENT_PATTERN})\\})`]:
+      '$1$2',
 
     // Fix inconsistent blank lines after environments (universally preferred)
     '(\\\\end\\{(equation|align|figure|table|itemize|enumerate|description)\\})([A-Za-z])':

--- a/src/test/replacement/equationLinebreaks.test.ts
+++ b/src/test/replacement/equationLinebreaks.test.ts
@@ -1,0 +1,56 @@
+import { strict as assert } from 'assert';
+
+import { applyReplacements } from '@replacement/engine';
+import { EQUATION_STYLE_REPLACEMENTS } from '@replacement/rulesRegex';
+
+describe('equation environment linebreak normalization', () => {
+  it('collapses multiple blank lines after equation begins', () => {
+    const input = ['\\begin{align}', '', '', '  x &= y', '\\end{align}'].join(
+      '\n',
+    );
+    const expected = ['\\begin{align}', '  x &= y', '\\end{align}'].join('\n');
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+
+    assert.strictEqual(result, expected);
+  });
+
+  it('collapses multiple blank lines before equation ends', () => {
+    const input = [
+      '\\begin{gather}',
+      '  y = z',
+      '',
+      '',
+      '    \\end{gather}',
+    ].join('\n');
+    const expected = ['\\begin{gather}', '  y = z', '    \\end{gather}'].join(
+      '\n',
+    );
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+
+    assert.strictEqual(result, expected);
+  });
+
+  it('handles Windows newlines for starred environments', () => {
+    const input = [
+      '\\begin{equation*}',
+      '',
+      '',
+      'a = b',
+      '',
+      '',
+      '\\end{equation*}',
+    ].join('\r\n');
+    const expected = ['\\begin{equation*}', 'a = b', '\\end{equation*}'].join(
+      '\r\n',
+    );
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+
+    assert.strictEqual(result, expected);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a reusable equation-environment pattern for regex rules
- collapse redundant blank lines immediately after \begin{...} and before \end{...} across equation-style environments
- cover the normalization with a focused unit test exercising align, gather, and starred equation cases

## Testing
- npm run format
- npm run lint
- npm run compile-tests
- node - <<'NODE' …

------
https://chatgpt.com/codex/tasks/task_e_69028bb92b388324a67ca5903a76c455

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Collapses redundant blank lines around LaTeX equation environments via new regex pattern and adds focused tests.
> 
> - **Regex rules (`src/replacement/rulesRegex.ts`)**:
>   - Introduce reusable `EQUATION_ENVIRONMENT_PATTERN` for equation-style environments.
>   - Add normalization to collapse multiple blank lines:
>     - Immediately after `\begin{...}` → keep a single newline.
>     - Immediately before `\end{...}` → keep a single newline.
> - **Tests (`src/test/replacement/equationLinebreaks.test.ts`)**:
>   - Add unit tests covering `align`, `gather`, and starred `equation*`, including Windows newlines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d519366260c815c591e97a92d64d2eb506aa580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->