### PR TITLE
Add cat-n formatting to read_file output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - Strip unsupported Gemini tool-call identifiers from follow-up history and fix tool dispatch context typing so orchestration errors surface immediately instead of silently skipping tool runs.
 - Return PDFs and common image formats from the `read_file` tool as native attachments with guidance for models that cannot display binary results, preventing corrupted text output.
 
+### Improvements
+
+- Format `read_file` text responses with `cat -n` style line numbers and update edit guidance so downstream tools can target exact content reliably.
+
 ## [0.34.1] - 2025-10-24
 
 ### Bug Fixes

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -20,7 +20,7 @@ Use the `glob`, `grep`, and `ls` tools to explore the workspace without leaving 
 When derivations are required, it presents steps inside `\begin{aligned} ... \end{aligned}` blocks
 to keep mathematical discussions accurate.
 
-> **Heads up:** `read_file` returns at most the first 400 lines of a file so tool outputs stay readable.
+> **Heads up:** `read_file` returns at most the first 2,000 lines of a file and prefixes each line with a `cat -n` style line number so tool outputs stay readable.
 
 ### `ask`
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -173,7 +173,7 @@ workspace utilities like `bash`, `read_file`, `write_file`, `edit_file`,
 `str_replace_editor`, `wolfram`,
 `web_fetch`, and `web_search`.
 
-> **Tip:** The `read_file` tool returns only the first 400 lines of a file to prevent massive responses from overwhelming the progress log. Provide an optional `range` object (for example, `{"start": 401, "end": 450}`) to page through a file beyond the first 400 lines. The tool enforces the same 400-line limit on each requested window, reports the specific line range that was returned, and notes when the requested end exceeds the file length so you know the response was clipped.
+> **Tip:** The `read_file` tool returns only the first 2,000 lines of a file (per request) to prevent massive responses from overwhelming the progress log. Provide an optional `range` object (for example, `{"start": 401, "end": 450}`) to page through a file beyond the first 2,000 lines. The tool enforces the same 2,000-line limit on each requested window, prefixes each line with a `cat -n` style line number, reports the specific line range that was returned, and notes when the requested end exceeds the file length so you know the response was clipped. When copying text for `edit_file`, use only the content after the line-number prefix.
 
 For a minimal read-only configuration, see the built-in `ask` agent
 (`resources/tool_use_agents/ask.yaml`), which only grants `read_file`, `glob`,

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -5,6 +5,9 @@ import { FileType } from 'vscode';
 import { ReadFileTool, READ_FILE_MAX_LINES } from '@tools/ReadTool';
 import { WorkspaceFS } from '@utils/files';
 
+const catFormat = (lineNumber: number, content: string): string =>
+  `${lineNumber.toString().padStart(6, ' ')}\t${content}`;
+
 suite('ReadFileTool', () => {
   let originalRead: typeof WorkspaceFS.read;
   let originalExists: typeof WorkspaceFS.exists;
@@ -51,10 +54,10 @@ suite('ReadFileTool', () => {
       READ_FILE_MAX_LINES + 1,
       'Output should include the limit and truncation marker line',
     );
-    assert.strictEqual(outputLines[0], 'line 1');
+    assert.strictEqual(outputLines[0], catFormat(1, 'line 1'));
     assert.strictEqual(
       outputLines[READ_FILE_MAX_LINES - 1],
-      `line ${READ_FILE_MAX_LINES}`,
+      catFormat(READ_FILE_MAX_LINES, `line ${READ_FILE_MAX_LINES}`),
     );
     assert.strictEqual(
       outputLines[READ_FILE_MAX_LINES],
@@ -76,7 +79,11 @@ suite('ReadFileTool', () => {
     const result = await tool.call({ path: 'short.txt' });
 
     assert.strictEqual(result.summary, 'Read short.txt');
-    assert.strictEqual(result.output, content);
+    const expected = content
+      .split('\n')
+      .map((line, index) => catFormat(index + 1, line))
+      .join('\n');
+    assert.strictEqual(result.output, expected);
   });
 
   test('reads requested range beyond default limit', async () => {
@@ -103,8 +110,14 @@ suite('ReadFileTool', () => {
     );
     const outputLines = result.output?.split('\n') ?? [];
     assert.strictEqual(outputLines.length, rangeEnd - rangeStart + 1);
-    assert.strictEqual(outputLines[0], `row ${rangeStart}`);
-    assert.strictEqual(outputLines[outputLines.length - 1], `row ${rangeEnd}`);
+    assert.strictEqual(
+      outputLines[0],
+      catFormat(rangeStart, `row ${rangeStart}`),
+    );
+    assert.strictEqual(
+      outputLines[outputLines.length - 1],
+      catFormat(rangeEnd, `row ${rangeEnd}`),
+    );
   });
 
   test('notes when requested range exceeds file length', async () => {
@@ -170,7 +183,7 @@ suite('ReadFileTool', () => {
     });
 
     assert.strictEqual(result.summary, 'Read line 5 of single.txt');
-    assert.strictEqual(result.output, 'line 5');
+    assert.strictEqual(result.output, catFormat(5, 'line 5'));
   });
 
   test('handles empty file gracefully', async () => {
@@ -308,10 +321,10 @@ suite('ReadFileTool', () => {
     );
     const outputLines = result.output?.split('\n') ?? [];
     assert.strictEqual(outputLines.length, READ_FILE_MAX_LINES);
-    assert.strictEqual(outputLines[0], 'line 100');
+    assert.strictEqual(outputLines[0], catFormat(100, 'line 100'));
     assert.strictEqual(
       outputLines[READ_FILE_MAX_LINES - 1],
-      `line ${expectedEnd}`,
+      catFormat(expectedEnd, `line ${expectedEnd}`),
     );
   });
 
@@ -337,7 +350,7 @@ suite('ReadFileTool', () => {
     );
     const outputLines = result.output?.split('\n') ?? [];
     assert.strictEqual(outputLines.length, 50);
-    assert.strictEqual(outputLines[0], 'line 1');
-    assert.strictEqual(outputLines[49], 'line 50');
+    assert.strictEqual(outputLines[0], catFormat(1, 'line 1'));
+    assert.strictEqual(outputLines[49], catFormat(50, 'line 50'));
   });
 });

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -40,7 +40,7 @@ function countOccurrences(haystack: string, needle: string): number {
 export class EditFileTool extends defineTool({
   name: 'edit_file',
   description:
-    'Performs exact string replacements in workspace files using literal matching.',
+    'Performs exact string replacements in workspace files using literal matching. Copy text exactly as it appears in read_file output after the line-number prefix.',
   schema: EditInputSchema,
 }) {
   protected async execute(input: EditInput): Promise<ToolResult> {
@@ -48,7 +48,7 @@ export class EditFileTool extends defineTool({
 
     if (old_string.length === 0) {
       throw new ToolError(
-        `old_string must not be empty for ${targetPath}. Provide the exact text to replace from read_file output.`,
+        `old_string must not be empty for ${targetPath}. Provide the exact text to replace from read_file output after the line-number prefix.`,
       );
     }
 
@@ -57,7 +57,7 @@ export class EditFileTool extends defineTool({
 
     if (occurrences === 0) {
       throw new ToolError(
-        `The provided old_string was not found in ${targetPath}. Ensure it matches the read_file output exactly.`,
+        `The provided old_string was not found in ${targetPath}. Ensure it matches the read_file output exactly after the line-number prefix.`,
       );
     }
 

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -88,7 +88,11 @@ export class ReadFileTool extends defineTool({
 
     const segments: string[] = [];
     if (visibleLines.length > 0) {
-      segments.push(visibleLines.join('\n'));
+      const numberedLines = this.formatWithLineNumbers(
+        visibleLines,
+        startIndex + 1,
+      );
+      segments.push(numberedLines.join('\n'));
     }
     if (truncated) {
       segments.push(
@@ -116,6 +120,18 @@ export class ReadFileTool extends defineTool({
     return toolResult({
       summary,
       output: segments.join('\n'),
+    });
+  }
+
+  private formatWithLineNumbers(
+    lines: string[],
+    startingLine: number,
+  ): string[] {
+    const width = 6;
+    return lines.map((line, index) => {
+      const lineNumber = startingLine + index;
+      const prefix = lineNumber.toString().padStart(width, ' ');
+      return `${prefix}\t${line}`;
     });
   }
 


### PR DESCRIPTION
## Summary
- format the read_file tool's text output with cat -n style numbering so downstream edits can target exact lines
- clarify edit_file guidance to copy content after the numbering prefix and document the new behavior
- update tests, docs, and changelog entries to reflect numbered output and the 2,000-line window limit

## Testing
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_6904d788e9b88324a1de37407c3a5f16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Number `read_file` text output with cat -n style prefixes (2,000-line windows) and update `edit_file` guidance, docs, and tests accordingly.
> 
> - **Tools**:
>   - **`read_file` (`ReadFileTool`)**: Prefixes text lines with `cat -n` style numbers; keeps truncation marker; preserves range handling with a 2,000-line per-request cap.
>   - **`edit_file` (`EditFileTool`)**: Description and error messages updated to instruct copying text after the line-number prefix.
> - **Tests**:
>   - Update `src/test/tools/ReadTool.test.ts` to expect numbered output across truncation, full reads, ranged reads, and edge cases.
> - **Docs**:
>   - Update guides to document 2,000-line window and numbered `read_file` output, with guidance for `edit_file` to use content after the prefix.
> - **Changelog**:
>   - Add improvement entry for numbered `read_file` output and updated edit guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5ef4e9f15672de6eece4f8027879f096840a91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->