### PR TITLE
fix: normalize markdown edge spacing

### DIFF
--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -5,6 +5,14 @@
   overflow: visible;
 }
 
+.markdown-content > :first-child {
+  margin-top: 0;
+}
+
+.markdown-content > :last-child {
+  margin-bottom: 0;
+}
+
 /* Banner content for model responses - uses normal whitespace handling */
 .banner-content--model {
   padding: 0;


### PR DESCRIPTION
## Summary
- remove markdown whitespace trimming to restore original formatting pipeline
- adjust progress view markdown styles to eliminate top and bottom spacing caused by block margins

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6908d26045b08324a1b147aab7f535c5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize markdown edge spacing by trimming leading/trailing block margins in `.markdown-content` containers.
> 
> - **Styles (progress view)**:
>   - Normalize edge spacing in `markdown.css` by zeroing `margin-top` of `.markdown-content > :first-child` and `margin-bottom` of `.markdown-content > :last-child` to remove extra top/bottom gaps from block margins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 659b207e23c16094f74e8d9daf9eeb5df1a68f72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->