### PR TITLE
fix: fall back to inline file upload when timeout occurs

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -2,7 +2,7 @@
 import { Buffer } from 'node:buffer';
 
 // Third-party imports
-import OpenAI, { toFile } from 'openai';
+import OpenAI, { APIConnectionTimeoutError, toFile } from 'openai';
 import type {
   EasyInputMessage,
   Response,
@@ -431,6 +431,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
     } catch (err) {
       const formattedError = formatProviderHttpError(err);
+
+      if (
+        err instanceof APIConnectionTimeoutError ||
+        formattedError.message.includes('Request timed out')
+      ) {
+        this.logger.warn(
+          `Timed out uploading file ${filename}. Falling back to inline payload.`,
+        );
+        return;
+      }
+
       this.logger.error(
         `Failed to upload file ${filename}: ${formattedError.message}`,
         undefined,


### PR DESCRIPTION
## Summary
- fall back to sending the inline file payload when the OpenAI Files API upload times out

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df2e2eb1483248640c7a8a6075174)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On OpenAI file upload timeout, skip upload and send inline file payload instead, logging a warning.
> 
> - **OpenAI Responses handler (`src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`)**:
>   - **File upload timeout handling**: Detects `APIConnectionTimeoutError` or "Request timed out" during `files.create`; logs a warning and falls back to inline `file_data` instead of throwing.
>   - Imports `APIConnectionTimeoutError` from `openai` to support the new timeout check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73bac53feadc39ee7997a381cea166537feb04c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->