### PR TITLE
fix: guard progress view toggle handler

### DIFF
--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -143,16 +143,20 @@ export class EventsManager {
     document.addEventListener(
       'toggle',
       (e) => {
+        const target = e.target;
+        if (!(target instanceof HTMLElement)) {
+          return;
+        }
+
         if (
-          e.target &&
-          (e.target.classList.contains('banner-details') ||
-            e.target.classList.contains('file-list-details') ||
-            e.target.classList.contains('latexdiff-details') ||
-            e.target.classList.contains('statistics-details'))
+          target.classList.contains('banner-details') ||
+          target.classList.contains('file-list-details') ||
+          target.classList.contains('latexdiff-details') ||
+          target.classList.contains('statistics-details')
         ) {
-          const toggleIcon = e.target.querySelector('.toggle-icon');
+          const toggleIcon = target.querySelector('.toggle-icon');
           if (toggleIcon) {
-            const isOpen = e.target.open;
+            const isOpen = target.open;
             setChevronIconHorizontal(toggleIcon, isOpen);
           }
         }


### PR DESCRIPTION
## Summary
- prevent the progress view toggle listener from running when the event target is not an HTMLElement, avoiding null classList accesses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690ca5cb252483249173b877542b8c6d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard toggle event handler to ignore non-HTMLElement targets, preventing errors when accessing classList/open and updating chevron state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eef2568787d2739e57d0adecf1c32f20b1122b5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->