### PR TITLE
fix: include date in run selector labels

### DIFF
--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -3,7 +3,10 @@ import { ELEMENT_IDS } from '../constants.js';
 // Local imports - shared helpers
 import { safeGetElementById } from '@common/domUtils.js';
 
-const RUN_LABEL_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+const RUN_LABEL_DATETIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
   hour: '2-digit',
   minute: '2-digit',
   second: '2-digit',
@@ -291,7 +294,7 @@ export class RunSelector {
       return '';
     }
 
-    return RUN_LABEL_TIME_FORMATTER.format(date);
+    return RUN_LABEL_DATETIME_FORMATTER.format(date);
   }
 
   _syncVisibility() {


### PR DESCRIPTION
## Summary
- include the session start date in the progress view run selector labels so entries show both date and time

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69109bd5692c83248039d45af97c8679)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show session date in progress view run selector labels by using a datetime formatter (adds year/month/day) and updating its usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2215374b176630de9b807b355f86b297806c7071. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->