### PR TITLE
Render tool-use payloads in YAML

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -66,7 +66,8 @@
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",
-          "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0"
+          "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0",
+          "yaml": "https://esm.sh/yaml@2.8.1"
         }
       }
     </script>

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -16,6 +16,7 @@ import markdownItKatex from '@vscode/markdown-it-katex';
 // Third-party imports
 import MarkdownIt from 'markdown-it';
 import highlight from 'markdown-it-highlightjs';
+import { stringify as yamlStringify } from 'yaml';
 
 // Local imports - progress view
 import { STATUS, GROUP_DOM_IDS } from './constants.js';
@@ -57,6 +58,21 @@ const TIME_FORMAT_OPTIONS = {
   minute: '2-digit',
   second: '2-digit',
   hour12: false,
+};
+
+const toYamlString = (value) => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    const yamlValue = yamlStringify(value);
+    return typeof yamlValue === 'string'
+      ? yamlValue.replace(/\n$/, '')
+      : String(yamlValue);
+  } catch (error) {
+    return String(value);
+  }
 };
 
 /**
@@ -503,15 +519,7 @@ export class LogEntryFormatter {
 
       let fallbackContent = rawContent;
       if (!fallbackContent && structuredData !== undefined) {
-        if (typeof structuredData === 'string') {
-          fallbackContent = structuredData;
-        } else {
-          try {
-            fallbackContent = JSON.stringify(structuredData, null, 2);
-          } catch (error) {
-            fallbackContent = String(structuredData);
-          }
-        }
+        fallbackContent = toYamlString(structuredData);
       }
 
       contentElem.innerHTML = `
@@ -593,10 +601,7 @@ export class LogEntryFormatter {
     const sections = [];
 
     if (parsed.input !== undefined) {
-      const inputValue =
-        typeof parsed.input === 'string'
-          ? parsed.input
-          : JSON.stringify(parsed.input, null, 2);
+      const inputValue = toYamlString(parsed.input);
       sections.push(`
         <div class="tool-use-section">
           <div class="tool-use-subsection">
@@ -649,11 +654,7 @@ export class LogEntryFormatter {
     }
 
     if (outputCandidate && outputCandidate.diagnostics !== undefined) {
-      const diagnosticsJson = JSON.stringify(
-        outputCandidate.diagnostics,
-        null,
-        2,
-      );
+      const diagnosticsJson = toYamlString(outputCandidate.diagnostics);
       sections.push(`
         <div class="tool-use-section">
           <div class="tool-use-subsection">
@@ -687,14 +688,8 @@ export class LogEntryFormatter {
     }
 
     if (sections.length === 0) {
-      const fallbackJson = (() => {
-        try {
-          return JSON.stringify(parsed, null, 2);
-        } catch (error) {
-          return rawContent;
-        }
-      })();
-      contentElem.innerHTML = `<pre>${encodeHtml(fallbackJson || '')}</pre>`;
+      const fallbackYaml = toYamlString(parsed) || rawContent;
+      contentElem.innerHTML = `<pre>${encodeHtml(fallbackYaml || '')}</pre>`;
     } else {
       contentElem.innerHTML = sections.join('<hr class="tool-use-separator">');
     }

--- a/src/test/progressView/Formatters.test.ts
+++ b/src/test/progressView/Formatters.test.ts
@@ -164,7 +164,9 @@ describe('LogEntryFormatter DOM', () => {
 
     const inputPre = el.querySelector('.tool-use-section pre');
     assert.ok(inputPre);
-    assert.ok(inputPre.textContent?.includes('/tmp/example.tex'));
+    const inputContent = inputPre?.textContent ?? '';
+    assert.ok(inputContent.includes('path: /tmp/example.tex'));
+    assert.ok(!inputContent.includes('{'));
 
     const outputFull = el.querySelector('.tool-output-full');
     assert.ok(outputFull);


### PR DESCRIPTION
## Summary
- add the yaml ESM import to the progress view webview import map
- render tool-use payload sections with YAML formatting instead of JSON
- update the formatter test to assert against the YAML structure

## Testing
- npm run format
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6908be70f8008324975329eb82265d13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Render tool-use payloads as YAML (with new yaml ESM import) and update tests accordingly.
> 
> - **Progress View**:
>   - Add `yaml` ESM import in `src/progressView/index.html` import map.
>   - In `modules/formatters.js`:
>     - Import `yaml.stringify` and add `toYamlString()` helper.
>     - Use YAML for tool-use sections: `input`, `diagnostics`, and fallback/raw content (replacing JSON stringification).
>     - Keep other rendering logic unchanged.
> - **Tests**:
>   - Update `Formatters.test.ts` to assert YAML-structured input (e.g., `path: /tmp/example.tex`) and absence of JSON braces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0417d1bd51a52e0ab6ee8150136ff3d67a4dc2a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->