### PR TITLE
fix: normalize duplicated latex environment tags

### DIFF
--- a/src/replacement/helpers.ts
+++ b/src/replacement/helpers.ts
@@ -150,6 +150,17 @@ export function generateXmlLatexConversions(environments: string[]): {
     // LaTeX with incorrect XML ending
     patterns[`\\begin${env}`] = `\\begin{${env}}`;
     patterns[`\\end${env}`] = `\\end{${env}}`;
+
+    // LaTeX with duplicated begin/end keywords
+    patterns[`\\begin{begin{${env}}`] = `\\begin{${env}}`;
+    patterns[`\\begin{begin{${env}}}`] = `\\begin{${env}}`;
+    patterns[`\\begin{\\begin{${env}}`] = `\\begin{${env}}`;
+    patterns[`\\begin{\\begin{${env}}}`] = `\\begin{${env}}`;
+
+    patterns[`\\end{end{${env}}`] = `\\end{${env}}`;
+    patterns[`\\end{end{${env}}}`] = `\\end{${env}}`;
+    patterns[`\\end{\\end{${env}}`] = `\\end{${env}}`;
+    patterns[`\\end{\\end{${env}}}`] = `\\end{${env}}`;
   });
 
   return patterns;


### PR DESCRIPTION
## Summary
- collapse duplicated begin/end keywords in generated LaTeX environment replacements so errant sequences like `\end{end{eqnarray}` become valid

## Testing
- npm run format
- npm run lint
- npm run compile
- npm test *(fails: Cannot find module '@cfworker/json-schema')*

------
https://chatgpt.com/codex/tasks/task_e_690a106885cc8324be9a611e9cd20c82

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add patterns to collapse duplicated `begin`/`end` in LaTeX environment tags (e.g., `\begin{begin{env}}`, `\end{\end{env}}`) to valid forms.
> 
> - **Replacement helpers (`src/replacement/helpers.ts`)**:
>   - Update `generateXmlLatexConversions` to normalize duplicated `begin`/`end` in LaTeX environments:
>     - Handles `\begin{begin{env}}`, `\begin{\begin{env}}` → `\begin{env}`
>     - Handles `\end{end{env}}`, `\end{\end{env}}` → `\end{env}`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d18f57f6e4d36d584d8f4b3b7db1730b248213b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->