### PR TITLE
fix: streamline multiple agent fallback resolution

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -231,27 +231,13 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
   };
 
   const fullConfig = parseAgentConfig(configInput);
-  const originalAgentName = fullConfig.agent;
-  let resolvedAgentName = getAgentName(
-    originalAgentName,
-    fullConfig.useMultipleOutputs,
-  );
+  const requestedAgentName = fullConfig.agent;
 
-  let agentPathInfo: AgentPathResolution;
-  try {
-    agentPathInfo = await getAgentPath(resolvedAgentName);
-  } catch (err) {
-    if (resolvedAgentName !== originalAgentName) {
-      resolvedAgentName = originalAgentName;
-      agentPathInfo = await getAgentPath(originalAgentName);
-    } else {
-      throw err;
-    }
-  }
+  const agentPathInfo = await getAgentPath(requestedAgentName);
 
   const [loadedAgentSetting, agentPrompt] = await loadAgentSettingAndPrompts(
     agentPathInfo,
-    resolvedAgentName,
+    requestedAgentName,
     { preferMultiple: fullConfig.useMultipleOutputs },
   );
 
@@ -264,7 +250,7 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
 
   const agentConfig: AgentConfig = {
     ...fullConfig,
-    agent: originalAgentName,
+    agent: requestedAgentName,
     agentType: sessionDescriptor.agentType,
     session: sessionDescriptor,
   };

--- a/src/test/agent/runtime/agentLoad.test.ts
+++ b/src/test/agent/runtime/agentLoad.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 // Local imports - agent runtime
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { AgentDirectorySource } from '@agent/runtime/AgentPathTypes';
+import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 
 suite('loadAgentSettingAndPrompts', () => {
@@ -106,14 +107,35 @@ suite('loadAgentSettingAndPrompts', () => {
       ].join('\n'),
     );
 
-    const [, prompts] = await loadAgentSettingAndPrompts(
-      agentPathInfo,
-      'summarize',
-      {
-        preferMultiple: true,
-      },
-    );
+    const recordedWarnings: { channel: string; message: string }[] = [];
+    const loggerAny = logger as typeof logger & {
+      warn: typeof logger.warn;
+    };
+    const originalWarn = loggerAny.warn;
+    loggerAny.warn = (channel, message) => {
+      recordedWarnings.push({ channel, message });
+    };
 
-    assert.strictEqual(prompts.userRequest, 'base only');
+    try {
+      const [, prompts] = await loadAgentSettingAndPrompts(
+        agentPathInfo,
+        'summarize',
+        {
+          preferMultiple: true,
+        },
+      );
+
+      assert.strictEqual(prompts.userRequest, 'base only');
+    } finally {
+      loggerAny.warn = originalWarn;
+    }
+
+    assert.deepStrictEqual(recordedWarnings, [
+      {
+        channel: 'agentLoad',
+        message:
+          'Requested multiple outputs for agent "summarize" but no _multiple definition was found. Falling back to base definition.',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- rely on resolveAgentDefinition for _multiple fallback handling inside prepareAgentInstance
- extend agent load tests to assert the fallback warning is emitted when _multiple YAML is missing

## Testing
- npm test -- --grep "agent runtime" *(fails: existing type errors in src/webview/managers/ExecutionManager.ts complaining about null not assignable to string[])*

------
https://chatgpt.com/codex/tasks/task_e_69071d421eac83249e398795e6f4d089

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies agent name/path resolution to rely on loader’s preferMultiple handling and adds tests asserting a warning when _multiple YAML is missing.
> 
> - **Runtime**:
>   - Simplify `prepareAgentInstance` to use `requestedAgentName` directly, call `getAgentPath` once, and pass `{ preferMultiple }` to `loadAgentSettingAndPrompts`.
>   - Set `agent` in `AgentConfig` to `requestedAgentName` (no fallback renaming in this layer).
> - **Tests**:
>   - Extend `agentLoad.test.ts` to mock logger and assert a warning when `preferMultiple: true` but no `_multiple` YAML exists.
>   - Keep validation that `_multiple` variant is used when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5430cdb7a80647f8b1f1e9e2b4391846fc0781ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->