### PR TITLE
fix: trust loader agent type normalization

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -20,10 +20,7 @@ import {
   MergeAgent,
   BaseToolUseAgent,
 } from '@agent/implementations';
-import {
-  loadAgentSettingAndPrompts,
-  ensureAgentTypeForSource,
-} from '@agent/runtime/agentLoad';
+import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { ModelFactory } from '@agent/runtime/ModelFactory';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -255,10 +252,7 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
     { preferMultiple: fullConfig.useMultipleOutputs },
   );
 
-  const agentSetting = ensureAgentTypeForSource(
-    loadedAgentSetting,
-    agentPathInfo.source,
-  );
+  const agentSetting = loadedAgentSetting;
 
   const sessionDescriptor = getAgentSessionDescriptor(agentSetting);
 

--- a/src/test/agent/runtime/agentLoad.test.ts
+++ b/src/test/agent/runtime/agentLoad.test.ts
@@ -2,9 +2,14 @@
 import { strict as assert } from 'assert';
 import * as path from 'path';
 
+// Local imports - agent core
+import { AgentType } from '@agent/core/AgentDataclass';
+
 // Local imports - agent runtime
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { AgentDirectorySource } from '@agent/runtime/AgentPathTypes';
+
+// Local imports - utilities
 import { AbsoluteFS } from '@utils/files';
 
 suite('loadAgentSettingAndPrompts', () => {
@@ -115,5 +120,33 @@ suite('loadAgentSettingAndPrompts', () => {
     );
 
     assert.strictEqual(prompts.userRequest, 'base only');
+  });
+
+  test('sets tool-use agent type for built-in tool agents without explicit type', async () => {
+    const agentPath = path.join('/', 'tmp', 'tool-use');
+    const baseDefinitionPath = path.join(agentPath, 'toolsmith.yaml');
+    const agentPathInfo = {
+      directory: agentPath,
+      source: AgentDirectorySource.BuiltInToolUse,
+    } as const;
+
+    fileContents.set(
+      normalize(baseDefinitionPath),
+      [
+        'name: toolsmith',
+        'settings:',
+        '  temperature: 0.1',
+        'prompts:',
+        '  userRequest: gather tools',
+        '',
+      ].join('\n'),
+    );
+
+    const [settings] = await loadAgentSettingAndPrompts(
+      agentPathInfo,
+      'toolsmith',
+    );
+
+    assert.strictEqual(settings.agentType, AgentType.ToolUse);
   });
 });


### PR DESCRIPTION
## Summary
- rely on loadAgentSettingAndPrompts to provide normalized agent settings during agent preparation
- add a unit test covering tool-use agent type defaults when loading definitions

## Testing
- npm test -- loadAgent *(fails: TypeScript errors in src/webview/managers/ExecutionManager.ts unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_69071d670a1483248d5cd770d4ea9247

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors agent state/flows and logging, removes tool edit-approval (and UI), migrates texra.* config keys, and updates FS, persistence, tools, and docs accordingly.
> 
> - **Core/Runtime**:
>   - Replace `AgentSharedStore`/`AgentWorkspaceState` with `ToolState`, `AgentStateRound`, and `AgentStateGlobal`; update response/tool-use flows and model handlers.
>   - Drop `AgentExecutionContext`; simplify `BaseAgent` lifecycle and usage tracking.
> - **Logging/Progress View**:
>   - Rework logger (groups/transport), remove registry; adjust progress events and message parsing.
>   - Remove approval UI and related commands; polish follow-up/usage rendering.
> - **Tools**:
>   - Remove edit-approval pipeline; `write_file`, `edit_file`, and `file_op` write directly.
>   - Tweak outputs (e.g., use `system` instead of `userInstruction`).
> - **Config/Settings**:
>   - Migrate many keys from `texra.*` to shorter namespaces (e.g., `model.*`, `latex.*`, `files.*`, `toolUse.*`, `ui.*`).
>   - Update main view/agent option readers to new keys.
> - **Filesystem**:
>   - Replace `BaseFS` with revamped `AbsoluteFS`/`RelativeFS`; safer delete/ensureDir and JSON helpers.
> - **Agent Loading**:
>   - Improve YAML loading/resolution (handle `_multiple`, default ToolUse type for built-in tool agents).
> - **Persistence**:
>   - Harden tool-use session persistence (conditional enable, TTL cleanup, migration), snapshot schema uses `ToolState`.
> - **Docs/UI**:
>   - Update guides to reflect behavior changes; remove pocketflow state doc; inline UI/copy tweaks.
> - **Dependencies**:
>   - Adjust versions (e.g., MCP SDK, fast-xml-parser, eslint) and related lockfile changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e493154c358302f27f29795f601fe5be8f848d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->