### PR TITLE
Add extract_bib_entries LaTeX tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Add an `extract_bib_entries` LaTeX tool with shared helpers so agents can gather cited BibTeX records and surface missing files or keys directly in tool responses.
+
 ## [0.34.3] - 2025-11-07
 
 ### Features

--- a/docs/guide/tool-integration.md
+++ b/docs/guide/tool-integration.md
@@ -24,6 +24,20 @@ TeXRA can use `texcount` (often included with LaTeX) to provide document statist
 
 Ensure `texcount` is in your system's PATH.
 
+**Bibliography Extraction:**
+Tool-use agents can call `extract_bib_entries` to resolve the bibliography context of a LaTeX file. The tool finds `\bibliography{}`/`\addbibresource{}` directives, loads the referenced `.bib` files, and returns the raw BibTeX entries for every cited key (including warnings for missing files or unresolved keys). Example payload:
+
+```json
+{
+  "name": "extract_bib_entries",
+  "arguments": {
+    "texPath": "paper/main.tex"
+  }
+}
+```
+
+Use this when you need the exact BibTeX records for citations you plan to edit, format, or validate.
+
 ### 2. Figure & Media Handling
 
 Processing visual elements for analysis and inclusion.

--- a/docs/guide/working-with-figures.md
+++ b/docs/guide/working-with-figures.md
@@ -64,6 +64,8 @@ When you are running a tool-use agent outside the UI controls, you can explicitl
   - `compile` (default `true`): set to `false` to skip compilation and just receive a summary of discovered figures.
   - Attachments are limited to the first 12 compiled PDFs to keep responses lightweight.
 
+Need the accompanying references as well? Use the complementary `extract_bib_entries` tool to pull the BibTeX records for every citation found in the same LaTeX file. See the [Tool Integration guide](./tool-integration.md#bibliography-extraction) for details and a sample payload.
+
 Example tool call payload for `extract_figures`:
 
 ```json

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@google/genai": "^1.29.0",
         "@jamesgopsill/crossref-client": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.21.1",
+        "@retorquere/bibtex-parser": "^9.0.26",
         "@vscode-elements/elements": "^2.3.1",
         "@vscode/codicons": "^0.0.41",
         "@vscode/markdown-it-katex": "^1.1.2",
@@ -929,6 +930,31 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pomgui/deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pomgui/deep/-/deep-3.0.3.tgz",
+      "integrity": "sha512-xTLqLKASCb3OkM/tySjESKAhXGQt5pp/MPGDmMh21wuGHFnMU2VriIs1tIT9KPoJsS70PxOCGogrvD8OKojdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@retorquere/bibtex-parser": {
+      "version": "9.0.26",
+      "resolved": "https://registry.npmjs.org/@retorquere/bibtex-parser/-/bibtex-parser-9.0.26.tgz",
+      "integrity": "sha512-JDHDxAZAejIMwwW2i4Df2H6wr40uIRL3f+5aFly/JEJBf1G93iBl+NxNoAQhtE0p94nHK5mJiS4z3LXLc95eKQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@unified-latex/unified-latex-util-pegjs": "^1.8.1",
+        "@unified-latex/unified-latex-util-print-raw": "^1.8.0",
+        "@unified-latex/unified-latex-util-replace": "^1.8.3",
+        "@unified-latex/unified-latex-util-visit": "^1.8.3",
+        "i": "^0.3.7",
+        "lodash.merge": "^4.6.2",
+        "moo": "^0.5.2",
+        "nearley": "^2.20.1",
+        "unicode2latex": "^7.0.25",
+        "wink-eng-lite-web-model": "^1.8.1",
+        "wink-nlp": "^2.4.0"
+      }
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -1171,6 +1197,12 @@
       "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
       "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
@@ -1426,6 +1458,87 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-types": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-types/-/unified-latex-types-1.8.0.tgz",
+      "integrity": "sha512-GLJbBmmfDOWtdEbpQCLb7++zPxXin36aC9XOVCuiVNMR9VYv3szOJa+ZdTilVCFHpOeFhKh6zRws96vJgz2tGA==",
+      "license": "MIT"
+    },
+    "node_modules/@unified-latex/unified-latex-util-match": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-match/-/unified-latex-util-match-1.8.0.tgz",
+      "integrity": "sha512-fjuLI1KVhWTHkfWn0kR8/RhM2oD2hxWhzgskUMLJ/IZMye9ESvVo8ItG4y+BtpwGFWpTmCtpMNXHjknIQxza9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.0",
+        "@unified-latex/unified-latex-util-print-raw": "^1.8.0"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-pegjs": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-pegjs/-/unified-latex-util-pegjs-1.8.1.tgz",
+      "integrity": "sha512-1N6WknnzKGACFCmgaEZ2j89j5C2dKhmAOCfy6moD+AMm6nUb69Xp9pJ1jDfqz+Uz9+zRo5I6ksr6q5GgmAJvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.0",
+        "@unified-latex/unified-latex-util-match": "^1.8.0"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-print-raw": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-print-raw/-/unified-latex-util-print-raw-1.8.0.tgz",
+      "integrity": "sha512-lMuLqnHXCDNqrjslf6hBAA2McEI+oaaxvjA9zfeAeWZyZh+DUJjkmwiuxYejwHHKbQvqzregNP4wtb9OvaC21g==",
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.0"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-replace/-/unified-latex-util-replace-1.8.3.tgz",
+      "integrity": "sha512-HdrWVF+pwfsXkAiIGK5q7y2klBt5QK7r5sxbSZD+X3wXzpJFuFCYQQYe2Tmi5lOcssqLK94+1OUqRTrmA/rFbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.0",
+        "@unified-latex/unified-latex-util-match": "^1.8.0",
+        "@unified-latex/unified-latex-util-split": "^1.8.0",
+        "@unified-latex/unified-latex-util-trim": "^1.8.3",
+        "@unified-latex/unified-latex-util-visit": "^1.8.3",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-split": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-split/-/unified-latex-util-split-1.8.0.tgz",
+      "integrity": "sha512-gRlRge72wcvLRs6bEoVbh0fDACbkioEPDJOr7XaCuQqjNNu1VTXlcvImZQVXCdMG6CJ4lqiaJRwnUupK4rsmsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.0",
+        "@unified-latex/unified-latex-util-match": "^1.8.0"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-trim/-/unified-latex-util-trim-1.8.3.tgz",
+      "integrity": "sha512-Vb5YcVyebWuwU0koBTsVOvxKFWKfqP1T7nJdpzT+IUrfX7zcMiA4HlGdL/3imbEfuLBTHJb3IoLsymU0XfWCZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.0",
+        "@unified-latex/unified-latex-util-match": "^1.8.0",
+        "@unified-latex/unified-latex-util-visit": "^1.8.3",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-visit": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-visit/-/unified-latex-util-visit-1.8.3.tgz",
+      "integrity": "sha512-y1uxwXLbzXliAhTrxaDx4+LgIWaeNWMgS7q4DC/i/5RXXRQOImdCqQsTWwvQk2x5/8zQ3eweiTsd3q1gbBCqAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.0",
+        "@unified-latex/unified-latex-util-match": "^1.8.0"
       }
     },
     "node_modules/@vscode-elements/elements": {
@@ -2068,6 +2181,16 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -2870,6 +2993,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -4194,6 +4323,14 @@
         "node": ">=18.18.0"
       }
     },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4321,6 +4458,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-core-module": {
@@ -4904,7 +5064,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -5332,6 +5491,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5361,6 +5526,34 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -6140,6 +6333,25 @@
       ],
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6340,6 +6552,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/reusify": {
@@ -7164,6 +7385,12 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/tiny-merge-patch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tiny-merge-patch/-/tiny-merge-patch-0.1.2.tgz",
+      "integrity": "sha512-NLoA//tTMBPTr0oGdq+fxnvVR0tDa8tOcG9ZGbuovGzROadZ404qOV4g01jeWa5S8MC9nAOvu5bQgCW7s8tlWQ==",
+      "license": "MIT"
+    },
     "node_modules/tldts": {
       "version": "7.0.17",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.17.tgz",
@@ -7239,6 +7466,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-algebra": {
@@ -7390,6 +7627,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicode2latex": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/unicode2latex/-/unicode2latex-7.0.25.tgz",
+      "integrity": "sha512-CO/oXk5rs1FgPn50/G3bPve3lurjipy1R4QjIWt81k5sB+tmfAj+A2ZH3uNgJcrdSrmGNxqpOuyBslZMOnN/Og==",
+      "license": "ISC",
+      "dependencies": {
+        "@pomgui/deep": "^3.0.3",
+        "tiny-merge-patch": "^0.1.2"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -7400,6 +7647,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -7489,6 +7768,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -7768,6 +8077,21 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wink-eng-lite-web-model": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/wink-eng-lite-web-model/-/wink-eng-lite-web-model-1.8.1.tgz",
+      "integrity": "sha512-M2tSOU/rVNkDj8AS8IoKJaM7apJJjS0cN+hE8CPazfnB4A/ojyc9+7RMPk18UOiIdSyWk7MR6w8z9lWix2l5tA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/wink-nlp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/wink-nlp/-/wink-nlp-2.4.0.tgz",
+      "integrity": "sha512-d02inlNJL0LLNTLoYfkxZYGrqnYDSZV4HI4WpeuyIEfpu7UcUqUW1ZYWr+JTFm4ZR6dQdzOW/FtHEQRO+o/zzA==",
       "license": "MIT"
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -1502,6 +1502,7 @@
     "@google/genai": "^1.29.0",
     "@jamesgopsill/crossref-client": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.21.1",
+    "@retorquere/bibtex-parser": "^9.0.26",
     "@vscode-elements/elements": "^2.3.1",
     "@vscode/codicons": "^0.0.41",
     "@vscode/markdown-it-katex": "^1.1.2",

--- a/resources/tool_use_agents/ask.yaml
+++ b/resources/tool_use_agents/ask.yaml
@@ -7,6 +7,7 @@ settings:
     - grep
     - ls
     - extract_figures
+    - extract_bib_entries
     - extract_tikz_figures
     - arxiv_search
     - arxiv_metadata

--- a/resources/tool_use_agents/chat.yaml
+++ b/resources/tool_use_agents/chat.yaml
@@ -10,6 +10,7 @@ settings:
     - grep
     - ls
     - extract_figures
+    - extract_bib_entries
     - extract_tikz_figures
     - arxiv_search
     - arxiv_metadata
@@ -37,6 +38,6 @@ prompts:
     (2) Do not create excessive markdown files or documentation unless explicitly requested.
     {% endif %}
 
-    Guidelines on using Tools: (1) For bash operations, distinguish between safe and potentially risky commands. Safe commands (execute without confirmation): ls, pwd, cat, echo, grep, find, which, date, whoami. Potentially complicated operations: Ask for confirmation before executing (e.g., rm, mv, cp with wildcards, curl/wget, npm/pip install, git operations beyond status/log). (2) Clearly explain what any command will do before executing it. (3) Use `extract_figures` to gather image assets referenced in LaTeX documents and `extract_tikz_figures` to compile TikZ diagrams when the user needs visual outputs. (4) For some tool use users have the options to reject or edit the changes before they are applied. Pay attention to the user's feedback and adjust your behavior accordingly.
+    Guidelines on using Tools: (1) For bash operations, distinguish between safe and potentially risky commands. Safe commands (execute without confirmation): ls, pwd, cat, echo, grep, find, which, date, whoami. Potentially complicated operations: Ask for confirmation before executing (e.g., rm, mv, cp with wildcards, curl/wget, npm/pip install, git operations beyond status/log). (2) Clearly explain what any command will do before executing it. (3) Use `extract_figures` to gather image assets referenced in LaTeX documents, `extract_bib_entries` to pull BibTeX records for cited references, and `extract_tikz_figures` to compile TikZ diagrams when the user needs visual outputs. (4) For some tool use users have the options to reject or edit the changes before they are applied. Pay attention to the user's feedback and adjust your behavior accordingly.
   userRequest: |
     {{ INSTRUCTION }}

--- a/resources/tool_use_agents/tex_linter_fix.yaml
+++ b/resources/tool_use_agents/tex_linter_fix.yaml
@@ -5,11 +5,12 @@ settings:
     - str_replace_editor
     - diagnostics
     - extract_figures
+    - extract_bib_entries
     - extract_tikz_figures
 prompts:
   systemPrompt: |
     You fix LaTeX linter issues. Use the diagnostics tool to list current problems and the str_replace_editor tool to apply minimal edits.
-    When lint failures relate to missing figures or TikZ assets, call the extract_figures or extract_tikz_figures tools to surface the referenced files for review.
+    When lint failures relate to missing figures, bibliography entries, or TikZ assets, call the extract_figures, extract_bib_entries, or extract_tikz_figures tools to surface the referenced files for review.
   userPrefix: |
     Fix linter issues in {{ INPUT_FILE }}. The first problem context is:
     {{ ERROR_CONTEXT }}

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -4,8 +4,8 @@ import * as path from 'path';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
-const DIRECTIVE_PATTERN =
-  /\\(?:bibliography|addbibresource)(?:\s*\[[^\]]*\])?\s*\{([^}]*)\}/g;
+const DIRECTIVE_PATTERN_SOURCE =
+  '\\(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}';
 const CITE_COMMANDS = [
   'cite',
   'citet',
@@ -22,10 +22,16 @@ const CITE_COMMANDS = [
   'Parencite',
   'Footcite',
 ];
-const CITATION_PATTERN = new RegExp(
-  `\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\{([^}]*)\}`,
-  'g',
-);
+function createDirectivePattern(): RegExp {
+  return new RegExp(DIRECTIVE_PATTERN_SOURCE, 'g');
+}
+
+function createCitationPattern(): RegExp {
+  return new RegExp(
+    `\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\{([^}]*)\}`,
+    'g',
+  );
+}
 const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
 
 export interface BibliographyReferenceResult {
@@ -62,8 +68,9 @@ function normalizeBibPath(baseDir: string, target: string): string {
 function collectBibliographyPaths(baseDir: string, content: string): string[] {
   const paths = new Set<string>();
   let match: RegExpExecArray | null;
+  const directivePattern = createDirectivePattern();
 
-  while ((match = DIRECTIVE_PATTERN.exec(content)) !== null) {
+  while ((match = directivePattern.exec(content)) !== null) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const normalized = normalizeBibPath(baseDir, raw);
@@ -79,8 +86,9 @@ function collectBibliographyPaths(baseDir: string, content: string): string[] {
 function collectCitationKeys(content: string): string[] {
   const keys = new Set<string>();
   let match: RegExpExecArray | null;
+  const citationPattern = createCitationPattern();
 
-  while ((match = CITATION_PATTERN.exec(content)) !== null) {
+  while ((match = citationPattern.exec(content)) !== null) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const key = raw.trim();
@@ -172,14 +180,16 @@ export async function loadBibliographyEntries(
   citationKeys: string[],
 ): Promise<BibliographyEntriesResult> {
   const entries = new Map<string, string>();
-  const requestedKeys = new Set(citationKeys);
+  const hasWildcard = citationKeys.includes('*');
+  const filteredKeys = citationKeys.filter((key) => key !== '*');
+  const requestedKeys = new Set(filteredKeys);
 
   for (const filePath of bibliographyFiles) {
     const content = await WorkspaceFS.read(filePath);
     const parsed = parseBibEntries(content);
     for (const [key, value] of parsed.entries()) {
       if (
-        (requestedKeys.size === 0 || requestedKeys.has(key)) &&
+        (hasWildcard || requestedKeys.size === 0 || requestedKeys.has(key)) &&
         !entries.has(key)
       ) {
         entries.set(key, value);
@@ -187,7 +197,7 @@ export async function loadBibliographyEntries(
     }
   }
 
-  const missingKeys = citationKeys.filter((key) => !entries.has(key));
+  const missingKeys = filteredKeys.filter((key) => !entries.has(key));
 
   return {
     entries,

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -1,6 +1,9 @@
 // Standard library imports
 import * as path from 'path';
 
+// Third-party imports
+import { parse as parseBibTeX } from '@retorquere/bibtex-parser';
+
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
@@ -130,46 +133,16 @@ export async function extractBibliographyContext(
 }
 
 function parseBibEntries(content: string): Map<string, string> {
+  const library = parseBibTeX(content);
   const entries = new Map<string, string>();
-  const entryPattern = /@([\w-]+)\s*(\{|\()/g;
-  let match: RegExpExecArray | null;
 
-  while ((match = entryPattern.exec(content)) !== null) {
-    const startIndex = match.index;
-    const delimiter = match[2];
-    const openChar = delimiter;
-    const closeChar = delimiter === '{' ? '}' : ')';
-    let depth = 1;
-    let cursor = entryPattern.lastIndex;
-
-    while (cursor < content.length && depth > 0) {
-      const char = content[cursor];
-      if (char === openChar) {
-        depth += 1;
-      } else if (char === closeChar) {
-        depth -= 1;
-      }
-      cursor += 1;
-    }
-
-    if (depth !== 0) {
-      entryPattern.lastIndex = cursor;
+  for (const entry of library.entries) {
+    const key = entry.key?.trim();
+    if (!key || entries.has(key)) {
       continue;
     }
 
-    const entryText = content.slice(startIndex, cursor).trim();
-    const keyMatch = entryText.match(/@[^({]*[({]\s*([^,\s]+)\s*,/);
-    if (!keyMatch) {
-      entryPattern.lastIndex = cursor;
-      continue;
-    }
-
-    const key = keyMatch[1].trim();
-    if (!entries.has(key)) {
-      entries.set(key, entryText);
-    }
-
-    entryPattern.lastIndex = cursor;
+    entries.set(key, entry.input.trim());
   }
 
   return entries;

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -1,0 +1,216 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - utils
+import { WorkspaceFS } from '@utils/files';
+
+const DIRECTIVE_PATTERN =
+  /\\(?:bibliography|addbibresource)(?:\s*\[[^\]]*\])?\s*\{([^}]*)\}/g;
+const CITE_COMMANDS = [
+  'cite',
+  'citet',
+  'citep',
+  'textcite',
+  'parencite',
+  'footcite',
+  'autocite',
+  'nocite',
+  'Cite',
+  'Citet',
+  'Citep',
+  'Textcite',
+  'Parencite',
+  'Footcite',
+];
+const CITATION_PATTERN = new RegExp(
+  `\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\{([^}]*)\}`,
+  'g',
+);
+const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
+
+export interface BibliographyReferenceResult {
+  /** Paths to bibliography files that exist, relative to the workspace. */
+  bibliographyFiles: string[];
+  /** Bibliography files referenced but not found. */
+  missingBibliographyFiles: string[];
+  /** Citation keys discovered in the LaTeX document. */
+  citationKeys: string[];
+}
+
+export interface BibliographyEntriesResult {
+  /** Map of citation key to raw BibTeX entry text. */
+  entries: Map<string, string>;
+  /** Citation keys without matching entries across the loaded files. */
+  missingKeys: string[];
+}
+
+function stripComments(content: string): string {
+  return content.replace(COMMENT_PATTERN, '$1');
+}
+
+function normalizeBibPath(baseDir: string, target: string): string {
+  const trimmed = target.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const withExtension = trimmed.endsWith('.bib') ? trimmed : `${trimmed}.bib`;
+  const resolved = path.normalize(path.join(baseDir, withExtension));
+  return resolved;
+}
+
+function collectBibliographyPaths(baseDir: string, content: string): string[] {
+  const paths = new Set<string>();
+  let match: RegExpExecArray | null;
+
+  while ((match = DIRECTIVE_PATTERN.exec(content)) !== null) {
+    const block = match[1];
+    for (const raw of block.split(',')) {
+      const normalized = normalizeBibPath(baseDir, raw);
+      if (normalized) {
+        paths.add(normalized);
+      }
+    }
+  }
+
+  return Array.from(paths);
+}
+
+function collectCitationKeys(content: string): string[] {
+  const keys = new Set<string>();
+  let match: RegExpExecArray | null;
+
+  while ((match = CITATION_PATTERN.exec(content)) !== null) {
+    const block = match[1];
+    for (const raw of block.split(',')) {
+      const key = raw.trim();
+      if (key) {
+        keys.add(key);
+      }
+    }
+  }
+
+  return Array.from(keys);
+}
+
+export async function extractBibliographyContext(
+  texPath: string,
+): Promise<BibliographyReferenceResult> {
+  const texDir = path.dirname(texPath);
+  const content = await WorkspaceFS.read(texPath);
+  const uncommented = stripComments(content);
+
+  const referencedPaths = collectBibliographyPaths(texDir, uncommented);
+  const existing: string[] = [];
+  const missing: string[] = [];
+
+  for (const candidate of referencedPaths) {
+    if (await WorkspaceFS.exists(candidate)) {
+      existing.push(candidate);
+    } else {
+      missing.push(candidate);
+    }
+  }
+
+  const citationKeys = collectCitationKeys(uncommented);
+
+  return {
+    bibliographyFiles: existing,
+    missingBibliographyFiles: missing,
+    citationKeys,
+  };
+}
+
+function parseBibEntries(content: string): Map<string, string> {
+  const entries = new Map<string, string>();
+  const entryPattern = /@([\w-]+)\s*(\{|\()/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = entryPattern.exec(content)) !== null) {
+    const startIndex = match.index;
+    const delimiter = match[2];
+    const openChar = delimiter;
+    const closeChar = delimiter === '{' ? '}' : ')';
+    let depth = 1;
+    let cursor = entryPattern.lastIndex;
+
+    while (cursor < content.length && depth > 0) {
+      const char = content[cursor];
+      if (char === openChar) {
+        depth += 1;
+      } else if (char === closeChar) {
+        depth -= 1;
+      }
+      cursor += 1;
+    }
+
+    if (depth !== 0) {
+      entryPattern.lastIndex = cursor;
+      continue;
+    }
+
+    const entryText = content.slice(startIndex, cursor).trim();
+    const keyMatch = entryText.match(/@[^({]*[({]\s*([^,\s]+)\s*,/);
+    if (!keyMatch) {
+      entryPattern.lastIndex = cursor;
+      continue;
+    }
+
+    const key = keyMatch[1].trim();
+    if (!entries.has(key)) {
+      entries.set(key, entryText);
+    }
+
+    entryPattern.lastIndex = cursor;
+  }
+
+  return entries;
+}
+
+export async function loadBibliographyEntries(
+  bibliographyFiles: string[],
+  citationKeys: string[],
+): Promise<BibliographyEntriesResult> {
+  const entries = new Map<string, string>();
+  const requestedKeys = new Set(citationKeys);
+
+  for (const filePath of bibliographyFiles) {
+    const content = await WorkspaceFS.read(filePath);
+    const parsed = parseBibEntries(content);
+    for (const [key, value] of parsed.entries()) {
+      if (
+        (requestedKeys.size === 0 || requestedKeys.has(key)) &&
+        !entries.has(key)
+      ) {
+        entries.set(key, value);
+      }
+    }
+  }
+
+  const missingKeys = citationKeys.filter((key) => !entries.has(key));
+
+  return {
+    entries,
+    missingKeys,
+  };
+}
+
+export function summarizeBibliographyEntries(
+  entries: Map<string, string>,
+  limit: number,
+): string[] {
+  const values = Array.from(entries.values());
+  const limited = values.slice(0, limit);
+  const lines: string[] = [];
+
+  for (const entry of limited) {
+    lines.push(entry);
+    lines.push('');
+  }
+
+  if (lines.length > 0) {
+    lines.pop();
+  }
+
+  return lines;
+}

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -4,6 +4,15 @@ export { TikzPictureManager, tikzPictureManager } from './TikzPictureManager';
 // Export figure extraction functionality
 export { extractFigurePathsFromLatex } from './extractFigure';
 
+// Export bibliography extraction helpers
+export {
+  extractBibliographyContext,
+  loadBibliographyEntries,
+  summarizeBibliographyEntries,
+  type BibliographyEntriesResult,
+  type BibliographyReferenceResult,
+} from './extractBibliography';
+
 // Export text connection functionality
 export {
   bestConnectionMethod,

--- a/src/test/latex/extractBibliography.test.ts
+++ b/src/test/latex/extractBibliography.test.ts
@@ -1,0 +1,105 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+// Local imports - latex helpers
+import {
+  extractBibliographyContext,
+  loadBibliographyEntries,
+  summarizeBibliographyEntries,
+} from '@latex/extractBibliography';
+
+// Local imports - utils
+import { WorkspaceFS } from '@utils/files';
+
+suite('extractBibliography helpers', () => {
+  const originalRead = WorkspaceFS.read;
+  const originalExists = WorkspaceFS.exists;
+
+  teardown(() => {
+    (WorkspaceFS as unknown as { read: typeof originalRead }).read =
+      originalRead;
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      originalExists;
+  });
+
+  test('collects bibliography paths and citation keys', async () => {
+    const texPath = path.join('chapters', 'main.tex');
+    const expectedBibPath = path.join('chapters', 'references.bib');
+
+    (WorkspaceFS as unknown as { read: typeof originalRead }).read =
+      async () => `
+      % comment
+      \documentclass{article}
+      \addbibresource[location=local]{references}
+      Some text \cite{alpha , beta}
+      More citations \nocite{gamma}
+      % \cite{ignored}
+    `;
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      async (file: string) => file === expectedBibPath;
+
+    const result = await extractBibliographyContext(texPath);
+
+    assert.deepStrictEqual(result.bibliographyFiles, [expectedBibPath]);
+    assert.deepStrictEqual(result.missingBibliographyFiles, []);
+    assert.deepStrictEqual(
+      new Set(result.citationKeys),
+      new Set(['alpha', 'beta', 'gamma']),
+    );
+  });
+
+  test('marks missing bibliography files and ignores empty citations', async () => {
+    const texPath = 'paper.tex';
+
+    (WorkspaceFS as unknown as { read: typeof originalRead }).read =
+      async () => `
+      \bibliography{bib/one, bib/two.bib, } % trailing comma
+      \cite{first} \cite{second, third}
+    `;
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      async (file: string) => file === path.join('bib', 'two.bib');
+
+    const result = await extractBibliographyContext(texPath);
+
+    assert.deepStrictEqual(result.bibliographyFiles, [
+      path.join('bib', 'two.bib'),
+    ]);
+    assert.deepStrictEqual(result.missingBibliographyFiles, [
+      path.join('bib', 'one.bib'),
+    ]);
+    assert.deepStrictEqual(
+      new Set(result.citationKeys),
+      new Set(['first', 'second', 'third']),
+    );
+  });
+
+  test('loads requested bibliography entries and reports missing keys', async () => {
+    const expectedContent = `@article{alpha,
+  title = {Alpha Paper},
+}
+
+@book{beta,
+  title = {Beta Book},
+}`;
+
+    (WorkspaceFS as unknown as { read: typeof originalRead }).read = async () =>
+      expectedContent;
+
+    const { entries, missingKeys } = await loadBibliographyEntries(
+      ['references.bib'],
+      ['alpha', 'gamma'],
+    );
+
+    assert.strictEqual(entries.size, 1);
+    assert.strictEqual(
+      entries.get('alpha'),
+      '@article{alpha,\n  title = {Alpha Paper},\n}',
+    );
+    assert.deepStrictEqual(missingKeys, ['gamma']);
+
+    const formatted = summarizeBibliographyEntries(entries, 5);
+    assert.deepStrictEqual(formatted, [
+      '@article{alpha,\n  title = {Alpha Paper},\n}',
+    ]);
+  });
+});

--- a/src/test/latex/extractBibliography.test.ts
+++ b/src/test/latex/extractBibliography.test.ts
@@ -48,6 +48,33 @@ suite('extractBibliography helpers', () => {
     );
   });
 
+  test('handles wildcard nocite directives consistently across runs', async () => {
+    const texPath = 'paper.tex';
+    const expectedBibPath = 'refs.bib';
+    const texContent = `
+      % bibliographies
+      \\bibliography{refs}
+      Intro text
+      \\nocite{*}
+    `;
+
+    (WorkspaceFS as unknown as { read: typeof originalRead }).read = async () =>
+      texContent;
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      async () => true;
+
+    const first = await extractBibliographyContext(texPath);
+    const second = await extractBibliographyContext(texPath);
+
+    const expectedKeys = new Set(['*']);
+
+    assert.deepStrictEqual(first.bibliographyFiles, [expectedBibPath]);
+    assert.deepStrictEqual(second.bibliographyFiles, [expectedBibPath]);
+    assert.deepStrictEqual(new Set(first.citationKeys), expectedKeys);
+    assert.deepStrictEqual(new Set(second.citationKeys), expectedKeys);
+    assert.deepStrictEqual(second, first);
+  });
+
   test('marks missing bibliography files and ignores empty citations', async () => {
     const texPath = 'paper.tex';
 
@@ -101,5 +128,28 @@ suite('extractBibliography helpers', () => {
     assert.deepStrictEqual(formatted, [
       '@article{alpha,\n  title = {Alpha Paper},\n}',
     ]);
+  });
+
+  test('loads all entries when nocite wildcard is present', async () => {
+    const expectedContent = `@article{alpha,
+  title = {Alpha Paper},
+}
+
+@book{beta,
+  title = {Beta Book},
+}`;
+
+    (WorkspaceFS as unknown as { read: typeof originalRead }).read = async () =>
+      expectedContent;
+
+    const { entries, missingKeys } = await loadBibliographyEntries(
+      ['references.bib'],
+      ['*'],
+    );
+
+    assert.strictEqual(entries.size, 2);
+    assert.deepStrictEqual(missingKeys, []);
+    assert.ok(entries.has('alpha'));
+    assert.ok(entries.has('beta'));
   });
 });

--- a/src/test/tools/latex/ExtractBibliographyTool.test.ts
+++ b/src/test/tools/latex/ExtractBibliographyTool.test.ts
@@ -1,0 +1,126 @@
+import * as assert from 'assert';
+
+// Local imports - latex helpers
+import * as bibliographyModule from '@latex/extractBibliography';
+
+// Local imports - tools
+import { ExtractBibliographyTool } from '@tools/latex';
+
+// Local imports - utils
+import { WorkspaceFS } from '@utils/files';
+
+suite('ExtractBibliographyTool', () => {
+  const originalExists = WorkspaceFS.exists;
+  const originalContext = bibliographyModule.extractBibliographyContext;
+  const originalLoad = bibliographyModule.loadBibliographyEntries;
+  const originalSummarize = bibliographyModule.summarizeBibliographyEntries;
+
+  teardown(() => {
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      originalExists;
+    (
+      bibliographyModule as {
+        extractBibliographyContext: typeof originalContext;
+      }
+    ).extractBibliographyContext = originalContext;
+    (
+      bibliographyModule as { loadBibliographyEntries: typeof originalLoad }
+    ).loadBibliographyEntries = originalLoad;
+    (
+      bibliographyModule as {
+        summarizeBibliographyEntries: typeof originalSummarize;
+      }
+    ).summarizeBibliographyEntries = originalSummarize;
+  });
+
+  test('returns bibliography entries and summary', async () => {
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      async (path: string) => path === 'main.tex';
+    (
+      bibliographyModule as {
+        extractBibliographyContext: typeof originalContext;
+      }
+    ).extractBibliographyContext = async () => ({
+      citationKeys: ['alpha', 'beta'],
+      bibliographyFiles: ['references.bib'],
+      missingBibliographyFiles: [],
+    });
+    (
+      bibliographyModule as { loadBibliographyEntries: typeof originalLoad }
+    ).loadBibliographyEntries = async () => ({
+      entries: new Map([
+        ['alpha', '@article{alpha,...}'],
+        ['beta', '@book{beta,...}'],
+      ]),
+      missingKeys: [],
+    });
+    (
+      bibliographyModule as {
+        summarizeBibliographyEntries: typeof originalSummarize;
+      }
+    ).summarizeBibliographyEntries = () => [
+      '@article{alpha,...}',
+      '@book{beta,...}',
+    ];
+
+    const tool = new ExtractBibliographyTool();
+    const result = await tool.call({ texPath: 'main.tex' });
+
+    assert.strictEqual(
+      result.summary,
+      'Resolved 2 bibliography entries for 2 citation keys in main.tex.',
+    );
+    assert.ok(result.output?.includes('BibTeX entries cited in main.tex'));
+    assert.ok(result.output?.includes('@article{alpha,...}'));
+    assert.ok(result.output?.includes('@book{beta,...}'));
+    assert.strictEqual(result.userInstruction, undefined);
+  });
+
+  test('reports missing bibliography files and keys', async () => {
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      async (path: string) => path === 'paper.tex';
+    (
+      bibliographyModule as {
+        extractBibliographyContext: typeof originalContext;
+      }
+    ).extractBibliographyContext = async () => ({
+      citationKeys: ['alpha'],
+      bibliographyFiles: [],
+      missingBibliographyFiles: ['references.bib'],
+    });
+    (
+      bibliographyModule as { loadBibliographyEntries: typeof originalLoad }
+    ).loadBibliographyEntries = async () => ({
+      entries: new Map(),
+      missingKeys: ['alpha'],
+    });
+    (
+      bibliographyModule as {
+        summarizeBibliographyEntries: typeof originalSummarize;
+      }
+    ).summarizeBibliographyEntries = () => [];
+
+    const tool = new ExtractBibliographyTool();
+    const result = await tool.call({ texPath: 'paper.tex' });
+
+    assert.ok(
+      result.summary?.includes(
+        'No matching bibliography entries found for 1 citation key in paper.tex.',
+      ),
+    );
+    assert.ok(result.output?.includes('No matching entries found.'));
+    assert.ok(result.userInstruction?.includes('Missing bibliography files'));
+    assert.ok(result.userInstruction?.includes('Missing citation keys'));
+  });
+
+  test('returns error when tex file is missing', async () => {
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      async () => false;
+
+    const tool = new ExtractBibliographyTool();
+    const result = await tool.call({ texPath: 'missing.tex' });
+
+    assert.strictEqual(result.isError, true);
+    assert.ok(result.error?.includes('LaTeX file not found'));
+  });
+});

--- a/src/test/tools/latex/ExtractBibliographyTool.test.ts
+++ b/src/test/tools/latex/ExtractBibliographyTool.test.ts
@@ -123,4 +123,90 @@ suite('ExtractBibliographyTool', () => {
     assert.strictEqual(result.isError, true);
     assert.ok(result.error?.includes('LaTeX file not found'));
   });
+
+  test('includes explicit bibliography path when provided', async () => {
+    const calls: { paths: string[]; keys: string[] }[] = [];
+
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      async (path: string) => path === 'thesis.tex' || path === 'extra.bib';
+    (
+      bibliographyModule as {
+        extractBibliographyContext: typeof originalContext;
+      }
+    ).extractBibliographyContext = async () => ({
+      citationKeys: ['alpha'],
+      bibliographyFiles: [],
+      missingBibliographyFiles: [],
+    });
+    (
+      bibliographyModule as { loadBibliographyEntries: typeof originalLoad }
+    ).loadBibliographyEntries = async (paths, keys) => {
+      calls.push({ paths, keys });
+      return {
+        entries: new Map([['alpha', '@article{alpha,...}']]),
+        missingKeys: [],
+      };
+    };
+    (
+      bibliographyModule as {
+        summarizeBibliographyEntries: typeof originalSummarize;
+      }
+    ).summarizeBibliographyEntries = () => ['@article{alpha,...}'];
+
+    const tool = new ExtractBibliographyTool();
+    const result = await tool.call({
+      texPath: 'thesis.tex',
+      bibPath: 'extra.bib',
+    });
+
+    assert.strictEqual(calls.length, 1);
+    assert.deepStrictEqual(calls[0].paths, ['extra.bib']);
+    assert.deepStrictEqual(calls[0].keys, ['alpha']);
+    assert.ok(result.summary?.includes('Resolved 1 bibliography entry'));
+  });
+
+  test('falls back to wildcard when only a bibliography path is supplied', async () => {
+    const calls: { paths: string[]; keys: string[] }[] = [];
+
+    (WorkspaceFS as unknown as { exists: typeof originalExists }).exists =
+      async (path: string) => path === 'standalone.tex' || path === 'refs.bib';
+    (
+      bibliographyModule as {
+        extractBibliographyContext: typeof originalContext;
+      }
+    ).extractBibliographyContext = async () => ({
+      citationKeys: [],
+      bibliographyFiles: [],
+      missingBibliographyFiles: [],
+    });
+    (
+      bibliographyModule as { loadBibliographyEntries: typeof originalLoad }
+    ).loadBibliographyEntries = async (paths, keys) => {
+      calls.push({ paths, keys });
+      return {
+        entries: new Map(),
+        missingKeys: [],
+      };
+    };
+    (
+      bibliographyModule as {
+        summarizeBibliographyEntries: typeof originalSummarize;
+      }
+    ).summarizeBibliographyEntries = () => [];
+
+    const tool = new ExtractBibliographyTool();
+    const result = await tool.call({
+      texPath: 'standalone.tex',
+      bibPath: 'refs.bib',
+    });
+
+    assert.strictEqual(calls.length, 1);
+    assert.deepStrictEqual(calls[0].paths, ['refs.bib']);
+    assert.deepStrictEqual(calls[0].keys, ['*']);
+    assert.ok(
+      result.summary?.includes(
+        'No matching bibliography entries found for 1 citation key in standalone.tex.',
+      ),
+    );
+  });
 });

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -1,0 +1,134 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - latex
+import {
+  extractBibliographyContext,
+  loadBibliographyEntries,
+  summarizeBibliographyEntries,
+} from '@latex/extractBibliography';
+
+// Local imports - tools
+import { defineTool } from '../core/define';
+import { ToolError, toolResult } from '@tools/result';
+import { formatToolOutput, resolveAndFormat } from '@tools/utils';
+
+// Local imports - utils
+import { WorkspaceFS } from '@utils/files';
+
+const ExtractBibliographyInputSchema = z.strictObject({
+  texPath: z
+    .string()
+    .min(1, 'texPath is required.')
+    .describe('Path to the LaTeX file to scan for citations.'),
+});
+
+export type ExtractBibliographyInput = z.infer<
+  typeof ExtractBibliographyInputSchema
+>;
+
+const DEFAULT_MAX_ENTRIES = 25;
+
+export class ExtractBibliographyTool extends defineTool({
+  name: 'extract_bib_entries',
+  description:
+    'Collect BibTeX records for citations referenced in a LaTeX document.',
+  schema: ExtractBibliographyInputSchema,
+}) {
+  protected async execute({ texPath }: ExtractBibliographyInput) {
+    const { resolved, display } = resolveAndFormat(texPath);
+
+    if (!(await WorkspaceFS.exists(resolved.relative))) {
+      throw new ToolError(`LaTeX file not found: ${display}`);
+    }
+
+    const context = await extractBibliographyContext(resolved.relative);
+    const { citationKeys, bibliographyFiles, missingBibliographyFiles } =
+      context;
+
+    if (
+      citationKeys.length === 0 &&
+      bibliographyFiles.length === 0 &&
+      missingBibliographyFiles.length === 0
+    ) {
+      const summary = `No citations or bibliography directives found in ${display}.`;
+      return toolResult({
+        summary,
+        output: formatToolOutput(`BibTeX entries in ${display}`, null),
+      });
+    }
+
+    if (citationKeys.length === 0) {
+      const summary = `No citation commands found in ${display}.`;
+      const result = toolResult({
+        summary,
+        output: formatToolOutput(`BibTeX entries in ${display}`, null),
+      });
+      if (missingBibliographyFiles.length > 0) {
+        result.userInstruction = `Missing bibliography files: ${missingBibliographyFiles
+          .map((file) => resolveAndFormat(file).display)
+          .join(', ')}.`;
+      }
+      return result;
+    }
+
+    const { entries, missingKeys } = await loadBibliographyEntries(
+      bibliographyFiles,
+      citationKeys,
+    );
+
+    const entryLines = summarizeBibliographyEntries(
+      entries,
+      DEFAULT_MAX_ENTRIES,
+    );
+    const output = formatToolOutput(
+      `BibTeX entries cited in ${display}`,
+      entryLines,
+      'No matching entries found.',
+    );
+
+    const entryCount = entries.size;
+    const citationCount = citationKeys.length;
+
+    const summary =
+      entryCount === 0
+        ? `No matching bibliography entries found for ${citationCount} citation key${
+            citationCount === 1 ? '' : 's'
+          } in ${display}.`
+        : `Resolved ${entryCount} bibliography entr${
+            entryCount === 1 ? 'y' : 'ies'
+          } for ${citationCount} citation key${
+            citationCount === 1 ? '' : 's'
+          } in ${display}.`;
+
+    const result = toolResult({
+      summary,
+      output,
+    });
+
+    const instructions: string[] = [];
+    if (missingBibliographyFiles.length > 0) {
+      instructions.push(
+        `Missing bibliography files: ${missingBibliographyFiles
+          .map((file) => resolveAndFormat(file).display)
+          .join(', ')}.`,
+      );
+    }
+    if (missingKeys.length > 0) {
+      instructions.push(
+        `Missing citation keys: ${missingKeys
+          .map((key) => `\`${key}\``)
+          .join(', ')}.`,
+      );
+    }
+    if (entries.size > DEFAULT_MAX_ENTRIES) {
+      instructions.push(`Limited output to ${DEFAULT_MAX_ENTRIES} entries.`);
+    }
+
+    if (instructions.length > 0) {
+      result.userInstruction = instructions.join(' ');
+    }
+
+    return result;
+  }
+}

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -21,6 +21,11 @@ const ExtractBibliographyInputSchema = z.strictObject({
     .string()
     .min(1, 'texPath is required.')
     .describe('Path to the LaTeX file to scan for citations.'),
+  bibPath: z
+    .string()
+    .min(1, 'bibPath cannot be empty if provided.')
+    .describe('Optional path to a BibTeX file to include when resolving citations.')
+    .optional(),
 });
 
 export type ExtractBibliographyInput = z.infer<
@@ -35,7 +40,7 @@ export class ExtractBibliographyTool extends defineTool({
     'Collect BibTeX records for citations referenced in a LaTeX document.',
   schema: ExtractBibliographyInputSchema,
 }) {
-  protected async execute({ texPath }: ExtractBibliographyInput) {
+  protected async execute({ texPath, bibPath }: ExtractBibliographyInput) {
     const { resolved, display } = resolveAndFormat(texPath);
 
     if (!(await WorkspaceFS.exists(resolved.relative))) {
@@ -43,8 +48,23 @@ export class ExtractBibliographyTool extends defineTool({
     }
 
     const context = await extractBibliographyContext(resolved.relative);
-    const { citationKeys, bibliographyFiles, missingBibliographyFiles } =
-      context;
+    const bibliographyFiles = [...context.bibliographyFiles];
+    const missingBibliographyFiles = [...context.missingBibliographyFiles];
+    let citationKeys = [...context.citationKeys];
+
+    if (bibPath) {
+      const { resolved: bibResolved } = resolveAndFormat(bibPath);
+      const candidate = bibResolved.relative;
+      const exists = await WorkspaceFS.exists(candidate);
+      const target = exists ? bibliographyFiles : missingBibliographyFiles;
+      if (!target.includes(candidate)) {
+        target.push(candidate);
+      }
+    }
+
+    if (bibPath && citationKeys.length === 0) {
+      citationKeys = ['*'];
+    }
 
     if (
       citationKeys.length === 0 &&

--- a/src/tools/latex/index.ts
+++ b/src/tools/latex/index.ts
@@ -1,2 +1,3 @@
 export { ExtractLatexFiguresTool } from './ExtractFiguresTool';
+export { ExtractBibliographyTool } from './ExtractBibliographyTool';
 export { ExtractTikzFiguresTool } from './ExtractTikzFiguresTool';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -8,7 +8,11 @@ import { FileOpTool } from './fileOp';
 import { GlobTool } from './glob';
 import { GrepTool } from './grep';
 import { LsTool } from './ls';
-import { ExtractLatexFiguresTool, ExtractTikzFiguresTool } from './latex';
+import {
+  ExtractBibliographyTool,
+  ExtractLatexFiguresTool,
+  ExtractTikzFiguresTool,
+} from './latex';
 import { ArxivDownloadTool, ArxivMetadataTool, ArxivSearchTool } from './arxiv';
 import { ReadFileTool } from './ReadTool';
 import { TextEditorTool } from './TextEditorTool';
@@ -35,6 +39,7 @@ export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   arxiv_metadata: new ArxivMetadataTool(),
   arxiv_search: new ArxivSearchTool(),
   extract_figures: new ExtractLatexFiguresTool(),
+  extract_bib_entries: new ExtractBibliographyTool(),
   extract_tikz_figures: new ExtractTikzFiguresTool(),
   crossref_doi: new CrossrefDoiTool(),
   crossref_search: new CrossrefSearchTool(),


### PR DESCRIPTION
## Summary
- add shared LaTeX helpers to locate bibliography files, gather citations, and load BibTeX entries
- introduce the extract_bib_entries tool, register it for agents, and wire it into documentation and change log
- add targeted unit tests for the helpers and tool behavior

## Testing
- `npm run format`
- `npm run compile`
- `npm run lint`
- `npm test` *(terminated manually after excessive VS Code test runner output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f43e1fe883249b4f541fe2bbba76)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a LaTeX `extract_bib_entries` tool that resolves cited BibTeX entries (with missing files/keys surfaced), integrates it into agents/docs, and includes unit tests.
> 
> - **Tools/Backend**:
>   - Add `extract_bib_entries` tool (`src/tools/latex/ExtractBibliographyTool.ts`) to collect cited BibTeX records, support `\nocite{*}`, and emit `userInstruction` for missing files/keys; register in `DEFAULT_TOOL_REGISTRY` and export from `tools/latex/index.ts`.
>   - New helpers (`src/latex/extractBibliography.ts`): detect `\bibliography{}`/`\addbibresource{}`, extract citation keys, load/parse `.bib` via `@retorquere/bibtex-parser`, and summarize entries; exported in `src/latex/index.ts`.
> - **Agents**:
>   - Enable `extract_bib_entries` in `resources/tool_use_agents/{ask,chat,tex_linter_fix}.yaml` with updated guidance.
> - **Docs**:
>   - Add “Bibliography Extraction” section to `docs/guide/tool-integration.md` with sample payload; reference in `docs/guide/working-with-figures.md`.
>   - Update `CHANGELOG.md` (Unreleased) with the new tool.
> - **Tests**:
>   - Add unit tests for helpers and the tool (`src/test/latex/extractBibliography.test.ts`, `src/test/tools/latex/ExtractBibliographyTool.test.ts`).
> - **Dependencies**:
>   - Add `@retorquere/bibtex-parser` in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05637ab8063a9d800b51442d881d81aca3e52354. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->