### PR TITLE
Refactor logging group handling across agent pipeline

### DIFF
--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -219,9 +219,8 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
 
   protected async trackRoundUsage(
     stateGlobal: AgentStateGlobal,
-    groupId?: string,
   ): Promise<void> {
-    await this.usageMonitor.recordUsage(stateGlobal, groupId);
+    await this.usageMonitor.recordUsage(stateGlobal);
   }
 
   /**

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -39,7 +39,6 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { LatexMediaManager } from '@latex';
 
 // Local imports - logging
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - model definitions
 import type { ToolDefinition } from '@model';
@@ -55,12 +54,10 @@ import { WorkspaceFS } from '@utils/files';
  *
  * @property outputFile - The path to the file where the round's output will be saved.
  * @property endTurn - A flag indicating whether the current turn should be ended after processing.
- * @property processGroupId - (Optional) An identifier for grouping related processes, useful for tracking or managing outputs.
  */
 export interface RoundOutputOptions {
   outputFile: string;
   endTurn: boolean;
-  processGroupId?: string;
 }
 
 export interface ReflectionRoundContext {
@@ -92,7 +89,6 @@ interface RoundPipelineContext {
   preparedMessages: any[];
   prefill: string;
   outputPath: string;
-  roundGroupId: string;
 }
 
 /**
@@ -225,24 +221,18 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<RoundOutputArtifacts> {
-    const { outputFile, endTurn, processGroupId } = options;
+    const { outputFile, endTurn } = options;
+    const activeGroupId = this.logger.getActiveGroupId();
     try {
-      // Instead of creating a new group, use the round group directly
-      // this.logger.debug(
-      //   `State global: ${JSON.stringify(stateGlobal)}`,
-      //   processGroupId,
-      // );
-
       await this.handleOutput(currRound, stateRound, stateGlobal, options);
 
-      this.logger.debug(`Completed round ${currRound}`, processGroupId);
+      this.logger.debug(`Completed round ${currRound}`, activeGroupId);
     } catch (error) {
       throw error;
     }
 
     await this.outputHandler.finalizeRound(outputFile, currRound, {
       endTurn,
-      groupId: processGroupId,
     });
 
     const artifacts = await this.outputHandler.getRoundArtifacts(currRound);
@@ -266,9 +256,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
+    const { outputFile, endTurn } = options;
+    const activeGroupId = this.logger.getActiveGroupId();
     // Record usage statistics at the end of each round
-    await this.trackRoundUsage(stateGlobal, processGroupId);
+    await this.trackRoundUsage(stateGlobal);
 
     // If this is the end of a turn, handle latexdiff operations as a separate step
     if (endTurn && this.outputHandler.hasRoundOutputs(currRound)) {
@@ -282,12 +273,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         await this.outputHandler.diffManager.handleLatexdiffofOutput(
           currRound,
           mapping,
-          processGroupId,
         );
       } else {
         this.logger.debug(
           `Skipping latexdiff for round ${currRound} - base files missing`,
-          processGroupId,
+          activeGroupId,
         );
       }
     }
@@ -307,7 +297,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * @param preparedMessages - Messages prepared for the model before execution.
    * @param prefill - Initial text inserted into the model response buffer.
    * @param outputPath - Filesystem path where model output for this round is stored.
-   * @param roundGroupId - Identifier for grouping related log and output operations.
    * @returns Updated round/global state, messages, completion flag, and tool state after execution.
    */
   private async runRoundPipeline({
@@ -318,7 +307,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     preparedMessages,
     prefill,
     outputPath,
-    roundGroupId,
   }: RoundPipelineContext): Promise<ReflectionRoundResult> {
     const [endTurn, updatedMessages] =
       await this.modelHandler.initializeOutputAndPrefill(
@@ -328,7 +316,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         toolState,
         outputPath,
         prefill,
-        roundGroupId,
       );
 
     if (!endTurn) {
@@ -348,14 +335,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         {
           outputFile: outputPath,
           endTurn: cycleResult.endTurn,
-          processGroupId: roundGroupId,
         },
       );
 
       if (roundIndex === 0) {
         this.logger.debug(
           `stateGlobal: ${JSON.stringify(cycleResult.stateGlobal)}`,
-          roundGroupId,
         );
       }
 
@@ -376,7 +361,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       {
         outputFile: outputPath,
         endTurn,
-        processGroupId: roundGroupId,
       },
     );
 
@@ -409,7 +393,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     _stateGlobal: AgentStateGlobal,
     messages: any[],
     toolState: ToolState,
-    roundGroupId: string,
   ): Promise<{
     stateRound: AgentStateRound;
     preparedMessages: any[];
@@ -441,11 +424,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           this.agentConfig.agent,
           this.executionId,
         );
-        this.logger.info(
-          `Saved input prompt to ${promptPath}`,
-          roundGroupId,
-          MESSAGE_TYPES.DEFAULT,
-        );
+        this.logger.info(`Saved input prompt to ${promptPath}`);
       }
 
       const initialMessages = await this.modelHandler.initializeMessages(
@@ -500,7 +479,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   private async prepareToolState(
     currRound: number,
     toolState: ToolState,
-    roundGroupId: string,
   ): Promise<void> {
     if (currRound === 0) {
       const inputFiles = [
@@ -527,7 +505,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         this.agentConfig.toolConfig,
         this.modelHandler.capabilities.supportsVision,
         extraMedia,
-        roundGroupId,
       );
       return;
     }
@@ -549,7 +526,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       toolState,
       this.agentConfig.toolConfig,
       this.modelHandler.capabilities.supportsVision,
-      roundGroupId,
     );
   }
 
@@ -561,21 +537,20 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     this.logger.debug(`Processing round ${roundIndex}`);
     const toolState = new ToolState();
 
-    return this.withRoundGroup(`r${roundIndex}`, async (roundGroupId) => {
+    return this.withRoundGroup(`r${roundIndex}`, async (_roundGroupId) => {
       const shared: ReflectionRoundShared = {
         runtime: {
           toolState,
         },
         hooks: {
           prepareToolState: () =>
-            this.prepareToolState(roundIndex, toolState, roundGroupId),
+            this.prepareToolState(roundIndex, toolState),
           prepareRoundContext: () =>
             this.prepareRoundContext(
               roundIndex,
               globalState,
               messages,
               toolState,
-              roundGroupId,
             ),
           runRoundPipeline: ({ stateRound, preparedMessages, prefill }) =>
             this.runRoundPipeline({
@@ -586,7 +561,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
               preparedMessages,
               prefill,
               outputPath: this.outputFile[roundIndex],
-              roundGroupId,
             }),
           createSkipResult: (stateRound) => ({
             roundState: stateRound,

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -3,9 +3,6 @@ import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
 
-// Local imports - logging
-import { withLogGroup } from '@logger/logGroupUtils';
-
 /**
  * Chain of Thought (CoT) agent implementation that extends BaseReflectionAgent.
  * Adds XML structure validation and specialized output handling for multi-step reasoning.
@@ -42,55 +39,31 @@ export class CoTAgent extends BaseReflectionAgent {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
+    const { outputFile, endTurn } = options;
 
-    const runOutputHandling = async (groupId?: string): Promise<string[]> => {
-      const effectiveGroupId = groupId ?? this.logger.getActiveGroupId();
+    try {
+      this.outputHandler.ensureRound(currRound);
 
-      try {
-        this.outputHandler.ensureRound(currRound);
+      if (endTurn) {
+        this.logger.debug(`Processing output for round ${currRound}`);
 
-        if (endTurn) {
-          this.logger.debug(
-            `Processing output for round ${currRound}`,
-            effectiveGroupId,
-          );
-
-          await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-            outputFile,
-            this.agentSetting.documentTag,
-          );
-
-          await this.outputHandler.processOutputFiles(
-            outputFile,
-            currRound,
-            effectiveGroupId,
-          );
-        }
-
-        return super.handleOutput(currRound, stateRound, stateGlobal, {
+        await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
           outputFile,
-          endTurn,
-          processGroupId: effectiveGroupId,
-        });
-      } catch (error) {
-        this.logger.error(
-          `Error in handleOutput for round ${currRound}: ${error}`,
-          effectiveGroupId,
+          this.agentSetting.documentTag,
         );
-        throw error;
+
+        await this.outputHandler.processOutputFiles(outputFile, currRound);
       }
-    };
 
-    if (processGroupId) {
-      return runOutputHandling(processGroupId);
+      return super.handleOutput(currRound, stateRound, stateGlobal, {
+        outputFile,
+        endTurn,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Error in handleOutput for round ${currRound}: ${error}`,
+      );
+      throw error;
     }
-
-    return withLogGroup(
-      this.logger,
-      `OutputProcessing-Round${currRound}`,
-      runOutputHandling,
-      { parentGroupId: this.logger.getActiveGroupId() },
-    );
   }
 }

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -4,9 +4,6 @@ import { AgentStateRound, AgentStateGlobal } from '../core/AgentState';
 import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 import { getOutputFileName } from '@agent/output';
 
-// Local imports - logging
-import { withLogGroup } from '@logger/logGroupUtils';
-
 /**
  * Direct agent implementation that processes requests in a single pass.
  * Extends BaseReflectionAgent with simplified output handling and no intermediate steps.
@@ -43,61 +40,31 @@ export class DirectAgent extends BaseReflectionAgent {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
+    const { outputFile, endTurn } = options;
+    try {
+      this.outputHandler.ensureRound(currRound);
 
-    const runOutputHandling = async (groupId?: string): Promise<string[]> => {
-      const effectiveGroupId = groupId ?? this.logger.getActiveGroupId();
+      if (endTurn) {
+        this.logger.debug(`Processing output for round ${currRound}`);
 
-      try {
-        this.outputHandler.ensureRound(currRound);
-
-        if (endTurn) {
-          this.logger.debug(
-            `Processing output for round ${currRound}`,
-            effectiveGroupId,
-          );
-
-          if (this.useScratchpad) {
-            await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-              outputFile,
-              this.agentSetting.documentTag,
-            );
-          }
-
-          await this.outputHandler.processOutputFiles(
+        if (this.useScratchpad) {
+          await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
             outputFile,
-            currRound,
-            effectiveGroupId,
-          );
-          this.logger.debug(
-            `Output files processed for round ${currRound}`,
-            effectiveGroupId,
+            this.agentSetting.documentTag,
           );
         }
 
-        return super.handleOutput(currRound, stateRound, stateGlobal, {
-          outputFile,
-          endTurn,
-          processGroupId: effectiveGroupId,
-        });
-      } catch (error) {
-        this.logger.error(
-          `Error in DirectAgent.handleOutput: ${error}`,
-          effectiveGroupId,
-        );
-        throw error;
+        await this.outputHandler.processOutputFiles(outputFile, currRound);
+        this.logger.debug(`Output files processed for round ${currRound}`);
       }
-    };
 
-    if (processGroupId) {
-      return runOutputHandling(processGroupId);
+      return super.handleOutput(currRound, stateRound, stateGlobal, {
+        outputFile,
+        endTurn,
+      });
+    } catch (error) {
+      this.logger.error(`Error in DirectAgent.handleOutput: ${error}`);
+      throw error;
     }
-
-    return withLogGroup(
-      this.logger,
-      `OutputProcessing-Round${currRound}`,
-      runOutputHandling,
-      { parentGroupId: this.logger.getActiveGroupId() },
-    );
   }
 }

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -143,12 +143,9 @@ export class MergeAgent extends DirectAgent {
     stateGlobal: AgentStateGlobal,
     options: RoundOutputOptions,
   ): Promise<string[]> {
-    const { outputFile, endTurn, processGroupId } = options;
+    const { outputFile, endTurn } = options;
     if (endTurn) {
-      this.logger.debug(
-        `Processing merge output for round ${currRound}`,
-        processGroupId,
-      );
+      this.logger.debug(`Processing merge output for round ${currRound}`);
       const files = await super.handleOutput(
         currRound,
         stateRound,
@@ -156,10 +153,9 @@ export class MergeAgent extends DirectAgent {
         {
           outputFile,
           endTurn,
-          processGroupId,
         },
       );
-      this.logger.info(`Merge output file: ${outputFile}`, processGroupId);
+      this.logger.info(`Merge output file: ${outputFile}`);
       return files;
     }
     return [];

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -691,7 +691,6 @@ export abstract class ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, M[]]>;
 
   /**

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1097,7 +1097,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, MessageParam[]]> {
     const workflowSetting = requireWorkflowSetting(agentSetting);
     let endTurn = false;
@@ -1146,7 +1145,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      this.logger.info(scratchpad, undefined, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     await WorkspaceFS.write(outputFile, fileContent);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -918,7 +918,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, Content[]]> {
     let endTurn = false;
     this.logger.debug(
@@ -961,7 +960,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      this.logger.info(scratchpad, undefined, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     await WorkspaceFS.write(outputFile, fileContent);

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -838,7 +838,6 @@ export class ModelHandlerOpenAI extends ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, any[]]> {
     let endTurn = false;
 
@@ -872,7 +871,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      this.logger.info(scratchpad, undefined, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     // Write file content to output file

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1064,7 +1064,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, ResponseInputItem[]]> {
     let endTurn = false;
 
@@ -1096,7 +1095,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      this.logger.info(scratchpad, undefined, MESSAGE_TYPES.SCRATCHPAD);
     }
 
     await WorkspaceFS.write(outputFile, fileContent);

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -138,7 +138,6 @@ export interface IModelHandler<
     toolState: ToolState,
     outputFile: string,
     prefill: string,
-    groupId?: string,
   ): Promise<[boolean, M[]]>;
 
   /** Compute the cost for a response. */

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -42,24 +42,24 @@ export class LatexDiffManager {
   private logLatexdiffResult(
     result: LaTeXdiffResult,
     operation: string = 'latexdiff',
-    groupId?: string,
   ): void {
+    const activeGroupId = this.logger.getActiveGroupId();
     if (result.success) {
       this.logger.debug(
         `Successfully generated ${operation} file: ${result.diffFileName}`,
-        groupId,
+        activeGroupId,
       );
     } else {
       if (result.message && result.message.includes('document environment')) {
         this.logger.debug(
           `Skipping ${operation}: ${result.message}`,
-          groupId,
+          activeGroupId,
           MESSAGE_TYPES.INTERNAL,
         );
       } else {
         this.logger.warn(
           `Failed to generate ${operation}: ${result.message}`,
-          groupId,
+          activeGroupId,
           MESSAGE_TYPES.INTERNAL,
         );
       }
@@ -69,9 +69,8 @@ export class LatexDiffManager {
   async handleLatexdiffofOutput(
     currRound: number,
     mapping: RoundFileMapping,
-    groupId?: string,
   ): Promise<void> {
-    const diffProcessGroupId = groupId ?? this.logger.getActiveGroupId();
+    const diffProcessGroupId = this.logger.getActiveGroupId();
     const generateBetweenRoundDiffs = this.dependencies.getConfig<boolean>(
       'latexdiff.generateBetweenRoundDiffs',
       false,
@@ -137,7 +136,7 @@ export class LatexDiffManager {
             outputFile,
             currRound,
           );
-          this.logLatexdiffResult(result, 'round-diff', diffProcessGroupId);
+          this.logLatexdiffResult(result, 'round-diff');
           aggregated.push({
             base: baseFile,
             revised: outputFile,
@@ -195,7 +194,6 @@ export class LatexDiffManager {
           this.logLatexdiffResult(
             result,
             'between-rounds-diff',
-            diffProcessGroupId,
           );
           aggregated.push({
             base: prevOutputFile,

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -59,7 +59,6 @@ export class OutputHandler implements IOutputHandler {
   private roundMappings: { [key: number]: RoundFileMapping };
   private roundXmlSummaries: { [key: number]: OutputXmlSummary };
   public baseFiles: string[];
-  public processGroupId?: string;
   protected logger: AgentLogger;
   protected channel: string;
   public readonly xmlManager: XmlOutputManager;
@@ -167,10 +166,6 @@ export class OutputHandler implements IOutputHandler {
   ): void {
     if (groupId) {
       this.logger.endGroup(groupId, status);
-    } else if (this.processGroupId) {
-      // this.logger.info(`Completed output processing`, this.processGroupId);
-      this.logger.endGroup(this.processGroupId, status);
-      this.processGroupId = undefined;
     }
   }
 
@@ -302,8 +297,8 @@ export class OutputHandler implements IOutputHandler {
   public async validateExpectedOutputs(
     outputFile: string,
     currRound: number,
-    groupId?: string,
   ): Promise<void> {
+    const activeGroupId = this.logger.getActiveGroupId();
     const expected = this.agentConfig.outputFiles;
     if (!expected || expected.length === 0) {
       bus.emit('updateMissingOutputs', {
@@ -352,7 +347,7 @@ export class OutputHandler implements IOutputHandler {
         documentTag: this.agentSetting.documentTag,
       };
 
-      this.logger.missingOutputs(missingOutputsData, groupId);
+      this.logger.missingOutputs(missingOutputsData, activeGroupId);
     }
 
     bus.emit('updateMissingOutputs', {
@@ -369,9 +364,10 @@ export class OutputHandler implements IOutputHandler {
   public async finalizeRound(
     outputFile: string,
     currRound: number,
-    options: { endTurn: boolean; groupId?: string },
+    options: { endTurn: boolean },
   ): Promise<void> {
-    const { endTurn, groupId } = options;
+    const { endTurn } = options;
+    const activeGroupId = this.logger.getActiveGroupId();
     this.ensureRound(currRound);
     this.rawOutputs[currRound] = outputFile || null;
     const fileInfos = await this.gatherOutputFileInfo(currRound);
@@ -379,17 +375,17 @@ export class OutputHandler implements IOutputHandler {
 
     if (endTurn) {
       try {
-        await this.validateExpectedOutputs(outputFile, currRound, groupId);
+        await this.validateExpectedOutputs(outputFile, currRound);
         this.logger.debug(
           `Expected outputs validated for round ${currRound}`,
-          groupId,
+          activeGroupId,
         );
       } catch (error) {
         this.logger.error(
           `Expected output validation failed after round ${currRound}: ${
             error instanceof Error ? error.message : String(error)
           }`,
-          groupId,
+          activeGroupId,
         );
       }
     }
@@ -412,7 +408,7 @@ export class OutputHandler implements IOutputHandler {
           `Failed to open output file ${filePath}: ${
             error instanceof Error ? error.message : String(error)
           }`,
-          groupId,
+          activeGroupId,
         );
       }
     }
@@ -424,9 +420,8 @@ export class OutputHandler implements IOutputHandler {
   public async processOutputFiles(
     outputFile: string,
     currRound: number,
-    groupId?: string,
   ): Promise<void> {
-    const activeGroupId = groupId || this.logger.getActiveGroupId();
+    const activeGroupId = this.logger.getActiveGroupId();
     this.ensureRound(currRound);
 
     if (

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -28,11 +28,8 @@ export class UsageMonitor {
     private readonly logger: AgentLogger,
   ) {}
 
-  async recordUsage(
-    stateGlobal: AgentStateGlobal,
-    groupId?: string,
-  ): Promise<void> {
-    const statsGroupId = groupId ?? this.logger.getActiveGroupId();
+  async recordUsage(stateGlobal: AgentStateGlobal): Promise<void> {
+    const statsGroupId = this.logger.getActiveGroupId();
 
     try {
       let responseUsage:

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -37,8 +37,8 @@ export class LatexMediaManager {
   private async compilePdfs(
     files: string[],
     toolState: ToolState,
-    groupId?: string,
   ): Promise<void> {
+    const activeGroupId = this.logger.getActiveGroupId();
     const texFiles = files.filter((file) =>
       file.toLowerCase().endsWith('.tex'),
     );
@@ -52,34 +52,37 @@ export class LatexMediaManager {
           buildDir,
           true,
         );
-        if (compiled) {
-          const pdfFile = path.join(
-            buildDir,
-            path.basename(file).replace(/\.tex$/, '.pdf'),
-          );
-          if (await WorkspaceFS.exists(pdfFile)) {
-            try {
-              const stats = await WorkspaceFS.stat(pdfFile);
-              if (stats.size === 0) {
-                this.logger.warn(
-                  `Compiled PDF is empty for ${file}: ${pdfFile}`,
-                  groupId,
+          if (compiled) {
+            const pdfFile = path.join(
+              buildDir,
+              path.basename(file).replace(/\.tex$/, '.pdf'),
+            );
+            if (await WorkspaceFS.exists(pdfFile)) {
+              try {
+                const stats = await WorkspaceFS.stat(pdfFile);
+                if (stats.size === 0) {
+                  this.logger.warn(
+                    `Compiled PDF is empty for ${file}: ${pdfFile}`,
+                    activeGroupId,
+                  );
+                  return undefined;
+                }
+              } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                this.logger.error(
+                  `Failed to stat compiled PDF ${pdfFile}: ${message}`,
+                  activeGroupId,
                 );
                 return undefined;
               }
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              this.logger.error(
-                `Failed to stat compiled PDF ${pdfFile}: ${message}`,
-                groupId,
-              );
-              return undefined;
-            }
 
-            this.logger.info(`Compiled PDF for ${file}: ${pdfFile}`, groupId);
-            return pdfFile;
+              this.logger.info(
+                `Compiled PDF for ${file}: ${pdfFile}`,
+                activeGroupId,
+              );
+              return pdfFile;
+            }
           }
-        }
         return undefined;
       }),
     );
@@ -93,8 +96,8 @@ export class LatexMediaManager {
   private async extractFiguresFromFiles(
     files: string[],
     toolState: ToolState,
-    groupId?: string,
   ): Promise<void> {
+    const activeGroupId = this.logger.getActiveGroupId();
     const figureResults = await Promise.allSettled(
       files.map((file) => extractFigurePathsFromLatex(file)),
     );
@@ -107,7 +110,7 @@ export class LatexMediaManager {
         const file = files[idx];
         this.logger.debug(
           `Extracted ${result.value.length} figures from ${file}`,
-          groupId,
+          activeGroupId,
         );
         toolState.addMediaFiles(result.value);
       }
@@ -118,8 +121,8 @@ export class LatexMediaManager {
     files: string[],
     toolState: ToolState,
     logSummary: boolean,
-    groupId?: string,
   ): Promise<void> {
+    const activeGroupId = this.logger.getActiveGroupId();
     const tikzResults = await Promise.allSettled(
       files.map((file) => tikzPictureManager.compile(file)),
     );
@@ -135,7 +138,7 @@ export class LatexMediaManager {
     if (logSummary) {
       this.logger.debug(
         `Extracted ${tikzResults.length} TikZ figures`,
-        groupId,
+        activeGroupId,
       );
     }
   }
@@ -151,14 +154,12 @@ export class LatexMediaManager {
       includePdfCompilation,
       extraMediaFiles = [],
       logTikzSummary = false,
-      groupId,
     }: {
       includeFigureExtraction: boolean;
       includeTikzCompilation: boolean;
       includePdfCompilation: boolean;
       extraMediaFiles?: string[];
       logTikzSummary?: boolean;
-      groupId?: string;
     },
   ): Promise<void> {
     if (!files || files.length === 0) {
@@ -190,7 +191,7 @@ export class LatexMediaManager {
     }
 
     if (includeFigureExtraction && cfg.autoExtractFigure) {
-      await this.extractFiguresFromFiles(existingFiles, toolState, groupId);
+      await this.extractFiguresFromFiles(existingFiles, toolState);
     }
 
     if (includeTikzCompilation && cfg.autoExtractTikzFigure) {
@@ -198,12 +199,11 @@ export class LatexMediaManager {
         existingFiles,
         toolState,
         logTikzSummary,
-        groupId,
       );
     }
 
     if (includePdfCompilation && cfg.autoCompileInputPdf) {
-      await this.compilePdfs(existingFiles, toolState, groupId);
+      await this.compilePdfs(existingFiles, toolState);
     }
   }
 
@@ -217,7 +217,6 @@ export class LatexMediaManager {
     cfg: ToolConfig,
     supportsVision: boolean,
     extraMediaFiles: string[] = [],
-    groupId?: string,
   ): Promise<void> {
     await this.processFiles(inputFiles, toolState, cfg, supportsVision, {
       includeFigureExtraction: true,
@@ -225,7 +224,6 @@ export class LatexMediaManager {
       includePdfCompilation: true,
       extraMediaFiles,
       logTikzSummary: true,
-      groupId,
     });
   }
 
@@ -237,13 +235,11 @@ export class LatexMediaManager {
     toolState: ToolState,
     cfg: ToolConfig,
     supportsVision: boolean,
-    groupId?: string,
   ): Promise<void> {
     await this.processFiles(outputFiles, toolState, cfg, supportsVision, {
       includeFigureExtraction: false,
       includeTikzCompilation: true,
       includePdfCompilation: true,
-      groupId,
     });
   }
 }

--- a/src/test/output/LatexDiffManager.test.ts
+++ b/src/test/output/LatexDiffManager.test.ts
@@ -110,7 +110,7 @@ describe('LatexDiffManager mapping reuse', () => {
       runDiffBetweenRounds: async () => ({ success: true }),
     };
 
-    await manager.handleLatexdiffofOutput(0, mapping, 'group');
+    await manager.handleLatexdiffofOutput(0, mapping);
 
     assert.deepEqual(roundPairs, [
       {
@@ -184,7 +184,7 @@ describe('LatexDiffManager mapping reuse', () => {
       },
     };
 
-    await manager.handleLatexdiffofOutput(1, mapping, 'group');
+    await manager.handleLatexdiffofOutput(1, mapping);
 
     assert.deepEqual(roundPairs, [
       {


### PR DESCRIPTION
## Summary
- stop threading round and process group IDs through the reflection pipeline and delegate lookups to the logger
- simplify output, diff, and media managers plus agent subclasses to compute the active group internally
- update model handler interfaces, implementations, and usage monitoring to match the new signatures

## Testing
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69073053b10883248a2e55a99dd68b7f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove explicit group IDs throughout the agent/model/output stack and rely on the logger’s active group; update interfaces, implementations, and tests accordingly.
> 
> - **Logging/Groups**:
>   - Replace threaded `groupId`/`processGroupId` params with `logger.getActiveGroupId()` across agents, model handlers, output, diff, media, and usage monitoring.
>   - Simplify log calls and remove unused `MESSAGE_TYPES` references where possible.
> - **Agent Pipeline**:
>   - `BaseAgent.trackRoundUsage` no longer accepts `groupId`.
>   - `BaseReflectionAgent` drops `processGroupId` plumbing; uses active group for debug; latexdiff and finalize calls updated.
>   - `CoTAgent`, `DirectAgent`, `MergeAgent`: remove `withLogGroup` wrappers and `processGroupId` handling; streamline `handleOutput` and logging.
> - **Model Handlers**:
>   - `IModelHandler.initializeOutputAndPrefill(...)` signature removed `groupId`; all implementations (`Anthropic`, `GoogleGenAI`, `OpenAI`, `OpenAIResponse`) updated and scratchpad/info logs adjusted.
> - **Output/Diff/Media**:
>   - `OutputHandler.validateExpectedOutputs`, `finalizeRound`, `processOutputFiles` now derive active group internally.
>   - `LatexDiffManager.logLatexdiffResult`/`handleLatexdiffofOutput` use active group; call sites updated.
>   - `LatexMediaManager` methods drop `groupId` params; logging uses active group.
> - **Tests**:
>   - Update `LatexDiffManager.test.ts` to call `handleLatexdiffofOutput` without `group` argument.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c57ac7a4e4d16870c73de4c80e9d43ffa66eaf8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->