### PR TITLE
fix: focus follow-up textarea when waiting

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -216,6 +216,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       container.classList.toggle('is-visible', isToolAgent);
       container.setAttribute('aria-hidden', isToolAgent ? 'false' : 'true');
     }
+    dom.followUpInput.setContainerVisibility(Boolean(isToolAgent && container));
 
     dom.approvalRequests.setActiveStream(message.activeStream, isToolAgent);
 
@@ -449,6 +450,23 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const hasExecution = state.hasExecutionId(state.activeStream);
     dom.status.setExecutionIdAvailability(Boolean(hasExecution));
     dom.status.update(message.status);
+
+    const targetsActiveStream =
+      !message.stream || message.stream === state.activeStream;
+    if (!targetsActiveStream) {
+      return;
+    }
+
+    const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
+    const isContainerVisible = Boolean(
+      container &&
+        container.classList.contains('is-visible') &&
+        container.getAttribute('aria-hidden') === 'false',
+    );
+
+    if (message.status === STATUS.WAITING && isContainerVisible) {
+      dom.followUpInput.focus({ scrollIntoView: true });
+    }
   }
 
   handleUpdateUsage(message) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -457,14 +457,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
-    const isContainerVisible = Boolean(
-      container &&
-        container.classList.contains('is-visible') &&
-        container.getAttribute('aria-hidden') === 'false',
-    );
-
-    if (message.status === STATUS.WAITING && isContainerVisible) {
+    if (message.status === STATUS.WAITING) {
       dom.followUpInput.focus({ scrollIntoView: true });
     }
   }

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -18,6 +18,8 @@ export class FollowUpInputManager {
     this.vscode = vscode;
     this.textarea = null;
     this.approvalBypassButton = null;
+    this._isContainerVisible = false;
+    this._focusTimer = null;
     this.recordingButton = new RecordingButtonManager(vscode, {
       buttonId: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,
       startCommand: COMMANDS.START_RECORDING,
@@ -135,7 +137,7 @@ export class FollowUpInputManager {
     if (!this.textarea) return;
 
     this.textarea.value = '';
-    this.textarea.focus();
+    this.focus();
   }
 
   _resetApprovalBypass() {
@@ -146,6 +148,46 @@ export class FollowUpInputManager {
 
   setRecording(recording) {
     this.recordingButton.setRecording(recording);
+  }
+
+  setContainerVisibility(isVisible) {
+    this._isContainerVisible = Boolean(isVisible);
+    if (!this._isContainerVisible) {
+      this._clearPendingFocus();
+    }
+  }
+
+  focus(options = {}) {
+    if (!this.textarea || !this._isContainerVisible) {
+      return;
+    }
+
+    const { scrollIntoView = false } = options;
+
+    this._clearPendingFocus();
+
+    this._focusTimer = window.setTimeout(() => {
+      this._focusTimer = null;
+      if (!this.textarea || !this._isContainerVisible) {
+        return;
+      }
+
+      this.textarea.focus();
+
+      if (
+        scrollIntoView &&
+        typeof this.textarea.scrollIntoView === 'function'
+      ) {
+        this.textarea.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }, 0);
+  }
+
+  _clearPendingFocus() {
+    if (this._focusTimer) {
+      clearTimeout(this._focusTimer);
+      this._focusTimer = null;
+    }
   }
 
   applyPolishedText(text) {
@@ -162,7 +204,7 @@ export class FollowUpInputManager {
     }
 
     this.textarea.value = text;
-    this.textarea.focus();
+    this.focus({ scrollIntoView: true });
   }
 
   insertTranscription(text) {
@@ -171,7 +213,7 @@ export class FollowUpInputManager {
     }
 
     insertTextAtCursor(this.textarea, text);
-    this.textarea.focus();
+    this.focus({ scrollIntoView: true });
   }
 
   setApprovalBypassState(isBypassed) {


### PR DESCRIPTION
## Summary
- add a follow-up input focus helper that tracks container visibility and scrolls into view when needed
- update the progress view status handler to focus the follow-up textarea when tool-use sessions transition to waiting
- clear any pending focus timers when the follow-up container hides to avoid repeated focus attempts

## Testing
- npm run format
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916438323888324a3c542576b4a0a0c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a follow-up input focus helper that respects container visibility and auto-scrolls, and focuses the input when tool-use sessions transition to WAITING.
> 
> - **Progress View UI**:
>   - **Follow-up input focus helper**: Add `FollowUpInputManager.setContainerVisibility`, debounced `focus({ scrollIntoView })`, and pending-focus cleanup; replace direct `textarea.focus()` calls with the helper.
>   - **Visibility wiring**: On stream updates, set follow-up container visibility via `dom.followUpInput.setContainerVisibility(Boolean(isToolAgent && container))`.
>   - **Status handling**: When status targets the active stream and is `STATUS.WAITING`, focus the follow-up input (with optional scroll into view).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ffa5e676fff3e435aed5a87103c401a4507f9c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->