### PR TITLE
fix: execute string commands via shell

### DIFF
--- a/src/test/utils/system/execUtils.test.ts
+++ b/src/test/utils/system/execUtils.test.ts
@@ -1,0 +1,27 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - utils
+import { executeCommand } from '@utils/system/execUtils';
+
+describe('executeCommand', () => {
+  it('runs string commands with shell operators intact', async () => {
+    const result = await executeCommand(
+      'node -e "process.stdout.write(\'one\')" && echo two',
+    );
+
+    assert.ok(result.success);
+    assert.strictEqual(result.stdout, 'onetwo');
+    assert.strictEqual(result.stderr, null);
+  });
+
+  it('preserves fallback execution with logical OR', async () => {
+    const result = await executeCommand(
+      'node -e "process.exit(1)" || echo fallback',
+    );
+
+    assert.ok(result.success);
+    assert.strictEqual(result.stdout, 'fallback');
+    assert.strictEqual(result.stderr, null);
+  });
+});

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import { execa, type Options, ExecaError } from 'execa';
-import { parse as shellParse } from 'shell-quote';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -84,23 +83,11 @@ export async function executeCommand(
       exitCode = result.exitCode ?? 1;
       timedOut = result.timedOut ?? false;
     } else {
-      // Parse string command into arguments using shell-quote to handle quoted arguments
-      const parsedArgs = shellParse(command);
-      // Filter out non-string elements (shell-quote can return objects for operators)
-      const stringArgs = parsedArgs.filter(
-        (arg): arg is string => typeof arg === 'string',
-      );
-
-      if (stringArgs.length === 0) {
-        throw new Error('Invalid command: no executable found');
-      }
-
-      const [cmd, ...args] = stringArgs;
-      logger.debug(
-        options.channel ?? CHANNEL,
-        `Running command: ${cmd} ${args.join(' ')}`,
-      );
-      const result = await execa(cmd, args, execaOptions);
+      logger.debug(options.channel ?? CHANNEL, `Running command: ${command}`);
+      const result = await execa(command, {
+        ...execaOptions,
+        shell: true,
+      });
       stdout = (result.stdout as string) ?? '';
       stderr = (result.stderr as string) ?? '';
       exitCode = result.exitCode ?? 1;

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { execa, type Options, ExecaError } from 'execa';
+import { quote as shellQuote } from 'shell-quote';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -73,9 +74,10 @@ export async function executeCommand(
     if (Array.isArray(command)) {
       // Use execa directly with argument array to avoid shell injection
       const [cmd, ...args] = command;
+      const commandForLog = shellQuote([cmd, ...args]);
       logger.debug(
         options.channel ?? CHANNEL,
-        `Running command: ${cmd} ${args.join(' ')}`,
+        `Running command: ${commandForLog}`,
       );
       const result = await execa(cmd, args, execaOptions);
       stdout = (result.stdout as string) ?? '';


### PR DESCRIPTION
## Summary
- run string commands through the system shell so built-in operators remain intact
- add regression coverage ensuring executeCommand supports logical AND/OR chains

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_6908a420be7c83248a114560fc01ff4e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Run string commands via the system shell to preserve operators, add tests for &&/||, and improve logging for array commands.
> 
> - **Utils (`src/utils/system/execUtils.ts`)**:
>   - Execute string commands via `execa(command, { shell: true })` to preserve shell operators.
>   - Improve logging for array commands using `shell-quote` to safely render `commandForLog`.
>   - Remove string command parsing logic; log raw string command instead.
> - **Tests (`src/test/utils/system/execUtils.test.ts`)**:
>   - Add regression tests verifying `&&` chains and `||` fallback behavior with `executeCommand`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dd89b5374b8a4409c38aa760d0c26ccd9e9a3e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->