### PR TITLE
refactor: drop google history converter

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -17,8 +17,6 @@ import {
   createPartFromFunctionCall,
   createPartFromFunctionResponse,
   createPartFromBase64,
-  createUserContent,
-  createModelContent,
   GenerateContentConfig,
   type CreateChatParameters,
   type SendMessageParameters,
@@ -70,8 +68,6 @@ import { K_SLICE } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 
-type GoogleRole = 'user' | 'model';
-
 function isTextPart(part: Part): part is Part & { text: string } {
   return typeof (part as { text?: unknown }).text === 'string';
 }
@@ -96,58 +92,42 @@ function ensureCallId(call: FunctionCall): string {
   return call.id?.trim() || randomUUID();
 }
 
-function toGoogleRole(role?: string, logger?: AgentLogger): GoogleRole | null {
-  if (role === 'assistant' || role === 'model') {
-    return 'model';
+export function assertGoogleContentHistory(messages: Content[]): void {
+  if (messages.length === 0) {
+    return;
   }
-  if (role === 'user') {
-    return 'user';
-  }
-  if (role === 'system') {
-    logger?.debug(
-      `Converting system role to user role for Google API compatibility`,
-    );
-    return 'user';
-  }
-  return null;
-}
 
-export function convertMessagesToGoogleContentHistory(
-  messages: Content[],
-  logger: AgentLogger,
-): Content[] {
-  const history: Content[] = [];
-  messages.forEach((message) => {
-    const role = toGoogleRole(message.role, logger);
-    if (!role) {
-      logger.warn(
-        `Skipping message with unsupported role during history conversion: ${message.role}`,
+  let previousRole: 'user' | 'model' | null = null;
+
+  messages.forEach((message, index) => {
+    const role = message.role;
+    if (role !== 'user' && role !== 'model') {
+      throw new Error(
+        `Google chat history must use user/model roles. Found ${String(
+          role,
+        )} at index ${index}.`,
       );
-      return;
     }
 
     const parts = Array.isArray(message.parts) ? message.parts : [];
     if (parts.length === 0) {
-      return;
+      throw new Error(
+        `Google chat history message at index ${index} is missing parts.`,
+      );
     }
 
-    const normalized =
-      role === 'user' ? createUserContent(parts) : createModelContent(parts);
-    const normalizedParts = normalized.parts ?? [];
-
-    const last = history.at(-1);
-    if (last && last.role === normalized.role) {
-      const existingParts = Array.isArray(last.parts) ? last.parts : [];
-      last.parts = [...existingParts, ...normalizedParts];
-    } else {
-      history.push({ ...normalized, parts: normalizedParts });
+    if (index === 0 && role !== 'user') {
+      throw new Error('Google chat history must start with a user message.');
     }
+
+    if (previousRole === role) {
+      throw new Error(
+        `Google chat history must alternate roles but encountered consecutive ${role} messages at index ${index - 1} and ${index}.`,
+      );
+    }
+
+    previousRole = role;
   });
-
-  logger.debug(
-    `Converted message history length for chat init: ${history.length}`,
-  );
-  return history;
 }
 
 /**
@@ -313,13 +293,13 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const historyMessages = messages.slice(0, -1);
     const lastMessage = messages.at(-1);
 
-    // chatHistory intentionally excludes the final user message because
-    // we send it separately with `chat.sendMessage` below
+    if (historyMessages.length > 0) {
+      assertGoogleContentHistory(historyMessages);
+    }
 
-    const chatHistory = convertMessagesToGoogleContentHistory(
-      historyMessages,
-      this.logger,
-    );
+    if (lastMessage?.role !== 'user') {
+      throw new Error('Last Google message must use the user role.');
+    }
 
     const lastMessageParts = Array.isArray(lastMessage?.parts)
       ? lastMessage.parts
@@ -349,7 +329,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     const chatParams: CreateChatParameters = {
       model: this.config.fullName,
-      history: chatHistory,
+      history: historyMessages,
       config: generationConfig,
       ...(systemPrompt && {
         systemInstruction: {
@@ -368,7 +348,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             parts: [createPartFromText(systemPrompt)],
           });
         }
-        countContents.push(...chatHistory);
+        countContents.push(...historyMessages);
         // The token count API expects the upcoming message as part of the
         // history, so append the final user message that will be sent next.
         countContents.push({ role: 'user', parts: [...lastMessageParts] });
@@ -416,7 +396,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     try {
       this.logger.debug(
-        `Creating chat session with history length: ${chatHistory.length}`,
+        `Creating chat session with history length: ${historyMessages.length}`,
       );
       const chat = client.chats.create(chatParams);
 

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -18,7 +18,7 @@ import {
 // Local imports - agent
 import {
   ModelHandlerGoogleGenAI,
-  convertMessagesToGoogleContentHistory,
+  assertGoogleContentHistory,
 } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
@@ -302,30 +302,37 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
   });
 });
 
-describe('convertMessagesToGoogleContentHistory', () => {
-  it('groups consecutive turns using SDK helpers', () => {
-    const { logger } = createLoggerStub();
+describe('assertGoogleContentHistory', () => {
+  it('accepts alternating user/model messages with parts', () => {
+    const messages: Content[] = [
+      { role: 'user', parts: [createPartFromText('prompt')] },
+      { role: 'model', parts: [createPartFromText('reply')] },
+      { role: 'user', parts: [createPartFromText('follow up')] },
+      { role: 'model', parts: [createPartFromText('final')] },
+    ];
+
+    assert.doesNotThrow(() => assertGoogleContentHistory(messages));
+  });
+
+  it('throws when roles do not alternate', () => {
     const messages: Content[] = [
       { role: 'user', parts: [createPartFromText('first')] },
       { role: 'user', parts: [createPartFromText('second')] },
-      { role: 'model', parts: [createPartFromText('reply one')] },
-      { role: 'model', parts: [createPartFromText('reply two')] },
     ];
 
-    const history = convertMessagesToGoogleContentHistory(messages, logger);
+    assert.throws(() => assertGoogleContentHistory(messages));
+  });
 
-    assert.equal(history.length, 2, 'user and model messages should merge');
-    assert.equal(history[0].role, 'user');
-    const userParts = history[0].parts ?? [];
-    assert.equal(userParts.length, 2);
-    assert.equal((userParts[0] as Part & { text: string }).text, 'first');
-    assert.equal((userParts[1] as Part & { text: string }).text, 'second');
+  it('throws when roles are not supported', () => {
+    const messages: Content[] = [
+      { role: 'user', parts: [createPartFromText('first')] },
+      {
+        role: 'system' as Content['role'],
+        parts: [createPartFromText('oops')],
+      },
+    ];
 
-    assert.equal(history[1].role, 'model');
-    const modelParts = history[1].parts ?? [];
-    assert.equal(modelParts.length, 2);
-    assert.equal((modelParts[0] as Part & { text: string }).text, 'reply one');
-    assert.equal((modelParts[1] as Part & { text: string }).text, 'reply two');
+    assert.throws(() => assertGoogleContentHistory(messages));
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the Google message history converter in favour of direct validation
- require well-formed user/model turns before calling the native Google chat API
- cover the new history invariant checks with unit tests

## Testing
- npm run format
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_690c9b9e3b348324a04e0a4308c574d9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace the Google history converter with strict user/model history validation, update createResponse to use raw history and require a final user message, and add unit tests for the new invariant.
> 
> - **ModelHandler (`src/agent/modelHandlers/modelHandlerGoogleGenAI.ts`)**:
>   - Remove history conversion helpers and roles mapping; add `assertGoogleContentHistory` to validate chat history (must start with `user`, alternate `user`/`model`, and include non-empty `parts`).
>   - Update `createResponse` to:
>     - Validate `historyMessages` with `assertGoogleContentHistory`.
>     - Require the last message be `user` and have non-empty `parts`.
>     - Pass raw `historyMessages` directly to `chatParams.history` and token counting.
>     - Adjust logs to reference new history handling.
> - **Tests (`src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts`)**:
>   - Replace converter tests with `assertGoogleContentHistory` tests (valid alternation, reject consecutive same roles, reject unsupported roles).
>   - Keep media upload and tool attachment tests intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee90d95097cdb04f64c9b9281d86ec7eec027a37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->