### PR TITLE
fix: migrate progress view legacy storage

### DIFF
--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
 // Local imports - progress view
 import {
   PersistentMapManager,
@@ -147,18 +150,12 @@ export class OutputFilesManager extends PersistentMapManager<
     }>(WorkspaceStateKey.MISSING_OUTPUTS, {});
 
     if (saved && Object.keys(saved).length > 0) {
-      const processed = new Map<StreamTabId, Map<number, string[]>>();
+      this._missingOutputs = this.deserializeMissingOutputs(saved);
+      return;
+    }
 
-      for (const [stream, rounds] of Object.entries(saved)) {
-        const roundEntries = Object.entries(rounds).map(
-          ([round, files]) =>
-            [parseInt(round, 10), files] as [number, string[]],
-        );
-        processed.set(stream, new Map(roundEntries));
-      }
-
-      this._missingOutputs = processed;
-    } else {
+    const migrated = await this.migrateLegacyMissingOutputs();
+    if (!migrated) {
       this._missingOutputs.clear();
     }
   }
@@ -172,6 +169,42 @@ export class OutputFilesManager extends PersistentMapManager<
       ]),
     );
     await this.storage.update(WorkspaceStateKey.MISSING_OUTPUTS, obj);
+  }
+
+  private deserializeMissingOutputs(saved: {
+    [key: string]: { [key: number]: string[] };
+  }): Map<StreamTabId, Map<number, string[]>> {
+    const processed = new Map<StreamTabId, Map<number, string[]>>();
+
+    for (const [stream, rounds] of Object.entries(saved)) {
+      const roundEntries = Object.entries(rounds).map(
+        ([round, files]) => [parseInt(round, 10), files] as [number, string[]],
+      );
+      processed.set(stream, new Map(roundEntries));
+    }
+
+    return processed;
+  }
+
+  private async migrateLegacyMissingOutputs(): Promise<boolean> {
+    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workspacePath) {
+      return false;
+    }
+
+    const legacyKey = `${WorkspaceStateKey.MISSING_OUTPUTS}.${workspacePath}`;
+    const legacy = this.storage.get<{
+      [key: string]: { [key: number]: string[] };
+    }>(legacyKey, {});
+
+    if (!legacy || Object.keys(legacy).length === 0) {
+      return false;
+    }
+
+    this._missingOutputs = this.deserializeMissingOutputs(legacy);
+    await this.saveMissingOutputs();
+    await this.storage.update(legacyKey, undefined as never);
+    return true;
   }
 
   protected override serialize(

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -22,7 +22,7 @@ export class StreamTabsManager extends PersistentMapManager<
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {
-    super(WorkspaceStateKey.STREAM_TABS, storage);
+    super(WorkspaceStateKey.STREAM_TABS, storage, ['texra.logStreams']);
     this.logger = new AgentLogger('StreamTabsManager');
   }
 

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -30,7 +30,7 @@ export class TaskGroupManager extends PersistentMapManager<
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {
-    super(WorkspaceStateKey.TASK_GROUPS, storage);
+    super(WorkspaceStateKey.TASK_GROUPS, storage, ['texra.logGroups']);
     this.logger = new AgentLogger('TaskGroupManager');
   }
 

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -21,7 +21,7 @@ export class UsageStatsManager extends PersistentMapManager<
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {
-    super(WorkspaceStateKey.USAGE_STATS, storage);
+    super(WorkspaceStateKey.USAGE_STATS, storage, ['texra.usageStats']);
     this.logger = new AgentLogger('UsageStatsManager');
   }
 

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
 // Local imports
 import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
 
@@ -15,8 +18,13 @@ export abstract class PersistentMapManager<K extends string, V> {
   protected items: Map<K, V> = new Map();
   protected readonly storage: StateStorage;
   protected readonly storageKey: WorkspaceStateKey;
+  private readonly legacyKeyRoots: string[];
 
-  constructor(storageKey: WorkspaceStateKey, storage?: StateStorage) {
+  constructor(
+    storageKey: WorkspaceStateKey,
+    storage?: StateStorage,
+    legacyKeyRoots: string[] = [],
+  ) {
     const resolvedStorage = storage ?? workspaceSM;
     if (!resolvedStorage) {
       throw new Error('workspace state manager is not initialized');
@@ -24,6 +32,7 @@ export abstract class PersistentMapManager<K extends string, V> {
 
     this.storage = resolvedStorage;
     this.storageKey = storageKey;
+    this.legacyKeyRoots = legacyKeyRoots;
   }
 
   /** Add an entry to the map and persist it */
@@ -89,13 +98,12 @@ export abstract class PersistentMapManager<K extends string, V> {
     );
 
     if (saved && Object.keys(saved).length > 0) {
-      const entries: [K, V][] = [];
-      for (const [key, value] of Object.entries(saved)) {
-        const deserialized = await this.deserialize(value, key as K);
-        entries.push([key as K, deserialized]);
-      }
-      this.items = new Map(entries);
-    } else {
+      await this.populateFromRecord(saved);
+      return;
+    }
+
+    const migrated = await this.migrateLegacyState();
+    if (!migrated) {
       this.items.clear();
     }
   }
@@ -108,5 +116,40 @@ export abstract class PersistentMapManager<K extends string, V> {
     ]);
     const obj = Object.fromEntries(serialized);
     await this.storage.update(this.storageKey, obj);
+  }
+
+  private async populateFromRecord(
+    record: Record<string, unknown>,
+  ): Promise<void> {
+    const entries: [K, V][] = [];
+    for (const [key, value] of Object.entries(record)) {
+      const deserialized = await this.deserialize(value, key as K);
+      entries.push([key as K, deserialized]);
+    }
+    this.items = new Map(entries);
+  }
+
+  private async migrateLegacyState(): Promise<boolean> {
+    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workspacePath) {
+      return false;
+    }
+
+    const candidates = [this.storageKey as string, ...this.legacyKeyRoots];
+
+    for (const root of candidates) {
+      const legacyKey = `${root}.${workspacePath}`;
+      const legacy = this.storage.get<Record<string, unknown>>(legacyKey, {});
+      if (!legacy || Object.keys(legacy).length === 0) {
+        continue;
+      }
+
+      await this.populateFromRecord(legacy);
+      await this.save();
+      await this.storage.update(legacyKey, undefined as never);
+      return true;
+    }
+
+    return false;
   }
 }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
 // Local imports - progress view
 import {
   StreamTabsManager,
@@ -336,16 +339,18 @@ export class ProgressViewState {
    * Load task states from persistence
    */
   private async loadTaskStates(): Promise<void> {
-    const raw = this.storage.get<unknown>(WorkspaceStateKey.TASK_STATES, {});
+    const raw = await this.loadRecordWithLegacyFallback(
+      WorkspaceStateKey.TASK_STATES,
+    );
 
     this.taskStates.clear();
 
-    if (!raw || typeof raw !== 'object') {
+    if (Object.keys(raw).length === 0) {
       this.cleanupToolUseAgentRegistry();
       return;
     }
 
-    const container = raw as Record<string, unknown>;
+    const container = raw;
     const buckets: Record<string, unknown>[] = [];
 
     if (
@@ -412,19 +417,60 @@ export class ProgressViewState {
    * Load execution IDs from persistence
    */
   private async loadExecutionIds(): Promise<void> {
-    const savedIds = this.storage.get<Record<string, ExecutionId>>(
+    const savedIdsRecord = await this.loadRecordWithLegacyFallback(
       WorkspaceStateKey.EXECUTION_IDS,
-      {},
     );
 
-    if (savedIds && Object.keys(savedIds).length > 0) {
-      this._executionIds = new Map(Object.entries(savedIds));
-      this.logger.debug(
-        `Loaded execution IDs for ${this._executionIds.size} streams`,
-      );
+    const entries = Object.entries(savedIdsRecord).filter(
+      (entry): entry is [StreamTabId, ExecutionId] =>
+        typeof entry[1] === 'string' && entry[1].length > 0,
+    );
+
+    if (entries.length > 0) {
+      this._executionIds = new Map(entries);
+      this.logger.debug(`Loaded execution IDs for ${entries.length} streams`);
     } else {
       this._executionIds.clear();
     }
+  }
+
+  private async loadRecordWithLegacyFallback(
+    key: WorkspaceStateKey,
+    legacyRoots: string[] = [],
+  ): Promise<Record<string, unknown>> {
+    const current = this.storage.get<unknown>(key);
+    if (
+      current &&
+      typeof current === 'object' &&
+      !Array.isArray(current) &&
+      Object.keys(current as Record<string, unknown>).length > 0
+    ) {
+      return current as Record<string, unknown>;
+    }
+
+    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (workspacePath) {
+      for (const root of [key as string, ...legacyRoots]) {
+        const legacyKey = `${root}.${workspacePath}`;
+        const legacy = this.storage.get<unknown>(legacyKey);
+        if (
+          legacy &&
+          typeof legacy === 'object' &&
+          !Array.isArray(legacy) &&
+          Object.keys(legacy as Record<string, unknown>).length > 0
+        ) {
+          await this.storage.update(key, legacy as Record<string, unknown>);
+          await this.storage.update(legacyKey, undefined as never);
+          return legacy as Record<string, unknown>;
+        }
+      }
+    }
+
+    if (current && typeof current === 'object' && !Array.isArray(current)) {
+      return current as Record<string, unknown>;
+    }
+
+    return {};
   }
 
   /**

--- a/src/test/progressView/state/ProgressViewState.test.ts
+++ b/src/test/progressView/state/ProgressViewState.test.ts
@@ -261,6 +261,28 @@ describe('ProgressViewState.load', () => {
       cost: 1,
     };
 
+    await storage.update(`texra.taskStates.${workspacePath}`, {
+      [streamId]: {
+        agentConfig: {
+          model: 'test-model',
+          agent: 'legacy-agent',
+          instruction: 'Restore me',
+          agentType: AgentType.Direct,
+          agentCategory: AgentCategory.Workflow,
+          inputFile: 'main.tex',
+          outputFiles: [],
+          useMultipleOutputs: false,
+        },
+        activeFiles: {
+          input: true,
+          reference: false,
+          auxiliary: false,
+          media: false,
+          output: false,
+        },
+      },
+    });
+
     await storage.update(`texra.logStreams.${workspacePath}`, {
       [streamId]: [logEntry],
     });
@@ -289,6 +311,10 @@ describe('ProgressViewState.load', () => {
 
     await storage.update(`texra.usageStats.${workspacePath}`, {
       [streamId]: usage,
+    });
+
+    await storage.update(`texra.executionIds.${workspacePath}`, {
+      [streamId]: 'exec-1',
     });
 
     storage.saved.length = 0;
@@ -321,12 +347,24 @@ describe('ProgressViewState.load', () => {
     assert.ok(restoredUsage);
     assert.deepStrictEqual(restoredUsage, usage);
 
+    const restoredTaskState = state.getTaskState(streamId);
+    assert.ok(restoredTaskState);
+    assert.equal(
+      restoredTaskState!.session.agentCategory,
+      AgentCategory.Workflow,
+    );
+
+    const executionId = state.getExecutionId(streamId);
+    assert.equal(executionId, 'exec-1');
+
     const savedKeys = storage.saved.map((entry) => entry.key);
     assert.ok(savedKeys.includes(WorkspaceStateKey.STREAM_TABS));
     assert.ok(savedKeys.includes(WorkspaceStateKey.TASK_GROUPS));
     assert.ok(savedKeys.includes(WorkspaceStateKey.OUTPUT_FILES));
     assert.ok(savedKeys.includes(WorkspaceStateKey.MISSING_OUTPUTS));
     assert.ok(savedKeys.includes(WorkspaceStateKey.USAGE_STATS));
+    assert.ok(savedKeys.includes(WorkspaceStateKey.TASK_STATES));
+    assert.ok(savedKeys.includes(WorkspaceStateKey.EXECUTION_IDS));
 
     assert.ok(
       savedKeys.includes(`texra.logStreams.${workspacePath}`),
@@ -347,6 +385,14 @@ describe('ProgressViewState.load', () => {
     assert.ok(
       savedKeys.includes(`texra.usageStats.${workspacePath}`),
       'expected legacy usage key to be cleared',
+    );
+    assert.ok(
+      savedKeys.includes(`texra.taskStates.${workspacePath}`),
+      'expected legacy task state key to be cleared',
+    );
+    assert.ok(
+      savedKeys.includes(`texra.executionIds.${workspacePath}`),
+      'expected legacy execution id key to be cleared',
     );
   });
 });

--- a/src/test/progressView/state/ProgressViewState.test.ts
+++ b/src/test/progressView/state/ProgressViewState.test.ts
@@ -1,6 +1,9 @@
 // Standard library imports
 import { strict as assert } from 'assert';
 
+// Third-party imports
+import * as vscode from 'vscode';
+
 // Local imports - progress view
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { StateStorage } from '@progressView/persistence/PersistentMapManager';
@@ -10,6 +13,8 @@ import { WorkspaceStateKey } from '@common/state/stateManager';
 import { parseAgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import type { WorkflowTaskState } from '@logger/TaskState';
+import type { LogMessageData, TaskGroup } from '@logger/LogTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 
 class FakeStorage implements StateStorage {
   public readonly saved: { key: string; value: unknown }[] = [];
@@ -221,6 +226,127 @@ describe('ProgressViewState.load', () => {
     assert.equal(
       serializedState.agentConfig.session.agentCategory,
       AgentCategory.Workflow,
+    );
+  });
+
+  it('migrates workspace-scoped progress view data saved under legacy keys', async () => {
+    const storage = new FakeStorage();
+    const state = new ProgressViewState(storage);
+    const workspacePath = '/fake/workspace';
+    const originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+    (vscode.workspace as any).workspaceFolders = [
+      { uri: { fsPath: workspacePath } },
+    ] as vscode.WorkspaceFolder[];
+
+    const streamId = 'legacy-stream';
+    const groupId = 'legacy-group';
+
+    const logEntry: LogMessageData = {
+      id: 'log-1' as any,
+      text: 'legacy message',
+      level: 'info',
+      timestamp: 1700000000000,
+    };
+
+    const taskGroup: TaskGroup = {
+      id: groupId as any,
+      name: 'Legacy group',
+      startTime: 1700000000000,
+      status: 'running',
+    };
+
+    const usage: TokenUsageStats = {
+      inputTokens: 10,
+      outputTokens: 5,
+      cost: 1,
+    };
+
+    await storage.update(`texra.logStreams.${workspacePath}`, {
+      [streamId]: [logEntry],
+    });
+
+    await storage.update(`texra.logGroups.${workspacePath}`, {
+      [streamId]: {
+        [groupId]: taskGroup,
+      },
+    });
+
+    await storage.update(`texra.outputFiles.${workspacePath}`, {
+      [streamId]: {
+        0: [
+          {
+            path: 'out.tex',
+          },
+        ],
+      },
+    });
+
+    await storage.update(`texra.missingOutputs.${workspacePath}`, {
+      [streamId]: {
+        0: ['missing.tex'],
+      },
+    });
+
+    await storage.update(`texra.usageStats.${workspacePath}`, {
+      [streamId]: usage,
+    });
+
+    storage.saved.length = 0;
+
+    try {
+      await state.load();
+    } finally {
+      (vscode.workspace as any).workspaceFolders = originalWorkspaceFolders;
+    }
+
+    const messages = state.streamTabs.getMessages(streamId);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].text, 'legacy message');
+
+    const restoredGroup = state.taskGroups.getGroup(streamId, groupId);
+    assert.ok(restoredGroup);
+    assert.equal(restoredGroup!.name, 'Legacy group');
+
+    const files = state.outputFiles.getFiles(streamId);
+    const roundFiles = files.get(0);
+    assert.ok(roundFiles);
+    assert.equal(roundFiles![0].path, 'out.tex');
+
+    const missing = state.outputFiles.getMissingOutputs(streamId);
+    const roundMissing = missing.get(0);
+    assert.ok(roundMissing);
+    assert.deepStrictEqual(roundMissing, ['missing.tex']);
+
+    const restoredUsage = state.usageStats.getStreamUsage(streamId);
+    assert.ok(restoredUsage);
+    assert.deepStrictEqual(restoredUsage, usage);
+
+    const savedKeys = storage.saved.map((entry) => entry.key);
+    assert.ok(savedKeys.includes(WorkspaceStateKey.STREAM_TABS));
+    assert.ok(savedKeys.includes(WorkspaceStateKey.TASK_GROUPS));
+    assert.ok(savedKeys.includes(WorkspaceStateKey.OUTPUT_FILES));
+    assert.ok(savedKeys.includes(WorkspaceStateKey.MISSING_OUTPUTS));
+    assert.ok(savedKeys.includes(WorkspaceStateKey.USAGE_STATS));
+
+    assert.ok(
+      savedKeys.includes(`texra.logStreams.${workspacePath}`),
+      'expected legacy stream key to be cleared',
+    );
+    assert.ok(
+      savedKeys.includes(`texra.logGroups.${workspacePath}`),
+      'expected legacy group key to be cleared',
+    );
+    assert.ok(
+      savedKeys.includes(`texra.outputFiles.${workspacePath}`),
+      'expected legacy output key to be cleared',
+    );
+    assert.ok(
+      savedKeys.includes(`texra.missingOutputs.${workspacePath}`),
+      'expected legacy missing output key to be cleared',
+    );
+    assert.ok(
+      savedKeys.includes(`texra.usageStats.${workspacePath}`),
+      'expected legacy usage key to be cleared',
     );
   });
 });


### PR DESCRIPTION
## Summary
- migrate persistent map managers to probe workspace-scoped legacy keys and resave canonical entries
- configure stream and task managers with legacy key roots and migrate missing-output workspace state
- cover the migration path with a regression test that seeds 0.34.3-style storage payloads

## Testing
- npm run compile-tests
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f701804c0832492ee366383f51d10)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds migration and fallback loading for legacy workspace-scoped progress view storage across managers, plus regression tests.
> 
> - **Persistence**:
>   - Add legacy migration in `PersistentMapManager` to read from `${root}.${workspacePath}` keys and resave under canonical `WorkspaceStateKey`.
>   - Support multiple legacy roots via constructor param.
> - **Managers**:
>   - `StreamTabsManager`, `TaskGroupManager`, `UsageStatsManager`: pass legacy roots (`texra.logStreams`, `texra.logGroups`, `texra.usageStats`).
>   - `OutputFilesManager`: migrate `MISSING_OUTPUTS` via workspace-scoped legacy key; refactor deserialization helpers.
> - **ProgressViewState**:
>   - Add `loadRecordWithLegacyFallback` for `TASK_STATES` and `EXECUTION_IDS`.
>   - Load/normalize legacy task states and execution IDs; clear legacy keys after migration.
> - **Tests**:
>   - Add regression test seeding legacy (0.34.3-style) data and verifying migration of logs, groups, outputs, missing outputs, usage, task states, and execution IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e78507a6bf19e29cdfcbc6b71ac561737355087. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->