### PR TITLE
fix: simplify google stream aggregation

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -475,9 +475,16 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             if (chunk.modelVersion) {
               baseResponse.modelVersion = chunk.modelVersion;
             }
-            if (chunk.automaticFunctionCallingHistory) {
+            if (chunk.automaticFunctionCallingHistory?.length) {
+              const existingHistory =
+                baseResponse.automaticFunctionCallingHistory ?? [];
               baseResponse.automaticFunctionCallingHistory =
-                chunk.automaticFunctionCallingHistory;
+                existingHistory.length === 0
+                  ? [...chunk.automaticFunctionCallingHistory]
+                  : [
+                      ...existingHistory,
+                      ...chunk.automaticFunctionCallingHistory,
+                    ];
             }
             if (chunk.responseId) {
               baseResponse.responseId = chunk.responseId;
@@ -493,7 +500,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         if (candidateSource) {
           const candidateParts = aggregatedParts.length
             ? aggregatedParts
-            : candidateSource.content?.parts ?? [];
+            : (candidateSource.content?.parts ?? []);
           baseResponse.candidates = [
             {
               ...candidateSource,
@@ -511,7 +518,25 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
         const finalReasoning = this.processThinkingBlock(baseResponse);
         thinking.finalize(finalReasoning ?? undefined);
-        output?.finalize(aggregatedText || baseResponse.text || '');
+
+        let finalOutputText = aggregatedText;
+        if (!finalOutputText) {
+          const partsText = aggregatedParts
+            .filter(isTextPart)
+            .map((part) => part.text)
+            .join('');
+          if (partsText) {
+            finalOutputText = partsText;
+          } else if (baseResponse.text) {
+            finalOutputText = baseResponse.text;
+            this.logger.warn(
+              'Finalizing Google stream with base response text fallback; no chunk text aggregated.',
+            );
+          } else {
+            finalOutputText = '';
+          }
+        }
+        output?.finalize(finalOutputText);
 
         return baseResponse;
       }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -431,50 +431,89 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         };
         const stream = await chat.sendMessageStream(streamParams);
 
-        type StreamWithResponse = AsyncGenerator<GenerateContentResponse> & {
-          response?: Promise<GenerateContentResponse>;
-        };
-        const streamWithResponse = stream as StreamWithResponse;
-
         const thinking = this.createThinkingStream();
         const output = this.isOutputStreamingEnabled()
           ? this.createOutputStream()
           : undefined;
-        let interimUsage: GenerateContentResponseUsageMetadata | undefined;
-        for await (const chunk of stream) {
-          const chunkText = chunk.text ?? '';
-          if (chunkText.length > 0) {
-            output?.append(chunkText);
-          }
 
-          const parts = chunk.candidates?.[0]?.content?.parts ?? [];
-          for (const part of parts) {
-            if (part.thought && isTextPart(part)) {
-              thinking.append(part.text);
+        let baseResponse: GenerateContentResponse | undefined;
+        let latestCandidate:
+          | NonNullable<GenerateContentResponse['candidates']>[number]
+          | undefined;
+        const aggregatedParts: Part[] = [];
+        let aggregatedText = '';
+        let usageFromChunks: GenerateContentResponseUsageMetadata | undefined;
+
+        for await (const chunk of stream) {
+          baseResponse ??= chunk;
+          const candidate = chunk.candidates?.[0];
+          if (candidate) {
+            latestCandidate = candidate;
+            const parts = candidate.content?.parts ?? [];
+            aggregatedParts.push(...parts);
+            for (const part of parts) {
+              if (part.thought && isTextPart(part)) {
+                thinking.append(part.text);
+              }
             }
           }
 
+          const chunkText = chunk.text ?? '';
+          if (chunkText) {
+            aggregatedText += chunkText;
+            output?.append(chunkText);
+          }
+
           if (chunk.usageMetadata) {
-            interimUsage = chunk.usageMetadata;
+            usageFromChunks = chunk.usageMetadata;
+          }
+
+          if (baseResponse && chunk !== baseResponse) {
+            if (chunk.promptFeedback) {
+              baseResponse.promptFeedback = chunk.promptFeedback;
+            }
+            if (chunk.modelVersion) {
+              baseResponse.modelVersion = chunk.modelVersion;
+            }
+            if (chunk.automaticFunctionCallingHistory) {
+              baseResponse.automaticFunctionCallingHistory =
+                chunk.automaticFunctionCallingHistory;
+            }
+            if (chunk.responseId) {
+              baseResponse.responseId = chunk.responseId;
+            }
           }
         }
 
-        const finalResponse = streamWithResponse.response
-          ? await streamWithResponse.response
-          : undefined;
-        if (!finalResponse) {
-          throw new Error('Stream yielded no response');
-        }
-        if (!finalResponse.usageMetadata && interimUsage) {
-          finalResponse.usageMetadata = interimUsage;
+        if (!baseResponse) {
+          throw new Error('Stream produced no response');
         }
 
-        const finalReasoning = this.processThinkingBlock(finalResponse);
-        thinking.finalize(finalReasoning ?? undefined);
-        if (output) {
-          output.finalize(finalResponse.text ?? '');
+        const candidateSource = latestCandidate ?? baseResponse.candidates?.[0];
+        if (candidateSource) {
+          const candidateParts = aggregatedParts.length
+            ? aggregatedParts
+            : candidateSource.content?.parts ?? [];
+          baseResponse.candidates = [
+            {
+              ...candidateSource,
+              content: {
+                role: candidateSource.content?.role ?? 'model',
+                parts: candidateParts,
+              },
+            },
+          ];
         }
-        return finalResponse;
+
+        if (!baseResponse.usageMetadata && usageFromChunks) {
+          baseResponse.usageMetadata = usageFromChunks;
+        }
+
+        const finalReasoning = this.processThinkingBlock(baseResponse);
+        thinking.finalize(finalReasoning ?? undefined);
+        output?.finalize(aggregatedText || baseResponse.text || '');
+
+        return baseResponse;
       }
 
       const sendParams: SendMessageParameters = {

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -238,4 +238,96 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
     assert.equal('tool_call_id' in functionCall, false);
     assert.equal('tool_use_id' in functionCall, false);
   });
+
+  it('aggregates streamed chunks without relying on SDK response promises', async () => {
+    const handler = new ModelHandlerGoogleGenAI({
+      name: 'test-google-model',
+      fullName: 'google/test',
+      provider: ModelProvider.GOOGLE,
+      maxOutputTokens: 1024,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 4096,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    });
+
+    (handler as any).capabilities.supportsTokenCounting = false;
+    handler.setOutputStreaming(true);
+    (handler as any).logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      statistics: () => {},
+      createStream: () => ({
+        append: () => {},
+        finalize: () => {},
+      }),
+      withCurrentGroup: () => undefined,
+      runWithinCurrentGroup: async (fn: () => any) => fn(),
+      runWithGroup: async (_groupId: string | undefined, fn: () => any) => fn(),
+    };
+    (handler as any).getStreamingConfig = () => true;
+
+    const chunkOne = new GenerateContentResponse();
+    chunkOne.candidates = [
+      {
+        content: {
+          role: 'model',
+          parts: [createPartFromText('Hello')],
+        },
+      } as any,
+    ];
+
+    const chunkTwo = new GenerateContentResponse();
+    chunkTwo.candidates = [
+      {
+        content: {
+          role: 'model',
+          parts: [createPartFromText(' world')],
+        },
+        finishReason: FinishReason.STOP,
+      } as any,
+    ];
+    chunkTwo.usageMetadata = {
+      inputTokenCount: 1,
+      outputTokenCount: 2,
+      totalTokenCount: 3,
+    } as any;
+
+    const fakeClient = {
+      chats: {
+        create: () => ({
+          sendMessageStream: async () =>
+            (async function* () {
+              yield chunkOne;
+              yield chunkTwo;
+            })(),
+          sendMessage: async () => {
+            throw new Error('sendMessage should not be called when streaming is enabled');
+          },
+        }),
+      },
+      models: {},
+    } as any;
+
+    const messages: Content[] = [
+      { role: 'user', parts: [createPartFromText('Hi there')] },
+    ];
+
+    const response = await handler.createResponse(fakeClient, messages, 0);
+
+    assert.ok(response, 'expected a response to be returned');
+    const candidate = response.candidates?.[0];
+    assert.ok(candidate, 'expected a candidate in the aggregated response');
+    assert.equal(
+      candidate.content?.parts?.length,
+      2,
+      'expected both streamed parts to be present',
+    );
+    assert.equal(response.text, 'Hello world');
+    assert.equal(candidate.finishReason, FinishReason.STOP);
+    assert.deepEqual(response.usageMetadata, chunkTwo.usageMetadata);
+  });
 });

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -279,7 +279,6 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
         },
       } as any,
     ];
-
     const chunkTwo = new GenerateContentResponse();
     chunkTwo.candidates = [
       {
@@ -305,7 +304,9 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
               yield chunkTwo;
             })(),
           sendMessage: async () => {
-            throw new Error('sendMessage should not be called when streaming is enabled');
+            throw new Error(
+              'sendMessage should not be called when streaming is enabled',
+            );
           },
         }),
       },
@@ -329,5 +330,92 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
     assert.equal(response.text, 'Hello world');
     assert.equal(candidate.finishReason, FinishReason.STOP);
     assert.deepEqual(response.usageMetadata, chunkTwo.usageMetadata);
+  });
+
+  it('concatenates automaticFunctionCallingHistory across streamed chunks', async () => {
+    const handler = new ModelHandlerGoogleGenAI({
+      name: 'test-google-model',
+      fullName: 'google/test',
+      provider: ModelProvider.GOOGLE,
+      maxOutputTokens: 1024,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 4096,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    });
+
+    (handler as any).capabilities.supportsTokenCounting = false;
+    handler.setOutputStreaming(true);
+    (handler as any).logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      statistics: () => {},
+      createStream: () => ({
+        append: () => {},
+        finalize: () => {},
+      }),
+      withCurrentGroup: () => undefined,
+      runWithinCurrentGroup: async (fn: () => any) => fn(),
+      runWithGroup: async (_groupId: string | undefined, fn: () => any) => fn(),
+    };
+    (handler as any).getStreamingConfig = () => true;
+
+    const chunkOne = new GenerateContentResponse();
+    chunkOne.candidates = [
+      {
+        content: {
+          role: 'model',
+          parts: [createPartFromText('First')],
+        },
+      } as any,
+    ];
+    chunkOne.automaticFunctionCallingHistory = [{ name: 'callOne' } as any];
+
+    const chunkTwo = new GenerateContentResponse();
+    chunkTwo.candidates = [
+      {
+        content: {
+          role: 'model',
+          parts: [createPartFromText('Second')],
+        },
+      } as any,
+    ];
+    chunkTwo.automaticFunctionCallingHistory = [{ name: 'callTwo' } as any];
+
+    const fakeClient = {
+      chats: {
+        create: () => ({
+          sendMessageStream: async () =>
+            (async function* () {
+              yield chunkOne;
+              yield chunkTwo;
+            })(),
+          sendMessage: async () => {
+            throw new Error(
+              'sendMessage should not be called when streaming is enabled',
+            );
+          },
+        }),
+      },
+      models: {},
+    } as any;
+
+    const messages: Content[] = [
+      { role: 'user', parts: [createPartFromText('Hi there')] },
+    ];
+
+    const response = await handler.createResponse(fakeClient, messages, 0);
+
+    assert.ok(response.automaticFunctionCallingHistory);
+    assert.equal(response.automaticFunctionCallingHistory?.length, 2);
+    assert.deepEqual(response.automaticFunctionCallingHistory?.[0], {
+      name: 'callOne',
+    });
+    assert.deepEqual(response.automaticFunctionCallingHistory?.[1], {
+      name: 'callTwo',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- simplify the Gemini streaming aggregation to collect chunk content directly without extra bookkeeping while still synthesizing the final response and preserving metadata

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_690cd404fa9c83249a821dab0842ef50

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aggregate Gemini streaming chunks directly, merging parts/text/usage and function-calling history to build the final response, with tests covering aggregation and history concatenation.
> 
> - **Model handling (`src/agent/modelHandlers/modelHandlerGoogleGenAI.ts`)**:
>   - Replace reliance on SDK stream response promise with on-the-fly aggregation of streamed chunks.
>   - Build a base response, track latest candidate, and aggregate `parts` and concatenated text for output streaming.
>   - Merge metadata from chunks: `usageMetadata`, `promptFeedback`, `modelVersion`, `responseId`, and concatenate `automaticFunctionCallingHistory`.
>   - Finalize thinking/output streams using aggregated content; return synthesized `baseResponse`.
>   - Adjust error message when no streamed response is produced.
> - **Tests (`src/test/modelHandlers/ModelHandlerGoogle.test.ts`)**:
>   - Add tests validating chunk aggregation without SDK promises and concatenation of `automaticFunctionCallingHistory`.
>   - Ensure final `text`, `parts`, `finishReason`, and `usageMetadata` are correctly synthesized.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d876c0b05d2c5ebbfc1bc4cdb662614d4b9614e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->