### PR TITLE
fix: relocate progress usage summary to footer

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -98,7 +98,6 @@
                   class="status-indicator stopped"
                   data-status="Ready"
                 ></span>
-                <span id="runSummary" class="run-summary"></span>
               </div>
               <vscode-toolbar-container
                 id="toolbarContainer"
@@ -170,6 +169,9 @@
             class="log-container"
           ></vscode-scrollable>
           <div id="generatedFiles" class="files-container"></div>
+          <div class="usage-summary-footer" hidden>
+            <span id="runSummary" class="run-summary"></span>
+          </div>
           <div id="followUpContainer" class="follow-up-container">
             <vscode-textarea
               id="followUpInput"

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -30,7 +30,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       status: new Status(),
       usageSummary,
       usageGroup: new UsageGroupManager(usageSummary),
-      fileList: new FileList(usageSummary),
+      fileList: new FileList(),
       runSelector,
       taskGroups: new TaskGroupDomManager(runSelector),
       logEntries: new LogEntryManager(),

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -1,7 +1,6 @@
 // Local imports - progress view
 import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 // Local imports
-import { formatTokens } from '../formatters.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
 import { getBasename } from '@common/pathUtils.js';
@@ -10,9 +9,6 @@ import { getBasename } from '@common/pathUtils.js';
  * Manages file list rendering.
  */
 export class FileList {
-  constructor(usageSummary = null) {
-    this.usageSummary = usageSummary;
-  }
   /**
    * Get the effective base file for comparison operations.
    * @param {string|null|undefined} base - The explicit base file path
@@ -53,29 +49,6 @@ export class FileList {
     if (!filesByRound || Object.keys(filesByRound).length === 0) {
       container.textContent = 'No generated files';
       return;
-    }
-
-    // Add total usage header
-    const usageHeader = document.createElement('div');
-    usageHeader.className = 'files-usage-header';
-
-    // Calculate total usage from all groups
-    const totals = this.usageSummary?.computeTotal() || {
-      inputTokens: 0,
-      outputTokens: 0,
-      cost: 0,
-    };
-
-    if (totals.inputTokens || totals.outputTokens || totals.cost) {
-      usageHeader.innerHTML = `
-        <span class="files-usage-label">Total Usage:</span>
-        <span class="files-usage-stats">
-          <i class="codicon codicon-arrow-up"></i> ${formatTokens(totals.inputTokens)},
-          <i class="codicon codicon-arrow-down"></i> ${formatTokens(totals.outputTokens)},
-          $${totals.cost.toFixed(3)}
-        </span>
-      `;
-      container.appendChild(usageHeader);
     }
 
     const rounds = Object.keys(filesByRound)

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -14,7 +14,7 @@ export class UsageSummary {
   }
 
   /**
-   * Update token and cost summary in the header by aggregating usage from
+   * Update token and cost summary in the footer by aggregating usage from
    * "Round" groups. Falls back to the provided usage if given.
    * @param {Object} [usage] - Optional pre-computed usage totals
    */
@@ -24,6 +24,7 @@ export class UsageSummary {
       this._summaryElem = document.getElementById(ELEMENT_IDS.RUN_SUMMARY);
     }
     if (!this._summaryElem) return;
+    const footer = this._summaryElem.closest('.usage-summary-footer');
     // If usage is not provided, compute it from existing log groups
     const totals = usage ?? this.computeTotal();
 
@@ -34,7 +35,14 @@ export class UsageSummary {
     if (!inputTokens && !outputTokens && !cost) {
       this._summaryElem.textContent = '';
       this._summaryElem.removeAttribute('aria-label');
+      if (footer) {
+        footer.hidden = true;
+      }
       return;
+    }
+
+    if (footer) {
+      footer.hidden = false;
     }
 
     const parts = [
@@ -153,7 +161,7 @@ export class UsageGroupManager {
       this.propagateUsageToParents(groupId);
     }
 
-    // Refresh the cumulative summary displayed in the header
+    // Refresh the cumulative summary displayed in the footer
     this.usageSummary.update();
   }
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -268,26 +268,18 @@
   flex-shrink: 0;
 }
 
-/* Files usage header */
-.files-usage-header {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-medium);
-  padding: var(--spacing-small) var(--spacing-small);
-  margin-bottom: var(--spacing-medium);
+.usage-summary-footer {
+  border-top: 1px solid var(--vscode-panel-border);
   background-color: var(--vscode-sideBarSectionHeader-background);
-  border-radius: var(--border-radius-small);
+  padding: var(--spacing-small) var(--spacing-medium);
+  display: flex;
+  justify-content: flex-end;
   font-size: var(--font-size-sm);
-}
-
-.files-usage-label {
-  font-weight: 600;
-  color: var(--vscode-foreground);
-}
-
-.files-usage-stats {
   color: var(--vscode-descriptionForeground);
-  opacity: var(--opacity-subtle);
+}
+
+.usage-summary-footer .run-summary {
+  margin-left: auto;
 }
 
 .file-item {


### PR DESCRIPTION
## Summary
- move the shared usage summary out of the progress header and into a footer below the generated files list
- drop the redundant file-list usage banner and update styling to match the VS Code layout
- toggle footer visibility via UsageSummary updates and simplify FileList wiring

## Testing
- npm run format
- npm run lint
- npm run compile
- CI=1 npm test *(fails: VS Code binary requires libatk-bridge-2.0.so.0 in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e43c7fe483249b33c03f602651b9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relocates the aggregated usage summary to a new footer below generated files, removes the file-list usage banner, and updates logic/styles and wiring accordingly.
> 
> - **UI Layout (index.html)**:
>   - Add `usage-summary-footer` with `#runSummary` below `#generatedFiles`.
>   - Remove `#runSummary` from header.
> - **Usage Summary Logic (usageManagers.js)**:
>   - Update `UsageSummary.update` to target footer and toggle footer visibility.
>   - Keep total computation; adjust aria/markup accordingly.
> - **File List (FileList.js)**:
>   - Remove dependency on `UsageSummary` and the per-list "Total Usage" banner.
>   - Keep file rendering and actions; no usage formatting.
> - **DOM Wiring (domHandlers.js)**:
>   - Instantiate `FileList()` without passing `usageSummary`.
> - **Styles (logs.css)**:
>   - Remove `.files-usage-header` styles.
>   - Add `.usage-summary-footer` styling and integrate with `.run-summary`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f2cab845c89384e519e33f1483e80925c92ba27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->