### PR TITLE
fix: simplify OpenRouter handler integration

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -436,7 +436,9 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       let processedResponse: string | undefined;
       let bestConnector: string | undefined;
       if (newResponse) {
-        processedResponse = replacementEngine.applyAll(newResponse);
+        processedResponse = options.modelHandler.shouldApplyReplacementEngine()
+          ? replacementEngine.applyAll(newResponse)
+          : newResponse;
 
         if (!repetitionResult.massiveRepetitionDetected) {
           const connector = await bestConnectionMethod(

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -136,6 +136,11 @@ export abstract class ModelHandler<
     return this.outputStreaming;
   }
 
+  /** Indicates whether the replacement engine should transform responses. */
+  public shouldApplyReplacementEngine(): boolean {
+    return true;
+  }
+
   /**
    * Enables or disables Progress view updates.
    */

--- a/src/agent/modelHandlers/index.ts
+++ b/src/agent/modelHandlers/index.ts
@@ -11,9 +11,6 @@ export { ModelHandlerDeepSeek } from './modelHandlerDeepSeek';
 export { ModelHandlerXAI } from './modelHandlerXAI';
 export { ModelHandlerKimi } from './modelHandlerKimi';
 export { ModelHandlerDashScope } from './modelHandlerDashScope';
-export {
-  ModelHandlerOpenRouter,
-  ModelHandlerAnthropicViaOpenRouter,
-} from './modelHandlerOpenRouter';
+export { ModelHandlerOpenRouter } from './modelHandlerOpenRouter';
 export { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 export { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -33,6 +33,119 @@ import { K_SLICE } from '@utils/config';
  * Handler for models accessed through OpenRouter.
  */
 export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
+  override shouldApplyReplacementEngine(): boolean {
+    return false;
+  }
+
+  override async initializeMessages(
+    userPrefix: string,
+    userRequest: string,
+    _mediaFiles?: string[],
+    systemPrompt?: string,
+  ): Promise<any[]> {
+    return super.initializeMessages(
+      userPrefix,
+      userRequest,
+      undefined,
+      systemPrompt,
+    );
+  }
+
+  override async createRoundMessages(
+    messages: any[],
+    userMessage: string,
+    _mediaFiles?: string[],
+  ): Promise<any[]> {
+    return super.createRoundMessages(messages, userMessage, undefined);
+  }
+
+  override async createMediaMessage(_mediaFiles: string[]): Promise<any[]> {
+    return [];
+  }
+
+  override updateMessageContentWithPrefill(
+    messages: any[],
+    bestConnector: string,
+    newResponse: string,
+    toolState: AgentWorkspaceState,
+  ): void {
+    if (!this.config.capabilities.supportsAssistantPrefill) {
+      super.updateMessageContentWithPrefill(
+        messages,
+        bestConnector,
+        newResponse,
+        toolState,
+      );
+      return;
+    }
+
+    const lastMessage = messages.at(-1);
+    if (!lastMessage || lastMessage.role !== 'assistant') {
+      return;
+    }
+
+    if (Array.isArray(lastMessage.content)) {
+      const updatedText =
+        toolState.assembly?.accumulatedOutput ??
+        `${bestConnector}${newResponse}`;
+      const lastIndex = lastMessage.content.length - 1;
+      const lastPart = lastMessage.content.at(-1);
+      if (lastPart && typeof lastPart === 'object' && 'text' in lastPart) {
+        lastMessage.content[lastIndex] = {
+          ...lastPart,
+          text: updatedText,
+        };
+      } else {
+        lastMessage.content = [
+          ...lastMessage.content,
+          { type: 'text', text: updatedText },
+        ];
+      }
+      return;
+    }
+
+    if (typeof lastMessage.content === 'string') {
+      lastMessage.content = [
+        {
+          type: 'text',
+          text:
+            toolState.assembly?.accumulatedOutput ??
+            `${bestConnector}${newResponse}`,
+        },
+      ];
+    }
+  }
+
+  override updateMessageContentWithoutPrefill(
+    messages: any[],
+    bestConnector: string,
+    newResponse: string,
+    toolState: AgentWorkspaceState,
+  ): void {
+    if (this.config.capabilities.supportsAssistantPrefill) {
+      const lastMessage = messages.at(-1);
+      if (lastMessage?.role === 'user' || lastMessage?.role === 'system') {
+        messages.push({
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: toolState.assembly.accumulatedOutput,
+            },
+          ],
+        });
+      }
+      return;
+    }
+
+    super.updateMessageContentWithoutPrefill(
+      messages,
+      bestConnector,
+      newResponse,
+      toolState,
+    );
+  }
+
   override async getClient(): Promise<OpenAI> {
     const baseURL = this.getBaseUrl();
     const client = await createOpenRouterClient({
@@ -184,57 +297,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       `OpenRouter reasoning preview: ${reasoning.substring(0, K_SLICE)}...`,
     );
     return reasoning;
-  }
-}
-
-/**
- * Handler for Anthropic models using OpenAI-compatible API via OpenRouter.
- */
-export class ModelHandlerAnthropicViaOpenRouter extends ModelHandlerOpenRouter {
-  updateMessageContentWithPrefill(
-    messages: any[],
-    bestConnector: string,
-    newResponse: string,
-    toolState: AgentWorkspaceState,
-  ): void {
-    const lastMessage = messages.at(-1);
-    // although OpenAI models do not support assistant prefill, some models (such as Anthropic/DeepSeek perhaps?) via OpenRouter might do
-    if (lastMessage.role === 'assistant') {
-      if (Array.isArray(lastMessage.content)) {
-        const lastPart = lastMessage.content.at(-1);
-        if (lastPart && typeof lastPart === 'object' && 'text' in lastPart) {
-          lastPart.text = `${bestConnector}${newResponse}`;
-        }
-      } else if (typeof lastMessage.content === 'string') {
-        lastMessage.content = [
-          {
-            type: 'text',
-            text: toolState.assembly.accumulatedOutput,
-          },
-        ];
-      }
-    }
-  }
-
-  /** Updates message content for models with prefill support. */
-  updateMessageContentWithoutPrefill(
-    messages: any[],
-    bestConnector: string,
-    newResponse: string,
-    toolState: AgentWorkspaceState,
-  ): void {
-    const lastMessage = messages.at(-1);
-    if (lastMessage.role === 'user' || lastMessage.role === 'system') {
-      messages.push({
-        role: 'assistant',
-        content: [
-          {
-            type: 'text',
-            text: toolState.assembly.accumulatedOutput,
-          },
-        ],
-      });
-    }
   }
 }
 

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -51,6 +51,9 @@ export interface IModelHandler<
   /** Check if output streaming is enabled. */
   isOutputStreamingEnabled(): boolean;
 
+  /** Determine if the replacement engine should process responses. */
+  shouldApplyReplacementEngine(): boolean;
+
   /** Indicates if the model is served by Google. */
   readonly isGoogle: boolean;
 

--- a/src/agent/modelHandlers/utils/openRouterConversion.ts
+++ b/src/agent/modelHandlers/utils/openRouterConversion.ts
@@ -6,6 +6,42 @@ import type { ExtendedCompletionUsage } from '@agent/core/ResponseUsage';
 export type OpenRouterMessage = Record<string, unknown>;
 export type OpenRouterChatResponse = Record<string, any>;
 
+function normalizeContent(
+  content: ChatCompletionMessageParam['content'],
+): ChatCompletionMessageParam['content'] {
+  if (!Array.isArray(content)) {
+    return content ?? '';
+  }
+
+  return content.map((part: any) => {
+    if (!part || typeof part !== 'object') {
+      return part;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(part, 'image_url')) {
+      const { image_url, ...rest } = part as Record<string, unknown> & {
+        image_url?: unknown;
+      };
+      return {
+        ...rest,
+        imageUrl: image_url,
+      };
+    }
+
+    if (Object.prototype.hasOwnProperty.call(part, 'input_audio')) {
+      const { input_audio, ...rest } = part as Record<string, unknown> & {
+        input_audio?: unknown;
+      };
+      return {
+        ...rest,
+        inputAudio: input_audio,
+      };
+    }
+
+    return part;
+  });
+}
+
 export function convertMessagesToOpenRouter(
   messages: ChatCompletionMessageParam[],
 ): OpenRouterMessage[] {
@@ -13,7 +49,7 @@ export function convertMessagesToOpenRouter(
     if (message.role === 'assistant') {
       const payload: Record<string, unknown> = {
         role: 'assistant',
-        content: message.content ?? '',
+        content: normalizeContent(message.content),
       };
 
       const toolCalls = (message as any).tool_calls;
@@ -56,7 +92,7 @@ export function convertMessagesToOpenRouter(
 
     const base: Record<string, unknown> = {
       role: message.role,
-      content: message.content ?? '',
+      content: normalizeContent(message.content),
     };
 
     if (typeof (message as any).name === 'string') {
@@ -81,22 +117,37 @@ function toOpenAIContent(content: any): ChatCompletionMessageParam['content'] {
   }
 
   return content.map((part: any) => {
-    if (part?.type === 'text') {
-      return { type: 'text', text: part.text ?? '' };
+    if (!part || typeof part !== 'object') {
+      return part;
     }
 
-    if (part?.type === 'image_url') {
-      return { type: 'image_url', image_url: part.imageUrl ?? part.image_url };
-    }
-
-    if (part?.type === 'input_audio') {
+    if (
+      Object.prototype.hasOwnProperty.call(part, 'imageUrl') &&
+      !Object.prototype.hasOwnProperty.call(part, 'image_url')
+    ) {
+      const { imageUrl, ...rest } = part as Record<string, unknown> & {
+        imageUrl?: unknown;
+      };
       return {
-        type: 'input_audio',
-        input_audio: part.inputAudio ?? part.input_audio,
+        ...rest,
+        image_url: imageUrl,
       };
     }
 
-    return { type: 'text', text: '' };
+    if (
+      Object.prototype.hasOwnProperty.call(part, 'inputAudio') &&
+      !Object.prototype.hasOwnProperty.call(part, 'input_audio')
+    ) {
+      const { inputAudio, ...rest } = part as Record<string, unknown> & {
+        inputAudio?: unknown;
+      };
+      return {
+        ...rest,
+        input_audio: inputAudio,
+      };
+    }
+
+    return part;
   });
 }
 

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -8,7 +8,6 @@ import {
   ModelHandlerKimi,
   ModelHandlerDashScope,
   ModelHandlerOpenRouter,
-  ModelHandlerAnthropicViaOpenRouter,
   ModelHandlerOpenAI,
   ModelHandlerOpenAIResponse,
 } from '@agent/modelHandlers';
@@ -47,10 +46,6 @@ export class ModelFactory {
         config.openrouterFullName = `${config.provider}/${config.fullName}`;
       }
 
-      // Route to appropriate OpenRouter handler
-      if (config.provider === ModelProvider.ANTHROPIC) {
-        return new ModelHandlerAnthropicViaOpenRouter(config);
-      }
       return new ModelHandlerOpenRouter(config);
     }
 


### PR DESCRIPTION
## Summary
- disable replacement engine and inline media handling for OpenRouter sessions
- route Anthropic OpenRouter behavior through capability checks instead of a separate handler
- trim OpenRouter content conversion to minimal camelCase remapping

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5735bfe08324bf87c69e223647b7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables replacement engine for OpenRouter and streamlines OpenRouter message/content handling with capability-gated prefill, consolidated routing, and minimal camelCase remapping.
> 
> - **Model handling (OpenRouter)**:
>   - Disables replacement engine via `shouldApplyReplacementEngine()` override.
>   - Ignores inline media; uses base message builders without media.
>   - Capability-gated prefill updates for assistant messages; adds fallback assistant message when needed.
>   - Custom client initialization and streaming accumulation with reasoning support; converts responses to OpenAI format.
> - **Content conversion utils**:
>   - Add `normalizeContent` and improve `toOpenAIContent` for minimal camelCase remapping (`image_url`⇄`imageUrl`, `input_audio`⇄`inputAudio`).
>   - Update `convertMessagesToOpenRouter` to use normalized content; retain tool/metadata mapping; add streaming helpers.
> - **Core flow**:
>   - Gate replacement engine application in `ResponseCycleFlow` by `modelHandler.shouldApplyReplacementEngine()`.
> - **Base/interface**:
>   - Add `shouldApplyReplacementEngine()` (default true) to `ModelHandler` and `IModelHandler`.
> - **Factory/exports**:
>   - Remove `ModelHandlerAnthropicViaOpenRouter`; route all OpenRouter uses to `ModelHandlerOpenRouter` and update exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f31ad92a876bddde737e3291fe72152c858845fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->