### PR TITLE
Simplify persistence parsing and prompt schema

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -1,7 +1,6 @@
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - agent
 // Local imports - model types
 import { ToolDefinitionSchema } from '@model';
 
@@ -192,10 +191,13 @@ export function hasEndTag(
 }
 
 /** Zod schema for AgentPrompt validation */
+const promptEntrySchema = z.union([z.string(), z.array(z.string())]);
+
 export const AgentPromptSchema = z.object({
   systemPrompt: z.string().prefault(''),
   userPrefix: z.string().prefault(''),
-  userRequest: z.union([z.string(), z.array(z.string())]).prefault(''),
+  userRequest: promptEntrySchema.prefault(''),
+  userReflect: z.string().optional(),
 });
 
 export type AgentPrompt = z.infer<typeof AgentPromptSchema>;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -108,16 +108,7 @@ export abstract class ModelHandler<
   }
 
   constructor(config: ModelConfig) {
-    this.config = {
-      ...config,
-      toolConfig: config.toolConfig || {
-        autoExtractFigure: false,
-        autoExtractTikzFigure: false,
-        attachTeXCount: false,
-        attachDiagnostics: false,
-        autoCompileInputPdf: false,
-      },
-    };
+    this.config = { ...config };
     this.capabilities = cloneCapabilities(config.capabilities);
     this.continueLimit = DEFAULT_CONTINUE_LIMIT;
     this.inputTokenLimit = DEFAULT_INPUT_TOKEN_LIMIT;

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -252,38 +252,6 @@ export async function loadAgentSettingAndPrompts(
       });
     }
 
-    // Normalize legacy userReflect field by merging into userRequest
-    if ('userReflect' in prompts && prompts.userReflect) {
-      const userRequest = Array.isArray(prompts.userRequest)
-        ? prompts.userRequest
-        : prompts.userRequest
-          ? [prompts.userRequest]
-          : [];
-      const userReflect = Array.isArray(prompts.userReflect)
-        ? prompts.userReflect
-        : [prompts.userReflect];
-
-      prompts.userRequest = [...userRequest, ...userReflect].filter(Boolean);
-      delete (prompts as any).userReflect;
-
-      // Show warning for legacy userReflect field
-      const migrationGuide = 'View Migration Guide';
-      void vscode.window
-        .showWarningMessage(
-          `Agent "${agentNameFromFile}" uses deprecated "userReflect" field. Please migrate to array-based "userRequest" format for better compatibility.`,
-          migrationGuide,
-        )
-        .then((selection) => {
-          if (selection === migrationGuide) {
-            void vscode.env.openExternal(
-              vscode.Uri.parse(
-                'https://texra.ai/docs/guide/custom-agents#reflection-tips',
-              ),
-            );
-          }
-        });
-    }
-
     // Apply defaults and validate the final settings and prompts
     const validatedSettings = parseAgentSetting(settings);
     const validatedPrompts = AgentPromptSchema.parse(prompts);

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -17,6 +17,32 @@ import type {
 const CHANNEL = 'ToolUseSessionManager';
 const logger = new AgentLogger(CHANNEL);
 
+interface SnapshotBackend {
+  save(payload: SaveToolUseSnapshotPayload): Promise<void>;
+  load(executionId: ExecutionId): Promise<ToolUseSessionSnapshot | null>;
+  delete(executionId: ExecutionId): Promise<void>;
+  list(): Promise<ToolUseSessionSnapshot[]>;
+  deleteAll(): Promise<void>;
+}
+
+const noopSnapshotBackend: SnapshotBackend = {
+  async save() {},
+  async load() {
+    return null;
+  },
+  async delete() {},
+  async list() {
+    return [];
+  },
+  async deleteAll() {},
+};
+
+function resolveSnapshotBackend(): SnapshotBackend {
+  return getToolUsePersistenceEnabled()
+    ? (ToolUseSnapshotStore as SnapshotBackend)
+    : noopSnapshotBackend;
+}
+
 interface ResumingSessionState {
   queuedFollowUps: string[];
 }
@@ -141,20 +167,16 @@ export class ToolUseSessionManager {
   public static async saveSnapshot(
     payload: SaveToolUseSnapshotPayload,
   ): Promise<void> {
-    if (!this.isPersistenceEnabled()) {
-      return;
-    }
-    await ToolUseSnapshotStore.save(payload);
+    const store = resolveSnapshotBackend();
+    await store.save(payload);
   }
 
   /** Loads a tool-use session snapshot from persistent storage. */
   public static async loadSnapshot(
     executionId: ExecutionId,
   ): Promise<ToolUseSessionSnapshot | null> {
-    if (!this.isPersistenceEnabled()) {
-      return null;
-    }
-    return await ToolUseSnapshotStore.load(executionId);
+    const store = resolveSnapshotBackend();
+    return await store.load(executionId);
   }
 
   /** Deletes a persisted tool-use session snapshot. */
@@ -172,23 +194,20 @@ export class ToolUseSessionManager {
       }
     }
 
-    await ToolUseSnapshotStore.delete(executionId);
+    const store = resolveSnapshotBackend();
+    await store.delete(executionId);
   }
 
   /** Lists all persisted tool-use session snapshots. */
   public static async listSnapshots(): Promise<ToolUseSessionSnapshot[]> {
-    if (!this.isPersistenceEnabled()) {
-      return [];
-    }
-    return await ToolUseSnapshotStore.list();
+    const store = resolveSnapshotBackend();
+    return await store.list();
   }
 
   /** Deletes all persisted tool-use session snapshots. */
   public static async deleteAllSnapshots(): Promise<void> {
-    if (!this.isPersistenceEnabled()) {
-      return;
-    }
-    await ToolUseSnapshotStore.deleteAll();
+    const store = resolveSnapshotBackend();
+    await store.deleteAll();
   }
 }
 

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -42,6 +42,43 @@ function containsExcludedDirectory(
   );
 }
 
+interface ListingOptions {
+  includeExtensions?: string[];
+  excludeExtensions?: string[];
+  excludeDirectories?: string[];
+  excludeKeywords?: string[];
+  excludeFiles?: string[];
+}
+
+interface NormalizedListingOptions {
+  includeExt: string[];
+  excludeExt: string[];
+  excludeKeywords: string[];
+  excludeDirs: string[];
+  excludeFiles: string[];
+  excludePattern?: vscode.RelativePattern;
+}
+
+function normalizeListingOptions(
+  patternRoot: string,
+  options: ListingOptions,
+): NormalizedListingOptions {
+  const includeExtensions = options.includeExtensions ?? [];
+  const excludeExtensions = options.excludeExtensions ?? [];
+  const excludeDirectories = options.excludeDirectories ?? [];
+  const excludeKeywords = options.excludeKeywords ?? [];
+  const excludeFiles = options.excludeFiles ?? [];
+
+  return {
+    includeExt: includeExtensions.map((ext) => ext.toLowerCase()),
+    excludeExt: excludeExtensions.map((ext) => ext.toLowerCase()),
+    excludeKeywords: excludeKeywords.map((keyword) => keyword.toLowerCase()),
+    excludeDirs: excludeDirectories.map((dir) => dir.toLowerCase()),
+    excludeFiles: excludeFiles.map((file) => file.toLowerCase()),
+    excludePattern: createExcludePattern(patternRoot, excludeDirectories),
+  };
+}
+
 export async function getFilesInDirectory(
   dir: string,
   includeExtensions: string[] = [],
@@ -49,33 +86,32 @@ export async function getFilesInDirectory(
   excludeDirectories: string[] = [],
   excludeKeywords: string[] = [],
 ): Promise<string[]> {
-  const normalizedIncludeExt = includeExtensions.map((e) => e.toLowerCase());
-  const normalizedExcludeExt = excludeExtensions.map((e) => e.toLowerCase());
-  const normalizedExcludeKeywords = excludeKeywords.map((k) => k.toLowerCase());
-  const normalizedExcludeDirs = excludeDirectories.map((d) => d.toLowerCase());
-  const excludePattern = createExcludePattern(dir, excludeDirectories);
+  const filters = normalizeListingOptions(dir, {
+    includeExtensions,
+    excludeExtensions,
+    excludeDirectories,
+    excludeKeywords,
+  });
   const files = await vscode.workspace.findFiles(
     new vscode.RelativePattern(dir, '*'),
-    excludePattern,
+    filters.excludePattern,
   );
 
   return files
     .filter((uri) => {
       // Check if the file is inside an excluded directory (for symlinks, case-insensitive)
       const relativePath = path.relative(dir, uri.fsPath);
-      return !containsExcludedDirectory(relativePath, normalizedExcludeDirs);
+      return !containsExcludedDirectory(relativePath, filters.excludeDirs);
     })
     .map((uri) => path.basename(uri.fsPath))
     .filter((name) => {
       const nameLower = name.toLowerCase();
       return (
         !name.startsWith('.') &&
-        (normalizedIncludeExt.length === 0 ||
-          normalizedIncludeExt.some((ext) => nameLower.endsWith(ext))) &&
-        !normalizedExcludeExt.some((ext) => nameLower.endsWith(ext)) &&
-        !normalizedExcludeKeywords.some((keyword) =>
-          nameLower.includes(keyword),
-        )
+        (filters.includeExt.length === 0 ||
+          filters.includeExt.some((ext) => nameLower.endsWith(ext))) &&
+        !filters.excludeExt.some((ext) => nameLower.endsWith(ext)) &&
+        !filters.excludeKeywords.some((keyword) => nameLower.includes(keyword))
       );
     });
 }
@@ -89,15 +125,16 @@ export async function getFilesRecursively(
   excludeKeywords: string[] = [],
   excludeFiles: string[] = [],
 ): Promise<string[]> {
-  const normalizedIncludeExt = includeExtensions.map((e) => e.toLowerCase());
-  const normalizedExcludeExt = excludeExtensions.map((e) => e.toLowerCase());
-  const normalizedExcludeKeywords = excludeKeywords.map((k) => k.toLowerCase());
-  const normalizedExcludeFiles = excludeFiles.map((f) => f.toLowerCase());
-  const normalizedExcludeDirs = excludeDirectories.map((d) => d.toLowerCase());
-  const excludePattern = createExcludePattern(root, excludeDirectories);
+  const filters = normalizeListingOptions(root, {
+    includeExtensions,
+    excludeExtensions,
+    excludeDirectories,
+    excludeKeywords,
+    excludeFiles,
+  });
   const files = await vscode.workspace.findFiles(
     new vscode.RelativePattern(dir, '**/*'),
-    excludePattern,
+    filters.excludePattern,
   );
 
   return files
@@ -112,7 +149,7 @@ export async function getFilesRecursively(
       }
 
       // Check if any segment of the path matches an excluded directory
-      if (containsExcludedDirectory(relativePath, normalizedExcludeDirs)) {
+      if (containsExcludedDirectory(relativePath, filters.excludeDirs)) {
         return false;
       }
 
@@ -120,13 +157,13 @@ export async function getFilesRecursively(
       const fileNameLower = fileName.toLowerCase();
 
       return (
-        (normalizedIncludeExt.length === 0 ||
-          normalizedIncludeExt.some((ext) => fileNameLower.endsWith(ext))) &&
-        !normalizedExcludeExt.some((ext) => fileNameLower.endsWith(ext)) &&
-        !normalizedExcludeKeywords.some((keyword) =>
+        (filters.includeExt.length === 0 ||
+          filters.includeExt.some((ext) => fileNameLower.endsWith(ext))) &&
+        !filters.excludeExt.some((ext) => fileNameLower.endsWith(ext)) &&
+        !filters.excludeKeywords.some((keyword) =>
           fileNameLower.includes(keyword),
         ) &&
-        !normalizedExcludeFiles.includes(fileNameLower)
+        !filters.excludeFiles.includes(fileNameLower)
       );
     });
 }

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -6,12 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports - agent metadata
 import { type AgentConfig, parseAgentConfig } from '@agent/core/AgentConfig';
-import {
-  AgentCategory,
-  AgentType,
-  type AgentSessionDescriptor,
-  resolveAgentSessionDescriptor,
-} from '@agent/core/AgentDataclass';
+import { type AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - workspace state
@@ -80,13 +75,13 @@ export class AgentHistoryManager {
   public static async getHistory(): Promise<AgentHistoryItem[]> {
     const storageKey = this.getWorkspaceStorageKey();
     const history = workspaceSM.get<unknown[]>(storageKey, []);
-    return history.reduce<AgentHistoryItem[]>((acc, item) => {
-      const normalized = this.normalizeHistoryItem(item);
-      if (normalized) {
-        acc.push(normalized);
-      }
-      return acc;
-    }, []);
+    const { normalized, mutated } = this.sanitizeHistoryEntries(history);
+
+    if (mutated) {
+      await this.saveHistory(normalized);
+    }
+
+    return normalized;
   }
 
   /**
@@ -97,59 +92,63 @@ export class AgentHistoryManager {
     await workspaceSM.update(storageKey, history);
   }
 
-  private static normalizeHistoryItem(item: unknown): AgentHistoryItem | null {
-    const candidate = item as Partial<{
-      id: ExecutionId;
-      timestamp: string;
-      config: AgentConfig;
-      session?: AgentSessionDescriptor;
-      agentType?: AgentType;
-      agentSessionKind?: AgentCategory;
-    }>;
+  private static sanitizeHistoryEntries(entries: unknown[]): {
+    normalized: AgentHistoryItem[];
+    mutated: boolean;
+  } {
+    let mutated = false;
+    const normalized: AgentHistoryItem[] = [];
 
-    if (!candidate.id || !candidate.timestamp || !candidate.config) {
-      return null;
-    }
-
-    // Derive session from the most canonical source available
-    const baseConfig = structuredClone(candidate.config);
-    if (!baseConfig.session) {
-      if (candidate.session) {
-        baseConfig.session = candidate.session;
-      } else if (candidate.agentType || candidate.agentSessionKind) {
-        baseConfig.session = resolveAgentSessionDescriptor(
-          candidate.agentType ?? baseConfig.agentType,
-          candidate.agentSessionKind,
-        );
+    for (const rawEntry of entries) {
+      if (!rawEntry || typeof rawEntry !== 'object') {
+        mutated = true;
+        continue;
       }
+
+      const candidate = rawEntry as Partial<AgentHistoryItem> & {
+        config?: AgentConfig;
+      };
+
+      if (!candidate.id || !candidate.timestamp || !candidate.config) {
+        mutated = true;
+        continue;
+      }
+
+      let normalizedConfig: AgentConfig;
+      try {
+        normalizedConfig = parseAgentConfig(candidate.config);
+      } catch (error) {
+        mutated = true;
+        logger.warn(
+          CHANNEL,
+          'Discarding malformed agent history entry',
+          undefined,
+          undefined,
+          false,
+          error,
+        );
+        continue;
+      }
+
+      const session = normalizedConfig.session;
+      if (!session) {
+        mutated = true;
+        continue;
+      }
+
+      normalized.push({
+        id: candidate.id,
+        timestamp: candidate.timestamp,
+        config: normalizedConfig,
+        session,
+      });
     }
 
-    let normalizedConfig: AgentConfig;
-    try {
-      normalizedConfig = parseAgentConfig(baseConfig);
-    } catch (error) {
-      logger.warn(
-        CHANNEL,
-        'Discarding malformed agent history entry',
-        undefined,
-        undefined,
-        false,
-        error,
-      );
-      return null;
+    if (normalized.length !== entries.length) {
+      mutated = true;
     }
 
-    const session = normalizedConfig.session;
-    if (!session) {
-      return null;
-    }
-
-    return {
-      id: candidate.id,
-      timestamp: candidate.timestamp,
-      config: normalizedConfig,
-      session,
-    };
+    return { normalized, mutated };
   }
 
   /**

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -197,73 +197,32 @@ export class OutputFilesManager extends PersistentMapManager<
     streamId: StreamTabId,
   ): Promise<{ [key: number]: OutputFileInfo[] }> {
     if (!data || typeof data !== 'object') {
-      this.logger.warn(
-        `Invalid output files payload for stream ${streamId}; resetting entry`,
-      );
       return {};
     }
 
     const rounds = data as Record<string, unknown>;
     const roundMap: { [key: number]: OutputFileInfo[] } = {};
-    const streamFilesProcessed = Object.values(rounds).reduce<number>(
-      (sum, value) => {
-        if (Array.isArray(value)) {
-          return sum + value.length;
-        }
-        return sum;
-      },
-      0,
-    );
-    this.totalFilesProcessed += streamFilesProcessed;
 
-    for (const [roundStr, value] of Object.entries(rounds)) {
-      const roundNum = parseInt(roundStr, 10);
-      if (Number.isNaN(roundNum)) {
-        this.logger.warn(
-          `Skipping non-numeric round key "${roundStr}" for stream ${streamId}`,
-        );
-        continue;
-      }
-
-      if (!Array.isArray(value)) {
-        this.logger.warn(
-          `Skipping invalid output metadata for stream ${streamId}, round ${roundNum}`,
-        );
+    for (const [roundKey, value] of Object.entries(rounds)) {
+      const round = Number.parseInt(roundKey, 10);
+      if (Number.isNaN(round) || !Array.isArray(value)) {
         continue;
       }
 
       const infos = value as OutputFileInfo[];
-      this.logger.debug(
-        `Checking ${infos.length} files in stream ${streamId}, round ${roundNum}`,
-      );
+      this.totalFilesProcessed += infos.length;
 
       try {
         const filtered = await WorkspaceFS.filterExistingFiles(infos);
-        const removedCount = infos.length - filtered.length;
-
-        if (removedCount > 0) {
-          this.logger.debug(
-            `Removed ${removedCount} missing file(s) from stream ${streamId}, round ${roundNum}`,
-          );
-          this.totalFilesRemoved += removedCount;
-          const removedFiles = infos.filter(
-            (info) => !filtered.find((f) => f.path === info.path),
-          );
-          removedFiles.forEach((file) => {
-            this.logger.debug(`  - Removed missing file: ${file.path}`);
-          });
+        const removed = infos.length - filtered.length;
+        if (removed > 0) {
+          this.totalFilesRemoved += removed;
         }
-
-        if (infos.length > 0) {
-          roundMap[roundNum] = filtered;
+        if (filtered.length > 0) {
+          roundMap[round] = filtered;
         }
-      } catch (error) {
-        this.logger.warn(
-          `Error checking files in stream ${streamId}, round ${roundNum}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-        roundMap[roundNum] = infos;
+      } catch {
+        roundMap[round] = infos;
       }
     }
 

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -1,9 +1,6 @@
 // Standard library imports
 import { randomUUID } from 'crypto';
 
-// Third-party imports
-import { decode as decodeHtml } from 'he';
-
 // Local imports - persistence
 import { PersistentMapManager } from '../persistence/PersistentMapManager';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
@@ -13,9 +10,6 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
-
-const LEGACY_MESSAGE_TYPES: ReadonlySet<LogMessageData['messageType']> =
-  new Set(['fileList', 'missingOutputs', 'latexdiff', 'statistics']);
 
 /**
  * Manages stream tabs collection with persistence.
@@ -131,46 +125,42 @@ export class StreamTabsManager extends PersistentMapManager<
     _key: StreamTabId,
   ): Promise<LogMessageData[]> {
     const messages = Array.isArray(data) ? data : [];
-    return messages.map((msg: any) => {
-      if (!msg.id) {
-        msg.id = randomUUID();
-      }
-      if (msg.text === undefined && msg.message !== undefined) {
-        msg.text = msg.message;
-      }
-      if (msg.timestamp === undefined) {
-        const attrMatch =
-          typeof msg.text === 'string'
-            ? msg.text.match(/data-full-timestamp="([^"]+)"/)
-            : null;
-        const timeString =
-          attrMatch?.[1] ||
-          (typeof msg.text === 'string'
-            ? (msg.text.match(/\[(.*?)\]/)?.[1] ?? '')
-            : '');
-        const timestamp = new Date(timeString).getTime();
-        msg.timestamp = isNaN(timestamp) ? Date.now() : timestamp;
-      }
-      const log = msg as LogMessageData;
-      if (log.data === undefined && typeof log.text === 'string') {
-        if (log.messageType && LEGACY_MESSAGE_TYPES.has(log.messageType)) {
-          try {
-            const decoded = decodeHtml(log.text);
-            const parsed = JSON.parse(decoded);
-            if (typeof parsed === 'object' && parsed !== null) {
-              log.data = parsed;
-            }
-          } catch (error) {
-            const reason =
-              error instanceof Error ? error.message : String(error);
-            this.logger.warn(`Failed to parse legacy log data: ${reason}`);
-          }
+    return messages.map((raw) => {
+      const message = raw as Partial<LogMessageData> & {
+        message?: string;
+      };
+
+      const rawTimestamp = message.timestamp;
+      let timestamp = Date.now();
+      if (typeof rawTimestamp === 'number') {
+        timestamp = rawTimestamp;
+      } else if (typeof rawTimestamp === 'string') {
+        const numeric = Number(rawTimestamp);
+        if (!Number.isNaN(numeric)) {
+          timestamp = numeric;
         }
       }
-      if (!log.messageType) {
-        log.messageType = 'default';
-      }
-      return log;
+
+      const text =
+        typeof message.text === 'string'
+          ? message.text
+          : typeof message.message === 'string'
+            ? message.message
+            : '';
+
+      return {
+        id:
+          typeof message.id === 'string' && message.id
+            ? message.id
+            : randomUUID(),
+        text,
+        level: message.level ?? 'info',
+        timestamp,
+        messageType: message.messageType ?? 'default',
+        data: message.data,
+        groupId: message.groupId,
+        verbose: message.verbose,
+      } satisfies LogMessageData;
     });
   }
 }

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -1,12 +1,13 @@
-// Local imports - progress view
-// Local imports
+// Local imports - progress view persistence
 import { PersistentMapManager } from '../persistence/PersistentMapManager';
 import { StatePersistenceManager } from '../persistence/StatePersistenceManager';
+
+// Local imports - identifiers and logging
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 
-// Types
+// Local imports - types
 import { TaskGroup } from '@logger/LogTypes';
 
 export interface TaskGroupUpdatePayload {
@@ -135,24 +136,27 @@ export class TaskGroupManager extends PersistentMapManager<
     data: unknown,
     _key: StreamTabId,
   ): Promise<Map<string, TaskGroup>> {
-    const groups = data as Record<string, TaskGroup>;
-    const map = new Map<string, TaskGroup>();
-    for (const [id, group] of Object.entries(groups)) {
-      const normalized: TaskGroup = {
-        ...group,
-        startTime:
-          typeof group.startTime === 'string'
-            ? new Date(group.startTime).getTime()
-            : group.startTime,
-        endTime:
-          group.endTime !== undefined
-            ? typeof group.endTime === 'string'
-              ? new Date(group.endTime).getTime()
-              : group.endTime
-            : undefined,
-      };
-      map.set(id, normalized);
+    if (!data || typeof data !== 'object') {
+      return new Map();
     }
-    return map;
+
+    const entries = Object.entries(
+      data as Record<string, (TaskGroup & { id?: string }) | undefined>,
+    );
+    const groups = new Map<string, TaskGroup>();
+
+    for (const [key, value] of entries) {
+      if (!value) {
+        continue;
+      }
+
+      const group: TaskGroup = {
+        ...value,
+        id: value.id ?? key,
+      } as TaskGroup;
+      groups.set(key, group);
+    }
+
+    return groups;
   }
 }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -23,11 +23,7 @@ import {
   isToolUseTaskState,
   isWorkflowTaskState,
 } from '@logger/TaskState';
-import {
-  objectToTaskState,
-  getConfig,
-  agentConfigToTaskState,
-} from '@utils/config';
+import { getConfig, agentConfigToTaskState } from '@utils/config';
 // Local imports - agents
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
 
@@ -340,52 +336,25 @@ export class ProgressViewState {
    * Load task states from persistence
    */
   private async loadTaskStates(): Promise<void> {
-    const savedTaskStates = await this.persistence.load<
-      | {
-          workflow?: Record<string, Record<string, any>>;
-          toolUse?: Record<string, Record<string, any>>;
-        }
-      | { [key: string]: Record<string, any> }
-      | [string, Record<string, any>][]
-    >(WorkspaceStateKey.TASK_STATES, {});
+    const savedTaskStates = await this.persistence.load<{
+      workflow?: Record<string, TaskState>;
+      toolUse?: Record<string, TaskState>;
+    }>(WorkspaceStateKey.TASK_STATES, {});
 
     this.workflowTaskStates.clear();
     this.toolUseTaskStates.clear();
 
-    const processState = (
-      stream: string,
-      rawState: Record<string, any>,
-    ): void => {
-      const taskState = objectToTaskState(rawState);
-      if (isWorkflowTaskState(taskState)) {
-        this.workflowTaskStates.set(stream as StreamTabId, taskState);
-      } else if (isToolUseTaskState(taskState)) {
-        this.toolUseTaskStates.set(stream as StreamTabId, taskState);
+    const workflowStates = savedTaskStates?.workflow ?? {};
+    for (const [stream, state] of Object.entries(workflowStates)) {
+      if (state && isWorkflowTaskState(state)) {
+        this.workflowTaskStates.set(stream as StreamTabId, state);
       }
-    };
-
-    if (!savedTaskStates) {
-      return;
     }
 
-    if (Array.isArray(savedTaskStates)) {
-      for (const [stream, state] of savedTaskStates) {
-        processState(stream, state);
-      }
-    } else if ('workflow' in savedTaskStates || 'toolUse' in savedTaskStates) {
-      const { workflow = {}, toolUse = {} } = savedTaskStates as {
-        workflow?: Record<string, Record<string, any>>;
-        toolUse?: Record<string, Record<string, any>>;
-      };
-      for (const [stream, state] of Object.entries(workflow)) {
-        processState(stream, state);
-      }
-      for (const [stream, state] of Object.entries(toolUse)) {
-        processState(stream, state);
-      }
-    } else {
-      for (const [stream, state] of Object.entries(savedTaskStates)) {
-        processState(stream, state);
+    const toolUseStates = savedTaskStates?.toolUse ?? {};
+    for (const [stream, state] of Object.entries(toolUseStates)) {
+      if (state && isToolUseTaskState(state)) {
+        this.toolUseTaskStates.set(stream as StreamTabId, state);
       }
     }
 

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -1,12 +1,13 @@
 // Standard library imports
 // (none needed)
 
-// Third-party imports
-// (none needed)
-
 // Local imports - models
 import { type AgentConfig, parseAgentConfig } from '@agent/core/AgentConfig';
-import { type TaskState, isWorkflowTaskState } from '@logger/TaskState';
+import {
+  type TaskState,
+  isWorkflowTaskState,
+  isToolUseTaskState,
+} from '@logger/TaskState';
 import {
   AgentCategory,
   AgentType,
@@ -146,80 +147,30 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
  * @returns A TaskState representing the same configuration
  */
 export function objectToTaskState(obj: Record<string, any>): TaskState {
-  // Check if this is already in the new format with nested agentConfig
-  if (obj.agentConfig && typeof obj.agentConfig === 'object') {
-    const configSource = obj.agentConfig as Record<string, any>;
-    const sessionDescriptor = resolveSessionDescriptor(configSource, obj);
-    const configInput = {
-      ...configSource,
-      ...(sessionDescriptor ? { session: sessionDescriptor } : {}),
-    };
-    const state = agentConfigToTaskState(parseAgentConfig(configInput));
+  const nestedConfig = isObjectRecord(obj.agentConfig)
+    ? (obj.agentConfig as Record<string, unknown>)
+    : null;
 
-    if (isWorkflowTaskState(state)) {
-      state.activeFiles =
-        obj.activeFiles || createActiveFilesFromArrays(configSource);
-    } else if (isObjectRecord(obj.toolSessionState)) {
-      state.toolSessionState = { ...obj.toolSessionState };
-    }
-
-    return state;
-  }
-
-  // Old format: extract UI-specific and tool config fields for backward compatibility
-  const {
-    activeFiles,
-    agentSessionKind: _agentSessionKind,
-    // Extract tool config fields that might be at top level in old format
-    autoExtractFigure,
-    autoExtractTikzFigure,
-    autoCompileInputPdf,
-    attachTeXCount,
-    toolSessionState,
-    toolConfig: legacyToolConfig,
-    ...agentConfigData
-  } = obj;
-
-  void _agentSessionKind;
-
-  const workflowActiveFiles = isObjectRecord(activeFiles)
-    ? (activeFiles as Record<FileType, boolean>)
-    : undefined;
-  const legacyToolState = isObjectRecord(toolSessionState)
-    ? toolSessionState
-    : undefined;
-
-  const baseToolConfig = isObjectRecord(legacyToolConfig)
-    ? (legacyToolConfig as Record<string, unknown>)
-    : {};
-
-  const mergedToolConfig: Record<string, unknown> = {
-    ...baseToolConfig,
-    ...(autoExtractFigure !== undefined && { autoExtractFigure }),
-    ...(autoExtractTikzFigure !== undefined && { autoExtractTikzFigure }),
-    ...(autoCompileInputPdf !== undefined && { autoCompileInputPdf }),
-    ...(attachTeXCount !== undefined && { attachTeXCount }),
-  };
+  const configSource = nestedConfig ?? obj;
+  const sessionDescriptor = resolveSessionDescriptor(configSource, obj);
 
   const configInput: Record<string, unknown> = {
-    ...agentConfigData,
-    toolConfig: mergedToolConfig,
+    ...configSource,
+    ...(sessionDescriptor ? { session: sessionDescriptor } : {}),
   };
 
-  const sessionDescriptor = resolveSessionDescriptor(obj, configInput);
-  if (sessionDescriptor) {
-    configInput.session = sessionDescriptor;
-  }
-
-  const normalized = parseAgentConfig(configInput);
-  const taskState = agentConfigToTaskState(normalized);
+  const normalizedConfig = parseAgentConfig(configInput);
+  const taskState = agentConfigToTaskState(normalizedConfig);
 
   if (isWorkflowTaskState(taskState)) {
-    if (workflowActiveFiles) {
-      taskState.activeFiles = workflowActiveFiles;
+    if (isObjectRecord(obj.activeFiles)) {
+      taskState.activeFiles = obj.activeFiles as Record<FileType, boolean>;
     }
-  } else if (legacyToolState) {
-    taskState.toolSessionState = { ...legacyToolState };
+  } else if (
+    isToolUseTaskState(taskState) &&
+    isObjectRecord(obj.toolSessionState)
+  ) {
+    taskState.toolSessionState = { ...obj.toolSessionState };
   }
 
   return taskState;

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -26,9 +26,9 @@ import {
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
 
-function getFilesIfNotEmpty<T>(files: T[] | undefined | null): T[] | null {
+function getFilesIfNotEmpty<T>(files: T[] | undefined | null): T[] {
   if (!Array.isArray(files) || files.length === 0) {
-    return null;
+    return [];
   }
   return files;
 }
@@ -106,7 +106,7 @@ export class ExecutionManager {
       // pipeline never attempts to resolve `_multiple` agent variants or
       // manage output file selections that the UI disables for this mode.
       useMultipleOutputs: false,
-      outputFiles: null,
+      outputFiles: [],
     };
   }
 
@@ -141,13 +141,11 @@ export class ExecutionManager {
       auxiliaryFile: message.auxiliaryFile ?? null,
       auxiliaryFiles: getFilesIfNotEmpty<string>(message.auxiliaryFiles),
       mediaFile: mapMediaPath(message.mediaFile ?? null),
-      mediaFiles: message.mediaFiles
-        ? getFilesIfNotEmpty<string>(
-            message.mediaFiles
-              .map(mapMediaPath)
-              .filter((f: string | null): f is string => f !== null),
-          )
-        : null,
+      mediaFiles: getFilesIfNotEmpty<string>(
+        (message.mediaFiles ?? [])
+          .map(mapMediaPath)
+          .filter((f: string | null): f is string => f !== null),
+      ),
       editedFile: null,
       toolConfig,
       agentType: session.agentType,


### PR DESCRIPTION
## Summary
- simplify the agent prompt schema by treating user reflections as optional strings
- replace schema-heavy persistence parsing with direct iteration across history and progress view managers
- streamline task-state conversion to rely on canonical agent configs without redundant migration helpers

## Testing
- npm run format
- npm run lint
- npm run compile
- CI=1 npm test *(fails: vscode-test requires libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6906a631b3908324a6365ed59bac235c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies agent prompt schema and replaces legacy migrations with stricter, unified persistence deserialization and a pluggable snapshot backend; also normalizes file-listing filters.
> 
> - **Core (agents)**
>   - Simplify `AgentPromptSchema`: factor `promptEntrySchema`, allow optional `userReflect` string.
>   - Minor cleanups in `hasEndTag` helpers.
> - **Runtime (agent loading)**
>   - Remove legacy `userReflect`→`userRequest` migration; validate prompts/settings directly via schemas.
> - **Model Handling**
>   - `ModelHandler` constructor no longer injects default `toolConfig`; use given `config` as-is.
> - **Tool-use Sessions**
>   - Introduce pluggable snapshot backend with noop fallback; all CRUD methods route through `resolveSnapshotBackend()`.
> - **Frontend (files)**
>   - Add listing options normalization; apply unified filters (extensions, keywords, dirs, files) and VS Code exclude pattern for both flat and recursive listings.
> - **History/Progress Persistence**
>   - `AgentHistoryManager`: sanitize entries on load; auto-save if mutated.
>   - `StreamTabsManager`: simplify message normalization (ids, timestamps, text, defaults); drop legacy HTML/JSON decoding paths.
>   - `TaskGroupManager`: robust map deserialization; ensure IDs.
>   - `OutputFilesManager`: streamline deserialization with counting and file-existence filtering.
>   - `ProgressViewState`: load `workflow`/`toolUse` task states directly; remove generic object migration paths.
> - **Config Conversion**
>   - Streamline `objectToTaskState` to derive from canonical `AgentConfig`; preserve `activeFiles`/`toolSessionState` when applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f04bd2cd591471f4717a11fb150a37ddcb94cb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->