### PR TITLE
fix: optimize usage aggregation propagation

### DIFF
--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -8,7 +8,8 @@ import { WebviewStateManager } from '@common/webviewState.js';
 class TaskGroups {
   constructor() {
     this.groups = new Map();
-    this._cachedTotals = null;
+    this.childrenByParent = new Map();
+    this.parentByChild = new Map();
   }
 
   get(id) {
@@ -28,8 +29,18 @@ class TaskGroups {
       console.error('TaskGroups.set: group must be an object');
       return;
     }
+    const previousParentId = this.parentByChild.get(id);
+    if (previousParentId) {
+      this._removeChild(previousParentId, id);
+    }
+
     this.groups.set(id, group);
-    this._cachedTotals = null; // Invalidate cache
+
+    if (group.parentGroupId) {
+      this._addChild(group.parentGroupId, id);
+    } else {
+      this.parentByChild.delete(id);
+    }
   }
 
   getGroupMap() {
@@ -38,7 +49,8 @@ class TaskGroups {
 
   clear() {
     this.groups.clear();
-    this._cachedTotals = null; // Invalidate cache
+    this.childrenByParent.clear();
+    this.parentByChild.clear();
   }
 
   /**
@@ -81,8 +93,53 @@ class TaskGroups {
       group.usage = updates.usage;
     }
 
-    this.groups.set(groupId, group);
-    this._cachedTotals = null; // Invalidate cache
+    this.set(groupId, group);
+  }
+
+  getChildIds(parentId) {
+    if (!parentId) {
+      return [];
+    }
+
+    const children = this.childrenByParent.get(parentId);
+    if (!children) {
+      return [];
+    }
+
+    return Array.from(children);
+  }
+
+  _addChild(parentId, childId) {
+    if (!parentId || !childId) {
+      return;
+    }
+
+    let children = this.childrenByParent.get(parentId);
+    if (!children) {
+      children = new Set();
+      this.childrenByParent.set(parentId, children);
+    }
+    children.add(childId);
+    this.parentByChild.set(childId, parentId);
+  }
+
+  _removeChild(parentId, childId) {
+    if (!parentId || !childId) {
+      return;
+    }
+
+    const children = this.childrenByParent.get(parentId);
+    if (!children) {
+      return;
+    }
+
+    children.delete(childId);
+    if (this.parentByChild.get(childId) === parentId) {
+      this.parentByChild.delete(childId);
+    }
+    if (children.size === 0) {
+      this.childrenByParent.delete(parentId);
+    }
   }
 }
 

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -154,11 +154,28 @@ export class UsageGroupManager {
     // Persist usage on the group state so the summary can be computed
     const group = progressViewState.taskGroups.get(groupId);
     if (group) {
-      group.usage = { inputTokens, outputTokens, cost };
+      const previousUsage = group.usage || {
+        inputTokens: 0,
+        outputTokens: 0,
+        cost: 0,
+      };
+
+      const nextUsage = { inputTokens, outputTokens, cost };
+      group.usage = nextUsage;
       progressViewState.taskGroups.set(groupId, group);
-    }
-    if (!skipPropagate) {
-      this.propagateUsageToParents(groupId);
+
+      if (!skipPropagate) {
+        const delta = {
+          inputTokens: nextUsage.inputTokens - (previousUsage.inputTokens || 0),
+          outputTokens:
+            nextUsage.outputTokens - (previousUsage.outputTokens || 0),
+          cost: nextUsage.cost - (previousUsage.cost || 0),
+        };
+
+        if (!this._isZeroDelta(delta)) {
+          this.propagateUsageToParents(groupId, delta);
+        }
+      }
     }
 
     // Refresh the cumulative summary displayed in the footer
@@ -171,19 +188,23 @@ export class UsageGroupManager {
    */
   computeAggregatedUsage(parentId) {
     const totals = { inputTokens: 0, outputTokens: 0, cost: 0 };
-    const taskGroups = progressViewState.taskGroups.getGroupMap();
-    for (const group of taskGroups.values()) {
-      if (group.parentGroupId === parentId) {
-        if (group.usage) {
-          totals.inputTokens += group.usage.inputTokens || 0;
-          totals.outputTokens += group.usage.outputTokens || 0;
-          totals.cost += group.usage.cost || 0;
-        }
-        const childTotals = this.computeAggregatedUsage(group.id);
-        totals.inputTokens += childTotals.inputTokens;
-        totals.outputTokens += childTotals.outputTokens;
-        totals.cost += childTotals.cost;
+    const childIds = progressViewState.taskGroups.getChildIds(parentId);
+    for (const childId of childIds) {
+      const child = progressViewState.taskGroups.get(childId);
+      if (!child) {
+        continue;
       }
+
+      if (child.usage) {
+        totals.inputTokens += child.usage.inputTokens || 0;
+        totals.outputTokens += child.usage.outputTokens || 0;
+        totals.cost += child.usage.cost || 0;
+      }
+
+      const childTotals = this.computeAggregatedUsage(child.id);
+      totals.inputTokens += childTotals.inputTokens;
+      totals.outputTokens += childTotals.outputTokens;
+      totals.cost += childTotals.cost;
     }
     return totals;
   }
@@ -192,28 +213,53 @@ export class UsageGroupManager {
    * Propagate usage updates to parent groups
    * @private
    */
-  propagateUsageToParents(groupId) {
-    const group = progressViewState.taskGroups.get(groupId);
-    if (!group) return;
+  propagateUsageToParents(groupId, delta) {
+    if (!delta || this._isZeroDelta(delta)) {
+      return;
+    }
 
-    // If this group has a parent, update the parent with aggregated usage
-    if (group.parentGroupId) {
-      const totals = {
-        ...this.computeAggregatedUsage(group.parentGroupId),
+    const group = progressViewState.taskGroups.get(groupId);
+    if (!group) {
+      return;
+    }
+
+    let parentId = group.parentGroupId;
+    while (parentId) {
+      const parent = progressViewState.taskGroups.get(parentId);
+      if (!parent) {
+        break;
+      }
+
+      const previousUsage = parent.usage || {
+        inputTokens: 0,
+        outputTokens: 0,
+        cost: 0,
       };
+
+      const updatedUsage = {
+        inputTokens:
+          (previousUsage.inputTokens || 0) + (delta.inputTokens || 0),
+        outputTokens:
+          (previousUsage.outputTokens || 0) + (delta.outputTokens || 0),
+        cost: (previousUsage.cost || 0) + (delta.cost || 0),
+      };
+
       this.update({
-        groupId: group.parentGroupId,
-        usage: totals,
+        groupId: parentId,
+        usage: updatedUsage,
         skipPropagate: true,
       });
-      this.propagateUsageToParents(group.parentGroupId);
-    } else {
-      // This is a top-level group, update it with aggregated usage from its children
-      const totals = {
-        ...this.computeAggregatedUsage(groupId),
-      };
-      this.update({ groupId, usage: totals, skipPropagate: true });
+
+      parentId = parent.parentGroupId;
     }
+  }
+
+  _isZeroDelta(delta) {
+    return (
+      (!delta.inputTokens || delta.inputTokens === 0) &&
+      (!delta.outputTokens || delta.outputTokens === 0) &&
+      (!delta.cost || delta.cost === 0)
+    );
   }
 
   /**

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -199,6 +199,7 @@ export class UsageGroupManager {
         totals.inputTokens += child.usage.inputTokens || 0;
         totals.outputTokens += child.usage.outputTokens || 0;
         totals.cost += child.usage.cost || 0;
+        continue;
       }
 
       const childTotals = this.computeAggregatedUsage(child.id);
@@ -223,8 +224,17 @@ export class UsageGroupManager {
       return;
     }
 
+    const visitedParents = new Set();
     let parentId = group.parentGroupId;
     while (parentId) {
+      if (visitedParents.has(parentId)) {
+        console.error(
+          `UsageGroupManager.propagateUsageToParents: detected circular parent reference for group ${groupId}`,
+        );
+        break;
+      }
+      visitedParents.add(parentId);
+
       const parent = progressViewState.taskGroups.get(parentId);
       if (!parent) {
         break;


### PR DESCRIPTION
## Summary
- maintain cached parent/child relationships for progress view task groups
- propagate usage deltas to ancestors without re-scanning the entire map
- leverage cached child lists when recomputing aggregated usage totals

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917097527208324bfad0321d584d37b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cache parent/child relationships for task groups and propagate incremental usage deltas up ancestors to avoid full-map rescans.
> 
> - **Progress View State (`src/progressView/modules/progressViewState.js`)**:
>   - **TaskGroups**:
>     - Add cached mappings: `childrenByParent` and `parentByChild`.
>     - Update `set` to maintain parent/child links; remove previous parent linkage when reparenting.
>     - Add `getChildIds`, `_addChild`, `_removeChild`; `clear` now resets relationship caches.
>     - `update` now delegates to `set` for consistent state maintenance.
> - **Usage Management (`src/progressView/modules/usageManagers.js`)**:
>   - **Incremental propagation**:
>     - `update` computes usage delta from previous to next and calls `propagateUsageToParents(delta)`; skips when zero.
>     - `propagateUsageToParents` now walks ancestor chain, updates parents with accumulated deltas, guards against cycles, and uses `skipPropagate` to prevent re-entry.
>   - **Aggregation**:
>     - `computeAggregatedUsage` now uses `TaskGroups.getChildIds` instead of scanning all groups.
>   - **Utility**:
>     - Add `_isZeroDelta` to short-circuit no-op updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a424f0d5df0b8e1dbc20509976baa47c1b2f688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->