### PR TITLE
Refactor shared agent flows to centralize lifecycle handling

### DIFF
--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -20,7 +20,7 @@ export interface AgentSharedStoreSlices {
   user: UserVariableChannels;
 }
 
-interface AgentSharedStoreConfig extends AgentSharedStoreSlices {
+interface AgentSharedStoreOptions extends AgentSharedStoreSlices {
   onRoundFinalized?: AgentRoundFinalizedCallback;
 }
 
@@ -38,7 +38,7 @@ export class AgentSharedStore {
   private readonly userChannels: UserVariableChannels;
   private readonly onRoundFinalized?: AgentRoundFinalizedCallback;
 
-  constructor(config: AgentSharedStoreConfig) {
+  constructor(config: AgentSharedStoreOptions) {
     this.roundState = config.round;
     this.runState = config.run;
     this.workspaceState = config.workspace;

--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -3,11 +3,25 @@ import { AgentRunState, ConversationRoundState } from './AgentState';
 import { AgentWorkspaceState } from './AgentWorkspaceState';
 import type { UserVariableChannels } from './AgentCycleOptions';
 
+export interface AgentRoundFinalizedContext {
+  round: ConversationRoundState;
+  run: AgentRunState;
+  workspace: AgentWorkspaceState;
+}
+
+export type AgentRoundFinalizedCallback = (
+  context: AgentRoundFinalizedContext,
+) => void | Promise<void>;
+
 export interface AgentSharedStoreSlices {
   round: ConversationRoundState;
   run: AgentRunState;
   workspace: AgentWorkspaceState;
   user: UserVariableChannels;
+}
+
+interface AgentSharedStoreConfig extends AgentSharedStoreSlices {
+  onRoundFinalized?: AgentRoundFinalizedCallback;
 }
 
 /**
@@ -22,12 +36,14 @@ export class AgentSharedStore {
   private readonly runState: AgentRunState;
   private readonly workspaceState: AgentWorkspaceState;
   private readonly userChannels: UserVariableChannels;
+  private readonly onRoundFinalized?: AgentRoundFinalizedCallback;
 
-  constructor(slices: AgentSharedStoreSlices) {
-    this.roundState = slices.round;
-    this.runState = slices.run;
-    this.workspaceState = slices.workspace;
-    this.userChannels = slices.user;
+  constructor(config: AgentSharedStoreConfig) {
+    this.roundState = config.round;
+    this.runState = config.run;
+    this.workspaceState = config.workspace;
+    this.userChannels = config.user;
+    this.onRoundFinalized = config.onRoundFinalized;
   }
 
   get round(): ConversationRoundState {
@@ -36,6 +52,11 @@ export class AgentSharedStore {
 
   setRound(roundState: ConversationRoundState): void {
     this.roundState = roundState;
+  }
+
+  resetRound(roundIndex: number): ConversationRoundState {
+    this.roundState = new ConversationRoundState(roundIndex);
+    return this.roundState;
   }
 
   get run(): AgentRunState {
@@ -50,7 +71,41 @@ export class AgentSharedStore {
     return this.userChannels;
   }
 
-  finalizeRound(): void {
+  async finalizeRound(): Promise<void> {
     this.runState.recordRound(this.roundState);
+    if (this.onRoundFinalized) {
+      await this.onRoundFinalized({
+        round: this.roundState,
+        run: this.runState,
+        workspace: this.workspaceState,
+      });
+    }
   }
+}
+
+interface SharedStoreFactoryParams {
+  roundIndex: number;
+  runState: AgentRunState;
+  workspaceState: AgentWorkspaceState;
+  userChannels: UserVariableChannels;
+  roundState?: ConversationRoundState;
+  onRoundFinalized?: AgentRoundFinalizedCallback;
+}
+
+export function createSharedStore({
+  roundIndex,
+  runState,
+  workspaceState,
+  userChannels,
+  roundState,
+  onRoundFinalized,
+}: SharedStoreFactoryParams): AgentSharedStore {
+  const initialRound = roundState ?? new ConversationRoundState(roundIndex);
+  return new AgentSharedStore({
+    round: initialRound,
+    run: runState,
+    workspace: workspaceState,
+    user: userChannels,
+    onRoundFinalized,
+  });
 }

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -54,6 +54,7 @@ export async function runResponseCycle<C = unknown>(
       responseTime: undefined,
       stopReason: undefined,
       processedResponse: undefined,
+      roundFinalized: false,
     } satisfies ResponseCycleState,
   };
 

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -1,6 +1,5 @@
 // Local imports - agent components
 import { AgentSharedStore } from './AgentSharedStore';
-import { AgentRunState, ConversationRoundState } from './AgentState';
 import { AgentWorkspaceState } from './AgentWorkspaceState';
 
 // Local imports - flow orchestration
@@ -24,19 +23,12 @@ export interface ToolUseCycleOptions<C = unknown>
   toolRegistry: Record<string, BaseTool<any>>;
   toolState: AgentWorkspaceState;
   modelName?: string;
-  onUsageRecorded?: (event: ToolUseUsageEvent) => Promise<void> | void;
 }
 
 export interface ToolUseCycleContext<C = unknown> {
   options: ToolUseCycleOptions<C>;
   messages: ProviderMessage[];
   store: AgentSharedStore;
-}
-
-export interface ToolUseUsageEvent {
-  run: AgentRunState;
-  round: ConversationRoundState;
-  endTurn: boolean;
 }
 
 export async function runToolUseCycle<C = unknown>(

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -88,6 +88,7 @@ export interface ResponseCycleRuntimeState {
   responseTime?: number;
   stopReason?: ProviderStopReason;
   processedResponse?: string;
+  roundFinalized: boolean;
 }
 
 export type ResponseCycleState = ResponseCycleInputState &
@@ -100,6 +101,19 @@ function resetResponseCycleState(cycle: ResponseCycleRuntimeState): void {
   cycle.responseTime = undefined;
   cycle.stopReason = undefined;
   cycle.processedResponse = undefined;
+  cycle.roundFinalized = false;
+}
+
+async function finalizeRoundIfNeeded(
+  store: AgentSharedStore,
+  state: ResponseCycleRuntimeState,
+): Promise<void> {
+  if (state.roundFinalized) {
+    return;
+  }
+
+  state.roundFinalized = true;
+  await store.finalizeRound();
 }
 
 export interface ResponseCycleShared<C = unknown> {
@@ -456,6 +470,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     if ('skipped' in execRes) {
       state.endTurn = false;
+      await finalizeRoundIfNeeded(store, state);
       return FlowTransition.COMPLETE;
     }
 
@@ -463,11 +478,11 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     state.stopReason = result.stopReason;
     state.processedResponse = result.processedResponse;
-    await store.finalizeRound();
 
     if (result.repetitionDetected) {
       state.endTurn = false;
       state.shouldStop = true;
+      await finalizeRoundIfNeeded(store, state);
       return FlowTransition.COMPLETE;
     }
 
@@ -476,6 +491,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if (!processedResponse) {
       state.endTurn = false;
       state.shouldStop = true;
+      await finalizeRoundIfNeeded(store, state);
       return FlowTransition.COMPLETE;
     }
 
@@ -620,6 +636,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     if ('skipped' in execRes) {
       state.endTurn = false;
       state.shouldStop = true;
+      await finalizeRoundIfNeeded(store, state);
       return FlowTransition.COMPLETE;
     }
 
@@ -629,6 +646,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     state.shouldStop = shouldStop;
 
     if (shouldStop) {
+      await finalizeRoundIfNeeded(store, state);
       return FlowTransition.COMPLETE;
     }
 
@@ -636,6 +654,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
     const willContinue = shouldContinue || reachedTokenLimit;
 
     if (!willContinue) {
+      await finalizeRoundIfNeeded(store, state);
       return FlowTransition.COMPLETE;
     }
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -463,7 +463,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
     state.stopReason = result.stopReason;
     state.processedResponse = result.processedResponse;
-    store.run.recordRound(store.round);
+    await store.finalizeRound();
 
     if (result.repetitionDetected) {
       state.endTurn = false;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -6,7 +6,6 @@ import { FlowTransition } from './FlowTransitions';
 
 // Local imports - agent components
 import { AgentSharedStore } from '@agent/core/AgentSharedStore';
-import { ConversationRoundState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
 
@@ -423,27 +422,19 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleShared<C>> {
     }
 
     const completedRound = store.round;
-    store.finalizeRound();
+    await store.finalizeRound();
     store.run.incrementRounds();
-
-    await Promise.resolve(
-      options.onUsageRecorded?.({
-        run: store.run,
-        round: completedRound,
-        endTurn: execRes.endTurn,
-      }),
-    );
 
     const nextRoundIndex = completedRound.roundIndex + 1;
 
     if (execRes.endTurn) {
       state.shouldStop = true;
       state.stopReason = execRes.stopReason;
-      store.setRound(new ConversationRoundState(nextRoundIndex));
+      store.resetRound(nextRoundIndex);
       return FlowTransition.COMPLETE;
     }
 
-    store.setRound(new ConversationRoundState(nextRoundIndex));
+    store.resetRound(nextRoundIndex);
     return undefined;
   }
 }

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -15,6 +15,7 @@ import type {
   AgentCycleBaseOptions,
   UserVariableChannels,
 } from '@agent/core/AgentCycleOptions';
+import type { AgentRoundFinalizedCallback } from '../core/AgentSharedStore';
 import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 
 // Local imports - logging
@@ -238,6 +239,14 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     options?: { runKind?: 'workflow' | 'tool-use' },
   ): Promise<void> {
     await this.usageMonitor.recordUsage(stateGlobal, options);
+  }
+
+  public getUsageRecorder(
+    runKind: 'workflow' | 'tool-use' = 'workflow',
+  ): AgentRoundFinalizedCallback {
+    return async ({ run }) => {
+      await this.trackRoundUsage(run, { runKind });
+    };
   }
 
   /**

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -7,7 +7,7 @@ import {
   requireWorkflowSetting,
 } from '@agent/core/AgentDataclass';
 import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
-import { AgentSharedStore } from '@agent/core/AgentSharedStore';
+import { createSharedStore } from '@agent/core/AgentSharedStore';
 import { runResponseCycle } from '@agent/core/ResponseCycle';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
@@ -18,9 +18,11 @@ import {
   type ReflectionRunLifecycle,
   type ReflectionRunShared,
   type ReflectionRunState,
+  type ReflectionRunPhase,
 } from '@agent/implementations/flows/ReflectionRunFlow';
 import { runAgentFlow } from '@agent/implementations/flows/common/AgentRunFlowRunner';
 import type { AgentRunHooks } from '@agent/implementations/flows/common/types';
+import { createLifecycleState } from '@agent/implementations/flows/common/lifecycle';
 import {
   createReflectionRoundFlow,
   type ReflectionRoundShared,
@@ -67,13 +69,13 @@ export interface RoundOutputOptions {
 
 export interface ReflectionRoundContext {
   roundIndex: number;
-  globalState: AgentRunState;
+  runState: AgentRunState;
   messages: any[];
 }
 
 export interface ReflectionRoundResult {
   roundState: ConversationRoundState;
-  globalState: AgentRunState;
+  runState: AgentRunState;
   messages: any[];
   shouldContinue: boolean;
   toolState: AgentWorkspaceState;
@@ -89,7 +91,7 @@ export interface AgentRuntimeXmlExports {
 interface RoundPipelineContext {
   roundIndex: number;
   roundState: ConversationRoundState;
-  globalState: AgentRunState;
+  runState: AgentRunState;
   toolState: AgentWorkspaceState;
   preparedMessages: any[];
   prefill: string;
@@ -223,13 +225,13 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   private async handleRoundCompletion(
     currRound: number,
     stateRound: ConversationRoundState,
-    stateGlobal: AgentRunState,
+    runState: AgentRunState,
     options: RoundOutputOptions,
   ): Promise<RoundOutputArtifacts> {
     const { outputFile, endTurn, stage } = options;
 
     const execute = async (scope: AgentLogStage | undefined) => {
-      await this.handleOutput(currRound, stateRound, stateGlobal, {
+      await this.handleOutput(currRound, stateRound, runState, {
         ...options,
         stage: scope,
       });
@@ -256,8 +258,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   /**
    * Processes output files for current round.
    * This method orchestrates the overall output processing flow with clear separation of concerns:
-   * 1. Usage tracking via trackRoundUsage
-   * 2. LaTeX diff operations via diffManager.handleLatexdiffofOutput (only when endTurn is true)
+   * - LaTeX diff operations via diffManager.handleLatexdiffofOutput (only when endTurn is true)
    *
    * The actual file processing is handled separately in processOutputFiles.
    *
@@ -266,13 +267,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   protected async handleOutput(
     currRound: number,
     stateRound: ConversationRoundState,
-    stateGlobal: AgentRunState,
+    _runState: AgentRunState,
     options: RoundOutputOptions,
   ): Promise<string[]> {
     const { outputFile, endTurn, stage } = options;
-    // Record usage statistics at the end of each round
-    await this.trackRoundUsage(stateGlobal);
-
     // If this is the end of a turn, handle latexdiff operations as a separate step
     if (endTurn && this.outputHandler.hasRoundOutputs(currRound)) {
       const existingBase = await Promise.all(
@@ -304,7 +302,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    *
    * @param currRound - Zero-based index of the round being executed.
    * @param stateRound - Mutable state scoped to the current round of execution.
-   * @param stateGlobal - Shared agent state that spans all rounds.
+   * @param runState - Shared agent state that spans all rounds.
    * @param toolState - Current tool invocation state passed between rounds.
    * @param preparedMessages - Messages prepared for the model before execution.
    * @param prefill - Initial text inserted into the model response buffer.
@@ -314,7 +312,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   private async runRoundPipeline({
     roundIndex,
     roundState,
-    globalState,
+    runState,
     toolState,
     preparedMessages,
     prefill,
@@ -330,13 +328,16 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         prefill,
       );
 
+    const store = createSharedStore({
+      roundIndex: roundState.roundIndex,
+      roundState,
+      runState,
+      workspaceState: toolState,
+      userChannels: this.userVarChannels,
+      onRoundFinalized: this.getUsageRecorder('workflow'),
+    });
+
     if (!endTurn) {
-      const store = new AgentSharedStore({
-        round: roundState,
-        run: globalState,
-        workspace: toolState,
-        user: this.userVarChannels,
-      });
       const cycleResult = await runResponseCycle({
         options: this.createResponseCycleOptions(),
         messages: updatedMessages,
@@ -354,13 +355,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         },
       );
 
-      if (roundIndex === 0) {
-        this.logger.debug(`stateGlobal: ${JSON.stringify(store.run)}`);
-      }
-
       return {
         roundState: store.round,
-        globalState: store.run,
+        runState: store.run,
         messages: updatedMessages,
         shouldContinue: cycleResult.endTurn,
         toolState: store.workspace,
@@ -368,10 +365,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       };
     }
 
+    await store.finalizeRound();
+
     const artifacts = await this.handleRoundCompletion(
       roundIndex,
-      roundState,
-      globalState,
+      store.round,
+      store.run,
       {
         outputFile: outputPath,
         endTurn,
@@ -379,8 +378,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     );
 
     return {
-      roundState,
-      globalState,
+      roundState: store.round,
+      runState: store.run,
       messages: updatedMessages,
       shouldContinue: endTurn,
       toolState,
@@ -404,7 +403,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
   private async prepareRoundContext(
     currRound: number,
-    _stateGlobal: AgentRunState,
+    _runState: AgentRunState,
     messages: any[],
     toolState: AgentWorkspaceState,
   ): Promise<{
@@ -545,7 +544,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
   public async runReflectionRound({
     roundIndex,
-    globalState,
+    runState,
     messages,
   }: ReflectionRoundContext): Promise<ReflectionRoundResult> {
     this.logger.debug(`Processing round ${roundIndex}`);
@@ -560,17 +559,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           prepareAgentWorkspaceState: () =>
             this.prepareAgentWorkspaceState(roundIndex, toolState),
           prepareRoundContext: () =>
-            this.prepareRoundContext(
-              roundIndex,
-              globalState,
-              messages,
-              toolState,
-            ),
+            this.prepareRoundContext(roundIndex, runState, messages, toolState),
           runRoundPipeline: ({ stateRound, preparedMessages, prefill }) =>
             this.runRoundPipeline({
               roundIndex,
               roundState: stateRound,
-              globalState,
+              runState,
               toolState,
               preparedMessages,
               prefill,
@@ -578,7 +572,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
             }),
           createSkipResult: (stateRound) => ({
             roundState: stateRound,
-            globalState,
+            runState,
             messages,
             shouldContinue: true,
             toolState,
@@ -608,11 +602,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       documents: [],
       singleOutputFile: null,
     };
-    const lifecycle: ReflectionRunLifecycle = {
-      phase: 'idle',
-      status: 'pending',
-      error: undefined,
-    };
+    const lifecycle = createLifecycleState<ReflectionRunPhase>('idle');
 
     const totalRounds = this.getTotalRounds();
 
@@ -625,7 +615,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
           currentRound: 0,
           continueRounds: true,
           messages: [],
-          globalState: new AgentRunState(),
+          runState: new AgentRunState(),
         }) satisfies ReflectionRunState,
       createFlow: () => createReflectionRunFlow<C>(),
       extendHooks: (baseHooks: AgentRunHooks) => {

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -143,6 +143,9 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       await runAgentFlow<ToolUseRunShared<C>>({
         agent: this,
         lifecycle,
+        hookOverrides: {
+          start: async () => undefined,
+        },
         createState: () => {
           const state: ToolUseRunState<C> = {
             messages: [],

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -7,9 +7,7 @@ import { runToolUseCycle } from '../core/ToolUseCycle';
 import type { ToolUseCycleOptions } from '../core/ToolUseCycle';
 import type { IModelHandler } from '../modelHandlers';
 import type { ProviderMessage } from '../modelHandlers/types/ProviderMessage';
-import { getSystemPromptWithRules } from '../utils/promptHelpers';
-import { renderPrompt } from '../utils/promptUtils';
-import { TOOL_USE_INSTRUCTIONS } from '../utils/toolUsePrompt';
+import { buildInitialToolUsePrompts } from '../utils/PromptBuilder';
 // Base class for tool-use agents
 
 // Standard library imports
@@ -22,9 +20,11 @@ import {
   type ToolUseRunLifecycle,
   type ToolUseRunShared,
   type ToolUseRunState,
+  type ToolUseRunPhase,
 } from '@agent/implementations/flows/ToolUseRunFlow';
 import { runAgentFlow } from '@agent/implementations/flows/common/AgentRunFlowRunner';
 import type { AgentRunHooks } from '@agent/implementations/flows/common/types';
+import { createLifecycleState } from '@agent/implementations/flows/common/lifecycle';
 import type { ToolDefinition } from '@model';
 import { BaseTool } from '@tools/core/base';
 import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
@@ -44,9 +44,8 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
   private toolRegistry: Record<string, BaseTool<any>>;
   private followUpQueue: string[] = [];
   private followUpResolver: ((v: string | null) => void) | null = null;
-  private messages: ProviderMessage[] = [];
-  private toolState: AgentWorkspaceState | null = null;
   private resumeSnapshot: ToolUseSessionSnapshot | null = null;
+  private activeState: ToolUseRunState<C> | null = null;
 
   constructor(
     modelHandler: IModelHandler<any, any, any, any, C>,
@@ -138,66 +137,66 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
   }
 
   public async run(): Promise<void> {
-    const lifecycle: ToolUseRunLifecycle = {
-      phase: 'idle',
-      status: 'pending',
-      error: undefined,
-    };
+    const lifecycle = createLifecycleState<ToolUseRunPhase>('idle');
 
-    await runAgentFlow<ToolUseRunShared<C>>({
-      agent: this,
-      lifecycle,
-      createState: () =>
-        ({
-          messages: this.messages,
-          toolState: this.toolState,
-          cycleOptions: null,
-          shouldSkipCycle: false,
-          store: null,
-          runState: new AgentRunState(),
-          nextRoundIndex: 0,
-        }) satisfies ToolUseRunState<C>,
-      createFlow: () => createToolUseRunFlow<C>(),
-      extendHooks: (baseHooks: AgentRunHooks) => ({
-        ...baseHooks,
-        start: async () => undefined,
-        init: (runStage) => this.init(runStage, { createStage: false }),
-        prepareState: () => this.prepareInitialSessionState(),
-        buildCycleOptions: (toolState) =>
-          this.buildToolUseCycleOptions(toolState),
-        runCycle: (options, messages, store) =>
-          runToolUseCycle({
-            options,
-            messages,
-            store,
-          }),
-        checkInterruption: () => this.checkInterruption(),
-        hasQueuedFollowUp: () => this.followUpQueue.length > 0,
-        enterWaitingState: () => this.enterWaitingState(),
-        clearPersistedSnapshot: () => this.clearPersistedSnapshot(),
-        waitForFollowUp: () => this.waitForFollowUp(),
-        markRunning: () => this.markRunning(),
-        applyFollowUp: async (followUp, messages) => {
-          this.logger.userMessage(followUp);
-          const updatedMessages =
-            await this.modelHandler.createUserFollowUpMessages(
+    try {
+      await runAgentFlow<ToolUseRunShared<C>>({
+        agent: this,
+        lifecycle,
+        createState: () => {
+          const state: ToolUseRunState<C> = {
+            messages: [],
+            toolState: null,
+            cycleOptions: null,
+            shouldSkipCycle: false,
+            store: null,
+            runState: new AgentRunState(),
+            nextRoundIndex: 0,
+          };
+          this.activeState = state;
+          return state;
+        },
+        createFlow: () => createToolUseRunFlow<C>(),
+        extendHooks: (baseHooks: AgentRunHooks) => ({
+          ...baseHooks,
+          init: (runStage) => this.init(runStage, { createStage: false }),
+          prepareState: () => this.prepareInitialSessionState(),
+          buildCycleOptions: (toolState) =>
+            this.buildToolUseCycleOptions(toolState),
+          runCycle: (options, messages, store) =>
+            runToolUseCycle({
+              options,
               messages,
-              followUp,
-            );
-          this.messages = updatedMessages;
-          return updatedMessages;
-        },
-        end: async (status) => {
-          await baseHooks.end(status);
-        },
-        cleanup: async () => {
-          await baseHooks.cleanup();
-        },
-        logFinalizeWarning: (message, error) => {
-          this.logger.warn(message, undefined, undefined, error);
-        },
-      }),
-    });
+              store,
+            }),
+          checkInterruption: () => this.checkInterruption(),
+          hasQueuedFollowUp: () => this.followUpQueue.length > 0,
+          enterWaitingState: () => this.enterWaitingState(),
+          clearPersistedSnapshot: () => this.clearPersistedSnapshot(),
+          waitForFollowUp: () => this.waitForFollowUp(),
+          markRunning: () => this.markRunning(),
+          applyFollowUp: async (followUp, messages) => {
+            this.logger.userMessage(followUp);
+            const updatedMessages =
+              await this.modelHandler.createUserFollowUpMessages(
+                messages,
+                followUp,
+              );
+            this.getActiveState().messages = updatedMessages;
+            return updatedMessages;
+          },
+          logFinalizeWarning: (message, error) => {
+            this.logger.warn(message, undefined, undefined, error);
+          },
+          cleanup: async () => {
+            await baseHooks.cleanup();
+            this.activeState = null;
+          },
+        }),
+      });
+    } finally {
+      this.activeState = null;
+    }
   }
 
   private async prepareInitialSessionState(): Promise<{
@@ -205,6 +204,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     toolState: AgentWorkspaceState;
     shouldSkipCycle: boolean;
   }> {
+    const state = this.getActiveState();
     if (this.resumeSnapshot) {
       this.logger.debug('Resuming tool-use session from saved state.');
       const snapshot = this.resumeSnapshot;
@@ -226,8 +226,9 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
         toolState = new AgentWorkspaceState();
       }
 
-      this.messages = messages;
-      this.toolState = toolState;
+      state.messages = messages;
+      state.toolState = toolState;
+      state.shouldSkipCycle = true;
 
       return {
         messages,
@@ -236,30 +237,27 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       };
     }
 
-    const initialRequest = Array.isArray(this.agentPrompt.userRequest)
-      ? (this.agentPrompt.userRequest[0] ?? '')
-      : this.agentPrompt.userRequest;
-
-    const [systemPrompt, userRequest, userPrefix] = await Promise.all([
-      getSystemPromptWithRules(
-        `${this.agentPrompt.systemPrompt}\n${TOOL_USE_INSTRUCTIONS}`,
+    const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
+      await buildInitialToolUsePrompts(
+        this.agentPrompt,
         this.userVars,
-      ),
-      renderPrompt(initialRequest, this.userVars),
-      renderPrompt(this.agentPrompt.userPrefix, this.userVars),
-    ]);
+        this.logger,
+      );
 
     const messages = await this.modelHandler.initializeMessages(
       userPrefix,
       userRequest,
       undefined,
-      systemPrompt,
+      systemPrompt
+        ? `${systemPrompt}\n${instructionSuffix}`
+        : instructionSuffix,
     );
 
     const toolState = new AgentWorkspaceState();
 
-    this.messages = messages;
-    this.toolState = toolState;
+    state.messages = messages;
+    state.toolState = toolState;
+    state.shouldSkipCycle = false;
 
     return {
       messages,
@@ -288,9 +286,6 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       toolRegistry: this.toolRegistry,
       toolState,
       modelName: this.agentConfig.model,
-      onUsageRecorded: async ({ run }) => {
-        await this.trackRoundUsage(run, { runKind: 'tool-use' });
-      },
     };
   }
 
@@ -302,7 +297,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
 
     const stream = this.getStreamTabId();
     const executionId = this.getExecutionId();
-    const state = this.toolState;
+    const { toolState, messages } = this.getActiveState();
 
     await ToolUseSessionPersistence.maybePersistIdleSnapshot({
       executionId,
@@ -310,8 +305,8 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       agentName: this.agentConfig.agent,
       model: this.agentConfig.model,
       session: this.getSessionMetadata(),
-      messages: this.messages,
-      toolState: state ?? null,
+      messages,
+      toolState: toolState ?? null,
       hasQueuedFollowUps: () => this.followUpQueue.length > 0,
     });
 
@@ -331,5 +326,12 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
   private async clearPersistedSnapshot(): Promise<void> {
     const executionId = this.getExecutionId();
     await ToolUseSessionPersistence.clearPersistedSnapshot(executionId);
+  }
+
+  private getActiveState(): ToolUseRunState<C> {
+    if (!this.activeState) {
+      throw new Error('Tool-use run state is not initialized.');
+    }
+    return this.activeState;
   }
 }

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -12,39 +12,40 @@ import type {
   ReflectionRoundResult,
 } from '../BaseReflectionAgent';
 import { AgentInitNode } from '@agent/implementations/flows/common/AgentInitNode';
-import type { AgentRunShared } from '@agent/implementations/flows/common/types';
-import type { AgentLogStage } from '@logger/AgentLogger';
+import type {
+  AgentLifecycleState,
+  AgentRunHooks,
+  AgentRunShared,
+} from '@agent/implementations/flows/common/types';
 import {
   beginLifecyclePhase,
   completeLifecycle,
   failLifecycle,
   setLifecyclePhase,
 } from '@agent/implementations/flows/common/lifecycle';
+import { buildRunFlow } from '@agent/implementations/flows/common/buildRunFlow';
+import { finalizeLifecycle } from '@agent/implementations/flows/common/finalizeLifecycle';
+import { BaseRunStateSchema } from '@agent/implementations/flows/common/types';
+import { z } from 'zod';
 
-type RunPhase = 'idle' | 'init' | 'rounds' | 'finalize';
-type RunStatus = 'pending' | 'running' | 'error' | 'completed';
+export type ReflectionRunPhase = 'idle' | 'init' | 'rounds' | 'finalize';
 
-export interface ReflectionRunLifecycle {
-  phase: RunPhase;
-  status: RunStatus;
-  error?: unknown;
-}
+export type ReflectionRunLifecycle = AgentLifecycleState<ReflectionRunPhase>;
 
-export interface ReflectionRunHooks {
-  start(): Promise<AgentLogStage>;
-  init(runStage: AgentLogStage): Promise<void>;
-  resetPromptBuilder(): void;
-  initializeClient(): Promise<void>;
-  end(status: 'stopped' | 'error'): void | Promise<void>;
-  cleanup(): void | Promise<void>;
-}
+const ReflectionRunStateSchemaBase = BaseRunStateSchema.extend({
+  totalRounds: z.number().nonnegative(),
+  currentRound: z.number().nonnegative(),
+  continueRounds: z.boolean(),
+});
 
-export interface ReflectionRunState {
-  totalRounds: number;
-  currentRound: number;
-  continueRounds: boolean;
+type ReflectionRunStateStruct = z.infer<typeof ReflectionRunStateSchemaBase>;
+
+export type ReflectionRunState = Omit<ReflectionRunStateStruct, 'messages'> & {
   messages: any[];
-  globalState: AgentRunState;
+};
+
+export interface ReflectionRunHooks extends AgentRunHooks {
+  resetPromptBuilder(): void;
 }
 
 export type ReflectionRunShared<C = unknown> = AgentRunShared<
@@ -60,7 +61,7 @@ interface ReflectionRoundPrep<C> {
   shouldFinalize: boolean;
   roundIndex: number;
   messages: any[];
-  globalState: AgentRunState;
+  runState: AgentRunState;
 }
 
 interface ReflectionRoundExec<C> extends ReflectionRoundPrep<C> {
@@ -71,10 +72,6 @@ interface ReflectionRoundExec<C> extends ReflectionRoundPrep<C> {
 interface ReflectionFinalizePrep {
   hooks: ReflectionRunHooks;
   lifecycle: ReflectionRunLifecycle;
-}
-
-interface ReflectionFinalizeExec {
-  endError?: unknown;
 }
 
 class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
@@ -91,7 +88,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
       shouldFinalize,
       roundIndex: state.currentRound,
       messages: state.messages,
-      globalState: state.globalState,
+      runState: state.runState,
     };
   }
 
@@ -106,7 +103,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
       prepRes.agent.setCurrentRound(prepRes.roundIndex);
       const result = await prepRes.agent.runReflectionRound({
         roundIndex: prepRes.roundIndex,
-        globalState: prepRes.state.globalState,
+        runState: prepRes.state.runState,
         messages: prepRes.state.messages,
       } satisfies ReflectionRoundContext);
 
@@ -157,11 +154,11 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
       shared.agent.roundOutputArtifacts[result.outputArtifacts.round] =
         result.outputArtifacts;
     }
-    shared.state.globalState = result.globalState;
+    shared.state.runState = result.runState;
     shared.state.messages = result.messages;
     shared.state.continueRounds = result.shouldContinue;
     shared.state.currentRound += 1;
-    shared.state.globalState.incrementRounds();
+    shared.state.runState.incrementRounds();
 
     if (shared.agent.isInterruptionRequested()) {
       return FlowTransition.FINALIZE;
@@ -188,38 +185,14 @@ class ReflectionFinalizeNode<C> extends BaseNode<ReflectionRunShared<C>> {
     };
   }
 
-  async exec(prepRes: ReflectionFinalizePrep): Promise<ReflectionFinalizeExec> {
+  async exec(prepRes: ReflectionFinalizePrep): Promise<void> {
     const status = prepRes.lifecycle.error ? 'error' : 'stopped';
-    try {
-      await Promise.resolve(prepRes.hooks.end(status));
-      return {};
-    } catch (error) {
-      return { endError: error };
-    }
-  }
-
-  async post(
-    shared: ReflectionRunShared<C>,
-    prepRes: ReflectionFinalizePrep,
-    execRes: ReflectionFinalizeExec,
-  ): Promise<string | undefined> {
-    let error = shared.lifecycle.error ?? execRes.endError;
-
-    try {
-      await Promise.resolve(prepRes.hooks.cleanup());
-    } catch (cleanupError) {
-      if (!error) {
-        error = cleanupError;
-      }
-    }
-
-    if (error) {
-      failLifecycle(shared.lifecycle, error);
-    } else {
-      completeLifecycle(shared.lifecycle);
-    }
-
-    return undefined;
+    await finalizeLifecycle({
+      lifecycle: prepRes.lifecycle,
+      runFinalize: () => Promise.resolve(prepRes.hooks.end(status)),
+      runCleanup: () => Promise.resolve(prepRes.hooks.cleanup()),
+      onSuccess: () => completeLifecycle(prepRes.lifecycle),
+    });
   }
 }
 
@@ -237,11 +210,13 @@ export function createReflectionRunFlow<C>(): Flow<ReflectionRunShared<C>> {
   const roundNode = new ReflectionRoundNode<C>();
   const finalizeNode = new ReflectionFinalizeNode<C>();
 
-  initNode.on(FlowTransition.ROUND, roundNode);
-  initNode.on(FlowTransition.FINALIZE, finalizeNode);
-
-  roundNode.on(FlowTransition.CONTINUE, roundNode);
-  roundNode.on(FlowTransition.FINALIZE, finalizeNode);
-
-  return new Flow<ReflectionRunShared<C>>(initNode);
+  return buildRunFlow({
+    init: initNode,
+    finalize: finalizeNode,
+    links: [
+      { from: initNode, on: FlowTransition.ROUND, to: roundNode },
+      { from: roundNode, on: FlowTransition.CONTINUE, to: roundNode },
+      { from: roundNode, on: FlowTransition.FINALIZE },
+    ],
+  });
 }

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -5,21 +5,31 @@ import { BaseNode, Flow } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 
 // Local imports - agent components
-import { AgentSharedStore } from '@agent/core/AgentSharedStore';
-import { AgentRunState, ConversationRoundState } from '@agent/core/AgentState';
+import {
+  AgentSharedStore,
+  createSharedStore,
+} from '@agent/core/AgentSharedStore';
+import { AgentRunState } from '@agent/core/AgentState';
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
-import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { BaseToolUseAgent } from '../BaseToolUseAgent';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { AgentInitNode } from '@agent/implementations/flows/common/AgentInitNode';
-import type { AgentRunShared } from '@agent/implementations/flows/common/types';
-import type { AgentLogStage } from '@logger/AgentLogger';
+import type {
+  AgentLifecycleState,
+  AgentRunHooks,
+  AgentRunShared,
+} from '@agent/implementations/flows/common/types';
 import {
   beginLifecyclePhase,
   failLifecycle,
   setLifecyclePhase,
   setLifecycleStatus,
 } from '@agent/implementations/flows/common/lifecycle';
+import { buildRunFlow } from '@agent/implementations/flows/common/buildRunFlow';
+import { finalizeLifecycle } from '@agent/implementations/flows/common/finalizeLifecycle';
+import { BaseRunStateSchema } from '@agent/implementations/flows/common/types';
+import { z } from 'zod';
 
 interface ToolUsePrepareResult<C> {
   messages: ProviderMessage[];
@@ -42,34 +52,36 @@ interface ToolUseFinalizePrep<C> {
   lifecycle: ToolUseRunLifecycle;
 }
 
-interface ToolUseFinalizeExecResult {
-  snapshotError?: unknown;
-  endError?: unknown;
-}
+export type ToolUseRunPhase =
+  | 'idle'
+  | 'init'
+  | 'prepare'
+  | 'cycle'
+  | 'finalize';
 
-type ToolUseRunPhase = 'idle' | 'init' | 'prepare' | 'cycle' | 'finalize';
-type ToolUseRunStatus = 'pending' | 'running' | 'error' | 'completed';
+export type ToolUseRunLifecycle = AgentLifecycleState<ToolUseRunPhase>;
 
-export interface ToolUseRunLifecycle {
-  phase: ToolUseRunPhase;
-  status: ToolUseRunStatus;
-  error?: unknown;
-}
+const ToolUseRunStateSchemaBase = BaseRunStateSchema.extend({
+  toolState: z.instanceof(AgentWorkspaceState).nullable(),
+  cycleOptions: z.any().nullable(),
+  shouldSkipCycle: z.boolean(),
+  store: z.instanceof(AgentSharedStore).nullable(),
+  nextRoundIndex: z.number().nonnegative(),
+});
 
-export interface ToolUseRunState<C = unknown> {
+type ToolUseRunStateStruct = z.infer<typeof ToolUseRunStateSchemaBase>;
+
+export type ToolUseRunState<C = unknown> = Omit<
+  ToolUseRunStateStruct,
+  'cycleOptions' | 'store' | 'toolState' | 'messages'
+> & {
   messages: ProviderMessage[];
   toolState: AgentWorkspaceState | null;
   cycleOptions: ToolUseCycleOptions<C> | null;
-  shouldSkipCycle: boolean;
   store: AgentSharedStore | null;
-  runState: AgentRunState;
-  nextRoundIndex: number;
-}
+};
 
-export interface ToolUseRunHooks<C = unknown> {
-  start(): Promise<AgentLogStage | undefined>;
-  init(runStage: AgentLogStage | undefined): Promise<void>;
-  initializeClient(): Promise<void>;
+export interface ToolUseRunHooks<C = unknown> extends AgentRunHooks {
   prepareState(): Promise<{
     messages: ProviderMessage[];
     toolState: AgentWorkspaceState;
@@ -91,8 +103,6 @@ export interface ToolUseRunHooks<C = unknown> {
     followUp: string,
     messages: ProviderMessage[],
   ): Promise<ProviderMessage[]>;
-  end(status: 'stopped' | 'error'): Promise<void>;
-  cleanup(): Promise<void>;
   logFinalizeWarning?(message: string, error: unknown): void;
 }
 
@@ -159,20 +169,17 @@ class ToolUsePrepareNode<C> extends BaseNode<ToolUseRunShared<C>> {
     shared.state.toolState = toolState;
     shared.state.shouldSkipCycle = shouldSkipCycle;
     shared.state.cycleOptions = cycleOptions;
+
     if (!shared.state.store) {
-      const roundState = new ConversationRoundState(
-        shared.state.nextRoundIndex,
-      );
-      shared.state.store = new AgentSharedStore({
-        round: roundState,
-        run: shared.state.runState,
-        workspace: toolState,
-        user: shared.agent.getUserVarChannels(),
+      shared.state.store = createSharedStore({
+        roundIndex: shared.state.nextRoundIndex,
+        runState: shared.state.runState,
+        workspaceState: toolState,
+        userChannels: shared.agent.getUserVarChannels(),
+        onRoundFinalized: shared.agent.getUsageRecorder('tool-use'),
       });
     } else {
-      shared.state.store.setRound(
-        new ConversationRoundState(shared.state.nextRoundIndex),
-      );
+      shared.state.store.resetRound(shared.state.nextRoundIndex);
     }
 
     beginLifecyclePhase(shared.lifecycle, 'cycle');
@@ -255,73 +262,22 @@ class ToolUseFinalizeNode<C> extends BaseNode<ToolUseRunShared<C>> {
     };
   }
 
-  async exec(
-    prepRes: ToolUseFinalizePrep<C>,
-  ): Promise<ToolUseFinalizeExecResult> {
+  async exec(prepRes: ToolUseFinalizePrep<C>): Promise<void> {
     const status = prepRes.lifecycle.status === 'error' ? 'error' : 'stopped';
-    const result: ToolUseFinalizeExecResult = {};
-
-    try {
-      await prepRes.hooks.clearPersistedSnapshot();
-    } catch (error) {
-      result.snapshotError = error;
-    }
-
-    try {
-      await prepRes.hooks.end(status);
-    } catch (error) {
-      result.endError = error;
-    }
-
-    return result;
-  }
-
-  async post(
-    shared: ToolUseRunShared<C>,
-    prepRes: ToolUseFinalizePrep<C>,
-    execRes: ToolUseFinalizeExecResult,
-  ): Promise<string | undefined> {
-    const errors: unknown[] = [];
-
-    if (shared.lifecycle.error) {
-      errors.push(shared.lifecycle.error);
-    }
-
-    if (execRes.snapshotError) {
-      errors.push(execRes.snapshotError);
-    }
-
-    if (execRes.endError) {
-      errors.push(execRes.endError);
-    }
-
-    let error = errors[0];
-
-    try {
-      await prepRes.hooks.cleanup();
-    } catch (cleanupError: unknown) {
-      errors.push(cleanupError);
-      if (!error) {
-        error = cleanupError;
-      }
-    }
-
-    if (errors.length > 1) {
-      errors.slice(1).forEach((err) => {
+    await finalizeLifecycle({
+      lifecycle: prepRes.lifecycle,
+      runFinalize: async () => {
+        await prepRes.hooks.clearPersistedSnapshot();
+        await prepRes.hooks.end(status);
+      },
+      runCleanup: () => Promise.resolve(prepRes.hooks.cleanup()),
+      onSuccess: () => setLifecycleStatus(prepRes.lifecycle, 'completed'),
+      onSecondaryError: (error) =>
         prepRes.hooks.logFinalizeWarning?.(
           'Additional finalize error encountered.',
-          err,
-        );
-      });
-    }
-
-    if (error) {
-      failLifecycle(shared.lifecycle, error);
-    } else {
-      setLifecycleStatus(shared.lifecycle, 'completed');
-    }
-
-    return undefined;
+          error,
+        ),
+    });
   }
 }
 
@@ -337,13 +293,14 @@ export function createToolUseRunFlow<C>(): Flow<ToolUseRunShared<C>> {
   const cycleNode = new ToolUseCycleNode<C>();
   const finalizeNode = new ToolUseFinalizeNode<C>();
 
-  initNode.on(FlowTransition.EXECUTE, prepareNode);
-  initNode.on(FlowTransition.FINALIZE, finalizeNode);
-
-  prepareNode.on(FlowTransition.EXECUTE, cycleNode);
-  prepareNode.on(FlowTransition.FINALIZE, finalizeNode);
-
-  cycleNode.on(FlowTransition.FINALIZE, finalizeNode);
-
-  return new Flow<ToolUseRunShared<C>>(initNode);
+  return buildRunFlow({
+    init: initNode,
+    finalize: finalizeNode,
+    links: [
+      { from: initNode, on: FlowTransition.EXECUTE, to: prepareNode },
+      { from: prepareNode, on: FlowTransition.EXECUTE, to: cycleNode },
+      { from: prepareNode, on: FlowTransition.FINALIZE },
+      { from: cycleNode, on: FlowTransition.FINALIZE },
+    ],
+  });
 }

--- a/src/agent/implementations/flows/common/AgentInitNode.ts
+++ b/src/agent/implementations/flows/common/AgentInitNode.ts
@@ -2,10 +2,10 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { BaseNode } from '@agent/node';
 
 import { beginLifecyclePhase, failLifecycle } from './lifecycle';
-import type { AgentRunHooks, AgentRunLifecycleBase } from './types';
+import type { AgentRunHooks, AgentLifecycleState } from './types';
 
 export interface AgentInitShared<
-  Lifecycle extends AgentRunLifecycleBase,
+  Lifecycle extends AgentLifecycleState<string>,
   Hooks extends AgentRunHooks,
 > {
   lifecycle: Lifecycle;

--- a/src/agent/implementations/flows/common/AgentRunFlowRunner.ts
+++ b/src/agent/implementations/flows/common/AgentRunFlowRunner.ts
@@ -3,7 +3,7 @@ import type { BaseAgent } from '@agent/implementations/BaseAgent';
 
 import type {
   AgentRunHooks,
-  AgentRunLifecycleBase,
+  AgentLifecycleState,
   AgentRunShared,
 } from './types';
 
@@ -13,7 +13,7 @@ type AgentRunFlowOptionsBase<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
-    AgentRunLifecycleBase,
+    AgentLifecycleState<string>,
     AgentRunHooks
   >,
 > = {
@@ -29,7 +29,7 @@ type AgentRunFlowOptionsWithExtend<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
-    AgentRunLifecycleBase,
+    AgentLifecycleState<string>,
     AgentRunHooks
   >,
 > = AgentRunFlowOptionsBase<Shared> & {
@@ -40,7 +40,7 @@ type AgentRunFlowOptionsWithoutExtend<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
-    AgentRunLifecycleBase,
+    AgentLifecycleState<string>,
     AgentRunHooks
   >,
 > =
@@ -52,7 +52,7 @@ export type AgentRunFlowOptions<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
-    AgentRunLifecycleBase,
+    AgentLifecycleState<string>,
     AgentRunHooks
   >,
 > =
@@ -63,7 +63,7 @@ function hasExtendHooks<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
-    AgentRunLifecycleBase,
+    AgentLifecycleState<string>,
     AgentRunHooks
   >,
 >(
@@ -79,7 +79,7 @@ async function runAgentFlowWithExtend<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
-    AgentRunLifecycleBase,
+    AgentLifecycleState<string>,
     AgentRunHooks
   >,
 >(options: AgentRunFlowOptionsWithExtend<Shared>): Promise<Shared> {
@@ -110,7 +110,7 @@ async function runAgentFlowWithoutExtend<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
-    AgentRunLifecycleBase,
+    AgentLifecycleState<string>,
     AgentRunHooks
   >,
 >(options: AgentRunFlowOptionsWithoutExtend<Shared>): Promise<Shared> {
@@ -140,7 +140,7 @@ export async function runAgentFlow<
   Shared extends AgentRunShared<
     BaseAgent<any>,
     any,
-    AgentRunLifecycleBase,
+    AgentLifecycleState<string>,
     AgentRunHooks
   >,
 >(options: AgentRunFlowOptions<Shared>): Promise<Shared> {

--- a/src/agent/implementations/flows/common/buildRunFlow.ts
+++ b/src/agent/implementations/flows/common/buildRunFlow.ts
@@ -1,0 +1,27 @@
+import { Flow, BaseNode } from '@agent/node';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+
+interface FlowLink<Shared> {
+  from: BaseNode<Shared>;
+  on: string;
+  to?: BaseNode<Shared>;
+}
+
+interface BuildRunFlowOptions<Shared> {
+  init: BaseNode<Shared>;
+  finalize: BaseNode<Shared>;
+  links: FlowLink<Shared>[];
+}
+
+export function buildRunFlow<Shared>({
+  init,
+  finalize,
+  links,
+}: BuildRunFlowOptions<Shared>): Flow<Shared> {
+  init.on(FlowTransition.FINALIZE, finalize);
+  for (const link of links) {
+    const target = link.to ?? finalize;
+    link.from.on(link.on, target);
+  }
+  return new Flow<Shared>(init);
+}

--- a/src/agent/implementations/flows/common/finalizeLifecycle.ts
+++ b/src/agent/implementations/flows/common/finalizeLifecycle.ts
@@ -1,0 +1,47 @@
+import { failLifecycle } from './lifecycle';
+import type { AgentLifecycleState } from './types';
+
+interface FinalizeLifecycleOptions<Phase extends string> {
+  lifecycle: AgentLifecycleState<Phase>;
+  runFinalize: () => Promise<void>;
+  runCleanup: () => Promise<void>;
+  onSuccess: () => void;
+  onSecondaryError?: (error: unknown) => void;
+}
+
+export async function finalizeLifecycle<Phase extends string>({
+  lifecycle,
+  runFinalize,
+  runCleanup,
+  onSuccess,
+  onSecondaryError,
+}: FinalizeLifecycleOptions<Phase>): Promise<void> {
+  const errors: unknown[] = [];
+  if (lifecycle.error) {
+    errors.push(lifecycle.error);
+  }
+
+  try {
+    await runFinalize();
+  } catch (error) {
+    errors.push(error);
+  }
+
+  try {
+    await runCleanup();
+  } catch (error) {
+    errors.push(error);
+  }
+
+  if (errors.length > 1 && onSecondaryError) {
+    errors.slice(1).forEach((error) => onSecondaryError(error));
+  }
+
+  const primaryError = errors[0];
+  if (primaryError) {
+    failLifecycle(lifecycle, primaryError);
+    return;
+  }
+
+  onSuccess();
+}

--- a/src/agent/implementations/flows/common/lifecycle.ts
+++ b/src/agent/implementations/flows/common/lifecycle.ts
@@ -1,13 +1,23 @@
-import type { AgentRunLifecycleBase } from './types';
+import type { AgentLifecycleState } from './types';
 
-export function setLifecyclePhase<L extends AgentRunLifecycleBase>(
+export function createLifecycleState<Phase extends string>(
+  phase: Phase,
+): AgentLifecycleState<Phase> {
+  return {
+    phase,
+    status: 'pending',
+    error: undefined,
+  };
+}
+
+export function setLifecyclePhase<L extends AgentLifecycleState<string>>(
   lifecycle: L,
   phase: L['phase'],
 ): void {
   lifecycle.phase = phase;
 }
 
-export function beginLifecyclePhase<L extends AgentRunLifecycleBase>(
+export function beginLifecyclePhase<L extends AgentLifecycleState<string>>(
   lifecycle: L,
   phase: L['phase'],
 ): void {
@@ -16,7 +26,7 @@ export function beginLifecyclePhase<L extends AgentRunLifecycleBase>(
   lifecycle.error = undefined;
 }
 
-export function failLifecycle<L extends AgentRunLifecycleBase>(
+export function failLifecycle<L extends AgentLifecycleState<string>>(
   lifecycle: L,
   error: unknown,
 ): void {
@@ -24,7 +34,7 @@ export function failLifecycle<L extends AgentRunLifecycleBase>(
   lifecycle.error = error;
 }
 
-export function setLifecycleStatus<L extends AgentRunLifecycleBase>(
+export function setLifecycleStatus<L extends AgentLifecycleState<string>>(
   lifecycle: L,
   status: L['status'],
 ): void {
@@ -34,7 +44,7 @@ export function setLifecycleStatus<L extends AgentRunLifecycleBase>(
   }
 }
 
-export function completeLifecycle<L extends AgentRunLifecycleBase>(
+export function completeLifecycle<L extends AgentLifecycleState<string>>(
   lifecycle: L,
 ): void {
   setLifecycleStatus(lifecycle, 'completed');

--- a/src/agent/implementations/flows/common/types.ts
+++ b/src/agent/implementations/flows/common/types.ts
@@ -1,16 +1,30 @@
+import { z } from 'zod';
+
+import { AgentRunState } from '@agent/core/AgentState';
 import type { AgentRunHooks } from '@agent/core/IAgent';
 import type { BaseAgent } from '@agent/implementations/BaseAgent';
 
-export interface AgentRunLifecycleBase {
-  phase: string;
-  status: 'pending' | 'running' | 'error' | 'completed';
+export type AgentLifecycleStatus =
+  | 'pending'
+  | 'running'
+  | 'error'
+  | 'completed';
+
+export interface AgentLifecycleState<Phase extends string> {
+  phase: Phase;
+  status: AgentLifecycleStatus;
   error?: unknown;
 }
+
+export const BaseRunStateSchema = z.object({
+  messages: z.array(z.any()),
+  runState: z.instanceof(AgentRunState),
+});
 
 export interface AgentRunShared<
   A extends BaseAgent<any>,
   State,
-  Lifecycle extends AgentRunLifecycleBase,
+  Lifecycle extends AgentLifecycleState<string>,
   Hooks extends AgentRunHooks,
 > {
   agent: A;

--- a/src/agent/utils/PromptBuilder.ts
+++ b/src/agent/utils/PromptBuilder.ts
@@ -1,8 +1,6 @@
 // Local imports - agent
-import type {
-  AgentPrompt,
-  AgentWorkflowSetting,
-} from '@agent/core/AgentDataclass';
+import type { AgentPrompt } from '@agent/core/AgentDataclass';
+import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 
 // Local imports - log
 import type { AgentLogger } from '@logger/AgentLogger';
@@ -10,6 +8,9 @@ import type { AgentLogger } from '@logger/AgentLogger';
 // Local imports - utilities
 import { getSystemPromptWithRules } from './promptHelpers';
 import { renderPrompt } from './promptUtils';
+import { TOOL_USE_INSTRUCTIONS } from './toolUsePrompt';
+
+type PromptBuilderSetting = Pick<AgentWorkflowSetting, 'prefills'>;
 
 /**
  * Centralises prompt construction logic for multi-round agents.
@@ -30,7 +31,7 @@ import { renderPrompt } from './promptUtils';
 export class PromptBuilder {
   constructor(
     private readonly agentPrompt: AgentPrompt,
-    private readonly agentSetting: AgentWorkflowSetting,
+    private readonly agentSetting: PromptBuilderSetting,
     private readonly userVars: Record<string, any>,
     private readonly logger?: AgentLogger,
   ) {}
@@ -130,3 +131,22 @@ export class PromptBuilder {
 export type InitialPrompts = Awaited<
   ReturnType<PromptBuilder['buildInitialPrompts']>
 >;
+
+export async function buildInitialToolUsePrompts(
+  agentPrompt: AgentPrompt,
+  userVars: Record<string, any>,
+  logger?: AgentLogger,
+): Promise<InitialPrompts & { instructionSuffix: string }> {
+  const builder = new PromptBuilder(
+    agentPrompt,
+    { prefills: [] },
+    userVars,
+    logger,
+  );
+  const initial = await builder.buildInitialPrompts();
+
+  return {
+    ...initial,
+    instructionSuffix: TOOL_USE_INSTRUCTIONS,
+  };
+}


### PR DESCRIPTION
## Summary
- add AgentSharedStore factory/finalize callback wiring so usage tracking is centralised
- refactor tool-use and reflection run flows onto shared lifecycle helpers and lean schemas
- reuse PromptBuilder when bootstrapping tool-use sessions and drop redundant agent state fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690cf627e108832498fb1e7aec63ab24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes lifecycle and round-finalization/usage tracking, refactors tool-use and reflection flows onto shared helpers, and unifies tool-use prompt bootstrapping.
> 
> - **Core store (`AgentSharedStore`)**:
>   - Add `onRoundFinalized` callback with context and make `finalizeRound` async; introduce `resetRound`.
>   - Provide `createSharedStore` factory to wire slices and finalize hook.
> - **Response cycle**:
>   - Track `roundFinalized` in state and call `finalizeRound` via `finalizeRoundIfNeeded` at all exit paths.
> - **Tool-use cycle/flow**:
>   - Await `store.finalizeRound()` and use `store.resetRound(...)` for next rounds; remove ad hoc usage callbacks.
> - **Agents**:
>   - `BaseAgent`: add `getUsageRecorder` to supply finalize hook.
>   - `BaseReflectionAgent`: switch to `createSharedStore`; rename `globalState`→`runState`; use lifecycle helpers; usage recorded via finalize hook.
>   - `BaseToolUseAgent`: rework run loop with lifecycle helpers and internal active state; initialize messages via `PromptBuilder` helper; snapshot/waiting logic updated to use active state.
> - **Flow infrastructure (common)**:
>   - New `buildRunFlow`, `finalizeLifecycle`, and `createLifecycleState`; replace lifecycle base types with `AgentLifecycleState`; update `AgentInitNode` and runner to use them; add Zod-backed base state schema.
> - **Prompt building**:
>   - Add `buildInitialToolUsePrompts` and narrow `PromptBuilder` setting type; use shared tool-use instruction suffix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7fe136c7d4b083c1f4c171bd8f52d717ee271fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->