### PR TITLE
Add arXiv and DOI metadata tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,10 @@
         "@vscode-elements/elements": "^2.3.1",
         "@vscode/codicons": "^0.0.41",
         "@vscode/markdown-it-katex": "^1.1.2",
+        "arxiv-api-ts": "^1.0.4",
         "axios": "^1.13.1",
+        "citation-js": "^0.7.21",
+        "dblp-json": "^1.1.0",
         "deepmerge": "^4.3.1",
         "diff-match-patch": "^1.0.5",
         "difflib": "^0.2.4",
@@ -45,7 +48,8 @@
         "turndown-plugin-gfm": "^1.0.2",
         "winston": "^3.18.3",
         "yaml": "^2.8.1",
-        "zod": "^4.1.12"
+        "zod": "^4.1.12",
+        "zotero-api-client": "^0.47.0"
       },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^5.4.0",
@@ -154,6 +158,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
+      "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.43.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
@@ -177,6 +193,167 @@
         "node-html-better-parser": ">=1.4.0",
         "pako": "^1.0.11",
         "tslib": ">=2"
+      }
+    },
+    "node_modules/@citation-js/cli": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@citation-js/cli/-/cli-0.7.21.tgz",
+      "integrity": "sha512-9OS49kC7Z8MKar7Wf6rMOuPyU5eg3mYU4q7iQD+ss9G6bEfTWolUFfMVqZ5P0EvgmDoM5He1ENygRdk6is7Btw==",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/core": "^0.7.21",
+        "@citation-js/plugin-bibjson": "^0.7.21",
+        "@citation-js/plugin-bibtex": "^0.7.21",
+        "@citation-js/plugin-csl": "^0.7.21",
+        "@citation-js/plugin-doi": "^0.7.21",
+        "@citation-js/plugin-ris": "^0.7.21",
+        "@citation-js/plugin-wikidata": "^0.7.21",
+        "commander": "^11.0.0"
+      },
+      "bin": {
+        "citation-js": "lib/index.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@citation-js/cli/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@citation-js/core": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.7.21.tgz",
+      "integrity": "sha512-Vobv2/Yfnn6C6BVO/pvj7madQ7Mfzl83/jAWwixbemGF6ZThhGMz8++FD9hWHyHXDMYuLGa6fK68c2VsolZmTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/date": "^0.5.0",
+        "@citation-js/name": "^0.4.2",
+        "fetch-ponyfill": "^7.1.0",
+        "sync-fetch": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@citation-js/date": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@citation-js/date/-/date-0.5.1.tgz",
+      "integrity": "sha512-1iDKAZ4ie48PVhovsOXQ+C6o55dWJloXqtznnnKy6CltJBQLIuLLuUqa8zlIvma0ZigjVjgDUhnVaNU1MErtZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@citation-js/name": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@citation-js/name/-/name-0.4.2.tgz",
+      "integrity": "sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@citation-js/plugin-bibjson": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibjson/-/plugin-bibjson-0.7.21.tgz",
+      "integrity": "sha512-Q3eRpeV3pDqX91fvJ8xoYGJk4jB5MQD2woEr6GAoAauAzGVE19J5Lw0SksCHegoAn4z0ZbWMXtOq6rwZPtERbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/date": "^0.5.0",
+        "@citation-js/name": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@citation-js/core": "^0.7.0"
+      }
+    },
+    "node_modules/@citation-js/plugin-bibtex": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.7.21.tgz",
+      "integrity": "sha512-O008pSsJgiYKn4+7gAWrbNpNdUH++aMeYmZaJ2oFQ8X1tcY5jNBxJcr0zZojNtUi5CVOaXXHQ0yIifoUhuF2Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/date": "^0.5.0",
+        "@citation-js/name": "^0.4.2",
+        "moo": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@citation-js/core": "^0.7.0"
+      }
+    },
+    "node_modules/@citation-js/plugin-csl": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-csl/-/plugin-csl-0.7.21.tgz",
+      "integrity": "sha512-23ySPYCWDiU1JqhvqTYLn6+C11LkeJxTfyPKKXCK2wan9iF9ODvY7JYNl/OJgtwvu485dKfDpqqptWv6i71Meg==",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/date": "^0.5.0",
+        "citeproc": "^2.4.6"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@citation-js/core": "^0.7.0"
+      }
+    },
+    "node_modules/@citation-js/plugin-doi": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-doi/-/plugin-doi-0.7.21.tgz",
+      "integrity": "sha512-KmViSt6CjfQS5dPHlHI6m6ahfshHUivSd8jQ0z5SvZCj2mKMH+t85tY57/880Xj9hVoXdRLmh53Uf0b+craNHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/date": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@citation-js/core": "^0.7.0"
+      }
+    },
+    "node_modules/@citation-js/plugin-ris": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-ris/-/plugin-ris-0.7.21.tgz",
+      "integrity": "sha512-swVpYTEYHgO8DRjCeWzaQLQa9B9BiO1bCH67sU+U/dbNw7S71wAHjK9MNI5CqRMndwKldOg6SswBQWzLtBsbeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/date": "^0.5.0",
+        "@citation-js/name": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@citation-js/core": "^0.7.0"
+      }
+    },
+    "node_modules/@citation-js/plugin-wikidata": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-wikidata/-/plugin-wikidata-0.7.21.tgz",
+      "integrity": "sha512-+2m7nPRa1XstNo/GsqkCJIv1twG7K0hI2fXnQz8ddMzJMp3pKcJyVTd70OFc7x9QX7ZYk3nSQaohU2uTZdvxRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/date": "^0.5.0",
+        "@citation-js/name": "^0.4.2",
+        "@larsgw/wikibase-sdk": "^10.2.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@citation-js/core": "^0.7.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -718,6 +895,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@larsgw/wikibase-sdk": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@larsgw/wikibase-sdk/-/wikibase-sdk-10.2.1.tgz",
+      "integrity": "sha512-tn5SsNJnM/zwe0sW+oKBZIJVlQSaq0hIWbZ3F0Zxnhh/AsgqZseP63xRGmwdgkvpI8NyRfjvdMQnzIavTMPglA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
@@ -1780,6 +1966,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -1849,7 +2041,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1976,12 +2167,72 @@
       "integrity": "sha512-L0XlBwfx9QetHOsbLDrE/vh2t018w9462HM3iaFfxRiK83aJjAt/Ja3NMkOW7FICwWTlQBa3ZbL5FKhuQWkDrg==",
       "license": "MIT"
     },
+    "node_modules/arxiv-api-ts": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arxiv-api-ts/-/arxiv-api-ts-1.0.4.tgz",
+      "integrity": "sha512-+dzrmNLm65WYe/SJRsAbz6wYw4v1eKoQeckd0qyPrZiIqyj7ZVhIvcxoXqEe9FMFKNt+sXKzot8xIcqgnGT3ng==",
+      "license": "ISC",
+      "dependencies": {
+        "fast-xml-parser": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/arxiv-api-ts/node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/arxiv-api-ts/node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -1993,6 +2244,21 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "license": "MIT"
     },
     "node_modules/axios": {
@@ -2041,6 +2307,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/bidi-js": {
@@ -2120,7 +2395,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2168,6 +2442,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2224,6 +2522,24 @@
         "monocart-coverage-reports": {
           "optional": true
         }
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2299,11 +2615,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2320,7 +2641,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -2372,6 +2692,54 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/citation-js": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/citation-js/-/citation-js-0.7.21.tgz",
+      "integrity": "sha512-h1v3Il3LlCprzJz6qAEfTTcnU67aXpV30E2pLbF14JRLtug06Rajrs2Utf2unUwRaZ20+PNwljqBWRSh/lO0uQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@citation-js/cli": "0.7.21",
+        "@citation-js/core": "0.7.21",
+        "@citation-js/date": "0.5.1",
+        "@citation-js/name": "0.4.2",
+        "@citation-js/plugin-bibjson": "0.7.21",
+        "@citation-js/plugin-bibtex": "0.7.21",
+        "@citation-js/plugin-csl": "0.7.21",
+        "@citation-js/plugin-doi": "0.7.21",
+        "@citation-js/plugin-ris": "0.7.21",
+        "@citation-js/plugin-wikidata": "0.7.21",
+        "citeproc": "^2.4.59",
+        "patch-package": "^8.0.1"
+      },
+      "bin": {
+        "citation-js": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/citeproc": {
+      "version": "2.4.63",
+      "resolved": "https://registry.npmjs.org/citeproc/-/citeproc-2.4.63.tgz",
+      "integrity": "sha512-68F95Bp4UbgZU/DBUGQn0qV3HDZLCdI9+Bb2ByrTaNJDL5VEm9LqaiNaxljsvoaExSLEXe1/r6n2Z06SCzW3/Q==",
+      "license": "CPAL-1.0 OR AGPL-1.0"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -2617,6 +2985,17 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.46.0.tgz",
+      "integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -2635,6 +3014,57 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/cross-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -2686,6 +3116,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -2707,6 +3149,18 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/dblp-json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dblp-json/-/dblp-json-1.1.0.tgz",
+      "integrity": "sha512-2ZN66iZxXEaznHgDwJg1z+7hDN61g95/JG852IHpsZpwuNcqOnYIqIiBUDEZW2t/poHzlZ4ONPjwVxmjx5r9/g==",
+      "license": "ISC",
+      "dependencies": {
+        "joi": "^14.3.1",
+        "request": "^2.88.0",
+        "util": "^0.11.1",
+        "xml2js": "^0.4.19"
       }
     },
     "node_modules/debug": {
@@ -2760,6 +3214,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -2838,6 +3309,16 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -3331,6 +3812,15 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3358,7 +3848,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -3451,6 +3940,57 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fetch-ponyfill": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
+      "integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "~2.6.1"
+      }
+    },
+    "node_modules/fetch-ponyfill/node_modules/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-ponyfill/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-ponyfill/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/fetch-ponyfill/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -3483,7 +4023,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3524,6 +4063,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/flat": {
@@ -3597,6 +4145,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/form-data": {
@@ -3808,6 +4365,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
@@ -3960,14 +4526,48 @@
         "node": ">=18"
       }
     },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -4032,6 +4632,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/hoek": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+      "license": "BSD-3-Clause"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -4108,6 +4715,21 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -4150,6 +4772,26 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -4275,6 +4917,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4324,7 +4981,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4390,6 +5046,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -4402,12 +5064,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "punycode": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4424,6 +5110,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4523,6 +5215,18 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+      "deprecated": "This module has moved and is now available at @hapi/joi. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "hoek": "6.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -4535,6 +5239,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "27.1.0",
@@ -4599,6 +5309,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
@@ -4616,8 +5332,26 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4625,6 +5359,18 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4649,6 +5395,30 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/jszip": {
@@ -4719,6 +5489,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kuler": {
@@ -5005,7 +5784,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5019,7 +5797,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5075,6 +5852,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -5267,6 +6053,12 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5469,6 +6261,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5488,6 +6289,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/on-finished": {
@@ -5531,6 +6341,22 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5781,6 +6607,49 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -5855,6 +6724,12 @@
         "type": "paypal",
         "url": "https://www.paypal.me/yakovmeister"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6021,11 +6896,22 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6186,6 +7072,95 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/request/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/request/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/require-directory": {
@@ -6364,6 +7339,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -6438,7 +7419,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6492,6 +7472,23 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setimmediate": {
@@ -6646,6 +7643,15 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sortablejs": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
@@ -6681,6 +7687,37 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/stack-trace": {
@@ -6894,6 +7931,61 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sync-fetch": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.4.5.tgz",
+      "integrity": "sha512-esiWJ7ixSKGpd9DJPBTC4ckChqdOjIwJfYhVHkcQ2Gnm41323p1TRmEI+esTQ9ppD+b5opps2OTEGTCGX5kF+g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.7.1",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/sync-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sync-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/sync-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/sync-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -7114,11 +8206,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7134,6 +8234,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "deprecated": "This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "hoek": "6.x.x"
       }
     },
     "node_modules/tough-cookie": {
@@ -7227,6 +8337,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/turndown": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
@@ -7241,6 +8363,12 @@
       "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
       "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
       "license": "MIT"
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7385,10 +8513,18 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
       }
     },
     "node_modules/util-deprecate": {
@@ -7396,6 +8532,22 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "license": "ISC"
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -7420,6 +8572,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -7918,6 +9090,28 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -8088,6 +9282,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zotero-api-client": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/zotero-api-client/-/zotero-api-client-0.47.0.tgz",
+      "integrity": "sha512-SAvdbPo6GLjWsHGt/WqfL32iphSD38i7+AI6fb4pd6MYNGildnd8ygXOd66xNHeA0ThgRhNvk0dtC+mgP/E+lg==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "@babel/runtime-corejs3": "^7.26.7",
+        "cross-fetch": "^4.1.0",
+        "spark-md5": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1492,7 +1492,10 @@
     "@vscode-elements/elements": "^2.3.1",
     "@vscode/codicons": "^0.0.41",
     "@vscode/markdown-it-katex": "^1.1.2",
+    "arxiv-api-ts": "^1.0.4",
     "axios": "^1.13.1",
+    "citation-js": "^0.7.21",
+    "dblp-json": "^1.1.0",
     "deepmerge": "^4.3.1",
     "diff-match-patch": "^1.0.5",
     "difflib": "^0.2.4",
@@ -1521,6 +1524,7 @@
     "turndown-plugin-gfm": "^1.0.2",
     "winston": "^3.18.3",
     "yaml": "^2.8.1",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "zotero-api-client": "^0.47.0"
   }
 }

--- a/src/tools/doi/DblpSearchTool.ts
+++ b/src/tools/doi/DblpSearchTool.ts
@@ -1,0 +1,162 @@
+// Third-party imports
+import DBLP, { DblpCoauthorsResult, DblpPublicationsResult } from 'dblp-json';
+import { z } from 'zod';
+
+// Local imports - tools
+import { defineTool } from '../core/define';
+import { ToolError, toolResult } from '../result';
+import { formatToolOutput } from '../utils';
+
+const DblpSearchInputSchema = z.strictObject({
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  pid: z.string().optional(),
+  homepage: z.string().optional(),
+  includePublications: z.boolean().optional(),
+  maxPublications: z.number().int().min(1).max(50).optional(),
+});
+
+export type DblpSearchInput = z.infer<typeof DblpSearchInputSchema>;
+
+const ensureQuery = (input: DblpSearchInput) => {
+  if (input.pid || input.homepage) {
+    return;
+  }
+
+  if (!input.firstName || !input.lastName) {
+    throw new ToolError(
+      'Provide either pid, homepage, or both firstName and lastName to query DBLP.',
+    );
+  }
+};
+
+const formatPublications = (
+  publications: DblpPublicationsResult,
+  maxItems: number,
+): string => {
+  const items = publications.pubs.slice(0, maxItems);
+  if (items.length === 0) {
+    return 'No publications found.';
+  }
+
+  return items
+    .map((publication, index) => {
+      const title =
+        typeof publication.title === 'string'
+          ? publication.title
+          : 'Untitled work';
+      const year =
+        typeof publication.year === 'string' ? publication.year : undefined;
+      const doi =
+        typeof publication.doi === 'string' ? publication.doi : undefined;
+      const ee = publication.ee;
+      const entryLines = [
+        `**Title:** ${title}`,
+        year ? `**Year:** ${year}` : undefined,
+        doi ? `**DOI:** ${doi}` : undefined,
+        typeof ee === 'string' ? `**Link:** ${ee}` : undefined,
+      ].filter((line): line is string => Boolean(line));
+
+      return formatToolOutput(`${index + 1}. ${title}`, entryLines.join('\n'));
+    })
+    .join('\n\n');
+};
+
+const formatCoauthors = (coauthors: DblpCoauthorsResult): string => {
+  const list = Array.isArray(coauthors.coauthors) ? coauthors.coauthors : [];
+  if (list.length === 0) {
+    return 'No coauthors were listed for this person.';
+  }
+
+  return list
+    .map((entry, index) => {
+      const name = typeof entry.name === 'string' ? entry.name : 'Unknown';
+      const pid = typeof entry.pid === 'string' ? entry.pid : undefined;
+      const count = typeof entry.count === 'string' ? entry.count : undefined;
+      const url = typeof entry.url === 'string' ? entry.url : undefined;
+
+      const lines = [
+        `**Name:** ${name}`,
+        pid ? `**PID:** ${pid}` : undefined,
+        count ? `**Joint publications:** ${count}` : undefined,
+        url ? `**Profile:** ${url}` : undefined,
+      ].filter((line): line is string => Boolean(line));
+
+      return formatToolOutput(`${index + 1}. ${name}`, lines.join('\n'));
+    })
+    .join('\n\n');
+};
+
+export class DblpSearchTool extends defineTool({
+  name: 'search_dblp',
+  description:
+    'Retrieve DBLP author information along with selected publications and coauthors.',
+  schema: DblpSearchInputSchema,
+}) {
+  protected async execute(input: DblpSearchInput) {
+    ensureQuery(input);
+
+    const client = new DBLP();
+
+    let person;
+    try {
+      if (input.pid) {
+        person = await client.getByPID(input.pid.trim());
+      } else if (input.homepage) {
+        person = await client.getByHomepage(input.homepage.trim());
+      } else {
+        person = await client.getByName(
+          input.firstName!.trim(),
+          input.lastName!.trim(),
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ToolError(`Failed to query DBLP: ${message}`);
+    }
+
+    const personInfo = person.getPerson();
+    const publications = person.getPublications();
+    const coauthors = person.getCoauthors();
+
+    const profileLines = [
+      personInfo.name ? `**Name:** ${personInfo.name}` : undefined,
+      personInfo.pid ? `**PID:** ${personInfo.pid}` : undefined,
+      typeof personInfo.url === 'string'
+        ? `**Profile:** ${personInfo.url}`
+        : undefined,
+      typeof personInfo.homepage === 'string'
+        ? `**Homepage:** ${personInfo.homepage}`
+        : undefined,
+      personInfo['n-publications']
+        ? `**Publications indexed:** ${personInfo['n-publications']}`
+        : undefined,
+    ].filter((line): line is string => Boolean(line));
+
+    const maxPublications = input.maxPublications ?? 10;
+    const includePublications = input.includePublications ?? true;
+
+    const sections = [
+      formatToolOutput('Author summary', profileLines.join('\n')),
+    ];
+
+    if (includePublications) {
+      sections.push(
+        formatToolOutput(
+          'Selected publications',
+          formatPublications(publications, maxPublications),
+        ),
+      );
+    }
+
+    sections.push(formatToolOutput('Coauthors', formatCoauthors(coauthors)));
+
+    const summaryName = personInfo.name ?? 'Unknown DBLP author';
+    const summary = `Retrieved DBLP profile for ${summaryName}.`;
+
+    return toolResult({
+      summary,
+      output: sections.join('\n\n'),
+    });
+  }
+}

--- a/src/tools/doi/DoiMetadataTool.ts
+++ b/src/tools/doi/DoiMetadataTool.ts
@@ -1,0 +1,198 @@
+// Third-party imports
+import Cite from 'citation-js';
+import { z } from 'zod';
+
+// Local imports - tools
+import { defineTool } from '../core/define';
+import { ToolError, toolResult } from '../result';
+import { formatToolOutput } from '../utils';
+
+const DoiMetadataInputSchema = z.strictObject({
+  doi: z.string(),
+  bibliographyStyle: z.string().optional(),
+  includeBibTeX: z.boolean().optional(),
+});
+
+export type DoiMetadataInput = z.infer<typeof DoiMetadataInputSchema>;
+
+type CiteRecord = (typeof Cite)['prototype']['data'][number];
+type CiteName = NonNullable<CiteRecord['author']>[number];
+
+const normalizeDoi = (value: string): string =>
+  value
+    .trim()
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .replace(/^doi:/i, '')
+    .trim();
+
+const formatName = (name: CiteName | undefined): string | undefined => {
+  if (!name) {
+    return undefined;
+  }
+
+  if (typeof name.literal === 'string' && name.literal.trim().length > 0) {
+    return name.literal.trim();
+  }
+
+  const parts = [name.given, name.family].filter(
+    (component): component is string =>
+      Boolean(component && component.trim().length > 0),
+  );
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  return parts.join(' ');
+};
+
+const formatDate = (record: CiteRecord): string | undefined => {
+  const issued =
+    record.issued?.['date-parts'] ?? record.published?.['date-parts'];
+  if (!issued || issued.length === 0 || issued[0].length === 0) {
+    return undefined;
+  }
+
+  const [year, month, day] = issued[0];
+  const components = [year, month, day]
+    .map((component) =>
+      typeof component === 'number' || typeof component === 'string'
+        ? String(component)
+        : undefined,
+    )
+    .filter((component): component is string => Boolean(component));
+
+  if (components.length === 0) {
+    return undefined;
+  }
+
+  return components.join('-');
+};
+
+const getContainerTitle = (record: CiteRecord): string | undefined => {
+  const container = record['container-title'];
+  if (!container) {
+    return undefined;
+  }
+
+  if (Array.isArray(container)) {
+    return container[0];
+  }
+
+  return container;
+};
+
+const buildOutput = (
+  record: CiteRecord,
+  bibliography?: string,
+  bibtex?: string,
+): string => {
+  const authors = (record.author ?? [])
+    .map((entry) => formatName(entry))
+    .filter((name): name is string => Boolean(name));
+
+  const basicInfo: string[] = [
+    `**Title:** ${record.title ?? 'Untitled work'}`,
+    record.DOI ? `**DOI:** ${record.DOI}` : undefined,
+    record.type ? `**Type:** ${record.type}` : undefined,
+    getContainerTitle(record)
+      ? `**Container:** ${getContainerTitle(record)}`
+      : undefined,
+    record.publisher ? `**Publisher:** ${record.publisher}` : undefined,
+    formatDate(record)
+      ? `**Publication date:** ${formatDate(record)}`
+      : undefined,
+    record.URL ? `**URL:** ${record.URL}` : undefined,
+  ].filter((line): line is string => Boolean(line));
+
+  const sections: string[] = [
+    formatToolOutput('DOI metadata', basicInfo.join('\n')),
+  ];
+
+  if (authors.length > 0) {
+    sections.push(
+      formatToolOutput(
+        'Authors',
+        authors.map((name, index) => `${index + 1}. ${name}`).join('\n'),
+      ),
+    );
+  }
+
+  if (
+    typeof record.abstract === 'string' &&
+    record.abstract.trim().length > 0
+  ) {
+    sections.push(formatToolOutput('Abstract', record.abstract.trim()));
+  }
+
+  if (bibliography) {
+    sections.push(formatToolOutput('Formatted citation', bibliography));
+  }
+
+  if (bibtex) {
+    sections.push(
+      formatToolOutput('BibTeX', ['```bibtex', bibtex, '```'].join('\n')),
+    );
+  }
+
+  return sections.join('\n\n');
+};
+
+export class DoiMetadataTool extends defineTool({
+  name: 'get_doi_metadata',
+  description:
+    'Fetch metadata for a DOI using citation-js, including authors, publication details, and formatted citations.',
+  schema: DoiMetadataInputSchema,
+}) {
+  protected async execute(input: DoiMetadataInput) {
+    const doi = normalizeDoi(input.doi);
+    if (!doi) {
+      throw new ToolError('Provide a DOI to look up.');
+    }
+
+    let cite: Cite;
+    try {
+      cite = await Cite.async(doi);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ToolError(`Failed to resolve DOI ${doi}: ${message}`);
+    }
+
+    const record = cite.data?.[0];
+    if (!record) {
+      throw new ToolError(`No metadata was returned for DOI ${doi}.`);
+    }
+
+    let bibliography: string | undefined;
+    if (input.bibliographyStyle) {
+      try {
+        bibliography = cite.format('bibliography', {
+          format: 'text',
+          template: input.bibliographyStyle,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new ToolError(`Failed to format bibliography: ${message}`);
+      }
+    }
+
+    let bibtex: string | undefined;
+    if (input.includeBibTeX ?? true) {
+      try {
+        bibtex = cite.format('bibtex');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new ToolError(`Failed to generate BibTeX output: ${message}`);
+      }
+    }
+
+    const summaryTitle = record.title ?? record.DOI ?? doi;
+    const summary = `Retrieved metadata for DOI ${doi}: ${summaryTitle}`;
+    const output = buildOutput(record, bibliography, bibtex);
+
+    return toolResult({
+      summary,
+      output,
+    });
+  }
+}

--- a/src/tools/doi/DoiSearchTool.ts
+++ b/src/tools/doi/DoiSearchTool.ts
@@ -1,0 +1,161 @@
+// Third-party imports
+import api, { ZoteroApiResponse } from 'zotero-api-client';
+import { z } from 'zod';
+
+// Local imports - tools
+import { defineTool } from '../core/define';
+import { ToolError, toolResult } from '../result';
+import { formatToolOutput } from '../utils';
+
+const DoiSearchInputSchema = z.strictObject({
+  query: z.string().min(1, 'Provide text to search for.'),
+  apiKey: z.string().optional(),
+  libraryType: z.enum(['user', 'group']).optional(),
+  libraryId: z.number().int().nonnegative().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+  qmode: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+export type DoiSearchInput = z.infer<typeof DoiSearchInputSchema>;
+
+type ZoteroItem = {
+  key?: string;
+  title?: string;
+  DOI?: string;
+  date?: string;
+  url?: string;
+  abstractNote?: string;
+  extra?: string;
+  creators?: Array<{
+    firstName?: string;
+    lastName?: string;
+    name?: string;
+  }>;
+  [key: string]: unknown;
+};
+
+type ZoteroResponseData =
+  | Array<{ data?: ZoteroItem } | ZoteroItem>
+  | ZoteroItem
+  | undefined;
+
+const toArray = (value: ZoteroResponseData): ZoteroItem[] => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => {
+      if (entry && typeof entry === 'object' && 'data' in entry) {
+        const wrapped = entry as { data?: ZoteroItem };
+        return wrapped.data ?? {};
+      }
+
+      return (entry ?? {}) as ZoteroItem;
+    });
+  }
+
+  return [value as ZoteroItem];
+};
+
+const formatCreators = (item: ZoteroItem): string => {
+  const creators = item.creators ?? [];
+  const names = creators
+    .map((creator) => {
+      if (creator.name && creator.name.trim().length > 0) {
+        return creator.name.trim();
+      }
+
+      const parts = [creator.firstName, creator.lastName].filter(
+        (part): part is string => Boolean(part && part.trim().length > 0),
+      );
+
+      return parts.length > 0 ? parts.join(' ') : undefined;
+    })
+    .filter((name): name is string => Boolean(name));
+
+  return names.length > 0 ? names.join(', ') : 'Not listed';
+};
+
+const formatResult = (item: ZoteroItem, index: number): string => {
+  const lines: string[] = [
+    `**Title:** ${item.title ?? 'Untitled item'}`,
+    item.DOI ? `**DOI:** ${item.DOI}` : undefined,
+    `**Creators:** ${formatCreators(item)}`,
+    item.date ? `**Date:** ${item.date}` : undefined,
+    item.url ? `**URL:** ${item.url}` : undefined,
+  ].filter((line): line is string => Boolean(line));
+
+  if (item.abstractNote) {
+    lines.push('', item.abstractNote);
+  }
+
+  return formatToolOutput(
+    `${index + 1}. ${item.title ?? 'Untitled item'}`,
+    lines.join('\n'),
+  );
+};
+
+const requireLibraryConfiguration = (input: DoiSearchInput) => {
+  if (!input.libraryType || typeof input.libraryId !== 'number') {
+    throw new ToolError(
+      'Zotero queries require both libraryType ("user" or "group") and libraryId.',
+    );
+  }
+};
+
+export class DoiSearchTool extends defineTool({
+  name: 'search_doi',
+  description:
+    'Search a configured Zotero library for items matching the query and surface DOI details.',
+  schema: DoiSearchInputSchema,
+}) {
+  protected async execute(input: DoiSearchInput) {
+    requireLibraryConfiguration(input);
+
+    let client = api(input.apiKey ?? '');
+    client = client.library(input.libraryType!, input.libraryId!);
+    client = client.items();
+
+    const requestOptions: Record<string, unknown> = {
+      q: input.query,
+      limit: input.limit ?? 10,
+      include: 'data',
+    };
+
+    if (input.qmode) {
+      requestOptions.qmode = input.qmode;
+    }
+
+    if (input.sort) {
+      requestOptions.sort = input.sort;
+    }
+
+    let response: ZoteroApiResponse<ZoteroResponseData>;
+    try {
+      response = await client.get(requestOptions);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ToolError(`Zotero API request failed: ${message}`);
+    }
+
+    const items = toArray(response.getData());
+
+    if (items.length === 0) {
+      return toolResult({
+        summary: 'No Zotero items matched the requested query.',
+        output: 'The search did not return any records.',
+      });
+    }
+
+    const outputSections = items.map((item, index) =>
+      formatResult(item, index),
+    );
+
+    return toolResult({
+      summary: `Retrieved ${items.length} Zotero item(s) for "${input.query.trim()}".`,
+      output: outputSections.join('\n\n'),
+    });
+  }
+}

--- a/src/tools/doi/index.ts
+++ b/src/tools/doi/index.ts
@@ -1,0 +1,3 @@
+export { DoiMetadataTool } from './DoiMetadataTool';
+export { DoiSearchTool } from './DoiSearchTool';
+export { DblpSearchTool } from './DblpSearchTool';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,5 +16,6 @@ export * from './registry';
 export * from './wolfram';
 export * from './texcount';
 export * from './latex';
+export * from './doi';
 export * from './web/WebFetchTool';
 export * from './web/WebSearchTool';

--- a/src/tools/latex/ArxivMetadataTool.ts
+++ b/src/tools/latex/ArxivMetadataTool.ts
@@ -1,0 +1,157 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - latex
+import { arxivProcessor } from '@latex/arxivProcessor';
+
+// Local imports - latex utils
+import {
+  NormalizedArxivEntry,
+  arxivParser,
+  parseArxivEntry,
+  toArray,
+} from './arxivUtils';
+
+// Local imports - tools
+import { defineTool } from '../core/define';
+import { ToolError, toolResult } from '../result';
+import { formatToolOutput } from '../utils';
+
+const ArxivMetadataInputSchema = z.strictObject({
+  id: z.string(),
+  includeAbstract: z.boolean().optional(),
+});
+
+export type ArxivMetadataInput = z.infer<typeof ArxivMetadataInputSchema>;
+
+const formatMetadataOutput = (
+  metadata: NormalizedArxivEntry,
+  includeAbstract: boolean,
+): string => {
+  const lines: string[] = [];
+
+  lines.push(
+    formatToolOutput(
+      'Basic information',
+      [
+        `**Title:** ${metadata.title}`,
+        `**ArXiv ID:** ${metadata.arxivId}`,
+        `**DOI:** ${metadata.doi ?? 'Not available'}`,
+        `**Published:** ${metadata.published ?? 'Unknown'}`,
+        `**Last updated:** ${metadata.updated ?? 'Unknown'}`,
+        `**Primary category:** ${metadata.primaryCategory ?? 'Unknown'}`,
+        `**Categories:** ${
+          metadata.categories.length > 0
+            ? metadata.categories.join(', ')
+            : 'Not listed'
+        }`,
+        `**Authors:** ${
+          metadata.authors.length > 0
+            ? metadata.authors.join(', ')
+            : 'Not listed'
+        }`,
+        metadata.comment ? `**Comment:** ${metadata.comment}` : undefined,
+        metadata.journalReference
+          ? `**Journal reference:** ${metadata.journalReference}`
+          : undefined,
+      ]
+        .filter((line): line is string => Boolean(line))
+        .join('\n'),
+    ),
+  );
+
+  const linkLines: string[] = [];
+  if (metadata.htmlUrl) {
+    linkLines.push(`- [Abstract page](${metadata.htmlUrl})`);
+  }
+  if (metadata.pdfUrl) {
+    linkLines.push(`- [PDF download](${metadata.pdfUrl})`);
+  }
+  if (metadata.doi) {
+    linkLines.push(`- [DOI link](https://doi.org/${metadata.doi})`);
+  }
+  if (linkLines.length > 0) {
+    lines.push(formatToolOutput('Links', linkLines.join('\n')));
+  }
+
+  if (includeAbstract && metadata.summary) {
+    lines.push(formatToolOutput('Abstract', metadata.summary));
+  }
+
+  return lines.join('\n\n');
+};
+
+export class ArxivMetadataTool extends defineTool({
+  name: 'get_arxiv_metadata',
+  description:
+    'Fetch citation metadata for a specific arXiv identifier, including DOI and author details.',
+  schema: ArxivMetadataInputSchema,
+}) {
+  protected async execute(input: ArxivMetadataInput) {
+    const requestedId = input.id.trim();
+    const validationError = arxivProcessor.validateId(requestedId);
+
+    if (validationError) {
+      throw new ToolError(validationError);
+    }
+
+    const url = new URL('https://export.arxiv.org/api/query');
+    url.searchParams.set('search_query', `id:${requestedId}`);
+    url.searchParams.set('max_results', '5');
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          'User-Agent': 'TeXRA arXiv metadata tool',
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ToolError(`Failed to reach arXiv API: ${message}`);
+    }
+
+    if (!response.ok) {
+      throw new ToolError(
+        `arXiv API request failed with status ${response.status}`,
+      );
+    }
+
+    const xml = await response.text();
+
+    let parsed: Record<string, any>;
+    try {
+      parsed = arxivParser.parse(xml) as Record<string, any>;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ToolError(`Failed to parse arXiv response: ${message}`);
+    }
+
+    const entries = toArray(parsed.feed?.entry);
+
+    if (entries.length === 0) {
+      throw new ToolError(
+        'No metadata was returned for the requested arXiv identifier.',
+      );
+    }
+
+    const normalizedEntries = entries.map((entry) =>
+      parseArxivEntry(entry, requestedId),
+    );
+
+    const metadata =
+      normalizedEntries.find((entry) => entry.arxivId === requestedId) ??
+      normalizedEntries[0];
+
+    const summary = `Retrieved metadata for arXiv ${metadata.arxivId}: ${metadata.title}`;
+    const output = formatMetadataOutput(
+      metadata,
+      input.includeAbstract ?? true,
+    );
+
+    return toolResult({
+      summary,
+      output,
+    });
+  }
+}

--- a/src/tools/latex/ArxivSearchTool.ts
+++ b/src/tools/latex/ArxivSearchTool.ts
@@ -1,0 +1,210 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - latex
+import { arxivProcessor } from '@latex/arxivProcessor';
+
+// Local imports - latex utils
+import {
+  NormalizedArxivEntry,
+  arxivParser,
+  parseArxivEntry,
+  toArray,
+} from './arxivUtils';
+
+// Local imports - tools
+import { defineTool } from '../core/define';
+import { ToolError, toolResult } from '../result';
+import { formatToolOutput } from '../utils';
+
+const SORT_BY_VALUES = [
+  'relevance',
+  'lastUpdatedDate',
+  'submittedDate',
+] as const;
+const SORT_ORDER_VALUES = ['ascending', 'descending'] as const;
+
+const ArxivSearchInputSchema = z.strictObject({
+  query: z.string().min(1, 'Provide at least one search term.'),
+  author: z.string().optional(),
+  title: z.string().optional(),
+  category: z.string().optional(),
+  start: z.number().int().min(0).optional(),
+  maxResults: z.number().int().min(1).max(50).optional(),
+  sortBy: z.enum(SORT_BY_VALUES).optional(),
+  sortOrder: z.enum(SORT_ORDER_VALUES).optional(),
+  includeAbstract: z.boolean().optional(),
+});
+
+export type ArxivSearchInput = z.infer<typeof ArxivSearchInputSchema>;
+
+const sanitizeTerm = (term: string): string => {
+  const trimmed = term.trim();
+  if (trimmed.length === 0) {
+    return '';
+  }
+
+  const cleaned = trimmed.replace(/"/g, '');
+  return cleaned.includes(' ') ? `"${cleaned}"` : cleaned;
+};
+
+const appendTerm = (
+  parts: string[],
+  prefix: string,
+  rawValue: string | undefined,
+): void => {
+  if (!rawValue) {
+    return;
+  }
+
+  const sanitized = sanitizeTerm(rawValue);
+  if (sanitized.length === 0) {
+    return;
+  }
+
+  parts.push(`${prefix}:${sanitized}`);
+};
+
+const buildSearchQuery = (input: ArxivSearchInput): string => {
+  const segments: string[] = [];
+
+  appendTerm(segments, 'all', input.query);
+  appendTerm(segments, 'ti', input.title);
+  appendTerm(segments, 'au', input.author);
+
+  if (input.category) {
+    input.category
+      .split(',')
+      .forEach((value) => appendTerm(segments, 'cat', value));
+  }
+
+  return segments.join(' AND ');
+};
+
+const formatEntry = (
+  entry: NormalizedArxivEntry,
+  index: number,
+  includeAbstract: boolean,
+): string => {
+  const lines: string[] = [
+    `**Title:** ${entry.title}`,
+    `**ArXiv ID:** ${entry.arxivId}`,
+    entry.doi ? `**DOI:** ${entry.doi}` : undefined,
+    `**Authors:** ${entry.authors.length > 0 ? entry.authors.join(', ') : 'Not listed'}`,
+    entry.categories.length > 0
+      ? `**Categories:** ${entry.categories.join(', ')}`
+      : undefined,
+    entry.published ? `**Published:** ${entry.published}` : undefined,
+    entry.updated ? `**Updated:** ${entry.updated}` : undefined,
+    entry.comment ? `**Comment:** ${entry.comment}` : undefined,
+    entry.journalReference
+      ? `**Journal reference:** ${entry.journalReference}`
+      : undefined,
+  ].filter((line): line is string => Boolean(line));
+
+  const links: string[] = [];
+  if (entry.htmlUrl) {
+    links.push(`- [Abstract page](${entry.htmlUrl})`);
+  }
+  if (entry.pdfUrl) {
+    links.push(`- [PDF download](${entry.pdfUrl})`);
+  }
+  if (entry.doi) {
+    links.push(`- [DOI link](https://doi.org/${entry.doi})`);
+  }
+
+  if (links.length > 0) {
+    lines.push('**Links:**');
+    lines.push(...links);
+  }
+
+  if (includeAbstract && entry.summary) {
+    lines.push('', entry.summary);
+  }
+
+  return formatToolOutput(`${index + 1}. ${entry.title}`, lines.join('\n'));
+};
+
+export class ArxivSearchTool extends defineTool({
+  name: 'search_arxiv',
+  description:
+    'Search the arXiv catalogue by keyword, author, title, or category and return structured matches.',
+  schema: ArxivSearchInputSchema,
+}) {
+  protected async execute(input: ArxivSearchInput) {
+    const validationError = arxivProcessor.validateId(input.query.trim());
+    const hasExactIdQuery = !validationError;
+
+    const query = buildSearchQuery(input);
+    if (!query) {
+      throw new ToolError(
+        'Unable to build search query. Provide at least one valid filter.',
+      );
+    }
+
+    const url = new URL('https://export.arxiv.org/api/query');
+    url.searchParams.set('search_query', query);
+    url.searchParams.set('max_results', String(input.maxResults ?? 10));
+    url.searchParams.set('start', String(input.start ?? 0));
+    if (input.sortBy) {
+      url.searchParams.set('sortBy', input.sortBy);
+    }
+    if (input.sortOrder) {
+      url.searchParams.set('sortOrder', input.sortOrder);
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          'User-Agent': 'TeXRA arXiv search tool',
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ToolError(`Failed to reach arXiv API: ${message}`);
+    }
+
+    if (!response.ok) {
+      throw new ToolError(
+        `arXiv API request failed with status ${response.status}`,
+      );
+    }
+
+    const xml = await response.text();
+
+    let parsed: Record<string, any>;
+    try {
+      parsed = arxivParser.parse(xml) as Record<string, any>;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ToolError(`Failed to parse arXiv response: ${message}`);
+    }
+
+    const entries = toArray(parsed.feed?.entry);
+    if (entries.length === 0) {
+      return toolResult({
+        summary: 'No arXiv results found for the supplied query.',
+        output: 'The search did not return any matches.',
+      });
+    }
+
+    const normalized = entries.map((entry) =>
+      parseArxivEntry(entry, input.query.trim()),
+    );
+    const includeAbstract = input.includeAbstract ?? false;
+
+    const outputSections = normalized.map((entry, index) =>
+      formatEntry(entry, index, includeAbstract),
+    );
+
+    const summary = hasExactIdQuery
+      ? `Retrieved ${normalized.length} result(s) for arXiv ID ${input.query.trim()}.`
+      : `Retrieved ${normalized.length} arXiv result(s) matching "${input.query.trim()}".`;
+
+    return toolResult({
+      summary,
+      output: outputSections.join('\n\n'),
+    });
+  }
+}

--- a/src/tools/latex/arxivUtils.ts
+++ b/src/tools/latex/arxivUtils.ts
@@ -1,0 +1,149 @@
+// Third-party imports
+import { XMLParser } from 'fast-xml-parser';
+
+export interface NormalizedArxivEntry {
+  arxivId: string;
+  title: string;
+  summary?: string;
+  doi?: string;
+  published?: string;
+  updated?: string;
+  authors: string[];
+  primaryCategory?: string;
+  categories: string[];
+  comment?: string;
+  journalReference?: string;
+  pdfUrl?: string;
+  htmlUrl?: string;
+}
+
+export const arxivParser = new XMLParser({
+  allowBooleanAttributes: true,
+  alwaysCreateTextNode: false,
+  attributeNamePrefix: '',
+  ignoreAttributes: false,
+  removeNSPrefix: true,
+  textNodeName: '#text',
+  trimValues: true,
+});
+
+export const toArray = <T>(value: T | T[] | undefined): T[] => {
+  if (!value) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [value];
+};
+
+const extractArxivId = (rawId: unknown, fallback: string): string => {
+  if (typeof rawId !== 'string') {
+    return fallback;
+  }
+
+  const match = rawId.match(/\/abs\/([^/?#]+)/);
+  return match ? match[1] : fallback;
+};
+
+const normalizeAuthors = (rawAuthors: unknown): string[] =>
+  toArray(rawAuthors)
+    .map((author) => {
+      if (typeof author === 'string') {
+        return author;
+      }
+
+      if (author && typeof author === 'object' && 'name' in author) {
+        const value = (author as Record<string, unknown>).name;
+        return typeof value === 'string' ? value : '';
+      }
+
+      return '';
+    })
+    .filter((name) => name.trim().length > 0);
+
+const normalizeLinks = (
+  rawLinks: unknown,
+): { pdfUrl?: string; htmlUrl?: string } => {
+  const links = toArray(rawLinks).map((link) =>
+    typeof link === 'object' && link !== null
+      ? (link as Record<string, unknown>)
+      : {},
+  );
+
+  const html = links.find((item) => item.rel === 'alternate');
+  const pdf = links.find(
+    (item) => item.title === 'pdf' || item.type === 'application/pdf',
+  );
+
+  return {
+    htmlUrl: typeof html?.href === 'string' ? html.href : undefined,
+    pdfUrl: typeof pdf?.href === 'string' ? pdf.href : undefined,
+  };
+};
+
+const normalizeCategories = (entry: Record<string, unknown>): string[] => {
+  const categories = new Set<string>();
+
+  const primary = entry['arxiv:primary_category'];
+  if (primary && typeof primary === 'object' && 'term' in primary) {
+    const value = (primary as Record<string, unknown>).term;
+    if (typeof value === 'string') {
+      categories.add(value);
+    }
+  }
+
+  const additional = toArray(entry.category);
+  additional.forEach((item) => {
+    if (item && typeof item === 'object' && 'term' in item) {
+      const term = (item as Record<string, unknown>).term;
+      if (typeof term === 'string') {
+        categories.add(term);
+      }
+    }
+  });
+
+  return [...categories];
+};
+
+export const parseArxivEntry = (
+  entry: unknown,
+  fallbackId: string,
+): NormalizedArxivEntry => {
+  const record =
+    entry && typeof entry === 'object'
+      ? (entry as Record<string, unknown>)
+      : {};
+
+  const arxivId = extractArxivId(record.id, fallbackId);
+  const authors = normalizeAuthors(record.author);
+  const { htmlUrl, pdfUrl } = normalizeLinks(record.link);
+  const categories = normalizeCategories(record);
+
+  const doiRaw = record['arxiv:doi'];
+  const doi = typeof doiRaw === 'string' ? doiRaw : undefined;
+
+  const commentRaw = record['arxiv:comment'];
+  const comment = typeof commentRaw === 'string' ? commentRaw : undefined;
+
+  const journalRaw = record['arxiv:journal_ref'];
+  const journalReference =
+    typeof journalRaw === 'string' ? journalRaw : undefined;
+
+  const primaryCategory = categories[0];
+
+  return {
+    arxivId,
+    title: typeof record.title === 'string' ? record.title : fallbackId,
+    summary: typeof record.summary === 'string' ? record.summary : undefined,
+    doi,
+    published:
+      typeof record.published === 'string' ? record.published : undefined,
+    updated: typeof record.updated === 'string' ? record.updated : undefined,
+    authors,
+    primaryCategory,
+    categories,
+    comment,
+    journalReference,
+    pdfUrl,
+    htmlUrl,
+  };
+};

--- a/src/tools/latex/index.ts
+++ b/src/tools/latex/index.ts
@@ -1,3 +1,5 @@
 export { ArxivDownloadTool } from './ArxivDownloadTool';
+export { ArxivMetadataTool } from './ArxivMetadataTool';
+export { ArxivSearchTool } from './ArxivSearchTool';
 export { ExtractLatexFiguresTool } from './ExtractFiguresTool';
 export { ExtractTikzFiguresTool } from './ExtractTikzFiguresTool';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -10,6 +10,8 @@ import { GrepTool } from './grep';
 import { LsTool } from './ls';
 import {
   ArxivDownloadTool,
+  ArxivMetadataTool,
+  ArxivSearchTool,
   ExtractLatexFiguresTool,
   ExtractTikzFiguresTool,
 } from './latex';
@@ -20,6 +22,7 @@ import { WebFetchTool } from './web/WebFetchTool';
 import { WebSearchTool } from './web/WebSearchTool';
 import { WolframTool } from './wolfram';
 import { TexcountTool } from './texcount';
+import { DblpSearchTool, DoiMetadataTool, DoiSearchTool } from './doi';
 
 export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   str_replace_editor: new TextEditorTool(),
@@ -34,8 +37,13 @@ export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   grep: new GrepTool(),
   ls: new LsTool(),
   download_arxiv_source: new ArxivDownloadTool(),
+  get_arxiv_metadata: new ArxivMetadataTool(),
+  search_arxiv: new ArxivSearchTool(),
   extract_figures: new ExtractLatexFiguresTool(),
   extract_tikz_figures: new ExtractTikzFiguresTool(),
+  get_doi_metadata: new DoiMetadataTool(),
+  search_doi: new DoiSearchTool(),
+  search_dblp: new DblpSearchTool(),
   wolfram: new WolframTool(),
   texcount: new TexcountTool(),
   web_fetch: new WebFetchTool(),

--- a/src/types/external/external-modules.d.ts
+++ b/src/types/external/external-modules.d.ts
@@ -1,0 +1,136 @@
+declare module 'citation-js' {
+  interface CiteName {
+    given?: string;
+    family?: string;
+    literal?: string;
+  }
+
+  interface CiteDateParts {
+    'date-parts'?: Array<Array<number | string>>;
+  }
+
+  interface CiteData {
+    id?: string;
+    DOI?: string;
+    title?: string;
+    type?: string;
+    author?: CiteName[];
+    editor?: CiteName[];
+    issued?: CiteDateParts;
+    published?: CiteDateParts;
+    abstract?: string;
+    'container-title'?: string | string[];
+    publisher?: string;
+    volume?: string;
+    issue?: string;
+    page?: string;
+    URL?: string;
+    [key: string]: unknown;
+  }
+
+  class Cite {
+    constructor(data?: unknown);
+    static async(
+      data: unknown,
+      options?: Record<string, unknown>,
+    ): Promise<Cite>;
+    data: CiteData[];
+    format(type: string, options?: Record<string, unknown>): string;
+    get(options?: Record<string, unknown>): unknown;
+  }
+
+  export default Cite;
+}
+
+declare module 'zotero-api-client' {
+  interface ZoteroApiConfig {
+    [key: string]: unknown;
+  }
+
+  interface ZoteroApiResponse<T = unknown> {
+    getData(): T;
+    getMeta(): Record<string, unknown> | undefined;
+    getTotalResults?(): number | string | undefined;
+  }
+
+  interface ZoteroChainedApi {
+    library(typeOrKey: string, id?: number): ZoteroChainedApi;
+    items(key?: string | null): ZoteroChainedApi;
+    collections(key?: string | null): ZoteroChainedApi;
+    publications(key?: string | null): ZoteroChainedApi;
+    top(): ZoteroChainedApi;
+    get<T = unknown>(opts?: ZoteroApiConfig): Promise<ZoteroApiResponse<T>>;
+  }
+
+  type ZoteroApiFactory = (
+    apiKey?: string,
+    opts?: ZoteroApiConfig,
+  ) => ZoteroChainedApi;
+
+  const api: ZoteroApiFactory;
+  export default api;
+  export type { ZoteroApiConfig, ZoteroApiResponse, ZoteroChainedApi };
+}
+
+declare module 'dblp-json' {
+  interface DblpPublication {
+    key?: string;
+    title?: string;
+    year?: string;
+    doi?: string;
+    ee?: string | string[];
+    url?: string;
+    journal?: string;
+    booktitle?: string;
+    type?: string;
+    [key: string]: unknown;
+  }
+
+  interface DblpCoauthor {
+    name?: string;
+    pid?: string;
+    url?: string;
+    count?: string;
+  }
+
+  interface DblpPersonSummary {
+    name?: string;
+    url?: string;
+    homepage?: string;
+    pid?: string;
+    ['n-publications']?: string;
+    [key: string]: unknown;
+  }
+
+  interface DblpPublicationsResult {
+    n: string;
+    pubs: DblpPublication[];
+  }
+
+  interface DblpCoauthorsResult {
+    n: string;
+    coauthors: DblpCoauthor[];
+  }
+
+  interface DblpPerson {
+    getPerson(): DblpPersonSummary;
+    getPublications(): DblpPublicationsResult;
+    getCoauthors(): DblpCoauthorsResult;
+  }
+
+  export default class DBLP {
+    constructor();
+    getByName(first: string, last: string): Promise<DblpPerson>;
+    getByPID(pid: string): Promise<DblpPerson>;
+    getByHomepage(homepage: string): Promise<DblpPerson>;
+  }
+
+  export type {
+    DblpCoauthor,
+    DblpCoauthorsResult,
+    DblpPublication,
+    DblpPublicationsResult,
+    DblpPerson,
+    DblpPersonSummary,
+  };
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,15 +20,34 @@ const extensionConfig = {
     filename: 'extension.js',
     libraryTarget: 'commonjs2',
   },
-  externals: {
-    bufferutil: 'bufferutil',
-    'utf-8-validate': 'utf-8-validate',
-    fsevents: 'require("fsevents")',
-    'split.js': 'Split',
-    '@vscode/codicons': 'commonjs @vscode/codicons',
-    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-    // modules added here also need to be added in the .vscodeignore file
-  },
+  externals: [
+    {
+      bufferutil: 'bufferutil',
+      'utf-8-validate': 'utf-8-validate',
+      fsevents: 'require("fsevents")',
+      'split.js': 'Split',
+      '@vscode/codicons': 'commonjs @vscode/codicons',
+      vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+      // modules added here also need to be added in the .vscodeignore file
+      'zotero-api-client': 'commonjs zotero-api-client',
+      '@babel/runtime-corejs3': 'commonjs @babel/runtime-corejs3',
+      'core-js-pure': 'commonjs core-js-pure',
+    },
+    ({ request }, callback) => {
+      if (typeof request !== 'string') {
+        return callback();
+      }
+
+      if (
+        request.startsWith('@babel/runtime-corejs3/') ||
+        request.startsWith('core-js-pure/')
+      ) {
+        return callback(null, `commonjs ${request}`);
+      }
+
+      return callback();
+    },
+  ],
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
     extensions: ['.ts', '.js'],


### PR DESCRIPTION
## Summary
- add arXiv metadata and search tools backed by shared XML parsing helpers
- add DOI and DBLP lookup tools using citation-js, zotero-api-client, and dblp-json
- declare ambient module types and externalize runtime-only dependencies to fix the webpack build

## Testing
- npm run format
- npm run lint
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_690bc44f51708324a12453dbfa48a04d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds arXiv search/metadata, DOI metadata/search, and DBLP author tools, updates exports/registry, declares typings, and externalizes runtime deps in webpack with new dependencies.
> 
> - **Tools**:
>   - **arXiv**: Add `get_arxiv_metadata`, `search_arxiv` with shared XML helpers in `latex/arxivUtils.ts`.
>   - **DOI**: Add `get_doi_metadata` (via `citation-js`) and `search_doi` (via `zotero-api-client`).
>   - **DBLP**: Add `search_dblp` for author profiles, publications, and coauthors.
>   - Register all new tools in `src/tools/registry.ts` and export via `src/tools/latex/index.ts`, `src/tools/doi/index.ts`, and `src/tools/index.ts`.
> - **Build/Types**:
>   - Add ambient typings for `citation-js`, `zotero-api-client`, and `dblp-json` in `src/types/external/external-modules.d.ts`.
>   - Update `webpack.config.js` to externalize `zotero-api-client`, `@babel/runtime-corejs3`, `core-js-pure` (incl. subpaths).
> - **Dependencies**:
>   - Install `citation-js`, `zotero-api-client`, `dblp-json`, `arxiv-api-ts` and transitive deps; update `package.json` and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638bdf7aea021f111b10a70d342de2c09b63115e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->