### PR TITLE
refactor: inline capability cloning

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -42,20 +42,6 @@ const DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
 // Default proxy domain
 const DEFAULT_PROXY_DOMAIN = 'proxy.texra.ai';
 
-function cloneCapabilities(capabilities: ModelCapabilities): ModelCapabilities {
-  const globalStructuredClone = (
-    globalThis as {
-      structuredClone?: <T>(value: T) => T;
-    }
-  ).structuredClone;
-
-  if (typeof globalStructuredClone === 'function') {
-    return globalStructuredClone(capabilities);
-  }
-
-  return JSON.parse(JSON.stringify(capabilities)) as ModelCapabilities;
-}
-
 /** Flags for token-based stop conditions. */
 interface TokenFlags {
   continuationLimit: boolean;
@@ -102,7 +88,7 @@ export abstract class ModelHandler<
 
   constructor(config: ModelConfig) {
     this.config = { ...config };
-    this.capabilities = cloneCapabilities(config.capabilities);
+    this.capabilities = structuredClone(config.capabilities);
     this.continueLimit = DEFAULT_CONTINUE_LIMIT;
     this.inputTokenLimit = DEFAULT_INPUT_TOKEN_LIMIT;
     this.maxOutputTokensFactor = DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR;


### PR DESCRIPTION
## Summary
- inline capability cloning logic by using `structuredClone` directly in the model handler constructor

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690cc42f45bc832494f1ac67ff33fa29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace custom capability cloning helper with direct `structuredClone` in `src/agent/modelHandlers/ModelHandler.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 589aa3baa1c9c777767c4a5e8e5180eeb594da13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->