### PR TITLE
Fix debug saver storage path handling

### DIFF
--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -10,7 +10,10 @@ import { getConfig } from '@utils/config';
 
 // Local imports
 import { WorkspaceFS, StorageFS } from '@utils/files';
-import { getRunDir } from '@utils/files/taskRunStorage';
+import {
+  ensureRunDir,
+  TASK_RUNS_DIR,
+} from '@utils/files/taskRunStorage';
 
 /**
  * Context information for the debug save operation
@@ -87,23 +90,28 @@ export async function maybeSaveDebugObject({
   const modelPart = modelName ? `_${modelName.replace(/[\\/]/g, '_')}` : '';
   const debugFileName = `${fileBase}${modelPart}${cont}.json`;
 
-  const debugFilePath = executionId
-    ? path.join(getRunDir(executionId), debugFileName)
-    : WorkspaceFS.fullPath(debugFileName);
-
   try {
     if (executionId) {
-      await StorageFS.writeJson(debugFilePath, object);
+      await ensureRunDir(executionId);
+      const relativePath = path.join(
+        TASK_RUNS_DIR,
+        executionId,
+        debugFileName,
+      );
+      await StorageFS.writeJson(relativePath, object);
+      const debugFilePath = StorageFS.fullPath(relativePath);
+      logger.info(
+        `Saved ${objectType} object to ${debugFilePath}`,
+        activeGroupId,
+      );
     } else {
-      await WorkspaceFS.writeJson(
-        WorkspaceFS.relativePath(debugFilePath),
-        object,
+      await WorkspaceFS.writeJson(debugFileName, object);
+      const debugFilePath = WorkspaceFS.fullPath(debugFileName);
+      logger.info(
+        `Saved ${objectType} object to ${debugFilePath}`,
+        activeGroupId,
       );
     }
-    logger.info(
-      `Saved ${objectType} object to ${debugFilePath}`,
-      activeGroupId,
-    );
   } catch (error) {
     logger.error(
       `Failed to save ${objectType} object: ${error}`,

--- a/src/test/agent/utils/debugMessageSaver.test.ts
+++ b/src/test/agent/utils/debugMessageSaver.test.ts
@@ -1,0 +1,134 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports - agent
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+
+// Local imports - config
+import * as configModule from '@utils/config';
+
+// Local imports - filesystem
+import { WorkspaceFS, StorageFS } from '@utils/files';
+import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
+
+describe('maybeSaveDebugObject', () => {
+  type StorageFsMutable = {
+    writeJson: typeof StorageFS.writeJson;
+    ensureDir: typeof StorageFS.ensureDir;
+    fullPath: typeof StorageFS.fullPath;
+  };
+
+  type WorkspaceFsMutable = {
+    writeJson: typeof WorkspaceFS.writeJson;
+    fullPath: typeof WorkspaceFS.fullPath;
+  };
+
+  const storageFs = StorageFS as unknown as StorageFsMutable;
+  const workspaceFs = WorkspaceFS as unknown as WorkspaceFsMutable;
+
+  const originalStorageWriteJson = storageFs.writeJson;
+  const originalStorageEnsureDir = storageFs.ensureDir;
+  const originalStorageFullPath = storageFs.fullPath;
+  const originalWorkspaceWriteJson = workspaceFs.writeJson;
+  const originalWorkspaceFullPath = workspaceFs.fullPath;
+  const originalGetConfig = configModule.getConfig;
+
+  let storageWrites: { relativePath: string; value: unknown }[];
+  let ensured: string[];
+  let workspaceWrites: { relativePath: string; value: unknown }[];
+  let infoLogs: { message: string; groupId: unknown }[];
+  let errorLogs: { message: string; groupId: unknown }[];
+
+  beforeEach(() => {
+    storageWrites = [];
+    ensured = [];
+    workspaceWrites = [];
+    infoLogs = [];
+    errorLogs = [];
+
+    storageFs.writeJson = async (relativePath, value) => {
+      storageWrites.push({ relativePath, value });
+    };
+
+    storageFs.ensureDir = async (relativePath) => {
+      ensured.push(relativePath);
+    };
+
+    storageFs.fullPath = (relativePath) =>
+      path.join('/mock/storage', relativePath);
+
+    workspaceFs.writeJson = async (relativePath, value) => {
+      workspaceWrites.push({ relativePath, value });
+    };
+
+    workspaceFs.fullPath = (relativePath) =>
+      path.join('/mock/workspace', relativePath);
+
+    (configModule as { getConfig: typeof originalGetConfig }).getConfig = ((
+      key: string,
+      defaultValue?: unknown,
+    ) => {
+      if (key === 'texra.debug.saveDebugObjects') {
+        return true;
+      }
+      return defaultValue;
+    }) as typeof originalGetConfig;
+  });
+
+  afterEach(() => {
+    storageFs.writeJson = originalStorageWriteJson;
+    storageFs.ensureDir = originalStorageEnsureDir;
+    storageFs.fullPath = originalStorageFullPath;
+    workspaceFs.writeJson = originalWorkspaceWriteJson;
+    workspaceFs.fullPath = originalWorkspaceFullPath;
+    (configModule as { getConfig: typeof originalGetConfig }).getConfig =
+      originalGetConfig;
+  });
+
+  it('creates the run directory and writes debug objects under storage when executionId is provided', async () => {
+    const executionId = 'run-42' as ExecutionId;
+
+    const logger = {
+      info: (message: string, groupId: unknown) => {
+        infoLogs.push({ message, groupId });
+      },
+      error: (message: string, groupId: unknown) => {
+        errorLogs.push({ message, groupId });
+      },
+      withCurrentGroup: (callback: (groupId: string) => string) =>
+        callback('logger-group'),
+    } as unknown as import('@logger/AgentLogger').AgentLogger;
+
+    await maybeSaveDebugObject({
+      object: { foo: 'bar' },
+      objectType: 'response',
+      context: {
+        logger,
+        executionId,
+        groupId: 'test-group',
+      },
+    });
+
+    const expectedDir = path.join(TASK_RUNS_DIR, executionId);
+    assert.deepEqual(ensured, [TASK_RUNS_DIR, expectedDir]);
+
+    assert.equal(storageWrites.length, 1);
+    const expectedRelativePath = path.join(expectedDir, 'response.json');
+    assert.equal(storageWrites[0].relativePath, expectedRelativePath);
+    assert.equal(workspaceWrites.length, 0);
+
+    assert.equal(infoLogs.length, 1);
+    assert.equal(infoLogs[0].groupId, 'test-group');
+    assert.equal(errorLogs.length, 0);
+    assert.equal(
+      infoLogs[0].message,
+      `Saved response object to ${path.join(
+        '/mock/storage',
+        expectedRelativePath,
+      )}`,
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure the debug message saver prepares the run directory before persisting execution logs
- write debug artifacts via storage-relative paths and log their resolved location
- add unit coverage confirming run directories and storage writes when debug saves are enabled

## Testing
- npm run lint
- npm run compile-tests

------
https://chatgpt.com/codex/tasks/task_e_690d16f384148324a518b5fc3f668dd2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure run dir creation and write debug artifacts via storage-relative paths, with a new test verifying directory creation, pathing, and logging.
> 
> - **Agent utils**:
>   - `maybeSaveDebugObject` now ensures the run directory via `ensureRunDir(executionId)` and writes using `StorageFS` with storage-relative paths under `TASK_RUNS_DIR`.
>   - Logs the resolved full path after writes; simplifies workspace writes to `WorkspaceFS.writeJson(debugFileName, ...)`.
> - **Tests**:
>   - Adds unit test `debugMessageSaver.test.ts` verifying run dir creation, storage-relative write under `TASK_RUNS_DIR`, and info logging when `executionId` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db58e577bff74ebe99b7abc98b38f754306a797e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->