### PR TITLE
feat: isolate agent run artifacts in task storage

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -53,7 +53,11 @@ import type { ToolDefinition } from '@model';
 import { getConfig } from '@utils/config';
 
 // Local imports - filesystem utilities
-import { WorkspaceFS } from '@utils/files';
+import {
+  TaskRunFileService,
+  WorkspaceFS,
+  isValidExecutionId,
+} from '@utils/files';
 
 /**
  * Options for handling round output.
@@ -123,6 +127,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     documents: [],
     singleOutputFile: null,
   };
+  protected readonly runFileService?: TaskRunFileService;
 
   constructor(
     modelHandler: IModelHandler<any, any, any, any, C>,
@@ -142,6 +147,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       context,
     );
     this.agentSetting = workflowSetting;
+
+    if (this.executionId && isValidExecutionId(this.executionId)) {
+      this.runFileService = new TaskRunFileService(this.executionId);
+    }
 
     // Initialize basic attributes
     const numRounds = this.getTotalRounds();
@@ -174,6 +183,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       this.logId,
       this.baseFiles,
       this.logger,
+      this.runFileService,
     );
 
     this.latexMediaManager = new LatexMediaManager(this.logger);

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -25,6 +25,10 @@ export class CoTAgent extends BaseReflectionAgent {
       fileExtension,
       currRound,
       this.agentConfig.editedFile || undefined,
+      {
+        outputDir:
+          this.runFileService?.getStorageDirForWorkspaceFile(baseOutputFile),
+      },
     );
   }
 

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -27,6 +27,10 @@ export class DirectAgent extends BaseReflectionAgent {
       this.agentSetting.outputExt,
       currRound,
       this.agentConfig.editedFile || undefined,
+      {
+        outputDir:
+          this.runFileService?.getStorageDirForWorkspaceFile(baseOutputFile),
+      },
     );
   }
 

--- a/src/agent/implementations/MergeAgent.ts
+++ b/src/agent/implementations/MergeAgent.ts
@@ -98,7 +98,9 @@ export class MergeAgent extends DirectAgent {
 
     // Construct output filename
     const outputFile = `${finalBase}_${agent}_r${roundNum}_full_${model}.tex`;
-    const outputPath = path.join(inputDir, outputFile);
+    const targetDir =
+      this.runFileService?.getStorageDirForWorkspaceFile(inputFile) || inputDir;
+    const outputPath = path.join(targetDir, outputFile);
     return outputPath;
   }
 

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -8,6 +8,7 @@ import { compileLatex2Pdf } from '@latex/texTools';
 import { AgentLogger, type AgentLogStage } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { getConfig } from '@utils/config';
+import { TaskRunFileService } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
 
 // Local imports - types
@@ -27,6 +28,7 @@ const defaultLatexDiffDependencies: LatexDiffDependencies = {
 
 export class LatexDiffManager {
   private readonly latexdiffService: LaTeXdiffService;
+  private readonly runFiles?: TaskRunFileService;
 
   constructor(
     private readonly agentSetting: AgentWorkflowSetting,
@@ -34,9 +36,11 @@ export class LatexDiffManager {
     private readonly baseFiles: string[],
     private readonly logger: AgentLogger,
     private readonly channel: string,
+    runFiles?: TaskRunFileService,
     private readonly dependencies: LatexDiffDependencies = defaultLatexDiffDependencies,
   ) {
-    this.latexdiffService = new LaTeXdiffService(channel);
+    this.runFiles = runFiles;
+    this.latexdiffService = new LaTeXdiffService(channel, runFiles);
   }
 
   private logLatexdiffResult(
@@ -125,22 +129,23 @@ export class LatexDiffManager {
             baseFile,
             outputFile,
             currRound,
+            undefined,
+            { runFiles: this.runFiles },
           );
           this.logLatexdiffResult(result, 'round-diff');
+          const diffPath =
+            result.outputPath ||
+            (result.diffFileName
+              ? path.join(path.dirname(baseFile), result.diffFileName)
+              : '');
           aggregated.push({
             base: baseFile,
             revised: outputFile,
-            output: result.diffFileName
-              ? path.join(path.dirname(baseFile), result.diffFileName)
-              : '',
+            output: diffPath,
             status: result.success ? 'success' : 'error',
             message: result.success ? undefined : result.message,
           });
-          if (result.success && result.diffFileName) {
-            const diffPath = path.join(
-              path.dirname(baseFile),
-              result.diffFileName,
-            );
+          if (result.success && diffPath) {
             const buildDir = path.join(path.dirname(diffPath), 'build');
             await this.dependencies.compileLatex2Pdf(
               diffPath,
@@ -175,22 +180,23 @@ export class LatexDiffManager {
           const result = await this.latexdiffService.runDiffBetweenRounds(
             prevOutputFile,
             currOutputFile,
+            undefined,
+            { runFiles: this.runFiles },
           );
           this.logLatexdiffResult(result, 'between-rounds-diff');
+          const diffPath =
+            result.outputPath ||
+            (result.diffFileName
+              ? path.join(path.dirname(prevOutputFile), result.diffFileName)
+              : '');
           aggregated.push({
             base: prevOutputFile,
             revised: currOutputFile,
-            output: result.diffFileName
-              ? path.join(path.dirname(prevOutputFile), result.diffFileName)
-              : '',
+            output: diffPath,
             status: result.success ? 'success' : 'error',
             message: result.success ? undefined : result.message,
           });
-          if (result.success && result.diffFileName) {
-            const diffPath = path.join(
-              path.dirname(prevOutputFile),
-              result.diffFileName,
-            );
+          if (result.success && diffPath) {
             const buildDir = path.join(path.dirname(diffPath), 'build');
             await this.dependencies.compileLatex2Pdf(
               diffPath,

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -38,7 +38,7 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - utilities
 import { replaceInputCommands, createFileMapping } from '@utils/files';
-import { WorkspaceFS, AbsoluteFS } from '@utils/files';
+import { WorkspaceFS, AbsoluteFS, TaskRunFileService } from '@utils/files';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 import {
   extractMultipleTextFromTag,
@@ -65,6 +65,7 @@ export class OutputHandler implements IOutputHandler {
   public readonly diffManager: LatexDiffManager;
   private diffStatsManager: DiffStatsManager;
   private readonly openedOutputs: Set<string>;
+  private readonly runFiles?: TaskRunFileService;
 
   constructor(
     agentSetting: AgentSetting,
@@ -72,6 +73,7 @@ export class OutputHandler implements IOutputHandler {
     logId: number,
     baseFiles: string[] = [],
     logger?: AgentLogger,
+    runFiles?: TaskRunFileService,
   ) {
     this.agentSetting = requireWorkflowSetting(agentSetting);
     this.agentConfig = agentConfig;
@@ -85,11 +87,13 @@ export class OutputHandler implements IOutputHandler {
     this.baseFiles = baseFiles;
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
+    this.runFiles = runFiles;
 
     this.xmlManager = new XmlOutputManager(
       this.agentSetting,
       this.agentConfig,
       this.logger,
+      this.runFiles,
     );
     this.diffManager = new LatexDiffManager(
       this.agentSetting,
@@ -97,6 +101,7 @@ export class OutputHandler implements IOutputHandler {
       this.baseFiles,
       this.logger,
       this.channel,
+      this.runFiles,
     );
     this.diffStatsManager = new DiffStatsManager();
     this.openedOutputs = new Set();
@@ -184,14 +189,20 @@ export class OutputHandler implements IOutputHandler {
         Array.from(mapping.prevToOutput.entries()).find(
           ([, out]) => out === file,
         )?.[0] || null;
+      const workspacePath = mapping.workspaceByOutput.get(file) || null;
       const originalFile = mapping.originByOutput.get(file) || null;
-      const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
+      const diffBase = getEffectiveBaseFile(
+        baseFile,
+        originalFile,
+        workspacePath ?? file,
+      );
       const stats = await this.diffStatsManager.computeDiffStats(
         diffBase,
         file,
       );
       infos.push({
         path: file,
+        workspacePath,
         base: baseFile,
         prev: prevFile,
         original: originalFile,
@@ -225,14 +236,19 @@ export class OutputHandler implements IOutputHandler {
             true,
           )
         : new Map<string, string>();
+    const namedOutputs = this.getNamedOutputs(currRound);
     const originByOutput = new Map(
-      this.getNamedOutputs(currRound).map((p) => [p.path, p.source]),
+      namedOutputs.map((p) => [p.path, p.workspaceSource ?? p.source]),
+    );
+    const workspaceByOutput = new Map(
+      namedOutputs.map((p) => [p.path, p.workspacePath ?? p.path]),
     );
 
     const mapping: RoundFileMapping = {
       baseToOutput,
       prevToOutput,
       originByOutput,
+      workspaceByOutput,
     };
     this.roundMappings[currRound] = mapping;
     return mapping;
@@ -306,6 +322,12 @@ export class OutputHandler implements IOutputHandler {
                 this.agentConfig.model,
                 'xml',
                 currRound,
+                this.agentConfig.editedFile || undefined,
+                {
+                  outputDir: this.runFiles?.getStorageDirForWorkspaceFile(
+                    this.agentConfig.inputFile,
+                  ),
+                },
               );
 
           const xmlExists = path.isAbsolute(xmlPath)
@@ -468,9 +490,14 @@ export class OutputHandler implements IOutputHandler {
           this.logger.debug(`Processing single output for ${outputFile}`);
 
           try {
+            const workspaceFallback = this.runFiles
+              ? this.runFiles.getWorkspacePathFromStorage(outputFile)
+              : outputFile;
             let processed: NamedOutputFile = {
-              source: outputFile,
+              source: workspaceFallback,
+              workspaceSource: workspaceFallback,
               path: outputFile,
+              workspacePath: workspaceFallback,
             };
             const hasScratchpadPrefill =
               this.agentSetting.prefills?.some((prefill) =>

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -17,7 +17,7 @@ import {
 } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
-import { WorkspaceFS } from '@utils/files';
+import { AbsoluteFS, WorkspaceFS, TaskRunFileService } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 
 export class XmlOutputManager {
@@ -25,7 +25,32 @@ export class XmlOutputManager {
     private readonly agentSetting: AgentSetting,
     private readonly agentConfig: AgentConfig,
     private readonly logger: AgentLogger,
+    private readonly runFiles?: TaskRunFileService,
   ) {}
+
+  private resolveWorkspaceAbsolute(filePath: string): string {
+    return path.isAbsolute(filePath)
+      ? filePath
+      : WorkspaceFS.fullPath(filePath);
+  }
+
+  private getStorageDirForWorkspace(filePath: string): string {
+    const workspaceAbsolute = this.resolveWorkspaceAbsolute(filePath);
+    return this.runFiles
+      ? this.runFiles.getStorageDirForWorkspaceFile(workspaceAbsolute)
+      : path.dirname(workspaceAbsolute);
+  }
+
+  private getWorkspacePathForStorage(storagePath: string): string {
+    return this.runFiles
+      ? this.runFiles.getWorkspacePathFromStorage(storagePath)
+      : storagePath;
+  }
+
+  private async writeFile(target: string, content: string): Promise<void> {
+    await AbsoluteFS.ensureDir(path.dirname(target));
+    await WorkspaceFS.write(target, content);
+  }
 
   async processXmlContent(content: string): Promise<string> {
     content = replacementEngine.applyNonRegex(content);
@@ -139,7 +164,7 @@ export class XmlOutputManager {
       documentTag,
     );
     if (namedDocumentContent) {
-      await WorkspaceFS.write(texFile, namedDocumentContent);
+      await this.writeFile(texFile, namedDocumentContent);
       return texFile;
     }
 
@@ -159,7 +184,7 @@ export class XmlOutputManager {
         documentTag,
       );
       if (latexDocument) {
-        await WorkspaceFS.write(texFile, latexDocument);
+        await this.writeFile(texFile, latexDocument);
         return texFile;
       }
       throw new Error(
@@ -260,17 +285,27 @@ export class XmlOutputManager {
         continue;
       }
 
-      const { ext } = path.parse(source);
+      const workspaceSource = this.resolveWorkspaceAbsolute(source);
+      const { ext } = path.parse(workspaceSource);
       const extension = ext.replace('.', '') || 'tex';
       const texFile = getOutputFileName(
-        source,
+        workspaceSource,
         agent,
         model,
         extension,
         currRound,
+        undefined,
+        {
+          outputDir: this.getStorageDirForWorkspace(workspaceSource),
+        },
       );
-      await WorkspaceFS.write(texFile, doc.content.trim());
-      outputFiles.push({ source, path: texFile });
+      await this.writeFile(texFile, doc.content.trim());
+      outputFiles.push({
+        source: workspaceSource,
+        workspaceSource,
+        path: texFile,
+        workspacePath: this.getWorkspacePathForStorage(texFile),
+      });
       this.logger.debug(
         `XML Source: ${source} -> TeX file written: ${texFile}`,
       );
@@ -294,9 +329,15 @@ export class XmlOutputManager {
       original = nameMatch[1].trim();
     }
 
+    const resolvedOriginal = original
+      ? this.resolveWorkspaceAbsolute(original)
+      : this.agentConfig.inputFile;
+
     return {
-      source: original || this.agentConfig.inputFile,
+      source: resolvedOriginal,
+      workspaceSource: resolvedOriginal,
       path: processedOutputFile,
+      workspacePath: this.getWorkspacePathForStorage(processedOutputFile),
     };
   }
 
@@ -335,6 +376,6 @@ export class XmlOutputManager {
         }
       }
     }
-    await WorkspaceFS.write(filePath, content);
+    await this.writeFile(filePath, content);
   }
 }

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -4,10 +4,13 @@ import type { DiffStats } from '@agent/types/DiffTypes';
 export interface NamedOutputFile {
   source: string;
   path: string;
+  workspaceSource?: string | null;
+  workspacePath?: string | null;
 }
 
 export interface OutputFileInfo extends DiffStats {
   path: string;
+  workspacePath?: string | null;
   base?: string | null;
   prev?: string | null;
   original?: string | null;
@@ -17,4 +20,5 @@ export interface RoundFileMapping {
   baseToOutput: Map<string, string>;
   prevToOutput: Map<string, string>;
   originByOutput: Map<string, string | undefined>;
+  workspaceByOutput: Map<string, string | undefined>;
 }

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -18,6 +18,7 @@ export function getOutputFileName(
   outputExt: string,
   currRound: number,
   editedFile?: string,
+  options?: { outputDir?: string },
 ): string {
   const { dir, name: fileName } = path.parse(inputFile);
   const agentFirstNameChunk = agent.split('_')[0];
@@ -30,5 +31,6 @@ export function getOutputFileName(
   }
 
   const outputBaseName = `${fileName}_${agentFirstNameChunk}_r${newRound}_${model}.${outputExt}`;
-  return path.join(dir, outputBaseName);
+  const targetDir = options?.outputDir ?? dir;
+  return path.join(targetDir, outputBaseName);
 }

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -9,7 +9,11 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utilities
 import { getConfig } from '@utils/config';
-import { WorkspaceFS } from '@utils/files';
+import {
+  TaskRunFileService,
+  WorkspaceFS,
+  extractExecutionIdFromPath,
+} from '@utils/files';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 
 // Local imports - latex utils
@@ -63,6 +67,21 @@ async function ensureLatexdiffToolInstalled(
   return false;
 }
 
+function resolveRunFileService(
+  ...paths: string[]
+): TaskRunFileService | undefined {
+  for (const candidate of paths) {
+    if (!candidate) {
+      continue;
+    }
+    const executionId = extractExecutionIdFromPath(candidate);
+    if (executionId) {
+      return new TaskRunFileService(executionId);
+    }
+  }
+  return undefined;
+}
+
 /**
  * Prompts the user to select a math markup granularity for latexdiff operations.
  * @returns The selected math markup option, or undefined if the user cancels.
@@ -104,11 +123,12 @@ async function promptForLatexdiffMathMarkup(): Promise<
 async function openLatexdiffResult(
   basePath: string,
   diffFileName: string,
+  explicitPath?: string,
 ): Promise<string | undefined> {
   const baseDirectory = path.extname(basePath)
     ? path.dirname(basePath)
     : basePath;
-  const diffFilePath = path.join(baseDirectory, diffFileName);
+  const diffFilePath = explicitPath || path.join(baseDirectory, diffFileName);
 
   if (!(await WorkspaceFS.exists(diffFilePath))) {
     await showLoggedMessage(
@@ -188,6 +208,7 @@ async function handleLatexdiff(
       `Running latexdiff with math markup mode: ${mathMarkup}`,
     );
 
+    const runFiles = resolveRunFileService(fileToUse, editedFile);
     // Get the result from LaTeXdiffService
     const result = await service.runDiff(
       fileToUse,
@@ -195,13 +216,18 @@ async function handleLatexdiff(
       '_diff',
       false,
       mathMarkup,
+      { runFiles },
     );
 
     if (!result.success || !result.diffFileName) {
       throw new Error(result.message || 'Failed to generate diff file');
     }
 
-    await openLatexdiffResult(fileToUse, result.diffFileName);
+    await openLatexdiffResult(
+      fileToUse,
+      result.diffFileName,
+      result.outputPath,
+    );
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error creating LaTeX diff', err);
   }
@@ -498,6 +524,7 @@ async function handleRunLatexdiff(config: any) {
           message?: string;
           basePath?: string;
           diffFileName?: string;
+          outputPath?: string;
         }> = [];
 
         // Process each input file and its outputs
@@ -506,6 +533,11 @@ async function handleRunLatexdiff(config: any) {
             increment: 0,
             message: `Running diffs for ${path.basename(inputFile)}...`,
           });
+
+          const runFiles = resolveRunFileService(
+            inputFile,
+            ...roundOutputs.values(),
+          );
 
           // Sort rounds to ensure we process them in order
           const rounds = Array.from(roundOutputs.keys()).sort((a, b) => a - b);
@@ -525,6 +557,7 @@ async function handleRunLatexdiff(config: any) {
               outputFile,
               round,
               mathMarkup,
+              { runFiles },
             );
 
             results.push({
@@ -532,6 +565,7 @@ async function handleRunLatexdiff(config: any) {
               message: result.message,
               basePath: inputFile,
               diffFileName: result.diffFileName,
+              outputPath: result.outputPath,
             });
 
             completedOperations++;
@@ -560,6 +594,7 @@ async function handleRunLatexdiff(config: any) {
                 currentFile,
                 nextFile,
                 mathMarkup,
+                { runFiles },
               );
 
               results.push({
@@ -567,6 +602,7 @@ async function handleRunLatexdiff(config: any) {
                 message: result.message,
                 basePath: currentFile,
                 diffFileName: result.diffFileName,
+                outputPath: result.outputPath,
               });
 
               completedOperations++;
@@ -602,6 +638,7 @@ async function handleRunLatexdiff(config: any) {
             const diffFilePath = await openLatexdiffResult(
               result.basePath,
               result.diffFileName,
+              result.outputPath,
             );
             if (diffFilePath) {
               logger.debug(

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -13,7 +13,7 @@ import {
   logErrorMessage,
   formatError,
 } from '@common/errors/errorHandlingUtils';
-import { WorkspaceFS } from '@utils/files';
+import { AbsoluteFS, TaskRunFileService, WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
 
 // Local imports - latex utils
@@ -29,6 +29,8 @@ export interface LaTeXdiffResult {
   success: boolean;
   diffFileName?: string;
   message?: string;
+  outputPath?: string;
+  workspacePath?: string;
 }
 
 export interface LaTeXdiffMultipleResult {
@@ -50,7 +52,10 @@ export class LaTeXdiffService {
   private readonly fileProcessor: DiffFileProcessor;
   private readonly commandExecutor: DiffCommandExecutor;
 
-  constructor(private readonly channel: string = CHANNEL) {
+  constructor(
+    private readonly channel: string = CHANNEL,
+    private readonly defaultRunFiles?: TaskRunFileService,
+  ) {
     this.fileNameManager = new DiffFileNameManager();
     this.fileProcessor = new DiffFileProcessor(channel);
     this.commandExecutor = new DiffCommandExecutor(
@@ -72,6 +77,7 @@ export class LaTeXdiffService {
     suffix = '_diff',
     runIndent = true,
     mathMarkup?: MathMarkupOption,
+    options?: { runFiles?: TaskRunFileService },
   ): Promise<LaTeXdiffResult> {
     let diffFileName = '';
     let outputPath = '';
@@ -82,62 +88,89 @@ export class LaTeXdiffService {
         return { success: false, message: 'Input file is empty or undefined' };
       }
 
+      const runFiles = options?.runFiles ?? this.defaultRunFiles;
+      const inputAbsolute = path.isAbsolute(inputFile)
+        ? inputFile
+        : WorkspaceFS.fullPath(inputFile);
+      const editedAbsolute = path.isAbsolute(editedFile)
+        ? editedFile
+        : WorkspaceFS.fullPath(editedFile);
+
       if (
-        !(await WorkspaceFS.exists(inputFile)) ||
-        !(await WorkspaceFS.exists(editedFile))
+        !(await WorkspaceFS.exists(inputAbsolute)) ||
+        !(await WorkspaceFS.exists(editedAbsolute))
       ) {
-        const message = `One or both files do not exist. Input: ${inputFile}, Edited: ${editedFile}`;
+        const message = `One or both files do not exist. Input: ${inputAbsolute}, Edited: ${editedAbsolute}`;
         logger.warn(this.channel, message);
         return { success: false, message };
       }
 
       // Validate document structure
-      if (!(await this.validateDocumentStructure(inputFile, editedFile))) {
+      if (
+        !(await this.validateDocumentStructure(inputAbsolute, editedAbsolute))
+      ) {
         return {
           success: false,
           message: 'Files missing document environment',
         };
       }
 
+      let diffInput = inputAbsolute;
+      let diffEdited = editedAbsolute;
+
+      if (runFiles) {
+        if (!runFiles.isInRunDir(diffInput)) {
+          diffInput = await runFiles.ensureWorkspaceSymlink(diffInput);
+        }
+        if (!runFiles.isInRunDir(diffEdited)) {
+          diffEdited = await runFiles.ensureWorkspaceSymlink(diffEdited);
+        }
+      }
+
       diffFileName = this.fileNameManager.generateDiffFileName(
-        inputFile,
-        editedFile,
+        diffInput,
+        diffEdited,
         suffix,
       );
-      outputPath = path.join(path.dirname(inputFile), diffFileName);
+      outputPath = path.join(path.dirname(diffInput), diffFileName);
 
       logger.debug(
         this.channel,
-        `Running latexdiff for ${inputFile} and ${editedFile}`,
+        `Running latexdiff for ${diffInput} and ${diffEdited}`,
       );
 
       // Format files if requested
       if (runIndent) {
-        await this.formatFiles([inputFile, editedFile]);
+        await this.formatFiles([diffInput, diffEdited]);
       }
 
       // Execute latexdiff command
       const result = await this.commandExecutor.executeDiff(
-        inputFile,
-        editedFile,
-        { mathMarkup },
+        diffInput,
+        diffEdited,
+        { mathMarkup, cwd: runFiles?.getRoot() },
       );
       if (!result.stdout) {
         throw new Error('Latexdiff produced no output');
       }
 
       // Write and process output
+      await AbsoluteFS.ensureDir(path.dirname(outputPath));
       await WorkspaceFS.write(outputPath, result.stdout);
       await this.fileProcessor.processDiffFile(outputPath);
 
       logger.debug(
         this.channel,
-        `Latexdiff succeeded: ${inputFile} -> ${editedFile}`,
+        `Latexdiff succeeded: ${diffInput} -> ${diffEdited}`,
       );
 
       return {
         success: true,
         diffFileName,
+        outputPath,
+        workspacePath: runFiles
+          ? runFiles.getWorkspacePathFromStorage(outputPath)
+          : outputPath,
         message: `LaTeXdiff completed successfully: ${diffFileName}`,
       };
     } catch (err) {
@@ -149,7 +182,11 @@ export class LaTeXdiffService {
         undefined,
         MESSAGE_TYPES.INTERNAL,
       );
-      return { success: false, message };
+      return {
+        success: false,
+        message,
+        outputPath: outputPath || undefined,
+      };
     }
   }
 
@@ -263,6 +300,7 @@ export class LaTeXdiffService {
     outputFile: string,
     _round: number,
     mathMarkup?: MathMarkupOption,
+    options?: { runFiles?: TaskRunFileService },
   ): Promise<LaTeXdiffResult> {
     try {
       if (
@@ -275,6 +313,7 @@ export class LaTeXdiffService {
           '_diff',
           false,
           mathMarkup,
+          options,
         );
       }
 
@@ -292,6 +331,7 @@ export class LaTeXdiffService {
     outputFile1: string,
     outputFile2: string,
     mathMarkup?: MathMarkupOption,
+    options?: { runFiles?: TaskRunFileService },
   ): Promise<LaTeXdiffResult> {
     try {
       if (
@@ -316,6 +356,7 @@ export class LaTeXdiffService {
           diffSuffix,
           false,
           mathMarkup,
+          options,
         );
       }
 

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -34,6 +34,7 @@ const ERROR_MESSAGES = {
  */
 interface DiffExecutionOptions {
   mathMarkup?: MathMarkupOption;
+  cwd?: string;
 }
 
 export class DiffCommandExecutor {
@@ -56,6 +57,7 @@ export class DiffCommandExecutor {
           options?.mathMarkup,
         ),
       'latexdiff',
+      options,
     );
   }
 
@@ -73,6 +75,7 @@ export class DiffCommandExecutor {
           options?.mathMarkup,
         ),
       'latexdiff-vc',
+      options,
     );
   }
 
@@ -132,11 +135,13 @@ export class DiffCommandExecutor {
   private async executeWithFallback(
     commandBuilder: (useFlatten: boolean) => string[],
     commandType: string,
+    options?: DiffExecutionOptions,
   ): Promise<ExecResult> {
     logger.debug(this.channel, `Attempting ${commandType} with --flatten flag`);
     let result = await executeCommand(commandBuilder(true), {
       channel: this.channel,
       timeout: this.timeoutMs,
+      cwd: options?.cwd,
     });
 
     if (!result.success) {
@@ -158,6 +163,7 @@ export class DiffCommandExecutor {
         result = await executeCommand(commandBuilder(false), {
           channel: this.channel,
           timeout: this.timeoutMs,
+          cwd: options?.cwd,
         });
 
         if (!result.success) {

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -117,7 +117,7 @@ export class FileList {
         const statsSpan = clone.querySelector('.file-stats');
 
         // Use original name if available, otherwise use generated path
-        const displayPath = file.original || file.path;
+        const displayPath = file.workspacePath || file.original || file.path;
         const basename = getBasename(displayPath);
         const idx = Math.max(
           displayPath.lastIndexOf('/'),
@@ -131,12 +131,15 @@ export class FileList {
           fileItem.dataset.original = file.original || '';
           fileItem.dataset.base = file.base || '';
           fileItem.dataset.round = round;
+          if (file.workspacePath) {
+            fileItem.dataset.workspace = file.workspacePath;
+          }
         }
 
         // Set the file path display
         if (dirSpan) dirSpan.textContent = dirPath;
         if (basenameSpan) basenameSpan.textContent = basename;
-        if (filePathSpan) filePathSpan.title = file.path;
+        if (filePathSpan) filePathSpan.title = displayPath;
 
         // Handle file stats
         if (statsSpan) {

--- a/src/test/output/LatexDiffManager.test.ts
+++ b/src/test/output/LatexDiffManager.test.ts
@@ -95,6 +95,7 @@ describe('LatexDiffManager mapping reuse', () => {
       baseFiles,
       testLogger,
       'channel',
+      undefined,
       {
         checkToolInstalled: async () => true,
         compileLatex2Pdf: async () => true,
@@ -163,6 +164,7 @@ describe('LatexDiffManager mapping reuse', () => {
       baseFiles,
       testLogger,
       'channel',
+      undefined,
       {
         checkToolInstalled: async () => true,
         compileLatex2Pdf: async () => true,

--- a/src/test/utils/files/taskRunStorage.test.ts
+++ b/src/test/utils/files/taskRunStorage.test.ts
@@ -1,0 +1,338 @@
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+import {
+  TaskRunFileService,
+  TASK_RUNS_DIR,
+  StorageFS,
+  WorkspaceFS,
+  AbsoluteFS,
+  extractExecutionIdFromPath,
+} from '@utils/files';
+import { LaTeXdiffService } from '@latex/latexdiff';
+
+suite('taskRunStorage utilities', () => {
+  type StorageFsMutable = {
+    ensureDir: typeof StorageFS.ensureDir;
+    fullPath: typeof StorageFS.fullPath;
+  };
+
+  type WorkspaceFsMutable = {
+    relativePath: typeof WorkspaceFS.relativePath;
+    getPath: typeof WorkspaceFS.getPath;
+    fullPath: typeof WorkspaceFS.fullPath;
+    exists: typeof WorkspaceFS.exists;
+    read: typeof WorkspaceFS.read;
+    write: typeof WorkspaceFS.write;
+  };
+
+  type AbsoluteFsMutable = {
+    ensureDir: typeof AbsoluteFS.ensureDir;
+    delete: typeof AbsoluteFS.delete;
+    symlink: typeof AbsoluteFS.symlink;
+    exists: typeof AbsoluteFS.exists;
+  };
+
+  const storageFs = StorageFS as unknown as StorageFsMutable;
+  const workspaceFs = WorkspaceFS as unknown as WorkspaceFsMutable;
+  const absoluteFs = AbsoluteFS as unknown as AbsoluteFsMutable;
+
+  const originalStorageEnsureDir = storageFs.ensureDir;
+  const originalStorageFullPath = storageFs.fullPath;
+  const originalWorkspaceRelativePath = workspaceFs.relativePath;
+  const originalWorkspaceGetPath = workspaceFs.getPath;
+  const originalWorkspaceFullPath = workspaceFs.fullPath;
+  const originalWorkspaceExists = workspaceFs.exists;
+  const originalWorkspaceRead = workspaceFs.read;
+  const originalWorkspaceWrite = workspaceFs.write;
+  const originalAbsoluteEnsureDir = absoluteFs.ensureDir;
+  const originalAbsoluteDelete = absoluteFs.delete;
+  const originalAbsoluteSymlink = absoluteFs.symlink;
+  const originalAbsoluteExists = absoluteFs.exists;
+
+  suite('TaskRunFileService', () => {
+    let ensuredStorage: string[];
+    let ensuredAbsolute: string[];
+    let symlinks: Array<{ target: string; link: string }>;
+    const executionId = 'run-001';
+
+    beforeEach(() => {
+      ensuredStorage = [];
+      ensuredAbsolute = [];
+      symlinks = [];
+
+      storageFs.ensureDir = async (relative) => {
+        ensuredStorage.push(relative);
+      };
+
+      storageFs.fullPath = (relative) => path.join('/mock/storage', relative);
+
+      workspaceFs.relativePath = (filePath) =>
+        filePath.replace('/mock/workspace/', '');
+      workspaceFs.getPath = () => '/mock/workspace';
+      workspaceFs.fullPath = (relative) =>
+        path.join('/mock/workspace', relative);
+
+      absoluteFs.ensureDir = async (dir) => {
+        ensuredAbsolute.push(dir);
+      };
+      absoluteFs.delete = async (_target) => {
+        // no-op for tests
+      };
+      absoluteFs.symlink = async (target, link) => {
+        symlinks.push({ target, link });
+      };
+      absoluteFs.exists = async () => false;
+    });
+
+    afterEach(() => {
+      storageFs.ensureDir = originalStorageEnsureDir;
+      storageFs.fullPath = originalStorageFullPath;
+      workspaceFs.relativePath = originalWorkspaceRelativePath;
+      workspaceFs.getPath = originalWorkspaceGetPath;
+      workspaceFs.fullPath = originalWorkspaceFullPath;
+      absoluteFs.ensureDir = originalAbsoluteEnsureDir;
+      absoluteFs.delete = originalAbsoluteDelete;
+      absoluteFs.symlink = originalAbsoluteSymlink;
+      absoluteFs.exists = originalAbsoluteExists;
+    });
+
+    test('maps workspace files into the run directory structure', () => {
+      const service = new TaskRunFileService(executionId as any);
+      const storagePath = service.getStoragePathForWorkspaceFile(
+        '/mock/workspace/docs/chapter.tex',
+      );
+
+      assert.strictEqual(
+        storagePath,
+        path.join(
+          '/mock/storage',
+          TASK_RUNS_DIR,
+          executionId,
+          'docs',
+          'chapter.tex',
+        ),
+      );
+    });
+
+    test('ensures run directories for mirrored files', async () => {
+      const service = new TaskRunFileService(executionId as any);
+      await service.ensureDirForWorkspaceFile('/mock/workspace/docs/main.tex');
+
+      assert.deepStrictEqual(ensuredStorage, [
+        TASK_RUNS_DIR,
+        path.join(TASK_RUNS_DIR, executionId),
+        path.join(TASK_RUNS_DIR, executionId, 'docs'),
+      ]);
+    });
+
+    test('creates symlinks inside the run directory', async () => {
+      const service = new TaskRunFileService(executionId as any);
+      const mirror = await service.ensureWorkspaceSymlink(
+        '/mock/workspace/docs/main.tex',
+      );
+
+      assert.strictEqual(
+        mirror,
+        path.join(
+          '/mock/storage',
+          TASK_RUNS_DIR,
+          executionId,
+          'docs',
+          'main.tex',
+        ),
+      );
+      assert.deepStrictEqual(ensuredAbsolute, [path.dirname(mirror)]);
+      assert.deepStrictEqual(symlinks, [
+        { target: '/mock/workspace/docs/main.tex', link: mirror },
+      ]);
+    });
+
+    test('maps storage paths back to the workspace tree', () => {
+      const service = new TaskRunFileService(executionId as any);
+      const workspacePath = service.getWorkspacePathFromStorage(
+        path.join(
+          '/mock/storage',
+          TASK_RUNS_DIR,
+          executionId,
+          'docs',
+          'output.tex',
+        ),
+      );
+
+      assert.strictEqual(
+        workspacePath,
+        path.join('/mock/workspace', 'docs', 'output.tex'),
+      );
+    });
+  });
+
+  suite('extractExecutionIdFromPath', () => {
+    test('returns execution id when present in the path', () => {
+      const id = extractExecutionIdFromPath(
+        path.join('/tmp', TASK_RUNS_DIR, 'abc-123', 'file.tex'),
+      );
+      assert.strictEqual(id, 'abc-123');
+    });
+
+    test('returns undefined when the path does not include the run directory', () => {
+      const id = extractExecutionIdFromPath('/tmp/workspace/file.tex');
+      assert.strictEqual(id, undefined);
+    });
+  });
+
+  suite('LaTeXdiffService runDiff', () => {
+    let writes: Array<{ path: string; content: string | Uint8Array }>;
+    let ensuredStorage: string[];
+    let ensuredAbsolute: string[];
+    let symlinks: Array<{ target: string; link: string }>;
+    let capturedCwd: string | undefined;
+
+    beforeEach(() => {
+      writes = [];
+      ensuredStorage = [];
+      ensuredAbsolute = [];
+      symlinks = [];
+      capturedCwd = undefined;
+
+      storageFs.ensureDir = async (relative) => {
+        ensuredStorage.push(relative);
+      };
+      storageFs.fullPath = (relative) => path.join('/mock/storage', relative);
+
+      workspaceFs.relativePath = (filePath) =>
+        filePath.replace('/mock/workspace/', '');
+      workspaceFs.getPath = () => '/mock/workspace';
+      workspaceFs.fullPath = (relative) =>
+        path.join('/mock/workspace', relative);
+      workspaceFs.exists = async () => true;
+      workspaceFs.read = async () => '\\begin{document}Content\\end{document}';
+      workspaceFs.write = async (filePath, content) => {
+        writes.push({ path: filePath, content });
+      };
+
+      absoluteFs.ensureDir = async (dir) => {
+        ensuredAbsolute.push(dir);
+      };
+      absoluteFs.delete = async () => {};
+      absoluteFs.symlink = async (target, link) => {
+        symlinks.push({ target, link });
+      };
+      absoluteFs.exists = async () => false;
+    });
+
+    afterEach(() => {
+      storageFs.ensureDir = originalStorageEnsureDir;
+      storageFs.fullPath = originalStorageFullPath;
+      workspaceFs.relativePath = originalWorkspaceRelativePath;
+      workspaceFs.getPath = originalWorkspaceGetPath;
+      workspaceFs.fullPath = originalWorkspaceFullPath;
+      workspaceFs.exists = originalWorkspaceExists;
+      workspaceFs.read = originalWorkspaceRead;
+      workspaceFs.write = originalWorkspaceWrite;
+      absoluteFs.ensureDir = originalAbsoluteEnsureDir;
+      absoluteFs.delete = originalAbsoluteDelete;
+      absoluteFs.symlink = originalAbsoluteSymlink;
+      absoluteFs.exists = originalAbsoluteExists;
+    });
+
+    test('writes diff output inside the task run directory', async () => {
+      const executionId = 'exec-99';
+      const runFiles = new TaskRunFileService(executionId as any);
+      const service = new LaTeXdiffService('TestChannel');
+
+      const executor = (service as any).commandExecutor as {
+        executeDiff: (
+          input: string,
+          edited: string,
+          options?: { cwd?: string },
+        ) => Promise<{
+          success: boolean;
+          stdout: string;
+          stderr: string | null;
+          timedOut: boolean;
+        }>;
+      };
+      const originalExecuteDiff = executor.executeDiff;
+      executor.executeDiff = async (_input, _edited, options) => {
+        capturedCwd = options?.cwd;
+        return {
+          success: true,
+          stdout: 'diff-content',
+          stderr: null,
+          timedOut: false,
+        };
+      };
+
+      const processor = (service as any).fileProcessor as {
+        processDiffFile: (file: string) => Promise<void>;
+      };
+      const originalProcessDiffFile = processor.processDiffFile;
+      processor.processDiffFile = async () => {};
+
+      try {
+        const result = await service.runDiff(
+          '/mock/workspace/docs/base.tex',
+          path.join(
+            '/mock/storage',
+            TASK_RUNS_DIR,
+            executionId,
+            'docs',
+            'edited.tex',
+          ),
+          '_diff',
+          false,
+          undefined,
+          { runFiles },
+        );
+
+        const expectedDiffPath = path.join(
+          '/mock/storage',
+          TASK_RUNS_DIR,
+          executionId,
+          'docs',
+          'base_diff.tex',
+        );
+
+        assert.equal(result.success, true);
+        assert.equal(result.outputPath, expectedDiffPath);
+        assert.equal(
+          result.workspacePath,
+          path.join('/mock/workspace', 'docs', 'base_diff.tex'),
+        );
+
+        assert.deepStrictEqual(ensuredStorage, [
+          TASK_RUNS_DIR,
+          path.join(TASK_RUNS_DIR, executionId),
+          path.join(TASK_RUNS_DIR, executionId, 'docs'),
+        ]);
+        assert.deepStrictEqual(ensuredAbsolute, [
+          path.join('/mock/storage', TASK_RUNS_DIR, executionId, 'docs'),
+          path.join('/mock/storage', TASK_RUNS_DIR, executionId, 'docs'),
+        ]);
+        assert.deepStrictEqual(symlinks, [
+          {
+            target: '/mock/workspace/docs/base.tex',
+            link: path.join(
+              '/mock/storage',
+              TASK_RUNS_DIR,
+              executionId,
+              'docs',
+              'base.tex',
+            ),
+          },
+        ]);
+        assert.equal(writes.length, 1);
+        assert.equal(writes[0].path, expectedDiffPath);
+        assert.equal(typeof writes[0].content, 'string');
+        assert.equal(
+          capturedCwd,
+          path.join('/mock/storage', TASK_RUNS_DIR, executionId),
+        );
+      } finally {
+        executor.executeDiff = originalExecuteDiff;
+        processor.processDiffFile = originalProcessDiffFile;
+      }
+    });
+  });
+});

--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import { promises as fs } from 'fs';
 import * as path from 'path';
 
 // Local imports - filesystem
@@ -19,6 +20,10 @@ export class AbsoluteFS extends BaseFS {
     if (!path.isAbsolute(resolvedPath)) {
       throw new Error(`Path must be absolute: ${original}`);
     }
+  }
+
+  public static async symlink(target: string, linkPath: string): Promise<void> {
+    await fs.symlink(target, linkPath, 'file');
   }
 }
 

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -1,8 +1,10 @@
 // Standard library imports
 import * as path from 'path';
 
-// Local imports - storage
+// Local imports - filesystem
+import { AbsoluteFS } from './absoluteFS';
 import { StorageFS } from './storageFS';
+import { WorkspaceFS } from './workspaceFS';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 /**
@@ -52,4 +54,138 @@ export async function ensureRunDir(id: ExecutionId): Promise<void> {
   }
   await StorageFS.ensureDir(TASK_RUNS_DIR);
   await StorageFS.ensureDir(path.join(TASK_RUNS_DIR, id));
+}
+
+/**
+ * Lightweight helper for working with files persisted under a task run directory.
+ */
+export class TaskRunFileService {
+  constructor(public readonly executionId: ExecutionId) {}
+
+  /** Ensure that the run directory exists. */
+  public async ensureBaseDir(): Promise<void> {
+    await ensureRunDir(this.executionId);
+  }
+
+  /** Absolute path to the root directory for this execution. */
+  public getRoot(): string {
+    return getRunDir(this.executionId);
+  }
+
+  /**
+   * Compute the workspace-relative path for a given workspace file.
+   */
+  public getRelativePath(workspacePath: string): string {
+    const relative = WorkspaceFS.relativePath(workspacePath);
+    return relative === '' ? path.basename(workspacePath) : relative;
+  }
+
+  private getRunRelativePath(target: string): string {
+    return path.join(TASK_RUNS_DIR, this.executionId, target);
+  }
+
+  /**
+   * Resolve a workspace file path to an absolute storage path inside the run directory.
+   */
+  public getStoragePathForWorkspaceFile(workspacePath: string): string {
+    const relative = this.getRelativePath(workspacePath);
+    return StorageFS.fullPath(this.getRunRelativePath(relative));
+  }
+
+  /**
+   * Resolve a workspace file path to the storage directory that should contain related artifacts.
+   */
+  public getStorageDirForWorkspaceFile(workspacePath: string): string {
+    const relative = this.getRelativePath(workspacePath);
+    const relativeDir = path.dirname(relative);
+    const runRelative =
+      relativeDir && relativeDir !== '.'
+        ? this.getRunRelativePath(relativeDir)
+        : path.join(TASK_RUNS_DIR, this.executionId);
+    return StorageFS.fullPath(runRelative);
+  }
+
+  /** Resolve an arbitrary relative path to an absolute path inside the run directory. */
+  public getStoragePathForRelative(relativePath: string): string {
+    return StorageFS.fullPath(this.getRunRelativePath(relativePath));
+  }
+
+  /** Ensure that the directory for a workspace file exists inside the run directory. */
+  public async ensureDirForWorkspaceFile(workspacePath: string): Promise<void> {
+    const relative = this.getRelativePath(workspacePath);
+    await this.ensureDirForRelative(path.dirname(relative));
+  }
+
+  /** Ensure that a relative directory exists inside the run directory. */
+  public async ensureDirForRelative(relativeDir: string): Promise<void> {
+    await this.ensureBaseDir();
+    if (!relativeDir || relativeDir === '.' || relativeDir === path.sep) {
+      return;
+    }
+    await StorageFS.ensureDir(this.getRunRelativePath(relativeDir));
+  }
+
+  /**
+   * Ensure a symlink exists within the run directory pointing at the workspace file.
+   * Returns the absolute path to the mirrored file inside the run directory.
+   */
+  public async ensureWorkspaceSymlink(workspacePath: string): Promise<string> {
+    const relative = this.getRelativePath(workspacePath);
+    await this.ensureDirForRelative(path.dirname(relative));
+
+    const mirrorPath = this.getStoragePathForRelative(relative);
+    const mirrorDir = path.dirname(mirrorPath);
+    await AbsoluteFS.ensureDir(mirrorDir);
+
+    if (await AbsoluteFS.exists(mirrorPath)) {
+      await AbsoluteFS.delete(mirrorPath, {
+        recursive: false,
+        useTrash: false,
+      });
+    }
+
+    await AbsoluteFS.symlink(workspacePath, mirrorPath);
+    return mirrorPath;
+  }
+
+  /** Determine whether a path already points inside this run directory. */
+  public isInRunDir(targetPath: string): boolean {
+    const normalizedRoot = this.getRoot();
+    const normalizedTarget = path.resolve(targetPath);
+    return normalizedTarget.startsWith(path.resolve(normalizedRoot));
+  }
+
+  /** Compute the run-relative path for a storage file. */
+  public getRelativeFromStorage(storagePath: string): string {
+    return path.relative(this.getRoot(), storagePath);
+  }
+
+  /** Map a storage path back to the equivalent workspace location. */
+  public getWorkspacePathFromStorage(storagePath: string): string {
+    const relative = this.getRelativeFromStorage(storagePath);
+    return this.getWorkspacePathForRelative(relative);
+  }
+
+  /** Resolve a run-relative path to the workspace tree. */
+  public getWorkspacePathForRelative(relativePath: string): string {
+    const workspaceRoot = WorkspaceFS.getPath();
+    return workspaceRoot
+      ? path.join(workspaceRoot, relativePath)
+      : relativePath;
+  }
+}
+
+export function extractExecutionIdFromPath(
+  filePath: string,
+): ExecutionId | undefined {
+  const normalized = path.normalize(filePath);
+  const segments = normalized.split(path.sep);
+  const index = segments.lastIndexOf(TASK_RUNS_DIR);
+  if (index >= 0) {
+    const candidate = segments[index + 1];
+    if (candidate && isValidExecutionId(candidate as ExecutionId)) {
+      return candidate as ExecutionId;
+    }
+  }
+  return undefined;
 }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -48,10 +48,11 @@ export async function executeCommand(
     truncate?: boolean;
     env?: Record<string, string>;
     timeout?: number;
+    cwd?: string;
   } = {},
 ): Promise<ExecResult> {
   try {
-    const workspacePath = WorkspaceFS.getPath();
+    const workspacePath = options.cwd ?? WorkspaceFS.getPath();
     if (!workspacePath) {
       throw new Error('No workspace path found');
     }


### PR DESCRIPTION
## Summary
- route agent output paths through a run-scoped file service so generated XML and TeX land under the task run directory
- mirror workspace inputs into run storage when executing latexdiff and propagate storage paths through progress view metadata
- extend run-directory utilities with symlink helpers and add unit coverage for the new storage and diff behaviour

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9228e53c8324bca25655ba6b57ac)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes agent outputs and latexdiff artifacts through a run-scoped storage service, adds symlink-based mirroring, and propagates workspace/storage paths to UI and commands.
> 
> - **Agent output/storage**:
>   - Introduce `TaskRunFileService` and wire into `BaseReflectionAgent`, `OutputHandler`, `XmlOutputManager`, `LatexDiffManager`.
>   - Route generated outputs via `getOutputFileName(..., { outputDir })` to run-scoped directories; `MergeAgent`, `CoTAgent`, `DirectAgent` updated accordingly.
>   - Track and emit `workspacePath`/`workspaceSource` in `NamedOutputFile`, mappings, and file infos.
> - **LaTeX diff pipeline**:
>   - `LaTeXdiffService` accepts run storage, mirrors workspace files via symlinks, runs commands with `cwd` set to run root, and returns `outputPath`/`workspacePath`.
>   - `LatexDiffManager` passes run storage, uses returned `outputPath`, and compiles PDFs from storage paths.
>   - VS Code commands resolve run context from paths, pass it to service, and open results via explicit paths.
> - **Filesystem/system utils**:
>   - Add `AbsoluteFS.symlink` and run-dir helpers (`ensureRunDir`, mapping functions, execution id extraction) in `taskRunStorage`.
>   - `executeCommand` supports custom `cwd`.
> - **UI**:
>   - Progress view `FileList` displays `workspacePath` and sets related data attributes.
> - **Tests**:
>   - Add comprehensive tests for task run storage and latexdiff storage behavior; adjust `LatexDiffManager` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8040f47c553ebbf56de02dde91ca7d93e7aff07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->