### PR TITLE
fix: skip OpenRouter file uploads

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -82,6 +82,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   OpenAIAPIResponseUsage,
   ResponseFunctionToolCallItem
 > {
+  private isOpenRouterRoutingEnabled(): boolean {
+    return (
+      this.config.openRouterOnly ||
+      getConfig<boolean>('texra.model.useOpenRouter', false)
+    );
+  }
+
   protected override get supportsToolFileOutputs(): boolean {
     return true;
   }
@@ -402,6 +409,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     client: OpenAI,
     content: ResponseInputFile,
   ): Promise<void> {
+    if (this.isOpenRouterRoutingEnabled()) {
+      this.logger.debug(
+        'OpenRouter routing active; skipping inline file upload.',
+      );
+      return;
+    }
+
     const fileData = content.file_data;
     if (!fileData) {
       return;
@@ -1367,6 +1381,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     client: OpenAI,
     attachments: ToolFileAttachment[],
   ): Promise<UploadedOpenAIResponseAttachment[]> {
+    if (this.isOpenRouterRoutingEnabled()) {
+      this.logger.debug(
+        'OpenRouter routing active; skipping tool attachment uploads.',
+      );
+      return [];
+    }
+
     const uploaded: UploadedOpenAIResponseAttachment[] = [];
 
     for (const attachment of attachments) {


### PR DESCRIPTION
## Summary
- skip inline file uploads when OpenRouter routing is active to avoid failing against the Files API
- bypass tool attachment uploads under OpenRouter so the fallback summary remains available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fe1d25cb48324967e9036c20cea64)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips uploading inline files and tool attachments when OpenRouter routing is enabled, using existing fallbacks instead.
> 
> - **Responses handler (`modelHandlerOpenAIResponse.ts`)**
>   - Adds `isOpenRouterRoutingEnabled()` to detect OpenRouter routing (`config.openRouterOnly` or `texra.model.useOpenRouter`).
>   - Inline file uploads: `replaceFileDataWithUpload` now early-returns with a debug log when OpenRouter routing is active.
>   - Tool attachments: `uploadToolAttachments` now early-returns an empty list with a debug log when OpenRouter routing is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49692bfb4eace4b6a91190ba6f87bec03e841abd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->