### PR TITLE
refactor: decouple logger transport responsibilities

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -543,8 +543,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           toolState,
         },
         hooks: {
-          prepareToolState: () =>
-            this.prepareToolState(roundIndex, toolState),
+          prepareToolState: () => this.prepareToolState(roundIndex, toolState),
           prepareRoundContext: () =>
             this.prepareRoundContext(
               roundIndex,

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -191,10 +191,7 @@ export class LatexDiffManager {
             prevOutputFile,
             currOutputFile,
           );
-          this.logLatexdiffResult(
-            result,
-            'between-rounds-diff',
-          );
+          this.logLatexdiffResult(result, 'between-rounds-diff');
           aggregated.push({
             base: prevOutputFile,
             revised: currOutputFile,

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -52,37 +52,37 @@ export class LatexMediaManager {
           buildDir,
           true,
         );
-          if (compiled) {
-            const pdfFile = path.join(
-              buildDir,
-              path.basename(file).replace(/\.tex$/, '.pdf'),
-            );
-            if (await WorkspaceFS.exists(pdfFile)) {
-              try {
-                const stats = await WorkspaceFS.stat(pdfFile);
-                if (stats.size === 0) {
-                  this.logger.warn(
-                    `Compiled PDF is empty for ${file}: ${pdfFile}`,
-                    activeGroupId,
-                  );
-                  return undefined;
-                }
-              } catch (err) {
-                const message = err instanceof Error ? err.message : String(err);
-                this.logger.error(
-                  `Failed to stat compiled PDF ${pdfFile}: ${message}`,
+        if (compiled) {
+          const pdfFile = path.join(
+            buildDir,
+            path.basename(file).replace(/\.tex$/, '.pdf'),
+          );
+          if (await WorkspaceFS.exists(pdfFile)) {
+            try {
+              const stats = await WorkspaceFS.stat(pdfFile);
+              if (stats.size === 0) {
+                this.logger.warn(
+                  `Compiled PDF is empty for ${file}: ${pdfFile}`,
                   activeGroupId,
                 );
                 return undefined;
               }
-
-              this.logger.info(
-                `Compiled PDF for ${file}: ${pdfFile}`,
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              this.logger.error(
+                `Failed to stat compiled PDF ${pdfFile}: ${message}`,
                 activeGroupId,
               );
-              return pdfFile;
+              return undefined;
             }
+
+            this.logger.info(
+              `Compiled PDF for ${file}: ${pdfFile}`,
+              activeGroupId,
+            );
+            return pdfFile;
           }
+        }
         return undefined;
       }),
     );
@@ -195,11 +195,7 @@ export class LatexMediaManager {
     }
 
     if (includeTikzCompilation && cfg.autoExtractTikzFigure) {
-      await this.compileTikzFigures(
-        existingFiles,
-        toolState,
-        logTikzSummary,
-      );
+      await this.compileTikzFigures(existingFiles, toolState, logTikzSummary);
     }
 
     if (includePdfCompilation && cfg.autoCompileInputPdf) {

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -162,7 +162,7 @@ export class AgentLogger {
    * @param status Status to set for the group ('error' or 'stopped')
    */
   endGroup(groupId: string, status: 'error' | 'stopped' = 'stopped'): void {
-    logger.endGroup(this.channelId, groupId, status);
+    logger.endGroup(this.channelId, groupId, status, this.isAgentLogger);
   }
 
   /**
@@ -170,7 +170,7 @@ export class AgentLogger {
    * @returns The active group ID, or undefined if no active group
    */
   getActiveGroupId(): string | undefined {
-    return logger.getActiveGroupId(this.channelId);
+    return logger.getActiveGroupId(this.channelId, this.isAgentLogger);
   }
 
   /**
@@ -178,6 +178,6 @@ export class AgentLogger {
    * @param groupId The group ID to set as active, or undefined to clear
    */
   setActiveGroupId(groupId: string | undefined): void {
-    logger.setActiveGroupId(this.channelId, groupId);
+    logger.setActiveGroupId(this.channelId, groupId, this.isAgentLogger);
   }
 }

--- a/src/logger/LogChannelRegistry.ts
+++ b/src/logger/LogChannelRegistry.ts
@@ -32,18 +32,18 @@ export class LogChannelRegistry {
     return this.getOrCreate(channel, options).logger;
   }
 
-  getTransport(channel: string): VSCodeTransport | undefined {
-    return this.channels.get(channel)?.transport;
+  getTransport(
+    channel: string,
+    options?: ChannelOptions,
+  ): VSCodeTransport | undefined {
+    const key = this.getKey(channel, options?.isAgent ?? false);
+    return this.channels.get(key)?.transport;
   }
 
   private getOrCreate(channel: string, options: ChannelOptions): ChannelEntry {
-    const existing = this.channels.get(channel);
+    const key = this.getKey(channel, options.isAgent);
+    const existing = this.channels.get(key);
     if (existing) {
-      if (existing.options.isAgent !== options.isAgent) {
-        throw new Error(
-          `Channel ${channel} already registered with isAgent=${existing.options.isAgent}, cannot reuse with isAgent=${options.isAgent}.`,
-        );
-      }
       return existing;
     }
 
@@ -81,7 +81,7 @@ export class LogChannelRegistry {
     });
 
     const entry: ChannelEntry = { logger, transport, options };
-    this.channels.set(channel, entry);
+    this.channels.set(key, entry);
     return entry;
   }
 
@@ -90,6 +90,10 @@ export class LogChannelRegistry {
       this.mainOutputChannel = vscode.window.createOutputChannel('TeXRA');
     }
     return this.mainOutputChannel;
+  }
+
+  private getKey(channel: string, isAgent: boolean): string {
+    return `${channel}::${isAgent ? 'agent' : 'shared'}`;
   }
 }
 

--- a/src/logger/LogChannelRegistry.ts
+++ b/src/logger/LogChannelRegistry.ts
@@ -13,6 +13,7 @@ import type { LogEventSink } from './types/LogEventSink';
 interface ChannelEntry {
   logger: winston.Logger;
   transport: VSCodeTransport;
+  options: ChannelOptions;
 }
 
 interface ChannelOptions {
@@ -23,8 +24,8 @@ export class LogChannelRegistry {
   private mainOutputChannel: vscode.OutputChannel | null = null;
   private readonly channels = new Map<string, ChannelEntry>();
 
-  ensure(channel: string, options: ChannelOptions): void {
-    this.getOrCreate(channel, options);
+  ensure(channel: string, options: ChannelOptions): ChannelEntry {
+    return this.getOrCreate(channel, options);
   }
 
   getLogger(channel: string, options: ChannelOptions): winston.Logger {
@@ -38,6 +39,11 @@ export class LogChannelRegistry {
   private getOrCreate(channel: string, options: ChannelOptions): ChannelEntry {
     const existing = this.channels.get(channel);
     if (existing) {
+      if (existing.options.isAgent !== options.isAgent) {
+        throw new Error(
+          `Channel ${channel} already registered with isAgent=${existing.options.isAgent}, cannot reuse with isAgent=${options.isAgent}.`,
+        );
+      }
       return existing;
     }
 
@@ -74,7 +80,7 @@ export class LogChannelRegistry {
       transports: [transport],
     });
 
-    const entry: ChannelEntry = { logger, transport };
+    const entry: ChannelEntry = { logger, transport, options };
     this.channels.set(channel, entry);
     return entry;
   }
@@ -88,4 +94,3 @@ export class LogChannelRegistry {
 }
 
 export const registry = new LogChannelRegistry();
-

--- a/src/logger/LogChannelRegistry.ts
+++ b/src/logger/LogChannelRegistry.ts
@@ -1,0 +1,91 @@
+// Third-party imports
+import * as winston from 'winston';
+import * as vscode from 'vscode';
+
+// Local imports - config
+import { getConfig } from '@utils/config';
+
+// Local imports - logger
+import { ProgressViewSink } from './sinks/ProgressViewSink';
+import { VSCodeTransport } from './transports/VSCodeTransport';
+import type { LogEventSink } from './types/LogEventSink';
+
+interface ChannelEntry {
+  logger: winston.Logger;
+  transport: VSCodeTransport;
+}
+
+interface ChannelOptions {
+  isAgent: boolean;
+}
+
+export class LogChannelRegistry {
+  private mainOutputChannel: vscode.OutputChannel | null = null;
+  private readonly channels = new Map<string, ChannelEntry>();
+
+  ensure(channel: string, options: ChannelOptions): void {
+    this.getOrCreate(channel, options);
+  }
+
+  getLogger(channel: string, options: ChannelOptions): winston.Logger {
+    return this.getOrCreate(channel, options).logger;
+  }
+
+  getTransport(channel: string): VSCodeTransport | undefined {
+    return this.channels.get(channel)?.transport;
+  }
+
+  private getOrCreate(channel: string, options: ChannelOptions): ChannelEntry {
+    const existing = this.channels.get(channel);
+    if (existing) {
+      return existing;
+    }
+
+    const outputChannel = options.isAgent
+      ? vscode.window.createOutputChannel(`TeXRA ${channel}`)
+      : this.getMainOutputChannel();
+
+    const sink: LogEventSink | undefined = options.isAgent
+      ? new ProgressViewSink()
+      : undefined;
+
+    const transport = new VSCodeTransport({
+      channel: outputChannel,
+      streamName: channel,
+      sink,
+      isAgentChannel: options.isAgent,
+      includeStructuredData: () =>
+        getConfig<boolean>('texra.logger.debugMode', false),
+    });
+
+    const logger = winston.createLogger({
+      levels: {
+        error: 0,
+        warn: 1,
+        info: 2,
+        debug: 3,
+      },
+      level: 'debug',
+      format: winston.format.combine(
+        winston.format.timestamp({
+          format: 'YYYY-MM-DD HH:mm:ss.SSS',
+        }),
+      ),
+      transports: [transport],
+    });
+
+    const entry: ChannelEntry = { logger, transport };
+    this.channels.set(channel, entry);
+    return entry;
+  }
+
+  private getMainOutputChannel(): vscode.OutputChannel {
+    if (!this.mainOutputChannel) {
+      this.mainOutputChannel = vscode.window.createOutputChannel('TeXRA');
+    }
+    return this.mainOutputChannel;
+  }
+}
+
+export const registry = new LogChannelRegistry();
+

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -1,436 +1,130 @@
 // Third-party imports
-import * as vscode from 'vscode';
-import * as winston from 'winston';
-import Transport from 'winston-transport';
-import { encode as encodeHtml } from 'he';
 import { randomUUID } from 'crypto';
 
-// Local imports - progressView
-import { bus } from '@eventBus/ProgressEventBus';
-import { getConfig } from '@utils/config';
-import { TaskGroup, LogMessageData } from './LogTypes';
-import { MESSAGE_TYPES, type MessageType } from './messageTypes';
-import { AgentLogger } from './AgentLogger';
+// Local imports - logger
+import { registry } from './LogChannelRegistry';
+import type { MessageType } from './messageTypes';
+import type { VSCodeTransport } from './transports/VSCodeTransport';
 
-function isValidMessageType(type: unknown): type is MessageType {
-  return Object.values(MESSAGE_TYPES).includes(type as MessageType);
+function getTransport(channel: string): VSCodeTransport | undefined {
+  return registry.getTransport(channel);
 }
 
-const { combine, timestamp } = winston.format;
-
-// Define log levels
-const logLevels = {
-  error: 0,
-  warn: 1,
-  info: 2,
-  debug: 3,
-};
-
-// Centralised emoji mapping for log levels
-export const EMOJI_BY_LEVEL: Record<string, string> = {
-  error: '🔴', // Red dot
-  warn: '🟡', // Yellow dot
-  info: '🟢', // Green dot
-  debug: '🔍', // Magnifying glass
-};
-
-/**
- * Returns the emoji icon associated with a log level.
- * Falls back to a bullet if the level is not recognised.
- */
-export function getColorForLevel(level: string): string {
-  return EMOJI_BY_LEVEL[level.toLowerCase()] ?? '•';
-}
-
-function serializeLogData(data: unknown): unknown {
-  if (data instanceof Error) {
-    return { name: data.name, message: data.message, stack: data.stack };
-  }
-  return data;
-}
-
-// Group State
-
-// Main TeXRA output channel for non-agent logs
-let mainOutputChannel: vscode.OutputChannel | null = null;
-
-// Function to get or create the main output channel
-function getMainOutputChannel(): vscode.OutputChannel {
-  if (!mainOutputChannel) {
-    mainOutputChannel = vscode.window.createOutputChannel('TeXRA');
-  }
-  return mainOutputChannel;
-}
-
-// Create VSCode output channel transport
-class VSCodeTransport extends Transport {
-  private channel: vscode.OutputChannel;
-  private streamName: string;
-  private isAgentChannel: boolean;
-  private groups: Map<string, TaskGroup> = new Map();
-  private activeGroupId?: string;
-
-  constructor(
-    channel: vscode.OutputChannel,
-    streamName: string,
-    isAgentChannel: boolean,
-    opts?: Transport.TransportStreamOptions,
-  ) {
-    super(opts);
-    this.channel = channel;
-    this.streamName = streamName;
-    this.isAgentChannel = isAgentChannel;
-  }
-
-  log(info: any, callback: () => void) {
-    const { level, message, timestamp, messageType } = info;
-    const structuredData = serializeLogData(info.data);
-    const groupId = info.groupId || this.activeGroupId;
-
-    this.writeToChannel(level, message, timestamp, structuredData);
-
-    if (!this.shouldEmitToProgressView(level, messageType)) {
-      callback();
-      return;
-    }
-
-    this.emitToProgressView(
-      level,
-      message,
-      timestamp,
-      groupId,
-      messageType,
-      structuredData,
-    );
-
-    callback();
-  }
-
-  private writeToChannel(
-    level: string,
-    message: string,
-    timestamp: string,
-    structuredData: unknown,
-  ): void {
-    const emoji = getColorForLevel(level);
-    const channelPrefix = this.isAgentChannel ? '' : `[${this.streamName}] `;
-    const formattedMessage = `${emoji} [${timestamp}] ${channelPrefix}${message}`;
-    this.channel.appendLine(formattedMessage);
-
-    if (
-      structuredData !== undefined &&
-      getConfig<boolean>('texra.logger.debugMode', false)
-    ) {
-      const dataString =
-        typeof structuredData === 'string'
-          ? structuredData
-          : JSON.stringify(structuredData, null, 2);
-      this.channel.appendLine(dataString);
-    }
-  }
-
-  private shouldEmitToProgressView(
-    level: string,
-    messageType?: MessageType,
-  ): boolean {
-    if (
-      level === 'debug' &&
-      !getConfig<boolean>('texra.logger.debugMode', false)
-    ) {
-      return false;
-    }
-    if (messageType === MESSAGE_TYPES.INTERNAL) {
-      return false;
-    }
-    if (!this.isAgentChannel) {
-      return false;
-    }
-    return true;
-  }
-
-  private emitToProgressView(
-    level: string,
-    message: string,
-    timestamp: string,
-    groupId: string | undefined,
-    messageType: MessageType | undefined,
-    structuredData: unknown,
-  ): void {
-    const processedMessage = encodeHtml(message);
-    const msgType: MessageType = isValidMessageType(messageType)
-      ? messageType
-      : MESSAGE_TYPES.DEFAULT;
-    const isVerbose = getConfig<boolean>('texra.logger.debugMode', false);
-    const id = randomUUID();
-    const numericTimestamp = new Date(timestamp).getTime();
-    const logMessage = {
-      id,
-      text: processedMessage,
-      level: level as 'error' | 'warn' | 'info' | 'debug',
-      timestamp: numericTimestamp,
-      groupId,
-      messageType: msgType,
-      verbose: isVerbose,
-      data: structuredData,
-    } satisfies import('./LogTypes').LogMessageData;
-    bus.emit('addLogMessage', {
-      stream: this.streamName,
-      logMessage,
-    });
-  }
-
-  // Create a new log group and make it active
-  startGroup(
-    groupName: string,
-    id: string = randomUUID(),
-    parentGroupId?: string,
-  ): string {
-    const groupId = id;
-    const now = Date.now();
-
-    this.groups.set(groupId, {
-      id: groupId,
-      name: groupName,
-      startTime: now,
-      status: 'running',
-      parentGroupId,
-    });
-
-    this.activeGroupId = groupId;
-
-    // Skip progress view updates for non-agent channels
-    if (!this.isAgentChannel) {
-      return groupId;
-    }
-
-    bus.emit('addTaskGroup', {
-      stream: this.streamName,
-      groupId,
-      groupName,
-      startTime: now,
-      status: 'running',
-      endTime: undefined,
-      parentGroupId,
-    });
-
-    return groupId;
-  }
-
-  // End the current group
-  endGroup(groupId: string, status: 'error' | 'stopped' = 'stopped'): void {
-    const group = this.groups.get(groupId);
-    if (!group) {
-      return;
-    }
-
-    const now = Date.now();
-    group.endTime = now;
-    group.status = status;
-
-    // Skip progress view updates for non-agent channels
-    if (!this.isAgentChannel) {
-      return;
-    }
-
-    bus.emit('updateTaskGroup', {
-      stream: this.streamName,
-      groupId,
-      status,
-      endTime: group.endTime,
-    });
-
-    if (this.activeGroupId === groupId) {
-      // If this group has a parent, set that as the active group
-      const parentGroupId = group.parentGroupId;
-      this.activeGroupId = parentGroupId;
-    }
-  }
-
-  // Get the active group ID
-  getActiveGroupId(): string | undefined {
-    return this.activeGroupId;
-  }
-
-  // Set the active group ID explicitly (useful for switching context)
-  setActiveGroupId(groupId: string | undefined): void {
-    if (groupId === undefined || this.groups.has(groupId)) {
-      this.activeGroupId = groupId;
-    }
-  }
-
-  // Get a group by ID
-  getGroup(groupId: string): TaskGroup | undefined {
-    return this.groups.get(groupId);
-  }
-}
-
-// Map to store loggers for different categories
-const channelLoggers = new Map<string, winston.Logger>();
-const channelTransports = new Map<string, VSCodeTransport>();
-
-export function initialize(defaultChannel: string, isAgent = false): void {
-  // Create default logger if it doesn't exist
-  if (!channelLoggers.has(defaultChannel)) {
-    createLoggerForChannel(defaultChannel, isAgent);
-  }
-}
-
-function createLoggerForChannel(
+function getOrCreateTransport(
   channel: string,
-  isAgent = false,
-): winston.Logger {
-  // Check if channel already exists
-  if (channelLoggers.has(channel)) {
-    return channelLoggers.get(channel)!;
+  isAgent: boolean,
+): VSCodeTransport {
+  registry.ensure(channel, { isAgent });
+  const transport = getTransport(channel);
+  if (!transport) {
+    throw new Error(`Failed to initialise logger transport for channel ${channel}`);
   }
-
-  const outputChannel: vscode.OutputChannel = isAgent
-    ? vscode.window.createOutputChannel('TeXRA ' + channel)
-    : getMainOutputChannel();
-
-  // Create transport
-  const transport = new VSCodeTransport(outputChannel, channel, isAgent);
-  channelTransports.set(channel, transport);
-
-  const logger = winston.createLogger({
-    levels: logLevels,
-    level: 'debug',
-    format: combine(
-      timestamp({
-        format: 'YYYY-MM-DD HH:mm:ss.SSS', // Add milliseconds for better precision
-      }),
-    ),
-    transports: [transport],
-  });
-
-  channelLoggers.set(channel, logger);
-  return logger;
+  return transport;
 }
 
-// Start a log group for the given channel
+function logWithGroup(
+  channel: string,
+  level: 'debug' | 'info' | 'warn' | 'error',
+  message: string,
+  groupId?: string,
+  messageType?: MessageType,
+  isAgent = false,
+  data?: unknown,
+): void {
+  const logger = registry.getLogger(channel, { isAgent });
+  const transport = getTransport(channel);
+  const activeGroupId = groupId ?? transport?.getActiveGroupId();
+
+  // @ts-expect-error - winston logger exposes dynamic level helpers
+  logger[level](message, { groupId: activeGroupId, messageType, data });
+}
+
+export function initialize(channel: string, isAgent = false): void {
+  registry.ensure(channel, { isAgent });
+}
+
 export function startGroup(
   channel: string,
   groupName: string,
-  id: string = randomUUID(),
+  id?: string,
   parentGroupId?: string,
   isAgent = false,
 ): string {
-  const transport = channelTransports.get(channel);
-  if (!transport) {
-    createLoggerForChannel(channel, isAgent);
-    const newTransport = channelTransports.get(channel)!;
-    return newTransport.startGroup(groupName, id, parentGroupId);
-  }
-
-  return transport.startGroup(groupName, id, parentGroupId);
+  const transport = getOrCreateTransport(channel, isAgent);
+  const groupId = id ?? randomUUID();
+  return transport.startGroup(groupName, groupId, parentGroupId);
 }
 
-// End a log group
 export function endGroup(
   channel: string,
   groupId: string,
   status: 'error' | 'stopped' = 'stopped',
 ): void {
-  const transport = channelTransports.get(channel);
-  if (transport) {
-    transport.endGroup(groupId, status);
-  }
+  const transport = getTransport(channel);
+  transport?.endGroup(groupId, status);
 }
 
-// Get the active group ID for a channel
 export function getActiveGroupId(channel: string): string | undefined {
-  const transport = channelTransports.get(channel);
+  const transport = getTransport(channel);
   return transport?.getActiveGroupId();
 }
 
-// Set the active group ID for a channel
 export function setActiveGroupId(
   channel: string,
   groupId: string | undefined,
 ): void {
-  const transport = channelTransports.get(channel);
-  if (transport) {
-    transport.setActiveGroupId(groupId);
-  }
+  const transport = getTransport(channel);
+  transport?.setActiveGroupId(groupId);
 }
 
-// Log with group association
-function logWithGroup(
+export function debug(
   channel: string,
-  level: string,
   message: string,
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
   data?: unknown,
 ): void {
-  const logger = getOrCreateLogger(channel, isAgent);
-  const transport = channelTransports.get(channel);
-
-  // If no groupId provided, use the active group
-  const actualGroupId = groupId || transport?.getActiveGroupId();
-
-  // @ts-ignore - We're adding a custom property to the winston log
-  logger[level](message, { groupId: actualGroupId, messageType, data });
+  logWithGroup(channel, 'debug', message, groupId, messageType, isAgent, data);
 }
 
-// Simplified logging methods that use channel as channel name
-export const debug = (
+export function info(
   channel: string,
   message: string,
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
   data?: unknown,
-): void => {
-  logWithGroup(channel, 'debug', message, groupId, messageType, isAgent, data);
-};
-
-export const info = (
-  channel: string,
-  message: string,
-  groupId?: string,
-  messageType?: MessageType,
-  isAgent = false,
-  data?: unknown,
-): void => {
+): void {
   logWithGroup(channel, 'info', message, groupId, messageType, isAgent, data);
-};
+}
 
-export const warn = (
+export function warn(
   channel: string,
   message: string,
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
   data?: unknown,
-): void => {
+): void {
   logWithGroup(channel, 'warn', message, groupId, messageType, isAgent, data);
-};
+}
 
-export const error = (
+export function error(
   channel: string,
   message: string,
   groupId?: string,
   messageType?: MessageType,
   isAgent = false,
   data?: unknown,
-): void => {
+): void {
   logWithGroup(channel, 'error', message, groupId, messageType, isAgent, data);
-};
-
-function getOrCreateLogger(channel: string, isAgent = false): winston.Logger {
-  if (!channelLoggers.has(channel)) {
-    return createLoggerForChannel(channel, isAgent);
-  }
-  return channelLoggers.get(channel)!;
 }
 
 export function getTimestamp(): string {
   return new Date()
     .toLocaleString('en-US', {
       year: '2-digit',
-      // we do not want to show the year
       month: '2-digit',
       day: '2-digit',
       hour12: false,
@@ -440,3 +134,4 @@ export function getTimestamp(): string {
     })
     .replace(',', '');
 }
+

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -14,12 +14,8 @@ function getOrCreateTransport(
   channel: string,
   isAgent: boolean,
 ): VSCodeTransport {
-  registry.ensure(channel, { isAgent });
-  const transport = getTransport(channel);
-  if (!transport) {
-    throw new Error(`Failed to initialise logger transport for channel ${channel}`);
-  }
-  return transport;
+  const entry = registry.ensure(channel, { isAgent });
+  return entry.transport;
 }
 
 function logWithGroup(
@@ -31,12 +27,11 @@ function logWithGroup(
   isAgent = false,
   data?: unknown,
 ): void {
-  const logger = registry.getLogger(channel, { isAgent });
-  const transport = getTransport(channel);
-  const activeGroupId = groupId ?? transport?.getActiveGroupId();
+  const entry = registry.ensure(channel, { isAgent });
+  const { logger, transport } = entry;
+  const activeGroupId = groupId ?? transport.getActiveGroupId();
 
-  // @ts-expect-error - winston logger exposes dynamic level helpers
-  logger[level](message, { groupId: activeGroupId, messageType, data });
+  logger.log(level, message, { groupId: activeGroupId, messageType, data });
 }
 
 export function initialize(channel: string, isAgent = false): void {
@@ -134,4 +129,3 @@ export function getTimestamp(): string {
     })
     .replace(',', '');
 }
-

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -6,8 +6,11 @@ import { registry } from './LogChannelRegistry';
 import type { MessageType } from './messageTypes';
 import type { VSCodeTransport } from './transports/VSCodeTransport';
 
-function getTransport(channel: string): VSCodeTransport | undefined {
-  return registry.getTransport(channel);
+function getTransport(
+  channel: string,
+  isAgent = false,
+): VSCodeTransport | undefined {
+  return registry.getTransport(channel, { isAgent });
 }
 
 function getOrCreateTransport(
@@ -54,21 +57,26 @@ export function endGroup(
   channel: string,
   groupId: string,
   status: 'error' | 'stopped' = 'stopped',
+  isAgent = false,
 ): void {
-  const transport = getTransport(channel);
+  const transport = getTransport(channel, isAgent);
   transport?.endGroup(groupId, status);
 }
 
-export function getActiveGroupId(channel: string): string | undefined {
-  const transport = getTransport(channel);
+export function getActiveGroupId(
+  channel: string,
+  isAgent = false,
+): string | undefined {
+  const transport = getTransport(channel, isAgent);
   return transport?.getActiveGroupId();
 }
 
 export function setActiveGroupId(
   channel: string,
   groupId: string | undefined,
+  isAgent = false,
 ): void {
-  const transport = getTransport(channel);
+  const transport = getTransport(channel, isAgent);
   transport?.setActiveGroupId(groupId);
 }
 

--- a/src/logger/sinks/ProgressViewSink.ts
+++ b/src/logger/sinks/ProgressViewSink.ts
@@ -73,4 +73,3 @@ export class ProgressViewSink implements LogEventSink {
     });
   }
 }
-

--- a/src/logger/sinks/ProgressViewSink.ts
+++ b/src/logger/sinks/ProgressViewSink.ts
@@ -1,0 +1,76 @@
+// Third-party imports
+import { randomUUID } from 'crypto';
+import { encode as encodeHtml } from 'he';
+
+// Local imports - progress view
+import { bus } from '@eventBus/ProgressEventBus';
+import { getConfig } from '@utils/config';
+import type { LogMessageData } from '../LogTypes';
+import { MESSAGE_TYPES, type MessageType } from '../messageTypes';
+import type {
+  LogEventSink,
+  LogGroupFinishedEvent,
+  LogGroupStartedEvent,
+  LogMessageEvent,
+} from '../types/LogEventSink';
+
+function isValidMessageType(type: unknown): type is MessageType {
+  return Object.values(MESSAGE_TYPES).includes(type as MessageType);
+}
+
+export class ProgressViewSink implements LogEventSink {
+  handleLogMessage(event: LogMessageEvent): void {
+    if (event.messageType === MESSAGE_TYPES.INTERNAL) {
+      return;
+    }
+
+    const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
+    if (event.level === 'debug' && !debugMode) {
+      return;
+    }
+
+    const processedMessage = encodeHtml(event.message);
+    const messageType: MessageType = isValidMessageType(event.messageType)
+      ? event.messageType
+      : MESSAGE_TYPES.DEFAULT;
+    const id = randomUUID();
+    const timestamp = new Date(event.timestamp).getTime();
+    const logMessage: LogMessageData = {
+      id,
+      text: processedMessage,
+      level: event.level as LogMessageData['level'],
+      timestamp,
+      groupId: event.groupId,
+      messageType,
+      verbose: debugMode,
+      data: event.data,
+    };
+
+    bus.emit('addLogMessage', {
+      stream: event.stream,
+      logMessage,
+    });
+  }
+
+  handleGroupStarted(event: LogGroupStartedEvent): void {
+    bus.emit('addTaskGroup', {
+      stream: event.stream,
+      groupId: event.groupId,
+      groupName: event.groupName,
+      startTime: event.startTime,
+      status: 'running',
+      endTime: undefined,
+      parentGroupId: event.parentGroupId,
+    });
+  }
+
+  handleGroupFinished(event: LogGroupFinishedEvent): void {
+    bus.emit('updateTaskGroup', {
+      stream: event.stream,
+      groupId: event.groupId,
+      status: event.status,
+      endTime: event.endTime,
+    });
+  }
+}
+

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -1,0 +1,158 @@
+// Third-party imports
+import * as vscode from 'vscode';
+import Transport from 'winston-transport';
+
+// Local imports - logger
+import { getColorForLevel } from '../utils/levelColors';
+import type {
+  LogEventSink,
+  LogGroupFinishedEvent,
+  LogGroupStartedEvent,
+  LogMessageEvent,
+} from '../types/LogEventSink';
+import { serializeLogData } from '../utils/serializeLogData';
+
+interface VSCodeTransportOptions extends Transport.TransportStreamOptions {
+  channel: vscode.OutputChannel;
+  streamName: string;
+  sink?: LogEventSink;
+  isAgentChannel: boolean;
+  includeStructuredData?: () => boolean;
+}
+
+interface TransportGroup {
+  id: string;
+  name: string;
+  startTime: number;
+  status: 'running' | 'error' | 'stopped';
+  parentGroupId?: string;
+  endTime?: number;
+}
+
+export class VSCodeTransport extends Transport {
+  private readonly channel: vscode.OutputChannel;
+  private readonly streamName: string;
+  private readonly sink?: LogEventSink;
+  private readonly isAgentChannel: boolean;
+  private readonly includeStructuredData?: () => boolean;
+  private readonly groups = new Map<string, TransportGroup>();
+  private activeGroupId?: string;
+
+  constructor(options: VSCodeTransportOptions) {
+    super(options);
+    this.channel = options.channel;
+    this.streamName = options.streamName;
+    this.sink = options.sink;
+    this.isAgentChannel = options.isAgentChannel;
+    this.includeStructuredData = options.includeStructuredData;
+  }
+
+  log(info: any, callback: () => void): void {
+    const { level, message, timestamp, messageType } = info;
+    const structuredData = serializeLogData(info.data);
+    const groupId = info.groupId ?? this.activeGroupId;
+
+    this.writeToChannel(level, message, timestamp, structuredData);
+    this.emitLogEvent({
+      level,
+      message,
+      timestamp,
+      stream: this.streamName,
+      groupId,
+      messageType,
+      data: structuredData,
+    });
+
+    callback();
+  }
+
+  startGroup(groupName: string, id: string, parentGroupId?: string): string {
+    const now = Date.now();
+    const group: TransportGroup = {
+      id,
+      name: groupName,
+      startTime: now,
+      status: 'running',
+      parentGroupId,
+    };
+    this.groups.set(id, group);
+    this.activeGroupId = id;
+
+    this.emitGroupStarted({
+      stream: this.streamName,
+      groupId: id,
+      groupName,
+      startTime: now,
+      parentGroupId,
+    });
+
+    return id;
+  }
+
+  endGroup(groupId: string, status: 'error' | 'stopped'): void {
+    const group = this.groups.get(groupId);
+    if (!group) {
+      return;
+    }
+
+    group.endTime = Date.now();
+    group.status = status;
+    this.emitGroupFinished({
+      stream: this.streamName,
+      groupId,
+      status,
+      endTime: group.endTime,
+    });
+
+    if (this.activeGroupId === groupId) {
+      this.activeGroupId = group.parentGroupId;
+    }
+  }
+
+  getActiveGroupId(): string | undefined {
+    return this.activeGroupId;
+  }
+
+  setActiveGroupId(groupId: string | undefined): void {
+    if (groupId === undefined || this.groups.has(groupId)) {
+      this.activeGroupId = groupId;
+    }
+  }
+
+  private writeToChannel(
+    level: string,
+    message: string,
+    timestamp: string,
+    structuredData: unknown,
+  ): void {
+    const emoji = getColorForLevel(level);
+    const channelPrefix = this.isAgentChannel ? '' : `[${this.streamName}] `;
+    const formattedMessage = `${emoji} [${timestamp}] ${channelPrefix}${message}`;
+    this.channel.appendLine(formattedMessage);
+
+    if (
+      structuredData !== undefined &&
+      structuredData !== null &&
+      this.includeStructuredData?.()
+    ) {
+      const dataString =
+        typeof structuredData === 'string'
+          ? structuredData
+          : JSON.stringify(structuredData, null, 2);
+      this.channel.appendLine(dataString);
+    }
+  }
+
+  private emitLogEvent(event: LogMessageEvent): void {
+    this.sink?.handleLogMessage(event);
+  }
+
+  private emitGroupStarted(event: LogGroupStartedEvent): void {
+    this.sink?.handleGroupStarted(event);
+  }
+
+  private emitGroupFinished(event: LogGroupFinishedEvent): void {
+    this.sink?.handleGroupFinished(event);
+  }
+}
+

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -155,4 +155,3 @@ export class VSCodeTransport extends Transport {
     this.sink?.handleGroupFinished(event);
   }
 }
-

--- a/src/logger/types/LogEventSink.ts
+++ b/src/logger/types/LogEventSink.ts
@@ -1,0 +1,37 @@
+// Third-party imports
+// (none)
+
+// Local imports - logger
+import type { MessageType } from '../messageTypes';
+
+export interface LogMessageEvent {
+  level: string;
+  message: string;
+  timestamp: string;
+  stream: string;
+  groupId?: string;
+  messageType?: MessageType;
+  data?: unknown;
+}
+
+export interface LogGroupStartedEvent {
+  stream: string;
+  groupId: string;
+  groupName: string;
+  startTime: number;
+  parentGroupId?: string;
+}
+
+export interface LogGroupFinishedEvent {
+  stream: string;
+  groupId: string;
+  status: 'error' | 'stopped';
+  endTime: number;
+}
+
+export interface LogEventSink {
+  handleLogMessage(event: LogMessageEvent): void;
+  handleGroupStarted(event: LogGroupStartedEvent): void;
+  handleGroupFinished(event: LogGroupFinishedEvent): void;
+}
+

--- a/src/logger/types/LogEventSink.ts
+++ b/src/logger/types/LogEventSink.ts
@@ -34,4 +34,3 @@ export interface LogEventSink {
   handleGroupStarted(event: LogGroupStartedEvent): void;
   handleGroupFinished(event: LogGroupFinishedEvent): void;
 }
-

--- a/src/logger/utils/levelColors.ts
+++ b/src/logger/utils/levelColors.ts
@@ -1,0 +1,17 @@
+// Third-party imports
+// (none)
+
+// Local imports - types
+// (none)
+
+const EMOJI_BY_LEVEL: Record<string, string> = {
+  error: '🔴',
+  warn: '🟡',
+  info: '🟢',
+  debug: '🔍',
+};
+
+export function getColorForLevel(level: string): string {
+  return EMOJI_BY_LEVEL[level.toLowerCase()] ?? '•';
+}
+

--- a/src/logger/utils/levelColors.ts
+++ b/src/logger/utils/levelColors.ts
@@ -14,4 +14,3 @@ const EMOJI_BY_LEVEL: Record<string, string> = {
 export function getColorForLevel(level: string): string {
   return EMOJI_BY_LEVEL[level.toLowerCase()] ?? '•';
 }
-

--- a/src/logger/utils/serializeLogData.ts
+++ b/src/logger/utils/serializeLogData.ts
@@ -5,9 +5,11 @@
 // (none)
 
 export function serializeLogData(data: unknown): unknown {
+  if (data === undefined || data === null) {
+    return data;
+  }
   if (data instanceof Error) {
     return { name: data.name, message: data.message, stack: data.stack };
   }
   return data;
 }
-

--- a/src/logger/utils/serializeLogData.ts
+++ b/src/logger/utils/serializeLogData.ts
@@ -1,0 +1,13 @@
+// Third-party imports
+// (none)
+
+// Local imports - types
+// (none)
+
+export function serializeLogData(data: unknown): unknown {
+  if (data instanceof Error) {
+    return { name: data.name, message: data.message, stack: data.stack };
+  }
+  return data;
+}
+


### PR DESCRIPTION
## Summary
- introduce a log channel registry to own logger and transport lifecycles
- extract the VS Code transport and progress view sink into focused modules
- simplify logUtils to delegate logging and group operations through the registry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69079033784883248cb545527a9b32cf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a registry-backed logger with modular VS Code transport and progress view sink, refactoring log utilities and AgentLogger; minor LaTeX/agent call cleanups.
> 
> - **Logger Architecture**:
>   - **Registry**: Add `src/logger/LogChannelRegistry.ts` to own logger/transport lifecycles and main/shared channels.
>   - **Transport & Sink**: Extract `VSCodeTransport` (`src/logger/transports/VSCodeTransport.ts`) and `ProgressViewSink` (`src/logger/sinks/ProgressViewSink.ts`).
>   - **Utilities**: Add `utils/levelColors.ts` and `utils/serializeLogData.ts`; define `types/LogEventSink.ts` for typed events.
>   - **logUtils Refactor**: Replace inlined transport/logger logic with delegation to `registry`; expose `initialize`, `startGroup`, `endGroup`, `get/setActiveGroupId`, and level methods.
>   - **AgentLogger Integration**: Pass `isAgentLogger` through to group/active-group operations.
> - **Latex/Agent Minor Changes**:
>   - Streamline function calls and logging in `LatexDiffManager` and `LatexMediaManager`.
>   - Tiny formatting cleanup in `BaseReflectionAgent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 620abf3627f8f523991ce2a01148f5ee5e37cd19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->