### PR TITLE
feat: simplify runtime output exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- No changes yet.
+### Features
+
+- Capture XML output summaries (detected tag contents, serialized `<document>` elements, and single-output paths) so orchestrated workflows can reuse generated artifacts without re-selecting files.
 
 ## [0.34.2] - 2025-10-31
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -139,6 +139,7 @@ This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the ext
 
 - Files specified in `requiredFiles` or `requiredFilesInternal` are available as `{{ VARNAME_CONTENT }}` (e.g., `{{ TEMPLATE_CONTENT }}`).
 - Files matched by `filePatternsContain` are available as `{{ VARNAME_CONTENT }}` (e.g., `{{ BIBLIOGRAPHY_CONTENT }}`).
+- When agents finish, TeXRA automatically captures detected XML segments so orchestrated workflows can reuse them without going through the file picker again (details below).
 
 **Example Usage in `userPrefix`:**
 
@@ -163,6 +164,19 @@ userPrefix: |
 - **Multiple Outputs:** If your agent needs to generate multiple distinct files, ensure your prompts generate the required XML structure. See the [Handling Multiple Files](./multiple-output.md) guide.
 - **Start Simple:** Begin with basic settings/prompts and add complexity incrementally.
 - **Test Iteratively:** Test frequently and review logs in the ProgressBoard.
+
+### Runtime XML exports
+
+Reflection-style agents automatically collect a lightweight summary of the XML they generate. The summary is exposed as
+`runtimeXmlExports` on the agent instance so pipeline orchestrators can forward the results to follow-up steps.
+
+The structure includes three simple fields:
+
+- `tagContents`: a dictionary of detected XML tags. For `<document>` outputs this contains either a single string or an array of strings (when the model generated multiple named documents). A `<scratchpad>` tag is captured when present.
+- `documents`: a list of serialized `<document>` elements suitable for pasting directly into the next prompt.
+- `singleOutputFile`: the processed output path when the agent produced exactly one LaTeX document.
+
+Because this data lives alongside the run state, orchestrators can choose how to apply it—for example, by inserting the serialized documents straight into the next request or by handing off the processed file path to a critique step.
 
 ### Tool-Use Agents
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -25,7 +25,11 @@ import {
   type ReflectionRoundShared,
 } from '@agent/implementations/flows/ReflectionRoundFlow';
 import type { IModelHandler } from '@agent/modelHandlers';
-import { OutputHandler, NamedOutputFile, IOutputHandler } from '@agent/output';
+import {
+  OutputHandler,
+  IOutputHandler,
+  type RoundOutputArtifacts,
+} from '@agent/output';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import { writePromptToXml } from '@agent/utils/promptUtils';
@@ -71,6 +75,13 @@ export interface ReflectionRoundResult {
   messages: any[];
   shouldContinue: boolean;
   toolState: ToolState;
+  outputArtifacts: RoundOutputArtifacts | null;
+}
+
+export interface AgentRuntimeXmlExports {
+  tagContents: Record<string, string | string[]>;
+  documents: string[];
+  singleOutputFile: string | null;
 }
 
 interface RoundPipelineContext {
@@ -103,6 +114,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   protected promptBuilder?: PromptBuilder;
   public roundStates: AgentStateRound[] = [];
   public toolStates: ToolState[] = [];
+  public roundOutputArtifacts: RoundOutputArtifacts[] = [];
+  public runtimeXmlExports: AgentRuntimeXmlExports = {
+    tagContents: {},
+    documents: [],
+    singleOutputFile: null,
+  };
 
   constructor(
     modelHandler: IModelHandler<any, any, any, any, C>,
@@ -206,7 +223,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     stateRound: AgentStateRound,
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
-  ): Promise<void> {
+  ): Promise<RoundOutputArtifacts> {
     const { outputFile, endTurn, processGroupId } = options;
     try {
       // Instead of creating a new group, use the round group directly
@@ -226,6 +243,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       endTurn,
       groupId: processGroupId,
     });
+
+    const artifacts = await this.outputHandler.getRoundArtifacts(currRound);
+    this.roundOutputArtifacts[currRound] = artifacts;
+    return artifacts;
   }
 
   /**
@@ -319,7 +340,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         outputFile: outputPath,
       });
 
-      await this.handleRoundCompletion(
+      const artifacts = await this.handleRoundCompletion(
         roundIndex,
         cycleResult.stateRound,
         cycleResult.stateGlobal,
@@ -343,14 +364,20 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         messages: updatedMessages,
         shouldContinue: cycleResult.endTurn,
         toolState: cycleResult.toolState,
+        outputArtifacts: artifacts,
       };
     }
 
-    await this.handleRoundCompletion(roundIndex, roundState, globalState, {
-      outputFile: outputPath,
-      endTurn,
-      processGroupId: roundGroupId,
-    });
+    const artifacts = await this.handleRoundCompletion(
+      roundIndex,
+      roundState,
+      globalState,
+      {
+        outputFile: outputPath,
+        endTurn,
+        processGroupId: roundGroupId,
+      },
+    );
 
     return {
       roundState,
@@ -358,6 +385,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       messages: updatedMessages,
       shouldContinue: endTurn,
       toolState,
+      outputArtifacts: artifacts,
     };
   }
 
@@ -567,6 +595,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
             messages,
             shouldContinue: true,
             toolState,
+            outputArtifacts: null,
           }),
         },
       };
@@ -586,6 +615,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * Main execution method that processes inputs and generates outputs.
    */
   public async run(): Promise<void> {
+    this.roundOutputArtifacts = [];
+    this.runtimeXmlExports = {
+      tagContents: {},
+      documents: [],
+      singleOutputFile: null,
+    };
     const lifecycle: ReflectionRunLifecycle = {
       phase: 'idle',
       status: 'pending',
@@ -626,5 +661,40 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         } satisfies ReflectionRunHooks;
       },
     });
+
+    this.runtimeXmlExports = this.computeRuntimeXmlExports();
+  }
+
+  protected computeRuntimeXmlExports(): AgentRuntimeXmlExports {
+    const summary: AgentRuntimeXmlExports = {
+      tagContents: {},
+      documents: [],
+      singleOutputFile: null,
+    };
+
+    if (this.roundOutputArtifacts.length === 0) {
+      return summary;
+    }
+
+    const lastWithSummary = [...this.roundOutputArtifacts]
+      .reverse()
+      .find((artifact) => {
+        const xml = artifact.xmlSummary;
+        return (
+          Object.keys(xml.tagContents).length > 0 ||
+          xml.documents.length > 0 ||
+          xml.singleOutputFile !== null
+        );
+      });
+
+    if (!lastWithSummary) {
+      return summary;
+    }
+
+    summary.tagContents = { ...lastWithSummary.xmlSummary.tagContents };
+    summary.documents = [...lastWithSummary.xmlSummary.documents];
+    summary.singleOutputFile = lastWithSummary.xmlSummary.singleOutputFile;
+
+    return summary;
   }
 }

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -152,6 +152,10 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
 
     shared.agent.roundStates.push(result.roundState);
     shared.agent.toolStates.push(result.toolState);
+    if (result.outputArtifacts) {
+      shared.agent.roundOutputArtifacts[result.outputArtifacts.round] =
+        result.outputArtifacts;
+    }
     shared.state.globalState = result.globalState;
     shared.state.messages = result.messages;
     shared.state.continueRounds = result.shouldContinue;

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -3,7 +3,12 @@ import { LatexDiffManager } from './LatexDiffManager';
 import { XmlOutputManager } from './XmlOutputManager';
 
 // Local imports - types
-import { NamedOutputFile, OutputFileInfo, RoundFileMapping } from './types';
+import {
+  NamedOutputFile,
+  OutputFileInfo,
+  RoundFileMapping,
+} from './types';
+import type { OutputXmlSummary, RoundOutputArtifacts } from './OutputHandler';
 
 /** Interface describing OutputHandler behavior used by agents. */
 export interface IOutputHandler {
@@ -60,4 +65,7 @@ export interface IOutputHandler {
       groupId?: string;
     },
   ): Promise<void>;
+
+  getRoundArtifacts(round: number): Promise<RoundOutputArtifacts>;
+  getRoundXmlSummary(round: number): OutputXmlSummary;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -40,6 +40,10 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { replaceInputCommands, createFileMapping } from '@utils/files';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
+import {
+  extractMultipleTextFromTag,
+  extractTextFromTag,
+} from '@utils/text/xmlUtils';
 
 // Local imports - types
 
@@ -50,7 +54,10 @@ export class OutputHandler implements IOutputHandler {
   public logId: number;
   public outputFiles: { [key: number]: string[] };
   public outputMappings: { [key: number]: NamedOutputFile[] };
+  private rawOutputs: { [key: number]: string | null };
+  private roundFileInfos: { [key: number]: OutputFileInfo[] };
   private roundMappings: { [key: number]: RoundFileMapping };
+  private roundXmlSummaries: { [key: number]: OutputXmlSummary };
   public baseFiles: string[];
   public processGroupId?: string;
   protected logger: AgentLogger;
@@ -72,7 +79,10 @@ export class OutputHandler implements IOutputHandler {
     this.logId = logId;
     this.outputFiles = {};
     this.outputMappings = {};
+    this.rawOutputs = {};
+    this.roundFileInfos = {};
     this.roundMappings = {};
+    this.roundXmlSummaries = {};
     this.baseFiles = baseFiles;
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
@@ -350,7 +360,9 @@ export class OutputHandler implements IOutputHandler {
   ): Promise<void> {
     const { endTurn, groupId } = options;
     this.ensureRound(currRound);
+    this.rawOutputs[currRound] = outputFile || null;
     const fileInfos = await this.gatherOutputFileInfo(currRound);
+    this.roundFileInfos[currRound] = fileInfos;
 
     if (endTurn) {
       try {
@@ -427,6 +439,11 @@ export class OutputHandler implements IOutputHandler {
           );
 
           this.setRoundOutputs(currRound, processedFiles, processedPairs);
+          await this.captureXmlSummary(
+            currRound,
+            outputFile,
+            processedPairs,
+          );
 
           if (this.baseFiles && this.baseFiles.length > 0) {
             await replaceInputCommands(
@@ -441,6 +458,7 @@ export class OutputHandler implements IOutputHandler {
             activeGroupId,
           );
           this.setRoundOutputs(currRound, [], []);
+          await this.captureXmlSummary(currRound, outputFile, []);
         }
       } catch (err) {
         this.logger.debug(
@@ -449,6 +467,7 @@ export class OutputHandler implements IOutputHandler {
           MESSAGE_TYPES.INTERNAL,
         );
         this.setRoundOutputs(currRound, [], []);
+        await this.captureXmlSummary(currRound, outputFile, []);
       }
     } else {
       // Single output file case
@@ -483,12 +502,14 @@ export class OutputHandler implements IOutputHandler {
           );
 
           this.setRoundOutputs(currRound, [processed.path], [processed]);
+          await this.captureXmlSummary(currRound, outputFile, [processed]);
         } else {
           this.logger.debug(
             `No processed file was generated from ${outputFile}`,
             activeGroupId,
           );
           this.setRoundOutputs(currRound, [], []);
+          await this.captureXmlSummary(currRound, outputFile, []);
         }
       } catch (err) {
         this.logger.debug(
@@ -507,22 +528,135 @@ export class OutputHandler implements IOutputHandler {
           filesByRound: { [currRound]: [] },
         });
         this.setRoundOutputs(currRound, [], []);
+        await this.captureXmlSummary(currRound, outputFile, []);
       }
     }
   }
-  /** Processes output files for current round. */
-  protected async handleOutput(
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
-    outputFile: string,
-    endTurn: boolean,
-    currRound: number = 0,
-    roundGroupId?: string,
-  ): Promise<string[]> {
-    this.ensureRound(currRound);
-    return this.outputFiles[currRound];
+
+  public async getRoundArtifacts(
+    round: number,
+  ): Promise<RoundOutputArtifacts> {
+    const outputFiles = this.ensureRound(round).slice();
+    const processed = (this.outputMappings[round] || []).map((entry) => ({
+      ...entry,
+    }));
+    let fileInfos = this.roundFileInfos[round];
+    if (!fileInfos) {
+      fileInfos = await this.gatherOutputFileInfo(round);
+      this.roundFileInfos[round] = fileInfos;
+    }
+
+    return {
+      round,
+      rawOutputPath: this.rawOutputs[round] ?? null,
+      outputFiles,
+      processedFiles: processed,
+      fileInfos,
+      xmlSummary: this.getRoundXmlSummary(round),
+    };
+  }
+
+  public getRoundXmlSummary(round: number): OutputXmlSummary {
+    return (
+      this.roundXmlSummaries[round] ?? {
+        tagContents: {},
+        documents: [],
+        singleOutputFile: null,
+      }
+    );
+  }
+
+  private async captureXmlSummary(
+    round: number,
+    rawOutputPath: string,
+    processed: NamedOutputFile[],
+  ): Promise<void> {
+    const singleFile = processed.length === 1 ? processed[0].path : null;
+
+    if (!rawOutputPath) {
+      this.roundXmlSummaries[round] = {
+        tagContents: {},
+        documents: [],
+        singleOutputFile: singleFile,
+      };
+      return;
+    }
+
+    try {
+      const rawContent = await WorkspaceFS.read(rawOutputPath);
+      const tagContents: Record<string, string | string[]> = {};
+      const documents: string[] = [];
+
+      const documentTag = this.agentSetting.documentTag;
+      const documentEntries = extractMultipleTextFromTag(
+        rawContent,
+        documentTag,
+      );
+      if (documentEntries.length > 0) {
+        const trimmedDocuments = documentEntries.map((entry) =>
+          entry.content.trim(),
+        );
+        if (trimmedDocuments.length === 1) {
+          tagContents[documentTag] = trimmedDocuments[0];
+        } else {
+          tagContents[documentTag] = trimmedDocuments;
+        }
+
+        for (const entry of documentEntries) {
+          const nameAttr = entry.name ? ` name="${entry.name}"` : '';
+          const trimmed = entry.content.trim();
+          documents.push(
+            `<${documentTag}${nameAttr}>${trimmed}</${documentTag}>`,
+          );
+        }
+      } else {
+        const singleDocument = extractTextFromTag(rawContent, documentTag).trim();
+        if (singleDocument) {
+          tagContents[documentTag] = singleDocument;
+          documents.push(
+            `<${documentTag}>${singleDocument}</${documentTag}>`,
+          );
+        }
+      }
+
+      const scratchpadContent = extractTextFromTag(rawContent, 'scratchpad').trim();
+      if (scratchpadContent) {
+        tagContents.scratchpad = scratchpadContent;
+      }
+
+      this.roundXmlSummaries[round] = {
+        tagContents,
+        documents,
+        singleOutputFile: singleFile,
+      };
+    } catch (error) {
+      this.logger.debug(
+        `Failed to collect XML summary for round ${round}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
+      );
+      this.roundXmlSummaries[round] = {
+        tagContents: {},
+        documents: [],
+        singleOutputFile: singleFile,
+      };
+    }
   }
 }
 
-export { NamedOutputFile };
-export { getOutputFileName } from '@agent/utils/outputFileUtils';
+export interface RoundOutputArtifacts {
+  round: number;
+  rawOutputPath: string | null;
+  outputFiles: string[];
+  processedFiles: NamedOutputFile[];
+  fileInfos: OutputFileInfo[];
+  xmlSummary: OutputXmlSummary;
+}
+
+export interface OutputXmlSummary {
+  tagContents: Record<string, string | string[]>;
+  documents: string[];
+  singleOutputFile: string | null;
+}

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -21,6 +21,14 @@ import { WorkspaceFS } from '@utils/files';
 /**
  * Build all user variables needed for prompt rendering.
  */
+type LoadedFileEntry = {
+  path: string;
+  ok: boolean;
+  varName: string;
+  source: string;
+  internal?: boolean;
+};
+
 export async function buildUserVars(
   agentConfig: AgentConfig,
   agentSetting: AgentSetting,
@@ -30,13 +38,7 @@ export async function buildUserVars(
   logger: AgentLogger,
 ): Promise<Record<string, any>> {
   const userVars: Record<string, any> = {};
-  const allLoadedFiles: {
-    path: string;
-    ok: boolean;
-    varName: string;
-    source: string;
-    internal?: boolean;
-  }[] = [];
+  const allLoadedFiles: LoadedFileEntry[] = [];
 
   Object.assign(userVars, getBasicVars(agentConfig, modelHandler));
   Object.assign(userVars, await getFileVars(agentConfig));
@@ -146,22 +148,10 @@ async function getRequiredFileVars(
   logger: AgentLogger,
 ): Promise<{
   vars: Record<string, any>;
-  files: Array<{
-    path: string;
-    ok: boolean;
-    varName: string;
-    source: string;
-    internal?: boolean;
-  }>;
+  files: LoadedFileEntry[];
 }> {
   const userVars: Record<string, any> = {};
-  const files: {
-    path: string;
-    ok: boolean;
-    varName: string;
-    source: string;
-    internal?: boolean;
-  }[] = [];
+  const files: LoadedFileEntry[] = [];
 
   if (agentSetting.requiredFiles) {
     for (const [varName, filePath] of Object.entries(
@@ -212,22 +202,10 @@ async function getPatternBasedFileVars(
   logger: AgentLogger,
 ): Promise<{
   vars: Record<string, any>;
-  files: Array<{
-    path: string;
-    ok: boolean;
-    varName: string;
-    source: string;
-    internal?: boolean;
-  }>;
+  files: LoadedFileEntry[];
 }> {
   const userVars: Record<string, any> = {};
-  const files: {
-    path: string;
-    ok: boolean;
-    varName: string;
-    source: string;
-    internal?: boolean;
-  }[] = [];
+  const files: LoadedFileEntry[] = [];
 
   if (agentSetting.filePatternsContain) {
     for (const patternConfig of agentSetting.filePatternsContain) {

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -9,7 +9,7 @@ import {
   AgentCategory,
 } from '@agent/core/AgentDataclass';
 import type { AgentPrompt } from '@agent/core/AgentDataclass';
-import { getToolFlags } from '@agent/utils/userVars';
+import { buildUserVars, getToolFlags } from '@agent/utils/userVars';
 import * as configModule from '@utils/config';
 
 const baseSetting: AgentSetting = {
@@ -97,3 +97,4 @@ describe('getToolFlags', () => {
     assert.equal(flags.ROUNDS, 3);
   });
 });
+

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -14,6 +14,7 @@ import { OutputHandler } from '@agent/output';
 // Local imports
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
+import { WorkspaceFS } from '@utils/files';
 
 class MockOutputHandler extends OutputHandler {
   public gatherCalled = false;
@@ -196,5 +197,92 @@ describe('OutputHandler.finalizeRound', () => {
     assert.strictEqual(handler.validateCalled, false);
     assert.equal(events.length, 1);
     dispose();
+  });
+});
+
+describe('OutputHandler XML summaries', () => {
+  const originalRead = WorkspaceFS.read;
+
+  afterEach(() => {
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+      originalRead;
+  });
+
+  it('captures tag contents and scratchpad for single outputs', async () => {
+    const handler = new OutputHandler(
+      baseSetting,
+      baseConfig,
+      0,
+      [],
+      new AgentLogger('TestXmlSummarySingle'),
+    );
+
+    handler.indentLatexFile = async () => {};
+    handler.xmlManager.processSingleXmlOutput = async () => ({
+      source: 'input.tex',
+      path: 'output.tex',
+    });
+
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+      async (filePath: string) => {
+        if (filePath === 'out.xml') {
+          return [
+            '<document>\\section{Results}</document>',
+            '<scratchpad>draft notes</scratchpad>',
+          ].join('');
+        }
+        return '';
+      };
+
+    await handler.processOutputFiles('out.xml', 0);
+
+    const summary = handler.getRoundXmlSummary(0);
+    assert.equal(summary.singleOutputFile, 'output.tex');
+    assert.equal(summary.tagContents.document, '\\section{Results}');
+    assert.equal(summary.tagContents.scratchpad, 'draft notes');
+    assert.deepEqual(summary.documents, [
+      '<document>\\section{Results}</document>',
+    ]);
+  });
+
+  it('captures multiple documents when present', async () => {
+    const multiConfig = parseAgentConfig({
+      ...baseConfig,
+      outputFiles: ['draft.tex', 'notes.tex'],
+    });
+    const handler = new OutputHandler(
+      baseSetting,
+      multiConfig,
+      0,
+      [],
+      new AgentLogger('TestXmlSummaryMulti'),
+    );
+
+    handler.indentLatexFiles = async () => {};
+    handler.xmlManager.processMultipleXmlOutputs = async () => [
+      { source: 'draft.tex', path: 'draft.tex' },
+      { source: 'notes.tex', path: 'notes.tex' },
+    ];
+
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
+      async (filePath: string) => {
+        if (filePath === 'out.xml') {
+          return [
+            '<document name="draft">First</document>',
+            '<document name="notes">Second</document>',
+          ].join('');
+        }
+        return '';
+      };
+
+    await handler.processOutputFiles('out.xml', 0);
+
+    const summary = handler.getRoundXmlSummary(0);
+    assert.deepEqual(summary.tagContents.document, ['First', 'Second']);
+    assert.deepEqual(summary.documents, [
+      '<document name="draft">First</document>',
+      '<document name="notes">Second</document>',
+    ]);
+    assert.equal(summary.singleOutputFile, null);
   });
 });

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -108,6 +108,8 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
     throw new Error('AgentConfig is missing canonical session metadata.');
   }
 
+  const sanitizedConfig: AgentConfig = { ...config };
+
   if (session.agentCategory === AgentCategory.ToolUse) {
     const toolUseSession: AgentSessionDescriptor & {
       agentCategory: AgentCategory.ToolUse;
@@ -116,7 +118,7 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
       agentCategory: AgentCategory.ToolUse,
     };
     return {
-      agentConfig: config,
+      agentConfig: sanitizedConfig,
       session: toolUseSession,
       toolSessionState: {},
     };
@@ -130,7 +132,7 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
   };
 
   return {
-    agentConfig: config,
+    agentConfig: sanitizedConfig,
     session: workflowSession,
     activeFiles: createActiveFilesFromArrays(config),
   };


### PR DESCRIPTION
## Summary
- remove the runtimeVars and exposedOutputs plumbing from agent schemas to keep configuration minimal
- capture XML summaries (tag contents, serialized documents, single-output path) inside OutputHandler and surface them via BaseReflectionAgent.runtimeXmlExports
- add coverage for the new summaries and refresh the documentation and changelog entries

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_69067f5aa3ec83248d26fe2ff88e65cb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Captures XML output summaries (tag contents, serialized documents, single-output path) per round in `OutputHandler` and exposes them via `BaseReflectionAgent.runtimeXmlExports`, with flow wiring, tests, and docs/changelog updates.
> 
> - **Agent Runtime Exports**:
>   - `BaseReflectionAgent`: stores `roundOutputArtifacts` and computes `runtimeXmlExports` (fields: `tagContents`, `documents`, `singleOutputFile`); returns artifacts from round completion.
>   - `ReflectionRunFlow`: persists `outputArtifacts` from each round to the agent.
> - **Output Handling**:
>   - `OutputHandler`: collects per-round artifacts via `getRoundArtifacts` and `getRoundXmlSummary`; captures XML summaries from raw outputs (including `<scratchpad>`), tracks `rawOutputPath`/file infos, and records `singleOutputFile` for single-output runs.
>   - `IOutputHandler`: adds `getRoundArtifacts`/`getRoundXmlSummary` to interface.
> - **Utils/Config**:
>   - `userVars`: minor type cleanups; exports `buildUserVars` in tests.
>   - `configConversion`: sanitize by cloning config before embedding in `TaskState`.
> - **Docs & Changelog**:
>   - `docs/guide/custom-agents.md`: new "Runtime XML exports" section describing `runtimeXmlExports` structure and usage.
>   - `CHANGELOG.md`: adds feature note for captured XML summaries.
> - **Tests**:
>   - `OutputHandler.test.ts`: coverage for XML summary capture (single/multiple documents).
>   - `userVars.test.ts`: updates imports/rounds flag check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32c7a3fae868899495f815f00eab79bff0c585db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->