### PR TITLE
Refactor tool-use follow-up coordination

### DIFF
--- a/src/agent/toolUse/ToolUseFollowUpCoordinator.ts
+++ b/src/agent/toolUse/ToolUseFollowUpCoordinator.ts
@@ -1,0 +1,198 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import { AgentType } from '@agent/core/AgentDataclass';
+import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import {
+  executeAgentWithLogging,
+  prepareAgentInstance,
+} from '@agent/runtime/executeAgent';
+import { getToolUseAgent } from '@agent/toolUse/ToolUseAgentRegistry';
+import {
+  ToolUseSessionManager,
+  type ToolUseSessionSnapshot,
+} from '@agent/toolUse/ToolUseSessionManager';
+import type {
+  ExecutionId,
+  StreamTabId,
+} from '@agent/types/IdentifierTypes';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { STATUS } from '@progressView/modules/constants.js';
+
+// Local imports - logging
+import { isToolUseTaskState } from '@logger/TaskState';
+import {
+  logErrorMessage,
+  showLoggedErrorMessage,
+} from '@common/errors/errorHandlingUtils';
+
+const CHANNEL = 'ToolUseFollowUpCoordinator';
+
+async function buildToolUseAgent(
+  snapshot: ToolUseSessionSnapshot,
+): Promise<{ agent: BaseToolUseAgent; agentType: AgentType }> {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    throw new Error('Progress view provider is not initialized.');
+  }
+
+  const taskState = provider.state.getTaskState(snapshot.streamId);
+  if (!taskState) {
+    throw new Error('No saved task state found for stream.');
+  }
+
+  if (!isToolUseTaskState(taskState)) {
+    throw new Error('Saved task state is not a tool-use session.');
+  }
+
+  const fullConfig = AgentConfigSchema.parse(taskState.agentConfig);
+  const { agent, agentType } = await prepareAgentInstance<BaseToolUseAgent>({
+    agentName: fullConfig.agent,
+    configPayload: fullConfig,
+    executionId: snapshot.executionId as ExecutionId,
+  });
+
+  if (!(agent instanceof BaseToolUseAgent) || agentType !== AgentType.ToolUse) {
+    throw new Error('Attempted to resume a non tool-use agent.');
+  }
+
+  return { agent, agentType };
+}
+
+export interface ResumeAgentResult {
+  success: boolean;
+  lostFollowUps?: number;
+}
+
+async function showResumeFailureWarning(
+  baseMessage: string,
+  lostFollowUps: number,
+): Promise<void> {
+  const suffix =
+    lostFollowUps > 0
+      ? ` ${lostFollowUps} queued ${
+          lostFollowUps === 1 ? 'follow-up was' : 'follow-ups were'
+        } lost.`
+      : '';
+
+  await vscode.window.showWarningMessage(`${baseMessage}${suffix}`);
+}
+
+export async function resumeFromSnapshot(
+  snapshot: ToolUseSessionSnapshot,
+  followUp?: string,
+): Promise<ResumeAgentResult> {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    return { success: false };
+  }
+
+  const streamId = snapshot.streamId as StreamTabId;
+  const existingStatus = provider.eventHandler.getStreamStatus(snapshot.streamId);
+  if (existingStatus === STATUS.RUNNING || existingStatus === STATUS.RESUMING) {
+    return { success: false };
+  }
+
+  const shouldMarkResuming = !ToolUseSessionManager.isResumingSession(streamId);
+  if (shouldMarkResuming) {
+    ToolUseSessionManager.setResumingSession(streamId);
+  }
+
+  provider.eventHandler.setStreamStatus(snapshot.streamId, STATUS.RESUMING);
+
+  let queuedFollowUps: string[] = [];
+  try {
+    const { agent, agentType } = await buildToolUseAgent(snapshot);
+    agent.resumeFromSnapshot(snapshot);
+
+    if (followUp !== undefined) {
+      agent.appendFollowUp(followUp);
+    }
+
+    queuedFollowUps = ToolUseSessionManager.drainQueuedFollowUps(streamId);
+    for (const queuedFollowUp of queuedFollowUps) {
+      agent.appendFollowUp(queuedFollowUp);
+    }
+
+    await executeAgentWithLogging(
+      snapshot.agentName,
+      async () => ({
+        agent,
+        agentType,
+      }),
+      snapshot.executionId as ExecutionId,
+      { resume: true },
+    );
+
+    ToolUseSessionManager.consumeSnapshotForStream(streamId);
+    ToolUseSessionManager.clearResumingSession(streamId);
+    provider.eventHandler.setStreamStatus(snapshot.streamId, STATUS.WAITING);
+
+    return { success: true };
+  } catch (error) {
+    const lostFollowUps =
+      queuedFollowUps.length > 0
+        ? queuedFollowUps
+        : ToolUseSessionManager.drainQueuedFollowUps(streamId);
+
+    ToolUseSessionManager.clearResumingSession(streamId);
+    provider.eventHandler.setStreamStatus(snapshot.streamId, STATUS.WAITING);
+
+    const baseMessage = logErrorMessage(
+      CHANNEL,
+      'Failed to resume tool-use session',
+      error,
+    );
+    await showResumeFailureWarning(baseMessage, lostFollowUps.length);
+
+    return { success: false, lostFollowUps: lostFollowUps.length };
+  }
+}
+
+export async function sendFollowUp(
+  streamId: StreamTabId,
+  text: string,
+): Promise<void> {
+  const agent = getToolUseAgent(streamId);
+  if (agent) {
+    try {
+      agent.appendFollowUp(text);
+    } catch (err) {
+      await showLoggedErrorMessage(
+        CHANNEL,
+        'Failed to send follow-up',
+        err,
+      );
+    }
+    return;
+  }
+
+  if (
+    ToolUseSessionManager.isResumingSession(streamId) &&
+    ToolUseSessionManager.enqueueFollowUpWhileResuming(streamId, text)
+  ) {
+    console.log(
+      `[${CHANNEL}] queued follow-up while stream ${streamId} is resuming`,
+    );
+    return;
+  }
+
+  const snapshot = ToolUseSessionManager.getSnapshotForStream(streamId);
+  if (snapshot) {
+    console.log(`[${CHANNEL}] resuming agent lazily for stream ${streamId}`);
+    const result = await resumeFromSnapshot(snapshot, text);
+    if (!result.success && result.lostFollowUps) {
+      console.log(
+        `[${CHANNEL}] resume failed and ${result.lostFollowUps} queued follow-ups were lost`,
+      );
+    }
+    return;
+  }
+
+  console.log(`[${CHANNEL}] no active session found for stream ${streamId}`);
+  void vscode.window.showWarningMessage(
+    'No active tool-use session found for this follow-up.',
+  );
+}

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -2,13 +2,8 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { getToolUseAgent } from '@agent/toolUse/ToolUseAgentRegistry';
-import { ToolUseSessionManager } from '@agent/toolUse/ToolUseSessionManager';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUpCoordinator';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-
-// Local imports - utilities
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
-import type { ResumeAgentResult } from './resumeCommand';
 
 const CHANNEL = 'followUpCommand';
 console.log(`[${CHANNEL}] command registered`);
@@ -19,81 +14,7 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
       'texra.sendFollowUp',
       async (payload: { stream: string; text: string }) => {
         const streamId = payload.stream as StreamTabId;
-        const agent = getToolUseAgent(streamId);
-        if (agent) {
-          try {
-            agent.appendFollowUp(payload.text);
-          } catch (err) {
-            await showLoggedErrorMessage(
-              CHANNEL,
-              'Failed to send follow-up',
-              err,
-            );
-          }
-          return;
-        }
-
-        if (
-          ToolUseSessionManager.isResumingSession(streamId) &&
-          ToolUseSessionManager.enqueueFollowUpWhileResuming(
-            streamId,
-            payload.text,
-          )
-        ) {
-          console.log(
-            `[${CHANNEL}] queued follow-up while stream ${payload.stream} is resuming`,
-          );
-          return;
-        }
-
-        const pendingSnapshot =
-          ToolUseSessionManager.getSnapshotForStream(streamId);
-        if (pendingSnapshot) {
-          console.log(
-            `[${CHANNEL}] resuming agent lazily for stream ${payload.stream}`,
-          );
-          ToolUseSessionManager.setResumingSession(streamId);
-          try {
-            const result = (await vscode.commands.executeCommand(
-              'texra.resumeAgent',
-              {
-                snapshot: pendingSnapshot,
-                followUp: payload.text,
-              },
-            )) as ResumeAgentResult | undefined;
-
-            if (result?.success) {
-              // Only consume the snapshot after successful resume
-              ToolUseSessionManager.consumeSnapshotForStream(streamId);
-            }
-          } catch (err) {
-            const lostFollowUps =
-              ToolUseSessionManager.drainQueuedFollowUps(streamId);
-            if (lostFollowUps.length > 0) {
-              const followUpLabel =
-                lostFollowUps.length === 1
-                  ? 'follow-up was'
-                  : 'follow-ups were';
-              await vscode.window.showWarningMessage(
-                `Resume failed. ${lostFollowUps.length} queued ${followUpLabel} lost.`,
-              );
-            }
-            ToolUseSessionManager.clearResumingSession(streamId);
-            await showLoggedErrorMessage(
-              CHANNEL,
-              'Failed to resume tool-use session for follow-up',
-              err,
-            );
-          }
-          return;
-        }
-
-        console.log(
-          `[${CHANNEL}] no active session found for stream ${payload.stream}`,
-        );
-        void vscode.window.showWarningMessage(
-          'No active tool-use session found for this follow-up.',
-        );
+        await sendFollowUp(streamId, payload.text);
       },
     ),
   );

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -2,165 +2,39 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { AgentConfigSchema } from '@agent/core/AgentConfig';
-import { AgentType } from '@agent/core/AgentDataclass';
-import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
 import {
-  executeAgentWithLogging,
-  prepareAgentInstance,
-} from '@agent/runtime/executeAgent';
+  resumeFromSnapshot,
+  type ResumeAgentResult,
+} from '@agent/toolUse/ToolUseFollowUpCoordinator';
 import {
   ToolUseSessionManager,
   type ToolUseSessionSnapshot,
 } from '@agent/toolUse/ToolUseSessionManager';
-import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
-import { STATUS } from '@progressView/modules/constants.js';
-import { isToolUseTaskState } from '@logger/TaskState';
-import { logErrorMessage } from '@common/errors/errorHandlingUtils';
-
-async function buildToolUseAgent(
-  snapshot: ToolUseSessionSnapshot,
-  _context: vscode.ExtensionContext,
-): Promise<{ agent: BaseToolUseAgent; agentType: AgentType }> {
-  const provider = ProgressViewProvider.getInstance();
-  if (!provider) {
-    throw new Error('Progress view provider is not initialized.');
-  }
-
-  const taskState = provider.state.getTaskState(snapshot.streamId);
-  if (!taskState) {
-    throw new Error('No saved task state found for stream.');
-  }
-
-  if (!isToolUseTaskState(taskState)) {
-    throw new Error('Saved task state is not a tool-use session.');
-  }
-
-  const fullConfig = AgentConfigSchema.parse(taskState.agentConfig);
-  const { agent, agentType } = await prepareAgentInstance<BaseToolUseAgent>({
-    agentName: fullConfig.agent,
-    configPayload: fullConfig,
-    executionId: snapshot.executionId as ExecutionId,
-  });
-
-  if (!(agent instanceof BaseToolUseAgent) || agentType !== AgentType.ToolUse) {
-    throw new Error('Attempted to resume a non tool-use agent.');
-  }
-
-  return { agent, agentType };
-}
 
 interface ResumeAgentCommandPayload {
   snapshot: ToolUseSessionSnapshot;
   followUp?: string;
 }
 
-const CHANNEL = 'resumeAgentCommand';
-
-export interface ResumeAgentResult {
-  success: boolean;
-  lostFollowUps?: number;
-}
-
 export function registerResumeAgentCommand(
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
 ): vscode.Disposable {
   return vscode.commands.registerCommand(
     'texra.resumeAgent',
     async (
       payload: ResumeAgentCommandPayload | undefined,
     ): Promise<ResumeAgentResult> => {
-      const snapshot = payload?.snapshot;
-      const followUp = payload?.followUp;
-      if (!snapshot || !ToolUseSessionManager.isPersistenceEnabled()) {
+      if (!payload?.snapshot) {
         return { success: false };
       }
 
-      const provider = ProgressViewProvider.getInstance();
-      if (!provider) {
+      if (!ToolUseSessionManager.isPersistenceEnabled()) {
         return { success: false };
       }
 
-      const streamId = snapshot.streamId as StreamTabId;
-      let queuedFollowUps: string[] = [];
-
-      try {
-        const executionId = snapshot.executionId as ExecutionId;
-        const existingStatus = provider.eventHandler.getStreamStatus(
-          snapshot.streamId,
-        );
-        if (
-          existingStatus === STATUS.RUNNING ||
-          existingStatus === STATUS.RESUMING
-        ) {
-          return { success: false };
-        }
-
-        provider.eventHandler.setStreamStatus(
-          snapshot.streamId,
-          STATUS.RESUMING,
-        );
-
-        const { agent, agentType } = await buildToolUseAgent(snapshot, context);
-
-        agent.resumeFromSnapshot(snapshot);
-        if (followUp !== undefined) {
-          agent.appendFollowUp(followUp);
-        }
-
-        queuedFollowUps = ToolUseSessionManager.drainQueuedFollowUps(streamId);
-        for (const queuedFollowUp of queuedFollowUps) {
-          agent.appendFollowUp(queuedFollowUp);
-        }
-
-        await executeAgentWithLogging(
-          snapshot.agentName,
-          async () => ({
-            agent,
-            agentType,
-          }),
-          executionId,
-          { resume: true },
-        );
-
-        ToolUseSessionManager.clearResumingSession(streamId);
-        provider.eventHandler.setStreamStatus(
-          snapshot.streamId,
-          STATUS.WAITING,
-        );
-
-        return { success: true };
-      } catch (error) {
-        const lostFollowUps =
-          queuedFollowUps.length > 0
-            ? queuedFollowUps
-            : ToolUseSessionManager.drainQueuedFollowUps(streamId);
-
-        ToolUseSessionManager.clearResumingSession(streamId);
-        provider.eventHandler.setStreamStatus(
-          snapshot.streamId,
-          STATUS.WAITING,
-        );
-
-        const baseMessage = logErrorMessage(
-          CHANNEL,
-          'Failed to resume tool-use session',
-          error,
-        );
-        const lostCount = lostFollowUps.length;
-        const followUpSuffix =
-          lostCount > 0
-            ? ` ${lostCount} queued ${
-                lostCount === 1 ? 'follow-up was' : 'follow-ups were'
-              } lost.`
-            : '';
-        await vscode.window.showWarningMessage(
-          `${baseMessage}${followUpSuffix}`,
-        );
-
-        return { success: false, lostFollowUps: lostCount };
-      }
+      return resumeFromSnapshot(payload.snapshot, payload.followUp);
     },
   );
 }
+
+export type { ResumeAgentResult } from '@agent/toolUse/ToolUseFollowUpCoordinator';

--- a/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
@@ -1,0 +1,419 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent
+import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
+import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import * as ExecuteAgentModule from '@agent/runtime/executeAgent';
+import * as ToolUseAgentRegistry from '@agent/toolUse/ToolUseAgentRegistry';
+import {
+  ToolUseSessionManager,
+  type ToolUseSessionSnapshot,
+} from '@agent/toolUse/ToolUseSessionManager';
+import type {
+  ExecutionId,
+  StreamTabId,
+} from '@agent/types/IdentifierTypes';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { STATUS } from '@progressView/modules/constants.js';
+
+// Local imports - coordinator
+import {
+  resumeFromSnapshot,
+  sendFollowUp,
+} from '@agent/toolUse/ToolUseFollowUpCoordinator';
+
+describe('ToolUseFollowUpCoordinator', () => {
+  const streamId = 'stream-1' as StreamTabId;
+  const executionId = 'exec-1' as ExecutionId;
+  const snapshot: ToolUseSessionSnapshot = {
+    version: 1,
+    executionId,
+    streamId,
+    agentName: 'test-agent',
+    model: 'model',
+    session: { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse },
+    messages: [],
+    toolState: {
+      texcountStats: null,
+      lastResponse: '',
+      accumulatedOutput: '',
+      mediaFiles: [],
+      thinkingBlocks: [],
+      thinkingAdded: false,
+    },
+    lastUpdated: Date.now(),
+  };
+
+  const taskState = {
+    agentConfig: {
+      model: 'model',
+      agent: 'test-agent',
+      instruction: '',
+      useMultipleOutputs: false,
+      session: {
+        agentType: AgentType.ToolUse,
+        agentCategory: AgentCategory.ToolUse,
+      },
+      inputFile: '',
+      inputFiles: null,
+      referenceFile: null,
+      referenceFiles: null,
+      auxiliaryFile: null,
+      auxiliaryFiles: null,
+      mediaFile: null,
+      mediaFiles: null,
+      outputFiles: null,
+      editedFile: null,
+    },
+  };
+
+  let provider: any;
+
+  let warningMessages: string[];
+
+  const originalGetInstance = ProgressViewProvider.getInstance;
+  const originalShowWarningMessage = vscode.window.showWarningMessage;
+  const originalIsPersistenceEnabled = ToolUseSessionManager.isPersistenceEnabled;
+  const originalGetSnapshot = ToolUseSessionManager.getSnapshotForStream;
+  const originalConsumeSnapshot = ToolUseSessionManager.consumeSnapshotForStream;
+  const originalSetResuming = ToolUseSessionManager.setResumingSession;
+  const originalClearResuming = ToolUseSessionManager.clearResumingSession;
+  const originalDrainQueued = ToolUseSessionManager.drainQueuedFollowUps;
+  const originalEnqueueFollowUp = ToolUseSessionManager.enqueueFollowUpWhileResuming;
+  const originalIsResuming = ToolUseSessionManager.isResumingSession;
+  const originalPrepareAgentInstance = ExecuteAgentModule.prepareAgentInstance;
+  const originalExecuteAgentWithLogging = ExecuteAgentModule.executeAgentWithLogging;
+  const originalGetToolUseAgent = ToolUseAgentRegistry.getToolUseAgent;
+
+  beforeEach(() => {
+    provider = {
+      state: {
+        getTaskState: (stream: string) => (stream === streamId ? taskState : undefined),
+      },
+      eventHandler: {
+        getStreamStatus: () => STATUS.WAITING,
+        setStreamStatus: () => {},
+      },
+    };
+
+    warningMessages = [];
+
+    (ProgressViewProvider as typeof ProgressViewProvider & {
+      getInstance: typeof ProgressViewProvider.getInstance;
+    }).getInstance = () => provider as unknown as ProgressViewProvider;
+
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warningMessages.push(message);
+      return undefined;
+    };
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).isPersistenceEnabled = () => true;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).getSnapshotForStream = () => snapshot;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).consumeSnapshotForStream = () => undefined;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).setResumingSession = () => {};
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).clearResumingSession = () => {};
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).drainQueuedFollowUps = () => [];
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).enqueueFollowUpWhileResuming = () => true;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).isResumingSession = () => false;
+
+    (ExecuteAgentModule as typeof ExecuteAgentModule & {
+      prepareAgentInstance: typeof ExecuteAgentModule.prepareAgentInstance;
+      executeAgentWithLogging: typeof ExecuteAgentModule.executeAgentWithLogging;
+    }).prepareAgentInstance = async () =>
+      ({
+        agent: {
+          resumeFromSnapshot: () => {},
+          appendFollowUp: () => {},
+        } as unknown as BaseToolUseAgent,
+        agentType: AgentType.ToolUse,
+      }) as any;
+
+    (ExecuteAgentModule as typeof ExecuteAgentModule & {
+      prepareAgentInstance: typeof ExecuteAgentModule.prepareAgentInstance;
+      executeAgentWithLogging: typeof ExecuteAgentModule.executeAgentWithLogging;
+    }).executeAgentWithLogging = async (_agentName, factory) => {
+      await factory();
+    };
+
+    (ToolUseAgentRegistry as typeof ToolUseAgentRegistry & {
+      getToolUseAgent: typeof ToolUseAgentRegistry.getToolUseAgent;
+    }).getToolUseAgent = () => undefined;
+  });
+
+  afterEach(() => {
+    (ProgressViewProvider as typeof ProgressViewProvider & {
+      getInstance: typeof ProgressViewProvider.getInstance;
+    }).getInstance = originalGetInstance;
+
+    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).isPersistenceEnabled = originalIsPersistenceEnabled;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).getSnapshotForStream = originalGetSnapshot;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).consumeSnapshotForStream = originalConsumeSnapshot;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).setResumingSession = originalSetResuming;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).clearResumingSession = originalClearResuming;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).drainQueuedFollowUps = originalDrainQueued;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).enqueueFollowUpWhileResuming = originalEnqueueFollowUp;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isPersistenceEnabled: typeof ToolUseSessionManager.isPersistenceEnabled;
+      getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+      setResumingSession: typeof ToolUseSessionManager.setResumingSession;
+      clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+    }).isResumingSession = originalIsResuming;
+
+    (ExecuteAgentModule as typeof ExecuteAgentModule & {
+      prepareAgentInstance: typeof ExecuteAgentModule.prepareAgentInstance;
+      executeAgentWithLogging: typeof ExecuteAgentModule.executeAgentWithLogging;
+    }).prepareAgentInstance = originalPrepareAgentInstance;
+
+    (ExecuteAgentModule as typeof ExecuteAgentModule & {
+      prepareAgentInstance: typeof ExecuteAgentModule.prepareAgentInstance;
+      executeAgentWithLogging: typeof ExecuteAgentModule.executeAgentWithLogging;
+    }).executeAgentWithLogging = originalExecuteAgentWithLogging;
+
+    (ToolUseAgentRegistry as typeof ToolUseAgentRegistry & {
+      getToolUseAgent: typeof ToolUseAgentRegistry.getToolUseAgent;
+    }).getToolUseAgent = originalGetToolUseAgent;
+  });
+
+  it('successfully resumes and consumes the snapshot', async () => {
+    const consumed: StreamTabId[] = [];
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
+    }).consumeSnapshotForStream = (stream: StreamTabId) => {
+      consumed.push(stream);
+      return undefined;
+    };
+
+    const result = await resumeFromSnapshot(snapshot);
+    assert.deepStrictEqual(result, { success: true });
+    assert.deepStrictEqual(consumed, [streamId]);
+    assert.strictEqual(warningMessages.length, 0);
+  });
+
+  it('reports failures and warns about lost follow-ups', async () => {
+    const lostFollowUps = ['first', 'second'];
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
+    }).drainQueuedFollowUps = () => lostFollowUps;
+
+    (ExecuteAgentModule as typeof ExecuteAgentModule & {
+      executeAgentWithLogging: typeof ExecuteAgentModule.executeAgentWithLogging;
+    }).executeAgentWithLogging = async () => {
+      throw new Error('boom');
+    };
+
+    const result = await resumeFromSnapshot(snapshot);
+    assert.deepStrictEqual(result, {
+      success: false,
+      lostFollowUps: lostFollowUps.length,
+    });
+    assert.strictEqual(warningMessages.length, 1);
+    assert.ok(
+      warningMessages[0].includes('boom'),
+      'warning should include failure reason',
+    );
+    assert.ok(
+      warningMessages[0].includes('2 queued follow-ups were lost'),
+      'warning should include lost follow-up count',
+    );
+  });
+
+  it('queues follow-ups when a resume is already in progress', async () => {
+    const queued: Array<{ stream: StreamTabId; followUp: string }> = [];
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+    }).isResumingSession = () => true;
+
+    (ToolUseSessionManager as typeof ToolUseSessionManager & {
+      isResumingSession: typeof ToolUseSessionManager.isResumingSession;
+      enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
+    }).enqueueFollowUpWhileResuming = (stream, followUp) => {
+      queued.push({ stream, followUp });
+      return true;
+    };
+
+    await sendFollowUp(streamId, 'deferred');
+
+    assert.deepStrictEqual(queued, [
+      { stream: streamId, followUp: 'deferred' },
+    ]);
+  });
+
+  it('appends to an active agent without resuming', async () => {
+    const received: string[] = [];
+    const agent: BaseToolUseAgent = {
+      resumeFromSnapshot: () => {},
+      appendFollowUp: (text: string) => {
+        received.push(text);
+      },
+    } as unknown as BaseToolUseAgent;
+
+    (ToolUseAgentRegistry as typeof ToolUseAgentRegistry & {
+      getToolUseAgent: typeof ToolUseAgentRegistry.getToolUseAgent;
+    }).getToolUseAgent = () => agent;
+
+    await sendFollowUp(streamId, 'direct');
+
+    assert.deepStrictEqual(received, ['direct']);
+  });
+});

--- a/src/test/commands/agent/followUpCommand.test.ts
+++ b/src/test/commands/agent/followUpCommand.test.ts
@@ -5,17 +5,8 @@ import { strict as assert } from 'assert';
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import type { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import * as Coordinator from '@agent/toolUse/ToolUseFollowUpCoordinator';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
-import {
-  registerToolUseAgent,
-  clearToolUseAgents,
-} from '@agent/toolUse/ToolUseAgentRegistry';
-import {
-  ToolUseSessionManager,
-  type ToolUseSessionSnapshot,
-} from '@agent/toolUse/ToolUseSessionManager';
 
 // Local imports - commands
 import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
@@ -23,49 +14,8 @@ import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
 describe('followUpCommand', () => {
   let context: vscode.ExtensionContext;
   let registeredCommands: Map<string, (...args: any[]) => unknown>;
-  let warningMessages: string[];
-  let executeCalls: { command: string; args: any[] }[];
-  let followUpHandler:
-    | ((payload: { stream: string; text: string }) => Promise<void>)
-    | undefined;
-  let getSnapshotCalls: StreamTabId[];
-  let getSnapshotImplementation:
-    | ((streamId: StreamTabId) => ToolUseSessionSnapshot | undefined)
-    | undefined;
-  let consumeCalls: StreamTabId[];
-  let consumeImplementation:
-    | ((streamId: StreamTabId) => ToolUseSessionSnapshot | undefined)
-    | undefined;
-  let setResumingCalls: StreamTabId[];
-  let isResumingCalls: StreamTabId[];
-  let isResumingImplementation:
-    | ((streamId: StreamTabId) => boolean)
-    | undefined;
-  let enqueueCalls: { streamId: StreamTabId; followUp: string }[];
-  let enqueueImplementation:
-    | ((streamId: StreamTabId, followUp: string) => boolean)
-    | undefined;
-  let drainCalls: StreamTabId[];
-  let drainImplementation: ((streamId: StreamTabId) => string[]) | undefined;
-  let clearCalls: StreamTabId[];
-  let executeImplementation:
-    | ((command: string, ...args: any[]) => Promise<unknown>)
-    | undefined;
-
   const originalRegisterCommand = vscode.commands.registerCommand;
-  const originalExecuteCommand = vscode.commands.executeCommand;
-  const originalShowWarningMessage = vscode.window.showWarningMessage;
-  const originalGetSnapshot = ToolUseSessionManager.getSnapshotForStream;
-  const originalConsumeSnapshot =
-    ToolUseSessionManager.consumeSnapshotForStream;
-  const originalSetResumingSession = ToolUseSessionManager.setResumingSession;
-  const originalIsResumingSession = ToolUseSessionManager.isResumingSession;
-  const originalEnqueueFollowUp =
-    ToolUseSessionManager.enqueueFollowUpWhileResuming;
-  const originalClearResumingSession =
-    ToolUseSessionManager.clearResumingSession;
-  const originalDrainQueuedFollowUps =
-    ToolUseSessionManager.drainQueuedFollowUps;
+  const originalSendFollowUp = Coordinator.sendFollowUp;
 
   beforeEach(() => {
     context = {
@@ -73,21 +23,6 @@ describe('followUpCommand', () => {
     } as unknown as vscode.ExtensionContext;
 
     registeredCommands = new Map();
-    warningMessages = [];
-    executeCalls = [];
-    getSnapshotCalls = [];
-    getSnapshotImplementation = undefined;
-    consumeCalls = [];
-    consumeImplementation = undefined;
-    setResumingCalls = [];
-    isResumingCalls = [];
-    isResumingImplementation = undefined;
-    enqueueCalls = [];
-    enqueueImplementation = undefined;
-    drainCalls = [];
-    drainImplementation = undefined;
-    clearCalls = [];
-    executeImplementation = undefined;
 
     (vscode.commands as any).registerCommand = (
       command: string,
@@ -96,327 +31,32 @@ describe('followUpCommand', () => {
       registeredCommands.set(command, callback);
       return { dispose() {} };
     };
-
-    (vscode.commands as any).executeCommand = async (
-      command: string,
-      ...args: any[]
-    ) => {
-      executeCalls.push({ command, args });
-      if (executeImplementation) {
-        return executeImplementation(command, ...args);
-      }
-      return undefined;
-    };
-
-    (vscode.window as any).showWarningMessage = (message: string) => {
-      warningMessages.push(message);
-      return Promise.resolve(undefined);
-    };
-
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
-        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
-        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
-      }
-    ).getSnapshotForStream = (streamId: StreamTabId) => {
-      getSnapshotCalls.push(streamId);
-      if (getSnapshotImplementation) {
-        return getSnapshotImplementation(streamId);
-      }
-      return undefined;
-    };
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
-        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
-        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
-      }
-    ).consumeSnapshotForStream = (streamId: StreamTabId) => {
-      consumeCalls.push(streamId);
-      if (consumeImplementation) {
-        return consumeImplementation(streamId);
-      }
-      return undefined;
-    };
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
-        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
-        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
-      }
-    ).setResumingSession = (streamId: StreamTabId) => {
-      setResumingCalls.push(streamId);
-    };
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
-      }
-    ).enqueueFollowUpWhileResuming = (
-      streamId: StreamTabId,
-      followUp: string,
-    ) => {
-      enqueueCalls.push({ streamId, followUp });
-      if (enqueueImplementation) {
-        return enqueueImplementation(streamId, followUp);
-      }
-      return false;
-    };
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
-        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
-      }
-    ).isResumingSession = (streamId: StreamTabId) => {
-      isResumingCalls.push(streamId);
-      if (isResumingImplementation) {
-        return isResumingImplementation(streamId);
-      }
-      return false;
-    };
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
-      }
-    ).drainQueuedFollowUps = (streamId: StreamTabId) => {
-      drainCalls.push(streamId);
-      if (drainImplementation) {
-        return drainImplementation(streamId);
-      }
-      return [];
-    };
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
-      }
-    ).clearResumingSession = (streamId: StreamTabId) => {
-      clearCalls.push(streamId);
-    };
-
-    registerFollowUpCommand(context);
-    followUpHandler = registeredCommands.get('texra.sendFollowUp') as
-      | ((payload: { stream: string; text: string }) => Promise<void>)
-      | undefined;
-    assert.ok(followUpHandler, 'follow-up command should be registered');
   });
 
   afterEach(() => {
-    clearToolUseAgents();
     (vscode.commands as any).registerCommand = originalRegisterCommand;
-    (vscode.commands as any).executeCommand = originalExecuteCommand;
-    (vscode.window as any).showWarningMessage = originalShowWarningMessage;
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
-      }
-    ).getSnapshotForStream = originalGetSnapshot;
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        getSnapshotForStream: typeof ToolUseSessionManager.getSnapshotForStream;
-        consumeSnapshotForStream: typeof ToolUseSessionManager.consumeSnapshotForStream;
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
-        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
-      }
-    ).consumeSnapshotForStream = originalConsumeSnapshot;
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        enqueueFollowUpWhileResuming: typeof ToolUseSessionManager.enqueueFollowUpWhileResuming;
-      }
-    ).enqueueFollowUpWhileResuming = originalEnqueueFollowUp;
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        clearResumingSession: typeof ToolUseSessionManager.clearResumingSession;
-      }
-    ).clearResumingSession = originalClearResumingSession;
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        isResumingSession: typeof ToolUseSessionManager.isResumingSession;
-      }
-    ).isResumingSession = originalIsResumingSession;
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        drainQueuedFollowUps: typeof ToolUseSessionManager.drainQueuedFollowUps;
-      }
-    ).drainQueuedFollowUps = originalDrainQueuedFollowUps;
-    (
-      ToolUseSessionManager as typeof ToolUseSessionManager & {
-        setResumingSession: typeof ToolUseSessionManager.setResumingSession;
-      }
-    ).setResumingSession = originalSetResumingSession;
+    (Coordinator as typeof Coordinator & {
+      sendFollowUp: typeof Coordinator.sendFollowUp;
+    }).sendFollowUp = originalSendFollowUp;
   });
 
-  function createSnapshot(streamId: StreamTabId): ToolUseSessionSnapshot {
-    return {
-      version: 1,
-      executionId: 'exec-id',
-      streamId,
-      agentName: 'demo-agent',
-      model: 'demo-model',
-      session: {
-        agentType: AgentType.ToolUse,
-        agentCategory: AgentCategory.ToolUse,
-      },
-      messages: [],
-      toolState: {
-        texcountStats: null,
-        lastResponse: '',
-        accumulatedOutput: '',
-        mediaFiles: [],
-        thinkingBlocks: [],
-        thinkingAdded: false,
-      },
-      lastUpdated: Date.now(),
+  it('forwards follow-up payloads to the coordinator', async () => {
+    const calls: Array<{ stream: StreamTabId; text: string }> = [];
+    (Coordinator as typeof Coordinator & {
+      sendFollowUp: typeof Coordinator.sendFollowUp;
+    }).sendFollowUp = async (stream: StreamTabId, text: string) => {
+      calls.push({ stream, text });
     };
-  }
 
-  it('sends follow-up to an active agent', async () => {
-    const streamId = 'stream-1' as StreamTabId;
-    const received: string[] = [];
-    const agent = {
-      appendFollowUp: (text: string) => {
-        received.push(text);
-      },
-    } as unknown as BaseToolUseAgent;
+    registerFollowUpCommand(context);
 
-    registerToolUseAgent(streamId, agent);
+    const handler = registeredCommands.get('texra.sendFollowUp');
+    assert.ok(handler, 'Command handler should be registered');
 
-    await followUpHandler!({ stream: streamId, text: 'hello' });
+    await handler({ stream: 'stream-123', text: 'Hello world' });
 
-    assert.deepStrictEqual(received, ['hello']);
-    assert.strictEqual(executeCalls.length, 0);
-    assert.strictEqual(warningMessages.length, 0);
-    assert.strictEqual(consumeCalls.length, 0);
-  });
-
-  it('resumes lazily when a pending snapshot exists', async () => {
-    const streamId = 'stream-2' as StreamTabId;
-    const snapshot = createSnapshot(streamId);
-    let snapshotAvailable: ToolUseSessionSnapshot | undefined = snapshot;
-
-    getSnapshotImplementation = () => snapshotAvailable;
-    consumeImplementation = () => {
-      const current = snapshotAvailable;
-      snapshotAvailable = undefined;
-      return current;
-    };
-    executeImplementation = async () => ({ success: true });
-
-    await followUpHandler!({ stream: streamId, text: 'resume me' });
-
-    assert.deepStrictEqual(getSnapshotCalls, [streamId]);
-    assert.strictEqual(consumeCalls.length, 1);
-    assert.deepStrictEqual(setResumingCalls, [streamId]);
-    assert.deepStrictEqual(isResumingCalls, [streamId]);
-    assert.strictEqual(executeCalls.length, 1);
-    assert.strictEqual(executeCalls[0].command, 'texra.resumeAgent');
-    assert.strictEqual(executeCalls[0].args.length, 1);
-    const payload = executeCalls[0].args[0] as {
-      snapshot: ToolUseSessionSnapshot;
-      followUp?: string;
-    };
-    assert.strictEqual(payload.followUp, 'resume me');
-    assert.strictEqual(payload.snapshot, snapshot);
-    assert.strictEqual(warningMessages.length, 0);
-    assert.strictEqual(enqueueCalls.length, 0);
-  });
-
-  it('queues follow-ups when resume is already in progress', async () => {
-    const streamId = 'stream-4' as StreamTabId;
-
-    enqueueImplementation = () => true;
-    isResumingImplementation = () => true;
-    getSnapshotImplementation = () => undefined;
-
-    await followUpHandler!({ stream: streamId, text: 'queued follow-up' });
-
-    assert.deepStrictEqual(isResumingCalls, [streamId]);
-    assert.strictEqual(getSnapshotCalls.length, 0);
-    assert.strictEqual(consumeCalls.length, 0);
-    assert.deepStrictEqual(enqueueCalls, [
-      { streamId, followUp: 'queued follow-up' },
+    assert.deepStrictEqual(calls, [
+      { stream: 'stream-123' as StreamTabId, text: 'Hello world' },
     ]);
-    assert.strictEqual(executeCalls.length, 0);
-    assert.strictEqual(warningMessages.length, 0);
-    assert.strictEqual(setResumingCalls.length, 0);
-  });
-
-  it('warns when no session is available', async () => {
-    const streamId = 'stream-3' as StreamTabId;
-
-    getSnapshotImplementation = () => undefined;
-    await followUpHandler!({ stream: streamId, text: 'missing' });
-
-    assert.deepStrictEqual(isResumingCalls, [streamId]);
-    assert.deepStrictEqual(getSnapshotCalls, [streamId]);
-    assert.strictEqual(consumeCalls.length, 0);
-    assert.strictEqual(executeCalls.length, 0);
-    assert.strictEqual(warningMessages.length, 1);
-    assert.strictEqual(
-      warningMessages[0],
-      'No active tool-use session found for this follow-up.',
-    );
-    assert.strictEqual(enqueueCalls.length, 0);
-    assert.strictEqual(setResumingCalls.length, 0);
-  });
-
-  it('drains queued follow-ups and warns when resume fails', async () => {
-    const streamId = 'stream-5' as StreamTabId;
-    const snapshot = createSnapshot(streamId);
-
-    getSnapshotImplementation = () => snapshot;
-    consumeImplementation = () => snapshot;
-    drainImplementation = () => ['first follow-up', 'second follow-up'];
-    executeImplementation = async () => {
-      await ToolUseSessionManager.clearResumingSession(streamId);
-      await vscode.window.showWarningMessage(
-        'Resume failed. 2 queued follow-ups were lost.',
-      );
-      return { success: false, lostFollowUps: 2 };
-    };
-
-    await followUpHandler!({ stream: streamId, text: 'trigger resume' });
-
-    assert.deepStrictEqual(getSnapshotCalls, [streamId]);
-    assert.strictEqual(executeCalls.length, 1);
-    assert.strictEqual(executeCalls[0].command, 'texra.resumeAgent');
-    assert.strictEqual(drainCalls.length, 0);
-    assert.deepStrictEqual(clearCalls, [streamId]);
-    assert.deepStrictEqual(setResumingCalls, [streamId]);
-    assert.strictEqual(warningMessages.length, 1);
-    assert.strictEqual(
-      warningMessages[0],
-      'Resume failed. 2 queued follow-ups were lost.',
-    );
-    assert.strictEqual(consumeCalls.length, 0);
   });
 });


### PR DESCRIPTION
## Summary
- add `ToolUseFollowUpCoordinator` to own queue draining, resume logic, lost follow-up warnings, and snapshot consumption for tool-use sessions
- have `followUpCommand` and `resumeCommand` delegate to the coordinator instead of duplicating control flow
- add coordinator unit tests for success/failure/queued scenarios and simplify the follow-up command test to verify delegation

## Testing
- npm run lint
- npm run compile-tests
- npm test -- ToolUseFollowUpCoordinator *(fails: vscode-test missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_69052a5a7bd88324ac7d97eab890d5d5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a coordinator to handle tool-use follow-ups and resume flow, and refactor commands to delegate to it with new targeted tests.
> 
> - **Agent Tool-Use**:
>   - **New `ToolUseFollowUpCoordinator`**: Centralizes follow-up handling (`sendFollowUp`) and resume logic (`resumeFromSnapshot`), including queue draining, lazy resume from snapshots, status transitions, snapshot consumption, and failure warnings.
> - **Commands**:
>   - `followUpCommand`: Replaced inline logic with delegation to `sendFollowUp`.
>   - `resumeCommand`: Simplified to call `resumeFromSnapshot`; re-exports `ResumeAgentResult`.
> - **Tests**:
>   - Added unit tests for coordinator covering success, failure (with lost follow-ups), and queued scenarios.
>   - Simplified follow-up command test to verify delegation only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ee309cbe1cac0e5c1a0b5b4e8ba6ccb4d662741. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->