### PR TITLE
Refactor state defaults across progress view and agent schemas

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -16,12 +16,17 @@ import { DEFAULT_TOOL_CONFIG, ToolConfigSchema } from './ToolConfig';
  * Checks that the number of output files does not exceed the number of input files.
  * Extracted as a separate function for clarity and reusability.
  */
-export const validateOutputFiles = (cfg: Record<string, any>): boolean => {
-  if (cfg.outputFiles) {
-    const inputs = [cfg.inputFile, ...(cfg.inputFiles || [])];
-    return cfg.outputFiles.length <= inputs.length;
+export const validateOutputFiles = (cfg: {
+  inputFile: string;
+  inputFiles: string[];
+  outputFiles: string[];
+}): boolean => {
+  if (cfg.outputFiles.length === 0) {
+    return true;
   }
-  return true;
+
+  const inputs = [cfg.inputFile, ...cfg.inputFiles];
+  return cfg.outputFiles.length <= inputs.length;
 };
 
 /**
@@ -29,6 +34,12 @@ export const validateOutputFiles = (cfg: Record<string, any>): boolean => {
  * The session field is the canonical source of truth for agent classification.
  */
 /** Zod schema for validating AgentConfig objects */
+const stringArrayField = () =>
+  z
+    .array(z.string())
+    .nullish()
+    .transform((value) => value ?? []);
+
 const AgentConfigBaseSchema = z
   .object({
     model: z.string().prefault('gemini25p'),
@@ -42,22 +53,33 @@ const AgentConfigBaseSchema = z
     session: AgentSessionDescriptorSchema.optional(),
 
     inputFile: z.string().prefault(''),
-    inputFiles: z.array(z.string()).nullable().prefault(null),
+    inputFiles: stringArrayField(),
     referenceFile: z.string().nullable().prefault(null),
-    referenceFiles: z.array(z.string()).nullable().prefault(null),
+    referenceFiles: stringArrayField(),
     auxiliaryFile: z.string().nullable().prefault(null),
-    auxiliaryFiles: z.array(z.string()).nullable().prefault(null),
+    auxiliaryFiles: stringArrayField(),
     mediaFile: z.string().nullable().prefault(null),
-    mediaFiles: z.array(z.string()).nullable().prefault(null),
-    outputFiles: z.array(z.string()).nullable().prefault(null),
+    mediaFiles: stringArrayField(),
+    outputFiles: stringArrayField(),
     editedFile: z.string().nullable().prefault(null),
 
     toolConfig: ToolConfigSchema.prefault(DEFAULT_TOOL_CONFIG),
   })
-  .refine(validateOutputFiles, {
-    path: ['outputFiles'],
-    error:
-      'Number of output files must not be greater than the number of input files.',
+  .superRefine((config, ctx) => {
+    if (
+      !validateOutputFiles({
+        inputFile: config.inputFile,
+        inputFiles: config.inputFiles,
+        outputFiles: config.outputFiles,
+      })
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['outputFiles'],
+        message:
+          'Number of output files must not be greater than the number of input files.',
+      });
+    }
   });
 
 export const AgentConfigSchema = AgentConfigBaseSchema.transform((config) => {

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -205,16 +205,18 @@ export type AgentPrompt = z.infer<typeof AgentPromptSchema>;
  * Includes the root name, optional inheritance target,
  * settings block and prompt configuration.
  */
+const DefinitionBlockSchema = z.record(z.string(), z.unknown()).default({});
+
 export const AgentDefinitionSchema = z.strictObject({
   name: z.string().trim().min(1),
   inherits: z.string().optional(),
-  settings: z.record(z.string(), z.unknown()).optional(),
-  prompts: z.record(z.string(), z.unknown()).optional(),
+  settings: DefinitionBlockSchema,
+  prompts: DefinitionBlockSchema,
 });
 
 export type AgentDefinition = z.infer<typeof AgentDefinitionSchema>;
 
 /** Parses a settings block into an {@link AgentSetting}. */
 export function parseAgentSetting(settings: unknown): AgentSetting {
-  return AgentSettingSchema.parse(settings ?? {});
+  return AgentSettingSchema.parse(settings);
 }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -147,9 +147,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     for (let i = 0; i < numRounds; i++) {
       this.outputFiles[i] = [];
     }
-    this.baseFiles = this.agentConfig.outputFiles || [
-      this.agentConfig.inputFile,
-    ];
+    this.baseFiles =
+      this.agentConfig.outputFiles.length > 0
+        ? [...this.agentConfig.outputFiles]
+        : [this.agentConfig.inputFile];
 
     // Check scratchpad usage
     // this is not so neat
@@ -504,7 +505,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     if (currRound === 0) {
       const inputFiles = [
         this.agentConfig.inputFile,
-        ...(this.agentConfig.inputFiles || []),
+        ...this.agentConfig.inputFiles,
       ];
       const extraMedia: string[] = [];
 
@@ -515,7 +516,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         ) {
           extraMedia.push(this.agentConfig.mediaFile);
         }
-        if (this.agentConfig.mediaFiles) {
+        if (this.agentConfig.mediaFiles.length > 0) {
           extraMedia.push(...this.agentConfig.mediaFiles);
         }
       }
@@ -531,10 +532,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       return;
     }
 
-    let outputFiles: string[] = [];
-    if (this.agentConfig.outputFiles) {
-      outputFiles = [...this.agentConfig.outputFiles];
-    } else {
+    let outputFiles = [...this.agentConfig.outputFiles];
+    if (outputFiles.length === 0) {
       const previousRoundFiles = this.outputHandler.ensureRound(currRound - 1);
       if (previousRoundFiles.length > 0) {
         outputFiles = [previousRoundFiles[0]];

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -211,12 +211,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       const snapshot = this.resumeSnapshot;
       this.resumeSnapshot = null;
 
-      const rawMessages = snapshot.messages ?? [];
-      if (!Array.isArray(rawMessages)) {
-        throw new Error('Invalid snapshot: messages must be an array');
-      }
-
-      const messages = rawMessages as ProviderMessage[];
+      const messages = snapshot.messages;
       let toolState: ToolState;
 
       try {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -169,6 +169,20 @@ export class ModelHandlerAnthropic extends ModelHandler<
     this.cacheControlledBlock = undefined;
   }
 
+  private getMutableBetas(options: MessageCreateParams): AnthropicBeta[] {
+    if (!options.betas) {
+      options.betas = [];
+    }
+    return options.betas;
+  }
+
+  private appendBeta(options: MessageCreateParams, beta: AnthropicBeta): void {
+    const betas = this.getMutableBetas(options);
+    if (!betas.includes(beta)) {
+      betas.push(beta);
+    }
+  }
+
   private findCacheControlCandidate(
     content: (ContentBlockParam | ContentBlock)[] | undefined,
   ): CacheControlEligibleBlock | undefined {
@@ -258,10 +272,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
       if (this.config.capabilities.supportsInterleavedThinking) {
-        const existingBetas = options.betas ?? [];
-        if (!existingBetas.includes(INTERLEAVED_THINKING_BETA)) {
-          options.betas = [...existingBetas, INTERLEAVED_THINKING_BETA];
-        }
+        this.appendBeta(options, INTERLEAVED_THINKING_BETA);
       }
     }
 
@@ -302,7 +313,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // useStreaming = true; should consider to be true by default
       // temperature already deleted above for reasoning models
 
-      options.betas = [SONNET_37_OUTPUT_BETA];
+      const sonnetBetas = this.getMutableBetas(options);
+      sonnetBetas.length = 0;
+      sonnetBetas.push(SONNET_37_OUTPUT_BETA);
       // Update max tokens to use the higher limit when streaming
       options.max_tokens = useStreaming ? 64000 : this.config.maxOutputTokens;
       // The thinking configuration is now handled above for all reasoning models
@@ -310,7 +323,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Opt-in beta for 1M context window on Claude Sonnet 4 family
     if (isAnthropic1MBetaActive) {
-      options.betas = [...(options.betas ?? []), CONTEXT_1M_BETA];
+      this.appendBeta(options, CONTEXT_1M_BETA);
     }
 
     if (this.capabilities.supportsTokenCounting) {
@@ -394,17 +407,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     if (hasFileReference) {
-      const existingBetas = options.betas ?? [];
-      if (!existingBetas.includes(FILES_API_BETA)) {
-        options.betas = [...existingBetas, FILES_API_BETA];
-      }
+      this.appendBeta(options, FILES_API_BETA);
     }
 
     if (this.agentType === AgentType.ToolUse) {
-      const existingBetas = options.betas ?? [];
-      if (!existingBetas.includes(CONTEXT_MANAGEMENT_BETA)) {
-        options.betas = [...existingBetas, CONTEXT_MANAGEMENT_BETA];
-      }
+      this.appendBeta(options, CONTEXT_MANAGEMENT_BETA);
 
       const contextManagementEdits = [
         ...(options.context_management?.edits ?? []),

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -19,7 +19,6 @@ import type {
   ResponseInputImage,
   ResponseInputText,
   ResponseStreamEvent,
-  ResponseOutputText,
 } from 'openai/resources/responses/responses';
 import type { Reasoning } from 'openai/resources/shared';
 import type { ResponseStreamParams } from 'openai/lib/responses/ResponseStream';
@@ -35,6 +34,7 @@ import {
   type ExtendedCompletionUsage,
 } from '../core/ResponseUsage';
 import { ToolState } from '../core/ToolState';
+import { z } from 'zod';
 
 // Local imports - base handler
 import { ModelHandler } from './ModelHandler';
@@ -61,6 +61,59 @@ import { sleep } from '@utils/helpers';
 import { WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 
+const ResponseOutputPartSchema = z
+  .object({
+    type: z.string(),
+    text: z.string().optional(),
+  })
+  .passthrough();
+
+const ResponseOutputItemSchema = z
+  .object({
+    type: z.string(),
+    content: z.array(ResponseOutputPartSchema).optional().default([]),
+  })
+  .passthrough();
+
+const ResponseUsageDetailsSchema = z
+  .object({
+    cached_tokens: z.number().int().nonnegative().default(0),
+  })
+  .passthrough()
+  .default({ cached_tokens: 0 });
+
+const ResponseOutputDetailsSchema = z
+  .object({
+    reasoning_tokens: z.number().int().nonnegative().default(0),
+  })
+  .passthrough()
+  .default({ reasoning_tokens: 0 });
+
+const ResponseUsageSchema = z
+  .object({
+    input_tokens: z.number().int().nonnegative(),
+    output_tokens: z.number().int().nonnegative(),
+    total_tokens: z.number().int().nonnegative(),
+    input_tokens_details: ResponseUsageDetailsSchema,
+    output_tokens_details: ResponseOutputDetailsSchema,
+  })
+  .passthrough();
+
+const ResponseEnvelopeSchema = z
+  .object({
+    status: z.string(),
+    usage: ResponseUsageSchema,
+    output_text: z
+      .string()
+      .optional()
+      .transform((value) => (value ?? '').trim()),
+    output: z
+      .array(ResponseOutputItemSchema)
+      .optional()
+      .transform((value) => value ?? []),
+  })
+  .passthrough();
+
 interface UploadedOpenAIResponseAttachment {
   attachment: ToolFileAttachment;
   fileId: string;
@@ -75,7 +128,7 @@ interface UploadedOpenAIResponseAttachment {
  */
 export class ModelHandlerOpenAIResponse extends ModelHandler<
   ResponseInputItem,
-  ResponseUsage | undefined,
+  ResponseUsage,
   OpenAIAPIResponseUsage,
   ResponseFunctionToolCallItem
 > {
@@ -613,32 +666,27 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   extractResponse(
     responseObject: Response,
     endTag: string,
-  ): [string, ResponseUsage | undefined, ProviderStopReason] {
-    const usage = responseObject.usage ?? {
-      input_tokens: 0,
-      output_tokens: 0,
-      total_tokens: 0,
-      input_tokens_details: { cached_tokens: 0 },
-      output_tokens_details: { reasoning_tokens: 0 },
-    };
+  ): [string, ResponseUsage, ProviderStopReason] {
+    const parsed = ResponseEnvelopeSchema.parse(responseObject);
+    const usage = parsed.usage;
 
-    const rawOutputText = responseObject.output_text;
-    let newResponse =
-      typeof rawOutputText === 'string' ? rawOutputText.trim() : '';
+    let newResponse = parsed.output_text;
 
     if (!newResponse) {
-      const fallbackSegments =
-        responseObject.output?.flatMap((item) => {
-          if (item.type !== 'message') {
-            return [];
-          }
+      const fallbackSegments: string[] = [];
 
-          return item.content
-            .filter(
-              (part): part is ResponseOutputText => part.type === 'output_text',
-            )
-            .map((part) => part.text);
-        }) ?? [];
+      for (const item of parsed.output) {
+        if (item.type !== 'message') {
+          continue;
+        }
+
+        for (const part of item.content) {
+          if (part.type === 'output_text' && typeof part.text === 'string') {
+            fallbackSegments.push(part.text);
+          }
+        }
+      }
+
       const fallbackText = fallbackSegments.join('').trim();
       if (fallbackText) {
         newResponse = fallbackText;
@@ -646,7 +694,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     const stopReason =
-      responseObject.status === 'completed'
+      parsed.status === 'completed'
         ? OPENAI_CHAT_FINISH.STOP
         : OPENAI_CHAT_FINISH.LENGTH;
 
@@ -662,11 +710,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /** Price computation adapted for Responses API token fields. */
-  computePrice(responseUsage: ResponseUsage | undefined): number {
-    if (!responseUsage) {
-      return 0.0;
-    }
-
+  computePrice(responseUsage: ResponseUsage): number {
     const promptTokens = responseUsage.input_tokens ?? 0;
     const completionTokens = responseUsage.output_tokens ?? 0;
 
@@ -697,28 +741,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /** Map usage fields and create usage statistics object. */
   computeResponseUsage(
-    responseUsage: ResponseUsage | undefined,
+    responseUsage: ResponseUsage,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
-    if (!responseUsage) {
-      const emptyUsage: ExtendedCompletionUsage = {
-        prompt_tokens: 0,
-        completion_tokens: 0,
-        total_tokens: 0,
-        prompt_tokens_details: { cached_tokens: 0 },
-        completion_tokens_details: {
-          reasoning_tokens: 0,
-          accepted_prediction_tokens: undefined,
-          rejected_prediction_tokens: undefined,
-        },
-      };
-      return ResponseUsageFactory.fromOpenAIResponse(
-        emptyUsage,
-        this.computePrice(responseUsage),
-        responseTime,
-      );
-    }
-
     const mapped: ExtendedCompletionUsage = {
       prompt_tokens: responseUsage.input_tokens ?? 0,
       completion_tokens: responseUsage.output_tokens ?? 0,

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -3,11 +3,7 @@ import { LatexDiffManager } from './LatexDiffManager';
 import { XmlOutputManager } from './XmlOutputManager';
 
 // Local imports - types
-import {
-  NamedOutputFile,
-  OutputFileInfo,
-  RoundFileMapping,
-} from './types';
+import { NamedOutputFile, OutputFileInfo, RoundFileMapping } from './types';
 import type { OutputXmlSummary, RoundOutputArtifacts } from './OutputHandler';
 
 /** Interface describing OutputHandler behavior used by agents. */

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -115,6 +115,12 @@ export class OutputHandler implements IOutputHandler {
     if (!this.outputMappings[round]) {
       this.outputMappings[round] = [];
     }
+    if (!this.roundFileInfos[round]) {
+      this.roundFileInfos[round] = [];
+    }
+    if (!Object.prototype.hasOwnProperty.call(this.rawOutputs, round)) {
+      this.rawOutputs[round] = null;
+    }
     return this.outputFiles[round];
   }
 
@@ -249,7 +255,7 @@ export class OutputHandler implements IOutputHandler {
           )
         : new Map<string, string>();
     const originByOutput = new Map(
-      (this.outputMappings[currRound] || []).map((p) => [p.path, p.source]),
+      this.getNamedOutputs(currRound).map((p) => [p.path, p.source]),
     );
 
     const mapping: RoundFileMapping = {
@@ -259,6 +265,13 @@ export class OutputHandler implements IOutputHandler {
     };
     this.roundMappings[currRound] = mapping;
     return mapping;
+  }
+
+  private getNamedOutputs(round: number): NamedOutputFile[] {
+    if (!this.outputMappings[round]) {
+      this.outputMappings[round] = [];
+    }
+    return this.outputMappings[round];
   }
 
   private invalidateRoundMapping(round: number): void {
@@ -439,11 +452,7 @@ export class OutputHandler implements IOutputHandler {
           );
 
           this.setRoundOutputs(currRound, processedFiles, processedPairs);
-          await this.captureXmlSummary(
-            currRound,
-            outputFile,
-            processedPairs,
-          );
+          await this.captureXmlSummary(currRound, outputFile, processedPairs);
 
           if (this.baseFiles && this.baseFiles.length > 0) {
             await replaceInputCommands(
@@ -533,11 +542,9 @@ export class OutputHandler implements IOutputHandler {
     }
   }
 
-  public async getRoundArtifacts(
-    round: number,
-  ): Promise<RoundOutputArtifacts> {
+  public async getRoundArtifacts(round: number): Promise<RoundOutputArtifacts> {
     const outputFiles = this.ensureRound(round).slice();
-    const processed = (this.outputMappings[round] || []).map((entry) => ({
+    const processed = this.getNamedOutputs(round).map((entry) => ({
       ...entry,
     }));
     let fileInfos = this.roundFileInfos[round];
@@ -610,16 +617,20 @@ export class OutputHandler implements IOutputHandler {
           );
         }
       } else {
-        const singleDocument = extractTextFromTag(rawContent, documentTag).trim();
+        const singleDocument = extractTextFromTag(
+          rawContent,
+          documentTag,
+        ).trim();
         if (singleDocument) {
           tagContents[documentTag] = singleDocument;
-          documents.push(
-            `<${documentTag}>${singleDocument}</${documentTag}>`,
-          );
+          documents.push(`<${documentTag}>${singleDocument}</${documentTag}>`);
         }
       }
 
-      const scratchpadContent = extractTextFromTag(rawContent, 'scratchpad').trim();
+      const scratchpadContent = extractTextFromTag(
+        rawContent,
+        'scratchpad',
+      ).trim();
       if (scratchpadContent) {
         tagContents.scratchpad = scratchpadContent;
       }

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -46,11 +46,6 @@ export function validateAgentYamlContent(
 ): AgentYamlValidationResult {
   const raw = typeof content === 'string' ? yaml.parse(content) : content;
   const data = AgentDefinitionSchema.parse(raw);
-
-  if (!data.settings || !data.prompts) {
-    throw new Error('missing settings or prompts block');
-  }
-
   const settingsBlock = parseAgentSetting(data.settings);
   const promptsBlock = AgentPromptSchema.parse(data.prompts);
   const rootName = typeof data.name === 'string' ? data.name.trim() : '';
@@ -216,8 +211,8 @@ export async function loadAgentSettingAndPrompts(
       );
 
       // Get current agent's specific settings and prompts from its YAML
-      const agentOwnSettings = config.settings ?? {};
-      const agentOwnPrompts = config.prompts ?? {};
+      const agentOwnSettings = config.settings;
+      const agentOwnPrompts = config.prompts;
 
       // Merge with parent settings and prompts
       settings = deepmerge(parentSettings, agentOwnSettings, {
@@ -228,10 +223,10 @@ export async function loadAgentSettingAndPrompts(
       });
     } else {
       // No inheritance, just take own settings and prompts
-      settings = deepmerge({}, config.settings ?? {}, {
+      settings = deepmerge({}, config.settings, {
         arrayMerge: (_d, s) => s,
       });
-      prompts = deepmerge({}, config.prompts ?? {}, {
+      prompts = deepmerge({}, config.prompts, {
         arrayMerge: (_d, s) => s,
       });
     }

--- a/src/agent/toolUse/ToolUseSnapshotTypes.ts
+++ b/src/agent/toolUse/ToolUseSnapshotTypes.ts
@@ -26,6 +26,14 @@ export const ToolStateSnapshotSchema = z
   })
   .strict();
 
+const ProviderMessageSchema = z.custom<ProviderMessage>(
+  (value): value is ProviderMessage =>
+    typeof value === 'object' && value !== null,
+  {
+    message: 'messages must contain provider message objects',
+  },
+);
+
 export const ToolUseSessionSnapshotSchema = z
   .object({
     version: z.literal(TOOL_USE_SNAPSHOT_VERSION),
@@ -35,7 +43,7 @@ export const ToolUseSessionSnapshotSchema = z
     model: z.string(),
     agentSessionKind: z.enum(AgentCategory).optional(),
     session: AgentSessionDescriptorSchema.optional(),
-    messages: z.array(z.unknown()),
+    messages: z.array(ProviderMessageSchema),
     toolState: ToolStateSnapshotSchema,
     lastUpdated: z.number(),
   })

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -6,6 +6,7 @@ import * as yaml from 'yaml';
 // Local imports - agent core
 import {
   AgentType,
+  AgentDefinitionSchema,
   parseAgentSetting,
   type AgentSetting,
 } from '@agent/core/AgentDataclass';
@@ -93,8 +94,8 @@ function readAgentDefinition(yamlPath?: string): AgentSetting | undefined {
   }
   try {
     const fileContent = AbsoluteFS.readSync(yamlPath);
-    const parsed = yaml.parse(fileContent) as { settings?: unknown };
-    return parseAgentSetting(parsed?.settings ?? {});
+    const parsed = AgentDefinitionSchema.parse(yaml.parse(fileContent));
+    return parseAgentSetting(parsed.settings);
   } catch {
     return undefined;
   }

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -84,15 +84,15 @@ async function getFileVars(
 
   const allInputFiles = [
     agentConfig.inputFile,
-    ...(agentConfig.inputFiles || []),
+    ...agentConfig.inputFiles,
   ].filter(Boolean) as string[];
   const allReferenceFiles = [
     agentConfig.referenceFile,
-    ...(agentConfig.referenceFiles || []),
+    ...agentConfig.referenceFiles,
   ].filter(Boolean) as string[];
   const allAuxiliaryFiles = [
     agentConfig.auxiliaryFile,
-    ...(agentConfig.auxiliaryFiles || []),
+    ...agentConfig.auxiliaryFiles,
   ].filter(Boolean) as string[];
 
   const singleFileMappings = {
@@ -109,17 +109,14 @@ async function getFileVars(
       : null;
   }
 
-  const collectionMappings: Record<string, [string[] | undefined, string[]]> = {
-    INPUT: [
-      agentConfig.inputFiles?.filter(Boolean) as string[] | undefined,
-      allInputFiles,
-    ],
+  const collectionMappings: Record<string, [string[], string[]]> = {
+    INPUT: [agentConfig.inputFiles.filter(Boolean) as string[], allInputFiles],
     REFERENCE: [
-      agentConfig.referenceFiles?.filter(Boolean) as string[] | undefined,
+      agentConfig.referenceFiles.filter(Boolean) as string[],
       allReferenceFiles,
     ],
     AUXILIARY: [
-      agentConfig.auxiliaryFiles?.filter(Boolean) as string[] | undefined,
+      agentConfig.auxiliaryFiles.filter(Boolean) as string[],
       allAuxiliaryFiles,
     ],
   };
@@ -127,16 +124,16 @@ async function getFileVars(
   for (const [prefix, [additionalFiles, allFiles]] of Object.entries(
     collectionMappings,
   )) {
-    const additionalXml = additionalFiles
-      ? await getXmlFormatFromFiles(additionalFiles as string[])
-      : null;
-    const allXml = allFiles
-      ? await getXmlFormatFromFiles(allFiles as string[])
-      : null;
+    const additionalXml =
+      additionalFiles.length > 0
+        ? await getXmlFormatFromFiles(additionalFiles)
+        : null;
+    const allXml =
+      allFiles.length > 0 ? await getXmlFormatFromFiles(allFiles) : null;
 
     userVars[`ADDITIONAL_${prefix}S`] = additionalXml;
     userVars[`ALL_${prefix}S`] = allXml;
-    userVars[`LIST_OF_ALL_${prefix}S`] = getListOfFiles(allFiles as string[]);
+    userVars[`LIST_OF_ALL_${prefix}S`] = getListOfFiles(allFiles);
   }
 
   return userVars;

--- a/src/frontend/ui/instruction.ts
+++ b/src/frontend/ui/instruction.ts
@@ -17,7 +17,7 @@ import { INSTRUCTION_PREFIX, globalSM } from '@common/state/stateManager';
 export async function showInstructionWithSuppress(
   key: string,
   message: string,
-  actions?: { title: string; callback: () => Thenable<void> | void }[],
+  actions: { title: string; callback: () => Thenable<void> | void }[] = [],
   showSuppress = true,
 ): Promise<void> {
   if (showSuppress) {
@@ -28,7 +28,7 @@ export async function showInstructionWithSuppress(
   }
 
   const never = 'Never remind again';
-  const buttons = actions?.map((a) => a.title) ?? [];
+  const buttons = actions.map((a) => a.title);
   const choice = await vscode.window.showInformationMessage(
     message,
     ...buttons,
@@ -38,7 +38,7 @@ export async function showInstructionWithSuppress(
   if (showSuppress && choice === never) {
     await globalSM.update(`${INSTRUCTION_PREFIX}${key}`, true);
   } else if (choice) {
-    const action = actions?.find((a) => a.title === choice);
+    const action = actions.find((a) => a.title === choice);
     await action?.callback();
   }
 }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -503,21 +503,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     command: 'texra.pack' | 'texra.clean',
   ): Promise<void> {
     const generated = this.provider.state.outputFiles.getFiles(stream);
-    const allFiles = new Set<string>(taskState.agentConfig.outputFiles || []);
-    if (generated) {
-      for (const [round, infos] of Object.entries(generated)) {
-        if (!Array.isArray(infos)) {
-          this.logger.warn(
-            `Skipping invalid output metadata for stream ${stream}, round ${round}`,
-          );
-          continue;
-        }
+    const allFiles = new Set<string>(taskState.agentConfig.outputFiles);
 
-        for (const info of infos) {
-          allFiles.add(info.path);
-          if (info.original) {
-            allFiles.add(info.original);
-          }
+    for (const [round, infos] of Object.entries(generated)) {
+      if (!Array.isArray(infos)) {
+        this.logger.warn(
+          `Skipping invalid output metadata for stream ${stream}, round ${round}`,
+        );
+        continue;
+      }
+
+      for (const info of infos) {
+        allFiles.add(info.path);
+        if (info.original) {
+          allFiles.add(info.original);
         }
       }
     }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -325,7 +325,7 @@ export class ProgressViewProvider
     }
 
     // Update only log content and groups (focused responsibility)
-    const messages = this.state.streamTabs.get(stream) || [];
+    const messages = this.state.streamTabs.getMessages(stream);
     const groups = Array.from(
       this.state.taskGroups.getStreamGroups(stream).values(),
     );

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -67,8 +67,11 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
     withErrorBoundary('failed to handle updateLogMessage', () => {
       const { stream, logMessage } = data;
 
-      const messages = state.streamTabs.get(stream);
-      if (!messages) return;
+      if (!state.streamTabs.has(stream)) {
+        return;
+      }
+
+      const messages = state.streamTabs.getMessages(stream);
 
       const existing = messages.find((m) => m.id === logMessage.id);
       if (!existing) return;

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -68,11 +68,12 @@ const registerOutputFileListeners = (
     withErrorBoundary('failed to handle addOutputFiles', () => {
       state.outputFiles.addFiles(stream, filesByRound);
       const files = state.outputFiles.getFiles(stream);
-      const updates: { files?: FilesByRound<OutputFileInfo> } = {};
-      if (files !== undefined) {
-        updates.files = files;
-      }
-      updateActiveStreamOutputs({ state, updater, stream, updates });
+      updateActiveStreamOutputs({
+        state,
+        updater,
+        stream,
+        updates: { files },
+      });
     });
   });
 
@@ -82,11 +83,12 @@ const registerOutputFileListeners = (
       withErrorBoundary('failed to handle updateMissingOutputs', () => {
         state.outputFiles.updateMissingOutputs(stream, filesByRound);
         const missing = state.outputFiles.getMissingOutputs(stream);
-        const updates: { missing?: FilesByRound<string> } = {};
-        if (missing !== undefined) {
-          updates.missing = missing;
-        }
-        updateActiveStreamOutputs({ state, updater, stream, updates });
+        updateActiveStreamOutputs({
+          state,
+          updater,
+          stream,
+          updates: { missing },
+        });
       });
     },
   );

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -142,18 +142,18 @@ export class ProgressEventHandler {
 
     const { updateInstruction = true } = options;
 
-    const messages = this.state.streamTabs.get(stream) || [];
+    const messages = this.state.streamTabs.getMessages(stream);
     const groups = Array.from(
       this.state.taskGroups.getStreamGroups(stream).values(),
     );
     this.webviewUpdater.updateLogContent(stream, messages, groups);
 
     // Send output files for current stream
-    const files = this.state.outputFiles.getFiles(stream) || {};
+    const files = this.state.outputFiles.getFiles(stream);
     this.webviewUpdater.updateFiles(stream, files);
 
     // Send missing outputs for current stream
-    const missing = this.state.outputFiles.getMissingOutputs(stream) || {};
+    const missing = this.state.outputFiles.getMissingOutputs(stream);
     this.webviewUpdater.updateMissingOutputs(stream, missing);
 
     // Send usage for current stream

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -35,9 +35,13 @@ export class OutputFilesManager extends PersistentMapManager<
     stream: StreamTabId,
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): void {
-    const existing = this.get(stream) || {};
-    const merged = { ...existing, ...filesByRound };
-    this.add(stream, merged);
+    const existing = this.ensureStreamFiles(stream);
+
+    for (const [round, files] of Object.entries(filesByRound)) {
+      existing[Number(round)] = files;
+    }
+
+    this.save();
   }
 
   /** Update missing outputs for a stream */
@@ -45,11 +49,7 @@ export class OutputFilesManager extends PersistentMapManager<
     stream: StreamTabId,
     filesByRound: { [key: number]: string[] },
   ): void {
-    if (!this._missingOutputs.has(stream)) {
-      this._missingOutputs.set(stream, {});
-    }
-
-    const streamMissing = this._missingOutputs.get(stream)!;
+    const streamMissing = this.ensureMissingOutputs(stream);
 
     for (const [round, files] of Object.entries(filesByRound)) {
       const roundNum = parseInt(round, 10);
@@ -60,17 +60,21 @@ export class OutputFilesManager extends PersistentMapManager<
   }
 
   /** Get output files for a stream */
-  getFiles(
-    stream: StreamTabId,
-  ): { [key: number]: OutputFileInfo[] } | undefined {
-    return this.get(stream);
+  getFiles(stream: StreamTabId): { [key: number]: OutputFileInfo[] } {
+    const files = this.items.get(stream);
+    if (files) {
+      return files;
+    }
+    return {};
   }
 
   /** Get missing outputs for a stream */
-  getMissingOutputs(
-    stream: StreamTabId,
-  ): { [key: number]: string[] } | undefined {
-    return this._missingOutputs.get(stream);
+  getMissingOutputs(stream: StreamTabId): { [key: number]: string[] } {
+    const missing = this._missingOutputs.get(stream);
+    if (missing) {
+      return missing;
+    }
+    return {};
   }
 
   /** Clear output files for a stream */
@@ -80,7 +84,9 @@ export class OutputFilesManager extends PersistentMapManager<
 
   /** Clear missing outputs for a stream */
   clearMissingOutputs(stream: StreamTabId): void {
-    this._missingOutputs.delete(stream);
+    if (!this._missingOutputs.delete(stream)) {
+      return;
+    }
     this.saveMissingOutputs();
   }
 
@@ -161,6 +167,28 @@ export class OutputFilesManager extends PersistentMapManager<
   saveMissingOutputs(): void {
     const obj = Object.fromEntries(this._missingOutputs.entries());
     this.persistence.save(WorkspaceStateKey.MISSING_OUTPUTS, obj);
+  }
+
+  private ensureStreamFiles(stream: StreamTabId): {
+    [key: number]: OutputFileInfo[];
+  } {
+    let files = this.items.get(stream);
+    if (!files) {
+      files = {};
+      this.items.set(stream, files);
+    }
+    return files;
+  }
+
+  private ensureMissingOutputs(stream: StreamTabId): {
+    [key: number]: string[];
+  } {
+    let missing = this._missingOutputs.get(stream);
+    if (!missing) {
+      missing = {};
+      this._missingOutputs.set(stream, missing);
+    }
+    return missing;
   }
 
   /** Validate and normalize loaded output files */

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -37,11 +37,7 @@ export class StreamTabsManager extends PersistentMapManager<
    * Add a log message to a stream
    */
   addMessage(stream: StreamTabId, message: LogMessageData): void {
-    if (!this.has(stream)) {
-      this.items.set(stream, []);
-    }
-
-    const messages = this.get(stream)!;
+    const messages = this.ensureMessages(stream);
 
     // Ensure message has required fields
     if (!message.id) {
@@ -66,7 +62,8 @@ export class StreamTabsManager extends PersistentMapManager<
    */
   ensureStream(stream: StreamTabId): void {
     if (!this.has(stream)) {
-      super.add(stream, []);
+      this.ensureMessages(stream);
+      this.save();
     }
   }
 
@@ -88,11 +85,26 @@ export class StreamTabsManager extends PersistentMapManager<
    * Clear content of a specific stream (but keep the stream)
    */
   clearContent(stream: StreamTabId): void {
-    if (this.has(stream)) {
-      const arr = this.get(stream)!;
-      arr.length = 0;
-      this.save();
+    if (!this.has(stream)) {
+      return;
     }
+
+    const messages = this.ensureMessages(stream);
+    messages.length = 0;
+    this.save();
+  }
+
+  getMessages(stream: StreamTabId): LogMessageData[] {
+    return this.ensureMessages(stream);
+  }
+
+  private ensureMessages(stream: StreamTabId): LogMessageData[] {
+    let messages = this.items.get(stream);
+    if (!messages) {
+      messages = [];
+      this.items.set(stream, messages);
+    }
+    return messages;
   }
 
   /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -286,18 +286,18 @@ export class WebviewUpdater {
 
     if (activeStream) {
       // Update log content for active stream
-      const messages = state.streamTabs.get(activeStream) || [];
+      const messages = state.streamTabs.getMessages(activeStream);
       const groups = Array.from(
         state.taskGroups.getStreamGroups(activeStream).values(),
       );
       this.updateLogContent(activeStream, messages, groups);
 
       // Update files for active stream
-      const files = state.outputFiles.getFiles(activeStream) || {};
+      const files = state.outputFiles.getFiles(activeStream);
       this.updateFiles(activeStream, files);
 
       // Update missing outputs for active stream
-      const missing = state.outputFiles.getMissingOutputs(activeStream) || {};
+      const missing = state.outputFiles.getMissingOutputs(activeStream);
       this.updateMissingOutputs(activeStream, missing);
 
       // Update usage for active stream

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -150,9 +150,7 @@ export class ProgressViewState {
       return false;
     }
 
-    const hasPersistedOutputs =
-      Array.isArray(taskState.agentConfig.outputFiles) &&
-      taskState.agentConfig.outputFiles.length > 0;
+    const hasPersistedOutputs = taskState.agentConfig.outputFiles.length > 0;
     const usesMultipleOutputs = taskState.agentConfig.useMultipleOutputs;
     const outputFlagEnabled = taskState.activeFiles.output;
 

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -57,12 +57,11 @@ export function buildStreamInfos(
   const infos = state.streamTabs.keys().reduce<StreamTabInfo[]>((acc, id) => {
     const taskState = state.getTaskState(id);
     const sessionKindHint = state.getSessionKindHint(id);
-    const logs = state.streamTabs.get(id);
+    const logs = state.streamTabs.getMessages(id);
     const lastTimestamp =
-      logs && logs.length > 0 ? logs[logs.length - 1].timestamp : undefined;
-    const creationTimestamp =
-      logs && logs.length > 0 ? logs[0].timestamp : undefined;
-    const outputs = taskState?.agentConfig.outputFiles || [];
+      logs.length > 0 ? logs[logs.length - 1].timestamp : undefined;
+    const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
+    const outputs = taskState?.agentConfig.outputFiles ?? [];
     const inputFile = taskState?.agentConfig.inputFile || '';
     const agentName = taskState?.agentConfig.agent || id.split('@')[0];
     let sessionCategory = taskState?.session?.agentCategory ?? sessionKindHint;
@@ -94,7 +93,7 @@ export function buildStreamInfos(
         sessionKind: sessionCategory,
         isToolAgent,
       },
-      hasMultipleOutputs: Array.isArray(outputs) && outputs.length > 1,
+      hasMultipleOutputs: outputs.length > 1,
       lastTimestamp,
       inputFile,
       creationTimestamp,

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -358,9 +358,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       'the earliest cache marker should be removed',
     );
     assert.deepEqual(
-      cacheControlledBlocks.map(
-        (block) => (block as { text?: string }).text,
-      ),
+      cacheControlledBlocks.map((block) => (block as { text?: string }).text),
       ['block-1', 'block-2', 'block-3', 'block-4'],
       'the four most recent blocks should retain cache control markers',
     );

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -97,4 +97,3 @@ describe('getToolFlags', () => {
     assert.equal(flags.ROUNDS, 3);
   });
 });
-

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -223,16 +223,17 @@ describe('OutputHandler XML summaries', () => {
       path: 'output.tex',
     });
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async (filePath: string) => {
-        if (filePath === 'out.xml') {
-          return [
-            '<document>\\section{Results}</document>',
-            '<scratchpad>draft notes</scratchpad>',
-          ].join('');
-        }
-        return '';
-      };
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read = async (
+      filePath: string,
+    ) => {
+      if (filePath === 'out.xml') {
+        return [
+          '<document>\\section{Results}</document>',
+          '<scratchpad>draft notes</scratchpad>',
+        ].join('');
+      }
+      return '';
+    };
 
     await handler.processOutputFiles('out.xml', 0);
 
@@ -264,16 +265,17 @@ describe('OutputHandler XML summaries', () => {
       { source: 'notes.tex', path: 'notes.tex' },
     ];
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async (filePath: string) => {
-        if (filePath === 'out.xml') {
-          return [
-            '<document name="draft">First</document>',
-            '<document name="notes">Second</document>',
-          ].join('');
-        }
-        return '';
-      };
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read = async (
+      filePath: string,
+    ) => {
+      if (filePath === 'out.xml') {
+        return [
+          '<document name="draft">First</document>',
+          '<document name="notes">Second</document>',
+        ].join('');
+      }
+      return '';
+    };
 
     await handler.processOutputFiles('out.xml', 0);
 

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -21,7 +21,7 @@ import { WorkspaceFS } from '@utils/files';
 
 const LsInputSchema = z.strictObject({
   path: z.string(),
-  ignore: z.array(z.string()).optional(),
+  ignore: z.array(z.string()).default([]),
 });
 
 export type LsInput = z.infer<typeof LsInputSchema>;
@@ -65,10 +65,9 @@ export class LsTool extends defineTool({
       throw new ToolError(`Path not found: ${display} (${message})`);
     }
 
-    const ignorePatterns = input.ignore ?? [];
-    const ignoreMatchers = ignorePatterns.map(createGlobMatcher);
+    const ignoreMatchers = input.ignore.map(createGlobMatcher);
     const matchesCustomIgnore =
-      ignorePatterns.length === 0
+      input.ignore.length === 0
         ? () => false
         : (entryPath: string) =>
             ignoreMatchers.some((matcher) => matcher(entryPath));

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -77,24 +77,21 @@ export function buildFileContextFromTaskState(
     }
   };
 
-  const assignArray = (
-    value: string[] | null | undefined,
-    key: keyof FileContext,
-  ) => {
-    if (Array.isArray(value) && value.length > 0) {
+  const assignArray = (value: string[], key: keyof FileContext) => {
+    if (value.length > 0) {
       (context[key] as string[]) = value;
     }
   };
 
   assignString(agentConfig.inputFile, 'inputFile');
-  assignArray(agentConfig.inputFiles ?? undefined, 'inputFiles');
+  assignArray(agentConfig.inputFiles, 'inputFiles');
   assignString(agentConfig.referenceFile, 'referenceFile');
-  assignArray(agentConfig.referenceFiles ?? undefined, 'referenceFiles');
+  assignArray(agentConfig.referenceFiles, 'referenceFiles');
   assignString(agentConfig.auxiliaryFile, 'auxiliaryFile');
-  assignArray(agentConfig.auxiliaryFiles ?? undefined, 'auxiliaryFiles');
+  assignArray(agentConfig.auxiliaryFiles, 'auxiliaryFiles');
   assignString(agentConfig.mediaFile, 'mediaFile');
-  assignArray(agentConfig.mediaFiles ?? undefined, 'mediaFiles');
-  assignArray(agentConfig.outputFiles ?? undefined, 'outputFiles');
+  assignArray(agentConfig.mediaFiles, 'mediaFiles');
+  assignArray(agentConfig.outputFiles, 'outputFiles');
 
   return context;
 }


### PR DESCRIPTION
## Summary
- ensure progress view managers return concrete collections and remove downstream fallbacks
- normalize agent configuration and tool-use snapshot schemas to emit typed defaults
- tighten Anthropic/OpenAI handlers, tool helpers, and UI utilities to avoid defensive guards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690696d4db448324bff02a1c990836f3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize agent and snapshot schemas to concrete defaults, refactor handlers and progress view to remove defensive fallbacks, and tighten Anthropic/OpenAI response/beta handling.
> 
> - **Core schemas**:
>   - AgentConfig: arrays normalized via transformers; custom `superRefine` for output-file validation; exported parse helpers.
>   - AgentDefinition/settings: `settings`/`prompts` now default objects; `parseAgentSetting` requires schema input.
>   - Tool-use snapshot: `messages` typed (`ProviderMessage`), stricter zod shapes.
> - **Agents/handlers**:
>   - Reflection/ToolUse agents: assume concrete arrays; simplify snapshot restore; input/media handling uses non-null lists.
>   - Anthropic handler: add beta helpers; consolidate beta flags (interleaved thinking, 1M context, files API, context management); Sonnet 3.7 output beta handling; cache-control utilities unchanged but cleaned.
>   - OpenAI Responses: zod-parse response envelope; usage now required; simplified price/usage mapping; improved output text fallback.
> - **Output processing**:
>   - OutputHandler: ensureRound initializes all caches; mapping/summaries helpers; artifact retrieval streamlined; validation logs include XML path.
> - **Progress View**:
>   - Managers return concrete collections (`getMessages`/`getFiles`/`getMissingOutputs`); add ensure helpers; events/providers updated to drop undefined guards; cleaner state resets and updates.
> - **Utils/UI/Tools**:
>   - userVars/textEnhancement use concrete arrays; instruction action list defaults to empty; `ls` tool `ignore` defaults to empty.
> - **Tests**:
>   - Adjusted for cache-control assertions, XML summary extraction, and concrete defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1589949b142aea35c55d64ea9b7e26639afd5d3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->