### PR TITLE
Add Dependabot configuration for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     ignore:
       - dependency-name: "@types/node"
       - dependency-name: "@types/vscode"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "@typescript-eslint/*"
+          - "eslint*"
+          - "prettier"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "@types/node"
+      - dependency-name: "@types/vscode"


### PR DESCRIPTION
## Summary
- add Dependabot configuration to enable weekly npm dependency updates while ignoring Node and VS Code API packages

## Testing
- not run (config change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef4b41d048324bee680ab3c1ad8d7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Dependabot config for weekly npm updates, grouping dev-dependency minors/patches and ignoring @types/node and @types/vscode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36730a4bf515d314711a1df9e02fd6885268d4f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->