### PR TITLE
fix: emit human-readable user patches

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -226,6 +226,7 @@ function buildToolResultPayload(result: ToolResult): Record<string, unknown> {
     payload.base64Image = result.base64Image;
   if (result.userInstruction !== undefined)
     payload.userInstruction = result.userInstruction;
+  if (result.userPatch !== undefined) payload.userPatch = result.userPatch;
   if (result.isError) payload.isError = true;
   if (result.diagnostics !== undefined)
     payload.diagnostics = result.diagnostics;

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -123,6 +123,7 @@ export class EditFileTool extends defineTool({
     return toolResult({
       summary,
       output,
+      userPatch: approval.userPatch,
     });
   }
 }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -352,6 +352,7 @@ export class TextEditorTool extends defineTool({
       return toolResult({
         summary: `Created file ${filePath}`,
         output,
+        userPatch: approval.userPatch,
       });
     } catch (error) {
       throw new ToolError(`Error creating file ${filePath}: ${String(error)}`);
@@ -467,6 +468,7 @@ export class TextEditorTool extends defineTool({
       return cliResult({
         summary: `Updated ${filePath}`,
         output: successMsg,
+        userPatch: approval.userPatch,
       });
     } catch (error) {
       if (error instanceof ToolError) {
@@ -581,6 +583,7 @@ export class TextEditorTool extends defineTool({
       return cliResult({
         summary: `Inserted text into ${filePath}`,
         output: successMsg,
+        userPatch: approval.userPatch,
       });
     } catch (error) {
       if (error instanceof ToolError) {
@@ -651,6 +654,7 @@ export class TextEditorTool extends defineTool({
       return cliResult({
         summary: `Undid edit on ${filePath}`,
         output,
+        userPatch: approval.userPatch,
       });
     } catch (error) {
       if (error instanceof ToolError) {

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -74,6 +74,7 @@ export class WriteFileTool extends defineTool({
     return toolResult({
       summary: `Wrote ${input.path}`,
       output,
+      userPatch: approval.userPatch,
     });
   }
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -310,18 +310,42 @@ function firstChangedLine(original: string, proposed: string): number | null {
   return 0;
 }
 
+interface ComputeUserPatchOptions {
+  contextLines?: number;
+}
+
 function computeUserPatch(
+  path: string,
   suggestedContent: string,
   appliedContent: string,
+  options?: ComputeUserPatchOptions,
 ): string | undefined {
   if (suggestedContent === appliedContent) {
     return undefined;
   }
 
-  const dmp = new diff_match_patch();
-  const patches = dmp.patch_make(suggestedContent, appliedContent);
-  const text = dmp.patch_toText(patches);
-  return text.trim().length > 0 ? text : undefined;
+  const diffOptions: Record<string, unknown> = {
+    fromfile: `${path} (proposed)`,
+    tofile: `${path} (final)`,
+    lineterm: '',
+  };
+
+  const contextLines = options?.contextLines ?? 3;
+  if (Number.isInteger(contextLines)) {
+    diffOptions.n = contextLines;
+  }
+
+  const diffLines = difflib.unifiedDiff(
+    suggestedContent.split('\n'),
+    appliedContent.split('\n'),
+    diffOptions,
+  );
+
+  if (!diffLines || diffLines.length === 0) {
+    return undefined;
+  }
+
+  return diffLines.join('\n');
 }
 
 async function revealFirstChange(
@@ -518,7 +542,11 @@ async function nativeRequestApproval(
         proposedUri,
         proposedContent,
       );
-      const userPatch = computeUserPatch(proposedContent, appliedContent);
+      const userPatch = computeUserPatch(
+        request.path,
+        proposedContent,
+        appliedContent,
+      );
       result = {
         ...result,
         appliedContent,
@@ -590,7 +618,7 @@ function finalizeApprovalResult(
   const userPatch =
     result.userPatch !== undefined
       ? result.userPatch
-      : computeUserPatch(request.proposedContent, appliedContent);
+      : computeUserPatch(request.path, request.proposedContent, appliedContent);
 
   return {
     ...result,
@@ -619,25 +647,18 @@ export function formatUnifiedApprovalUserDiff(
   appliedContent: string,
   options?: { contextLines?: number },
 ): string | undefined {
-  if (suggestedContent === appliedContent) {
-    return undefined;
-  }
-  const n = options?.contextLines ?? 3;
-  const fromfile = `${path} (proposed)`;
-  const tofile = `${path} (final)`;
-  const diffOptions: any = { fromfile, tofile, lineterm: '' };
-  if (Number.isInteger(n)) diffOptions.n = n;
-  const diffLines = difflib.unifiedDiff(
-    suggestedContent.split('\n'),
-    appliedContent.split('\n'),
-    diffOptions,
+  const diffBody = computeUserPatch(
+    path,
+    suggestedContent,
+    appliedContent,
+    options,
   );
 
-  if (!diffLines || diffLines.length === 0) {
+  if (!diffBody) {
     return undefined;
   }
-  const body = diffLines.join('\n');
-  return `User adjustments to ${path}:\n\n\`\`\`diff\n${body}\n\`\`\``;
+
+  return `User adjustments to ${path}:\n\n\`\`\`diff\n${diffBody}\n\`\`\``;
 }
 
 export interface WriteApprovedContentResult {

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -86,6 +86,7 @@ export class FileOpTool extends defineTool({
         return toolResult({
           summary: `Wrote ${path}`,
           output: userDiffNote ? `written\n\n${userDiffNote}` : 'written',
+          userPatch: approval.userPatch,
         });
       }
       case 'append': {
@@ -147,6 +148,7 @@ export class FileOpTool extends defineTool({
         return toolResult({
           summary: `Appended to ${path}`,
           output: userDiffNote ? `appended\n\n${userDiffNote}` : 'appended',
+          userPatch: approval.userPatch,
         });
       }
       default:

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -34,6 +34,7 @@ export interface ToolResult {
   error?: string;
   base64Image?: string;
   userInstruction?: string;
+  userPatch?: string;
   isError?: boolean;
   diagnostics?: ErrorDiagnostics; // Additional error details like validation issues
   files?: ToolFileAttachment[];


### PR DESCRIPTION
## Summary
- compute userPatch strings using difflib unified diffs so manual edits stay human readable
- reuse the unified diff builder when rendering approval notes, keeping model payloads and progress view output aligned

## Testing
- npm run format -- src/tools/approval/toolEditApproval.ts
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_6908e2469a848324aa3e66c56af5bc58

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch userPatch to unified diffs and include it in all tool results and model payloads.
> 
> - **Edit approval / patch generation**:
>   - Replace `diff-match-patch` text patch with `difflib.unifiedDiff` in `computeUserPatch`, adding filename headers and optional `contextLines`.
>   - Refactor `formatUnifiedApprovalUserDiff` to reuse `computeUserPatch` and wrap output consistently.
>   - Pass `path` into `computeUserPatch` callers and finalize results with the new patch format.
> - **Tool result propagation**:
>   - Add `userPatch` to `ToolResult` (in `src/tools/result.ts`) and include it in `buildToolResultPayload` for follow-up messages.
>   - Populate `userPatch` in results from `EditTool`, `TextEditorTool` (create/str_replace/insert/undo_edit), `WriteFileTool`, and `FileOpTool` (write/append).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e2369d839cbb0c218102f2d5d820b62adc1b583. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->