### PR TITLE
fix: return full command output

### DIFF
--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -100,25 +100,24 @@ class BashMockHandler extends ModelHandlerOpenAIResponse {
 
 suite('BashTool', () => {
   const originalExecuteCommand = execUtils.executeCommand;
+  const execUtilsMutable = execUtils as unknown as {
+    executeCommand: typeof originalExecuteCommand;
+  };
 
   teardown(() => {
-    (
-      execUtils as unknown as { executeCommand: typeof originalExecuteCommand }
-    ).executeCommand = originalExecuteCommand;
+    execUtilsMutable.executeCommand = originalExecuteCommand;
   });
 
   test('preserves long stdout for tool results and model payloads', async () => {
-    const longOutput = '0123456789'.repeat(35);
+    const longOutput = '0123456789'.repeat(35); // 350 chars, exceeds log truncation of 150
     const execResult: ExecResult = {
       success: true,
-      stdout: `${longOutput}\n`,
+      stdout: longOutput,
       stderr: null,
       timedOut: false,
     };
 
-    (
-      execUtils as unknown as { executeCommand: typeof originalExecuteCommand }
-    ).executeCommand = async () => execResult;
+    execUtilsMutable.executeCommand = async () => execResult;
 
     const bashTool = new BashTool();
     const directResult = await bashTool.call({ command: 'echo long' });
@@ -192,9 +191,9 @@ suite('BashTool', () => {
       (msg) => (msg as any).type === 'function_call_output',
     ) as any;
     assert.ok(toolOutputMessage, 'Tool output message was not produced');
-    assert.equal(
-      toolOutputMessage.output,
-      JSON.stringify({ output: longOutput }),
+    assert.ok(
+      typeof toolOutputMessage.output === 'string' &&
+        toolOutputMessage.output.includes(longOutput),
       'Model follow-up payload should contain the complete stdout text',
     );
   });

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -1,0 +1,201 @@
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import type OpenAI from 'openai';
+
+// Local imports - agent core
+import {
+  AgentCategory,
+  AgentPrompt,
+  AgentSetting,
+  AgentType,
+} from '@agent/core/AgentDataclass';
+import { AgentSharedStore } from '@agent/core/AgentSharedStore';
+import { AgentRunState, ConversationRoundState } from '@agent/core/AgentState';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import { runToolUseCycle } from '@agent/core/ToolUseCycle';
+import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
+
+// Local imports - agent runtime
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+
+// Local imports - agent model handlers
+import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+
+// Local imports - model
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelConfig,
+  ModelProvider,
+} from '@model/ModelConfig';
+
+// Local imports - tools
+import { BashTool } from '@tools/bash';
+
+// Local imports - utilities
+import type { ExecResult } from '@agent/types/ResultTypes';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import * as execUtils from '@utils/system/execUtils';
+import { AgentLogger } from '@logger/AgentLogger';
+
+class BashMockHandler extends ModelHandlerOpenAIResponse {
+  private callCount = 0;
+
+  async getClient(): Promise<OpenAI> {
+    return {} as OpenAI;
+  }
+
+  override async createResponse(): Promise<any> {
+    this.callCount += 1;
+    if (this.callCount === 1) {
+      return {
+        id: 'bash-call',
+        status: 'completed',
+        output_text: 'running bash',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              { type: 'output_text', text: 'running bash', annotations: [] },
+            ],
+          },
+          {
+            type: 'function_call',
+            call_id: 'bash-1',
+            name: 'bash',
+            arguments: '{"command":"echo long"}',
+          },
+        ],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      };
+    }
+    return {
+      id: 'bash-complete',
+      status: 'completed',
+      output_text: 'done',
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'done', annotations: [] }],
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    };
+  }
+
+  override extractResponse(resp: any): [string, any, any] {
+    if (resp.id === 'bash-call') {
+      return ['running bash', resp.usage, 'stop'];
+    }
+    if (resp.id === 'bash-complete') {
+      return ['done', resp.usage, 'stop'];
+    }
+    return ['', resp.usage, 'stop'];
+  }
+}
+
+suite('BashTool', () => {
+  const originalExecuteCommand = execUtils.executeCommand;
+
+  teardown(() => {
+    (
+      execUtils as unknown as { executeCommand: typeof originalExecuteCommand }
+    ).executeCommand = originalExecuteCommand;
+  });
+
+  test('preserves long stdout for tool results and model payloads', async () => {
+    const longOutput = '0123456789'.repeat(35);
+    const execResult: ExecResult = {
+      success: true,
+      stdout: `${longOutput}\n`,
+      stderr: null,
+      timedOut: false,
+    };
+
+    (
+      execUtils as unknown as { executeCommand: typeof originalExecuteCommand }
+    ).executeCommand = async () => execResult;
+
+    const bashTool = new BashTool();
+    const directResult = await bashTool.call({ command: 'echo long' });
+    assert.equal(
+      directResult.output,
+      longOutput,
+      'Bash tool should return the full stdout text',
+    );
+
+    const config: ModelConfig = {
+      name: 'test',
+      fullName: 'test',
+      provider: ModelProvider.OPENAI,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    };
+    const handler = new BashMockHandler(config);
+    const toolState = new AgentWorkspaceState();
+    const options: ToolUseCycleOptions<OpenAI> = {
+      modelHandler: handler,
+      agentSetting: {
+        agentType: AgentType.ToolUse,
+        agentCategory: AgentCategory.ToolUse,
+        documentTag: 'doc',
+        temperature: 0,
+        endTag: '</doc>',
+        requiredFiles: {},
+        requiredFilesInternal: {},
+        defaultOutputFiles: [],
+        filePatternsContain: [],
+        tools: [{ name: 'bash' }],
+      } satisfies AgentSetting,
+      agentPrompt: {
+        systemPrompt: '',
+        userPrefix: '',
+        userRequest: '',
+      } satisfies AgentPrompt,
+      userVars: {},
+      userVarChannels: {
+        input: Object.freeze({}) as Readonly<Record<string, any>>,
+        transient: {},
+        output: {},
+      },
+      logger: new AgentLogger('BashToolTest', true),
+      client: {} as OpenAI,
+      toolRegistry: { bash: bashTool },
+      checkInterruption: () => false,
+      setAbortController: () => {},
+      toolState,
+      modelName: 'test',
+      context: new AgentExecutionContext({
+        streamId: 'bash-tool' as StreamTabId,
+      }),
+    };
+
+    const store = new AgentSharedStore({
+      round: new ConversationRoundState(0),
+      run: new AgentRunState(),
+      workspace: toolState,
+      user: options.userVarChannels,
+    });
+
+    const messages: ProviderMessage[] = [];
+    await runToolUseCycle({ options, messages, store });
+
+    const toolOutputMessage = messages.find(
+      (msg) => (msg as any).type === 'function_call_output',
+    ) as any;
+    assert.ok(toolOutputMessage, 'Tool output message was not produced');
+    assert.equal(
+      toolOutputMessage.output,
+      JSON.stringify({ output: longOutput }),
+      'Model follow-up payload should contain the complete stdout text',
+    );
+  });
+});

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -112,7 +112,8 @@ suite('BashTool', () => {
     const longOutput = '0123456789'.repeat(35); // 350 chars, exceeds log truncation of 150
     const execResult: ExecResult = {
       success: true,
-      stdout: longOutput,
+      // executeCommand trims trailing whitespace before returning stdout
+      stdout: `${longOutput}\n`.trim(),
       stderr: null,
       timedOut: false,
     };

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -22,6 +22,8 @@ export class BashTool extends defineTool({
   schema: BashInputSchema,
 }) {
   protected async execute(input: BashInput): Promise<ToolResult> {
+    // Truncation only applies to internal logging so long-running commands keep
+    // the output channel readable while still returning the complete stdout.
     const result = await executeCommand(input.command, { truncate: true });
     if (result.success) {
       const commandPreview =

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -28,6 +28,14 @@ function truncateOutput(
   return text;
 }
 
+function normalizeOutput(text: string | null | undefined): string | null {
+  if (text == null) {
+    return null;
+  }
+  const trimmed = text.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 /**
  * Execute external command with output handling and workspace path management.
  */
@@ -97,29 +105,30 @@ export async function executeCommand(
     }
 
     const shouldTruncate = options.truncate ?? false;
-    const processOutput = (output: string | null) =>
-      shouldTruncate
-        ? truncateOutput(output?.trim() || null)
-        : output?.trim() || null;
+    const formatForLog = (output: string | null) =>
+      shouldTruncate && output ? truncateOutput(output) : output;
 
-    if (stderr && stderr.trim()) {
+    const normalizedStdout = normalizeOutput(stdout);
+    const normalizedStderr = normalizeOutput(stderr);
+
+    if (normalizedStderr) {
       logger.debug(
         options.channel ?? CHANNEL,
-        `Command stderr: ${processOutput(stderr)}`,
+        `Command stderr: ${formatForLog(normalizedStderr)}`,
       );
     }
 
-    // if (stdout && stdout.trim()) {
+    // if (normalizedStdout) {
     //   logger.debug(
     //     options.channel ?? CHANNEL,
-    //     `Command stdout: ${processOutput(stdout)}`,
+    //     `Command stdout: ${formatForLog(normalizedStdout)}`,
     //   );
     // }
 
     return {
       success: exitCode === 0 && !timedOut,
-      stdout: processOutput(stdout),
-      stderr: processOutput(stderr),
+      stdout: normalizedStdout,
+      stderr: normalizedStderr,
       timedOut,
     };
   } catch (err) {
@@ -137,13 +146,12 @@ export async function executeCommand(
 
     // With reject: false, this catch block only handles actual execution errors
     // (e.g., command not found), not timeouts or non-zero exit codes
-    const shouldTruncate = options.truncate ?? false;
+    const fallbackOutput = stderr ?? errorMessage;
+    const normalizedError = normalizeOutput(fallbackOutput) ?? fallbackOutput;
     return {
       success: false,
       stdout: null,
-      stderr: shouldTruncate
-        ? truncateOutput(stderr || errorMessage)
-        : stderr || errorMessage,
+      stderr: normalizedError,
       timedOut: false, // Real timeouts are handled in the main flow via result.timedOut
     };
   }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -147,7 +147,7 @@ export async function executeCommand(
     // With reject: false, this catch block only handles actual execution errors
     // (e.g., command not found), not timeouts or non-zero exit codes
     const fallbackOutput = stderr ?? errorMessage;
-    const normalizedError = normalizeOutput(fallbackOutput) ?? fallbackOutput;
+    const normalizedError = normalizeOutput(fallbackOutput);
     return {
       success: false,
       stdout: null,

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -146,7 +146,7 @@ export async function executeCommand(
 
     // With reject: false, this catch block only handles actual execution errors
     // (e.g., command not found), not timeouts or non-zero exit codes
-    const fallbackOutput = stderr ?? errorMessage;
+    const fallbackOutput = stderr || errorMessage;
     const normalizedError = normalizeOutput(fallbackOutput);
     return {
       success: false,

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -118,13 +118,6 @@ export async function executeCommand(
       );
     }
 
-    // if (normalizedStdout) {
-    //   logger.debug(
-    //     options.channel ?? CHANNEL,
-    //     `Command stdout: ${formatForLog(normalizedStdout)}`,
-    //   );
-    // }
-
     return {
       success: exitCode === 0 && !timedOut,
       stdout: normalizedStdout,


### PR DESCRIPTION
## Summary
- stop truncating stdout and stderr returned from executeCommand while keeping log output compact
- leave the bash tool using truncate logging so tool callers receive the complete shell output
- add a regression test that exercises the bash tool path with long stdout and verifies the tool-use payload keeps the full text

## Testing
- npm run compile-tests *(fails: missing @cfworker/json-schema types provided by @modelcontextprotocol/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_690b9f416a348324b867aa8f250519b2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop truncating returned stdout/stderr from command execution while keeping log output truncated; Bash tool opts into truncated logging and a regression test verifies long output propagation.
> 
> - **Core utils**:
>   - `src/utils/system/execUtils.ts`: Stop truncating returned `stdout`/`stderr`; add `normalizeOutput` to trim/null-empty; keep optional truncation for log messages only; refine error normalization.
> - **Tools**:
>   - `src/tools/bash.ts`: Call `executeCommand` with `{ truncate: true }` to keep logs compact while returning full `stdout`; keep concise command preview in summary.
> - **Tests**:
>   - `src/test/tools/BashTool.test.ts`: Add regression test ensuring long `stdout` is preserved in `BashTool` result and propagated in tool-use payload via mocked model handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dece760103f0dd7e56671d5cecacdcd83a8f8e05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->