### PR TITLE
fix: avoid AgentDataclass import in webview

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -43,7 +43,6 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 // Local imports - webview context
 import { vscode } from '@common/webviewContext.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
-import { AgentCategory } from '@agent/core/AgentDataclass';
 
 /**
  * Handles messages from the extension and syncs the webview state.
@@ -429,9 +428,9 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     const sessionCategory = state.session?.agentCategory;
 
     let sessionType = state.sessionType;
-    if (sessionCategory === AgentCategory.ToolUse) {
+    if (sessionCategory === SESSION_TYPES.TOOL_USE) {
       sessionType = SESSION_TYPES.TOOL_USE;
-    } else if (sessionCategory === AgentCategory.Workflow) {
+    } else if (sessionCategory === SESSION_TYPES.WORKFLOW) {
       sessionType = SESSION_TYPES.WORKFLOW;
     }
 


### PR DESCRIPTION
## Summary
- stop importing the TypeScript AgentDataclass module inside the webview bundle
- reuse the existing session type constants when restoring agent form state

## Testing
- npm run lint
- npm run compile *(hangs indefinitely in this environment, cancelled with Ctrl+C)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd3302eac8324a9026da57b6d9cfc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace cross-bundle AgentDataclass enum usage with local SESSION_TYPES when restoring session type in the webview.
> 
> - **Webview** (`src/webview/modules/messageHandlers.js`):
>   - Remove import of `AgentCategory` from `@agent/core/AgentDataclass`.
>   - Update session type restoration logic to compare `session.session?.agentCategory` against `SESSION_TYPES.TOOL_USE` and `SESSION_TYPES.WORKFLOW`.
>   - Continue normalizing via `normalizeSessionType` and setting related form fields using local `SESSION_TYPES` and `AGENT_SELECT_IDS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b6cb0ad7e84797bfa704f821f165f317e034762. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->