### PR TITLE
refactor: drop defensive agent wrappers

### DIFF
--- a/src/test/utils/files/RelativeFSJson.test.ts
+++ b/src/test/utils/files/RelativeFSJson.test.ts
@@ -11,10 +11,6 @@ class TestRelativeFS extends RelativeFS {
   protected static override getBasePath(): string {
     return BASE_DIR;
   }
-
-  protected static override getChannel(): string {
-    return 'TestRelativeFS';
-  }
 }
 
 suite('RelativeFS JSON helpers', () => {

--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -1,110 +1,62 @@
 // Standard library imports
 import * as fs from 'fs';
-import * as path from 'path';
 
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
-
 // Local imports - utils
 import { ensureDirCommon } from './ensureDirCommon';
 
-const CHANNEL = 'absoluteFS';
-logger.initialize(CHANNEL);
+const toUri = (filePath: string) => vscode.Uri.file(filePath);
 
 /**
- * AbsoluteFS provides a unified interface for file system operations on absolute paths.
- * All methods validate that paths are absolute before performing operations.
+ * Thin wrapper around VS Code's filesystem API for absolute paths.
+ * The implementation intentionally stays small—callers are expected
+ * to validate inputs before invoking these helpers.
  */
 export class AbsoluteFS {
-  /**
-   * Validates that a path is absolute
-   */
-  private static validatePath(filePath: string, methodName: string): void {
-    if (!path.isAbsolute(filePath)) {
-      throw new Error(
-        `${methodName}: Path must be absolute, got relative path: ${filePath}`,
-      );
-    }
-  }
-
   // ===== Async Methods =====
 
-  /**
-   * Check if a file or directory exists
-   */
   public static async exists(filePath: string): Promise<boolean> {
-    this.validatePath(filePath, 'exists');
     try {
-      await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
+      await vscode.workspace.fs.stat(toUri(filePath));
       return true;
     } catch {
       return false;
     }
   }
 
-  /**
-   * Read a file as UTF-8 text
-   */
   public static async read(filePath: string): Promise<string> {
-    this.validatePath(filePath, 'read');
-    const uri = vscode.Uri.file(filePath);
-    const content = await vscode.workspace.fs.readFile(uri);
+    const content = await vscode.workspace.fs.readFile(toUri(filePath));
     return Buffer.from(content).toString('utf-8');
   }
 
-  /**
-   * Read a file as raw bytes
-   */
   public static async readBytes(filePath: string): Promise<Buffer> {
-    this.validatePath(filePath, 'readBytes');
-    const uri = vscode.Uri.file(filePath);
-    const content = await vscode.workspace.fs.readFile(uri);
+    const content = await vscode.workspace.fs.readFile(toUri(filePath));
     return Buffer.from(content);
   }
 
-  /**
-   * Write content to a file (text or binary)
-   */
   public static async write(
     filePath: string,
     content: string | Uint8Array,
   ): Promise<void> {
-    this.validatePath(filePath, 'write');
-    const uri = vscode.Uri.file(filePath);
     const data =
       typeof content === 'string' ? Buffer.from(content, 'utf-8') : content;
-    await vscode.workspace.fs.writeFile(uri, data);
+    await vscode.workspace.fs.writeFile(toUri(filePath), data);
   }
 
-  /**
-   * Delete a file or directory
-   */
   public static async delete(
     filePath: string,
     options?: { recursive?: boolean; useTrash?: boolean },
   ): Promise<void> {
-    this.validatePath(filePath, 'delete');
-    const uri = vscode.Uri.file(filePath);
-    await vscode.workspace.fs.delete(uri, options);
+    await vscode.workspace.fs.delete(toUri(filePath), options);
   }
 
-  /**
-   * Create a directory (with parents if needed)
-   */
   public static async createDir(filePath: string): Promise<void> {
-    this.validatePath(filePath, 'createDir');
-    const uri = vscode.Uri.file(filePath);
-    await vscode.workspace.fs.createDirectory(uri);
+    await vscode.workspace.fs.createDirectory(toUri(filePath));
   }
 
-  /**
-   * Ensure a directory exists, creating it if necessary
-   */
   public static async ensureDir(filePath: string): Promise<void> {
-    this.validatePath(filePath, 'ensureDir');
     await ensureDirCommon(
       filePath,
       this.exists.bind(this),
@@ -112,87 +64,77 @@ export class AbsoluteFS {
     );
   }
 
-  /**
-   * Read directory contents
-   */
   public static async readDir(
     dirPath: string,
   ): Promise<[string, vscode.FileType][]> {
-    this.validatePath(dirPath, 'readDir');
-    const uri = vscode.Uri.file(dirPath);
-    return await vscode.workspace.fs.readDirectory(uri);
+    return vscode.workspace.fs.readDirectory(toUri(dirPath));
   }
 
-  /**
-   * Get file stats (VS Code API)
-   */
   public static async stat(filePath: string): Promise<vscode.FileStat> {
-    this.validatePath(filePath, 'stat');
-    const uri = vscode.Uri.file(filePath);
-    return await vscode.workspace.fs.stat(uri);
+    return vscode.workspace.fs.stat(toUri(filePath));
   }
 
-  /**
-   * Copy a file or directory
-   */
   public static async copy(
     source: string,
     destination: string,
     options?: { overwrite?: boolean },
   ): Promise<void> {
-    this.validatePath(source, 'copy source');
-    this.validatePath(destination, 'copy destination');
-    const sourceUri = vscode.Uri.file(source);
-    const destUri = vscode.Uri.file(destination);
-    await vscode.workspace.fs.copy(sourceUri, destUri, options);
+    await vscode.workspace.fs.copy(
+      toUri(source),
+      toUri(destination),
+      options,
+    );
   }
 
-  /**
-   * Move/rename a file or directory
-   */
   public static async rename(
     oldPath: string,
     newPath: string,
     options?: { overwrite?: boolean },
   ): Promise<void> {
-    this.validatePath(oldPath, 'rename oldPath');
-    this.validatePath(newPath, 'rename newPath');
-    const oldUri = vscode.Uri.file(oldPath);
-    const newUri = vscode.Uri.file(newPath);
-    await vscode.workspace.fs.rename(oldUri, newUri, options);
+    await vscode.workspace.fs.rename(toUri(oldPath), toUri(newPath), options);
+  }
+
+  public static async isDir(filePath: string): Promise<boolean> {
+    try {
+      return (await this.stat(filePath)).type === vscode.FileType.Directory;
+    } catch {
+      return false;
+    }
+  }
+
+  public static async isFile(filePath: string): Promise<boolean> {
+    try {
+      return (await this.stat(filePath)).type === vscode.FileType.File;
+    } catch {
+      return false;
+    }
+  }
+
+  public static async isSymbolicLink(filePath: string): Promise<boolean> {
+    try {
+      return (
+        (await this.stat(filePath)).type & vscode.FileType.SymbolicLink
+      ) === vscode.FileType.SymbolicLink;
+    } catch {
+      return false;
+    }
   }
 
   // ===== Sync Methods =====
 
-  /**
-   * Check if a file or directory exists (sync)
-   */
   public static existsSync(filePath: string): boolean {
-    this.validatePath(filePath, 'existsSync');
     return fs.existsSync(filePath);
   }
 
-  /**
-   * Read a file as UTF-8 text (sync)
-   */
   public static readSync(filePath: string): string {
-    this.validatePath(filePath, 'readSync');
     return fs.readFileSync(filePath, 'utf-8');
   }
 
-  /**
-   * Read a file as buffer (sync)
-   */
   public static readBytesSync(filePath: string): Buffer {
-    this.validatePath(filePath, 'readBytesSync');
     return fs.readFileSync(filePath);
   }
 
-  /**
-   * Write content to a file (sync)
-   */
   public static writeSync(filePath: string, content: string | Buffer): void {
-    this.validatePath(filePath, 'writeSync');
     if (typeof content === 'string') {
       fs.writeFileSync(filePath, content, 'utf-8');
     } else {
@@ -200,56 +142,33 @@ export class AbsoluteFS {
     }
   }
 
-  /**
-   * Delete a file (sync)
-   */
   public static deleteSync(filePath: string): void {
-    this.validatePath(filePath, 'deleteSync');
     fs.unlinkSync(filePath);
   }
 
-  /**
-   * Create a directory (sync)
-   */
   public static mkdirSync(
     dirPath: string,
     options?: { recursive?: boolean },
   ): void {
-    this.validatePath(dirPath, 'mkdirSync');
     fs.mkdirSync(dirPath, options);
   }
 
-  /**
-   * Ensure a directory exists (sync), creating it if necessary
-   */
   public static ensureDirSync(dirPath: string): void {
-    this.validatePath(dirPath, 'ensureDirSync');
     if (!this.existsSync(dirPath)) {
       this.mkdirSync(dirPath, { recursive: true });
     }
   }
 
-  /**
-   * Read directory contents (sync)
-   */
   public static readDirSync(dirPath: string): string[] {
-    this.validatePath(dirPath, 'readDirSync');
     return fs.readdirSync(dirPath);
   }
 
-  /**
-   * Get file stats (sync)
-   */
   public static statSync(filePath: string): fs.Stats {
-    this.validatePath(filePath, 'statSync');
     return fs.statSync(filePath);
   }
 
   // ===== Stream Methods =====
 
-  /**
-   * Create a read stream
-   */
   public static createReadStream(
     filePath: string,
     options?:
@@ -265,13 +184,9 @@ export class AbsoluteFS {
           highWaterMark?: number;
         }),
   ): fs.ReadStream {
-    this.validatePath(filePath, 'createReadStream');
     return fs.createReadStream(filePath, options);
   }
 
-  /**
-   * Create a write stream
-   */
   public static createWriteStream(
     filePath: string,
     options?:
@@ -285,63 +200,16 @@ export class AbsoluteFS {
           start?: number;
         }),
   ): fs.WriteStream {
-    this.validatePath(filePath, 'createWriteStream');
     return fs.createWriteStream(filePath, options);
   }
 
   // ===== Utility Methods =====
 
-  /**
-   * Delete a file with callback (for compatibility)
-   */
   public static unlink(
     filePath: string,
     callback: (err: NodeJS.ErrnoException | null) => void,
   ): void {
-    this.validatePath(filePath, 'unlink');
     fs.unlink(filePath, callback);
-  }
-
-  /**
-   * Check if path is a directory
-   */
-  public static async isDir(filePath: string): Promise<boolean> {
-    this.validatePath(filePath, 'isDir');
-    try {
-      const stats = await this.stat(filePath);
-      return stats.type === vscode.FileType.Directory;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Check if path is a file
-   */
-  public static async isFile(filePath: string): Promise<boolean> {
-    this.validatePath(filePath, 'isFile');
-    try {
-      const stats = await this.stat(filePath);
-      return stats.type === vscode.FileType.File;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Check if path is a symbolic link
-   */
-  public static async isSymbolicLink(filePath: string): Promise<boolean> {
-    this.validatePath(filePath, 'isSymbolicLink');
-    try {
-      const stats = await this.stat(filePath);
-      return (
-        (stats.type & vscode.FileType.SymbolicLink) ===
-        vscode.FileType.SymbolicLink
-      );
-    } catch {
-      return false;
-    }
   }
 }
 

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -4,141 +4,81 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
-
 // Local imports - utils
 import { ensureDirCommon } from './ensureDirCommon';
 
-const CHANNEL = 'relativeFS';
-logger.initialize(CHANNEL);
-
+/**
+ * Minimal filesystem helper backed by a configurable base path.
+ * Subclasses only need to provide {@link getBasePath}.
+ */
 export abstract class RelativeFS {
-  /**
-   * Return the base path for this filesystem. Implemented by subclasses.
-   */
+  /** Implemented by subclasses to point to their root directory. */
   protected static getBasePath(): string {
     throw new Error('getBasePath not implemented');
   }
 
-  /**
-   * Return the log channel for this filesystem. Subclasses can override.
-   */
-  protected static getChannel(): string {
-    return CHANNEL;
-  }
-
-  /**
-   * Resolve a relative path against the base path.
-   */
+  /** Resolve a relative path against the base path. */
   public static fullPath(relativePath: string): string {
     return path.join(this.getBasePath(), relativePath);
   }
 
-  /**
-   * Check if a file or directory exists.
-   */
   public static async exists(relativePath: string): Promise<boolean> {
     try {
-      const uri = vscode.Uri.file(this.fullPath(relativePath));
-      await vscode.workspace.fs.stat(uri);
+      await vscode.workspace.fs.stat(vscode.Uri.file(this.fullPath(relativePath)));
       return true;
     } catch {
       return false;
     }
   }
 
-  /**
-   * Read a file as UTF-8 text.
-   */
   public static async read(relativePath: string): Promise<string> {
-    const uri = vscode.Uri.file(this.fullPath(relativePath));
-    const content = await vscode.workspace.fs.readFile(uri);
+    const content = await vscode.workspace.fs.readFile(
+      vscode.Uri.file(this.fullPath(relativePath)),
+    );
     return Buffer.from(content).toString('utf-8');
   }
 
-  /**
-   * Write content to a file.
-   */
   public static async write(
     relativePath: string,
     content: string | Uint8Array,
   ): Promise<void> {
-    const uri = vscode.Uri.file(this.fullPath(relativePath));
     const data =
       typeof content === 'string' ? Buffer.from(content, 'utf-8') : content;
-    await vscode.workspace.fs.writeFile(uri, data);
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.file(this.fullPath(relativePath)),
+      data,
+    );
   }
 
-  /**
-   * Serialize an object to JSON and persist it to disk.
-   */
   public static async writeJson<T>(
     relativePath: string,
     value: T,
   ): Promise<void> {
-    try {
-      const json = JSON.stringify(value, null, 2);
-      await this.write(relativePath, json);
-    } catch (error) {
-      logger.warn(
-        this.getChannel(),
-        `Failed to write JSON file ${relativePath}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      throw error;
-    }
+    const json = JSON.stringify(value, null, 2);
+    await this.write(relativePath, json);
   }
 
-  /**
-   * Read a JSON file and deserialize it into a native object.
-   */
   public static async readJson<T>(relativePath: string): Promise<T> {
-    try {
-      const raw = await this.read(relativePath);
-      return JSON.parse(raw) as T;
-    } catch (error) {
-      if (
-        error instanceof vscode.FileSystemError &&
-        error.code === 'FileNotFound'
-      ) {
-        throw error;
-      }
-      logger.warn(
-        this.getChannel(),
-        `Failed to read JSON file ${relativePath}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      throw error;
-    }
+    const raw = await this.read(relativePath);
+    return JSON.parse(raw) as T;
   }
 
-  /**
-   * Delete a file or directory.
-   */
   public static async delete(
     relativePath: string,
     options?: { recursive?: boolean; useTrash?: boolean },
   ): Promise<void> {
-    const uri = vscode.Uri.file(this.fullPath(relativePath));
-    await vscode.workspace.fs.delete(uri, options);
-    logger.debug(this.getChannel(), `Deleted: ${relativePath}`);
+    await vscode.workspace.fs.delete(
+      vscode.Uri.file(this.fullPath(relativePath)),
+      options,
+    );
   }
 
-  /**
-   * Create a directory.
-   */
   public static async createDir(relativePath: string): Promise<void> {
-    const uri = vscode.Uri.file(this.fullPath(relativePath));
-    await vscode.workspace.fs.createDirectory(uri);
-    logger.debug(this.getChannel(), `Created directory: ${relativePath}`);
+    await vscode.workspace.fs.createDirectory(
+      vscode.Uri.file(this.fullPath(relativePath)),
+    );
   }
 
-  /**
-   * Ensure a directory exists, creating it if necessary.
-   */
   public static async ensureDir(relativePath: string): Promise<void> {
     await ensureDirCommon(
       relativePath,
@@ -147,108 +87,71 @@ export abstract class RelativeFS {
     );
   }
 
-  /**
-   * Read directory contents.
-   */
   public static async readDir(
     relativePath: string,
   ): Promise<[string, vscode.FileType][]> {
-    const uri = vscode.Uri.file(this.fullPath(relativePath));
-    return await vscode.workspace.fs.readDirectory(uri);
+    return vscode.workspace.fs.readDirectory(
+      vscode.Uri.file(this.fullPath(relativePath)),
+    );
   }
 
-  /**
-   * Get file stats.
-   */
   public static async stat(relativePath: string): Promise<vscode.FileStat> {
-    const uri = vscode.Uri.file(this.fullPath(relativePath));
-    return await vscode.workspace.fs.stat(uri);
+    return vscode.workspace.fs.stat(
+      vscode.Uri.file(this.fullPath(relativePath)),
+    );
   }
 
-  /**
-   * Copy a file or directory.
-   */
   public static async copy(
     source: string,
     destination: string,
     options?: { overwrite?: boolean },
   ): Promise<void> {
-    const sourceUri = vscode.Uri.file(this.fullPath(source));
-    const destUri = vscode.Uri.file(this.fullPath(destination));
-    await vscode.workspace.fs.copy(sourceUri, destUri, options);
-    logger.debug(
-      this.getChannel(),
-      `Copied: source=${source} to destination=${destination}`,
+    await vscode.workspace.fs.copy(
+      vscode.Uri.file(this.fullPath(source)),
+      vscode.Uri.file(this.fullPath(destination)),
+      options,
     );
   }
 
-  /**
-   * Move/rename a file or directory.
-   */
   public static async rename(
     oldPath: string,
     newPath: string,
     options?: { overwrite?: boolean },
   ): Promise<void> {
-    const oldUri = vscode.Uri.file(this.fullPath(oldPath));
-    const newUri = vscode.Uri.file(this.fullPath(newPath));
-    await vscode.workspace.fs.rename(oldUri, newUri, options);
-    logger.debug(this.getChannel(), `Renamed: ${oldPath} to ${newPath}`);
+    await vscode.workspace.fs.rename(
+      vscode.Uri.file(this.fullPath(oldPath)),
+      vscode.Uri.file(this.fullPath(newPath)),
+      options,
+    );
   }
 
-  /**
-   * Check if path is a directory.
-   */
   public static async isDir(relativePath: string): Promise<boolean> {
     try {
-      const stats = await this.stat(relativePath);
-      return stats.type === vscode.FileType.Directory;
+      return (
+        await this.stat(relativePath)
+      ).type === vscode.FileType.Directory;
     } catch {
       return false;
     }
   }
 
-  /**
-   * Check if path is a file.
-   */
   public static async isFile(relativePath: string): Promise<boolean> {
     try {
-      const stats = await this.stat(relativePath);
-      return stats.type === vscode.FileType.File;
+      return (
+        await this.stat(relativePath)
+      ).type === vscode.FileType.File;
     } catch {
       return false;
     }
   }
 
-  /**
-   * Remove files older than maxAgeMs from a directory.
-   */
-  public static async cleanupOldFiles(
-    relativePath: string,
-    maxAgeMs: number,
-  ): Promise<void> {
+  public static async isSymbolicLink(relativePath: string): Promise<boolean> {
     try {
-      const entries = await this.readDir(relativePath);
-      const now = Date.now();
-
-      for (const [name, type] of entries) {
-        if (type !== vscode.FileType.File) {
-          continue;
-        }
-
-        const filePath = path.join(relativePath, name);
-        try {
-          const stats = await this.stat(filePath);
-          if (now - stats.mtime > maxAgeMs) {
-            await this.delete(filePath);
-            logger.debug(this.getChannel(), `Deleted old file: ${filePath}`);
-          }
-        } catch {
-          // Ignore errors when checking individual files
-        }
-      }
+      return (
+        (await this.stat(relativePath)).type & vscode.FileType.SymbolicLink
+      ) === vscode.FileType.SymbolicLink;
     } catch {
-      // Ignore errors when cleaning directory
+      return false;
     }
   }
 }

--- a/src/utils/files/storageFS.ts
+++ b/src/utils/files/storageFS.ts
@@ -4,14 +4,6 @@ import * as vscode from 'vscode';
 // Local imports - fs
 import { RelativeFS } from './relativeFS';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
-
-const CHANNEL = 'storageFS';
-const GLOBAL_CHANNEL = 'globalStorageFS';
-logger.initialize(CHANNEL);
-logger.initialize(GLOBAL_CHANNEL);
-
 /**
  * StorageFS provides a unified interface for VS Code extension storage operations.
  * Supports both workspace storage (per-workspace) and global storage (shared across workspaces).
@@ -50,10 +42,6 @@ export class StorageFS extends RelativeFS {
     return this.context.globalStorageUri.fsPath;
   }
 
-  protected static override getChannel(): string {
-    return CHANNEL;
-  }
-
   // Inherit file operations from RelativeFS
 }
 
@@ -64,9 +52,6 @@ export class StorageFS extends RelativeFS {
 export class GlobalStorageFS extends RelativeFS {
   protected static override getBasePath(): string {
     return StorageFS.getGlobalPath();
-  }
-  protected static override getChannel(): string {
-    return GLOBAL_CHANNEL;
   }
 }
 

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -6,17 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports - utils
 import { AbsoluteFS } from './absoluteFS';
-import {
-  showLoggedErrorMessage,
-  showLoggedMessage,
-} from '@common/errors/errorHandlingUtils';
 import { RelativeFS } from './relativeFS';
-
-// Local imports - log
-import * as logger from '@logger/logUtils';
-
-const CHANNEL = 'workspaceFS';
-logger.initialize(CHANNEL);
 
 export class WorkspaceFS extends RelativeFS {
   protected static override getBasePath(): string {
@@ -25,10 +15,6 @@ export class WorkspaceFS extends RelativeFS {
       throw new Error('No workspace path found');
     }
     return workspaceFolders[0].uri.fsPath;
-  }
-
-  protected static override getChannel(): string {
-    return CHANNEL;
   }
 
   public static getPath(): string | undefined {
@@ -44,11 +30,6 @@ export class WorkspaceFS extends RelativeFS {
     return workspacePath ? path.relative(workspacePath, filePath) : filePath;
   }
 
-  /**
-   * Delete a file or directory. Tolerant of missing files (idempotent).
-   * @param relativePath The path to delete
-   * @param options Optional deletion options
-   */
   public static async delete(
     relativePath: string,
     options?: { recursive?: boolean; useTrash?: boolean },
@@ -56,18 +37,12 @@ export class WorkspaceFS extends RelativeFS {
     try {
       await super.delete(relativePath, options);
     } catch (err) {
-      // Make delete idempotent - if file doesn't exist, that's fine
       if (
         err instanceof vscode.FileSystemError &&
         err.code === 'FileNotFound'
       ) {
-        logger.debug(
-          CHANNEL,
-          `Skipping deletion of non-existent file: ${relativePath}`,
-        );
         return;
       }
-      // Re-throw other errors
       throw err;
     }
   }
@@ -76,19 +51,10 @@ export class WorkspaceFS extends RelativeFS {
     filePath: string,
     content: string,
   ): Promise<void> {
-    try {
-      const existing = (await this.exists(filePath))
-        ? await this.read(filePath)
-        : '';
-      await this.write(filePath, existing + content);
-      logger.debug(CHANNEL, `Successfully appended to file: ${filePath}`);
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error appending to file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      throw err;
-    }
+    const existing = (await this.exists(filePath))
+      ? await this.read(filePath)
+      : '';
+    await this.write(filePath, existing + content);
   }
 
   public static async existsAndNonTrivial(filePath: string): Promise<boolean> {
@@ -98,37 +64,15 @@ export class WorkspaceFS extends RelativeFS {
   }
 
   public static async readFileBytes(filePath: string): Promise<Buffer> {
-    try {
-      const fullPath = this.fullPath(filePath);
-      return await AbsoluteFS.readBytes(fullPath);
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error reading file bytes: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      throw err;
-    }
+    const fullPath = this.fullPath(filePath);
+    return AbsoluteFS.readBytes(fullPath);
   }
 
   public static readFileBytesSync(filePath: string): Buffer {
-    try {
-      const fullPath = this.fullPath(filePath);
-      return AbsoluteFS.readBytesSync(fullPath);
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error reading file bytes: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      throw err;
-    }
+    const fullPath = this.fullPath(filePath);
+    return AbsoluteFS.readBytesSync(fullPath);
   }
 
-  /**
-   * Filters an array of objects with path properties to only include those with existing files.
-   * Uses parallel execution for better performance when checking many files.
-   * @param items Array of items with a path property
-   * @returns Promise that resolves to filtered array containing only items with existing files
-   */
   public static async filterExistingFiles<T extends { path: string }>(
     items: T[],
   ): Promise<T[]> {
@@ -136,25 +80,14 @@ export class WorkspaceFS extends RelativeFS {
       return [];
     }
 
-    const fileCheckPromises = items.map(async (item) => {
-      try {
-        // Use the existing exists function which handles relative/absolute path conversion
-        const exists = await this.exists(item.path);
-        return { item, exists };
-      } catch (error) {
-        // If there's an error checking a specific file, assume it doesn't exist
-        // but log the error for debugging
-        console.warn(
-          `Error checking file existence for ${item.path}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        return { item, exists: false };
-      }
-    });
+    const results = await Promise.all(
+      items.map(async (item) => ({
+        item,
+        exists: await this.exists(item.path),
+      })),
+    );
 
-    const results = await Promise.all(fileCheckPromises);
-    return results
-      .filter((result) => result.exists)
-      .map((result) => result.item);
+    return results.filter((result) => result.exists).map((result) => result.item);
   }
 }
 


### PR DESCRIPTION
## Summary
- revert the defensive agent directory and webview plumbing added in the previous refactor
- remove the shared fs adapter layer and return to lean AbsoluteFS/RelativeFS/WorkspaceFS helpers
- keep agent lookup logic straightforward without extra glob match wrappers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69072c750dfc8324a2d8b7c03d334d52

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines filesystem helpers by removing logging and path-validation layers, consolidating VS Code fs calls, adding minimal helpers, and dropping unused utilities.
> 
> - **Filesystem utilities**:
>   - **AbsoluteFS**: Remove logging and absolute-path validation; introduce `toUri` helper; simplify all methods; add `isDir`, `isFile`, `isSymbolicLink`; keep sync and stream APIs lean.
>   - **RelativeFS**: Drop logging/channel plumbing; simplify read/write/delete/dir ops; add `writeJson`/`readJson`; add `isSymbolicLink`; remove `cleanupOldFiles`.
>   - **StorageFS**: Remove logging/channel code; keep initialization and base-path resolution; rely on `RelativeFS` for ops.
>   - **WorkspaceFS**: Remove logging and error-handling utilities; keep idempotent `delete`; simplify `appendFile`, file-bytes helpers, and `filterExistingFiles`.
> - **Tests**:
>   - Update `RelativeFSJson.test.ts` to reflect removal of channel overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8e910233f13b31831a8dc20e466f604fcdadad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->