### PR TITLE
fix: filter internal log entries from progress view

### DIFF
--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -12,6 +12,7 @@ import type { ProgressEventBusLike } from './types';
 
 // Local imports - logger
 import type { LogMessageUpdate } from '@logger/LogTypes';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { getConfig } from '@utils/config';
 
 import type { AgentLogger } from '@logger/AgentLogger';
@@ -46,6 +47,10 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
         return;
       }
 
+      if (logMessage.messageType === MESSAGE_TYPES.INTERNAL) {
+        return;
+      }
+
       state.streamTabs.addMessage(stream, logMessage);
 
       if (updater.isAvailable()) {
@@ -67,6 +72,13 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
 
       const existing = messages.find((m) => m.id === logMessage.id);
       if (!existing) return;
+
+      if (
+        existing.messageType === MESSAGE_TYPES.INTERNAL ||
+        logMessage.messageType === MESSAGE_TYPES.INTERNAL
+      ) {
+        return;
+      }
 
       if (logMessage.text !== undefined) {
         existing.text = logMessage.text;


### PR DESCRIPTION
## Summary
- ignore internal log messages when adding progress view entries
- skip updates for internal log entries so hidden logs stay hidden

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_69051b8053cc8324823711c9b4def369

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filter out INTERNAL log messages from the progress view and skip updates to INTERNAL entries.
> 
> - **Progress View** (`src/progressView/events/LogEvents.ts`):
>   - **Add filtering**: Ignore `MESSAGE_TYPES.INTERNAL` messages when handling `addLogMessage`.
>   - **Guard updates**: Skip `updateLogMessage` when either the existing or incoming message is `MESSAGE_TYPES.INTERNAL`.
>   - Uses `MESSAGE_TYPES` for type checks; existing debug-mode filter retained.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3facf688ef249f177fcc63714b0f2ee2d1b79c93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->