### PR TITLE
feat: surface run storage metadata in progress view

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -53,35 +53,39 @@ export class LatexDiffManager {
     workspaceDir?: string;
     displayPath: string;
   }> {
-    const workspaceDir = workspaceCandidate
-      ? path.dirname(toAbsolutePath(workspaceCandidate))
+    const workspaceAbsolute = workspaceCandidate
+      ? toAbsolutePath(workspaceCandidate)
       : undefined;
+    const workspaceExists = workspaceCandidate
+      ? await existsFlexible(workspaceCandidate)
+      : false;
+    const workspaceDir = workspaceAbsolute
+      ? path.dirname(workspaceAbsolute)
+      : undefined;
+    const displayPath = this.fileService.getWorkspaceDisplayPath(
+      workspaceCandidate ?? actualPath,
+    );
 
-    if (await existsFlexible(actualPath)) {
+    if (workspaceAbsolute && workspaceExists) {
       return {
-        actual: actualPath,
+        actual: workspaceAbsolute,
         workspaceDir,
-        displayPath: this.fileService.getWorkspaceDisplayPath(
-          workspaceCandidate ?? actualPath,
-        ),
+        displayPath,
       };
     }
 
-    if (workspaceCandidate && (await existsFlexible(workspaceCandidate))) {
+    if (await existsFlexible(actualPath)) {
       return {
-        actual: workspaceCandidate,
+        actual: toAbsolutePath(actualPath),
         workspaceDir,
-        displayPath:
-          this.fileService.getWorkspaceDisplayPath(workspaceCandidate),
+        displayPath,
       };
     }
 
     return {
       actual: null,
       workspaceDir,
-      displayPath: this.fileService.getWorkspaceDisplayPath(
-        workspaceCandidate ?? actualPath,
-      ),
+      displayPath,
     };
   }
 
@@ -212,7 +216,7 @@ export class LatexDiffManager {
             if (this.fileService.hasRunDirectory()) {
               const relocation =
                 await this.fileService.relocateToRunStorage(diffPath);
-              diffPath = relocation.storagePath;
+              diffPath = relocation.actualPath;
               await this.fileService.relocateToRunStorage(buildDir);
             }
           }
@@ -296,7 +300,7 @@ export class LatexDiffManager {
             if (this.fileService.hasRunDirectory()) {
               const relocation =
                 await this.fileService.relocateToRunStorage(diffPath);
-              diffPath = relocation.storagePath;
+              diffPath = relocation.actualPath;
               await this.fileService.relocateToRunStorage(buildDir);
             }
           }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -42,7 +42,9 @@ import {
   WorkspaceFS,
   AbsoluteFS,
   TaskRunFileService,
+  TaskRunFileDescriptor,
   readFlexible,
+  existsFlexible,
 } from '@utils/files';
 import { getEffectiveBaseFile } from '@utils/files/baseFileUtils';
 import {
@@ -51,6 +53,15 @@ import {
 } from '@utils/text/xmlUtils';
 
 // Local imports - types
+
+async function findFirstExistingPath(paths: string[]): Promise<string | null> {
+  for (const candidate of paths) {
+    if (await existsFlexible(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
 
 /** Handles output file processing and validation for agent responses. */
 export class OutputHandler implements IOutputHandler {
@@ -201,16 +212,33 @@ export class OutputHandler implements IOutputHandler {
         )?.[0] || null;
       const originalFile = mapping.originByOutput.get(file) || null;
       const diffBase = getEffectiveBaseFile(baseFile, originalFile, file);
-      const workspacePath = this.getNamedOutputs(currRound).find(
+      const namedEntry = this.getNamedOutputs(currRound).find(
         (p) => p.path === file,
-      )?.workspacePath;
+      );
+      const workspacePath = namedEntry?.workspacePath ?? null;
+      const runStoragePath = namedEntry?.runStoragePath ?? null;
+      const relativePath = namedEntry?.relativePath ?? null;
+      const displayName =
+        namedEntry?.displayName ??
+        (originalFile
+          ? path.basename(originalFile)
+          : path.basename(workspacePath ?? file));
+      const displayPath =
+        relativePath ??
+        (workspacePath
+          ? WorkspaceFS.relativePath(workspacePath)
+          : (runStoragePath ?? file));
       const stats = await this.diffStatsManager.computeDiffStats(
         diffBase,
         file,
       );
       infos.push({
         path: file,
-        workspacePath: workspacePath ?? null,
+        workspacePath,
+        runStoragePath,
+        relativePath,
+        displayName,
+        displayPath,
         base: baseFile,
         prev: prevFile,
         original: originalFile,
@@ -293,26 +321,41 @@ export class OutputHandler implements IOutputHandler {
     rawOutputPath: string,
     processed: NamedOutputFile[],
   ): Promise<{
-    raw: string;
+    raw: TaskRunFileDescriptor | null;
     processed: NamedOutputFile[];
   }> {
-    let relocatedRaw = rawOutputPath;
+    let relocatedRaw: TaskRunFileDescriptor | null = null;
     if (rawOutputPath) {
-      const relocation =
-        await this.fileService.relocateToRunStorage(rawOutputPath);
-      relocatedRaw = relocation.storagePath;
+      relocatedRaw = await this.fileService.relocateToRunStorage(rawOutputPath);
     }
 
     const relocatedProcessed: NamedOutputFile[] = [];
     for (const entry of processed) {
       try {
-        const relocation = await this.fileService.relocateToRunStorage(
+        const descriptor = await this.fileService.relocateToRunStorage(
           entry.path,
         );
+        const displayName =
+          entry.displayName ??
+          (entry.source
+            ? path.basename(entry.source)
+            : path.basename(descriptor.displayPath));
+        const relativePath =
+          entry.relativePath ??
+          descriptor.workspaceRelative ??
+          descriptor.runRelative ??
+          null;
+
         relocatedProcessed.push({
           ...entry,
-          path: relocation.storagePath,
-          workspacePath: entry.workspacePath ?? relocation.workspacePath,
+          path: descriptor.actualPath,
+          workspacePath:
+            entry.workspacePath ??
+            descriptor.workspacePath ??
+            descriptor.actualPath,
+          runStoragePath: descriptor.runStoragePath ?? null,
+          relativePath,
+          displayName,
         });
       } catch (error) {
         throw Object.assign(
@@ -433,9 +476,19 @@ export class OutputHandler implements IOutputHandler {
       async (scope) => {
         this.ensureRound(currRound);
         if (!this.rawOutputs[currRound]) {
-          this.rawOutputs[currRound] = outputFile
-            ? this.fileService.resolveExpectedPath(outputFile)
-            : null;
+          if (!outputFile) {
+            this.rawOutputs[currRound] = null;
+          } else {
+            const expectedPath =
+              this.fileService.resolveExpectedPath(outputFile);
+            const candidates = [outputFile];
+            if (expectedPath !== outputFile) {
+              candidates.push(expectedPath);
+            }
+
+            const existingPath = await findFirstExistingPath(candidates);
+            this.rawOutputs[currRound] = existingPath ?? outputFile;
+          }
         }
         const fileInfos = await this.gatherOutputFileInfo(currRound);
         this.roundFileInfos[currRound] = fileInfos;
@@ -459,6 +512,7 @@ export class OutputHandler implements IOutputHandler {
           stream: this.channel,
           groupId: this.currentRunId ?? undefined,
           filesByRound: { [currRound]: fileInfos },
+          session: this.fileService.getSessionMetadata(),
         });
 
         for (const { path: filePath } of fileInfos) {
@@ -529,14 +583,15 @@ export class OutputHandler implements IOutputHandler {
                 relocatedFiles,
                 relocated.processed,
               );
+              const relocatedRawPath = relocated.raw?.actualPath ?? outputFile;
               await this.captureXmlSummary(
                 currRound,
-                relocated.raw,
+                relocatedRawPath,
                 relocated.processed,
                 scope,
               );
-              outputFile = relocated.raw;
-              this.rawOutputs[currRound] = relocated.raw;
+              outputFile = relocatedRawPath;
+              this.rawOutputs[currRound] = relocatedRawPath;
               return;
             }
 
@@ -548,8 +603,8 @@ export class OutputHandler implements IOutputHandler {
             if (outputFile) {
               const relocation =
                 await this.fileService.relocateToRunStorage(outputFile);
-              outputFile = relocation.storagePath;
-              this.rawOutputs[currRound] = relocation.storagePath;
+              outputFile = relocation.actualPath;
+              this.rawOutputs[currRound] = relocation.actualPath;
             }
           } catch (err) {
             this.logger.debug(
@@ -569,6 +624,7 @@ export class OutputHandler implements IOutputHandler {
             let processed: NamedOutputFile = {
               source: outputFile,
               path: outputFile,
+              displayName: path.basename(outputFile),
             };
             const hasScratchpadPrefill =
               this.agentSetting.prefills?.some((prefill) =>
@@ -608,14 +664,15 @@ export class OutputHandler implements IOutputHandler {
                 relocatedFiles,
                 relocated.processed,
               );
+              const relocatedRawPath = relocated.raw?.actualPath ?? outputFile;
               await this.captureXmlSummary(
                 currRound,
-                relocated.raw,
+                relocatedRawPath,
                 relocated.processed,
                 scope,
               );
-              outputFile = relocated.raw;
-              this.rawOutputs[currRound] = relocated.raw;
+              outputFile = relocatedRawPath;
+              this.rawOutputs[currRound] = relocatedRawPath;
             } else {
               this.logger.debug(
                 `No processed file was generated from ${outputFile}`,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -270,7 +270,12 @@ export class XmlOutputManager {
         currRound,
       );
       await writeFlexible(texFile, doc.content.trim());
-      outputFiles.push({ source, path: texFile, workspacePath: texFile });
+      outputFiles.push({
+        source,
+        path: texFile,
+        workspacePath: texFile,
+        displayName: path.basename(source),
+      });
       this.logger.debug(
         `XML Source: ${source} -> TeX file written: ${texFile}`,
       );
@@ -298,6 +303,7 @@ export class XmlOutputManager {
       source: original || this.agentConfig.inputFile,
       path: processedOutputFile,
       workspacePath: processedOutputFile,
+      displayName: original ? path.basename(original) : undefined,
     };
   }
 

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -5,11 +5,18 @@ export interface NamedOutputFile {
   source: string;
   path: string;
   workspacePath?: string;
+  runStoragePath?: string | null;
+  relativePath?: string | null;
+  displayName?: string | null;
 }
 
 export interface OutputFileInfo extends DiffStats {
   path: string;
   workspacePath?: string | null;
+  runStoragePath?: string | null;
+  relativePath?: string | null;
+  displayName?: string | null;
+  displayPath?: string | null;
   base?: string | null;
   prev?: string | null;
   original?: string | null;

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -8,6 +8,7 @@ export enum WorkspaceStateKey {
   STREAM_TABS = 'texra.streamTabs',
   TASK_GROUPS = 'texra.taskGroups',
   OUTPUT_FILES = 'texra.outputFiles',
+  OUTPUT_RUN_METADATA = 'texra.outputRunMetadata',
   MISSING_OUTPUTS = 'texra.missingOutputs',
   RUN_INSTRUCTIONS = 'texra.runInstructions',
   RUN_USAGE = 'texra.runUsage',

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 // Local imports - agent
 import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
+import type { TaskRunSessionMetadata } from '@utils/files';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 
@@ -66,6 +67,7 @@ export interface ProgressEventPayloads {
     stream: StreamTabId;
     groupId?: string;
     filesByRound: { [key: number]: OutputFileInfo[] };
+    session?: TaskRunSessionMetadata;
   };
   updateMissingOutputs: {
     stream: StreamTabId;

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -25,8 +25,13 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     );
 
     const workspacePath = WorkspaceFS.getPath();
+    const absoluteFilePath = path.isAbsolute(filePath)
+      ? filePath
+      : workspacePath
+        ? path.join(workspacePath, filePath)
+        : path.resolve(filePath);
     const isWorkspaceFile =
-      !!workspacePath && filePath.startsWith(workspacePath);
+      !!workspacePath && absoluteFilePath.startsWith(workspacePath);
 
     // Get latexindent config from settings
     const latexindentConfig = getConfig<string>(
@@ -52,8 +57,8 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     await sleep(100);
 
     // Setup cleanup patterns relative to workspace
-    const fileBaseName = path.basename(filePath, '.tex');
-    const fileDir = path.dirname(filePath);
+    const fileBaseName = path.basename(absoluteFilePath, '.tex');
+    const fileDir = path.dirname(absoluteFilePath);
 
     logger.debug(CHANNEL, `File base name: ${fileBaseName}`);
     logger.debug(CHANNEL, `File directory: ${fileDir}`);
@@ -76,9 +81,8 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
       for (const pattern of backupPatterns) {
         logger.debug(CHANNEL, `Searching for pattern: ${pattern}`);
         const backupFiles = globSync(pattern, {
-          cwd: workspacePath,
           nodir: true,
-          absolute: false,
+          absolute: true,
         });
 
         logger.debug(
@@ -88,8 +92,11 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
 
         for (const backupFile of backupFiles) {
           try {
-            await WorkspaceFS.delete(backupFile);
-            logger.debug(CHANNEL, `Removed backup file: ${backupFile}`);
+            await AbsoluteFS.delete(backupFile);
+            const displayPath = workspacePath
+              ? WorkspaceFS.relativePath(backupFile)
+              : backupFile;
+            logger.debug(CHANNEL, `Removed backup file: ${displayPath}`);
           } catch (err) {
             logger.warn(
               CHANNEL,
@@ -105,14 +112,13 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
       );
     }
 
-    const indentLogPath = path.join(path.dirname(filePath), 'indent.log');
+    const indentLogPath = path.join(fileDir, 'indent.log');
     try {
-      if (isWorkspaceFile) {
-        await WorkspaceFS.delete(indentLogPath);
-      } else {
-        await AbsoluteFS.delete(indentLogPath);
-      }
-      logger.debug(CHANNEL, 'Removed indent.log');
+      await AbsoluteFS.delete(indentLogPath);
+      const displayPath = workspacePath
+        ? WorkspaceFS.relativePath(indentLogPath)
+        : indentLogPath;
+      logger.debug(CHANNEL, `Removed indent.log at ${displayPath}`);
     } catch (err) {
       logger.warn(CHANNEL, `Error removing indent.log: ${err}`);
     }

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -42,7 +42,9 @@ const updateActiveStreamOutputs = (
       Object.fromEntries(rounds.entries()),
     ]),
   );
-  updater.updateFiles(stream, filesPayload);
+  const metadataByRun = state.outputFiles.getRunMetadata(stream);
+  const metadataPayload = Object.fromEntries(metadataByRun.entries());
+  updater.updateFiles(stream, filesPayload, metadataPayload);
 
   const missingByRun = state.outputFiles.getMissingOutputs(stream);
   const missingPayload = Object.fromEntries(
@@ -62,9 +64,14 @@ const registerOutputFileListeners = (
 ): vscode.Disposable[] => {
   const addFiles = bus.on(
     'addOutputFiles',
-    ({ stream, groupId, filesByRound }) => {
+    ({ stream, groupId, filesByRound, session }) => {
       withErrorBoundary('failed to handle addOutputFiles', async () => {
-        await state.outputFiles.addFiles(stream, groupId ?? null, filesByRound);
+        await state.outputFiles.addFiles(
+          stream,
+          groupId ?? null,
+          filesByRound,
+          session,
+        );
         updateActiveStreamOutputs(state, updater, stream);
       });
     },

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -15,6 +15,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 // Types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { OutputFileInfo } from '@agent/output/types';
+import type { TaskRunSessionMetadata } from '@utils/files';
 
 const isValidOutputFile = (value: unknown): value is OutputFileInfo => {
   if (!value || typeof value !== 'object') {
@@ -37,6 +38,8 @@ export class OutputFilesManager extends PersistentMapManager<
     StreamTabId,
     Map<string, Map<number, string[]>>
   > = new Map();
+  private _runMetadata: Map<StreamTabId, Map<string, TaskRunSessionMetadata>> =
+    new Map();
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {
@@ -49,6 +52,7 @@ export class OutputFilesManager extends PersistentMapManager<
     stream: StreamTabId,
     groupId: string | null | undefined,
     filesByRound: { [key: number]: OutputFileInfo[] },
+    session?: TaskRunSessionMetadata,
   ): Promise<void> {
     const runId = normalizeRunId(groupId);
 
@@ -83,7 +87,19 @@ export class OutputFilesManager extends PersistentMapManager<
       runRounds.set(roundNum, normalizedFiles);
     }
 
+    if (session) {
+      let streamMetadata = this._runMetadata.get(stream);
+      if (!streamMetadata) {
+        streamMetadata = new Map();
+        this._runMetadata.set(stream, streamMetadata);
+      }
+      streamMetadata.set(runId, session);
+    }
+
     await this.save();
+    if (session) {
+      await this.saveRunMetadata();
+    }
   }
 
   /** Update missing outputs for a stream */
@@ -126,6 +142,12 @@ export class OutputFilesManager extends PersistentMapManager<
     return runs ? new Map(runs) : new Map();
   }
 
+  /** Get stored metadata for a stream */
+  getRunMetadata(stream: StreamTabId): Map<string, TaskRunSessionMetadata> {
+    const metadata = this._runMetadata.get(stream);
+    return metadata ? new Map(metadata) : new Map();
+  }
+
   /**
    * Return a flattened set of file paths known for the provided stream.
    * Includes both generated artifacts and their original counterparts.
@@ -160,6 +182,9 @@ export class OutputFilesManager extends PersistentMapManager<
   /** Clear output files for a stream */
   async clearFiles(stream: StreamTabId): Promise<void> {
     await this.delete(stream);
+    if (this._runMetadata.delete(stream)) {
+      await this.saveRunMetadata();
+    }
   }
 
   async clearRunFiles(
@@ -175,6 +200,17 @@ export class OutputFilesManager extends PersistentMapManager<
     const removed = runs.delete(runId);
     if (runs.size === 0) {
       this.items.delete(stream);
+    }
+
+    const metadata = this._runMetadata.get(stream);
+    if (metadata) {
+      const metaRemoved = metadata.delete(runId);
+      if (metadata.size === 0) {
+        this._runMetadata.delete(stream);
+      }
+      if (metaRemoved) {
+        await this.saveRunMetadata();
+      }
     }
 
     if (removed) {
@@ -214,6 +250,9 @@ export class OutputFilesManager extends PersistentMapManager<
   async deleteStream(stream: StreamTabId): Promise<void> {
     await super.delete(stream);
     this._missingOutputs.delete(stream);
+    if (this._runMetadata.delete(stream)) {
+      await this.saveRunMetadata();
+    }
     await this.saveMissingOutputs();
   }
 
@@ -221,12 +260,19 @@ export class OutputFilesManager extends PersistentMapManager<
   async clear(): Promise<void> {
     await super.clear();
     this._missingOutputs.clear();
+    this._runMetadata.clear();
     await this.saveMissingOutputs();
+    await this.saveRunMetadata();
   }
 
   /** Get all output files */
   getAllFiles(): Map<StreamTabId, Map<string, Map<number, OutputFileInfo[]>>> {
     return this.getAll();
+  }
+
+  /** Get all stored run metadata */
+  getAllRunMetadata(): Map<StreamTabId, Map<string, TaskRunSessionMetadata>> {
+    return new Map(this._runMetadata);
   }
 
   /** Get all missing outputs */
@@ -241,6 +287,12 @@ export class OutputFilesManager extends PersistentMapManager<
     this.setAll(files);
   }
 
+  setAllRunMetadata(
+    metadata: Map<StreamTabId, Map<string, TaskRunSessionMetadata>>,
+  ): void {
+    this._runMetadata = new Map(metadata);
+  }
+
   /** Set all missing outputs (used during loading) */
   setAllMissingOutputs(
     missing: Map<StreamTabId, Map<string, Map<number, string[]>>>,
@@ -252,6 +304,7 @@ export class OutputFilesManager extends PersistentMapManager<
   async load(): Promise<void> {
     await super.load();
     await this.loadMissingOutputs();
+    await this.loadRunMetadata();
   }
 
   /** Load missing outputs from persistence */
@@ -272,6 +325,20 @@ export class OutputFilesManager extends PersistentMapManager<
     }
   }
 
+  private async loadRunMetadata(): Promise<void> {
+    const saved = this.storage.get<Record<string, unknown>>(
+      WorkspaceStateKey.OUTPUT_RUN_METADATA,
+      {},
+    );
+
+    if (saved && Object.keys(saved).length > 0) {
+      this._runMetadata = this.deserializeRunMetadata(saved);
+      return;
+    }
+
+    this._runMetadata.clear();
+  }
+
   /** Save missing outputs to persistence */
   async saveMissingOutputs(): Promise<void> {
     const obj = Object.fromEntries(
@@ -286,6 +353,76 @@ export class OutputFilesManager extends PersistentMapManager<
       ]),
     );
     await this.storage.update(WorkspaceStateKey.MISSING_OUTPUTS, obj);
+  }
+
+  async saveRunMetadata(): Promise<void> {
+    const obj = Object.fromEntries(
+      Array.from(this._runMetadata.entries(), ([stream, runs]) => [
+        stream,
+        Object.fromEntries(runs.entries()),
+      ]),
+    );
+    await this.storage.update(WorkspaceStateKey.OUTPUT_RUN_METADATA, obj);
+  }
+
+  private deserializeRunMetadata(
+    saved: Record<string, unknown>,
+  ): Map<StreamTabId, Map<string, TaskRunSessionMetadata>> {
+    const processed = new Map<
+      StreamTabId,
+      Map<string, TaskRunSessionMetadata>
+    >();
+
+    for (const [stream, raw] of Object.entries(saved)) {
+      if (!raw || typeof raw !== 'object') {
+        processed.set(stream as StreamTabId, new Map());
+        continue;
+      }
+
+      const entries = Object.entries(raw as Record<string, unknown>);
+      const runMap = new Map<string, TaskRunSessionMetadata>();
+
+      for (const [runId, value] of entries) {
+        if (!value || typeof value !== 'object') {
+          continue;
+        }
+
+        const session = this.normalizeSessionMetadata(
+          value as Record<string, unknown>,
+        );
+        if (session) {
+          runMap.set(runId, session);
+        }
+      }
+
+      processed.set(stream as StreamTabId, runMap);
+    }
+
+    return processed;
+  }
+
+  private normalizeSessionMetadata(
+    candidate: Record<string, unknown>,
+  ): TaskRunSessionMetadata | null {
+    const mode = candidate.storageMode;
+    if (mode !== 'workspace' && mode !== 'taskRunStorage') {
+      return null;
+    }
+
+    const runDirectory =
+      typeof candidate.runDirectory === 'string'
+        ? candidate.runDirectory
+        : undefined;
+    const runRelativeRoot =
+      typeof candidate.runRelativeRoot === 'string'
+        ? candidate.runRelativeRoot
+        : undefined;
+
+    return {
+      storageMode: mode,
+      runDirectory,
+      runRelativeRoot,
+    };
   }
 
   private deserializeMissingOutputs(

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -15,6 +15,7 @@ import type {
   ToolEditApprovalPrompt,
 } from '../types';
 import type { OutputFileInfo } from '@agent/output/types';
+import type { TaskRunSessionMetadata } from '@utils/files';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
@@ -155,6 +156,7 @@ export class WebviewUpdater {
   updateFiles(
     stream: StreamTabId,
     filesByRun: Record<string, { [key: number]: OutputFileInfo[] }>,
+    metadataByRun?: Record<string, TaskRunSessionMetadata>,
   ): void {
     const webview = this.getWebview();
     if (!webview) return;
@@ -163,6 +165,7 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_FILES,
       stream,
       filesByRun,
+      metadataByRun,
     });
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -112,7 +112,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const filesByRound = activeRunId
       ? state.getRunFiles(stream, activeRunId) || {}
       : {};
-    dom.fileList.update(filesByRound);
+    const runMetadata = state.getRunMetadata(stream);
+    const sessionMetadata =
+      activeRunId && runMetadata ? runMetadata.get(activeRunId) || null : null;
+    dom.fileList.update(filesByRound, sessionMetadata);
   }
 
   _refreshUsageForActiveRun() {
@@ -489,6 +492,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       const filesByRun = message.filesByRun || {};
       Object.entries(filesByRun).forEach(([runId, files]) => {
         state.setRunFiles(targetStream, runId, files);
+      });
+      const metadataByRun = message.metadataByRun || {};
+      Object.entries(metadataByRun).forEach(([runId, metadata]) => {
+        if (metadata) {
+          state.setRunMetadata(targetStream, runId, metadata);
+        }
       });
       this._refreshOutputsForActiveRun();
     }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -233,6 +233,7 @@ export class ProgressViewState {
     this.runFiles = new Map();
     this.runMissingOutputs = new Map();
     this.runUsage = new Map();
+    this.runMetadata = new Map();
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
@@ -558,6 +559,15 @@ export class ProgressViewState {
     streamMap.set(runId, filesByRound || {});
   }
 
+  setRunMetadata(streamId, runId, metadata) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null || !runId || !metadata) {
+      return;
+    }
+    const streamMap = this._getStreamMap(this.runMetadata, targetStream, true);
+    streamMap.set(runId, metadata);
+  }
+
   getRunFiles(streamId, runId) {
     const targetStream = this._resolveStreamId(streamId);
     if (targetStream == null || !runId) {
@@ -570,6 +580,15 @@ export class ProgressViewState {
     return streamMap.get(runId) || null;
   }
 
+  getRunMetadata(streamId) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null) {
+      return null;
+    }
+    const streamMap = this.runMetadata.get(targetStream);
+    return streamMap ? new Map(streamMap) : null;
+  }
+
   clearRunFiles(streamId) {
     if (streamId !== undefined && streamId !== null) {
       const targetStream = this._resolveStreamId(streamId);
@@ -577,10 +596,12 @@ export class ProgressViewState {
         return;
       }
       this.runFiles.delete(targetStream);
+      this.runMetadata.delete(targetStream);
       return;
     }
 
     this.runFiles.clear();
+    this.runMetadata.clear();
   }
 
   deleteRunFiles(streamId, runId) {
@@ -595,6 +616,14 @@ export class ProgressViewState {
     streamMap.delete(runId);
     if (streamMap.size === 0) {
       this.runFiles.delete(targetStream);
+    }
+
+    const metadataMap = this.runMetadata.get(targetStream);
+    if (metadataMap) {
+      metadataMap.delete(runId);
+      if (metadataMap.size === 0) {
+        this.runMetadata.delete(targetStream);
+      }
     }
   }
 

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -38,7 +38,7 @@ export class FileList {
    * Update the generated files list
    * @param {Object} filesByRound - Files organized by round
    */
-  update(filesByRound) {
+  update(filesByRound, sessionMetadata = null) {
     const container = document.getElementById(ELEMENT_IDS.GENERATED_FILES);
     if (!container) return;
 
@@ -117,13 +117,15 @@ export class FileList {
         const statsSpan = clone.querySelector('.file-stats');
 
         // Use original name if available, otherwise use generated path
-        const displayPath = file.workspacePath || file.original || file.path;
-        const basename = getBasename(displayPath);
+        const displayPath =
+          file.displayPath || file.workspacePath || file.original || file.path;
+        const relativeDisplay = file.relativePath || displayPath;
+        const basename = file.displayName || getBasename(relativeDisplay);
         const idx = Math.max(
-          displayPath.lastIndexOf('/'),
-          displayPath.lastIndexOf('\\'),
+          relativeDisplay.lastIndexOf('/'),
+          relativeDisplay.lastIndexOf('\\'),
         );
-        const dirPath = idx >= 0 ? displayPath.slice(0, idx + 1) : '';
+        const dirPath = idx >= 0 ? relativeDisplay.slice(0, idx + 1) : '';
 
         // Set file data attributes
         if (fileItem) {

--- a/src/test/output/OutputHandler.test.ts
+++ b/src/test/output/OutputHandler.test.ts
@@ -183,6 +183,7 @@ describe('OutputHandler.finalizeRound', () => {
     assert.deepEqual(events[0].filesByRound[0], [
       { path: 'out0.tex', base: null, prev: null, original: null },
     ]);
+    assert.deepEqual(events[0].session, { storageMode: 'workspace' });
     dispose();
   });
 

--- a/src/test/utils/files/TaskRunFileService.test.ts
+++ b/src/test/utils/files/TaskRunFileService.test.ts
@@ -1,0 +1,253 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent
+import {
+  AgentCategory,
+  AgentType,
+  type AgentWorkflowSetting,
+} from '@agent/core/AgentDataclass';
+import { LatexDiffManager } from '@agent/output/LatexDiffManager';
+
+// Local imports - files
+import {
+  AbsoluteFS,
+  StorageFS,
+  TaskRunFileService,
+  WorkspaceFS,
+} from '@utils/files';
+
+// Local imports - logging
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - output types
+import type { RoundFileMapping } from '@agent/output/types';
+
+describe('TaskRunFileService run storage integration', () => {
+  const workspaceFsAny = WorkspaceFS as unknown as {
+    getPath: () => string | undefined;
+    fullPath: (target: string) => string;
+  };
+  const storageFsAny = StorageFS as unknown as {
+    fullPath: (target: string) => string;
+    ensureDir: (target: string) => Promise<void>;
+  };
+  const absoluteFsAny = AbsoluteFS as unknown as {
+    exists: (target: string) => Promise<boolean>;
+    read: (target: string) => Promise<string>;
+    write: (target: string, content: string | Uint8Array) => Promise<void>;
+  };
+
+  const originalWorkspaceGetPath = workspaceFsAny.getPath;
+  const originalWorkspaceFullPath = workspaceFsAny.fullPath;
+  const originalStorageFullPath = storageFsAny.fullPath;
+  const originalStorageEnsureDir = storageFsAny.ensureDir;
+  const originalAbsoluteExists = absoluteFsAny.exists;
+  const originalAbsoluteRead = absoluteFsAny.read;
+  const originalAbsoluteWrite = absoluteFsAny.write;
+  const originalGetConfiguration = vscode.workspace.getConfiguration;
+
+  let workspaceRoot: string;
+  let storageRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'texra-workspace-'),
+    );
+    storageRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-storage-'));
+
+    workspaceFsAny.getPath = () => workspaceRoot;
+    workspaceFsAny.fullPath = (target: string) =>
+      path.isAbsolute(target) ? target : path.join(workspaceRoot, target);
+
+    storageFsAny.fullPath = (target: string) => path.join(storageRoot, target);
+    storageFsAny.ensureDir = async (target: string) => {
+      await fs.mkdir(path.join(storageRoot, target), { recursive: true });
+    };
+
+    absoluteFsAny.exists = async (target: string) => {
+      try {
+        await fs.access(target);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    absoluteFsAny.read = async (target: string) => fs.readFile(target, 'utf-8');
+    absoluteFsAny.write = async (
+      target: string,
+      content: string | Uint8Array,
+    ) => {
+      const data = typeof content === 'string' ? content : Buffer.from(content);
+      await fs.writeFile(target, data);
+    };
+
+    (vscode.workspace as any).getConfiguration = (section?: string) => {
+      if (section === 'texra') {
+        return {
+          get: (key: string) =>
+            key === 'agentOutputs.storageMode' ? 'taskRunStorage' : undefined,
+        };
+      }
+
+      if (!section) {
+        return {
+          get: (key: string) =>
+            key === 'texra.agentOutputs.storageMode'
+              ? 'taskRunStorage'
+              : undefined,
+        };
+      }
+
+      return { get: () => undefined };
+    };
+  });
+
+  afterEach(async () => {
+    workspaceFsAny.getPath = originalWorkspaceGetPath;
+    workspaceFsAny.fullPath = originalWorkspaceFullPath;
+    storageFsAny.fullPath = originalStorageFullPath;
+    storageFsAny.ensureDir = originalStorageEnsureDir;
+    absoluteFsAny.exists = originalAbsoluteExists;
+    absoluteFsAny.read = originalAbsoluteRead;
+    absoluteFsAny.write = originalAbsoluteWrite;
+    (vscode.workspace as any).getConfiguration = originalGetConfiguration;
+
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+    await fs.rm(storageRoot, { recursive: true, force: true });
+  });
+
+  function createLogger(): AgentLogger {
+    const logger = new AgentLogger('TaskRunFileServiceTest');
+    const noop = () => {};
+    (logger as any).debug = noop;
+    (logger as any).info = noop;
+    (logger as any).warn = noop;
+    (logger as any).error = noop;
+    (logger as any).latexDiff = noop;
+    return logger;
+  }
+
+  const agentSetting: AgentWorkflowSetting = {
+    agentType: AgentType.CoT,
+    agentCategory: AgentCategory.Workflow,
+    documentTag: 'document',
+    temperature: 0,
+    isRewrite: true,
+    rounds: 1,
+    prefills: [],
+    outputExt: 'tex',
+    endTag: '</latex_document>',
+    requiredFiles: {},
+    requiredFilesInternal: {},
+    defaultOutputFiles: [],
+    isMultipleOutput: false,
+    filePatternsContain: [],
+    tools: [],
+  };
+
+  it('relocates files to run storage while keeping workspace access', async () => {
+    const executionId = 'exec-123';
+    const service = new TaskRunFileService(executionId);
+    const workspaceFile = path.join(workspaceRoot, 'outputs', 'result.tex');
+    await fs.mkdir(path.dirname(workspaceFile), { recursive: true });
+    await fs.writeFile(workspaceFile, 'workspace-content');
+
+    const relocation = await service.relocateToRunStorage(workspaceFile);
+
+    const expectedStoragePath = path.join(
+      storageRoot,
+      'taskRuns',
+      executionId,
+      'outputs',
+      'result.tex',
+    );
+    assert.strictEqual(relocation.actualPath, expectedStoragePath);
+    assert.strictEqual(relocation.runStoragePath, expectedStoragePath);
+    assert.strictEqual(relocation.workspacePath, workspaceFile);
+
+    const storageContent = await fs.readFile(relocation.actualPath, 'utf-8');
+    assert.strictEqual(storageContent, 'workspace-content');
+
+    const workspaceStat = await fs.lstat(workspaceFile);
+    if (workspaceStat.isSymbolicLink()) {
+      const linkTarget = await fs.readlink(workspaceFile);
+      assert.strictEqual(linkTarget, expectedStoragePath);
+    } else {
+      assert.ok(workspaceStat.isFile());
+      const workspaceContent = await fs.readFile(workspaceFile, 'utf-8');
+      assert.strictEqual(workspaceContent, 'workspace-content');
+    }
+  });
+
+  it('prefers workspace paths for latexdiff when files are relocated', async () => {
+    const executionId = 'exec-456';
+    const service = new TaskRunFileService(executionId);
+    const baseFile = path.join(workspaceRoot, 'paper.tex');
+    const outputFile = path.join(workspaceRoot, 'paper_r0.tex');
+    await fs.writeFile(baseFile, 'base');
+    await fs.writeFile(outputFile, 'revised');
+
+    const relocation = await service.relocateToRunStorage(outputFile);
+
+    const outputFiles: { [key: number]: string[] } = {
+      0: [relocation.actualPath],
+    };
+    const mapping: RoundFileMapping = {
+      baseToOutput: new Map([[baseFile, relocation.actualPath]]),
+      prevToOutput: new Map(),
+      originByOutput: new Map([[relocation.actualPath, outputFile]]),
+      workspaceByOutput: new Map([[relocation.actualPath, outputFile]]),
+    };
+
+    const logger = createLogger();
+    const dependencies = {
+      checkToolInstalled: async () => true,
+      compileLatex2Pdf: async () => true,
+      getConfig: <T>(_: string, defaultValue?: T) => defaultValue as T,
+    };
+
+    const manager = new LatexDiffManager(
+      agentSetting,
+      outputFiles,
+      [baseFile],
+      logger,
+      'channel',
+      service,
+      dependencies,
+    );
+
+    const calls: Array<{
+      base: string;
+      revised: string;
+      options?: { cwd?: string };
+    }> = [];
+
+    (manager as any).latexdiffService = {
+      runDiffForRound: async (
+        base: string,
+        revised: string,
+        _round: number,
+        _unused: unknown,
+        options?: { cwd?: string },
+      ) => {
+        calls.push({ base, revised, options });
+        return { success: true };
+      },
+      runDiffBetweenRounds: async () => ({ success: true }),
+    };
+
+    await manager.handleLatexdiffofOutput(0, mapping);
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].base, baseFile);
+    assert.strictEqual(calls[0].revised, outputFile);
+    assert.strictEqual(calls[0].options?.cwd, path.dirname(outputFile));
+  });
+});

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -15,6 +15,21 @@ import type { ExecutionId } from '@agent/types/IdentifierTypes';
  */
 export const TASK_RUNS_DIR = 'taskRuns';
 
+export interface TaskRunSessionMetadata {
+  storageMode: 'workspace' | 'taskRunStorage';
+  runDirectory?: string | null;
+  runRelativeRoot?: string | null;
+}
+
+export interface TaskRunFileDescriptor {
+  actualPath: string;
+  workspacePath?: string | null;
+  workspaceRelative?: string | null;
+  runStoragePath?: string | null;
+  runRelative?: string | null;
+  displayPath: string;
+}
+
 /**
  * Validate an execution ID to ensure it's safe for use in file paths.
  * Acts as a type guard to ensure the ID is defined and non-empty.
@@ -80,6 +95,15 @@ function toWorkspaceRelative(target: string): string {
   }
 
   throw new Error(`Cannot make path workspace-relative: ${target}`);
+}
+
+function tryMakeWorkspaceRelative(target: string): string | null {
+  try {
+    const relative = toWorkspaceRelative(target);
+    return relative;
+  } catch {
+    return null;
+  }
 }
 
 export function getRunRelativePath(id: ExecutionId, target: string): string {
@@ -153,6 +177,37 @@ async function moveToTarget(
   }
 }
 
+async function recreateWorkspaceLink(
+  originalPath: string,
+  storagePath: string,
+): Promise<void> {
+  const workspaceRoot = WorkspaceFS.getPath();
+  if (!workspaceRoot) {
+    return;
+  }
+
+  const normalizedWorkspaceRoot = path.resolve(workspaceRoot);
+  const normalizedOriginal = path.resolve(originalPath);
+  const relativeToWorkspace = path.relative(
+    normalizedWorkspaceRoot,
+    normalizedOriginal,
+  );
+  if (
+    relativeToWorkspace.startsWith('..') ||
+    path.isAbsolute(relativeToWorkspace)
+  ) {
+    return;
+  }
+
+  try {
+    await createSymlink(storagePath, originalPath);
+  } catch (error) {
+    console.warn(
+      `[TaskRunFileService] Failed to mirror ${storagePath} back to ${originalPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 async function createSymlink(
   source: string,
   destination: string,
@@ -205,15 +260,16 @@ function shouldSkipRelocation(relativePath: string): boolean {
 }
 
 export class TaskRunFileService {
+  private readonly storageMode: 'workspace' | 'taskRunStorage';
   private readonly useRunStorage: boolean;
 
   constructor(private readonly executionId?: ExecutionId) {
-    const storageMode = getConfig<'workspace' | 'taskRunStorage'>(
+    this.storageMode = getConfig<'workspace' | 'taskRunStorage'>(
       'texra.agentOutputs.storageMode',
       'workspace',
     );
     this.useRunStorage =
-      storageMode === 'taskRunStorage' && isValidExecutionId(executionId);
+      this.storageMode === 'taskRunStorage' && isValidExecutionId(executionId);
   }
 
   public hasRunDirectory(): boolean {
@@ -227,6 +283,18 @@ export class TaskRunFileService {
     return getRunDir(this.executionId);
   }
 
+  public getSessionMetadata(): TaskRunSessionMetadata {
+    if (!this.executionId || !this.useRunStorage) {
+      return { storageMode: this.storageMode };
+    }
+
+    return {
+      storageMode: this.storageMode,
+      runDirectory: getRunDir(this.executionId),
+      runRelativeRoot: path.join(TASK_RUNS_DIR, this.executionId),
+    };
+  }
+
   public async ensureRunDirectory(): Promise<void> {
     if (!this.executionId || !this.useRunStorage) {
       return;
@@ -234,87 +302,109 @@ export class TaskRunFileService {
     await ensureRunDir(this.executionId);
   }
 
-  public getWorkspaceDisplayPath(target: string): string {
-    const absolute = path.isAbsolute(target)
-      ? target
-      : WorkspaceFS.fullPath(target);
-    const workspaceRoot = WorkspaceFS.getPath();
-    if (!workspaceRoot) {
-      return absolute;
+  private resolveAbsolute(target: string): string {
+    if (path.isAbsolute(target)) {
+      return path.resolve(target);
     }
-    return path.relative(workspaceRoot, absolute);
+
+    const workspaceRoot = WorkspaceFS.getPath();
+    if (workspaceRoot) {
+      return path.resolve(WorkspaceFS.fullPath(target));
+    }
+
+    return path.resolve(target);
   }
 
-  public async relocateToRunStorage(target: string): Promise<{
-    storagePath: string;
-    workspacePath: string;
-    relativePath: string;
-  }> {
-    const absoluteSource = path.isAbsolute(target)
-      ? target
-      : WorkspaceFS.getPath()
-        ? WorkspaceFS.fullPath(target)
-        : target;
-    const workspaceRelative = toWorkspaceRelative(absoluteSource);
+  private describeLocation(
+    actualPath: string,
+    workspacePath?: string | null,
+  ): TaskRunFileDescriptor {
+    const normalizedActual = path.resolve(actualPath);
+    const normalizedWorkspace = workspacePath
+      ? path.resolve(workspacePath)
+      : undefined;
+
+    const workspaceRelative = normalizedWorkspace
+      ? tryMakeWorkspaceRelative(normalizedWorkspace)
+      : tryMakeWorkspaceRelative(normalizedActual);
+
+    let runStoragePath: string | null = null;
+    let runRelative: string | null = null;
+
+    if (this.executionId && this.useRunStorage) {
+      const storageRoot = path.resolve(StorageFS.fullPath(''));
+      const inStorage =
+        normalizedActual === storageRoot ||
+        normalizedActual.startsWith(`${storageRoot}${path.sep}`);
+
+      if (inStorage) {
+        runStoragePath = normalizedActual;
+        runRelative = tryMakeWorkspaceRelative(normalizedActual);
+      }
+    }
+
+    const displayPath =
+      workspaceRelative ??
+      (runRelative && this.executionId
+        ? path.join(TASK_RUNS_DIR, this.executionId, runRelative)
+        : normalizedActual);
+
+    return {
+      actualPath: normalizedActual,
+      workspacePath: normalizedWorkspace ?? null,
+      workspaceRelative,
+      runStoragePath,
+      runRelative,
+      displayPath,
+    };
+  }
+
+  public getWorkspaceDisplayPath(target: string): string {
+    const descriptor = this.describeLocation(this.resolveAbsolute(target));
+    return descriptor.displayPath;
+  }
+
+  public async relocateToRunStorage(
+    target: string,
+  ): Promise<TaskRunFileDescriptor> {
+    const absoluteSource = this.resolveAbsolute(target);
+    const workspaceRelative = tryMakeWorkspaceRelative(absoluteSource) ?? '';
 
     if (shouldSkipRelocation(workspaceRelative)) {
-      return {
-        storagePath: absoluteSource,
-        workspacePath: absoluteSource,
-        relativePath: workspaceRelative,
-      };
+      return this.describeLocation(absoluteSource, absoluteSource);
     }
 
     if (!this.executionId || !this.useRunStorage) {
-      return {
-        storagePath: absoluteSource,
-        workspacePath: absoluteSource,
-        relativePath: workspaceRelative,
-      };
+      return this.describeLocation(absoluteSource, absoluteSource);
     }
 
     await this.ensureRunDirectory();
     const { absolute } = getRunStoragePath(this.executionId, absoluteSource);
-    await moveToTarget(absoluteSource, absolute);
-    return {
-      storagePath: absolute,
-      workspacePath: absoluteSource,
-      relativePath: workspaceRelative,
-    };
+    const resolvedSource = path.resolve(absoluteSource);
+    await moveToTarget(resolvedSource, absolute);
+    if (resolvedSource !== absolute) {
+      await recreateWorkspaceLink(resolvedSource, absolute);
+    }
+    return this.describeLocation(absolute, resolvedSource);
   }
 
-  public async mirrorWorkspaceFile(workspaceFile: string): Promise<{
-    storagePath: string;
-    workspacePath: string;
-  }> {
-    const absoluteSource = path.isAbsolute(workspaceFile)
-      ? workspaceFile
-      : WorkspaceFS.getPath()
-        ? WorkspaceFS.fullPath(workspaceFile)
-        : workspaceFile;
+  public async mirrorWorkspaceFile(
+    workspaceFile: string,
+  ): Promise<TaskRunFileDescriptor> {
+    const absoluteSource = this.resolveAbsolute(workspaceFile);
 
     if (!this.executionId || !this.useRunStorage) {
-      return {
-        storagePath: absoluteSource,
-        workspacePath: absoluteSource,
-      };
+      return this.describeLocation(absoluteSource, absoluteSource);
     }
 
     await this.ensureRunDirectory();
     const { absolute } = getRunStoragePath(this.executionId, absoluteSource);
     await createSymlink(absoluteSource, absolute);
-    return {
-      storagePath: absolute,
-      workspacePath: absoluteSource,
-    };
+    return this.describeLocation(absolute, absoluteSource);
   }
 
   public resolveExpectedPath(target: string): string {
-    const absoluteSource = path.isAbsolute(target)
-      ? target
-      : WorkspaceFS.getPath()
-        ? WorkspaceFS.fullPath(target)
-        : target;
+    const absoluteSource = this.resolveAbsolute(target);
 
     if (!this.executionId || !this.useRunStorage) {
       return absoluteSource;


### PR DESCRIPTION
## Summary
- capture run-storage descriptors during output processing so finalizeRound reports stable paths and display names
- persist per-run storage metadata through the progress view pipeline and expose it to the webview for cleaner labels
- teach TaskRunFileService to describe workspace/run locations consistently and expand tests covering relocation and metadata handling

## Testing
- npm run format
- npm run compile
- npm run lint
- CI=1 npm test *(fails: vscode-test requires libatk-bridge-2.0.so.0 in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fe879cec48324ace336fb9ca35fa7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates per-run storage metadata and normalized file descriptors through output processing to the progress view, updating UI labels/paths and enhancing relocation, diff, and formatter handling with tests.
> 
> - **Output processing**:
>   - Enrich `NamedOutputFile`/`OutputFileInfo` with `runStoragePath`, `relativePath`, `displayName`, `displayPath` and propagate via `OutputHandler.gatherOutputFileInfo`.
>   - Use `TaskRunFileService` descriptors (`actualPath`, display/relative paths) in relocation; resolve raw output path from multiple candidates; emit session metadata via `addOutputFiles`.
>   - Improve XML processing to set `displayName` for single/multiple outputs.
> - **Diff generation**:
>   - `LatexDiffManager` prefers workspace paths when available, computes display paths, and uses `actualPath` after relocation.
> - **Run storage & files**:
>   - Expand `taskRunStorage` with session/file descriptors, workspace-relative helpers, symlink mirroring, and skip-relocation rules.
>   - Update `latexindentpt` to use absolute paths and clean backups/logs via `AbsoluteFS` with clearer display paths.
> - **Progress view**:
>   - Add per-run session metadata persistence (`OUTPUT_RUN_METADATA`) in `OutputFilesManager`; load/save/clear APIs.
>   - Wire metadata through `ProgressEventBus` → `OutputEvents` → `WebviewUpdater` → webview state; `FileList` uses `displayName/displayPath` for cleaner labels.
> - **Tests**:
>   - Add `TaskRunFileService` integration tests for relocation and latexdiff workspace preference; update `OutputHandler` test to expect session metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35e5b5b21c12b56aef02db3dbafbeede1fb9f2e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->