### PR TITLE
refactor: separate agent state responsibilities per Pocket Flow princ…

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -4,6 +4,9 @@ import {
   AnthropicAPIResponseUsage,
 } from './ResponseUsage';
 
+// Local imports - new state modules
+import { RoundMetricsState, RunMetricsState } from '@agent/state';
+
 // Local imports - logging
 import * as logger from '@logger/logUtils';
 
@@ -19,20 +22,55 @@ export interface IAgentStateRound {
   APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
 }
 
-/** Manages state and metrics for a single conversation round. */
+/**
+ * Manages state and metrics for a single conversation round.
+ *
+ * @deprecated This class is maintained for backward compatibility. New code should
+ * use RoundMetricsState from @agent/state which stores only distilled metrics
+ * (not raw API response objects) and doesn't track outputFile (which is managed
+ * by flows). This aligns with Pocket Flow's separation of shared data and compute.
+ *
+ * Internally, this class now delegates to RoundMetricsState for metric storage.
+ */
 export class AgentStateRound implements IAgentStateRound {
-  currRound: number;
-  continuationCount: number;
-  responseTime: number;
+  /** Internal metrics state using new focused structure */
+  private _metrics: RoundMetricsState;
+
+  /** Stored for backward compatibility - flows should track this separately */
   outputFile: string;
+
+  /** Stored for backward compatibility - raw API response */
   APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
 
   constructor(currRound: number) {
-    this.currRound = currRound;
-    this.continuationCount = 0;
-    this.responseTime = 0;
+    this._metrics = new RoundMetricsState(currRound);
     this.outputFile = '';
     this.APIUsage = null;
+  }
+
+  // Proxy properties to internal metrics
+  get currRound(): number {
+    return this._metrics.currRound;
+  }
+
+  set currRound(value: number) {
+    this._metrics.currRound = value;
+  }
+
+  get continuationCount(): number {
+    return this._metrics.continuationCount;
+  }
+
+  set continuationCount(value: number) {
+    this._metrics.continuationCount = value;
+  }
+
+  get responseTime(): number {
+    return this._metrics.responseTime;
+  }
+
+  set responseTime(value: number) {
+    this._metrics.responseTime = value;
   }
 
   /** Updates token usage metrics from model API response. */
@@ -40,16 +78,65 @@ export class AgentStateRound implements IAgentStateRound {
     responseUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage,
   ): void {
     this.APIUsage = responseUsage;
+
+    // Convert to distilled metrics
+    const metrics: any = {
+      totalInputTokens: responseUsage.totalInputTokens,
+      totalOutputTokens: responseUsage.totalOutputTokens,
+    };
+
+    // Extract cache tokens based on provider
+    if ('cache_read_input_tokens' in responseUsage) {
+      metrics.cacheReadInputTokens = responseUsage.cache_read_input_tokens ?? 0;
+      metrics.cacheCreationInputTokens =
+        responseUsage.cache_creation_input_tokens ?? 0;
+    } else if (
+      'prompt_tokens_details' in responseUsage &&
+      responseUsage.prompt_tokens_details
+    ) {
+      const promptDetails = responseUsage.prompt_tokens_details as {
+        cached_tokens?: number;
+      };
+      if ('cached_tokens' in promptDetails) {
+        metrics.cacheReadInputTokens = promptDetails.cached_tokens ?? 0;
+      }
+    }
+
+    // Extract reasoning tokens
+    if (
+      'completion_tokens_details' in responseUsage &&
+      responseUsage.completion_tokens_details
+    ) {
+      const completionDetails = responseUsage.completion_tokens_details as {
+        reasoning_tokens?: number;
+      };
+      if ('reasoning_tokens' in completionDetails) {
+        metrics.reasoningTokens = completionDetails.reasoning_tokens ?? 0;
+      }
+    } else if ('reasoning_tokens' in responseUsage) {
+      metrics.reasoningTokens = responseUsage.reasoning_tokens ?? 0;
+    }
+
+    // Extract tool use tokens
+    if (
+      'tool_use_tokens' in responseUsage &&
+      responseUsage.tool_use_tokens !== null &&
+      responseUsage.tool_use_tokens !== undefined
+    ) {
+      metrics.toolUseTokens = responseUsage.tool_use_tokens;
+    }
+
+    this._metrics.updateTokenMetrics(metrics);
   }
 
   /** Adds response time in milliseconds to the round total. */
   updateResponseTime(responseTime: number): void {
-    this.responseTime += responseTime;
+    this._metrics.updateResponseTime(responseTime);
   }
 
   /** Increments the continuation counter for tracking multi-turn responses. */
   incrementContinuation(): void {
-    this.continuationCount += 1;
+    this._metrics.incrementContinuation();
   }
 
   /** Converts state to a serializable object for persistence. */
@@ -63,6 +150,24 @@ export class AgentStateRound implements IAgentStateRound {
     };
     return stateObj;
   }
+
+  /**
+   * Gets the internal RoundMetricsState for code that wants to use the new structure.
+   * @internal
+   */
+  getMetrics(): RoundMetricsState {
+    return this._metrics;
+  }
+
+  /**
+   * Creates an AgentStateRound from an existing RoundMetricsState.
+   * @internal
+   */
+  static fromMetrics(metrics: RoundMetricsState): AgentStateRound {
+    const state = new AgentStateRound(metrics.currRound);
+    state._metrics = metrics;
+    return state;
+  }
 }
 
 /** Interface for tracking aggregate metrics across all conversation rounds. */
@@ -75,97 +180,110 @@ export interface IAgentStateGlobal {
   APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
 }
 
-/** Manages global state and aggregates metrics across conversation rounds. */
+/**
+ * Manages global state and aggregates metrics across conversation rounds.
+ *
+ * @deprecated This class is maintained for backward compatibility. New code should
+ * use RunMetricsState from @agent/state which stores only aggregated metrics
+ * (not raw API response objects). The APIUsage field in this class was never updated
+ * and remained null, highlighting the confusion of storing raw responses here.
+ *
+ * Internally, this class now delegates to RunMetricsState for metric aggregation.
+ */
 export class AgentStateGlobal implements IAgentStateGlobal {
-  firstInputTokens: number;
-  totalResponseTime: number;
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  totalRounds: number;
+  /** Internal run metrics using new focused structure */
+  private _metrics: RunMetricsState;
+
+  /** Stored for backward compatibility - never updated, always null */
   APIUsage: OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null;
-  public totalCacheReadInputTokens: number = 0;
-  public totalCacheCreationInputTokens: number = 0;
-  public totalReasoningTokens: number = 0;
-  public totalToolUseTokens: number = 0;
 
   constructor() {
-    this.firstInputTokens = 0;
-    this.totalResponseTime = 0;
-    this.totalInputTokens = 0;
-    this.totalOutputTokens = 0;
-    this.totalRounds = 0;
+    this._metrics = new RunMetricsState();
     this.APIUsage = null;
+  }
+
+  // Proxy properties to internal metrics
+  get firstInputTokens(): number {
+    return this._metrics.firstInputTokens;
+  }
+
+  set firstInputTokens(value: number) {
+    this._metrics.firstInputTokens = value;
+  }
+
+  get totalResponseTime(): number {
+    return this._metrics.totalResponseTime;
+  }
+
+  set totalResponseTime(value: number) {
+    this._metrics.totalResponseTime = value;
+  }
+
+  get totalInputTokens(): number {
+    return this._metrics.totalInputTokens;
+  }
+
+  set totalInputTokens(value: number) {
+    this._metrics.totalInputTokens = value;
+  }
+
+  get totalOutputTokens(): number {
+    return this._metrics.totalOutputTokens;
+  }
+
+  set totalOutputTokens(value: number) {
+    this._metrics.totalOutputTokens = value;
+  }
+
+  get totalRounds(): number {
+    return this._metrics.totalRounds;
+  }
+
+  set totalRounds(value: number) {
+    this._metrics.totalRounds = value;
+  }
+
+  get totalCacheReadInputTokens(): number {
+    return this._metrics.totalCacheReadInputTokens;
+  }
+
+  set totalCacheReadInputTokens(value: number) {
+    this._metrics.totalCacheReadInputTokens = value;
+  }
+
+  get totalCacheCreationInputTokens(): number {
+    return this._metrics.totalCacheCreationInputTokens;
+  }
+
+  set totalCacheCreationInputTokens(value: number) {
+    this._metrics.totalCacheCreationInputTokens = value;
+  }
+
+  get totalReasoningTokens(): number {
+    return this._metrics.totalReasoningTokens;
+  }
+
+  set totalReasoningTokens(value: number) {
+    this._metrics.totalReasoningTokens = value;
+  }
+
+  get totalToolUseTokens(): number {
+    return this._metrics.totalToolUseTokens;
+  }
+
+  set totalToolUseTokens(value: number) {
+    this._metrics.totalToolUseTokens = value;
   }
 
   /** Updates global metrics by incorporating round state data. */
   updateFromCurrRound(stateRound: AgentStateRound): void {
-    if (stateRound.APIUsage) {
-      if (this.firstInputTokens === 0) {
-        this.firstInputTokens = stateRound.APIUsage.totalInputTokens;
-      }
-
-      // For Anthropic models, handle cache tokens directly from response
-      if ('cache_read_input_tokens' in stateRound.APIUsage) {
-        const cacheRead = stateRound.APIUsage.cache_read_input_tokens ?? 0;
-        const cacheCreation =
-          stateRound.APIUsage.cache_creation_input_tokens ?? 0;
-        this.totalCacheReadInputTokens += cacheRead;
-        this.totalCacheCreationInputTokens += cacheCreation;
-        this.firstInputTokens += cacheRead + cacheCreation;
-      }
-      // For OpenAI models with auto prompt caching, handle cache tokens from prompt_tokens_details
-      else if (
-        'prompt_tokens_details' in stateRound.APIUsage &&
-        stateRound.APIUsage.prompt_tokens_details
-      ) {
-        const promptDetails = stateRound.APIUsage.prompt_tokens_details as {
-          cached_tokens?: number;
-        };
-        if ('cached_tokens' in promptDetails) {
-          this.totalCacheReadInputTokens += promptDetails.cached_tokens ?? 0;
-        }
-      }
-
-      // For OpenAI models, handle reasoning tokens from completion_tokens_details
-      if (
-        'completion_tokens_details' in stateRound.APIUsage &&
-        stateRound.APIUsage.completion_tokens_details
-      ) {
-        const completionDetails = stateRound.APIUsage
-          .completion_tokens_details as { reasoning_tokens?: number };
-        if ('reasoning_tokens' in completionDetails) {
-          this.totalReasoningTokens += completionDetails.reasoning_tokens ?? 0;
-        }
-      }
-      // For older OpenAI models, handle reasoning tokens directly
-      else if ('reasoning_tokens' in stateRound.APIUsage) {
-        this.totalReasoningTokens += stateRound.APIUsage.reasoning_tokens ?? 0;
-      }
-
-      // Track tokens used for tool calls
-      // Note: Only Google models provide tool_use_tokens (as toolUsePromptTokenCount)
-      // OpenAI and Anthropic don't provide this information in their API responses
-      if (
-        'tool_use_tokens' in stateRound.APIUsage &&
-        stateRound.APIUsage.tool_use_tokens !== null &&
-        stateRound.APIUsage.tool_use_tokens !== undefined
-      ) {
-        this.totalToolUseTokens += stateRound.APIUsage.tool_use_tokens;
-      }
-
-      // Update global totals
-      this.totalInputTokens += stateRound.APIUsage.totalInputTokens;
-      this.totalOutputTokens += stateRound.APIUsage.totalOutputTokens;
-    }
-
-    this.totalResponseTime += stateRound.responseTime;
+    this._metrics.updateFromRoundMetrics(stateRound.getMetrics());
   }
 
   incrementRounds(): void {
-    this.totalRounds += 1;
+    this._metrics.incrementRounds();
   }
 
-  // are the following two methods needed?
   /** Converts global state to a serializable object for persistence. */
   toObject(): Record<string, any> {
     return {
@@ -200,6 +318,24 @@ export class AgentStateGlobal implements IAgentStateGlobal {
       stateObj.totalCacheCreationInputTokens ?? 0;
     state.totalReasoningTokens = stateObj.totalReasoningTokens ?? 0;
     state.totalToolUseTokens = stateObj.totalToolUseTokens ?? 0;
+    return state;
+  }
+
+  /**
+   * Gets the internal RunMetricsState for code that wants to use the new structure.
+   * @internal
+   */
+  getMetrics(): RunMetricsState {
+    return this._metrics;
+  }
+
+  /**
+   * Creates an AgentStateGlobal from an existing RunMetricsState.
+   * @internal
+   */
+  static fromMetrics(metrics: RunMetricsState): AgentStateGlobal {
+    const state = new AgentStateGlobal();
+    state._metrics = metrics;
     return state;
   }
 }

--- a/src/agent/core/ToolState.ts
+++ b/src/agent/core/ToolState.ts
@@ -1,3 +1,6 @@
+// Local imports - new focused state modules
+import { ToolRuntimeStore } from '@agent/state/ToolRuntimeStore';
+
 /** Interface for managing tool-specific runtime state within a conversation round. */
 export interface IToolState {
   /** Statistics about TeX document structure */
@@ -24,30 +27,79 @@ export interface IToolState {
   resetThinkingCache(): void;
 }
 
-/** Manages tool-specific runtime state and operations within a conversation round. */
+/**
+ * Manages tool-specific runtime state and operations within a conversation round.
+ *
+ * @deprecated This class is maintained for backward compatibility. New code should
+ * use ToolRuntimeStore from @agent/state which provides a cleaner separation of
+ * concerns aligned with Pocket Flow principles.
+ *
+ * Internally, this class now delegates to ToolRuntimeStore to ensure consistency
+ * across the codebase.
+ */
 export class ToolState implements IToolState {
-  texcountStats: string | null;
-  lastResponse: string;
-  accumulatedOutput: string;
-  mediaFiles: string[];
-  thinkingBlocks: any[];
-  thinkingAdded: boolean;
+  /** Internal store using new focused state modules */
+  private _store: ToolRuntimeStore;
+
+  constructor() {
+    this._store = new ToolRuntimeStore();
+  }
 
   /**
    * Returns the first thinking block from thinkingBlocks array
    * @returns The first thinking block or null if none exists
    */
   get thinkingBlock(): any {
-    return this.thinkingBlocks.length > 0 ? this.thinkingBlocks[0] : null;
+    return this._store.reasoning.thinkingBlock;
   }
 
-  constructor() {
-    this.texcountStats = null;
-    this.lastResponse = '';
-    this.accumulatedOutput = '';
-    this.mediaFiles = [];
-    this.thinkingBlocks = [];
-    this.thinkingAdded = false;
+  // Proxy properties to the internal store
+  get texcountStats(): string | null {
+    return this._store.scratchpad.texcountStats;
+  }
+
+  set texcountStats(value: string | null) {
+    this._store.scratchpad.texcountStats = value;
+  }
+
+  get lastResponse(): string {
+    return this._store.scratchpad.lastResponse;
+  }
+
+  set lastResponse(value: string) {
+    this._store.scratchpad.lastResponse = value;
+  }
+
+  get accumulatedOutput(): string {
+    return this._store.scratchpad.accumulatedOutput;
+  }
+
+  set accumulatedOutput(value: string) {
+    this._store.scratchpad.accumulatedOutput = value;
+  }
+
+  get mediaFiles(): string[] {
+    return this._store.media.mediaFiles;
+  }
+
+  set mediaFiles(value: string[]) {
+    this._store.media.mediaFiles = value;
+  }
+
+  get thinkingBlocks(): any[] {
+    return this._store.reasoning.thinkingBlocks;
+  }
+
+  set thinkingBlocks(value: any[]) {
+    this._store.reasoning.thinkingBlocks = value;
+  }
+
+  get thinkingAdded(): boolean {
+    return this._store.reasoning.thinkingAdded;
+  }
+
+  set thinkingAdded(value: boolean) {
+    this._store.reasoning.thinkingAdded = value;
   }
 
   /**
@@ -55,7 +107,7 @@ export class ToolState implements IToolState {
    * @param response New response text from the model
    */
   updateLastResponse(response: string): void {
-    this.lastResponse = response;
+    this._store.scratchpad.updateLastResponse(response);
   }
 
   /**
@@ -63,7 +115,7 @@ export class ToolState implements IToolState {
    * @param output New content to store as accumulated output
    */
   updateAccumulatedOutput(output: string): void {
-    this.accumulatedOutput = output;
+    this._store.scratchpad.updateAccumulatedOutput(output);
   }
 
   /**
@@ -71,11 +123,7 @@ export class ToolState implements IToolState {
    * @param files Array of paths to new figure files
    */
   addMediaFiles(files: string[]): void {
-    for (const file of files) {
-      if (!this.mediaFiles.includes(file)) {
-        this.mediaFiles.push(file);
-      }
-    }
+    this._store.media.addMediaFiles(files);
   }
 
   /**
@@ -83,7 +131,24 @@ export class ToolState implements IToolState {
    * Used to ensure fresh thinking blocks for subsequent responses.
    */
   resetThinkingCache(): void {
-    this.thinkingBlocks = [];
-    this.thinkingAdded = false;
+    this._store.reasoning.resetThinkingCache();
+  }
+
+  /**
+   * Gets the internal ToolRuntimeStore for code that wants to use the new structure.
+   * @internal
+   */
+  getStore(): ToolRuntimeStore {
+    return this._store;
+  }
+
+  /**
+   * Creates a ToolState from an existing ToolRuntimeStore.
+   * @internal
+   */
+  static fromStore(store: ToolRuntimeStore): ToolState {
+    const toolState = new ToolState();
+    toolState._store = store;
+    return toolState;
   }
 }

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -543,8 +543,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           toolState,
         },
         hooks: {
-          prepareToolState: () =>
-            this.prepareToolState(roundIndex, toolState),
+          prepareToolState: () => this.prepareToolState(roundIndex, toolState),
           prepareRoundContext: () =>
             this.prepareRoundContext(
               roundIndex,

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -191,10 +191,7 @@ export class LatexDiffManager {
             prevOutputFile,
             currOutputFile,
           );
-          this.logLatexdiffResult(
-            result,
-            'between-rounds-diff',
-          );
+          this.logLatexdiffResult(result, 'between-rounds-diff');
           aggregated.push({
             base: prevOutputFile,
             revised: currOutputFile,

--- a/src/agent/state/AgentSharedStore.ts
+++ b/src/agent/state/AgentSharedStore.ts
@@ -1,0 +1,77 @@
+// Local imports - state components
+import { RoundMetricsState } from './RoundMetricsState';
+import { RunMetricsState } from './RunMetricsState';
+import { ToolRuntimeStore } from './ToolRuntimeStore';
+
+/**
+ * Typed shared store aligned with Pocket Flow design.
+ *
+ * This interface exposes a structured "shared store" surface that composes metrics
+ * and tool runtime state under well-named keys, making it explicit which node owns
+ * which slice of state. This aligns with Pocket Flow's documented "shared" store
+ * abstraction pattern.
+ */
+export interface AgentSharedStore {
+  /** Metrics for the current round */
+  roundMetrics: RoundMetricsState;
+
+  /** Aggregated metrics across all rounds */
+  runMetrics: RunMetricsState;
+
+  /** Tool runtime state (scratchpad, media, reasoning) */
+  toolRuntime: ToolRuntimeStore;
+
+  /** Output file path tracked by the flow */
+  outputFile: string;
+}
+
+/**
+ * Creates a new agent shared store with initialized state.
+ *
+ * @param currRound - The current round number for initializing round metrics
+ * @param outputFile - The output file path for this execution
+ * @returns A fully initialized shared store
+ */
+export function createAgentSharedStore(
+  currRound: number,
+  outputFile: string,
+): AgentSharedStore {
+  return {
+    roundMetrics: new RoundMetricsState(currRound),
+    runMetrics: new RunMetricsState(),
+    toolRuntime: new ToolRuntimeStore(),
+    outputFile,
+  };
+}
+
+/**
+ * Converts shared store to a serializable object for persistence.
+ */
+export function serializeAgentSharedStore(
+  store: AgentSharedStore,
+): Record<string, any> {
+  return {
+    roundMetrics: store.roundMetrics.toObject(),
+    runMetrics: store.runMetrics.toObject(),
+    toolRuntime: store.toolRuntime.toObject(),
+    outputFile: store.outputFile,
+  };
+}
+
+/**
+ * Reconstructs a shared store from a persisted state object.
+ */
+export function deserializeAgentSharedStore(
+  stateObj: Record<string, any> | null,
+): AgentSharedStore {
+  if (!stateObj) {
+    return createAgentSharedStore(0, '');
+  }
+
+  return {
+    roundMetrics: RoundMetricsState.fromObject(stateObj.roundMetrics ?? null),
+    runMetrics: RunMetricsState.fromObject(stateObj.runMetrics ?? null),
+    toolRuntime: ToolRuntimeStore.fromObject(stateObj.toolRuntime ?? null),
+    outputFile: stateObj.outputFile ?? '',
+  };
+}

--- a/src/agent/state/MediaAttachmentState.ts
+++ b/src/agent/state/MediaAttachmentState.ts
@@ -1,0 +1,60 @@
+/**
+ * State for managing media file attachments.
+ *
+ * This focused state module handles media file paths separately from text scratchpad
+ * and reasoning traces, maintaining clear boundaries between different runtime concerns.
+ */
+export interface IMediaAttachmentState {
+  /** Paths to figure files */
+  mediaFiles: string[];
+
+  addMediaFiles(files: string[]): void;
+}
+
+/**
+ * Manages media file attachments for tool runtime.
+ *
+ * Focuses exclusively on media file tracking to maintain clear separation
+ * of concerns from text and reasoning state.
+ */
+export class MediaAttachmentState implements IMediaAttachmentState {
+  mediaFiles: string[];
+
+  constructor() {
+    this.mediaFiles = [];
+  }
+
+  /**
+   * Adds new figure file paths to the collection.
+   * @param files Array of paths to new figure files
+   */
+  addMediaFiles(files: string[]): void {
+    for (const file of files) {
+      if (!this.mediaFiles.includes(file)) {
+        this.mediaFiles.push(file);
+      }
+    }
+  }
+
+  /** Converts state to a serializable object for persistence. */
+  toObject(): Record<string, any> {
+    return {
+      mediaFiles: [...this.mediaFiles],
+    };
+  }
+
+  /** Creates a MediaAttachmentState instance from a persisted state object. */
+  static fromObject(
+    stateObj: Record<string, any> | null,
+  ): MediaAttachmentState {
+    if (!stateObj) {
+      return new MediaAttachmentState();
+    }
+
+    const state = new MediaAttachmentState();
+    state.mediaFiles = Array.isArray(stateObj.mediaFiles)
+      ? [...stateObj.mediaFiles]
+      : [];
+    return state;
+  }
+}

--- a/src/agent/state/ReasoningTraceState.ts
+++ b/src/agent/state/ReasoningTraceState.ts
@@ -1,0 +1,70 @@
+/**
+ * State for managing model reasoning traces (thinking blocks).
+ *
+ * This focused state module handles Anthropic "thinking" caches and related metadata,
+ * separating these concerns from scratchpad text and media attachments.
+ */
+export interface IReasoningTraceState {
+  /** Collection of all thinking blocks from the response (used for Anthropic models) */
+  thinkingBlocks: any[];
+
+  /** Whether the thinking block has been added to the accumulated output */
+  thinkingAdded: boolean;
+
+  resetThinkingCache(): void;
+}
+
+/**
+ * Manages reasoning trace state including thinking blocks.
+ *
+ * Focuses exclusively on reasoning-related state to maintain clear boundaries
+ * between different runtime concerns.
+ */
+export class ReasoningTraceState implements IReasoningTraceState {
+  thinkingBlocks: any[];
+  thinkingAdded: boolean;
+
+  /**
+   * Returns the first thinking block from thinkingBlocks array
+   * @returns The first thinking block or null if none exists
+   */
+  get thinkingBlock(): any {
+    return this.thinkingBlocks.length > 0 ? this.thinkingBlocks[0] : null;
+  }
+
+  constructor() {
+    this.thinkingBlocks = [];
+    this.thinkingAdded = false;
+  }
+
+  /**
+   * Resets the thinking cache by clearing thinking blocks and reset flag.
+   * Used to ensure fresh thinking blocks for subsequent responses.
+   */
+  resetThinkingCache(): void {
+    this.thinkingBlocks = [];
+    this.thinkingAdded = false;
+  }
+
+  /** Converts state to a serializable object for persistence. */
+  toObject(): Record<string, any> {
+    return {
+      thinkingBlocks: [...this.thinkingBlocks],
+      thinkingAdded: this.thinkingAdded,
+    };
+  }
+
+  /** Creates a ReasoningTraceState instance from a persisted state object. */
+  static fromObject(stateObj: Record<string, any> | null): ReasoningTraceState {
+    if (!stateObj) {
+      return new ReasoningTraceState();
+    }
+
+    const state = new ReasoningTraceState();
+    state.thinkingBlocks = Array.isArray(stateObj.thinkingBlocks)
+      ? [...stateObj.thinkingBlocks]
+      : [];
+    state.thinkingAdded = stateObj.thinkingAdded ?? false;
+    return state;
+  }
+}

--- a/src/agent/state/RoundMetricsState.ts
+++ b/src/agent/state/RoundMetricsState.ts
@@ -1,0 +1,98 @@
+/**
+ * State for tracking metrics within a single conversation round.
+ *
+ * This class stores distilled metrics (not raw API response objects) for a single
+ * round, aligning with Pocket Flow's separation of shared data and compute steps.
+ */
+export interface IRoundMetricsState {
+  currRound: number;
+  continuationCount: number;
+  responseTime: number;
+  /** Computed token usage metrics (not raw API response) */
+  tokenMetrics: {
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
+    reasoningTokens?: number;
+    toolUseTokens?: number;
+  };
+}
+
+/**
+ * Manages metrics for a single conversation round.
+ *
+ * Stores only aggregated metrics instead of raw API usage objects to maintain
+ * a clean separation between data and computation.
+ */
+export class RoundMetricsState implements IRoundMetricsState {
+  currRound: number;
+  continuationCount: number;
+  responseTime: number;
+  tokenMetrics: {
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
+    reasoningTokens?: number;
+    toolUseTokens?: number;
+  };
+
+  constructor(currRound: number) {
+    this.currRound = currRound;
+    this.continuationCount = 0;
+    this.responseTime = 0;
+    this.tokenMetrics = {
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+    };
+  }
+
+  /** Updates token usage metrics from distilled API response. */
+  updateTokenMetrics(metrics: {
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
+    reasoningTokens?: number;
+    toolUseTokens?: number;
+  }): void {
+    this.tokenMetrics = { ...metrics };
+  }
+
+  /** Adds response time in milliseconds to the round total. */
+  updateResponseTime(responseTime: number): void {
+    this.responseTime += responseTime;
+  }
+
+  /** Increments the continuation counter for tracking multi-turn responses. */
+  incrementContinuation(): void {
+    this.continuationCount += 1;
+  }
+
+  /** Converts state to a serializable object for persistence. */
+  toObject(): Record<string, any> {
+    return {
+      currRound: this.currRound,
+      continuationCount: this.continuationCount,
+      responseTime: this.responseTime,
+      tokenMetrics: { ...this.tokenMetrics },
+    };
+  }
+
+  /** Creates a RoundMetricsState instance from a persisted state object. */
+  static fromObject(stateObj: Record<string, any> | null): RoundMetricsState {
+    if (!stateObj) {
+      return new RoundMetricsState(0);
+    }
+
+    const state = new RoundMetricsState(stateObj.currRound ?? 0);
+    state.continuationCount = stateObj.continuationCount ?? 0;
+    state.responseTime = stateObj.responseTime ?? 0;
+    state.tokenMetrics = stateObj.tokenMetrics ?? {
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+    };
+    return state;
+  }
+}

--- a/src/agent/state/RunMetricsState.ts
+++ b/src/agent/state/RunMetricsState.ts
@@ -1,0 +1,134 @@
+// Local imports - state
+import type { RoundMetricsState } from './RoundMetricsState';
+
+/**
+ * State for tracking aggregate metrics across all conversation rounds.
+ *
+ * This class stores only distilled metrics snapshots, not raw API response objects,
+ * aligning with Pocket Flow's principle of separating shared data from computation.
+ */
+export interface IRunMetricsState {
+  firstInputTokens: number;
+  totalResponseTime: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalRounds: number;
+  totalCacheReadInputTokens: number;
+  totalCacheCreationInputTokens: number;
+  totalReasoningTokens: number;
+  totalToolUseTokens: number;
+}
+
+/**
+ * Manages global state and aggregates metrics across conversation rounds.
+ *
+ * Stores only aggregated metric values instead of raw API usage objects to maintain
+ * a clean boundary between data storage and computation logic.
+ */
+export class RunMetricsState implements IRunMetricsState {
+  firstInputTokens: number;
+  totalResponseTime: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalRounds: number;
+  totalCacheReadInputTokens: number;
+  totalCacheCreationInputTokens: number;
+  totalReasoningTokens: number;
+  totalToolUseTokens: number;
+
+  constructor() {
+    this.firstInputTokens = 0;
+    this.totalResponseTime = 0;
+    this.totalInputTokens = 0;
+    this.totalOutputTokens = 0;
+    this.totalRounds = 0;
+    this.totalCacheReadInputTokens = 0;
+    this.totalCacheCreationInputTokens = 0;
+    this.totalReasoningTokens = 0;
+    this.totalToolUseTokens = 0;
+  }
+
+  /**
+   * Updates global metrics by incorporating distilled metrics from a round state.
+   *
+   * Accepts a metrics snapshot from the round state rather than mutating via a
+   * raw API response object, keeping computation separate from storage.
+   */
+  updateFromRoundMetrics(roundState: RoundMetricsState): void {
+    const metrics = roundState.tokenMetrics;
+
+    if (this.firstInputTokens === 0) {
+      this.firstInputTokens = metrics.totalInputTokens;
+
+      // Include cache tokens in first input count
+      if (metrics.cacheReadInputTokens !== undefined) {
+        this.firstInputTokens += metrics.cacheReadInputTokens;
+      }
+      if (metrics.cacheCreationInputTokens !== undefined) {
+        this.firstInputTokens += metrics.cacheCreationInputTokens;
+      }
+    }
+
+    // Accumulate cache tokens
+    if (metrics.cacheReadInputTokens !== undefined) {
+      this.totalCacheReadInputTokens += metrics.cacheReadInputTokens;
+    }
+    if (metrics.cacheCreationInputTokens !== undefined) {
+      this.totalCacheCreationInputTokens += metrics.cacheCreationInputTokens;
+    }
+
+    // Accumulate reasoning tokens
+    if (metrics.reasoningTokens !== undefined) {
+      this.totalReasoningTokens += metrics.reasoningTokens;
+    }
+
+    // Accumulate tool use tokens
+    if (metrics.toolUseTokens !== undefined) {
+      this.totalToolUseTokens += metrics.toolUseTokens;
+    }
+
+    // Update global totals
+    this.totalInputTokens += metrics.totalInputTokens;
+    this.totalOutputTokens += metrics.totalOutputTokens;
+    this.totalResponseTime += roundState.responseTime;
+  }
+
+  incrementRounds(): void {
+    this.totalRounds += 1;
+  }
+
+  /** Converts global state to a serializable object for persistence. */
+  toObject(): Record<string, any> {
+    return {
+      firstInputTokens: this.firstInputTokens,
+      totalResponseTime: this.totalResponseTime,
+      totalInputTokens: this.totalInputTokens,
+      totalOutputTokens: this.totalOutputTokens,
+      totalRounds: this.totalRounds,
+      totalCacheReadInputTokens: this.totalCacheReadInputTokens,
+      totalCacheCreationInputTokens: this.totalCacheCreationInputTokens,
+      totalReasoningTokens: this.totalReasoningTokens,
+      totalToolUseTokens: this.totalToolUseTokens,
+    };
+  }
+
+  /** Creates a RunMetricsState instance from a persisted state object. */
+  static fromObject(stateObj: Record<string, any> | null): RunMetricsState {
+    if (!stateObj) {
+      return new RunMetricsState();
+    }
+
+    const state = new RunMetricsState();
+    state.firstInputTokens = stateObj.firstInputTokens ?? 0;
+    state.totalResponseTime = stateObj.totalResponseTime ?? 0;
+    state.totalInputTokens = stateObj.totalInputTokens ?? 0;
+    state.totalOutputTokens = stateObj.totalOutputTokens ?? 0;
+    state.totalRounds = stateObj.totalRounds ?? 0;
+    state.totalCacheReadInputTokens = stateObj.totalCacheReadInputTokens ?? 0;
+    state.totalCacheCreationInputTokens =
+      stateObj.totalCacheCreationInputTokens ?? 0;
+    state.totalReasoningTokens = stateObj.totalReasoningTokens ?? 0;
+    state.totalToolUseTokens = stateObj.totalToolUseTokens ?? 0;
+    return state;
+  }
+}

--- a/src/agent/state/ToolRuntimeStore.ts
+++ b/src/agent/state/ToolRuntimeStore.ts
@@ -1,0 +1,61 @@
+// Local imports - state components
+import { ToolScratchpadState } from './ToolScratchpadState';
+import { MediaAttachmentState } from './MediaAttachmentState';
+import { ReasoningTraceState } from './ReasoningTraceState';
+
+/**
+ * Composed store for tool runtime state.
+ *
+ * This store brings together the three focused state modules (scratchpad, media,
+ * reasoning) under a single interface, providing a structured alternative to the
+ * monolithic ToolState while maintaining clear boundaries between concerns.
+ */
+export interface IToolRuntimeStore {
+  scratchpad: ToolScratchpadState;
+  media: MediaAttachmentState;
+  reasoning: ReasoningTraceState;
+}
+
+/**
+ * Manages tool runtime state through composed focused stores.
+ *
+ * Instead of mixing unrelated responsibilities in a single object, this store
+ * delegates to specialized state modules that each handle one concern.
+ */
+export class ToolRuntimeStore implements IToolRuntimeStore {
+  scratchpad: ToolScratchpadState;
+  media: MediaAttachmentState;
+  reasoning: ReasoningTraceState;
+
+  constructor() {
+    this.scratchpad = new ToolScratchpadState();
+    this.media = new MediaAttachmentState();
+    this.reasoning = new ReasoningTraceState();
+  }
+
+  /** Converts the entire tool runtime store to a serializable object. */
+  toObject(): Record<string, any> {
+    return {
+      scratchpad: this.scratchpad.toObject(),
+      media: this.media.toObject(),
+      reasoning: this.reasoning.toObject(),
+    };
+  }
+
+  /** Creates a ToolRuntimeStore instance from a persisted state object. */
+  static fromObject(stateObj: Record<string, any> | null): ToolRuntimeStore {
+    const store = new ToolRuntimeStore();
+
+    if (stateObj) {
+      store.scratchpad = ToolScratchpadState.fromObject(
+        stateObj.scratchpad ?? null,
+      );
+      store.media = MediaAttachmentState.fromObject(stateObj.media ?? null);
+      store.reasoning = ReasoningTraceState.fromObject(
+        stateObj.reasoning ?? null,
+      );
+    }
+
+    return store;
+  }
+}

--- a/src/agent/state/ToolScratchpadState.ts
+++ b/src/agent/state/ToolScratchpadState.ts
@@ -1,0 +1,76 @@
+/**
+ * State for managing tool scratchpad and text accumulation.
+ *
+ * This focused state module handles text-based runtime data including TeX statistics,
+ * response fragments, and accumulated output, separating these concerns from media
+ * attachments and reasoning traces.
+ */
+export interface IToolScratchpadState {
+  /** Statistics about TeX document structure */
+  texcountStats: string | null;
+
+  /** Most recent model response */
+  lastResponse: string;
+
+  /** Combined output from all responses */
+  accumulatedOutput: string;
+
+  updateLastResponse(response: string): void;
+  updateAccumulatedOutput(output: string): void;
+}
+
+/**
+ * Manages scratchpad text and accumulated output for tool runtime.
+ *
+ * Focuses exclusively on text-based state to maintain clear boundaries
+ * between different runtime concerns.
+ */
+export class ToolScratchpadState implements IToolScratchpadState {
+  texcountStats: string | null;
+  lastResponse: string;
+  accumulatedOutput: string;
+
+  constructor() {
+    this.texcountStats = null;
+    this.lastResponse = '';
+    this.accumulatedOutput = '';
+  }
+
+  /**
+   * Updates the most recent model response.
+   * @param response New response text from the model
+   */
+  updateLastResponse(response: string): void {
+    this.lastResponse = response;
+  }
+
+  /**
+   * Updates the accumulated output with new content.
+   * @param output New content to store as accumulated output
+   */
+  updateAccumulatedOutput(output: string): void {
+    this.accumulatedOutput = output;
+  }
+
+  /** Converts state to a serializable object for persistence. */
+  toObject(): Record<string, any> {
+    return {
+      texcountStats: this.texcountStats,
+      lastResponse: this.lastResponse,
+      accumulatedOutput: this.accumulatedOutput,
+    };
+  }
+
+  /** Creates a ToolScratchpadState instance from a persisted state object. */
+  static fromObject(stateObj: Record<string, any> | null): ToolScratchpadState {
+    if (!stateObj) {
+      return new ToolScratchpadState();
+    }
+
+    const state = new ToolScratchpadState();
+    state.texcountStats = stateObj.texcountStats ?? null;
+    state.lastResponse = stateObj.lastResponse ?? '';
+    state.accumulatedOutput = stateObj.accumulatedOutput ?? '';
+    return state;
+  }
+}

--- a/src/agent/state/index.ts
+++ b/src/agent/state/index.ts
@@ -1,0 +1,25 @@
+// Export all state modules
+export { RoundMetricsState } from './RoundMetricsState';
+export type { IRoundMetricsState } from './RoundMetricsState';
+
+export { RunMetricsState } from './RunMetricsState';
+export type { IRunMetricsState } from './RunMetricsState';
+
+export { ToolScratchpadState } from './ToolScratchpadState';
+export type { IToolScratchpadState } from './ToolScratchpadState';
+
+export { MediaAttachmentState } from './MediaAttachmentState';
+export type { IMediaAttachmentState } from './MediaAttachmentState';
+
+export { ReasoningTraceState } from './ReasoningTraceState';
+export type { IReasoningTraceState } from './ReasoningTraceState';
+
+export { ToolRuntimeStore } from './ToolRuntimeStore';
+export type { IToolRuntimeStore } from './ToolRuntimeStore';
+
+export type { AgentSharedStore } from './AgentSharedStore';
+export {
+  createAgentSharedStore,
+  serializeAgentSharedStore,
+  deserializeAgentSharedStore,
+} from './AgentSharedStore';

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -52,37 +52,37 @@ export class LatexMediaManager {
           buildDir,
           true,
         );
-          if (compiled) {
-            const pdfFile = path.join(
-              buildDir,
-              path.basename(file).replace(/\.tex$/, '.pdf'),
-            );
-            if (await WorkspaceFS.exists(pdfFile)) {
-              try {
-                const stats = await WorkspaceFS.stat(pdfFile);
-                if (stats.size === 0) {
-                  this.logger.warn(
-                    `Compiled PDF is empty for ${file}: ${pdfFile}`,
-                    activeGroupId,
-                  );
-                  return undefined;
-                }
-              } catch (err) {
-                const message = err instanceof Error ? err.message : String(err);
-                this.logger.error(
-                  `Failed to stat compiled PDF ${pdfFile}: ${message}`,
+        if (compiled) {
+          const pdfFile = path.join(
+            buildDir,
+            path.basename(file).replace(/\.tex$/, '.pdf'),
+          );
+          if (await WorkspaceFS.exists(pdfFile)) {
+            try {
+              const stats = await WorkspaceFS.stat(pdfFile);
+              if (stats.size === 0) {
+                this.logger.warn(
+                  `Compiled PDF is empty for ${file}: ${pdfFile}`,
                   activeGroupId,
                 );
                 return undefined;
               }
-
-              this.logger.info(
-                `Compiled PDF for ${file}: ${pdfFile}`,
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              this.logger.error(
+                `Failed to stat compiled PDF ${pdfFile}: ${message}`,
                 activeGroupId,
               );
-              return pdfFile;
+              return undefined;
             }
+
+            this.logger.info(
+              `Compiled PDF for ${file}: ${pdfFile}`,
+              activeGroupId,
+            );
+            return pdfFile;
           }
+        }
         return undefined;
       }),
     );
@@ -195,11 +195,7 @@ export class LatexMediaManager {
     }
 
     if (includeTikzCompilation && cfg.autoExtractTikzFigure) {
-      await this.compileTikzFigures(
-        existingFiles,
-        toolState,
-        logTikzSummary,
-      );
+      await this.compileTikzFigures(existingFiles, toolState, logTikzSummary);
     }
 
     if (includePdfCompilation && cfg.autoCompileInputPdf) {


### PR DESCRIPTION
…iples

This refactoring addresses three key issues with agent state management:

1. **Rename AgentStateRound/AgentStateGlobal to purpose-driven classes**
   - Created RoundMetricsState and RunMetricsState in src/agent/state/
   - Removed unused outputFile field from round state (tracked by flows)
   - Store only distilled metrics instead of raw API response objects
   - Existing classes now delegate to new implementations for compatibility

2. **Split ToolState into focused pocket-flow stores**
   - ToolScratchpadState: manages texcountStats, lastResponse, accumulatedOutput
   - MediaAttachmentState: manages mediaFiles array
   - ReasoningTraceState: manages thinkingBlocks and thinkingAdded
   - ToolRuntimeStore: composes the three focused stores
   - ToolState now delegates to ToolRuntimeStore internally

3. **Introduce typed AgentSharedStore aligned with Pocket Flow**
   - Defines centralized shared store interface composing metrics and tool runtime
   - Provides clear boundaries for state ownership
   - Includes serialization helpers for persistence

All changes maintain backward compatibility through delegation patterns, ensuring existing code continues to work while providing a path forward to the cleaner architecture.

Files changed:
- src/agent/state/: new directory with focused state modules
- src/agent/core/AgentState.ts: updated to delegate to new metrics states
- src/agent/core/ToolState.ts: updated to delegate to ToolRuntimeStore
- Minor formatting fixes from prettier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modularizes agent state into focused metrics and tool runtime stores, updates legacy classes to delegate to them, and introduces a typed shared store with serialization helpers.
> 
> - **State architecture (new `src/agent/state/` modules)**:
>   - `RoundMetricsState`, `RunMetricsState`: distilled per-round and run-level metrics with aggregation APIs and (de)serialization.
>   - `ToolScratchpadState`, `MediaAttachmentState`, `ReasoningTraceState`: split tool runtime concerns; composed via `ToolRuntimeStore`.
>   - `AgentSharedStore`: typed shared store with `createAgentSharedStore`, `serializeAgentSharedStore`, `deserializeAgentSharedStore`.
> - **Core refactors (backwards-compatible adapters)**:
>   - `AgentStateRound` and `AgentStateGlobal`: marked deprecated; now proxy to `RoundMetricsState`/`RunMetricsState` (getters/setters; `updateFromCurrRound` uses metrics); retain legacy fields for compatibility.
>   - `ToolState`: marked deprecated; now delegates to `ToolRuntimeStore` (proxy properties/methods) with `fromStore`/`getStore` helpers.
> - **Minor adjustments**:
>   - Logging/formatting cleanups in `LatexDiffManager` and `LatexMediaManager`.
>   - Small hook formatting in `BaseReflectionAgent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e954ab7faeec7fef732e408707914bec57c3c8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->