### PR TITLE
refactor: simplify agent logging scopes

### DIFF
--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -4,6 +4,7 @@ import type { AgentConfig } from './AgentConfig';
 import type { AgentSessionDescriptor } from './AgentDataclass';
 // Local imports - agent types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 
 /**
  * Minimal interface implemented by all agent types.
@@ -43,6 +44,9 @@ export interface IAgent {
    * Return the most recent run group identifier for logging fallbacks.
    */
   getLastRunGroupId(): string | undefined;
+
+  /** Retrieve the shared execution context for this agent. */
+  getExecutionContext(): AgentExecutionContext;
 
   /**
    * Retrieve the hooks used to orchestrate an agent run.

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -12,11 +12,11 @@ import { UsageMonitor } from '../utils/UsageMonitor';
 import { buildUserVars } from '../utils/userVars';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
-import { getStreamTabId as buildStreamTabId } from '@/logger/streamUtils';
 
 // Local imports - utilities
 import { SHORT_SLEEP_MS } from '@utils/config';
@@ -31,6 +31,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   protected agentSetting: AgentSetting;
   protected agentPrompt: AgentPrompt;
   protected agentPath: string;
+  protected readonly context: AgentExecutionContext;
   protected logger: AgentLogger;
   protected usageMonitor: UsageMonitor;
   protected runGroupId?: string;
@@ -47,6 +48,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     return this.agentConfig;
   }
 
+  public getExecutionContext(): AgentExecutionContext {
+    return this.context;
+  }
+
   public getSessionMetadata(): AgentSessionDescriptor {
     if (!this.agentConfig.session) {
       throw new Error('Agent configuration is missing session metadata.');
@@ -61,24 +66,20 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
+    context: AgentExecutionContext,
   ) {
     this.modelHandler = modelHandler;
     this.agentConfig = agentConfig;
     this.agentSetting = agentSetting;
     this.agentPrompt = agentPrompt;
     this.agentPath = agentPath;
-    this.executionId = executionId;
+    this.context = context;
+    this.executionId = context.executionId;
 
-    const streamTabId = this.getStreamTabId();
-    this.logger = new AgentLogger(streamTabId, true);
+    this.logger = context.logger;
     this.modelHandler.setLogger(this.logger);
     this.modelHandler.setAgentType(this.agentSetting.agentType);
-    this.usageMonitor = new UsageMonitor(
-      this.modelHandler,
-      this.logger.channelId,
-      this.logger,
-    );
+    this.usageMonitor = new UsageMonitor(this.modelHandler, context);
   }
 
   /** Initialize the API client. */
@@ -118,17 +119,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
 
   /** Compute the stream tab identifier for this agent execution. */
   public getStreamTabId(): StreamTabId {
-    const metadata = this.getSessionMetadata();
-    return buildStreamTabId(
-      this.agentConfig.agent,
-      this.agentConfig.model,
-      this.agentConfig.inputFile,
-      {
-        agentType: metadata.agentType,
-        executionId: this.executionId,
-        useMultipleOutputs: this.agentConfig.useMultipleOutputs,
-      },
-    );
+    return this.context.streamId;
   }
 
   /** Gather variables used for prompt rendering. */
@@ -149,36 +140,28 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     options?: { createGroup?: boolean },
   ): Promise<void> {
     const { createGroup = true } = options ?? {};
-    const initGroupId = createGroup
-      ? await this.logger.startGroup(`Init`, undefined, parentGroupId)
-      : parentGroupId;
-
-    try {
-      this.logger.debug(
-        `AgentConfig: ${JSON.stringify(this.agentConfig)}`,
-        initGroupId,
-      );
-      this.logger.debug(
-        `AgentSetting: ${JSON.stringify(this.agentSetting)}`,
-        initGroupId,
-      );
+    const runInit = async () => {
+      this.logger.debug(`AgentConfig: ${JSON.stringify(this.agentConfig)}`);
+      this.logger.debug(`AgentSetting: ${JSON.stringify(this.agentSetting)}`);
       this.logger.debug(
         `ModelConfig: ${JSON.stringify(this.modelHandler.config)}`,
-        initGroupId,
       );
 
       this.userVars = await this.getUserVars();
       this.registerRunningAgent(this.getStreamTabId());
+    };
 
-      if (createGroup && initGroupId) {
-        this.logger.endGroup(initGroupId, 'stopped');
-      }
-    } catch (error) {
-      if (createGroup && initGroupId) {
-        this.logger.endGroup(initGroupId, 'error');
-      }
-      throw error;
+    if (createGroup) {
+      await this.logger.withScope(`Init`, runInit, { parentGroupId });
+      return;
     }
+
+    if (parentGroupId) {
+      await this.logger.withActiveGroup(parentGroupId, runInit);
+      return;
+    }
+
+    await runInit();
   }
 
   /** Interrupt the agent's execution. */
@@ -230,23 +213,11 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
    */
   protected async withRoundGroup<T>(
     groupLabel: string,
-    callback: (groupId: string) => Promise<T>,
+    callback: () => Promise<T>,
   ): Promise<T> {
-    const groupId = await this.logger.startGroup(
-      groupLabel,
-      undefined,
-      this.runGroupId,
-    );
-
-    let status: 'stopped' | 'error' = 'stopped';
-    try {
-      return await callback(groupId);
-    } catch (error) {
-      status = 'error';
-      throw error;
-    } finally {
-      this.logger.endGroup(groupId, status);
-    }
+    return this.logger.withScope(groupLabel, callback, {
+      parentGroupId: this.runGroupId,
+    });
   }
 
   /**

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -30,7 +30,7 @@ import {
   IOutputHandler,
   type RoundOutputArtifacts,
 } from '@agent/output';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import { writePromptToXml } from '@agent/utils/promptUtils';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -123,7 +123,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
+    context: AgentExecutionContext,
   ) {
     const workflowSetting = requireWorkflowSetting(agentSetting);
     super(
@@ -132,7 +132,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       workflowSetting,
       agentPrompt,
       agentPath,
-      executionId,
+      context,
     );
     this.agentSetting = workflowSetting;
 
@@ -537,7 +537,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     this.logger.debug(`Processing round ${roundIndex}`);
     const toolState = new ToolState();
 
-    return this.withRoundGroup(`r${roundIndex}`, async (_roundGroupId) => {
+    return this.withRoundGroup(`r${roundIndex}`, async () => {
       const shared: ReflectionRoundShared = {
         runtime: {
           toolState,

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -27,7 +27,8 @@ import type { AgentRunHooks } from '@agent/implementations/flows/common/types';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
-import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   ToolUseSessionManager,
@@ -54,7 +55,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
+    context: AgentExecutionContext,
   ) {
     super(
       modelHandler,
@@ -62,7 +63,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       agentSetting,
       agentPrompt,
       agentPath,
-      executionId,
+      context,
     );
     this.toolRegistry = DEFAULT_TOOL_REGISTRY;
   }

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -10,7 +10,7 @@ import { RoundOutputOptions } from './BaseReflectionAgent';
 // Local imports - agent components
 import { DirectAgent } from './DirectAgent';
 import type { IModelHandler } from '@agent/modelHandlers';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 
 /**
  * Specialized agent for merging multiple edited files into a consolidated output.
@@ -23,7 +23,7 @@ export class MergeAgent extends DirectAgent {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
+    context: AgentExecutionContext,
   ) {
     super(
       modelHandler,
@@ -31,7 +31,7 @@ export class MergeAgent extends DirectAgent {
       agentSetting,
       agentPrompt,
       agentPath,
-      executionId,
+      context,
     );
     this.outputFile = [this.getOutputFile(0), this.getOutputFile(1)];
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1,9 +1,5 @@
-// Standard library imports
-import { randomUUID } from 'crypto';
-
 // Third-party imports
 import { FinishReason } from '@google/genai';
-import { encode as encodeHtml } from 'he';
 
 // Local imports - agent components
 import type { AgentConfig } from '../core/AgentConfig';
@@ -22,12 +18,9 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import { MediaAttachmentProcessor } from './support/MediaAttachmentProcessor';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
-// Local imports - events
-import { bus } from '@eventBus/ProgressEventBus';
-
 // Local imports - log
 import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES, MessageType } from '@logger/messageTypes';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
 import {
   ModelConfig,
@@ -165,106 +158,23 @@ export abstract class ModelHandler<
   }
 
   /**
-   * Creates a log stream for progressive updates to the Progress view.
-   *
-   * @param type Message type for the stream.
-   * @param groupId Optional log group identifier.
-   * @returns Object with `append` and `finalize` helpers.
-   */
-  protected createLogStream(type: MessageType, groupId?: string) {
-    const streamId = this.logger.channelId;
-    const id = randomUUID();
-    let buffer = '';
-    let isFirstUpdate = true;
-
-    return {
-      append: (text: string) => {
-        if (!text) return;
-        buffer += text;
-
-        if (!this.progressViewEnabled) {
-          return;
-        }
-
-        // Use addLogMessage for the first update, updateLogMessage for subsequent ones
-        if (isFirstUpdate) {
-          bus.emit('addLogMessage', {
-            stream: streamId,
-            logMessage: {
-              id,
-              text: encodeHtml(buffer),
-              level: 'info',
-              timestamp: Date.now(),
-              groupId,
-              messageType: type,
-            },
-          });
-          isFirstUpdate = false;
-        } else {
-          bus.emit('updateLogMessage', {
-            stream: streamId,
-            logMessage: {
-              id,
-              text: encodeHtml(buffer),
-              groupId,
-              messageType: type,
-            },
-          });
-        }
-      },
-      finalize: (finalText?: string) => {
-        if (typeof finalText === 'string') {
-          buffer = finalText;
-        }
-
-        if (!this.progressViewEnabled) {
-          this.logger.debug(`Final ${type} length: ${buffer.length}`, groupId);
-          return buffer;
-        }
-
-        // If we never appended anything, create the initial entry
-        if (isFirstUpdate) {
-          bus.emit('addLogMessage', {
-            stream: streamId,
-            logMessage: {
-              id,
-              text: encodeHtml(buffer),
-              level: 'info',
-              timestamp: Date.now(),
-              groupId,
-              messageType: type,
-            },
-          });
-        } else {
-          bus.emit('updateLogMessage', {
-            stream: streamId,
-            logMessage: {
-              id,
-              text: encodeHtml(buffer),
-              groupId,
-              messageType: type,
-            },
-          });
-        }
-
-        this.logger.debug(`Final ${type} length: ${buffer.length}`, groupId);
-        return buffer;
-      },
-    };
-  }
-
-  /**
    * Convenience wrapper for thinking streams.
    */
   protected createThinkingStream(groupId?: string) {
-    return this.createLogStream(MESSAGE_TYPES.THINKING, groupId);
+    return this.logger.createStream(MESSAGE_TYPES.THINKING, {
+      groupId,
+      progressViewEnabled: this.progressViewEnabled,
+    });
   }
 
   /**
    * Convenience wrapper for output streams.
    */
   protected createOutputStream(groupId?: string) {
-    return this.createLogStream(MESSAGE_TYPES.MODEL_RESPONSE, groupId);
+    return this.logger.createStream(MESSAGE_TYPES.MODEL_RESPONSE, {
+      groupId,
+      progressViewEnabled: this.progressViewEnabled,
+    });
   }
 
   /**

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -1,0 +1,32 @@
+// Local imports - agent types
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+
+// Local imports - logger
+import { AgentLogger } from '@logger/AgentLogger';
+import { AgentUsageReporter } from '@logger/AgentUsageReporter';
+
+export interface AgentExecutionContextInit {
+  streamId: StreamTabId;
+  executionId?: ExecutionId;
+}
+
+/**
+ * Aggregates shared execution state so collaborators avoid plumbing IDs.
+ */
+export class AgentExecutionContext {
+  public readonly logger: AgentLogger;
+  public readonly usageReporter: AgentUsageReporter;
+
+  constructor(private readonly init: AgentExecutionContextInit) {
+    this.logger = new AgentLogger(init.streamId, true);
+    this.usageReporter = new AgentUsageReporter(this.logger, init.streamId);
+  }
+
+  get streamId(): StreamTabId {
+    return this.init.streamId;
+  }
+
+  get executionId(): ExecutionId | undefined {
+    return this.init.executionId;
+  }
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -30,12 +30,16 @@ import {
   AgentDirectorySource,
   type AgentPathResolution,
 } from './AgentPathTypes';
+import {
+  AgentExecutionContext,
+  type AgentExecutionContextInit,
+} from './AgentExecutionContext';
 
 // Local imports - utilities
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
-import { withLogGroup } from '@logger/logGroupUtils';
+import { getStreamTabId } from '@/logger/streamUtils';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { agentConfigToTaskState } from '@utils/config';
@@ -61,7 +65,7 @@ type AgentConstructor = {
     agentSetting: AgentSetting,
     agentPrompt: AgentPrompt,
     agentPath: string,
-    executionId?: ExecutionId,
+    context: AgentExecutionContext,
   ): IAgent;
 };
 
@@ -163,6 +167,8 @@ interface PrepareAgentInstanceParams {
   executionId?: ExecutionId;
   /** Optional agent class to use instead of automatic selection based on agent type */
   agentClassOverride?: AgentConstructor;
+  /** Optional factory for constructing the execution context */
+  contextFactory?: (init: AgentExecutionContextInit) => AgentExecutionContext;
 }
 
 /**
@@ -204,8 +210,14 @@ interface PrepareAgentInstanceParams {
  */
 export async function prepareAgentInstance<T extends IAgent = IAgent>(
   params: PrepareAgentInstanceParams,
-): Promise<{ agent: T; agentType: AgentType }> {
-  const { agentName, configPayload, executionId, agentClassOverride } = params;
+): Promise<{ agent: T; agentType: AgentType; context: AgentExecutionContext }> {
+  const {
+    agentName,
+    configPayload,
+    executionId,
+    agentClassOverride,
+    contextFactory,
+  } = params;
 
   const configInput: Partial<AgentConfig> = {
     agent: agentName,
@@ -268,16 +280,30 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
   const AgentClass = (agentClassOverride ??
     getAgentClass(agentSetting)) as AgentConstructor;
 
+  const streamId = getStreamTabId(agentConfig.agent, modelName, agentConfig.inputFile, {
+    agentType: agentSetting.agentType,
+    executionId,
+    useMultipleOutputs: agentConfig.useMultipleOutputs,
+  });
+
+  const context = contextFactory
+    ? contextFactory({ streamId, executionId })
+    : new AgentExecutionContext({ streamId, executionId });
+
   const agent = new AgentClass(
     modelHandler,
     agentConfig,
     agentSetting,
     agentPrompt,
     resolution.directory,
-    executionId,
+    context,
   );
 
-  return { agent: agent as T, agentType: agentSetting.agentType };
+  return {
+    agent: agent as T,
+    agentType: agentSetting.agentType,
+    context,
+  };
 }
 
 /**
@@ -289,19 +315,37 @@ interface ExecuteAgentOptions {
 
 export async function executeAgentWithLogging<T extends IAgent>(
   agentName: string,
-  createAgentFn: () => Promise<{ agent: T; agentType?: AgentType }>,
+  createAgentFn: (
+    contextFactory: (init: AgentExecutionContextInit) => AgentExecutionContext,
+  ) => Promise<{
+    agent: T;
+    agentType?: AgentType;
+    context?: AgentExecutionContext;
+  }>,
   executionId?: ExecutionId,
   options?: ExecuteAgentOptions,
 ): Promise<void> {
   const isResume = options?.resume ?? false;
   let streamTabId: StreamTabId | undefined;
-  let agentStreamLogger: AgentLogger | undefined;
   let agent: T | undefined;
+  let executionContext: AgentExecutionContext | undefined;
+  let contextLogger: AgentLogger | undefined;
   try {
+    const contextFactory = (init: AgentExecutionContextInit) => {
+      if (executionContext?.streamId === init.streamId) {
+        return executionContext;
+      }
+      executionContext = new AgentExecutionContext(init);
+      return executionContext;
+    };
+
     // Create agent instance and extract its declared type
-    const created = await createAgentFn();
+    const created = await createAgentFn(contextFactory);
     agent = created.agent;
     const { agentType } = created;
+    executionContext = created.context ?? executionContext ?? agent.getExecutionContext();
+
+    contextLogger = executionContext.logger;
     const sessionMetadata = agent.getSessionMetadata();
 
     if (executionId) {
@@ -323,8 +367,6 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
     const activeStreamId: StreamTabId = streamTabId;
 
-    agentStreamLogger = new AgentLogger(activeStreamId, true);
-
     // Check if this stream is already running
     const provider = ProgressViewProvider.getInstance();
     const currentStatus =
@@ -334,37 +376,24 @@ export async function executeAgentWithLogging<T extends IAgent>(
       throw new Error(errorMsg);
     }
 
-    await withLogGroup(
-      logger,
+    await logger.withScope(
       `Task: ${agentName}@${config.model}`,
-      async (mainTaskGroupId) => {
+      async () => {
         try {
-          await withLogGroup(
-            logger,
+          await logger.withScope(
             `Task Details`,
-            async (taskDetailsGroupId) => {
-              if (!isResume && taskDetailsGroupId) {
-                logger.info(
-                  `Starting task execution for ${activeStreamId}`,
-                  taskDetailsGroupId,
-                );
-                logger.info(
-                  `Input file: ${config.inputFile}`,
-                  taskDetailsGroupId,
-                );
+            async () => {
+              if (!isResume) {
+                logger.info(`Starting task execution for ${activeStreamId}`);
+                logger.info(`Input file: ${config.inputFile}`);
               }
 
-              logger.debug(
-                `Creating stream with ID: ${activeStreamId}`,
-                taskDetailsGroupId,
-              );
+              logger.debug(`Creating stream with ID: ${activeStreamId}`);
               logger.debug(
                 `Agent name: ${agentName}, Model: ${config.model}, Input file: ${config.inputFile}`,
-                taskDetailsGroupId,
               );
               logger.debug(
                 `Config has output files: ${!!config.outputFiles}, Number of output files: ${config.outputFiles?.length || 0}, useMultipleOutputs: ${config.useMultipleOutputs}`,
-                taskDetailsGroupId,
               );
 
               // Switch to this stream and set its status to running
@@ -426,64 +455,42 @@ export async function executeAgentWithLogging<T extends IAgent>(
                     });
                 }
 
-                // Store taskState
-                logger.debug(
-                  `Storing taskState for stream: ${activeStreamId}`,
-                  taskDetailsGroupId,
-                );
-                logger.debug(
-                  `Config for taskState: ${JSON.stringify(config)}`,
-                  taskDetailsGroupId,
-                );
+                logger.debug(`Storing taskState for stream: ${activeStreamId}`);
+                logger.debug(`Config for taskState: ${JSON.stringify(config)}`);
 
-                // Convert AgentConfig to TaskState using utility function
                 bus.emit('setTaskState', {
                   streamTabId: activeStreamId,
                   executionId,
                   taskState: agentConfigToTaskState(config),
                 });
-                logger.debug(
-                  `Task state stored for stream: ${activeStreamId}`,
-                  mainTaskGroupId,
-                );
+                logger.debug(`Task state stored for stream: ${activeStreamId}`);
               }
             },
-            { parentGroupId: mainTaskGroupId, skip: isResume },
+            { skip: isResume },
           );
         } catch (err) {
           logger.error(
             `Task initialization failed: ${err instanceof Error ? err.message : String(err)}`,
-            mainTaskGroupId,
           );
           throw err;
         }
 
         try {
-          // Run the agent
-          logger.info(
-            `Executing ${agentName} with model ${config.model}`,
-            mainTaskGroupId,
-          );
+          logger.info(`Executing ${agentName} with model ${config.model}`);
           if (!agent) {
             throw new Error('Agent instance was not initialized');
           }
 
           await agent.run();
-          // await checkExpectedOutputs(config.outputFiles, agent);
-          // Mark the task as completed successfully
-          logger.debug(`Task completed successfully`, mainTaskGroupId);
-          // Update status to stopped on successful completion
+          logger.debug(`Task completed successfully`);
           bus.emit('updateStreamStatus', {
             stream: activeStreamId,
             status: 'stopped',
           });
         } catch (err) {
-          // Mark the task as failed
           logger.error(
             `Task failed: ${err instanceof Error ? err.message : String(err)}`,
-            mainTaskGroupId,
           );
-          // Update status to error if agent run fails
           bus.emit('updateStreamStatus', {
             stream: activeStreamId,
             status: 'error',
@@ -524,29 +531,35 @@ export async function executeAgentWithLogging<T extends IAgent>(
       vscode.window.showErrorMessage(errorMsg);
     }
 
-    if (agentStreamLogger || streamTabId) {
-      if (!agentStreamLogger && streamTabId) {
-        agentStreamLogger = new AgentLogger(streamTabId, true);
-      }
-      if (agentStreamLogger) {
-        const fallbackGroupId =
-          agentStreamLogger.getActiveGroupId() ?? agent?.getLastRunGroupId();
-        if (fallbackGroupId) {
-          agentStreamLogger.error(errorMsg, fallbackGroupId);
-        } else {
-          const agentErrorGroupId = await agentStreamLogger.startGroup(
-            `Error: ${agentName}`,
-          );
-          agentStreamLogger.error(errorMsg, agentErrorGroupId);
-          agentStreamLogger.endGroup(agentErrorGroupId, 'error');
-        }
+    const agentLoggerFallback =
+      executionContext?.logger ??
+      contextLogger ??
+      (streamTabId ? new AgentLogger(streamTabId, true) : undefined);
+    if (agentLoggerFallback) {
+      const fallbackGroupId =
+        agentLoggerFallback.getActiveGroupId() ?? agent?.getLastRunGroupId();
+      if (fallbackGroupId) {
+        await agentLoggerFallback.withActiveGroup(fallbackGroupId, async () => {
+          agentLoggerFallback.error(errorMsg);
+        });
+      } else {
+        await agentLoggerFallback.withScope(
+          `Error: ${agentName}`,
+          async () => {
+            agentLoggerFallback.error(errorMsg);
+          },
+          { errorStatus: 'error' },
+        );
       }
     }
 
-    // Create a temporary error group if no active group exists
-    const errorGroupId = await logger.startGroup(`Error: ${agentName}`);
-    logger.error(errorMsg, errorGroupId);
-    logger.endGroup(errorGroupId, 'error');
+    await logger.withScope(
+      `Error: ${agentName}`,
+      async () => {
+        logger.error(errorMsg);
+      },
+      { errorStatus: 'error' },
+    );
     throw new Error(errorMsg);
   }
 }
@@ -568,11 +581,12 @@ export async function executeAgent(
 
   await executeAgentWithLogging(
     agentName,
-    async () => {
-      const { agent, agentType } = await prepareAgentInstance({
+    async (contextFactory) => {
+      const { agent, agentType, context } = await prepareAgentInstance({
         agentName: requestedAgentName,
         configPayload: agentConfig,
         executionId,
+        contextFactory,
       });
 
       const { outputFiles, useMultipleOutputs } = agent.config;
@@ -586,7 +600,7 @@ export async function executeAgent(
         );
       }
 
-      return { agent, agentType };
+      return { agent, agentType, context };
     },
     executionId,
     { resume: false },
@@ -605,14 +619,15 @@ export async function executeMergeAgent(
 
   await executeAgentWithLogging(
     agentName,
-    async () => {
-      const { agent, agentType } = await prepareAgentInstance<MergeAgent>({
+    async (contextFactory) => {
+      const { agent, agentType, context } = await prepareAgentInstance<MergeAgent>({
         agentName,
         configPayload: { agent: agentName, model, inputFile, editedFile },
         agentClassOverride: MergeAgent,
+        contextFactory,
       });
 
-      return { agent, agentType };
+      return { agent, agentType, context };
     },
     undefined,
   );

--- a/src/agent/toolUse/ToolUseFollowUpCoordinator.ts
+++ b/src/agent/toolUse/ToolUseFollowUpCoordinator.ts
@@ -10,6 +10,10 @@ import {
   prepareAgentInstance,
 } from '@agent/runtime/executeAgent';
 import {
+  AgentExecutionContext,
+  type AgentExecutionContextInit,
+} from '@agent/runtime/AgentExecutionContext';
+import {
   ToolUseSessionManager,
   type ToolUseSessionSnapshot,
 } from '@agent/toolUse/ToolUseSessionManager';
@@ -31,7 +35,8 @@ const CHANNEL = 'toolUseFollowUpCoordinator';
 
 async function buildToolUseAgent(
   snapshot: ToolUseSessionSnapshot,
-): Promise<{ agent: BaseToolUseAgent; agentType: AgentType }> {
+  contextFactory: (init: AgentExecutionContextInit) => AgentExecutionContext,
+): Promise<{ agent: BaseToolUseAgent; agentType: AgentType; context: AgentExecutionContext }> {
   const provider = ProgressViewProvider.getInstance();
   if (!provider) {
     throw new Error('Progress view provider is not initialized.');
@@ -47,17 +52,18 @@ async function buildToolUseAgent(
   }
 
   const fullConfig = AgentConfigSchema.parse(taskState.agentConfig);
-  const { agent, agentType } = await prepareAgentInstance<BaseToolUseAgent>({
+  const { agent, agentType, context } = await prepareAgentInstance<BaseToolUseAgent>({
     agentName: fullConfig.agent,
     configPayload: fullConfig,
     executionId: snapshot.executionId as ExecutionId,
+    contextFactory,
   });
 
   if (!(agent instanceof BaseToolUseAgent) || agentType !== AgentType.ToolUse) {
     throw new Error('Attempted to resume a non tool-use agent.');
   }
 
-  return { agent, agentType };
+  return { agent, agentType, context };
 }
 
 export interface ResumeAgentResult {
@@ -137,24 +143,26 @@ export async function resumeFromSnapshot(
 
   let queuedFollowUps: string[] = [];
   try {
-    const { agent, agentType } = await buildToolUseAgent(snapshot);
-
-    agent.resumeFromSnapshot(snapshot);
-    if (followUp !== undefined) {
-      agent.appendFollowUp(followUp);
-    }
-
-    queuedFollowUps = ToolUseSessionManager.drainQueuedFollowUps(streamId);
-    for (const queuedFollowUp of queuedFollowUps) {
-      agent.appendFollowUp(queuedFollowUp);
-    }
-
     await executeAgentWithLogging(
       snapshot.agentName,
-      async () => ({
-        agent,
-        agentType,
-      }),
+      async (contextFactory) => {
+        const { agent, agentType, context } = await buildToolUseAgent(
+          snapshot,
+          contextFactory,
+        );
+
+        agent.resumeFromSnapshot(snapshot);
+        if (followUp !== undefined) {
+          agent.appendFollowUp(followUp);
+        }
+
+        queuedFollowUps = ToolUseSessionManager.drainQueuedFollowUps(streamId);
+        for (const queuedFollowUp of queuedFollowUps) {
+          agent.appendFollowUp(queuedFollowUp);
+        }
+
+        return { agent, agentType, context };
+      },
       snapshot.executionId as ExecutionId,
       { resume: true },
     );

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -14,9 +14,7 @@ import type {
   TokenUsageStats,
   ExtendedTokenUsageStats,
 } from '@agent/types/UsageTypes';
-import { bus } from '@eventBus/ProgressEventBus';
-// Local imports - log
-import { AgentLogger } from '@logger/AgentLogger';
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 
 /**
  * Handles recording usage statistics to the log and progress view.
@@ -24,12 +22,11 @@ import { AgentLogger } from '@logger/AgentLogger';
 export class UsageMonitor {
   constructor(
     private readonly modelHandler: IModelHandler,
-    private readonly channel: string,
-    private readonly logger: AgentLogger,
+    private readonly context: AgentExecutionContext,
   ) {}
 
   async recordUsage(stateGlobal: AgentStateGlobal): Promise<void> {
-    const statsGroupId = this.logger.getActiveGroupId();
+    const { logger, usageReporter } = this.context;
 
     try {
       let responseUsage:
@@ -98,20 +95,6 @@ export class UsageMonitor {
 
       const cost = this.modelHandler.computePrice(responseUsage);
 
-      if (statsGroupId) {
-        bus.emit('updateGroupUsage', {
-          stream: this.channel,
-          groupId: statsGroupId,
-          usage: {
-            inputTokens:
-              stateGlobal.totalInputTokens +
-              (stateGlobal.totalCacheCreationInputTokens ?? 0),
-            outputTokens: stateGlobal.totalOutputTokens,
-            cost,
-          },
-        });
-      }
-
       const cachingStats =
         this.modelHandler.capabilities.supportsPromptCaching ||
         this.modelHandler.capabilities.supportsAutoPromptCaching;
@@ -153,9 +136,9 @@ export class UsageMonitor {
         }),
       };
 
-      this.logger.statistics(payload, statsGroupId);
+      usageReporter.report(payload);
     } catch (error) {
-      this.logger.error(`Error printing statistics: ${error}`, statsGroupId);
+      logger.error(`Error printing statistics: ${error}`);
     }
   }
 }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -1,16 +1,36 @@
 // Third-party imports
-// (none needed)
+import { randomUUID } from 'crypto';
+import { encode as encodeHtml } from 'he';
+
+// Local imports - events
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - log
 import * as logger from './logUtils';
 import type { MessageType } from './messageTypes';
 import { MESSAGE_TYPES } from './messageTypes';
-import type {
-  TokenUsageStats,
-  ExtendedTokenUsageStats,
-} from '@agent/types/UsageTypes';
+import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 import { sleep } from '@utils/helpers';
 import { SHORT_SLEEP_MS } from '@utils/config';
+
+export interface LoggerScopeOptions {
+  parentGroupId?: string;
+  skip?: boolean;
+  successStatus?: 'stopped' | 'error';
+  errorStatus?: 'stopped' | 'error';
+  id?: string;
+}
+
+export interface AgentLogStreamOptions {
+  groupId?: string;
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  progressViewEnabled?: boolean;
+}
+
+export interface AgentLogStream {
+  append(text: string): void;
+  finalize(finalText?: string): string;
+}
 
 /**
  * Encapsulates logging functionality for agents with a dedicated channel.
@@ -133,19 +153,133 @@ export class AgentLogger {
     this.info(message, groupId, MESSAGE_TYPES.USER_MESSAGE);
   }
 
-  /**
-   * Start a new log group and make it active for this logger.
-   * @param groupName Name of the group to display
-   * @param id Optional custom ID for the group
-   * @param parentGroupId Optional parent group ID for nested groups
-   * @returns The group ID
-   */
+  async withScope<T>(
+    groupName: string,
+    fn: () => Promise<T>,
+    options: LoggerScopeOptions = {},
+  ): Promise<T> {
+    const {
+      skip = false,
+      successStatus = 'stopped',
+      errorStatus = 'error',
+      parentGroupId,
+      id,
+    } = options;
+
+    if (skip) {
+      if (parentGroupId) {
+        return this.withActiveGroup(parentGroupId, fn);
+      }
+      return fn();
+    }
+
+    const resolvedParent = parentGroupId ?? this.getActiveGroupId();
+    const groupId = await this.startGroup(groupName, id, resolvedParent);
+
+    try {
+      const result = await fn();
+      this.endGroup(groupId, successStatus);
+      return result;
+    } catch (error) {
+      this.endGroup(groupId, errorStatus);
+      throw error;
+    }
+  }
+
+  createStream(
+    type: MessageType,
+    options: AgentLogStreamOptions = {},
+  ): AgentLogStream {
+    const streamId = this.channelId;
+    const id = randomUUID();
+    let buffer = '';
+    let isFirstUpdate = true;
+    const level = options.level ?? 'info';
+    const progressEnabled = options.progressViewEnabled ?? true;
+    const groupId = options.groupId ?? this.getActiveGroupId();
+
+    return {
+      append: (text: string) => {
+        if (!text) {
+          return;
+        }
+
+        buffer += text;
+
+        if (!progressEnabled) {
+          return;
+        }
+
+        if (isFirstUpdate) {
+          bus.emit('addLogMessage', {
+            stream: streamId,
+            logMessage: {
+              id,
+              text: encodeHtml(buffer),
+              level,
+              timestamp: Date.now(),
+              groupId,
+              messageType: type,
+            },
+          });
+          isFirstUpdate = false;
+        } else {
+          bus.emit('updateLogMessage', {
+            stream: streamId,
+            logMessage: {
+              id,
+              text: encodeHtml(buffer),
+              groupId,
+              messageType: type,
+            },
+          });
+        }
+      },
+      finalize: (finalText?: string) => {
+        if (typeof finalText === 'string') {
+          buffer = finalText;
+        }
+
+        if (!progressEnabled) {
+          this.debug(`Final ${type} length: ${buffer.length}`, groupId);
+          return buffer;
+        }
+
+        if (isFirstUpdate) {
+          bus.emit('addLogMessage', {
+            stream: streamId,
+            logMessage: {
+              id,
+              text: encodeHtml(buffer),
+              level,
+              timestamp: Date.now(),
+              groupId,
+              messageType: type,
+            },
+          });
+        } else {
+          bus.emit('updateLogMessage', {
+            stream: streamId,
+            logMessage: {
+              id,
+              text: encodeHtml(buffer),
+              groupId,
+              messageType: type,
+            },
+          });
+        }
+
+        this.debug(`Final ${type} length: ${buffer.length}`, groupId);
+        return buffer;
+      },
+    };
+  }
+
   async startGroup(
     groupName: string,
     id?: string,
     parentGroupId?: string,
   ): Promise<string> {
-    // brief delay to ensure log order
     await sleep(SHORT_SLEEP_MS);
     return logger.startGroup(
       this.channelId,
@@ -156,28 +290,28 @@ export class AgentLogger {
     );
   }
 
-  /**
-   * End the specified log group.
-   * @param groupId ID of the group to end
-   * @param status Status to set for the group ('error' or 'stopped')
-   */
   endGroup(groupId: string, status: 'error' | 'stopped' = 'stopped'): void {
     logger.endGroup(this.channelId, groupId, status, this.isAgentLogger);
   }
 
-  /**
-   * Get the ID of the active log group for this logger.
-   * @returns The active group ID, or undefined if no active group
-   */
   getActiveGroupId(): string | undefined {
     return logger.getActiveGroupId(this.channelId, this.isAgentLogger);
   }
 
-  /**
-   * Set the active group ID for this logger.
-   * @param groupId The group ID to set as active, or undefined to clear
-   */
   setActiveGroupId(groupId: string | undefined): void {
     logger.setActiveGroupId(this.channelId, groupId, this.isAgentLogger);
+  }
+
+  async withActiveGroup<T>(
+    groupId: string | undefined,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.getActiveGroupId();
+    this.setActiveGroupId(groupId);
+    try {
+      return await fn();
+    } finally {
+      this.setActiveGroupId(previous);
+    }
   }
 }

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -1,0 +1,38 @@
+// Local imports - agent types
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
+import { bus } from '@eventBus/ProgressEventBus';
+
+// Local imports - logger
+import { AgentLogger } from './AgentLogger';
+
+/**
+ * Bridges usage statistics from model handlers into log transport events.
+ */
+export class AgentUsageReporter {
+  constructor(
+    private readonly logger: AgentLogger,
+    private readonly streamId: StreamTabId,
+  ) {}
+
+  /**
+   * Emit usage data to the progress view and attach detailed stats to the log.
+   */
+  public report(stats: ExtendedTokenUsageStats): void {
+    const groupId = this.logger.getActiveGroupId();
+
+    if (groupId) {
+      bus.emit('updateGroupUsage', {
+        stream: this.streamId,
+        groupId,
+        usage: {
+          inputTokens: stats.inputTokens + (stats.cacheCreationInputTokens ?? 0),
+          outputTokens: stats.outputTokens,
+          cost: stats.cost,
+        },
+      });
+    }
+
+    this.logger.statistics(stats);
+  }
+}

--- a/src/logger/logGroupUtils.ts
+++ b/src/logger/logGroupUtils.ts
@@ -19,25 +19,16 @@ export async function withLogGroup<T>(
   fn: (groupId?: string) => Promise<T>,
   options: WithLogGroupOptions = {},
 ): Promise<T> {
-  const {
-    parentGroupId,
-    skip = false,
-    successStatus = 'stopped',
-    errorStatus = 'error',
-  } = options;
+  const { parentGroupId, skip = false, successStatus, errorStatus } = options;
 
-  if (skip) {
-    return fn(undefined);
-  }
-
-  const groupId = await logger.startGroup(groupName, undefined, parentGroupId);
-
-  try {
-    const result = await fn(groupId);
-    logger.endGroup(groupId, successStatus);
-    return result;
-  } catch (error) {
-    logger.endGroup(groupId, errorStatus);
-    throw error;
-  }
+  return logger.withScope(
+    groupName,
+    () => fn(logger.getActiveGroupId() ?? parentGroupId),
+    {
+      parentGroupId,
+      skip,
+      successStatus,
+      errorStatus,
+    },
+  );
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -1,10 +1,114 @@
 // Third-party imports
+import { AsyncLocalStorage } from 'async_hooks';
 import { randomUUID } from 'crypto';
 
 // Local imports - logger
 import { registry } from './LogChannelRegistry';
 import type { MessageType } from './messageTypes';
 import type { VSCodeTransport } from './transports/VSCodeTransport';
+
+type ChannelKey = string;
+
+interface ChannelContext {
+  stack: string[];
+  override?: string;
+}
+
+const contextStorage = new AsyncLocalStorage<Map<ChannelKey, ChannelContext>>();
+const previousStacks = new Map<string, string[]>();
+
+function getChannelKey(channel: string, isAgent: boolean): ChannelKey {
+  return `${isAgent ? 'agent' : 'default'}::${channel}`;
+}
+
+function getStore(): Map<ChannelKey, ChannelContext> {
+  let store = contextStorage.getStore();
+  if (!store) {
+    store = new Map();
+    contextStorage.enterWith(store);
+  }
+  return store;
+}
+
+function getContext(channel: string, isAgent: boolean): ChannelContext | undefined {
+  const store = getStore();
+  return store.get(getChannelKey(channel, isAgent));
+}
+
+function setContext(
+  channel: string,
+  isAgent: boolean,
+  context: ChannelContext | undefined,
+): void {
+  const store = getStore();
+  const key = getChannelKey(channel, isAgent);
+
+  if (context) {
+    store.set(key, context);
+  } else {
+    store.delete(key);
+  }
+
+  contextStorage.enterWith(store);
+}
+
+function pushGroupContext(
+  channel: string,
+  groupId: string,
+  isAgent: boolean,
+): void {
+  const store = getStore();
+  const key = getChannelKey(channel, isAgent);
+  const context = store.get(key) ?? { stack: [] };
+
+  previousStacks.set(`${key}:${groupId}`, [...context.stack]);
+
+  const nextContext: ChannelContext = {
+    stack: [...context.stack, groupId],
+    override: context.override,
+  };
+
+  store.set(key, nextContext);
+  contextStorage.enterWith(store);
+}
+
+function popGroupContext(channel: string, groupId: string, isAgent: boolean): void {
+  const store = getStore();
+  const key = getChannelKey(channel, isAgent);
+  const previous = previousStacks.get(`${key}:${groupId}`);
+  previousStacks.delete(`${key}:${groupId}`);
+
+  const existing = store.get(key);
+
+  if (!previous || previous.length === 0) {
+    if (existing?.override !== undefined) {
+      store.set(key, { stack: [], override: existing.override });
+    } else {
+      store.delete(key);
+    }
+  } else {
+    store.set(key, { stack: [...previous], override: existing?.override });
+  }
+
+  contextStorage.enterWith(store);
+}
+
+function resolveActiveGroup(
+  channel: string,
+  groupId: string | undefined,
+  isAgent: boolean,
+): string | undefined {
+  if (groupId) {
+    return groupId;
+  }
+
+  const context = getContext(channel, isAgent);
+  if (!context) {
+    return undefined;
+  }
+
+  return context.override ?? context.stack.at(-1);
+}
 
 function getTransport(
   channel: string,
@@ -31,8 +135,8 @@ function logWithGroup(
   data?: unknown,
 ): void {
   const entry = registry.ensure(channel, { isAgent });
-  const { logger, transport } = entry;
-  const activeGroupId = groupId ?? transport.getActiveGroupId();
+  const { logger } = entry;
+  const activeGroupId = resolveActiveGroup(channel, groupId, isAgent);
 
   logger.log(level, message, { groupId: activeGroupId, messageType, data });
 }
@@ -50,6 +154,7 @@ export function startGroup(
 ): string {
   const transport = getOrCreateTransport(channel, isAgent);
   const groupId = id ?? randomUUID();
+  pushGroupContext(channel, groupId, isAgent);
   return transport.startGroup(groupName, groupId, parentGroupId);
 }
 
@@ -61,14 +166,14 @@ export function endGroup(
 ): void {
   const transport = getTransport(channel, isAgent);
   transport?.endGroup(groupId, status);
+  popGroupContext(channel, groupId, isAgent);
 }
 
 export function getActiveGroupId(
   channel: string,
   isAgent = false,
 ): string | undefined {
-  const transport = getTransport(channel, isAgent);
-  return transport?.getActiveGroupId();
+  return resolveActiveGroup(channel, undefined, isAgent);
 }
 
 export function setActiveGroupId(
@@ -76,8 +181,27 @@ export function setActiveGroupId(
   groupId: string | undefined,
   isAgent = false,
 ): void {
-  const transport = getTransport(channel, isAgent);
-  transport?.setActiveGroupId(groupId);
+  const context = getContext(channel, isAgent) ?? { stack: [] };
+  if (groupId === undefined) {
+    delete context.override;
+  } else {
+    context.override = groupId;
+  }
+  setContext(channel, isAgent, context);
+}
+
+export async function runWithGroupContext<T>(
+  channel: string,
+  groupId: string,
+  isAgent: boolean,
+  fn: () => Promise<T> | T,
+): Promise<T> {
+  pushGroupContext(channel, groupId, isAgent);
+  try {
+    return await fn();
+  } finally {
+    popGroupContext(channel, groupId, isAgent);
+  }
 }
 
 export function debug(

--- a/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
@@ -9,6 +9,7 @@ import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import { DEFAULT_TOOL_CONFIG } from '@agent/core/ToolConfig';
 import type { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
 import * as executeAgentModule from '@agent/runtime/executeAgent';
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 import {
   ToolUseSessionManager,
   type ToolUseSessionSnapshot,
@@ -50,7 +51,13 @@ describe('ToolUseFollowUpCoordinator', () => {
     | ((streamId: StreamTabId) => ToolUseSessionSnapshot | undefined)
     | undefined;
   let prepareAgentImplementation:
-    | (() => Promise<{ agent: BaseToolUseAgent; agentType: AgentType }>)
+    | ((
+        factory: (init: any) => AgentExecutionContext,
+      ) => Promise<{
+        agent: BaseToolUseAgent;
+        agentType: AgentType;
+        context?: AgentExecutionContext;
+      }>)
     | undefined;
   let executeCalls: {
     agentName: string;
@@ -184,11 +191,14 @@ describe('ToolUseFollowUpCoordinator', () => {
       executeAgentModule as typeof executeAgentModule & {
         prepareAgentInstance: typeof executeAgentModule.prepareAgentInstance;
       }
-    ).prepareAgentInstance = (async (..._args: any[]) => {
+    ).prepareAgentInstance = (async (params: any) => {
       if (!prepareAgentImplementation) {
         throw new Error('prepareAgentInstance was not stubbed');
       }
-      return prepareAgentImplementation();
+      const factory =
+        params.contextFactory ??
+        ((init: any) => new AgentExecutionContext(init));
+      return prepareAgentImplementation(factory);
     }) as typeof executeAgentModule.prepareAgentInstance;
 
     (
@@ -197,7 +207,9 @@ describe('ToolUseFollowUpCoordinator', () => {
       }
     ).executeAgentWithLogging = (async (
       agentName: string,
-      _factory: any,
+      createFn: (
+        factory: (init: any) => AgentExecutionContext,
+      ) => Promise<{ agent: BaseToolUseAgent }>,
       executionId: string,
       options: { resume?: boolean },
     ) => {
@@ -206,6 +218,7 @@ describe('ToolUseFollowUpCoordinator', () => {
         executionId,
         resume: Boolean(options.resume),
       });
+      await createFn((init) => new AgentExecutionContext(init));
       if (executeImplementation) {
         await executeImplementation();
       }
@@ -362,9 +375,13 @@ describe('ToolUseFollowUpCoordinator', () => {
       },
     } as unknown as BaseToolUseAgent;
 
-    prepareAgentImplementation = async () => ({
+    prepareAgentImplementation = async (factory) => ({
       agent,
       agentType: AgentType.ToolUse,
+      context: factory({
+        streamId,
+        executionId: snapshot.executionId,
+      }),
     });
 
     drainImplementation = () => ['queued-follow-up'];
@@ -411,9 +428,13 @@ describe('ToolUseFollowUpCoordinator', () => {
       },
     } as unknown as BaseToolUseAgent;
 
-    prepareAgentImplementation = async () => ({
+    prepareAgentImplementation = async (factory) => ({
       agent,
       agentType: AgentType.ToolUse,
+      context: factory({
+        streamId,
+        executionId: snapshot.executionId,
+      }),
     });
 
     drainImplementation = () => ['first', 'second'];

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -10,6 +10,8 @@ import {
   AgentCategory,
 } from '@agent/core/AgentDataclass';
 import { BaseToolUseAgent } from '@agent/implementations/BaseToolUseAgent';
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -154,7 +156,14 @@ describe('BaseToolUseAgent follow-up loop', () => {
         autoCompileInputPdf: false,
       },
     });
-    const agent = new TestAgent(handler, config, setting, prompt, '.');
+    const agent = new TestAgent(
+      handler,
+      config,
+      setting,
+      prompt,
+      '.',
+      new AgentExecutionContext({ streamId: 'test-stream' as StreamTabId }),
+    );
     const logs: any[] = [];
     const dispose = bus.on('addLogMessage', (e) => logs.push(e));
     const runPromise = agent.run();


### PR DESCRIPTION
## Summary
- remove the AgentLoggerScope wrapper in favour of async-local active groups
- update agent initialization and execution flows to log directly through AgentLogger
- tidy logGroup helpers to return group ids from the shared logger context

## Testing
- npm run lint
- npm run compile
- CI=1 npm test -- --runInBand *(fails: vscode-test requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690891e17e188324922a432744fb4f9b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a shared AgentExecutionContext and migrates agents/runtime to async‑local scoped AgentLogger, simplifying stream/group handling and centralizing usage reporting.
> 
> - **Core/Runtime**:
>   - Add `AgentExecutionContext` (provides `logger` and `AgentUsageReporter`) and expose via `IAgent.getExecutionContext`.
>   - Update `prepareAgentInstance`/`executeAgentWithLogging` to accept `contextFactory`, compute `streamId`, and construct agents with `context`.
> - **Agents**:
>   - `BaseAgent`, `BaseReflectionAgent`, `BaseToolUseAgent`, `MergeAgent` constructors now take `AgentExecutionContext`; `getStreamTabId()` reads from `context`.
>   - Initialization and round/run grouping use `logger.withScope`/`withActiveGroup`; `UsageMonitor` now uses `context`.
> - **Logging**:
>   - `AgentLogger` adds `withScope`, `withActiveGroup`, and `createStream` APIs; streaming moved from handlers to logger.
>   - `logUtils` switches to `AsyncLocalStorage` for active group stacks and overrides.
>   - New `AgentUsageReporter` to emit usage to progress view and log.
> - **Model Handlers**:
>   - Replace custom stream logic with `logger.createStream` in `ModelHandler`.
> - **Tool-use Resume**:
>   - `ToolUseFollowUpCoordinator` builds agents via `contextFactory`, resumes from snapshots, and drains queued follow-ups.
> - **Tests**:
>   - Update tests to construct/pass `AgentExecutionContext` and new factory signatures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f46e96ca67935379da38faaf9fab63c4256ca95e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->