### PR TITLE
refactor: align tool use state naming with workspace terminology

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -21,7 +21,7 @@ import type { AgentCycleBaseOptions } from './AgentCycleOptions';
 export interface ToolUseCycleOptions<C = unknown>
   extends AgentCycleBaseOptions<C> {
   toolRegistry: Record<string, BaseTool<any>>;
-  toolState: AgentWorkspaceState;
+  workspaceState: AgentWorkspaceState;
   modelName?: string;
 }
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -79,7 +79,7 @@ export interface ReflectionRoundResult {
   runState: AgentRunState;
   messages: any[];
   shouldContinue: boolean;
-  toolState: AgentWorkspaceState;
+  workspaceState: AgentWorkspaceState;
   outputArtifacts: RoundOutputArtifacts | null;
 }
 
@@ -93,7 +93,7 @@ interface RoundPipelineContext {
   roundIndex: number;
   roundState: ConversationRoundState;
   runState: AgentRunState;
-  toolState: AgentWorkspaceState;
+  workspaceState: AgentWorkspaceState;
   preparedMessages: any[];
   prefill: string;
   outputPath: string;
@@ -117,7 +117,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   protected latexMediaManager: LatexMediaManager;
   protected promptBuilder?: PromptBuilder;
   public roundStates: ConversationRoundState[] = [];
-  public toolStates: AgentWorkspaceState[] = [];
+  public workspaceStates: AgentWorkspaceState[] = [];
   public roundOutputArtifacts: RoundOutputArtifacts[] = [];
   public runtimeXmlExports: AgentRuntimeXmlExports = {
     tagContents: {},
@@ -383,7 +383,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * @param currRound - Zero-based index of the round being executed.
    * @param stateRound - Mutable state scoped to the current round of execution.
    * @param runState - Shared agent state that spans all rounds.
-   * @param toolState - Current tool invocation state passed between rounds.
+   * @param workspaceState - Current tool invocation state passed between rounds.
    * @param preparedMessages - Messages prepared for the model before execution.
    * @param prefill - Initial text inserted into the model response buffer.
    * @param outputPath - Filesystem path where model output for this round is stored.
@@ -393,7 +393,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     roundIndex,
     roundState,
     runState,
-    toolState,
+    workspaceState,
     preparedMessages,
     prefill,
     outputPath,
@@ -403,7 +403,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         this.agentConfig,
         this.agentSetting,
         preparedMessages,
-        toolState,
+        workspaceState,
         outputPath,
         prefill,
       );
@@ -412,7 +412,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       roundIndex: roundState.roundIndex,
       roundState,
       runState,
-      workspaceState: toolState,
+      workspaceState: workspaceState,
       userChannels: this.userVarChannels,
       onRoundFinalized: this.getUsageRecorder('workflow'),
     });
@@ -442,7 +442,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         runState: store.run,
         messages: updatedMessages,
         shouldContinue: cycleResult.endTurn,
-        toolState: store.workspace,
+        workspaceState: store.workspace,
         outputArtifacts: artifacts,
       };
     }
@@ -466,7 +466,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       runState: store.run,
       messages: updatedMessages,
       shouldContinue: endTurn,
-      toolState,
+      workspaceState,
       outputArtifacts: artifacts,
     };
   }
@@ -489,7 +489,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     currRound: number,
     _runState: AgentRunState,
     messages: any[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): Promise<{
     stateRound: ConversationRoundState;
     preparedMessages: any[];
@@ -504,8 +504,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         await promptBuilder.buildInitialPrompts();
 
       let prefixWithStats = userPrefix;
-      if (toolState.document.texcountStats) {
-        prefixWithStats = `${toolState.document.texcountStats}${userPrefix}`;
+      if (workspaceState.document.texcountStats) {
+        prefixWithStats = `${workspaceState.document.texcountStats}${userPrefix}`;
       }
 
       const shouldSaveInputPrompt = getConfig<boolean>(
@@ -527,12 +527,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       const initialMessages = await this.modelHandler.initializeMessages(
         prefixWithStats,
         userRequest,
-        toolState.media.files,
+        workspaceState.media.files,
         systemPrompt,
       );
 
       const prefill = await promptBuilder.buildPrefill(currRound);
-      toolState.assembly.updateAccumulatedOutput(prefill);
+      workspaceState.assembly.updateAccumulatedOutput(prefill);
 
       return {
         stateRound,
@@ -544,8 +544,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
     const userRequest = await promptBuilder.buildUserRequest(currRound);
     let userMessage = userRequest ? `${userRequest}\n` : '';
-    if (toolState.document.texcountStats) {
-      userMessage = `${toolState.document.texcountStats}${userMessage}`;
+    if (workspaceState.document.texcountStats) {
+      userMessage = `${workspaceState.document.texcountStats}${userMessage}`;
     }
 
     if (!userMessage.trim()) {
@@ -559,11 +559,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     const roundMessages = await this.modelHandler.createRoundMessages(
       messages,
       userMessage,
-      toolState.media.files,
+      workspaceState.media.files,
     );
 
     const prefill = await promptBuilder.buildPrefill(currRound);
-    toolState.assembly.updateAccumulatedOutput(prefill);
+    workspaceState.assembly.updateAccumulatedOutput(prefill);
 
     return {
       stateRound,
@@ -575,7 +575,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
   private async prepareAgentWorkspaceState(
     currRound: number,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): Promise<void> {
     if (currRound === 0) {
       const inputFiles = [
@@ -587,7 +587,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       if (this.modelHandler.capabilities.supportsVision) {
         if (
           this.agentConfig.mediaFile &&
-          !toolState.media.files.includes(this.agentConfig.mediaFile)
+          !workspaceState.media.files.includes(this.agentConfig.mediaFile)
         ) {
           extraMedia.push(this.agentConfig.mediaFile);
         }
@@ -598,7 +598,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
       await this.latexMediaManager.processInputFiles(
         inputFiles,
-        toolState,
+        workspaceState,
         this.agentConfig.toolConfig,
         this.modelHandler.capabilities.supportsVision,
         extraMedia,
@@ -620,7 +620,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
     await this.latexMediaManager.processOutputFiles(
       outputFiles,
-      toolState,
+      workspaceState,
       this.agentConfig.toolConfig,
       this.modelHandler.capabilities.supportsVision,
     );
@@ -632,24 +632,24 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     messages,
   }: ReflectionRoundContext): Promise<ReflectionRoundResult> {
     this.logger.debug(`Processing round ${roundIndex}`);
-    const toolState = new AgentWorkspaceState();
+    const workspaceState = new AgentWorkspaceState();
 
     return this.withRoundStage(`r${roundIndex}`, async () => {
       const shared: ReflectionRoundShared = {
         runtime: {
-          toolState,
+          workspaceState,
         },
         hooks: {
           prepareAgentWorkspaceState: () =>
-            this.prepareAgentWorkspaceState(roundIndex, toolState),
+            this.prepareAgentWorkspaceState(roundIndex, workspaceState),
           prepareRoundContext: () =>
-            this.prepareRoundContext(roundIndex, runState, messages, toolState),
+            this.prepareRoundContext(roundIndex, runState, messages, workspaceState),
           runRoundPipeline: ({ stateRound, preparedMessages, prefill }) =>
             this.runRoundPipeline({
               roundIndex,
               roundState: stateRound,
               runState,
-              toolState,
+              workspaceState,
               preparedMessages,
               prefill,
               outputPath: this.outputFile[roundIndex],
@@ -659,7 +659,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
             runState,
             messages,
             shouldContinue: true,
-            toolState,
+            workspaceState,
             outputArtifacts: null,
           }),
         },

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -278,7 +278,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     return {
       ...baseOptions,
       toolRegistry: this.toolRegistry,
-      toolState: store.workspace,
+      workspaceState: store.workspace,
       modelName: this.agentConfig.model,
     };
   }

--- a/src/agent/implementations/flows/ReflectionRoundFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRoundFlow.ts
@@ -29,7 +29,7 @@ export interface ReflectionRoundHooks {
 }
 
 export interface ReflectionRoundRuntime {
-  toolState: AgentWorkspaceState;
+  workspaceState: AgentWorkspaceState;
   roundState?: ConversationRoundState;
   preparedMessages?: any[];
   prefill?: string;

--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -143,7 +143,7 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
     }
 
     shared.agent.roundStates.push(result.roundState);
-    shared.agent.toolStates.push(result.toolState);
+    shared.agent.workspaceStates.push(result.workspaceState);
     if (result.outputArtifacts) {
       shared.agent.roundOutputArtifacts[result.outputArtifacts.round] =
         result.outputArtifacts;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -570,7 +570,7 @@ export abstract class ModelHandler<
   abstract addContinueMessageWithPrefill(
     messages: M[],
     stateRound: ConversationRoundState,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
   ): void;
@@ -582,7 +582,7 @@ export abstract class ModelHandler<
   abstract addContinueMessageWithoutPrefill(
     messages: M[],
     stateRound: ConversationRoundState,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
   ): void;
@@ -595,7 +595,7 @@ export abstract class ModelHandler<
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: M[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     outputFile: string,
     prefill: string,
   ): Promise<[boolean, M[]]>;
@@ -620,7 +620,7 @@ export abstract class ModelHandler<
     messages: M[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void;
 
   /**
@@ -631,7 +631,7 @@ export abstract class ModelHandler<
     messages: M[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void;
 
   /**
@@ -647,12 +647,12 @@ export abstract class ModelHandler<
   /**
    * Extracts thinking content from model responses
    * @param responseObject The raw response object from the model
-   * @param toolState Optional toolState to update with the thinking block
+   * @param workspaceState Optional workspaceState to update with the thinking block
    * @returns The extracted thinking content string or null if no thinking content is available
    */
   abstract processThinkingBlock(
     responseObject: any,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null;
 
   /**
@@ -673,7 +673,7 @@ export abstract class ModelHandler<
     name: string,
     call: T,
     result: Record<string, unknown>,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<M[]>;
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1066,7 +1066,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   addContinueMessageWithPrefill(
     _messages: MessageParam[],
     _stateRound: ConversationRoundState,
-    _toolState: AgentWorkspaceState,
+    _workspaceState: AgentWorkspaceState,
     _agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
   ): void {
@@ -1078,12 +1078,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
   addContinueMessageWithoutPrefill(
     messages: MessageParam[],
     _stateRound: ConversationRoundState,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
   ): void {
     // Create continuation message with last K tokens
-    const prefillTokens = toolState.assembly.lastResponse.slice(-K_SLICE);
+    const prefillTokens = workspaceState.assembly.lastResponse.slice(-K_SLICE);
     const userMessageContinuation = createContinuationMessage(
       agentSetting.endTag,
       prefillTokens,
@@ -1109,7 +1109,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: MessageParam[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     outputFile: string,
     prefill: string,
   ): Promise<[boolean, MessageParam[]]> {
@@ -1120,7 +1120,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (this.capabilities.supportsAssistantPrefill) {
         this.logger.debug(`Adding prefill message:\n${prefill}`);
         if (
-          toolState.assembly.accumulatedOutput.includes('<scratchpad>') &&
+          workspaceState.assembly.accumulatedOutput.includes('<scratchpad>') &&
           prefill === '<scratchpad>' // this is not so neat
         ) {
           await flexibleFS.write(outputFile, prefill);
@@ -1165,9 +1165,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     await flexibleFS.write(outputFile, fileContent);
 
-    // Update the toolState with the actual file content
-    toolState.assembly.updateAccumulatedOutput(fileContent);
-    toolState.assembly.updateLastResponse(fileContent);
+    // Update the workspaceState with the actual file content
+    workspaceState.assembly.updateAccumulatedOutput(fileContent);
+    workspaceState.assembly.updateLastResponse(fileContent);
 
     const lastMessage = messages.at(-1);
     if (hasEndTag(agentSetting, fileContent)) {
@@ -1218,7 +1218,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.addContinueMessageWithoutPrefill(
         messages,
         state,
-        toolState,
+        workspaceState,
         agentSetting,
         agentConfig,
       );
@@ -1289,7 +1289,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     messages: MessageParam[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     const lastMessage = messages.at(-1);
 
@@ -1304,7 +1304,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         lastMessage.content = [
           {
             type: 'text',
-            text: toolState.assembly.accumulatedOutput,
+            text: workspaceState.assembly.accumulatedOutput,
           } as ContentBlockParam,
         ];
       }
@@ -1320,7 +1320,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     messages: MessageParam[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     // For thinking-enabled anthropic models that don't support assistant prefill,
     // handle like OpenAI models where the last message is always a user message
@@ -1356,7 +1356,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Text blocks filtering removed - was unused
 
         // Anthropic models should include thinking blocks first in the content array
-        // Add all thinking blocks from toolState if we have them
+        // Add all thinking blocks from workspaceState if we have them
         if (thinkingBlocks.length > 0) {
           // if we have thinking blocks, then we use them
           this.logger.debug(
@@ -1383,12 +1383,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
           // let newThinkingContent: any[] = [];
 
-          // if (toolState.reasoning.thinkingAdded && toolState.reasoning.thinkingBlocks.length > 0) {
+          // if (workspaceState.reasoning.thinkingAdded && workspaceState.reasoning.thinkingBlocks.length > 0) {
           //   // if we have thinking blocks, then we use them
           //   this.logger.debug(
-          //     `Using ${toolState.reasoning.thinkingBlocks.length} existing thinking blocks from previous message`,
+          //     `Using ${workspaceState.reasoning.thinkingBlocks.length} existing thinking blocks from previous message`,
           //   );
-          //   newThinkingContent = [...toolState.reasoning.thinkingBlocks];
+          //   newThinkingContent = [...workspaceState.reasoning.thinkingBlocks];
           // }
 
           // let newContent: any[] = [];
@@ -1400,7 +1400,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           //     ...newThinkingContent,
           //     {
           //       type: 'text',
-          //       text: toolState.assembly.accumulatedOutput,
+          //       text: workspaceState.assembly.accumulatedOutput,
           //     },
           //   ];
           // }
@@ -1432,26 +1432,26 @@ export class ModelHandlerAnthropic extends ModelHandler<
         content: [],
       };
 
-      // Include all thinking blocks from toolState if available
+      // Include all thinking blocks from workspaceState if available
       if (
-        toolState.reasoning.thinkingBlocks &&
-        toolState.reasoning.thinkingBlocks.length > 0
+        workspaceState.reasoning.thinkingBlocks &&
+        workspaceState.reasoning.thinkingBlocks.length > 0
       ) {
         this.logger.debug(
-          `Adding ${toolState.reasoning.thinkingBlocks.length} thinking blocks to new assistant message`,
+          `Adding ${workspaceState.reasoning.thinkingBlocks.length} thinking blocks to new assistant message`,
         );
         if (Array.isArray(assistantMessage.content)) {
-          assistantMessage.content.push(...toolState.reasoning.thinkingBlocks);
+          assistantMessage.content.push(...workspaceState.reasoning.thinkingBlocks);
         }
         // Clear cached thinking so the next response can store fresh blocks
-        toolState.resetReasoning();
+        workspaceState.resetReasoning();
       }
 
       // Add the text content
       if (Array.isArray(assistantMessage.content)) {
         assistantMessage.content.push({
           type: 'text',
-          text: toolState.assembly.accumulatedOutput,
+          text: workspaceState.assembly.accumulatedOutput,
         } as ContentBlockParam);
       }
 
@@ -1507,14 +1507,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /**
    * Process thinking blocks for Anthropic models
    * @param responseObject The response object from Anthropic API
-   * @param toolState Optional toolState to update with the thinking blocks
+   * @param workspaceState Optional workspaceState to update with the thinking blocks
    * @returns The extracted thinking content (or null if none)
    * This preserves the full thinking objects including signature which is required
    * when sending back to the Anthropic API for continuing a conversation
    */
   processThinkingBlock(
     responseObject: BetaMessage,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null {
     if (!responseObject) {
       return null;
@@ -1555,22 +1555,22 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     this.logger.debug(`Found ${thinkingBlocks.length} thinking blocks`);
 
-    // If toolState is provided, update it with all thinking blocks
-    if (toolState && !toolState.reasoning.thinkingAdded) {
+    // If workspaceState is provided, update it with all thinking blocks
+    if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
       // Store all thinking blocks for future reference
       if (
         regularThinkingContent &&
         !this.containCutOffMessage(regularThinkingContent)
       ) {
-        toolState.reasoning.thinkingBlocks = thinkingBlocks;
+        workspaceState.reasoning.thinkingBlocks = thinkingBlocks;
         // thinkingBlock is now a getter that returns thinkingBlocks[0]
-        toolState.reasoning.thinkingAdded = true;
+        workspaceState.reasoning.thinkingAdded = true;
         this.logger.debug(
-          `Added ${thinkingBlocks.length} thinking blocks to toolState`,
+          `Added ${thinkingBlocks.length} thinking blocks to workspaceState`,
         );
       } else {
         this.logger.debug(
-          `Skipping adding thinking blocks to toolState because of cut off message`,
+          `Skipping adding thinking blocks to workspaceState because of cut off message`,
         );
       }
     }
@@ -1596,19 +1596,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
     name: string,
     call: ToolUseBlock,
     result: Record<string, unknown>,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<MessageParam[]> {
     const content: ContentBlockParam[] = [];
     if (
       this.capabilities.supportsReasoning &&
-      toolState?.reasoning.thinkingBlocks &&
-      toolState.reasoning.thinkingBlocks.length > 0
+      workspaceState?.reasoning.thinkingBlocks &&
+      workspaceState.reasoning.thinkingBlocks.length > 0
     ) {
       // Anthropic models expect thinking blocks before text
-      content.push(...toolState.reasoning.thinkingBlocks);
+      content.push(...workspaceState.reasoning.thinkingBlocks);
       // Clear cached thinking so the next response can store fresh blocks
-      toolState.resetReasoning();
+      workspaceState.resetReasoning();
     }
     if (text) {
       content.push({ type: 'text', text });

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -67,12 +67,12 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for DeepSeek models
    * @param responseObject The raw response object from the model
-   * @param toolState Optional toolState to update with the thinking block
+   * @param workspaceState Optional workspaceState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null {
     if (!responseObject) {
       return null;
@@ -97,18 +97,18 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
           'Found reasoning_content in choices[0].message.reasoning_content',
         );
 
-        // If toolState is provided and we have reasoning content,
-        // store it in the toolState for future use (similar to Anthropic thinking blocks)
-        if (toolState && !toolState.reasoning.thinkingAdded) {
+        // If workspaceState is provided and we have reasoning content,
+        // store it in the workspaceState for future use (similar to Anthropic thinking blocks)
+        if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
           // Create a thinking block in the same format as Anthropic for consistency
           const thinkingBlock = {
             type: 'thinking',
             thinking: reasoningContent,
           };
 
-          toolState.reasoning.thinkingBlocks = [thinkingBlock];
-          toolState.reasoning.thinkingAdded = true;
-          // this.logger.debug('Added reasoning content to toolState');
+          workspaceState.reasoning.thinkingBlocks = [thinkingBlock];
+          workspaceState.reasoning.thinkingAdded = true;
+          // this.logger.debug('Added reasoning content to workspaceState');
         }
         // For deepseek mode thinking content should not be attached back to the message as a content item.
         // Nevertheless one can include one in a bare way...
@@ -145,7 +145,7 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI {
     name: string,
     call: ChatCompletionMessageToolCall | ChatCompletionMessage.FunctionCall,
     result: Record<string, unknown>,
-    _toolState?: AgentWorkspaceState,
+    _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatCompletionMessageParam[]> {
     const toolCall = this.normalizeToolCall(id, name, call);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -802,11 +802,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   addContinueMessageWithoutPrefill(
     messages: Content[],
     _stateRound: ConversationRoundState,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
   ): void {
-    const prefillTokens = toolState.assembly.lastResponse.slice(-K_SLICE);
+    const prefillTokens = workspaceState.assembly.lastResponse.slice(-K_SLICE);
     const userMessageContinuation = createContinuationMessage(
       agentSetting.endTag,
       prefillTokens,
@@ -828,7 +828,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     messages: Content[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     this.logger.debug(
       'Updating message history for Google GenAI (no prefill).',
@@ -864,7 +864,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       this.logger.debug('Adding new model message for the response.');
       messages.push({
         role: 'model',
-        parts: [createPartFromText(toolState.assembly.accumulatedOutput)],
+        parts: [createPartFromText(workspaceState.assembly.accumulatedOutput)],
       });
     }
   }
@@ -873,7 +873,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: Content[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     outputFile: string,
     prefill: string,
   ): Promise<[boolean, Content[]]> {
@@ -886,7 +886,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       this.logger.debug(
         `Output file ${outputFile} does not exist or is empty.`,
       );
-      toolState.assembly.updateAccumulatedOutput(prefill);
+      workspaceState.assembly.updateAccumulatedOutput(prefill);
 
       // Add pseudo-prefill instruction instead of skipping it
       const lastMessage = messages[messages.length - 1];
@@ -942,13 +942,13 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     this.logger.debug(
       'Existing file content found without end tag - continuing generation.',
     );
-    toolState.assembly.updateAccumulatedOutput(fileContent);
-    toolState.assembly.lastResponse = fileContent;
+    workspaceState.assembly.updateAccumulatedOutput(fileContent);
+    workspaceState.assembly.lastResponse = fileContent;
     const state = new ConversationRoundState(0);
     this.addContinueMessageWithoutPrefill(
       messages,
       state,
-      toolState,
+      workspaceState,
       agentSetting,
       agentConfig,
     );
@@ -979,7 +979,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   processThinkingBlock(
     responseObject: GenerateContentResponse,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null {
     if (
       !responseObject ||
@@ -1009,13 +1009,13 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       .join('')
       .trim();
 
-    if (toolState && !toolState.reasoning.thinkingAdded) {
-      toolState.reasoning.thinkingBlocks = thoughtParts.map((p) => ({
+    if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
+      workspaceState.reasoning.thinkingBlocks = thoughtParts.map((p) => ({
         type: 'thinking',
         thinking: p.text,
         thoughtSignature: p.thoughtSignature,
       }));
-      toolState.reasoning.thinkingAdded = true;
+      workspaceState.reasoning.thinkingAdded = true;
     }
 
     if (thoughtContent) {
@@ -1086,7 +1086,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     name: string,
     call: FunctionCall,
     result: Record<string, unknown>,
-    _toolState?: AgentWorkspaceState,
+    _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<Content[]> {
     // Handle both args and input fields for backward compatibility

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -36,12 +36,12 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for Moonshot models
    * @param responseObject The raw response object from the model
-   * @param toolState Optional toolState to update with the thinking block
+   * @param workspaceState Optional workspaceState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null {
     if (!responseObject) {
       return null;
@@ -63,17 +63,17 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
           'Found reasoning_content in choices[0].message.reasoning_content',
         );
 
-        // If toolState is provided and we have reasoning content,
-        // store it in the toolState for future use (similar to Anthropic thinking blocks)
-        if (toolState && !toolState.reasoning.thinkingAdded) {
+        // If workspaceState is provided and we have reasoning content,
+        // store it in the workspaceState for future use (similar to Anthropic thinking blocks)
+        if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
           // Create a thinking block in the same format as Anthropic for consistency
           const thinkingBlock = {
             type: 'thinking',
             thinking: reasoningContent,
           };
 
-          toolState.reasoning.thinkingBlocks = [thinkingBlock];
-          toolState.reasoning.thinkingAdded = true;
+          workspaceState.reasoning.thinkingBlocks = [thinkingBlock];
+          workspaceState.reasoning.thinkingAdded = true;
         }
       }
     }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -912,7 +912,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
   addContinueMessageWithPrefill(
     _messages: any[],
     _stateRound: ConversationRoundState,
-    _toolState: AgentWorkspaceState,
+    _workspaceState: AgentWorkspaceState,
     _agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
   ): void {
@@ -924,12 +924,12 @@ export class ModelHandlerOpenAI extends ModelHandler<
   addContinueMessageWithoutPrefill(
     messages: any[],
     _stateRound: ConversationRoundState,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
   ): void {
     // Create continuation message with last K tokens
-    const prefillTokens = toolState.assembly.lastResponse.slice(-K_SLICE);
+    const prefillTokens = workspaceState.assembly.lastResponse.slice(-K_SLICE);
     const userMessageContinuation = createContinuationMessage(
       agentSetting.endTag,
       prefillTokens,
@@ -954,7 +954,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: any[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     outputFile: string,
     prefill: string,
   ): Promise<[boolean, any[]]> {
@@ -1031,17 +1031,17 @@ export class ModelHandlerOpenAI extends ModelHandler<
       'Output file exists but no end tag found - continuing from file',
     );
     if (fileContent.includes(prefill)) {
-      toolState.assembly.updateAccumulatedOutput(fileContent);
+      workspaceState.assembly.updateAccumulatedOutput(fileContent);
     } else {
-      toolState.assembly.updateAccumulatedOutput(prefill + fileContent);
-      await flexibleFS.write(outputFile, toolState.assembly.accumulatedOutput);
+      workspaceState.assembly.updateAccumulatedOutput(prefill + fileContent);
+      await flexibleFS.write(outputFile, workspaceState.assembly.accumulatedOutput);
     }
     const state = new ConversationRoundState(0);
-    toolState.assembly.lastResponse = toolState.assembly.accumulatedOutput;
+    workspaceState.assembly.lastResponse = workspaceState.assembly.accumulatedOutput;
     this.addContinueMessageWithoutPrefill(
       messages,
       state,
-      toolState,
+      workspaceState,
       agentSetting,
       agentConfig,
     );
@@ -1129,7 +1129,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     messages: any[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     this.logger.debug(
       'Updating message content for OpenAI models with prefill support',
@@ -1148,7 +1148,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
         lastMessage.content = [
           {
             type: 'text',
-            text: toolState.assembly.accumulatedOutput,
+            text: workspaceState.assembly.accumulatedOutput,
           },
         ];
       }
@@ -1169,7 +1169,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     messages: any[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     this.logger.debug(
       'Updating message content for OpenAI models without prefill support',
@@ -1209,7 +1209,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
           secondLastMessage.content = [
             {
               type: 'text',
-              text: toolState.assembly.accumulatedOutput,
+              text: workspaceState.assembly.accumulatedOutput,
             },
           ];
         }
@@ -1229,7 +1229,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
       );
       messages.push({
         role: 'assistant',
-        content: [{ type: 'text', text: toolState.assembly.accumulatedOutput }],
+        content: [{ type: 'text', text: workspaceState.assembly.accumulatedOutput }],
       });
     }
   }
@@ -1249,23 +1249,23 @@ export class ModelHandlerOpenAI extends ModelHandler<
   /**
    * Processes thinking blocks from API response. OpenAI models do not support thinking blocks.
    * @param responseObject The response object from the OpenAI API
-   * @param toolState Optional toolState to update with thinking blocks
+   * @param workspaceState Optional workspaceState to update with thinking blocks
    * @returns Always returns null as OpenAI doesn't support thinking blocks
    */
   processThinkingBlock(
     responseObject: any,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null {
     const reasoning = responseObject?.choices?.[0]?.message?.reasoning_content;
     if (typeof reasoning !== 'string' || !reasoning.trim()) {
       return null;
     }
 
-    if (toolState && !toolState.reasoning.thinkingAdded) {
-      toolState.reasoning.thinkingBlocks = [
+    if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
+      workspaceState.reasoning.thinkingBlocks = [
         { type: 'thinking', thinking: reasoning },
       ];
-      toolState.reasoning.thinkingAdded = true;
+      workspaceState.reasoning.thinkingAdded = true;
     }
 
     this.logger.debug(
@@ -1364,7 +1364,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     name: string,
     call: ChatCompletionMessageToolCall | ChatCompletionMessage.FunctionCall,
     result: Record<string, unknown>,
-    _toolState?: AgentWorkspaceState,
+    _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatCompletionMessageParam[]> {
     const toolCall = this.normalizeToolCall(id, name, call);

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -779,7 +779,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   addContinueMessageWithPrefill(
     _messages: ResponseInputItem[],
     _stateRound: ConversationRoundState,
-    _toolState: AgentWorkspaceState,
+    _workspaceState: AgentWorkspaceState,
     _agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
   ): void {
@@ -1045,11 +1045,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   addContinueMessageWithoutPrefill(
     messages: ResponseInputItem[],
     _stateRound: ConversationRoundState,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
     _agentConfig: AgentConfig,
   ): void {
-    const prefillTokens = toolState.assembly.lastResponse.slice(-K_SLICE);
+    const prefillTokens = workspaceState.assembly.lastResponse.slice(-K_SLICE);
     const userMessageContinuation = createContinuationMessage(
       agentSetting.endTag,
       prefillTokens,
@@ -1070,7 +1070,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: ResponseInputItem[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     outputFile: string,
     prefill: string,
   ): Promise<[boolean, ResponseInputItem[]]> {
@@ -1121,18 +1121,18 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       'Output file exists but no end tag found - continuing from file',
     );
     if (fileContent.includes(prefill)) {
-      toolState.assembly.updateAccumulatedOutput(fileContent);
+      workspaceState.assembly.updateAccumulatedOutput(fileContent);
     } else {
-      toolState.assembly.updateAccumulatedOutput(prefill + fileContent);
-      await flexibleFS.write(outputFile, toolState.assembly.accumulatedOutput);
+      workspaceState.assembly.updateAccumulatedOutput(prefill + fileContent);
+      await flexibleFS.write(outputFile, workspaceState.assembly.accumulatedOutput);
     }
 
     const state = new ConversationRoundState(0);
-    toolState.assembly.lastResponse = toolState.assembly.accumulatedOutput;
+    workspaceState.assembly.lastResponse = workspaceState.assembly.accumulatedOutput;
     this.addContinueMessageWithoutPrefill(
       messages,
       state,
-      toolState,
+      workspaceState,
       agentSetting,
       agentConfig,
     );
@@ -1146,7 +1146,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     messages: ResponseInputItem[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     this.logger.debug(
       'Updating message content for OpenAI Responses models with prefill support',
@@ -1161,7 +1161,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     messages.push(
-      this.createAssistantMessage(toolState.assembly.accumulatedOutput),
+      this.createAssistantMessage(workspaceState.assembly.accumulatedOutput),
     );
   }
 
@@ -1170,7 +1170,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     messages: ResponseInputItem[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     this.logger.debug(
       'Updating message content for OpenAI Responses models without prefill support',
@@ -1205,7 +1205,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           messages.pop();
         } else if (!appended) {
           messages.push(
-            this.createAssistantMessage(toolState.assembly.accumulatedOutput),
+            this.createAssistantMessage(workspaceState.assembly.accumulatedOutput),
           );
         }
       }
@@ -1214,7 +1214,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         'Last message is a request message rather than a continuation request',
       );
       messages.push(
-        this.createAssistantMessage(toolState.assembly.accumulatedOutput),
+        this.createAssistantMessage(workspaceState.assembly.accumulatedOutput),
       );
     }
   }
@@ -1234,7 +1234,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Process reasoning summaries from the Responses API. */
   processThinkingBlock(
     responseObject: Response,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null {
     const outputArr = responseObject?.output;
     if (!Array.isArray(outputArr)) {
@@ -1250,12 +1250,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     const thoughtContent = summaryParts.map((part) => part.text).join('\n\n'); // to make the thinking markdown rendering more readable
 
-    if (toolState && !toolState.reasoning.thinkingAdded) {
-      toolState.reasoning.thinkingBlocks = summaryParts.map((part) => ({
+    if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
+      workspaceState.reasoning.thinkingBlocks = summaryParts.map((part) => ({
         type: 'thinking',
         thinking: part.text,
       }));
-      toolState.reasoning.thinkingAdded = true;
+      workspaceState.reasoning.thinkingAdded = true;
     }
 
     if (thoughtContent) {
@@ -1283,7 +1283,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     name: string,
     call: ResponseFunctionToolCallItem,
     result: Record<string, unknown>,
-    _toolState?: AgentWorkspaceState,
+    _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ResponseInputItem[]> {
     const messages: ResponseInputItem[] = [];

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -97,7 +97,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   // Implementation for processing thinking blocks in OpenRouter responses
   processThinkingBlock(
     responseObject: any,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null {
     if (!responseObject) {
       return null;
@@ -141,7 +141,7 @@ export class ModelHandlerAnthropicViaOpenRouter extends ModelHandlerOpenRouter {
     messages: any[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     const lastMessage = messages.at(-1);
     // although OpenAI models do not support assistant prefill, some models (such as Anthropic/DeepSeek perhaps?) via OpenRouter might do
@@ -153,7 +153,7 @@ export class ModelHandlerAnthropicViaOpenRouter extends ModelHandlerOpenRouter {
         lastMessage.content = [
           {
             type: 'text',
-            text: toolState.assembly.accumulatedOutput,
+            text: workspaceState.assembly.accumulatedOutput,
           },
         ];
       }
@@ -165,7 +165,7 @@ export class ModelHandlerAnthropicViaOpenRouter extends ModelHandlerOpenRouter {
     messages: any[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void {
     const lastMessage = messages.at(-1);
     if (lastMessage.role === 'user' || lastMessage.role === 'system') {
@@ -174,7 +174,7 @@ export class ModelHandlerAnthropicViaOpenRouter extends ModelHandlerOpenRouter {
         content: [
           {
             type: 'text',
-            text: toolState.assembly.accumulatedOutput,
+            text: workspaceState.assembly.accumulatedOutput,
           },
         ],
       });

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -17,12 +17,12 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
   /**
    * Process thinking blocks for xAI models
    * @param responseObject The raw response object from the model
-   * @param toolState Optional toolState to update with the thinking block
+   * @param workspaceState Optional workspaceState to update with the thinking block
    * @returns The extracted reasoning_content or null if none
    */
   processThinkingBlock(
     responseObject: any,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null {
     if (!responseObject) {
       return null;
@@ -49,17 +49,17 @@ export class ModelHandlerXAI extends ModelHandlerOpenAI {
           'Found reasoning_content in choices[0].message.reasoning_content',
         );
 
-        // If toolState is provided and we have reasoning content,
-        // store it in the toolState for future use
-        if (toolState && !toolState.reasoning.thinkingAdded) {
+        // If workspaceState is provided and we have reasoning content,
+        // store it in the workspaceState for future use
+        if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
           // Create a thinking block in a consistent format
           const thinkingBlock = {
             type: 'thinking',
             thinking: reasoningContent,
           };
 
-          toolState.reasoning.thinkingBlocks = [thinkingBlock];
-          toolState.reasoning.thinkingAdded = true;
+          workspaceState.reasoning.thinkingBlocks = [thinkingBlock];
+          workspaceState.reasoning.thinkingAdded = true;
         }
       }
     }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -114,7 +114,7 @@ export interface IModelHandler<
   addContinueMessageWithPrefill(
     messages: M[],
     stateRound: ConversationRoundState,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
   ): void;
@@ -123,7 +123,7 @@ export interface IModelHandler<
   addContinueMessageWithoutPrefill(
     messages: M[],
     stateRound: ConversationRoundState,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
   ): void;
@@ -133,7 +133,7 @@ export interface IModelHandler<
     agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: M[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     outputFile: string,
     prefill: string,
   ): Promise<[boolean, M[]]>;
@@ -149,7 +149,7 @@ export interface IModelHandler<
     messages: M[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void;
 
   /** Update messages when prefill is not supported. */
@@ -157,7 +157,7 @@ export interface IModelHandler<
     messages: M[],
     bestConnector: string,
     newResponse: string,
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): void;
 
   /** Determine whether generation should continue. */
@@ -182,7 +182,7 @@ export interface IModelHandler<
   /** Extract intermediate "thinking" content from a response. */
   processThinkingBlock(
     responseObject: any,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
   ): string | null;
 
   /** Extract tool-use details from a provider response. */
@@ -203,7 +203,7 @@ export interface IModelHandler<
     name: string,
     call: T,
     result: Record<string, unknown>,
-    toolState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<M[]>;
 

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -70,11 +70,11 @@ export class LatexMediaManager {
 
   private async attachTeXCount(
     files: string[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     cfg: ToolConfig,
   ): Promise<void> {
     if (cfg.attachTeXCount && files.length > 0) {
-      toolState.document.texcountStats = await getTeXCountStats(files);
+      workspaceState.document.texcountStats = await getTeXCountStats(files);
     }
   }
 
@@ -83,7 +83,7 @@ export class LatexMediaManager {
    */
   private async compilePdfs(
     files: string[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): Promise<void> {
     const activeGroupId = this.logger.withCurrentGroup((id) => id);
     const texFiles = files.filter((file) =>
@@ -135,14 +135,14 @@ export class LatexMediaManager {
     );
     compileResults.forEach((result) => {
       if (result.status === 'fulfilled' && result.value) {
-        toolState.media.addMediaFiles([result.value]);
+        workspaceState.media.addMediaFiles([result.value]);
       }
     });
   }
 
   private async extractFiguresFromFiles(
     files: string[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
   ): Promise<void> {
     const activeGroupId = this.logger.withCurrentGroup((id) => id);
     const figureResults = await Promise.allSettled(
@@ -162,7 +162,7 @@ export class LatexMediaManager {
           `Extracted ${result.value.length} figures from ${file}`,
           activeGroupId,
         );
-        toolState.media.addMediaFiles(result.value);
+        workspaceState.media.addMediaFiles(result.value);
         mirrorTasks.push(
           this.mirrorFigureDependencies(file, result.value, activeGroupId),
         );
@@ -176,7 +176,7 @@ export class LatexMediaManager {
 
   private async compileTikzFigures(
     files: string[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     logSummary: boolean,
   ): Promise<void> {
     const activeGroupId = this.logger.withCurrentGroup((id) => id);
@@ -189,7 +189,7 @@ export class LatexMediaManager {
         result.value &&
         result.value.length > 0
       ) {
-        toolState.media.addMediaFiles(result.value);
+        workspaceState.media.addMediaFiles(result.value);
       }
     });
     if (logSummary) {
@@ -202,7 +202,7 @@ export class LatexMediaManager {
 
   private async processFiles(
     files: string[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     cfg: ToolConfig,
     supportsVision: boolean,
     {
@@ -237,26 +237,26 @@ export class LatexMediaManager {
       return;
     }
 
-    await this.attachTeXCount(existingFiles, toolState, cfg);
+    await this.attachTeXCount(existingFiles, workspaceState, cfg);
 
     if (!supportsVision) {
       return;
     }
 
     if (extraMediaFiles.length > 0) {
-      toolState.media.addMediaFiles(extraMediaFiles);
+      workspaceState.media.addMediaFiles(extraMediaFiles);
     }
 
     if (includeFigureExtraction && cfg.autoExtractFigure) {
-      await this.extractFiguresFromFiles(existingFiles, toolState);
+      await this.extractFiguresFromFiles(existingFiles, workspaceState);
     }
 
     if (includeTikzCompilation && cfg.autoExtractTikzFigure) {
-      await this.compileTikzFigures(existingFiles, toolState, logTikzSummary);
+      await this.compileTikzFigures(existingFiles, workspaceState, logTikzSummary);
     }
 
     if (includePdfCompilation && cfg.autoCompileInputPdf) {
-      await this.compilePdfs(existingFiles, toolState);
+      await this.compilePdfs(existingFiles, workspaceState);
     }
   }
 
@@ -266,12 +266,12 @@ export class LatexMediaManager {
    */
   async processInputFiles(
     inputFiles: string[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     cfg: ToolConfig,
     supportsVision: boolean,
     extraMediaFiles: string[] = [],
   ): Promise<void> {
-    await this.processFiles(inputFiles, toolState, cfg, supportsVision, {
+    await this.processFiles(inputFiles, workspaceState, cfg, supportsVision, {
       includeFigureExtraction: true,
       includeTikzCompilation: true,
       includePdfCompilation: true,
@@ -285,11 +285,11 @@ export class LatexMediaManager {
    */
   async processOutputFiles(
     outputFiles: string[],
-    toolState: AgentWorkspaceState,
+    workspaceState: AgentWorkspaceState,
     cfg: ToolConfig,
     supportsVision: boolean,
   ): Promise<void> {
-    await this.processFiles(outputFiles, toolState, cfg, supportsVision, {
+    await this.processFiles(outputFiles, workspaceState, cfg, supportsVision, {
       includeFigureExtraction: false,
       includeTikzCompilation: true,
       includePdfCompilation: true,

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -332,7 +332,7 @@ describe('ResponseCycle background reasoning logs', () => {
     const messages: ProviderMessage[] = [];
     const stateRound = new ConversationRoundState(1);
     const stateGlobal = new AgentRunState();
-    const toolState = new AgentWorkspaceState();
+    const workspaceState = new AgentWorkspaceState();
     const userVarChannels = {
       input: Object.freeze({}),
       transient: {} as Record<string, any>,
@@ -341,7 +341,7 @@ describe('ResponseCycle background reasoning logs', () => {
     const store = new AgentSharedStore({
       round: stateRound,
       run: stateGlobal,
-      workspace: toolState,
+      workspace: workspaceState,
       user: userVarChannels,
     });
 

--- a/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
+++ b/src/test/toolUse/BaseToolUseAgentFollowUp.test.ts
@@ -117,7 +117,7 @@ class DummyHandler extends ModelHandler<
     _name: string,
     _call: unknown,
     _result: Record<string, unknown>,
-    _toolState?: AgentWorkspaceState,
+    _workspaceState?: AgentWorkspaceState,
     _text?: string,
   ): Promise<ProviderMessage[]> {
     return [];

--- a/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
+++ b/src/test/toolUse/ToolUseCycleDeepSeek.test.ts
@@ -132,7 +132,7 @@ describe('runToolUseCycle DeepSeek', () => {
       userPrefix: '',
       userRequest: '',
     };
-    const toolState = new AgentWorkspaceState();
+    const workspaceState = new AgentWorkspaceState();
     const options: ToolUseCycleOptions<OpenAI> = {
       modelHandler: handler,
       agentSetting: setting,
@@ -148,7 +148,7 @@ describe('runToolUseCycle DeepSeek', () => {
       toolRegistry,
       checkInterruption: () => false,
       setAbortController: () => {},
-      toolState,
+      workspaceState,
       modelName: 'ds',
       context: new AgentExecutionContext({
         streamId: 'tool-use-stream' as StreamTabId,
@@ -157,7 +157,7 @@ describe('runToolUseCycle DeepSeek', () => {
     const store = new AgentSharedStore({
       round: new ConversationRoundState(0),
       run: new AgentRunState(),
-      workspace: toolState,
+      workspace: workspaceState,
       user: options.userVarChannels,
     });
     const events: any[] = [];
@@ -249,7 +249,7 @@ describe('runToolUseCycle DeepSeek', () => {
       userPrefix: '',
       userRequest: '',
     };
-    const toolState = new AgentWorkspaceState();
+    const workspaceState = new AgentWorkspaceState();
     const options: ToolUseCycleOptions<OpenAI> = {
       modelHandler: handler,
       agentSetting: setting,
@@ -265,7 +265,7 @@ describe('runToolUseCycle DeepSeek', () => {
       toolRegistry,
       checkInterruption: () => false,
       setAbortController: () => {},
-      toolState,
+      workspaceState,
       modelName: 'ds',
       context: new AgentExecutionContext({
         streamId: 'tool-use-deepseek-empty' as StreamTabId,
@@ -274,7 +274,7 @@ describe('runToolUseCycle DeepSeek', () => {
     const store = new AgentSharedStore({
       round: new ConversationRoundState(0),
       run: new AgentRunState(),
-      workspace: toolState,
+      workspace: workspaceState,
       user: options.userVarChannels,
     });
     const events: any[] = [];
@@ -349,7 +349,7 @@ describe('runToolUseCycle DeepSeek', () => {
       userPrefix: '',
       userRequest: '',
     };
-    const toolState = new AgentWorkspaceState();
+    const workspaceState = new AgentWorkspaceState();
     const options: ToolUseCycleOptions<OpenAI> = {
       modelHandler: handler,
       agentSetting: setting,
@@ -365,7 +365,7 @@ describe('runToolUseCycle DeepSeek', () => {
       toolRegistry,
       checkInterruption: () => false,
       setAbortController: () => {},
-      toolState,
+      workspaceState,
       modelName: 'ds',
       context: new AgentExecutionContext({
         streamId: 'tool-use-deepseek-args' as StreamTabId,
@@ -374,7 +374,7 @@ describe('runToolUseCycle DeepSeek', () => {
     const store = new AgentSharedStore({
       round: new ConversationRoundState(0),
       run: new AgentRunState(),
-      workspace: toolState,
+      workspace: workspaceState,
       user: options.userVarChannels,
     });
 

--- a/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
+++ b/src/test/toolUse/ToolUseCycleOpenAIResponse.test.ts
@@ -142,7 +142,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       userPrefix: '',
       userRequest: '',
     };
-    const toolState = new AgentWorkspaceState();
+    const workspaceState = new AgentWorkspaceState();
     const options: ToolUseCycleOptions<OpenAI> = {
       modelHandler: handler,
       agentSetting: setting,
@@ -158,7 +158,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       toolRegistry,
       checkInterruption: () => false,
       setAbortController: () => {},
-      toolState,
+      workspaceState,
       modelName: 'test',
       context: new AgentExecutionContext({
         streamId: 'tool-use-openai' as StreamTabId,
@@ -167,7 +167,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
     const store = new AgentSharedStore({
       round: new ConversationRoundState(0),
       run: new AgentRunState(),
-      workspace: toolState,
+      workspace: workspaceState,
       user: options.userVarChannels,
     });
     const events: any[] = [];
@@ -257,7 +257,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       userPrefix: '',
       userRequest: '',
     };
-    const toolState = new AgentWorkspaceState();
+    const workspaceState = new AgentWorkspaceState();
     const options: ToolUseCycleOptions<OpenAI> = {
       modelHandler: handler,
       agentSetting: setting,
@@ -273,7 +273,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
       toolRegistry,
       checkInterruption: () => false,
       setAbortController: () => {},
-      toolState,
+      workspaceState,
       modelName: 'test',
       context: new AgentExecutionContext({
         streamId: 'tool-use-openai-empty' as StreamTabId,
@@ -282,7 +282,7 @@ describe('runToolUseCycle OpenAIResponse', () => {
     const store = new AgentSharedStore({
       round: new ConversationRoundState(0),
       run: new AgentRunState(),
-      workspace: toolState,
+      workspace: workspaceState,
       user: options.userVarChannels,
     });
     const events: any[] = [];

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -137,7 +137,7 @@ suite('BashTool', () => {
       openRouterOnly: false,
     };
     const handler = new BashMockHandler(config);
-    const toolState = new AgentWorkspaceState();
+    const workspaceState = new AgentWorkspaceState();
     const options: ToolUseCycleOptions<OpenAI> = {
       modelHandler: handler,
       agentSetting: {
@@ -168,7 +168,7 @@ suite('BashTool', () => {
       toolRegistry: { bash: bashTool },
       checkInterruption: () => false,
       setAbortController: () => {},
-      toolState,
+      workspaceState,
       modelName: 'test',
       context: new AgentExecutionContext({
         streamId: 'bash-tool' as StreamTabId,
@@ -178,7 +178,7 @@ suite('BashTool', () => {
     const store = new AgentSharedStore({
       round: new ConversationRoundState(0),
       run: new AgentRunState(),
-      workspace: toolState,
+      workspace: workspaceState,
       user: options.userVarChannels,
     });
 


### PR DESCRIPTION
## Summary
- rename the tool state option on ToolUseCycle to workspaceState to match AgentWorkspaceState
- update base agents, model handlers, and flows to use workspaceState naming
- adjust latex integration and tests to reference workspaceState consistently

## Testing
- npm run lint *(fails: cannot find package 'eslint-plugin-import')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173468bc5883248861389fa1aa0497)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns tool-use state naming to workspaceState throughout core cycles, reflection pipeline, model handlers, LaTeX media manager, and tests.
> 
> - **Core & Agents**:
>   - Replace `toolState` with `workspaceState` in `ToolUseCycleOptions`, `BaseToolUseAgent`, and shared store usage.
>   - Reflection pipeline (`BaseReflectionAgent`, `ReflectionRoundFlow`, `ReflectionRunFlow`) now passes/returns `workspaceState` and tracks `workspaceStates`.
> - **Model Handlers (API surface change)**:
>   - Update method signatures and internal usage from `toolState` to `workspaceState` (e.g., `addContinueMessage*`, `initializeOutputAndPrefill`, `updateMessageContent*`, `processThinkingBlock`, `createToolUseFollowUpMessages`).
>   - Apply across OpenAI, OpenAI Responses, Anthropic, Google GenAI, DeepSeek, Kimi, OpenRouter, and xAI handlers.
> - **LaTeX Integration**:
>   - `LatexMediaManager` methods accept `workspaceState`; figure/PDF handling and texcount updates use `workspaceState`.
> - **Tests**:
>   - Adjust test setup and expectations to use `workspaceState` in tool-use and response cycles, including DeepSeek, OpenAI Responses, and Bash tool tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b11833221ce16ff0e53c568f129fc3670b1f585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->