### PR TITLE
fix: streamline progress task migration

### DIFF
--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -12,7 +12,8 @@ import { AgentLogger } from '@logger/AgentLogger';
 import type { AgentFilter } from '../types';
 // Local imports - agent types
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
-import { AgentCategory } from '@agent/core/AgentDataclass';
+import { resolveAgentSessionDescriptor } from '@agent/core/AgentDataclass';
+import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 
 // Types
 import {
@@ -339,53 +340,60 @@ export class ProgressViewState {
 
     this.taskStates.clear();
 
+    if (!raw || typeof raw !== 'object') {
+      this.cleanupToolUseAgentRegistry();
+      return;
+    }
+
+    const container = raw as Record<string, unknown>;
+    const buckets: Record<string, unknown>[] = [];
+
+    if (
+      typeof container.workflow === 'object' ||
+      typeof container.toolUse === 'object'
+    ) {
+      if (container.workflow && typeof container.workflow === 'object') {
+        buckets.push(container.workflow as Record<string, unknown>);
+      }
+      if (container.toolUse && typeof container.toolUse === 'object') {
+        buckets.push(container.toolUse as Record<string, unknown>);
+      }
+    } else {
+      buckets.push(container);
+    }
+
+    let migratedLegacyState = false;
     let loaded = 0;
-    const isTaskState = (value: unknown): value is TaskState => {
-      if (!value || typeof value !== 'object') {
-        return false;
-      }
-      return (
-        isWorkflowTaskState(value as TaskState) ||
-        isToolUseTaskState(value as TaskState)
-      );
-    };
 
-    const addFromRecord = (record: unknown): void => {
-      if (!record || typeof record !== 'object') {
-        return;
-      }
-
-      for (const [stream, value] of Object.entries(
-        record as Record<string, unknown>,
-      )) {
-        if (!isTaskState(value)) {
+    for (const record of buckets) {
+      for (const [stream, rawState] of Object.entries(record)) {
+        if (!rawState || typeof rawState !== 'object') {
           continue;
         }
 
-        this.taskStates.set(stream as StreamTabId, cloneTaskState(value));
+        const state = rawState as TaskState;
+
+        if (!state.session) {
+          const agentConfig = (state as { agentConfig?: any }).agentConfig;
+          if (!agentConfig || typeof agentConfig !== 'object') {
+            continue;
+          }
+
+          const session = resolveAgentSessionDescriptor(
+            agentConfig.agentType as AgentType | undefined,
+            agentConfig.agentCategory as AgentCategory | undefined,
+          );
+
+          state.session = session;
+          state.agentConfig = { ...agentConfig, session };
+          migratedLegacyState = true;
+        } else if (!state.agentConfig.session) {
+          state.agentConfig = { ...state.agentConfig, session: state.session };
+          migratedLegacyState = true;
+        }
+
+        this.taskStates.set(stream as StreamTabId, cloneTaskState(state));
         loaded += 1;
-      }
-    };
-
-    let migratedLegacyState = false;
-
-    if (raw && typeof raw === 'object') {
-      const container = raw as Record<string, unknown>;
-      const workflow = container['workflow'];
-      const toolUse = container['toolUse'];
-
-      const hasLegacyShape =
-        (!!workflow &&
-          typeof workflow === 'object' &&
-          !isTaskState(workflow)) ||
-        (!!toolUse && typeof toolUse === 'object' && !isTaskState(toolUse));
-
-      if (hasLegacyShape) {
-        migratedLegacyState = true;
-        addFromRecord(workflow);
-        addFromRecord(toolUse);
-      } else {
-        addFromRecord(container);
       }
     }
 

--- a/src/test/progressView/state/ProgressViewState.test.ts
+++ b/src/test/progressView/state/ProgressViewState.test.ts
@@ -162,3 +162,65 @@ describe('ProgressViewState.clearOutputState', () => {
     assert.deepStrictEqual(storage.saved, []);
   });
 });
+
+describe('ProgressViewState.load', () => {
+  it('restores legacy task states lacking session metadata', async () => {
+    const storage = new FakeStorage();
+    const state = new ProgressViewState(storage);
+
+    const streamId = 'legacy-stream';
+    const config = parseAgentConfig({
+      model: 'test-model',
+      agent: 'legacy-agent',
+      instruction: 'Restore me',
+      agentType: AgentType.Direct,
+      inputFile: 'main.tex',
+    });
+
+    const legacyConfig = { ...config } as Record<string, unknown>;
+    delete legacyConfig.session;
+
+    const legacyTaskState = {
+      agentConfig: legacyConfig,
+      activeFiles: {
+        input: true,
+        reference: false,
+        auxiliary: false,
+        media: false,
+        output: false,
+      },
+    };
+
+    await storage.update(WorkspaceStateKey.TASK_STATES, {
+      workflow: {
+        [streamId]: legacyTaskState,
+      },
+    });
+
+    storage.saved.length = 0;
+
+    await state.load();
+
+    const restored = state.getTaskState(streamId);
+    assert.ok(restored, 'expected legacy task state to be restored');
+    assert.equal(restored!.session.agentCategory, AgentCategory.Workflow);
+    assert.equal(
+      restored!.agentConfig.session.agentCategory,
+      AgentCategory.Workflow,
+    );
+
+    const persistedEntry = storage.saved.find(
+      (entry) => entry.key === WorkspaceStateKey.TASK_STATES,
+    );
+    assert.ok(persistedEntry, 'expected canonicalized task states to be saved');
+
+    const serialized = persistedEntry!.value as Record<string, any>;
+    assert.deepStrictEqual(Object.keys(serialized), [streamId]);
+    const serializedState = serialized[streamId];
+    assert.equal(serializedState.session.agentCategory, AgentCategory.Workflow);
+    assert.equal(
+      serializedState.agentConfig.session.agentCategory,
+      AgentCategory.Workflow,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- simplify task-state loading to handle legacy workflow/tool-use buckets without extra normalization helpers
- derive missing session descriptors on the fly and persist migrated entries only when needed

## Testing
- npm run format
- npm run lint
- npm run compile-tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690efe0e8ac88324959b02d4d2997192)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `ProgressViewState` task-state loading to handle legacy bucket shapes and auto-populate missing session metadata, persisting canonicalized states and adding tests.
> 
> - **State management (`src/progressView/state/ProgressViewState.ts`)**:
>   - Refactors `loadTaskStates` to accept both legacy `workflow`/`toolUse` buckets and flat maps, removing extra normalization helpers.
>   - Derives missing `session` data via `resolveAgentSessionDescriptor` and mirrors it into `agentConfig.session`; persists only when migration occurs.
>   - Early-exits and cleans up tool-use agent registry when no valid state; always cleans up after load.
>   - Updates imports to use `resolveAgentSessionDescriptor` and `AgentType`/`AgentCategory`.
> - **Tests (`src/test/progressView/state/ProgressViewState.test.ts`)**:
>   - Adds test ensuring legacy task states lacking `session` are restored and saved in canonical form.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a384e9b5bc819cb3aaf6929d125bc8496a6a708f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->