### PR TITLE
Fix audio content part typing for OpenAI handler

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -3,6 +3,7 @@ import { countTokens } from 'gpt-tokenizer';
 import OpenAI from 'openai';
 import {
   ChatCompletionContentPart,
+  ChatCompletionContentPartInputAudio,
   ChatCompletionAssistantMessageParam,
   ChatCompletionToolMessageParam,
   ChatCompletionMessageParam,
@@ -641,6 +642,27 @@ export class ModelHandlerOpenAI extends ModelHandler<
         if (media.media_type.includes('/')) {
           audioFormat = media.media_type.split('/')[1]; // e.g., 'wav' from 'audio/wav'
         }
+
+        type SupportedAudioFormat = 'wav' | 'mp3';
+        const normalizedAudioFormat = audioFormat.toLowerCase();
+        const supportedFormats = new Set<SupportedAudioFormat>(['wav', 'mp3']);
+        if (
+          !supportedFormats.has(normalizedAudioFormat as SupportedAudioFormat)
+        ) {
+          const errorMessage = `Unsupported audio format "${audioFormat}" for audio generation. Valid formats are: wav, mp3.`;
+          this.logger.error(errorMessage);
+          throw new Error(errorMessage);
+        }
+
+        const typedAudioFormat = normalizedAudioFormat as SupportedAudioFormat;
+
+        const audioContent: ChatCompletionContentPartInputAudio = {
+          type: 'input_audio',
+          input_audio: {
+            data: media.data,
+            format: typedAudioFormat,
+          },
+        };
         // actually, currently only mp3 and wav are supported
         // openai.BadRequestError: Error code: 400 - [{'error': {'code': 400, 'message': 'Invalid audio format "m4a" for audio generation. Valid formats are: [wav, mp3]', 'status': 'INVALID_ARGUMENT'}}]
 
@@ -657,13 +679,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
         // Let's adapt this to return the structured object expected within the message content array.
         return [
           { type: 'text', text: `Audio: ${media.file_name}` }, // Text description goes separately
-          {
-            type: 'input_audio' as any, // Cast as any to bypass strict OpenAI typing for now
-            input_audio: {
-              data: media.data,
-              format: audioFormat as any,
-            },
-          },
+          audioContent,
         ];
       } else if (media.media_category === 'audio') {
         this.logger.warn(


### PR DESCRIPTION
## Summary
- use the SDK ChatCompletionContentPartInputAudio type when constructing audio media payloads
- validate and normalize audio formats so unsupported types are rejected before building requests

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6904c92405308324b500e74daf8d09e2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use the SDK audio content type and validate/normalize audio formats (wav/mp3) for Google-compatible audio inputs.
> 
> - **OpenAI Model Handler** (`src/agent/modelHandlers/modelHandlerOpenAI.ts`):
>   - **Audio content typing**: Replace ad-hoc casting with `ChatCompletionContentPartInputAudio` when constructing `input_audio` parts.
>   - **Format handling**: Normalize audio MIME subtype to lowercase and validate against supported formats (`wav`, `mp3`); log and throw on unsupported formats.
>   - **Refactor**: Extract typed `audioContent` constant and reuse; minor adjustments to token counting placeholder for audio parts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8b47d7654a5daadb6f460bc6b2953e5677f9729. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->