### PR TITLE
fix: normalize agent file arrays

### DIFF
--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -26,10 +26,11 @@ import {
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
 
-function getFilesIfNotEmpty<T>(files: T[] | undefined | null): T[] | null {
-  if (!Array.isArray(files) || files.length === 0) {
-    return null;
+function getFilesIfNotEmpty<T>(files: T[] | undefined | null): T[] {
+  if (!Array.isArray(files)) {
+    return [];
   }
+
   return files;
 }
 
@@ -83,8 +84,7 @@ export class ExecutionManager {
     const baseConfig = this.composeBaseAgentConfig(message, session);
     const outputFiles = getFilesIfNotEmpty<string>(message.outputFiles);
     const useMultipleOutputs = Boolean(
-      message.outputFilesActive ||
-        (Array.isArray(outputFiles) && outputFiles.length > 1),
+      message.outputFilesActive || outputFiles.length > 1,
     );
 
     return {
@@ -106,7 +106,7 @@ export class ExecutionManager {
       // pipeline never attempts to resolve `_multiple` agent variants or
       // manage output file selections that the UI disables for this mode.
       useMultipleOutputs: false,
-      outputFiles: null,
+      outputFiles: [],
     };
   }
 
@@ -141,13 +141,11 @@ export class ExecutionManager {
       auxiliaryFile: message.auxiliaryFile ?? null,
       auxiliaryFiles: getFilesIfNotEmpty<string>(message.auxiliaryFiles),
       mediaFile: mapMediaPath(message.mediaFile ?? null),
-      mediaFiles: message.mediaFiles
-        ? getFilesIfNotEmpty<string>(
-            message.mediaFiles
-              .map(mapMediaPath)
-              .filter((f: string | null): f is string => f !== null),
-          )
-        : null,
+      mediaFiles: getFilesIfNotEmpty<string>(
+        (message.mediaFiles ?? [])
+          .map(mapMediaPath)
+          .filter((f: string | null): f is string => f !== null),
+      ),
       editedFile: null,
       toolConfig,
       agentType: session.agentType,


### PR DESCRIPTION
## Summary
- ensure ExecutionManager always passes arrays to AgentConfig fields
- normalize media file mapping to emit empty arrays after filtering
- keep tool-use agent payloads aligned with AgentConfig expectations

## Testing
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6907221d02a0832499fcda46873507b5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize `ExecutionManager` to always pass arrays for file fields, simplify multiple-outputs logic, and ensure tool-use and media files use empty arrays.
> 
> - **Webview · `ExecutionManager`**
>   - Normalize file array fields to always be arrays (possibly empty): `inputFiles`, `referenceFiles`, `auxiliaryFiles`, `mediaFiles`, `outputFiles`.
>   - Replace nullable returns in `getFilesIfNotEmpty` with empty arrays; update callers accordingly.
>   - Simplify multiple-output detection to `message.outputFilesActive || outputFiles.length > 1`.
>   - For tool-use agents, set `useMultipleOutputs: false` and `outputFiles: []`.
>   - Normalize `mediaFiles` by mapping/ filtering and always emitting an array.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03a130f617e6cc4500c9797a6b28b8fc67e9237f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->