### PR TITLE
fix: centralize agent directory resolution

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -93,9 +93,15 @@ export class MainViewProvider
 
   private async refreshOptionsAndView() {
     if (this._view) {
-      this._view.webview.html = this.contentProvider.getHtmlContent(
-        this._view.webview,
-      );
+      try {
+        this._view.webview.html = await this.contentProvider.getHtmlContent(
+          this._view.webview,
+        );
+      } catch (error) {
+        console.error('Error refreshing main view content', error);
+        this._view.webview.html =
+          '<html><body>Error loading content</body></html>';
+      }
     }
   }
 

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -3,7 +3,6 @@ import {
   buildAgentOptionsPayload,
   DEFAULT_TOOL_USE_AGENT,
   DEFAULT_WORKFLOW_AGENT,
-  type AgentDirectoryMap,
   type AgentOptionsPayload,
 } from '@agent/utils/agentOptionMetadata';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
@@ -45,14 +44,6 @@ export async function getAllAgents(): Promise<AgentNameBuckets> {
 /**
  * Get all agent directories.
  */
-async function getAgentDirectories(): Promise<AgentDirectoryMap> {
-  return {
-    custom: await agentDirectories.custom(),
-    builtIn: await agentDirectories.builtIn(),
-    builtInToolUse: await agentDirectories.builtInToolUse(),
-  };
-}
-
 /**
  * Compute agent <vscode-option> tags for the agent dropdown.
  * Agents missing a YAML definition are marked as disabled and cannot be selected.
@@ -62,7 +53,7 @@ async function getAgentDirectories(): Promise<AgentDirectoryMap> {
 export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
   const { allAgents, toolUseAgents, defaultWorkflowAgent } =
     await getAllAgents();
-  const dirs = await getAgentDirectories();
+  const dirs = await agentDirectories.getDirectoryMap();
 
   return buildAgentOptionsPayload(allAgents, dirs, toolUseAgents, {
     workflowAgent: defaultWorkflowAgent,

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -43,7 +43,9 @@ export abstract class BaseViewContentProvider {
   /**
    * Optional: Override to provide additional template variables
    */
-  protected getTemplateVariables(): Record<string, any> {
+  protected getTemplateVariables():
+    | Record<string, any>
+    | Promise<Record<string, any>> {
     return {};
   }
 
@@ -108,13 +110,13 @@ export abstract class BaseViewContentProvider {
   /**
    * Standard implementation that subclasses can override if needed
    */
-  public getHtmlContent(webview: vscode.Webview): string {
+  public async getHtmlContent(webview: vscode.Webview): Promise<string> {
     try {
       const htmlPath = this.getWebviewPath('index.html');
       const commonUris = this.getCommonModuleUris(webview);
       const sharedUris = this.getSharedModuleUris(webview);
       const specificUris = this.getModuleUris(webview);
-      const templateVariables = this.getTemplateVariables();
+      const templateVariables = await this.getTemplateVariables();
 
       this.logger.debug(
         this.channel,

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -11,7 +11,7 @@ export abstract class BaseWebviewProvider {
   protected _viewDisposables: vscode.Disposable[] = [];
 
   protected abstract contentProvider: {
-    getHtmlContent(webview: vscode.Webview): string;
+    getHtmlContent(webview: vscode.Webview): Promise<string>;
   };
   protected abstract messageHandler: {
     handleMessage(
@@ -36,9 +36,18 @@ export abstract class BaseWebviewProvider {
     this.cleanupView();
     this._view = webviewView;
 
-    webviewView.webview.html = this.contentProvider.getHtmlContent(
-      webviewView.webview,
-    );
+    this.contentProvider
+      .getHtmlContent(webviewView.webview)
+      .then((html) => {
+        if (this._view === webviewView) {
+          webviewView.webview.html = html;
+        }
+      })
+      .catch((error) => {
+        console.error('Error setting webview HTML', error);
+        webviewView.webview.html =
+          '<html><body>Error loading content</body></html>';
+      });
 
     this._viewDisposables.push(
       webviewView.webview.onDidReceiveMessage((message) =>

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -12,6 +12,9 @@ import { getConfig, updateConfig } from '@utils/config';
 import { GlobalStorageFS, StorageFS, AbsoluteFS } from '@utils/files';
 import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
 
+// Local imports - agent utilities
+import type { AgentDirectoryMap } from '@agent/utils/agentOptionMetadata';
+
 const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
 const DEFAULT_CUSTOM_AGENTS_DIR_NAME = 'custom_agents';
@@ -160,6 +163,18 @@ export class AgentDirectoryManager {
     await updateConfig('explorer.agentsDirectory', selectedPath);
 
     return selectedPath;
+  }
+
+  async getDirectoryMap(): Promise<AgentDirectoryMap> {
+    this.ensureInitialized();
+
+    const [builtIn, builtInToolUse, custom] = await Promise.all([
+      this.builtIn(),
+      this.builtInToolUse(),
+      this.custom(),
+    ]);
+
+    return { builtIn, builtInToolUse, custom };
   }
 }
 

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -136,10 +136,16 @@ export class HistoryViewProvider
    */
   private async updateWebviewContent() {
     if (this._view) {
-      // Set the HTML content first
-      this._view.webview.html = this.contentProvider.getHtmlContent(
-        this._view.webview,
-      );
+      try {
+        // Set the HTML content first
+        this._view.webview.html = await this.contentProvider.getHtmlContent(
+          this._view.webview,
+        );
+      } catch (error) {
+        console.error('Error updating history view content', error);
+        this._view.webview.html =
+          '<html><body>Error loading content</body></html>';
+      }
       // Then send the history data after a short delay
       setTimeout(() => {
         if (this._view) {

--- a/src/test/frontend/agents/AgentDirectoryManager.test.ts
+++ b/src/test/frontend/agents/AgentDirectoryManager.test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import * as vscode from 'vscode';
+
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
+import StorageFS from '@utils/files/storageFS';
+
+suite('AgentDirectoryManager', () => {
+  let tempDir: string;
+
+  function createContext(basePath: string): vscode.ExtensionContext {
+    const uri = vscode.Uri.file(basePath);
+    return {
+      globalStorageUri: uri,
+      storageUri: uri,
+    } as unknown as vscode.ExtensionContext;
+  }
+
+  setup(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-dirs-'));
+    const context = createContext(tempDir);
+    StorageFS.initialize(context);
+    agentDirectories.initialize(context);
+  });
+
+  teardown(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('getDirectoryMap returns consistent directory paths', async () => {
+    const map = await agentDirectories.getDirectoryMap();
+    const [builtIn, builtInToolUse, custom] = await Promise.all([
+      agentDirectories.builtIn(),
+      agentDirectories.builtInToolUse(),
+      agentDirectories.custom(),
+    ]);
+
+    assert.strictEqual(map.builtIn, builtIn);
+    assert.strictEqual(map.builtInToolUse, builtInToolUse);
+    assert.strictEqual(map.custom, custom);
+  });
+});

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import * as path from 'path';
-
 // Third-party imports
 import * as vscode from 'vscode';
 
@@ -12,6 +9,7 @@ import {
   type AgentDirectoryMap,
 } from '@agent/utils/agentOptionMetadata';
 import type { AgentOptionsPayload } from '@agent/computeAgentOptions';
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 
 // Local imports - webview
 import {
@@ -19,7 +17,6 @@ import {
   ModuleDescriptor,
 } from '@common/webview/BaseViewContentProvider';
 import { getConfig } from '@utils/config';
-import { GlobalStorageFS } from '@utils/files';
 
 export class MainViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
@@ -80,26 +77,33 @@ export class MainViewContentProvider extends BaseViewContentProvider {
     return this.buildUriRecord(webview, this.moduleDescriptors);
   }
 
-  protected getTemplateVariables(): Record<string, any> {
-    // Note: This uses synchronous approach for template generation
-    // Agent options with metadata are computed asynchronously via computeAgentOptions
+  protected override async getTemplateVariables(): Promise<
+    Record<string, any>
+  > {
     const configuredWorkflowAgents = getConfig<string[]>('agents', []);
     const configuredToolUseAgents = getConfig<string[]>('toolUseAgents', []);
-    const toolUseDir = GlobalStorageFS.fullPath('tool_use_agents');
-    const builtInDir = GlobalStorageFS.fullPath('agents');
-    const configuredCustomDir = getConfig<string>(
-      'explorer.agentsDirectory',
-      '',
-    ).trim();
-    const customDir = path.isAbsolute(configuredCustomDir)
-      ? configuredCustomDir
-      : '';
 
-    const agentDirectories: AgentDirectoryMap = {
-      custom: customDir,
-      builtIn: builtInDir,
-      builtInToolUse: toolUseDir,
-    };
+    agentDirectories.initialize(this.context);
+
+    let directories: AgentDirectoryMap | undefined;
+    let shouldShowAgentBanner = false;
+    let bannerText = 'Agent configuration is missing.';
+
+    try {
+      directories = await agentDirectories.getDirectoryMap();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        this.channel,
+        `Failed to resolve agent directories: ${message}`,
+      );
+      shouldShowAgentBanner = true;
+      bannerText = 'Agent directories could not be loaded.';
+    }
+
+    const resolvedDirectories: AgentDirectoryMap = directories ?? {};
+    const customDirSet = Boolean(resolvedDirectories.custom);
+
     const hasConfiguredWorkflowAgents = configuredWorkflowAgents.length > 0;
     const workflowAgents = hasConfiguredWorkflowAgents
       ? Array.from(new Set(configuredWorkflowAgents))
@@ -117,7 +121,7 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       : (workflowAgents[0] ?? DEFAULT_WORKFLOW_AGENT);
     const optionBuckets: AgentOptionsPayload = buildAgentOptionsPayload(
       allAgents,
-      agentDirectories,
+      resolvedDirectories,
       toolUseAgents,
       {
         workflowAgent: defaultWorkflowAgent,
@@ -132,10 +136,18 @@ export class MainViewContentProvider extends BaseViewContentProvider {
       )
       .join('\n');
 
+    const agentConfigBannerStyle = shouldShowAgentBanner
+      ? 'display: flex'
+      : 'display: none';
+    const agentConfigCustomDirSet = customDirSet ? 'true' : 'false';
+
     return {
       workflowAgentOptions: optionBuckets.workflow,
       toolUseAgentOptions: optionBuckets.toolUse,
       modelOptions,
+      agentConfigBannerStyle,
+      agentConfigBannerText: bannerText,
+      agentConfigCustomDirSet,
     };
   }
 }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -518,9 +518,10 @@
         <div
           id="agentConfigBanner"
           class="agent-config-banner"
-          style="display: none"
+          style="${agentConfigBannerStyle}"
+          data-custom-dir-set="${agentConfigCustomDirSet}"
         >
-          <span>Agent configuration is missing.</span>
+          <span>${agentConfigBannerText}</span>
           <div class="actions">
             <vscode-toolbar-button
               id="agentConfigEditButton"


### PR DESCRIPTION
## Summary
- add an AgentDirectoryManager.getDirectoryMap accessor that normalizes built-in, tool-use, and custom agent locations
- update the main webview content provider and shared webview infrastructure to await the centralized directory map with graceful banner fallback when resolution fails
- add coverage to ensure the accessor returns the same paths as the individual directory helpers

## Testing
- npm run lint
- CI=1 npm test -- --runTestsByPath src/test/frontend/agents/AgentDirectoryManager.test.ts *(fails: missing libatk-1.0.so.0 in VS Code test harness)*

------
https://chatgpt.com/codex/tasks/task_e_690529c7f958832482e8d205dce2cd70

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make webview HTML generation async with error handling and centralize agent directory resolution via AgentDirectoryManager, updating main/history views and UI banner, plus tests.
> 
> - **Webview infrastructure**
>   - Convert `BaseViewContentProvider.getHtmlContent` to `async` and allow `getTemplateVariables` to return a Promise; propagate awaiting and error fallbacks in `BaseWebviewProvider`, `MainViewProvider`, and `HistoryViewProvider`.
> - **Agent directories**
>   - Add `agentDirectories.getDirectoryMap()` to resolve `{ builtIn, builtInToolUse, custom }` in parallel.
>   - Update `computeAgentOptions` and `MainViewContentProvider` to use the centralized directory map.
> - **Main view**
>   - `MainViewContentProvider` now resolves directories asynchronously and exposes banner variables (`agentConfigBannerStyle`, `agentConfigBannerText`, `agentConfigCustomDirSet`) on failure.
>   - `index.html` binds the new banner variables.
> - **Tests**
>   - Add `AgentDirectoryManager.test.ts` verifying `getDirectoryMap` matches individual helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0434cf12159ea030d5676a8f9a85cbb25c3afb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->