### PR TITLE
Refine progress view refresh responsibilities

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -15,7 +15,6 @@ import { LogMessageData } from '@logger/LogTypes';
 import { ProgressEventHandler } from './events/ProgressEventHandler';
 import { WebviewUpdater } from './managers';
 // @ts-ignore - Import JavaScript module
-import { STATUS } from './modules/constants.js';
 import { ProgressViewContentProvider } from './ProgressViewContentProvider';
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 import { ProgressViewState } from './state/ProgressViewState';
@@ -24,14 +23,6 @@ import { ProgressViewState } from './state/ProgressViewState';
 
 // Type imports
 import type { ToolEditApprovalPrompt } from './types';
-
-// Type aliases for status values
-type StreamStatusType =
-  | typeof STATUS.RUNNING
-  | typeof STATUS.ERROR
-  | typeof STATUS.STOPPED
-  | typeof STATUS.WAITING
-  | typeof STATUS.RESUMING;
 
 /**
  * Refactored ProgressViewProvider using the new modular architecture.
@@ -179,28 +170,17 @@ export class ProgressViewProvider
       vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
         ? 'dark'
         : 'light';
-    this.webviewUpdater.updateTheme(theme);
 
-    // Validate and update active stream if necessary
-    const streams = this.state.streamTabs.keys();
-    if (!streams.includes(this.state.activeStream)) {
-      this.state.activeStream = streams[0] || '';
-    }
-
-    // Update all webview content using the new updater
-    this.webviewUpdater.updateAll(
+    const activeStream = this.webviewUpdater.updateAll(
       this.state,
       this.eventHandler.getAllStreamStatuses(),
+      theme,
     );
 
-    // Update status for current stream
-    if (this.state.activeStream) {
-      const status = this.eventHandler.getStreamStatus(this.state.activeStream);
-      if (status) {
-        this.webviewUpdater.updateStatus(status);
-      }
+    if (activeStream) {
+      this.eventHandler.refreshStreamSurface(activeStream);
     } else {
-      this.webviewUpdater.updateStatus(STATUS.READY);
+      this.eventHandler.refreshStreamSurface('');
     }
 
     this._pendingUpdate = false;

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -12,7 +12,7 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createErrorBoundary } from './errorHandling';
 
 // Type imports
-import type { ProgressEventBusLike } from './types';
+import type { ProgressEventBusLike, StreamStatusType } from './types';
 
 export interface OutputEventsModule {
   register(
@@ -28,6 +28,7 @@ interface OutputEventsShared {
     stream: string,
     options?: { updateInstruction?: boolean },
   ) => void;
+  getAllStreamStatuses: () => Map<string, StreamStatusType>;
 }
 
 const updateActiveStreamOutputs = (
@@ -127,7 +128,10 @@ const registerClearTaskOutput = (
       withErrorBoundary('failed to handle clearTaskOutput', () => {
         const cleared = state.clearOutputState(streamTabId);
         if (cleared) {
-          const activeStream = updater.updateAll(state);
+          const activeStream = updater.updateAll(
+            state,
+            shared.getAllStreamStatuses(),
+          );
           shared.refreshStreamSurface(activeStream);
         }
       });

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -24,6 +24,10 @@ export interface OutputEventsModule {
 
 interface OutputEventsShared {
   logger: AgentLogger;
+  refreshStreamSurface: (
+    stream: string,
+    options?: { updateInstruction?: boolean },
+  ) => void;
 }
 
 const updateActiveStreamOutputs = (
@@ -115,14 +119,16 @@ const registerClearTaskOutput = (
   bus: ProgressEventBusLike,
   state: ProgressViewState,
   updater: WebviewUpdater,
+  shared: OutputEventsShared,
   withErrorBoundary: ReturnType<typeof createErrorBoundary>,
 ): vscode.Disposable => {
   return new vscode.Disposable(
     bus.on('clearTaskOutput', (streamTabId: StreamTabId) => {
       withErrorBoundary('failed to handle clearTaskOutput', () => {
         const cleared = state.clearOutputState(streamTabId);
-        if (cleared && updater.isAvailable()) {
-          updater.updateAll(state);
+        if (cleared) {
+          const activeStream = updater.updateAll(state);
+          shared.refreshStreamSurface(activeStream);
         }
       });
     }),
@@ -147,7 +153,7 @@ export function createOutputEvents(
         withErrorBoundary,
       );
       disposables.push(
-        registerClearTaskOutput(bus, state, updater, withErrorBoundary),
+        registerClearTaskOutput(bus, state, updater, shared, withErrorBoundary),
       );
       return disposables;
     },

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -63,6 +63,8 @@ export class ProgressEventHandler {
     });
     this.outputEvents = createOutputEvents({
       logger: this.logger,
+      refreshStreamSurface: (stream, options) =>
+        this.refreshStreamSurface(stream, options),
     });
     this.usageEvents = createUsageEvents({
       logger: this.logger,
@@ -153,6 +155,18 @@ export class ProgressEventHandler {
 
     const { updateInstruction = true } = options;
 
+    if (!stream) {
+      this.webviewUpdater.updateLogContent('', [], []);
+      this.webviewUpdater.updateFiles('', {});
+      this.webviewUpdater.updateMissingOutputs('', {});
+      this.webviewUpdater.updateUsage('', {});
+      this.webviewUpdater.updateStatus(STATUS.READY);
+      if (updateInstruction) {
+        this.webviewUpdater.clearInstruction('');
+      }
+      return;
+    }
+
     const messages = this.state.streamTabs.getMessages(stream);
     const groups = Array.from(
       this.state.taskGroups.getStreamGroups(stream).values(),
@@ -190,10 +204,7 @@ export class ProgressEventHandler {
     this.webviewUpdater.updateMissingOutputs(stream, missingByRun);
 
     // Send usage for current stream
-    const usage = Object.fromEntries(
-      this.state.usageStats.getRunUsage(stream).entries(),
-    ) as Record<string, TokenUsageStats>;
-    this.webviewUpdater.updateUsage(stream, usage);
+    this.webviewUpdater.updateUsage(stream, usageByRun);
 
     // Update status for current stream - default to STOPPED when stream exists but no status is set
     const status = this._streamStatus.get(stream) || STATUS.STOPPED;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -65,6 +65,7 @@ export class ProgressEventHandler {
       logger: this.logger,
       refreshStreamSurface: (stream, options) =>
         this.refreshStreamSurface(stream, options),
+      getAllStreamStatuses: () => this.getAllStreamStatuses(),
     });
     this.usageEvents = createUsageEvents({
       logger: this.logger,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -330,28 +330,31 @@ export class WebviewUpdater {
   ): StreamTabId {
     const streams = buildStreamInfos(state, statuses, state.agentTypeFilter);
 
-    let activeStream = state.activeStream;
-    if (!streams.some((info) => info.name === activeStream)) {
-      activeStream = streams[0]?.name ?? '';
-      state.activeStream = activeStream;
+    const webview = this.getWebview();
+    let resolvedActiveStream = state.activeStream;
+    if (!streams.some((info) => info.name === resolvedActiveStream)) {
+      resolvedActiveStream = streams[0]?.name ?? '';
     }
 
-    const webview = this.getWebview();
     if (!webview) {
-      return activeStream;
+      return resolvedActiveStream;
+    }
+
+    if (resolvedActiveStream !== state.activeStream) {
+      state.activeStream = resolvedActiveStream;
     }
 
     if (theme) {
       this.updateTheme(theme);
     }
 
-    this.updateStreams(streams, activeStream, state.agentTypeFilter);
+    this.updateStreams(streams, resolvedActiveStream, state.agentTypeFilter);
 
     this.logger.debug(
-      `Updated webview streams (${streams.length}) active: ${activeStream}`,
+      `Updated webview streams (${streams.length}) active: ${resolvedActiveStream}`,
     );
 
-    return activeStream;
+    return resolvedActiveStream;
   }
 
   /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -320,12 +320,14 @@ export class WebviewUpdater {
   }
 
   /**
-   * Update all webview content based on current state
+   * Update stream metadata and theme for the webview.
+   * Returns the resolved active stream after applying the update.
    */
-  updateAll(state: ProgressViewState, statuses?: Map<string, string>): void {
-    const webview = this.getWebview();
-    if (!webview) return;
-
+  updateAll(
+    state: ProgressViewState,
+    statuses?: Map<string, string>,
+    theme?: 'dark' | 'light',
+  ): StreamTabId {
     const streams = buildStreamInfos(state, statuses, state.agentTypeFilter);
 
     let activeStream = state.activeStream;
@@ -334,73 +336,22 @@ export class WebviewUpdater {
       state.activeStream = activeStream;
     }
 
-    // Update streams and active stream
-    this.updateStreams(streams, activeStream, state.agentTypeFilter);
-
-    if (activeStream) {
-      // Update log content for active stream
-      const messages = state.streamTabs.getMessages(activeStream);
-      const groups = Array.from(
-        state.taskGroups.getStreamGroups(activeStream).values(),
-      );
-      const files = Object.fromEntries(
-        Array.from(
-          state.outputFiles.getFiles(activeStream).entries(),
-          ([runId, rounds]) => [runId, Object.fromEntries(rounds.entries())],
-        ),
-      );
-      const missing = Object.fromEntries(
-        Array.from(
-          state.outputFiles.getMissingOutputs(activeStream).entries(),
-          ([runId, rounds]) => [runId, Object.fromEntries(rounds.entries())],
-        ),
-      );
-      const runInstructions = Object.fromEntries(
-        state.runInstructions.getInstructions(activeStream).entries(),
-      );
-      const activeRunId = state.getActiveRunId(activeStream);
-
-      this.updateLogContent(activeStream, messages, groups, {
-        runInstructions,
-        activeRunId,
-        runFiles: files,
-        runMissingOutputs: missing,
-      });
-
-      // Update files for active stream
-      this.updateFiles(activeStream, files);
-
-      // Update missing outputs for active stream
-      this.updateMissingOutputs(activeStream, missing);
-
-      // Update usage for active stream
-      const usage = Object.fromEntries(
-        state.usageStats.getRunUsage(activeStream).entries(),
-      ) as Record<string, TokenUsageStats>;
-      this.updateUsage(activeStream, usage);
-
-      const taskState = state.getTaskState(activeStream);
-      const instructionUpdate =
-        WebviewUpdater.createInstructionUpdate(taskState);
-      const activeStreamInfo = streams.find((s) => s.name === activeStream);
-      const sessionKind = activeStreamInfo?.agentSessionKind;
-      if (instructionUpdate) {
-        this.updateInstruction(activeStream, instructionUpdate, sessionKind);
-      } else {
-        this.clearInstruction(activeStream);
-      }
-    } else {
-      // Clear content when no active stream
-      this.updateLogContent('', [], []);
-      this.updateFiles('', {});
-      this.updateMissingOutputs('', {});
-      this.updateUsage('', {});
-      this.clearInstruction('');
+    const webview = this.getWebview();
+    if (!webview) {
+      return activeStream;
     }
 
+    if (theme) {
+      this.updateTheme(theme);
+    }
+
+    this.updateStreams(streams, activeStream, state.agentTypeFilter);
+
     this.logger.debug(
-      `Updated webview with ${streams.length} streams, active: ${activeStream}`,
+      `Updated webview streams (${streams.length}) active: ${activeStream}`,
     );
+
+    return activeStream;
   }
 
   /**


### PR DESCRIPTION
## Summary
- limit ProgressViewProvider.updateWebview to theme plus stream metadata refresh
- centralize active stream surface updates in ProgressEventHandler.refreshStreamSurface, including clear-state handling
- have output event handlers reuse the centralized stream refresh while trimming WebviewUpdater.updateAll

## Testing
- npm run lint
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917202bde948324af32685ff6774200)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scope WebviewUpdater.updateAll to streams/theme and delegate active stream surface updates to ProgressEventHandler, with OutputEvents wired to use the centralized refresh.
> 
> - **Progress View orchestration**:
>   - Limit `ProgressViewProvider.updateWebview` to setting theme and stream metadata via `webviewUpdater.updateAll(...)`, then refresh the active stream surface.
>   - Centralize full surface refresh in `ProgressEventHandler.refreshStreamSurface`, including clear-state handling when no active stream and direct usage updates.
> - **Events**:
>   - `OutputEvents` now receives `refreshStreamSurface` and `getAllStreamStatuses`; `clearTaskOutput` reuses `updater.updateAll(...)` and triggers centralized refresh.
> - **Webview updater**:
>   - Refactor `WebviewUpdater.updateAll` to only update streams/theme and return the resolved active stream; remove content/usage updates from this method and adjust state `activeStream` resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f492bdf017eed2aa3e124d2220e30b8fbf91028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->