### PR TITLE
fix: refine tool-use flow lifecycle

### DIFF
--- a/src/agent/core/AgentCycleOptions.ts
+++ b/src/agent/core/AgentCycleOptions.ts
@@ -1,0 +1,19 @@
+// Local imports - agent configuration
+import type { AgentPrompt, AgentSetting } from './AgentDataclass';
+
+// Local imports - logging
+import type { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - model handlers
+import type { IModelHandler } from '@agent/modelHandlers';
+
+export interface AgentCycleBaseOptions<C = unknown> {
+  modelHandler: IModelHandler<any, any, any, any, C>;
+  agentSetting: AgentSetting;
+  agentPrompt: AgentPrompt;
+  userVars: Record<string, any>;
+  logger: AgentLogger;
+  client: C;
+  checkInterruption: () => Promise<boolean> | boolean;
+  setAbortController: (ctrl: AbortController | null) => void;
+}

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -9,32 +9,21 @@ import {
   type ResponseCycleState,
 } from './flows/ResponseCycleFlow';
 
+// Local imports - option helpers
+import type { AgentCycleBaseOptions } from './AgentCycleOptions';
+
 // Local imports - model handler types
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 // Local imports - identifier types
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
-// Local imports - logging
-import type { AgentLogger } from '@logger/AgentLogger';
-
-// Local imports - model handlers
-import type { IModelHandler } from '@agent/modelHandlers';
-
 // Local imports - agent configuration
 import type { AgentConfig } from './AgentConfig';
-import type { AgentPrompt, AgentSetting } from './AgentDataclass';
 
-export interface ResponseCycleOptions<C = unknown> {
-  modelHandler: IModelHandler<any, any, any, any, C>;
-  agentSetting: AgentSetting;
+export interface ResponseCycleOptions<C = unknown>
+  extends AgentCycleBaseOptions<C> {
   agentConfig: AgentConfig;
-  agentPrompt: AgentPrompt;
-  userVars: Record<string, any>;
-  logger: AgentLogger;
-  client: C;
-  checkInterruption: () => Promise<boolean> | boolean;
-  setAbortController: (ctrl: AbortController | null) => void;
 }
 
 export interface ResponseCycleContext<C = unknown> {

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -8,14 +8,10 @@ import {
   type ToolUseCycleState,
 } from './flows/ToolUseCycleFlow';
 
-// Local imports - agent configuration
-import type { AgentPrompt, AgentSetting } from './AgentDataclass';
-
-// Local imports - logging
-import type { AgentLogger } from '@logger/AgentLogger';
+// Local imports - option helpers
+import type { AgentCycleBaseOptions } from './AgentCycleOptions';
 
 // Local imports - model handlers
-import type { IModelHandler } from '@agent/modelHandlers';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 // Local imports - tools
@@ -24,16 +20,9 @@ import type { BaseTool } from '@tools/core/base';
 // Local imports - usage
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
-export interface ToolUseCycleOptions<C = unknown> {
-  modelHandler: IModelHandler<any, any, any, any, C>;
-  agentSetting: AgentSetting;
-  agentPrompt: AgentPrompt;
-  userVars: Record<string, any>;
-  logger: AgentLogger;
-  client: C;
+export interface ToolUseCycleOptions<C = unknown>
+  extends AgentCycleBaseOptions<C> {
   toolRegistry: Record<string, BaseTool<any>>;
-  checkInterruption: () => Promise<boolean> | boolean;
-  setAbortController: (ctrl: AbortController | null) => void;
   toolState: ToolState;
   modelName?: string;
   executionId?: ExecutionId;

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -12,6 +12,7 @@ import type { IModelHandler } from '../modelHandlers';
 import { UsageMonitor } from '../utils/UsageMonitor';
 import { buildUserVars } from '../utils/userVars';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
@@ -95,6 +96,28 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       throw new Error('Model client has not been initialized.');
     }
     return this.client;
+  }
+
+  protected buildCycleBaseOptions<S extends AgentSetting>(
+    params: {
+      agentSetting: S;
+      agentPrompt: AgentPrompt;
+      client: C;
+    },
+  ): AgentCycleBaseOptions<C> {
+    const { agentSetting, agentPrompt, client } = params;
+    return {
+      modelHandler: this.modelHandler,
+      agentSetting,
+      agentPrompt,
+      userVars: this.userVars,
+      logger: this.logger,
+      client,
+      checkInterruption: () => this.checkInterruption(),
+      setAbortController: (ctrl) => {
+        this.abortController = ctrl;
+      },
+    };
   }
 
   /** Compute the stream tab identifier for this agent execution. */

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -363,19 +363,16 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
   private createResponseCycleOptions(): ResponseCycleOptions<C> {
     const client = this.getClientInstance();
-    return {
-      modelHandler: this.modelHandler,
+    const baseOptions = this.buildCycleBaseOptions({
       agentSetting: this.agentSetting,
-      agentConfig: this.agentConfig,
       agentPrompt: this.agentPrompt,
-      userVars: this.userVars,
-      logger: this.logger,
       client,
-      checkInterruption: () => this.checkInterruption(),
-      setAbortController: (ctrl) => {
-        this.abortController = ctrl;
-      },
-    } as const;
+    });
+
+    return {
+      ...baseOptions,
+      agentConfig: this.agentConfig,
+    };
   }
 
   private async prepareRoundContext(

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -21,6 +21,13 @@ import { TOOL_USE_INSTRUCTIONS } from '../utils/toolUsePrompt';
 
 // Local imports - core
 import { BaseAgent } from './BaseAgent';
+import {
+  createToolUseRunFlow,
+  type ToolUseRunHooks,
+  type ToolUseRunLifecycle,
+  type ToolUseRunShared,
+  type ToolUseRunState,
+} from '@agent/implementations/flows/ToolUseRunFlow';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
@@ -147,128 +154,163 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
   }
 
   public async run(): Promise<void> {
-    try {
-      await this.init(undefined, { createGroup: false });
-      await this.initializeClient();
+    const lifecycle: ToolUseRunLifecycle = {
+      phase: 'idle',
+      status: 'pending',
+      error: undefined,
+    };
 
-      let shouldSkipCycle = false;
-
-      if (this.resumeSnapshot) {
-        this.logger.debug('Resuming tool-use session from saved state.');
-        // Validate messages before hydrating
-        const messages = this.resumeSnapshot.messages ?? [];
-        if (!Array.isArray(messages)) {
-          throw new Error('Invalid snapshot: messages must be an array');
-        }
-        // Cast with confidence after validation
-        this.messages = messages as ProviderMessage[];
-        try {
-          this.toolState = ToolUseSessionManager.hydrateToolStateFromSnapshot(
-            this.resumeSnapshot,
-          );
-        } catch (error) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : 'Unknown error while hydrating tool state';
-          this.logger.warn(
-            `Failed to hydrate tool state from snapshot: ${message}`,
-          );
-          // Snapshot hydration can fail if the saved payload is corrupted or
-          // originates from an outdated schema. Reset to a clean ToolState so
-          // the agent can continue operating without crashing.
-          this.toolState = new ToolState();
-        }
-        shouldSkipCycle = true;
-        this.resumeSnapshot = null;
-      } else {
-        const initialRequest = Array.isArray(this.agentPrompt.userRequest)
-          ? (this.agentPrompt.userRequest[0] ?? '')
-          : this.agentPrompt.userRequest;
-
-        const [systemPrompt, userRequest, userPrefix] = await Promise.all([
-          getSystemPromptWithRules(
-            `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
-            this.userVars,
-          ),
-          renderPrompt(initialRequest, this.userVars),
-          renderPrompt(this.agentPrompt.userPrefix, this.userVars),
-        ]);
-
-        this.messages = await this.modelHandler.initializeMessages(
-          userPrefix,
-          userRequest,
-          undefined,
-          systemPrompt,
-        );
-
-        this.toolState = new ToolState();
-      }
-
-      let toolState = this.toolState;
-      if (!toolState) {
-        this.logger.debug('Initializing fallback tool state instance.');
-        toolState = new ToolState();
-        this.toolState = toolState;
-      }
-
-      const resolvedSetting = {
-        ...this.agentSetting,
-        tools: this.getTools(),
-      };
-
-      const client = this.getClientInstance();
-      const cycleOptions: ToolUseCycleOptions<C> = {
-        modelHandler: this.modelHandler,
-        agentSetting: resolvedSetting,
-        agentPrompt: this.agentPrompt,
-        userVars: this.userVars,
-        logger: this.logger,
-        client,
-        toolRegistry: this.toolRegistry,
-        checkInterruption: () => this.checkInterruption(),
-        setAbortController: (ctrl: AbortController | null) => {
-          this.abortController = ctrl;
-        },
-        toolState,
-        modelName: this.agentConfig.model,
-      } as const;
-
-      while (true) {
-        if (!shouldSkipCycle) {
-          await runToolUseCycle({
-            options: cycleOptions,
-            messages: this.messages,
-          });
-        } else {
-          shouldSkipCycle = false;
-        }
-
-        if (this.checkInterruption()) break;
-
-        const hasQueuedFollowUp = this.followUpQueue.length > 0;
-        if (!hasQueuedFollowUp) {
-          await this.enterWaitingState();
-        } else {
-          await this.clearPersistedSnapshot();
-        }
-
-        const followUp = await this.waitForFollowUp();
-        if (!followUp || this.checkInterruption()) break;
-
-        await this.markRunning();
-        await this.clearPersistedSnapshot();
-
+    const hooks: ToolUseRunHooks<C> = {
+      start: async () => undefined,
+      init: (runGroupId) => this.init(runGroupId, { createGroup: false }),
+      initializeClient: () => this.initializeClient(),
+      prepareState: () => this.prepareInitialSessionState(),
+      buildCycleOptions: (toolState) => this.buildToolUseCycleOptions(toolState),
+      runCycle: (options, messages) =>
+        runToolUseCycle({
+          options,
+          messages,
+        }),
+      checkInterruption: () => this.checkInterruption(),
+      hasQueuedFollowUp: () => this.followUpQueue.length > 0,
+      enterWaitingState: () => this.enterWaitingState(),
+      clearPersistedSnapshot: () => this.clearPersistedSnapshot(),
+      waitForFollowUp: () => this.waitForFollowUp(),
+      markRunning: () => this.markRunning(),
+      applyFollowUp: async (followUp, messages) => {
         this.logger.userMessage(followUp);
-        this.messages = await this.modelHandler.createUserFollowUpMessages(
-          this.messages,
+        const updatedMessages = await this.modelHandler.createUserFollowUpMessages(
+          messages,
           followUp,
         );
-      }
-    } finally {
-      await this.clearPersistedSnapshot();
-      this.cleanup();
+        this.messages = updatedMessages;
+        return updatedMessages;
+      },
+      end: async (status) => {
+        this.endRunGroup(status);
+      },
+      cleanup: async () => {
+        this.cleanup();
+      },
+    };
+
+    const shared: ToolUseRunShared<C> = {
+      agent: this,
+      state: {
+        messages: this.messages,
+        toolState: this.toolState,
+        cycleOptions: null,
+        shouldSkipCycle: false,
+      } satisfies ToolUseRunState<C>,
+      lifecycle,
+      hooks,
+    };
+
+    const flow = createToolUseRunFlow<C>();
+    await flow.run(shared);
+
+    if (shared.lifecycle.error) {
+      throw shared.lifecycle.error;
     }
+  }
+
+  private async prepareInitialSessionState(): Promise<{
+    messages: ProviderMessage[];
+    toolState: ToolState;
+    shouldSkipCycle: boolean;
+  }> {
+    if (this.resumeSnapshot) {
+      this.logger.debug('Resuming tool-use session from saved state.');
+      const snapshot = this.resumeSnapshot;
+      this.resumeSnapshot = null;
+
+      const rawMessages = snapshot.messages ?? [];
+      if (!Array.isArray(rawMessages)) {
+        throw new Error('Invalid snapshot: messages must be an array');
+      }
+
+      const messages = rawMessages as ProviderMessage[];
+      let toolState: ToolState;
+
+      try {
+        toolState = ToolUseSessionManager.hydrateToolStateFromSnapshot(
+          snapshot,
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Unknown error while hydrating tool state';
+        this.logger.warn(
+          `Failed to hydrate tool state from snapshot: ${message}`,
+        );
+        toolState = new ToolState();
+      }
+
+      this.messages = messages;
+      this.toolState = toolState;
+
+      return {
+        messages,
+        toolState,
+        shouldSkipCycle: true,
+      };
+    }
+
+    const initialRequest = Array.isArray(this.agentPrompt.userRequest)
+      ? (this.agentPrompt.userRequest[0] ?? '')
+      : this.agentPrompt.userRequest;
+
+    const [systemPrompt, userRequest, userPrefix] = await Promise.all([
+      getSystemPromptWithRules(
+        `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
+        this.userVars,
+      ),
+      renderPrompt(initialRequest, this.userVars),
+      renderPrompt(this.agentPrompt.userPrefix, this.userVars),
+    ]);
+
+    const messages = await this.modelHandler.initializeMessages(
+      userPrefix,
+      userRequest,
+      undefined,
+      systemPrompt,
+    );
+
+    const toolState = new ToolState();
+
+    this.messages = messages;
+    this.toolState = toolState;
+
+    return {
+      messages,
+      toolState,
+      shouldSkipCycle: false,
+    };
+  }
+
+  private buildToolUseCycleOptions(
+    toolState: ToolState,
+  ): ToolUseCycleOptions<C> {
+    const client = this.getClientInstance();
+    const resolvedSetting = {
+      ...this.agentSetting,
+      tools: this.getTools(),
+    };
+
+    const baseOptions = this.buildCycleBaseOptions({
+      agentSetting: resolvedSetting,
+      agentPrompt: this.agentPrompt,
+      client,
+    });
+
+    return {
+      ...baseOptions,
+      toolRegistry: this.toolRegistry,
+      toolState,
+      modelName: this.agentConfig.model,
+      executionId: this.executionId,
+    };
   }
 
   private async enterWaitingState(): Promise<void> {

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -1,0 +1,353 @@
+// Local imports - core flow primitives
+import { BaseNode, Flow } from '@agent/node';
+
+// Local imports - flow constants
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+
+// Local imports - agent components
+import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
+import type { ToolState } from '@agent/core/ToolState';
+import type { BaseToolUseAgent } from '../BaseToolUseAgent';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+interface ToolUsePrepareResult<C> {
+  messages: ProviderMessage[];
+  toolState: ToolState;
+  shouldSkipCycle: boolean;
+  cycleOptions: ToolUseCycleOptions<C>;
+}
+
+type ToolUsePrepareExecResult<C> =
+  | {
+      result: ToolUsePrepareResult<C>;
+      error?: undefined;
+    }
+  | {
+    result?: undefined;
+    error: unknown;
+  };
+
+interface ToolUseInitPrep<C> {
+  hooks: ToolUseRunHooks<C>;
+  lifecycle: ToolUseRunLifecycle;
+}
+
+interface ToolUseInitExecResult {
+  error?: unknown;
+}
+
+interface ToolUseCycleExecResult {
+  error?: unknown;
+}
+
+interface ToolUseFinalizePrep<C> {
+  hooks: ToolUseRunHooks<C>;
+  lifecycle: ToolUseRunLifecycle;
+}
+
+interface ToolUseFinalizeExecResult {
+  snapshotError?: unknown;
+  endError?: unknown;
+}
+
+type ToolUseRunPhase = 'idle' | 'init' | 'prepare' | 'cycle' | 'finalize';
+type ToolUseRunStatus = 'pending' | 'running' | 'error' | 'completed';
+
+export interface ToolUseRunLifecycle {
+  phase: ToolUseRunPhase;
+  status: ToolUseRunStatus;
+  error?: unknown;
+}
+
+export interface ToolUseRunState<C = unknown> {
+  messages: ProviderMessage[];
+  toolState: ToolState | null;
+  cycleOptions: ToolUseCycleOptions<C> | null;
+  shouldSkipCycle: boolean;
+}
+
+export interface ToolUseRunHooks<C = unknown> {
+  start(): Promise<string | undefined>;
+  init(runGroupId?: string): Promise<void>;
+  initializeClient(): Promise<void>;
+  prepareState(): Promise<{
+    messages: ProviderMessage[];
+    toolState: ToolState;
+    shouldSkipCycle: boolean;
+  }>;
+  buildCycleOptions(toolState: ToolState): ToolUseCycleOptions<C>;
+  runCycle(
+    options: ToolUseCycleOptions<C>,
+    messages: ProviderMessage[],
+  ): Promise<void>;
+  checkInterruption(): boolean;
+  hasQueuedFollowUp(): boolean;
+  enterWaitingState(): Promise<void>;
+  clearPersistedSnapshot(): Promise<void>;
+  waitForFollowUp(): Promise<string | null>;
+  markRunning(): Promise<void>;
+  applyFollowUp(
+    followUp: string,
+    messages: ProviderMessage[],
+  ): Promise<ProviderMessage[]>;
+  end(status: 'stopped' | 'error'): Promise<void>;
+  cleanup(): Promise<void>;
+}
+
+export interface ToolUseRunShared<C = unknown> {
+  agent: BaseToolUseAgent<C>;
+  state: ToolUseRunState<C>;
+  lifecycle: ToolUseRunLifecycle;
+  hooks: ToolUseRunHooks<C>;
+}
+
+class ToolUseInitNode<C> extends BaseNode<ToolUseRunShared<C>> {
+  async prep(shared: ToolUseRunShared<C>): Promise<ToolUseInitPrep<C>> {
+    shared.lifecycle.phase = 'init';
+    shared.lifecycle.status = 'running';
+    shared.lifecycle.error = undefined;
+    return {
+      hooks: shared.hooks,
+      lifecycle: shared.lifecycle,
+    };
+  }
+
+  async exec(prepRes: ToolUseInitPrep<C>): Promise<ToolUseInitExecResult> {
+    try {
+      const runGroupId = await prepRes.hooks.start();
+      await prepRes.hooks.init(runGroupId);
+      await prepRes.hooks.initializeClient();
+      return {};
+    } catch (error: unknown) {
+      return { error };
+    }
+  }
+
+  async post(
+    shared: ToolUseRunShared<C>,
+    _prepRes: ToolUseInitPrep<C>,
+    execRes: ToolUseInitExecResult,
+  ): Promise<string | undefined> {
+    if (execRes.error) {
+      shared.lifecycle.status = 'error';
+      shared.lifecycle.error = execRes.error;
+      return FlowTransition.FINALIZE;
+    }
+
+    shared.lifecycle.phase = 'prepare';
+    shared.lifecycle.status = 'running';
+    shared.lifecycle.error = undefined;
+    return FlowTransition.EXECUTE;
+  }
+}
+
+class ToolUsePrepareNode<C> extends BaseNode<ToolUseRunShared<C>> {
+  async prep(shared: ToolUseRunShared<C>): Promise<ToolUseRunShared<C>> {
+    shared.lifecycle.phase = 'prepare';
+    shared.lifecycle.status = 'running';
+    shared.lifecycle.error = undefined;
+    return shared;
+  }
+
+  async exec(shared: ToolUseRunShared<C>): Promise<ToolUsePrepareExecResult<C>> {
+    try {
+      const prepared = await shared.hooks.prepareState();
+      if (!prepared) {
+        return {
+          error: new Error('Failed to prepare tool-use run: missing prepared state'),
+        };
+      }
+
+      const cycleOptions = shared.hooks.buildCycleOptions(prepared.toolState);
+      if (!cycleOptions) {
+        return {
+          error: new Error('Failed to prepare tool-use run: missing cycle options'),
+        };
+      }
+
+      return {
+        result: {
+          ...prepared,
+          cycleOptions,
+        },
+      };
+    } catch (error: unknown) {
+      return { error };
+    }
+  }
+
+  async post(
+    shared: ToolUseRunShared<C>,
+    _prepRes: ToolUseRunShared<C>,
+    execRes: ToolUsePrepareExecResult<C>,
+  ): Promise<string | undefined> {
+    if ('error' in execRes) {
+      const error = execRes.error;
+      shared.lifecycle.status = 'error';
+      shared.lifecycle.error = error;
+      return FlowTransition.FINALIZE;
+    }
+
+    const { messages, toolState, shouldSkipCycle, cycleOptions } = execRes.result;
+    shared.state.messages = messages;
+    shared.state.toolState = toolState;
+    shared.state.shouldSkipCycle = shouldSkipCycle;
+    shared.state.cycleOptions = cycleOptions;
+
+    shared.lifecycle.phase = 'cycle';
+    shared.lifecycle.status = 'running';
+    shared.lifecycle.error = undefined;
+
+    return FlowTransition.EXECUTE;
+  }
+}
+
+class ToolUseCycleNode<C> extends BaseNode<ToolUseRunShared<C>> {
+  async prep(shared: ToolUseRunShared<C>): Promise<ToolUseRunShared<C>> {
+    shared.lifecycle.phase = 'cycle';
+    shared.lifecycle.status = 'running';
+    shared.lifecycle.error = undefined;
+    return shared;
+  }
+
+  async exec(shared: ToolUseRunShared<C>): Promise<ToolUseCycleExecResult> {
+    const { hooks, state } = shared;
+
+    if (!state.cycleOptions) {
+      return { error: new Error('Tool-use cycle options are missing.') };
+    }
+
+    try {
+      while (true) {
+        if (!state.shouldSkipCycle) {
+          await hooks.runCycle(state.cycleOptions, state.messages);
+        } else {
+          state.shouldSkipCycle = false;
+        }
+
+        if (hooks.checkInterruption()) {
+          return {};
+        }
+
+        if (hooks.hasQueuedFollowUp()) {
+          await hooks.clearPersistedSnapshot();
+        } else {
+          await hooks.enterWaitingState();
+        }
+
+        const followUp = await hooks.waitForFollowUp();
+        if (!followUp || hooks.checkInterruption()) {
+          return {};
+        }
+
+        await hooks.markRunning();
+        await hooks.clearPersistedSnapshot();
+        const updatedMessages = await hooks.applyFollowUp(
+          followUp,
+          state.messages,
+        );
+        state.messages = updatedMessages;
+      }
+    } catch (error: unknown) {
+      return { error };
+    }
+  }
+
+  async post(
+    shared: ToolUseRunShared<C>,
+    _prepRes: ToolUseRunShared<C>,
+    execRes: ToolUseCycleExecResult,
+  ): Promise<string | undefined> {
+    if (execRes.error) {
+      shared.lifecycle.status = 'error';
+      shared.lifecycle.error = execRes.error;
+    } else {
+      shared.lifecycle.status = 'running';
+      shared.lifecycle.error = undefined;
+    }
+
+    return FlowTransition.FINALIZE;
+  }
+}
+
+class ToolUseFinalizeNode<C> extends BaseNode<ToolUseRunShared<C>> {
+  async prep(shared: ToolUseRunShared<C>): Promise<ToolUseFinalizePrep<C>> {
+    shared.lifecycle.phase = 'finalize';
+    return {
+      hooks: shared.hooks,
+      lifecycle: shared.lifecycle,
+    };
+  }
+
+  async exec(
+    prepRes: ToolUseFinalizePrep<C>,
+  ): Promise<ToolUseFinalizeExecResult> {
+    const status = prepRes.lifecycle.status === 'error' ? 'error' : 'stopped';
+    const result: ToolUseFinalizeExecResult = {};
+
+    try {
+      await prepRes.hooks.clearPersistedSnapshot();
+    } catch (error: unknown) {
+      result.snapshotError = error;
+    }
+
+    try {
+      await prepRes.hooks.end(status);
+    } catch (error: unknown) {
+      result.endError = error;
+    }
+
+    return result;
+  }
+
+  async post(
+    shared: ToolUseRunShared<C>,
+    prepRes: ToolUseFinalizePrep<C>,
+    execRes: ToolUseFinalizeExecResult,
+  ): Promise<string | undefined> {
+    let error = shared.lifecycle.error;
+
+    if (!error && execRes.snapshotError) {
+      error = execRes.snapshotError;
+    }
+
+    if (!error && execRes.endError) {
+      error = execRes.endError;
+    }
+
+    try {
+      await prepRes.hooks.cleanup();
+    } catch (cleanupError: unknown) {
+      if (!error) {
+        error = cleanupError;
+      }
+    }
+
+    if (error) {
+      shared.lifecycle.status = 'error';
+      shared.lifecycle.error = error;
+    } else {
+      shared.lifecycle.status = 'completed';
+      shared.lifecycle.error = undefined;
+    }
+
+    return undefined;
+  }
+}
+
+export function createToolUseRunFlow<C>(): Flow<ToolUseRunShared<C>> {
+  const initNode = new ToolUseInitNode<C>();
+  const prepareNode = new ToolUsePrepareNode<C>();
+  const cycleNode = new ToolUseCycleNode<C>();
+  const finalizeNode = new ToolUseFinalizeNode<C>();
+
+  initNode.on(FlowTransition.EXECUTE, prepareNode);
+  initNode.on(FlowTransition.FINALIZE, finalizeNode);
+
+  prepareNode.on(FlowTransition.EXECUTE, cycleNode);
+  prepareNode.on(FlowTransition.FINALIZE, finalizeNode);
+
+  cycleNode.on(FlowTransition.FINALIZE, finalizeNode);
+
+  return new Flow<ToolUseRunShared<C>>(initNode);
+}


### PR DESCRIPTION
## Summary
- require tool-use run hooks to expose asynchronous lifecycle helpers and wire BaseToolUseAgent through them
- stabilize lifecycle transitions in ToolUseRunFlow, including typed preparation results, consistent error propagation, and optional run group support for tool-use runs
- keep BaseToolUseAgent follow-up handling in sync with flow state while avoiding extra run-group banners in the UI

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_690317bdaf688324902eec4d048a97ff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dedicated tool-use run flow and consolidates shared cycle options, refactoring agents to use the new lifecycle and option builder.
> 
> - **Core Options**:
>   - Add `core/AgentCycleOptions.ts` with `AgentCycleBaseOptions` to consolidate shared fields (`modelHandler`, `agentSetting`, `agentPrompt`, `userVars`, `logger`, `client`, interruption/abort handlers).
>   - Update `ResponseCycleOptions` and `ToolUseCycleOptions` to extend `AgentCycleBaseOptions` (remove duplicated properties).
> - **Tool-Use Run Flow**:
>   - Add `implementations/flows/ToolUseRunFlow.ts` with nodes for `init → prepare → cycle → finalize`, typed hooks/state, and consistent error propagation.
> - **Agents**:
>   - `BaseAgent`: add `buildCycleBaseOptions` helper.
>   - `BaseReflectionAgent`: use `buildCycleBaseOptions` in `createResponseCycleOptions`.
>   - `BaseToolUseAgent`:
>     - Rework `run()` to use `createToolUseRunFlow` with async hooks (init, prepare state/resume, run cycle, follow-up handling, finalize/cleanup).
>     - Extract `prepareInitialSessionState()` (resume/snapshot hydration) and `buildToolUseCycleOptions()`; maintain snapshot persistence, waiting/running status, and follow-up application.
> - **Cycles**:
>   - `ResponseCycle.ts`/`ToolUseCycle.ts`: import base options; pass through `executionId` and other context; no behavior changes beyond option wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82208c9ecc4acb6a5df45e8d1ce98dc78436e69b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->