### PR TITLE
fix: correct multi-output input remapping

### DIFF
--- a/src/test/progressView/events/EventModules.test.ts
+++ b/src/test/progressView/events/EventModules.test.ts
@@ -1,23 +1,22 @@
 // Standard library imports
 import { strict as assert } from 'assert';
 
-// Local imports - progress view
+// Local type imports
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
-
-// Internal imports
-import { createStreamStatusEvents } from '@progressView/events/StreamStatusEvents';
-import { createOutputEvents } from '@progressView/events/OutputEvents';
-import { createUsageEvents } from '@progressView/events/UsageEvents';
-import { createLogEvents } from '@progressView/events/LogEvents';
-import { createTaskGroupEvents } from '@progressView/events/TaskGroupEvents';
-// Type imports
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
+import type { StreamStatusType } from '@progressView/events/types';
+
+// Local imports - progress view
+import { createLogEvents } from '@progressView/events/LogEvents';
+import { createOutputEvents } from '@progressView/events/OutputEvents';
+import { createStreamStatusEvents } from '@progressView/events/StreamStatusEvents';
+import { createTaskGroupEvents } from '@progressView/events/TaskGroupEvents';
+import { createUsageEvents } from '@progressView/events/UsageEvents';
 import { ProgressEventHandler } from '@progressView/events/ProgressEventHandler';
 
-import type { WebviewUpdater } from '@progressView/managers';
+// Local imports - event bus
 import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-import type { AgentLogger } from '@logger/AgentLogger';
 
 class FakeBus {
   public readonly events: (keyof ProgressEventPayloads)[] = [];
@@ -69,6 +68,11 @@ describe('Progress event modules', () => {
   } as unknown as AgentLogger;
   const stateStub = {} as ProgressViewState;
   const updaterStub = {} as WebviewUpdater;
+  const createOutputShared = () => ({
+    logger: loggerStub,
+    refreshStreamSurface: () => {},
+    getAllStreamStatuses: () => new Map<string, StreamStatusType>(),
+  });
 
   it('registers stream status handlers and disposes them', () => {
     const bus = new FakeBus();
@@ -93,9 +97,7 @@ describe('Progress event modules', () => {
 
   it('registers output handlers and disposes them', () => {
     const bus = new FakeBus();
-    const module = createOutputEvents({
-      logger: loggerStub,
-    });
+    const module = createOutputEvents(createOutputShared());
 
     const disposables = module.register(bus as any, stateStub, updaterStub);
     assert.deepStrictEqual(bus.events, [
@@ -112,9 +114,7 @@ describe('Progress event modules', () => {
 
   it('delegates clearTaskOutput to ProgressViewState.clearOutputState', () => {
     const bus = new FakeBus();
-    const module = createOutputEvents({
-      logger: loggerStub,
-    });
+    const module = createOutputEvents(createOutputShared());
 
     const calls: string[] = [];
     const state = {

--- a/src/test/utils/files/fileMappingUtils.test.ts
+++ b/src/test/utils/files/fileMappingUtils.test.ts
@@ -1,0 +1,66 @@
+// Node.js built-in imports
+import { strict as assert } from 'assert';
+
+// Internal imports
+import { replaceInputCommands } from '@utils/files/fileMappingUtils';
+import { flexibleFS } from '@utils/files/flexibleFS';
+
+describe('replaceInputCommands', () => {
+  it('rewrites nested and extensionless input commands', async () => {
+    const baseFiles = ['main.tex', 'chapters/intro.tex', 'appendix.tex'];
+    const outputFiles = ['main.tex', 'chapters/intro.tex', 'appendix.tex'];
+
+    const originalMain = [
+      '\\documentclass{article}',
+      '\\input{chapters/intro}',
+      '\\input{appendix}',
+      '\\input{chapters/intro.tex}',
+    ].join('\n');
+
+    const files = new Map<string, string>([
+      ['main.tex', originalMain],
+      ['chapters/intro.tex', 'Intro content'],
+      ['appendix.tex', 'Appendix content'],
+    ]);
+
+    const writes = new Map<string, string>();
+
+    const originalRead = flexibleFS.read;
+    const originalWrite = flexibleFS.write;
+
+    try {
+      (flexibleFS as unknown as { read: typeof flexibleFS.read }).read =
+        (async (target: string) =>
+          files.get(target) ?? '') as typeof flexibleFS.read;
+
+      (flexibleFS as unknown as { write: typeof flexibleFS.write }).write =
+        (async (target: string, content: string | Uint8Array) => {
+          const resolved =
+            typeof content === 'string'
+              ? content
+              : Buffer.from(content).toString('utf-8');
+          writes.set(target, resolved);
+          files.set(target, resolved);
+        }) as typeof flexibleFS.write;
+
+      await replaceInputCommands(baseFiles, outputFiles);
+
+      const updatedMain = writes.get('main.tex');
+      assert.ok(updatedMain, 'expected main.tex to be rewritten');
+      assert.strictEqual(
+        updatedMain,
+        [
+          '\\documentclass{article}',
+          '\\input{chapters/intro.tex}',
+          '\\input{appendix.tex}',
+          '\\input{chapters/intro.tex}',
+        ].join('\n'),
+      );
+    } finally {
+      (flexibleFS as unknown as { read: typeof flexibleFS.read }).read =
+        originalRead;
+      (flexibleFS as unknown as { write: typeof flexibleFS.write }).write =
+        originalWrite;
+    }
+  });
+});

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -7,6 +7,15 @@ import { AgentLogger } from '@logger/AgentLogger';
 // Local file imports
 import { flexibleFS } from './flexibleFS';
 
+const INPUT_COMMAND_PATTERN = /\\input\s*{([^}]+)}/g;
+
+const toPosix = (target: string): string => target.replace(/\+/g, '/');
+
+const stripExtension = (target: string): string => {
+  const ext = path.posix.extname(target);
+  return ext.length > 0 ? target.slice(0, -ext.length) : target;
+};
+
 /**
  * Create a mapping between two file lists based on name similarity.
  *
@@ -108,16 +117,61 @@ export async function replaceInputCommands(
     `File mappings for input replacement: ${Array.from(
       baseToOutputMap.entries(),
     )
-      .map(
-        ([base, output]) =>
-          `${path.basename(base)} -> ${path.basename(output)}`,
-      )
+      .map(([base, output]) => {
+        const normalizedBase = toPosix(flexibleFS.toWorkspaceRelative(base));
+        const normalizedOutput = toPosix(
+          flexibleFS.toWorkspaceRelative(output),
+        );
+        return `${normalizedBase} -> ${normalizedOutput}`;
+      })
       .join(', ')}`,
   );
 
   const baseToOutput = new Map<string, string>();
+  const registerMapping = (key: string | undefined, value: string) => {
+    if (!key) {
+      return;
+    }
+
+    const trimmed = key.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+
+    const normalizedValue = value.trim();
+    if (normalizedValue.length === 0) {
+      return;
+    }
+
+    baseToOutput.set(trimmed, normalizedValue);
+  };
+
   for (const [baseFile, outputFile] of baseToOutputMap.entries()) {
-    baseToOutput.set(path.basename(baseFile), path.basename(outputFile));
+    const workspaceBase = toPosix(
+      flexibleFS.toWorkspaceRelative(baseFile ?? ''),
+    );
+    const workspaceOutput = toPosix(
+      flexibleFS.toWorkspaceRelative(outputFile ?? ''),
+    );
+
+    if (!workspaceBase || !workspaceOutput) {
+      continue;
+    }
+
+    const baseWithoutExt = stripExtension(workspaceBase);
+    const baseName = path.posix.basename(workspaceBase);
+    const baseNameWithoutExt = stripExtension(baseName);
+
+    const variants = new Set([
+      workspaceBase,
+      baseWithoutExt,
+      baseName,
+      baseNameWithoutExt,
+    ]);
+
+    for (const variant of variants) {
+      registerMapping(variant, workspaceOutput);
+    }
   }
 
   for (const outputFile of outputFiles) {
@@ -127,8 +181,34 @@ export async function replaceInputCommands(
 
     try {
       const content = await flexibleFS.read(outputFile);
-      const newContent = content.replace(/\\input{([^}]+)}/g, (match, p1) =>
-        baseToOutput.has(p1) ? `\\input{${baseToOutput.get(p1)}}` : match,
+      const newContent = content.replace(
+        INPUT_COMMAND_PATTERN,
+        (match, rawTarget: string) => {
+          const normalized = toPosix(rawTarget.trim());
+          if (!normalized) {
+            return match;
+          }
+
+          const targetWithExt = normalized.endsWith('.tex')
+            ? normalized
+            : `${normalized}.tex`;
+
+          const candidates = [
+            targetWithExt,
+            normalized,
+            path.posix.basename(targetWithExt),
+            path.posix.basename(normalized),
+          ];
+
+          for (const candidate of candidates) {
+            const replacement = baseToOutput.get(candidate);
+            if (replacement) {
+              return `\\input{${replacement}}`;
+            }
+          }
+
+          return match;
+        },
       );
 
       if (newContent !== content) {


### PR DESCRIPTION
## Summary
- update `replaceInputCommands` to track workspace-relative keys, normalize `\input` targets, and preserve directory segments for multi-output LaTeX files
- add unit coverage for nested directories and extensionless `\input` directives when rewriting generated outputs
- tidy progress view event test imports and share output event stubs to satisfy updated type requirements

## Testing
- npm run format
- npm run lint
- npm run compile
- npm test *(fails: vscode-test requires libatk-bridge-2.0.so.0 in this container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177ba8d21883249d78053f55a8d518)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize workspace-relative paths and map basename/extension variants to robustly rewrite \input targets (including nested and extensionless); add unit tests and adjust progress view tests for updated OutputEvents API.
> 
> - **Utils**:
>   - Update `replaceInputCommands` in `src/utils/files/fileMappingUtils.ts` to:
>     - Normalize workspace-relative paths and add helpers (`INPUT_COMMAND_PATTERN`, `toPosix`, `stripExtension`).
>     - Build mapping variants (full path, no extension, basename, basename without extension) to preserve directories.
>     - Rewrite `\input{...}` targets handling extensionless and nested paths; write only on changes and improve debug logs.
> - **Tests**:
>   - Add `src/test/utils/files/fileMappingUtils.test.ts` covering nested and extensionless `\input` rewrites.
>   - Tidy `src/test/progressView/events/EventModules.test.ts` imports and share `createOutputShared` stub to satisfy `createOutputEvents` requirements; verify event registration order includes output events early.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c0eabb36f7f5189be71cdb11bcac92828f7a1a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->