### PR TITLE
Refactor agent log scope handling

### DIFF
--- a/src/agent/core/AgentCycleOptions.ts
+++ b/src/agent/core/AgentCycleOptions.ts
@@ -2,22 +2,18 @@
 import type { AgentPrompt, AgentSetting } from './AgentDataclass';
 
 // Local imports - logging
-import type { AgentLogger } from '@logger/AgentLogger';
+import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 
 // Local imports - model handlers
 import type { IModelHandler } from '@agent/modelHandlers';
-
-// Local imports - identifier types
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 export interface AgentCycleBaseOptions<C = unknown> {
   modelHandler: IModelHandler<any, any, any, any, C>;
   agentSetting: AgentSetting;
   agentPrompt: AgentPrompt;
   userVars: Record<string, any>;
-  logger: AgentLogger;
   client: C;
   checkInterruption: () => Promise<boolean> | boolean;
   setAbortController: (ctrl: AbortController | null) => void;
-  executionId?: ExecutionId;
+  context: AgentExecutionContext;
 }

--- a/src/agent/core/IAgent.ts
+++ b/src/agent/core/IAgent.ts
@@ -19,10 +19,7 @@ export interface IAgent {
    * @param options - Initialization options
    * @param options.createGroup - Whether to create a new log group (default: true)
    */
-  init(
-    parentGroupId?: string,
-    options?: { createGroup?: boolean },
-  ): Promise<void>;
+  init(options?: { createGroup?: boolean }): Promise<void>;
 
   /** Execute the agent. */
   run(): Promise<void>;
@@ -61,14 +58,10 @@ export interface IAgent {
  */
 export interface AgentRunHooks {
   /**
-   * Begin an agent run and optionally create a logging group.
-   *
-   * @returns The identifier for the run group used by subsequent lifecycle hooks.
-   *          Return `undefined` to indicate that the lifecycle should reuse an
-   *          existing log group (for example, interactive tool-use sessions).
+   * Begin an agent run and establish the logging scope for subsequent lifecycle hooks.
    */
-  start(): Promise<string | undefined>;
-  init(runGroupId: string | undefined): Promise<void>;
+  start(): Promise<void>;
+  init(): Promise<void>;
   initializeClient(): Promise<void>;
   end(status: 'stopped' | 'error'): void | Promise<void>;
   cleanup(): void | Promise<void>;

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -40,9 +40,10 @@ import xmlUtils from '@utils/text/xmlUtils';
 
 // Local imports - identifier types
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { AgentLogger } from '@logger/AgentLogger';
 
 interface DebugContext {
-  logger: ResponseCycleOptions['logger'];
+  logger: AgentLogger;
   modelName: string;
   executionId?: ExecutionId;
 }
@@ -127,7 +128,8 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
     debugFileOptions?: DebugFileOptions;
   }> {
     const { options, cycle } = shared;
-    const { agentPrompt, userVars, logger, agentConfig } = options;
+    const { agentPrompt, userVars, agentConfig } = options;
+    const { logger } = options.context;
     const interrupted = Boolean(await options.checkInterruption());
     const exists = await WorkspaceFS.exists(cycle.outputFile);
     const systemPrompt = interrupted
@@ -139,7 +141,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleShared<C>> {
       : {
           logger,
           modelName: agentConfig.model,
-          executionId: options.executionId,
+          executionId: options.context.executionId,
         };
 
     const debugFileOptions: DebugFileOptions | undefined = interrupted
@@ -214,8 +216,6 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     options.modelHandler.setOutputStreaming(false);
 
     let response: unknown;
-    const groupId = options.logger.getActiveGroupId();
-
     try {
       response = await options.modelHandler.createResponse(
         options.client,
@@ -233,7 +233,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         error instanceof Error
           ? `Model invocation failed: ${error.message}`
           : 'Model invocation failed with an unknown error';
-      options.logger.error(message, groupId);
+      options.context.logger.error(message);
       cycle.shouldStop = true;
       cycle.endTurn = false;
       throw error;
@@ -254,8 +254,6 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     execRes: { skipped: true } | { response: unknown; responseTime?: number },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
-    const groupId = options.logger.getActiveGroupId();
-
     if ('skipped' in execRes) {
       cycle.endTurn = false;
       return FlowTransition.COMPLETE;
@@ -272,9 +270,8 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     );
 
     if (!execRes.response) {
-      options.logger.warn(
+      options.context.logger.warn(
         'Model response was aborted or returned no data; output may be incomplete.',
-        groupId,
       );
       cycle.endTurn = false;
       cycle.shouldStop = true;
@@ -321,33 +318,26 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
         cycle.responseObject,
         options.agentSetting.endTag,
       );
-
-    const groupId = options.logger.getActiveGroupId();
-
     if (newResponse) {
-      options.logger.debug(
+      options.context.logger.debug(
         `Model response: ${newResponse.slice(0, 100)}`,
-        groupId,
       );
     }
 
     if (cycle.responseTime !== undefined) {
       cycle.stateRound.updateResponseTime(cycle.responseTime);
-      options.logger.debug(
+      options.context.logger.debug(
         `Response time: ${cycle.responseTime.toFixed(2)}s`,
-        groupId,
       );
     }
 
-    options.logger.debug(`Stop reason: ${stopReason}`, groupId);
-    options.logger.debug(
+    options.context.logger.debug(`Stop reason: ${stopReason}`);
+    options.context.logger.debug(
       `Token usage: ${JSON.stringify(responseUsage)}`,
-      groupId,
     );
 
     const thinkingContent = options.modelHandler.processThinkingBlock(
       cycle.responseObject,
-      groupId,
       cycle.toolState,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
@@ -355,7 +345,11 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (thinkingContent && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinkingContent);
       if (formatted.trim().length > 0) {
-        options.logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
+        options.context.logger.info(
+          formatted,
+          undefined,
+          MESSAGE_TYPES.THINKING,
+        );
       }
     }
 
@@ -364,12 +358,20 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       'scratchpad',
     );
     if (scratchpad) {
-      options.logger.info(scratchpad, groupId, MESSAGE_TYPES.SCRATCHPAD);
+      options.context.logger.info(
+        scratchpad,
+        undefined,
+        MESSAGE_TYPES.SCRATCHPAD,
+      );
     }
 
     if (newResponse && !useStreaming) {
       const formattedResponse = await xmlUtils.formatContent(newResponse);
-      options.logger.info(formattedResponse, groupId, MESSAGE_TYPES.INTERNAL);
+      options.context.logger.info(
+        formattedResponse,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
+      );
     }
 
     const apiUsage = options.modelHandler.computeResponseUsage(
@@ -385,21 +387,17 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     );
 
     if (repetitionResult.massiveRepetitionDetected && newResponse) {
-      options.logger.error(
+      options.context.logger.error(
         `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-        groupId,
       );
-      options.logger.error(
+      options.context.logger.error(
         'Massive repetition detected - skipping this response',
-        groupId,
       );
-      options.logger.error(
+      options.context.logger.error(
         'Message structure when repetition detected:',
-        groupId,
       );
-      options.logger.error(
+      options.context.logger.error(
         JSON.stringify(messageToSkeleton(cycle.messages), null, 2),
-        groupId,
       );
     }
 
@@ -442,8 +440,6 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     execRes: ProcessResult | { skipped: true },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
-    const groupId = options.logger.getActiveGroupId();
-
     if ('skipped' in execRes) {
       cycle.endTurn = false;
       return FlowTransition.COMPLETE;
@@ -459,13 +455,12 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     }
 
     if (!cycle.outputExists) {
-      options.logger.debug(`Creating new file: ${cycle.outputFile}`, groupId);
+      options.context.logger.debug(`Creating new file: ${cycle.outputFile}`);
       await WorkspaceFS.write(cycle.outputFile, execRes.processedResponse);
       cycle.outputExists = true;
     } else {
-      options.logger.debug(
+      options.context.logger.debug(
         `Appending to existing file: ${cycle.outputFile}`,
-        groupId,
       );
       await WorkspaceFS.appendFile(
         cycle.outputFile,
@@ -473,14 +468,12 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       );
     }
 
-    options.logger.debug('Response preview:', groupId);
-    options.logger.debug(
+    options.context.logger.debug('Response preview:');
+    options.context.logger.debug(
       `First ${K_SLICE} chars:\n${execRes.processedResponse.slice(0, K_SLICE)}`,
-      groupId,
     );
-    options.logger.debug(
+    options.context.logger.debug(
       `Last ${K_SLICE} chars:\n${execRes.processedResponse.slice(-K_SLICE)}`,
-      groupId,
     );
 
     if (options.modelHandler.capabilities.supportsAssistantPrefill) {
@@ -554,8 +547,6 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       | { skipped: true },
   ): Promise<string | undefined> {
     const { options, cycle } = prepRes;
-    const groupId = options.logger.getActiveGroupId();
-
     if ('skipped' in execRes) {
       cycle.endTurn = false;
       cycle.shouldStop = true;
@@ -570,9 +561,8 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     }
 
     cycle.stateRound.incrementContinuation();
-    options.logger.info(
+    options.context.logger.info(
       `Starting continuation #${cycle.stateRound.continuationCount}`,
-      groupId,
       MESSAGE_TYPES.PROGRESS_STATUS,
     );
 
@@ -580,9 +570,8 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       return FlowTransition.COMPLETE;
     }
 
-    options.logger.debug(
+    options.context.logger.debug(
       'Should continue - adding continuation message to conversation',
-      groupId,
     );
 
     if (options.modelHandler.capabilities.supportsAssistantPrefill) {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -35,11 +35,13 @@ import xmlUtils from '@utils/text/xmlUtils';
 
 // Local imports - usage types
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 interface DebugContext {
-  logger: ToolUseCycleOptions['logger'];
+  logger: AgentLogger;
   modelName?: string;
-  executionId?: ToolUseCycleOptions['executionId'];
+  executionId?: ExecutionId;
 }
 
 interface DebugFileOptions {
@@ -178,9 +180,9 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     const { options, state } = shared;
     const interrupted = Boolean(await options.checkInterruption());
     const debugContext: DebugContext = {
-      logger: options.logger,
+      logger: options.context.logger,
       modelName: options.modelName,
-      executionId: options.executionId,
+      executionId: options.context.executionId,
     };
     const debugFileOptions: DebugFileOptions = {
       continuationCount: state.iteration,
@@ -254,9 +256,9 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     }
 
     const debugContext: DebugContext = {
-      logger: options.logger,
+      logger: options.context.logger,
       modelName: options.modelName,
-      executionId: options.executionId,
+      executionId: options.context.executionId,
     };
     const debugFileOptions: DebugFileOptions = {
       continuationCount: state.iteration,
@@ -344,19 +346,19 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     if (state.shouldStop || !state.response) {
       return { skipped: true };
     }
-
-    const groupId = options.logger.getActiveGroupId();
-
     const thinking = options.modelHandler.processThinkingBlock(
       state.response,
-      groupId,
       state.toolState,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
     if (thinking && !useStreaming) {
       const formatted = await xmlUtils.formatContent(thinking);
       if (formatted.trim().length > 0) {
-        options.logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);
+        options.context.logger.info(
+          formatted,
+          undefined,
+          MESSAGE_TYPES.THINKING,
+        );
       }
     }
 
@@ -367,10 +369,14 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     );
 
     if (text) {
-      options.logger.debug(`Model response: ${text.slice(0, 100)}`, groupId);
+      options.context.logger.debug(`Model response: ${text.slice(0, 100)}`);
       if (!useStreaming) {
         const formatted = await xmlUtils.formatContent(text);
-        options.logger.info(formatted, groupId, MESSAGE_TYPES.MODEL_RESPONSE);
+        options.context.logger.info(
+          formatted,
+          undefined,
+          MESSAGE_TYPES.MODEL_RESPONSE,
+        );
       }
     }
 
@@ -385,7 +391,7 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         cost: normalized.cost,
         elapsedTime: normalized.responseTime,
       };
-      options.logger.statistics(stats, groupId);
+      options.context.logger.statistics(stats);
     }
 
     const endTurn = options.modelHandler.isEndTurnStop(stopReason);
@@ -446,9 +452,6 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     if (state.shouldStop || !state.toolInfo) {
       return { skipped: true };
     }
-
-    const groupId = options.logger.getActiveGroupId();
-
     const interrupted = Boolean(await options.checkInterruption());
     if (interrupted) {
       state.shouldStop = true;
@@ -466,7 +469,12 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         input: state.toolInfo,
         output: sanitizeToolResultForLog(errorResult),
       };
-      options.logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      options.context.logger.info(
+        '',
+        undefined,
+        MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
+      );
       return {
         handledError: true,
         toolName: 'unknown',
@@ -487,7 +495,12 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         input: parsed,
         output: sanitizeToolResultForLog(errorResult),
       };
-      options.logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      options.context.logger.info(
+        '',
+        undefined,
+        MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
+      );
       return {
         handledError: true,
         toolName: parsed.name || parsed.function?.name || 'unknown',
@@ -507,7 +520,12 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
         input: parsed,
         output: sanitizeToolResultForLog(errorResult),
       };
-      options.logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+      options.context.logger.info(
+        '',
+        undefined,
+        MESSAGE_TYPES.TOOL_USE,
+        toolUseLog,
+      );
       return {
         handledError: true,
         toolCallId,
@@ -547,7 +565,6 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       | ToolDispatchErrorResult,
   ): Promise<string | undefined> {
     const { options, state } = prepRes;
-    const groupId = options.logger.getActiveGroupId();
     if ('skipped' in execRes) {
       state.shouldStop = true;
       return FlowTransition.COMPLETE;
@@ -589,7 +606,7 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       state.shouldStop = false;
 
       if (fallbackMessage) {
-        options.logger.warn(fallbackMessage, groupId);
+        options.context.logger.warn(fallbackMessage);
       }
 
       return FlowTransition.CONTINUE;
@@ -610,8 +627,8 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
 
         result = await withToolEditApprovalContext(
           {
-            streamId: options.logger.channelId,
-            executionId: options.executionId,
+            streamId: options.context.logger.channelId,
+            executionId: options.context.executionId,
             toolCallId: execRes.toolCallId,
           },
           () => tool.call(execRes.input),
@@ -634,7 +651,12 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleShared<C>> {
       input: execRes.input ?? execRes.parsed,
       output: sanitizeToolResultForLog(result),
     };
-    options.logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
+    options.context.logger.info(
+      '',
+      undefined,
+      MESSAGE_TYPES.TOOL_USE,
+      toolUseLog,
+    );
 
     if (result.files && result.files.length > 0) {
       const existing = state.toolState.mediaFiles;

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -13,6 +13,7 @@ import { buildUserVars } from '../utils/userVars';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
 import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import type { AgentLogScopeToken } from '@agent/runtime/AgentLogScopeManager';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
@@ -32,10 +33,10 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   protected agentPrompt: AgentPrompt;
   protected agentPath: string;
   protected readonly context: AgentExecutionContext;
+  protected readonly logScopes: AgentExecutionContext['logScopes'];
   protected logger: AgentLogger;
   protected usageMonitor: UsageMonitor;
-  protected runGroupId?: string;
-  private lastRunGroupId?: string;
+  private runScope?: AgentLogScopeToken;
   protected userVars: Record<string, any> = {};
   protected client: C | null = null;
   protected isInterrupted = false;
@@ -77,6 +78,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     this.executionId = context.executionId;
 
     this.logger = context.logger;
+    this.logScopes = context.logScopes;
     this.modelHandler.setLogger(this.logger);
     this.modelHandler.setAgentType(this.agentSetting.agentType);
     this.usageMonitor = new UsageMonitor(this.modelHandler, context);
@@ -107,13 +109,12 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       agentSetting,
       agentPrompt,
       userVars: this.userVars,
-      logger: this.logger,
       client,
       checkInterruption: () => this.checkInterruption(),
       setAbortController: (ctrl) => {
         this.abortController = ctrl;
       },
-      executionId: this.executionId,
+      context: this.context,
     };
   }
 
@@ -135,10 +136,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   }
 
   /** Perform asynchronous initialization work. */
-  public async init(
-    parentGroupId?: string,
-    options?: { createGroup?: boolean },
-  ): Promise<void> {
+  public async init(options?: { createGroup?: boolean }): Promise<void> {
     const { createGroup = true } = options ?? {};
     const runInit = async () => {
       this.logger.debug(`AgentConfig: ${JSON.stringify(this.agentConfig)}`);
@@ -151,17 +149,12 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       this.registerRunningAgent(this.getStreamTabId());
     };
 
-    if (createGroup) {
-      await this.logger.withScope(`Init`, runInit, { parentGroupId });
+    if (!createGroup) {
+      await this.logScopes.within('run', runInit);
       return;
     }
 
-    if (parentGroupId) {
-      await this.logger.withActiveGroup(parentGroupId, runInit);
-      return;
-    }
-
-    await runInit();
+    await this.logScopes.runStage('init', { label: 'Init' }, runInit);
   }
 
   /** Interrupt the agent's execution. */
@@ -215,9 +208,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     groupLabel: string,
     callback: () => Promise<T>,
   ): Promise<T> {
-    return this.logger.withScope(groupLabel, callback, {
-      parentGroupId: this.runGroupId,
-    });
+    return this.logScopes.runStage('round', { label: groupLabel }, callback);
   }
 
   /**
@@ -225,14 +216,11 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
    * @param parentGroupId Optional parent group
    * @returns The created group ID
    */
-  protected async startRunGroup(parentGroupId?: string): Promise<string> {
-    this.runGroupId = await this.logger.startGroup(
+  protected async startRunGroup(): Promise<void> {
+    this.runScope = await this.logScopes.open(
+      'run',
       `Run: ${this.agentConfig.agent}@${this.agentConfig.model}`,
-      undefined,
-      parentGroupId,
     );
-    this.lastRunGroupId = this.runGroupId;
-    return this.runGroupId;
   }
 
   /**
@@ -240,18 +228,19 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
    * @param status Status to mark for the group
    */
   protected endRunGroup(status: 'stopped' | 'error' = 'stopped'): void {
-    if (this.runGroupId) {
-      this.lastRunGroupId = this.runGroupId;
-      this.logger.endGroup(this.runGroupId, status);
-      this.runGroupId = undefined;
+    if (!this.runScope) {
+      return;
     }
+
+    this.logScopes.close(this.runScope, status);
+    this.runScope = undefined;
   }
 
   /**
    * Retrieve the most recently used run group identifier.
    */
   public getLastRunGroupId(): string | undefined {
-    return this.lastRunGroupId;
+    return this.logScopes.getCurrent('run') ?? this.logScopes.getLastClosed('run');
   }
 
   public static getRunningAgent(
@@ -268,8 +257,8 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   public getRunHooks(overrides?: Partial<AgentRunHooks>): AgentRunHooks {
     const baseHooks: AgentRunHooks = {
       start: () => this.startRunGroup(),
-      init: (runGroupId) => this.init(runGroupId),
-      initializeClient: () => this.initializeClient(),
+      init: () => this.init(),
+      initializeClient: () => this.logScopes.within('run', () => this.initializeClient()),
       end: (status) => this.endRunGroup(status),
       cleanup: () => this.cleanup(),
     };

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -614,20 +614,13 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         }) satisfies ReflectionRunState,
       createFlow: () => createReflectionRunFlow<C>(),
       extendHooks: (baseHooks: AgentRunHooks) => {
-        const baseStart = baseHooks.start;
         return {
           ...baseHooks,
-          init: async (runGroupId) => {
-            await this.init(runGroupId, { createGroup: true });
+          init: async () => {
+            await this.init({ createGroup: true });
           },
           start: async () => {
-            const runGroupId = await baseStart();
-            if (!runGroupId) {
-              throw new Error(
-                'Run group identifier is required for reflection runs.',
-              );
-            }
-            return runGroupId;
+            await baseHooks.start();
           },
           resetPromptBuilder: () => this.resetPromptBuilder(),
         } satisfies ReflectionRunHooks;

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -163,8 +163,10 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       createFlow: () => createToolUseRunFlow<C>(),
       extendHooks: (baseHooks: AgentRunHooks) => ({
         ...baseHooks,
-        start: async () => undefined,
-        init: (runGroupId) => this.init(runGroupId, { createGroup: false }),
+        start: async () => {
+          // Tool-use sessions reuse the active logging scope from the invoker.
+        },
+        init: () => this.init({ createGroup: false }),
         prepareState: () => this.prepareInitialSessionState(),
         buildCycleOptions: (toolState) =>
           this.buildToolUseCycleOptions(toolState),

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -30,8 +30,8 @@ export interface ReflectionRunLifecycle {
 }
 
 export interface ReflectionRunHooks {
-  start(): Promise<string>;
-  init(runGroupId: string): Promise<void>;
+  start(): Promise<void>;
+  init(): Promise<void>;
   resetPromptBuilder(): void;
   initializeClient(): Promise<void>;
   end(status: 'stopped' | 'error'): void | Promise<void>;

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -61,8 +61,8 @@ export interface ToolUseRunState<C = unknown> {
 }
 
 export interface ToolUseRunHooks<C = unknown> {
-  start(): Promise<string | undefined>;
-  init(runGroupId: string | undefined): Promise<void>;
+  start(): Promise<void>;
+  init(): Promise<void>;
   initializeClient(): Promise<void>;
   prepareState(): Promise<{
     messages: ProviderMessage[];

--- a/src/agent/implementations/flows/common/AgentInitNode.ts
+++ b/src/agent/implementations/flows/common/AgentInitNode.ts
@@ -41,8 +41,8 @@ export class AgentInitNode<
 
   async exec(shared: Shared): Promise<AgentInitExecResult> {
     try {
-      const runGroupId = await shared.hooks.start();
-      await shared.hooks.init(runGroupId);
+      await shared.hooks.start();
+      await shared.hooks.init();
       if (this.config.beforeInitialize) {
         try {
           await this.config.beforeInitialize(shared);

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -656,13 +656,11 @@ export abstract class ModelHandler<
   /**
    * Extracts thinking content from model responses
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted thinking content string or null if no thinking content is available
    */
   abstract processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null;
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1489,7 +1489,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /**
    * Process thinking blocks for Anthropic models
    * @param responseObject The response object from Anthropic API
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking blocks
    * @returns The extracted thinking content (or null if none)
    * This preserves the full thinking objects including signature which is required
@@ -1497,7 +1496,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
    */
   processThinkingBlock(
     responseObject: BetaMessage,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -1526,7 +1524,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     } catch (e) {
       this.logger.error(
         `Error extracting thinking blocks: ${getSdkErrorMessage(e)}`,
-        groupId,
+        undefined,
         undefined,
         e,
       );
@@ -1539,7 +1537,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     this.logger.debug(
       `Found ${thinkingBlocks.length} thinking blocks`,
-      groupId,
     );
 
     // If toolState is provided, update it with all thinking blocks
@@ -1554,12 +1551,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         toolState.thinkingAdded = true;
         this.logger.debug(
           `Added ${thinkingBlocks.length} thinking blocks to toolState`,
-          groupId,
         );
       } else {
         this.logger.debug(
           `Skipping adding thinking blocks to toolState because of cut off message`,
-          groupId,
         );
       }
     }

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -64,13 +64,11 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for DeepSeek models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -94,7 +92,6 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
         reasoningContent = message.reasoning_content;
         this.logger.debug(
           'Found reasoning_content in choices[0].message.reasoning_content',
-          groupId,
         );
 
         // If toolState is provided and we have reasoning content,
@@ -108,7 +105,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
 
           toolState.thinkingBlocks = [thinkingBlock];
           toolState.thinkingAdded = true;
-          // this.logger.debug('Added reasoning content to toolState', groupId);
+          // this.logger.debug('Added reasoning content to toolState');
         }
         // For deepseek mode thinking content should not be attached back to the message as a content item.
         // Nevertheless one can include one in a bare way...
@@ -121,7 +118,6 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     // Log preview of thinking content (assuming it's a string)
     this.logger.debug(
       `DeepSeek reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
     );
 
     // Return the reasoning content (already a string for DeepSeek)

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1021,7 +1021,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   processThinkingBlock(
     responseObject: GenerateContentResponse,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (
@@ -1064,7 +1063,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (thoughtContent) {
       this.logger.debug(
         `Google GenAI thought summary preview: ${thoughtContent.substring(0, K_SLICE)}...`,
-        groupId,
       );
     }
 

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -31,13 +31,11 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for Moonshot models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -59,7 +57,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         reasoningContent = message.thinking_content;
         this.logger.debug(
           'Found thinking_content in choices[0].message.thinking_content',
-          groupId,
         );
 
         // If toolState is provided and we have reasoning content,
@@ -84,7 +81,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     // Log preview of thinking content
     this.logger.debug(
       `Kimi thinking content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
     );
 
     return reasoningContent;

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1130,13 +1130,11 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /**
    * Processes thinking blocks from API response. OpenAI models do not support thinking blocks.
    * @param responseObject The response object from the OpenAI API
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with thinking blocks
    * @returns Always returns null as OpenAI doesn't support thinking blocks
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     const reasoning = responseObject?.choices?.[0]?.message?.reasoning_content;
@@ -1151,7 +1149,6 @@ export class ModelHandlerOpenAI extends ModelHandler<
 
     this.logger.debug(
       `OpenAI reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
-      groupId,
     );
     return reasoning;
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1222,7 +1222,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Process reasoning summaries from the Responses API. */
   processThinkingBlock(
     responseObject: Response,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     const outputArr = responseObject?.output;
@@ -1250,7 +1249,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (thoughtContent) {
       this.logger.debug(
         `OpenAI Responses reasoning preview: ${thoughtContent.substring(0, K_SLICE)}...`,
-        groupId,
       );
     }
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -95,7 +95,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   // Implementation for processing thinking blocks in OpenRouter responses
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -110,13 +109,12 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       responseObject.choices[0].message.reasoning
     ) {
       const reasoning = responseObject.choices[0].message.reasoning;
-      this.logger.debug(`OpenRouter reasoning found`, groupId);
+      this.logger.debug(`OpenRouter reasoning found`);
 
       // Log preview of reasoning content
       if (typeof reasoning === 'string') {
         this.logger.debug(
           `Reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
-          groupId,
         );
         return reasoning;
       } else {
@@ -124,7 +122,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
         const reasoningStr = JSON.stringify(reasoning);
         this.logger.debug(
           `Reasoning preview: ${reasoningStr.substring(0, K_SLICE)}...`,
-          groupId,
         );
         return reasoningStr;
       }

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -18,13 +18,11 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for xAI models
    * @param responseObject The raw response object from the model
-   * @param groupId Optional group ID for logging
    * @param toolState Optional toolState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null {
     if (!responseObject) {
@@ -50,7 +48,6 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
         reasoningContent = message.reasoning_content;
         this.logger.debug(
           'Found reasoning_content in choices[0].message.reasoning_content',
-          groupId,
         );
 
         // If toolState is provided and we have reasoning content,
@@ -75,7 +72,6 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
     // Log preview of thinking content
     this.logger.debug(
       `xAI reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-      groupId,
     );
 
     return reasoningContent;

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -184,7 +184,6 @@ export interface IModelHandler<
   /** Extract intermediate "thinking" content from a response. */
   processThinkingBlock(
     responseObject: any,
-    groupId?: string,
     toolState?: ToolState,
   ): string | null;
 

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -5,6 +5,9 @@ import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 import { AgentUsageReporter } from '@logger/AgentUsageReporter';
 
+// Local imports - runtime helpers
+import { AgentLogScopeManager } from './AgentLogScopeManager';
+
 export interface AgentExecutionContextInit {
   streamId: StreamTabId;
   executionId?: ExecutionId;
@@ -16,10 +19,12 @@ export interface AgentExecutionContextInit {
 export class AgentExecutionContext {
   public readonly logger: AgentLogger;
   public readonly usageReporter: AgentUsageReporter;
+  public readonly logScopes: AgentLogScopeManager;
 
   constructor(private readonly init: AgentExecutionContextInit) {
     this.logger = new AgentLogger(init.streamId, true);
     this.usageReporter = new AgentUsageReporter(this.logger, init.streamId);
+    this.logScopes = new AgentLogScopeManager(this.logger);
   }
 
   get streamId(): StreamTabId {

--- a/src/agent/runtime/AgentLogScopeManager.ts
+++ b/src/agent/runtime/AgentLogScopeManager.ts
@@ -1,0 +1,134 @@
+// Local imports - logger
+import type { AgentLogger } from '@logger/AgentLogger';
+
+export type AgentLogStage = 'run' | 'init' | 'round' | 'output' | (string & {});
+
+export interface AgentLogScopeToken {
+  stage: AgentLogStage;
+  groupId: string;
+}
+
+interface StageScopeOptions {
+  id?: string;
+  successStatus?: 'stopped' | 'error';
+  errorStatus?: 'stopped' | 'error';
+  parentStage?: AgentLogStage;
+}
+
+interface StageRunOptions extends StageScopeOptions {
+  label: string;
+}
+
+const DEFAULT_STAGE_PARENTS: Partial<Record<AgentLogStage, AgentLogStage>> = {
+  init: 'run',
+  round: 'run',
+  output: 'round',
+};
+
+function last<T>(values: T[] | undefined): T | undefined {
+  if (!values || values.length === 0) {
+    return undefined;
+  }
+  return values[values.length - 1];
+}
+
+/**
+ * Manages lifecycle log scopes so agent collaborators avoid plumbing IDs.
+ */
+export class AgentLogScopeManager {
+  private readonly stageStacks = new Map<AgentLogStage, string[]>();
+  private readonly lastClosed = new Map<AgentLogStage, string>();
+
+  constructor(
+    private readonly logger: AgentLogger,
+    private readonly stageParents: Partial<Record<AgentLogStage, AgentLogStage>> = {},
+  ) {}
+
+  getLogger(): AgentLogger {
+    return this.logger;
+  }
+
+  getCurrent(stage: AgentLogStage): string | undefined {
+    return last(this.stageStacks.get(stage));
+  }
+
+  getLastClosed(stage: AgentLogStage): string | undefined {
+    return this.lastClosed.get(stage);
+  }
+
+  async runStage<T>(stage: AgentLogStage, options: StageRunOptions, fn: () => Promise<T>): Promise<T> {
+    const token = await this.open(stage, options.label, options);
+    return this.logger.withActiveGroup(token.groupId, async () => {
+      try {
+        const result = await fn();
+        this.close(token, options.successStatus ?? 'stopped');
+        return result;
+      } catch (error) {
+        this.close(token, options.errorStatus ?? 'error');
+        throw error;
+      }
+    });
+  }
+
+  async open(
+    stage: AgentLogStage,
+    label: string,
+    options: StageScopeOptions = {},
+  ): Promise<AgentLogScopeToken> {
+    const parentGroupId = this.resolveParent(stage, options.parentStage);
+    const groupId = await this.logger.startGroup(label, options.id, parentGroupId);
+    this.pushStage(stage, groupId);
+    return { stage, groupId };
+  }
+
+  close(token: AgentLogScopeToken | undefined, status: 'stopped' | 'error' = 'stopped'): void {
+    if (!token) {
+      return;
+    }
+
+    this.popStage(token);
+    this.lastClosed.set(token.stage, token.groupId);
+    this.logger.endGroup(token.groupId, status);
+  }
+
+  async within<T>(stage: AgentLogStage, fn: () => Promise<T>): Promise<T> {
+    const groupId = this.getCurrent(stage);
+    if (!groupId) {
+      return fn();
+    }
+    return this.logger.withActiveGroup(groupId, fn);
+  }
+
+  private resolveParent(stage: AgentLogStage, parentStage?: AgentLogStage): string | undefined {
+    const preferredStage = parentStage ?? this.stageParents[stage] ?? DEFAULT_STAGE_PARENTS[stage];
+    if (!preferredStage) {
+      return undefined;
+    }
+    return this.getCurrent(preferredStage);
+  }
+
+  private pushStage(stage: AgentLogStage, groupId: string): void {
+    const stack = this.stageStacks.get(stage) ?? [];
+    stack.push(groupId);
+    this.stageStacks.set(stage, stack);
+  }
+
+  private popStage(token: AgentLogScopeToken): void {
+    const stack = this.stageStacks.get(token.stage);
+    if (!stack || stack.length === 0) {
+      return;
+    }
+
+    const index = stack.lastIndexOf(token.groupId);
+    if (index === -1) {
+      return;
+    }
+
+    stack.splice(index, 1);
+    if (stack.length === 0) {
+      this.stageStacks.delete(token.stage);
+    } else {
+      this.stageStacks.set(token.stage, stack);
+    }
+  }
+}

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -24,6 +24,10 @@ import { OPENAI_CHAT_FINISH } from '@agent/modelHandlers/types/StopReasonTypes';
 // Local imports - logging
 import type { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES, type MessageType } from '@logger/messageTypes';
+import { AgentLogScopeManager } from '@agent/runtime/AgentLogScopeManager';
+import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import type { AgentUsageReporter } from '@logger/AgentUsageReporter';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports - model configuration
 import {
@@ -58,6 +62,21 @@ type ConfigGetter = (
   section: string | undefined,
   key: string | undefined,
 ) => unknown;
+
+function createExecutionContextStub(logger: AgentLogger): AgentExecutionContext {
+  const logScopes = new AgentLogScopeManager(logger);
+  return {
+    logger,
+    usageReporter: {} as AgentUsageReporter,
+    logScopes,
+    get streamId() {
+      return 'test-stream' as StreamTabId;
+    },
+    get executionId() {
+      return undefined;
+    },
+  } as AgentExecutionContext;
+}
 
 class StubOpenAIResponsesHandler extends ModelHandlerOpenAIResponse {
   constructor(config: ModelConfig) {
@@ -266,6 +285,8 @@ describe('ResponseCycle background reasoning logs', () => {
       endGroup() {},
       getActiveGroupId: () => undefined,
       setActiveGroupId() {},
+      withActiveGroup: async (_groupId?: string, fn?: () => unknown) =>
+        (await fn?.()) ?? undefined,
     } as unknown as AgentLogger;
 
     const handlerConfig: ModelConfig = {
@@ -339,7 +360,7 @@ describe('ResponseCycle background reasoning logs', () => {
         agentConfig,
         agentPrompt,
         userVars: {},
-        logger: loggerStub,
+        context: createExecutionContextStub(loggerStub),
         client: {} as OpenAI,
         checkInterruption: () => false,
         setAbortController: () => {},
@@ -388,6 +409,8 @@ describe('ResponseCycle background reasoning logs', () => {
       endGroup() {},
       getActiveGroupId: () => undefined,
       setActiveGroupId() {},
+      withActiveGroup: async (_groupId?: string, fn?: () => unknown) =>
+        (await fn?.()) ?? undefined,
     } as unknown as AgentLogger;
 
     const handlerConfig: ModelConfig = {

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -19,6 +19,10 @@ import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { AgentLogScopeManager } from '@agent/runtime/AgentLogScopeManager';
+import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import type { AgentUsageReporter } from '@logger/AgentUsageReporter';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import {
   ModelConfig,
   ModelProvider,
@@ -81,6 +85,21 @@ class MockHandler extends ModelHandlerDeepSeek {
   }
 }
 
+function createExecutionContextStub(logger: AgentLogger): AgentExecutionContext {
+  const logScopes = new AgentLogScopeManager(logger);
+  return {
+    logger,
+    usageReporter: {} as AgentUsageReporter,
+    logScopes,
+    get streamId() {
+      return 'tool-use-test' as StreamTabId;
+    },
+    get executionId() {
+      return undefined;
+    },
+  } as AgentExecutionContext;
+}
+
 describe('runToolUseCycle DeepSeek', () => {
   it('logs tool calls and creates follow-up message', async () => {
     const config: ModelConfig = {
@@ -120,7 +139,7 @@ describe('runToolUseCycle DeepSeek', () => {
       agentSetting: setting,
       agentPrompt: prompt,
       userVars: {},
-      logger,
+      context: createExecutionContextStub(logger),
       client: {} as OpenAI,
       toolRegistry,
       checkInterruption: () => false,

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -21,6 +21,10 @@ import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { AgentLogScopeManager } from '@agent/runtime/AgentLogScopeManager';
+import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import type { AgentUsageReporter } from '@logger/AgentUsageReporter';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import {
   ModelConfig,
   ModelProvider,
@@ -93,6 +97,21 @@ class MockHandler extends ModelHandlerOpenAIResponse {
   }
 }
 
+function createExecutionContextStub(logger: AgentLogger): AgentExecutionContext {
+  const logScopes = new AgentLogScopeManager(logger);
+  return {
+    logger,
+    usageReporter: {} as AgentUsageReporter,
+    logScopes,
+    get streamId() {
+      return 'tool-use-test' as StreamTabId;
+    },
+    get executionId() {
+      return undefined;
+    },
+  } as AgentExecutionContext;
+}
+
 describe('runToolUseCycle OpenAIResponse', () => {
   it('logs tool calls and creates follow-up message', async () => {
     const config: ModelConfig = {
@@ -132,7 +151,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       agentSetting: setting,
       agentPrompt: prompt,
       userVars: {},
-      logger,
+      context: createExecutionContextStub(logger),
       client: {} as OpenAI,
       toolRegistry,
       checkInterruption: () => false,


### PR DESCRIPTION
## Summary
- add an AgentLogScopeManager to own run/init/round scopes and expose it through AgentExecutionContext and BaseAgent
- thread AgentExecutionContext through cycle options and agent flows so logging uses shared context instead of manual group IDs
- drop the groupId parameter from processThinkingBlock implementations and update related tests to use execution-context stubs

## Testing
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_6908e2626afc8324a9adebeaf28acf82

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces AgentLogScopeManager and threads AgentExecutionContext through agent flows and cycles, removing manual groupId plumbing and updating hooks, handlers, and tests.
> 
> - **Runtime/Logging**:
>   - Add `AgentLogScopeManager` and expose via `AgentExecutionContext` as `logScopes`.
>   - `BaseAgent` now manages run/init/round scopes with `logScopes`; removes manual group IDs.
>   - Update `AgentRunHooks`/`IAgent`: `start()`/`init()` no longer pass/require group IDs.
> - **Core Options/Flows**:
>   - `AgentCycleOptions` now carries `context`; remove `logger`/`executionId` fields.
>   - `ResponseCycleFlow` and `ToolUseCycleFlow` use `options.context.logger` and `options.context.executionId`; drop `groupId` usage.
> - **Model Handlers**:
>   - Simplify `processThinkingBlock(responseObject, toolState?)` (removed `groupId` param) and update all implementations (`Anthropic`, `OpenAI`, `OpenAIResponse`, `GoogleGenAI`, `OpenRouter`, `DeepSeek`, `Kimi`, `XAI`).
>   - Adjust internal logging to not require group IDs.
> - **Agents/Flows**:
>   - `BaseReflectionAgent`/`BaseToolUseAgent` adopt new hooks and scope handling.
>   - Common init node updated to call `start()`/`init()` without IDs.
> - **Tests**:
>   - Update tests to create execution-context stubs and use `context.logger`; remove direct logger/groupId assumptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4047bd001e13370f4948cceace9e2b07dd2f14ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->