### PR TITLE
fix: prevent tool-use sessions from using multi-output pipeline

### DIFF
--- a/src/test/webview/ExecutionManager.test.ts
+++ b/src/test/webview/ExecutionManager.test.ts
@@ -1,0 +1,63 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - webview
+import { ExecutionManager } from '@webview/managers/ExecutionManager';
+
+function createMessage(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    command: 'execute',
+    isToolUseAgent: false,
+    agent: 'chat',
+    model: 'model',
+    instruction: 'do something',
+    inputFile: 'main.tex',
+    outputFilesActive: false,
+    outputFiles: [],
+    autoExtractFigure: false,
+    autoExtractTikzFigure: false,
+    attachTeXCount: false,
+    attachDiagnostics: false,
+    autoCompileInputPdf: false,
+    ...overrides,
+  };
+}
+
+describe('ExecutionManager', () => {
+  const originalExecuteCommand = vscode.commands.executeCommand;
+
+  afterEach(() => {
+    (vscode.commands as any).executeCommand = originalExecuteCommand;
+  });
+
+  it('disables multiple outputs for tool-use sessions', async () => {
+    const manager = new ExecutionManager();
+    const executed: Array<{ command: string; payload: any }> = [];
+
+    (vscode.commands as any).executeCommand = async (
+      command: string,
+      payload: any,
+    ) => {
+      executed.push({ command, payload });
+      return undefined;
+    };
+
+    const message = createMessage({
+      isToolUseAgent: true,
+      outputFilesActive: true,
+      outputFiles: ['a.tex', 'b.tex'],
+    });
+
+    await manager.handleExecute(message);
+
+    assert.strictEqual(executed.length, 1);
+    assert.strictEqual(executed[0]?.command, 'texra.execute');
+    const config = executed[0]?.payload;
+    assert.ok(config, 'Expected payload to be provided');
+    assert.strictEqual(config.useMultipleOutputs, false);
+    assert.strictEqual(config.outputFiles, null);
+  });
+});

--- a/src/test/webview/MainViewStateSessionType.test.ts
+++ b/src/test/webview/MainViewStateSessionType.test.ts
@@ -1,0 +1,224 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+// @ts-ignore jsdom lacks ESM typings in this context
+import { JSDOM } from 'jsdom';
+
+// Local imports - constants
+// @ts-ignore lack of type definitions for webview modules
+import {
+  ELEMENT_IDS,
+  SESSION_TYPES,
+  SESSION_TYPE_INPUT,
+} from '@webview/modules/constants.js';
+
+describe('MainViewState session transitions', () => {
+  let dom: JSDOM;
+  let persistedState: Record<string, unknown>;
+  let mainViewState: any;
+  let collectCurrentContext: any;
+
+  beforeEach(async () => {
+    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      url: 'http://localhost',
+    });
+
+    const { window } = dom;
+    (global as any).window = window;
+    (global as any).document = window.document;
+    (global as any).HTMLElement = window.HTMLElement;
+    (global as any).HTMLInputElement = window.HTMLInputElement;
+    (global as any).Element = window.Element;
+    (global as any).CustomEvent = window.CustomEvent;
+    (global as any).navigator = window.navigator;
+
+    persistedState = {};
+    const api = {
+      getState: () => ({ ...persistedState }),
+      setState: (value: Record<string, unknown>) => {
+        persistedState = { ...value };
+      },
+      postMessage: () => {},
+    };
+    (global as any).acquireVsCodeApi = () => api;
+
+    const { document } = window;
+
+    const sessionInput = document.createElement('input');
+    sessionInput.id = SESSION_TYPE_INPUT;
+    sessionInput.value = SESSION_TYPES.WORKFLOW;
+    document.body.appendChild(sessionInput);
+
+    const sessionToggle = document.createElement('div');
+    sessionToggle.id = ELEMENT_IDS.SESSION_TYPE_TOGGLE;
+    document.body.appendChild(sessionToggle);
+
+    const workflowAgent = document.createElement('div');
+    workflowAgent.id = 'workflowAgent';
+    document.body.appendChild(workflowAgent);
+
+    const toolUseAgent = document.createElement('div');
+    toolUseAgent.id = 'toolUseAgent';
+    document.body.appendChild(toolUseAgent);
+
+    const modelInput = document.createElement('input');
+    modelInput.id = 'model';
+    modelInput.value = 'model';
+    document.body.appendChild(modelInput);
+
+    const instruction = document.createElement('textarea');
+    instruction.id = ELEMENT_IDS.INSTRUCTION;
+    instruction.value = '';
+    document.body.appendChild(instruction);
+
+    const commitInput = document.createElement('input');
+    commitInput.id = ELEMENT_IDS.COMMIT_SELECT;
+    commitInput.value = 'HEAD';
+    document.body.appendChild(commitInput);
+
+    const fileSelectionGroup = document.createElement('div');
+    fileSelectionGroup.className = 'file-selection-group';
+    document.body.appendChild(fileSelectionGroup);
+
+    const createToggle = (id: string) => {
+      const toggle = document.createElement('div');
+      toggle.id = id;
+      const icon = document.createElement('i');
+      toggle.appendChild(icon);
+      document.body.appendChild(toggle);
+    };
+
+    createToggle(ELEMENT_IDS.TOGGLE_OUTPUT_FILES);
+    ['Input', 'Reference', 'Auxiliary', 'Media'].forEach((name) =>
+      createToggle(`toggle${name}Files`),
+    );
+
+    const outputContainer = document.createElement('div');
+    outputContainer.id = ELEMENT_IDS.OUTPUT_FILES_CONTAINER;
+    outputContainer.style.display = 'block';
+    const outputList = document.createElement('div');
+    outputList.id = ELEMENT_IDS.OUTPUT_FILES;
+    const fileItem = document.createElement('div');
+    fileItem.className = 'file-item';
+    fileItem.dataset.path = 'draft.pdf';
+    outputList.appendChild(fileItem);
+    outputContainer.appendChild(outputList);
+    fileSelectionGroup.appendChild(outputContainer);
+
+    ['input', 'reference', 'auxiliary', 'media'].forEach((type) => {
+      const single = document.createElement('input');
+      single.id = `${type}File`;
+      single.value = `${type}.tex`;
+      document.body.appendChild(single);
+
+      const multiContainer = document.createElement('div');
+      multiContainer.id = `${type}FilesContainer`;
+      multiContainer.style.display = 'none';
+      const multiList = document.createElement('div');
+      multiList.id = `${type}Files`;
+      multiContainer.appendChild(multiList);
+      fileSelectionGroup.appendChild(multiContainer);
+    });
+
+    [
+      'autoExtractFigure',
+      'autoExtractTikzFigure',
+      'autoCompileInputPdf',
+      'attachTeXCount',
+      'attachDiagnostics',
+    ].forEach((id) => {
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.id = id;
+      document.body.appendChild(checkbox);
+    });
+
+    const latexdiffsContent = document.createElement('div');
+    latexdiffsContent.id = ELEMENT_IDS.LATEXDIFFS_CONTENT;
+    latexdiffsContent.style.display = 'none';
+    document.body.appendChild(latexdiffsContent);
+
+    const latexdiffsToggle = document.createElement('div');
+    latexdiffsToggle.id = ELEMENT_IDS.TOGGLE_LATEXDIFFS;
+    latexdiffsToggle.appendChild(document.createElement('i'));
+    document.body.appendChild(latexdiffsToggle);
+
+    // @ts-ignore dynamic import without typings
+    const mainViewModule = await import('@webview/modules/mainViewState.js');
+    mainViewState = mainViewModule.mainViewState;
+    // @ts-ignore dynamic import without typings
+    const contextModule = await import(
+      '@webview/modules/state/currentContext.js'
+    );
+    collectCurrentContext = contextModule.collectCurrentContext;
+
+    mainViewState.setDefaults();
+
+    const refreshedOutputList = document.getElementById(
+      ELEMENT_IDS.OUTPUT_FILES,
+    );
+    if (refreshedOutputList) {
+      refreshedOutputList.innerHTML = '';
+      const refreshedItem = document.createElement('div');
+      refreshedItem.className = 'file-item';
+      refreshedItem.dataset.path = 'draft.pdf';
+      refreshedOutputList.appendChild(refreshedItem);
+    }
+    const refreshedContainer = document.getElementById(
+      ELEMENT_IDS.OUTPUT_FILES_CONTAINER,
+    );
+    if (refreshedContainer) {
+      refreshedContainer.style.display = 'block';
+    }
+  });
+
+  afterEach(() => {
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).HTMLElement;
+    delete (global as any).HTMLInputElement;
+    delete (global as any).Element;
+    delete (global as any).CustomEvent;
+    delete (global as any).navigator;
+    delete (global as any).acquireVsCodeApi;
+  });
+
+  it('collapses output files when switching to tool-use mode', () => {
+    const outputContainer = document.getElementById(
+      ELEMENT_IDS.OUTPUT_FILES_CONTAINER,
+    ) as HTMLDivElement;
+    const outputList = document.getElementById(
+      ELEMENT_IDS.OUTPUT_FILES,
+    ) as HTMLDivElement;
+
+    const beforeChildren = outputList.children.length;
+    assert.strictEqual(beforeChildren > 0, true);
+
+    mainViewState.applySessionType(SESSION_TYPES.TOOL_USE);
+
+    assert.strictEqual(outputContainer.style.display, 'none');
+    assert.strictEqual(outputList.children.length, 0);
+
+    const state = mainViewState.get();
+    assert.strictEqual(state.outputFilesActive, false);
+    assert.strictEqual(state.outputFilesVisible, false);
+    assert.deepStrictEqual(state.outputFiles, []);
+
+    const context = collectCurrentContext();
+    assert.strictEqual(
+      Object.prototype.hasOwnProperty.call(
+        context.multipleFileSelections,
+        ELEMENT_IDS.OUTPUT_FILES,
+      ),
+      false,
+    );
+    assert.strictEqual(
+      Object.prototype.hasOwnProperty.call(
+        context.multipleFileSelections,
+        `${ELEMENT_IDS.OUTPUT_FILES}Active`,
+      ),
+      false,
+    );
+  });
+});

--- a/src/test/webview/MainViewStateSessionType.test.ts
+++ b/src/test/webview/MainViewStateSessionType.test.ts
@@ -18,6 +18,7 @@ describe('MainViewState session transitions', () => {
   let persistedState: Record<string, unknown>;
   let mainViewState: any;
   let collectCurrentContext: any;
+  let fileListManager: any;
 
   beforeEach(async () => {
     dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
@@ -99,12 +100,18 @@ describe('MainViewState session transitions', () => {
     outputContainer.style.display = 'block';
     const outputList = document.createElement('div');
     outputList.id = ELEMENT_IDS.OUTPUT_FILES;
-    const fileItem = document.createElement('div');
-    fileItem.className = 'file-item';
-    fileItem.dataset.path = 'draft.pdf';
-    outputList.appendChild(fileItem);
     outputContainer.appendChild(outputList);
     fileSelectionGroup.appendChild(outputContainer);
+
+    const fileTemplate = document.createElement('template');
+    fileTemplate.id = 'fileListEntryTemplate';
+    fileTemplate.innerHTML = `
+      <div class="file-item" data-path="">
+        <span class="file-name"></span>
+        <button class="remove-button" type="button"></button>
+      </div>
+    `;
+    document.body.appendChild(fileTemplate);
 
     ['input', 'reference', 'auxiliary', 'media'].forEach((type) => {
       const single = document.createElement('input');
@@ -152,25 +159,18 @@ describe('MainViewState session transitions', () => {
       '@webview/modules/state/currentContext.js'
     );
     collectCurrentContext = contextModule.collectCurrentContext;
+    // @ts-ignore dynamic import without typings
+    const fileListModule = await import(
+      '@webview/modules/uiManagers/FileList.js'
+    );
+    fileListManager = fileListModule.fileList;
 
     mainViewState.setDefaults();
-
-    const refreshedOutputList = document.getElementById(
+    fileListManager.update(
       ELEMENT_IDS.OUTPUT_FILES,
+      ELEMENT_IDS.TOGGLE_OUTPUT_FILES,
+      ['draft.pdf'],
     );
-    if (refreshedOutputList) {
-      refreshedOutputList.innerHTML = '';
-      const refreshedItem = document.createElement('div');
-      refreshedItem.className = 'file-item';
-      refreshedItem.dataset.path = 'draft.pdf';
-      refreshedOutputList.appendChild(refreshedItem);
-    }
-    const refreshedContainer = document.getElementById(
-      ELEMENT_IDS.OUTPUT_FILES_CONTAINER,
-    );
-    if (refreshedContainer) {
-      refreshedContainer.style.display = 'block';
-    }
   });
 
   afterEach(() => {

--- a/src/types/webview-modules.d.ts
+++ b/src/types/webview-modules.d.ts
@@ -11,3 +11,7 @@ declare module '@webview/modules/mainViewState.js' {
 declare module '@webview/modules/state/currentContext.js' {
   export function collectCurrentContext(options?: any): any;
 }
+
+declare module '@webview/modules/uiManagers/FileList.js' {
+  export const fileList: any;
+}

--- a/src/types/webview-modules.d.ts
+++ b/src/types/webview-modules.d.ts
@@ -1,0 +1,13 @@
+declare module '@webview/modules/constants.js' {
+  export const ELEMENT_IDS: Record<string, string>;
+  export const SESSION_TYPES: Record<string, string>;
+  export const SESSION_TYPE_INPUT: string;
+}
+
+declare module '@webview/modules/mainViewState.js' {
+  export const mainViewState: any;
+}
+
+declare module '@webview/modules/state/currentContext.js' {
+  export function collectCurrentContext(options?: any): any;
+}

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -64,19 +64,50 @@ export class ExecutionManager {
       return null;
     }
 
-    return this.composeAgentConfig(message, {
+    return this.composeWorkflowAgentConfig(message, {
       agentCategory: AgentCategory.Workflow,
     });
   }
 
   private buildToolUseCommandPayload(message: any): AgentConfig {
-    return this.composeAgentConfig(message, {
+    return this.composeToolUseAgentConfig(message, {
       agentType: AgentType.ToolUse,
       agentCategory: AgentCategory.ToolUse,
     });
   }
 
-  private composeAgentConfig(
+  private composeWorkflowAgentConfig(
+    message: any,
+    session: AgentSessionDescriptor,
+  ): AgentConfig {
+    const baseConfig = this.composeBaseAgentConfig(message, session);
+    const outputFiles = getFilesIfNotEmpty<string>(message.outputFiles);
+    const useMultipleOutputs = Boolean(
+      message.outputFilesActive ||
+        (Array.isArray(outputFiles) && outputFiles.length > 1),
+    );
+
+    return {
+      ...baseConfig,
+      useMultipleOutputs,
+      outputFiles,
+    };
+  }
+
+  private composeToolUseAgentConfig(
+    message: any,
+    session: AgentSessionDescriptor,
+  ): AgentConfig {
+    const baseConfig = this.composeBaseAgentConfig(message, session);
+
+    return {
+      ...baseConfig,
+      useMultipleOutputs: false,
+      outputFiles: null,
+    };
+  }
+
+  private composeBaseAgentConfig(
     message: any,
     session: AgentSessionDescriptor,
   ): AgentConfig {
@@ -96,17 +127,11 @@ export class ExecutionManager {
       return f;
     };
 
-    const outputFiles = getFilesIfNotEmpty<string>(message.outputFiles);
-    const useMultipleOutputs = Boolean(
-      message.outputFilesActive ||
-        (Array.isArray(outputFiles) && outputFiles.length > 1),
-    );
-
     return {
       agent: message.agent,
       model: message.model,
       instruction: message.instruction,
-      useMultipleOutputs,
+      useMultipleOutputs: false,
       inputFile: message.inputFile ?? '',
       inputFiles: getFilesIfNotEmpty<string>(message.inputFiles),
       referenceFile: message.referenceFile ?? null,
@@ -121,7 +146,7 @@ export class ExecutionManager {
               .filter((f: string | null): f is string => f !== null),
           )
         : null,
-      outputFiles,
+      outputFiles: null,
       editedFile: null,
       toolConfig,
       agentType: session.agentType,

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -110,7 +110,7 @@ export class ExecutionManager {
   private composeBaseAgentConfig(
     message: any,
     session: AgentSessionDescriptor,
-  ): AgentConfig {
+  ): Omit<AgentConfig, 'useMultipleOutputs' | 'outputFiles'> {
     const toolConfig: ToolConfig = {
       autoExtractFigure: message.autoExtractFigure,
       autoExtractTikzFigure: message.autoExtractTikzFigure,
@@ -131,7 +131,6 @@ export class ExecutionManager {
       agent: message.agent,
       model: message.model,
       instruction: message.instruction,
-      useMultipleOutputs: false,
       inputFile: message.inputFile ?? '',
       inputFiles: getFilesIfNotEmpty<string>(message.inputFiles),
       referenceFile: message.referenceFile ?? null,
@@ -146,7 +145,6 @@ export class ExecutionManager {
               .filter((f: string | null): f is string => f !== null),
           )
         : null,
-      outputFiles: null,
       editedFile: null,
       toolConfig,
       agentType: session.agentType,

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -102,6 +102,9 @@ export class ExecutionManager {
 
     return {
       ...baseConfig,
+      // Tool-use runs intentionally stay single-output so the execution
+      // pipeline never attempts to resolve `_multiple` agent variants or
+      // manage output file selections that the UI disables for this mode.
       useMultipleOutputs: false,
       outputFiles: null,
     };

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -251,6 +251,13 @@ export class MainViewState {
       state[id] = fileList.getSelected(elementDiv);
     });
 
+    const outputContainer = safeGetElementById(
+      ELEMENT_IDS.OUTPUT_FILES_CONTAINER,
+    );
+    state.outputFilesActive = Boolean(
+      outputContainer && outputContainer.style.display === 'block',
+    );
+
     const sessionTypeValue =
       state.sessionType ?? safeGetElementValue(SESSION_TYPE_INPUT);
     const normalizedSessionType = normalizeSessionType(sessionTypeValue);
@@ -331,9 +338,32 @@ export class MainViewState {
       }
     });
 
+    if (isToolUseSession) {
+      this._resetOutputFilesForToolUse();
+    }
+
     if (!skipSave) {
       this.save();
     }
+  }
+
+  _resetOutputFilesForToolUse() {
+    fileList.empty(
+      ELEMENT_IDS.OUTPUT_FILES,
+      ELEMENT_IDS.TOGGLE_OUTPUT_FILES,
+      false,
+    );
+
+    const container = safeGetElementById(ELEMENT_IDS.OUTPUT_FILES_CONTAINER);
+    if (container) {
+      container.style.display = 'none';
+    }
+
+    this.update({
+      outputFiles: [],
+      outputFilesVisible: false,
+      outputFilesActive: false,
+    });
   }
 }
 

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -251,12 +251,7 @@ export class MainViewState {
       state[id] = fileList.getSelected(elementDiv);
     });
 
-    const outputContainer = safeGetElementById(
-      ELEMENT_IDS.OUTPUT_FILES_CONTAINER,
-    );
-    state.outputFilesActive = Boolean(
-      outputContainer && outputContainer.style.display === 'block',
-    );
+    state.outputFilesActive = this._isOutputFilesActive();
 
     const sessionTypeValue =
       state.sessionType ?? safeGetElementValue(SESSION_TYPE_INPUT);
@@ -347,16 +342,32 @@ export class MainViewState {
     }
   }
 
-  _resetOutputFilesForToolUse() {
-    fileList.empty(
-      ELEMENT_IDS.OUTPUT_FILES,
-      ELEMENT_IDS.TOGGLE_OUTPUT_FILES,
-      false,
-    );
+  _getOutputFilesContainer() {
+    return safeGetElementById(ELEMENT_IDS.OUTPUT_FILES_CONTAINER);
+  }
 
-    const container = safeGetElementById(ELEMENT_IDS.OUTPUT_FILES_CONTAINER);
+  _setOutputFilesContainerVisible(visible) {
+    const container = this._getOutputFilesContainer();
     if (container) {
-      container.style.display = 'none';
+      container.style.display = visible ? 'block' : 'none';
+    }
+  }
+
+  _isOutputFilesActive() {
+    const container = this._getOutputFilesContainer();
+    return Boolean(container && container.style.display === 'block');
+  }
+
+  _resetOutputFilesForToolUse() {
+    const wasActive = this._isOutputFilesActive();
+    if (wasActive) {
+      fileList.empty(
+        ELEMENT_IDS.OUTPUT_FILES,
+        ELEMENT_IDS.TOGGLE_OUTPUT_FILES,
+        false,
+      );
+
+      this._setOutputFilesContainerVisible(false);
     }
 
     this.update({

--- a/src/webview/modules/state/currentContext.js
+++ b/src/webview/modules/state/currentContext.js
@@ -48,9 +48,14 @@ function collectSingleFileSelections(singleFileTypes) {
   return selections;
 }
 
-function collectMultipleFileSelections(singleFiles, fileList) {
+function collectMultipleFileSelections(singleFiles, fileList, options = {}) {
+  const { excludedIds } = options;
+  const skippedIds = excludedIds instanceof Set ? excludedIds : undefined;
   const selections = {};
   MULTIPLE_SELECTIONS.forEach((id) => {
+    if (skippedIds?.has(id)) {
+      return;
+    }
     const container = safeGetElementById(`${id}Container`);
     const isActive = container?.style.display !== 'none';
     selections[`${id}Active`] = isActive;
@@ -92,14 +97,15 @@ export function collectCurrentContext(options = {}) {
   const sessionType = getSessionType();
   const agent = getAgent(sessionType);
   const singleFileSelections = collectSingleFileSelections(singleFileTypes);
+  const excludedMultipleIds =
+    sessionType === SESSION_TYPES.TOOL_USE
+      ? new Set([ELEMENT_IDS.OUTPUT_FILES])
+      : undefined;
   const multipleFileSelections = collectMultipleFileSelections(
     singleFileSelections,
     fileList,
+    { excludedIds: excludedMultipleIds },
   );
-  if (sessionType === SESSION_TYPES.TOOL_USE) {
-    delete multipleFileSelections[`${ELEMENT_IDS.OUTPUT_FILES}Active`];
-    delete multipleFileSelections[ELEMENT_IDS.OUTPUT_FILES];
-  }
   const checkboxValues = collectCheckboxValues();
 
   return {

--- a/src/webview/modules/state/currentContext.js
+++ b/src/webview/modules/state/currentContext.js
@@ -96,6 +96,10 @@ export function collectCurrentContext(options = {}) {
     singleFileSelections,
     fileList,
   );
+  if (sessionType === SESSION_TYPES.TOOL_USE) {
+    delete multipleFileSelections[`${ELEMENT_IDS.OUTPUT_FILES}Active`];
+    delete multipleFileSelections[ELEMENT_IDS.OUTPUT_FILES];
+  }
   const checkboxValues = collectCheckboxValues();
 
   return {


### PR DESCRIPTION
## Summary
- split workflow and tool-use agent config paths so tool-use sessions never request _multiple variants or pass output files
- collapse and clear the output file UI/state when switching into tool-use mode and strip multi-output flags from the webview context payload
- add regression coverage for the new behavior and provide module shims for the JS webview imports used in tests

## Testing
- npm run lint
- npm run compile-tests
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_6902a9c108008324bf835724ecddbdf2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tool-use sessions now always run single-output, with output files cleared/hidden in the UI and excluded from context; adds targeted tests and typings shims.
> 
> - **Execution pipeline**:
>   - Split config building into `composeWorkflowAgentConfig` and `composeToolUseAgentConfig`; tool-use forces `useMultipleOutputs=false` and `outputFiles=null`.
>   - Extracted `composeBaseAgentConfig` for shared fields.
> - **Webview state/UI**:
>   - On switching to `SESSION_TYPES.TOOL_USE`, clear `ELEMENT_IDS.OUTPUT_FILES`, hide its container, and set `outputFilesActive=false` via `_resetOutputFilesForToolUse`.
>   - Track `outputFilesActive` in saved state; add helpers to get/set visibility.
>   - Exclude `OUTPUT_FILES` from `multipleFileSelections` when in tool-use in `collectCurrentContext`.
> - **Tests**:
>   - Add `ExecutionManager.test.ts` to verify tool-use disables multi-output.
>   - Add `MainViewStateSessionType.test.ts` to verify output files collapse/clear on tool-use.
> - **Types**:
>   - Add `src/types/webview-modules.d.ts` shims for webview module imports used in tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8f4d69f60503a45066df934b6d2ed2fae4ee92a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->