### PR TITLE
Fix missing json schema dependency for compile tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
         "@cantoo/pdf-lib": "^2.5.3",
+        "@cfworker/json-schema": "^4.1.1",
         "@google/genai": "^1.29.0",
         "@modelcontextprotocol/sdk": "^1.21.0",
         "@vscode-elements/elements": "^2.3.1",
@@ -178,6 +179,12 @@
         "pako": "^1.0.11",
         "tslib": ">=2"
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1494,6 +1494,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",
     "@cantoo/pdf-lib": "^2.5.3",
+    "@cfworker/json-schema": "^4.1.1",
     "@google/genai": "^1.29.0",
     "@modelcontextprotocol/sdk": "^1.21.0",
     "@vscode-elements/elements": "^2.3.1",

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -29,7 +29,7 @@ function truncateOutput(
 }
 
 function normalizeOutput(text: string | null | undefined): string | null {
-  if (text == null) {
+  if (text === null || text === undefined) {
     return null;
   }
   const trimmed = text.trim();


### PR DESCRIPTION
## Summary
- add the missing @cfworker/json-schema dependency required by the MCP SDK
- clean up execUtils null check to satisfy the lint configuration

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_690c7cfec57c832486d2ad6505433e70

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing `@cfworker/json-schema` dependency and updates `execUtils.normalizeOutput` to explicitly handle `null`/`undefined`.
> 
> - **Dependencies**:
>   - Add `@cfworker/json-schema` to `package.json`.
> - **Utilities**:
>   - Update `src/utils/system/execUtils.ts`: `normalizeOutput` now explicitly handles `null` and `undefined` instead of a loose null check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 167907d29bb3838c45dddf4fd49f2ed6c553df32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->