### PR TITLE
docs: update changelog for unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.34.3] - 2025-11-06
+
 ### Features
 
-- Add a **Clone Overleaf Project** command so you can pull remote Overleaf
-  workspaces directly into the current VS Code folder without leaving TeXRA.
-- Require approving tool-proposed edits from the progress board with a pending
-  approvals list, one-click diff viewing, and unified, line-numbered diffs that
-  turn rejection notes into follow-up instructions.
-- Capture XML output summaries (detected tag contents, serialized `<document>`
-  elements, and single-output paths) so orchestrated workflows can reuse
-  generated artifacts without re-selecting files.
+- Add a **Clone Overleaf Project** command that initializes a local workspace
+  from an Overleaf project so newcomers can bootstrap a folder without manual
+  downloads or Git juggling.
+- Require approving tool-proposed edits from the progress board, complete with
+  a pending approvals queue, unified diffs, and the ability to turn rejection
+  notes directly into follow-up instructions.
+- Capture XML output summaries—including detected tag contents, serialized
+  `<document>` elements, and single-output paths—so orchestrated workflows can
+  reuse generated artifacts without re-running the same tools.
 - Add dedicated arXiv metadata/search and Crossref DOI lookup tools to the
   default registry so agents can fetch paper details without manual API calls.
 - Add Kimi K2 thinking variants to the model catalog so the latest Moonshot
@@ -21,28 +24,26 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
-- Expand the progress board empty state reminder with a quick link to the
-  Overleaf clone command.
-- Streamline the progress view header with a toolbar-based session switcher,
-  compact dropdowns, and clearer delete affordances to keep controls tidy.
-- Harden the Overleaf clone flow with workspace preflight checks, stricter
-  token validation, and clearer error handling before running `git clone`.
-- Update Kimi K2 model names and pricing to match the latest Moonshot release
-  and reuse shared vision helpers so image attachments stay consistent across
-  providers.
+- Expand the progress board empty state with a direct shortcut to the Overleaf
+  clone flow and streamline the header with toolbar session switching, tighter
+  dropdowns, and clearer delete affordances.
+- Harden the new Overleaf initialization by validating tokens, enforcing
+  workspace preflight checks, and surfacing full command output when cloning.
+- Render progress tool logs and tour output in YAML to keep structured
+  responses readable at a glance.
+- Update Kimi K2 naming and pricing while reusing shared vision helpers so
+  image attachments stay consistent across providers.
 - Stabilize agent logging, tool-use persistence, and continuation reporting so
   usage totals, follow-up prompts, and streaming status badges stay in sync.
 
 ### Bug Fixes
 
-- Resolve Google Gemini invocation failures by simplifying stream aggregation
-  and aligning tool call handling with the provider API.
-- Reset arXiv metadata and search tool state between invocations so repeated
-  lookups return fresh abstracts and figure links.
+- Stabilize Google Gemini tool calls by simplifying stream aggregation and
+  aligning tool-call handling with the provider API.
+- Keep the new arXiv metadata tools fresh by resetting cached search state so
+  repeat lookups always return current abstracts and figure links.
 - Guard progress board detail toggles and approval actions to eliminate
   runtime errors while reviewing runs.
-- Ensure Overleaf operations return complete command output, validate stored
-  tokens, and enforce empty-workspace checks before cloning.
 - Fix duplicated LaTeX environment tags that produced malformed `eqnarray`
   blocks in generated documents.
 - Restore tool-use cost tracking and keep user edit patches synchronized with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,47 @@ All notable changes to this project will be documented in this file.
 
 - Add a **Clone Overleaf Project** command so you can pull remote Overleaf
   workspaces directly into the current VS Code folder without leaving TeXRA.
+- Require approving tool-proposed edits from the progress board with a pending
+  approvals list, one-click diff viewing, and unified, line-numbered diffs that
+  turn rejection notes into follow-up instructions.
 - Capture XML output summaries (detected tag contents, serialized `<document>`
   elements, and single-output paths) so orchestrated workflows can reuse
   generated artifacts without re-selecting files.
+- Add dedicated arXiv metadata/search and Crossref DOI lookup tools to the
+  default registry so agents can fetch paper details without manual API calls.
+- Add Kimi K2 thinking variants to the model catalog so the latest Moonshot
+  releases are immediately available in TeXRA.
 
 ### Improvements
 
 - Expand the progress board empty state reminder with a quick link to the
   Overleaf clone command.
-- Render approval “User adjustments” as line-numbered unified diffs using a
-  native line diff (difflib). This replaces raw percent-encoded patch text with
-  clean `diff` code blocks that show hunk ranges and readable `+`/`-` lines.
+- Streamline the progress view header with a toolbar-based session switcher,
+  compact dropdowns, and clearer delete affordances to keep controls tidy.
+- Harden the Overleaf clone flow with workspace preflight checks, stricter
+  token validation, and clearer error handling before running `git clone`.
+- Update Kimi K2 model names and pricing to match the latest Moonshot release
+  and reuse shared vision helpers so image attachments stay consistent across
+  providers.
+- Stabilize agent logging, tool-use persistence, and continuation reporting so
+  usage totals, follow-up prompts, and streaming status badges stay in sync.
+
+### Bug Fixes
+
+- Resolve Google Gemini invocation failures by simplifying stream aggregation
+  and aligning tool call handling with the provider API.
+- Reset arXiv metadata and search tool state between invocations so repeated
+  lookups return fresh abstracts and figure links.
+- Guard progress board detail toggles and approval actions to eliminate
+  runtime errors while reviewing runs.
+- Ensure Overleaf operations return complete command output, validate stored
+  tokens, and enforce empty-workspace checks before cloning.
+- Fix duplicated LaTeX environment tags that produced malformed `eqnarray`
+  blocks in generated documents.
+- Restore tool-use cost tracking and keep user edit patches synchronized with
+  the approvals workflow.
+- Prevent YAML log loaders from failing when generated files expose quick
+  actions.
 
 ## [0.34.2] - 2025-10-31
 


### PR DESCRIPTION
## Summary
- expand the Unreleased changelog entry with newly shipped tooling and model catalog updates
- document progress board improvements, hardened Overleaf cloning, and logging refinements
- note recent bug fixes across Google streaming, arXiv tools, approvals, LaTeX cleanup, and YAML loaders

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690d0a428c3083249c6305a2da6e7746

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CHANGELOG with 0.34.3 features, improvements, and bug fixes, highlighting Overleaf cloning, approvals workflow, XML summaries, arXiv/Crossref tools, Kimi K2 updates, and stability fixes.
> 
> - **Documentation**: Update `CHANGELOG.md` for `0.34.3`.
>   - **Features**:
>     - Overleaf clone command for initializing local workspaces.
>     - Required approvals workflow with unified diffs and rejection-to-follow-up.
>     - XML output summaries for reuse in workflows.
>     - arXiv metadata/search and Crossref DOI lookup tools.
>     - Kimi K2 thinking variants added to model catalog.
>   - **Improvements**:
>     - Progress board tweaks (empty-state shortcut, header streamlining).
>     - Hardened Overleaf initialization (token validation, preflight checks, verbose output).
>     - YAML rendering for tool logs and tour output.
>     - Kimi K2 naming/pricing updates and shared vision helpers.
>     - Stabilized logging, tool-use persistence, and continuation reporting.
>   - **Bug Fixes**:
>     - More stable Gemini tool calls and provider-aligned handling.
>     - Fresh arXiv metadata via cache resets.
>     - Guarded progress board toggles/approvals to prevent runtime errors.
>     - Fix malformed LaTeX `eqnarray` blocks and duplicate env tags.
>     - Restore tool-use cost tracking and sync user edits with approvals.
>     - Prevent YAML log loader failures with quick actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4b2ad8eec3cd3413607c1c88093b57b505f7d1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->