### PR TITLE
Restore progress view usage badges

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -94,7 +94,13 @@
                 class="status-indicator stopped"
                 data-status="Ready"
               ></span>
-              <span id="runSummary" class="run-summary"></span>
+              <span
+                id="runSummary"
+                class="run-summary"
+                role="status"
+                aria-live="polite"
+                aria-hidden="true"
+              ></span>
             </div>
             <vscode-toolbar-container
               id="toolbarContainer"
@@ -219,6 +225,12 @@
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
+          </template>
+          <template id="usageSummaryBadgeTemplate">
+            <vscode-badge class="usage-summary__badge" appearance="secondary">
+              <i class="usage-summary__icon codicon" aria-hidden="true"></i>
+              <span class="usage-summary__value"></span>
+            </vscode-badge>
           </template>
           <template id="usageTemplate">
             <span class="group-usage">

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -1,7 +1,6 @@
 // Local imports - progress view
 import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 // Local imports
-import { formatTokens } from '../formatters.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
 import { getBasename } from '@common/pathUtils.js';
@@ -44,43 +43,42 @@ export class FileList {
 
     container.innerHTML = '';
 
-    const template = document.getElementById(ELEMENT_IDS.FILE_ITEM_TEMPLATE);
-    if (!template) {
-      console.error('File item template not found');
-      return;
+    if (this.usageSummary) {
+      this.usageSummary.update();
     }
 
     if (!filesByRound || Object.keys(filesByRound).length === 0) {
-      container.textContent = 'No generated files';
+      const emptyMessage = document.createElement('div');
+      emptyMessage.className = 'files-empty';
+      emptyMessage.textContent =
+        'No generated files yet. Usage totals are displayed above.';
+      container.appendChild(emptyMessage);
       return;
-    }
-
-    // Add total usage header
-    const usageHeader = document.createElement('div');
-    usageHeader.className = 'files-usage-header';
-
-    // Calculate total usage from all groups
-    const totals = this.usageSummary?.computeTotal() || {
-      inputTokens: 0,
-      outputTokens: 0,
-      cost: 0,
-    };
-
-    if (totals.inputTokens || totals.outputTokens || totals.cost) {
-      usageHeader.innerHTML = `
-        <span class="files-usage-label">Total Usage:</span>
-        <span class="files-usage-stats">
-          <i class="codicon codicon-arrow-up"></i> ${formatTokens(totals.inputTokens)},
-          <i class="codicon codicon-arrow-down"></i> ${formatTokens(totals.outputTokens)},
-          $${totals.cost.toFixed(3)}
-        </span>
-      `;
-      container.appendChild(usageHeader);
     }
 
     const rounds = Object.keys(filesByRound)
       .map((r) => parseInt(r, 10))
       .sort((a, b) => a - b);
+
+    const hasAnyFiles = rounds.some((round) => {
+      const files = filesByRound[round];
+      return Array.isArray(files) && files.length > 0;
+    });
+
+    if (!hasAnyFiles) {
+      const emptyMessage = document.createElement('div');
+      emptyMessage.className = 'files-empty';
+      emptyMessage.textContent =
+        'No generated files yet. Usage totals are displayed above.';
+      container.appendChild(emptyMessage);
+      return;
+    }
+
+    const template = document.getElementById(ELEMENT_IDS.FILE_ITEM_TEMPLATE);
+    if (!template) {
+      console.error('File item template not found');
+      return;
+    }
 
     rounds.forEach((round) => {
       const files = filesByRound[round];

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -27,8 +27,64 @@ export class UsageSummary {
     // If usage is not provided, compute it from existing log groups
     const totals = usage ?? this.computeTotal();
 
-    // Clear the summary - we're showing total usage in the files section now
-    this._summaryElem.textContent = '';
+    const inputTokens = Number(totals?.inputTokens ?? 0) || 0;
+    const outputTokens = Number(totals?.outputTokens ?? 0) || 0;
+    const cost = Number(totals?.cost ?? 0) || 0;
+
+    if (!inputTokens && !outputTokens && !cost) {
+      this._summaryElem.replaceChildren();
+      this._summaryElem.setAttribute('aria-hidden', 'true');
+      return;
+    }
+
+    const badgeTemplate = document.getElementById('usageSummaryBadgeTemplate');
+    const createBadge = (iconName, value, ariaLabel) => {
+      /** @type {HTMLElement | null} */
+      let badge = null;
+      if (badgeTemplate instanceof HTMLTemplateElement) {
+        const clone = badgeTemplate.content.cloneNode(true);
+        badge = clone.querySelector('vscode-badge');
+        if (badge) {
+          const icon = badge.querySelector('.usage-summary__icon');
+          const text = badge.querySelector('.usage-summary__value');
+          if (icon) {
+            icon.classList.add(`codicon-${iconName}`);
+          }
+          if (text) {
+            text.textContent = value;
+          }
+        }
+      }
+
+      if (!badge) {
+        badge = document.createElement('vscode-badge');
+        badge.classList.add('usage-summary__badge');
+        badge.setAttribute('appearance', 'secondary');
+        const icon = document.createElement('i');
+        icon.className = `usage-summary__icon codicon codicon-${iconName}`;
+        icon.setAttribute('aria-hidden', 'true');
+        const text = document.createElement('span');
+        text.className = 'usage-summary__value';
+        text.textContent = value;
+        badge.append(icon, text);
+      }
+
+      badge.setAttribute('aria-label', ariaLabel);
+      return badge;
+    };
+
+    const inputText = formatTokens(inputTokens);
+    const outputText = formatTokens(outputTokens);
+    const costText = `$${cost.toFixed(3)}`;
+
+    const badges = [
+      createBadge('arrow-up', inputText, `Input tokens: ${inputText}`),
+      createBadge('arrow-down', outputText, `Output tokens: ${outputText}`),
+      createBadge('symbol-number', costText, `Cost: ${costText}`),
+    ].filter(Boolean);
+
+    this._summaryElem.replaceChildren(...badges);
+    this._summaryElem.setAttribute('aria-hidden', 'false');
   }
 
   /**

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -20,6 +20,7 @@ window.addEventListener('beforeunload', () => {
 document.addEventListener('DOMContentLoaded', () => {
   validateTemplates([
     'fileItemTemplate',
+    'usageSummaryBadgeTemplate',
     'usageTemplate',
     'bulletTemplate',
     'streamTabTemplate',

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -123,7 +123,26 @@
 }
 
 .run-summary {
-  opacity: var(--opacity-subtle);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  flex-wrap: wrap;
+  margin-left: var(--spacing-small);
+}
+
+.run-summary[aria-hidden='true'] {
+  display: none;
+}
+
+.usage-summary__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  font-size: var(--font-size-sm);
+}
+
+.usage-summary__icon {
+  font-size: var(--font-size-sm);
 }
 
 /* Status indicator styling */
@@ -202,26 +221,10 @@
   flex-shrink: 0;
 }
 
-/* Files usage header */
-.files-usage-header {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-medium);
-  padding: var(--spacing-small) var(--spacing-small);
-  margin-bottom: var(--spacing-medium);
-  background-color: var(--vscode-sideBarSectionHeader-background);
-  border-radius: var(--border-radius-small);
-  font-size: var(--font-size-sm);
-}
-
-.files-usage-label {
-  font-weight: 600;
-  color: var(--vscode-foreground);
-}
-
-.files-usage-stats {
+.files-empty {
+  padding: var(--spacing-small);
   color: var(--vscode-descriptionForeground);
-  opacity: var(--opacity-subtle);
+  font-size: var(--font-size-sm);
 }
 
 .file-item {

--- a/src/test/progressView/FileList.test.ts
+++ b/src/test/progressView/FileList.test.ts
@@ -1,0 +1,57 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+// @ts-ignore: jsdom lacks ESM typings in this context
+import { JSDOM } from 'jsdom';
+
+// Local imports - progress view
+// @ts-ignore: file list manager is a JS module without typings
+import { FileList } from '../../progressView/modules/uiManagers/FileList.js';
+
+describe('FileList empty state', () => {
+  beforeEach(() => {
+    const dom = new JSDOM(`<!doctype html><html><body>
+      <div id="generatedFiles"></div>
+      <span id="runSummary">Totals</span>
+    </body></html>`);
+    global.document = dom.window.document as any;
+    global.window = dom.window as any;
+  });
+
+  afterEach(() => {
+    delete (global as any).document;
+    delete (global as any).window;
+  });
+
+  it('shows a friendly empty message and refreshes usage summary', () => {
+    const summaryElement = document.getElementById('runSummary');
+    assert.ok(summaryElement, 'summary element should exist');
+
+    let updateCalled = false;
+    const usageSummary = {
+      update() {
+        updateCalled = true;
+        if (summaryElement) {
+          summaryElement.textContent = 'Totals (refreshed)';
+        }
+      },
+    } as any;
+
+    const fileList = new FileList(usageSummary);
+    fileList.update({});
+
+    const emptyMessage = document.querySelector('.files-empty');
+    assert.ok(emptyMessage, 'empty state message should render');
+    assert.equal(
+      emptyMessage?.textContent?.trim(),
+      'No generated files yet. Usage totals are displayed above.',
+    );
+    assert.equal(updateCalled, true, 'usage summary should refresh');
+    assert.equal(
+      summaryElement?.textContent,
+      'Totals (refreshed)',
+      'usage banner should stay populated',
+    );
+  });
+});

--- a/src/test/webview/UsageSummaryRender.test.ts
+++ b/src/test/webview/UsageSummaryRender.test.ts
@@ -1,0 +1,87 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+// @ts-ignore: jsdom lacks ESM typings in this context
+import { JSDOM } from 'jsdom';
+
+// Local imports - progress view
+// @ts-ignore: usage manager is a JS module without typings
+import { UsageSummary } from '../../progressView/modules/usageManagers.js';
+// @ts-ignore: progress view state is a JS module without typings
+import { progressViewState } from '../../progressView/modules/progressViewState.js';
+
+describe('UsageSummary badges', () => {
+  beforeEach(() => {
+    const dom = new JSDOM(`<!doctype html><html><body>
+      <span id="runSummary" class="run-summary"></span>
+      <template id="usageSummaryBadgeTemplate">
+        <vscode-badge class="usage-summary__badge" appearance="secondary">
+          <i class="usage-summary__icon codicon" aria-hidden="true"></i>
+          <span class="usage-summary__value"></span>
+        </vscode-badge>
+      </template>
+    </body></html>`);
+    global.document = dom.window.document as any;
+    global.window = dom.window as any;
+    progressViewState.taskGroups.clear();
+  });
+
+  afterEach(() => {
+    delete (global as any).document;
+    delete (global as any).window;
+    progressViewState.taskGroups.clear();
+  });
+
+  it('renders badges with aggregated totals', () => {
+    progressViewState.taskGroups.set('group-1', {
+      id: 'group-1',
+      usage: { inputTokens: 5200, outputTokens: 1875, cost: 1.234 },
+    } as any);
+
+    const summary = new UsageSummary();
+    summary.update();
+
+    const summaryEl = document.getElementById('runSummary');
+    assert.ok(summaryEl, 'summary element should exist');
+
+    const badges = summaryEl?.querySelectorAll('vscode-badge') ?? [];
+    assert.equal(badges.length, 3, 'should render three badges');
+
+    const [inputBadge, outputBadge, costBadge] = Array.from(badges);
+    assert.equal(
+      inputBadge?.querySelector('.usage-summary__value')?.textContent,
+      '5k',
+      'input badge should abbreviate tokens',
+    );
+    assert.equal(
+      outputBadge?.querySelector('.usage-summary__value')?.textContent,
+      '1875',
+      'output badge should show exact token count below threshold',
+    );
+    assert.equal(
+      costBadge?.querySelector('.usage-summary__value')?.textContent,
+      '$1.234',
+      'cost badge should include currency formatting',
+    );
+    assert.equal(
+      summaryEl?.getAttribute('aria-hidden'),
+      'false',
+      'usage summary should be announced when data is available',
+    );
+  });
+
+  it('hides badges when no usage is available', () => {
+    const summary = new UsageSummary();
+    summary.update({ inputTokens: 0, outputTokens: 0, cost: 0 });
+
+    const summaryEl = document.getElementById('runSummary');
+    assert.ok(summaryEl, 'summary element should exist');
+    assert.equal(summaryEl?.children.length, 0, 'no badges should render');
+    assert.equal(
+      summaryEl?.getAttribute('aria-hidden'),
+      'true',
+      'summary container should be hidden without totals',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- render aggregated token and cost usage in the progress header using VS Code badges and hide the banner when totals are empty
- simplify the generated files pane by removing the redundant totals header and showing an empty-state message that keeps the banner visible
- cover the new UI behaviour with jsdom tests for both the usage summary badges and the generated-files empty state

## Testing
- npm run format
- npm run lint
- npm run compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690de853e9188324b4aa2e4235e788dd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Render aggregated token/cost usage as header badges and replace files pane totals with a friendly empty-state, with tests covering both.
> 
> - **UI/Accessibility**:
>   - **Header usage badges**: Add `usageSummaryBadgeTemplate` and render aggregated input/output tokens and cost as `vscode-badge`s in `#runSummary`; toggle `aria-hidden` and use `role="status"`/`aria-live="polite"`.
>   - **Files pane**: Remove totals header; refresh usage summary on update and show an empty-state message when no files are present.
>   - **Styles**: Add `.run-summary` layout, `.usage-summary__badge`/`.usage-summary__icon`, and `.files-empty` styles; hide summary when `aria-hidden=true`.
>   - **Init**: Validate new `usageSummaryBadgeTemplate` on DOM load.
> - **Logic**:
>   - `UsageSummary.update` builds badges (with fallbacks), formats values, and hides when totals are zero.
>   - `FileList.update` refreshes usage summary, checks for any files across rounds, and renders the empty state.
> - **Tests**:
>   - Add jsdom tests for usage summary badge rendering/visibility and for the file list empty state refreshing the banner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ae0bd22e1896d76f9a0c0609e964a8786511c62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->