### PR TITLE
feat: add command to clone Overleaf projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Capture XML output summaries (detected tag contents, serialized `<document>` elements, and single-output paths) so orchestrated workflows can reuse generated artifacts without re-selecting files.
+- Add a **Clone Overleaf Project** command so you can pull remote Overleaf
+  workspaces directly into the current VS Code folder without leaving TeXRA.
+- Capture XML output summaries (detected tag contents, serialized `<document>`
+  elements, and single-output paths) so orchestrated workflows can reuse
+  generated artifacts without re-selecting files.
 
 ### Improvements
 
-- Render approval “User adjustments” as line-numbered unified diffs using a native line diff (difflib). This replaces raw percent-encoded patch text with clean `diff` code blocks that show hunk ranges and readable `+`/`-` lines.
+- Expand the progress board empty state reminder with a quick link to the
+  Overleaf clone command.
+- Render approval “User adjustments” as line-numbered unified diffs using a
+  native line diff (difflib). This replaces raw percent-encoded patch text with
+  clean `diff` code blocks that show hunk ranges and readable `+`/`-` lines.
 
 ## [0.34.2] - 2025-10-31
 

--- a/docs/guide/working-with-overleaf.md
+++ b/docs/guide/working-with-overleaf.md
@@ -19,7 +19,18 @@ This guide outlines a workflow to clone your Overleaf project, leverage TeXRA lo
 
 ## Workflow Steps
 
-### 1. Get Overleaf Git URL & Clone
+### 1. Clone Your Overleaf Project
+
+#### Option A: Use TeXRA's clone command (recommended)
+
+1.  In VS Code, open the command palette (<kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>) and run **TeXRA: Clone Overleaf Project**.
+2.  Paste the Overleaf project URL or 24-character project ID when prompted.
+3.  Enter your Overleaf Git token (it begins with `olp_`). TeXRA saves it to VS Code's secret storage so future clones can reuse it.
+4.  The command runs `git clone` directly into your workspace root so the cloned project becomes the repository you're working in. Make sure that folder is empty before starting.
+
+> **Token storage:** Reset the cached token anytime via the VS Code command **Developer: Clear Secret Storage**.
+
+#### Option B: Manual terminal fallback
 
 1.  **Overleaf:** Go to your project > **Menu** > **Git**. Copy the Git **clone URL** (`https://git.overleaf.com/YOUR_PROJECT_ID`).
     ![Overleaf Git Menu](/images/overleaf-git.png)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "activationEvents": [
     "onColorTheme",
-    "onCommand:texra.openGettingStarted"
+    "onCommand:texra.openGettingStarted",
+    "onCommand:texra.cloneOverleafProject"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -912,6 +913,12 @@
         "command": "texra.getRecentCommits",
         "title": "Get Recent Commits",
         "category": "TeXRA"
+      },
+      {
+        "command": "texra.cloneOverleafProject",
+        "title": "Clone Overleaf Project",
+        "category": "TeXRA",
+        "icon": "$(repo-clone)"
       },
       {
         "command": "texra.refreshCommits",

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -1,7 +1,8 @@
 // Standard library imports
-import { execa, execaSync } from 'execa';
+import { promises as fs } from 'fs';
 
 // Third-party imports
+import { execa, execaSync } from 'execa';
 import * as vscode from 'vscode';
 
 // Local imports - utilities
@@ -131,7 +132,7 @@ async function cloneOverleafProject(
     return;
   }
 
-  const match = input.trim().match(/[a-f0-9]{24}/);
+  const match = input.trim().match(/[a-f0-9]{24}/i);
   if (!match) {
     vscode.window.showErrorMessage(
       'Enter a valid Overleaf project URL or 24-character project ID.',
@@ -164,11 +165,47 @@ async function cloneOverleafProject(
       return;
     }
 
-    token = tokenInput.trim();
+    const trimmedToken = tokenInput.trim();
+    if (!trimmedToken) {
+      vscode.window.showWarningMessage('Overleaf clone cancelled.');
+      return;
+    }
+
+    token = trimmedToken;
     await context.secrets.store(tokenKey, token);
   }
 
-  const remote = `https://git:${token}@git.overleaf.com/${projectId}`;
+  if (!token) {
+    vscode.window.showWarningMessage('Overleaf clone cancelled.');
+    return;
+  }
+
+  token = token.trim();
+  if (!token) {
+    vscode.window.showWarningMessage('Overleaf clone cancelled.');
+    return;
+  }
+
+  const encodedToken = encodeURIComponent(token);
+  const remote = `https://git:${encodedToken}@git.overleaf.com/${projectId}`;
+
+  let directoryEntries: string[];
+  try {
+    directoryEntries = await fs.readdir(workspacePath);
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      'Unable to inspect the workspace folder before cloning the Overleaf project.',
+    );
+    console.error('Failed to read workspace contents:', error);
+    return;
+  }
+
+  if (directoryEntries.length > 0) {
+    vscode.window.showErrorMessage(
+      'The workspace folder must be empty before cloning an Overleaf project.',
+    );
+    return;
+  }
 
   try {
     await vscode.window.withProgress(
@@ -187,11 +224,18 @@ async function cloneOverleafProject(
       'Overleaf project cloned into the workspace root.',
     );
   } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : 'Failed to clone Overleaf project.';
-    vscode.window.showErrorMessage(message);
+    vscode.window.showErrorMessage(
+      'Failed to clone Overleaf project. Check your connection, token, and workspace folder.',
+    );
+
+    if (error instanceof Error) {
+      const sanitizedMessage = error.message
+        .replaceAll(token, '********')
+        .replaceAll(encodedToken, '********');
+      console.error('Overleaf clone failed:', sanitizedMessage);
+    } else {
+      console.error('Overleaf clone failed with non-error value:', error);
+    }
   }
 }
 

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -150,7 +150,13 @@ async function cloneOverleafProject(
   }
 
   const tokenKey = 'overleaf.gitToken';
-  let token = await context.secrets.get(tokenKey);
+  const validateToken = (value: string): boolean => value.startsWith('olp_');
+
+  let token = (await context.secrets.get(tokenKey))?.trim() ?? '';
+  if (token && !validateToken(token)) {
+    await context.secrets.delete(tokenKey);
+    token = '';
+  }
 
   if (!token) {
     const tokenInput = await vscode.window.showInputBox({
@@ -171,19 +177,17 @@ async function cloneOverleafProject(
       return;
     }
 
+    if (!validateToken(trimmedToken)) {
+      vscode.window.showErrorMessage(
+        'Enter a valid Overleaf Git token. Tokens start with "olp_".',
+      );
+      return;
+    }
+
     token = trimmedToken;
     await context.secrets.store(tokenKey, token);
-  }
-
-  if (!token) {
-    vscode.window.showWarningMessage('Overleaf clone cancelled.');
-    return;
-  }
-
-  token = token.trim();
-  if (!token) {
-    vscode.window.showWarningMessage('Overleaf clone cancelled.');
-    return;
+  } else {
+    token = token.trim();
   }
 
   const encodedToken = encodeURIComponent(token);

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import type { Dirent } from 'fs';
 import { promises as fs } from 'fs';
 
 // Third-party imports
@@ -186,16 +187,22 @@ async function cloneOverleafProject(
 
     token = trimmedToken;
     await context.secrets.store(tokenKey, token);
-  } else {
-    token = token.trim();
   }
 
   const encodedToken = encodeURIComponent(token);
   const remote = `https://git:${encodedToken}@git.overleaf.com/${projectId}`;
 
-  let directoryEntries: string[];
+  const gitCheck = execaSync('git', ['--version'], { reject: false });
+  if (gitCheck.exitCode !== 0) {
+    vscode.window.showErrorMessage(
+      'Git must be installed and available in PATH to clone an Overleaf project.',
+    );
+    return;
+  }
+
+  let directoryEntries: Dirent[];
   try {
-    directoryEntries = await fs.readdir(workspacePath);
+    directoryEntries = await fs.readdir(workspacePath, { withFileTypes: true });
   } catch (error) {
     vscode.window.showErrorMessage(
       'Unable to inspect the workspace folder before cloning the Overleaf project.',
@@ -204,7 +211,12 @@ async function cloneOverleafProject(
     return;
   }
 
-  if (directoryEntries.length > 0) {
+  const ignoredWorkspaceEntries = new Set(['.DS_Store', 'Thumbs.db']);
+  const nonIgnoredEntries = directoryEntries.filter(
+    (entry) => !ignoredWorkspaceEntries.has(entry.name),
+  );
+
+  if (nonIgnoredEntries.length > 0) {
     vscode.window.showErrorMessage(
       'The workspace folder must be empty before cloning an Overleaf project.',
     );

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { execaSync } from 'execa';
+import { execa, execaSync } from 'execa';
 
 // Third-party imports
 import * as vscode from 'vscode';
@@ -17,6 +17,9 @@ export function registerGitCommands(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'texra.findCommitInHistory',
       findCommitInHistory,
+    ),
+    vscode.commands.registerCommand('texra.cloneOverleafProject', () =>
+      cloneOverleafProject(context),
     ),
   );
 }
@@ -114,8 +117,87 @@ async function findCommitInHistory(commitHash: string): Promise<string | null> {
   return label || sanitizedCommit;
 }
 
+async function cloneOverleafProject(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const input = await vscode.window.showInputBox({
+    title: 'Clone Overleaf Project',
+    prompt: 'Enter an Overleaf project URL or 24-character project ID.',
+    placeHolder: 'https://git.overleaf.com/<project-id>',
+    ignoreFocusOut: true,
+  });
+
+  if (!input) {
+    return;
+  }
+
+  const match = input.trim().match(/[a-f0-9]{24}/);
+  if (!match) {
+    vscode.window.showErrorMessage(
+      'Enter a valid Overleaf project URL or 24-character project ID.',
+    );
+    return;
+  }
+
+  const projectId = match[0];
+  const workspacePath = WorkspaceFS.getPath();
+  if (!workspacePath) {
+    vscode.window.showErrorMessage(
+      'Open a workspace folder before cloning an Overleaf project.',
+    );
+    return;
+  }
+
+  const tokenKey = 'overleaf.gitToken';
+  let token = await context.secrets.get(tokenKey);
+
+  if (!token) {
+    const tokenInput = await vscode.window.showInputBox({
+      title: 'Overleaf Git Token',
+      prompt: 'Enter your Overleaf Git token (starts with "olp_").',
+      ignoreFocusOut: true,
+      password: true,
+    });
+
+    if (!tokenInput) {
+      vscode.window.showWarningMessage('Overleaf clone cancelled.');
+      return;
+    }
+
+    token = tokenInput.trim();
+    await context.secrets.store(tokenKey, token);
+  }
+
+  const remote = `https://git:${token}@git.overleaf.com/${projectId}`;
+
+  try {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Cloning Overleaf project…',
+      },
+      async () => {
+        await execa('git', ['clone', remote, '.'], {
+          cwd: workspacePath,
+          env: { GIT_TERMINAL_PROMPT: '0' },
+        });
+      },
+    );
+    vscode.window.showInformationMessage(
+      'Overleaf project cloned into the workspace root.',
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Failed to clone Overleaf project.';
+    vscode.window.showErrorMessage(message);
+  }
+}
+
 export const gitCommands = {
   isGitRepository,
   getRecentCommits,
   findCommitInHistory,
+  cloneOverleafProject,
 };

--- a/src/progressView/modules/uiManagers/Placeholder.js
+++ b/src/progressView/modules/uiManagers/Placeholder.js
@@ -25,9 +25,11 @@ export class Placeholder {
         '<a href="command:texra.openGettingStarted">open the getting started walkthrough</a>';
       const sampleLink =
         '<a href="command:texra.createSampleProject">create a sample project</a>';
+      const overleafLink =
+        '<a href="command:texra.cloneOverleafProject">clone an Overleaf project</a>';
       const arxivLink =
         '<a href="command:texra.downloadArXivSource">download an arXiv source</a>';
-      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${walkthroughLink}, ${sampleLink}, or ${arxivLink}.`;
+      this._element.innerHTML = `No runs yet—use TeXRA commands to start. Try ${walkthroughLink}, ${sampleLink}, ${overleafLink}, or ${arxivLink}.`;
     }
 
     container.innerHTML = '';


### PR DESCRIPTION
## Summary
- add a `texra.cloneOverleafProject` command that clones Overleaf repositories into the workspace root and reuses a stored Git token
- surface the new command in the progress board empty state reminder, activation events, command palette metadata, and changelog
- update the Overleaf workflow guide with the recommended command workflow and token storage notes

## Testing
- npm run format
- npm run lint
- npm run compile
- npm test *(fails: missing dependency `@cfworker/json-schema` from modelcontextprotocol SDK)*

------
https://chatgpt.com/codex/tasks/task_e_690b4233a96c8324b2c6bab892f89002

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `texra.cloneOverleafProject` to clone Overleaf repos into the workspace root with cached token, and surfaces it in the command palette, progress view, docs, and changelog.
> 
> - **Feature**:
>   - Add `texra.cloneOverleafProject` in `src/commands/git/gitCommands.ts` to clone Overleaf projects into the workspace root.
>     - Extracts project ID from URL/ID, prompts and caches `olp_` token in VS Code secret storage, verifies Git, requires empty workspace, runs `git clone` with progress, and sanitizes token in errors.
> - **VS Code Contributions (`package.json`)**:
>   - Register activation event `onCommand:texra.cloneOverleafProject` and contribute the `Clone Overleaf Project` command with icon.
> - **UI**:
>   - Add quick link to clone Overleaf projects in the progress board empty state (`src/progressView/modules/uiManagers/Placeholder.js`).
> - **Docs**:
>   - Update `docs/guide/working-with-overleaf.md` to recommend the clone command and note token storage.
> - **Changelog**:
>   - Document the new command under Features and the empty-state link under Improvements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6aa145f01d55248f04b9d4bb9a9f95bcf245114. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->