### PR TITLE
Fix duplicated LaTeX environment wrappers

### DIFF
--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -366,6 +366,10 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
     [`(\\r?\\n)(?:[ \t]*\\r?\\n)+([ \t]*\\\\end\\{(${EQUATION_ENVIRONMENT_PATTERN})\\})`]:
       '$1$2',
 
+    // Fix duplicated begin/end wrappers such as \begin{begin{align}}
+    '\\\\begin\\{begin\\{([a-zA-Z*]+)\\}\\}': '\\begin{$1}',
+    '\\\\end\\{end\\{([a-zA-Z*]+)\\}\\}': '\\end{$1}',
+
     // Fix inconsistent blank lines after environments (universally preferred)
     '(\\\\end\\{(equation|align|figure|table|itemize|enumerate|description)\\})([A-Za-z])':
       '$1\n\n$3',

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -6,7 +6,7 @@ import {
 } from './constants';
 
 const EQUATION_ENVIRONMENT_PATTERN =
-  '(?:align\\*?|aligned\\*?|alignat\\*?|flalign\\*?|gather\\*?|multline\\*?|equation\\*?|split\\*?)';
+  '(?:align\\*?|aligned\\*?|alignat\\*?|flalign\\*?|gather\\*?|multline\\*?|equation\\*?|eqnarray\\*?|split\\*?)';
 
 const convertFencedLatexBlock: ReplacementFunction = (
   match,
@@ -367,8 +367,8 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
       '$1$2',
 
     // Fix duplicated begin/end wrappers such as \begin{begin{align}}
-    '\\\\begin\\{begin\\{([a-zA-Z*]+)\\}\\}': '\\begin{$1}',
-    '\\\\end\\{end\\{([a-zA-Z*]+)\\}\\}': '\\end{$1}',
+    [`\\\\begin\\{begin\\{(${EQUATION_ENVIRONMENT_PATTERN})\\}\\}`]: '\\begin{$1}',
+    [`\\\\end\\{end\\{(${EQUATION_ENVIRONMENT_PATTERN})\\}\\}`]: '\\end{$1}',
 
     // Fix inconsistent blank lines after environments (universally preferred)
     '(\\\\end\\{(equation|align|figure|table|itemize|enumerate|description)\\})([A-Za-z])':

--- a/src/test/replacement/equationLinebreaks.test.ts
+++ b/src/test/replacement/equationLinebreaks.test.ts
@@ -53,4 +53,19 @@ describe('equation environment linebreak normalization', () => {
 
     assert.strictEqual(result, expected);
   });
+
+  it('fixes duplicated begin/end environment wrappers', () => {
+    const input = String.raw`\\begin{begin{eqnarray}}
+x = y\\
+\\end{end{eqnarray}}`;
+    const expected = String.raw`\\begin{eqnarray}
+x = y\\
+\\end{eqnarray}`;
+
+    const result = applyReplacements(input, EQUATION_STYLE_REPLACEMENTS, {
+      processMathUnicode: false,
+    });
+
+    assert.strictEqual(result, expected);
+  });
 });


### PR DESCRIPTION
## Summary
- normalize duplicated LaTeX begin/end wrappers so nested begin{begin{...}} and end{end{...}} collapse to a single environment
- add a regression test covering the eqnarray helper case

## Testing
- npm test -- equationLinebreaks.test.ts *(fails: missing dependency `@cfworker/json-schema` from project setup)*
- npm run format


------
https://chatgpt.com/codex/tasks/task_e_690a106885cc8324be9a611e9cd20c82

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes duplicated LaTeX begin/end wrappers and extends equation environment matching to include `eqnarray`, with a new regression test.
> 
> - **Equation style replacements (`src/replacement/rulesRegex.ts`)**:
>   - Add patterns to collapse duplicated environment wrappers: `\begin{begin{...}}` → `\begin{...}` and `\end{end{...}}` → `\end{...}` for equation environments.
>   - Extend `EQUATION_ENVIRONMENT_PATTERN` to include `eqnarray`/`eqnarray*`.
> - **Tests (`src/test/replacement/equationLinebreaks.test.ts`)**:
>   - Add regression test for duplicated `begin/end` wrappers using `eqnarray`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3c1e6321f1b582c4628647ca29a5e89fb25cbf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->