### PR TITLE
refactor: share agent run context across execution

### DIFF
--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -2,6 +2,8 @@
 import type { AgentConfig } from './AgentConfig';
 // Local imports - agent components
 import type { AgentSessionDescriptor } from './AgentDataclass';
+// Local imports - agent runtime
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 // Local imports - agent types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
@@ -11,6 +13,9 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 export interface IAgent {
   /** Agent configuration used during execution. */
   readonly config: AgentConfig;
+
+  /** Apply the shared runtime context for this execution. */
+  applyRunContext(context: AgentRunContext): void;
 
   /**
    * Initialize the agent before running.

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -13,10 +13,12 @@ import { buildUserVars } from '../utils/userVars';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
 
+// Local imports - runtime
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
+
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { getStreamTabId as buildStreamTabId } from '@/logger/streamUtils';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
@@ -31,8 +33,8 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   protected agentSetting: AgentSetting;
   protected agentPrompt: AgentPrompt;
   protected agentPath: string;
-  protected logger: AgentLogger;
-  protected usageMonitor: UsageMonitor;
+  protected logger!: AgentLogger;
+  protected usageMonitor!: UsageMonitor;
   protected runGroupId?: string;
   private lastRunGroupId?: string;
   protected userVars: Record<string, any> = {};
@@ -40,6 +42,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   protected isInterrupted = false;
   protected abortController: AbortController | null = null;
   protected executionId?: ExecutionId;
+  private runContext?: AgentRunContext;
 
   private static runningAgents: Map<string, BaseAgent> = new Map();
 
@@ -61,24 +64,26 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ) {
     this.modelHandler = modelHandler;
     this.agentConfig = agentConfig;
     this.agentSetting = agentSetting;
     this.agentPrompt = agentPrompt;
     this.agentPath = agentPath;
-    this.executionId = executionId;
+  }
 
-    const streamTabId = this.getStreamTabId();
-    this.logger = new AgentLogger(streamTabId, true);
-    this.modelHandler.setLogger(this.logger);
+  public applyRunContext(context: AgentRunContext): void {
+    this.runContext = context;
+    this.executionId = context.executionId;
+    this.logger = context.logger;
+    this.modelHandler.setLogger(context.logger);
     this.modelHandler.setAgentType(this.agentSetting.agentType);
-    this.usageMonitor = new UsageMonitor(
-      this.modelHandler,
-      this.logger.channelId,
-      this.logger,
-    );
+    this.usageMonitor = new UsageMonitor(this.modelHandler, context);
+    this.onRunContextApplied(context);
+  }
+
+  protected onRunContextApplied(_context: AgentRunContext): void {
+    // Subclasses can override to perform setup that depends on the run context.
   }
 
   /** Initialize the API client. */
@@ -118,17 +123,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
 
   /** Compute the stream tab identifier for this agent execution. */
   public getStreamTabId(): StreamTabId {
-    const metadata = this.getSessionMetadata();
-    return buildStreamTabId(
-      this.agentConfig.agent,
-      this.agentConfig.model,
-      this.agentConfig.inputFile,
-      {
-        agentType: metadata.agentType,
-        executionId: this.executionId,
-        useMultipleOutputs: this.agentConfig.useMultipleOutputs,
-      },
-    );
+    if (!this.runContext) {
+      throw new Error('Agent run context has not been applied.');
+    }
+    return this.runContext.streamTabId;
   }
 
   /** Gather variables used for prompt rendering. */

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -26,7 +26,7 @@ import {
 } from '@agent/implementations/flows/ReflectionRoundFlow';
 import type { IModelHandler } from '@agent/modelHandlers';
 import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import { writePromptToXml } from '@agent/utils/promptUtils';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -98,8 +98,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   protected useScratchpad: boolean = false;
   protected logId: number = 0;
   /** Handler for output file processing and validation. */
-  protected outputHandler: IOutputHandler;
-  protected latexMediaManager: LatexMediaManager;
+  protected outputHandler!: IOutputHandler;
+  protected latexMediaManager!: LatexMediaManager;
   protected promptBuilder?: PromptBuilder;
   public roundStates: AgentStateRound[] = [];
   public toolStates: ToolState[] = [];
@@ -110,17 +110,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ) {
     const workflowSetting = requireWorkflowSetting(agentSetting);
-    super(
-      modelHandler,
-      agentConfig,
-      workflowSetting,
-      agentPrompt,
-      agentPath,
-      executionId,
-    );
+    super(modelHandler, agentConfig, workflowSetting, agentPrompt, agentPath);
     this.agentSetting = workflowSetting;
 
     // Initialize basic attributes
@@ -146,16 +138,17 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
     // Initialize logging
     this.logId = 0;
+  }
 
+  protected override onRunContextApplied(context: AgentRunContext): void {
     this.outputHandler = new OutputHandler(
       this.agentSetting,
       this.agentConfig,
       this.logId,
       this.baseFiles,
-      this.logger,
+      context,
     );
-
-    this.latexMediaManager = new LatexMediaManager(this.logger);
+    this.latexMediaManager = new LatexMediaManager(context.logger);
   }
 
   protected getPromptBuilder(): PromptBuilder {

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -27,7 +27,7 @@ import type { AgentRunHooks } from '@agent/implementations/flows/common/types';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
-import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   ToolUseSessionManager,
@@ -54,16 +54,8 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ) {
-    super(
-      modelHandler,
-      agentConfig,
-      agentSetting,
-      agentPrompt,
-      agentPath,
-      executionId,
-    );
+    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
     this.toolRegistry = DEFAULT_TOOL_REGISTRY;
   }
 

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -10,7 +10,6 @@ import { RoundOutputOptions } from './BaseReflectionAgent';
 // Local imports - agent components
 import { DirectAgent } from './DirectAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 /**
  * Specialized agent for merging multiple edited files into a consolidated output.
@@ -23,16 +22,8 @@ export class MergeAgent extends DirectAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ) {
-    super(
-      modelHandler,
-      agentConfig,
-      agentSetting,
-      agentPrompt,
-      agentPath,
-      executionId,
-    );
+    super(modelHandler, agentConfig, agentSetting, agentPrompt, agentPath);
     this.outputFile = [this.getOutputFile(0), this.getOutputFile(1)];
   }
 

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -33,13 +33,14 @@ import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { runLatexFormatter } from '@latex/texFormatter';
 
 // Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - utilities
 import { replaceInputCommands, createFileMapping } from '@utils/files';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
+import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - types
 
@@ -53,19 +54,26 @@ export class OutputHandler implements IOutputHandler {
   private roundMappings: { [key: number]: RoundFileMapping };
   public baseFiles: string[];
   public processGroupId?: string;
-  protected logger: AgentLogger;
-  protected channel: string;
+  protected context: AgentRunContext;
   public readonly xmlManager: XmlOutputManager;
   public readonly diffManager: LatexDiffManager;
   private diffStatsManager: DiffStatsManager;
   private readonly openedOutputs: Set<string>;
+
+  protected get logger(): AgentLogger {
+    return this.context.logger;
+  }
+
+  protected get channel(): string {
+    return this.context.streamTabId;
+  }
 
   constructor(
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
     logId: number,
     baseFiles: string[] = [],
-    logger?: AgentLogger,
+    context: AgentRunContext,
   ) {
     this.agentSetting = requireWorkflowSetting(agentSetting);
     this.agentConfig = agentConfig;
@@ -74,20 +82,19 @@ export class OutputHandler implements IOutputHandler {
     this.outputMappings = {};
     this.roundMappings = {};
     this.baseFiles = baseFiles;
-    this.logger = logger || new AgentLogger('OutputHandler');
-    this.channel = this.logger.channelId;
+    this.context = context;
 
     this.xmlManager = new XmlOutputManager(
       this.agentSetting,
       this.agentConfig,
-      this.logger,
+      this.context.logger,
     );
     this.diffManager = new LatexDiffManager(
       this.agentSetting,
       this.outputFiles,
       this.baseFiles,
-      this.logger,
-      this.channel,
+      this.context.logger,
+      this.context.streamTabId,
     );
     this.diffStatsManager = new DiffStatsManager();
     this.openedOutputs = new Set();

--- a/src/agent/runtime/AgentRunContext.ts
+++ b/src/agent/runtime/AgentRunContext.ts
@@ -1,0 +1,28 @@
+// Local imports - agent components
+import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+
+// Local imports - logging
+import { AgentLogger } from '@logger/AgentLogger';
+
+/**
+ * Shared execution context for a single agent run.
+ *
+ * Encapsulates identifiers and logging state so that every component
+ * participating in the run (agent, model handler, utilities) can rely on the
+ * same identifiers and logger instance.
+ */
+export interface AgentRunContext {
+  /** Fully-qualified stream tab identifier used for routing logs and updates. */
+  readonly streamTabId: StreamTabId;
+  /** Optional execution identifier used for persisted runs. */
+  readonly executionId?: ExecutionId;
+  /** Human-readable agent name for diagnostics. */
+  readonly agentName: string;
+  /** Model identifier configured for the run. */
+  readonly model: string;
+  /** Session classification metadata. */
+  readonly session: AgentSessionDescriptor;
+  /** Primary logger scoped to the stream tab. */
+  readonly logger: AgentLogger;
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -26,6 +26,7 @@ import {
 } from '@agent/runtime/agentLoad';
 import { ModelFactory } from '@agent/runtime/ModelFactory';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   AgentDirectorySource,
@@ -37,6 +38,7 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
 import { withLogGroup } from '@logger/logGroupUtils';
+import { getStreamTabId as buildStreamTabId } from '@logger/streamUtils';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { agentConfigToTaskState } from '@utils/config';
@@ -75,7 +77,6 @@ type AgentConstructor = {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
   ): IAgent;
 };
 
@@ -305,7 +306,6 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
     agentSetting,
     agentPrompt,
     agentPathInfo.directory,
-    executionId,
   );
 
   return { agent: agent as T, agentType: agentSetting.agentType };
@@ -333,28 +333,48 @@ export async function executeAgentWithLogging<T extends IAgent>(
     const created = await createAgentFn();
     agent = created.agent;
     const { agentType } = created;
-    const sessionMetadata = agent.getSessionMetadata();
 
     if (executionId) {
       await ensureRunDir(executionId);
     }
 
-    // Get the full stream tab ID
     const config = agent.config;
     const metadata = config.session;
     if (!metadata) {
       throw new Error('Agent configuration is missing session metadata.');
     }
 
-    streamTabId = agent.getStreamTabId();
+    const resolvedStreamTabId = buildStreamTabId(
+      config.agent,
+      config.model,
+      config.inputFile,
+      {
+        agentType: metadata.agentType,
+        executionId,
+        useMultipleOutputs: config.useMultipleOutputs,
+      },
+    );
 
-    if (!streamTabId) {
+    if (!resolvedStreamTabId) {
       throw new Error('Failed to resolve stream tab ID for agent execution');
     }
 
-    const activeStreamId: StreamTabId = streamTabId;
+    const runContext: AgentRunContext = {
+      streamTabId: resolvedStreamTabId,
+      executionId,
+      agentName,
+      model: config.model,
+      session: metadata,
+      logger: new AgentLogger(resolvedStreamTabId, true),
+    };
 
-    agentStreamLogger = new AgentLogger(activeStreamId, true);
+    agent.applyRunContext(runContext);
+
+    streamTabId = resolvedStreamTabId;
+
+    const activeStreamId: StreamTabId = resolvedStreamTabId;
+
+    agentStreamLogger = runContext.logger;
 
     // Check if this stream is already running
     const provider = ProgressViewProvider.getInstance();

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1,3 +1,4 @@
 export * from './executeAgent';
 export * from './agentLoad';
 export * from './ModelFactory';
+export * from './AgentRunContext';

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -14,9 +14,8 @@ import type {
   TokenUsageStats,
   ExtendedTokenUsageStats,
 } from '@agent/types/UsageTypes';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 import { bus } from '@eventBus/ProgressEventBus';
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
 
 /**
  * Handles recording usage statistics to the log and progress view.
@@ -24,15 +23,14 @@ import { AgentLogger } from '@logger/AgentLogger';
 export class UsageMonitor {
   constructor(
     private readonly modelHandler: IModelHandler,
-    private readonly channel: string,
-    private readonly logger: AgentLogger,
+    private readonly context: AgentRunContext,
   ) {}
 
   async recordUsage(
     stateGlobal: AgentStateGlobal,
     groupId?: string,
   ): Promise<void> {
-    const statsGroupId = groupId ?? this.logger.getActiveGroupId();
+    const statsGroupId = groupId ?? this.context.logger.getActiveGroupId();
 
     try {
       let responseUsage:
@@ -103,7 +101,7 @@ export class UsageMonitor {
 
       if (statsGroupId) {
         bus.emit('updateGroupUsage', {
-          stream: this.channel,
+          stream: this.context.streamTabId,
           groupId: statsGroupId,
           usage: {
             inputTokens:
@@ -156,9 +154,12 @@ export class UsageMonitor {
         }),
       };
 
-      this.logger.statistics(payload, statsGroupId);
+      this.context.logger.statistics(payload, statsGroupId);
     } catch (error) {
-      this.logger.error(`Error printing statistics: ${error}`, statsGroupId);
+      this.context.logger.error(
+        `Error printing statistics: ${error}`,
+        statsGroupId,
+      );
     }
   }
 }

--- a/src/test/agent/runtime/executeAgentWithLogging.test.ts
+++ b/src/test/agent/runtime/executeAgentWithLogging.test.ts
@@ -1,0 +1,187 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent
+import { parseAgentConfig, type AgentConfig } from '@agent/core/AgentConfig';
+import {
+  AgentType,
+  AgentCategory,
+  type AgentSessionDescriptor,
+} from '@agent/core/AgentDataclass';
+import type { AgentRunHooks, IAgent } from '@agent/core/IAgent';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
+import { executeAgentWithLogging } from '@agent/runtime/executeAgent';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+
+// Local imports - progress view
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+
+// Local imports - logging
+import { getStreamTabId as buildStreamTabId } from '@logger/streamUtils';
+
+class StubAgent implements IAgent {
+  public config: AgentConfig;
+  public appliedContext?: AgentRunContext;
+  public initCalled = false;
+  public runCalled = false;
+
+  constructor(config: AgentConfig, session: AgentSessionDescriptor) {
+    this.config = { ...config, session };
+  }
+
+  applyRunContext(context: AgentRunContext): void {
+    this.appliedContext = context;
+  }
+
+  async init(): Promise<void> {
+    this.initCalled = true;
+  }
+
+  async run(): Promise<void> {
+    if (!this.appliedContext) {
+      throw new Error('run invoked without applied context');
+    }
+    this.runCalled = true;
+  }
+
+  interrupt(): void {
+    /* noop */
+  }
+
+  getStreamTabId(): StreamTabId {
+    if (!this.appliedContext) {
+      throw new Error('stream requested without context');
+    }
+    return this.appliedContext.streamTabId;
+  }
+
+  getSessionMetadata(): AgentSessionDescriptor {
+    if (!this.config.session) {
+      throw new Error('missing session metadata');
+    }
+    return this.config.session;
+  }
+
+  getLastRunGroupId(): string | undefined {
+    return undefined;
+  }
+
+  getRunHooks(): AgentRunHooks {
+    return {
+      start: async () => undefined,
+      init: async () => {},
+      initializeClient: async () => {},
+      end: () => {},
+      cleanup: () => {},
+    };
+  }
+}
+
+describe('executeAgentWithLogging', () => {
+  const originalGetInstance = ProgressViewProvider.getInstance;
+  const originalExecuteCommand = vscode.commands.executeCommand;
+  const originalShowInformation = vscode.window.showInformationMessage;
+  const originalShowError = vscode.window.showErrorMessage;
+
+  afterEach(() => {
+    (
+      ProgressViewProvider as typeof ProgressViewProvider & {
+        getInstance: typeof ProgressViewProvider.getInstance;
+      }
+    ).getInstance = originalGetInstance;
+    (
+      vscode.commands as typeof vscode.commands & {
+        executeCommand: typeof vscode.commands.executeCommand;
+      }
+    ).executeCommand = originalExecuteCommand;
+    (
+      vscode.window as typeof vscode.window & {
+        showInformationMessage: typeof vscode.window.showInformationMessage;
+      }
+    ).showInformationMessage = originalShowInformation;
+    (
+      vscode.window as typeof vscode.window & {
+        showErrorMessage: typeof vscode.window.showErrorMessage;
+      }
+    ).showErrorMessage = originalShowError;
+  });
+
+  it('applies a shared run context before running the agent', async () => {
+    const config = parseAgentConfig({
+      agent: 'stub-agent',
+      model: 'stub-model',
+      instruction: 'demo',
+      inputFile: 'input.tex',
+    });
+
+    const session: AgentSessionDescriptor = {
+      agentType: AgentType.Direct,
+      agentCategory: AgentCategory.Workflow,
+    };
+
+    const agent = new StubAgent(config, session);
+    const statuses: Record<string, string | undefined> = {};
+
+    (
+      ProgressViewProvider as typeof ProgressViewProvider & {
+        getInstance: typeof ProgressViewProvider.getInstance;
+      }
+    ).getInstance = () =>
+      ({
+        isViewVisible: () => true,
+        eventHandler: {
+          getStreamStatus: (stream: string) => statuses[stream],
+          setStreamStatus: (stream: string, status: string) => {
+            statuses[stream] = status;
+          },
+        },
+      }) as unknown as ProgressViewProvider;
+
+    (
+      vscode.commands as typeof vscode.commands & {
+        executeCommand: typeof vscode.commands.executeCommand;
+      }
+    ).executeCommand = () => Promise.resolve(undefined) as any;
+
+    (
+      vscode.window as typeof vscode.window & {
+        showInformationMessage: typeof vscode.window.showInformationMessage;
+      }
+    ).showInformationMessage = () => Promise.resolve(undefined) as any;
+
+    (
+      vscode.window as typeof vscode.window & {
+        showErrorMessage: typeof vscode.window.showErrorMessage;
+      }
+    ).showErrorMessage = () => Promise.resolve(undefined) as any;
+
+    await executeAgentWithLogging('stub-agent', async () => ({
+      agent,
+      agentType: AgentType.Direct,
+    }));
+
+    assert.ok(agent.appliedContext, 'expected run context to be applied');
+    const context = agent.appliedContext!;
+
+    const expectedStreamId = buildStreamTabId(
+      config.agent,
+      config.model,
+      config.inputFile,
+      {
+        agentType: session.agentType,
+        executionId: undefined,
+        useMultipleOutputs: config.useMultipleOutputs,
+      },
+    );
+
+    assert.strictEqual(context.streamTabId, expectedStreamId);
+    assert.strictEqual(context.logger.channelId, expectedStreamId);
+    assert.deepStrictEqual(context.session, session);
+    assert.ok(agent.initCalled, 'expected init to run');
+    assert.ok(agent.runCalled, 'expected run to execute');
+    assert.strictEqual(statuses[expectedStreamId], 'stopped');
+  });
+});

--- a/src/test/output/LatexDiffManager.test.ts
+++ b/src/test/output/LatexDiffManager.test.ts
@@ -8,12 +8,14 @@ import {
   AgentCategory,
   AgentSetting,
   AgentType,
+  type AgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
 import { OutputHandler } from '@agent/output';
 import { LatexDiffManager } from '@agent/output/LatexDiffManager';
 
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
 
 describe('LatexDiffManager mapping reuse', () => {
   const baseSetting: AgentSetting = {
@@ -49,26 +51,38 @@ describe('LatexDiffManager mapping reuse', () => {
     },
   });
 
-  function createLogger(): AgentLogger {
-    const logger = new AgentLogger('LatexDiffManagerTest');
+  const baseSession: AgentSessionDescriptor = {
+    agentType: AgentType.CoT,
+    agentCategory: AgentCategory.Workflow,
+  };
+
+  function createContext(label: string): AgentRunContext {
+    const logger = new AgentLogger(label);
     const noop = () => {};
     (logger as any).debug = noop;
     (logger as any).info = noop;
     (logger as any).warn = noop;
     (logger as any).error = noop;
     (logger as any).latexDiff = noop;
-    return logger;
+    return {
+      streamTabId: label,
+      executionId: undefined,
+      agentName: 'test-agent',
+      model: 'test-model',
+      session: baseSession,
+      logger,
+    };
   }
 
   it('uses shared base mapping for round diffs', async () => {
-    const logger = createLogger();
+    const context = createContext('LatexDiffManagerTest');
     const baseFiles = [path.join('workspace', 'chapter.tex')];
     const handler = new OutputHandler(
       baseSetting,
       baseConfig,
       0,
       baseFiles,
-      logger,
+      context,
     );
 
     handler.outputFiles[0] = [path.join('workspace', 'chapter_r0.tex')];
@@ -85,7 +99,8 @@ describe('LatexDiffManager mapping reuse', () => {
       [];
     const aggregated: unknown[][] = [];
 
-    const testLogger = createLogger();
+    const testContext = createContext('LatexDiffManagerTest-diff');
+    const testLogger = testContext.logger;
     (testLogger as any).latexDiff = (entries: unknown[]) =>
       aggregated.push(entries);
 
@@ -94,7 +109,7 @@ describe('LatexDiffManager mapping reuse', () => {
       handler.outputFiles,
       baseFiles,
       testLogger,
-      'channel',
+      testContext.streamTabId,
       {
         checkToolInstalled: async () => true,
         compileLatex2Pdf: async () => true,
@@ -124,14 +139,14 @@ describe('LatexDiffManager mapping reuse', () => {
   });
 
   it('uses shared previous mapping for between-round diffs', async () => {
-    const logger = createLogger();
+    const context = createContext('LatexDiffManagerTest');
     const baseFiles = [path.join('workspace', 'paper.tex')];
     const handler = new OutputHandler(
       baseSetting,
       baseConfig,
       0,
       baseFiles,
-      logger,
+      context,
     );
 
     handler.outputFiles[0] = [path.join('workspace', 'paper_r0.tex')];
@@ -155,14 +170,15 @@ describe('LatexDiffManager mapping reuse', () => {
       [];
     const betweenPairs: Array<{ previous: string; current: string }> = [];
 
-    const testLogger = createLogger();
+    const testContext = createContext('LatexDiffManagerTest-between');
+    const testLogger = testContext.logger;
 
     const manager = new LatexDiffManager(
       handler.agentSetting,
       handler.outputFiles,
       baseFiles,
       testLogger,
-      'channel',
+      testContext.streamTabId,
       {
         checkToolInstalled: async () => true,
         compileLatex2Pdf: async () => true,

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -8,19 +8,37 @@ import {
   AgentSetting,
   AgentType,
   AgentCategory,
+  type AgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
 import { OutputHandler } from '@agent/output';
 
 // Local imports
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
+import type { AgentRunContext } from '@agent/runtime/AgentRunContext';
+
+const baseSession: AgentSessionDescriptor = {
+  agentType: AgentType.CoT,
+  agentCategory: AgentCategory.Workflow,
+};
+
+function createRunContext(label: string): AgentRunContext {
+  return {
+    streamTabId: label,
+    executionId: undefined,
+    agentName: 'test-agent',
+    model: 'test-model',
+    session: baseSession,
+    logger: new AgentLogger(label),
+  };
+}
 
 class MockOutputHandler extends OutputHandler {
   public gatherCalled = false;
   public validateCalled = false;
 
   constructor(setting: AgentSetting, config: AgentConfig) {
-    super(setting, config, 0, [], new AgentLogger('TestOutputHandler'));
+    super(setting, config, 0, [], createRunContext('TestOutputHandler'));
   }
 
   public override async gatherOutputFileInfo(round: number) {
@@ -137,7 +155,7 @@ describe('OutputHandler.getRoundMapping', () => {
       baseConfig,
       0,
       [path.join('workspace', 'chapter.tex')],
-      new AgentLogger('TestOutputHandlerMapping'),
+      createRunContext('TestOutputHandlerMapping'),
     );
 
     handler.outputFiles[0] = [path.join('workspace', 'chapter_r0.tex')];


### PR DESCRIPTION
## Summary
- introduce an AgentRunContext definition to hold shared stream IDs, execution IDs, and the primary AgentLogger for a run
- update executeAgentWithLogging/BaseAgent to apply the shared context and reuse the logger across model handlers, usage monitoring, and output handling
- adjust OutputHandler utilities and related unit tests, adding coverage that executeAgentWithLogging wires the run context before execution

## Testing
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_69067eef167083249e4b09bc004d5fb0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce AgentRunContext and refactor agents, execution, and output/usage utilities to share stream ID, execution ID, and logger across a run, with updated tests.
> 
> - **Runtime**:
>   - Add `AgentRunContext` (stream/tab ID, execution ID, logger, session, model) and export via `runtime/index`.
>   - In `executeAgentWithLogging`, compute `streamTabId` with `buildStreamTabId`, build a shared `AgentRunContext`, and `applyRunContext` to the agent.
> - **Core/Agents**:
>   - Extend `IAgent` with `applyRunContext(context)`.
>   - Refactor `BaseAgent` to lazily set `logger`, `executionId`, and `UsageMonitor` from `AgentRunContext`; `getStreamTabId()` now returns `context.streamTabId`.
>   - Remove `executionId` ctor arg from agents; add `onRunContextApplied` hook; update `BaseReflectionAgent`, `BaseToolUseAgent`, and `MergeAgent` accordingly.
> - **Output/Usage**:
>   - Update `OutputHandler` to accept `AgentRunContext` and use `context.logger`/`context.streamTabId`; propagate to `XmlOutputManager`/`LatexDiffManager`.
>   - Refactor `UsageMonitor` to use `AgentRunContext` for logging and bus events.
> - **Tests**:
>   - Add `executeAgentWithLogging` test validating context application and stream status.
>   - Update `OutputHandler` and `LatexDiffManager` tests to construct handlers with `AgentRunContext`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3edd5f775f5f4d08b6af4c9540f6cf48783c0931. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->