### PR TITLE
fix: normalize progress output files access

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -504,7 +504,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   ): Promise<void> {
     const generated = this.provider.state.outputFiles.getFiles(stream);
     const allFiles = new Set<string>(taskState.agentConfig.outputFiles || []);
-    if (generated) {
+    if (Object.keys(generated).length > 0) {
       for (const [round, infos] of Object.entries(generated)) {
         if (!Array.isArray(infos)) {
           this.logger.warn(

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -27,7 +27,7 @@ interface OutputEventsShared {
   logger: AgentLogger;
 }
 
-type FilesByRound<T> = { [key: number]: T[] };
+type FilesByRound<T> = Record<number, T[]>;
 
 interface ActiveStreamOutputUpdate {
   state: ProgressViewState;
@@ -50,11 +50,11 @@ const updateActiveStreamOutputs = ({
   }
 
   if (updates.files !== undefined) {
-    updater.updateFiles(stream, updates.files ?? {});
+    updater.updateFiles(stream, updates.files);
   }
 
   if (updates.missing !== undefined) {
-    updater.updateMissingOutputs(stream, updates.missing ?? {});
+    updater.updateMissingOutputs(stream, updates.missing);
   }
 };
 
@@ -68,10 +68,9 @@ const registerOutputFileListeners = (
     withErrorBoundary('failed to handle addOutputFiles', () => {
       state.outputFiles.addFiles(stream, filesByRound);
       const files = state.outputFiles.getFiles(stream);
-      const updates: { files?: FilesByRound<OutputFileInfo> } = {};
-      if (files !== undefined) {
-        updates.files = files;
-      }
+      const updates: { files?: FilesByRound<OutputFileInfo> } = {
+        files,
+      };
       updateActiveStreamOutputs({ state, updater, stream, updates });
     });
   });
@@ -82,10 +81,9 @@ const registerOutputFileListeners = (
       withErrorBoundary('failed to handle updateMissingOutputs', () => {
         state.outputFiles.updateMissingOutputs(stream, filesByRound);
         const missing = state.outputFiles.getMissingOutputs(stream);
-        const updates: { missing?: FilesByRound<string> } = {};
-        if (missing !== undefined) {
-          updates.missing = missing;
-        }
+        const updates: { missing?: FilesByRound<string> } = {
+          missing,
+        };
         updateActiveStreamOutputs({ state, updater, stream, updates });
       });
     },

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -149,11 +149,11 @@ export class ProgressEventHandler {
     this.webviewUpdater.updateLogContent(stream, messages, groups);
 
     // Send output files for current stream
-    const files = this.state.outputFiles.getFiles(stream) || {};
+    const files = this.state.outputFiles.getFiles(stream);
     this.webviewUpdater.updateFiles(stream, files);
 
     // Send missing outputs for current stream
-    const missing = this.state.outputFiles.getMissingOutputs(stream) || {};
+    const missing = this.state.outputFiles.getMissingOutputs(stream);
     this.webviewUpdater.updateMissingOutputs(stream, missing);
 
     // Send usage for current stream

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -33,9 +33,9 @@ export class OutputFilesManager extends PersistentMapManager<
   /** Add output files for a stream and round */
   addFiles(
     stream: StreamTabId,
-    filesByRound: { [key: number]: OutputFileInfo[] },
+    filesByRound: Record<number, OutputFileInfo[]>,
   ): void {
-    const existing = this.get(stream) || {};
+    const existing = this.getFiles(stream);
     const merged = { ...existing, ...filesByRound };
     this.add(stream, merged);
   }
@@ -60,17 +60,13 @@ export class OutputFilesManager extends PersistentMapManager<
   }
 
   /** Get output files for a stream */
-  getFiles(
-    stream: StreamTabId,
-  ): { [key: number]: OutputFileInfo[] } | undefined {
-    return this.get(stream);
+  getFiles(stream: StreamTabId): Record<number, OutputFileInfo[]> {
+    return this.get(stream) ?? {};
   }
 
   /** Get missing outputs for a stream */
-  getMissingOutputs(
-    stream: StreamTabId,
-  ): { [key: number]: string[] } | undefined {
-    return this._missingOutputs.get(stream);
+  getMissingOutputs(stream: StreamTabId): Record<number, string[]> {
+    return this._missingOutputs.get(stream) ?? {};
   }
 
   /** Clear output files for a stream */

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -293,11 +293,11 @@ export class WebviewUpdater {
       this.updateLogContent(activeStream, messages, groups);
 
       // Update files for active stream
-      const files = state.outputFiles.getFiles(activeStream) || {};
+      const files = state.outputFiles.getFiles(activeStream);
       this.updateFiles(activeStream, files);
 
       // Update missing outputs for active stream
-      const missing = state.outputFiles.getMissingOutputs(activeStream) || {};
+      const missing = state.outputFiles.getMissingOutputs(activeStream);
       this.updateMissingOutputs(activeStream, missing);
 
       // Update usage for active stream

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -12,6 +12,7 @@ import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { AgentLogger } from '@logger/AgentLogger';
+import type { OutputFileInfo } from '@agent/output/types';
 
 class FakeBus {
   public readonly events: (keyof ProgressEventPayloads)[] = [];
@@ -114,9 +115,9 @@ describe('Progress event modules', () => {
     const state = {
       outputFiles: {
         addFiles: () => {},
-        getFiles: () => undefined,
+        getFiles: () => ({} as Record<number, OutputFileInfo[]>),
         updateMissingOutputs: () => {},
-        getMissingOutputs: () => undefined,
+        getMissingOutputs: () => ({} as Record<number, string[]>),
         clearMissingOutputs: () => {},
         clearFiles: () => {},
       },
@@ -151,6 +152,50 @@ describe('Progress event modules', () => {
 
     disposables.forEach((disposable) => disposable.dispose());
     assert.deepStrictEqual(bus.disposed, bus.events);
+  });
+
+  it('sends empty output updates when no files exist', () => {
+    const bus = new FakeBus();
+    const module = createOutputEvents({
+      logger: loggerStub,
+    });
+
+    const filesUpdates: Record<number, OutputFileInfo[]>[] = [];
+    const missingUpdates: Record<number, string[]>[] = [];
+
+    const state = {
+      outputFiles: {
+        addFiles: () => {},
+        getFiles: () => ({} as Record<number, OutputFileInfo[]>),
+        updateMissingOutputs: () => {},
+        getMissingOutputs: () => ({} as Record<number, string[]>),
+        clearMissingOutputs: () => {},
+        clearFiles: () => {},
+      },
+      clearOutputState: () => {},
+      activeStream: 'stream-1',
+    } as unknown as ProgressViewState;
+
+    const updater = {
+      isAvailable: () => true,
+      updateFiles: (_stream: string, files: Record<number, OutputFileInfo[]>) => {
+        filesUpdates.push(files);
+      },
+      updateMissingOutputs: (
+        _stream: string,
+        files: Record<number, string[]>,
+      ) => {
+        missingUpdates.push(files);
+      },
+    } as unknown as WebviewUpdater;
+
+    module.register(bus as any, state, updater);
+
+    bus.trigger('addOutputFiles', { stream: 'stream-1', filesByRound: {} });
+    bus.trigger('updateMissingOutputs', { stream: 'stream-1', filesByRound: {} });
+
+    assert.deepStrictEqual(filesUpdates, [{}]);
+    assert.deepStrictEqual(missingUpdates, [{}]);
   });
 
   it('registers log handlers and disposes them', () => {


### PR DESCRIPTION
## Summary
- return empty records from `OutputFilesManager` getters so callers never receive `undefined`
- rely on normalized data in progress view managers/events and guard toolbar usage aggregation via object keys
- extend progress view event tests to assert empty payloads are preserved for streams without files

## Testing
- npm run compile-tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69069a3fff78832484ac6821efc90ef6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize output files APIs to always return empty records and propagate them through events/webview, updating handlers accordingly and adding tests.
> 
> - **Output files normalization**:
>   - `OutputFilesManager.getFiles`/`getMissingOutputs` now return empty `Record` objects instead of `undefined`.
>   - Type cleanups: use `Record<number, T[]>` for `FilesByRound` and method params.
> - **Event/Webview updates**:
>   - `OutputEvents` and `ProgressEventHandler` pass through returned records directly (no `|| {}`), and send empty payloads when applicable.
>   - `WebviewUpdater.updateAll` and related callers now use normalized getters when updating files/missing outputs.
> - **Toolbar file ops**:
>   - `ProgressViewMessageHandler.handleFileOperation` checks `Object.keys(generated).length > 0` before iterating.
> - **Tests**:
>   - Extend event module tests to assert empty output/missing payloads are emitted for streams without files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 141eac7c22c0bcc43f40aae5f71dd0cad5b2b7aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->