### PR TITLE
Add async log group context for agent logging

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -214,7 +214,6 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     options.modelHandler.setOutputStreaming(false);
 
     let response: unknown;
-    const groupId = options.logger.getActiveGroupId();
 
     try {
       response = await options.modelHandler.createResponse(
@@ -233,7 +232,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         error instanceof Error
           ? `Model invocation failed: ${error.message}`
           : 'Model invocation failed with an unknown error';
-      options.logger.error(message, groupId);
+      options.logger.error(message);
       cycle.shouldStop = true;
       cycle.endTurn = false;
       throw error;
@@ -254,8 +253,6 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     execRes: { skipped: true } | { response: unknown; responseTime?: number },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
-    const groupId = options.logger.getActiveGroupId();
-
     if ('skipped' in execRes) {
       cycle.endTurn = false;
       return FlowTransition.COMPLETE;
@@ -274,7 +271,6 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (!execRes.response) {
       options.logger.warn(
         'Model response was aborted or returned no data; output may be incomplete.',
-        groupId,
       );
       cycle.endTurn = false;
       cycle.shouldStop = true;
@@ -322,32 +318,20 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
         options.agentSetting.endTag,
       );
 
-    const groupId = options.logger.getActiveGroupId();
-
     if (newResponse) {
-      options.logger.debug(
-        `Model response: ${newResponse.slice(0, 100)}`,
-        groupId,
-      );
+      options.logger.debug(`Model response: ${newResponse.slice(0, 100)}`);
     }
 
     if (cycle.responseTime !== undefined) {
       cycle.stateRound.updateResponseTime(cycle.responseTime);
-      options.logger.debug(
-        `Response time: ${cycle.responseTime.toFixed(2)}s`,
-        groupId,
-      );
+      options.logger.debug(`Response time: ${cycle.responseTime.toFixed(2)}s`);
     }
 
-    options.logger.debug(`Stop reason: ${stopReason}`, groupId);
-    options.logger.debug(
-      `Token usage: ${JSON.stringify(responseUsage)}`,
-      groupId,
-    );
+    options.logger.debug(`Stop reason: ${stopReason}`);
+    options.logger.debug(`Token usage: ${JSON.stringify(responseUsage)}`);
 
     const thinkingContent = options.modelHandler.processThinkingBlock(
       cycle.responseObject,
-      groupId,
       cycle.toolState,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
@@ -355,7 +339,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (thinkingContent && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinkingContent);
       if (formatted.trim().length > 0) {
-        options.logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
+        options.logger.info(formatted, MESSAGE_TYPES.THINKING);
       }
     }
 
@@ -364,12 +348,12 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       'scratchpad',
     );
     if (scratchpad) {
-      options.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      options.logger.info(scratchpad, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     if (newResponse && !useStreaming) {
       const formattedResponse = await xmlUtils.formatContent(newResponse);
-      options.logger.info(formattedResponse, groupId, MESSAGE_TYPES.INTERNAL);
+      options.logger.info(formattedResponse, MESSAGE_TYPES.INTERNAL);
     }
 
     const apiUsage = options.modelHandler.computeResponseUsage(
@@ -387,19 +371,13 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (repetitionResult.massiveRepetitionDetected && newResponse) {
       options.logger.error(
         `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-        groupId,
       );
       options.logger.error(
         'Massive repetition detected - skipping this response',
-        groupId,
       );
-      options.logger.error(
-        'Message structure when repetition detected:',
-        groupId,
-      );
+      options.logger.error('Message structure when repetition detected:');
       options.logger.error(
         JSON.stringify(messageToSkeleton(cycle.messages), null, 2),
-        groupId,
       );
     }
 
@@ -442,8 +420,6 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     execRes: ProcessResult | { skipped: true },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
-    const groupId = options.logger.getActiveGroupId();
-
     if ('skipped' in execRes) {
       cycle.endTurn = false;
       return FlowTransition.COMPLETE;
@@ -459,28 +435,23 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     }
 
     if (!cycle.outputExists) {
-      options.logger.debug(`Creating new file: ${cycle.outputFile}`, groupId);
+      options.logger.debug(`Creating new file: ${cycle.outputFile}`);
       await WorkspaceFS.write(cycle.outputFile, execRes.processedResponse);
       cycle.outputExists = true;
     } else {
-      options.logger.debug(
-        `Appending to existing file: ${cycle.outputFile}`,
-        groupId,
-      );
+      options.logger.debug(`Appending to existing file: ${cycle.outputFile}`);
       await WorkspaceFS.appendFile(
         cycle.outputFile,
         (execRes.bestConnector ?? '') + execRes.processedResponse,
       );
     }
 
-    options.logger.debug('Response preview:', groupId);
+    options.logger.debug('Response preview:');
     options.logger.debug(
       `First ${K_SLICE} chars:\n${execRes.processedResponse.slice(0, K_SLICE)}`,
-      groupId,
     );
     options.logger.debug(
       `Last ${K_SLICE} chars:\n${execRes.processedResponse.slice(-K_SLICE)}`,
-      groupId,
     );
 
     if (options.modelHandler.capabilities.supportsAssistantPrefill) {
@@ -554,8 +525,6 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       | { skipped: true },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
-    const groupId = options.logger.getActiveGroupId();
-
     if ('skipped' in execRes) {
       cycle.endTurn = false;
       cycle.shouldStop = true;
@@ -572,7 +541,6 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     cycle.stateRound.incrementContinuation();
     options.logger.info(
       `Starting continuation #${cycle.stateRound.continuationCount}`,
-      groupId,
       MESSAGE_TYPES.PROGRESS_STATUS,
     );
 
@@ -582,7 +550,6 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     options.logger.debug(
       'Should continue - adding continuation message to conversation',
-      groupId,
     );
 
     if (options.modelHandler.capabilities.supportsAssistantPrefill) {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -347,7 +347,6 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
     const thinking = options.modelHandler.processThinkingBlock(
       state.response,
-      groupId,
       state.toolState,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
@@ -383,7 +382,7 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         cost: normalized.cost,
         elapsedTime: normalized.responseTime,
       };
-      options.logger.statistics(stats, groupId);
+      options.logger.statistics(stats);
     }
 
     const endTurn = options.modelHandler.isEndTurnStop(stopReason);

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -236,21 +236,18 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     groupLabel: string,
     callback: (groupId: string) => Promise<T>,
   ): Promise<T> {
-    const groupId = await this.logger.startGroup(
+    return this.logger.withGroup(
       groupLabel,
-      undefined,
-      this.runGroupId,
+      async (groupId) => {
+        if (!groupId) {
+          throw new Error(
+            'Round group identifier is required for round logging.',
+          );
+        }
+        return callback(groupId);
+      },
+      { parentGroupId: this.runGroupId },
     );
-
-    let status: 'stopped' | 'error' = 'stopped';
-    try {
-      return await callback(groupId);
-    } catch (error) {
-      status = 'error';
-      throw error;
-    } finally {
-      this.logger.endGroup(groupId, status);
-    }
   }
 
   /**

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1016,13 +1016,11 @@ export abstract class ModelHandler<
   /**
    * Extracts thinking content from model responses
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted thinking content string or null if no thinking content is available
    */
   abstract processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null;
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1432,7 +1432,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /**
    * Process thinking blocks for Anthropic models
    * @param responseObject The response object from Anthropic API
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking blocks
    * @returns The extracted thinking content (or null if none)
    * This preserves the full thinking objects including signature which is required
@@ -1440,7 +1439,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
    */
   processThinkingBlock(
     responseObject: BetaMessage,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -1469,7 +1467,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     } catch (e) {
       this.logger.error(
         `Error extracting thinking blocks: ${getSdkErrorMessage(e)}`,
-        groupId,
         undefined,
         e,
       );
@@ -1480,10 +1477,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return null;
     }
 
-    this.logger.debug(
-      `Found ${thinkingBlocks.length} thinking blocks`,
-      groupId,
-    );
+    this.logger.debug(`Found ${thinkingBlocks.length} thinking blocks`);
 
     // If toolState is provided, update it with all thinking blocks
     if (toolState && !toolState.thinkingAdded) {
@@ -1497,12 +1491,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         toolState.thinkingAdded = true;
         this.logger.debug(
           `Added ${thinkingBlocks.length} thinking blocks to toolState`,
-          groupId,
         );
       } else {
         this.logger.debug(
           `Skipping adding thinking blocks to toolState because of cut off message`,
-          groupId,
         );
       }
     }

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -64,13 +64,11 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for DeepSeek models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -94,7 +92,6 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
         reasoningContent = message.reasoning_content;
         this.logger.debug(
           'Found reasoning_content in choices[0].message.reasoning_content',
-          groupId,
         );
 
         // If toolState is provided and we have reasoning content,
@@ -108,7 +105,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
 
           toolState.thinkingBlocks = [thinkingBlock];
           toolState.thinkingAdded = true;
-          // this.logger.debug('Added reasoning content to toolState', groupId);
+          // this.logger.debug('Added reasoning content to toolState');
         }
         // For deepseek mode thinking content should not be attached back to the message as a content item.
         // Nevertheless one can include one in a bare way...
@@ -121,7 +118,6 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     // Log preview of thinking content (assuming it's a string)
     this.logger.debug(
       `DeepSeek reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
     );
 
     // Return the reasoning content (already a string for DeepSeek)

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1023,7 +1023,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   processThinkingBlock(
     responseObject: GenerateContentResponse,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (
@@ -1066,7 +1065,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (thoughtContent) {
       this.logger.debug(
         `Google GenAI thought summary preview: ${thoughtContent.substring(0, K_SLICE)}...`,
-        groupId,
       );
     }
 

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -31,13 +31,11 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for Moonshot models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -59,7 +57,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         reasoningContent = message.thinking_content;
         this.logger.debug(
           'Found thinking_content in choices[0].message.thinking_content',
-          groupId,
         );
 
         // If toolState is provided and we have reasoning content,
@@ -84,7 +81,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     // Log preview of thinking content
     this.logger.debug(
       `Kimi thinking content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
     );
 
     return reasoningContent;

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1131,13 +1131,11 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /**
    * Processes thinking blocks from API response. OpenAI models do not support thinking blocks.
    * @param responseObject The response object from the OpenAI API
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with thinking blocks
    * @returns Always returns null as OpenAI doesn't support thinking blocks
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     const reasoning = responseObject?.choices?.[0]?.message?.reasoning_content;
@@ -1152,7 +1150,6 @@ export class ModelHandlerOpenAI extends ModelHandler<
 
     this.logger.debug(
       `OpenAI reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
-      groupId,
     );
     return reasoning;
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1197,7 +1197,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Process reasoning summaries from the Responses API. */
   processThinkingBlock(
     responseObject: Response,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     const outputArr = responseObject?.output;
@@ -1225,7 +1224,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (thoughtContent) {
       this.logger.debug(
         `OpenAI Responses reasoning preview: ${thoughtContent.substring(0, K_SLICE)}...`,
-        groupId,
       );
     }
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -95,7 +95,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   // Implementation for processing thinking blocks in OpenRouter responses
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -110,13 +109,12 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       responseObject.choices[0].message.reasoning
     ) {
       const reasoning = responseObject.choices[0].message.reasoning;
-      this.logger.debug(`OpenRouter reasoning found`, groupId);
+      this.logger.debug(`OpenRouter reasoning found`);
 
       // Log preview of reasoning content
       if (typeof reasoning === 'string') {
         this.logger.debug(
           `Reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
-          groupId,
         );
         return reasoning;
       } else {
@@ -124,7 +122,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
         const reasoningStr = JSON.stringify(reasoning);
         this.logger.debug(
           `Reasoning preview: ${reasoningStr.substring(0, K_SLICE)}...`,
-          groupId,
         );
         return reasoningStr;
       }

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -18,13 +18,11 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for xAI models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -50,7 +48,6 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
         reasoningContent = message.reasoning_content;
         this.logger.debug(
           'Found reasoning_content in choices[0].message.reasoning_content',
-          groupId,
         );
 
         // If toolState is provided and we have reasoning content,
@@ -75,7 +72,6 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
     // Log preview of thinking content
     this.logger.debug(
       `xAI reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
     );
 
     return reasoningContent;

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -185,7 +185,6 @@ export interface IModelHandler<
   /** Extract intermediate "thinking" content from a response. */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null;
 

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -228,7 +228,7 @@ export class LatexDiffManager {
       }
 
       if (aggregated.length > 0) {
-        this.logger.latexDiff(aggregated, diffProcessGroupId);
+        this.logger.latexDiff(aggregated);
       } else {
         this.logger.debug('No latexdiff results to report', diffProcessGroupId);
       }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -119,26 +119,33 @@ export class OutputHandler implements IOutputHandler {
   }
 
   /**
-   * Starts a processing group for output handling.
-   * Creates a log group at the same level as ResponseCycle.
+   * Run processing logic within a scoped log group.
+   * Creates a log group at the same level as ResponseCycle and ensures
+   * asynchronous work inherits the processing context.
    * @param processName Name of the processing operation
-   * @param roundGroupId Parent round group ID
-   * @returns The created process group ID
+   * @param callback Work to execute while the processing group is active
+   * @param options.parentGroupId Optional parent round group ID
    */
-  async startProcessing(
+  async startProcessing<T>(
     processName: string,
-    roundGroupId?: string,
-  ): Promise<string> {
-    // Create a log group as a child of the round group if provided
-    const groupName = `OutputHandler: ${processName}`;
-    const groupId = await this.logger.startGroup(
-      groupName,
-      undefined,
-      roundGroupId,
+    callback: (groupId: string) => Promise<T>,
+    options: { parentGroupId?: string } = {},
+  ): Promise<T> {
+    return this.logger.withGroup(
+      `OutputHandler: ${processName}`,
+      async (groupId) => {
+        if (!groupId) {
+          throw new Error('Processing group identifier is required.');
+        }
+        this.processGroupId = groupId;
+        try {
+          return await callback(groupId);
+        } finally {
+          this.processGroupId = undefined;
+        }
+      },
+      { parentGroupId: options.parentGroupId },
     );
-    // Comment out this line as it creates confusing log order
-    // this.logger.info(`Starting ${processName}`, groupId);
-    return groupId;
   }
 
   /**

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -336,7 +336,7 @@ export class OutputHandler implements IOutputHandler {
         documentTag: this.agentSetting.documentTag,
       };
 
-      this.logger.missingOutputs(missingOutputsData, groupId);
+      this.logger.missingOutputs(missingOutputsData);
     }
 
     bus.emit('updateMissingOutputs', {
@@ -508,7 +508,7 @@ export class OutputHandler implements IOutputHandler {
           xmlFile: outputFile,
           documentTag: this.agentSetting.documentTag,
         };
-        this.logger.missingOutputs(missingOutputsData, activeGroupId);
+        this.logger.missingOutputs(missingOutputsData);
         bus.emit('updateMissingOutputs', {
           stream: this.channel,
           filesByRound: { [currRound]: [] },

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -39,6 +39,7 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
 import { withLogGroup } from '@logger/logGroupUtils';
+import { runWithChannelGroup } from '@logger/logContext';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { agentConfigToTaskState } from '@utils/config';
@@ -377,29 +378,18 @@ export async function executeAgentWithLogging<T extends IAgent>(
           await withLogGroup(
             logger,
             `Task Details`,
-            async (taskDetailsGroupId) => {
-              if (!isResume && taskDetailsGroupId) {
-                logger.info(
-                  `Starting task execution for ${activeStreamId}`,
-                  taskDetailsGroupId,
-                );
-                logger.info(
-                  `Input file: ${config.inputFile}`,
-                  taskDetailsGroupId,
-                );
+            async () => {
+              if (!isResume) {
+                logger.info(`Starting task execution for ${activeStreamId}`);
+                logger.info(`Input file: ${config.inputFile}`);
               }
 
-              logger.debug(
-                `Creating stream with ID: ${activeStreamId}`,
-                taskDetailsGroupId,
-              );
+              logger.debug(`Creating stream with ID: ${activeStreamId}`);
               logger.debug(
                 `Agent name: ${agentName}, Model: ${config.model}, Input file: ${config.inputFile}`,
-                taskDetailsGroupId,
               );
               logger.debug(
                 `Config has output files: ${!!config.outputFiles}, Number of output files: ${config.outputFiles?.length || 0}, useMultipleOutputs: ${config.useMultipleOutputs}`,
-                taskDetailsGroupId,
               );
 
               // Switch to this stream and set its status to running
@@ -462,14 +452,8 @@ export async function executeAgentWithLogging<T extends IAgent>(
                 }
 
                 // Store taskState
-                logger.debug(
-                  `Storing taskState for stream: ${activeStreamId}`,
-                  taskDetailsGroupId,
-                );
-                logger.debug(
-                  `Config for taskState: ${JSON.stringify(config)}`,
-                  taskDetailsGroupId,
-                );
+                logger.debug(`Storing taskState for stream: ${activeStreamId}`);
+                logger.debug(`Config for taskState: ${JSON.stringify(config)}`);
 
                 // Convert AgentConfig to TaskState using utility function
                 bus.emit('setTaskState', {
@@ -477,10 +461,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
                   executionId,
                   taskState: agentConfigToTaskState(config, metadata),
                 });
-                logger.debug(
-                  `Task state stored for stream: ${activeStreamId}`,
-                  mainTaskGroupId,
-                );
+                logger.debug(`Task state stored for stream: ${activeStreamId}`);
               }
             },
             { parentGroupId: mainTaskGroupId, skip: isResume },
@@ -488,17 +469,13 @@ export async function executeAgentWithLogging<T extends IAgent>(
         } catch (err) {
           logger.error(
             `Task initialization failed: ${err instanceof Error ? err.message : String(err)}`,
-            mainTaskGroupId,
           );
           throw err;
         }
 
         try {
           // Run the agent
-          logger.info(
-            `Executing ${agentName} with model ${config.model}`,
-            mainTaskGroupId,
-          );
+          logger.info(`Executing ${agentName} with model ${config.model}`);
           if (!agent) {
             throw new Error('Agent instance was not initialized');
           }
@@ -506,7 +483,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           await agent.run();
           // await checkExpectedOutputs(config.outputFiles, agent);
           // Mark the task as completed successfully
-          logger.debug(`Task completed successfully`, mainTaskGroupId);
+          logger.debug(`Task completed successfully`);
           // Update status to stopped on successful completion
           bus.emit('updateStreamStatus', {
             stream: activeStreamId,
@@ -516,7 +493,6 @@ export async function executeAgentWithLogging<T extends IAgent>(
           // Mark the task as failed
           logger.error(
             `Task failed: ${err instanceof Error ? err.message : String(err)}`,
-            mainTaskGroupId,
           );
           // Update status to error if agent run fails
           bus.emit('updateStreamStatus', {
@@ -563,25 +539,34 @@ export async function executeAgentWithLogging<T extends IAgent>(
       if (!agentStreamLogger && streamTabId) {
         agentStreamLogger = new AgentLogger(streamTabId, true);
       }
-      if (agentStreamLogger) {
+      const loggerRef = agentStreamLogger;
+      if (loggerRef) {
         const fallbackGroupId =
-          agentStreamLogger.getActiveGroupId() ?? agent?.getLastRunGroupId();
+          loggerRef.getActiveGroupId() ?? agent?.getLastRunGroupId();
         if (fallbackGroupId) {
-          agentStreamLogger.error(errorMsg, fallbackGroupId);
+          runWithChannelGroup(loggerRef.channelId, fallbackGroupId, () => {
+            loggerRef.error(errorMsg);
+          });
         } else {
-          const agentErrorGroupId = await agentStreamLogger.startGroup(
+          await loggerRef.withGroup(
             `Error: ${agentName}`,
+            async () => {
+              loggerRef.error(errorMsg);
+            },
+            { successStatus: 'error' },
           );
-          agentStreamLogger.error(errorMsg, agentErrorGroupId);
-          agentStreamLogger.endGroup(agentErrorGroupId, 'error');
         }
       }
     }
 
     // Create a temporary error group if no active group exists
-    const errorGroupId = await logger.startGroup(`Error: ${agentName}`);
-    logger.error(errorMsg, errorGroupId);
-    logger.endGroup(errorGroupId, 'error');
+    await logger.withGroup(
+      `Error: ${agentName}`,
+      async () => {
+        logger.error(errorMsg);
+      },
+      { successStatus: 'error' },
+    );
     throw new Error(errorMsg);
   }
 }

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -156,7 +156,7 @@ export class UsageMonitor {
         }),
       };
 
-      this.logger.statistics(payload, statsGroupId);
+      this.logger.statistics(payload);
     } catch (error) {
       this.logger.error(`Error printing statistics: ${error}`, statsGroupId);
     }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -3,6 +3,7 @@
 
 // Local imports - log
 import * as logger from './logUtils';
+import { runWithChannelGroup } from './logContext';
 import type { MessageType } from './messageTypes';
 import { MESSAGE_TYPES } from './messageTypes';
 import type {
@@ -27,6 +28,14 @@ export class AgentLogger {
     logger.initialize(this.channelId, this.isAgentLogger);
     this.channelId = channelId;
   }
+
+  /**
+   * Options used to control group lifecycle behaviour when using withGroup.
+   */
+  public static readonly defaultGroupStatus = {
+    success: 'stopped' as const,
+    error: 'error' as const,
+  };
 
   debug(
     message: string,
@@ -180,4 +189,48 @@ export class AgentLogger {
   setActiveGroupId(groupId: string | undefined): void {
     logger.setActiveGroupId(this.channelId, groupId);
   }
+
+  /**
+   * Run the provided callback within a log group scope, automatically handling
+   * start/end semantics and ensuring the group remains active for asynchronous
+   * work spawned by the callback.
+   */
+  async withGroup<T>(
+    groupName: string,
+    fn: (groupId?: string) => Promise<T>,
+    options: LoggerGroupOptions = {},
+  ): Promise<T> {
+    const {
+      parentGroupId,
+      skip = false,
+      successStatus = AgentLogger.defaultGroupStatus.success,
+      errorStatus = AgentLogger.defaultGroupStatus.error,
+    } = options;
+
+    if (skip) {
+      return fn(undefined);
+    }
+
+    const groupId = await this.startGroup(groupName, undefined, parentGroupId);
+
+    return runWithChannelGroup(this.channelId, groupId, async () => {
+      try {
+        const result = await fn(groupId);
+        this.endGroup(groupId, successStatus);
+        return result;
+      } catch (error) {
+        this.endGroup(groupId, errorStatus);
+        throw error;
+      }
+    });
+  }
+}
+
+type GroupStatus = Parameters<typeof logger.endGroup>[2];
+
+export interface LoggerGroupOptions {
+  parentGroupId?: string;
+  skip?: boolean;
+  successStatus?: GroupStatus;
+  errorStatus?: GroupStatus;
 }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -37,64 +37,48 @@ export class AgentLogger {
     error: 'error' as const,
   };
 
-  debug(
-    message: string,
-    groupId?: string,
-    messageType?: MessageType,
-    data?: unknown,
-  ): void {
+  debug(message: string, ...args: unknown[]): void {
+    const { messageType, data } = AgentLogger.resolveLogArguments(args);
     logger.debug(
       this.channelId,
       message,
-      groupId,
+      undefined,
       messageType,
       this.isAgentLogger,
       data,
     );
   }
 
-  info(
-    message: string,
-    groupId?: string,
-    messageType?: MessageType,
-    data?: unknown,
-  ): void {
+  info(message: string, ...args: unknown[]): void {
+    const { messageType, data } = AgentLogger.resolveLogArguments(args);
     logger.info(
       this.channelId,
       message,
-      groupId,
+      undefined,
       messageType,
       this.isAgentLogger,
       data,
     );
   }
 
-  warn(
-    message: string,
-    groupId?: string,
-    messageType?: MessageType,
-    data?: unknown,
-  ): void {
+  warn(message: string, ...args: unknown[]): void {
+    const { messageType, data } = AgentLogger.resolveLogArguments(args);
     logger.warn(
       this.channelId,
       message,
-      groupId,
+      undefined,
       messageType,
       this.isAgentLogger,
       data,
     );
   }
 
-  error(
-    message: string,
-    groupId?: string,
-    messageType?: MessageType,
-    data?: unknown,
-  ): void {
+  error(message: string, ...args: unknown[]): void {
+    const { messageType, data } = AgentLogger.resolveLogArguments(args);
     logger.error(
       this.channelId,
       message,
-      groupId,
+      undefined,
       messageType,
       this.isAgentLogger,
       data,
@@ -104,42 +88,42 @@ export class AgentLogger {
   /**
    * Log a list of files that were processed.
    */
-  fileList(files: unknown[], groupId?: string): void {
+  fileList(files: unknown[]): void {
     const summary = `Loaded ${files.length} file${files.length === 1 ? '' : 's'}`;
-    this.info(summary, groupId, MESSAGE_TYPES.FILE_LIST, files);
+    this.info(summary, MESSAGE_TYPES.FILE_LIST, files);
   }
 
   /**
    * Log missing output information.
    */
-  missingOutputs(info: unknown, groupId?: string): void {
+  missingOutputs(info: unknown): void {
     const missing = (info as any).missing as unknown[] | undefined;
     const count = missing ? missing.length : 0;
     const summary = `${count} output file${count === 1 ? '' : 's'} missing`;
-    this.info(summary, groupId, MESSAGE_TYPES.MISSING_OUTPUTS, info);
+    this.info(summary, MESSAGE_TYPES.MISSING_OUTPUTS, info);
   }
 
   /**
    * Log latexdiff results.
    */
-  latexDiff(results: unknown[], groupId?: string): void {
+  latexDiff(results: unknown[]): void {
     const summary = `Latexdiff results: ${results.length}`;
-    this.info(summary, groupId, MESSAGE_TYPES.LATEXDIFF, results);
+    this.info(summary, MESSAGE_TYPES.LATEXDIFF, results);
   }
 
   /**
    * Log statistics information (only shown in debug mode).
    */
-  statistics(stats: ExtendedTokenUsageStats, groupId?: string): void {
+  statistics(stats: ExtendedTokenUsageStats): void {
     const summary = `Usage - input: ${stats.inputTokens ?? 0}, output: ${stats.outputTokens ?? 0}`;
-    this.debug(summary, groupId, MESSAGE_TYPES.STATISTICS, stats);
+    this.debug(summary, MESSAGE_TYPES.STATISTICS, stats);
   }
 
   /**
    * Log a user follow-up message.
    */
-  userMessage(message: string, groupId?: string): void {
-    this.info(message, groupId, MESSAGE_TYPES.USER_MESSAGE);
+  userMessage(message: string): void {
+    this.info(message, MESSAGE_TYPES.USER_MESSAGE);
   }
 
   /**
@@ -223,6 +207,42 @@ export class AgentLogger {
         throw error;
       }
     });
+  }
+
+  private static resolveLogArguments(args: unknown[]): {
+    messageType?: MessageType;
+    data?: unknown;
+  } {
+    if (args.length === 0) {
+      return {};
+    }
+
+    const [first, second, third] = args;
+
+    if (AgentLogger.isMessageType(first)) {
+      return { messageType: first, data: second };
+    }
+
+    if (AgentLogger.isMessageType(second)) {
+      return { messageType: second, data: third };
+    }
+
+    if (args.length === 1) {
+      return { data: first };
+    }
+
+    if (args.length === 2) {
+      return { data: second };
+    }
+
+    return { data: third };
+  }
+
+  private static isMessageType(value: unknown): value is MessageType {
+    return (
+      typeof value === 'string' &&
+      Object.values(MESSAGE_TYPES).includes(value as MessageType)
+    );
   }
 }
 

--- a/src/logger/logContext.ts
+++ b/src/logger/logContext.ts
@@ -1,0 +1,46 @@
+// Standard library imports
+import { AsyncLocalStorage } from 'async_hooks';
+
+interface LogContextState {
+  readonly groups: Map<string, string | undefined>;
+}
+
+const storage = new AsyncLocalStorage<LogContextState>();
+
+function cloneStateWithUpdate(
+  channelId: string,
+  groupId: string | undefined,
+  baseState: LogContextState | undefined,
+): LogContextState {
+  const nextGroups = new Map(baseState?.groups ?? []);
+  if (groupId === undefined) {
+    nextGroups.delete(channelId);
+  } else {
+    nextGroups.set(channelId, groupId);
+  }
+  return { groups: nextGroups };
+}
+
+/**
+ * Run the provided callback within a context that sets the active log group
+ * for the specified channel. Nested calls correctly shadow previously active
+ * groups for the duration of the callback.
+ */
+export function runWithChannelGroup<T>(
+  channelId: string,
+  groupId: string | undefined,
+  callback: () => T,
+): T {
+  const parentState = storage.getStore();
+  const nextState = cloneStateWithUpdate(channelId, groupId, parentState);
+  return storage.run(nextState, callback);
+}
+
+/**
+ * Resolve the currently active group identifier for a channel from the async
+ * context if one has been set.
+ */
+export function getContextGroupId(channelId: string): string | undefined {
+  const state = storage.getStore();
+  return state?.groups.get(channelId);
+}

--- a/src/logger/logGroupUtils.ts
+++ b/src/logger/logGroupUtils.ts
@@ -1,17 +1,11 @@
 // Local imports - log
-import type { AgentLogger } from './AgentLogger';
+import type { AgentLogger, LoggerGroupOptions } from './AgentLogger';
 
-type GroupStatus = Parameters<AgentLogger['endGroup']>[1];
-
-interface WithLogGroupOptions {
-  parentGroupId?: string;
-  skip?: boolean;
-  successStatus?: GroupStatus;
-  errorStatus?: GroupStatus;
-}
+export type WithLogGroupOptions = LoggerGroupOptions;
 
 /**
  * Utility helper to start a log group, run a function, and automatically end the group.
+ * @deprecated Use AgentLogger.withGroup directly instead.
  */
 export async function withLogGroup<T>(
   logger: AgentLogger,
@@ -19,25 +13,5 @@ export async function withLogGroup<T>(
   fn: (groupId?: string) => Promise<T>,
   options: WithLogGroupOptions = {},
 ): Promise<T> {
-  const {
-    parentGroupId,
-    skip = false,
-    successStatus = 'stopped',
-    errorStatus = 'error',
-  } = options;
-
-  if (skip) {
-    return fn(undefined);
-  }
-
-  const groupId = await logger.startGroup(groupName, undefined, parentGroupId);
-
-  try {
-    const result = await fn(groupId);
-    logger.endGroup(groupId, successStatus);
-    return result;
-  } catch (error) {
-    logger.endGroup(groupId, errorStatus);
-    throw error;
-  }
+  return logger.withGroup(groupName, fn, options);
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -11,6 +11,7 @@ import { getConfig } from '@utils/config';
 import { TaskGroup, LogMessageData } from './LogTypes';
 import { MESSAGE_TYPES, type MessageType } from './messageTypes';
 import { AgentLogger } from './AgentLogger';
+import { getContextGroupId } from './logContext';
 
 function isValidMessageType(type: unknown): type is MessageType {
   return Object.values(MESSAGE_TYPES).includes(type as MessageType);
@@ -363,9 +364,11 @@ function logWithGroup(
 ): void {
   const logger = getOrCreateLogger(channel, isAgent);
   const transport = channelTransports.get(channel);
+  const contextGroupId = getContextGroupId(channel);
 
-  // If no groupId provided, use the active group
-  const actualGroupId = groupId || transport?.getActiveGroupId();
+  // If no groupId provided, prefer the async context before falling back to the transport state
+  const actualGroupId =
+    groupId ?? contextGroupId ?? transport?.getActiveGroupId();
 
   // @ts-ignore - We're adding a custom property to the winston log
   logger[level](message, { groupId: actualGroupId, messageType, data });

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -357,7 +357,8 @@ function logWithGroup(
   channel: string,
   level: string,
   message: string,
-  groupId?: string,
+  // Deprecated: groupId is ignored now that async context handles scoping
+  _groupId?: string,
   messageType?: MessageType,
   isAgent = false,
   data?: unknown,
@@ -367,8 +368,7 @@ function logWithGroup(
   const contextGroupId = getContextGroupId(channel);
 
   // If no groupId provided, prefer the async context before falling back to the transport state
-  const actualGroupId =
-    groupId ?? contextGroupId ?? transport?.getActiveGroupId();
+  const actualGroupId = contextGroupId ?? transport?.getActiveGroupId();
 
   // @ts-ignore - We're adding a custom property to the winston log
   logger[level](message, { groupId: actualGroupId, messageType, data });

--- a/src/test/logger/groupContext.test.ts
+++ b/src/test/logger/groupContext.test.ts
@@ -1,0 +1,122 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - logger
+import { AgentLogger } from '@logger/AgentLogger';
+import { bus } from '@eventBus/ProgressEventBus';
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('AgentLogger async group context', () => {
+  it('associates log entries with the current withGroup scope', async () => {
+    const logger = new AgentLogger('TestAsyncGroupPrimary');
+    const captured = new Map<string, string | undefined>();
+    const off = bus.on('addLogMessage', (payload) => {
+      if (payload.stream === 'TestAsyncGroupPrimary') {
+        captured.set(payload.logMessage.text, payload.logMessage.groupId);
+      }
+    });
+
+    await logger.withGroup('Primary', async (groupId) => {
+      assert.ok(groupId, 'expected group identifier to be defined');
+      logger.info('parent-entry');
+      await delay(1);
+      logger.info('parent-complete');
+    });
+
+    off();
+
+    assert.strictEqual(
+      captured.get('parent-entry'),
+      captured.get('parent-complete'),
+    );
+    assert.ok(
+      captured.get('parent-entry'),
+      'parent logs should be associated with a group',
+    );
+  });
+
+  it('isolates concurrent nested groups without manual group IDs', async () => {
+    const logger = new AgentLogger('TestAsyncGroupConcurrent');
+    const logs: { text: string; groupId?: string }[] = [];
+    const off = bus.on('addLogMessage', (payload) => {
+      if (payload.stream === 'TestAsyncGroupConcurrent') {
+        logs.push({
+          text: payload.logMessage.text,
+          groupId: payload.logMessage.groupId,
+        });
+      }
+    });
+
+    await logger.withGroup('Root', async () => {
+      logger.info('root-start');
+      await Promise.all([
+        logger.withGroup('ChildA', async () => {
+          logger.info('child-a-start');
+          await delay(2);
+          logger.info('child-a-end');
+        }),
+        logger.withGroup('ChildB', async () => {
+          logger.info('child-b-start');
+          await delay(1);
+          logger.info('child-b-end');
+        }),
+      ]);
+      logger.info('root-end');
+    });
+
+    off();
+
+    const groupFor = (label: string): Set<string | undefined> => {
+      return new Set(
+        logs
+          .filter((entry) => entry.text === label)
+          .map((entry) => entry.groupId),
+      );
+    };
+
+    const parentGroups = new Set(
+      logs
+        .filter((entry) => entry.text.startsWith('root-'))
+        .map((entry) => entry.groupId),
+    );
+    const childAGroups = new Set(
+      logs
+        .filter((entry) => entry.text.startsWith('child-a'))
+        .map((entry) => entry.groupId),
+    );
+    const childBGroups = new Set(
+      logs
+        .filter((entry) => entry.text.startsWith('child-b'))
+        .map((entry) => entry.groupId),
+    );
+
+    assert.strictEqual(parentGroups.size, 1, 'root logs should share a group');
+    assert.strictEqual(
+      childAGroups.size,
+      1,
+      'child A logs should share a group',
+    );
+    assert.strictEqual(
+      childBGroups.size,
+      1,
+      'child B logs should share a group',
+    );
+
+    const [parentGroupId] = Array.from(parentGroups);
+    const [childAGroupId] = Array.from(childAGroups);
+    const [childBGroupId] = Array.from(childBGroups);
+
+    assert.notStrictEqual(parentGroupId, childAGroupId);
+    assert.notStrictEqual(parentGroupId, childBGroupId);
+    assert.notStrictEqual(childAGroupId, childBGroupId);
+    assert.ok(childAGroupId, 'child A logs should have a group');
+    assert.ok(childBGroupId, 'child B logs should have a group');
+
+    // Ensure the helper covers repeated log entries with the same label
+    const repeatedGroup = groupFor('child-a-end');
+    assert.strictEqual(repeatedGroup.size, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- add an AsyncLocalStorage-backed log context to scope group identifiers per asynchronous execution
- expose `AgentLogger.withGroup` and refactor agent runtime helpers to rely on scoped logging instead of manual group IDs
- update log utilities and add regression tests covering concurrent nested logging groups

## Testing
- npm run lint
- npm run compile-tests
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_6905d127c30c832486f8948a96872be6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces AsyncLocalStorage-backed log group scoping and refactors logging across agents/handlers/flows to use `AgentLogger.withGroup` and context, removing manual `groupId` plumbing; adds tests and minor API cleanups.
> 
> - **Logger/Core**:
>   - Add async log context via `AsyncLocalStorage` (`logger/logContext.ts`) and integrate with `logUtils` to auto-associate entries with active groups.
>   - Introduce `AgentLogger.withGroup(...)` and argument parser for `debug/info/warn/error`; deprecate `withLogGroup` (now thin wrapper).
>   - Simplify structured logs: `fileList`, `missingOutputs`, `latexDiff`, `statistics`, `userMessage` drop explicit `groupId`.
> - **Agent Runtime**:
>   - Refactor `executeAgent` to use `withGroup` and `runWithChannelGroup` for error reporting; remove manual `groupId` passing.
>   - Update `BaseAgent.withRoundGroup` to use `logger.withGroup`.
> - **Flows**:
>   - `ResponseCycleFlow` and `ToolUseCycleFlow` remove `groupId` usage, streamline logging, and keep behavior unchanged.
> - **Model Handlers API**:
>   - Remove `groupId` parameter from `processThinkingBlock` across implementations (Anthropic, OpenAI, OpenAIResponse, Google GenAI, DeepSeek, Kimi, OpenRouter, xAI) and interface; update call sites.
>   - Minor logging tweaks (debug/previews) to rely on scoped context.
> - **Output/Usage**:
>   - `OutputHandler.startProcessing` now runs work within a scoped group and sets `processGroupId` automatically.
>   - `LatexDiffManager`/`UsageMonitor` emit stats/diffs without explicit `groupId`.
> - **Tests**:
>   - Add `groupContext.test.ts` verifying scoped group association and concurrent nested groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ebfbb729da42994b66538a04dd2a4411f89078f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->