### PR TITLE
Refactor agent execution to share run context

### DIFF
--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -4,6 +4,7 @@ import type { AgentConfig } from './AgentConfig';
 import type { AgentSessionDescriptor } from './AgentDataclass';
 // Local imports - agent types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 
 /**
  * Minimal interface implemented by all agent types.
@@ -50,6 +51,11 @@ export interface IAgent {
    * @param overrides - Optional overrides for default hook implementations.
    */
   getRunHooks(overrides?: Partial<AgentRunHooks>): AgentRunHooks;
+
+  /**
+   * Apply the shared execution context that should be reused across all agent components.
+   */
+  applyRunContext(context: AgentRunContext): void;
 }
 
 /**

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -12,12 +12,12 @@ import type { IModelHandler } from '../modelHandlers';
 import { UsageMonitor } from '../utils/UsageMonitor';
 import { buildUserVars } from '../utils/userVars';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { getStreamTabId as buildStreamTabId } from '@/logger/streamUtils';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
@@ -33,14 +33,14 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   protected agentPrompt: AgentPrompt;
   protected agentPath: string;
   protected logger: AgentLogger;
-  protected usageMonitor: UsageMonitor;
+  protected usageMonitor!: UsageMonitor;
   protected runGroupId?: string;
   private lastRunGroupId?: string;
   protected userVars: Record<string, any> = {};
   protected client: C | null = null;
   protected isInterrupted = false;
   protected abortController: AbortController | null = null;
-  protected executionId?: ExecutionId;
+  protected runContext?: AgentRunContext;
 
   private static runningAgents: Map<string, BaseAgent> = new Map();
 
@@ -64,24 +64,21 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ) {
     this.modelHandler = modelHandler;
     this.agentConfig = agentConfig;
     this.agentSetting = agentSetting;
     this.agentPrompt = agentPrompt;
     this.agentPath = agentPath;
-    this.executionId = executionId;
+    this.logger = new AgentLogger('Agent');
+  }
 
-    const streamTabId = this.getStreamTabId();
-    this.logger = new AgentLogger(streamTabId, true);
-    this.modelHandler.setLogger(this.logger);
+  public applyRunContext(context: AgentRunContext): void {
+    this.runContext = context;
+    this.logger = context.logger;
+    this.modelHandler.applyRunContext(context);
     this.modelHandler.setAgentType(this.agentSetting.agentType);
-    this.usageMonitor = new UsageMonitor(
-      this.modelHandler,
-      this.logger.channelId,
-      this.logger,
-    );
+    this.usageMonitor = new UsageMonitor(this.modelHandler, context);
   }
 
   /** Initialize the API client. */
@@ -115,23 +112,16 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       setAbortController: (ctrl) => {
         this.abortController = ctrl;
       },
-      executionId: this.executionId,
+      executionId: this.runContext?.executionId,
     };
   }
 
   /** Compute the stream tab identifier for this agent execution. */
   public getStreamTabId(): StreamTabId {
-    const metadata = this.getSessionMetadata();
-    return buildStreamTabId(
-      this.agentConfig.agent,
-      this.agentConfig.model,
-      this.agentConfig.inputFile,
-      {
-        agentType: metadata.agentType,
-        executionId: this.executionId,
-        useMultipleOutputs: this.agentConfig.useMultipleOutputs,
-      },
-    );
+    if (!this.runContext) {
+      throw new Error('Agent run context has not been applied yet.');
+    }
+    return this.runContext.streamTabId;
   }
 
   /** Gather variables used for prompt rendering. */
@@ -212,12 +202,8 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     return this.isInterrupted;
   }
 
-  public setExecutionId(id: ExecutionId): void {
-    this.executionId = id;
-  }
-
   public getExecutionId(): ExecutionId | undefined {
-    return this.executionId;
+    return this.runContext?.executionId;
   }
 
   protected async trackRoundUsage(
@@ -294,8 +280,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   }
 
   protected cleanup(): void {
-    const streamTabId = this.getStreamTabId();
-    this.unregisterRunningAgent(streamTabId);
+    if (!this.runContext) {
+      return;
+    }
+    this.unregisterRunningAgent(this.runContext.streamTabId);
   }
 
   public getRunHooks(overrides?: Partial<AgentRunHooks>): AgentRunHooks {

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -26,7 +26,7 @@ import {
 } from '@agent/implementations/flows/ReflectionRoundFlow';
 import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import { writePromptToXml } from '@agent/utils/promptUtils';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -98,8 +98,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   protected useScratchpad: boolean = false;
   protected logId: number = 0;
   /** Handler for output file processing and validation. */
-  protected outputHandler: IOutputHandler;
-  protected latexMediaManager: LatexMediaManager;
+  protected outputHandler!: IOutputHandler;
+  protected latexMediaManager!: LatexMediaManager;
   protected promptBuilder?: PromptBuilder;
   public roundStates: AgentStateRound[] = [];
   public toolStates: ToolState[] = [];
@@ -110,7 +110,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ) {
     const workflowSetting = requireWorkflowSetting(agentSetting);
     super(
@@ -119,7 +118,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       workflowSetting,
       agentPrompt,
       agentPath,
-      executionId,
     );
     this.agentSetting = workflowSetting;
 
@@ -147,15 +145,18 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     // Initialize logging
     this.logId = 0;
 
+  }
+
+  public override applyRunContext(context: AgentRunContext): void {
+    super.applyRunContext(context);
     this.outputHandler = new OutputHandler(
       this.agentSetting,
       this.agentConfig,
       this.logId,
       this.baseFiles,
-      this.logger,
+      context,
     );
-
-    this.latexMediaManager = new LatexMediaManager(this.logger);
+    this.latexMediaManager = new LatexMediaManager(context.logger);
   }
 
   protected getPromptBuilder(): PromptBuilder {
@@ -410,7 +411,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           userRequest,
           this.agentConfig.inputFile,
           this.agentConfig.agent,
-          this.executionId,
+          this.getExecutionId(),
         );
         this.logger.info(
           `Saved input prompt to ${promptPath}`,

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -33,7 +33,7 @@ import type { AgentRunHooks } from '@agent/implementations/flows/common/types';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
-import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   ToolUseSessionManager,
@@ -60,7 +60,6 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ) {
     super(
       modelHandler,
@@ -68,7 +67,6 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       agentSetting,
       agentPrompt,
       agentPath,
-      executionId,
     );
     this.toolRegistry = DEFAULT_TOOL_REGISTRY;
   }

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -10,7 +10,6 @@ import { RoundOutputOptions } from './BaseReflectionAgent';
 // Local imports - agent components
 import { DirectAgent } from './DirectAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 /**
  * Specialized agent for merging multiple edited files into a consolidated output.
@@ -23,7 +22,6 @@ export class MergeAgent extends DirectAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ) {
     super(
       modelHandler,
@@ -31,7 +29,6 @@ export class MergeAgent extends DirectAgent {
       agentSetting,
       agentPrompt,
       agentPath,
-      executionId,
     );
     this.outputFile = [this.getOutputFile(0), this.getOutputFile(1)];
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -46,6 +46,7 @@ import { getConfig } from '@utils/config';
 // Local imports - utilities
 import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
 import { normalizeUrl } from '@utils/urlUtils';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;
@@ -107,6 +108,7 @@ export abstract class ModelHandler<
   protected backgroundModeSupported = false;
   protected progressViewEnabled = true;
   protected agentType?: AgentType;
+  protected runContext?: AgentRunContext;
 
   protected get supportsToolFileOutputs(): boolean {
     return false;
@@ -140,6 +142,11 @@ export abstract class ModelHandler<
    */
   public setLogger(logger: AgentLogger): void {
     this.logger = logger;
+  }
+
+  public applyRunContext(context: AgentRunContext): void {
+    this.runContext = context;
+    this.setLogger(context.logger);
   }
 
   /**

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -11,6 +11,7 @@ import type { ProviderStopReason } from './StopReasonTypes';
 
 // Local imports - logging and model metadata
 import type { AgentLogger } from '@logger/AgentLogger';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 import type { ModelConfig, ModelCapabilities, ToolDefinition } from '@model';
 
 /**
@@ -59,6 +60,9 @@ export interface IModelHandler<
 
   /** Set the logger instance for the handler. */
   setLogger(logger: AgentLogger): void;
+
+  /** Apply the active agent run context to the handler. */
+  applyRunContext(context: AgentRunContext): void;
 
   /** Inform the handler about the active agent type. */
   setAgentType(agentType?: AgentType | null): void;

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -35,6 +35,7 @@ import { runLatexFormatter } from '@latex/texFormatter';
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 
 // Local imports - utilities
 import { replaceInputCommands, createFileMapping } from '@utils/files';
@@ -65,7 +66,7 @@ export class OutputHandler implements IOutputHandler {
     agentConfig: AgentConfig,
     logId: number,
     baseFiles: string[] = [],
-    logger?: AgentLogger,
+    context: AgentRunContext,
   ) {
     this.agentSetting = requireWorkflowSetting(agentSetting);
     this.agentConfig = agentConfig;
@@ -74,8 +75,8 @@ export class OutputHandler implements IOutputHandler {
     this.outputMappings = {};
     this.roundMappings = {};
     this.baseFiles = baseFiles;
-    this.logger = logger || new AgentLogger('OutputHandler');
-    this.channel = this.logger.channelId;
+    this.logger = context.logger;
+    this.channel = context.streamTabId;
 
     this.xmlManager = new XmlOutputManager(
       this.agentSetting,

--- a/src/agent/runtime/AgentRunContext.ts
+++ b/src/agent/runtime/AgentRunContext.ts
@@ -1,0 +1,48 @@
+// Local imports - agent components
+import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+
+// Local imports - logging
+import { AgentLogger } from '@logger/AgentLogger';
+
+export interface AgentRunContextMetadata {
+  agentName: string;
+  model: string;
+  inputFile?: string | null;
+}
+
+export interface AgentRunContext {
+  readonly streamTabId: StreamTabId;
+  readonly executionId?: ExecutionId;
+  readonly logger: AgentLogger;
+  readonly session: AgentSessionDescriptor;
+  readonly metadata: AgentRunContextMetadata;
+}
+
+export interface CreateAgentRunContextParams {
+  streamTabId: StreamTabId;
+  executionId?: ExecutionId;
+  session: AgentSessionDescriptor;
+  agentName: string;
+  model: string;
+  inputFile?: string | null;
+}
+
+export function createAgentRunContext(
+  params: CreateAgentRunContextParams,
+): AgentRunContext {
+  const { streamTabId, executionId, session, agentName, model, inputFile } =
+    params;
+
+  return {
+    streamTabId,
+    executionId,
+    logger: new AgentLogger(streamTabId, true),
+    session,
+    metadata: {
+      agentName,
+      model,
+      inputFile: inputFile ?? undefined,
+    },
+  };
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -33,12 +33,17 @@ import {
   AgentDirectorySource,
   type AgentPathResolution,
 } from './AgentPathTypes';
+import {
+  AgentRunContext,
+  createAgentRunContext,
+} from './AgentRunContext';
 
 // Local imports - utilities
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
 import { withLogGroup } from '@logger/logGroupUtils';
+import { getStreamTabId as buildStreamTabId } from '@/logger/streamUtils';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { agentConfigToTaskState } from '@utils/config';
@@ -77,7 +82,6 @@ type AgentConstructor = {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ): IAgent;
 };
 
@@ -179,8 +183,6 @@ interface PrepareAgentInstanceParams {
   agentName: string;
   /** Partial agent configuration to merge with defaults */
   configPayload: Partial<AgentConfig>;
-  /** Optional execution ID for tracking and logging */
-  executionId?: ExecutionId;
   /** Optional agent class to use instead of automatic selection based on agent type */
   agentClassOverride?: AgentConstructor;
 }
@@ -225,7 +227,7 @@ interface PrepareAgentInstanceParams {
 export async function prepareAgentInstance<T extends IAgent = IAgent>(
   params: PrepareAgentInstanceParams,
 ): Promise<{ agent: T; agentType: AgentType }> {
-  const { agentName, configPayload, executionId, agentClassOverride } = params;
+  const { agentName, configPayload, agentClassOverride } = params;
 
   const configInput: Partial<AgentConfig> = {
     agent: agentName,
@@ -307,7 +309,6 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
     agentSetting,
     agentPrompt,
     agentPathInfo.directory,
-    executionId,
   );
 
   return { agent: agent as T, agentType: agentSetting.agentType };
@@ -328,7 +329,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
 ): Promise<void> {
   const isResume = options?.resume ?? false;
   let streamTabId: StreamTabId | undefined;
-  let agentStreamLogger: AgentLogger | undefined;
+  let runContext: AgentRunContext | undefined;
   let agent: T | undefined;
   try {
     // Create agent instance and extract its declared type
@@ -350,15 +351,33 @@ export async function executeAgentWithLogging<T extends IAgent>(
         sessionMetadata.agentCategory,
       );
 
-    streamTabId = agent.getStreamTabId();
+    streamTabId = buildStreamTabId(
+      config.agent,
+      config.model,
+      config.inputFile,
+      {
+        agentType: metadata.agentType,
+        executionId,
+        useMultipleOutputs: config.useMultipleOutputs,
+      },
+    );
 
     if (!streamTabId) {
       throw new Error('Failed to resolve stream tab ID for agent execution');
     }
 
-    const activeStreamId: StreamTabId = streamTabId;
+    runContext = createAgentRunContext({
+      streamTabId,
+      executionId,
+      session: metadata,
+      agentName,
+      model: config.model,
+      inputFile: config.inputFile,
+    });
 
-    agentStreamLogger = new AgentLogger(activeStreamId, true);
+    agent.applyRunContext(runContext);
+
+    const activeStreamId: StreamTabId = streamTabId;
 
     // Check if this stream is already running
     const provider = ProgressViewProvider.getInstance();
@@ -559,22 +578,18 @@ export async function executeAgentWithLogging<T extends IAgent>(
       vscode.window.showErrorMessage(errorMsg);
     }
 
-    if (agentStreamLogger || streamTabId) {
-      if (!agentStreamLogger && streamTabId) {
-        agentStreamLogger = new AgentLogger(streamTabId, true);
-      }
-      if (agentStreamLogger) {
-        const fallbackGroupId =
-          agentStreamLogger.getActiveGroupId() ?? agent?.getLastRunGroupId();
-        if (fallbackGroupId) {
-          agentStreamLogger.error(errorMsg, fallbackGroupId);
-        } else {
-          const agentErrorGroupId = await agentStreamLogger.startGroup(
-            `Error: ${agentName}`,
-          );
-          agentStreamLogger.error(errorMsg, agentErrorGroupId);
-          agentStreamLogger.endGroup(agentErrorGroupId, 'error');
-        }
+    if (runContext) {
+      const agentLogger = runContext.logger;
+      const fallbackGroupId =
+        agentLogger.getActiveGroupId() ?? agent?.getLastRunGroupId();
+      if (fallbackGroupId) {
+        agentLogger.error(errorMsg, fallbackGroupId);
+      } else {
+        const agentErrorGroupId = await agentLogger.startGroup(
+          `Error: ${agentName}`,
+        );
+        agentLogger.error(errorMsg, agentErrorGroupId);
+        agentLogger.endGroup(agentErrorGroupId, 'error');
       }
     }
 
@@ -607,7 +622,6 @@ export async function executeAgent(
       const { agent, agentType } = await prepareAgentInstance({
         agentName: requestedAgentName,
         configPayload: agentConfig,
-        executionId,
       });
 
       const { outputFiles, useMultipleOutputs } = agent.config;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -14,6 +14,7 @@ import type {
   TokenUsageStats,
   ExtendedTokenUsageStats,
 } from '@agent/types/UsageTypes';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 import { bus } from '@eventBus/ProgressEventBus';
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
@@ -24,9 +25,12 @@ import { AgentLogger } from '@logger/AgentLogger';
 export class UsageMonitor {
   constructor(
     private readonly modelHandler: IModelHandler,
-    private readonly channel: string,
-    private readonly logger: AgentLogger,
+    private readonly context: AgentRunContext,
   ) {}
+
+  private get logger(): AgentLogger {
+    return this.context.logger;
+  }
 
   async recordUsage(
     stateGlobal: AgentStateGlobal,
@@ -103,7 +107,7 @@ export class UsageMonitor {
 
       if (statsGroupId) {
         bus.emit('updateGroupUsage', {
-          stream: this.channel,
+          stream: this.context.streamTabId,
           groupId: statsGroupId,
           usage: {
             inputTokens:

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -41,7 +41,6 @@ async function buildToolUseAgent(
   const { agent, agentType } = await prepareAgentInstance<BaseToolUseAgent>({
     agentName: fullConfig.agent,
     configPayload: fullConfig,
-    executionId: snapshot.executionId as ExecutionId,
   });
 
   if (!(agent instanceof BaseToolUseAgent) || agentType !== AgentType.ToolUse) {

--- a/src/test/agent/runtime/AgentRunContext.test.ts
+++ b/src/test/agent/runtime/AgentRunContext.test.ts
@@ -1,0 +1,268 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - agent components
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentType, AgentCategory } from '@agent/core/AgentDataclass';
+import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
+import { BaseAgent } from '@agent/implementations/BaseAgent';
+import type { IModelHandler } from '@agent/modelHandlers';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
+import { MCP_STOP } from '@agent/modelHandlers/types/StopReasonTypes';
+import { createAgentRunContext } from '@agent/runtime/AgentRunContext';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type { ModelConfig, ModelCapabilities } from '@model/ModelConfig';
+import { ModelProvider, ReasoningEffort } from '@model/ModelConfig';
+import { DEFAULT_TOOL_CONFIG } from '@agent/core/ToolConfig';
+
+class StubModelHandler implements IModelHandler {
+  public config: ModelConfig;
+  public capabilities: ModelCapabilities;
+  public continueLimit = 0;
+  public inputTokenLimit = 0;
+  public maxOutputTokensFactor = 0;
+  public isOpenai = false;
+  public isAnthropic = false;
+  public isGoogle = false;
+  public isOpenaiCompatible = false;
+  public appliedContext: AgentRunContext | undefined;
+  public lastLoggerId: string | undefined;
+  private agentType?: AgentType;
+
+  constructor() {
+    this.capabilities = {
+      supportsFunctionCalling: false,
+      supportsNativeMCPServer: false,
+      supportsNativeWebSearch: false,
+      supportsNativeCodeExecution: false,
+      supportsPromptCaching: false,
+      supportsAutoPromptCaching: false,
+      cacheDiscountFactor: 0,
+      supportsReasoning: false,
+      supportsInterleavedThinking: false,
+      reasoningEffort: ReasoningEffort.NONE,
+      supportsVision: false,
+      supportsNativePdf: false,
+      supportsAssistantPrefill: false,
+      supportsPredictiveOutput: false,
+      supportsTokenCounting: false,
+      supportsSystemPrompt: true,
+      supportsIntermDevMsgs: false,
+      supportsReasoningEffort: false,
+      supportsNativeAudio: false,
+    };
+
+    this.config = {
+      name: 'test-model',
+      fullName: 'test-model-full',
+      provider: ModelProvider.ANTHROPIC,
+      maxOutputTokens: 1,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1,
+      capabilities: this.capabilities,
+      openRouterOnly: false,
+      toolConfig: DEFAULT_TOOL_CONFIG,
+    } as ModelConfig;
+  }
+
+  public applyRunContext(context: AgentRunContext): void {
+    this.appliedContext = context;
+    this.lastLoggerId = context.logger.channelId;
+  }
+
+  public setLogger(logger: any): void {
+    this.lastLoggerId = logger.channelId;
+  }
+
+  public setAgentType(agentType?: AgentType | null): void {
+    this.agentType = agentType ?? undefined;
+  }
+
+  public getAgentType(): AgentType | undefined {
+    return this.agentType;
+  }
+
+  public getStreamingConfig(): boolean {
+    return false;
+  }
+
+  public setOutputStreaming(): void {}
+
+  public isOutputStreamingEnabled(): boolean {
+    return false;
+  }
+
+  public async getClient(): Promise<unknown> {
+    return {};
+  }
+
+  public async createResponse(): Promise<any> {
+    return {};
+  }
+
+  public async initializeMessages(): Promise<ProviderMessage[]> {
+    return [];
+  }
+
+  public async createRoundMessages(): Promise<ProviderMessage[]> {
+    return [];
+  }
+
+  public createMediaContent(): any[] {
+    return [];
+  }
+
+  public extractResponse(): [string, unknown, ProviderStopReason] {
+    return ['', {}, MCP_STOP.END_TURN];
+  }
+
+  public addContinueMessageWithPrefill(): void {}
+
+  public addContinueMessageWithoutPrefill(): void {}
+
+  public async initializeOutputAndPrefill(): Promise<[boolean, ProviderMessage[]]> {
+    return [false, []];
+  }
+
+  public computePrice(): number {
+    return 0;
+  }
+
+  public computeResponseUsage(): any {
+    return {};
+  }
+
+  public updateMessageContentWithPrefill(): void {}
+
+  public updateMessageContentWithoutPrefill(): void {}
+
+  public shouldContinue(): boolean {
+    return false;
+  }
+
+  public checkStopConditions(): [boolean, boolean] {
+    return [false, false];
+  }
+
+  public processThinkingBlock(): string | null {
+    return null;
+  }
+
+  public extractToolUse(): string | null {
+    return null;
+  }
+
+  public async createToolUseFollowUpMessages(): Promise<ProviderMessage[]> {
+    return [];
+  }
+
+  public async createUserFollowUpMessages(): Promise<ProviderMessage[]> {
+    return [];
+  }
+
+  public createAssistantMessage(): ProviderMessage {
+    return {} as ProviderMessage;
+  }
+
+  public async createToolResultMessages(): Promise<ProviderMessage[]> {
+    return [];
+  }
+
+  public async finalizeResponse(): Promise<unknown> {
+    return {};
+  }
+
+  public createProgressiveResponse(): { append: () => void; finalize: () => void } {
+    return { append: () => {}, finalize: () => {} };
+  }
+
+  public isEndTurnStop(reason: ProviderStopReason): boolean {
+    return reason === MCP_STOP.END_TURN;
+  }
+}
+
+class TestAgent extends BaseAgent {
+  public async run(): Promise<void> {}
+}
+
+const agentConfig: AgentConfig = {
+  model: 'test-model',
+  agent: 'test-agent',
+  instruction: '',
+  useMultipleOutputs: false,
+  session: { agentType: AgentType.Direct, agentCategory: AgentCategory.Workflow },
+  inputFile: 'input.tex',
+  inputFiles: null,
+  referenceFile: null,
+  referenceFiles: null,
+  auxiliaryFile: null,
+  auxiliaryFiles: null,
+  mediaFile: null,
+  mediaFiles: null,
+  outputFiles: null,
+  editedFile: null,
+  toolConfig: DEFAULT_TOOL_CONFIG,
+};
+
+const agentSetting: AgentSetting = {
+  agentType: AgentType.Direct,
+  agentCategory: AgentCategory.Workflow,
+  documentTag: 'document',
+  endTag: '</document>',
+  temperature: 0,
+  requiredFiles: {},
+  requiredFilesInternal: {},
+  defaultOutputFiles: [],
+  filePatternsContain: [],
+  tools: [],
+  isRewrite: true,
+  rounds: 1,
+  prefills: [],
+  outputExt: 'tex',
+  isMultipleOutput: false,
+};
+
+const agentPrompt: AgentPrompt = {
+  systemPrompt: '',
+  userPrefix: '',
+  userRequest: '',
+};
+
+function buildContext(streamId: StreamTabId, executionId?: ExecutionId): AgentRunContext {
+  return createAgentRunContext({
+    streamTabId: streamId,
+    executionId,
+    session: { agentType: AgentType.Direct, agentCategory: AgentCategory.Workflow },
+    agentName: agentConfig.agent,
+    model: agentConfig.model,
+    inputFile: agentConfig.inputFile,
+  });
+}
+
+describe('AgentRunContext', () => {
+  it('applies shared logger and identifiers to agent components', () => {
+    const modelHandler = new StubModelHandler();
+    const agent = new TestAgent(
+      modelHandler,
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      '/tmp',
+    );
+
+    const context = buildContext('stream-ctx' as StreamTabId, 'exec-ctx' as ExecutionId);
+    agent.applyRunContext(context);
+
+    assert.strictEqual(agent.getStreamTabId(), context.streamTabId);
+    assert.strictEqual(agent.getExecutionId(), context.executionId);
+    assert.strictEqual(modelHandler.appliedContext, context);
+    assert.strictEqual(modelHandler.lastLoggerId, context.logger.channelId);
+
+    const usageMonitor = (agent as any).usageMonitor;
+    assert.strictEqual(usageMonitor.context.streamTabId, context.streamTabId);
+    assert.strictEqual(agent['logger'].channelId, context.logger.channelId);
+  });
+});

--- a/src/test/output/LatexDiffManager.test.ts
+++ b/src/test/output/LatexDiffManager.test.ts
@@ -11,9 +11,9 @@ import {
 } from '@agent/core/AgentDataclass';
 import { OutputHandler } from '@agent/output';
 import { LatexDiffManager } from '@agent/output/LatexDiffManager';
-
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
+import { createAgentRunContext } from '@agent/runtime/AgentRunContext';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 describe('LatexDiffManager mapping reuse', () => {
   const baseSetting: AgentSetting = {
@@ -58,26 +58,37 @@ describe('LatexDiffManager mapping reuse', () => {
     },
   };
 
-  function createLogger(): AgentLogger {
-    const logger = new AgentLogger('LatexDiffManagerTest');
+  function createContext(name: string): AgentRunContext {
+    const context = createAgentRunContext({
+      streamTabId: name as StreamTabId,
+      executionId: undefined,
+      session: {
+        agentType: AgentType.CoT,
+        agentCategory: AgentCategory.Workflow,
+      },
+      agentName: 'agent',
+      model: baseConfig.model,
+      inputFile: baseConfig.inputFile,
+    });
     const noop = () => {};
-    (logger as any).debug = noop;
-    (logger as any).info = noop;
-    (logger as any).warn = noop;
-    (logger as any).error = noop;
-    (logger as any).latexDiff = noop;
-    return logger;
+    const logger = context.logger as any;
+    logger.debug = noop;
+    logger.info = noop;
+    logger.warn = noop;
+    logger.error = noop;
+    logger.latexDiff = noop;
+    return context;
   }
 
   it('uses shared base mapping for round diffs', async () => {
-    const logger = createLogger();
+    const context = createContext('latexdiff-round');
     const baseFiles = [path.join('workspace', 'chapter.tex')];
     const handler = new OutputHandler(
       baseSetting,
       baseConfig,
       0,
       baseFiles,
-      logger,
+      context,
     );
 
     handler.outputFiles[0] = [path.join('workspace', 'chapter_r0.tex')];
@@ -94,16 +105,16 @@ describe('LatexDiffManager mapping reuse', () => {
       [];
     const aggregated: unknown[][] = [];
 
-    const testLogger = createLogger();
-    (testLogger as any).latexDiff = (entries: unknown[]) =>
+    const testContext = createContext('latexdiff-round-manager');
+    (testContext.logger as any).latexDiff = (entries: unknown[]) =>
       aggregated.push(entries);
 
     const manager = new LatexDiffManager(
       handler.agentSetting,
       handler.outputFiles,
       baseFiles,
-      testLogger,
-      'channel',
+      testContext.logger,
+      testContext.streamTabId,
       {
         checkToolInstalled: async () => true,
         compileLatex2Pdf: async () => true,
@@ -133,14 +144,14 @@ describe('LatexDiffManager mapping reuse', () => {
   });
 
   it('uses shared previous mapping for between-round diffs', async () => {
-    const logger = createLogger();
+    const context = createContext('latexdiff-between');
     const baseFiles = [path.join('workspace', 'paper.tex')];
     const handler = new OutputHandler(
       baseSetting,
       baseConfig,
       0,
       baseFiles,
-      logger,
+      context,
     );
 
     handler.outputFiles[0] = [path.join('workspace', 'paper_r0.tex')];
@@ -164,14 +175,14 @@ describe('LatexDiffManager mapping reuse', () => {
       [];
     const betweenPairs: Array<{ previous: string; current: string }> = [];
 
-    const testLogger = createLogger();
+    const testContext = createContext('latexdiff-between-manager');
 
     const manager = new LatexDiffManager(
       handler.agentSetting,
       handler.outputFiles,
       baseFiles,
-      testLogger,
-      'channel',
+      testContext.logger,
+      testContext.streamTabId,
       {
         checkToolInstalled: async () => true,
         compileLatex2Pdf: async () => true,

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -10,17 +10,19 @@ import {
   AgentCategory,
 } from '@agent/core/AgentDataclass';
 import { OutputHandler } from '@agent/output';
+import { createAgentRunContext } from '@agent/runtime/AgentRunContext';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports
 import { bus } from '@eventBus/ProgressEventBus';
-import { AgentLogger } from '@logger/AgentLogger';
 
 class MockOutputHandler extends OutputHandler {
   public gatherCalled = false;
   public validateCalled = false;
 
-  constructor(setting: AgentSetting, config: AgentConfig) {
-    super(setting, config, 0, [], new AgentLogger('TestOutputHandler'));
+  constructor(setting: AgentSetting, config: AgentConfig, context: AgentRunContext) {
+    super(setting, config, 0, [], context);
   }
 
   public override async gatherOutputFileInfo(round: number) {
@@ -86,9 +88,27 @@ const baseConfig: AgentConfig = {
   },
 };
 
+function createTestContext(name: string): AgentRunContext {
+  return createAgentRunContext({
+    streamTabId: name as StreamTabId,
+    executionId: undefined,
+    session: {
+      agentType: AgentType.CoT,
+      agentCategory: AgentCategory.Workflow,
+    },
+    agentName: 'test-agent',
+    model: baseConfig.model,
+    inputFile: baseConfig.inputFile,
+  });
+}
+
 describe('OutputHandler round helpers', () => {
   it('ensures round storage and returns the same reference', () => {
-    const handler = new MockOutputHandler(baseSetting, baseConfig);
+    const handler = new MockOutputHandler(
+      baseSetting,
+      baseConfig,
+      createTestContext('round-helpers'),
+    );
     const roundOutputs = handler.ensureRound(2);
 
     assert.ok(Array.isArray(roundOutputs));
@@ -102,7 +122,11 @@ describe('OutputHandler round helpers', () => {
   });
 
   it('reflects whether rounds contain outputs', () => {
-    const handler = new MockOutputHandler(baseSetting, baseConfig);
+    const handler = new MockOutputHandler(
+      baseSetting,
+      baseConfig,
+      createTestContext('round-has-output'),
+    );
 
     assert.strictEqual(handler.hasRoundOutputs(1), false);
 
@@ -113,7 +137,11 @@ describe('OutputHandler round helpers', () => {
   });
 
   it('ensureRound creates storage for uninitialized rounds', () => {
-    const handler = new MockOutputHandler(baseSetting, baseConfig);
+    const handler = new MockOutputHandler(
+      baseSetting,
+      baseConfig,
+      createTestContext('ensure-round'),
+    );
     const outputs = handler.ensureRound(5);
 
     assert.ok(Array.isArray(outputs));
@@ -125,7 +153,11 @@ describe('OutputHandler round helpers', () => {
   });
 
   it('ensureRound returns existing outputs when called multiple times', () => {
-    const handler = new MockOutputHandler(baseSetting, baseConfig);
+    const handler = new MockOutputHandler(
+      baseSetting,
+      baseConfig,
+      createTestContext('ensure-round-existing'),
+    );
     handler.ensureRound(2).push('existing.tex');
 
     const outputs = handler.ensureRound(2);
@@ -146,7 +178,7 @@ describe('OutputHandler.getRoundMapping', () => {
       baseConfig,
       0,
       [path.join('workspace', 'chapter.tex')],
-      new AgentLogger('TestOutputHandlerMapping'),
+      createTestContext('mapping'),
     );
 
     handler.outputFiles[0] = [path.join('workspace', 'chapter_r0.tex')];
@@ -179,7 +211,11 @@ describe('OutputHandler.getRoundMapping', () => {
 
 describe('OutputHandler.finalizeRound', () => {
   it('emits addOutputFiles and validates when endTurn', async () => {
-    const handler = new MockOutputHandler(baseSetting, baseConfig);
+    const handler = new MockOutputHandler(
+      baseSetting,
+      baseConfig,
+      createTestContext('finalize-end'),
+    );
     const events: any[] = [];
     const dispose = bus.on('addOutputFiles', (data) => events.push(data));
 
@@ -195,7 +231,11 @@ describe('OutputHandler.finalizeRound', () => {
   });
 
   it('skips validation when not endTurn', async () => {
-    const handler = new MockOutputHandler(baseSetting, baseConfig);
+    const handler = new MockOutputHandler(
+      baseSetting,
+      baseConfig,
+      createTestContext('finalize-skip'),
+    );
     const events: any[] = [];
     const dispose = bus.on('addOutputFiles', (data) => events.push(data));
 


### PR DESCRIPTION
## Summary
- add an AgentRunContext helper so stream identifiers, execution ids, and loggers are built once
- update BaseAgent, executeAgentWithLogging, and supporting utilities to reuse the shared context
- adjust output/usage handlers and resume/tests to reflect the new wiring

## Testing
- npm run compile-tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6905d111ec4483248f1d0da0390be966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `AgentRunContext` to centralize `streamTabId`, `executionId`, and logging, refactoring agents, model handlers, output/usage, and execution flow to consume the shared context, with tests and resume flow updated.
> 
> - **Runtime**:
>   - Add `AgentRunContext` (`src/agent/runtime/AgentRunContext.ts`) and factory `createAgentRunContext`.
>   - Update `executeAgentWithLogging` to build `streamTabId`, create/apply run context, and route errors via context logger.
>   - Remove constructor `executionId` plumbing from agent creation paths.
> - **Agents**:
>   - Extend `IAgent` with `applyRunContext(context: AgentRunContext)`.
>   - Refactor `BaseAgent` to store/use run context for `logger`, `usageMonitor`, `getStreamTabId`, and `getExecutionId`.
>   - Update `BaseReflectionAgent` and `BaseToolUseAgent` to initialize components (e.g., `OutputHandler`, `LatexMediaManager`) from context.
>   - `MergeAgent` constructor simplified (no `executionId`).
> - **Model Handlers**:
>   - Add `applyRunContext` to `IModelHandler` and implement in `ModelHandler` (propagates logger from context).
> - **Output/Usage**:
>   - `OutputHandler` now takes `AgentRunContext` (uses `context.logger` and `context.streamTabId`).
>   - `UsageMonitor` constructed with context and emits usage with `context.streamTabId`.
> - **Resume/Commands**:
>   - `resumeCommand` uses updated `prepareAgentInstance` (no `executionId` param).
> - **Tests**:
>   - Add `AgentRunContext` tests and update `OutputHandler`/`LatexDiffManager` tests to use the new context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 091f9b561051e8343f58fcf4ed4677b2a74b6ab2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->