### PR TITLE
Enhance stream tab delete affordance

### DIFF
--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -45,6 +45,8 @@
   align-items: center;
   position: relative;
   width: 100%;
+  gap: var(--spacing-small);
+  padding-right: var(--spacing-small);
 }
 
 .tab {
@@ -109,39 +111,43 @@
 }
 
 .tab-delete {
-  display: none;
-  padding: var(--spacing-tiny);
-  border: none;
-  background: none;
-  color: var(--vscode-foreground);
-  opacity: var(--opacity-subtle);
-  cursor: pointer;
-  margin-right: var(--spacing-small);
-  font-size: var(--font-size-sm);
-  width: calc(var(--height-control) - var(--spacing-small));
-  height: calc(var(--height-control) - var(--spacing-small));
-  align-items: center;
-  justify-content: center;
-}
-
-.tab-container:hover .tab-delete {
   display: flex;
   align-items: center;
-}
-
-.tab-delete:hover {
-  opacity: var(--opacity-full);
-  color: var(--vscode-errorForeground);
-}
-
-.tab-delete .codicon {
-  font-size: var(--font-size-sm);
-  color: var(--vscode-foreground);
+  justify-content: center;
+  width: var(--height-control);
+  height: var(--height-control);
+  margin: 0;
+  color: var(--vscode-icon-foreground, var(--vscode-foreground));
   opacity: var(--opacity-subtle);
-  margin-right: 0;
+  transition: opacity 120ms ease, color 120ms ease;
 }
 
-.tab-delete:hover .codicon {
+.tab-delete::part(control) {
+  padding: 0;
+  border-radius: var(--border-radius-small);
+}
+
+.tab-container:hover .tab-delete,
+.tab-delete:focus-within {
   opacity: var(--opacity-full);
+}
+
+.tab-delete:hover::part(control),
+.tab-delete:focus-within::part(control) {
+  background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.tab-delete:hover,
+.tab-delete:focus-within {
   color: var(--vscode-errorForeground);
+}
+
+.tab-delete vscode-icon {
+  opacity: var(--opacity-subtle);
+  transition: opacity 120ms ease, color 120ms ease;
+}
+
+.tab-container:hover .tab-delete vscode-icon,
+.tab-delete:focus-within vscode-icon {
+  opacity: var(--opacity-full);
 }


### PR DESCRIPTION
## Summary
- adjust stream tab spacing so the delete action sits inline with tab content
- restyle the delete affordance to stay visible with VS Code-like hover and focus feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6908e31fdea0832498bfba4daf182991

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the stream tab delete control inline and always visible with VS Code-like hover/focus feedback, and tweak tab spacing.
> 
> - **Styles (ProgressView tabs)**:
>   - **`tabs.css` layout**:
>     - Add `gap` and right padding to ``.tab-container`` for inline spacing.
>   - **Delete affordance (`.tab-delete`)**:
>     - Always rendered as a flex control with fixed `height/width` and no margin; uses `--vscode-icon-foreground`.
>     - Add opacity/color transitions; show at full opacity on container hover or focus.
>     - Style `::part(control)` with no padding and small border radius; apply hover background.
>     - Update icon (`vscode-icon`) opacity transitions to match hover/focus behavior.
>     - Use error color on hover/focus for the control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbe2a307a046beaad76eeb641956603161d46b2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->