### PR TITLE
refactor: use structuredClone in OpenAI message normalization

### DIFF
--- a/src/agent/modelHandlers/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openAIMessageUtils.ts
@@ -22,24 +22,6 @@ type MessageLike = {
 
 type ContentArray = Array<Record<string, unknown>>;
 
-function cloneContent(content: unknown): unknown {
-  if (!Array.isArray(content)) {
-    return content;
-  }
-
-  return (content as ContentArray).map((part) =>
-    part && typeof part === 'object' ? { ...part } : part,
-  );
-}
-
-function cloneMessage<T extends MessageLike>(message: T): T {
-  const cloned = { ...message } as T;
-  if (Array.isArray(message.content)) {
-    cloned.content = cloneContent(message.content);
-  }
-  return cloned;
-}
-
 function mergeMessageContent(
   previous: MessageLike,
   current: MessageLike,
@@ -50,7 +32,7 @@ function mergeMessageContent(
   if (Array.isArray(prevContent) && Array.isArray(currContent)) {
     previous.content = [
       ...(prevContent as ContentArray),
-      ...((cloneContent(currContent) as ContentArray) ?? []),
+      ...((structuredClone(currContent) as ContentArray) ?? []),
     ];
     return;
   }
@@ -66,7 +48,7 @@ function mergeMessageContent(
   }
 
   if (Array.isArray(currContent)) {
-    const clonedCurrent = cloneContent(currContent);
+    const clonedCurrent = structuredClone(currContent);
     if (typeof prevContent === 'string' && prevContent.length > 0) {
       previous.content = [
         { type: 'text', text: prevContent },
@@ -121,7 +103,7 @@ export function normalizeOpenAIMessageContent<T extends MessageLike>(
     convertContentToString: asString = false,
   } = options;
 
-  let working: T[] = messages.map((message) => cloneMessage(message));
+  let working: T[] = messages.map((message) => structuredClone(message));
 
   if (mergeConsecutiveRoles) {
     const merged: T[] = [];


### PR DESCRIPTION
## Summary
- replace the bespoke message/content cloning helpers with native structuredClone
- keep merge behavior intact by cloning array content when combining messages

## Testing
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_690cc453aaec8324a2b81c844535c584

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches message/content cloning in `openAIMessageUtils.ts` to native `structuredClone`, preserving merge behavior.
> 
> - **Utils** (`src/agent/modelHandlers/openAIMessageUtils.ts`):
>   - Replace bespoke `cloneContent`/`cloneMessage` with native `structuredClone` for deep cloning.
>   - Update merge logic to `structuredClone` array content when concatenating and when copying messages.
>   - Maintain existing role-merge and string conversion behavior (`convertContentToString`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb35fd93072e77c77903742ed9f177672c98f880. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->