### PR TITLE
perf: streamline progress view state hydration

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -40,7 +40,6 @@ import {
 } from '@utils/text/textEnhancementUtils';
 import { RecordingManager } from '@webview/managers/RecordingManager';
 
-
 // @ts-ignore - Import JavaScript module
 
 // Type imports
@@ -294,7 +293,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleRestoreState(message: any): Promise<void> {
-    const taskState = this.provider.state.getTaskState(message.stream);
+    const taskState = this.provider.state.peekTaskState(message.stream);
     if (taskState) {
       await vscode.commands.executeCommand('texra.restoreState', taskState);
     }
@@ -314,7 +313,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       return;
     }
 
-    const taskState = this.provider.state.getTaskState(stream) as
+    const taskState = this.provider.state.peekTaskState(stream) as
       | TaskState
       | undefined;
     if (!taskState) {
@@ -741,7 +740,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     stream: string,
     action: (taskState: WorkflowTaskState) => Promise<void>,
   ): Promise<void> {
-    const taskState = this.provider.state.getTaskState(stream);
+    const taskState = this.provider.state.peekTaskState(stream);
     if (!taskState || !isWorkflowTaskState(taskState)) {
       return;
     }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -93,8 +93,19 @@ export class ProgressViewProvider
     // Listen for workspace folder changes
     this._disposables.push(
       vscode.workspace.onDidChangeWorkspaceFolders(async () => {
-        await this.state.load();
+        await this.state.loadEssential();
         this.updateWebview();
+
+        void this.state.loadDeferred().then(
+          () => this.updateWebview(),
+          (error) =>
+            this.logger.error(
+              'Failed to hydrate deferred progress state after workspace change',
+              undefined,
+              undefined,
+              error instanceof Error ? error : new Error(String(error)),
+            ),
+        );
       }),
     );
   }
@@ -103,10 +114,25 @@ export class ProgressViewProvider
    * Initialize provider state. Must be called after construction.
    */
   public async initialize(): Promise<void> {
-    await this.state.load();
+    await this.state.loadEssential();
+    const deferredLoad = this.state.loadDeferred();
 
     // Setup event listeners using the new architecture
     this._disposables.push(...this.eventHandler.setupEventListeners());
+
+    void deferredLoad.then(
+      () => {
+        this.logger.debug('Deferred progress state hydrated');
+        this.updateWebview();
+      },
+      (error) =>
+        this.logger.error(
+          'Failed to hydrate deferred progress state',
+          undefined,
+          undefined,
+          error instanceof Error ? error : new Error(String(error)),
+        ),
+    );
 
     this.logger.debug(
       'ProgressViewProvider initialized with new modular architecture',

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -3,8 +3,6 @@ import * as vscode from 'vscode';
 
 // Local imports - agent and usage types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-import type { OutputFileInfo } from '@agent/output/types';
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
 // Internal imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -113,7 +111,7 @@ export class ProgressEventHandler {
       return;
     }
 
-    const taskState = this.state.getTaskState(stream);
+    const taskState = this.state.peekTaskState(stream);
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
     const sessionKindHint = this.state.getSessionKindHint(stream);
     const sessionKind = taskState?.session?.agentCategory ?? sessionKindHint;
@@ -161,19 +159,14 @@ export class ProgressEventHandler {
       persist: false,
     });
 
-    const runInstructions = Object.fromEntries(
-      this.state.runInstructions.getInstructions(stream).entries(),
-    );
+    const streamId = stream as StreamTabId;
+    const runInstructions =
+      this.state.runInstructions.getInstructionRecord(streamId);
 
-    const filesByRun = this.formatRunOutputs(
-      this.state.outputFiles.getFiles(stream),
-    );
-    const missingByRun = this.formatRunStringOutputs(
-      this.state.outputFiles.getMissingOutputs(stream),
-    );
-    const usageByRun = Object.fromEntries(
-      this.state.usageStats.getRunUsage(stream).entries(),
-    ) as Record<string, TokenUsageStats>;
+    const filesByRun = this.state.outputFiles.getFilesRecord(streamId);
+    const missingByRun =
+      this.state.outputFiles.getMissingOutputsRecord(streamId);
+    const usageByRun = this.state.usageStats.getUsageRecord(streamId);
 
     this.webviewUpdater.updateLogContent(stream, messages, groups, {
       runInstructions,
@@ -190,10 +183,7 @@ export class ProgressEventHandler {
     this.webviewUpdater.updateMissingOutputs(stream, missingByRun);
 
     // Send usage for current stream
-    const usage = Object.fromEntries(
-      this.state.usageStats.getRunUsage(stream).entries(),
-    ) as Record<string, TokenUsageStats>;
-    this.webviewUpdater.updateUsage(stream, usage);
+    this.webviewUpdater.updateUsage(stream, usageByRun);
 
     // Update status for current stream - default to STOPPED when stream exists but no status is set
     const status = this._streamStatus.get(stream) || STATUS.STOPPED;
@@ -238,26 +228,6 @@ export class ProgressEventHandler {
         this.webviewUpdater.updateStatus(status);
       }
     }
-  }
-
-  private formatRunOutputs(
-    runs: Map<string, Map<number, OutputFileInfo[]>>,
-  ): Record<string, { [key: number]: OutputFileInfo[] }> {
-    const payload: Record<string, { [key: number]: OutputFileInfo[] }> = {};
-    for (const [runId, rounds] of runs.entries()) {
-      payload[runId] = Object.fromEntries(rounds.entries());
-    }
-    return payload;
-  }
-
-  private formatRunStringOutputs(
-    runs: Map<string, Map<number, string[]>>,
-  ): Record<string, { [key: number]: string[] }> {
-    const payload: Record<string, { [key: number]: string[] }> = {};
-    for (const [runId, rounds] of runs.entries()) {
-      payload[runId] = Object.fromEntries(rounds.entries());
-    }
-    return payload;
   }
 
   /**

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -25,7 +25,6 @@ import type {
   StreamStatusOrReadyType,
 } from './types';
 
-
 export interface StreamStatusEventShared {
   logger: AgentLogger;
   streamStatus: Map<string, StreamStatusType>;
@@ -102,7 +101,7 @@ export function createStreamStatusEvents(
     state.setTaskState(streamTabId, taskState);
     state.clearSessionKindHint(streamTabId);
 
-    const normalizedState = state.getTaskState(streamTabId);
+    const normalizedState = state.peekTaskState(streamTabId);
 
     if (!normalizedState) {
       shared.logger.warn(

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -137,6 +137,36 @@ export class OutputFilesManager extends PersistentMapManager<
     return runs ? new Map(runs) : new Map();
   }
 
+  getFilesRecord(
+    stream: StreamTabId,
+  ): Record<string, { [key: number]: OutputFileInfo[] }> {
+    const runs = this.items.get(stream);
+    if (!runs || runs.size === 0) {
+      return {};
+    }
+
+    const payload: Record<string, { [key: number]: OutputFileInfo[] }> = {};
+    for (const [runId, rounds] of runs.entries()) {
+      if (!rounds || rounds.size === 0) {
+        continue;
+      }
+
+      const runRecord: { [key: number]: OutputFileInfo[] } = {};
+      for (const [round, infos] of rounds.entries()) {
+        if (!infos || infos.length === 0) {
+          continue;
+        }
+        runRecord[round] = infos;
+      }
+
+      if (Object.keys(runRecord).length > 0) {
+        payload[runId] = runRecord;
+      }
+    }
+
+    return payload;
+  }
+
   getRun(
     stream: StreamTabId,
     runId: string,
@@ -353,6 +383,36 @@ export class OutputFilesManager extends PersistentMapManager<
     return missing ? new Map(missing) : new Map();
   }
 
+  getMissingOutputsRecord(
+    stream: StreamTabId,
+  ): Record<string, { [key: number]: string[] }> {
+    const missing = this._missingOutputs.get(stream);
+    if (!missing || missing.size === 0) {
+      return {};
+    }
+
+    const payload: Record<string, { [key: number]: string[] }> = {};
+    for (const [runId, rounds] of missing.entries()) {
+      if (!rounds || rounds.size === 0) {
+        continue;
+      }
+
+      const runRecord: { [key: number]: string[] } = {};
+      for (const [round, infos] of rounds.entries()) {
+        if (!infos || infos.length === 0) {
+          continue;
+        }
+        runRecord[round] = infos;
+      }
+
+      if (Object.keys(runRecord).length > 0) {
+        payload[runId] = runRecord;
+      }
+    }
+
+    return payload;
+  }
+
   /** Clear output files for a stream */
   async clearFiles(stream: StreamTabId): Promise<void> {
     await this.delete(stream);
@@ -470,18 +530,41 @@ export class OutputFilesManager extends PersistentMapManager<
 
   /** Save missing outputs to persistence */
   async saveMissingOutputs(): Promise<void> {
-    const obj = Object.fromEntries(
-      Array.from(this._missingOutputs.entries(), ([stream, runs]) => [
-        stream,
-        Object.fromEntries(
-          Array.from(runs.entries(), ([runId, rounds]) => [
-            runId,
-            Object.fromEntries(rounds.entries()),
-          ]),
-        ),
-      ]),
-    );
-    await this.storage.update(WorkspaceStateKey.MISSING_OUTPUTS, obj);
+    const payload: Record<
+      string,
+      Record<string, { [key: number]: string[] }>
+    > = {};
+
+    for (const [stream, runs] of this._missingOutputs.entries()) {
+      if (!runs || runs.size === 0) {
+        continue;
+      }
+
+      const runRecord: Record<string, { [key: number]: string[] }> = {};
+      for (const [runId, rounds] of runs.entries()) {
+        if (!rounds || rounds.size === 0) {
+          continue;
+        }
+
+        const roundRecord: { [key: number]: string[] } = {};
+        for (const [round, files] of rounds.entries()) {
+          if (!files || files.length === 0) {
+            continue;
+          }
+          roundRecord[round] = files;
+        }
+
+        if (Object.keys(roundRecord).length > 0) {
+          runRecord[runId] = roundRecord;
+        }
+      }
+
+      if (Object.keys(runRecord).length > 0) {
+        payload[stream] = runRecord;
+      }
+    }
+
+    await this.storage.update(WorkspaceStateKey.MISSING_OUTPUTS, payload);
   }
 
   private deserializeMissingOutputs(

--- a/src/progressView/managers/RunInstructionManager.ts
+++ b/src/progressView/managers/RunInstructionManager.ts
@@ -1,4 +1,3 @@
-
 // Local imports - identifiers and logging
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
@@ -33,6 +32,19 @@ export class RunInstructionManager extends PersistentMapManager<
 
   getInstructions(stream: StreamTabId): InstructionMap {
     return new Map(this.get(stream) ?? []);
+  }
+
+  getInstructionRecord(stream: StreamTabId): Record<string, InstructionUpdate> {
+    const entries = this.items.get(stream);
+    if (!entries || entries.size === 0) {
+      return {};
+    }
+
+    const record: Record<string, InstructionUpdate> = {};
+    for (const [runId, instruction] of entries.entries()) {
+      record[runId] = instruction;
+    }
+    return record;
   }
 
   async setInstruction(

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -91,6 +91,19 @@ export class UsageStatsManager extends PersistentMapManager<
     return new Map(this.items.get(stream) ?? []);
   }
 
+  getUsageRecord(stream: StreamTabId): Record<string, TokenUsageStats> {
+    const usage = this.items.get(stream);
+    if (!usage || usage.size === 0) {
+      return {};
+    }
+
+    const record: Record<string, TokenUsageStats> = {};
+    for (const [runId, stats] of usage.entries()) {
+      record[runId] = stats;
+    }
+    return record;
+  }
+
   /**
    * Get total usage across all runs for a stream
    */

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -343,21 +343,10 @@ export class WebviewUpdater {
       const groups = Array.from(
         state.taskGroups.getStreamGroups(activeStream).values(),
       );
-      const files = Object.fromEntries(
-        Array.from(
-          state.outputFiles.getFiles(activeStream).entries(),
-          ([runId, rounds]) => [runId, Object.fromEntries(rounds.entries())],
-        ),
-      );
-      const missing = Object.fromEntries(
-        Array.from(
-          state.outputFiles.getMissingOutputs(activeStream).entries(),
-          ([runId, rounds]) => [runId, Object.fromEntries(rounds.entries())],
-        ),
-      );
-      const runInstructions = Object.fromEntries(
-        state.runInstructions.getInstructions(activeStream).entries(),
-      );
+      const files = state.outputFiles.getFilesRecord(activeStream);
+      const missing = state.outputFiles.getMissingOutputsRecord(activeStream);
+      const runInstructions =
+        state.runInstructions.getInstructionRecord(activeStream);
       const activeRunId = state.getActiveRunId(activeStream);
 
       this.updateLogContent(activeStream, messages, groups, {
@@ -374,12 +363,10 @@ export class WebviewUpdater {
       this.updateMissingOutputs(activeStream, missing);
 
       // Update usage for active stream
-      const usage = Object.fromEntries(
-        state.usageStats.getRunUsage(activeStream).entries(),
-      ) as Record<string, TokenUsageStats>;
+      const usage = state.usageStats.getUsageRecord(activeStream);
       this.updateUsage(activeStream, usage);
 
-      const taskState = state.getTaskState(activeStream);
+      const taskState = state.peekTaskState(activeStream);
       const instructionUpdate =
         WebviewUpdater.createInstructionUpdate(taskState);
       const activeStreamInfo = streams.find((s) => s.name === activeStream);

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -10,6 +10,7 @@ import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
 // Type imports
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { OutputFileInfo } from '@agent/output/types';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 // Internal imports
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
 import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
@@ -24,7 +25,7 @@ import type { TaskGroup } from '@logger/LogTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - progress view managers
-import type { AgentFilter } from '@progressView/types';
+import type { AgentFilter, InstructionUpdate } from '@progressView/types';
 // Internal imports
 import {
   StreamTabsManager,
@@ -85,6 +86,8 @@ export class ProgressViewState {
   private _activeRunIds: Map<StreamTabId, string | null> = new Map();
   private readonly storage: StateStorage;
   private readonly logger: AgentLogger;
+  private deferredLoadPromise: Promise<void> | undefined;
+  private deferredStateLoaded = false;
 
   constructor(storage?: StateStorage) {
     const resolvedStorage = storage ?? workspaceSM;
@@ -366,8 +369,12 @@ export class ProgressViewState {
     this.cleanupToolUseAgentRegistry();
   }
 
+  peekTaskState(streamTabId: StreamTabId): TaskState | undefined {
+    return this.taskStates.get(streamTabId);
+  }
+
   getTaskState(streamTabId: StreamTabId): TaskState | undefined {
-    const stored = this.taskStates.get(streamTabId);
+    const stored = this.peekTaskState(streamTabId);
     return stored ? cloneTaskState(stored) : undefined;
   }
 
@@ -478,24 +485,68 @@ export class ProgressViewState {
   /**
    * Load all state from persistence
    */
-  async load(): Promise<void> {
-    // Load basic state first
-    await Promise.all([
-      this._streamTabs.load(),
-      this._taskGroups.load(),
-      this._outputFiles.load(),
-      this._usageStats.load(),
-      this._runInstructions.load(),
-    ]);
+  async load(options: { includeDeferred?: boolean } = {}): Promise<void> {
+    await this.loadEssential();
 
-    // Load dependent state after basic state is loaded
+    if (options.includeDeferred ?? true) {
+      await this.loadDeferred();
+    }
+  }
+
+  async loadEssential(): Promise<void> {
+    this.deferredStateLoaded = false;
+    this.deferredLoadPromise = undefined;
+
+    // Load essential managers eagerly
+    await Promise.all([this._streamTabs.load(), this._taskGroups.load()]);
+
+    // Clear heavy managers so deferred hydration can repopulate them
+    this._outputFiles.setAll(
+      new Map<StreamTabId, Map<string, Map<number, OutputFileInfo[]>>>(),
+    );
+    this._outputFiles.setAllMissingOutputs(
+      new Map<StreamTabId, Map<string, Map<number, string[]>>>(),
+    );
+    this._usageStats.setAll(
+      new Map<StreamTabId, Map<string, TokenUsageStats>>(),
+    );
+    this._runInstructions.setAll(
+      new Map<StreamTabId, Map<string, InstructionUpdate>>(),
+    );
+
     await Promise.all([
-      this.loadActiveStream(), // Depends on stream tabs being loaded
+      this.loadActiveStream(),
       this.loadTaskStates(),
       this.loadExecutionIds(),
       this.loadStreamSortOrder(),
       this.loadAgentTypeFilter(),
       this.loadActiveRunIds(),
+    ]);
+  }
+
+  async loadDeferred(): Promise<void> {
+    if (this.deferredStateLoaded) {
+      return;
+    }
+
+    if (!this.deferredLoadPromise) {
+      this.deferredLoadPromise = this.loadDeferredInternal()
+        .then(() => {
+          this.deferredStateLoaded = true;
+        })
+        .finally(() => {
+          this.deferredLoadPromise = undefined;
+        });
+    }
+
+    await this.deferredLoadPromise;
+  }
+
+  private async loadDeferredInternal(): Promise<void> {
+    await Promise.all([
+      this._outputFiles.load(),
+      this._usageStats.load(),
+      this._runInstructions.load(),
     ]);
   }
 

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -58,7 +58,7 @@ export function buildStreamInfos(
   filter: AgentFilter = 'all',
 ): StreamTabInfo[] {
   const infos = state.streamTabs.keys().reduce<StreamTabInfo[]>((acc, id) => {
-    const taskState = state.getTaskState(id);
+    const taskState = state.peekTaskState(id);
     const sessionKindHint = state.getSessionKindHint(id);
     const logs = state.streamTabs.getMessages(id);
     const lastTimestamp =


### PR DESCRIPTION
## Summary
- add a peekTaskState accessor and update read-only consumers to avoid unnecessary cloning
- expose zero-copy record helpers on progress view managers and reduce allocations in webview updates
- split progress view state loading into essential and deferred phases and hydrate heavy data asynchronously

## Testing
- npm run lint *(fails: missing eslint-plugin-import in the container)*
- npm run compile *(cancelled after hanging without output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171904fbc88324ab4bf271edcc484d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers heavy progress state loading and switches read-only flows to zero-copy accessors with record-based payloads, updating providers/handlers to reduce cloning and allocations.
> 
> - **State Management (ProgressViewState/Provider)**:
>   - Split loading into `loadEssential()` and `loadDeferred()`; hydrate heavy managers asynchronously with readiness flags.
>   - Provider initializes essential state first and hydrates deferred state later (also on workspace folder changes), updating the webview with error logging.
>   - Added `peekTaskState()` and replaced read-only `getTaskState()` usages to avoid cloning.
> - **Webview Updates & Event Handling**:
>   - `WebviewUpdater.updateAll` and `ProgressEventHandler.refreshStreamSurface` now use record-based getters for files, missing outputs, usage, and run instructions; reduced intermediate map cloning and conversions.
>   - Instruction updates and stream info generation switched to `peekTaskState()`.
> - **Managers**:
>   - Output files: add `getFilesRecord()` and `getMissingOutputsRecord()`; optimize `saveMissingOutputs()` serialization to skip empty entries.
>   - Run instructions: add `getInstructionRecord()`.
>   - Usage stats: add `getUsageRecord()`.
> - **Misc**:
>   - Updated message handler and stream status events to use `peekTaskState()`; toolbar actions guard with `isWorkflowTaskState`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c04b2ff4cba93ed8ca8f393f2e7efef55365a7d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->