### PR TITLE
Refactor cycles to rely on logger context

### DIFF
--- a/src/agent/core/AgentCycleOptions.ts
+++ b/src/agent/core/AgentCycleOptions.ts
@@ -7,6 +7,9 @@ import type { AgentLogger } from '@logger/AgentLogger';
 // Local imports - model handlers
 import type { IModelHandler } from '@agent/modelHandlers';
 
+// Local imports - identifier types
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+
 export interface AgentCycleBaseOptions<C = unknown> {
   modelHandler: IModelHandler<any, any, any, any, C>;
   agentSetting: AgentSetting;
@@ -16,4 +19,5 @@ export interface AgentCycleBaseOptions<C = unknown> {
   client: C;
   checkInterruption: () => Promise<boolean> | boolean;
   setAbortController: (ctrl: AbortController | null) => void;
+  executionId?: ExecutionId;
 }

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -15,9 +15,6 @@ import type { AgentCycleBaseOptions } from './AgentCycleOptions';
 // Local imports - model handler types
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
-// Local imports - identifier types
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
-
 // Local imports - agent configuration
 import type { AgentConfig } from './AgentConfig';
 
@@ -33,8 +30,6 @@ export interface ResponseCycleContext<C = unknown> {
   stateGlobal: AgentStateGlobal;
   toolState: ToolState;
   outputFile: string;
-  roundGroupId?: string;
-  executionId?: ExecutionId;
 }
 
 export interface ResponseCycleResult {
@@ -55,8 +50,6 @@ export async function runResponseCycle<C = unknown>(
       stateGlobal: context.stateGlobal,
       toolState: context.toolState,
       outputFile: context.outputFile,
-      roundGroupId: context.roundGroupId,
-      executionId: context.executionId,
       endTurn: false,
       shouldStop: false,
       outputExists: false,

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -17,21 +17,16 @@ import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage
 // Local imports - tools
 import type { BaseTool } from '@tools/core/base';
 
-// Local imports - usage
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
-
 export interface ToolUseCycleOptions<C = unknown>
   extends AgentCycleBaseOptions<C> {
   toolRegistry: Record<string, BaseTool<any>>;
   toolState: ToolState;
   modelName?: string;
-  executionId?: ExecutionId;
 }
 
 export interface ToolUseCycleContext<C = unknown> {
   options: ToolUseCycleOptions<C>;
   messages: ProviderMessage[];
-  groupId?: string;
 }
 
 export async function runToolUseCycle<C = unknown>(
@@ -42,7 +37,6 @@ export async function runToolUseCycle<C = unknown>(
     state: {
       messages: context.messages,
       toolState: context.options.toolState,
-      groupId: context.groupId,
       iteration: 0,
       shouldStop: false,
       response: undefined,

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -45,7 +45,6 @@ interface DebugContext {
   logger: ResponseCycleOptions['logger'];
   modelName: string;
   executionId?: ExecutionId;
-  groupId?: string;
 }
 
 interface DebugFileOptions {
@@ -77,8 +76,6 @@ export interface ResponseCycleInputState {
   stateGlobal: AgentStateGlobal;
   toolState: ToolState;
   outputFile: string;
-  roundGroupId?: string;
-  executionId?: ExecutionId;
 }
 
 export interface ResponseCycleRuntimeState {
@@ -142,8 +139,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
       : {
           logger,
           modelName: agentConfig.model,
-          executionId: cycle.executionId,
-          groupId: cycle.roundGroupId,
+          executionId: options.executionId,
         };
 
     const debugFileOptions: DebugFileOptions | undefined = interrupted
@@ -218,6 +214,8 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     options.modelHandler.setOutputStreaming(false);
 
     let response: unknown;
+    const groupId = options.logger.getActiveGroupId();
+
     try {
       response = await options.modelHandler.createResponse(
         options.client,
@@ -235,7 +233,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         error instanceof Error
           ? `Model invocation failed: ${error.message}`
           : 'Model invocation failed with an unknown error';
-      options.logger.error(message, cycle.roundGroupId);
+      options.logger.error(message, groupId);
       cycle.shouldStop = true;
       cycle.endTurn = false;
       throw error;
@@ -256,6 +254,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     execRes: { skipped: true } | { response: unknown; responseTime?: number },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
+    const groupId = options.logger.getActiveGroupId();
 
     if ('skipped' in execRes) {
       cycle.endTurn = false;
@@ -275,7 +274,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (!execRes.response) {
       options.logger.warn(
         'Model response was aborted or returned no data; output may be incomplete.',
-        cycle.roundGroupId,
+        groupId,
       );
       cycle.endTurn = false;
       cycle.shouldStop = true;
@@ -323,10 +322,12 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
         options.agentSetting.endTag,
       );
 
+    const groupId = options.logger.getActiveGroupId();
+
     if (newResponse) {
       options.logger.debug(
         `Model response: ${newResponse.slice(0, 100)}`,
-        cycle.roundGroupId,
+        groupId,
       );
     }
 
@@ -334,19 +335,19 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       cycle.stateRound.updateResponseTime(cycle.responseTime);
       options.logger.debug(
         `Response time: ${cycle.responseTime.toFixed(2)}s`,
-        cycle.roundGroupId,
+        groupId,
       );
     }
 
-    options.logger.debug(`Stop reason: ${stopReason}`, cycle.roundGroupId);
+    options.logger.debug(`Stop reason: ${stopReason}`, groupId);
     options.logger.debug(
       `Token usage: ${JSON.stringify(responseUsage)}`,
-      cycle.roundGroupId,
+      groupId,
     );
 
     const thinkingContent = options.modelHandler.processThinkingBlock(
       cycle.responseObject,
-      cycle.roundGroupId,
+      groupId,
       cycle.toolState,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
@@ -356,7 +357,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       if (formatted.trim().length > 0) {
         options.logger.info(
           formatted,
-          cycle.roundGroupId,
+          groupId,
           MESSAGE_TYPES.THINKING,
         );
       }
@@ -369,7 +370,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (scratchpad) {
       options.logger.info(
         scratchpad,
-        cycle.roundGroupId,
+        groupId,
         MESSAGE_TYPES.SCRATCHPAD,
       );
     }
@@ -378,7 +379,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       const formattedResponse = await xmlUtils.formatContent(newResponse);
       options.logger.info(
         formattedResponse,
-        cycle.roundGroupId,
+        groupId,
         MESSAGE_TYPES.INTERNAL,
       );
     }
@@ -396,22 +397,22 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     );
 
     if (repetitionResult.massiveRepetitionDetected && newResponse) {
-      options.logger.error(
-        `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-        cycle.roundGroupId,
-      );
-      options.logger.error(
-        'Massive repetition detected - skipping this response',
-        cycle.roundGroupId,
-      );
-      options.logger.error(
-        'Message structure when repetition detected:',
-        cycle.roundGroupId,
-      );
-      options.logger.error(
-        JSON.stringify(messageToSkeleton(cycle.messages), null, 2),
-        cycle.roundGroupId,
-      );
+        options.logger.error(
+          `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
+          groupId,
+        );
+        options.logger.error(
+          'Massive repetition detected - skipping this response',
+          groupId,
+        );
+        options.logger.error(
+          'Message structure when repetition detected:',
+          groupId,
+        );
+        options.logger.error(
+          JSON.stringify(messageToSkeleton(cycle.messages), null, 2),
+          groupId,
+        );
     }
 
     let processedResponse: string | undefined;
@@ -453,6 +454,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     execRes: ProcessResult | { skipped: true },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
+    const groupId = options.logger.getActiveGroupId();
 
     if ('skipped' in execRes) {
       cycle.endTurn = false;
@@ -471,14 +473,14 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (!cycle.outputExists) {
       options.logger.debug(
         `Creating new file: ${cycle.outputFile}`,
-        cycle.roundGroupId,
+        groupId,
       );
       await WorkspaceFS.write(cycle.outputFile, execRes.processedResponse);
       cycle.outputExists = true;
     } else {
       options.logger.debug(
         `Appending to existing file: ${cycle.outputFile}`,
-        cycle.roundGroupId,
+        groupId,
       );
       await WorkspaceFS.appendFile(
         cycle.outputFile,
@@ -486,14 +488,14 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       );
     }
 
-    options.logger.debug('Response preview:', cycle.roundGroupId);
+    options.logger.debug('Response preview:', groupId);
     options.logger.debug(
       `First ${K_SLICE} chars:\n${execRes.processedResponse.slice(0, K_SLICE)}`,
-      cycle.roundGroupId,
+      groupId,
     );
     options.logger.debug(
       `Last ${K_SLICE} chars:\n${execRes.processedResponse.slice(-K_SLICE)}`,
-      cycle.roundGroupId,
+      groupId,
     );
 
     if (options.modelHandler.capabilities.supportsAssistantPrefill) {
@@ -567,6 +569,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       | { skipped: true },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
+    const groupId = options.logger.getActiveGroupId();
 
     if ('skipped' in execRes) {
       cycle.endTurn = false;
@@ -584,7 +587,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     cycle.stateRound.incrementContinuation();
     options.logger.info(
       `Starting continuation #${cycle.stateRound.continuationCount}`,
-      cycle.roundGroupId,
+      groupId,
       MESSAGE_TYPES.PROGRESS_STATUS,
     );
 
@@ -594,7 +597,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     options.logger.debug(
       'Should continue - adding continuation message to conversation',
-      cycle.roundGroupId,
+      groupId,
     );
 
     if (options.modelHandler.capabilities.supportsAssistantPrefill) {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -39,7 +39,7 @@ import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 interface DebugContext {
   logger: ToolUseCycleOptions['logger'];
   modelName?: string;
-  groupId?: string;
+  executionId?: ToolUseCycleOptions['executionId'];
 }
 
 interface DebugFileOptions {
@@ -140,7 +140,6 @@ type ToolDispatchErrorResult = {
 export interface ToolUseCycleInputState {
   messages: ProviderMessage[];
   toolState: ToolState;
-  groupId?: string;
   iteration: number;
 }
 
@@ -181,7 +180,7 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     const debugContext: DebugContext = {
       logger: options.logger,
       modelName: options.modelName,
-      groupId: state.groupId,
+      executionId: options.executionId,
     };
     const debugFileOptions: DebugFileOptions = {
       continuationCount: state.iteration,
@@ -255,7 +254,7 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     const debugContext: DebugContext = {
       logger: options.logger,
       modelName: options.modelName,
-      groupId: state.groupId,
+      executionId: options.executionId,
     };
     const debugFileOptions: DebugFileOptions = {
       continuationCount: state.iteration,
@@ -344,16 +343,18 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       return { skipped: true };
     }
 
+    const groupId = options.logger.getActiveGroupId();
+
     const thinking = options.modelHandler.processThinkingBlock(
       state.response,
-      state.groupId,
+      groupId,
       state.toolState,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
     if (thinking && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinking);
       if (formatted.trim().length > 0) {
-        options.logger.info(formatted, state.groupId, MESSAGE_TYPES.THINKING);
+        options.logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
       }
     }
 
@@ -366,13 +367,13 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     if (text) {
       options.logger.debug(
         `Model response: ${text.slice(0, 100)}`,
-        state.groupId,
+        groupId,
       );
       if (!useStreaming) {
         const formatted = await xmlUtils.formatContent(text);
         options.logger.info(
           formatted,
-          state.groupId,
+          groupId,
           MESSAGE_TYPES.MODEL_RESPONSE,
         );
       }
@@ -389,7 +390,7 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         cost: normalized.cost,
         elapsedTime: normalized.responseTime,
       };
-      options.logger.statistics(stats, state.groupId);
+      options.logger.statistics(stats, groupId);
     }
 
     const endTurn = options.modelHandler.isEndTurnStop(stopReason);
@@ -451,6 +452,8 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       return { skipped: true };
     }
 
+    const groupId = options.logger.getActiveGroupId();
+
     const interrupted = Boolean(await options.checkInterruption());
     if (interrupted) {
       state.shouldStop = true;
@@ -470,7 +473,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       };
       options.logger.info(
         '',
-        state.groupId,
+        groupId,
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
@@ -496,7 +499,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       };
       options.logger.info(
         '',
-        state.groupId,
+        groupId,
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
@@ -521,7 +524,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       };
       options.logger.info(
         '',
-        state.groupId,
+        groupId,
         MESSAGE_TYPES.TOOL_USE,
         toolUseLog,
       );
@@ -564,6 +567,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       | ToolDispatchErrorResult,
   ): Promise<string | undefined> {
     const { options, state } = prepRes;
+    const groupId = options.logger.getActiveGroupId();
     if ('skipped' in execRes) {
       state.shouldStop = true;
       return FlowTransition.COMPLETE;
@@ -605,7 +609,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       state.shouldStop = false;
 
       if (fallbackMessage) {
-        options.logger.warn(fallbackMessage, state.groupId);
+        options.logger.warn(fallbackMessage, groupId);
       }
 
       return FlowTransition.CONTINUE;
@@ -639,7 +643,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       input: execRes.input ?? execRes.parsed,
       output: sanitizeToolResultForLog(result),
     };
-    options.logger.info('', state.groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+    options.logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
 
     if (result.files && result.files.length > 0) {
       const existing = state.toolState.mediaFiles;

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -115,6 +115,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       setAbortController: (ctrl) => {
         this.abortController = ctrl;
       },
+      executionId: this.executionId,
     };
   }
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -315,8 +315,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         stateGlobal: globalState,
         toolState,
         outputFile: outputPath,
-        roundGroupId,
-        executionId: this.executionId,
       });
 
       await this.handleRoundCompletion(

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -313,7 +313,6 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       toolRegistry: this.toolRegistry,
       toolState,
       modelName: this.agentConfig.model,
-      executionId: this.executionId,
     };
   }
 

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -75,6 +75,7 @@ export async function maybeSaveDebugObject({
   }
 
   const { logger, modelName, executionId, groupId } = context;
+  const activeGroupId = groupId ?? logger.getActiveGroupId();
   const { outputFile, baseName = objectType, continuationCount } = fileOptions;
 
   const fileBase =
@@ -99,8 +100,8 @@ export async function maybeSaveDebugObject({
         object,
       );
     }
-    logger.info(`Saved ${objectType} object to ${debugFilePath}`, groupId);
+    logger.info(`Saved ${objectType} object to ${debugFilePath}`, activeGroupId);
   } catch (error) {
-    logger.error(`Failed to save ${objectType} object: ${error}`, groupId);
+    logger.error(`Failed to save ${objectType} object: ${error}`, activeGroupId);
   }
 }


### PR DESCRIPTION
## Summary
- let agent cycle options carry the execution ID from the base agent
- simplify response and tool-use cycles to pull the active log group from the logger
- allow the debug message saver to fall back to the logger's active group instead of requiring callers to supply one

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903ec448e008324829b50afbc5027e3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes cycle logging to use the logger’s active group and threads executionId via base options, removing ad-hoc group/execution IDs from cycles and flows.
> 
> - **Core**:
>   - Add `executionId` to `AgentCycleBaseOptions` and propagate from `BaseAgent`.
>   - Simplify `ResponseCycle` and `ToolUseCycle` contexts by removing `roundGroupId`/`groupId`/`executionId` fields.
> - **Flows**:
>   - Use `logger.getActiveGroupId()` for all logging in `ResponseCycleFlow` and `ToolUseCycleFlow`.
>   - Include `executionId` (from options) in debug contexts; remove group ID from debug contexts.
>   - Keep debug save calls but route context through `maybeSaveDebugObject`.
> - **Implementations**:
>   - `BaseReflectionAgent` and `BaseToolUseAgent`: update cycle option construction and calls to match new contexts.
> - **Utils**:
>   - `debugMessageSaver`: fall back to logger’s active group when `groupId` is not provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 051a8ac0e7f51073181ae6e78a5b781ab58bfc6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->