### PR TITLE
Fix agent YAML loader to trust zod defaults

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -208,13 +208,13 @@ export type AgentPrompt = z.infer<typeof AgentPromptSchema>;
 export const AgentDefinitionSchema = z.strictObject({
   name: z.string().trim().min(1),
   inherits: z.string().optional(),
-  settings: z.record(z.string(), z.unknown()).optional(),
-  prompts: z.record(z.string(), z.unknown()).optional(),
+  settings: z.record(z.string(), z.unknown()).default({}),
+  prompts: z.record(z.string(), z.unknown()).default({}),
 });
 
 export type AgentDefinition = z.infer<typeof AgentDefinitionSchema>;
 
 /** Parses a settings block into an {@link AgentSetting}. */
 export function parseAgentSetting(settings: unknown): AgentSetting {
-  return AgentSettingSchema.parse(settings ?? {});
+  return AgentSettingSchema.parse(settings);
 }

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -216,22 +216,19 @@ export async function loadAgentSettingAndPrompts(
       );
 
       // Get current agent's specific settings and prompts from its YAML
-      const agentOwnSettings = config.settings ?? {};
-      const agentOwnPrompts = config.prompts ?? {};
-
       // Merge with parent settings and prompts
-      settings = deepmerge(parentSettings, agentOwnSettings, {
+      settings = deepmerge(parentSettings, config.settings, {
         arrayMerge: (_d, s) => s,
       });
-      prompts = deepmerge(parentPrompts, agentOwnPrompts, {
+      prompts = deepmerge(parentPrompts, config.prompts, {
         arrayMerge: (_d, s) => s,
       });
     } else {
       // No inheritance, just take own settings and prompts
-      settings = deepmerge({}, config.settings ?? {}, {
+      settings = deepmerge({}, config.settings, {
         arrayMerge: (_d, s) => s,
       });
-      prompts = deepmerge({}, config.prompts ?? {}, {
+      prompts = deepmerge({}, config.prompts, {
         arrayMerge: (_d, s) => s,
       });
     }

--- a/src/test/agent/runtime/agentLoad.test.ts
+++ b/src/test/agent/runtime/agentLoad.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 // Local imports - agent runtime
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { AgentDirectorySource } from '@agent/runtime/AgentPathTypes';
+import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
 import { AbsoluteFS } from '@utils/files';
 
 suite('loadAgentSettingAndPrompts', () => {
@@ -115,5 +116,76 @@ suite('loadAgentSettingAndPrompts', () => {
     );
 
     assert.strictEqual(prompts.userRequest, 'base only');
+  });
+
+  test('merges inherited settings and resolves tool registry entries', async () => {
+    const agentPath = path.join('/', 'tmp', 'agents');
+    const baseDefinitionPath = path.join(agentPath, 'base.yaml');
+    const childDefinitionPath = path.join(agentPath, 'child.yaml');
+    const agentPathInfo = {
+      directory: agentPath,
+      source: AgentDirectorySource.Custom,
+    } as const;
+
+    fileContents.set(
+      normalize(baseDefinitionPath),
+      [
+        'name: base',
+        'settings:',
+        '  agentType: direct',
+        '  documentTag: parentDoc',
+        '  requiredFiles:',
+        '    shared: shared.tex',
+        '  defaultOutputFiles:',
+        '    - parent.txt',
+        '  tools:',
+        '    - str_replace_editor',
+        'prompts:',
+        '  systemPrompt: Parent system prompt',
+        '  userRequest:',
+        '    - base request',
+        '',
+      ].join('\n'),
+    );
+
+    fileContents.set(
+      normalize(childDefinitionPath),
+      [
+        'name: child',
+        'inherits: base',
+        'settings:',
+        '  endTag: </custom>',
+        '  requiredFiles:',
+        '    child: child.tex',
+        '  defaultOutputFiles:',
+        '    - child.txt',
+        'prompts:',
+        '  userRequest:',
+        '    - child request',
+        '',
+      ].join('\n'),
+    );
+
+    const [settings, prompts] = await loadAgentSettingAndPrompts(
+      agentPathInfo,
+      'child',
+    );
+
+    assert.strictEqual(settings.documentTag, 'parentDoc');
+    assert.strictEqual(settings.endTag, '</custom>');
+    assert.deepEqual(settings.requiredFiles, {
+      shared: 'shared.tex',
+      child: 'child.tex',
+    });
+    assert.deepEqual(settings.defaultOutputFiles, ['child.txt']);
+    assert.strictEqual(prompts.systemPrompt, 'Parent system prompt');
+    assert.deepEqual(prompts.userRequest, ['child request']);
+
+    const resolvedTool = settings.tools?.[0];
+    assert.ok(resolvedTool, 'expected inherited tool to be present');
+    assert.strictEqual(
+      resolvedTool,
+      DEFAULT_TOOL_REGISTRY.str_replace_editor.definition,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- default agent definition settings and prompts to empty objects and rely on parseAgentSetting for normalization
- simplify agent loader inheritance merging now that the schema guarantees normalized blocks
- extend loadAgentSettingAndPrompts tests to cover inherited definitions and registry-backed tools

## Testing
- npm run compile-tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69069a26cc6c83248c6e64769787321c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default `settings`/`prompts` via schema, simplify loader merges using guaranteed blocks, and add tests covering inheritance and tool registry resolution.
> 
> - **Core (schemas)**:
>   - Default `AgentDefinitionSchema.settings` and `prompts` to `{}`; `parseAgentSetting` now parses input directly (trusts schema defaults).
> - **Runtime (loader)**:
>   - Simplify inheritance merge by using `config.settings`/`config.prompts` directly; remove manual null-coalescing.
>   - Preserve array override behavior during deep merges.
>   - Ensure tool names in `settings.tools` resolve via `DEFAULT_TOOL_REGISTRY`.
> - **Tests**:
>   - Add test verifying inherited settings/prompts merge, array overrides, and registry-backed tool resolution.
>   - Keep multiple-definition selection/fallback behavior validated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daeb79a9351b2c0b0b438566bc0f204546a3a595. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->