### PR TITLE
fix: enable native audio media for openrouter

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -633,10 +633,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
         ];
       } else if (
         media.media_category === 'audio' &&
-        this.isGoogle &&
         this.config.capabilities.supportsNativeAudio
       ) {
-        // Currently only Google via OpenAI compatibility layer supports this
+        // Currently OpenRouter's OpenAI-compatible audio branch is the only consumer
         let audioFormat = media.media_type;
         if (media.media_type.includes('/')) {
           audioFormat = media.media_type.split('/')[1]; // e.g., 'wav' from 'audio/wav'


### PR DESCRIPTION
## Summary
- allow the OpenAI model handler to format audio content for any provider that advertises native audio support
- update the inline comment to reflect the OpenRouter compatibility branch now that the Google shim has been removed

## Testing
- npm run lint *(passes with existing eqeqeq warning in src/utils/system/execUtils.ts)*

------
https://chatgpt.com/codex/tasks/task_e_690c802165588324afc2ec01fdac366b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes provider-specific check so `createMediaContent` formats audio as `input_audio` whenever `supportsNativeAudio` is true; updates inline comment to reflect OpenRouter consumption.
> 
> - **Model handler (`src/agent/modelHandlers/modelHandlerOpenAI.ts`)**:
>   - **Audio handling**: In `createMediaContent`, remove provider-specific condition and rely solely on `config.capabilities.supportsNativeAudio` to include `input_audio` content.
>   - **Comment update**: Note OpenRouter’s OpenAI-compatible audio branch as the current consumer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beda42efb424fb5f60883273aa955ffd47a5d95c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->