### PR TITLE
fix: align anthropic beta request types

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -11,13 +11,13 @@ import type {
   BetaMessage,
   BetaRequestDocumentBlock,
   BetaTextBlockParam,
+  MessageCountTokensParams,
+  MessageCreateParams,
 } from '@anthropic-ai/sdk/resources/beta/messages';
-import {
+import type {
   MessageParam,
   ContentBlock,
   ContentBlockParam,
-  MessageCreateParams,
-  MessageCountTokensParams,
   ToolUseBlock,
   TextBlockParam,
   ImageBlockParam,
@@ -94,16 +94,6 @@ import xmlUtils from '@utils/text/xmlUtils';
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.
  */
-
-// The new implicit prompt caching is worth checking out (can eliminate many controls of previous caching)
-type BetaMessageCreateParams = MessageCreateParams & {
-  betas?: AnthropicBeta[];
-  context_management?: BetaContextManagementConfig | null;
-};
-type BetaMessageCountTokensParams = MessageCountTokensParams & {
-  betas?: AnthropicBeta[];
-  context_management?: BetaContextManagementConfig | null;
-};
 
 const CONTEXT_1M_BETA: AnthropicBeta = 'context-1m-2025-08-07';
 const FILES_API_BETA: AnthropicBeta = 'files-api-2025-04-14';
@@ -249,7 +239,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     let hasFileReference = documentAnalysis.hasFileSource;
 
     // Prepare options for the API call
-    const options: BetaMessageCreateParams = {
+    const options: MessageCreateParams = {
       model: this.config.fullName,
       max_tokens: this.config.maxOutputTokens,
       messages,
@@ -324,7 +314,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           'Skipping token counting because Anthropic countTokens does not support file-based document sources.',
         );
       } else {
-        const countTokensParams: BetaMessageCountTokensParams = {
+        const countTokensParams: MessageCountTokensParams = {
           model: this.config.fullName,
           system: systemPrompt,
           messages,


### PR DESCRIPTION
## Summary
- remove the locally-defined Anthropic beta request parameter aliases
- rely on the SDK-provided beta MessageCreate/MessageCountTokens param types
- update the Anthropic model handler to use the SDK types directly

## Testing
- npm run format
- npm run compile -- --progress --color

------
https://chatgpt.com/codex/tasks/task_e_6904c84c52248324a1bc263df90e9844

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace local Anthropic beta request param aliases with SDK-provided types and update handler to use them directly.
> 
> - **Model handler (`src/agent/modelHandlers/modelHandlerAnthropic.ts`)**:
>   - Remove locally-defined `BetaMessageCreateParams`/`BetaMessageCountTokensParams` aliases.
>   - Import and use SDK beta types `MessageCreateParams` and `MessageCountTokensParams` from `@anthropic-ai/sdk/resources/beta/messages`.
>   - Update variables to these types (e.g., `options`, `countTokensParams`) and keep beta flags/context management usage intact.
>   - Minor import cleanup to use `import type` for message types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f6129edf9e20ff39f10f018ffb17b3ed5c7d595. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->