### PR TITLE
Add run selector to progress view

### DIFF
--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -32,6 +32,7 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
     { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
     { key: 'eventsUri', path: 'modules/uiManagers/EventsManager.js' },
     { key: 'placeholderUri', path: 'modules/uiManagers/Placeholder.js' },
+    { key: 'runSelectorUri', path: 'modules/uiManagers/RunSelector.js' },
     {
       key: 'instructionPanelUri',
       path: 'modules/uiManagers/InstructionPanel.js',

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -46,6 +46,7 @@
           "./modules/uiManagers/FileList.js": "${fileListUri}",
           "./modules/uiManagers/EventsManager.js": "${eventsUri}",
           "./modules/uiManagers/Placeholder.js": "${placeholderUri}",
+          "./modules/uiManagers/RunSelector.js": "${runSelectorUri}",
           "./modules/uiManagers/InstructionPanel.js": "${instructionPanelUri}",
           "./modules/uiManagers/FollowUpInputManager.js": "${followUpInputManagerUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
@@ -88,7 +89,16 @@
         <div slot="start" class="content-area">
           <div class="log-header">
             <div class="header-left">
-              <span id="activeStreamName"></span>
+              <div class="stream-header">
+                <span id="activeStreamName"></span>
+                <vscode-dropdown
+                  id="runSelector"
+                  class="run-selector"
+                  aria-label="Select run"
+                  disabled
+                  hidden
+                ></vscode-dropdown>
+              </div>
               <span
                 id="statusIndicator"
                 class="status-indicator stopped"
@@ -353,9 +363,9 @@
             </details>
           </template>
           <template id="groupDetailsTemplate">
-            <details class="log-group">
+            <div class="log-group">
               <div class="log-group-content"></div>
-            </details>
+            </div>
           </template>
           <template id="groupHeaderTemplate">
             <summary class="log-group-header">

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -26,6 +26,7 @@ export const ELEMENT_IDS = {
   GENERATED_FILES: 'generatedFiles',
   STREAM_TABS: 'streamTabs',
   ACTIVE_STREAM_NAME: 'activeStreamName',
+  RUN_SELECTOR: 'runSelector',
   STATUS_INDICATOR: 'statusIndicator',
   RUN_SUMMARY: 'runSummary',
   INSTRUCTION_CONTAINER: 'instructionContainer',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -8,6 +8,7 @@ import { FileList } from './uiManagers/FileList.js';
 import { Status } from './uiManagers/Status.js';
 import { StreamTabs } from './uiManagers/StreamTabs.js';
 import { Placeholder } from './uiManagers/Placeholder.js';
+import { RunSelector } from './uiManagers/RunSelector.js';
 import { InstructionPanel } from './uiManagers/InstructionPanel.js';
 import { FollowUpInputManager } from './uiManagers/FollowUpInputManager.js';
 import { ApprovalRequests } from './uiManagers/ApprovalRequests.js';
@@ -22,6 +23,7 @@ import { vscode } from '@common/webviewContext.js';
 class ProgressViewDomHandler extends BaseDomHandler {
   constructor() {
     const usageSummary = new UsageSummary();
+    const runSelector = new RunSelector();
     super({
       streamTabs: new StreamTabs(),
       toolbar: new Toolbar(),
@@ -29,7 +31,8 @@ class ProgressViewDomHandler extends BaseDomHandler {
       usageSummary,
       usageGroup: new UsageGroupManager(usageSummary),
       fileList: new FileList(usageSummary),
-      taskGroups: new TaskGroupDomManager(),
+      runSelector,
+      taskGroups: new TaskGroupDomManager(runSelector),
       logEntries: new LogEntryManager(),
       events: new EventsManager(),
       placeholder: new Placeholder(),

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,5 +1,5 @@
 // Local imports - progress view
-import { COMMANDS, STATUS, ELEMENT_IDS } from './constants.js';
+import { COMMANDS, STATUS, ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
 import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
 import { createThemeHandlers } from './handlers/themeHandlers.js';
 import { appendFormatted } from './utils.js';
@@ -43,6 +43,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       ...createThemeHandlers(),
       ...this._createHandlers(),
     };
+    dom.runSelector.onDidChange((runId) =>
+      this._handleRunSelectionChange(runId),
+    );
   }
 
   /**
@@ -54,6 +57,32 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.placeholder.show();
     } else {
       dom.placeholder.hide();
+    }
+  }
+
+  _handleRunSelectionChange(runId) {
+    state.setActiveRunId(runId);
+    dom.taskGroups.showRun(runId);
+    this._refreshInstructionForActiveRun();
+  }
+
+  _refreshInstructionForActiveRun() {
+    if (state.activeSessionKind === 'toolUse') {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const activeRunId = state.getActiveRunId();
+    if (!activeRunId) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const instruction = state.getRunInstruction(activeRunId);
+    if (instruction && instruction.text) {
+      dom.instructionPanel.show(instruction.text, instruction.metadata);
+    } else {
+      dom.instructionPanel.hide();
     }
   }
 
@@ -144,6 +173,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       'workflow'; // Default fallback
     const isToolAgent = sessionKind === 'toolUse';
 
+    state.activeSessionKind = sessionKind;
+
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
     if (container) {
       container.classList.toggle('is-visible', isToolAgent);
@@ -161,10 +192,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (!message.activeStream) {
       dom.status.update(STATUS.READY);
       dom.instructionPanel.hide();
+      dom.runSelector.clear();
+      state.clearRunInstructions();
+      state.setActiveRunId(null);
     } else {
       const streamStatus = state.streamStatuses.get(message.activeStream);
       dom.status.update(streamStatus || STATUS.STOPPED);
     }
+
+    this._refreshInstructionForActiveRun();
   }
 
   handleUpdateLogs(message) {
@@ -172,6 +208,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream === state.activeStream) {
       dom.taskGroups.clear();
       state.taskGroups.clear();
+      state.clearRunInstructions();
+      const previousRunId = state.getActiveRunId();
+      state.setActiveRunId(null);
       logContent.innerHTML = '';
       if (message.groups && message.groups.length > 0) {
         const parentGroups = message.groups.filter((g) => !g.parentGroupId);
@@ -182,6 +221,21 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         childGroups
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.addGroup(g));
+
+        if (parentGroups.length > 0) {
+          const runIds = parentGroups.map((group) => group.id);
+          const preferredRun =
+            previousRunId && runIds.includes(previousRunId)
+              ? previousRunId
+              : runIds[runIds.length - 1];
+          state.setActiveRunId(preferredRun);
+          dom.runSelector.setActiveRun(preferredRun);
+          dom.taskGroups.showRun(preferredRun);
+        } else {
+          dom.taskGroups.showRun(null);
+        }
+      } else {
+        dom.taskGroups.showRun(null);
       }
       const sortedMessages = [...message.messages].sort(
         (a, b) => a.timestamp - b.timestamp,
@@ -201,6 +255,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
       // Recalculate cumulative usage after loading groups
       dom.usageSummary.update();
+      this._refreshInstructionForActiveRun();
     }
 
     this._updatePlaceholderVisibility();
@@ -212,9 +267,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     dom.taskGroups.clear();
     state.taskGroups.clear();
     state.toggleStates.clearSelection(groupIds);
+    state.clearRunInstructions();
+    state.setActiveRunId(null);
     if (logContent) {
       logContent.innerHTML = '';
     }
+
+    dom.instructionPanel.hide();
 
     this._updatePlaceholderVisibility();
   }
@@ -274,6 +333,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       dom.taskGroups.addGroup(message.group);
+      if (message.group && !message.group.parentGroupId) {
+        state.setActiveRunId(message.group.id);
+        state.clearRunInstruction(message.group.id);
+        dom.runSelector.setActiveRun(message.group.id);
+        dom.taskGroups.showRun(message.group.id);
+        this._refreshInstructionForActiveRun();
+      }
       scrollToBottom(logContent);
     }
   }
@@ -356,52 +422,72 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    const payload = message.instruction;
+    const payload = message.instruction || null;
     const text = payload?.text ?? '';
-
-    if (!text.trim()) {
-      dom.instructionPanel.hide();
-      return;
-    }
-
-    const sessionKind = message.sessionKind || 'workflow';
+    const metadata = payload?.metadata;
+    const sessionKind =
+      message.sessionKind || state.activeSessionKind || 'workflow';
     const isToolUseAgent = sessionKind === 'toolUse';
 
+    state.activeSessionKind = sessionKind;
+
+    const activeRunId =
+      state.getActiveRunId() || dom.runSelector.getActiveRunId();
+
+    if (activeRunId) {
+      if (typeof text === 'string' && text.trim()) {
+        state.setRunInstruction(activeRunId, { text, metadata });
+      } else {
+        state.clearRunInstruction(activeRunId);
+      }
+    }
+
     if (isToolUseAgent) {
-      // For Tool Use agents, show instruction as a user message in chat
       dom.instructionPanel.hide();
+
+      if (!text || !text.trim()) {
+        this._refreshInstructionForActiveRun();
+        return;
+      }
 
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       if (logContent) {
-        // Check if instruction message already exists
-        const existingInstruction = logContent.querySelector(
+        const targetContentId = activeRunId
+          ? `${GROUP_DOM_IDS.CONTENT_PREFIX}${activeRunId}`
+          : null;
+        const targetContainer = targetContentId
+          ? document.getElementById(targetContentId)
+          : logContent;
+        const scope = targetContainer || logContent;
+
+        const existingInstruction = scope.querySelector(
           '.user-message-container[data-instruction="true"]',
         );
+
         if (!existingInstruction) {
           const userMessage = this._entryFormatter.format({
-            id: `instruction-${activeStream}`,
+            id: `instruction-${activeStream}-${activeRunId || 'default'}`,
             messageType: 'userMessage',
-            text: text,
+            text,
             timestamp: Date.now(),
-            groupId: undefined,
+            groupId: activeRunId || undefined,
           });
 
           if (userMessage) {
             userMessage.dataset.instruction = 'true';
-            // Insert at the beginning of the log content
-            if (logContent.firstChild) {
-              logContent.insertBefore(userMessage, logContent.firstChild);
+            if (scope.firstChild) {
+              scope.insertBefore(userMessage, scope.firstChild);
             } else {
-              logContent.appendChild(userMessage);
+              scope.appendChild(userMessage);
             }
           }
         }
       }
-    } else {
-      // For Workflow agents, show in instruction panel
-      const metadata = payload?.metadata ?? {};
-      dom.instructionPanel.show(text, metadata);
+
+      return;
     }
+
+    this._refreshInstructionForActiveRun();
   }
 
   handleDeleteStream(message) {
@@ -412,6 +498,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
         state.toggleStates.clearSelection(groupIds);
         dom.instructionPanel.hide();
+        state.clearRunInstructions();
+        state.setActiveRunId(null);
+        dom.runSelector.clear();
       }
     }
   }
@@ -420,6 +509,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.toggleStates.clearAll();
     state.resetExecutionIdAvailability();
     dom.instructionPanel.hide();
+    state.clearRunInstructions();
+    state.setActiveRunId(null);
+    dom.runSelector.clear();
   }
 
   handleFollowUpTextPolished(message) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -225,6 +225,9 @@ export class ProgressViewState {
     this.pendingFilterUpdate = false;
     this.currentGroupId = null;
     this.approvalBypassActive = false;
+    this.activeRunId = null;
+    this.activeSessionKind = 'workflow';
+    this.runInstructions = new Map();
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
@@ -266,6 +269,49 @@ export class ProgressViewState {
     } catch (e) {
       console.error('Failed to save state:', e);
     }
+  }
+
+  setActiveRunId(runId) {
+    this.activeRunId = runId || null;
+  }
+
+  getActiveRunId() {
+    return this.activeRunId;
+  }
+
+  setRunInstruction(runId, instruction) {
+    if (!runId) {
+      return;
+    }
+    const text = instruction?.text ?? '';
+    if (typeof text !== 'string' || !text.trim()) {
+      this.runInstructions.delete(runId);
+      return;
+    }
+
+    const normalizedInstruction = {
+      text,
+      metadata: instruction?.metadata,
+    };
+    this.runInstructions.set(runId, normalizedInstruction);
+  }
+
+  clearRunInstruction(runId) {
+    if (!runId) {
+      return;
+    }
+    this.runInstructions.delete(runId);
+  }
+
+  getRunInstruction(runId) {
+    if (!runId) {
+      return null;
+    }
+    return this.runInstructions.get(runId) || null;
+  }
+
+  clearRunInstructions() {
+    this.runInstructions.clear();
   }
 }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -10,11 +10,12 @@ import { createFromTemplate } from '@common/templateUtils.js';
  * Manages task group DOM operations.
  */
 export class TaskGroupDomManager {
-  constructor() {
+  constructor(runSelector) {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
     this.toggleListeners = new Map();
+    this.runSelector = runSelector || null;
   }
 
   /**
@@ -33,59 +34,78 @@ export class TaskGroupDomManager {
         this.groupElements.delete(group.id);
       } else {
         progressViewState.taskGroups.set(group.id, group);
-        this.updateGroup({
-          groupId: group.id,
-          updates: {
-            status: group.status,
-            endTime: group.endTime,
-          },
-        });
+        if (!group.parentGroupId) {
+          this.runSelector?.addRun(group);
+        } else {
+          this.updateGroup({
+            groupId: group.id,
+            updates: {
+              status: group.status,
+              endTime: group.endTime,
+            },
+          });
+        }
         return;
       }
     }
 
-    const detailsElem = createFromTemplate('groupDetailsTemplate');
-    if (!detailsElem) {
+    const baseGroupElement = createFromTemplate('groupDetailsTemplate');
+    if (!baseGroupElement) {
       console.error(
         'TaskGroupDomManager.addGroup: groupDetailsTemplate not found',
       );
       return;
     }
-    detailsElem.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
 
-    const headerElement = this.headerFormatter.create(group);
-    if (!headerElement) {
-      console.error(
-        'TaskGroupDomManager.addGroup: failed to create group header',
-      );
-      detailsElem.remove();
-      return;
-    }
-
-    const groupContainer = detailsElem.querySelector('.log-group-content');
+    const groupContainer = baseGroupElement.querySelector('.log-group-content');
     if (!groupContainer) {
       console.error(
         'TaskGroupDomManager.addGroup: missing group content container',
       );
-      detailsElem.remove();
+      baseGroupElement.remove();
       return;
     }
     groupContainer.id = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;
 
+    const isRootGroup = !group.parentGroupId;
+    let detailsElem = null;
+
+    if (isRootGroup) {
+      detailsElem = baseGroupElement;
+      detailsElem.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
+      detailsElem.classList.add('log-run');
+    } else {
+      const headerElement = this.headerFormatter.create(group);
+      if (!headerElement) {
+        console.error(
+          'TaskGroupDomManager.addGroup: failed to create group header',
+        );
+        baseGroupElement.remove();
+        return;
+      }
+
+      detailsElem = document.createElement('details');
+      detailsElem.className = 'log-group';
+      detailsElem.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
+      detailsElem.appendChild(headerElement);
+      detailsElem.appendChild(groupContainer);
+
+      const isCollapsed = progressViewState.toggleStates.get(group.id);
+      detailsElem.open = isCollapsed !== true;
+
+      const toggleListener = () => {
+        progressViewState.toggleStates.set(group.id, !detailsElem.open);
+      };
+      detailsElem.addEventListener('toggle', toggleListener);
+      this.toggleListeners.set(group.id, toggleListener);
+    }
+
     progressViewState.taskGroups.set(group.id, group);
-
-    const isCollapsed = progressViewState.toggleStates.get(group.id);
-    detailsElem.open = isCollapsed !== true;
-
-    detailsElem.prepend(headerElement);
-
-    const toggleListener = () => {
-      progressViewState.toggleStates.set(group.id, !detailsElem.open);
-    };
-    detailsElem.addEventListener('toggle', toggleListener);
-    this.toggleListeners.set(group.id, toggleListener);
-
     this.groupElements.set(group.id, detailsElem);
+
+    if (isRootGroup && this.runSelector) {
+      this.runSelector.addRun(group);
+    }
 
     // Insert the group at the right position in the parent
     const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
@@ -119,7 +139,6 @@ export class TaskGroupDomManager {
       timestamp: group.startTime,
     });
 
-    // For top-level groups, update current group and collapse the previous active group
     if (!group.parentGroupId) {
       progressViewState.currentGroupId = group.id;
       this.collapsePreviousActiveGroup();
@@ -215,6 +234,24 @@ export class TaskGroupDomManager {
     }
 
     progressViewState.taskGroups.set(groupId, group);
+  }
+
+  showRun(groupId) {
+    const hasTarget = Boolean(groupId && this.groupElements.has(groupId));
+
+    for (const [id, element] of this.groupElements.entries()) {
+      if (!element) {
+        continue;
+      }
+
+      const group = progressViewState.taskGroups.get(id);
+      if (!group || group.parentGroupId) {
+        continue;
+      }
+
+      const shouldShow = hasTarget ? id === groupId : true;
+      element.hidden = !shouldShow;
+    }
   }
 
   /**
@@ -323,6 +360,9 @@ export class TaskGroupDomManager {
     this.groupElements.clear();
     this.toggleListeners.clear();
     this.previousActiveGroupId = null;
+    if (this.runSelector) {
+      this.runSelector.clear();
+    }
   }
 
   _removeToggleListener(groupId) {

--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -16,20 +16,34 @@ export class RunSelector {
   constructor() {
     this._dropdown = null;
     this._options = new Map();
+    this._pendingRuns = new Map();
+    this._pendingActiveRunId = null;
     this._onDidChange = null;
     this._changeHandler = this._handleChange.bind(this);
+    this._domReadyHandler = null;
   }
 
   _getDropdown() {
-    if (!this._dropdown) {
-      const dropdown = safeGetElementById(ELEMENT_IDS.RUN_SELECTOR);
-      if (!dropdown) {
-        return null;
+    if (this._dropdown) {
+      const body = document.body;
+      if (body && body.contains(this._dropdown)) {
+        return this._dropdown;
       }
+      this._dropdown = null;
+    }
+
+    const dropdown = safeGetElementById(ELEMENT_IDS.RUN_SELECTOR);
+    if (dropdown) {
       dropdown.addEventListener('change', this._changeHandler);
       this._dropdown = dropdown;
+      this._flushPendingRuns();
+      this._applyPendingActiveRun();
+      this._syncVisibility();
+      return this._dropdown;
     }
-    return this._dropdown;
+
+    this._scheduleDomReadyCheck();
+    return null;
   }
 
   _handleChange() {
@@ -51,28 +65,30 @@ export class RunSelector {
   }
 
   addRun(group) {
-    const dropdown = this._getDropdown();
-    if (!dropdown || !group || !group.id) {
+    if (!group || !group.id) {
       return;
     }
 
-    const label = this._formatRunLabel(group);
-
-    let option = this._options.get(group.id);
-    if (!option) {
-      option = document.createElement('vscode-option');
-      option.value = group.id;
-      dropdown.appendChild(option);
-      this._options.set(group.id, option);
+    const dropdown = this._getDropdown();
+    if (!dropdown) {
+      this._pendingRuns.set(group.id, group);
+      return;
     }
 
-    option.textContent = label;
+    this._createOrUpdateOption(group);
     this._syncVisibility();
   }
 
   setRuns(groups = []) {
     const dropdown = this._getDropdown();
     if (!dropdown) {
+      this._options.clear();
+      this._pendingRuns.clear();
+      groups.forEach((group) => {
+        if (group?.id) {
+          this._pendingRuns.set(group.id, group);
+        }
+      });
       return;
     }
 
@@ -85,8 +101,11 @@ export class RunSelector {
   setActiveRun(groupId) {
     const dropdown = this._getDropdown();
     if (!dropdown) {
+      this._pendingActiveRunId = groupId || null;
       return;
     }
+
+    this._pendingActiveRunId = null;
 
     if (groupId && this._options.has(groupId)) {
       dropdown.value = groupId;
@@ -103,7 +122,7 @@ export class RunSelector {
   getActiveRunId() {
     const dropdown = this._getDropdown();
     if (!dropdown) {
-      return null;
+      return this._pendingActiveRunId || null;
     }
 
     const value = dropdown.value;
@@ -111,8 +130,17 @@ export class RunSelector {
   }
 
   removeRun(groupId) {
+    if (!groupId) {
+      return;
+    }
+
     const dropdown = this._getDropdown();
-    if (!dropdown || !groupId) {
+    if (!dropdown) {
+      this._pendingRuns.delete(groupId);
+      this._options.delete(groupId);
+      if (this._pendingActiveRunId === groupId) {
+        this._pendingActiveRunId = null;
+      }
       return;
     }
 
@@ -130,8 +158,11 @@ export class RunSelector {
     if (dropdown) {
       dropdown.innerHTML = '';
       dropdown.value = '';
+    } else {
+      this._pendingRuns.clear();
     }
     this._options.clear();
+    this._pendingActiveRunId = null;
     this._syncVisibility();
   }
 
@@ -172,7 +203,7 @@ export class RunSelector {
 
     const hasRuns = this._options.size > 0;
     dropdown.disabled = !hasRuns;
-    dropdown.hidden = !hasRuns;
+    dropdown.toggleAttribute('hidden', !hasRuns);
     dropdown.setAttribute('aria-hidden', hasRuns ? 'false' : 'true');
   }
 
@@ -180,8 +211,73 @@ export class RunSelector {
     if (this._dropdown) {
       this._dropdown.removeEventListener('change', this._changeHandler);
     }
+    if (this._domReadyHandler) {
+      document.removeEventListener('DOMContentLoaded', this._domReadyHandler);
+      this._domReadyHandler = null;
+    }
     this._dropdown = null;
     this._options.clear();
+    this._pendingRuns.clear();
+    this._pendingActiveRunId = null;
     this._onDidChange = null;
+  }
+
+  _createOrUpdateOption(group) {
+    if (!group || !group.id || !this._dropdown) {
+      return;
+    }
+
+    let option = this._options.get(group.id);
+    if (!option) {
+      option = document.createElement('vscode-option');
+      option.value = group.id;
+      this._dropdown.appendChild(option);
+      this._options.set(group.id, option);
+    }
+
+    option.textContent = this._formatRunLabel(group);
+  }
+
+  _flushPendingRuns() {
+    if (!this._dropdown || this._pendingRuns.size === 0) {
+      return;
+    }
+
+    const pending = Array.from(this._pendingRuns.values());
+    this._pendingRuns.clear();
+    pending.forEach((group) => this._createOrUpdateOption(group));
+  }
+
+  _applyPendingActiveRun() {
+    if (!this._dropdown) {
+      return;
+    }
+
+    if (this._pendingActiveRunId) {
+      this.setActiveRun(this._pendingActiveRunId);
+    } else {
+      this._syncVisibility();
+    }
+  }
+
+  _scheduleDomReadyCheck() {
+    if (this._domReadyHandler) {
+      return;
+    }
+
+    this._domReadyHandler = () => {
+      this._domReadyHandler = null;
+      this._getDropdown();
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', this._domReadyHandler, {
+        once: true,
+      });
+    } else if (typeof queueMicrotask === 'function') {
+      queueMicrotask(this._domReadyHandler);
+    } else {
+      Promise.resolve().then(this._domReadyHandler);
+    }
   }
 }

--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -1,0 +1,187 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+// Local imports - shared helpers
+import { safeGetElementById } from '@common/domUtils.js';
+
+const RUN_LABEL_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+});
+
+/**
+ * Manages the run selector dropdown in the progress view header.
+ */
+export class RunSelector {
+  constructor() {
+    this._dropdown = null;
+    this._options = new Map();
+    this._onDidChange = null;
+    this._changeHandler = this._handleChange.bind(this);
+  }
+
+  _getDropdown() {
+    if (!this._dropdown) {
+      const dropdown = safeGetElementById(ELEMENT_IDS.RUN_SELECTOR);
+      if (!dropdown) {
+        return null;
+      }
+      dropdown.addEventListener('change', this._changeHandler);
+      this._dropdown = dropdown;
+    }
+    return this._dropdown;
+  }
+
+  _handleChange() {
+    const dropdown = this._getDropdown();
+    if (!dropdown || !this._onDidChange) {
+      return;
+    }
+
+    const value = dropdown.value;
+    this._onDidChange(value || null);
+  }
+
+  onDidChange(callback) {
+    if (typeof callback === 'function') {
+      this._onDidChange = callback;
+    } else {
+      this._onDidChange = null;
+    }
+  }
+
+  addRun(group) {
+    const dropdown = this._getDropdown();
+    if (!dropdown || !group || !group.id) {
+      return;
+    }
+
+    const label = this._formatRunLabel(group);
+
+    let option = this._options.get(group.id);
+    if (!option) {
+      option = document.createElement('vscode-option');
+      option.value = group.id;
+      dropdown.appendChild(option);
+      this._options.set(group.id, option);
+    }
+
+    option.textContent = label;
+    this._syncVisibility();
+  }
+
+  setRuns(groups = []) {
+    const dropdown = this._getDropdown();
+    if (!dropdown) {
+      return;
+    }
+
+    dropdown.innerHTML = '';
+    this._options.clear();
+    groups.forEach((group) => this.addRun(group));
+    this._syncVisibility();
+  }
+
+  setActiveRun(groupId) {
+    const dropdown = this._getDropdown();
+    if (!dropdown) {
+      return;
+    }
+
+    if (groupId && this._options.has(groupId)) {
+      dropdown.value = groupId;
+    } else if (this._options.size > 0) {
+      const firstKey = this._options.keys().next().value;
+      dropdown.value = firstKey ?? '';
+    } else {
+      dropdown.value = '';
+    }
+
+    this._syncVisibility();
+  }
+
+  getActiveRunId() {
+    const dropdown = this._getDropdown();
+    if (!dropdown) {
+      return null;
+    }
+
+    const value = dropdown.value;
+    return value || null;
+  }
+
+  removeRun(groupId) {
+    const dropdown = this._getDropdown();
+    if (!dropdown || !groupId) {
+      return;
+    }
+
+    const option = this._options.get(groupId);
+    if (option) {
+      option.remove();
+      this._options.delete(groupId);
+    }
+
+    this._syncVisibility();
+  }
+
+  clear() {
+    const dropdown = this._getDropdown();
+    if (dropdown) {
+      dropdown.innerHTML = '';
+      dropdown.value = '';
+    }
+    this._options.clear();
+    this._syncVisibility();
+  }
+
+  _formatRunLabel(group) {
+    const name = typeof group.name === 'string' ? group.name.trim() : '';
+    const timestamp = this._formatTimestamp(group.startTime);
+
+    if (name && timestamp) {
+      return `${name} • ${timestamp}`;
+    }
+    if (name) {
+      return name;
+    }
+    if (timestamp) {
+      return `Run • ${timestamp}`;
+    }
+    return 'Run';
+  }
+
+  _formatTimestamp(value) {
+    if (!value) {
+      return '';
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+
+    return RUN_LABEL_TIME_FORMATTER.format(date);
+  }
+
+  _syncVisibility() {
+    const dropdown = this._getDropdown();
+    if (!dropdown) {
+      return;
+    }
+
+    const hasRuns = this._options.size > 0;
+    dropdown.disabled = !hasRuns;
+    dropdown.hidden = !hasRuns;
+    dropdown.setAttribute('aria-hidden', hasRuns ? 'false' : 'true');
+  }
+
+  cleanup() {
+    if (this._dropdown) {
+      this._dropdown.removeEventListener('change', this._changeHandler);
+    }
+    this._dropdown = null;
+    this._options.clear();
+    this._onDidChange = null;
+  }
+}

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -92,7 +92,7 @@ export class UsageGroupManager {
         return;
       }
       // Determine the group level by checking for the 'top-level' class
-      const level = groupHeader.classList.contains('top-level')
+      const level = groupHeader?.classList?.contains('top-level')
         ? TaskGroupLevel.ROOT
         : TaskGroupLevel.NESTED;
       this.insertUsageElement(groupHeader, usageElem, level);

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -39,6 +39,15 @@
     var(--vscode-editorGroupHeader-tabsBorder);
 }
 
+.log-run {
+  border: none;
+}
+
+.log-run > .log-group-content {
+  padding-left: 0;
+  border-left: none;
+}
+
 .group-status-icon {
   margin-right: var(--spacing-small);
 }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -110,6 +110,24 @@
   min-width: 0;
 }
 
+.stream-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  min-width: 0;
+}
+
+.stream-header #activeStreamName {
+  flex: 1;
+  min-width: 0;
+}
+
+.run-selector {
+  min-width: 160px;
+  max-width: 220px;
+  flex-shrink: 0;
+}
+
 #activeStreamName,
 #runSummary {
   overflow: hidden;


### PR DESCRIPTION
## Summary
- add a run selector dropdown to the progress view header and hide root task banners
- introduce a RunSelector UI manager and update task/message/state managers to track runs and per-run instructions
- adjust styles to support the new header layout and visible log groups

## Testing
- npm run compile
- npm run lint
- npm test *(fails: command aborted due to console output limits)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f92eb31a48324a5378e4596ac5e0c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a run selector dropdown to the progress view, tracks active runs and per-run instructions, and updates DOM structure and styles to show/hide runs and instructions appropriately.
> 
> - **UI/Frontend**:
>   - **Run Selector**: Add `vscode-dropdown#runSelector` to header; new `RunSelector` manager (`modules/uiManagers/RunSelector.js`) with option management and change events.
>   - **DOM Structure**: Root groups rendered as `.log-run` containers (no `<details>`); group template adjusted; header layout updated with `.stream-header`.
>   - **Styles**: New styles for `.log-run`, run selector, and header layout adjustments.
> - **State/Logic**:
>   - **State**: Track `activeRunId`, `activeSessionKind`, and per-run `runInstructions` in `ProgressViewState` with getters/setters and clearing helpers.
>   - **Task Groups**: `TaskGroupDomManager` integrates with `RunSelector`, adds `showRun(groupId)`, handles root vs nested groups, and clears selector on reset.
>   - **Message Handling**: `ProgressViewMessageHandler` wires run selector changes, manages active run on updates, clears/sets runs on log updates, and refreshes/hides the instruction panel based on session kind; tool-use instructions rendered as user messages within the appropriate run.
>   - **Constants/Plumbing**: Add `ELEMENT_IDS.RUN_SELECTOR`, export `GROUP_DOM_IDS`, import/map `RunSelector` in content provider and HTML import map.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f391d46c21b6dcc8d857bb131087750d72fcba74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->