### PR TITLE
fix: reset arxiv client state between tool invocations

### DIFF
--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -1,11 +1,11 @@
 // Third-party imports
-import arxivClient from 'arxiv-client';
 import { z } from 'zod';
 
 // Local imports - latex
 import { arxivProcessor } from '@latex/arxivProcessor';
 import {
   type ArxivPaperMetadata,
+  createArxivClient,
   extractEntryIdentifier,
   getAuthorNames,
   normaliseArxivIdentifier,
@@ -47,7 +47,7 @@ export class ArxivMetadataTool extends defineTool({
       // Respect arXiv API rate limits
       await waitForRateLimit('arxiv', ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS);
       // Use arxiv-client's ids() method for direct ID lookup
-      entries = await arxivClient.ids([requestId]).execute();
+      entries = await createArxivClient().ids([requestId]).execute();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new ToolError(`Failed to query arXiv API: ${message}`);

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -1,10 +1,11 @@
 // Third-party imports
-import arxivClient, { all, and, category as catQuery } from 'arxiv-client';
+import { all, and, category as catQuery } from 'arxiv-client';
 import { z } from 'zod';
 
 // Local imports - latex
 import {
   type ArxivSearchResult,
+  createArxivClient,
   extractEntryIdentifier,
   getAuthorNames,
   normaliseArxivIdentifier,
@@ -70,17 +71,17 @@ export class ArxivSearchTool extends defineTool({
       }
     }
 
-    let client = arxivClient
+    const client = createArxivClient()
       .query(query)
       .start(input.start ?? 0)
       .maxResults(input.maxResults ?? ARXIV_CONSTANTS.DEFAULT_RESULTS);
 
     if (input.sortBy) {
-      client = client.sortBy(input.sortBy);
+      client.sortBy(input.sortBy);
     }
 
     if (input.sortOrder) {
-      client = client.sortOrder(input.sortOrder);
+      client.sortOrder(input.sortOrder);
     }
 
     let entries;

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -71,17 +71,17 @@ export class ArxivSearchTool extends defineTool({
       }
     }
 
-    const client = createArxivClient()
+    let client = createArxivClient()
       .query(query)
       .start(input.start ?? 0)
       .maxResults(input.maxResults ?? ARXIV_CONSTANTS.DEFAULT_RESULTS);
 
     if (input.sortBy) {
-      client.sortBy(input.sortBy);
+      client = client.sortBy(input.sortBy);
     }
 
     if (input.sortOrder) {
-      client.sortOrder(input.sortOrder);
+      client = client.sortOrder(input.sortOrder);
     }
 
     let entries;

--- a/src/tools/latex/arxivShared.ts
+++ b/src/tools/latex/arxivShared.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import arxivClient from 'arxiv-client';
 import { extract as extractArxivId } from 'identifiers-arxiv';
 
 // Local imports - none
@@ -33,6 +34,15 @@ export interface ArxivPaperMetadata extends ArxivPaperBase {
   comment: string | null;
   links: unknown;
 }
+
+export type ArxivClientInstance = typeof arxivClient;
+
+export const createArxivClient = (options?: unknown): ArxivClientInstance => {
+  const ClientCtor = arxivClient.constructor as {
+    new (ctorOptions?: unknown): ArxivClientInstance;
+  };
+  return new ClientCtor(options);
+};
 
 /**
  * Normalize an arXiv identifier by extracting it from various formats.


### PR DESCRIPTION
## Summary
- add a helper that creates a fresh `arxiv-client` instance for each tool call
- update the search and metadata tools to use the helper so requests do not share mutable state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690cdd079ee08324877cf68e4596db7f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `createArxivClient` and update search/metadata tools to instantiate a new arxiv client per request, avoiding shared mutable state.
> 
> - **Arxiv client instantiation**:
>   - Add `createArxivClient` factory and `ArxivClientInstance` type in `src/tools/latex/arxivShared.ts`.
> - **Tools updated**:
>   - `src/tools/arxiv/ArxivMetadataTool.ts`: use `createArxivClient().ids([...]).execute()` instead of default client.
>   - `src/tools/arxiv/ArxivSearchTool.ts`: use `createArxivClient()` in query chain; adjust imports to only use query builders (`all`, `and`, `category`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 159cf87eafb775b638937c6fd6a288f661ab59f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->