### PR TITLE
Refine media attachment processor and inline test fixtures

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1,7 +1,5 @@
 // Standard library imports
-import * as path from 'path';
 import { randomUUID } from 'crypto';
-import { Buffer } from 'buffer';
 
 // Third-party imports
 import { FinishReason } from '@google/genai';
@@ -21,12 +19,7 @@ import {
   MCP_STOP,
 } from './types/StopReasonTypes';
 import { MediaEntry } from '@agent/utils/mediaTypes';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
-import {
-  getBase64EncodedMedia,
-  countPdfPages,
-  processPdf2Png,
-} from '@frontend/media/img';
+import { MediaAttachmentProcessor } from './support/MediaAttachmentProcessor';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 // Local imports - events
@@ -44,7 +37,6 @@ import {
 import { getConfig } from '@utils/config';
 
 // Local imports - utilities
-import { WorkspaceFS, AbsoluteFS, getMimeType } from '@utils/files';
 import { normalizeUrl } from '@utils/urlUtils';
 
 // Default continuation limits
@@ -84,8 +76,6 @@ interface MarkerFlags {
   encounterDocumentTag: boolean;
 }
 
-export type MediaFileResult = { path: string; ok: boolean };
-
 /**
  * Abstract base class for model-specific handlers that manage API interactions, message processing, and response handling.
  */
@@ -107,6 +97,7 @@ export abstract class ModelHandler<
   protected backgroundModeSupported = false;
   protected progressViewEnabled = true;
   protected agentType?: AgentType;
+  protected mediaProcessor: MediaAttachmentProcessor;
 
   protected get supportsToolFileOutputs(): boolean {
     return false;
@@ -133,6 +124,10 @@ export abstract class ModelHandler<
     this.maxOutputTokensFactor = DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR;
     // Initialize with default channel, will be overwritten by agent
     this.logger = new AgentLogger('Agent');
+    this.mediaProcessor = new MediaAttachmentProcessor(this.logger, {
+      getCapabilities: () => this.capabilities,
+      isOpenAIProvider: () => this.isOpenai,
+    });
   }
 
   /**
@@ -140,6 +135,7 @@ export abstract class ModelHandler<
    */
   public setLogger(logger: AgentLogger): void {
     this.logger = logger;
+    this.mediaProcessor.setLogger(logger);
   }
 
   /**
@@ -515,278 +511,17 @@ export abstract class ModelHandler<
     return effort;
   }
 
-  /** Determine if extension corresponds to an audio format. */
-  private isAudio(ext: string): boolean {
-    const mimeType = getMimeType(ext);
-    return mimeType !== null && mimeType.startsWith('audio/');
-  }
-
-  /**
-   * Process an image file for model ingestion.
-   * Handles PDFs and other common image formats.
-   */
-  protected async processImage(
-    mediaFile: string,
-    ext: string,
-  ): Promise<[string | string[], string, 'image']> {
-    let mediaType: string;
-    let mediaData: string | string[];
-
-    if (ext === '.pdf') {
-      const pageCount = await countPdfPages(mediaFile);
-      if (pageCount === 0) {
-        throw new Error(`Failed to process PDF file as image: ${mediaFile}`);
-      }
-
-      if (this.capabilities.supportsNativePdf) {
-        this.logger.debug(
-          `Using native PDF for ${mediaFile}. Page count: ${pageCount}`,
-        );
-        mediaType = 'application/pdf';
-        mediaData = await getBase64EncodedMedia(mediaFile);
-        return [mediaData, mediaType, 'image'];
-      }
-
-      mediaType = 'image/png';
-      this.logger.debug(`Converting PDF to PNG: ${mediaFile}`);
-      const pdfResult = await processPdf2Png(mediaFile);
-      if (pdfResult === null) {
-        throw new Error(`Failed to process PDF file as image: ${mediaFile}`);
-      }
-      mediaData = pdfResult;
-    } else {
-      const mimeType = getMimeType(mediaFile);
-      if (mimeType && mimeType.startsWith('image/')) {
-        mediaType = mimeType;
-        this.logger.debug(
-          `Processing as image: ${mediaFile}, type: ${mediaType}`,
-        );
-        mediaData = await getBase64EncodedMedia(mediaFile);
-      } else {
-        throw new Error(
-          `Unsupported image extension: ${ext}. Image support: ${this.capabilities.supportsVision}`,
-        );
-      }
-    }
-
-    return [mediaData, mediaType, 'image'];
-  }
-
-  /** Process an audio file for models supporting native audio input. */
-  protected async processAudio(
-    mediaFile: string,
-    ext: string,
-  ): Promise<[string, string, 'audio']> {
-    const mimeType = getMimeType(mediaFile);
-    if (
-      !mimeType ||
-      !mimeType.startsWith('audio/') ||
-      !this.capabilities.supportsNativeAudio
-    ) {
-      throw new Error(
-        `Unsupported or disabled audio extension: ${ext}. Audio support: ${this.capabilities.supportsNativeAudio}`,
-      );
-    }
-
-    const mediaType = mimeType;
-    this.logger.debug(`Processing as audio: ${mediaFile}, type: ${mediaType}`);
-    let mediaData = await getBase64EncodedMedia(mediaFile);
-    if (Array.isArray(mediaData)) {
-      this.logger.warn(
-        `Audio file ${mediaFile} processed into multiple parts, using only the first.`,
-      );
-      mediaData = mediaData[0];
-    }
-    return [mediaData, mediaType, 'audio'];
-  }
-
-  /**
-   * Process image or audio for models.
-   * @param mediaFile Path to the media file
-   * @param fileExtension File extension (e.g. '.jpg', '.pdf', '.wav')
-   * @returns Tuple of [base64 encoded media data, media type, media category ('image' or 'audio')]
-   */
-  protected async processMedia(
-    mediaFile: string,
-    fileExtension: string,
-  ): Promise<[string | string[], string, 'image' | 'audio']> {
-    const ext = fileExtension.toLowerCase();
-    return this.isAudio(ext)
-      ? this.processAudio(mediaFile, ext)
-      : this.processImage(mediaFile, ext);
-  }
-
   /**
    * Create image/audio messages for the conversation.
    * This is a shared implementation that can be used by all providers.
    * Individual providers can override if needed.
    */
   public async createMediaMessage(mediaFiles: string[]): Promise<any[]> {
-    const { entries, results } = await this.buildMediaEntries(mediaFiles);
-    this.logMediaResults(results);
-    return this.createMediaContent(entries);
-  }
-
-  protected logMediaResults(results: MediaFileResult[]): void {
-    if (results.length === 0) {
-      return;
-    }
-    if (results.some((result) => !result.ok)) {
-      this.logger.warn('Some media files failed to load');
-    }
-    this.logger.fileList(results);
-  }
-
-  protected async buildMediaEntries(
-    mediaFiles: string[],
-  ): Promise<{ entries: MediaEntry[]; results: MediaFileResult[] }> {
-    const settledResults = await Promise.allSettled(
-      mediaFiles.map((mediaFile) => this.loadMediaEntry(mediaFile)),
+    const { entries, results } = await this.mediaProcessor.loadEntries(
+      mediaFiles,
     );
-
-    const entries: MediaEntry[] = [];
-    const results: MediaFileResult[] = [];
-
-    settledResults.forEach((settledResult, index) => {
-      if (settledResult.status === 'fulfilled') {
-        const { entry, result } = settledResult.value;
-        results.push(result);
-
-        if (result.ok && entry) {
-          const entryList = Array.isArray(entry) ? entry : [entry];
-          entries.push(...entryList);
-        }
-      } else {
-        const reason = settledResult.reason;
-        const mediaFile = mediaFiles[index];
-        this.logger.error(
-          `Failed to load media entry for ${mediaFile}: ${getSdkErrorMessage(reason)}`,
-          undefined,
-          undefined,
-          reason,
-        );
-        results.push({ path: mediaFile, ok: false });
-      }
-    });
-
-    return { entries, results };
-  }
-
-  protected async loadMediaEntry(
-    mediaFile: string,
-  ): Promise<{ entry?: MediaEntry | MediaEntry[]; result: MediaFileResult }> {
-    const absolutePath = path.isAbsolute(mediaFile)
-      ? mediaFile
-      : WorkspaceFS.fullPath(mediaFile);
-    const fileExistsResult = await AbsoluteFS.exists(absolutePath);
-
-    if (!fileExistsResult) {
-      this.logger.error(`File not found: ${mediaFile}`);
-      return { result: { path: mediaFile, ok: false } };
-    }
-
-    let fileSize: number | null = null;
-    try {
-      const stats = await AbsoluteFS.stat(absolutePath);
-      fileSize = stats.size;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.error(
-        `Unable to read file info for ${mediaFile}: ${message}`,
-      );
-      return { result: { path: mediaFile, ok: false } };
-    }
-
-    if (fileSize === 0) {
-      this.logger.warn(`Skipping empty media file: ${mediaFile}`);
-      return { result: { path: mediaFile, ok: false } };
-    }
-
-    const fileExtension = path.extname(mediaFile).toLowerCase();
-
-    try {
-      const [mediaData, mediaType, mediaCategory] = await this.processMedia(
-        mediaFile,
-        fileExtension,
-      );
-      this.logger.debug(
-        `Processed ${mediaCategory}: ${mediaFile}, type: ${mediaType}`,
-      );
-
-      const isDerivedFromConversion =
-        fileExtension === '.pdf' && mediaType !== 'application/pdf';
-
-      const createEntry = (
-        fileName: string,
-        data: string,
-        matchesSource: boolean = !isDerivedFromConversion,
-      ): MediaEntry => {
-        const entry: MediaEntry = {
-          file_name: fileName,
-          data,
-          media_type: mediaType,
-          media_category: mediaCategory,
-          binary_data: Buffer.from(data, 'base64'),
-          bytes_match_source: matchesSource,
-        };
-
-        if (matchesSource) {
-          entry.source_path = absolutePath;
-        }
-
-        return entry;
-      };
-
-      if (
-        this.isOpenai &&
-        this.capabilities.supportsVision &&
-        this.capabilities.supportsNativePdf &&
-        mediaType === 'application/pdf'
-      ) {
-        const pdfEntry = createEntry(
-          path.basename(mediaFile),
-          Array.isArray(mediaData) ? mediaData[0] : mediaData,
-        );
-        this.logger.debug(`Added native PDF: ${mediaFile}`);
-        return {
-          entry: pdfEntry,
-          result: { path: mediaFile, ok: true },
-        };
-      }
-
-      if (!Array.isArray(mediaData)) {
-        this.logger.debug(
-          `Adding single part to the media contents: ${mediaFile}`,
-        );
-        return {
-          entry: createEntry(path.basename(mediaFile), mediaData),
-          result: { path: mediaFile, ok: true },
-        };
-      }
-
-      this.logger.debug(
-        `Adding ${mediaData.length} pages/parts to the media contents`,
-      );
-      const entryList = mediaData.map((data, index) =>
-        createEntry(
-          `${path.basename(mediaFile)}_page_${index + 1}`,
-          data,
-          false,
-        ),
-      );
-      return {
-        entry: entryList,
-        result: { path: mediaFile, ok: true },
-      };
-    } catch (err) {
-      this.logger.error(
-        `Failed to process media ${mediaFile}: ${getSdkErrorMessage(err)}`,
-        undefined,
-        undefined,
-        err,
-      );
-      return { result: { path: mediaFile, ok: false } };
-    }
+    this.mediaProcessor.logResults(results);
+    return this.createMediaContent(entries);
   }
 
   /** Calculates token-based stop flags. */

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -39,10 +39,8 @@ import {
 import { ToolState } from '@agent/core/ToolState';
 
 // Local imports - agent components
-import {
-  ModelHandler,
-  type MediaFileResult,
-} from '@agent/modelHandlers/ModelHandler';
+import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import type { MediaFileResult } from './support/MediaAttachmentProcessor';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
@@ -712,8 +710,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       return [];
     }
 
-    const { entries, results } = await this.buildMediaEntries(mediaFiles);
-    this.logMediaResults(results);
+    const { entries, results } = await this.mediaProcessor.loadEntries(
+      mediaFiles,
+    );
+    this.mediaProcessor.logResults(results);
 
     if (entries.length === 0) {
       return [];

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -1,0 +1,361 @@
+// Standard library imports
+import * as path from 'path';
+import { Buffer } from 'buffer';
+
+// Local imports - agent utils
+import { MediaEntry } from '@agent/utils/mediaTypes';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  countPdfPages,
+  getBase64EncodedMedia,
+  processPdf2Png,
+} from '@frontend/media/img';
+import { AgentLogger } from '@logger/AgentLogger';
+import type { ModelCapabilities } from '@model/ModelConfig';
+import { AbsoluteFS, WorkspaceFS, getMimeType } from '@utils/files';
+
+export type MediaFileResult = { path: string; ok: boolean };
+
+export type ProcessImageResult = {
+  kind: 'image';
+  mediaType: string;
+  data: string | string[];
+};
+
+export type ProcessAudioResult = {
+  kind: 'audio';
+  mediaType: string;
+  data: string;
+};
+
+export type ProcessedMediaResult = ProcessImageResult | ProcessAudioResult;
+
+interface MediaAttachmentProcessorOptions {
+  getCapabilities: () => ModelCapabilities;
+  isOpenAIProvider: () => boolean;
+}
+
+export class MediaAttachmentProcessor {
+  constructor(
+    private logger: AgentLogger,
+    private readonly options: MediaAttachmentProcessorOptions,
+  ) {}
+
+  public setLogger(logger: AgentLogger): void {
+    this.logger = logger;
+  }
+
+  private get capabilities(): ModelCapabilities {
+    return this.options.getCapabilities();
+  }
+
+  private get isOpenAIProvider(): boolean {
+    return this.options.isOpenAIProvider();
+  }
+
+  public async processImage(
+    mediaFile: string,
+    ext: string,
+  ): Promise<ProcessImageResult> {
+    let mediaType: string;
+    let mediaData: string | string[];
+
+    if (ext === '.pdf') {
+      const pageCount = await countPdfPages(mediaFile);
+      if (pageCount === 0) {
+        throw new Error(`Failed to process PDF file as image: ${mediaFile}`);
+      }
+
+      if (this.capabilities.supportsNativePdf) {
+        this.logger.debug(
+          `Using native PDF for ${mediaFile}. Page count: ${pageCount}`,
+        );
+        mediaType = 'application/pdf';
+        mediaData = await getBase64EncodedMedia(mediaFile);
+        return { kind: 'image', mediaType, data: mediaData };
+      }
+
+      mediaType = 'image/png';
+      this.logger.debug(`Converting PDF to PNG: ${mediaFile}`);
+      const pdfResult = await processPdf2Png(mediaFile);
+      if (pdfResult === null) {
+        throw new Error(`Failed to process PDF file as image: ${mediaFile}`);
+      }
+      mediaData = pdfResult;
+    } else {
+      const mimeType = getMimeType(mediaFile);
+      if (mimeType && mimeType.startsWith('image/')) {
+        mediaType = mimeType;
+        this.logger.debug(
+          `Processing as image: ${mediaFile}, type: ${mediaType}`,
+        );
+        mediaData = await getBase64EncodedMedia(mediaFile);
+      } else {
+        throw new Error(
+          `Unsupported image extension: ${ext}. Image support: ${this.capabilities.supportsVision}`,
+        );
+      }
+    }
+
+    return { kind: 'image', mediaType, data: mediaData };
+  }
+
+  public async processAudio(
+    mediaFile: string,
+    ext: string,
+  ): Promise<ProcessAudioResult> {
+    const mimeType = getMimeType(mediaFile);
+    if (
+      !mimeType ||
+      !mimeType.startsWith('audio/') ||
+      !this.capabilities.supportsNativeAudio
+    ) {
+      throw new Error(
+        `Unsupported or disabled audio extension: ${ext}. Audio support: ${this.capabilities.supportsNativeAudio}`,
+      );
+    }
+
+    const mediaType = mimeType;
+    this.logger.debug(`Processing as audio: ${mediaFile}, type: ${mediaType}`);
+    let mediaData = await getBase64EncodedMedia(mediaFile);
+    if (Array.isArray(mediaData)) {
+      this.logger.warn(
+        `Audio file ${mediaFile} processed into multiple parts, using only the first.`,
+      );
+      mediaData = mediaData[0];
+    }
+
+    return { kind: 'audio', mediaType, data: mediaData };
+  }
+
+  public async processMedia(
+    mediaFile: string,
+    fileExtension: string,
+  ): Promise<ProcessedMediaResult> {
+    const ext = fileExtension.toLowerCase();
+    return this.isAudio(ext)
+      ? this.processAudio(mediaFile, ext)
+      : this.processImage(mediaFile, ext);
+  }
+
+  public async loadEntries(
+    mediaFiles: string[],
+  ): Promise<{ entries: MediaEntry[]; results: MediaFileResult[] }> {
+    if (mediaFiles.length === 0) {
+      return { entries: [], results: [] };
+    }
+
+    const settledResults = await Promise.allSettled(
+      mediaFiles.map((mediaFile) => this.loadMediaEntry(mediaFile)),
+    );
+
+    const entries: MediaEntry[] = [];
+    const results: MediaFileResult[] = [];
+
+    settledResults.forEach((settledResult, index) => {
+      if (settledResult.status === 'fulfilled') {
+        const { entry, result } = settledResult.value;
+        results.push(result);
+
+        if (entry) {
+          const entryList = Array.isArray(entry) ? entry : [entry];
+          entries.push(...entryList);
+        }
+      } else {
+        const reason = settledResult.reason;
+        const mediaFile = mediaFiles[index];
+        this.logger.error(
+          `Failed to load media entry for ${mediaFile}: ${getSdkErrorMessage(reason)}`,
+          undefined,
+          undefined,
+          reason,
+        );
+        results.push({ path: mediaFile, ok: false });
+      }
+    });
+
+    return { entries, results };
+  }
+
+  public logResults(results: MediaFileResult[]): void {
+    if (results.length === 0) {
+      return;
+    }
+
+    if (results.some((result) => !result.ok)) {
+      this.logger.warn('Some media files failed to load');
+    }
+
+    this.logger.fileList(results);
+  }
+
+  private async loadMediaEntry(
+    mediaFile: string,
+  ): Promise<{ entry?: MediaEntry | MediaEntry[]; result: MediaFileResult }> {
+    const absolutePath = this.resolveAbsolutePath(mediaFile);
+    const fileExistsResult = await AbsoluteFS.exists(absolutePath);
+
+    if (!fileExistsResult) {
+      this.logger.error(`File not found: ${mediaFile}`);
+      return { result: { path: mediaFile, ok: false } };
+    }
+
+    let fileSize: number;
+    try {
+      const stats = await AbsoluteFS.stat(absolutePath);
+      fileSize = stats.size;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Unable to read file info for ${mediaFile}: ${message}`,
+      );
+      return { result: { path: mediaFile, ok: false } };
+    }
+
+    if (fileSize === 0) {
+      this.logger.warn(`Skipping empty media file: ${mediaFile}`);
+      return { result: { path: mediaFile, ok: false } };
+    }
+
+    const fileExtension = path.extname(mediaFile).toLowerCase();
+
+    try {
+      const processed = await this.processMedia(mediaFile, fileExtension);
+      this.logger.debug(
+        `Processed ${processed.kind}: ${mediaFile}, type: ${processed.mediaType}`,
+      );
+
+      const entry = this.createEntriesForProcessedMedia(
+        mediaFile,
+        absolutePath,
+        fileExtension,
+        processed,
+      );
+
+      return {
+        entry,
+        result: { path: mediaFile, ok: true },
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to process media ${mediaFile}: ${getSdkErrorMessage(err)}`,
+        undefined,
+        undefined,
+        err,
+      );
+      return { result: { path: mediaFile, ok: false } };
+    }
+  }
+
+  private resolveAbsolutePath(mediaFile: string): string {
+    return path.isAbsolute(mediaFile)
+      ? mediaFile
+      : WorkspaceFS.fullPath(mediaFile);
+  }
+
+  private shouldReturnNativePdf(
+    processed: ProcessImageResult,
+    fileExtension: string,
+  ): boolean {
+    return (
+      fileExtension === '.pdf' &&
+      processed.mediaType === 'application/pdf' &&
+      this.isOpenAIProvider &&
+      this.capabilities.supportsVision &&
+      this.capabilities.supportsNativePdf
+    );
+  }
+
+  private createEntriesForProcessedMedia(
+    mediaFile: string,
+    absolutePath: string,
+    fileExtension: string,
+    processed: ProcessedMediaResult,
+  ): MediaEntry | MediaEntry[] {
+    if (
+      processed.kind === 'image' &&
+      this.shouldReturnNativePdf(processed, fileExtension)
+    ) {
+      const pdfData = Array.isArray(processed.data)
+        ? processed.data[0]
+        : processed.data;
+      const entry = this.createEntry(
+        path.basename(mediaFile),
+        pdfData,
+        processed.mediaType,
+        processed.kind,
+        absolutePath,
+        true,
+      );
+      this.logger.debug(`Added native PDF: ${mediaFile}`);
+      return entry;
+    }
+
+    const dataParts = Array.isArray(processed.data)
+      ? processed.data
+      : [processed.data];
+    const isImage = processed.kind === 'image';
+    const derivedFromConversion =
+      isImage &&
+      fileExtension === '.pdf' &&
+      processed.mediaType !== 'application/pdf';
+    const baseName = path.basename(mediaFile);
+
+    const entries = dataParts.map((data, index) => {
+      const matchesSource = !derivedFromConversion && dataParts.length === 1;
+      const fileName =
+        dataParts.length === 1
+          ? baseName
+          : `${baseName}_page_${index + 1}`;
+      return this.createEntry(
+        fileName,
+        data,
+        processed.mediaType,
+        processed.kind,
+        absolutePath,
+        matchesSource,
+      );
+    });
+
+    if (entries.length === 1) {
+      this.logger.debug(
+        `Adding single part to the media contents: ${mediaFile}`,
+      );
+      return entries[0];
+    }
+
+    this.logger.debug(
+      `Adding ${entries.length} pages/parts to the media contents`,
+    );
+    return entries;
+  }
+
+  private createEntry(
+    fileName: string,
+    data: string,
+    mediaType: string,
+    mediaCategory: ProcessedMediaResult['kind'],
+    absolutePath: string,
+    matchesSource: boolean,
+  ): MediaEntry {
+    const entry: MediaEntry = {
+      file_name: fileName,
+      data,
+      media_type: mediaType,
+      media_category: mediaCategory,
+      binary_data: Buffer.from(data, 'base64'),
+      bytes_match_source: matchesSource,
+    };
+
+    if (matchesSource) {
+      entry.source_path = absolutePath;
+    }
+
+    return entry;
+  }
+
+  private isAudio(ext: string): boolean {
+    const mimeType = getMimeType(ext);
+    return mimeType !== null && mimeType.startsWith('audio/');
+  }
+}

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -314,7 +314,8 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
 
   it('builds media entries once and delegates upload inside createMediaMessage', async () => {
     const uploadedEntries: MediaEntry[][] = [];
-    const buildCalls: string[][] = [];
+    const loadCalls: string[][] = [];
+    const loggedResults: Array<Array<{ path: string; ok: boolean }>> = [];
 
     class RecordingHandler extends ModelHandlerGoogleGenAI {
       constructor(config: ModelConfig) {
@@ -323,25 +324,6 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
 
       override async getClient(): Promise<any> {
         throw new Error('getClient should not be called in this test');
-      }
-
-      override async buildMediaEntries(mediaFiles: string[]): Promise<{
-        entries: MediaEntry[];
-        results: Array<{ path: string; ok: boolean }>;
-      }> {
-        buildCalls.push(mediaFiles);
-        return {
-          entries: [
-            {
-              file_name: 'doc.pdf',
-              data: Buffer.from('%PDF-1.4').toString('base64'),
-              media_type: 'application/pdf',
-              media_category: 'image',
-              binary_data: Buffer.from('%PDF-1.4'),
-            },
-          ],
-          results: [{ path: 'doc.pdf', ok: true }],
-        };
       }
 
       override async uploadMediaEntries(
@@ -356,15 +338,60 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
     const { logger, stub } = createLoggerStub();
     handler.setLogger(logger);
 
+    const handlerMediaProcessor = handler as unknown as {
+      mediaProcessor: {
+        loadEntries: (
+          mediaFiles: string[],
+        ) => Promise<{
+          entries: MediaEntry[];
+          results: Array<{ path: string; ok: boolean }>;
+        }>;
+        logResults: (results: Array<{ path: string; ok: boolean }>) => void;
+      };
+    };
+    const originalLoadEntries = handlerMediaProcessor.mediaProcessor.loadEntries.bind(
+      handlerMediaProcessor.mediaProcessor,
+    );
+    const originalLogResults = handlerMediaProcessor.mediaProcessor.logResults.bind(
+      handlerMediaProcessor.mediaProcessor,
+    );
+
+    handlerMediaProcessor.mediaProcessor.loadEntries = async (
+      mediaFiles: string[],
+    ) => {
+      loadCalls.push(mediaFiles);
+      return {
+        entries: [
+          {
+            file_name: 'doc.pdf',
+            data: Buffer.from('%PDF-1.4').toString('base64'),
+            media_type: 'application/pdf',
+            media_category: 'image',
+            binary_data: Buffer.from('%PDF-1.4'),
+          },
+        ],
+        results: [{ path: 'doc.pdf', ok: true }],
+      };
+    };
+
+    handlerMediaProcessor.mediaProcessor.logResults = (results) => {
+      loggedResults.push(results);
+      originalLogResults(results);
+    };
+
     const parts = await handler.createMediaMessage(['doc.pdf']);
 
+    assert.deepEqual(loadCalls, [['doc.pdf']]);
     assert.deepEqual(parts, [
       createPartFromUri('files/doc', 'application/pdf'),
     ]);
-    assert.deepEqual(buildCalls, [['doc.pdf']]);
     assert.equal(uploadedEntries.length, 1, 'uploads should run once');
     assert.equal(uploadedEntries[0][0].file_name, 'doc.pdf');
     assert.equal(stub.fileListEntries.length, 1, 'should log processed media');
+    assert.deepEqual(loggedResults, [[{ path: 'doc.pdf', ok: true }]]);
+
+    handlerMediaProcessor.mediaProcessor.loadEntries = originalLoadEntries;
+    handlerMediaProcessor.mediaProcessor.logResults = originalLogResults;
   });
 });
 

--- a/src/test/agent/modelHandlers/support/MediaAttachmentProcessor.test.ts
+++ b/src/test/agent/modelHandlers/support/MediaAttachmentProcessor.test.ts
@@ -1,0 +1,232 @@
+// Standard library imports
+import { Buffer } from 'buffer';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import { PDFDocument, StandardFonts } from '@cantoo/pdf-lib';
+
+// Local imports - agent
+import {
+  MediaAttachmentProcessor,
+  type MediaFileResult,
+} from '@agent/modelHandlers/support/MediaAttachmentProcessor';
+import type { AgentLogger } from '@logger/AgentLogger';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelCapabilities,
+} from '@model/ModelConfig';
+import { AbsoluteFS } from '@utils/files';
+
+interface LoggerStub extends Partial<AgentLogger> {
+  channelId: string;
+  debugMessages: string[];
+  warnMessages: string[];
+  errorMessages: string[];
+  fileListEntries: MediaFileResult[][];
+}
+
+function createLoggerStub(): { logger: AgentLogger; stub: LoggerStub } {
+  const stub: LoggerStub = {
+    channelId: 'media-test',
+    debugMessages: [],
+    warnMessages: [],
+    errorMessages: [],
+    fileListEntries: [],
+    debug(message: string) {
+      this.debugMessages.push(message);
+    },
+    info: () => {
+      /* no-op */
+    },
+    warn(message: string) {
+      this.warnMessages.push(message);
+    },
+    error(message: string) {
+      this.errorMessages.push(message);
+    },
+    fileList(entries: MediaFileResult[]) {
+      this.fileListEntries.push(entries);
+    },
+    getActiveGroupId: () => undefined,
+  };
+
+  return { logger: stub as unknown as AgentLogger, stub };
+}
+
+describe('MediaAttachmentProcessor', () => {
+  const absoluteFsAny = AbsoluteFS as unknown as {
+    exists: (filePath: string) => Promise<boolean>;
+    stat: (
+      filePath: string,
+    ) => Promise<{ type: number; ctime: number; mtime: number; size: number }>;
+  };
+  const originalExists = absoluteFsAny.exists;
+  const originalStat = absoluteFsAny.stat;
+
+  before(() => {
+    absoluteFsAny.exists = async (filePath: string) => {
+      if (!path.isAbsolute(filePath)) {
+        throw new Error(`Expected absolute path, received ${filePath}`);
+      }
+      return fs.existsSync(filePath);
+    };
+
+    absoluteFsAny.stat = async (filePath: string) => {
+      if (!path.isAbsolute(filePath)) {
+        throw new Error(`Expected absolute path, received ${filePath}`);
+      }
+      const stats = fs.statSync(filePath);
+      return {
+        type: 0,
+        ctime: stats.ctimeMs,
+        mtime: stats.mtimeMs,
+        size: stats.size,
+      };
+    };
+  });
+
+  after(() => {
+    absoluteFsAny.exists = originalExists;
+    absoluteFsAny.stat = originalStat;
+  });
+
+  function createProcessor(
+    logger: AgentLogger,
+    capabilities: Partial<ModelCapabilities>,
+    isOpenAIProvider: boolean = true,
+  ): MediaAttachmentProcessor {
+    const mergedCapabilities: ModelCapabilities = {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      ...capabilities,
+    };
+
+    return new MediaAttachmentProcessor(logger, {
+      getCapabilities: () => mergedCapabilities,
+      isOpenAIProvider: () => isOpenAIProvider,
+    });
+  }
+
+  function createTempFile(fileName: string, contents: Buffer): string {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'media-processor-test-'),
+    );
+    const filePath = path.join(directory, fileName);
+    fs.writeFileSync(filePath, contents);
+    return filePath;
+  }
+
+  async function createPdfFixture(): Promise<string> {
+    const pdfDoc = await PDFDocument.create();
+    const page = pdfDoc.addPage([200, 200]);
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    page.setFont(font);
+    page.setFontSize(12);
+    page.drawText('Media processor PDF fixture', { x: 24, y: 100 });
+    const pdfBytes = await pdfDoc.save();
+    return createTempFile('fixture.pdf', Buffer.from(pdfBytes));
+  }
+
+  function createSilenceWavBuffer(
+    durationMs = 250,
+    sampleRate = 8000,
+  ): Buffer {
+    const bytesPerSample = 2; // 16-bit mono audio
+    const sampleCount = Math.max(1, Math.floor((sampleRate * durationMs) / 1000));
+    const pcmData = Buffer.alloc(sampleCount * bytesPerSample);
+
+    const header = Buffer.alloc(44);
+    header.write('RIFF', 0);
+    header.writeUInt32LE(36 + pcmData.length, 4);
+    header.write('WAVE', 8);
+    header.write('fmt ', 12);
+    header.writeUInt32LE(16, 16); // Subchunk1Size for PCM
+    header.writeUInt16LE(1, 20); // Audio format PCM
+    header.writeUInt16LE(1, 22); // Mono
+    header.writeUInt32LE(sampleRate, 24);
+    header.writeUInt32LE(sampleRate * bytesPerSample, 28); // Byte rate
+    header.writeUInt16LE(bytesPerSample, 32); // Block align
+    header.writeUInt16LE(16, 34); // Bits per sample
+    header.write('data', 36);
+    header.writeUInt32LE(pcmData.length, 40);
+
+    return Buffer.concat([header, pcmData]);
+  }
+
+  function createAudioFixture(): string {
+    return createTempFile('fixture.wav', createSilenceWavBuffer());
+  }
+
+  function createEmptyFixture(): string {
+    return createTempFile('empty.bin', Buffer.alloc(0));
+  }
+
+  it('processes PDF fixtures using native ingestion when supported', async () => {
+    const pdfPath = await createPdfFixture();
+    const { logger, stub } = createLoggerStub();
+    const processor = createProcessor(logger, {
+      supportsVision: true,
+      supportsNativePdf: true,
+    });
+
+    const { entries, results } = await processor.loadEntries([pdfPath]);
+
+    assert.deepEqual(results, [{ path: pdfPath, ok: true }]);
+    assert.equal(entries.length, 1, 'expected a single PDF entry');
+
+    const [entry] = entries;
+    assert.equal(entry.media_type, 'application/pdf');
+    assert.equal(entry.media_category, 'image');
+    assert.equal(entry.source_path, pdfPath);
+    assert.equal(entry.bytes_match_source, true);
+    assert.ok(entry.data.length > 0, 'PDF data should be base64 encoded');
+
+    processor.logResults(results);
+    assert.equal(stub.fileListEntries.length, 1, 'should log processed PDF');
+    assert.equal(stub.warnMessages.length, 0, 'no warnings expected for valid PDF');
+  });
+
+  it('processes native audio fixtures into audio media entries', async () => {
+    const audioPath = createAudioFixture();
+    const { logger, stub } = createLoggerStub();
+    const processor = createProcessor(
+      logger,
+      {
+        supportsNativeAudio: true,
+      },
+      false,
+    );
+
+    const { entries, results } = await processor.loadEntries([audioPath]);
+
+    assert.deepEqual(results, [{ path: audioPath, ok: true }]);
+    assert.equal(entries.length, 1, 'expected a single audio entry');
+
+    const [entry] = entries;
+    assert.equal(entry.media_category, 'audio');
+    assert.ok(entry.media_type.startsWith('audio/'));
+    assert.equal(entry.source_path, audioPath);
+    assert.equal(entry.bytes_match_source, true);
+    assert.ok(entry.data.length > 0, 'Audio data should be base64 encoded');
+
+    processor.logResults(results);
+    assert.equal(stub.fileListEntries.length, 1, 'should log processed audio');
+  });
+
+  it('reports empty media fixtures as failed loads', async () => {
+    const emptyPath = createEmptyFixture();
+    const { logger, stub } = createLoggerStub();
+    const processor = createProcessor(logger, { supportsVision: true });
+
+    const { entries, results } = await processor.loadEntries([emptyPath]);
+
+    assert.equal(entries.length, 0, 'empty files should not yield entries');
+    assert.deepEqual(results, [{ path: emptyPath, ok: false }]);
+
+    processor.logResults(results);
+    assert.equal(stub.fileListEntries.length, 1, 'should log failed media');
+    assert.equal(stub.warnMessages.length, 1, 'should warn about failed media');
+  });
+});


### PR DESCRIPTION
## Summary
- streamline the media attachment processor with helpers for resolving paths, sharing PDF handling, and building entry payloads
- generate PDF, audio, and empty fixtures on the fly during unit tests to keep binary assets out of the repository
- delete the previously added binary media samples from resources

## Testing
- npm run compile-tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6905cd1bcee48324b65d1fc55af6413f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes media (PDF/image/audio) handling into `MediaAttachmentProcessor` and updates `ModelHandler`/Google GenAI handler to delegate loading/logging, with new fixture-based tests.
> 
> - **Agent core**:
>   - **Media processing extraction**: New `support/MediaAttachmentProcessor` handles path resolution, mime detection, PDF-to-PNG/native PDF, audio/image base64 encoding, entry creation, and result logging (`logResults`).
>   - **`ModelHandler` integration**: Adds `mediaProcessor` field; delegates `createMediaMessage` to `mediaProcessor.loadEntries` + `logResults`; removes in-class media processing.
> - **Google GenAI handler**:
>   - Uses `mediaProcessor.loadEntries`/`logResults` in `createMediaMessage`; uploads entries via existing `uploadMediaEntries` flow; keeps `createMediaContent` as deprecated shim.
> - **Tests**:
>   - New `support/MediaAttachmentProcessor.test.ts` generating PDF/audio/empty fixtures on-the-fly; verifies native PDF/audio handling and logging.
>   - Updated `ModelHandlerGoogleGenAI.test.ts` to assert single-load delegation, upload behavior, and logging; avoids duplicate fileList logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9bf2892c95958448cad99f543e0bc0e04df58f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->