### PR TITLE
fix: add bibtex parser module types

### DIFF
--- a/src/types/retorquere__bibtex-parser.d.ts
+++ b/src/types/retorquere__bibtex-parser.d.ts
@@ -1,0 +1,14 @@
+declare module '@retorquere/bibtex-parser' {
+  export interface BibTeXEntry {
+    entryType: string;
+    key?: string | null;
+    input: string;
+    fields: Record<string, unknown>;
+  }
+
+  export interface BibTeXLibrary {
+    entries: BibTeXEntry[];
+  }
+
+  export function parse(content: string): BibTeXLibrary;
+}


### PR DESCRIPTION
## Summary
- add an ambient module declaration for `@retorquere/bibtex-parser`
- model parsed entries with the fields used by the bibliography loader

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691331b984908324978e8ef7bb76e56f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add TypeScript ambient module declarations for `@retorquere/bibtex-parser`, including `BibTeXEntry`, `BibTeXLibrary`, and `parse()`.
> 
> - **Types**:
>   - Add ambient module `@retorquere/bibtex-parser` in `src/types/retorquere__bibtex-parser.d.ts`.
>     - Define `BibTeXEntry` and `BibTeXLibrary` interfaces.
>     - Export `parse(content: string): BibTeXLibrary`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 468cbde3dca3b7eb3c731ebc0647cf5d1c78c381. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->