### PR TITLE
fix: preserve progress view output history during housekeeping

### DIFF
--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -5,10 +5,7 @@ import * as vscode from 'vscode';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Internal imports
-import {
-  showLoggedErrorMessage,
-  showLoggedMessage,
-} from '@common/errors/errorHandlingUtils';
+import { showLoggedMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
@@ -82,9 +79,7 @@ async function handleCleanSingle(
   const streamId = getStreamTabId(agent, model, inputFile, {
     useMultipleOutputs: false,
   });
-  bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
-  bus.emit('clearTaskOutput', streamId);
 }
 
 async function handleCleanMultiple(
@@ -117,9 +112,7 @@ async function handleCleanMultiple(
   const streamId = getStreamTabId(agent, model, inputFile, {
     useMultipleOutputs: true,
   });
-  bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
-  bus.emit('clearTaskOutput', streamId);
 }
 
 export async function handleClean(config: {
@@ -174,9 +167,7 @@ export async function handleClean(config: {
     });
 
   if (!config.skipProgressViewClear) {
-    bus.emit('clearOutputFiles', streamId);
     bus.emit('clearMissingOutputs', streamId);
-    bus.emit('clearTaskOutput', streamId);
   }
 }
 

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -5,10 +5,7 @@ import * as vscode from 'vscode';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Internal imports
-import {
-  showLoggedErrorMessage,
-  showLoggedMessage,
-} from '@common/errors/errorHandlingUtils';
+import { showLoggedMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -118,9 +115,7 @@ async function handlePack(config: {
     });
 
   if (!config.skipProgressViewClear) {
-    bus.emit('clearOutputFiles', streamId);
     bus.emit('clearMissingOutputs', streamId);
-    bus.emit('clearTaskOutput', streamId);
   }
 }
 
@@ -152,9 +147,7 @@ async function handlePackSingle(
   const streamId = getStreamTabId(agent, model, inputFile, {
     useMultipleOutputs: false,
   });
-  bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
-  bus.emit('clearTaskOutput', streamId);
 }
 
 async function handlePackMultiple(
@@ -188,9 +181,7 @@ async function handlePackMultiple(
   const streamId = getStreamTabId(agent, model, inputFile, {
     useMultipleOutputs: true,
   });
-  bus.emit('clearOutputFiles', streamId);
   bus.emit('clearMissingOutputs', streamId);
-  bus.emit('clearTaskOutput', streamId);
 }
 
 export const packCommands = {


### PR DESCRIPTION
## Summary
- stop pack/clean commands from emitting clearOutputFiles and clearTaskOutput so progress view output history remains intact
- retain the existing missing-output cleanup while respecting skipProgressViewClear

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178fd1db088324982de524d68f2ee6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop emitting `clearOutputFiles` and `clearTaskOutput` from clean/pack commands; only `clearMissingOutputs` is emitted and respects `skipProgressViewClear`.
> 
> - **Housekeeping Commands (progress view behavior)**
>   - **Clean (`src/commands/housekeeping/cleanCommands.ts`)**:
>     - Remove `bus.emit('clearOutputFiles')` and `bus.emit('clearTaskOutput')` after operations.
>     - Continue emitting `clearMissingOutputs`; gated by `skipProgressViewClear` in `handleClean`.
>   - **Pack (`src/commands/housekeeping/packCommands.ts`)**:
>     - Remove `bus.emit('clearOutputFiles')` and `bus.emit('clearTaskOutput')` after operations.
>     - Continue emitting `clearMissingOutputs`; gated by `skipProgressViewClear` in `handlePack`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffa6ec354dd33a08d1714fdbaa2c3db0244dec31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->