### PR TITLE
Improve progress view reload performance

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -258,16 +258,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       const previousRunId = state.getActiveRunId(message.stream);
       state.clearActiveRun(message.stream);
       logContent.innerHTML = '';
-      if (message.groups && message.groups.length > 0) {
-        const parentGroups = message.groups.filter((g) => !g.parentGroupId);
-        const childGroups = message.groups.filter((g) => g.parentGroupId);
+      const groups = message.groups || [];
+      if (groups.length > 0) {
+        const parentGroups = groups.filter((g) => !g.parentGroupId);
         dom.runSelector.setRuns(parentGroups);
-        parentGroups
-          .sort((a, b) => a.startTime - b.startTime)
-          .forEach((g) => dom.taskGroups.addGroup(g));
-        childGroups
-          .sort((a, b) => a.startTime - b.startTime)
-          .forEach((g) => dom.taskGroups.addGroup(g));
+        dom.taskGroups.renderInitial(groups);
 
         if (message.runInstructions) {
           Object.entries(message.runInstructions).forEach(
@@ -324,10 +319,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       } else {
         dom.taskGroups.showRun(null);
       }
-      const sortedMessages = [...message.messages].sort(
-        (a, b) => a.timestamp - b.timestamp,
-      );
-      sortedMessages.forEach((msg) => {
+      const logMessages = message.messages || [];
+      logMessages.forEach((msg) => {
         if (msg.groupId) {
           if (!dom.logEntries.append(msg)) {
             const formatted = this._entryFormatter.format(msg);

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -37,6 +37,31 @@ class TaskGroups {
     }
   }
 
+  delete(id) {
+    if (!id) {
+      return;
+    }
+
+    const parentId = this.parentByChild.get(id);
+    if (parentId) {
+      this._removeChild(parentId, id);
+    } else {
+      this.parentByChild.delete(id);
+    }
+
+    const children = this.childrenByParent.get(id);
+    if (children) {
+      for (const childId of children) {
+        if (this.parentByChild.get(childId) === id) {
+          this.parentByChild.delete(childId);
+        }
+      }
+      this.childrenByParent.delete(id);
+    }
+
+    this.groups.delete(id);
+  }
+
   getGroupMap() {
     return this.groups;
   }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -13,31 +13,25 @@ class TaskGroups {
   }
 
   get(id) {
-    if (!id) {
-      console.error('TaskGroups.get: id is required');
-      return null;
-    }
-    return this.groups.get(id);
+    return this.groups.get(id) ?? null;
   }
 
   set(id, group) {
-    if (!id) {
-      console.error('TaskGroups.set: id is required');
+    if (!id || !group) {
       return;
     }
-    if (!group || typeof group !== 'object') {
-      console.error('TaskGroups.set: group must be an object');
-      return;
-    }
+
     const previousParentId = this.parentByChild.get(id);
-    if (previousParentId) {
+    const nextParentId = group.parentGroupId || null;
+
+    if (previousParentId && previousParentId !== nextParentId) {
       this._removeChild(previousParentId, id);
     }
 
     this.groups.set(id, group);
 
-    if (group.parentGroupId) {
-      this._addChild(group.parentGroupId, id);
+    if (nextParentId) {
+      this._addChild(nextParentId, id);
     } else {
       this.parentByChild.delete(id);
     }
@@ -58,20 +52,13 @@ class TaskGroups {
    * @param {{ groupId: string, updates?: Object }} payload
    */
   update(payload) {
-    if (!payload || typeof payload !== 'object') {
-      console.error('TaskGroups.update: payload must be an object');
+    if (!payload) {
       return;
     }
 
     const { groupId, updates = {} } = payload;
-    if (!groupId) {
-      console.error('TaskGroups.update: groupId is required');
-      return;
-    }
-
     const group = this.groups.get(groupId);
     if (!group) {
-      console.error(`TaskGroups.update: group not found for id ${groupId}`);
       return;
     }
 
@@ -97,10 +84,6 @@ class TaskGroups {
   }
 
   getChildIds(parentId) {
-    if (!parentId) {
-      return [];
-    }
-
     const children = this.childrenByParent.get(parentId);
     if (!children) {
       return [];
@@ -110,10 +93,6 @@ class TaskGroups {
   }
 
   _addChild(parentId, childId) {
-    if (!parentId || !childId) {
-      return;
-    }
-
     let children = this.childrenByParent.get(parentId);
     if (!children) {
       children = new Set();
@@ -124,10 +103,6 @@ class TaskGroups {
   }
 
   _removeChild(parentId, childId) {
-    if (!parentId || !childId) {
-      return;
-    }
-
     const children = this.childrenByParent.get(parentId);
     if (!children) {
       return;
@@ -153,18 +128,8 @@ class ToggleStates {
   }
 
   set(id, collapsed) {
-    if (!id) {
-      console.error('ToggleStates.set: id is required');
-      return;
-    }
-    if (typeof collapsed !== 'boolean') {
-      console.error('ToggleStates.set: collapsed must be a boolean');
-      return;
-    }
     this.states.set(id, collapsed);
-    if (this.saveCallback) {
-      this.saveCallback();
-    }
+    this.saveCallback?.();
   }
 
   get(id) {
@@ -173,7 +138,6 @@ class ToggleStates {
 
   clearSelection(ids) {
     if (!Array.isArray(ids)) {
-      console.error('ToggleStates.clearSelection: ids must be an array');
       return;
     }
     ids.forEach((id) => {
@@ -181,16 +145,12 @@ class ToggleStates {
         this.states.delete(id);
       }
     });
-    if (this.saveCallback) {
-      this.saveCallback();
-    }
+    this.saveCallback?.();
   }
 
   clearAll() {
     this.states.clear();
-    if (this.saveCallback) {
-      this.saveCallback();
-    }
+    this.saveCallback?.();
   }
 
   /** Get all entries for serialization */
@@ -218,20 +178,13 @@ class StreamStatuses {
 
   set(stream, status) {
     if (!stream) {
-      console.error('StreamStatuses.set: stream is required');
       return;
     }
-    if (!status) {
-      console.error('StreamStatuses.set: status is required');
+    if (!status || status === 'ready') {
+      this.statuses.delete(stream);
       return;
     }
-    if (typeof status !== 'string') {
-      console.error('StreamStatuses.set: status must be a string');
-      return;
-    }
-    if (status !== 'ready') {
-      this.statuses.set(stream, status);
-    }
+    this.statuses.set(stream, status);
   }
 
   delete(stream) {
@@ -248,10 +201,6 @@ class ExecutionIdAvailability {
   }
 
   setAvailable(stream, hasExecutionId) {
-    if (!stream) {
-      console.error('ExecutionIdAvailability.setAvailable: stream is required');
-      return;
-    }
     this.availability.set(stream, Boolean(hasExecutionId));
   }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -83,48 +83,75 @@ export class TaskGroupDomManager {
     }
 
     const topLevel = [];
-    const childGroups = [];
+    const childrenByParent = new Map();
     for (const group of groups) {
       if (group.parentGroupId) {
-        childGroups.push(group);
+        const parentId = group.parentGroupId;
+        let bucket = childrenByParent.get(parentId);
+        if (!bucket) {
+          bucket = [];
+          childrenByParent.set(parentId, bucket);
+        }
+        bucket.push(group);
       } else {
         topLevel.push(group);
       }
     }
 
     const fragment = document.createDocumentFragment();
+    const traversalQueue = [];
     for (const group of topLevel) {
       const element = this._createGroupElement(group);
-      if (element) {
-        fragment.appendChild(element);
+      if (!element) {
+        this._discardGroup(group.id);
+        continue;
       }
+      fragment.appendChild(element);
+      traversalQueue.push(group.id);
     }
-    container.appendChild(fragment);
+    if (fragment.childNodes.length > 0) {
+      container.appendChild(fragment);
+    }
 
-    if (childGroups.length > 0) {
-      const fragmentByParent = new Map();
-      for (const group of childGroups) {
-        const element = this._createGroupElement(group);
-        if (!element) {
-          continue;
-        }
-        const parentContent = this._resolveGroupContent(group.parentGroupId);
-        if (!parentContent) {
-          continue;
-        }
-        let bucket = fragmentByParent.get(parentContent);
-        if (!bucket) {
-          bucket = document.createDocumentFragment();
-          fragmentByParent.set(parentContent, bucket);
-        }
-        bucket.appendChild(element);
+    while (traversalQueue.length > 0) {
+      const parentId = traversalQueue.shift();
+      const children = childrenByParent.get(parentId);
+      if (!children || children.length === 0) {
+        continue;
       }
 
-      for (const [
-        parentContent,
-        fragmentForParent,
-      ] of fragmentByParent.entries()) {
-        parentContent.appendChild(fragmentForParent);
+      const parentContent = this._resolveGroupContent(parentId);
+      if (!parentContent) {
+        for (const child of children) {
+          this._discardGroup(child.id);
+        }
+        childrenByParent.delete(parentId);
+        continue;
+      }
+
+      const parentFragment = document.createDocumentFragment();
+      for (const child of children) {
+        const element = this._createGroupElement(child);
+        if (!element) {
+          this._discardGroup(child.id);
+          continue;
+        }
+        parentFragment.appendChild(element);
+        traversalQueue.push(child.id);
+      }
+
+      if (parentFragment.childNodes.length > 0) {
+        parentContent.appendChild(parentFragment);
+      }
+
+      childrenByParent.delete(parentId);
+    }
+
+    if (childrenByParent.size > 0) {
+      for (const orphans of childrenByParent.values()) {
+        for (const orphan of orphans) {
+          this._discardGroup(orphan.id);
+        }
       }
     }
 
@@ -161,8 +188,7 @@ export class TaskGroupDomManager {
 
     const targetContainer = this._resolveGroupContent(group.parentGroupId);
     if (!targetContainer) {
-      this._removeToggleListener(group.id);
-      this.groupElements.delete(group.id);
+      this._discardGroup(group.id);
       return;
     }
 
@@ -427,6 +453,15 @@ export class TaskGroupDomManager {
       element.removeEventListener('toggle', listener);
     }
     this.toggleListeners.delete(groupId);
+  }
+
+  _discardGroup(groupId) {
+    if (!groupId) {
+      return;
+    }
+    this._removeToggleListener(groupId);
+    this.groupElements.delete(groupId);
+    progressViewState.taskGroups.delete(groupId);
   }
 }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -18,57 +18,20 @@ export class TaskGroupDomManager {
     this.runSelector = runSelector || null;
   }
 
-  /**
-   * Adds a log group to the DOM
-   * @param {Object} group - Group data
-   */
-  addGroup(group) {
-    const existingGroup = this.groupElements.get(group.id);
-    if (existingGroup) {
-      if (!progressViewState.taskGroups.get(group.id)) {
-        console.warn(
-          `Group ${group.id} exists in DOM but not in state - removing from DOM`,
-        );
-        this._removeToggleListener(group.id);
-        existingGroup.remove();
-        this.groupElements.delete(group.id);
-      } else {
-        progressViewState.taskGroups.set(group.id, group);
-        if (group.parentGroupId) {
-          this.updateGroup({
-            groupId: group.id,
-            updates: {
-              status: group.status,
-              endTime: group.endTime,
-            },
-          });
-        }
-        return;
-      }
-    }
-
+  _createGroupElement(group) {
     const baseGroupElement = createFromTemplate('groupDetailsTemplate');
     if (!baseGroupElement) {
-      console.error(
-        'TaskGroupDomManager.addGroup: groupDetailsTemplate not found',
-      );
-      return;
+      return null;
     }
 
     const groupContainer = baseGroupElement.querySelector('.log-group-content');
     if (!groupContainer) {
-      console.error(
-        'TaskGroupDomManager.addGroup: missing group content container',
-      );
-      baseGroupElement.remove();
-      return;
+      return null;
     }
     groupContainer.id = `${GROUP_DOM_IDS.CONTENT_PREFIX}${group.id}`;
 
-    const isRootGroup = !group.parentGroupId;
-    let detailsElem = null;
-
-    if (isRootGroup) {
+    let detailsElem;
+    if (!group.parentGroupId) {
       detailsElem = baseGroupElement;
       detailsElem.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
       detailsElem.classList.add('log-run');
@@ -76,11 +39,7 @@ export class TaskGroupDomManager {
     } else {
       const headerElement = this.headerFormatter.create(group);
       if (!headerElement) {
-        console.error(
-          'TaskGroupDomManager.addGroup: failed to create group header',
-        );
-        baseGroupElement.remove();
-        return;
+        return null;
       }
 
       detailsElem = document.createElement('details');
@@ -88,8 +47,6 @@ export class TaskGroupDomManager {
       detailsElem.id = `${GROUP_DOM_IDS.DETAILS_PREFIX}${group.id}`;
       detailsElem.appendChild(headerElement);
       detailsElem.appendChild(groupContainer);
-      baseGroupElement.replaceChildren();
-      baseGroupElement.remove();
 
       const isCollapsed = progressViewState.toggleStates.get(group.id);
       detailsElem.open = isCollapsed !== true;
@@ -104,35 +61,114 @@ export class TaskGroupDomManager {
     progressViewState.taskGroups.set(group.id, group);
     this.groupElements.set(group.id, detailsElem);
 
-    // Insert the group at the right position in the parent
+    return detailsElem;
+  }
+
+  _resolveGroupContent(parentGroupId) {
+    if (!parentGroupId) {
+      return document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    }
+    const parentDetails = this.groupElements.get(parentGroupId);
+    return parentDetails?.querySelector('.log-group-content') ?? null;
+  }
+
+  renderInitial(groups) {
+    if (!Array.isArray(groups) || groups.length === 0) {
+      return;
+    }
+
     const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (!container) {
-      console.error(
-        'TaskGroupDomManager.addGroup: missing log content container',
-      );
+      return;
+    }
+
+    const topLevel = [];
+    const childGroups = [];
+    for (const group of groups) {
+      if (group.parentGroupId) {
+        childGroups.push(group);
+      } else {
+        topLevel.push(group);
+      }
+    }
+
+    const fragment = document.createDocumentFragment();
+    for (const group of topLevel) {
+      const element = this._createGroupElement(group);
+      if (element) {
+        fragment.appendChild(element);
+      }
+    }
+    container.appendChild(fragment);
+
+    if (childGroups.length > 0) {
+      const fragmentByParent = new Map();
+      for (const group of childGroups) {
+        const element = this._createGroupElement(group);
+        if (!element) {
+          continue;
+        }
+        const parentContent = this._resolveGroupContent(group.parentGroupId);
+        if (!parentContent) {
+          continue;
+        }
+        let bucket = fragmentByParent.get(parentContent);
+        if (!bucket) {
+          bucket = document.createDocumentFragment();
+          fragmentByParent.set(parentContent, bucket);
+        }
+        bucket.appendChild(element);
+      }
+
+      for (const [
+        parentContent,
+        fragmentForParent,
+      ] of fragmentByParent.entries()) {
+        parentContent.appendChild(fragmentForParent);
+      }
+    }
+
+    if (topLevel.length > 0) {
+      progressViewState.currentGroupId = topLevel[topLevel.length - 1].id;
+      this.collapsePreviousActiveGroup();
+    }
+  }
+
+  /**
+   * Adds a log group to the DOM
+   * @param {Object} group - Group data
+   */
+  addGroup(group) {
+    const existingElement = this.groupElements.get(group.id);
+    if (existingElement) {
+      progressViewState.taskGroups.set(group.id, group);
+      if (group.parentGroupId) {
+        this.updateGroup({
+          groupId: group.id,
+          updates: {
+            status: group.status,
+            endTime: group.endTime,
+          },
+        });
+      }
+      return;
+    }
+
+    const element = this._createGroupElement(group);
+    if (!element) {
+      return;
+    }
+
+    const targetContainer = this._resolveGroupContent(group.parentGroupId);
+    if (!targetContainer) {
       this._removeToggleListener(group.id);
       this.groupElements.delete(group.id);
       return;
     }
 
-    if (group.parentGroupId) {
-      const parentDetails = this.groupElements.get(group.parentGroupId);
-      const parentGroupContent =
-        parentDetails?.querySelector('.log-group-content');
-      if (parentGroupContent) {
-        insertChronologically({
-          container: parentGroupContent,
-          element: detailsElem,
-          timestamp: group.startTime,
-        });
-        return;
-      }
-    }
-
-    // For top-level groups, insert in chronological order
     insertChronologically({
-      container,
-      element: detailsElem,
+      container: targetContainer,
+      element,
       timestamp: group.startTime,
     });
 

--- a/src/progressView/modules/utils.js
+++ b/src/progressView/modules/utils.js
@@ -66,11 +66,23 @@ export function insertChronologically({
 
   const targetTime =
     timestamp instanceof Date ? timestamp.getTime() : timestamp;
+  const childExtractor = getChildTimestamp ?? defaultChildTimestamp;
+
+  const lastChild = container.lastElementChild;
+  if (!lastChild) {
+    container.appendChild(element);
+    return;
+  }
+
+  const lastChildTime = childExtractor(lastChild);
+  if (lastChildTime !== null && targetTime >= lastChildTime) {
+    container.appendChild(element);
+    return;
+  }
+
   const children = Array.from(container.children);
   for (const child of children) {
-    const childTime = getChildTimestamp
-      ? getChildTimestamp(child)
-      : defaultChildTimestamp(child);
+    const childTime = childExtractor(child);
     if (childTime !== null && targetTime < childTime) {
       container.insertBefore(element, child);
       return;


### PR DESCRIPTION
## Summary
- batch render task groups when rebuilding the progress view and avoid redundant re-sorting of messages
- simplify progress view state helpers now that inputs are trusted from the backend
- short-circuit chronological insertion when groups arrive pre-sorted

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177f6c48a083248bbdc1df1ae6692d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Batch-render task groups on reload, simplify state helpers, and optimize chronological insertion to improve progress view performance.
> 
> - **Progress View UI**:
>   - **Batch render**: New `dom.taskGroups.renderInitial(groups)` builds full hierarchy using document fragments and a traversal queue; adds `_createGroupElement`, `_resolveGroupContent`, `_discardGroup` helpers.
>   - **Incremental add**: `addGroup` updated to reuse existing elements, update headers, and insert into the correct container chronologically.
>   - **Show/Collapse logic**: Maintains `currentGroupId`, collapses previous groups after initial render.
> - **Utilities**:
>   - **insertChronologically**: Adds fast-path using `lastElementChild` and customizable `getChildTimestamp` with a default extractor.
> - **State Management**:
>   - **TaskGroups**: Simplified `get/set/update`, added `delete`, and improved parent/child bookkeeping.
>   - **ToggleStates/StreamStatuses/ExecutionIdAvailability**: Streamlined APIs and removed redundant checks; optional callbacks.
> - **Message Handling**:
>   - **Reload flow**: Uses `groups = message.groups || []` and `logMessages = message.messages || []`; initializes runs from parent groups and calls `renderInitial`.
>   - Avoids re-sorting messages; processes in received order; retains run selection and usage/instruction/file syncing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14b34ff98f1c1907b46342771456ae3fa22f9bff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->