### PR TITLE
feat: add run selector to progress view

### DIFF
--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -40,6 +40,7 @@ export class ProgressViewContentProvider extends BaseViewContentProvider {
       key: 'followUpInputManagerUri',
       path: 'modules/uiManagers/FollowUpInputManager.js',
     },
+    { key: 'runSelectorUri', path: 'modules/uiManagers/RunSelector.js' },
   ];
 
   protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -48,6 +48,7 @@
           "./modules/uiManagers/Placeholder.js": "${placeholderUri}",
           "./modules/uiManagers/InstructionPanel.js": "${instructionPanelUri}",
           "./modules/uiManagers/FollowUpInputManager.js": "${followUpInputManagerUri}",
+          "./modules/uiManagers/RunSelector.js": "${runSelectorUri}",
           "./modules/handlers/themeHandlers.js": "${themeHandlersUri}",
           "./modules/katexMacros.js": "${katexMacrosUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
@@ -94,7 +95,17 @@
                 class="status-indicator stopped"
                 data-status="Ready"
               ></span>
-              <span id="runSummary" class="run-summary"></span>
+              <div
+                id="runSelectorContainer"
+                class="run-selector-container"
+                hidden
+              >
+                <vscode-dropdown
+                  id="runSelector"
+                  class="run-selector__dropdown"
+                ></vscode-dropdown>
+                <span id="runSummary" class="run-summary"></span>
+              </div>
             </div>
             <vscode-toolbar-container
               id="toolbarContainer"

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -27,6 +27,8 @@ export const ELEMENT_IDS = {
   STREAM_TABS: 'streamTabs',
   ACTIVE_STREAM_NAME: 'activeStreamName',
   STATUS_INDICATOR: 'statusIndicator',
+  RUN_SELECTOR_CONTAINER: 'runSelectorContainer',
+  RUN_SELECTOR: 'runSelector',
   RUN_SUMMARY: 'runSummary',
   INSTRUCTION_CONTAINER: 'instructionContainer',
   INSTRUCTION_TEXT: 'instructionText',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -12,6 +12,7 @@ import { InstructionPanel } from './uiManagers/InstructionPanel.js';
 import { FollowUpInputManager } from './uiManagers/FollowUpInputManager.js';
 import { ApprovalRequests } from './uiManagers/ApprovalRequests.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
+import { RunSelector } from './uiManagers/RunSelector.js';
 import { UsageSummary, UsageGroupManager } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
 import { vscode } from '@common/webviewContext.js';
@@ -22,6 +23,7 @@ import { vscode } from '@common/webviewContext.js';
 class ProgressViewDomHandler extends BaseDomHandler {
   constructor() {
     const usageSummary = new UsageSummary();
+    const runSelector = new RunSelector();
     super({
       streamTabs: new StreamTabs(),
       toolbar: new Toolbar(),
@@ -29,13 +31,19 @@ class ProgressViewDomHandler extends BaseDomHandler {
       usageSummary,
       usageGroup: new UsageGroupManager(usageSummary),
       fileList: new FileList(usageSummary),
-      taskGroups: new TaskGroupDomManager(),
+      runSelector,
+      taskGroups: new TaskGroupDomManager(runSelector),
       logEntries: new LogEntryManager(),
       events: new EventsManager(),
       placeholder: new Placeholder(),
       instructionPanel: new InstructionPanel(),
       followUpInput: new FollowUpInputManager(vscode),
       approvalRequests: new ApprovalRequests(),
+    });
+
+    runSelector.bind({
+      taskGroups: this.taskGroups,
+      instructionPanel: this.instructionPanel,
     });
   }
 }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -170,19 +170,25 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateLogs(message) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (message.stream === state.activeStream) {
+      dom.runSelector.beginUpdate();
       dom.taskGroups.clear();
       state.taskGroups.clear();
       logContent.innerHTML = '';
       if (message.groups && message.groups.length > 0) {
         const parentGroups = message.groups.filter((g) => !g.parentGroupId);
         const childGroups = message.groups.filter((g) => g.parentGroupId);
+        const rootIds = parentGroups.map((g) => g.id);
+        state.runState.retainRuns(rootIds);
         parentGroups
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.addGroup(g));
         childGroups
           .sort((a, b) => a.startTime - b.startTime)
           .forEach((g) => dom.taskGroups.addGroup(g));
+      } else {
+        state.runState.retainRuns([]);
       }
+      dom.runSelector.finalizeUpdate();
       const sortedMessages = [...message.messages].sort(
         (a, b) => a.timestamp - b.timestamp,
       );
@@ -212,6 +218,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     dom.taskGroups.clear();
     state.taskGroups.clear();
     state.toggleStates.clearSelection(groupIds);
+    state.runState.clear();
+    dom.runSelector.clear();
     if (logContent) {
       logContent.innerHTML = '';
     }
@@ -358,49 +366,74 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     const payload = message.instruction;
     const text = payload?.text ?? '';
+    const runId = state.currentGroupId;
 
     if (!text.trim()) {
-      dom.instructionPanel.hide();
+      if (runId) {
+        state.runState.setInstruction(runId, null);
+      }
+      if (!runId || state.runState.getSelectedRunId() === runId) {
+        dom.instructionPanel.hide();
+      }
       return;
     }
 
     const sessionKind = message.sessionKind || 'workflow';
     const isToolUseAgent = sessionKind === 'toolUse';
 
+    if (runId) {
+      state.runState.setInstruction(runId, {
+        text,
+        metadata: payload?.metadata,
+        sessionKind,
+      });
+    }
+
     if (isToolUseAgent) {
       // For Tool Use agents, show instruction as a user message in chat
       dom.instructionPanel.hide();
 
-      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      if (logContent) {
-        // Check if instruction message already exists
-        const existingInstruction = logContent.querySelector(
-          '.user-message-container[data-instruction="true"]',
-        );
-        if (!existingInstruction) {
-          const userMessage = this._entryFormatter.format({
-            id: `instruction-${activeStream}`,
-            messageType: 'userMessage',
-            text: text,
-            timestamp: Date.now(),
-            groupId: undefined,
-          });
+      const container =
+        (runId && dom.taskGroups.getGroupContainer(runId)) ||
+        document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      if (container) {
+        const instructionSelector = runId
+          ? `.user-message-container[data-instruction="${runId}"]`
+          : '.user-message-container[data-instruction="stream"]';
+        const existingInstruction =
+          container.querySelector(instructionSelector);
+        if (existingInstruction) {
+          existingInstruction.remove();
+        }
 
-          if (userMessage) {
-            userMessage.dataset.instruction = 'true';
-            // Insert at the beginning of the log content
-            if (logContent.firstChild) {
-              logContent.insertBefore(userMessage, logContent.firstChild);
-            } else {
-              logContent.appendChild(userMessage);
-            }
+        const userMessage = this._entryFormatter.format({
+          id: `instruction-${activeStream}-${runId || 'default'}`,
+          messageType: 'userMessage',
+          text,
+          timestamp: Date.now(),
+          groupId: runId || undefined,
+        });
+
+        if (userMessage) {
+          userMessage.dataset.instruction = runId || 'stream';
+          if (container.firstChild) {
+            container.insertBefore(userMessage, container.firstChild);
+          } else {
+            container.appendChild(userMessage);
           }
         }
       }
     } else {
       // For Workflow agents, show in instruction panel
       const metadata = payload?.metadata ?? {};
-      dom.instructionPanel.show(text, metadata);
+      const selectedRun = state.runState.getSelectedRunId();
+      if (!selectedRun || selectedRun === runId) {
+        dom.instructionPanel.show(text, metadata);
+        if (!selectedRun && runId) {
+          state.runState.setSelectedRun(runId);
+          dom.runSelector.select(runId);
+        }
+      }
     }
   }
 
@@ -412,6 +445,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
         state.toggleStates.clearSelection(groupIds);
         dom.instructionPanel.hide();
+        state.runState.clear();
+        dom.runSelector.clear();
       }
     }
   }
@@ -420,6 +455,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.toggleStates.clearAll();
     state.resetExecutionIdAvailability();
     dom.instructionPanel.hide();
+    state.runState.clear();
+    dom.runSelector.clear();
   }
 
   handleFollowUpTextPolished(message) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -215,6 +215,77 @@ class ExecutionIdAvailability {
 }
 
 /**
+ * Tracks run-level state such as selection and stored instructions.
+ */
+class RunState {
+  constructor() {
+    this.selectedRunId = null;
+    this.instructions = new Map();
+  }
+
+  setSelectedRun(runId) {
+    this.selectedRunId = runId || null;
+  }
+
+  getSelectedRunId() {
+    return this.selectedRunId;
+  }
+
+  setInstruction(runId, instruction) {
+    if (!runId) {
+      return;
+    }
+
+    const text = instruction?.text?.trim();
+    if (!text) {
+      this.instructions.delete(runId);
+      return;
+    }
+
+    this.instructions.set(runId, {
+      text,
+      metadata: instruction?.metadata,
+      sessionKind: instruction?.sessionKind,
+    });
+  }
+
+  getInstruction(runId) {
+    if (!runId) {
+      return null;
+    }
+    return this.instructions.get(runId) || null;
+  }
+
+  deleteRun(runId) {
+    if (!runId) {
+      return;
+    }
+    this.instructions.delete(runId);
+    if (this.selectedRunId === runId) {
+      this.selectedRunId = null;
+    }
+  }
+
+  retainRuns(runIds) {
+    const keep = new Set(runIds);
+    for (const key of this.instructions.keys()) {
+      if (!keep.has(key)) {
+        this.instructions.delete(key);
+      }
+    }
+
+    if (this.selectedRunId && !keep.has(this.selectedRunId)) {
+      this.selectedRunId = null;
+    }
+  }
+
+  clear() {
+    this.instructions.clear();
+    this.selectedRunId = null;
+  }
+}
+
+/**
  * Manages progress view state and handles persistence.
  */
 export class ProgressViewState {
@@ -231,6 +302,7 @@ export class ProgressViewState {
     this.toggleStates = new ToggleStates(() => this.saveToggleStates());
     this.streamStatuses = new StreamStatuses();
     this.executionIdAvailability = new ExecutionIdAvailability();
+    this.runState = new RunState();
   }
 
   setExecutionIdAvailable(stream, hasExecutionId) {

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -10,11 +10,13 @@ import { createFromTemplate } from '@common/templateUtils.js';
  * Manages task group DOM operations.
  */
 export class TaskGroupDomManager {
-  constructor() {
+  constructor(runSelector) {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
     this.toggleListeners = new Map();
+    this.runSelector = runSelector || null;
+    this.rootGroupIds = new Set();
   }
 
   /**
@@ -74,8 +76,18 @@ export class TaskGroupDomManager {
 
     progressViewState.taskGroups.set(group.id, group);
 
-    const isCollapsed = progressViewState.toggleStates.get(group.id);
-    detailsElem.open = isCollapsed !== true;
+    const isRootGroup = !group.parentGroupId;
+    if (isRootGroup) {
+      this.rootGroupIds.add(group.id);
+      detailsElem.classList.add('run-group');
+    }
+
+    if (isRootGroup && this.runSelector) {
+      detailsElem.open = true;
+    } else {
+      const isCollapsed = progressViewState.toggleStates.get(group.id);
+      detailsElem.open = isCollapsed !== true;
+    }
 
     detailsElem.prepend(headerElement);
 
@@ -120,9 +132,13 @@ export class TaskGroupDomManager {
     });
 
     // For top-level groups, update current group and collapse the previous active group
-    if (!group.parentGroupId) {
+    if (isRootGroup) {
       progressViewState.currentGroupId = group.id;
-      this.collapsePreviousActiveGroup();
+      if (this.runSelector) {
+        this.runSelector.registerRun(group);
+      } else {
+        this.collapsePreviousActiveGroup();
+      }
     }
   }
 
@@ -323,6 +339,37 @@ export class TaskGroupDomManager {
     this.groupElements.clear();
     this.toggleListeners.clear();
     this.previousActiveGroupId = null;
+    this.rootGroupIds.clear();
+  }
+
+  /**
+   * Show only the selected run (or all runs when runId is null).
+   * @param {string|null} runId
+   */
+  showRun(runId) {
+    const target = runId || null;
+    for (const id of this.rootGroupIds) {
+      const element = this.groupElements.get(id);
+      if (!element) {
+        continue;
+      }
+      const shouldShow = !target || id === target;
+      element.classList.toggle('run-group--hidden', !shouldShow);
+      element.style.display = shouldShow ? '' : 'none';
+      if (shouldShow) {
+        element.open = true;
+      }
+    }
+  }
+
+  /**
+   * Retrieve the content container for a group by ID.
+   * @param {string} groupId
+   * @returns {HTMLElement|null}
+   */
+  getGroupContainer(groupId) {
+    const detailsElem = this.groupElements.get(groupId);
+    return detailsElem?.querySelector('.log-group-content') ?? null;
   }
 
   _removeToggleListener(groupId) {

--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -1,0 +1,279 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+import { TaskGroupLevel } from '../formatters.js';
+import { progressViewState } from '../progressViewState.js';
+
+/**
+ * Manages the run selector dropdown and coordinates run visibility.
+ */
+export class RunSelector {
+  constructor() {
+    this._runs = new Map();
+    this._dropdown = null;
+    this._container = null;
+    this._instructionPanel = null;
+    this._taskGroups = null;
+    this._isInitialized = false;
+    this._isBatching = false;
+    this._autoSelect = true;
+  }
+
+  /**
+   * Bind dependencies that are created in the DOM handler.
+   * @param {{ taskGroups: import('../taskManagers.js').TaskGroupDomManager, instructionPanel: any }} deps
+   */
+  bind(deps = {}) {
+    if (deps.taskGroups) {
+      this._taskGroups = deps.taskGroups;
+    }
+    if (deps.instructionPanel) {
+      this._instructionPanel = deps.instructionPanel;
+    }
+  }
+
+  /**
+   * Initialize DOM references and event listeners.
+   */
+  setup() {
+    if (this._isInitialized) {
+      return;
+    }
+
+    this._dropdown = document.getElementById(ELEMENT_IDS.RUN_SELECTOR);
+    this._container = document.getElementById(
+      ELEMENT_IDS.RUN_SELECTOR_CONTAINER,
+    );
+    if (!this._dropdown) {
+      return;
+    }
+
+    const attachListener = () => {
+      this._dropdown.addEventListener('change', (event) => {
+        const target = event?.target;
+        const value = target?.value ?? this._dropdown.value;
+        this.select(value || null, { userInitiated: true });
+      });
+    };
+
+    if (this._dropdown.updateComplete) {
+      this._dropdown.updateComplete.then(attachListener);
+    } else {
+      attachListener();
+    }
+
+    this._isInitialized = true;
+    this._renderOptions();
+    this._applySelection(progressViewState.runState.getSelectedRunId());
+    this._toggleVisibility();
+  }
+
+  /**
+   * Begin a batch update of runs. Clears previous run metadata.
+   */
+  beginUpdate() {
+    this._isBatching = true;
+    this._runs.clear();
+  }
+
+  /**
+   * Register a root run group with the selector.
+   * @param {Object} group
+   */
+  registerRun(group) {
+    if (!group || !group.id) {
+      return;
+    }
+
+    const startTime = Number(group.startTime) || Date.now();
+    const label = this._formatLabel(startTime);
+    this._runs.set(group.id, { label, startTime });
+
+    if (!this._isBatching) {
+      this._renderOptions();
+      this._ensureSelection();
+    }
+  }
+
+  /**
+   * Finalize the batch update and ensure selection is in sync.
+   */
+  finalizeUpdate() {
+    this._isBatching = false;
+    this._renderOptions();
+    this._ensureSelection();
+  }
+
+  /**
+   * Clear all runs and reset selection state.
+   */
+  clear() {
+    this._runs.clear();
+    this._autoSelect = true;
+    progressViewState.runState.clear();
+    if (this._isInitialized) {
+      this._renderOptions();
+    }
+    this._applySelection(null);
+    this._toggleVisibility();
+  }
+
+  /**
+   * Select a run either programmatically or from user interaction.
+   * @param {string|null} runId
+   * @param {{ userInitiated?: boolean }} [options]
+   */
+  select(runId, options = {}) {
+    const { userInitiated = false } = options;
+
+    if (userInitiated) {
+      this._autoSelect = false;
+    }
+
+    const hasRun = runId && this._runs.has(runId);
+    const targetRunId = hasRun
+      ? runId
+      : this._autoSelect
+        ? this._getNewestRunId()
+        : progressViewState.runState.getSelectedRunId();
+
+    this._applySelection(targetRunId || null, { force: true });
+  }
+
+  /**
+   * Ensure the selection is valid after runs change.
+   */
+  _ensureSelection() {
+    const selected = progressViewState.runState.getSelectedRunId();
+    if (selected && this._runs.has(selected)) {
+      this._applySelection(selected, { force: true });
+      return;
+    }
+
+    if (this._runs.size === 0) {
+      this._applySelection(null);
+      return;
+    }
+
+    const fallback = this._getNewestRunId();
+    this._applySelection(fallback, { force: true });
+  }
+
+  /**
+   * Apply the provided selection to DOM and dependent managers.
+   * @param {string|null} runId
+   * @param {{ force?: boolean }} [options]
+   */
+  _applySelection(runId, options = {}) {
+    const { force = false } = options;
+    const normalized = runId && this._runs.has(runId) ? runId : null;
+    const current = progressViewState.runState.getSelectedRunId();
+    if (!force && normalized === current) {
+      return;
+    }
+
+    progressViewState.runState.setSelectedRun(normalized);
+
+    if (this._isInitialized && this._dropdown) {
+      const dropdownValue = normalized ?? '';
+      if (this._dropdown.value !== dropdownValue) {
+        this._dropdown.value = dropdownValue;
+      }
+    }
+
+    this._taskGroups?.showRun(normalized);
+    this._updateInstructionPanel(normalized);
+    this._toggleVisibility();
+  }
+
+  /**
+   * Update the instruction panel based on the selected run.
+   * @param {string|null} runId
+   */
+  _updateInstructionPanel(runId) {
+    if (!this._instructionPanel) {
+      return;
+    }
+
+    if (!runId) {
+      this._instructionPanel.hide();
+      return;
+    }
+
+    const data = progressViewState.runState.getInstruction(runId);
+    const text = data?.text?.trim();
+    if (!text || data?.sessionKind === 'toolUse') {
+      this._instructionPanel.hide();
+      return;
+    }
+
+    this._instructionPanel.show(text, data?.metadata ?? {});
+  }
+
+  /**
+   * Update dropdown options to match the known runs.
+   */
+  _renderOptions() {
+    if (!this._isInitialized || !this._dropdown) {
+      return;
+    }
+
+    while (this._dropdown.firstChild) {
+      this._dropdown.removeChild(this._dropdown.firstChild);
+    }
+
+    const sortedRuns = [...this._runs.entries()].sort(
+      (a, b) => a[1].startTime - b[1].startTime,
+    );
+
+    for (const [id, data] of sortedRuns) {
+      const option = document.createElement('vscode-option');
+      option.value = id;
+      option.textContent = data.label;
+      this._dropdown.appendChild(option);
+    }
+  }
+
+  /**
+   * Toggle visibility of the selector container and root layout styling.
+   */
+  _toggleVisibility() {
+    if (this._isInitialized && this._container) {
+      const shouldHide = this._runs.size === 0;
+      this._container.toggleAttribute('hidden', shouldHide);
+    }
+
+    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    if (logContent) {
+      logContent.classList.toggle('run-selector-active', this._runs.size > 0);
+    }
+  }
+
+  /**
+   * Format the dropdown label using the same timestamp style as headers.
+   * @param {number} startTime
+   * @returns {string}
+   */
+  _formatLabel(startTime) {
+    try {
+      return TaskGroupLevel.ROOT.formatTime(new Date(startTime));
+    } catch (error) {
+      return new Date(startTime).toISOString();
+    }
+  }
+
+  /**
+   * Get the newest run ID based on start time.
+   * @returns {string|null}
+   */
+  _getNewestRunId() {
+    let newestId = null;
+    let latestTime = -Infinity;
+    for (const [id, data] of this._runs.entries()) {
+      if (data.startTime >= latestTime) {
+        newestId = id;
+        latestTime = data.startTime;
+      }
+    }
+    return newestId;
+  }
+}

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -37,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ]);
   progressViewDomHandler.toolbar.render('workflow');
   progressViewDomHandler.placeholder.show();
+  progressViewDomHandler.runSelector.setup();
   // Setup UI event listeners
   progressViewDomHandler.events.setupEventListeners();
   progressViewDomHandler.followUpInput.setup();

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -115,3 +115,17 @@
   background-color: var(--vscode-panel-border);
   display: none; /* Start hidden, only show on advanced view option */
 }
+
+.run-group--hidden {
+  display: none;
+}
+
+#logContent.run-selector-active .run-group > .log-group-header {
+  display: none;
+}
+
+#logContent.run-selector-active .run-group > .log-group-content {
+  border-left: none;
+  padding-left: 0;
+  margin-left: 0;
+}

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -126,6 +126,27 @@
   opacity: var(--opacity-subtle);
 }
 
+.run-selector-container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  min-width: 0;
+}
+
+.run-selector-container .run-summary {
+  flex: 1;
+  min-width: 0;
+}
+
+.run-selector-container[hidden] {
+  display: none;
+}
+
+.run-selector__dropdown {
+  min-width: 200px;
+  flex-shrink: 0;
+}
+
 /* Status indicator styling */
 .status-indicator {
   width: var(--spacing-medium);


### PR DESCRIPTION
## Summary
- add a VS Code dropdown to the progress view header so runs can be selected without stacked timestamp banners
- persist per-run instruction metadata and update message handlers so switching runs restores the correct instructions and tool-use notes
- hide the redundant top-level group headers and update CSS/layout to show only the selected run’s content

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9122e2f08324a143da4c33511ac4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a run selector dropdown to switch between runs and persist per-run instruction metadata, updating DOM/state, message handling, and styles.
> 
> - **UI/Frontend**:
>   - Add `RunSelector` dropdown in header (`index.html`) with container IDs `runSelectorContainer`/`runSelector`.
>   - Wire new module `modules/uiManagers/RunSelector.js` through content provider/import map.
>   - Initialize selector in `script.js` and `domHandlers`.
> - **State Management**:
>   - Add `RunState` to `progressViewState` to track `selectedRunId` and per-run instructions; add `retainRuns`, `clear` helpers.
> - **Message Handling** (`messageHandlers.js`):
>   - Batch/register runs on `UPDATE_LOGS`; sync `RunState`; finalize selection.
>   - Persist/restore per-run instructions in `UPDATE_INSTRUCTION`; show as user message for `toolUse` within the correct group; coordinate panel visibility with selection.
>   - Clear selector/state on `CLEAR_LOGS`, `DELETE_STREAM`, `DELETE_ALL`.
> - **Task Groups** (`taskManagers.js`):
>   - Accept `runSelector`; mark root groups as runs, auto-open, register with selector.
>   - Add `showRun(runId)` to filter visible root groups; expose `getGroupContainer`.
> - **Styles**:
>   - Add styles for run selector and run-group visibility; hide top-level group headers when selector active and adjust layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3790ddd1f1d0ee88849a25dbd6fb7687d8cc0e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->