### PR TITLE
fix: restore chat agent defaults on state resets

### DIFF
--- a/src/test/webview/MessageHandlersRestore.test.ts
+++ b/src/test/webview/MessageHandlersRestore.test.ts
@@ -267,6 +267,7 @@ function loadMessageHandlerModule(dom: JSDOM) {
     '@common/webview/commands.js': 'commands',
     '@common/webviewContext.js': 'webviewContext',
     '@common/BaseWebviewMessageHandler.js': 'baseHandler',
+    '@agent/core/AgentDataclass': 'agentDataclass',
   };
 
   code = code.replace(
@@ -330,6 +331,8 @@ function loadMessageHandlerModule(dom: JSDOM) {
       toolUse: 'toolUseAgentSelect',
     },
     AGENT_SELECT_LIST: ['workflowAgentSelect', 'toolUseAgentSelect'],
+    normalizeSessionType: (type: string) =>
+      type === 'toolUse' ? 'toolUse' : 'workflow',
   };
 
   const domUtilsMock = {
@@ -435,6 +438,12 @@ function loadMessageHandlerModule(dom: JSDOM) {
       BaseWebviewMessageHandler: class {
         setup() {}
         cleanup() {}
+      },
+    },
+    agentDataclass: {
+      AgentCategory: {
+        Workflow: 'workflow',
+        ToolUse: 'toolUse',
       },
     },
   };
@@ -601,5 +610,60 @@ describe('MainViewMessageHandler state restoration', () => {
     assert.deepEqual(mocks.mainViewStateUpdateCalls.pop(), {
       inputFiles: ['beta.tex'],
     });
+  });
+
+  it('restores tool-use agent selection from session agent category metadata', () => {
+    const dom = createTestDom(`
+      <vscode-single-select id="sessionType" value="workflow">
+        <vscode-option value="workflow">Workflow</vscode-option>
+        <vscode-option value="toolUse">Tool Use</vscode-option>
+      </vscode-single-select>
+      <vscode-single-select id="workflowAgentSelect">
+        <vscode-option value="agent-a">Agent A</vscode-option>
+        <vscode-option value="agent-b">Agent B</vscode-option>
+      </vscode-single-select>
+      <vscode-single-select id="toolUseAgentSelect">
+        <vscode-option value="agent-a">Agent A</vscode-option>
+        <vscode-option value="agent-b">Agent B</vscode-option>
+      </vscode-single-select>
+      <input id="model" />
+      <textarea id="instruction"></textarea>
+      <vscode-radio-group id="sessionTypeToggle">
+        <vscode-radio data-session-type="workflow" value="workflow"></vscode-radio>
+        <vscode-radio data-session-type="toolUse" value="toolUse"></vscode-radio>
+      </vscode-radio-group>
+    `);
+
+    const { MainViewMessageHandler, mocks } = loadMessageHandlerModule(dom);
+    const handler = new MainViewMessageHandler();
+
+    handler._handleStateRestoration({
+      agentConfig: {
+        session: { agentCategory: 'toolUse' },
+        agent: 'agent-b',
+      },
+    });
+
+    const sessionTypeSelect = dom.window.document.getElementById(
+      'sessionType',
+    ) as HTMLInputElement | null;
+    const workflowAgentSelect = dom.window.document.getElementById(
+      'workflowAgentSelect',
+    ) as HTMLInputElement | null;
+    const toolUseAgentSelect = dom.window.document.getElementById(
+      'toolUseAgentSelect',
+    ) as HTMLInputElement | null;
+
+    assert.strictEqual(sessionTypeSelect?.value, 'toolUse');
+    assert.strictEqual(workflowAgentSelect?.value ?? '', '');
+    assert.strictEqual(toolUseAgentSelect?.value, 'agent-b');
+
+    const savedState = mocks.mainViewStateSetCalls[0];
+    assert.strictEqual(savedState.sessionType, 'toolUse');
+    assert.strictEqual(savedState.agent, 'agent-b');
+    assert.strictEqual(savedState.toolUseAgent, 'agent-b');
+    assert.strictEqual(savedState.workflowAgent, '');
+
+    assert.strictEqual(mocks.restoreCalled(), true);
   });
 });

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -101,6 +101,24 @@ export class MainViewState {
   setDefaults() {
     this.applySessionType(SESSION_TYPES.WORKFLOW, { skipSave: true });
 
+    const workflowAgentDefault = getSelectDefaultValue(
+      AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
+      DEFAULT_WORKFLOW_AGENT,
+    );
+    safeSetElementValue(
+      AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
+      workflowAgentDefault,
+    );
+
+    const toolUseAgentDefault = getSelectDefaultValue(
+      AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
+      DEFAULT_TOOL_USE_AGENT,
+    );
+    safeSetElementValue(
+      AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
+      toolUseAgentDefault,
+    );
+
     MULTIPLE_SELECTIONS.forEach((id) => {
       const toggleId = `toggle${capitalize(id)}`;
       fileList.setVisibility(id, toggleId, false);

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -12,6 +12,7 @@ import {
   SESSION_TYPE_INPUT,
   AGENT_SELECT_IDS,
   AGENT_SELECT_LIST,
+  normalizeSessionType,
 } from './constants.js';
 import { webviewEventBus } from './eventBus.js';
 import { createFileHandlers } from './handlers/fileHandlers.js';
@@ -42,6 +43,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - webview context
 import { vscode } from '@common/webviewContext.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 /**
  * Handles messages from the extension and syncs the webview state.
@@ -424,21 +426,32 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _restoreFormFields(state, savedState) {
-    const sessionType = state.sessionType
-      ? state.sessionType
-      : state.isToolUseAgent
+    const sessionCategory = state.session?.agentCategory;
+
+    let sessionType = state.sessionType;
+    if (sessionCategory === AgentCategory.ToolUse) {
+      sessionType = SESSION_TYPES.TOOL_USE;
+    } else if (sessionCategory === AgentCategory.Workflow) {
+      sessionType = SESSION_TYPES.WORKFLOW;
+    }
+
+    if (!sessionType) {
+      sessionType = state.isToolUseAgent
         ? SESSION_TYPES.TOOL_USE
         : SESSION_TYPES.WORKFLOW;
+    }
+
+    const normalizedSessionType = normalizeSessionType(sessionType);
+    const isToolUseSession = normalizedSessionType === SESSION_TYPES.TOOL_USE;
+
     const workflowAgentValue =
       state.workflowAgent ??
-      (!state.isToolUseAgent ? state.agent : undefined) ??
+      (!isToolUseSession ? state.agent : undefined) ??
       '';
     const toolUseAgentValue =
-      state.toolUseAgent ??
-      (state.isToolUseAgent ? state.agent : undefined) ??
-      '';
+      state.toolUseAgent ?? (isToolUseSession ? state.agent : undefined) ?? '';
 
-    safeSetElementValue(SESSION_TYPE_INPUT, sessionType);
+    safeSetElementValue(SESSION_TYPE_INPUT, normalizedSessionType);
     safeSetElementValue(
       AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
       workflowAgentValue,
@@ -467,14 +480,12 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
     const toolConfig = state.toolConfig || {};
     Object.assign(savedState, {
-      sessionType,
+      sessionType: normalizedSessionType,
       workflowAgent: workflowAgentValue,
       toolUseAgent: toolUseAgentValue,
       agent:
         state.agent ??
-        (sessionType === SESSION_TYPES.TOOL_USE
-          ? toolUseAgentValue
-          : workflowAgentValue),
+        (isToolUseSession ? toolUseAgentValue : workflowAgentValue),
       model: state.model,
       instruction: instructionContent,
       inputFile: state.inputFile,


### PR DESCRIPTION
## Summary
- populate workflow and tool-use agent selects with defaults before persisting new webview state
- honor session agentCategory metadata when restoring saved state to keep tool-use selections
- cover tool-use session restoration with a regression test

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc79834a08324afe4d0921148057e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Populate default workflow/tool-use agent selects and correctly restore tool-use sessions using session agentCategory, with regression test coverage.
> 
> - **Webview state/handlers**:
>   - Initialize default agent selections in `mainViewState.setDefaults()` using `getSelectDefaultValue` and set both `workflow` and `toolUse` selects.
>   - In `messageHandlers._restoreFormFields()`, derive `sessionType` from `state.session.agentCategory` (`AgentCategory`) and `normalizeSessionType`, then set/select agents accordingly and persist normalized values.
> - **Tests**:
>   - Update mocks (add `@agent/core/AgentDataclass`, `normalizeSessionType`) and add regression test to ensure tool-use agent selection restores from `session.agentCategory` metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 905466daa46ce6c8a4aa5c0fdccca6ef63674cff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->