### PR TITLE
Fix Google GenAI attachment forwarding

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -52,12 +52,16 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
 import {
+  DEFAULT_ATTACHMENT_MIME_TYPE,
   describeAttachments,
   extractToolAttachments,
   loadAttachmentBuffer,
 } from './utils/toolAttachmentUtils';
 import { cleanFileContent } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
+
+// Local imports - tools
+import type { ToolFileAttachment } from '@tools/result';
 
 // Google finish reasons are re-exported from the SDK
 
@@ -281,7 +285,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     for (const entry of entries) {
       const fileName = entry.file_name || 'unnamed-file';
-      const mimeType = entry.media_type || 'application/octet-stream';
+      const mimeType = entry.media_type || DEFAULT_ATTACHMENT_MIME_TYPE;
       const uploadSource = this.getUploadSource(entry, mimeType);
 
       if (!uploadSource) {
@@ -379,7 +383,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (entry.media_type && entry.media_type.length > 0) {
       return entry.media_type;
     }
-    return 'application/octet-stream';
+    return DEFAULT_ATTACHMENT_MIME_TYPE;
   }
   async getClient(): Promise<GoogleGenAI> {
     if (!this.googleClient) {
@@ -1091,6 +1095,40 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return null;
   }
 
+  private async buildAttachmentPart(
+    attachment: ToolFileAttachment,
+  ): Promise<FunctionResponsePart | null> {
+    try {
+      const buffer = await loadAttachmentBuffer(attachment);
+      if (!buffer || buffer.length === 0) {
+        this.logger.warn(
+          `Skipping empty attachment '${attachment.path}' in Google function response.`,
+        );
+        return null;
+      }
+
+      const mimeType =
+        typeof attachment.mimeType === 'string' &&
+        attachment.mimeType.length > 0
+          ? attachment.mimeType
+          : DEFAULT_ATTACHMENT_MIME_TYPE;
+
+      return createFunctionResponsePartFromBase64(
+        buffer.toString('base64'),
+        mimeType,
+      );
+    } catch (attachmentError) {
+      const message =
+        attachmentError instanceof Error
+          ? attachmentError.message
+          : String(attachmentError);
+      this.logger.warn(
+        `Failed to encode attachment '${attachment.path}' for Google function response: ${message}`,
+      );
+      return null;
+    }
+  }
+
   async createToolUseFollowUpMessages(
     _client: GoogleGenAI | undefined,
     id: string,
@@ -1136,49 +1174,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         `Attachments available:\n${describeAttachments(attachments).join('\n')}`;
 
       const encodedParts = await Promise.all(
-        attachments.map(async (attachment) => {
-          try {
-            const buffer = await loadAttachmentBuffer(attachment);
-            if (!buffer || buffer.length === 0) {
-              this.logger.warn(
-                `Skipping empty attachment '${attachment.path}' in Google function response.`,
-              );
-              return null;
-            }
-
-            const base64Payload = buffer.toString('base64');
-            if (!base64Payload) {
-              this.logger.warn(
-                `Skipping attachment '${attachment.path}' with no encodable payload.`,
-              );
-              return null;
-            }
-
-            const mimeType =
-              typeof attachment.mimeType === 'string' &&
-              attachment.mimeType.length > 0
-                ? attachment.mimeType
-                : 'application/octet-stream';
-
-            return createFunctionResponsePartFromBase64(
-              base64Payload,
-              mimeType,
-            );
-          } catch (attachmentError) {
-            const message =
-              attachmentError instanceof Error
-                ? attachmentError.message
-                : String(attachmentError);
-            this.logger.warn(
-              `Failed to encode attachment '${attachment.path}' for Google function response: ${message}`,
-            );
-            return null;
-          }
-        }),
+        attachments.map((attachment) => this.buildAttachmentPart(attachment)),
       );
 
       responseParts = encodedParts.filter(
-        (part): part is FunctionResponsePart => Boolean(part),
+        (part): part is FunctionResponsePart => part !== null,
       );
     }
     const resultPart = createPartFromFunctionResponse(

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -17,12 +17,11 @@ import {
   createPartFromUri,
   createPartFromFunctionCall,
   createPartFromFunctionResponse,
-  createFunctionResponsePartFromBase64,
+  createPartFromBase64,
   GenerateContentConfig,
   type CreateChatParameters,
   type SendMessageParameters,
   type UploadFileParameters,
-  type FunctionResponsePart,
 } from '@google/genai';
 
 // Local imports - agent
@@ -1097,7 +1096,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   private async buildAttachmentPart(
     attachment: ToolFileAttachment,
-  ): Promise<FunctionResponsePart | null> {
+  ): Promise<Part | null> {
     try {
       const buffer = await loadAttachmentBuffer(attachment);
       if (!buffer || buffer.length === 0) {
@@ -1113,10 +1112,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           ? attachment.mimeType
           : DEFAULT_ATTACHMENT_MIME_TYPE;
 
-      return createFunctionResponsePartFromBase64(
-        buffer.toString('base64'),
-        mimeType,
-      );
+      return createPartFromBase64(buffer.toString('base64'), mimeType);
     } catch (attachmentError) {
       const message =
         attachmentError instanceof Error
@@ -1168,24 +1164,31 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     // Use the same ID for the result to maintain correlation
     const { attachments, sanitizedResult } = extractToolAttachments(result);
-    let responseParts: FunctionResponsePart[] = [];
+    let attachmentParts: Part[] = [];
     if (attachments.length > 0) {
       (sanitizedResult as Record<string, unknown>).attachmentSummary =
-        `Attachments available:\n${describeAttachments(attachments).join('\n')}`;
+        `Attachments included in this response:\n${describeAttachments(
+          attachments,
+        ).join('\n')}`;
 
       const encodedParts = await Promise.all(
         attachments.map((attachment) => this.buildAttachmentPart(attachment)),
       );
 
-      responseParts = encodedParts.filter(
-        (part): part is FunctionResponsePart => part !== null,
+      attachmentParts = encodedParts.filter(
+        (part): part is Part => part !== null,
       );
+
+      if (attachmentParts.length === 0) {
+        this.logger.warn(
+          `All attachments for Google function response '${functionName}' failed to encode.`,
+        );
+      }
     }
     const resultPart = createPartFromFunctionResponse(
       callId,
       functionName,
       sanitizedResult,
-      responseParts.length > 0 ? responseParts : undefined,
     );
     const callParts: Part[] = [];
     if (text) {
@@ -1196,7 +1199,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       role: 'model',
       parts: sanitizeFunctionCallParts(callParts),
     };
-    const resultMsg: Content = { role: 'user', parts: [resultPart] };
+    const resultParts: Part[] = [resultPart, ...attachmentParts];
+    const resultMsg: Content = { role: 'user', parts: resultParts };
     return [callMsg, resultMsg];
   }
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -17,10 +17,12 @@ import {
   createPartFromUri,
   createPartFromFunctionCall,
   createPartFromFunctionResponse,
+  createFunctionResponsePartFromBase64,
   GenerateContentConfig,
   type CreateChatParameters,
   type SendMessageParameters,
   type UploadFileParameters,
+  type FunctionResponsePart,
 } from '@google/genai';
 
 // Local imports - agent
@@ -52,6 +54,7 @@ import type { ToolDefinition } from '@model';
 import {
   describeAttachments,
   extractToolAttachments,
+  loadAttachmentBuffer,
 } from './utils/toolAttachmentUtils';
 import { cleanFileContent } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
@@ -1127,16 +1130,62 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     // Use the same ID for the result to maintain correlation
     const { attachments, sanitizedResult } = extractToolAttachments(result);
+    let responseParts: FunctionResponsePart[] = [];
     if (attachments.length > 0) {
       (sanitizedResult as Record<string, unknown>).attachmentSummary =
-        `Attachments available:\n${describeAttachments(attachments).join(
-          '\n',
-        )}\nUse the read_file tool to download them.`;
+        `Attachments available:\n${describeAttachments(attachments).join('\n')}`;
+
+      const encodedParts = await Promise.all(
+        attachments.map(async (attachment) => {
+          try {
+            const buffer = await loadAttachmentBuffer(attachment);
+            if (!buffer || buffer.length === 0) {
+              this.logger.warn(
+                `Skipping empty attachment '${attachment.path}' in Google function response.`,
+              );
+              return null;
+            }
+
+            const base64Payload = buffer.toString('base64');
+            if (!base64Payload) {
+              this.logger.warn(
+                `Skipping attachment '${attachment.path}' with no encodable payload.`,
+              );
+              return null;
+            }
+
+            const mimeType =
+              typeof attachment.mimeType === 'string' &&
+              attachment.mimeType.length > 0
+                ? attachment.mimeType
+                : 'application/octet-stream';
+
+            return createFunctionResponsePartFromBase64(
+              base64Payload,
+              mimeType,
+            );
+          } catch (attachmentError) {
+            const message =
+              attachmentError instanceof Error
+                ? attachmentError.message
+                : String(attachmentError);
+            this.logger.warn(
+              `Failed to encode attachment '${attachment.path}' for Google function response: ${message}`,
+            );
+            return null;
+          }
+        }),
+      );
+
+      responseParts = encodedParts.filter(
+        (part): part is FunctionResponsePart => Boolean(part),
+      );
     }
     const resultPart = createPartFromFunctionResponse(
       callId,
       functionName,
       sanitizedResult,
+      responseParts.length > 0 ? responseParts : undefined,
     );
     const callParts: Part[] = [];
     if (text) {

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -4,6 +4,8 @@ import type { ToolFileAttachment, ToolResult } from '@tools/result';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
+export const DEFAULT_ATTACHMENT_MIME_TYPE = 'application/octet-stream';
+
 export interface ExtractedToolAttachments {
   attachments: ToolFileAttachment[];
   sanitizedResult: Record<string, unknown>;
@@ -59,7 +61,7 @@ export function describeAttachments(
     const type =
       typeof file.mimeType === 'string' && file.mimeType.length > 0
         ? file.mimeType
-        : 'application/octet-stream';
+        : DEFAULT_ATTACHMENT_MIME_TYPE;
     return `- ${path} (${type})`;
   });
 }

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -400,18 +400,35 @@ describe('ModelHandlerGoogleGenAI tool attachments', () => {
       toolResult,
     );
 
-    assert.equal(messages.length, 2, 'should produce call and response messages');
+    assert.equal(
+      messages.length,
+      2,
+      'should produce call and response messages',
+    );
 
     const responseParts = messages[1].parts ?? [];
-    assert.equal(responseParts.length, 1, 'response should contain a single part');
+    assert.equal(
+      responseParts.length,
+      1,
+      'response should contain a single part',
+    );
     const [responsePart] = responseParts;
 
     const functionResponse = responsePart.functionResponse;
-    assert(functionResponse, 'response part should include functionResponse payload');
+    assert(
+      functionResponse,
+      'response part should include functionResponse payload',
+    );
 
-    const sanitizedResponse = functionResponse.response as Record<string, unknown>;
+    const sanitizedResponse = functionResponse.response as Record<
+      string,
+      unknown
+    >;
     const attachmentSummary = sanitizedResponse.attachmentSummary as string;
-    assert(attachmentSummary, 'attachment summary should be present on sanitized response');
+    assert(
+      attachmentSummary,
+      'attachment summary should be present on sanitized response',
+    );
     assert(!attachmentSummary.includes('read_file'));
 
     const files = sanitizedResponse.files as Array<Record<string, unknown>>;
@@ -424,7 +441,11 @@ describe('ModelHandlerGoogleGenAI tool attachments', () => {
     ]);
 
     const functionResponseParts = functionResponse?.parts ?? [];
-    assert.equal(functionResponseParts.length, 1, 'should include encoded attachment');
+    assert.equal(
+      functionResponseParts.length,
+      1,
+      'should include encoded attachment',
+    );
     const [attachmentPart] = functionResponseParts;
     assert.equal(attachmentPart.inlineData?.mimeType, 'image/png');
     assert.equal(

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -369,7 +369,7 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
 });
 
 describe('ModelHandlerGoogleGenAI tool attachments', () => {
-  it('embeds tool attachments into function response parts', async () => {
+  it('appends tool attachments as inline data parts', async () => {
     const handler = new ModelHandlerGoogleGenAI(buildGoogleConfig());
     const { logger } = createLoggerStub();
     handler.setLogger(logger);
@@ -409,10 +409,10 @@ describe('ModelHandlerGoogleGenAI tool attachments', () => {
     const responseParts = messages[1].parts ?? [];
     assert.equal(
       responseParts.length,
-      1,
-      'response should contain a single part',
+      2,
+      'response should contain function response and attachment parts',
     );
-    const [responsePart] = responseParts;
+    const [responsePart, attachmentPart] = responseParts;
 
     const functionResponse = responsePart.functionResponse;
     assert(
@@ -440,13 +440,11 @@ describe('ModelHandlerGoogleGenAI tool attachments', () => {
       },
     ]);
 
-    const functionResponseParts = functionResponse?.parts ?? [];
-    assert.equal(
-      functionResponseParts.length,
-      1,
-      'should include encoded attachment',
+    assert(
+      !functionResponse?.parts,
+      'function response should not embed parts',
     );
-    const [attachmentPart] = functionResponseParts;
+
     assert.equal(attachmentPart.inlineData?.mimeType, 'image/png');
     assert.equal(
       attachmentPart.inlineData?.data,

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -2,7 +2,12 @@
 import { strict as assert } from 'assert';
 
 // Third-party imports
-import type { File, Part, UploadFileParameters } from '@google/genai';
+import type {
+  File,
+  Part,
+  UploadFileParameters,
+  FunctionCall,
+} from '@google/genai';
 import { createPartFromUri } from '@google/genai';
 
 // Local imports - agent
@@ -360,5 +365,71 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
     assert.equal(uploadedEntries.length, 1, 'uploads should run once');
     assert.equal(uploadedEntries[0][0].file_name, 'doc.pdf');
     assert.equal(stub.fileListEntries.length, 1, 'should log processed media');
+  });
+});
+
+describe('ModelHandlerGoogleGenAI tool attachments', () => {
+  it('embeds tool attachments into function response parts', async () => {
+    const handler = new ModelHandlerGoogleGenAI(buildGoogleConfig());
+    const { logger } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const attachmentBytes = new Uint8Array([1, 2, 3, 4]);
+    const toolResult: Record<string, unknown> = {
+      output: 'generated figures',
+      files: [
+        {
+          path: 'figures/plot.png',
+          mimeType: 'image/png',
+          bytes: attachmentBytes,
+          description: 'Plot preview',
+        },
+      ],
+    };
+
+    const functionCall: FunctionCall = {
+      name: 'extract_figures',
+      args: { source: 'doc.tex' },
+    };
+
+    const messages = await handler.createToolUseFollowUpMessages(
+      undefined,
+      'call-123',
+      'extract_figures',
+      functionCall,
+      toolResult,
+    );
+
+    assert.equal(messages.length, 2, 'should produce call and response messages');
+
+    const responseParts = messages[1].parts ?? [];
+    assert.equal(responseParts.length, 1, 'response should contain a single part');
+    const [responsePart] = responseParts;
+
+    const functionResponse = responsePart.functionResponse;
+    assert(functionResponse, 'response part should include functionResponse payload');
+
+    const sanitizedResponse = functionResponse.response as Record<string, unknown>;
+    const attachmentSummary = sanitizedResponse.attachmentSummary as string;
+    assert(attachmentSummary, 'attachment summary should be present on sanitized response');
+    assert(!attachmentSummary.includes('read_file'));
+
+    const files = sanitizedResponse.files as Array<Record<string, unknown>>;
+    assert.deepEqual(files, [
+      {
+        path: 'figures/plot.png',
+        mimeType: 'image/png',
+        description: 'Plot preview',
+      },
+    ]);
+
+    const functionResponseParts = functionResponse?.parts ?? [];
+    assert.equal(functionResponseParts.length, 1, 'should include encoded attachment');
+    const [attachmentPart] = functionResponseParts;
+    assert.equal(attachmentPart.inlineData?.mimeType, 'image/png');
+    assert.equal(
+      attachmentPart.inlineData?.data,
+      Buffer.from(attachmentBytes).toString('base64'),
+    );
   });
 });

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -93,10 +93,7 @@ suite('ReadFileTool', () => {
     const outputLines = result.output?.split('\n') ?? [];
     assert.strictEqual(outputLines.length, rangeEnd - rangeStart + 1);
     assert.strictEqual(outputLines[0], `row ${rangeStart}`);
-    assert.strictEqual(
-      outputLines[outputLines.length - 1],
-      `row ${rangeEnd}`,
-    );
+    assert.strictEqual(outputLines[outputLines.length - 1], `row ${rangeEnd}`);
   });
 
   test('notes when requested range exceeds file length', async () => {


### PR DESCRIPTION
## Summary
- forward tool attachments from Google GenAI handler using SDK function response parts
- include attachment summaries while skipping unencodable payloads with logging
- add regression coverage ensuring attachments reach the function response payload

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_69046b180fe0832496ee7dc97fa57ce1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Forwards tool file attachments from the Google GenAI handler as inline data parts with summaries, adds attachment buffer loading and a shared default MIME type, and updates tests to cover attachment propagation.
> 
> - **Google GenAI handler (`modelHandlerGoogleGenAI.ts`)**:
>   - Forward tool attachments as inline `parts` using `createPartFromBase64`, appended to the function response message.
>   - Add `attachmentSummary` to sanitized function responses; log and skip unencodable/empty attachments.
>   - Introduce `buildAttachmentPart` using `loadAttachmentBuffer`; use `DEFAULT_ATTACHMENT_MIME_TYPE` for fallbacks.
>   - Use shared default MIME type in media upload and MIME resolution.
> - **Attachment utils (`utils/toolAttachmentUtils.ts`)**:
>   - Add `DEFAULT_ATTACHMENT_MIME_TYPE` and `loadAttachmentBuffer`.
>   - Sanitize `files` by stripping raw payload fields; improve `describeAttachments` defaulting.
> - **Tests**:
>   - Add regression test ensuring attachments are included as inline parts and summarized in function responses.
>   - Minor assertion formatting tweak in `ReadTool.test`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b5c71984bb848c156c1e0c0aa12bcf081474378. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->