### PR TITLE
fix: streamline provider error messaging

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -26,6 +26,9 @@ import { bestConnectionMethod } from '@latex';
 // Local imports - logging
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
+// Local imports - errors
+import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+
 // Local imports - replacement engine
 import replacementEngine from '@replacement/engine';
 
@@ -241,11 +244,14 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
 
       return { response, responseTime };
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? `Model invocation failed: ${error.message}`
-          : 'Model invocation failed with an unknown error';
-      options.logger.error(message);
+      const formattedError = formatProviderHttpError(error);
+      const message = `Model invocation failed: ${formattedError.message}`;
+      options.logger.error(
+        message,
+        undefined,
+        MESSAGE_TYPES.PROGRESS_STATUS,
+        formattedError,
+      );
       state.shouldStop = true;
       state.endTurn = false;
       throw error;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -81,7 +81,10 @@ import {
 } from './utils/toolAttachmentUtils';
 
 // Local imports - error utils
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  getSdkErrorMessage,
+} from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
 import { cleanFileContent } from '@replacement/engine';
@@ -494,11 +497,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
         response = await client.beta.messages.create(options, { signal });
       }
     } catch (err) {
+      const formattedError = formatProviderHttpError(err);
       this.logger.error(
-        `Error creating response: ${getSdkErrorMessage(err)}`,
+        `Error creating response: ${formattedError.message}`,
         undefined,
-        undefined,
-        err,
+        MESSAGE_TYPES.PROGRESS_STATUS,
+        formattedError,
       );
       throw err;
     }
@@ -617,11 +621,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
             file_id: uploadedFile.id,
           } as BetaRequestDocumentBlock['source'];
         } catch (err) {
+          const formattedError = formatProviderHttpError(err);
           this.logger.error(
-            `Failed to upload document ${filename}: ${getSdkErrorMessage(err)}`,
+            `Failed to upload document ${filename}: ${formattedError.message}`,
             undefined,
-            undefined,
-            err,
+            MESSAGE_TYPES.PROGRESS_STATUS,
+            formattedError,
           );
           throw err;
         } finally {
@@ -737,11 +742,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
           mediaType: normalized,
         });
       } catch (err) {
+        const formattedError = formatProviderHttpError(err);
         this.logger.error(
-          `Failed to upload attachment ${attachment.path ?? 'attachment'}: ${getSdkErrorMessage(err)}`,
+          `Failed to upload attachment ${attachment.path ?? 'attachment'}: ${formattedError.message}`,
           undefined,
-          undefined,
-          err,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
         unsupported.push(attachment);
       } finally {
@@ -845,11 +851,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
         roundContent.push(...formattedMediaContent);
       } catch (err) {
+        const formattedError = formatProviderHttpError(err);
         this.logger.error(
-          `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
+          `Error processing media files for follow-up round: ${formattedError.message}`,
           undefined,
-          undefined,
-          err,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
       }
     }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -45,7 +45,10 @@ import type { MediaFileResult } from './support/MediaAttachmentProcessor';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  getSdkErrorMessage,
+} from '@common/errors/sdkErrorUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
@@ -250,11 +253,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         uploadedParts.push(createPartFromUri(fileUri, resolvedMimeType));
         uploadSummaries.push({ path: fileName, ok: true });
       } catch (error) {
+        const formattedError = formatProviderHttpError(error);
         this.logger.error(
-          `Failed to upload media entry ${fileName}: ${getSdkErrorMessage(error)}`,
+          `Failed to upload media entry ${fileName}: ${formattedError.message}`,
           undefined,
-          undefined,
-          error,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
         uploadSummaries.push({ path: fileName, ok: false });
       }
@@ -549,11 +553,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
       return result;
     } catch (error) {
+      const formattedError = formatProviderHttpError(error);
       this.logger.error(
-        `Error during Google GenAI Chat API call: ${getSdkErrorMessage(error)}`,
+        `Error during Google GenAI Chat API call: ${formattedError.message}`,
         undefined,
-        undefined,
-        error,
+        MESSAGE_TYPES.PROGRESS_STATUS,
+        formattedError,
       );
       if (
         error instanceof Error &&

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -12,7 +12,11 @@ import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - utilities
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  getSdkErrorMessage,
+} from '@common/errors/sdkErrorUtils';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ToolDefinition } from '@model';
 import { K_SLICE } from '@utils/config';
 
@@ -134,11 +138,12 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         });
         return response;
       } catch (err) {
+        const formattedError = formatProviderHttpError(err);
         this.logger.error(
-          `Error in createResponse for Kimi thinking model: ${getSdkErrorMessage(err)}`,
+          `Error in createResponse for Kimi thinking model: ${formattedError.message}`,
           undefined,
-          undefined,
-          err,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
         throw err;
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -38,7 +38,10 @@ import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  getSdkErrorMessage,
+} from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ModelConfig, ToolDefinition } from '@model';
 import { cleanFileContent } from '@replacement/engine';
@@ -398,11 +401,12 @@ export class ModelHandlerOpenAI extends ModelHandler<
         // in the future if we pass stream to outside (signal: controller.signal)), calling stream.controller.abort() will abort the stream; which will be very useful for our stop button (controller.abort();)
         // we should also make sure partial results can be returned in the presence of errors!
       } catch (err) {
+        const formattedError = formatProviderHttpError(err);
         this.logger.error(
-          `Error in createResponse(streaming): ${getSdkErrorMessage(err)}`,
+          `Error in createResponse(streaming): ${formattedError.message}`,
           undefined,
-          undefined,
-          err,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
         throw err;
       }
@@ -414,11 +418,12 @@ export class ModelHandlerOpenAI extends ModelHandler<
         });
         return response;
       } catch (err) {
+        const formattedError = formatProviderHttpError(err);
         this.logger.error(
-          `Error in createResponse: ${getSdkErrorMessage(err)}`,
+          `Error in createResponse: ${formattedError.message}`,
           undefined,
-          undefined,
-          err,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
         throw err;
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -51,7 +51,10 @@ import {
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  getSdkErrorMessage,
+} from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { ModelConfig, ToolDefinition } from '@model';
 import type { ToolFileAttachment } from '@tools/result';
@@ -189,11 +192,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         )) as ResponseInputMessageContentList;
         userContent.push(...mediaContent);
       } catch (err) {
+        const formattedError = formatProviderHttpError(err);
         this.logger.error(
-          `Error processing media files: ${getSdkErrorMessage(err)}`,
+          `Error processing media files: ${formattedError.message}`,
           undefined,
-          undefined,
-          err,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
       }
     }
@@ -245,11 +249,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         )) as ResponseInputMessageContentList;
         roundContent.push(...formattedMediaContent);
       } catch (err) {
+        const formattedError = formatProviderHttpError(err);
         this.logger.error(
-          `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
+          `Error processing media files for follow-up round: ${formattedError.message}`,
           undefined,
-          undefined,
-          err,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
       }
     }
@@ -425,11 +430,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         delete content.filename;
       }
     } catch (err) {
+      const formattedError = formatProviderHttpError(err);
       this.logger.error(
-        `Failed to upload file ${filename}: ${getSdkErrorMessage(err)}`,
+        `Failed to upload file ${filename}: ${formattedError.message}`,
         undefined,
-        undefined,
-        err,
+        MESSAGE_TYPES.PROGRESS_STATUS,
+        formattedError,
       );
       throw err;
     } finally {
@@ -609,11 +615,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.sentMessages = messages.length;
       return response;
     } catch (err) {
+      const formattedError = formatProviderHttpError(err);
       this.logger.error(
-        `Error in createResponse: ${getSdkErrorMessage(err)}`,
+        `Error in createResponse: ${formattedError.message}`,
         undefined,
-        undefined,
-        err,
+        MESSAGE_TYPES.PROGRESS_STATUS,
+        formattedError,
       );
       throw err;
     }
@@ -1380,11 +1387,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           isImage: mimeType.startsWith('image/'),
         });
       } catch (err) {
+        const formattedError = formatProviderHttpError(err);
         this.logger.error(
-          `Failed to upload attachment ${attachment.path ?? 'attachment'}: ${getSdkErrorMessage(err)}`,
+          `Failed to upload attachment ${attachment.path ?? 'attachment'}: ${formattedError.message}`,
           undefined,
-          undefined,
-          err,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          formattedError,
         );
       } finally {
         if (buffer) {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -35,10 +35,14 @@ import {
   type AgentExecutionContextInit,
 } from './AgentExecutionContext';
 
+// Local imports - errors
+import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+
 // Local imports - utilities
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { getStreamTabId } from '@/logger/streamUtils';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -507,12 +511,17 @@ export async function executeAgentWithLogging<T extends IAgent>(
       { skip: isResume },
     );
   } catch (err) {
-    const errorMsg = `Error executing agent ${agentName}: ${err instanceof Error ? err.message : String(err)}`;
+    const formattedError = formatProviderHttpError(err);
+    const rawErrorMessage =
+      formattedError.rawMessage ??
+      (err instanceof Error ? err.message : String(err));
+    const errorMsg = `Error executing agent ${agentName}: ${formattedError.message}`;
+    const errorData = { ...formattedError, rawMessage: rawErrorMessage };
 
     // Check if the error is related to missing API key
     if (
-      errorMsg.includes('Missing API key') ||
-      errorMsg.includes('API key not found')
+      rawErrorMessage.includes('Missing API key') ||
+      rawErrorMessage.includes('API key not found')
     ) {
       const setKey = 'Set API Key';
       const openGuide = 'Open Settings Guide';
@@ -547,7 +556,12 @@ export async function executeAgentWithLogging<T extends IAgent>(
         await agentLoggerFallback.withExistingGroup(
           fallbackGroupId,
           async () => {
-            agentLoggerFallback.error(errorMsg);
+            agentLoggerFallback.error(
+              errorMsg,
+              undefined,
+              MESSAGE_TYPES.PROGRESS_STATUS,
+              errorData,
+            );
           },
           { label: `Error: ${agentName}` },
         );
@@ -555,7 +569,12 @@ export async function executeAgentWithLogging<T extends IAgent>(
         await agentLoggerFallback.withScope(
           `Error: ${agentName}`,
           async () => {
-            agentLoggerFallback.error(errorMsg);
+            agentLoggerFallback.error(
+              errorMsg,
+              undefined,
+              MESSAGE_TYPES.PROGRESS_STATUS,
+              errorData,
+            );
           },
           { errorStatus: 'error' },
         );
@@ -565,7 +584,12 @@ export async function executeAgentWithLogging<T extends IAgent>(
     await logger.withScope(
       `Error: ${agentName}`,
       async () => {
-        logger.error(errorMsg);
+        logger.error(
+          errorMsg,
+          undefined,
+          MESSAGE_TYPES.PROGRESS_STATUS,
+          errorData,
+        );
       },
       { errorStatus: 'error' },
     );

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -10,10 +10,7 @@ import { getConfig } from '@utils/config';
 
 // Local imports
 import { WorkspaceFS, StorageFS } from '@utils/files';
-import {
-  ensureRunDir,
-  TASK_RUNS_DIR,
-} from '@utils/files/taskRunStorage';
+import { ensureRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 
 /**
  * Context information for the debug save operation
@@ -93,11 +90,7 @@ export async function maybeSaveDebugObject({
   try {
     if (executionId) {
       await ensureRunDir(executionId);
-      const relativePath = path.join(
-        TASK_RUNS_DIR,
-        executionId,
-        debugFileName,
-      );
+      const relativePath = path.join(TASK_RUNS_DIR, executionId, debugFileName);
       await StorageFS.writeJson(relativePath, object);
       const debugFilePath = StorageFS.fullPath(relativePath);
       logger.info(

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -3,113 +3,423 @@ import {
   APIConnectionError as AnthropicConnectionError,
   APIConnectionTimeoutError as AnthropicConnectionTimeoutError,
   APIError as AnthropicAPIError,
+  APIUserAbortError as AnthropicUserAbortError,
   AuthenticationError as AnthropicAuthenticationError,
+  BadRequestError as AnthropicBadRequestError,
+  ConflictError as AnthropicConflictError,
+  InternalServerError as AnthropicInternalServerError,
+  NotFoundError as AnthropicNotFoundError,
   PermissionDeniedError as AnthropicPermissionDeniedError,
   RateLimitError as AnthropicRateLimitError,
-  BadRequestError as AnthropicBadRequestError,
-  NotFoundError as AnthropicNotFoundError,
-  ConflictError as AnthropicConflictError,
   UnprocessableEntityError as AnthropicUnprocessableEntityError,
-  InternalServerError as AnthropicInternalServerError,
-  APIUserAbortError as AnthropicUserAbortError,
 } from '@anthropic-ai/sdk';
+import { ApiError as GoogleGenAIApiError } from '@google/genai';
 import {
   APIConnectionError as OpenAIConnectionError,
   APIConnectionTimeoutError as OpenAIConnectionTimeoutError,
   APIError as OpenAIAPIError,
+  APIUserAbortError as OpenAIUserAbortError,
   AuthenticationError as OpenAIAuthenticationError,
+  BadRequestError as OpenAIBadRequestError,
+  ConflictError as OpenAIConflictError,
+  InternalServerError as OpenAIInternalServerError,
+  NotFoundError as OpenAINotFoundError,
   PermissionDeniedError as OpenAIPermissionDeniedError,
   RateLimitError as OpenAIRateLimitError,
-  BadRequestError as OpenAIBadRequestError,
-  NotFoundError as OpenAINotFoundError,
-  ConflictError as OpenAIConflictError,
   UnprocessableEntityError as OpenAIUnprocessableEntityError,
-  InternalServerError as OpenAIInternalServerError,
-  APIUserAbortError as OpenAIUserAbortError,
 } from 'openai';
 
-// Local imports - configuration
-import { getConfig } from '@utils/config';
-
-// Google GenAI errors are still not exported as of v1.5.1 of the SDK,
-// but the runtime uses the names `ClientError` and `ServerError`.
-// We detect them via those names when inspecting the error object.
-// The OpenAI Responses API reuses the standard OpenAI error classes so
-// no additional imports are required.
-
 /**
- * Returns a human-readable message for common SDK errors.
- * In debug mode (logger.debugMode = true), returns the full error message.
- * Otherwise, returns a graceful, user-friendly message.
+ * Structured representation of a provider SDK error.
  */
-export function getSdkErrorMessage(err: unknown): string {
-  const isDebugMode = getConfig<boolean>('texra.logger.debugMode', false);
+export interface ProviderHttpErrorDetails {
+  /** Final message shown to the user/logs. */
+  message: string;
+  /** Raw message extracted from the original error, when available. */
+  rawMessage?: string;
+  /** HTTP status code reported by the provider (if present). */
+  statusCode?: number;
+  /** HTTP status text associated with the status code. */
+  statusText?: string;
+  /** Provider hint (openai, anthropic, google, etc.). */
+  provider?: string;
+}
 
-  // In debug mode, always show the full error message
-  if (isDebugMode) {
-    return err instanceof Error ? err.message : String(err);
+const STATUS_TITLES: Record<number, string> = {
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  402: 'Payment Required',
+  403: 'Forbidden',
+  404: 'Not Found',
+  409: 'Conflict',
+  422: 'Unprocessable Entity',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+};
+
+const STATUS_DESCRIPTIONS: Record<number, string> = {
+  400: 'Invalid parameters',
+  401: 'Invalid API key',
+  402: 'Insufficient credits',
+  403: 'Permission denied',
+  404: 'Resource not found',
+  409: 'Conflict error',
+  422: 'Unprocessable entity',
+  429: 'Rate limit exceeded',
+  500: 'Provider error',
+  502: 'Provider error',
+  503: 'No available providers',
+  504: 'Provider timeout',
+};
+
+type ErrorConstructor<T extends Error = Error> = abstract new (
+  ...args: never[]
+) => T;
+
+interface NativeMessageErrorEntry {
+  ctor: ErrorConstructor;
+  provider: string;
+  message?: string;
+}
+
+interface NativeHttpErrorEntry {
+  ctor: ErrorConstructor;
+  provider: string;
+  fallbackStatusCode?: number;
+}
+
+const NATIVE_MESSAGE_ERRORS: NativeMessageErrorEntry[] = [
+  {
+    ctor: OpenAIConnectionTimeoutError,
+    provider: 'openai',
+    message: 'Connection timed out',
+  },
+  {
+    ctor: AnthropicConnectionTimeoutError,
+    provider: 'anthropic',
+    message: 'Connection timed out',
+  },
+  {
+    ctor: OpenAIConnectionError,
+    provider: 'openai',
+    message: 'Connection error',
+  },
+  {
+    ctor: AnthropicConnectionError,
+    provider: 'anthropic',
+    message: 'Connection error',
+  },
+  {
+    ctor: OpenAIUserAbortError,
+    provider: 'openai',
+    message: 'Request aborted',
+  },
+  {
+    ctor: AnthropicUserAbortError,
+    provider: 'anthropic',
+    message: 'Request aborted',
+  },
+];
+
+const NATIVE_HTTP_ERRORS: NativeHttpErrorEntry[] = [
+  { ctor: OpenAIBadRequestError, provider: 'openai', fallbackStatusCode: 400 },
+  {
+    ctor: AnthropicBadRequestError,
+    provider: 'anthropic',
+    fallbackStatusCode: 400,
+  },
+  {
+    ctor: OpenAIAuthenticationError,
+    provider: 'openai',
+    fallbackStatusCode: 401,
+  },
+  {
+    ctor: AnthropicAuthenticationError,
+    provider: 'anthropic',
+    fallbackStatusCode: 401,
+  },
+  {
+    ctor: OpenAIPermissionDeniedError,
+    provider: 'openai',
+    fallbackStatusCode: 403,
+  },
+  {
+    ctor: AnthropicPermissionDeniedError,
+    provider: 'anthropic',
+    fallbackStatusCode: 403,
+  },
+  { ctor: OpenAINotFoundError, provider: 'openai', fallbackStatusCode: 404 },
+  {
+    ctor: AnthropicNotFoundError,
+    provider: 'anthropic',
+    fallbackStatusCode: 404,
+  },
+  { ctor: OpenAIConflictError, provider: 'openai', fallbackStatusCode: 409 },
+  {
+    ctor: AnthropicConflictError,
+    provider: 'anthropic',
+    fallbackStatusCode: 409,
+  },
+  {
+    ctor: OpenAIUnprocessableEntityError,
+    provider: 'openai',
+    fallbackStatusCode: 422,
+  },
+  {
+    ctor: AnthropicUnprocessableEntityError,
+    provider: 'anthropic',
+    fallbackStatusCode: 422,
+  },
+  { ctor: OpenAIRateLimitError, provider: 'openai', fallbackStatusCode: 429 },
+  {
+    ctor: AnthropicRateLimitError,
+    provider: 'anthropic',
+    fallbackStatusCode: 429,
+  },
+  {
+    ctor: OpenAIInternalServerError,
+    provider: 'openai',
+    fallbackStatusCode: 500,
+  },
+  {
+    ctor: AnthropicInternalServerError,
+    provider: 'anthropic',
+    fallbackStatusCode: 500,
+  },
+  { ctor: OpenAIAPIError, provider: 'openai' },
+  { ctor: AnthropicAPIError, provider: 'anthropic' },
+  { ctor: GoogleGenAIApiError, provider: 'google' },
+];
+
+function matchNativeMessageError(
+  err: unknown,
+): ProviderHttpErrorDetails | undefined {
+  for (const entry of NATIVE_MESSAGE_ERRORS) {
+    if (err instanceof entry.ctor) {
+      const rawMessage = extractMessage(err);
+      const message =
+        entry.message ?? rawMessage ?? 'An unexpected provider error occurred';
+      return {
+        message,
+        rawMessage,
+        provider: entry.provider,
+      };
+    }
   }
 
-  // In normal mode, provide graceful error messages
-  const errorMapping: [new (...args: any[]) => any, string][] = [
-    [OpenAIRateLimitError, 'Rate limit exceeded.'],
-    [AnthropicRateLimitError, 'Rate limit exceeded.'],
-    [OpenAIConnectionTimeoutError, 'Connection timed out.'],
-    [AnthropicConnectionTimeoutError, 'Connection timed out.'],
-    [OpenAIConnectionError, 'Connection error.'],
-    [AnthropicConnectionError, 'Connection error.'],
-    [OpenAIAuthenticationError, 'Authentication failed.'],
-    [AnthropicAuthenticationError, 'Authentication failed.'],
-    [OpenAIPermissionDeniedError, 'Permission denied.'],
-    [AnthropicPermissionDeniedError, 'Permission denied.'],
-    [OpenAIBadRequestError, 'Bad request.'],
-    [AnthropicBadRequestError, 'Bad request.'],
-    [OpenAINotFoundError, 'Resource not found.'],
-    [AnthropicNotFoundError, 'Resource not found.'],
-    [OpenAIConflictError, 'Conflict error.'],
-    [AnthropicConflictError, 'Conflict error.'],
-    [OpenAIUnprocessableEntityError, 'Unprocessable entity.'],
-    [AnthropicUnprocessableEntityError, 'Unprocessable entity.'],
-    [OpenAIInternalServerError, 'Internal server error.'],
-    [AnthropicInternalServerError, 'Internal server error.'],
-    [OpenAIUserAbortError, 'Request aborted.'],
-    [AnthropicUserAbortError, 'Request aborted.'],
+  return undefined;
+}
+
+function matchNativeHttpError(
+  err: unknown,
+): ProviderHttpErrorDetails | undefined {
+  for (const entry of NATIVE_HTTP_ERRORS) {
+    if (!(err instanceof entry.ctor)) {
+      continue;
+    }
+
+    const statusCode = detectStatusCode(err) ?? entry.fallbackStatusCode;
+    const statusText = detectStatusText(err, statusCode);
+    const rawMessage = extractMessage(err);
+    const fallbackMessage = statusCode
+      ? STATUS_DESCRIPTIONS[statusCode]
+      : undefined;
+    const finalMessage =
+      rawMessage ?? fallbackMessage ?? 'An unexpected provider error occurred';
+
+    if (statusCode) {
+      const prefix = `HTTP ${statusCode}${statusText ? ` ${statusText}` : ''}`;
+      return {
+        message: `${prefix} – ${finalMessage}`,
+        rawMessage,
+        statusCode,
+        statusText,
+        provider: entry.provider,
+      };
+    }
+
+    return {
+      message: finalMessage,
+      rawMessage,
+      provider: entry.provider,
+    };
+  }
+
+  return undefined;
+}
+
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value === 'object' && value !== null) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function detectStatusCode(err: unknown): number | undefined {
+  const record = asRecord(err);
+  if (!record) {
+    return undefined;
+  }
+
+  const candidates = [
+    toNumber(record['status']),
+    toNumber(record['statusCode']),
+    toNumber(record['code']),
   ];
 
-  for (const [ErrorClass, message] of errorMapping) {
-    if (err instanceof ErrorClass) {
-      return message;
-    }
-  }
-  const maybeCode = err as { code?: number; status?: number } | undefined;
-  const code = maybeCode?.code ?? maybeCode?.status;
-  if (typeof code === 'number') {
-    const codeMapping: Record<number, string> = {
-      400: 'Bad request.',
-      401: 'Authentication failed.',
-      403: 'Permission denied.',
-      404: 'Resource not found.',
-      409: 'Conflict error.',
-      422: 'Unprocessable entity.',
-      429: 'Rate limit exceeded.',
-      500: 'Internal server error.',
-      503: 'Service unavailable.',
-      504: 'Deadline exceeded.',
-    };
-    const mapped = codeMapping[code];
-    if (mapped) {
-      return mapped;
-    }
-  }
-  if (err instanceof OpenAIAPIError || err instanceof AnthropicAPIError) {
-    return 'API error occurred.';
-  }
-  if ((err as Error)?.name === 'ClientError') {
-    return 'Google GenAI client error occurred.';
-  }
-  if ((err as Error)?.name === 'ServerError') {
-    return 'Google GenAI server error occurred.';
+  const response = asRecord(record['response']);
+  if (response) {
+    candidates.push(toNumber(response['status']));
   }
 
-  return 'An unexpected error occurred.';
+  const nestedError = asRecord(record['error']);
+  if (nestedError) {
+    candidates.push(toNumber(nestedError['status']));
+  }
+
+  return candidates.find((value): value is number => value !== undefined);
+}
+
+function detectStatusText(
+  err: unknown,
+  statusCode?: number,
+): string | undefined {
+  const record = asRecord(err);
+  if (!record) {
+    return statusCode ? STATUS_TITLES[statusCode] : undefined;
+  }
+
+  const response = asRecord(record['response']);
+  const nestedError = asRecord(record['error']);
+  const fallback = statusCode ? STATUS_TITLES[statusCode] : undefined;
+  const rawText =
+    record['statusText'] ??
+    response?.['statusText'] ??
+    nestedError?.['statusText'] ??
+    fallback;
+
+  return typeof rawText === 'string' ? rawText : undefined;
+}
+
+function detectProvider(err: unknown): string | undefined {
+  const record = asRecord(err);
+  if (!record) {
+    return undefined;
+  }
+
+  if (typeof record['provider'] === 'string') {
+    return record['provider'] as string;
+  }
+
+  const constructorValue = record['constructor'];
+  const constructorName =
+    typeof constructorValue === 'function'
+      ? constructorValue.name
+      : asRecord(constructorValue)?.['name'];
+  const names = [record['name'], constructorName];
+
+  for (const name of names) {
+    if (typeof name !== 'string') {
+      continue;
+    }
+
+    const lowered = name.toLowerCase();
+    if (lowered.includes('openai')) {
+      return 'openai';
+    }
+    if (lowered.includes('anthropic')) {
+      return 'anthropic';
+    }
+    if (lowered.includes('google')) {
+      return 'google';
+    }
+    if (lowered.includes('kimi')) {
+      return 'kimi';
+    }
+  }
+
+  return undefined;
+}
+
+function extractMessage(err: unknown): string | undefined {
+  if (err instanceof Error && typeof err.message === 'string') {
+    const trimmed = err.message.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (typeof err === 'string') {
+    const trimmed = err.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Formats provider SDK errors into a consistent HTTP-oriented message.
+ *
+ * Native SDK errors are matched first (OpenAI, Anthropic, Google). When the
+ * error isn't recognized, the helper inspects common fields to infer status
+ * codes, status text, and provider hints while keeping the logic lightweight.
+ */
+export function formatProviderHttpError(
+  err: unknown,
+): ProviderHttpErrorDetails {
+  const nativeMessage = matchNativeMessageError(err);
+  if (nativeMessage) {
+    return nativeMessage;
+  }
+
+  const nativeHttp = matchNativeHttpError(err);
+  if (nativeHttp) {
+    return nativeHttp;
+  }
+
+  const statusCode = detectStatusCode(err);
+  const statusText = detectStatusText(err, statusCode);
+  const provider = detectProvider(err);
+
+  const rawMessage = extractMessage(err);
+  const fallbackMessage = statusCode
+    ? STATUS_DESCRIPTIONS[statusCode]
+    : undefined;
+  const finalMessage =
+    rawMessage ?? fallbackMessage ?? 'An unexpected provider error occurred';
+
+  if (statusCode) {
+    const prefix = `HTTP ${statusCode}${statusText ? ` ${statusText}` : ''}`;
+    return {
+      message: `${prefix} – ${finalMessage}`,
+      rawMessage,
+      statusCode,
+      statusText,
+      provider,
+    };
+  }
+
+  return {
+    message: finalMessage,
+    rawMessage,
+    provider,
+  };
+}
+
+export function getSdkErrorMessage(err: unknown): string {
+  return formatProviderHttpError(err).message;
 }

--- a/src/test/agent/utils/debugMessageSaver.test.ts
+++ b/src/test/agent/utils/debugMessageSaver.test.ts
@@ -131,4 +131,3 @@ describe('maybeSaveDebugObject', () => {
     );
   });
 });
-


### PR DESCRIPTION
## Summary
- simplify provider error formatting by adding raw message metadata and lighter status/provider detection
- standardize fallback HTTP descriptions and keep native SDK matches for Anthropic, OpenAI, and Google errors
- reuse the formatted raw message when surfacing agent execution failures

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db2c7a19483248f374f1f15053781)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies provider SDK error formatting with structured HTTP details and updates handlers/runtime to log standardized messages, improving API-key detection and debug output.
> 
> - **Errors/SDK**:
>   - Add `formatProviderHttpError` with structured details (`message`, `rawMessage`, `statusCode`, `statusText`, `provider`) and lightweight status/provider detection; keep `getSdkErrorMessage` as wrapper.
>   - Map native OpenAI/Anthropic/Google errors to consistent HTTP-style messages.
> - **Model Handlers** (`Anthropic`, `OpenAI`, `OpenAIResponse`, `GoogleGenAI`, `Kimi`):
>   - Replace ad-hoc error messages with `formatProviderHttpError(...)` and log via `MESSAGE_TYPES.PROGRESS_STATUS`, passing formatted details for failures (response creation, media/file uploads, media processing, streaming).
> - **Core/Runtime**:
>   - `ResponseCycleFlow`: on model invocation failure, log formatted error details and mark state to stop.
>   - `executeAgent`: format errors, preserve `rawMessage`, improve API key detection using raw text, and log structured error payloads to fallbacks and scoped logs.
> - **Debug Utils/Tests**:
>   - Simplify debug file path join in `debugMessageSaver`; update test expectations accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1056efeb004cae45e30f198862a30f9a40f3fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->