### PR TITLE
fix: expose bibtex parser types

### DIFF
--- a/src/types/vendor/retorquere__bibtex-parser.d.ts
+++ b/src/types/vendor/retorquere__bibtex-parser.d.ts
@@ -1,0 +1,3 @@
+declare module '@retorquere/bibtex-parser' {
+  export * from '@retorquere/bibtex-parser/dist/types/index';
+}


### PR DESCRIPTION
## Summary
- add a local module declaration that re-exports the upstream TypeScript definitions for `@retorquere/bibtex-parser`
- unblock extension builds that previously failed due to missing type declarations for the BibTeX parser dependency

## Testing
- npm run format
- npm run lint
- npm run compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691331b984908324978e8ef7bb76e56f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-exports upstream TypeScript types for `@retorquere/bibtex-parser` via a local module declaration to resolve missing type declarations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 880c96de1ffc9133d5c52dd32eeaadbb607db874. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->