### PR TITLE
feat: expose round output exports

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -54,6 +54,11 @@ export const AgentConfigSchema = z
     mediaFiles: z.array(z.string()).nullable().prefault(null),
     outputFiles: z.array(z.string()).nullable().prefault(null),
     editedFile: z.string().nullable().prefault(null),
+    workflowContext: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .nullable()
+      .prefault(null),
 
     toolConfig: ToolConfigSchema.prefault(DEFAULT_TOOL_CONFIG),
   })

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -3,7 +3,12 @@ import { LatexDiffManager } from './LatexDiffManager';
 import { XmlOutputManager } from './XmlOutputManager';
 
 // Local imports - types
-import { NamedOutputFile, OutputFileInfo, RoundFileMapping } from './types';
+import {
+  NamedOutputFile,
+  OutputFileInfo,
+  RoundFileMapping,
+  RoundOutputExport,
+} from './types';
 
 /** Interface describing OutputHandler behavior used by agents. */
 export interface IOutputHandler {
@@ -43,6 +48,12 @@ export interface IOutputHandler {
 
   /** Retrieve the cached mapping metadata for a round. */
   getRoundMapping(currRound: number): RoundFileMapping;
+
+  /** Retrieve normalized export metadata for a round. */
+  getRoundExports(
+    currRound: number,
+    options?: { includeContent?: boolean },
+  ): Promise<RoundOutputExport[]>;
 
   /** Validate expected output files for the given round. */
   validateExpectedOutputs(

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -12,6 +12,7 @@ import type {
   NamedOutputFile,
   OutputFileInfo,
   RoundFileMapping,
+  RoundOutputExport,
 } from './types';
 import { XmlOutputManager } from './XmlOutputManager';
 
@@ -51,6 +52,10 @@ export class OutputHandler implements IOutputHandler {
   public outputFiles: { [key: number]: string[] };
   public outputMappings: { [key: number]: NamedOutputFile[] };
   private roundMappings: { [key: number]: RoundFileMapping };
+  private roundExportCache: { [key: number]: RoundOutputExport[] };
+  private roundExportContentCache: {
+    [key: number]: Map<string, string | null>;
+  };
   public baseFiles: string[];
   public processGroupId?: string;
   protected logger: AgentLogger;
@@ -73,6 +78,8 @@ export class OutputHandler implements IOutputHandler {
     this.outputFiles = {};
     this.outputMappings = {};
     this.roundMappings = {};
+    this.roundExportCache = {};
+    this.roundExportContentCache = {};
     this.baseFiles = baseFiles;
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
@@ -251,13 +258,144 @@ export class OutputHandler implements IOutputHandler {
     return mapping;
   }
 
+  private buildRoundExports(round: number): RoundOutputExport[] {
+    const roundOutputs = this.outputFiles[round] ?? [];
+    if (roundOutputs.length === 0) {
+      const emptyExports: RoundOutputExport[] = [];
+      this.roundExportCache[round] = emptyExports;
+      return emptyExports;
+    }
+
+    const mapping = this.getRoundMapping(round);
+    const baseByOutput = new Map<string, string>();
+    const prevByOutput = new Map<string, string>();
+    for (const [base, output] of mapping.baseToOutput.entries()) {
+      baseByOutput.set(output, base);
+    }
+    for (const [prev, output] of mapping.prevToOutput.entries()) {
+      prevByOutput.set(output, prev);
+    }
+
+    const namedByPath = new Map<string, NamedOutputFile>();
+    for (const named of this.outputMappings[round] || []) {
+      namedByPath.set(named.path, named);
+    }
+
+    const usedIds = new Map<string, number>();
+    const exports = roundOutputs.map((filePath) => {
+      const named = namedByPath.get(filePath);
+      const exportId = this.resolveExportId(filePath, named, usedIds);
+      const source = named?.source ?? filePath;
+      const original =
+        mapping.originByOutput.get(filePath) ?? named?.source ?? null;
+      return {
+        exportId,
+        source,
+        path: filePath,
+        base: baseByOutput.get(filePath) ?? null,
+        prev: prevByOutput.get(filePath) ?? null,
+        original,
+      };
+    });
+
+    this.roundExportCache[round] = exports;
+    return exports;
+  }
+
+  private resolveExportId(
+    filePath: string,
+    named: NamedOutputFile | undefined,
+    usedIds: Map<string, number>,
+  ): string {
+    const candidates = [named?.exportId, named?.source, filePath];
+    for (const candidate of candidates) {
+      if (!candidate) {
+        continue;
+      }
+      const sanitized = this.sanitizeExportId(candidate);
+      if (!sanitized) {
+        continue;
+      }
+      const count = usedIds.get(sanitized);
+      if (!count) {
+        usedIds.set(sanitized, 1);
+        return sanitized;
+      }
+      const nextCount = count + 1;
+      usedIds.set(sanitized, nextCount);
+      return `${sanitized}_${nextCount}`;
+    }
+
+    const fallback = `output_${usedIds.size + 1}`;
+    usedIds.set(fallback, 1);
+    return fallback;
+  }
+
+  private sanitizeExportId(candidate: string): string {
+    const parsed = path.parse(candidate.trim());
+    const base = parsed.name || parsed.base || candidate;
+    const normalized = base
+      .replace(/[^a-zA-Z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .toLowerCase();
+    return normalized;
+  }
+
+  public async getRoundExports(
+    currRound: number,
+    options: { includeContent?: boolean } = {},
+  ): Promise<RoundOutputExport[]> {
+    this.ensureRound(currRound);
+    const includeContent = options.includeContent ?? false;
+
+    const cached = this.roundExportCache[currRound] ?? null;
+    const exports = cached ?? this.buildRoundExports(currRound);
+
+    if (!includeContent) {
+      return exports.map((entry) => ({ ...entry }));
+    }
+
+    let contentCache = this.roundExportContentCache[currRound];
+    if (!contentCache) {
+      contentCache = new Map();
+      this.roundExportContentCache[currRound] = contentCache;
+    }
+
+    const results: RoundOutputExport[] = [];
+    for (const entry of exports) {
+      if (!contentCache.has(entry.path)) {
+        try {
+          const fileContent = await WorkspaceFS.read(entry.path);
+          contentCache.set(entry.path, fileContent);
+        } catch (error) {
+          this.logger.error(
+            `Failed to read output file ${entry.path}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          contentCache.set(entry.path, null);
+        }
+      }
+
+      results.push({ ...entry, content: contentCache.get(entry.path) ?? null });
+    }
+
+    return results;
+  }
+
   private invalidateRoundMapping(round: number): void {
     delete this.roundMappings[round];
+    this.clearRoundExports(round);
   }
 
   private invalidateMappingsFromRound(round: number): void {
     this.invalidateRoundMapping(round);
     this.invalidateRoundMapping(round + 1);
+  }
+
+  private clearRoundExports(round: number): void {
+    delete this.roundExportCache[round];
+    delete this.roundExportContentCache[round];
   }
 
   /**

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -292,7 +292,11 @@ export class XmlOutputManager {
         currRound,
       );
       await WorkspaceFS.write(texFile, doc.content.trim());
-      outputFiles.push({ source, path: texFile });
+      outputFiles.push({
+        source,
+        path: texFile,
+        exportId: this.normalizeExportId(source, texFile),
+      });
       this.logger.debug(
         `XML Source: ${source} -> TeX file written: ${texFile}`,
       );
@@ -316,9 +320,11 @@ export class XmlOutputManager {
       original = nameMatch[1].trim();
     }
 
+    const fallbackSource = original || this.agentConfig.inputFile;
     return {
-      source: original || this.agentConfig.inputFile,
+      source: fallbackSource,
       path: processedOutputFile,
+      exportId: this.normalizeExportId(fallbackSource, processedOutputFile),
     };
   }
 
@@ -358,5 +364,22 @@ export class XmlOutputManager {
       }
     }
     await WorkspaceFS.write(filePath, content);
+  }
+
+  private normalizeExportId(
+    preferredName: string | undefined,
+    filePath: string,
+  ): string {
+    const candidate =
+      preferredName && preferredName.trim().length > 0
+        ? preferredName.trim()
+        : filePath;
+    const parsed = path.parse(candidate);
+    const base = parsed.name || parsed.base || 'output';
+    const normalized = base
+      .replace(/[^a-zA-Z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .toLowerCase();
+    return normalized || 'output';
   }
 }

--- a/src/agent/output/index.ts
+++ b/src/agent/output/index.ts
@@ -1,4 +1,4 @@
 export * from './OutputHandler';
 export * from './IOutputHandler';
-export { NamedOutputFile } from './types';
+export { NamedOutputFile, RoundOutputExport } from './types';
 export { getOutputFileName } from '@agent/utils/outputFileUtils';

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -4,6 +4,7 @@ import type { DiffStats } from '@agent/types/DiffTypes';
 export interface NamedOutputFile {
   source: string;
   path: string;
+  exportId?: string;
 }
 
 export interface OutputFileInfo extends DiffStats {
@@ -17,4 +18,14 @@ export interface RoundFileMapping {
   baseToOutput: Map<string, string>;
   prevToOutput: Map<string, string>;
   originByOutput: Map<string, string | undefined>;
+}
+
+export interface RoundOutputExport {
+  exportId: string;
+  source: string;
+  path: string;
+  base: string | null;
+  prev: string | null;
+  original: string | null;
+  content?: string | null;
 }

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -54,6 +54,8 @@ export async function buildUserVars(
   Object.assign(userVars, getOutputFilesOrder(agentConfig, agentSetting));
   Object.assign(userVars, getToolFlags(agentConfig, agentSetting, agentPrompt));
 
+  applyWorkflowContext(userVars, agentConfig);
+
   // Emit aggregated file list if any files were loaded
   if (allLoadedFiles.length > 0) {
     logger.fileList(allLoadedFiles);
@@ -303,6 +305,23 @@ function getOutputFilesOrder(
     userVars.OUTPUT_FILES_ORDER = agentSetting.defaultOutputFiles.join(', ');
   }
   return userVars;
+}
+
+function applyWorkflowContext(
+  userVars: Record<string, any>,
+  agentConfig: AgentConfig,
+): void {
+  const context = agentConfig.workflowContext;
+  if (!context || typeof context !== 'object') {
+    return;
+  }
+
+  const existingWorkflow =
+    userVars.WORKFLOW && typeof userVars.WORKFLOW === 'object'
+      ? { ...userVars.WORKFLOW }
+      : {};
+
+  userVars.WORKFLOW = { ...existingWorkflow, ...context };
 }
 
 export function getToolFlags(

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -327,6 +327,7 @@ describe('ResponseCycle background reasoning logs', () => {
       mediaFiles: null,
       outputFiles: null,
       editedFile: null,
+      workflowContext: null,
       toolConfig: {
         autoExtractFigure: false,
         autoExtractTikzFigure: false,

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -9,8 +9,9 @@ import {
   AgentCategory,
 } from '@agent/core/AgentDataclass';
 import type { AgentPrompt } from '@agent/core/AgentDataclass';
-import { getToolFlags } from '@agent/utils/userVars';
+import { buildUserVars, getToolFlags } from '@agent/utils/userVars';
 import * as configModule from '@utils/config';
+import { AgentLogger } from '@logger/AgentLogger';
 
 const baseSetting: AgentSetting = {
   agentType: AgentType.CoT,
@@ -51,6 +52,7 @@ const baseConfig: AgentConfig = {
   mediaFiles: null,
   outputFiles: null,
   editedFile: null,
+  workflowContext: null,
   toolConfig: {
     autoExtractFigure: false,
     autoExtractTikzFigure: false,
@@ -104,5 +106,37 @@ describe('getToolFlags', () => {
 
     const flags = getToolFlags(baseConfig, setting, prompt);
     assert.equal(flags.ROUNDS, 3);
+  });
+});
+
+describe('buildUserVars', () => {
+  it('merges workflow context under WORKFLOW namespace', async () => {
+    const configWithContext: AgentConfig = {
+      ...baseConfig,
+      inputFile: '',
+      workflowContext: {
+        steps: {
+          derive: { summary: 'complete' },
+        },
+      },
+    };
+
+    const logger = new AgentLogger('WorkflowUserVarsTest');
+    const modelHandler: any = {
+      isOpenai: false,
+      isAnthropic: false,
+      isGoogle: false,
+    };
+
+    const userVars = await buildUserVars(
+      configWithContext,
+      baseSetting,
+      basePrompt,
+      __dirname,
+      modelHandler,
+      logger,
+    );
+
+    assert.deepEqual(userVars.WORKFLOW, configWithContext.workflowContext);
   });
 });

--- a/src/test/output/LatexDiffManager.test.ts
+++ b/src/test/output/LatexDiffManager.test.ts
@@ -49,6 +49,7 @@ describe('LatexDiffManager mapping reuse', () => {
     mediaFiles: null,
     outputFiles: null,
     editedFile: null,
+    workflowContext: null,
     toolConfig: {
       autoExtractFigure: false,
       autoExtractTikzFigure: false,

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -14,6 +14,7 @@ import { OutputHandler } from '@agent/output';
 // Local imports
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
+import { WorkspaceFS } from '@utils/files';
 
 class MockOutputHandler extends OutputHandler {
   public gatherCalled = false;
@@ -77,6 +78,7 @@ const baseConfig: AgentConfig = {
   mediaFiles: null,
   outputFiles: null,
   editedFile: null,
+  workflowContext: null,
   toolConfig: {
     autoExtractFigure: false,
     autoExtractTikzFigure: false,
@@ -174,6 +176,80 @@ describe('OutputHandler.getRoundMapping', () => {
       first,
       'expected mapping to refresh after invalidation',
     );
+  });
+});
+
+describe('OutputHandler.getRoundExports', () => {
+  it('returns exports with optional content and caches reads', async () => {
+    const handler = new OutputHandler(
+      baseSetting,
+      baseConfig,
+      0,
+      [],
+      new AgentLogger('TestRoundExports'),
+    );
+
+    handler.outputFiles[0] = ['chapter_r0.tex'];
+    handler.outputMappings[0] = [
+      { source: 'chapter.tex', path: 'chapter_r0.tex' },
+    ];
+
+    const readCalls: string[] = [];
+    const originalRead = WorkspaceFS.read;
+    (WorkspaceFS as any).read = async (filePath: string) => {
+      readCalls.push(filePath);
+      return `content:${path.basename(filePath)}`;
+    };
+
+    try {
+      const metadataOnly = await handler.getRoundExports(0);
+      assert.equal(metadataOnly.length, 1);
+      assert.equal(metadataOnly[0].path, 'chapter_r0.tex');
+      assert.equal(metadataOnly[0].source, 'chapter.tex');
+      assert.ok(metadataOnly[0].exportId.length > 0);
+      assert.equal(metadataOnly[0].content, undefined);
+
+      const withContent = await handler.getRoundExports(0, {
+        includeContent: true,
+      });
+      assert.equal(readCalls.length, 1);
+      assert.equal(withContent[0].content, 'content:chapter_r0.tex');
+
+      const second = await handler.getRoundExports(0, {
+        includeContent: true,
+      });
+      assert.equal(readCalls.length, 1, 'expected content to be cached');
+      assert.equal(second[0].content, 'content:chapter_r0.tex');
+    } finally {
+      (WorkspaceFS as any).read = originalRead;
+    }
+  });
+
+  it('refreshes exports when round outputs change', async () => {
+    const handler = new OutputHandler(
+      baseSetting,
+      baseConfig,
+      0,
+      [],
+      new AgentLogger('TestRoundExportsRefresh'),
+    );
+
+    handler.outputFiles[0] = ['first_r0.tex'];
+    handler.outputMappings[0] = [{ source: 'first.tex', path: 'first_r0.tex' }];
+
+    await handler.getRoundExports(0);
+
+    (handler as any).setRoundOutputs(
+      0,
+      ['second_r0.tex'],
+      [{ source: 'second.tex', path: 'second_r0.tex' }],
+    );
+
+    const exports = await handler.getRoundExports(0);
+    assert.equal(exports.length, 1);
+    assert.equal(exports[0].path, 'second_r0.tex');
+    assert.equal(exports[0].source, 'second.tex');
+    assert.ok(exports[0].exportId.includes('second'));
   });
 });
 

--- a/src/test/output/XmlOutputManager.test.ts
+++ b/src/test/output/XmlOutputManager.test.ts
@@ -48,6 +48,7 @@ describe('XmlOutputManager markdown fallback', () => {
     mediaFiles: null,
     outputFiles: null,
     editedFile: null,
+    workflowContext: null,
     toolConfig: {
       autoExtractFigure: false,
       autoExtractTikzFigure: false,

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -155,6 +155,7 @@ describe('BaseToolUseAgent follow-up loop', () => {
       mediaFiles: null,
       outputFiles: null,
       editedFile: null,
+      workflowContext: null,
       toolConfig: {
         autoExtractFigure: false,
         autoExtractTikzFigure: false,

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -149,6 +149,7 @@ export class ExecutionManager {
           )
         : null,
       editedFile: null,
+      workflowContext: null,
       toolConfig,
       agentType: session.agentType,
       session,


### PR DESCRIPTION
## Summary
- expose a structured round export API on `OutputHandler` so orchestrated flows can reuse named outputs with cached content
- annotate XML processing with stable export identifiers and thread workflow context into prompt variables
- cover the new helpers with unit tests and ensure UI/config defaults supply a workflow context slot

## Testing
- npm run compile-tests
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_69051c8fe4688324959fa73e5097a550

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a normalized round export API (with optional cached content) and threads workflowContext into prompt variables, annotating XML outputs with stable export IDs and updating types and tests.
> 
> - **Output handling**:
>   - Add `OutputHandler.getRoundExports(currRound, { includeContent? })` returning normalized `RoundOutputExport[]` with optional cached file content; invalidate caches on round changes.
>   - Implement export ID resolution/sanitization and per-round export/content caches.
>   - Update XML processing to emit `NamedOutputFile` with `exportId` via `normalizeExportId` (single/multiple XML paths).
>   - Types: add `RoundOutputExport`; extend `NamedOutputFile` with optional `exportId`; re-export from `@agent/output`.
> - **Config & prompt vars**:
>   - Extend `AgentConfig` with optional `workflowContext` and merge into `userVars.WORKFLOW` via `applyWorkflowContext`.
> - **Webview**:
>   - Ensure composed configs include `workflowContext: null`.
> - **Tests**:
>   - Add/expand unit tests for round export API, XML manager export IDs, and workflow context merging; update existing tests to include `workflowContext`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d607be5e65d434a3992f49eb6c333827c1493b43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->