### PR TITLE
Refactor agent lifecycle management into centralized controller

### DIFF
--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -2,6 +2,11 @@
 import type { AgentConfig } from './AgentConfig';
 // Local imports - agent components
 import type { AgentSessionDescriptor } from './AgentDataclass';
+// Local imports - agent lifecycle
+import type {
+  AgentLifecycleHooks,
+  AgentRunHookOverrides,
+} from '@agent/implementations/flows/common/AgentLifecycleController';
 // Local imports - agent types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
@@ -49,23 +54,5 @@ export interface IAgent {
    *
    * @param overrides - Optional overrides for default hook implementations.
    */
-  getRunHooks(overrides?: Partial<AgentRunHooks>): AgentRunHooks;
-}
-
-/**
- * Core hook contract used to orchestrate agent runs.
- */
-export interface AgentRunHooks {
-  /**
-   * Begin an agent run and optionally create a logging group.
-   *
-   * @returns The identifier for the run group used by subsequent lifecycle hooks.
-   *          Return `undefined` to indicate that the lifecycle should reuse an
-   *          existing log group (for example, interactive tool-use sessions).
-   */
-  start(): Promise<string | undefined>;
-  init(runGroupId: string | undefined): Promise<void>;
-  initializeClient(): Promise<void>;
-  end(status: 'stopped' | 'error'): void | Promise<void>;
-  cleanup(): void | Promise<void>;
+  getRunHooks(overrides?: AgentRunHookOverrides): AgentLifecycleHooks;
 }

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -7,16 +7,20 @@ import {
   resolveAgentSessionDescriptor,
 } from '../core/AgentDataclass';
 import { AgentStateGlobal } from '../core/AgentState';
-import { IAgent, type AgentRunHooks } from '../core/IAgent';
+import { IAgent } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';
 import { UsageMonitor } from '../utils/UsageMonitor';
 import { buildUserVars } from '../utils/userVars';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
+import {
+  AgentLifecycleController,
+  type AgentLifecycleHooks,
+  type AgentRunHookOverrides,
+} from '@agent/implementations/flows/common/AgentLifecycleController';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { getStreamTabId as buildStreamTabId } from '@/logger/streamUtils';
 
 // Local imports - utilities
@@ -34,13 +38,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   protected agentPath: string;
   protected logger: AgentLogger;
   protected usageMonitor: UsageMonitor;
-  protected runGroupId?: string;
-  private lastRunGroupId?: string;
   protected userVars: Record<string, any> = {};
   protected client: C | null = null;
-  protected isInterrupted = false;
-  protected abortController: AbortController | null = null;
   protected executionId?: ExecutionId;
+  protected readonly lifecycle: AgentLifecycleController;
 
   private static runningAgents: Map<string, BaseAgent> = new Map();
 
@@ -82,6 +83,19 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       this.logger.channelId,
       this.logger,
     );
+    this.lifecycle = this.createLifecycleController(streamTabId);
+  }
+
+  protected createLifecycleController(
+    streamTabId: StreamTabId,
+  ): AgentLifecycleController {
+    return new AgentLifecycleController({
+      logger: this.logger,
+      runLabel: `Run: ${this.agentConfig.agent}@${this.agentConfig.model}`,
+      streamId: streamTabId,
+      onRegister: (id) => this.registerRunningAgent(id),
+      onUnregister: (id) => this.unregisterRunningAgent(id),
+    });
   }
 
   /** Initialize the API client. */
@@ -111,9 +125,9 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       userVars: this.userVars,
       logger: this.logger,
       client,
-      checkInterruption: () => this.checkInterruption(),
+      checkInterruption: () => this.lifecycle.checkInterruption(),
       setAbortController: (ctrl) => {
-        this.abortController = ctrl;
+        this.lifecycle.setAbortController(ctrl);
       },
       executionId: this.executionId,
     };
@@ -171,7 +185,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       );
 
       this.userVars = await this.getUserVars();
-      this.registerRunningAgent(this.getStreamTabId());
+      this.lifecycle.registerRunningAgent();
 
       if (createGroup && initGroupId) {
         this.logger.endGroup(initGroupId, 'stopped');
@@ -186,10 +200,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
 
   /** Interrupt the agent's execution. */
   public interrupt(): void {
-    this.isInterrupted = true;
-    if (this.abortController) {
-      this.abortController.abort();
-    }
+    this.lifecycle.requestInterruption();
     this.logger.error(
       'Agent execution interrupted by user. Active request aborted; partial output may remain.',
     );
@@ -197,19 +208,11 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
 
   /** Check if the agent should stop due to user interruption. */
   protected checkInterruption(): boolean {
-    if (this.isInterrupted) {
-      this.logger.info(
-        'Stopping due to user interruption',
-        undefined,
-        MESSAGE_TYPES.PROGRESS_STATUS,
-      );
-      return true;
-    }
-    return false;
+    return this.lifecycle.checkInterruption();
   }
 
   public isInterruptionRequested(): boolean {
-    return this.isInterrupted;
+    return this.lifecycle.isInterruptionRequested();
   }
 
   public setExecutionId(id: ExecutionId): void {
@@ -239,7 +242,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     const groupId = await this.logger.startGroup(
       groupLabel,
       undefined,
-      this.runGroupId,
+      this.lifecycle.getCurrentRunGroupId(),
     );
 
     let status: 'stopped' | 'error' = 'stopped';
@@ -254,37 +257,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   }
 
   /**
-   * Start a log group for this agent's run and store its ID.
-   * @param parentGroupId Optional parent group
-   * @returns The created group ID
-   */
-  protected async startRunGroup(parentGroupId?: string): Promise<string> {
-    this.runGroupId = await this.logger.startGroup(
-      `Run: ${this.agentConfig.agent}@${this.agentConfig.model}`,
-      undefined,
-      parentGroupId,
-    );
-    this.lastRunGroupId = this.runGroupId;
-    return this.runGroupId;
-  }
-
-  /**
-   * End the current run group.
-   * @param status Status to mark for the group
-   */
-  protected endRunGroup(status: 'stopped' | 'error' = 'stopped'): void {
-    if (this.runGroupId) {
-      this.lastRunGroupId = this.runGroupId;
-      this.logger.endGroup(this.runGroupId, status);
-      this.runGroupId = undefined;
-    }
-  }
-
-  /**
    * Retrieve the most recently used run group identifier.
    */
   public getLastRunGroupId(): string | undefined {
-    return this.lastRunGroupId;
+    return this.lifecycle.getLastRunGroupId();
   }
 
   public static getRunningAgent(
@@ -293,28 +269,17 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     return BaseAgent.runningAgents.get(streamTabId);
   }
 
-  protected cleanup(): void {
-    const streamTabId = this.getStreamTabId();
-    this.unregisterRunningAgent(streamTabId);
-  }
+  protected async onCleanup(): Promise<void> {}
 
-  public getRunHooks(overrides?: Partial<AgentRunHooks>): AgentRunHooks {
-    const baseHooks: AgentRunHooks = {
-      start: () => this.startRunGroup(),
-      init: (runGroupId) => this.init(runGroupId),
-      initializeClient: () => this.initializeClient(),
-      end: (status) => this.endRunGroup(status),
-      cleanup: () => this.cleanup(),
-    };
-
-    return {
-      start: overrides?.start ?? baseHooks.start,
-      init: overrides?.init ?? baseHooks.init,
-      initializeClient:
-        overrides?.initializeClient ?? baseHooks.initializeClient,
-      end: overrides?.end ?? baseHooks.end,
-      cleanup: overrides?.cleanup ?? baseHooks.cleanup,
-    };
+  public getRunHooks(overrides?: AgentRunHookOverrides): AgentLifecycleHooks {
+    return this.lifecycle.createHooks(
+      {
+        init: (runGroupId) => this.init(runGroupId),
+        initializeClient: () => this.initializeClient(),
+        cleanup: () => this.onCleanup(),
+      },
+      overrides,
+    );
   }
 
   protected registerRunningAgent(streamTabId: StreamTabId): void {

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -19,7 +19,7 @@ import {
   type ReflectionRunState,
 } from '@agent/implementations/flows/ReflectionRunFlow';
 import { runAgentFlow } from '@agent/implementations/flows/common/AgentRunFlowRunner';
-import type { AgentRunHooks } from '@agent/implementations/flows/common/types';
+import type { AgentLifecycleHooks } from '@agent/implementations/flows/common/AgentLifecycleController';
 import {
   createReflectionRoundFlow,
   type ReflectionRoundShared,
@@ -606,7 +606,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           globalState: new AgentStateGlobal(),
         }) satisfies ReflectionRunState,
       createFlow: () => createReflectionRunFlow<C>(),
-      extendHooks: (baseHooks: AgentRunHooks) => {
+      extendHooks: (baseHooks: AgentLifecycleHooks) => {
         const baseStart = baseHooks.start;
         return {
           ...baseHooks,

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -29,12 +29,14 @@ import {
   type ToolUseRunState,
 } from '@agent/implementations/flows/ToolUseRunFlow';
 import { runAgentFlow } from '@agent/implementations/flows/common/AgentRunFlowRunner';
-import type { AgentRunHooks } from '@agent/implementations/flows/common/types';
+import type {
+  AgentLifecycleHooks,
+  ToolUseLifecycleHooks,
+} from '@agent/implementations/flows/common/AgentLifecycleController';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   ToolUseSessionManager,
   type ToolUseSessionSnapshot,
@@ -46,13 +48,9 @@ import {
 
 export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
   private toolRegistry: Record<string, BaseTool<any>>;
-  private followUpQueue: string[] = [];
-  private followUpResolver: ((v: string | null) => void) | null = null;
   private messages: ProviderMessage[] = [];
   private toolState: ToolState | null = null;
-  private resumeSnapshot: ToolUseSessionSnapshot | null = null;
-  private hasPersistedSnapshot = false;
-  private persistenceLock = false; // Lock to prevent race conditions during persistence
+  private readonly toolUseLifecycle: ToolUseLifecycleHooks;
 
   constructor(
     modelHandler: IModelHandler<any, any, any, any, C>,
@@ -71,6 +69,16 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       executionId,
     );
     this.toolRegistry = DEFAULT_TOOL_REGISTRY;
+    this.toolUseLifecycle = this.lifecycle.configureToolUseLifecycle({
+      getExecutionId: () => this.getExecutionId(),
+      getMessages: () => this.messages,
+      getToolState: () => this.toolState,
+      getSessionDescriptor: () => this.getSessionMetadata(),
+      getAgentIdentifier: () => ({
+        agentName: this.agentConfig.agent,
+        modelName: this.agentConfig.model,
+      }),
+    });
   }
 
   protected override registerRunningAgent(streamTabId: StreamTabId): void {
@@ -115,16 +123,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
    * @param text - The follow-up message text
    */
   public appendFollowUp(text: string): void {
-    if (this.followUpResolver) {
-      this.followUpResolver(text);
-      this.followUpResolver = null;
-    } else {
-      this.followUpQueue.push(text);
-    }
-    // If we're in the middle of persisting, mark for cleanup
-    if (this.persistenceLock) {
-      this.hasPersistedSnapshot = true; // Will trigger cleanup in the next cycle
-    }
+    this.toolUseLifecycle.appendFollowUp(text);
   }
 
   /**
@@ -132,27 +131,12 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
    * @param snapshot - The snapshot to resume from
    */
   public resumeFromSnapshot(snapshot: ToolUseSessionSnapshot): void {
-    this.resumeSnapshot = snapshot;
-    this.hasPersistedSnapshot = true;
-  }
-
-  private async waitForFollowUp(): Promise<string | null> {
-    if (this.followUpQueue.length > 0) {
-      return this.followUpQueue.shift()!;
-    }
-    if (this.isInterrupted) return null;
-    return new Promise<string | null>((resolve) => {
-      this.followUpResolver = resolve;
-    });
+    this.toolUseLifecycle.resumeFromSnapshot(snapshot);
   }
 
   public override interrupt(): void {
     super.interrupt();
-    if (this.followUpResolver) {
-      this.followUpResolver(null);
-      this.followUpResolver = null;
-    }
-    void this.clearPersistedSnapshot();
+    void this.toolUseLifecycle.clearPersistedSnapshot();
   }
 
   public async run(): Promise<void> {
@@ -173,7 +157,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
           shouldSkipCycle: false,
         }) satisfies ToolUseRunState<C>,
       createFlow: () => createToolUseRunFlow<C>(),
-      extendHooks: (baseHooks: AgentRunHooks) => ({
+      extendHooks: (baseHooks: AgentLifecycleHooks) => ({
         ...baseHooks,
         start: async () => undefined,
         init: (runGroupId) => this.init(runGroupId, { createGroup: false }),
@@ -185,12 +169,13 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
             options,
             messages,
           }),
-        checkInterruption: () => this.checkInterruption(),
-        hasQueuedFollowUp: () => this.followUpQueue.length > 0,
-        enterWaitingState: () => this.enterWaitingState(),
-        clearPersistedSnapshot: () => this.clearPersistedSnapshot(),
-        waitForFollowUp: () => this.waitForFollowUp(),
-        markRunning: () => this.markRunning(),
+        checkInterruption: () => this.lifecycle.checkInterruption(),
+        hasQueuedFollowUp: () => this.toolUseLifecycle.hasQueuedFollowUp(),
+        enterWaitingState: () => this.toolUseLifecycle.enterWaitingState(),
+        clearPersistedSnapshot: () =>
+          this.toolUseLifecycle.clearPersistedSnapshot(),
+        waitForFollowUp: () => this.toolUseLifecycle.waitForFollowUp(),
+        markRunning: () => this.toolUseLifecycle.markRunning(),
         applyFollowUp: async (followUp, messages) => {
           this.logger.userMessage(followUp);
           const updatedMessages =
@@ -219,12 +204,10 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     toolState: ToolState;
     shouldSkipCycle: boolean;
   }> {
-    if (this.resumeSnapshot) {
+    const resumeSnapshot = this.toolUseLifecycle.consumeResumeSnapshot();
+    if (resumeSnapshot) {
       this.logger.debug('Resuming tool-use session from saved state.');
-      const snapshot = this.resumeSnapshot;
-      this.resumeSnapshot = null;
-
-      const rawMessages = snapshot.messages ?? [];
+      const rawMessages = resumeSnapshot.messages ?? [];
       if (!Array.isArray(rawMessages)) {
         throw new Error('Invalid snapshot: messages must be an array');
       }
@@ -234,7 +217,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
 
       try {
         toolState =
-          ToolUseSessionManager.hydrateToolStateFromSnapshot(snapshot);
+          ToolUseSessionManager.hydrateToolStateFromSnapshot(resumeSnapshot);
       } catch (error) {
         const message =
           error instanceof Error
@@ -309,77 +292,5 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       toolState,
       modelName: this.agentConfig.model,
     };
-  }
-
-  private async enterWaitingState(): Promise<void> {
-    // Early check to avoid unnecessary work
-    if (this.followUpQueue.length > 0) {
-      return;
-    }
-
-    const stream = this.getStreamTabId();
-    const executionId = this.getExecutionId();
-    const state = this.toolState;
-
-    // Persist snapshot with lock to prevent race conditions
-    if (state && executionId && ToolUseSessionManager.isPersistenceEnabled()) {
-      // Acquire lock to prevent race conditions
-      this.persistenceLock = true;
-
-      try {
-        // Double-check queue is still empty under lock
-        if (this.followUpQueue.length === 0) {
-          await ToolUseSessionManager.saveSnapshot({
-            executionId,
-            streamId: stream,
-            agentName: this.agentConfig.agent,
-            model: this.agentConfig.model,
-            session: this.getSessionMetadata(),
-            messages: this.messages,
-            toolState: state,
-          });
-
-          // Final check after save completes
-          if (this.followUpQueue.length > 0) {
-            // A follow-up arrived while we were saving
-            await ToolUseSessionManager.deleteSnapshot(executionId);
-            this.hasPersistedSnapshot = false;
-          } else {
-            this.hasPersistedSnapshot = true;
-          }
-        }
-      } finally {
-        // Always release lock
-        this.persistenceLock = false;
-      }
-    }
-
-    bus.emit('updateStreamStatus', {
-      stream,
-      status: 'waiting', // Using string literal here as it's part of the bus event API
-    });
-  }
-
-  private async markRunning(): Promise<void> {
-    bus.emit('updateStreamStatus', {
-      stream: this.getStreamTabId(),
-      status: 'running', // Using string literal here as it's part of the bus event API
-    });
-  }
-
-  private async clearPersistedSnapshot(): Promise<void> {
-    if (!this.hasPersistedSnapshot) {
-      return;
-    }
-    const executionId = this.getExecutionId();
-    if (!executionId) {
-      this.hasPersistedSnapshot = false;
-      return;
-    }
-    try {
-      await ToolUseSessionManager.deleteSnapshot(executionId);
-    } finally {
-      this.hasPersistedSnapshot = false;
-    }
   }
 }

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -12,6 +12,7 @@ import type {
   ReflectionRoundResult,
 } from '../BaseReflectionAgent';
 import { AgentInitNode } from '@agent/implementations/flows/common/AgentInitNode';
+import type { AgentLifecycleHooks } from '@agent/implementations/flows/common/AgentLifecycleController';
 import type { AgentRunShared } from '@agent/implementations/flows/common/types';
 import {
   beginLifecyclePhase,
@@ -29,13 +30,8 @@ export interface ReflectionRunLifecycle {
   error?: unknown;
 }
 
-export interface ReflectionRunHooks {
-  start(): Promise<string>;
-  init(runGroupId: string): Promise<void>;
+export interface ReflectionRunHooks extends AgentLifecycleHooks {
   resetPromptBuilder(): void;
-  initializeClient(): Promise<void>;
-  end(status: 'stopped' | 'error'): void | Promise<void>;
-  cleanup(): void | Promise<void>;
 }
 
 export interface ReflectionRunState {

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -10,6 +10,7 @@ import type { ToolState } from '@agent/core/ToolState';
 import type { BaseToolUseAgent } from '../BaseToolUseAgent';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { AgentInitNode } from '@agent/implementations/flows/common/AgentInitNode';
+import type { AgentLifecycleHooks } from '@agent/implementations/flows/common/AgentLifecycleController';
 import type { AgentRunShared } from '@agent/implementations/flows/common/types';
 import {
   beginLifecyclePhase,
@@ -60,10 +61,7 @@ export interface ToolUseRunState<C = unknown> {
   shouldSkipCycle: boolean;
 }
 
-export interface ToolUseRunHooks<C = unknown> {
-  start(): Promise<string | undefined>;
-  init(runGroupId: string | undefined): Promise<void>;
-  initializeClient(): Promise<void>;
+export interface ToolUseRunHooks<C = unknown> extends AgentLifecycleHooks {
   prepareState(): Promise<{
     messages: ProviderMessage[];
     toolState: ToolState;
@@ -84,8 +82,6 @@ export interface ToolUseRunHooks<C = unknown> {
     followUp: string,
     messages: ProviderMessage[],
   ): Promise<ProviderMessage[]>;
-  end(status: 'stopped' | 'error'): Promise<void>;
-  cleanup(): Promise<void>;
   logFinalizeWarning?(message: string, error: unknown): void;
 }
 

--- a/src/agent/implementations/flows/common/AgentInitNode.ts
+++ b/src/agent/implementations/flows/common/AgentInitNode.ts
@@ -2,11 +2,12 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { BaseNode } from '@agent/node';
 
 import { beginLifecyclePhase, failLifecycle } from './lifecycle';
-import type { AgentRunHooks, AgentRunLifecycleBase } from './types';
+import type { AgentLifecycleHooks } from '@agent/implementations/flows/common/AgentLifecycleController';
+import type { AgentRunLifecycleBase } from './types';
 
 export interface AgentInitShared<
   Lifecycle extends AgentRunLifecycleBase,
-  Hooks extends AgentRunHooks,
+  Hooks extends AgentLifecycleHooks,
 > {
   lifecycle: Lifecycle;
   hooks: Hooks;

--- a/src/agent/implementations/flows/common/AgentLifecycleController.ts
+++ b/src/agent/implementations/flows/common/AgentLifecycleController.ts
@@ -1,0 +1,340 @@
+// Local imports - agent types
+import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
+import type { ToolState } from '@agent/core/ToolState';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+
+// Local imports - logging
+import type { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+// Local imports - events & persistence
+import { bus } from '@eventBus/ProgressEventBus';
+import {
+  ToolUseSessionManager,
+  type ToolUseSessionSnapshot,
+} from '@agent/toolUse/ToolUseSessionManager';
+
+export interface AgentLifecycleControllerOptions {
+  logger: AgentLogger;
+  runLabel: string;
+  streamId: StreamTabId;
+  onRegister?(streamId: StreamTabId): void;
+  onUnregister?(streamId: StreamTabId): void;
+}
+
+export interface AgentLifecycleHooks {
+  start(): Promise<string | undefined>;
+  init(runGroupId: string | undefined): Promise<void>;
+  initializeClient(): Promise<void>;
+  end(status: 'stopped' | 'error'): void | Promise<void>;
+  cleanup(): void | Promise<void>;
+  requestInterruption(): void;
+  isInterruptionRequested(): boolean;
+  checkInterruption(): boolean;
+  setAbortController(controller: AbortController | null): void;
+}
+
+export type AgentRunHookOverrides = Partial<
+  Pick<
+    AgentLifecycleHooks,
+    'start' | 'init' | 'initializeClient' | 'end' | 'cleanup'
+  >
+>;
+
+export interface ToolUseLifecycleOptions {
+  getExecutionId(): ExecutionId | undefined;
+  getMessages(): ProviderMessage[];
+  getToolState(): ToolState | null;
+  getSessionDescriptor(): AgentSessionDescriptor;
+  getAgentIdentifier(): { agentName: string; modelName: string };
+}
+
+export interface ToolUseLifecycleHooks {
+  appendFollowUp(text: string): void;
+  hasQueuedFollowUp(): boolean;
+  waitForFollowUp(): Promise<string | null>;
+  enterWaitingState(): Promise<void>;
+  clearPersistedSnapshot(): Promise<void>;
+  markRunning(): Promise<void>;
+  resumeFromSnapshot(snapshot: ToolUseSessionSnapshot): void;
+  consumeResumeSnapshot(): ToolUseSessionSnapshot | null;
+  cancelPendingFollowUpWait(): void;
+  reset(): void;
+}
+
+class ToolUseLifecycle implements ToolUseLifecycleHooks {
+  private followUpQueue: string[] = [];
+  private followUpResolver: ((value: string | null) => void) | null = null;
+  private resumeSnapshot: ToolUseSessionSnapshot | null = null;
+  private hasPersistedSnapshot = false;
+  private persistenceLock = false;
+
+  constructor(
+    private readonly controller: AgentLifecycleController,
+    private readonly options: ToolUseLifecycleOptions,
+  ) {}
+
+  appendFollowUp(text: string): void {
+    if (this.followUpResolver) {
+      this.followUpResolver(text);
+      this.followUpResolver = null;
+    } else {
+      this.followUpQueue.push(text);
+    }
+
+    if (this.persistenceLock) {
+      // Flag to ensure the snapshot is cleaned up on the next cycle
+      this.hasPersistedSnapshot = true;
+    }
+  }
+
+  hasQueuedFollowUp(): boolean {
+    return this.followUpQueue.length > 0;
+  }
+
+  async waitForFollowUp(): Promise<string | null> {
+    if (this.followUpQueue.length > 0) {
+      return this.followUpQueue.shift()!;
+    }
+
+    if (this.controller.isInterruptionRequested()) {
+      return null;
+    }
+
+    return new Promise<string | null>((resolve) => {
+      this.followUpResolver = resolve;
+    });
+  }
+
+  async enterWaitingState(): Promise<void> {
+    if (this.followUpQueue.length > 0) {
+      return;
+    }
+
+    const executionId = this.options.getExecutionId();
+    const toolState = this.options.getToolState();
+
+    if (
+      toolState &&
+      executionId &&
+      ToolUseSessionManager.isPersistenceEnabled()
+    ) {
+      this.persistenceLock = true;
+
+      try {
+        if (this.followUpQueue.length === 0) {
+          const { agentName, modelName } = this.options.getAgentIdentifier();
+          await ToolUseSessionManager.saveSnapshot({
+            executionId,
+            streamId: this.controller.getStreamId(),
+            agentName,
+            model: modelName,
+            session: this.options.getSessionDescriptor(),
+            messages: this.options.getMessages(),
+            toolState,
+          });
+
+          if (this.followUpQueue.length > 0) {
+            await ToolUseSessionManager.deleteSnapshot(executionId);
+            this.hasPersistedSnapshot = false;
+          } else {
+            this.hasPersistedSnapshot = true;
+          }
+        }
+      } finally {
+        this.persistenceLock = false;
+      }
+    }
+
+    bus.emit('updateStreamStatus', {
+      stream: this.controller.getStreamId(),
+      status: 'waiting',
+    });
+  }
+
+  async clearPersistedSnapshot(): Promise<void> {
+    if (!this.hasPersistedSnapshot) {
+      return;
+    }
+
+    const executionId = this.options.getExecutionId();
+    if (!executionId) {
+      this.hasPersistedSnapshot = false;
+      return;
+    }
+
+    try {
+      await ToolUseSessionManager.deleteSnapshot(executionId);
+    } finally {
+      this.hasPersistedSnapshot = false;
+    }
+  }
+
+  async markRunning(): Promise<void> {
+    bus.emit('updateStreamStatus', {
+      stream: this.controller.getStreamId(),
+      status: 'running',
+    });
+  }
+
+  resumeFromSnapshot(snapshot: ToolUseSessionSnapshot): void {
+    this.resumeSnapshot = snapshot;
+    this.hasPersistedSnapshot = true;
+  }
+
+  consumeResumeSnapshot(): ToolUseSessionSnapshot | null {
+    const snapshot = this.resumeSnapshot;
+    this.resumeSnapshot = null;
+    return snapshot;
+  }
+
+  cancelPendingFollowUpWait(): void {
+    if (this.followUpResolver) {
+      this.followUpResolver(null);
+      this.followUpResolver = null;
+    }
+  }
+
+  reset(): void {
+    this.cancelPendingFollowUpWait();
+    this.followUpQueue = [];
+    this.resumeSnapshot = null;
+    this.hasPersistedSnapshot = false;
+    this.persistenceLock = false;
+  }
+}
+
+export class AgentLifecycleController {
+  private readonly logger: AgentLogger;
+  private readonly runLabel: string;
+  private readonly streamId: StreamTabId;
+  private readonly register?: (streamId: StreamTabId) => void;
+  private readonly unregister?: (streamId: StreamTabId) => void;
+
+  private runGroupId?: string;
+  private lastRunGroupId?: string;
+  private abortController: AbortController | null = null;
+  private interrupted = false;
+
+  private toolUseLifecycle?: ToolUseLifecycle;
+
+  constructor(options: AgentLifecycleControllerOptions) {
+    this.logger = options.logger;
+    this.runLabel = options.runLabel;
+    this.streamId = options.streamId;
+    this.register = options.onRegister;
+    this.unregister = options.onUnregister;
+  }
+
+  public getStreamId(): StreamTabId {
+    return this.streamId;
+  }
+
+  public getCurrentRunGroupId(): string | undefined {
+    return this.runGroupId;
+  }
+
+  public getLastRunGroupId(): string | undefined {
+    return this.lastRunGroupId;
+  }
+
+  public registerRunningAgent(): void {
+    this.register?.(this.streamId);
+  }
+
+  public configureToolUseLifecycle(
+    options: ToolUseLifecycleOptions,
+  ): ToolUseLifecycleHooks {
+    this.toolUseLifecycle = new ToolUseLifecycle(this, options);
+    return this.toolUseLifecycle;
+  }
+
+  public getToolUseLifecycle(): ToolUseLifecycleHooks | undefined {
+    return this.toolUseLifecycle;
+  }
+
+  public createHooks(
+    hooks: {
+      init(runGroupId: string | undefined): Promise<void>;
+      initializeClient(): Promise<void>;
+      cleanup?(): Promise<void> | void;
+    },
+    overrides?: AgentRunHookOverrides,
+  ): AgentLifecycleHooks {
+    const baseHooks: AgentLifecycleHooks = {
+      start: overrides?.start ?? (() => this.startRunGroup()),
+      init: overrides?.init ?? hooks.init,
+      initializeClient: overrides?.initializeClient ?? hooks.initializeClient,
+      end: overrides?.end ?? ((status) => this.endRunGroup(status)),
+      cleanup: overrides?.cleanup ?? (() => this.cleanup(hooks.cleanup)),
+      requestInterruption: () => this.requestInterruption(),
+      isInterruptionRequested: () => this.interrupted,
+      checkInterruption: () => this.checkInterruption(),
+      setAbortController: (controller) => this.setAbortController(controller),
+    };
+
+    return baseHooks;
+  }
+
+  public isInterruptionRequested(): boolean {
+    return this.interrupted;
+  }
+
+  private async startRunGroup(parentGroupId?: string): Promise<string> {
+    const groupId = await this.logger.startGroup(
+      this.runLabel,
+      undefined,
+      parentGroupId,
+    );
+    this.runGroupId = groupId;
+    this.lastRunGroupId = groupId;
+    this.interrupted = false;
+    return groupId;
+  }
+
+  private endRunGroup(status: 'stopped' | 'error'): void {
+    if (this.runGroupId) {
+      this.lastRunGroupId = this.runGroupId;
+      this.logger.endGroup(this.runGroupId, status);
+      this.runGroupId = undefined;
+    }
+  }
+
+  private async cleanup(cleanup?: () => Promise<void> | void): Promise<void> {
+    try {
+      if (cleanup) {
+        await cleanup();
+      }
+    } finally {
+      this.toolUseLifecycle?.reset();
+      this.abortController = null;
+      this.interrupted = false;
+      this.unregister?.(this.streamId);
+    }
+  }
+
+  public checkInterruption(): boolean {
+    if (this.interrupted) {
+      this.logger.info(
+        'Stopping due to user interruption',
+        undefined,
+        MESSAGE_TYPES.PROGRESS_STATUS,
+      );
+      return true;
+    }
+    return false;
+  }
+
+  public setAbortController(controller: AbortController | null): void {
+    this.abortController = controller;
+  }
+
+  public requestInterruption(): void {
+    this.interrupted = true;
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.toolUseLifecycle?.cancelPendingFollowUpWait();
+  }
+}

--- a/src/agent/implementations/flows/common/AgentRunFlowRunner.ts
+++ b/src/agent/implementations/flows/common/AgentRunFlowRunner.ts
@@ -2,19 +2,17 @@ import type { Flow } from '@agent/node';
 import type { BaseAgent } from '@agent/implementations/BaseAgent';
 
 import type {
-  AgentRunHooks,
-  AgentRunLifecycleBase,
-  AgentRunShared,
-} from './types';
-
-export type AgentRunHookOverrides = Partial<AgentRunHooks>;
+  AgentLifecycleHooks,
+  AgentRunHookOverrides,
+} from '@agent/implementations/flows/common/AgentLifecycleController';
+import type { AgentRunLifecycleBase, AgentRunShared } from './types';
 
 type AgentRunFlowOptionsBase<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
     AgentRunLifecycleBase,
-    AgentRunHooks
+    AgentLifecycleHooks
   >,
 > = {
   agent: Shared['agent'];
@@ -30,10 +28,10 @@ type AgentRunFlowOptionsWithExtend<
     BaseAgent<any>,
     any,
     AgentRunLifecycleBase,
-    AgentRunHooks
+    AgentLifecycleHooks
   >,
 > = AgentRunFlowOptionsBase<Shared> & {
-  extendHooks: (baseHooks: AgentRunHooks) => Shared['hooks'];
+  extendHooks: (baseHooks: AgentLifecycleHooks) => Shared['hooks'];
 };
 
 type AgentRunFlowOptionsWithoutExtend<
@@ -41,10 +39,10 @@ type AgentRunFlowOptionsWithoutExtend<
     BaseAgent<any>,
     any,
     AgentRunLifecycleBase,
-    AgentRunHooks
+    AgentLifecycleHooks
   >,
 > =
-  Shared extends AgentRunShared<any, any, any, AgentRunHooks>
+  Shared extends AgentRunShared<any, any, any, AgentLifecycleHooks>
     ? AgentRunFlowOptionsBase<Shared> & { extendHooks?: undefined }
     : never;
 
@@ -53,7 +51,7 @@ export type AgentRunFlowOptions<
     BaseAgent<any>,
     any,
     AgentRunLifecycleBase,
-    AgentRunHooks
+    AgentLifecycleHooks
   >,
 > =
   | AgentRunFlowOptionsWithExtend<Shared>
@@ -64,7 +62,7 @@ function hasExtendHooks<
     BaseAgent<any>,
     any,
     AgentRunLifecycleBase,
-    AgentRunHooks
+    AgentLifecycleHooks
   >,
 >(
   options: AgentRunFlowOptions<Shared>,
@@ -80,7 +78,7 @@ async function runAgentFlowWithExtend<
     BaseAgent<any>,
     any,
     AgentRunLifecycleBase,
-    AgentRunHooks
+    AgentLifecycleHooks
   >,
 >(options: AgentRunFlowOptionsWithExtend<Shared>): Promise<Shared> {
   const state = options.createState();
@@ -111,7 +109,7 @@ async function runAgentFlowWithoutExtend<
     BaseAgent<any>,
     any,
     AgentRunLifecycleBase,
-    AgentRunHooks
+    AgentLifecycleHooks
   >,
 >(options: AgentRunFlowOptionsWithoutExtend<Shared>): Promise<Shared> {
   const state = options.createState();
@@ -141,7 +139,7 @@ export async function runAgentFlow<
     BaseAgent<any>,
     any,
     AgentRunLifecycleBase,
-    AgentRunHooks
+    AgentLifecycleHooks
   >,
 >(options: AgentRunFlowOptions<Shared>): Promise<Shared> {
   if (hasExtendHooks(options)) {

--- a/src/agent/implementations/flows/common/types.ts
+++ b/src/agent/implementations/flows/common/types.ts
@@ -1,4 +1,4 @@
-import type { AgentRunHooks } from '@agent/core/IAgent';
+import type { AgentLifecycleHooks } from '@agent/implementations/flows/common/AgentLifecycleController';
 import type { BaseAgent } from '@agent/implementations/BaseAgent';
 
 export interface AgentRunLifecycleBase {
@@ -11,12 +11,10 @@ export interface AgentRunShared<
   A extends BaseAgent<any>,
   State,
   Lifecycle extends AgentRunLifecycleBase,
-  Hooks extends AgentRunHooks,
+  Hooks extends AgentLifecycleHooks,
 > {
   agent: A;
   state: State;
   lifecycle: Lifecycle;
   hooks: Hooks;
 }
-
-export type { AgentRunHooks };


### PR DESCRIPTION
## Summary
- add an AgentLifecycleController to encapsulate logging groups, interruption, follow-up handling, and snapshot persistence
- refactor BaseAgent and BaseToolUseAgent to delegate lifecycle responsibilities to the controller and streamline tool-use state management
- update flow runner wiring and hook typings to consume the new AgentLifecycleHooks API across reflection and tool-use flows

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_6905ccdf0ef483248f4759eb0baafaf8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a centralized AgentLifecycleController for run logging, interruption, and tool-use session handling, refactoring agents and flows to the new AgentLifecycleHooks API.
> 
> - **Core Lifecycle**:
>   - Add `AgentLifecycleController` managing run groups, interruption/abort, stream status, and tool-use follow-ups + snapshot persistence (`flows/common/AgentLifecycleController`).
>   - Replace `AgentRunHooks` with `AgentLifecycleHooks`; add `AgentRunHookOverrides`.
> - **Base Agent Refactor**:
>   - `BaseAgent` delegates lifecycle (run groups, interruption, cleanup) to the controller and exposes `getRunHooks(overrides?: AgentRunHookOverrides)`.
>   - `IAgent` updated to return `AgentLifecycleHooks`.
> - **Tool-Use Agents**:
>   - `BaseToolUseAgent` uses controller’s `ToolUseLifecycle` for follow-ups, waiting/running status, and snapshot resume/cleanup; session prep moved to lifecycle hooks.
> - **Reflection Flow**:
>   - Update to use `AgentLifecycleHooks`; ensure run group required; reset prompt builder via hooks.
> - **Flow Orchestration**:
>   - Update `AgentInitNode`, `AgentRunFlowRunner`, and shared `types` to the new lifecycle hooks across reflection/tool-use flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66dae6557f4fd84bf75c0198f44c67ea6c0ed301. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->