### PR TITLE
fix: restore tool arguments parsing after blank input

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -161,8 +161,7 @@ const ToolCallPayloadSchema =
       if (typeof candidate === 'string') {
         const trimmed = candidate.trim();
         if (!trimmed) {
-          input = {};
-          break;
+          continue;
         }
         try {
           input = JSON.parse(trimmed);

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -59,6 +59,7 @@ class MockHandler extends ModelHandlerDeepSeek {
                 {
                   id: 'c1',
                   type: 'function',
+                  input: '',
                   function: { name: 'echo', arguments: '{"value":"hello"}' },
                 },
               ],

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -65,6 +65,7 @@ class MockHandler extends ModelHandlerOpenAIResponse {
             type: 'function_call',
             call_id: 'c1',
             name: 'echo',
+            input: '',
             arguments: '{"value":"hello"}',
           },
         ],


### PR DESCRIPTION
## Summary
- ignore empty string tool payloads so argument fallbacks are used during tool dispatch
- cover blank `input` values in OpenAI and DeepSeek tool-use cycle tests to prevent regression

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc7a436d88324873f57736fbeede0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ignores empty string tool payloads during tool-call normalization and updates DeepSeek/OpenAI tests to cover blank input.
> 
> - **Core (tool-call normalization)**:
>   - In `src/agent/core/flows/ToolUseCycleFlow.ts`, skip empty-string `input`/`arguments` and continue to fallback sources (e.g., `function.arguments`), restoring proper tool argument parsing.
> - **Tests**:
>   - `src/test/toolUse/ToolUseCycleDeepSeek.test.ts`: add blank `input` in tool call and assert parsed input/flow remain correct.
>   - `src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts`: add blank `input` in function call and verify logging/messages and outputs remain correct.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 582603ce077312dd802934c45f8b3cfd04d2f045. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->