### PR TITLE
Align Anthropic cache control typing with SDK

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -6,11 +6,13 @@ import { basename } from 'node:path';
 import { Anthropic, toFile } from '@anthropic-ai/sdk';
 import type {
   BetaBase64ImageSource,
+  BetaCacheControlEphemeral,
   BetaContextManagementConfig,
   BetaImageBlockParam,
   BetaMessage,
   BetaRequestDocumentBlock,
   BetaTextBlockParam,
+  BetaToolResultBlockParam,
 } from '@anthropic-ai/sdk/resources/beta/messages';
 import {
   MessageParam,
@@ -114,14 +116,17 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
-type CacheControlBlock = (ContentBlockParam | ContentBlock) & {
-  type: 'text' | 'tool_result';
-  cache_control?: { type: 'ephemeral' };
+type CacheControlEligibleBlock =
+  | (ContentBlockParam & BetaTextBlockParam)
+  | (ContentBlockParam & BetaToolResultBlockParam);
+
+const EPHEMERAL_CACHE_CONTROL: BetaCacheControlEphemeral = {
+  type: 'ephemeral',
 };
 
 const isCacheControlEligibleBlock = (
   block: ContentBlockParam | ContentBlock | undefined,
-): block is CacheControlBlock => {
+): block is CacheControlEligibleBlock => {
   if (!block || typeof block !== 'object') {
     return false;
   }
@@ -137,7 +142,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   ToolUseBlock,
   Anthropic
 > {
-  private cacheControlledBlock?: CacheControlBlock;
+  private cacheControlledBlock?: CacheControlEligibleBlock;
 
   protected override get supportsToolFileOutputs(): boolean {
     return true;
@@ -147,12 +152,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return true;
   }
 
-  private setCacheControlTarget(block: ContentBlockParam | ContentBlock): void {
+  private setCacheControlTarget(block: CacheControlEligibleBlock): void {
     if (!this.capabilities.supportsPromptCaching) {
-      return;
-    }
-
-    if (!isCacheControlEligibleBlock(block)) {
       return;
     }
 
@@ -160,7 +161,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       delete this.cacheControlledBlock.cache_control;
     }
 
-    block.cache_control = { type: 'ephemeral' };
+    block.cache_control = EPHEMERAL_CACHE_CONTROL;
     this.cacheControlledBlock = block;
   }
 
@@ -178,7 +179,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   private findCacheControlCandidate(
     content: (ContentBlockParam | ContentBlock)[] | undefined,
-  ): CacheControlBlock | undefined {
+  ): CacheControlEligibleBlock | undefined {
     if (!Array.isArray(content) || content.length === 0) {
       return undefined;
     }
@@ -1693,7 +1694,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const toolResultBlock = Array.isArray(resultMsg.content)
       ? resultMsg.content.at(-1)
       : undefined;
-    if (toolResultBlock) {
+    if (isCacheControlEligibleBlock(toolResultBlock)) {
       this.setCacheControlTarget(toolResultBlock);
     }
 


### PR DESCRIPTION
## Summary
- replace the bespoke cache-control alias with intersections of the SDK's Beta text and tool result block params
- reuse the SDK's `BetaCacheControlEphemeral` helper when marking cacheable content
- guard tool result cache assignments by checking for Anthropic cache-control capable blocks

## Testing
- npm run compile-tests


------
https://chatgpt.com/codex/tasks/task_e_6904c8c58d008324a55ec6049cfe293b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces custom cache-control typing with SDK-aligned types, adds a typed ephemeral cache-control constant, and guards cache assignment to only eligible blocks.
> 
> - **Anthropic model handler**:
>   - **Type alignment**: Replace bespoke `CacheControlBlock` with SDK intersections `ContentBlockParam & BetaTextBlockParam` and `ContentBlockParam & BetaToolResultBlockParam` (`CacheControlEligibleBlock`).
>   - **Ephemeral cache control**: Introduce `EPHEMERAL_CACHE_CONTROL: BetaCacheControlEphemeral` and use it when marking blocks.
>   - **APIs updated**:
>     - Update field and method signatures to `CacheControlEligibleBlock` (property, `setCacheControlTarget`, `findCacheControlCandidate`).
>     - Use `isCacheControlEligibleBlock` to guard setting cache on tool result blocks in `createToolUseFollowUpMessages`.
>   - **Imports**: Add `BetaCacheControlEphemeral` and `BetaToolResultBlockParam` from SDK.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 870de2a54fcf76e8d326837a57725ee9ddb1db82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->