### PR TITLE
fix: raise read tool line window

### DIFF
--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -27,7 +27,10 @@ suite('ReadFileTool', () => {
 
     const result = await tool.call({ path: 'long.txt' });
 
-    assert.strictEqual(result.summary, 'Read lines 1-400 of long.txt');
+    assert.strictEqual(
+      result.summary,
+      `Read lines 1-${READ_FILE_MAX_LINES} of long.txt`,
+    );
 
     assert.ok(result.output, 'Expected tool output when truncating file');
 
@@ -65,10 +68,12 @@ suite('ReadFileTool', () => {
     assert.strictEqual(result.output, content);
   });
 
-  test('reads requested range beyond 400th line', async () => {
+  test('reads requested range beyond default limit', async () => {
     const tool = new ReadFileTool();
 
     const totalLines = READ_FILE_MAX_LINES + 50;
+    const rangeStart = READ_FILE_MAX_LINES + 1;
+    const rangeEnd = rangeStart + 49;
     const content = Array.from(
       { length: totalLines },
       (_, index) => `row ${index + 1}`,
@@ -78,20 +83,28 @@ suite('ReadFileTool', () => {
 
     const result = await tool.call({
       path: 'paged.txt',
-      range: { start: 401, end: 450 },
+      range: { start: rangeStart, end: rangeEnd },
     });
 
-    assert.strictEqual(result.summary, 'Read lines 401-450 of paged.txt');
+    assert.strictEqual(
+      result.summary,
+      `Read lines ${rangeStart}-${rangeEnd} of paged.txt`,
+    );
     const outputLines = result.output?.split('\n') ?? [];
-    assert.strictEqual(outputLines.length, 50);
-    assert.strictEqual(outputLines[0], 'row 401');
-    assert.strictEqual(outputLines[outputLines.length - 1], 'row 450');
+    assert.strictEqual(outputLines.length, rangeEnd - rangeStart + 1);
+    assert.strictEqual(outputLines[0], `row ${rangeStart}`);
+    assert.strictEqual(
+      outputLines[outputLines.length - 1],
+      `row ${rangeEnd}`,
+    );
   });
 
   test('notes when requested range exceeds file length', async () => {
     const tool = new ReadFileTool();
 
     const totalLines = READ_FILE_MAX_LINES + 50;
+    const rangeStart = READ_FILE_MAX_LINES + 1;
+    const requestedEnd = totalLines + 50;
     const content = Array.from(
       { length: totalLines },
       (_, index) => `row ${index + 1}`,
@@ -101,12 +114,12 @@ suite('ReadFileTool', () => {
 
     const result = await tool.call({
       path: 'clipped.txt',
-      range: { start: 401, end: totalLines + 50 },
+      range: { start: rangeStart, end: requestedEnd },
     });
 
     assert.strictEqual(
       result.summary,
-      `Read lines 401-450 of clipped.txt (requested end ${totalLines + 50} exceeds file length ${totalLines})`,
+      `Read lines ${rangeStart}-${totalLines} of clipped.txt (requested end ${requestedEnd} exceeds file length ${totalLines})`,
     );
   });
 
@@ -163,10 +176,10 @@ suite('ReadFileTool', () => {
     assert.strictEqual(result.output, '');
   });
 
-  test('defaults range end to start + 399 when only start provided', async () => {
+  test('defaults range end to start + limit - 1 when only start provided', async () => {
     const tool = new ReadFileTool();
 
-    const totalLines = 1000;
+    const totalLines = READ_FILE_MAX_LINES + 1000;
     const content = Array.from(
       { length: totalLines },
       (_, index) => `line ${index + 1}`,
@@ -179,12 +192,20 @@ suite('ReadFileTool', () => {
       range: { start: 100 },
     });
 
-    // Should read lines 100-499 (400 lines)
-    assert.strictEqual(result.summary, 'Read lines 100-499 of windowed.txt');
+    const expectedEnd = 100 + READ_FILE_MAX_LINES - 1;
+
+    // Should read READ_FILE_MAX_LINES lines starting at 100
+    assert.strictEqual(
+      result.summary,
+      `Read lines 100-${expectedEnd} of windowed.txt`,
+    );
     const outputLines = result.output?.split('\n') ?? [];
-    assert.strictEqual(outputLines.length, 400);
+    assert.strictEqual(outputLines.length, READ_FILE_MAX_LINES);
     assert.strictEqual(outputLines[0], 'line 100');
-    assert.strictEqual(outputLines[399], 'line 499');
+    assert.strictEqual(
+      outputLines[READ_FILE_MAX_LINES - 1],
+      `line ${expectedEnd}`,
+    );
   });
 
   test('handles range starting at line 1 with end exceeding file length', async () => {

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -11,7 +11,7 @@ import { ToolResult, toolResult } from '@tools/result';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
-export const READ_FILE_MAX_LINES = 400;
+export const READ_FILE_MAX_LINES = 2000;
 
 const ReadInputSchema = z.strictObject({
   path: z.string(),


### PR DESCRIPTION
## Summary
- increase the read tool maximum window to 2000 lines so default truncation matches the higher ceiling
- refresh the ReadTool unit tests to assert the expanded window, truncation summary, and window default behavior

## Testing
- CI=1 npm test -- ReadTool *(fails: vscode-test binary requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6903a60ef3f48324ac461c707b977ceb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raises `READ_FILE_MAX_LINES` to 2000 and updates range/truncation logic and tests to match the new limit.
> 
> - **Tooling**:
>   - Increase `READ_FILE_MAX_LINES` from `400` to `2000` in `src/tools/ReadTool.ts`.
>   - Adjust default end calculation when only `range.start` is provided to cap at `start + READ_FILE_MAX_LINES - 1` and respect file length.
>   - Preserve clamped slicing, truncation handling, and enriched summaries (including out-of-bounds messages).
> - **Tests** (`src/test/tools/ReadTool.test.ts`):
>   - Update assertions to reference `READ_FILE_MAX_LINES` dynamically.
>   - Revise summaries and expectations for truncation markers and ranges beyond the default limit.
>   - Add/adjust cases for clipped ranges, empty files, single-line ranges, and default window behavior under the new limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81a11a36ffc0389b2df48ebc95391c857dfd3e26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->