### PR TITLE
fix: correct citation regex escaping

### DIFF
--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -31,7 +31,7 @@ function createDirectivePattern(): RegExp {
 
 function createCitationPattern(): RegExp {
   return new RegExp(
-    `\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\{([^}]*)\}`,
+    `\\\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\{([^}]*)\}`,
     'g',
   );
 }


### PR DESCRIPTION
## Summary
- correct the LaTeX citation matching regex to escape the leading backslash properly

## Testing
- npm test -- --runTestsByPath src/test/latex/extractBibliography.test.ts *(fails: vscode-test missing system dependency libatk-bridge-2.0.so.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691497629c68832482119170248348bc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the LaTeX citation-matching regex to correctly match backslash-prefixed cite commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa64ac6a58ff9f9bf0f2be0f53d80bb4aefa5e66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->