### PR TITLE
Fix Anthropic cache control limit enforcement

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -114,6 +114,8 @@ const EPHEMERAL_CACHE_CONTROL: BetaCacheControlEphemeral = {
   type: 'ephemeral',
 };
 
+const MAX_CACHE_CONTROLLED_BLOCKS = 4;
+
 const isCacheControlEligibleBlock = (
   block: ContentBlockParam | ContentBlock | undefined,
 ): block is CacheControlEligibleBlock => {
@@ -235,6 +237,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const effectiveContextWindow = isAnthropic1MBetaActive
       ? ANTHROPIC_1M_CONTEXT_WINDOW
       : this.config.contextWindow;
+
+    this.enforceCacheControlLimit(messages);
 
     const documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
@@ -494,6 +498,53 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     return response;
+  }
+
+  private enforceCacheControlLimit(messages: MessageParam[]): void {
+    if (!this.capabilities.supportsPromptCaching) {
+      return;
+    }
+
+    const cacheControlledBlocks: CacheControlEligibleBlock[] = [];
+
+    for (const message of messages) {
+      const content = message.content;
+      if (!Array.isArray(content) || content.length === 0) {
+        continue;
+      }
+
+      for (const block of content) {
+        if (!isCacheControlEligibleBlock(block)) {
+          if (
+            block &&
+            typeof block === 'object' &&
+            'cache_control' in block &&
+            (block as { cache_control?: unknown }).cache_control
+          ) {
+            delete (block as { cache_control?: unknown }).cache_control;
+          }
+          continue;
+        }
+
+        if (block.cache_control) {
+          cacheControlledBlocks.push(block);
+        }
+      }
+    }
+
+    if (cacheControlledBlocks.length <= MAX_CACHE_CONTROLLED_BLOCKS) {
+      this.cacheControlledBlock = cacheControlledBlocks.at(-1);
+      return;
+    }
+
+    const excess = cacheControlledBlocks.length - MAX_CACHE_CONTROLLED_BLOCKS;
+    for (let idx = 0; idx < excess; idx += 1) {
+      const block = cacheControlledBlocks[idx];
+      delete block.cache_control;
+    }
+
+    const remainingBlocks = cacheControlledBlocks.slice(excess);
+    this.cacheControlledBlock = remainingBlocks.at(-1);
   }
 
   private async replaceDocumentDataWithUploads(

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -326,6 +326,46 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('limits cache control markers to the latest four blocks', () => {
+    const handler = createAnthropicHandler();
+    const messageContent: ContentBlockParam[] = [];
+
+    for (let idx = 0; idx < 5; idx += 1) {
+      messageContent.push({
+        type: 'text',
+        text: `block-${idx}`,
+        citations: null,
+        cache_control: { type: 'ephemeral' },
+      } as ContentBlockParam & { cache_control: { type: 'ephemeral' } });
+    }
+
+    const messages: MessageParam[] = [
+      { role: 'user', content: messageContent },
+    ];
+
+    (handler as any).enforceCacheControlLimit(messages);
+
+    const cacheControlledBlocks = messageContent.filter(
+      (block) =>
+        'cache_control' in block &&
+        (block as { cache_control?: unknown }).cache_control !== undefined,
+    );
+
+    assert.equal(cacheControlledBlocks.length, 4);
+    assert.equal(
+      (messageContent[0] as { cache_control?: unknown }).cache_control,
+      undefined,
+      'the earliest cache marker should be removed',
+    );
+    assert.deepEqual(
+      cacheControlledBlocks.map(
+        (block) => (block as { text?: string }).text,
+      ),
+      ['block-1', 'block-2', 'block-3', 'block-4'],
+      'the four most recent blocks should retain cache control markers',
+    );
+  });
+
   it('trims follow-up text and rejects empty follow-ups', async () => {
     const handler = createAnthropicHandler();
     const baseMessages = await handler.initializeMessages('prefix', 'request');


### PR DESCRIPTION
## Summary
- ensure Anthropic message payloads never exceed four cache_control markers by pruning older entries
- clean up stray cache metadata on ineligible blocks while keeping the newest marker reference current
- add unit coverage for the cache control limiter to confirm only the latest four markers remain

## Testing
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_69066493a4148324a37ce73373296dd2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces a hard limit of four cache_control markers by pruning older/ineligible blocks before requests, and adds a unit test to verify the behavior.
> 
> - **Model handler (`src/agent/modelHandlers/modelHandlerAnthropic.ts`)**:
>   - Add `MAX_CACHE_CONTROLLED_BLOCKS = 4` and `enforceCacheControlLimit()` to cap `cache_control` markers to four.
>   - Prune earliest markers beyond the limit and remove stray `cache_control` from ineligible blocks.
>   - Update `createResponse()` to invoke the limiter; keep latest eligible block reference via `cacheControlledBlock`.
> - **Tests (`src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts`)**:
>   - Add test ensuring only the four most recent blocks retain `cache_control` markers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 048b2c61c7a614214cb66e767668682f1111a83b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->