### PR TITLE
fix: focus progress view directly

### DIFF
--- a/src/commands/progress/progressViewCommands.ts
+++ b/src/commands/progress/progressViewCommands.ts
@@ -11,10 +11,7 @@ const logger = new AgentLogger(CHANNEL);
  * Show the Progress View panel
  */
 async function showProgressView() {
-  // Focus the view in the panel
-  await safeExecuteCommand('workbench.view.extension.texra-panel', [], CHANNEL);
-
-  // Then specifically focus the progress view
+  // Focus the progress view
   await safeExecuteCommand('texra.progressView.focus', [], CHANNEL);
 
   logger.info('ProgressView panel shown');


### PR DESCRIPTION
## Summary
- update the progress view command to focus the progress board directly without switching the sidebar

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_6908e394ec04832499c0b2ba84d0ed22

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses the Progress View directly using `texra.progressView.focus`, removing the intermediate panel focus.
> 
> - **Progress View Commands**:
>   - Update `showProgressView` to focus the progress view directly via `texra.progressView.focus`, removing the prior `workbench.view.extension.texra-panel` focus step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15ce3b83dee1b6aed0c670d31a0f1a595fd5fdb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->