### PR TITLE
Fix tool argument parsing for empty input strings

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -161,8 +161,7 @@ const ToolCallPayloadSchema =
       if (typeof candidate === 'string') {
         const trimmed = candidate.trim();
         if (!trimmed) {
-          input = {};
-          break;
+          continue;
         }
         try {
           input = JSON.parse(trimmed);

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -33,10 +33,14 @@ import { ToolResult, toolResult } from '@tools/result';
 import type OpenAI from 'openai';
 
 class EchoTool extends BaseTool<{ value: string }> {
+  public readonly calls: Array<{ value: string }> = [];
+
   constructor() {
     super({ name: 'echo' }, z.object({ value: z.string() }));
   }
+
   protected async execute(input: { value: string }): Promise<ToolResult> {
+    this.calls.push(input);
     return toolResult({ output: input.value });
   }
 }
@@ -180,6 +184,111 @@ describe('runToolUseCycle DeepSeek', () => {
       role: 'tool',
       tool_call_id: 'c1',
       content: JSON.stringify({ output: 'hello' }),
+    });
+  });
+
+  it('falls back to function.arguments when other fields are empty', async () => {
+    class EmptyInputHandler extends MockHandler {
+      override extractToolUse(resp: any): string | null {
+        const original = super.extractToolUse(resp);
+        if (!original) {
+          return original;
+        }
+        const parsed = JSON.parse(original);
+        return JSON.stringify({
+          ...parsed,
+          input: '',
+          arguments: '',
+          function: {
+            name: parsed.name ?? 'echo',
+            arguments: '{"value":"fallback"}',
+          },
+        });
+      }
+    }
+
+    const config: ModelConfig = {
+      name: 'ds',
+      fullName: 'ds',
+      provider: ModelProvider.DEEPSEEK,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    };
+    const handler = new EmptyInputHandler(config);
+    const logger = new AgentLogger('TestHandler', true);
+    const tool = new EchoTool();
+    const toolRegistry = { echo: tool };
+    const setting: AgentSetting = {
+      agentType: AgentType.ToolUse,
+      agentCategory: AgentCategory.ToolUse,
+      documentTag: 'doc',
+      temperature: 0,
+      endTag: '</doc>',
+      requiredFiles: {},
+      requiredFilesInternal: {},
+      defaultOutputFiles: [],
+      filePatternsContain: [],
+      tools: [{ name: 'echo' }],
+    };
+    const prompt: AgentPrompt = {
+      systemPrompt: '',
+      userPrefix: '',
+      userRequest: '',
+    };
+    const toolState = new AgentWorkspaceState();
+    const options: ToolUseCycleOptions<OpenAI> = {
+      modelHandler: handler,
+      agentSetting: setting,
+      agentPrompt: prompt,
+      userVars: {},
+      userVarChannels: {
+        input: Object.freeze({}) as Readonly<Record<string, any>>,
+        transient: {},
+        output: {},
+      },
+      logger,
+      client: {} as OpenAI,
+      toolRegistry,
+      checkInterruption: () => false,
+      setAbortController: () => {},
+      toolState,
+      modelName: 'ds',
+      context: new AgentExecutionContext({
+        streamId: 'tool-use-deepseek-empty' as StreamTabId,
+      }),
+    };
+    const store = new AgentSharedStore({
+      round: new ConversationRoundState(0),
+      run: new AgentRunState(),
+      workspace: toolState,
+      user: options.userVarChannels,
+    });
+    const events: any[] = [];
+    const dispose = bus.on('addLogMessage', (e) => events.push(e));
+    const messages: ProviderMessage[] = [];
+
+    await runToolUseCycle({ options, messages, store });
+    dispose();
+
+    assert.deepEqual(tool.calls, [{ value: 'fallback' }]);
+
+    const toolEvents = events.filter(
+      (e) => e.logMessage.messageType === MESSAGE_TYPES.TOOL_USE,
+    );
+    assert.equal(toolEvents.length, 2);
+    const structuredLog = toolEvents.find(
+      (e) => e.logMessage.data && e.logMessage.data.tool === 'echo',
+    );
+    assert.ok(structuredLog, 'Tool use log entry missing structured payload');
+    assert.deepEqual(structuredLog?.logMessage.data?.input, {
+      value: 'fallback',
+    });
+    assert.deepEqual(structuredLog?.logMessage.data?.output, {
+      output: 'fallback',
     });
   });
 });

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -35,10 +35,14 @@ import { ToolResult, toolResult } from '@tools/result';
 import type OpenAI from 'openai';
 
 class EchoTool extends BaseTool<{ value: string }> {
+  public readonly calls: Array<{ value: string }> = [];
+
   constructor() {
     super({ name: 'echo' }, z.object({ value: z.string() }));
   }
+
   protected async execute(input: { value: string }): Promise<ToolResult> {
+    this.calls.push(input);
     return toolResult({ output: input.value });
   }
 }
@@ -194,6 +198,107 @@ describe('runToolUseCycle OpenAIResponse', () => {
       type: 'function_call_output',
       call_id: 'c1',
       output: JSON.stringify({ output: 'hello' }),
+    });
+  });
+
+  it('falls back to arguments when input string is empty', async () => {
+    class EmptyInputHandler extends MockHandler {
+      override extractToolUse(resp: any): string | null {
+        const original = super.extractToolUse(resp);
+        if (!original) {
+          return original;
+        }
+        const parsed = JSON.parse(original);
+        return JSON.stringify({
+          ...parsed,
+          input: '',
+          arguments: '{"value":"fallback"}',
+        });
+      }
+    }
+
+    const config: ModelConfig = {
+      name: 'test',
+      fullName: 'test',
+      provider: ModelProvider.OPENAI,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    };
+    const handler = new EmptyInputHandler(config);
+    const logger = new AgentLogger('TestHandler', true);
+    const tool = new EchoTool();
+    const toolRegistry = { echo: tool };
+    const setting: AgentSetting = {
+      agentType: AgentType.ToolUse,
+      agentCategory: AgentCategory.ToolUse,
+      documentTag: 'doc',
+      temperature: 0,
+      endTag: '</doc>',
+      requiredFiles: {},
+      requiredFilesInternal: {},
+      defaultOutputFiles: [],
+      filePatternsContain: [],
+      tools: [{ name: 'echo' }],
+    };
+    const prompt: AgentPrompt = {
+      systemPrompt: '',
+      userPrefix: '',
+      userRequest: '',
+    };
+    const toolState = new AgentWorkspaceState();
+    const options: ToolUseCycleOptions<OpenAI> = {
+      modelHandler: handler,
+      agentSetting: setting,
+      agentPrompt: prompt,
+      userVars: {},
+      userVarChannels: {
+        input: Object.freeze({}) as Readonly<Record<string, any>>,
+        transient: {},
+        output: {},
+      },
+      logger,
+      client: {} as OpenAI,
+      toolRegistry,
+      checkInterruption: () => false,
+      setAbortController: () => {},
+      toolState,
+      modelName: 'test',
+      context: new AgentExecutionContext({
+        streamId: 'tool-use-openai-empty' as StreamTabId,
+      }),
+    };
+    const store = new AgentSharedStore({
+      round: new ConversationRoundState(0),
+      run: new AgentRunState(),
+      workspace: toolState,
+      user: options.userVarChannels,
+    });
+    const events: any[] = [];
+    const dispose = bus.on('addLogMessage', (e) => events.push(e));
+    const messages: ProviderMessage[] = [];
+
+    await runToolUseCycle({ options, messages, store });
+    dispose();
+
+    assert.deepEqual(tool.calls, [{ value: 'fallback' }]);
+
+    const toolEvents = events.filter(
+      (e) => e.logMessage.messageType === MESSAGE_TYPES.TOOL_USE,
+    );
+    assert.equal(toolEvents.length, 2);
+    const structuredLog = toolEvents.find(
+      (e) => e.logMessage.data && e.logMessage.data.tool === 'echo',
+    );
+    assert.ok(structuredLog, 'Tool use log entry missing structured payload');
+    assert.deepEqual(structuredLog?.logMessage.data?.input, {
+      value: 'fallback',
+    });
+    assert.deepEqual(structuredLog?.logMessage.data?.output, {
+      output: 'fallback',
     });
   });
 });


### PR DESCRIPTION
## Summary
- skip blank string tool payloads when normalizing tool arguments so Gemini and DeepSeek tool calls retain their parameters
- add regression tests covering OpenAI response and DeepSeek flows when the provider sends arguments outside of the `input` field

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc7a436d88324873f57736fbeede0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize tool call arguments by ignoring empty strings and falling back to `arguments`/`function.arguments`, with regression tests for DeepSeek and OpenAIResponse flows.
> 
> - **Core Tool Use**:
>   - Normalize tool call inputs in `src/agent/core/flows/ToolUseCycleFlow.ts` to ignore empty string `input` values and parse from `arguments` or `function.arguments`.
> - **Tests**:
>   - Add regression cases in `ToolUseCycleDeepSeek.test.ts` and `ToolUseCycleOpenAIResponse.test.ts` verifying fallback when `input` is empty and ensuring structured tool-use logging.
>   - Enhance `EchoTool` in tests to track invocations via a `calls` array.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c923ba7e4ac084ae6a1f5275edc6c880acc4b61a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->