### PR TITLE
Fix extract bibliography regex crash

### DIFF
--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -8,7 +8,7 @@ import { BibEntry, parseBibFile } from 'bibtex';
 import { WorkspaceFS } from '@utils/files';
 
 const DIRECTIVE_PATTERN_SOURCE =
-  '\\(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}';
+  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}';
 const CITE_COMMANDS = [
   'cite',
   'citet',
@@ -197,7 +197,9 @@ function parseBibEntries(content: string): Map<string, string> {
   const entries = new Map<string, string>();
 
   for (const rawEntry of library.entries_raw) {
-    const formatted = formatBibEntry(rawEntry, library.entries$[rawEntry._id]);
+    const processedEntry =
+      rawEntry._id !== undefined ? library.entries$[rawEntry._id] : undefined;
+    const formatted = formatBibEntry(rawEntry, processedEntry);
     const key = rawEntry._id?.trim();
 
     if (!key || !formatted || entries.has(key)) {

--- a/src/types/bibtex.d.ts
+++ b/src/types/bibtex.d.ts
@@ -1,0 +1,16 @@
+declare module 'bibtex' {
+  export interface BibEntry {
+    _id?: string;
+    type?: string;
+    fields: Record<string, unknown>;
+    getField(field: string): unknown;
+  }
+
+  export interface BibLibrary {
+    entries_raw: BibEntry[];
+    entries$: Record<string, BibEntry | undefined>;
+    getEntry(id: string): BibEntry | undefined;
+  }
+
+  export function parseBibFile(content: string): BibLibrary;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     },
     "moduleResolution": "node",
     "strict": true /* enable all strict type-checking options */,
+    "skipLibCheck": true,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules */
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
## Summary
- correct the bibliography directive regex so extractBibliography no longer throws a syntax error and guard raw entry lookups
- add local bibtex typings and enable skipLibCheck to work around upstream declaration issues

## Testing
- npm run compile-tests
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691360f93fc483249569205d871f325e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes LaTeX bibliography directive parsing and guards BibTeX entry lookups; adds local `bibtex` typings and enables `skipLibCheck`.
> 
> - **LaTeX bibliography extraction (`src/latex/extractBibliography.ts`)**:
>   - Corrects `DIRECTIVE_PATTERN_SOURCE` regex to avoid invalid escape handling when constructing the `RegExp`.
>   - Guards access to `library.entries$` by checking `rawEntry._id` before lookup.
> - **Types**:
>   - Adds local `src/types/bibtex.d.ts` providing typings for `bibtex` (`BibEntry`, `BibLibrary`, `parseBibFile`).
> - **Config**:
>   - Enables `"skipLibCheck": true` in `tsconfig.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c4639b7852faf7135e9cfc77a73f96901cdb2d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->