### PR TITLE
Refactor conversation state handling into explicit slices

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -1,205 +1,35 @@
-// Local imports - agent components
-import {
-  OpenAIAPIResponseUsage,
-  AnthropicAPIResponseUsage,
-} from './ResponseUsage';
+// Local imports - conversation state
+export {
+  RoundMetricsState,
+  SessionUsageState,
+  type RoundMetricsSnapshot,
+  type SessionUsageSnapshot,
+  RoundMetricsState as AgentStateRound,
+  SessionUsageState as AgentStateGlobal,
+} from './state/ConversationState';
 
-// Local imports - logging
-import * as logger from '@logger/logUtils';
+// Local imports - tool response state slices
+export {
+  DocumentAssetState,
+  ResponseDraftState,
+  ReasoningTraceState,
+  type DocumentAssetSnapshot,
+  type ResponseDraftSnapshot,
+  type ReasoningTraceSnapshot,
+  type ToolResponseState,
+  type ToolResponseSnapshot,
+  createToolResponseState,
+  toolResponseStateFromSnapshot,
+  toolResponseStateToSnapshot,
+} from './state/ToolResponseState';
 
-const CHANNEL = 'Agent';
-logger.initialize(CHANNEL);
-
-/** Interface for tracking state within a single conversation round. */
-export interface IAgentStateRound {
-  currRound: number;
-  continuationCount: number;
-  responseTime: number;
-  outputFile: string;
-  APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
-}
-
-/** Manages state and metrics for a single conversation round. */
-export class AgentStateRound implements IAgentStateRound {
-  currRound: number;
-  continuationCount: number;
-  responseTime: number;
-  outputFile: string;
-  APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
-
-  constructor(currRound: number) {
-    this.currRound = currRound;
-    this.continuationCount = 0;
-    this.responseTime = 0;
-    this.outputFile = '';
-    this.APIUsage = null;
-  }
-
-  /** Updates token usage metrics from model API response. */
-  updateTokenCounts(
-    responseUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage,
-  ): void {
-    this.APIUsage = responseUsage;
-  }
-
-  /** Adds response time in milliseconds to the round total. */
-  updateResponseTime(responseTime: number): void {
-    this.responseTime += responseTime;
-  }
-
-  /** Increments the continuation counter for tracking multi-turn responses. */
-  incrementContinuation(): void {
-    this.continuationCount += 1;
-  }
-
-  /** Converts state to a serializable object for persistence. */
-  toObject(): Record<string, any> {
-    const stateObj = {
-      currRound: this.currRound,
-      continuationCount: this.continuationCount,
-      responseTime: this.responseTime,
-      outputFile: this.outputFile,
-      APIUsage: this.APIUsage,
-    };
-    return stateObj;
-  }
-}
-
-/** Interface for tracking aggregate metrics across all conversation rounds. */
-export interface IAgentStateGlobal {
-  firstInputTokens: number;
-  totalResponseTime: number;
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  totalRounds: number;
-  APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
-}
-
-/** Manages global state and aggregates metrics across conversation rounds. */
-export class AgentStateGlobal implements IAgentStateGlobal {
-  firstInputTokens: number;
-  totalResponseTime: number;
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  totalRounds: number;
-  APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
-  public totalCacheReadInputTokens: number = 0;
-  public totalCacheCreationInputTokens: number = 0;
-  public totalReasoningTokens: number = 0;
-  public totalToolUseTokens: number = 0;
-
-  constructor() {
-    this.firstInputTokens = 0;
-    this.totalResponseTime = 0;
-    this.totalInputTokens = 0;
-    this.totalOutputTokens = 0;
-    this.totalRounds = 0;
-    this.APIUsage = null;
-  }
-
-  /** Updates global metrics by incorporating round state data. */
-  updateFromCurrRound(stateRound: AgentStateRound): void {
-    if (stateRound.APIUsage) {
-      if (this.firstInputTokens === 0) {
-        this.firstInputTokens = stateRound.APIUsage.totalInputTokens;
-      }
-
-      // For Anthropic models, handle cache tokens directly from response
-      if ('cache_read_input_tokens' in stateRound.APIUsage) {
-        const cacheRead = stateRound.APIUsage.cache_read_input_tokens ?? 0;
-        const cacheCreation =
-          stateRound.APIUsage.cache_creation_input_tokens ?? 0;
-        this.totalCacheReadInputTokens += cacheRead;
-        this.totalCacheCreationInputTokens += cacheCreation;
-        this.firstInputTokens += cacheRead + cacheCreation;
-      }
-      // For OpenAI models with auto prompt caching, handle cache tokens from prompt_tokens_details
-      else if (
-        'prompt_tokens_details' in stateRound.APIUsage &&
-        stateRound.APIUsage.prompt_tokens_details
-      ) {
-        const promptDetails = stateRound.APIUsage.prompt_tokens_details as {
-          cached_tokens?: number;
-        };
-        if ('cached_tokens' in promptDetails) {
-          this.totalCacheReadInputTokens += promptDetails.cached_tokens ?? 0;
-        }
-      }
-
-      // For OpenAI models, handle reasoning tokens from completion_tokens_details
-      if (
-        'completion_tokens_details' in stateRound.APIUsage &&
-        stateRound.APIUsage.completion_tokens_details
-      ) {
-        const completionDetails = stateRound.APIUsage
-          .completion_tokens_details as { reasoning_tokens?: number };
-        if ('reasoning_tokens' in completionDetails) {
-          this.totalReasoningTokens += completionDetails.reasoning_tokens ?? 0;
-        }
-      }
-      // For older OpenAI models, handle reasoning tokens directly
-      else if ('reasoning_tokens' in stateRound.APIUsage) {
-        this.totalReasoningTokens += stateRound.APIUsage.reasoning_tokens ?? 0;
-      }
-
-      // Track tokens used for tool calls
-      // Note: Only Google models provide tool_use_tokens (as toolUsePromptTokenCount)
-      // OpenAI and Anthropic don't provide this information in their API responses
-      if (
-        'tool_use_tokens' in stateRound.APIUsage &&
-        stateRound.APIUsage.tool_use_tokens !== null &&
-        stateRound.APIUsage.tool_use_tokens !== undefined
-      ) {
-        this.totalToolUseTokens += stateRound.APIUsage.tool_use_tokens;
-      }
-
-      // Update global totals
-      this.totalInputTokens += stateRound.APIUsage.totalInputTokens;
-      this.totalOutputTokens += stateRound.APIUsage.totalOutputTokens;
-    }
-
-    this.totalResponseTime += stateRound.responseTime;
-  }
-
-  incrementRounds(): void {
-    this.totalRounds += 1;
-  }
-
-  // are the following two methods needed?
-  /** Converts global state to a serializable object for persistence. */
-  toObject(): Record<string, any> {
-    return {
-      firstInputTokens: this.firstInputTokens,
-      totalResponseTime: this.totalResponseTime,
-      totalInputTokens: this.totalInputTokens,
-      totalOutputTokens: this.totalOutputTokens,
-      totalRounds: this.totalRounds,
-      APIUsage: this.APIUsage,
-      totalCacheReadInputTokens: this.totalCacheReadInputTokens,
-      totalCacheCreationInputTokens: this.totalCacheCreationInputTokens,
-      totalReasoningTokens: this.totalReasoningTokens,
-      totalToolUseTokens: this.totalToolUseTokens,
-    };
-  }
-
-  /** Creates an AgentStateGlobal instance from a persisted state object. */
-  static fromObject(stateObj: Record<string, any> | null): AgentStateGlobal {
-    if (!stateObj) {
-      return new AgentStateGlobal();
-    }
-
-    const state = new AgentStateGlobal();
-    state.firstInputTokens = stateObj.firstInputTokens ?? 0;
-    state.totalResponseTime = stateObj.totalResponseTime ?? 0;
-    state.totalInputTokens = stateObj.totalInputTokens ?? 0;
-    state.totalOutputTokens = stateObj.totalOutputTokens ?? 0;
-    state.totalRounds = stateObj.totalRounds ?? 0;
-    state.APIUsage = stateObj.APIUsage ?? null;
-    state.totalCacheReadInputTokens = stateObj.totalCacheReadInputTokens ?? 0;
-    state.totalCacheCreationInputTokens =
-      stateObj.totalCacheCreationInputTokens ?? 0;
-    state.totalReasoningTokens = stateObj.totalReasoningTokens ?? 0;
-    state.totalToolUseTokens = stateObj.totalToolUseTokens ?? 0;
-    return state;
-  }
-}
+// Local imports - response cycle store helpers
+export {
+  createResponseCycleStore,
+  resetResponseCycleRuntime,
+  type ResponseCycleRuntimeState,
+  type ResponseCycleStore,
+  DocumentAssetState as CycleDocumentAssetState,
+  ResponseDraftState as CycleResponseDraftState,
+  ReasoningTraceState as CycleReasoningTraceState,
+} from './state/ResponseCycleStore';

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -1,12 +1,15 @@
-// Local imports - agent components
-import { AgentStateGlobal, AgentStateRound } from './AgentState';
-import { ToolState } from './ToolState';
+// Local imports - agent state
+import {
+  RoundMetricsState,
+  SessionUsageState,
+  type ToolResponseState,
+  createResponseCycleStore,
+} from './AgentState';
 
 // Local imports - flow orchestration
 import {
   createResponseCycleFlow,
   type ResponseCycleShared,
-  type ResponseCycleState,
 } from './flows/ResponseCycleFlow';
 
 // Local imports - option helpers
@@ -26,51 +29,42 @@ export interface ResponseCycleOptions<C = unknown>
 export interface ResponseCycleContext<C = unknown> {
   options: ResponseCycleOptions<C>;
   messages: ProviderMessage[];
-  stateRound: AgentStateRound;
-  stateGlobal: AgentStateGlobal;
-  toolState: ToolState;
+  stateRound: RoundMetricsState;
+  stateGlobal: SessionUsageState;
+  toolState: ToolResponseState;
   outputFile: string;
 }
 
 export interface ResponseCycleResult {
-  stateRound: AgentStateRound;
-  stateGlobal: AgentStateGlobal;
-  toolState: ToolState;
+  stateRound: RoundMetricsState;
+  stateGlobal: SessionUsageState;
+  toolState: ToolResponseState;
   endTurn: boolean;
 }
 
 export async function runResponseCycle<C = unknown>(
   context: ResponseCycleContext<C>,
 ): Promise<ResponseCycleResult> {
+  const store = createResponseCycleStore({
+    messages: context.messages,
+    outputFile: context.outputFile,
+    round: context.stateRound,
+    session: context.stateGlobal,
+    toolState: context.toolState,
+  });
+
   const shared: ResponseCycleShared<C> = {
     options: context.options,
-    cycle: {
-      messages: context.messages,
-      stateRound: context.stateRound,
-      stateGlobal: context.stateGlobal,
-      toolState: context.toolState,
-      outputFile: context.outputFile,
-      endTurn: false,
-      shouldStop: false,
-      outputExists: false,
-      systemPrompt: undefined,
-      debugContext: undefined,
-      debugFileOptions: undefined,
-      startTime: undefined,
-      responseObject: undefined,
-      responseTime: undefined,
-      stopReason: undefined,
-      processedResponse: undefined,
-    } satisfies ResponseCycleState,
+    store,
   };
 
   const flow = createResponseCycleFlow<C>();
   await flow.run(shared);
 
   return {
-    stateRound: shared.cycle.stateRound,
-    stateGlobal: shared.cycle.stateGlobal,
-    toolState: shared.cycle.toolState,
-    endTurn: shared.cycle.endTurn,
+    stateRound: shared.store.round,
+    stateGlobal: shared.store.session,
+    toolState: shared.store.tool,
+    endTurn: shared.store.runtime.endTurn,
   };
 }

--- a/src/agent/core/ToolState.ts
+++ b/src/agent/core/ToolState.ts
@@ -1,89 +1,11 @@
-/** Interface for managing tool-specific runtime state within a conversation round. */
-export interface IToolState {
-  /** Statistics about TeX document structure */
-  texcountStats: string | null;
-
-  /** Most recent model response */
-  lastResponse: string;
-
-  /** Combined output from all responses */
-  accumulatedOutput: string;
-
-  /** Paths to figure files */
-  mediaFiles: string[];
-
-  /** Collection of all thinking blocks from the response (used for Anthropic models) */
-  thinkingBlocks: any[];
-
-  /** Whether the thinking block has been added to the accumulated output */
-  thinkingAdded: boolean;
-
-  updateLastResponse(response: string): void;
-  updateAccumulatedOutput(output: string): void;
-  addMediaFiles(files: string[]): void;
-  resetThinkingCache(): void;
-}
-
-/** Manages tool-specific runtime state and operations within a conversation round. */
-export class ToolState implements IToolState {
-  texcountStats: string | null;
-  lastResponse: string;
-  accumulatedOutput: string;
-  mediaFiles: string[];
-  thinkingBlocks: any[];
-  thinkingAdded: boolean;
-
-  /**
-   * Returns the first thinking block from thinkingBlocks array
-   * @returns The first thinking block or null if none exists
-   */
-  get thinkingBlock(): any {
-    return this.thinkingBlocks.length > 0 ? this.thinkingBlocks[0] : null;
-  }
-
-  constructor() {
-    this.texcountStats = null;
-    this.lastResponse = '';
-    this.accumulatedOutput = '';
-    this.mediaFiles = [];
-    this.thinkingBlocks = [];
-    this.thinkingAdded = false;
-  }
-
-  /**
-   * Updates the most recent model response.
-   * @param response New response text from the model
-   */
-  updateLastResponse(response: string): void {
-    this.lastResponse = response;
-  }
-
-  /**
-   * Updates the accumulated output with new content.
-   * @param output New content to store as accumulated output
-   */
-  updateAccumulatedOutput(output: string): void {
-    this.accumulatedOutput = output;
-  }
-
-  /**
-   * Adds new figure file paths to the collection.
-   * @param files Array of paths to new figure files
-   */
-  addMediaFiles(files: string[]): void {
-    for (const file of files) {
-      if (!this.mediaFiles.includes(file)) {
-        this.mediaFiles.push(file);
-      }
-    }
-  }
-
-  /**
-   * Resets the thinking cache by clearing thinking blocks and reset flag.
-   * Used to ensure fresh thinking blocks for subsequent responses.
-   */
-  resetThinkingCache(): void {
-    this.thinkingBlocks = [];
-    this.thinkingAdded = false;
-  }
-}
+// Deprecated compatibility re-export. Prefer importing from './AgentState'.
+export {
+  ToolResponseState as ToolState,
+  createToolResponseState,
+  toolResponseStateFromSnapshot,
+  toolResponseStateToSnapshot,
+  type ToolResponseSnapshot,
+  type DocumentAssetSnapshot,
+  type ResponseDraftSnapshot,
+  type ReasoningTraceSnapshot,
+} from './AgentState';

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -1,5 +1,5 @@
-// Local imports - agent components
-import { ToolState } from './ToolState';
+// Local imports - agent state
+import type { ToolResponseState } from './AgentState';
 
 // Local imports - flow orchestration
 import {
@@ -20,7 +20,7 @@ import type { BaseTool } from '@tools/core/base';
 export interface ToolUseCycleOptions<C = unknown>
   extends AgentCycleBaseOptions<C> {
   toolRegistry: Record<string, BaseTool<any>>;
-  toolState: ToolState;
+  toolState: ToolResponseState;
   modelName?: string;
 }
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -5,13 +5,14 @@ import { BaseNode, Flow } from '@agent/node';
 import { FlowTransition } from './FlowTransitions';
 
 // Local imports - agent components
-import { AgentStateGlobal, AgentStateRound } from '@agent/core/AgentState';
-import { ToolState } from '@agent/core/ToolState';
+import {
+  resetResponseCycleRuntime,
+  type ResponseCycleStore,
+  type ResponseDebugContext,
+  type ResponseDebugFileOptions,
+} from '@agent/core/AgentState';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
-
-// Local imports - model handler types
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 // Local imports - utilities
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
@@ -41,16 +42,12 @@ import xmlUtils from '@utils/text/xmlUtils';
 // Local imports - identifier types
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
-interface DebugContext {
+interface DebugContext extends ResponseDebugContext {
   logger: ResponseCycleOptions['logger'];
-  modelName: string;
   executionId?: ExecutionId;
 }
 
-interface DebugFileOptions {
-  continuationCount: number;
-  outputFile: string;
-}
+type DebugFileOptions = ResponseDebugFileOptions;
 
 async function maybeSaveDebug(
   debugContext: DebugContext | undefined,
@@ -70,43 +67,9 @@ async function maybeSaveDebug(
   });
 }
 
-export interface ResponseCycleInputState {
-  messages: ProviderMessage[];
-  stateRound: AgentStateRound;
-  stateGlobal: AgentStateGlobal;
-  toolState: ToolState;
-  outputFile: string;
-}
-
-export interface ResponseCycleRuntimeState {
-  endTurn: boolean;
-  shouldStop: boolean;
-  outputExists: boolean;
-  systemPrompt?: string;
-  debugContext?: DebugContext;
-  debugFileOptions?: DebugFileOptions;
-  startTime?: number;
-  responseObject?: unknown;
-  responseTime?: number;
-  stopReason?: ProviderStopReason;
-  processedResponse?: string;
-}
-
-export type ResponseCycleState = ResponseCycleInputState &
-  ResponseCycleRuntimeState;
-
-function resetResponseCycleState(cycle: ResponseCycleRuntimeState): void {
-  cycle.shouldStop = false;
-  cycle.endTurn = false;
-  cycle.responseObject = undefined;
-  cycle.responseTime = undefined;
-  cycle.stopReason = undefined;
-  cycle.processedResponse = undefined;
-}
-
 export interface ResponseCycleShared<C = unknown> {
   options: ResponseCycleOptions<C>;
-  cycle: ResponseCycleState;
+  store: ResponseCycleStore;
 }
 
 // Each node in the response cycle progressively hydrates the shared cycle
@@ -126,10 +89,11 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
     debugContext?: DebugContext;
     debugFileOptions?: DebugFileOptions;
   }> {
-    const { options, cycle } = shared;
+    const { options, store } = shared;
+    const { runtime } = store;
     const { agentPrompt, userVars, logger, agentConfig } = options;
     const interrupted = Boolean(await options.checkInterruption());
-    const exists = await WorkspaceFS.exists(cycle.outputFile);
+    const exists = await WorkspaceFS.exists(store.outputFile);
     const systemPrompt = interrupted
       ? undefined
       : await getSystemPromptWithRules(agentPrompt.systemPrompt, userVars);
@@ -145,8 +109,8 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const debugFileOptions: DebugFileOptions | undefined = interrupted
       ? undefined
       : {
-          continuationCount: cycle.stateRound.continuationCount,
-          outputFile: cycle.outputFile,
+          continuationCount: store.round.continuationCount,
+          outputFile: store.outputFile,
         };
 
     return {
@@ -159,7 +123,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
   }
 
   async post(
-    { cycle }: ResponseCycleShared<C>,
+    { store }: ResponseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       exists: boolean;
@@ -168,23 +132,24 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
       debugFileOptions?: DebugFileOptions;
     },
   ): Promise<string | undefined> {
+    const { runtime } = store;
+    resetResponseCycleRuntime(runtime);
+
     if (prepRes.interrupted) {
-      resetResponseCycleState(cycle);
-      cycle.shouldStop = true;
+      runtime.shouldStop = true;
       return FlowTransition.COMPLETE;
     }
 
-    cycle.outputExists = prepRes.exists;
-    cycle.systemPrompt = prepRes.systemPrompt;
-    cycle.debugContext = prepRes.debugContext;
-    cycle.debugFileOptions = prepRes.debugFileOptions;
-    cycle.startTime = Date.now();
-    resetResponseCycleState(cycle);
+    runtime.outputExists = prepRes.exists;
+    runtime.systemPrompt = prepRes.systemPrompt;
+    runtime.debugContext = prepRes.debugContext;
+    runtime.debugFileOptions = prepRes.debugFileOptions;
+    runtime.startTime = Date.now();
 
     await maybeSaveDebug(
-      cycle.debugContext,
-      cycle.debugFileOptions,
-      cycle.messages,
+      runtime.debugContext,
+      runtime.debugFileOptions,
+      store.messages,
       'messages',
     );
 
@@ -204,8 +169,9 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async exec(
     context: ResponseCycleShared<C>,
   ): Promise<{ skipped: true } | { response: unknown; responseTime?: number }> {
-    const { options, cycle } = context;
-    if (cycle.shouldStop) {
+    const { options, store } = context;
+    const { runtime } = store;
+    if (runtime.shouldStop) {
       return { skipped: true };
     }
 
@@ -219,9 +185,9 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     try {
       response = await options.modelHandler.createResponse(
         options.client,
-        cycle.messages,
+        store.messages,
         options.agentSetting.temperature || 0.0,
-        cycle.systemPrompt,
+        runtime.systemPrompt,
         options.agentSetting.endTag,
         abortController.signal,
         options.modelHandler.capabilities.supportsFunctionCalling
@@ -234,15 +200,15 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
           ? `Model invocation failed: ${error.message}`
           : 'Model invocation failed with an unknown error';
       options.logger.error(message, groupId);
-      cycle.shouldStop = true;
-      cycle.endTurn = false;
+      runtime.shouldStop = true;
+      runtime.endTurn = false;
       throw error;
     } finally {
       options.setAbortController(null);
     }
 
-    const responseTime = cycle.startTime
-      ? (Date.now() - cycle.startTime) / 1000
+    const responseTime = runtime.startTime
+      ? (Date.now() - runtime.startTime) / 1000
       : undefined;
 
     return { response, responseTime };
@@ -253,20 +219,21 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     prepRes: ResponseCycleShared<C>,
     execRes: { skipped: true } | { response: unknown; responseTime?: number },
   ): Promise<string | undefined> {
-    const { options, cycle } = prepRes;
+    const { options, store } = prepRes;
+    const { runtime } = store;
     const groupId = options.logger.getActiveGroupId();
 
     if ('skipped' in execRes) {
-      cycle.endTurn = false;
+      runtime.endTurn = false;
       return FlowTransition.COMPLETE;
     }
 
-    cycle.responseObject = execRes.response;
-    cycle.responseTime = execRes.responseTime;
+    runtime.responseObject = execRes.response;
+    runtime.responseTime = execRes.responseTime;
 
     await maybeSaveDebug(
-      cycle.debugContext,
-      cycle.debugFileOptions,
+      runtime.debugContext,
+      runtime.debugFileOptions,
       execRes.response,
       'response',
     );
@@ -276,8 +243,8 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         'Model response was aborted or returned no data; output may be incomplete.',
         groupId,
       );
-      cycle.endTurn = false;
-      cycle.shouldStop = true;
+      runtime.endTurn = false;
+      runtime.shouldStop = true;
       return FlowTransition.COMPLETE;
     }
 
@@ -311,14 +278,15 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async exec(
     context: ResponseCycleShared<C>,
   ): Promise<ProcessResult | { skipped: true }> {
-    const { options, cycle } = context;
-    if (cycle.shouldStop || !cycle.responseObject) {
+    const { options, store } = context;
+    const { runtime } = store;
+    if (runtime.shouldStop || !runtime.responseObject) {
       return { skipped: true };
     }
 
     const [newResponse, responseUsage, stopReason] =
       options.modelHandler.extractResponse(
-        cycle.responseObject,
+        runtime.responseObject,
         options.agentSetting.endTag,
       );
 
@@ -331,10 +299,10 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       );
     }
 
-    if (cycle.responseTime !== undefined) {
-      cycle.stateRound.updateResponseTime(cycle.responseTime);
+    if (runtime.responseTime !== undefined) {
+      store.round.addResponseTime(runtime.responseTime);
       options.logger.debug(
-        `Response time: ${cycle.responseTime.toFixed(2)}s`,
+        `Response time: ${runtime.responseTime.toFixed(2)}s`,
         groupId,
       );
     }
@@ -346,9 +314,9 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     );
 
     const thinkingContent = options.modelHandler.processThinkingBlock(
-      cycle.responseObject,
+      runtime.responseObject,
       groupId,
-      cycle.toolState,
+      store.tool,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
 
@@ -374,13 +342,13 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     const apiUsage = options.modelHandler.computeResponseUsage(
       responseUsage,
-      cycle.responseTime ?? 0,
+      runtime.responseTime ?? 0,
     );
-    cycle.stateRound.updateTokenCounts(apiUsage);
-    cycle.stateGlobal.updateFromCurrRound(cycle.stateRound);
+    store.round.recordUsage(apiUsage);
+    store.session.updateFromRound(store.round);
 
     const repetitionResult = checkForMassiveRepetition(
-      cycle.toolState.lastResponse,
+      store.tool.draft.lastResponse,
       newResponse,
     );
 
@@ -398,7 +366,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
         groupId,
       );
       options.logger.error(
-        JSON.stringify(messageToSkeleton(cycle.messages), null, 2),
+        JSON.stringify(messageToSkeleton(store.messages), null, 2),
         groupId,
       );
     }
@@ -410,13 +378,13 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
       if (!repetitionResult.massiveRepetitionDetected) {
         const connector = await bestConnectionMethod(
-          cycle.toolState.lastResponse.slice(-K_SLICE),
+          store.tool.draft.lastResponse.slice(-K_SLICE),
           processedResponse.slice(0, K_SLICE),
         );
         bestConnector = connector.connector;
-        cycle.toolState.updateLastResponse(processedResponse);
-        cycle.toolState.updateAccumulatedOutput(
-          cycle.toolState.accumulatedOutput +
+        store.tool.draft.setLastResponse(processedResponse);
+        store.tool.draft.setAccumulatedOutput(
+          store.tool.draft.accumulatedOutput +
             (bestConnector ?? '') +
             processedResponse,
         );
@@ -441,34 +409,35 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     prepRes: ResponseCycleShared<C>,
     execRes: ProcessResult | { skipped: true },
   ): Promise<string | undefined> {
-    const { options, cycle } = prepRes;
+    const { options, store } = prepRes;
+    const { runtime } = store;
     const groupId = options.logger.getActiveGroupId();
 
     if ('skipped' in execRes) {
-      cycle.endTurn = false;
+      runtime.endTurn = false;
       return FlowTransition.COMPLETE;
     }
 
-    cycle.stopReason = execRes.stopReason;
-    cycle.processedResponse = execRes.processedResponse;
+    runtime.stopReason = execRes.stopReason;
+    runtime.processedResponse = execRes.processedResponse;
 
     if (execRes.repetitionDetected || !execRes.processedResponse) {
-      cycle.endTurn = false;
-      cycle.shouldStop = true;
+      runtime.endTurn = false;
+      runtime.shouldStop = true;
       return FlowTransition.COMPLETE;
     }
 
-    if (!cycle.outputExists) {
-      options.logger.debug(`Creating new file: ${cycle.outputFile}`, groupId);
-      await WorkspaceFS.write(cycle.outputFile, execRes.processedResponse);
-      cycle.outputExists = true;
+    if (!runtime.outputExists) {
+      options.logger.debug(`Creating new file: ${store.outputFile}`, groupId);
+      await WorkspaceFS.write(store.outputFile, execRes.processedResponse);
+      runtime.outputExists = true;
     } else {
       options.logger.debug(
-        `Appending to existing file: ${cycle.outputFile}`,
+        `Appending to existing file: ${store.outputFile}`,
         groupId,
       );
       await WorkspaceFS.appendFile(
-        cycle.outputFile,
+        store.outputFile,
         (execRes.bestConnector ?? '') + execRes.processedResponse,
       );
     }
@@ -485,17 +454,17 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     if (options.modelHandler.capabilities.supportsAssistantPrefill) {
       options.modelHandler.updateMessageContentWithPrefill(
-        cycle.messages,
+        store.messages,
         execRes.bestConnector ?? '',
         execRes.processedResponse,
-        cycle.toolState,
+        store.tool,
       );
     } else {
       options.modelHandler.updateMessageContentWithoutPrefill(
-        cycle.messages,
+        store.messages,
         execRes.bestConnector ?? '',
         execRes.processedResponse,
-        cycle.toolState,
+        store.tool,
       );
     }
 
@@ -518,8 +487,9 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
     | { skipped: true }
   > {
-    const { options, cycle } = context;
-    if (cycle.shouldStop || !cycle.stopReason || !cycle.processedResponse) {
+    const { options, store } = context;
+    const { runtime } = store;
+    if (runtime.shouldStop || !runtime.stopReason || !runtime.processedResponse) {
       return { skipped: true };
     }
 
@@ -530,16 +500,16 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     const [shouldEndTurn, shouldStop] =
       options.modelHandler.checkStopConditions(
-        cycle.stopReason,
-        cycle.processedResponse,
-        cycle.stateRound,
-        cycle.stateGlobal,
+        runtime.stopReason,
+        runtime.processedResponse,
+        store.round,
+        store.session,
         options.agentSetting,
       );
 
     const shouldContinue = options.modelHandler.shouldContinue(
-      cycle.stopReason,
-      cycle.processedResponse,
+      runtime.stopReason,
+      runtime.processedResponse,
       options.agentSetting,
     );
 
@@ -553,25 +523,26 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       | { shouldEndTurn: boolean; shouldStop: boolean; shouldContinue: boolean }
       | { skipped: true },
   ): Promise<string | undefined> {
-    const { options, cycle } = prepRes;
+    const { options, store } = prepRes;
+    const { runtime } = store;
     const groupId = options.logger.getActiveGroupId();
 
     if ('skipped' in execRes) {
-      cycle.endTurn = false;
-      cycle.shouldStop = true;
+      runtime.endTurn = false;
+      runtime.shouldStop = true;
       return FlowTransition.COMPLETE;
     }
 
-    cycle.endTurn = execRes.shouldEndTurn;
-    cycle.shouldStop = execRes.shouldStop;
+    runtime.endTurn = execRes.shouldEndTurn;
+    runtime.shouldStop = execRes.shouldStop;
 
     if (execRes.shouldStop) {
       return FlowTransition.COMPLETE;
     }
 
-    cycle.stateRound.incrementContinuation();
+    store.round.incrementContinuation();
     options.logger.info(
-      `Starting continuation #${cycle.stateRound.continuationCount}`,
+      `Starting continuation #${store.round.continuationCount}`,
       groupId,
       MESSAGE_TYPES.PROGRESS_STATUS,
     );
@@ -587,17 +558,17 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     if (options.modelHandler.capabilities.supportsAssistantPrefill) {
       options.modelHandler.addContinueMessageWithPrefill(
-        cycle.messages,
-        cycle.stateRound,
-        cycle.toolState,
+        store.messages,
+        store.round,
+        store.tool,
         options.agentSetting,
         options.agentConfig,
       );
     } else {
       options.modelHandler.addContinueMessageWithoutPrefill(
-        cycle.messages,
-        cycle.stateRound,
-        cycle.toolState,
+        store.messages,
+        store.round,
+        store.tool,
         options.agentSetting,
         options.agentConfig,
       );

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -5,7 +5,7 @@ import { BaseNode, Flow } from '@agent/node';
 import { FlowTransition } from './FlowTransitions';
 
 // Local imports - agent components
-import { ToolState } from '@agent/core/ToolState';
+import type { ToolResponseState } from '@agent/core/AgentState';
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
 
 // Local imports - model handler types
@@ -139,7 +139,7 @@ type ToolDispatchErrorResult = {
 
 export interface ToolUseCycleInputState {
   messages: ProviderMessage[];
-  toolState: ToolState;
+  toolState: ToolResponseState;
   iteration: number;
 }
 
@@ -388,11 +388,11 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
     const endTurn = options.modelHandler.isEndTurnStop(stopReason);
 
-    if (!toolInfo || endTurn) {
-      if (text) {
-        state.messages.push(options.modelHandler.createAssistantMessage(text));
-        state.toolState.updateLastResponse(text);
-      }
+      if (!toolInfo || endTurn) {
+        if (text) {
+          state.messages.push(options.modelHandler.createAssistantMessage(text));
+          state.toolState.updateLastResponse(text);
+        }
       state.shouldStop = true;
       return { stopReason, text, endTurn: true };
     }

--- a/src/agent/core/index.ts
+++ b/src/agent/core/index.ts
@@ -2,7 +2,6 @@ export * from './AgentConfig';
 export * from './AgentDataclass';
 export * from './AgentState';
 export * from './ToolConfig';
-export * from './ToolState';
 export * from './ResponseUsage';
 export * from './IAgent';
 export * from './ResponseCycle';

--- a/src/agent/core/state/ConversationState.ts
+++ b/src/agent/core/state/ConversationState.ts
@@ -1,0 +1,184 @@
+// Local imports - usage types
+import {
+  type AnthropicAPIResponseUsage,
+  type OpenAIAPIResponseUsage,
+} from '../ResponseUsage';
+
+export type ModelUsage =
+  | OpenAIAPIResponseUsage
+  | AnthropicAPIResponseUsage;
+
+/** Snapshot shape for round metrics state. */
+export interface RoundMetricsSnapshot {
+  roundIndex: number;
+  continuationCount: number;
+  responseTime: number;
+  usage: ModelUsage | null;
+}
+
+/** Tracks metrics for a single round within a conversation. */
+export class RoundMetricsState {
+  roundIndex: number;
+  continuationCount: number;
+  responseTime: number;
+  usage: ModelUsage | null;
+
+  constructor(roundIndex: number) {
+    this.roundIndex = roundIndex;
+    this.continuationCount = 0;
+    this.responseTime = 0;
+    this.usage = null;
+  }
+
+  /** Records response usage information for the current round. */
+  recordUsage(usage: ModelUsage): void {
+    this.usage = usage;
+  }
+
+  /** Adds response time in seconds for this round. */
+  addResponseTime(durationSeconds: number): void {
+    this.responseTime += durationSeconds;
+  }
+
+  /** Increments the continuation counter. */
+  incrementContinuation(): void {
+    this.continuationCount += 1;
+  }
+
+  /** Converts the state into a serialisable snapshot. */
+  toSnapshot(): RoundMetricsSnapshot {
+    return {
+      roundIndex: this.roundIndex,
+      continuationCount: this.continuationCount,
+      responseTime: this.responseTime,
+      usage: this.usage,
+    };
+  }
+}
+
+/** Snapshot shape for session usage state. */
+export interface SessionUsageSnapshot {
+  firstInputTokens: number;
+  totalResponseTime: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalRounds: number;
+  totalCacheReadInputTokens: number;
+  totalCacheCreationInputTokens: number;
+  totalReasoningTokens: number;
+  totalToolUseTokens: number;
+}
+
+/** Aggregates usage metrics across all rounds in a session. */
+export class SessionUsageState {
+  firstInputTokens: number;
+  totalResponseTime: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalRounds: number;
+  totalCacheReadInputTokens: number;
+  totalCacheCreationInputTokens: number;
+  totalReasoningTokens: number;
+  totalToolUseTokens: number;
+
+  constructor() {
+    this.firstInputTokens = 0;
+    this.totalResponseTime = 0;
+    this.totalInputTokens = 0;
+    this.totalOutputTokens = 0;
+    this.totalRounds = 0;
+    this.totalCacheReadInputTokens = 0;
+    this.totalCacheCreationInputTokens = 0;
+    this.totalReasoningTokens = 0;
+    this.totalToolUseTokens = 0;
+  }
+
+  /** Incorporates metrics from a round-level snapshot. */
+  updateFromRound(round: RoundMetricsState): void {
+    if (!round.usage) {
+      return;
+    }
+
+    if (this.firstInputTokens === 0) {
+      this.firstInputTokens = round.usage.totalInputTokens;
+    }
+
+    if ('cache_read_input_tokens' in round.usage) {
+      const cacheRead = round.usage.cache_read_input_tokens ?? 0;
+      const cacheCreation = round.usage.cache_creation_input_tokens ?? 0;
+      this.totalCacheReadInputTokens += cacheRead;
+      this.totalCacheCreationInputTokens += cacheCreation;
+      this.firstInputTokens += cacheRead + cacheCreation;
+    } else if (
+      'prompt_tokens_details' in round.usage &&
+      round.usage.prompt_tokens_details
+    ) {
+      const promptDetails = round.usage
+        .prompt_tokens_details as { cached_tokens?: number };
+      if ('cached_tokens' in promptDetails) {
+        this.totalCacheReadInputTokens += promptDetails.cached_tokens ?? 0;
+      }
+    }
+
+    if (
+      'completion_tokens_details' in round.usage &&
+      round.usage.completion_tokens_details
+    ) {
+      const completionDetails = round.usage
+        .completion_tokens_details as { reasoning_tokens?: number };
+      if ('reasoning_tokens' in completionDetails) {
+        this.totalReasoningTokens += completionDetails.reasoning_tokens ?? 0;
+      }
+    } else if ('reasoning_tokens' in round.usage) {
+      this.totalReasoningTokens += round.usage.reasoning_tokens ?? 0;
+    }
+
+    if ('tool_use_tokens' in round.usage) {
+      const toolUseTokens = round.usage.tool_use_tokens;
+      if (typeof toolUseTokens === 'number') {
+        this.totalToolUseTokens += toolUseTokens;
+      }
+    }
+
+    this.totalInputTokens += round.usage.totalInputTokens;
+    this.totalOutputTokens += round.usage.totalOutputTokens;
+    this.totalResponseTime += round.responseTime;
+  }
+
+  incrementRounds(): void {
+    this.totalRounds += 1;
+  }
+
+  toSnapshot(): SessionUsageSnapshot {
+    return {
+      firstInputTokens: this.firstInputTokens,
+      totalResponseTime: this.totalResponseTime,
+      totalInputTokens: this.totalInputTokens,
+      totalOutputTokens: this.totalOutputTokens,
+      totalRounds: this.totalRounds,
+      totalCacheReadInputTokens: this.totalCacheReadInputTokens,
+      totalCacheCreationInputTokens: this.totalCacheCreationInputTokens,
+      totalReasoningTokens: this.totalReasoningTokens,
+      totalToolUseTokens: this.totalToolUseTokens,
+    };
+  }
+
+  static fromSnapshot(snapshot: SessionUsageSnapshot | null): SessionUsageState {
+    if (!snapshot) {
+      return new SessionUsageState();
+    }
+
+    const state = new SessionUsageState();
+    state.firstInputTokens = snapshot.firstInputTokens ?? 0;
+    state.totalResponseTime = snapshot.totalResponseTime ?? 0;
+    state.totalInputTokens = snapshot.totalInputTokens ?? 0;
+    state.totalOutputTokens = snapshot.totalOutputTokens ?? 0;
+    state.totalRounds = snapshot.totalRounds ?? 0;
+    state.totalCacheReadInputTokens = snapshot.totalCacheReadInputTokens ?? 0;
+    state.totalCacheCreationInputTokens =
+      snapshot.totalCacheCreationInputTokens ?? 0;
+    state.totalReasoningTokens = snapshot.totalReasoningTokens ?? 0;
+    state.totalToolUseTokens = snapshot.totalToolUseTokens ?? 0;
+    return state;
+  }
+}

--- a/src/agent/core/state/ResponseCycleStore.ts
+++ b/src/agent/core/state/ResponseCycleStore.ts
@@ -1,0 +1,80 @@
+// Local imports - conversation state
+import { RoundMetricsState, SessionUsageState } from './ConversationState';
+import {
+  DocumentAssetState,
+  ReasoningTraceState,
+  ResponseDraftState,
+  type ToolResponseState,
+  createToolResponseState,
+} from './ToolResponseState';
+
+// Local imports - provider types
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
+
+export interface ResponseDebugContext {
+  logger: unknown;
+  modelName: string;
+  executionId?: unknown;
+}
+
+export interface ResponseDebugFileOptions {
+  continuationCount: number;
+  outputFile: string;
+}
+
+export interface ResponseCycleRuntimeState {
+  endTurn: boolean;
+  shouldStop: boolean;
+  outputExists: boolean;
+  systemPrompt?: string;
+  debugContext?: ResponseDebugContext;
+  debugFileOptions?: ResponseDebugFileOptions;
+  startTime?: number;
+  responseObject?: unknown;
+  responseTime?: number;
+  stopReason?: ProviderStopReason;
+  processedResponse?: string;
+}
+
+export interface ResponseCycleStore {
+  messages: ProviderMessage[];
+  outputFile: string;
+  round: RoundMetricsState;
+  session: SessionUsageState;
+  tool: ToolResponseState;
+  runtime: ResponseCycleRuntimeState;
+}
+
+export function createResponseCycleStore(options: {
+  messages: ProviderMessage[];
+  outputFile: string;
+  round: RoundMetricsState;
+  session: SessionUsageState;
+  toolState?: ToolResponseState;
+}): ResponseCycleStore {
+  const toolState = options.toolState ?? createToolResponseState();
+  return {
+    messages: options.messages,
+    outputFile: options.outputFile,
+    round: options.round,
+    session: options.session,
+    tool: toolState,
+    runtime: {
+      endTurn: false,
+      shouldStop: false,
+      outputExists: false,
+    },
+  };
+}
+
+export function resetResponseCycleRuntime(runtime: ResponseCycleRuntimeState): void {
+  runtime.shouldStop = false;
+  runtime.endTurn = false;
+  runtime.responseObject = undefined;
+  runtime.responseTime = undefined;
+  runtime.stopReason = undefined;
+  runtime.processedResponse = undefined;
+}
+
+export { DocumentAssetState, ReasoningTraceState, ResponseDraftState };

--- a/src/agent/core/state/ToolResponseState.ts
+++ b/src/agent/core/state/ToolResponseState.ts
@@ -1,0 +1,252 @@
+/** Snapshot shape for document-related tool state. */
+export interface DocumentAssetSnapshot {
+  texcountStats: string | null;
+  mediaFiles: string[];
+}
+
+/** Manages extracted media and TeX statistics. */
+export class DocumentAssetState {
+  texcountStats: string | null;
+  mediaFiles: string[];
+
+  constructor() {
+    this.texcountStats = null;
+    this.mediaFiles = [];
+  }
+
+  setTeXCount(stats: string | null): void {
+    this.texcountStats = stats;
+  }
+
+  addMediaFiles(files: string[]): void {
+    for (const file of files) {
+      if (!this.mediaFiles.includes(file)) {
+        this.mediaFiles.push(file);
+      }
+    }
+  }
+
+  toSnapshot(): DocumentAssetSnapshot {
+    return {
+      texcountStats: this.texcountStats,
+      mediaFiles: [...this.mediaFiles],
+    };
+  }
+
+  static fromSnapshot(snapshot: DocumentAssetSnapshot | null): DocumentAssetState {
+    const state = new DocumentAssetState();
+    if (!snapshot) {
+      return state;
+    }
+
+    state.texcountStats = snapshot.texcountStats ?? null;
+    state.mediaFiles = [...(snapshot.mediaFiles ?? [])];
+    return state;
+  }
+}
+
+/** Snapshot shape for response drafting state. */
+export interface ResponseDraftSnapshot {
+  lastResponse: string;
+  accumulatedOutput: string;
+}
+
+/** Tracks incremental response drafting data. */
+export class ResponseDraftState {
+  lastResponse: string;
+  accumulatedOutput: string;
+
+  constructor() {
+    this.lastResponse = '';
+    this.accumulatedOutput = '';
+  }
+
+  setLastResponse(response: string): void {
+    this.lastResponse = response;
+  }
+
+  setAccumulatedOutput(output: string): void {
+    this.accumulatedOutput = output;
+  }
+
+  toSnapshot(): ResponseDraftSnapshot {
+    return {
+      lastResponse: this.lastResponse,
+      accumulatedOutput: this.accumulatedOutput,
+    };
+  }
+
+  static fromSnapshot(snapshot: ResponseDraftSnapshot | null): ResponseDraftState {
+    const state = new ResponseDraftState();
+    if (!snapshot) {
+      return state;
+    }
+
+    state.lastResponse = snapshot.lastResponse ?? '';
+    state.accumulatedOutput = snapshot.accumulatedOutput ?? '';
+    return state;
+  }
+}
+
+/** Snapshot shape for reasoning trace state. */
+export interface ReasoningTraceSnapshot {
+  thinkingBlocks: unknown[];
+  thinkingAdded: boolean;
+}
+
+/** Stores free-form thinking traces emitted by models. */
+export class ReasoningTraceState {
+  thinkingBlocks: unknown[];
+  thinkingAdded: boolean;
+
+  constructor() {
+    this.thinkingBlocks = [];
+    this.thinkingAdded = false;
+  }
+
+  get primaryBlock(): unknown | null {
+    return this.thinkingBlocks.length > 0 ? this.thinkingBlocks[0] : null;
+  }
+
+  reset(): void {
+    this.thinkingBlocks = [];
+    this.thinkingAdded = false;
+  }
+
+  toSnapshot(): ReasoningTraceSnapshot {
+    return {
+      thinkingBlocks: [...this.thinkingBlocks],
+      thinkingAdded: this.thinkingAdded,
+    };
+  }
+
+  static fromSnapshot(snapshot: ReasoningTraceSnapshot | null): ReasoningTraceState {
+    const state = new ReasoningTraceState();
+    if (!snapshot) {
+      return state;
+    }
+
+    state.thinkingBlocks = [...(snapshot.thinkingBlocks ?? [])];
+    state.thinkingAdded = snapshot.thinkingAdded ?? false;
+    return state;
+  }
+}
+
+/** Composite tool response state exposing slice-based accessors. */
+export class ToolResponseState {
+  document: DocumentAssetState;
+  draft: ResponseDraftState;
+  reasoning: ReasoningTraceState;
+
+  constructor(
+    document: DocumentAssetState = new DocumentAssetState(),
+    draft: ResponseDraftState = new ResponseDraftState(),
+    reasoning: ReasoningTraceState = new ReasoningTraceState(),
+  ) {
+    this.document = document;
+    this.draft = draft;
+    this.reasoning = reasoning;
+  }
+
+  get texcountStats(): string | null {
+    return this.document.texcountStats;
+  }
+
+  set texcountStats(value: string | null) {
+    this.document.setTeXCount(value);
+  }
+
+  get mediaFiles(): string[] {
+    return this.document.mediaFiles;
+  }
+
+  addMediaFiles(files: string[]): void {
+    this.document.addMediaFiles(files);
+  }
+
+  get lastResponse(): string {
+    return this.draft.lastResponse;
+  }
+
+  set lastResponse(value: string) {
+    this.draft.setLastResponse(value);
+  }
+
+  updateLastResponse(value: string): void {
+    this.draft.setLastResponse(value);
+  }
+
+  get accumulatedOutput(): string {
+    return this.draft.accumulatedOutput;
+  }
+
+  set accumulatedOutput(value: string) {
+    this.draft.setAccumulatedOutput(value);
+  }
+
+  updateAccumulatedOutput(value: string): void {
+    this.draft.setAccumulatedOutput(value);
+  }
+
+  get thinkingBlocks(): unknown[] {
+    return this.reasoning.thinkingBlocks;
+  }
+
+  set thinkingBlocks(blocks: unknown[]) {
+    this.reasoning.thinkingBlocks = [...blocks];
+  }
+
+  get thinkingBlock(): unknown | null {
+    return this.reasoning.primaryBlock;
+  }
+
+  get thinkingAdded(): boolean {
+    return this.reasoning.thinkingAdded;
+  }
+
+  set thinkingAdded(value: boolean) {
+    this.reasoning.thinkingAdded = value;
+  }
+
+  resetThinkingCache(): void {
+    this.reasoning.reset();
+  }
+
+  toSnapshot(): ToolResponseSnapshot {
+    return {
+      document: this.document.toSnapshot(),
+      draft: this.draft.toSnapshot(),
+      reasoning: this.reasoning.toSnapshot(),
+    };
+  }
+
+  static fromSnapshot(snapshot: ToolResponseSnapshot | null): ToolResponseState {
+    return new ToolResponseState(
+      DocumentAssetState.fromSnapshot(snapshot?.document ?? null),
+      ResponseDraftState.fromSnapshot(snapshot?.draft ?? null),
+      ReasoningTraceState.fromSnapshot(snapshot?.reasoning ?? null),
+    );
+  }
+}
+
+export interface ToolResponseSnapshot {
+  document: DocumentAssetSnapshot;
+  draft: ResponseDraftSnapshot;
+  reasoning: ReasoningTraceSnapshot;
+}
+
+export function createToolResponseState(): ToolResponseState {
+  return new ToolResponseState();
+}
+
+export function toolResponseStateFromSnapshot(
+  snapshot: ToolResponseSnapshot | null,
+): ToolResponseState {
+  return ToolResponseState.fromSnapshot(snapshot);
+}
+
+export function toolResponseStateToSnapshot(
+  state: ToolResponseState,
+): ToolResponseSnapshot {
+  return state.toSnapshot();
+}

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -1,8 +1,11 @@
 // Local imports - agent components
 import type { AgentConfig } from '../../core/AgentConfig';
 import { AgentSetting, AgentType } from '../../core/AgentDataclass';
-import { AgentStateRound, AgentStateGlobal } from '../../core/AgentState';
-import { ToolState } from '../../core/ToolState';
+import {
+  RoundMetricsState,
+  SessionUsageState,
+  type ToolResponseState,
+} from '../../core/AgentState';
 import type { MediaEntry } from '../../utils/mediaTypes';
 
 // Local imports - provider types
@@ -115,8 +118,8 @@ export interface IModelHandler<
   /** Handle continuation for models supporting prefill. */
   addContinueMessageWithPrefill(
     messages: M[],
-    stateRound: AgentStateRound,
-    toolState: ToolState,
+    stateRound: RoundMetricsState,
+    toolState: ToolResponseState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
   ): void;
@@ -124,8 +127,8 @@ export interface IModelHandler<
   /** Handle continuation for models without prefill. */
   addContinueMessageWithoutPrefill(
     messages: M[],
-    stateRound: AgentStateRound,
-    toolState: ToolState,
+    stateRound: RoundMetricsState,
+    toolState: ToolResponseState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
   ): void;
@@ -135,7 +138,7 @@ export interface IModelHandler<
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: M[],
-    toolState: ToolState,
+    toolState: ToolResponseState,
     outputFile: string,
     prefill: string,
     groupId?: string,
@@ -152,7 +155,7 @@ export interface IModelHandler<
     messages: M[],
     bestConnector: string,
     newResponse: string,
-    toolState: ToolState,
+    toolState: ToolResponseState,
   ): void;
 
   /** Update messages when prefill is not supported. */
@@ -160,7 +163,7 @@ export interface IModelHandler<
     messages: M[],
     bestConnector: string,
     newResponse: string,
-    toolState: ToolState,
+    toolState: ToolResponseState,
   ): void;
 
   /** Determine whether generation should continue. */
@@ -177,8 +180,8 @@ export interface IModelHandler<
   checkStopConditions(
     stopReason: ProviderStopReason,
     newResponse: string,
-    stateRound: AgentStateRound,
-    stateGlobal: AgentStateGlobal,
+    stateRound: RoundMetricsState,
+    stateGlobal: SessionUsageState,
     agentSetting: AgentSetting,
   ): [boolean, boolean];
 
@@ -186,7 +189,7 @@ export interface IModelHandler<
   processThinkingBlock(
     responseObject: any,
     groupId?: string,
-    toolState?: ToolState,
+    toolState?: ToolResponseState,
   ): string | null;
 
   /** Extract tool-use details from a provider response. */
@@ -207,7 +210,7 @@ export interface IModelHandler<
     name: string,
     call: T,
     result: Record<string, unknown>,
-    toolState?: ToolState,
+    toolState?: ToolResponseState,
     text?: string,
   ): Promise<M[]>;
 

--- a/src/agent/toolUse/ToolUseSnapshotStore.ts
+++ b/src/agent/toolUse/ToolUseSnapshotStore.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports - agent
 import { AgentType } from '@agent/core/AgentDataclass';
+import { toolResponseStateToSnapshot } from '@agent/core/ToolState';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
@@ -194,7 +195,7 @@ export const ToolUseSnapshotStore = {
           agentCategory: payload.session.agentCategory,
         },
         messages: structuredClone(payload.messages),
-        toolState: structuredClone(payload.toolState),
+        toolState: toolResponseStateToSnapshot(payload.toolState),
         lastUpdated: Date.now(),
       } as const;
 

--- a/src/agent/toolUse/ToolUseSnapshotTypes.ts
+++ b/src/agent/toolUse/ToolUseSnapshotTypes.ts
@@ -8,21 +8,42 @@ import {
   resolveAgentSessionDescriptor,
   type AgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
-import { ToolState } from '@agent/core/ToolState';
+import {
+  ToolResponseState,
+  toolResponseStateToSnapshot,
+} from '@agent/core/ToolState';
 import { AgentSessionDescriptorSchema } from '@agent/core/AgentSessionSchema';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 
 export const TOOL_USE_SNAPSHOT_VERSION = 1;
 
-export const ToolStateSnapshotSchema = z
+const DocumentAssetSnapshotSchema = z
   .object({
     texcountStats: z.string().nullable(),
+    mediaFiles: z.array(z.string()),
+  })
+  .strict();
+
+const ResponseDraftSnapshotSchema = z
+  .object({
     lastResponse: z.string(),
     accumulatedOutput: z.string(),
-    mediaFiles: z.array(z.string()),
+  })
+  .strict();
+
+const ReasoningTraceSnapshotSchema = z
+  .object({
     thinkingBlocks: z.array(z.unknown()),
     thinkingAdded: z.boolean(),
+  })
+  .strict();
+
+export const ToolStateSnapshotSchema = z
+  .object({
+    document: DocumentAssetSnapshotSchema,
+    draft: ResponseDraftSnapshotSchema,
+    reasoning: ReasoningTraceSnapshotSchema,
   })
   .strict();
 
@@ -67,7 +88,7 @@ export interface SaveToolUseSnapshotPayload {
   model: string;
   session: AgentSessionDescriptor;
   messages: ProviderMessage[];
-  toolState: ToolState;
+  toolState: ToolResponseState;
 }
 
 export function normalizeSnapshot(

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -6,7 +6,11 @@ import * as vscode from 'vscode';
 
 // Local imports - agent core
 import { parseAgentConfig, type AgentConfig } from '@agent/core/AgentConfig';
-import { AgentStateRound, AgentStateGlobal } from '@agent/core/AgentState';
+import {
+  RoundMetricsState,
+  SessionUsageState,
+  createToolResponseState,
+} from '@agent/core/AgentState';
 import {
   AgentSetting,
   AgentPrompt,
@@ -14,7 +18,6 @@ import {
   AgentCategory,
 } from '@agent/core/AgentDataclass';
 import { runResponseCycle } from '@agent/core/ResponseCycle';
-import { ToolState } from '@agent/core/ToolState';
 
 // Local imports - model handlers
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
@@ -328,9 +331,9 @@ describe('ResponseCycle background reasoning logs', () => {
     });
 
     const messages: ProviderMessage[] = [];
-    const stateRound = new AgentStateRound(1);
-    const stateGlobal = new AgentStateGlobal();
-    const toolState = new ToolState();
+    const stateRound = new RoundMetricsState(1);
+    const stateGlobal = new SessionUsageState();
+    const toolState = createToolResponseState();
 
     await runResponseCycle({
       options: {

--- a/src/test/toolUse/ToolUseSessionManagerQueue.test.ts
+++ b/src/test/toolUse/ToolUseSessionManagerQueue.test.ts
@@ -37,12 +37,9 @@ describe('ToolUseSessionManager queue handling', () => {
       },
       messages: [],
       toolState: {
-        texcountStats: null,
-        lastResponse: '',
-        accumulatedOutput: '',
-        mediaFiles: [],
-        thinkingBlocks: [],
-        thinkingAdded: false,
+        document: { texcountStats: null, mediaFiles: [] },
+        draft: { lastResponse: '', accumulatedOutput: '' },
+        reasoning: { thinkingBlocks: [], thinkingAdded: false },
       },
       lastUpdated: Date.now(),
     };

--- a/src/test/toolUse/ToolUseSnapshotStore.test.ts
+++ b/src/test/toolUse/ToolUseSnapshotStore.test.ts
@@ -84,12 +84,9 @@ describe('ToolUseSnapshotStore', () => {
       },
       messages: [],
       toolState: {
-        texcountStats: null,
-        lastResponse: 'last',
-        accumulatedOutput: 'all',
-        mediaFiles: ['media.png'],
-        thinkingBlocks: [],
-        thinkingAdded: false,
+        document: { texcountStats: null, mediaFiles: ['media.png'] },
+        draft: { lastResponse: 'last', accumulatedOutput: 'all' },
+        reasoning: { thinkingBlocks: [], thinkingAdded: false },
       },
       lastUpdated: Date.now(),
     };
@@ -163,7 +160,7 @@ describe('ToolUseSnapshotStore', () => {
     const stored = value as ReturnType<typeof buildSnapshot>;
     assert.equal(stored.session.agentType, AgentType.ToolUse);
     assert.notStrictEqual(stored.messages, payload.messages);
-    assert.equal(stored.toolState.lastResponse, 'last');
+    assert.equal(stored.toolState.draft.lastResponse, 'last');
   });
 
   it('list triggers TTL cleanup and filters invalid snapshots', async () => {


### PR DESCRIPTION
## Summary
- introduce dedicated state modules for round, session, and tool data and expose them through AgentState
- rework the response cycle flow to operate on a structured store built from the new state slices
- update tool-use snapshot schemas, persistence, and tests to capture the expanded tool state layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6907302fd648832493644d996733a7bc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split agent state into round/session/tool slices, add a response cycle store, and update flows, model handler types, snapshots, and tests accordingly.
> 
> - **Core state refactor**:
>   - Introduce `RoundMetricsState` and `SessionUsageState` in `state/ConversationState` and re-export as `AgentStateRound`/`AgentStateGlobal`.
>   - Add slice-based tool state in `state/ToolResponseState` (`DocumentAssetState`, `ResponseDraftState`, `ReasoningTraceState`) with snapshots and helpers.
>   - Deprecate legacy `ToolState` via compatibility re-exports.
> - **Response cycle**:
>   - Add `state/ResponseCycleStore` with `ResponseCycleRuntimeState` and helpers, and migrate `ResponseCycleFlow` to use `store` instead of ad-hoc cycle state.
>   - Update `ResponseCycle` to build/return from the new store.
> - **Tool use and snapshots**:
>   - Switch `ToolUseCycle`/`ToolUseCycleFlow` to `ToolResponseState`.
>   - Expand tool-use snapshot schema to nested `toolState` slices; convert state to snapshots on save in `ToolUseSnapshotStore`.
> - **API/interfaces**:
>   - Update `IModelHandler` method signatures to accept `RoundMetricsState`, `SessionUsageState`, and `ToolResponseState`.
> - **Tests**:
>   - Adjust tests to new state types and snapshot structure (`ResponseCycleBackground`, `ToolUseSessionManagerQueue`, `ToolUseSnapshotStore`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 895223a87d6432d6bbe49b313d547e1d7548938e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->