### PR TITLE
Fix thinking log race by reordering progress event registration

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -95,11 +95,14 @@ export class ProgressEventHandler {
     disposables.push(
       ...this.usageEvents.register(bus, this.state, this.webviewUpdater),
     );
-    disposables.push(
-      ...this.logEvents.register(bus, this.state, this.webviewUpdater),
-    );
+    // Task group events must be registered before log events so buffered group
+    // replays run first. Otherwise replayed thinking logs land before their
+    // containers exist, leaving the progress board with orphaned banners.
     disposables.push(
       ...this.taskGroupEvents.register(bus, this.state, this.webviewUpdater),
+    );
+    disposables.push(
+      ...this.logEvents.register(bus, this.state, this.webviewUpdater),
     );
     return disposables;
   }

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -11,7 +11,7 @@ import { ProgressEventHandler } from '@progressView/events/ProgressEventHandler'
 
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { WebviewUpdater } from '@progressView/managers';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { AgentLogger } from '@logger/AgentLogger';
 
 class FakeBus {
@@ -227,7 +227,6 @@ describe('Progress event modules', () => {
   });
 
   it('registers task groups before log handlers to avoid thinking replay races', () => {
-    const bus = new FakeBus();
     const state = {
       streamTabs: {
         ensureStream: async () => {},
@@ -283,24 +282,43 @@ describe('Progress event modules', () => {
       updateTaskGroup: () => {},
     } as unknown as WebviewUpdater;
 
-    const handler = new ProgressEventHandler(state, updater);
-    handler.setupEventListeners();
+    const registeredEvents: (keyof ProgressEventPayloads)[] = [];
+    const originalOn = bus.on.bind(bus);
 
-    assert.deepStrictEqual(bus.events, [
-      'setActiveStream',
-      'updateStreamStatus',
-      'setTaskState',
-      'addOutputFiles',
-      'updateMissingOutputs',
-      'clearMissingOutputs',
-      'clearOutputFiles',
-      'clearTaskOutput',
-      'updateGroupUsage',
-      'updateStreamUsage',
-      'addTaskGroup',
-      'updateTaskGroup',
-      'addLogMessage',
-      'updateLogMessage',
-    ]);
+    const restoreBus = () => {
+      (bus as unknown as { on: typeof bus.on }).on = originalOn;
+    };
+
+    (bus as unknown as { on: typeof bus.on }).on = ((event, listener) => {
+      registeredEvents.push(event);
+      return originalOn(event, listener);
+    }) as typeof bus.on;
+
+    const disposables: { dispose: () => void }[] = [];
+
+    try {
+      const handler = new ProgressEventHandler(state, updater);
+      disposables.push(...handler.setupEventListeners());
+
+      assert.deepStrictEqual(registeredEvents, [
+        'setActiveStream',
+        'updateStreamStatus',
+        'setTaskState',
+        'addOutputFiles',
+        'updateMissingOutputs',
+        'clearMissingOutputs',
+        'clearOutputFiles',
+        'clearTaskOutput',
+        'updateGroupUsage',
+        'updateStreamUsage',
+        'addTaskGroup',
+        'updateTaskGroup',
+        'addLogMessage',
+        'updateLogMessage',
+      ]);
+    } finally {
+      disposables.forEach((disposable) => disposable.dispose());
+      restoreBus();
+    }
   });
 });

--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -7,6 +7,7 @@ import { createOutputEvents } from '@progressView/events/OutputEvents';
 import { createUsageEvents } from '@progressView/events/UsageEvents';
 import { createLogEvents } from '@progressView/events/LogEvents';
 import { createTaskGroupEvents } from '@progressView/events/TaskGroupEvents';
+import { ProgressEventHandler } from '@progressView/events/ProgressEventHandler';
 
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { WebviewUpdater } from '@progressView/managers';
@@ -223,5 +224,83 @@ describe('Progress event modules', () => {
 
     assert.deepStrictEqual(initialized, ['stream-1']);
     assert.deepStrictEqual(bus.emissions, []);
+  });
+
+  it('registers task groups before log handlers to avoid thinking replay races', () => {
+    const bus = new FakeBus();
+    const state = {
+      streamTabs: {
+        ensureStream: async () => {},
+        has: () => true,
+        addMessage: async () => {},
+        getMessages: () => [],
+        save: async () => {},
+      },
+      taskGroups: {
+        addGroup: async () => {},
+        updateGroup: async () => {},
+        getStreamGroups: () => new Map(),
+      },
+      outputFiles: {
+        addFiles: async () => {},
+        updateMissingOutputs: async () => {},
+        clearMissingOutputs: async () => {},
+        clearFiles: async () => {},
+        getFiles: () => new Map(),
+        getMissingOutputs: () => new Map(),
+      },
+      usageStats: {
+        getRunUsage: () => new Map(),
+        setRunUsage: () => {},
+      },
+      runInstructions: {
+        getInstructions: () => new Map(),
+        setInstruction: async () => {},
+        deleteRun: async () => {},
+      },
+      agentTypeFilter: 'all',
+      setActiveRunId: () => {},
+      resolveRunId: () => null,
+      setSessionKindHint: () => {},
+      clearSessionKindHint: () => {},
+      clearRunInstructions: () => {},
+      clearRunFiles: () => {},
+      clearRunMissingOutputs: () => {},
+      clearRunUsage: () => {},
+      clearAllActiveRuns: () => {},
+      clearAllPendingInstructions: () => {},
+      getTaskState: () => undefined,
+      activeStream: '',
+    } as unknown as ProgressViewState;
+
+    const updater = {
+      isAvailable: () => false,
+      updateLogContent: () => {},
+      updateFiles: () => {},
+      updateMissingOutputs: () => {},
+      updateUsage: () => {},
+      addTaskGroup: () => {},
+      updateTaskGroup: () => {},
+    } as unknown as WebviewUpdater;
+
+    const handler = new ProgressEventHandler(state, updater);
+    handler.setupEventListeners();
+
+    assert.deepStrictEqual(bus.events, [
+      'setActiveStream',
+      'updateStreamStatus',
+      'setTaskState',
+      'addOutputFiles',
+      'updateMissingOutputs',
+      'clearMissingOutputs',
+      'clearOutputFiles',
+      'clearTaskOutput',
+      'updateGroupUsage',
+      'updateStreamUsage',
+      'addTaskGroup',
+      'updateTaskGroup',
+      'addLogMessage',
+      'updateLogMessage',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- ensure task group events are registered before log events so buffered thinking updates attach to their containers
- add a regression test that asserts the registration order to guard against future regressions

## Testing
- CI=1 FORCE_COLOR=0 npm test -- --runTestsByPath src/test/progressView/events/EventModules.test.ts *(fails: vscode-test missing libatk-bridge-2.0.so.0 in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a1ae28108324855bf9a1153901ef)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders progress event registration so task group events are registered before log events to avoid orphaned thinking logs, and adds a regression test that asserts the order.
> 
> - **Progress View**:
>   - Reorder `ProgressEventHandler.setupEventListeners` to register `taskGroupEvents` before `logEvents` with an explanatory comment.
> - **Tests**:
>   - Add regression test in `src/test/progressView/events/EventModules.test.ts` verifying registration order.
>   - Update test imports to use `ProgressEventHandler` and the shared `bus` from `@eventBus/ProgressEventBus`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba002182aaf665c3fcf7435880cc00e9099b6cbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->