### PR TITLE
refactor: share vision media helper across OpenAI handlers

### DIFF
--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -56,15 +56,7 @@ export class ModelHandlerDashScope extends ModelHandlerOpenAI {
   createMediaContent(mediaMessage: MediaEntry[]): any[] {
     return mediaMessage.flatMap((media): any[] => {
       if (media.media_category === 'image') {
-        return [
-          { type: 'text', text: `Image: ${media.file_name}` },
-          {
-            type: 'image_url',
-            image_url: {
-              url: `data:${media.media_type};base64,${media.data}`,
-            },
-          },
-        ];
+        return this.buildStandardVisionParts(media);
       } else {
         this.logger.warn(
           `Unsupported media category for DashScope: ${media.media_category}`,

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -163,15 +163,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
   createMediaContent(mediaMessage: MediaEntry[]): any[] {
     return mediaMessage.flatMap((media): any[] => {
       if (media.media_category === 'image') {
-        return [
-          { type: 'text', text: `Image: ${media.file_name}` },
-          {
-            type: 'image_url',
-            image_url: {
-              url: `data:${media.media_type};base64,${media.data}`,
-            },
-          },
-        ];
+        return this.buildStandardVisionParts(media);
       } else {
         this.logger.warn(
           `Unsupported media category for Kimi: ${media.media_category}`,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -615,22 +615,27 @@ export class ModelHandlerOpenAI extends ModelHandler<
     return { role: 'assistant', content: [{ type: 'text', text }] };
   }
 
+  /** Builds the default content parts for inline vision requests. */
+  protected buildStandardVisionParts(
+    media: MediaEntry,
+  ): ChatCompletionContentPart[] {
+    return [
+      { type: 'text', text: `Image: ${media.file_name}` },
+      {
+        type: 'image_url',
+        image_url: {
+          url: `data:${media.media_type};base64,${media.data}`,
+          detail: 'high',
+        },
+      },
+    ];
+  }
+
   /** Formats image/audio content for OpenAI/Google's vision/audio API. */
   createMediaContent(mediaMessage: MediaEntry[]): ChatCompletionContentPart[] {
     return mediaMessage.flatMap((media): ChatCompletionContentPart[] => {
       if (media.media_category === 'image') {
-        return [
-          { type: 'text', text: `Image: ${media.file_name}` },
-          {
-            type: 'image_url',
-            image_url: {
-              url: `data:${media.media_type};base64,${media.data}`,
-              detail: 'high',
-              // media_type and data are not standard OpenAI
-              // Re-add them if needed for other providers (which is not the case for Google/OpenRouter)
-            },
-          },
-        ];
+        return this.buildStandardVisionParts(media);
       } else if (
         media.media_category === 'audio' &&
         this.isGoogle &&


### PR DESCRIPTION
## Summary
- add a shared helper on the OpenAI-compatible handler for building inline vision parts
- update DashScope and Kimi handlers to reuse the helper while preserving provider-specific warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690cca4640f0832482beb9b21fa8dc08

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a shared `buildStandardVisionParts` in `ModelHandlerOpenAI` and updates DashScope/Kimi handlers to use it for image content.
> 
> - **Model Handlers**:
>   - **OpenAI**:
>     - Add `buildStandardVisionParts(media)` to standardize inline vision parts (`text` + `image_url` with `detail: 'high'`).
>     - `createMediaContent` now uses `buildStandardVisionParts` for `image` media.
>   - **DashScope (`modelHandlerDashScope.ts`)**:
>     - `createMediaContent` refactored to reuse `buildStandardVisionParts(media)`; retains provider-specific warnings for unsupported media.
>   - **Kimi (`modelHandlerKimi.ts`)**:
>     - `createMediaContent` refactored to reuse `buildStandardVisionParts(media)`; retains provider-specific warnings for unsupported media.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72c07fb5eb12eb7b918a22e9725192abb97007ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->