### PR TITLE
fix: preserve latex input prefixes

### DIFF
--- a/src/test/utils/files/fileMappingUtils.test.ts
+++ b/src/test/utils/files/fileMappingUtils.test.ts
@@ -1,0 +1,97 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { replaceInputCommands, flexibleFS } from '@utils/files';
+
+describe('replaceInputCommands', () => {
+  const originalRead = flexibleFS.read;
+  const originalWrite = flexibleFS.write;
+
+  afterEach(() => {
+    (flexibleFS as unknown as { read: typeof flexibleFS.read }).read =
+      originalRead;
+    (flexibleFS as unknown as { write: typeof flexibleFS.write }).write =
+      originalWrite;
+  });
+
+  it('preserves directory prefixes and extensionless inputs when rewriting', async () => {
+    const files = new Map<string, string>([
+      ['/tmp/output/main.tex', '\\input{sections/intro}'],
+      ['/tmp/output/sections/intro_r2.tex', '\\section{Intro}'],
+    ]);
+    const writes: Array<{ target: string; content: string }> = [];
+
+    (flexibleFS as unknown as { read: typeof flexibleFS.read }).read = async (
+      target: string,
+    ) => {
+      const content = files.get(target);
+      if (content === undefined) {
+        throw new Error(`Unexpected read: ${target}`);
+      }
+      return content;
+    };
+
+    (flexibleFS as unknown as { write: typeof flexibleFS.write }).write =
+      async (target: string, content: string | Uint8Array) => {
+        const resolved =
+          typeof content === 'string'
+            ? content
+            : Buffer.from(content).toString('utf-8');
+        writes.push({ target, content: resolved });
+        files.set(target, resolved);
+      };
+
+    await replaceInputCommands(
+      ['/tmp/base/main.tex', '/tmp/base/sections/intro.tex'],
+      ['/tmp/output/main.tex', '/tmp/output/sections/intro_r2.tex'],
+    );
+
+    assert.deepEqual(writes, [
+      {
+        target: '/tmp/output/main.tex',
+        content: '\\input{sections/intro_r2}',
+      },
+    ]);
+  });
+
+  it('updates explicit .tex inputs while keeping directory prefixes', async () => {
+    const files = new Map<string, string>([
+      ['/tmp/output/main.tex', '\\input{sections/intro.tex}'],
+      ['/tmp/output/sections/intro_r2.tex', '\\section{Intro}'],
+    ]);
+    const writes: Array<{ target: string; content: string }> = [];
+
+    (flexibleFS as unknown as { read: typeof flexibleFS.read }).read = async (
+      target: string,
+    ) => {
+      const content = files.get(target);
+      if (content === undefined) {
+        throw new Error(`Unexpected read: ${target}`);
+      }
+      return content;
+    };
+
+    (flexibleFS as unknown as { write: typeof flexibleFS.write }).write =
+      async (target: string, content: string | Uint8Array) => {
+        const resolved =
+          typeof content === 'string'
+            ? content
+            : Buffer.from(content).toString('utf-8');
+        writes.push({ target, content: resolved });
+        files.set(target, resolved);
+      };
+
+    await replaceInputCommands(
+      ['/tmp/base/main.tex', '/tmp/base/sections/intro.tex'],
+      ['/tmp/output/main.tex', '/tmp/output/sections/intro_r2.tex'],
+    );
+
+    assert.deepEqual(writes, [
+      {
+        target: '/tmp/output/main.tex',
+        content: '\\input{sections/intro_r2.tex}',
+      },
+    ]);
+  });
+});

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -87,6 +87,81 @@ export function createFileMapping(
  * @param outputFiles Output file paths
  * @param logger Optional logger for debug messages
  */
+const TEX_EXTENSION_REGEX = /\.tex$/i;
+
+function normalizeLatexPath(value: string): string {
+  if (!value) {
+    return value;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  const normalized = path.posix.normalize(trimmed.replace(/\\/g, '/'));
+  return normalized.startsWith('./') ? normalized.slice(2) : normalized;
+}
+
+function hasTexExtension(value: string): boolean {
+  return TEX_EXTENSION_REGEX.test(value);
+}
+
+function removeTexExtension(value: string): string {
+  return value.replace(TEX_EXTENSION_REGEX, '');
+}
+
+function getPathSegments(filePath: string): string[] {
+  return path
+    .normalize(filePath)
+    .split(path.sep)
+    .filter((segment) => segment !== '');
+}
+
+function buildReplacementLookup(
+  baseToOutputMap: Map<string, string>,
+): Map<string, string> {
+  const replacements = new Map<string, string>();
+
+  const registerReplacement = (source: string, target: string) => {
+    const normalizedSource = normalizeLatexPath(source);
+    const normalizedTarget = normalizeLatexPath(target);
+
+    if (!normalizedSource || replacements.has(normalizedSource)) {
+      return;
+    }
+
+    replacements.set(normalizedSource, normalizedTarget);
+  };
+
+  for (const [baseFile, outputFile] of baseToOutputMap.entries()) {
+    if (!baseFile || !outputFile) {
+      continue;
+    }
+
+    const baseSegments = getPathSegments(baseFile);
+    const outputSegments = getPathSegments(outputFile);
+    const maxDepth = Math.min(baseSegments.length, outputSegments.length);
+
+    for (let depth = maxDepth; depth >= 1; depth--) {
+      const baseSuffix = baseSegments.slice(-depth).join('/');
+      const outputSuffix = outputSegments.slice(-depth).join('/');
+
+      registerReplacement(baseSuffix, outputSuffix);
+
+      if (hasTexExtension(baseSuffix) && hasTexExtension(outputSuffix)) {
+        registerReplacement(
+          removeTexExtension(baseSuffix),
+          removeTexExtension(outputSuffix),
+        );
+      }
+    }
+  }
+
+  return replacements;
+}
+
 export async function replaceInputCommands(
   baseFiles: string[],
   outputFiles: string[],
@@ -108,16 +183,15 @@ export async function replaceInputCommands(
     `File mappings for input replacement: ${Array.from(
       baseToOutputMap.entries(),
     )
-      .map(
-        ([base, output]) =>
-          `${path.basename(base)} -> ${path.basename(output)}`,
-      )
+      .map(([base, output]) => `${base} -> ${output}`)
       .join(', ')}`,
   );
 
-  const baseToOutput = new Map<string, string>();
-  for (const [baseFile, outputFile] of baseToOutputMap.entries()) {
-    baseToOutput.set(path.basename(baseFile), path.basename(outputFile));
+  const replacementLookup = buildReplacementLookup(baseToOutputMap);
+
+  if (replacementLookup.size === 0) {
+    logger?.debug('No replacement entries derived from file mappings');
+    return;
   }
 
   for (const outputFile of outputFiles) {
@@ -127,8 +201,23 @@ export async function replaceInputCommands(
 
     try {
       const content = await flexibleFS.read(outputFile);
-      const newContent = content.replace(/\\input{([^}]+)}/g, (match, p1) =>
-        baseToOutput.has(p1) ? `\\input{${baseToOutput.get(p1)}}` : match,
+      const newContent = content.replace(
+        /\\input{([^}]+)}/g,
+        (match, rawPath) => {
+          const normalizedPath = normalizeLatexPath(rawPath);
+
+          if (!normalizedPath) {
+            return match;
+          }
+
+          const replacement = replacementLookup.get(normalizedPath);
+
+          if (replacement) {
+            return `\\input{${replacement}}`;
+          }
+
+          return match;
+        },
       );
 
       if (newContent !== content) {


### PR DESCRIPTION
## Summary
- build a suffix-aware replacement lookup so `replaceInputCommands` keeps directory-qualified inputs intact
- normalize LaTeX input paths and support extensionless `\input{...}` directives when rewriting
- add unit tests covering directory-prefixed and extensionless inputs mapped to relocated outputs

## Testing
- npm run format
- npm run lint
- npm run compile
- CI=1 npm test -- --runTestsByPath src/test/utils/files/fileMappingUtils.test.ts *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.106.0/code: error while loading shared libraries: libatk-bridge-2.0.so.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691785d13d1c832482a7e97ed6ae3f5a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure \input replacements keep directory prefixes and support extensionless paths; add targeted tests.
> 
> - **Utils (file mapping)**:
>   - Add `normalizeLatexPath`, `hasTexExtension`, `removeTexExtension`, and `buildReplacementLookup` to generate suffix-aware replacements from `baseFiles -> outputFiles`.
>   - Update `replaceInputCommands` to normalize paths and replace using the lookup, handling both `.tex` and extensionless inputs.
>   - Expand debug logging to show full `base -> output` mappings.
> - **Tests**:
>   - Add `src/test/utils/files/fileMappingUtils.test.ts` with cases for preserving directory prefixes and handling extensionless vs explicit `.tex` inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b1f525ddd8f0e44bcb152962833de76d3028de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->