### PR TITLE
Add progress view run selector

### DIFF
--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -32,6 +32,7 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
     { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
     { key: 'eventsUri', path: 'modules/uiManagers/EventsManager.js' },
     { key: 'placeholderUri', path: 'modules/uiManagers/Placeholder.js' },
+    { key: 'runSelectorUri', path: 'modules/uiManagers/RunSelector.js' },
     {
       key: 'instructionPanelUri',
       path: 'modules/uiManagers/InstructionPanel.js',

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -46,6 +46,7 @@
           "./modules/uiManagers/FileList.js": "${fileListUri}",
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
           "./modules/uiManagers/Placeholder.js": "${placeholderUri}",
+          "./modules/uiManagers/RunSelector.js": "${runSelectorUri}",
           "./modules/uiManagers/InstructionPanel.js": "${instructionPanelUri}",
           "./modules/uiManagers/FollowUpInputManager.js": "${followUpInputManagerUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
@@ -89,6 +90,12 @@
           <div class="log-header">
             <div class="header-left">
               <span id="activeStreamName"></span>
+              <vscode-dropdown
+                id="runSelector"
+                class="run-selector"
+                aria-label="Select run"
+                hidden
+              ></vscode-dropdown>
               <span
                 id="statusIndicator"
                 class="status-indicator stopped"
@@ -353,9 +360,9 @@
             </details>
           </template>
           <template id="groupDetailsTemplate">
-            <details class="log-group">
+            <section class="log-group">
               <div class="log-group-content"></div>
-            </details>
+            </section>
           </template>
           <template id="groupHeaderTemplate">
             <summary class="log-group-header">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -26,6 +26,7 @@ export const ELEMENT_IDS = {
   GENERATED_FILES: 'generatedFiles',
   STREAM_TABS: 'streamTabs',
   ACTIVE_STREAM_NAME: 'activeStreamName',
+  RUN_SELECTOR: 'runSelector',
   STATUS_INDICATOR: 'statusIndicator',
   RUN_SUMMARY: 'runSummary',
   INSTRUCTION_CONTAINER: 'instructionContainer',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -8,6 +8,7 @@ import { FileList } from './uiManagers/FileList.js';
 import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Placeholder } from './uiManagers/Placeholder.js';
+import { RunSelector } from './uiManagers/RunSelector.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
 import { FollowUpInputManager } from './uiManagers/FollowUpInputManager.js';
 import { ApprovalRequests } from './uiManagers/ApprovalRequests.js';
@@ -22,6 +23,7 @@ import { vscode } from '@common/webviewContext.js';
 class ProgressViewDomHandler extends BaseDomHandler {
   constructor() {
     const usageSummary = new UsageSummary();
+    const runSelector = new RunSelector();
     super({
       streamTabs: new StreamTabs(),
       toolbar: new Toolbar(),
@@ -29,7 +31,8 @@ class ProgressViewDomHandler extends BaseDomHandler {
       usageSummary,
       usageGroup: new UsageGroupManager(usageSummary),
       fileList: new FileList(usageSummary),
-      taskGroups: new TaskGroupDomManager(),
+      runSelector,
+      taskGroups: new TaskGroupDomManager(runSelector),
       logEntries: new LogEntryManager(),
       events: new EventsManager(),
       placeholder: new Placeholder(),

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,5 +1,5 @@
 // Local imports - progress view
-import { COMMANDS, STATUS, ELEMENT_IDS } from './constants.js';
+import { COMMANDS, STATUS, ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
 import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
 import { createThemeHandlers } from './handlers/themeHandlers.js';
 import { appendFormatted } from './utils.js';
@@ -43,6 +43,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       ...createThemeHandlers(),
       ...this._createHandlers(),
     };
+    dom.runSelector.setOnRunChange((runId) =>
+      this._handleRunSelectionChange(runId),
+    );
   }
 
   /**
@@ -54,6 +57,47 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.placeholder.show();
     } else {
       dom.placeholder.hide();
+    }
+  }
+
+  _handleRunSelectionChange(runId) {
+    state.setActiveRun(runId || null);
+    dom.taskGroups.showRun(runId || null);
+    this._refreshInstructionForRun(runId);
+  }
+
+  _refreshInstructionForRun(runId) {
+    if (!runId) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const instruction = state.getRunInstruction(runId);
+    const text = instruction?.text ?? '';
+    const sessionKind = instruction?.sessionKind || 'workflow';
+
+    if (!text.trim() || sessionKind === 'toolUse') {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    dom.instructionPanel.show(text, instruction?.metadata);
+  }
+
+  _removeToolUseInstructionMessage(runId) {
+    if (!runId) {
+      return;
+    }
+    const runContent = document.getElementById(
+      `${GROUP_DOM_IDS.CONTENT_PREFIX}${runId}`,
+    );
+    const target =
+      runContent || document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const existingInstruction = target?.querySelector(
+      '.user-message-container[data-instruction="true"]',
+    );
+    if (existingInstruction) {
+      existingInstruction.remove();
     }
   }
 
@@ -170,9 +214,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (message.stream === state.activeStream) {
+      const previousRunId = state.getActiveRun();
       dom.taskGroups.clear();
       state.taskGroups.clear();
-      logContent.innerHTML = '';
+      state.clearRunInstructions();
+      state.setActiveRun(null);
+      if (logContent) {
+        logContent.innerHTML = '';
+      }
       if (message.groups && message.groups.length > 0) {
         const parentGroups = message.groups.filter((g) => !g.parentGroupId);
         const childGroups = message.groups.filter((g) => g.parentGroupId);
@@ -183,6 +232,18 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.addGroup(g));
       }
+      const runIds = dom.runSelector.getRunIds();
+      let nextRunId = null;
+      if (previousRunId && runIds.includes(previousRunId)) {
+        nextRunId = previousRunId;
+      } else if (runIds.length > 0) {
+        nextRunId = runIds[runIds.length - 1];
+      }
+      dom.runSelector.setActiveRun(nextRunId);
+      state.setActiveRun(nextRunId);
+      dom.taskGroups.showRun(nextRunId);
+      this._refreshInstructionForRun(nextRunId);
+
       const sortedMessages = [...message.messages].sort(
         (a, b) => a.timestamp - b.timestamp,
       );
@@ -212,6 +273,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     dom.taskGroups.clear();
     state.taskGroups.clear();
     state.toggleStates.clearSelection(groupIds);
+    state.clearRunInstructions();
+    state.setActiveRun(null);
+    dom.runSelector.setActiveRun(null);
+    dom.taskGroups.showRun(null);
+    dom.instructionPanel.hide();
     if (logContent) {
       logContent.innerHTML = '';
     }
@@ -274,6 +340,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       dom.taskGroups.addGroup(message.group);
+      if (!message.group.parentGroupId) {
+        const runId = message.group.id;
+        dom.runSelector.setActiveRun(runId);
+        state.setActiveRun(runId);
+        dom.taskGroups.showRun(runId);
+        this._refreshInstructionForRun(runId);
+      }
       scrollToBottom(logContent);
     }
   }
@@ -358,50 +431,68 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     const payload = message.instruction;
     const text = payload?.text ?? '';
+    const metadata = payload?.metadata ?? {};
+    const sessionKind = message.sessionKind || 'workflow';
+    const runId = state.getActiveRun() || dom.runSelector.getActiveRunId();
+
+    if (runId) {
+      if (!text.trim()) {
+        state.setRunInstruction(runId, null);
+        this._removeToolUseInstructionMessage(runId);
+      } else {
+        state.setRunInstruction(runId, {
+          text,
+          metadata,
+          sessionKind,
+        });
+      }
+    }
 
     if (!text.trim()) {
       dom.instructionPanel.hide();
       return;
     }
 
-    const sessionKind = message.sessionKind || 'workflow';
     const isToolUseAgent = sessionKind === 'toolUse';
 
     if (isToolUseAgent) {
       // For Tool Use agents, show instruction as a user message in chat
       dom.instructionPanel.hide();
 
-      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      if (logContent) {
-        // Check if instruction message already exists
-        const existingInstruction = logContent.querySelector(
+      const runContent = runId
+        ? document.getElementById(`${GROUP_DOM_IDS.CONTENT_PREFIX}${runId}`)
+        : document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+
+      if (runContent) {
+        const existingInstruction = runContent.querySelector(
           '.user-message-container[data-instruction="true"]',
         );
-        if (!existingInstruction) {
-          const userMessage = this._entryFormatter.format({
-            id: `instruction-${activeStream}`,
-            messageType: 'userMessage',
-            text: text,
-            timestamp: Date.now(),
-            groupId: undefined,
-          });
+        if (existingInstruction) {
+          existingInstruction.remove();
+        }
 
-          if (userMessage) {
-            userMessage.dataset.instruction = 'true';
-            // Insert at the beginning of the log content
-            if (logContent.firstChild) {
-              logContent.insertBefore(userMessage, logContent.firstChild);
-            } else {
-              logContent.appendChild(userMessage);
-            }
+        const userMessage = this._entryFormatter.format({
+          id: `instruction-${activeStream}`,
+          messageType: 'userMessage',
+          text,
+          timestamp: Date.now(),
+          groupId: runId,
+        });
+
+        if (userMessage) {
+          userMessage.dataset.instruction = 'true';
+          if (runContent.firstChild) {
+            runContent.insertBefore(userMessage, runContent.firstChild);
+          } else {
+            runContent.appendChild(userMessage);
           }
         }
       }
     } else {
       // For Workflow agents, show in instruction panel
-      const metadata = payload?.metadata ?? {};
-      dom.instructionPanel.show(text, metadata);
     }
+
+    this._refreshInstructionForRun(runId);
   }
 
   handleDeleteStream(message) {
@@ -411,6 +502,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       if (message.stream === state.activeStream) {
         const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
         state.toggleStates.clearSelection(groupIds);
+        state.clearRunInstructions();
+        state.setActiveRun(null);
+        dom.runSelector.setActiveRun(null);
+        dom.taskGroups.showRun(null);
         dom.instructionPanel.hide();
       }
     }
@@ -419,6 +514,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleDeleteAll() {
     state.toggleStates.clearAll();
     state.resetExecutionIdAvailability();
+    state.clearRunInstructions();
+    state.setActiveRun(null);
+    dom.runSelector.setActiveRun(null);
+    dom.taskGroups.showRun(null);
     dom.instructionPanel.hide();
   }
 

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -225,6 +225,8 @@ export class ProgressViewState {
     this.pendingFilterUpdate = false;
     this.currentGroupId = null;
     this.approvalBypassActive = false;
+    this.activeRunId = null;
+    this.runInstructions = new Map();
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
@@ -247,6 +249,36 @@ export class ProgressViewState {
 
   resetExecutionIdAvailability() {
     this.executionIdAvailability.clear();
+  }
+
+  setActiveRun(runId) {
+    this.activeRunId = runId ?? null;
+  }
+
+  getActiveRun() {
+    return this.activeRunId;
+  }
+
+  setRunInstruction(runId, instruction) {
+    if (!runId) {
+      return;
+    }
+    if (!instruction || !instruction.text?.trim()) {
+      this.runInstructions.delete(runId);
+      return;
+    }
+    this.runInstructions.set(runId, instruction);
+  }
+
+  getRunInstruction(runId) {
+    if (!runId) {
+      return undefined;
+    }
+    return this.runInstructions.get(runId);
+  }
+
+  clearRunInstructions() {
+    this.runInstructions.clear();
   }
 
   /** Load saved state from VS Code storage. */

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -10,11 +10,13 @@ import { createFromTemplate } from '@common/templateUtils.js';
  * Manages task group DOM operations.
  */
 export class TaskGroupDomManager {
-  constructor() {
+  constructor(runSelector) {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
     this.toggleListeners = new Map();
+    this.runSelector = runSelector || null;
+    this.runContainers = new Map();
   }
 
   /**
@@ -44,86 +46,157 @@ export class TaskGroupDomManager {
       }
     }
 
-    const detailsElem = createFromTemplate('groupDetailsTemplate');
-    if (!detailsElem) {
-      console.error(
-        'TaskGroupDomManager.addGroup: groupDetailsTemplate not found',
-      );
-      return;
-    }
-    detailsElem.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
-
-    const headerElement = this.headerFormatter.create(group);
-    if (!headerElement) {
-      console.error(
-        'TaskGroupDomManager.addGroup: failed to create group header',
-      );
-      detailsElem.remove();
-      return;
-    }
-
-    const groupContainer = detailsElem.querySelector('.log-group-content');
-    if (!groupContainer) {
-      console.error(
-        'TaskGroupDomManager.addGroup: missing group content container',
-      );
-      detailsElem.remove();
-      return;
-    }
-    groupContainer.id = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;
-
-    progressViewState.taskGroups.set(group.id, group);
-
-    const isCollapsed = progressViewState.toggleStates.get(group.id);
-    detailsElem.open = isCollapsed !== true;
-
-    detailsElem.prepend(headerElement);
-
-    const toggleListener = () => {
-      progressViewState.toggleStates.set(group.id, !detailsElem.open);
-    };
-    detailsElem.addEventListener('toggle', toggleListener);
-    this.toggleListeners.set(group.id, toggleListener);
-
-    this.groupElements.set(group.id, detailsElem);
-
-    // Insert the group at the right position in the parent
     const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (!container) {
       console.error(
         'TaskGroupDomManager.addGroup: missing log content container',
       );
-      this._removeToggleListener(group.id);
-      this.groupElements.delete(group.id);
       return;
     }
 
-    if (group.parentGroupId) {
-      const parentDetails = this.groupElements.get(group.parentGroupId);
-      const parentGroupContent =
-        parentDetails?.querySelector('.log-group-content');
-      if (parentGroupContent) {
-        insertChronologically({
-          container: parentGroupContent,
-          element: detailsElem,
-          timestamp: group.startTime,
-        });
+    progressViewState.taskGroups.set(group.id, group);
+
+    const isRootGroup = !group.parentGroupId;
+    let elementToInsert = null;
+
+    if (isRootGroup) {
+      const runElement = this._createRunContainer(group);
+      if (!runElement) {
         return;
       }
+
+      this.groupElements.set(group.id, runElement);
+      this.runContainers.set(group.id, runElement);
+      elementToInsert = runElement;
+    } else {
+      const detailsElem = this._createNestedGroupElement(group);
+      if (!detailsElem) {
+        return;
+      }
+
+      const toggleListener = () => {
+        progressViewState.toggleStates.set(group.id, !detailsElem.open);
+      };
+      detailsElem.addEventListener('toggle', toggleListener);
+      this.toggleListeners.set(group.id, toggleListener);
+
+      this.groupElements.set(group.id, detailsElem);
+      elementToInsert = detailsElem;
     }
 
-    // For top-level groups, insert in chronological order
+    if (isRootGroup) {
+      insertChronologically({
+        container,
+        element: elementToInsert,
+        timestamp: group.startTime,
+        getChildTimestamp: TaskGroupDomManager._getRunTimestamp,
+      });
+
+      if (this.runSelector) {
+        this.runSelector.registerRun({
+          id: group.id,
+          startTime: group.startTime,
+        });
+      }
+      return;
+    }
+
+    const parentContent = this._resolveParentContent(group.parentGroupId);
+    if (parentContent) {
+      insertChronologically({
+        container: parentContent,
+        element: elementToInsert,
+        timestamp: group.startTime,
+      });
+      return;
+    }
+
     insertChronologically({
       container,
-      element: detailsElem,
+      element: elementToInsert,
       timestamp: group.startTime,
     });
+  }
 
-    // For top-level groups, update current group and collapse the previous active group
-    if (!group.parentGroupId) {
-      progressViewState.currentGroupId = group.id;
-      this.collapsePreviousActiveGroup();
+  _createRunContainer(group) {
+    const runSection = createFromTemplate('groupDetailsTemplate');
+    if (!runSection) {
+      console.error(
+        'TaskGroupDomManager.addGroup: groupDetailsTemplate not found',
+      );
+      return null;
     }
+
+    runSection.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
+    runSection.classList.add('log-run');
+    runSection.dataset.runId = group.id;
+    if (group.startTime !== undefined && group.startTime !== null) {
+      runSection.dataset.runStart = String(group.startTime);
+    }
+    runSection.hidden = false;
+    runSection.setAttribute('aria-hidden', 'false');
+
+    const groupContainer = runSection.querySelector('.log-group-content');
+    if (!groupContainer) {
+      console.error(
+        'TaskGroupDomManager.addGroup: missing group content container',
+      );
+      runSection.remove();
+      return null;
+    }
+
+    groupContainer.id = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;
+    groupContainer.dataset.groupId = group.id;
+    groupContainer.classList.add('log-run-content');
+
+    return runSection;
+  }
+
+  _createNestedGroupElement(group) {
+    const headerElement = this.headerFormatter.create(group);
+    if (!headerElement) {
+      console.error(
+        'TaskGroupDomManager.addGroup: failed to create group header',
+      );
+      return null;
+    }
+
+    const detailsElem = document.createElement('details');
+    detailsElem.classList.add('log-group');
+    detailsElem.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
+
+    const isCollapsed = progressViewState.toggleStates.get(group.id);
+    detailsElem.open = isCollapsed !== true;
+
+    detailsElem.appendChild(headerElement);
+
+    const contentContainer = document.createElement('div');
+    contentContainer.className = 'log-group-content';
+    contentContainer.id = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;
+    detailsElem.appendChild(contentContainer);
+
+    return detailsElem;
+  }
+
+  _resolveParentContent(parentGroupId) {
+    if (!parentGroupId) {
+      return null;
+    }
+    return document.getElementById(
+      `${GROUP_DOM_IDS.CONTENT_PREFIX}${parentGroupId}`,
+    );
+  }
+
+  static _getRunTimestamp(child) {
+    if (!child) {
+      return null;
+    }
+    const start = child.dataset?.runStart;
+    if (!start) {
+      return null;
+    }
+    const parsed = Number(start);
+    return Number.isNaN(parsed) ? null : parsed;
   }
 
   /**
@@ -167,6 +240,11 @@ export class TaskGroupDomManager {
 
     const detailsElem = this.groupElements.get(groupId);
     if (!detailsElem) {
+      return;
+    }
+
+    if (detailsElem.classList?.contains('log-run')) {
+      this.runContainers.set(groupId, detailsElem);
       return;
     }
 
@@ -233,7 +311,7 @@ export class TaskGroupDomManager {
 
     // Collapse this group
     const detailsElem = this.groupElements.get(groupId);
-    if (detailsElem) {
+    if (detailsElem && 'open' in detailsElem) {
       detailsElem.open = false;
       progressViewState.toggleStates.set(groupId, true);
     }
@@ -322,7 +400,28 @@ export class TaskGroupDomManager {
     }
     this.groupElements.clear();
     this.toggleListeners.clear();
+    this.runContainers.clear();
+    if (this.runSelector) {
+      this.runSelector.clear();
+    }
     this.previousActiveGroupId = null;
+  }
+
+  showRun(runId) {
+    if (this.runContainers.size === 0) {
+      return;
+    }
+
+    const activeId = runId || null;
+    for (const [id, element] of this.runContainers.entries()) {
+      if (!element) {
+        continue;
+      }
+      const shouldShow = !activeId || id === activeId;
+      element.hidden = !shouldShow;
+      element.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+      element.classList.toggle('is-active-run', shouldShow);
+    }
   }
 
   _removeToggleListener(groupId) {

--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -1,0 +1,244 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+
+// Local imports - shared helpers
+import { safeGetElementById } from '@common/domUtils.js';
+
+const DATETIME_FORMAT_OPTIONS = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+};
+
+/**
+ * Manages the dropdown that selects which run is visible in the log view.
+ */
+export class RunSelector {
+  constructor() {
+    this._dropdown = null;
+    this._runs = new Map();
+    this._orderedIds = [];
+    this._activeRunId = null;
+    this._changeHandler = null;
+    this._handleChange = this._onChange.bind(this);
+  }
+
+  _getDropdown() {
+    if (!this._dropdown) {
+      const dropdown = safeGetElementById(ELEMENT_IDS.RUN_SELECTOR);
+      if (!dropdown) {
+        return null;
+      }
+      dropdown.addEventListener('change', this._handleChange);
+      this._dropdown = dropdown;
+    }
+    return this._dropdown;
+  }
+
+  /**
+   * Register a run with the selector.
+   * @param {{ id: string, startTime: number }} run
+   */
+  registerRun(run) {
+    if (!run || !run.id) {
+      return;
+    }
+    this._runs.set(run.id, {
+      id: run.id,
+      startTime: run.startTime ?? Date.now(),
+    });
+    this._render();
+  }
+
+  /**
+   * Remove a run from the selector.
+   * @param {string} runId
+   */
+  removeRun(runId) {
+    if (!runId) {
+      return;
+    }
+    this._runs.delete(runId);
+    if (this._activeRunId === runId) {
+      this._activeRunId = null;
+    }
+    this._render();
+  }
+
+  /**
+   * Reset the selector to its initial state.
+   */
+  clear() {
+    this._runs.clear();
+    this._orderedIds = [];
+    this._activeRunId = null;
+    const dropdown = this._getDropdown();
+    if (dropdown) {
+      dropdown.innerHTML = '';
+      dropdown.hidden = true;
+      dropdown.value = '';
+      dropdown.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  /**
+   * Set a callback fired when the user selects a different run.
+   * @param {(runId: string | null) => void} handler
+   */
+  setOnRunChange(handler) {
+    this._changeHandler = typeof handler === 'function' ? handler : null;
+  }
+
+  /**
+   * Update the selected run.
+   * @param {string | null} runId
+   */
+  setActiveRun(runId) {
+    const dropdown = this._getDropdown();
+    if (!dropdown) {
+      this._activeRunId = runId ?? null;
+      return;
+    }
+
+    if (runId && !this._runs.has(runId)) {
+      this._activeRunId = null;
+      dropdown.value = '';
+      return;
+    }
+
+    this._activeRunId = runId ?? null;
+    dropdown.value = this._activeRunId ?? '';
+    this._syncVisibility();
+  }
+
+  /**
+   * Returns the currently selected run ID.
+   * @returns {string | null}
+   */
+  getActiveRunId() {
+    return this._activeRunId;
+  }
+
+  /**
+   * Returns true if the selector contains the provided run.
+   * @param {string} runId
+   */
+  hasRun(runId) {
+    return this._runs.has(runId);
+  }
+
+  /**
+   * Returns the latest (most recent) run ID.
+   * @returns {string | null}
+   */
+  getLatestRunId() {
+    if (this._orderedIds.length === 0) {
+      return null;
+    }
+    return this._orderedIds[this._orderedIds.length - 1];
+  }
+
+  getRunIds() {
+    return [...this._orderedIds];
+  }
+
+  _render() {
+    const dropdown = this._getDropdown();
+    if (!dropdown) {
+      return;
+    }
+
+    const runs = Array.from(this._runs.values()).sort(
+      (a, b) => (a.startTime || 0) - (b.startTime || 0),
+    );
+    this._orderedIds = runs.map((run) => run.id);
+
+    dropdown.innerHTML = '';
+
+    runs.forEach((run, index) => {
+      const option = document.createElement('vscode-option');
+      option.value = run.id;
+      option.textContent = this._formatLabel(index, run.startTime);
+      option.dataset.startTime = String(run.startTime ?? '');
+      dropdown.appendChild(option);
+    });
+
+    if (this._activeRunId && this._runs.has(this._activeRunId)) {
+      dropdown.value = this._activeRunId;
+    } else if (runs.length > 0) {
+      const latestId = runs[runs.length - 1].id;
+      this._activeRunId = latestId;
+      dropdown.value = latestId;
+    } else {
+      this._activeRunId = null;
+      dropdown.value = '';
+    }
+
+    this._syncVisibility();
+  }
+
+  _syncVisibility() {
+    const dropdown = this._dropdown;
+    if (!dropdown) {
+      return;
+    }
+    const hasRuns = this._runs.size > 0;
+    dropdown.hidden = !hasRuns;
+    dropdown.setAttribute('aria-hidden', hasRuns ? 'false' : 'true');
+  }
+
+  _formatLabel(index, startTime) {
+    const runNumber = index + 1;
+    const formattedTime = this._formatTime(startTime);
+    if (formattedTime) {
+      return `Run ${runNumber} — ${formattedTime}`;
+    }
+    return `Run ${runNumber}`;
+  }
+
+  _formatTime(time) {
+    if (!time) {
+      return '';
+    }
+    try {
+      const formatter = new Intl.DateTimeFormat(
+        undefined,
+        DATETIME_FORMAT_OPTIONS,
+      );
+      return formatter.format(new Date(time));
+    } catch (error) {
+      if (typeof time === 'number') {
+        return new Date(time).toISOString();
+      }
+      return String(time);
+    }
+  }
+
+  _onChange(event) {
+    const dropdown = event?.currentTarget;
+    if (!dropdown) {
+      return;
+    }
+    const newValue = dropdown.value || null;
+    this._activeRunId = newValue;
+    if (this._changeHandler) {
+      this._changeHandler(newValue);
+    }
+  }
+
+  /** Clean up event listeners. */
+  cleanup() {
+    if (this._dropdown) {
+      this._dropdown.removeEventListener('change', this._handleChange);
+    }
+    this._dropdown = null;
+    this._runs.clear();
+    this._orderedIds = [];
+    this._activeRunId = null;
+    this._changeHandler = null;
+  }
+}

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -54,6 +54,20 @@
   margin-left: var(--spacing-small);
 }
 
+.log-run {
+  margin: 0;
+  padding: 0;
+}
+
+.log-run[hidden] {
+  display: none !important;
+}
+
+.log-run-content {
+  padding-left: 0;
+  border-left: none;
+}
+
 .log-group-header.top-level .group-time {
   flex-grow: 1;
   margin-left: 0;

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -122,6 +122,16 @@
   margin-left: auto;
 }
 
+.run-selector {
+  min-width: 12rem;
+  max-width: 18rem;
+  flex-shrink: 0;
+}
+
+.run-selector[hidden] {
+  display: none;
+}
+
 .run-summary {
   opacity: var(--opacity-subtle);
 }


### PR DESCRIPTION
## Summary
- add a run selector dropdown to the progress view header and register its module with the content provider
- treat root task groups as runs so only the selected run stays visible while preserving nested log structure and per-run instructions
- store active run metadata in the progress view state and update message handling so instructions and logs follow the selected run, with styling updates for the new layout

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f92eb31a48324a5378e4596ac5e0c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a header run selector and treats root task groups as runs to toggle visible logs and instructions per selected run.
> 
> - **UI/Webview**:
>   - Add `vscode-dropdown` run selector in header (`index.html`), register `RunSelector` module in content provider and import map.
>   - Switch group container template to `<section class="log-group">` and expose run-specific containers.
> - **State**:
>   - Track `activeRunId` and per-run `runInstructions` in `ProgressViewState` with setters/getters and clearing.
> - **DOM/Managers**:
>   - Introduce `RunSelector` (`uiManagers/RunSelector.js`) to register runs, select active run, and emit changes.
>   - Update `TaskGroupDomManager` to treat root groups as runs (`log-run` containers), register runs, and `showRun(runId)` to toggle visibility.
>   - Wire `RunSelector` into `ProgressViewDomHandler` and `TaskGroupDomManager`.
> - **Message Handling**:
>   - Persist/restore active run across updates; on `UPDATE_LOGS`/`CLEAR_LOGS`/deletions, reset run state.
>   - Route instructions per run; for `toolUse`, inject user message into the active run content; for `workflow`, show in panel.
>   - Add helpers to refresh/hide instructions and remove injected tool-use instruction messages per run.
> - **Styles**:
>   - Add styles for `.run-selector`, `.log-run`, and `.log-run-content`; minor visibility and layout tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8aa542e93a8d7d5f33420f1dba15583a2a5c9913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->