### PR TITLE
Update changelog for 0.34.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Bug Fixes
+- No changes yet.
 
-- Prevent repeated-response suppression from mutating internal tool state so follow-up connectors stay aligned with written output.
-- Ensure Google Gemini tool calls synthesize stable identifiers so tool-use runs no longer spam "missing call_id" errors.
-- Strip unsupported Gemini tool-call identifiers from follow-up history and fix tool dispatch context typing so orchestration errors surface immediately instead of silently skipping tool runs.
-- Return PDFs and common image formats from the `read_file` tool as native attachments with guidance for models that cannot display binary results, preventing corrupted text output.
+## [0.34.2] - 2025-10-27
+
+### Features
+
+- Redesigned the Progress Board with a resizable split layout, a persistent instruction panel with copy support, and inline follow-up controls for polishing, recording, clearing, or sending responses without leaving the log view.
+- Streamlined the main command view with toolbar-based file pickers, context-menu toggles that close when clicking elsewhere, and a radio-group session selector to switch between workflow and chat agents faster.
 
 ### Improvements
 
-- Format `read_file` text responses with `cat -n` style line numbers and update edit guidance so downstream tools can target exact content reliably.
+- Format `read_file` text responses with padded line numbers, extend ranged reads to 2,000 lines, and report when callers request windows beyond the file length for easier downstream edits.
+- Expand LaTeX cleanup to convert common HTML entities, remove invalid section endings, and expand legacy equation macros into full environments for cleaner compiled documents.
+
+### Bug Fixes
+
+- Return PDFs and common image formats from the `read_file` tool as native attachments with model guidance so binary files are no longer streamed as corrupted text.
+- Sanitize Google Gemini tool-call payloads by stripping unsupported identifiers and synthesizing missing call IDs, eliminating the "missing call_id" errors seen in follow-up runs.
 
 ## [0.34.1] - 2025-10-24
 


### PR DESCRIPTION
## Summary
- document the progress board and main view UI changes shipped since 0.34.1
- record the expanded read_file output formatting and LaTeX cleanup rules
- note the binary attachment handling and Gemini tool-call fixes

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_6904ed731c1c832480bfb214c2aa4c24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CHANGELOG with 0.34.2 features, improvements, and fixes, plus an Unreleased placeholder.
> 
> - **Docs**:
>   - Update `CHANGELOG.md` with `0.34.2` release notes:
>     - UI: Progress Board redesign and streamlined main command view.
>     - Tools: enhanced `read_file` formatting/ranges and LaTeX cleanup.
>     - Fixes: binary attachment handling and Gemini tool-call ID sanitization.
>   - Add `[Unreleased]` section noting no changes yet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f336715f9447d178d7e19236cb063bb8abfabde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->