### PR TITLE
feat: add instruction metadata to task groups

### DIFF
--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -20,6 +20,7 @@ export interface AgentExecutionContextInit {
 export class AgentExecutionContext {
   public readonly logger: AgentLogger;
   public readonly usageReporter: AgentUsageReporter;
+  private activeRootGroupId?: string;
 
   constructor(private readonly init: AgentExecutionContextInit) {
     this.logger = new AgentLogger(init.streamId, true);
@@ -32,6 +33,14 @@ export class AgentExecutionContext {
 
   get executionId(): ExecutionId | undefined {
     return this.init.executionId;
+  }
+
+  setActiveRootGroupId(groupId: string | undefined): void {
+    this.activeRootGroupId = groupId;
+  }
+
+  getActiveRootGroupId(): string | undefined {
+    return this.activeRootGroupId;
   }
 
   stage(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -44,6 +44,7 @@ import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { buildTaskGroupInstruction } from '@logger/utils/instructionMetadata';
 import { getStreamTabId } from '@/logger/streamUtils';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -386,9 +387,15 @@ export async function executeAgentWithLogging<T extends IAgent>(
       throw new Error(errorMsg);
     }
 
-    await logger.withScope(
-      `Task: ${agentName}@${config.model}`,
-      async () => {
+    const instructionMetadata = buildTaskGroupInstruction(
+      config.instruction ?? '',
+      executionId,
+    );
+
+    try {
+      await logger.withScope(
+        `Task: ${agentName}@${config.model}`,
+        async () => {
         try {
           await logger.withScope(
             `Task Details`,
@@ -469,6 +476,8 @@ export async function executeAgentWithLogging<T extends IAgent>(
                   streamTabId: activeStreamId,
                   executionId,
                   taskState: agentConfigToTaskState(config),
+                  taskGroupId: executionContext?.getActiveRootGroupId(),
+                  instruction: instructionMetadata,
                 });
                 logger.debug(`Task state stored for stream: ${activeStreamId}`);
               }
@@ -499,8 +508,15 @@ export async function executeAgentWithLogging<T extends IAgent>(
           throw err;
         }
       },
-      { skip: isResume },
-    );
+        {
+          skip: isResume,
+          instruction: instructionMetadata,
+          onStart: (groupId) => executionContext?.setActiveRootGroupId(groupId),
+        },
+      );
+    } finally {
+      executionContext?.setActiveRootGroupId(undefined);
+    }
   } catch (err) {
     const formattedError = formatProviderHttpError(err);
     const rawErrorMessage = err instanceof Error ? err.message : String(err);

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -12,6 +12,7 @@ import type {
   LogMessageData,
   LogMessageUpdate,
   TaskGroup,
+  TaskGroupInstruction,
 } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
 
@@ -35,6 +36,7 @@ interface AddTaskGroupPayload {
   status: TaskGroupStatus;
   endTime?: number;
   parentGroupId?: string;
+  instruction?: TaskGroupInstruction;
 }
 
 interface UpdateTaskGroupPayload {
@@ -53,6 +55,8 @@ interface SetTaskStatePayload {
   streamTabId: StreamTabId;
   executionId?: ExecutionId;
   taskState: TaskState;
+  taskGroupId?: string;
+  instruction?: TaskGroupInstruction;
 }
 
 export interface ProgressEventPayloads {
@@ -65,10 +69,12 @@ export interface ProgressEventPayloads {
   addOutputFiles: {
     stream: StreamTabId;
     filesByRound: { [key: number]: OutputFileInfo[] };
+    taskGroupId?: string;
   };
   updateMissingOutputs: {
     stream: StreamTabId;
     filesByRound: { [key: number]: string[] };
+    taskGroupId?: string;
   };
   clearMissingOutputs: StreamTabId;
   clearOutputFiles: StreamTabId;
@@ -77,9 +83,14 @@ export interface ProgressEventPayloads {
     stream: StreamTabId;
     groupId: string;
     usage: TokenUsageStats;
+    taskGroupId?: string;
   };
   clearTaskOutput: StreamTabId;
-  updateStreamUsage: { stream: StreamTabId; usage: TokenUsageStats };
+  updateStreamUsage: {
+    stream: StreamTabId;
+    usage: TokenUsageStats;
+    taskGroupId?: string;
+  };
 }
 
 export type ProgressEvent = keyof ProgressEventPayloads;

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -9,6 +9,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 import * as logger from './logUtils';
 import type { MessageType } from './messageTypes';
 import { MESSAGE_TYPES } from './messageTypes';
+import type { TaskGroupInstruction } from './LogTypes';
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 import { sleep } from '@utils/helpers';
 import { SHORT_SLEEP_MS } from '@utils/config';
@@ -25,6 +26,8 @@ export interface LoggerScopeOptions {
   successStatus?: 'stopped' | 'error';
   errorStatus?: 'stopped' | 'error';
   id?: string;
+  instruction?: TaskGroupInstruction;
+  onStart?: (groupId?: string) => void;
 }
 
 export interface AgentLoggerStageOptions extends LoggerScopeOptions {
@@ -337,12 +340,15 @@ export class AgentLogger {
       parentGroupId,
       id,
       parent,
+      instruction,
+      onStart,
     } = options as AgentLoggerStageOptions;
 
     const resolvedParent =
       parent?.id ?? parentGroupId ?? this.resolveActiveGroupId();
 
     if (skip) {
+      onStart?.(resolvedParent);
       return new AgentLogStageHandle(this, {
         id: undefined,
         skip: true,
@@ -352,7 +358,13 @@ export class AgentLogger {
       });
     }
 
-    const groupId = await this.startGroup(groupName, id, resolvedParent);
+    const groupId = await this.startGroup(
+      groupName,
+      id,
+      resolvedParent,
+      instruction,
+    );
+    onStart?.(groupId);
     return new AgentLogStageHandle(this, {
       id: groupId,
       skip: false,
@@ -455,6 +467,7 @@ export class AgentLogger {
     groupName: string,
     id?: string,
     parentGroupId?: string,
+    instruction?: TaskGroupInstruction,
   ): Promise<string> {
     await sleep(SHORT_SLEEP_MS);
     return logger.startGroup(
@@ -463,6 +476,7 @@ export class AgentLogger {
       id,
       parentGroupId,
       this.isAgentLogger,
+      instruction,
     );
   }
 

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -3,8 +3,21 @@
  */
 
 // Local imports
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { TaskGroupId, LogMessageId } from './types/EntityTypes';
+
+export interface InstructionHints {
+  showToggle?: boolean;
+  expanded?: boolean;
+}
+
+export interface TaskGroupInstruction {
+  text: string;
+  executionId?: ExecutionId;
+  updatedAt?: number;
+  hints?: InstructionHints;
+}
 
 export interface TaskGroup {
   /** Unique identifier for the group */
@@ -21,6 +34,8 @@ export interface TaskGroup {
   parentGroupId?: TaskGroupId;
   /** Optional usage stats attached to the group */
   usage?: TokenUsageStats;
+  /** Optional instruction metadata associated with the group */
+  instruction?: TaskGroupInstruction;
 }
 
 export interface LogMessageData {

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 // Local imports - logger
 import { registry } from './LogChannelRegistry';
 import type { MessageType } from './messageTypes';
+import type { TaskGroupInstruction } from './LogTypes';
 import type { VSCodeTransport } from './transports/VSCodeTransport';
 
 type ChannelKey = string;
@@ -158,11 +159,12 @@ export function startGroup(
   id?: string,
   parentGroupId?: string,
   isAgent = false,
+  instruction?: TaskGroupInstruction,
 ): string {
   const transport = getOrCreateTransport(channel, isAgent);
   const groupId = id ?? randomUUID();
   pushGroupContext(channel, groupId, isAgent);
-  return transport.startGroup(groupName, groupId, parentGroupId);
+  return transport.startGroup(groupName, groupId, parentGroupId, instruction);
 }
 
 export function endGroup(

--- a/src/logger/sinks/ProgressViewSink.ts
+++ b/src/logger/sinks/ProgressViewSink.ts
@@ -61,6 +61,7 @@ export class ProgressViewSink implements LogEventSink {
       status: 'running',
       endTime: undefined,
       parentGroupId: event.parentGroupId,
+      instruction: event.instruction,
     });
   }
 

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -4,6 +4,7 @@ import Transport from 'winston-transport';
 
 // Local imports - logger
 import { getColorForLevel } from '../utils/levelColors';
+import type { TaskGroupInstruction } from '@logger/LogTypes';
 import type {
   LogEventSink,
   LogGroupFinishedEvent,
@@ -27,6 +28,7 @@ interface TransportGroup {
   status: 'running' | 'error' | 'stopped';
   parentGroupId?: string;
   endTime?: number;
+  instruction?: TaskGroupInstruction;
 }
 
 export class VSCodeTransport extends Transport {
@@ -66,7 +68,12 @@ export class VSCodeTransport extends Transport {
     callback();
   }
 
-  startGroup(groupName: string, id: string, parentGroupId?: string): string {
+  startGroup(
+    groupName: string,
+    id: string,
+    parentGroupId?: string,
+    instruction?: TaskGroupInstruction,
+  ): string {
     const now = Date.now();
     const group: TransportGroup = {
       id,
@@ -74,6 +81,7 @@ export class VSCodeTransport extends Transport {
       startTime: now,
       status: 'running',
       parentGroupId,
+      instruction,
     };
     this.groups.set(id, group);
     this.activeGroupId = id;
@@ -84,6 +92,7 @@ export class VSCodeTransport extends Transport {
       groupName,
       startTime: now,
       parentGroupId,
+      instruction,
     });
 
     return id;

--- a/src/logger/types/LogEventSink.ts
+++ b/src/logger/types/LogEventSink.ts
@@ -2,6 +2,7 @@
 // (none)
 
 // Local imports - logger
+import type { TaskGroupInstruction } from '@logger/LogTypes';
 import type { MessageType } from '../messageTypes';
 
 export interface LogMessageEvent {
@@ -20,6 +21,7 @@ export interface LogGroupStartedEvent {
   groupName: string;
   startTime: number;
   parentGroupId?: string;
+  instruction?: TaskGroupInstruction;
 }
 
 export interface LogGroupFinishedEvent {

--- a/src/logger/utils/instructionMetadata.ts
+++ b/src/logger/utils/instructionMetadata.ts
@@ -1,0 +1,35 @@
+// Local imports - logger
+import type { InstructionHints, TaskGroupInstruction } from '@logger/LogTypes';
+
+export function computeInstructionHints(
+  text: string,
+): InstructionHints | undefined {
+  const normalized = text.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const lineCount = normalized.split(/\r?\n/).length;
+  if (lineCount <= 6 && normalized.length <= 600) {
+    return undefined;
+  }
+
+  return { showToggle: true };
+}
+
+export function buildTaskGroupInstruction(
+  text: string,
+  executionId?: string,
+): TaskGroupInstruction | undefined {
+  const normalized = text.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  return {
+    text: normalized,
+    executionId,
+    updatedAt: Date.now(),
+    hints: computeInstructionHints(normalized),
+  };
+}

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -93,9 +93,10 @@ export function createStreamStatusEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
-    const { streamTabId, executionId, taskState } = data;
+    const { streamTabId, executionId, taskState, taskGroupId, instruction } =
+      data;
 
-    state.setTaskState(streamTabId, taskState);
+    state.setTaskState(streamTabId, taskState, { taskGroupId, instruction });
     state.clearSessionKindHint(streamTabId);
 
     const normalizedState = state.getTaskState(streamTabId);

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -48,6 +48,7 @@ export function createTaskGroupEvents(
         status,
         endTime,
         parentGroupId,
+        instruction,
       } = data;
 
       const hasStream = state.streamTabs.has(stream);
@@ -63,6 +64,7 @@ export function createTaskGroupEvents(
         endTime,
         status,
         parentGroupId,
+        instruction,
       };
 
       await state.taskGroups.addGroup(stream, groupId, group);

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -22,6 +22,7 @@ import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
+import { computeInstructionHints } from '@logger/utils/instructionMetadata';
 import type { TaskState } from '@logger/TaskState';
 
 // Type aliases for status values
@@ -52,23 +53,12 @@ export class WebviewUpdater {
       return undefined;
     }
 
-    const metadata = WebviewUpdater.computeInstructionMetadata(normalized);
+    const metadata = computeInstructionHints(normalized);
     const payload: InstructionUpdate = { text: normalized };
     if (metadata) {
       payload.metadata = metadata;
     }
     return payload;
-  }
-
-  private static computeInstructionMetadata(
-    text: string,
-  ): InstructionUpdate['metadata'] | undefined {
-    const lineCount = text.split(/\r?\n/).length;
-    const shouldShowToggle = lineCount > 6 || text.length > 600;
-    if (!shouldShowToggle) {
-      return undefined;
-    }
-    return { showToggle: true };
   }
 
   /**

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -24,6 +24,7 @@ import {
   isToolUseTaskState,
   isWorkflowTaskState,
 } from '@logger/TaskState';
+import type { TaskGroupInstruction } from '@logger/LogTypes';
 import { getConfig } from '@utils/config';
 // Local imports - agents
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
@@ -61,6 +62,8 @@ export class ProgressViewState {
   private _agentTypeFilter: AgentFilter = 'all';
   private readonly taskStates = new Map<StreamTabId, TaskState>();
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
+  private readonly taskGroupIds = new Map<StreamTabId, string>();
+  private readonly taskGroupInstructions = new Map<StreamTabId, TaskGroupInstruction>();
   /**
    * Ephemeral session-kind hints keyed by stream ID.
    *
@@ -192,9 +195,26 @@ export class ProgressViewState {
   }
 
   // Task state management
-  setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
+  setTaskState(
+    streamTabId: StreamTabId,
+    taskState: TaskState,
+    metadata?: {
+      taskGroupId?: string;
+      instruction?: TaskGroupInstruction;
+    },
+  ): void {
     this.taskStates.set(streamTabId, cloneTaskState(taskState));
     this.clearSessionKindHint(streamTabId);
+    if (metadata?.taskGroupId) {
+      this.taskGroupIds.set(streamTabId, metadata.taskGroupId);
+    } else {
+      this.taskGroupIds.delete(streamTabId);
+    }
+    if (metadata?.instruction) {
+      this.taskGroupInstructions.set(streamTabId, metadata.instruction);
+    } else {
+      this.taskGroupInstructions.delete(streamTabId);
+    }
     this.saveTaskStates();
     this.cleanupToolUseAgentRegistry();
   }
@@ -204,6 +224,16 @@ export class ProgressViewState {
     return stored ? cloneTaskState(stored) : undefined;
   }
 
+  getTaskGroupId(streamTabId: StreamTabId): string | undefined {
+    return this.taskGroupIds.get(streamTabId);
+  }
+
+  getTaskGroupInstruction(
+    streamTabId: StreamTabId,
+  ): TaskGroupInstruction | undefined {
+    return this.taskGroupInstructions.get(streamTabId);
+  }
+
   clearTaskState(streamTabId: StreamTabId): void {
     const didDelete = this.taskStates.delete(streamTabId);
     this.clearSessionKindHint(streamTabId);
@@ -211,6 +241,8 @@ export class ProgressViewState {
       this.saveTaskStates();
       this.cleanupToolUseAgentRegistry();
     }
+    this.taskGroupIds.delete(streamTabId);
+    this.taskGroupInstructions.delete(streamTabId);
   }
 
   getAllTaskStates(): Map<StreamTabId, TaskState> {
@@ -248,6 +280,8 @@ export class ProgressViewState {
     const removedState = this.taskStates.delete(stream);
     this._executionIds.delete(stream);
     this.clearSessionKindHint(stream);
+    this.taskGroupIds.delete(stream);
+    this.taskGroupInstructions.delete(stream);
 
     // Update active stream if necessary
     if (this._activeStream === stream) {
@@ -290,6 +324,8 @@ export class ProgressViewState {
     this.taskStates.clear();
     this._executionIds.clear();
     this._sessionCategoryHints.clear();
+    this.taskGroupIds.clear();
+    this.taskGroupInstructions.clear();
     this._activeStream = '';
     this.saveActiveStream();
     this.saveTaskStates();

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -2,6 +2,7 @@
 import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
+import type { InstructionHints } from '@logger/LogTypes';
 
 export interface StreamUITraits {
   /** Canonical session grouping for the stream. */
@@ -29,10 +30,7 @@ export interface StreamTabInfo {
 
 export type AgentFilter = AgentTypeFilter;
 
-export interface InstructionMetadata {
-  showToggle?: boolean;
-  expanded?: boolean;
-}
+export interface InstructionMetadata extends InstructionHints {}
 
 export interface InstructionUpdate {
   text: string;


### PR DESCRIPTION
## Summary
- add explicit instruction metadata types to the logging pipeline and VS Code transport
- propagate root task group identifiers and instruction payloads through agent execution and progress events
- persist new metadata in progress view state and reuse shared instruction hint helpers for the webview

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' referenced by eslint.config.mjs)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f85a3ef0c832495316583e36f95e5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce instruction metadata for task groups and track root group IDs across execution, logging, events, and Progress view state/UI.
> 
> - **Logger**:
>   - Add `TaskGroupInstruction`/`InstructionHints` types; plumb `instruction` through `startGroup` (`AgentLogger`, `logUtils`, `VSCodeTransport`, `ProgressViewSink`, `LogEventSink`).
>   - Extend `withScope`/`stage` options with `instruction` and `onStart` to expose group ID on start.
>   - New helper `computeInstructionHints` and `buildTaskGroupInstruction`.
> - **Runtime**:
>   - `executeAgent` builds instruction metadata, passes to logger scope, captures root group via `onStart`, and emits `setTaskState` with `taskGroupId` and `instruction`.
>   - `AgentExecutionContext` now tracks active root group ID.
> - **Event Bus**:
>   - Extend payloads (`addTaskGroup`, `setTaskState`, `addOutputFiles`, `updateMissingOutputs`, `updateStreamUsage`, `updateGroupUsage`) with `taskGroupId` and/or `instruction`.
> - **Progress View**:
>   - State persists per-stream `taskGroupId` and `instruction`; handlers consume new fields; `WebviewUpdater` uses shared instruction hint helper; types updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85d3352331f376c13ec952a571158525aa05a8a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->