### PR TITLE
fix: restore gemini tool args

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -89,6 +89,9 @@ const RawToolCallPayloadSchema = z
       })
       .optional(),
     input: z.unknown().optional(),
+    args: z
+      .union([z.string(), z.record(z.string(), z.unknown())])
+      .optional(),
     arguments: z
       .union([z.string(), z.record(z.string(), z.unknown())])
       .optional(),
@@ -149,6 +152,7 @@ const ToolCallPayloadSchema =
 
     const argumentSources: Array<unknown> = [
       payload.input,
+      payload.args,
       payload.arguments,
       payload.function?.arguments,
     ];

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -292,4 +292,87 @@ describe('runToolUseCycle DeepSeek', () => {
       output: 'fallback',
     });
   });
+
+  it('uses args payloads when present on tool calls', async () => {
+    class ArgsOnlyHandler extends MockHandler {
+      override extractToolUse(resp: any): string | null {
+        const original = super.extractToolUse(resp);
+        if (!original) {
+          return original;
+        }
+        return JSON.stringify({
+          id: 'c1',
+          name: 'echo',
+          args: { value: 'from-args' },
+        });
+      }
+    }
+
+    const config: ModelConfig = {
+      name: 'ds',
+      fullName: 'ds',
+      provider: ModelProvider.DEEPSEEK,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    };
+    const handler = new ArgsOnlyHandler(config);
+    const logger = new AgentLogger('TestHandler', true);
+    const tool = new EchoTool();
+    const toolRegistry = { echo: tool };
+    const setting: AgentSetting = {
+      agentType: AgentType.ToolUse,
+      agentCategory: AgentCategory.ToolUse,
+      documentTag: 'doc',
+      temperature: 0,
+      endTag: '</doc>',
+      requiredFiles: {},
+      requiredFilesInternal: {},
+      defaultOutputFiles: [],
+      filePatternsContain: [],
+      tools: [{ name: 'echo' }],
+    };
+    const prompt: AgentPrompt = {
+      systemPrompt: '',
+      userPrefix: '',
+      userRequest: '',
+    };
+    const toolState = new AgentWorkspaceState();
+    const options: ToolUseCycleOptions<OpenAI> = {
+      modelHandler: handler,
+      agentSetting: setting,
+      agentPrompt: prompt,
+      userVars: {},
+      userVarChannels: {
+        input: Object.freeze({}) as Readonly<Record<string, any>>,
+        transient: {},
+        output: {},
+      },
+      logger,
+      client: {} as OpenAI,
+      toolRegistry,
+      checkInterruption: () => false,
+      setAbortController: () => {},
+      toolState,
+      modelName: 'ds',
+      context: new AgentExecutionContext({
+        streamId: 'tool-use-deepseek-args' as StreamTabId,
+      }),
+    };
+    const store = new AgentSharedStore({
+      round: new ConversationRoundState(0),
+      run: new AgentRunState(),
+      workspace: toolState,
+      user: options.userVarChannels,
+    });
+
+    const messages: ProviderMessage[] = [];
+
+    await runToolUseCycle({ options, messages, store });
+
+    assert.deepEqual(tool.calls, [{ value: 'from-args' }]);
+  });
 });


### PR DESCRIPTION
## Summary
- include Gemini-style `args` payloads in ToolUseCycleFlow normalization
- add coverage ensuring tool calls execute when only `args` are provided

## Testing
- not run (covered by existing automation)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fda7e784832494b30db8c59bca7f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for `args` in tool call payloads (with precedence after `input`) and tests args-only execution plus existing fallbacks.
> 
> - **Core flow (`src/agent/core/flows/ToolUseCycleFlow.ts`)**:
>   - Parse and normalize Gemini-style `args` in tool call payloads (`RawToolCallPayloadSchema`).
>   - Argument precedence now: `input` → `args` → `arguments` → `function.arguments`.
> - **Tests (`src/test/toolUse/ToolUseCycleDeepSeek.test.ts`)**:
>   - Add test to execute tools when only `args` are provided.
>   - Preserve fallback test to `function.arguments` when other fields are empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7ec3b9a0aa33360ff0c53a1c455648f9d611e66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->