### PR TITLE
Refactor agent metrics state separation

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -10,36 +10,86 @@ import * as logger from '@logger/logUtils';
 const CHANNEL = 'Agent';
 logger.initialize(CHANNEL);
 
+/** Snapshot of usage metrics that a single round contributes to a run. */
+export interface RoundUsageMetricsSnapshot {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  reasoningTokens: number;
+  toolUseTokens: number;
+  firstInputTokenContribution: number;
+}
+
 /** Interface for tracking state within a single conversation round. */
-export interface IAgentStateRound {
+export interface IRoundMetricsState {
   currRound: number;
   continuationCount: number;
   responseTime: number;
-  outputFile: string;
-  APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
+  metrics: RoundUsageMetricsSnapshot | null;
+}
+
+function createEmptyMetrics(): RoundUsageMetricsSnapshot {
+  return {
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    reasoningTokens: 0,
+    toolUseTokens: 0,
+    firstInputTokenContribution: 0,
+  };
 }
 
 /** Manages state and metrics for a single conversation round. */
-export class AgentStateRound implements IAgentStateRound {
+export class RoundMetricsState implements IRoundMetricsState {
   currRound: number;
   continuationCount: number;
   responseTime: number;
-  outputFile: string;
-  APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
+  private usageMetrics: RoundUsageMetricsSnapshot;
+  private hasUsageMetrics: boolean;
 
   constructor(currRound: number) {
     this.currRound = currRound;
     this.continuationCount = 0;
     this.responseTime = 0;
-    this.outputFile = '';
-    this.APIUsage = null;
+    this.usageMetrics = createEmptyMetrics();
+    this.hasUsageMetrics = false;
   }
 
   /** Updates token usage metrics from model API response. */
-  updateTokenCounts(
+  updateUsageMetrics(
     responseUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage,
   ): void {
-    this.APIUsage = responseUsage;
+    const metrics = createEmptyMetrics();
+    metrics.totalInputTokens = responseUsage.totalInputTokens;
+    metrics.totalOutputTokens = responseUsage.totalOutputTokens;
+    metrics.firstInputTokenContribution = responseUsage.totalInputTokens;
+
+    if ('cache_read_input_tokens' in responseUsage) {
+      metrics.cacheReadInputTokens = responseUsage.cache_read_input_tokens ?? 0;
+      metrics.cacheCreationInputTokens =
+        responseUsage.cache_creation_input_tokens ?? 0;
+      metrics.firstInputTokenContribution +=
+        metrics.cacheReadInputTokens + metrics.cacheCreationInputTokens;
+    } else if ('cached_tokens' in responseUsage) {
+      metrics.cacheReadInputTokens = responseUsage.cached_tokens ?? 0;
+    }
+
+    if ('reasoning_tokens' in responseUsage) {
+      metrics.reasoningTokens = responseUsage.reasoning_tokens ?? 0;
+    }
+
+    if (
+      'tool_use_tokens' in responseUsage &&
+      responseUsage.tool_use_tokens !== null &&
+      responseUsage.tool_use_tokens !== undefined
+    ) {
+      metrics.toolUseTokens = responseUsage.tool_use_tokens;
+    }
+
+    this.usageMetrics = metrics;
+    this.hasUsageMetrics = true;
   }
 
   /** Adds response time in milliseconds to the round total. */
@@ -52,37 +102,38 @@ export class AgentStateRound implements IAgentStateRound {
     this.continuationCount += 1;
   }
 
+  /** Returns a copy of the usage metrics captured for this round. */
+  get metrics(): RoundUsageMetricsSnapshot | null {
+    return this.hasUsageMetrics ? { ...this.usageMetrics } : null;
+  }
+
   /** Converts state to a serializable object for persistence. */
   toObject(): Record<string, any> {
-    const stateObj = {
+    return {
       currRound: this.currRound,
       continuationCount: this.continuationCount,
       responseTime: this.responseTime,
-      outputFile: this.outputFile,
-      APIUsage: this.APIUsage,
+      metrics: this.metrics,
     };
-    return stateObj;
   }
 }
 
 /** Interface for tracking aggregate metrics across all conversation rounds. */
-export interface IAgentStateGlobal {
+export interface IRunMetricsState {
   firstInputTokens: number;
   totalResponseTime: number;
   totalInputTokens: number;
   totalOutputTokens: number;
   totalRounds: number;
-  APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
 }
 
 /** Manages global state and aggregates metrics across conversation rounds. */
-export class AgentStateGlobal implements IAgentStateGlobal {
+export class RunMetricsState implements IRunMetricsState {
   firstInputTokens: number;
   totalResponseTime: number;
   totalInputTokens: number;
   totalOutputTokens: number;
   totalRounds: number;
-  APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
   public totalCacheReadInputTokens: number = 0;
   public totalCacheCreationInputTokens: number = 0;
   public totalReasoningTokens: number = 0;
@@ -94,78 +145,34 @@ export class AgentStateGlobal implements IAgentStateGlobal {
     this.totalInputTokens = 0;
     this.totalOutputTokens = 0;
     this.totalRounds = 0;
-    this.APIUsage = null;
   }
 
   /** Updates global metrics by incorporating round state data. */
-  updateFromCurrRound(stateRound: AgentStateRound): void {
-    if (stateRound.APIUsage) {
+  updateFromRoundMetrics(
+    roundMetrics: RoundUsageMetricsSnapshot | null,
+    responseTime: number,
+  ): void {
+    if (roundMetrics) {
       if (this.firstInputTokens === 0) {
-        this.firstInputTokens = stateRound.APIUsage.totalInputTokens;
+        this.firstInputTokens = roundMetrics.firstInputTokenContribution;
       }
 
-      // For Anthropic models, handle cache tokens directly from response
-      if ('cache_read_input_tokens' in stateRound.APIUsage) {
-        const cacheRead = stateRound.APIUsage.cache_read_input_tokens ?? 0;
-        const cacheCreation =
-          stateRound.APIUsage.cache_creation_input_tokens ?? 0;
-        this.totalCacheReadInputTokens += cacheRead;
-        this.totalCacheCreationInputTokens += cacheCreation;
-        this.firstInputTokens += cacheRead + cacheCreation;
-      }
-      // For OpenAI models with auto prompt caching, handle cache tokens from prompt_tokens_details
-      else if (
-        'prompt_tokens_details' in stateRound.APIUsage &&
-        stateRound.APIUsage.prompt_tokens_details
-      ) {
-        const promptDetails = stateRound.APIUsage.prompt_tokens_details as {
-          cached_tokens?: number;
-        };
-        if ('cached_tokens' in promptDetails) {
-          this.totalCacheReadInputTokens += promptDetails.cached_tokens ?? 0;
-        }
-      }
-
-      // For OpenAI models, handle reasoning tokens from completion_tokens_details
-      if (
-        'completion_tokens_details' in stateRound.APIUsage &&
-        stateRound.APIUsage.completion_tokens_details
-      ) {
-        const completionDetails = stateRound.APIUsage
-          .completion_tokens_details as { reasoning_tokens?: number };
-        if ('reasoning_tokens' in completionDetails) {
-          this.totalReasoningTokens += completionDetails.reasoning_tokens ?? 0;
-        }
-      }
-      // For older OpenAI models, handle reasoning tokens directly
-      else if ('reasoning_tokens' in stateRound.APIUsage) {
-        this.totalReasoningTokens += stateRound.APIUsage.reasoning_tokens ?? 0;
-      }
-
-      // Track tokens used for tool calls
-      // Note: Only Google models provide tool_use_tokens (as toolUsePromptTokenCount)
-      // OpenAI and Anthropic don't provide this information in their API responses
-      if (
-        'tool_use_tokens' in stateRound.APIUsage &&
-        stateRound.APIUsage.tool_use_tokens !== null &&
-        stateRound.APIUsage.tool_use_tokens !== undefined
-      ) {
-        this.totalToolUseTokens += stateRound.APIUsage.tool_use_tokens;
-      }
-
-      // Update global totals
-      this.totalInputTokens += stateRound.APIUsage.totalInputTokens;
-      this.totalOutputTokens += stateRound.APIUsage.totalOutputTokens;
+      this.totalInputTokens += roundMetrics.totalInputTokens;
+      this.totalOutputTokens += roundMetrics.totalOutputTokens;
+      this.totalCacheReadInputTokens += roundMetrics.cacheReadInputTokens;
+      this.totalCacheCreationInputTokens +=
+        roundMetrics.cacheCreationInputTokens;
+      this.totalReasoningTokens += roundMetrics.reasoningTokens;
+      this.totalToolUseTokens += roundMetrics.toolUseTokens;
     }
 
-    this.totalResponseTime += stateRound.responseTime;
+    this.totalResponseTime += responseTime;
   }
 
   incrementRounds(): void {
     this.totalRounds += 1;
   }
 
-  // are the following two methods needed?
   /** Converts global state to a serializable object for persistence. */
   toObject(): Record<string, any> {
     return {
@@ -174,7 +181,6 @@ export class AgentStateGlobal implements IAgentStateGlobal {
       totalInputTokens: this.totalInputTokens,
       totalOutputTokens: this.totalOutputTokens,
       totalRounds: this.totalRounds,
-      APIUsage: this.APIUsage,
       totalCacheReadInputTokens: this.totalCacheReadInputTokens,
       totalCacheCreationInputTokens: this.totalCacheCreationInputTokens,
       totalReasoningTokens: this.totalReasoningTokens,
@@ -182,19 +188,18 @@ export class AgentStateGlobal implements IAgentStateGlobal {
     };
   }
 
-  /** Creates an AgentStateGlobal instance from a persisted state object. */
-  static fromObject(stateObj: Record<string, any> | null): AgentStateGlobal {
+  /** Creates a RunMetricsState instance from a persisted state object. */
+  static fromObject(stateObj: Record<string, any> | null): RunMetricsState {
     if (!stateObj) {
-      return new AgentStateGlobal();
+      return new RunMetricsState();
     }
 
-    const state = new AgentStateGlobal();
+    const state = new RunMetricsState();
     state.firstInputTokens = stateObj.firstInputTokens ?? 0;
     state.totalResponseTime = stateObj.totalResponseTime ?? 0;
     state.totalInputTokens = stateObj.totalInputTokens ?? 0;
     state.totalOutputTokens = stateObj.totalOutputTokens ?? 0;
     state.totalRounds = stateObj.totalRounds ?? 0;
-    state.APIUsage = stateObj.APIUsage ?? null;
     state.totalCacheReadInputTokens = stateObj.totalCacheReadInputTokens ?? 0;
     state.totalCacheCreationInputTokens =
       stateObj.totalCacheCreationInputTokens ?? 0;

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -1,5 +1,5 @@
 // Local imports - agent components
-import { AgentStateGlobal, AgentStateRound } from './AgentState';
+import { RunMetricsState, RoundMetricsState } from './AgentState';
 import { ToolState } from './ToolState';
 
 // Local imports - flow orchestration
@@ -26,15 +26,15 @@ export interface ResponseCycleOptions<C = unknown>
 export interface ResponseCycleContext<C = unknown> {
   options: ResponseCycleOptions<C>;
   messages: ProviderMessage[];
-  stateRound: AgentStateRound;
-  stateGlobal: AgentStateGlobal;
+  stateRound: RoundMetricsState;
+  stateGlobal: RunMetricsState;
   toolState: ToolState;
   outputFile: string;
 }
 
 export interface ResponseCycleResult {
-  stateRound: AgentStateRound;
-  stateGlobal: AgentStateGlobal;
+  stateRound: RoundMetricsState;
+  stateGlobal: RunMetricsState;
   toolState: ToolState;
   endTurn: boolean;
 }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -5,7 +5,7 @@ import { BaseNode, Flow } from '@agent/node';
 import { FlowTransition } from './FlowTransitions';
 
 // Local imports - agent components
-import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
+import { RunMetricsState, RoundMetricsState } from '@agent/core/AgentState';
 import { ToolState } from '@agent/core/ToolState';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
@@ -72,8 +72,8 @@ async function maybeSaveDebug(
 
 export interface ResponseCycleInputState {
   messages: ProviderMessage[];
-  stateRound: AgentStateRound;
-  stateGlobal: AgentStateGlobal;
+  stateRound: RoundMetricsState;
+  stateGlobal: RunMetricsState;
   toolState: ToolState;
   outputFile: string;
 }
@@ -376,8 +376,11 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       responseUsage,
       cycle.responseTime ?? 0,
     );
-    cycle.stateRound.updateTokenCounts(apiUsage);
-    cycle.stateGlobal.updateFromCurrRound(cycle.stateRound);
+    cycle.stateRound.updateUsageMetrics(apiUsage);
+    cycle.stateGlobal.updateFromRoundMetrics(
+      cycle.stateRound.metrics,
+      cycle.stateRound.responseTime,
+    );
 
     const repetitionResult = checkForMassiveRepetition(
       cycle.toolState.lastResponse,

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -5,7 +5,7 @@ import {
   AgentSetting,
   type AgentSessionDescriptor,
 } from '../core/AgentDataclass';
-import { AgentStateGlobal } from '../core/AgentState';
+import { RunMetricsState } from '../core/AgentState';
 import { IAgent, type AgentRunHooks } from '../core/IAgent';
 import type { IModelHandler } from '../modelHandlers';
 import { UsageMonitor } from '../utils/UsageMonitor';
@@ -218,7 +218,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   }
 
   protected async trackRoundUsage(
-    stateGlobal: AgentStateGlobal,
+    stateGlobal: RunMetricsState,
     groupId?: string,
   ): Promise<void> {
     await this.usageMonitor.recordUsage(stateGlobal, groupId);

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -6,7 +6,7 @@ import {
   AgentWorkflowSetting,
   requireWorkflowSetting,
 } from '@agent/core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
+import { RoundMetricsState, RunMetricsState } from '@agent/core/AgentState';
 import { runResponseCycle } from '@agent/core/ResponseCycle';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 import { ToolState } from '@agent/core/ToolState';
@@ -65,13 +65,13 @@ export interface RoundOutputOptions {
 
 export interface ReflectionRoundContext {
   roundIndex: number;
-  globalState: AgentStateGlobal;
+  globalState: RunMetricsState;
   messages: any[];
 }
 
 export interface ReflectionRoundResult {
-  roundState: AgentStateRound;
-  globalState: AgentStateGlobal;
+  roundState: RoundMetricsState;
+  globalState: RunMetricsState;
   messages: any[];
   shouldContinue: boolean;
   toolState: ToolState;
@@ -86,8 +86,8 @@ export interface AgentRuntimeXmlExports {
 
 interface RoundPipelineContext {
   roundIndex: number;
-  roundState: AgentStateRound;
-  globalState: AgentStateGlobal;
+  roundState: RoundMetricsState;
+  globalState: RunMetricsState;
   toolState: ToolState;
   preparedMessages: any[];
   prefill: string;
@@ -112,7 +112,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   protected outputHandler: IOutputHandler;
   protected latexMediaManager: LatexMediaManager;
   protected promptBuilder?: PromptBuilder;
-  public roundStates: AgentStateRound[] = [];
+  public roundStates: RoundMetricsState[] = [];
   public toolStates: ToolState[] = [];
   public roundOutputArtifacts: RoundOutputArtifacts[] = [];
   public runtimeXmlExports: AgentRuntimeXmlExports = {
@@ -220,8 +220,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    */
   private async handleRoundCompletion(
     currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: RunMetricsState,
     options: RoundOutputOptions,
   ): Promise<RoundOutputArtifacts> {
     const { outputFile, endTurn, processGroupId } = options;
@@ -261,8 +261,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    */
   protected async handleOutput(
     currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: RunMetricsState,
     options: RoundOutputOptions,
   ): Promise<string[]> {
     const { outputFile, endTurn, processGroupId } = options;
@@ -405,17 +405,17 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
   private async prepareRoundContext(
     currRound: number,
-    _stateGlobal: AgentStateGlobal,
+    _stateGlobal: RunMetricsState,
     messages: any[],
     toolState: ToolState,
     roundGroupId: string,
   ): Promise<{
-    stateRound: AgentStateRound;
+    stateRound: RoundMetricsState;
     preparedMessages: any[];
     prefill?: string;
     skip: boolean;
   }> {
-    const stateRound = new AgentStateRound(currRound);
+    const stateRound = new RoundMetricsState(currRound);
     const promptBuilder = this.getPromptBuilder();
 
     if (currRound === 0) {
@@ -638,7 +638,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           currentRound: 0,
           continueRounds: true,
           messages: [],
-          globalState: new AgentStateGlobal(),
+          globalState: new RunMetricsState(),
         }) satisfies ReflectionRunState,
       createFlow: () => createReflectionRunFlow<C>(),
       extendHooks: (baseHooks: AgentRunHooks) => {

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -1,5 +1,5 @@
 // Local imports - agent components
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
+import { RoundMetricsState, RunMetricsState } from '../core/AgentState';
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
 
@@ -38,8 +38,8 @@ export class CoTAgent extends BaseReflectionAgent {
    */
   protected async handleOutput(
     currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: RunMetricsState,
     options: RoundOutputOptions,
   ): Promise<string[]> {
     const { outputFile, endTurn, processGroupId } = options;

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -1,5 +1,5 @@
 // Local imports - agent
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
+import { RoundMetricsState, RunMetricsState } from '../core/AgentState';
 // Local imports - agent components
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
@@ -39,8 +39,8 @@ export class DirectAgent extends BaseReflectionAgent {
    */
   protected async handleOutput(
     currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: RunMetricsState,
     options: RoundOutputOptions,
   ): Promise<string[]> {
     const { outputFile, endTurn, processGroupId } = options;

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 // Local imports - agent
 import type { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, AgentPrompt } from '../core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
+import { RoundMetricsState, RunMetricsState } from '../core/AgentState';
 import { RoundOutputOptions } from './BaseReflectionAgent';
 
 // Local imports - agent components
@@ -139,8 +139,8 @@ export class MergeAgent extends DirectAgent {
    */
   protected async handleOutput(
     currRound: number,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: RunMetricsState,
     options: RoundOutputOptions,
   ): Promise<string[]> {
     const { outputFile, endTurn, processGroupId } = options;

--- a/src/agent/implementations/flows/ReflectionRoundFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRoundFlow.ts
@@ -5,19 +5,19 @@ import { BaseNode, Flow } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 
 // Local imports - agent components
-import type { AgentStateRound } from '@agent/core/AgentState';
+import type { RoundMetricsState } from '@agent/core/AgentState';
 import type { ToolState } from '@agent/core/ToolState';
 import type { ReflectionRoundResult } from '../BaseReflectionAgent';
 
 interface RoundPreparationResult {
-  stateRound: AgentStateRound;
+  stateRound: RoundMetricsState;
   preparedMessages: any[];
   prefill?: string;
   skip: boolean;
 }
 
 interface ReflectionRoundPipelineInput {
-  stateRound: AgentStateRound;
+  stateRound: RoundMetricsState;
   preparedMessages: any[];
   prefill: string;
 }
@@ -28,12 +28,12 @@ export interface ReflectionRoundHooks {
   runRoundPipeline(
     input: ReflectionRoundPipelineInput,
   ): Promise<ReflectionRoundResult>;
-  createSkipResult(stateRound: AgentStateRound): ReflectionRoundResult;
+  createSkipResult(stateRound: RoundMetricsState): ReflectionRoundResult;
 }
 
 export interface ReflectionRoundRuntime {
   toolState: ToolState;
-  roundState?: AgentStateRound;
+  roundState?: RoundMetricsState;
   preparedMessages?: any[];
   prefill?: string;
   result?: ReflectionRoundResult;
@@ -55,7 +55,7 @@ class ToolPreparationNode extends BaseNode<ReflectionRoundShared> {
 }
 
 interface RoundPreparationExec {
-  stateRound: AgentStateRound;
+  stateRound: RoundMetricsState;
   preparedMessages: any[];
   prefill?: string;
   skip: boolean;

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -5,7 +5,7 @@ import { BaseNode, Flow } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 
 // Local imports - agent components
-import type { AgentStateGlobal } from '@agent/core/AgentState';
+import type { RunMetricsState } from '@agent/core/AgentState';
 import type {
   BaseReflectionAgent,
   ReflectionRoundContext,
@@ -43,7 +43,7 @@ export interface ReflectionRunState {
   currentRound: number;
   continueRounds: boolean;
   messages: any[];
-  globalState: AgentStateGlobal;
+  globalState: RunMetricsState;
 }
 
 export type ReflectionRunShared<C = unknown> = AgentRunShared<
@@ -59,7 +59,7 @@ interface ReflectionRoundPrep<C> {
   shouldFinalize: boolean;
   roundIndex: number;
   messages: any[];
-  globalState: AgentStateGlobal;
+  globalState: RunMetricsState;
 }
 
 interface ReflectionRoundExec<C> extends ReflectionRoundPrep<C> {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -8,7 +8,7 @@ import { encode as encodeHtml } from 'he';
 // Local imports - agent components
 import type { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, AgentType, hasEndTag } from '../core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
+import { RoundMetricsState, RunMetricsState } from '../core/AgentState';
 import { ToolState } from '../core/ToolState';
 import type { IModelHandler } from './types/IModelHandler';
 import type { ProviderMessage } from './types/ProviderMessage';
@@ -525,8 +525,8 @@ export abstract class ModelHandler<
 
   /** Calculates token-based stop flags. */
   protected computeTokenFlags(
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: RunMetricsState,
   ): TokenFlags {
     const maxOutputTokens =
       stateGlobal.firstInputTokens > 0
@@ -567,8 +567,8 @@ export abstract class ModelHandler<
   public checkStopConditions(
     stopReason: ProviderStopReason,
     newResponse: string,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: RunMetricsState,
     agentSetting: AgentSetting,
   ): [boolean, boolean] {
     const tokenFlags = this.computeTokenFlags(stateRound, stateGlobal);
@@ -671,7 +671,7 @@ export abstract class ModelHandler<
    */
   abstract addContinueMessageWithPrefill(
     messages: M[],
-    stateRound: AgentStateRound,
+    stateRound: RoundMetricsState,
     toolState: ToolState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
@@ -683,7 +683,7 @@ export abstract class ModelHandler<
    */
   abstract addContinueMessageWithoutPrefill(
     messages: M[],
-    stateRound: AgentStateRound,
+    stateRound: RoundMetricsState,
     toolState: ToolState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -63,7 +63,7 @@ import {
   hasEndTag,
   requireWorkflowSetting,
 } from '@agent/core/AgentDataclass';
-import { AgentStateRound } from '@agent/core/AgentState';
+import { RoundMetricsState } from '@agent/core/AgentState';
 import {
   AnthropicAPIResponseUsage,
   ResponseUsageFactory,
@@ -379,7 +379,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
             }
           }
         }
-        // in the future we log this in firstInputTokens of the AgentStateGlobal
+        // in the future we log this in firstInputTokens of the RunMetricsState
       }
     }
 
@@ -1043,7 +1043,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /** Manages continuation with prefill support (typically no-op for models with prefill). */
   addContinueMessageWithPrefill(
     _messages: MessageParam[],
-    _stateRound: AgentStateRound,
+    _stateRound: RoundMetricsState,
     _toolState: ToolState,
     _agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
@@ -1055,7 +1055,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /** Manages continuation for models without prefill support by adding a continuation prompt. */
   addContinueMessageWithoutPrefill(
     messages: MessageParam[],
-    _stateRound: AgentStateRound,
+    _stateRound: RoundMetricsState,
     toolState: ToolState,
     agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
@@ -1193,7 +1193,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (!this.capabilities.supportsAssistantPrefill) {
       // For models that don't support assistant prefill, we need to:
       // add a continuation message in addition
-      const state = new AgentStateRound(0);
+      const state = new RoundMetricsState(0);
       this.addContinueMessageWithoutPrefill(
         messages,
         state,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -29,7 +29,7 @@ import { toGoogleTools } from './toolConversion';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
+import { RoundMetricsState, RunMetricsState } from '@agent/core/AgentState';
 import {
   OpenAIAPIResponseUsage,
   ResponseUsageFactory,
@@ -848,7 +848,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   addContinueMessageWithoutPrefill(
     messages: Content[],
-    _stateRound: AgentStateRound,
+    _stateRound: RoundMetricsState,
     toolState: ToolState,
     agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
@@ -987,7 +987,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     );
     toolState.updateAccumulatedOutput(fileContent);
     toolState.lastResponse = fileContent;
-    const state = new AgentStateRound(0);
+    const state = new RoundMetricsState(0);
     this.addContinueMessageWithoutPrefill(
       messages,
       state,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -16,7 +16,7 @@ import {
 // Local imports - agent components
 import type { AgentConfig } from '../core/AgentConfig';
 import { AgentSetting, hasEndTag } from '../core/AgentDataclass';
-import { AgentStateRound } from '../core/AgentState';
+import { RoundMetricsState } from '../core/AgentState';
 import {
   OpenAIAPIResponseUsage,
   ResponseUsageFactory,
@@ -792,7 +792,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /** Manages continuation with prefill support (typically no-op for models with prefill). */
   addContinueMessageWithPrefill(
     _messages: any[],
-    _stateRound: AgentStateRound,
+    _stateRound: RoundMetricsState,
     _toolState: ToolState,
     _agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
@@ -804,7 +804,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /** Manages continuation for models without prefill support by adding a continuation prompt. */
   addContinueMessageWithoutPrefill(
     messages: any[],
-    _stateRound: AgentStateRound,
+    _stateRound: RoundMetricsState,
     toolState: ToolState,
     agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
@@ -918,7 +918,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
       toolState.updateAccumulatedOutput(prefill + fileContent);
       await WorkspaceFS.write(outputFile, toolState.accumulatedOutput);
     }
-    const state = new AgentStateRound(0);
+    const state = new RoundMetricsState(0);
     toolState.lastResponse = toolState.accumulatedOutput;
     this.addContinueMessageWithoutPrefill(
       messages,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -28,7 +28,7 @@ import type { ResponseStreamParams } from 'openai/lib/responses/ResponseStream';
 import type { AgentConfig } from '../core/AgentConfig';
 import type { AgentSetting } from '../core/AgentDataclass';
 import { hasEndTag } from '../core/AgentDataclass';
-import { AgentStateRound } from '../core/AgentState';
+import { RoundMetricsState } from '../core/AgentState';
 import {
   ResponseUsageFactory,
   type OpenAIAPIResponseUsage,
@@ -744,7 +744,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Models with prefill support do not require additional continuation messages. */
   addContinueMessageWithPrefill(
     _messages: ResponseInputItem[],
-    _stateRound: AgentStateRound,
+    _stateRound: RoundMetricsState,
     _toolState: ToolState,
     _agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
@@ -1010,7 +1010,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Adds continuation instructions for models without prefill support. */
   addContinueMessageWithoutPrefill(
     messages: ResponseInputItem[],
-    _stateRound: AgentStateRound,
+    _stateRound: RoundMetricsState,
     toolState: ToolState,
     agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
@@ -1094,7 +1094,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       await WorkspaceFS.write(outputFile, toolState.accumulatedOutput);
     }
 
-    const state = new AgentStateRound(0);
+    const state = new RoundMetricsState(0);
     toolState.lastResponse = toolState.accumulatedOutput;
     this.addContinueMessageWithoutPrefill(
       messages,

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -1,7 +1,7 @@
 // Local imports - agent components
 import type { AgentConfig } from '../../core/AgentConfig';
 import { AgentSetting, AgentType } from '../../core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '../../core/AgentState';
+import { RoundMetricsState, RunMetricsState } from '../../core/AgentState';
 import { ToolState } from '../../core/ToolState';
 import type { MediaEntry } from '../../utils/mediaTypes';
 
@@ -115,7 +115,7 @@ export interface IModelHandler<
   /** Handle continuation for models supporting prefill. */
   addContinueMessageWithPrefill(
     messages: M[],
-    stateRound: AgentStateRound,
+    stateRound: RoundMetricsState,
     toolState: ToolState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
@@ -124,7 +124,7 @@ export interface IModelHandler<
   /** Handle continuation for models without prefill. */
   addContinueMessageWithoutPrefill(
     messages: M[],
-    stateRound: AgentStateRound,
+    stateRound: RoundMetricsState,
     toolState: ToolState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
@@ -177,8 +177,8 @@ export interface IModelHandler<
   checkStopConditions(
     stopReason: ProviderStopReason,
     newResponse: string,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: RunMetricsState,
     agentSetting: AgentSetting,
   ): [boolean, boolean];
 

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -3,11 +3,7 @@ import { LatexDiffManager } from './LatexDiffManager';
 import { XmlOutputManager } from './XmlOutputManager';
 
 // Local imports - types
-import {
-  NamedOutputFile,
-  OutputFileInfo,
-  RoundFileMapping,
-} from './types';
+import { NamedOutputFile, OutputFileInfo, RoundFileMapping } from './types';
 import type { OutputXmlSummary, RoundOutputArtifacts } from './OutputHandler';
 
 /** Interface describing OutputHandler behavior used by agents. */

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -23,7 +23,6 @@ import {
   AgentWorkflowSetting,
   requireWorkflowSetting,
 } from '@agent/core/AgentDataclass';
-import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { bus } from '@eventBus/ProgressEventBus';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
@@ -439,11 +438,7 @@ export class OutputHandler implements IOutputHandler {
           );
 
           this.setRoundOutputs(currRound, processedFiles, processedPairs);
-          await this.captureXmlSummary(
-            currRound,
-            outputFile,
-            processedPairs,
-          );
+          await this.captureXmlSummary(currRound, outputFile, processedPairs);
 
           if (this.baseFiles && this.baseFiles.length > 0) {
             await replaceInputCommands(
@@ -533,9 +528,7 @@ export class OutputHandler implements IOutputHandler {
     }
   }
 
-  public async getRoundArtifacts(
-    round: number,
-  ): Promise<RoundOutputArtifacts> {
+  public async getRoundArtifacts(round: number): Promise<RoundOutputArtifacts> {
     const outputFiles = this.ensureRound(round).slice();
     const processed = (this.outputMappings[round] || []).map((entry) => ({
       ...entry,
@@ -610,16 +603,20 @@ export class OutputHandler implements IOutputHandler {
           );
         }
       } else {
-        const singleDocument = extractTextFromTag(rawContent, documentTag).trim();
+        const singleDocument = extractTextFromTag(
+          rawContent,
+          documentTag,
+        ).trim();
         if (singleDocument) {
           tagContents[documentTag] = singleDocument;
-          documents.push(
-            `<${documentTag}>${singleDocument}</${documentTag}>`,
-          );
+          documents.push(`<${documentTag}>${singleDocument}</${documentTag}>`);
         }
       }
 
-      const scratchpadContent = extractTextFromTag(rawContent, 'scratchpad').trim();
+      const scratchpadContent = extractTextFromTag(
+        rawContent,
+        'scratchpad',
+      ).trim();
       if (scratchpadContent) {
         tagContents.scratchpad = scratchpadContent;
       }

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -2,7 +2,7 @@
 import { ResponseUsage } from 'openai/resources/responses/responses';
 
 // Local imports - agent
-import { AgentStateGlobal } from '@agent/core/AgentState';
+import { RunMetricsState } from '@agent/core/AgentState';
 import {
   ExtendedCompletionUsage,
   AnthropicUsage,
@@ -29,7 +29,7 @@ export class UsageMonitor {
   ) {}
 
   async recordUsage(
-    stateGlobal: AgentStateGlobal,
+    stateGlobal: RunMetricsState,
     groupId?: string,
   ): Promise<void> {
     const statsGroupId = groupId ?? this.logger.getActiveGroupId();

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports - agent core
 import { parseAgentConfig, type AgentConfig } from '@agent/core/AgentConfig';
-import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
+import { RoundMetricsState, RunMetricsState } from '@agent/core/AgentState';
 import {
   AgentSetting,
   AgentPrompt,
@@ -328,8 +328,8 @@ describe('ResponseCycle background reasoning logs', () => {
     });
 
     const messages: ProviderMessage[] = [];
-    const stateRound = new AgentStateRound(1);
-    const stateGlobal = new AgentStateGlobal();
+    const stateRound = new RoundMetricsState(1);
+    const stateGlobal = new RunMetricsState();
     const toolState = new ToolState();
 
     await runResponseCycle({

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -358,9 +358,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       'the earliest cache marker should be removed',
     );
     assert.deepEqual(
-      cacheControlledBlocks.map(
-        (block) => (block as { text?: string }).text,
-      ),
+      cacheControlledBlocks.map((block) => (block as { text?: string }).text),
       ['block-1', 'block-2', 'block-3', 'block-4'],
       'the four most recent blocks should retain cache control markers',
     );

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -97,4 +97,3 @@ describe('getToolFlags', () => {
     assert.equal(flags.ROUNDS, 3);
   });
 });
-

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -223,16 +223,17 @@ describe('OutputHandler XML summaries', () => {
       path: 'output.tex',
     });
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async (filePath: string) => {
-        if (filePath === 'out.xml') {
-          return [
-            '<document>\\section{Results}</document>',
-            '<scratchpad>draft notes</scratchpad>',
-          ].join('');
-        }
-        return '';
-      };
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read = async (
+      filePath: string,
+    ) => {
+      if (filePath === 'out.xml') {
+        return [
+          '<document>\\section{Results}</document>',
+          '<scratchpad>draft notes</scratchpad>',
+        ].join('');
+      }
+      return '';
+    };
 
     await handler.processOutputFiles('out.xml', 0);
 
@@ -264,16 +265,17 @@ describe('OutputHandler XML summaries', () => {
       { source: 'notes.tex', path: 'notes.tex' },
     ];
 
-    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read =
-      async (filePath: string) => {
-        if (filePath === 'out.xml') {
-          return [
-            '<document name="draft">First</document>',
-            '<document name="notes">Second</document>',
-          ].join('');
-        }
-        return '';
-      };
+    (WorkspaceFS as unknown as { read: typeof WorkspaceFS.read }).read = async (
+      filePath: string,
+    ) => {
+      if (filePath === 'out.xml') {
+        return [
+          '<document name="draft">First</document>',
+          '<document name="notes">Second</document>',
+        ].join('');
+      }
+      return '';
+    };
 
     await handler.processOutputFiles('out.xml', 0);
 


### PR DESCRIPTION
## Summary
- replace the per-round and global agent state classes with purpose-specific `RoundMetricsState` and `RunMetricsState`
- persist only aggregated usage metrics for each round and propagate the distilled snapshot through flows, agents, and model handlers
- update serialization helpers and tests to reflect the slimmer metrics payloads and new class names

## Testing
- `npm run format`
- `CI=1 npm test -- ResponseCycleBackground.test.ts` *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.105.1/code: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_69069af52b2483248e0f6498d5b649b3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce RoundMetricsState and RunMetricsState with per-round usage snapshots, aggregating at run-level; update flows, model handlers, output, usage monitor, and tests to use the new metrics API.
> 
> - **Core (metrics/state)**:
>   - Replace `AgentStateRound`/`AgentStateGlobal` with `RoundMetricsState` and `RunMetricsState`.
>   - Add `RoundUsageMetricsSnapshot` and `updateUsageMetrics`; aggregate via `updateFromRoundMetrics`.
>   - Remove direct API usage storage from state; keep only distilled metrics and response time.
> - **Flows**:
>   - Wire new state types through `ResponseCycle`, `ResponseCycleFlow`, `ReflectionRoundFlow`, and `ReflectionRunFlow`.
>   - In processing, compute usage, call `stateRound.updateUsageMetrics`, then aggregate into `stateGlobal`.
> - **Model Handlers**:
>   - Update interfaces and implementations (OpenAI, OpenAI Responses, Anthropic, Google) to accept new state types in continuation/stop checks and prefill helpers.
> - **Agents**:
>   - Base/Direct/CoT/Merge agents now use `RunMetricsState` and `RoundMetricsState`; usage tracking reads from run-level totals.
> - **Output**:
>   - Minor cleanups in `OutputHandler` and `IOutputHandler`; XML summary extraction formatting tweaks.
> - **Utils**:
>   - `UsageMonitor` composes provider-specific usage from `RunMetricsState` totals and logs aggregated cost/stats.
> - **Tests**:
>   - Update tests to new state classes and adjusted behaviors (background responses, Anthropic handler, XML summaries).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10dcce31865a3c318fc3ef77f65a8d04f3e0cd0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->