### PR TITLE
fix: reset empty agent selections to defaults

### DIFF
--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -31,6 +31,12 @@ import { WebviewStateManager } from '@common/webviewState.js';
 const DEFAULT_WORKFLOW_AGENT = 'correct';
 const DEFAULT_TOOL_USE_AGENT = 'chat';
 
+function getSessionDefaultAgent(sessionType) {
+  return sessionType === SESSION_TYPES.TOOL_USE
+    ? DEFAULT_TOOL_USE_AGENT
+    : DEFAULT_WORKFLOW_AGENT;
+}
+
 function setFileSelectionGroupDisabled(isDisabled) {
   const container = document.querySelector('.file-selection-group');
   if (!(container instanceof HTMLElement)) {
@@ -70,8 +76,9 @@ function getSelectDefaultValue(selectId, fallback) {
       return element.value;
     }
     const options = getSelectOptionElements(element);
-    if (options.length > 0) {
-      return options[0].value ?? '';
+    const firstValueOption = options.find((option) => option.value);
+    if (firstValueOption) {
+      return firstValueOption.value;
     }
   }
   return fallback;
@@ -272,7 +279,13 @@ export class MainViewState {
     const normalizedSessionType = normalizeSessionType(sessionTypeValue);
     const activeSelectId = AGENT_SELECT_IDS[normalizedSessionType];
     if (activeSelectId) {
-      state.agent = safeGetElementValue(activeSelectId) ?? '';
+      const defaultAgent = getSessionDefaultAgent(normalizedSessionType);
+      const agentValue = safeGetElementValue(activeSelectId) ?? '';
+      const resolvedAgent = agentValue || getSelectDefaultValue(activeSelectId, defaultAgent);
+      if (!agentValue && resolvedAgent) {
+        safeSetElementValue(activeSelectId, resolvedAgent);
+      }
+      state.agent = resolvedAgent ?? '';
       state.isToolUseAgent = normalizedSessionType === SESSION_TYPES.TOOL_USE;
     }
 
@@ -335,6 +348,13 @@ export class MainViewState {
       selectEl.classList.toggle('agent-select--hidden', !isActive);
       selectEl.setAttribute('aria-hidden', isActive ? 'false' : 'true');
       selectEl.tabIndex = isActive ? 0 : -1;
+      if (isActive && !selectEl.value) {
+        const fallback = getSelectDefaultValue(
+          selectId,
+          getSessionDefaultAgent(normalized),
+        );
+        safeSetElementValue(selectId, fallback);
+      }
     });
 
     setFileSelectionGroupDisabled(isToolUseSession);

--- a/src/webview/modules/state/currentContext.js
+++ b/src/webview/modules/state/currentContext.js
@@ -14,7 +14,17 @@ import {
   safeGetElementValue,
   safeGetElementChecked,
   isSelectLikeElement,
+  getSelectOptionElements,
 } from '@common/domUtils.js';
+
+const DEFAULT_WORKFLOW_AGENT = 'correct';
+const DEFAULT_TOOL_USE_AGENT = 'chat';
+
+function getSessionDefaultAgent(sessionType) {
+  return sessionType === SESSION_TYPES.TOOL_USE
+    ? DEFAULT_TOOL_USE_AGENT
+    : DEFAULT_WORKFLOW_AGENT;
+}
 
 const DEFAULT_SINGLE_FILE_TYPES = ['input', 'reference', 'auxiliary', 'media'];
 
@@ -33,10 +43,18 @@ function getAgent(sessionType) {
   const selectId =
     AGENT_SELECT_IDS[sessionType] ?? AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW];
   const selectElement = safeGetElementById(selectId);
-  if (isSelectLikeElement(selectElement) && selectElement.value) {
-    return selectElement.value;
+  if (isSelectLikeElement(selectElement)) {
+    if (selectElement.value) {
+      return selectElement.value;
+    }
+    const option = getSelectOptionElements(selectElement).find(
+      (item) => item.value,
+    );
+    if (option?.value) {
+      return option.value;
+    }
   }
-  return '';
+  return getSessionDefaultAgent(sessionType);
 }
 
 function collectSingleFileSelections(singleFileTypes) {


### PR DESCRIPTION
## Summary
- ensure main view agent selectors repopulate with a non-empty default whenever the DOM only has placeholder options
- fall back to default agent identifiers when collecting the current context so workflow and tool-use actions never carry an empty string

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179088ccd8832483481c81591248fa)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures agent selects auto-populate a non-empty default and context gathering falls back to defaults, avoiding empty agent values.
> 
> - **Webview state (`src/webview/modules/mainViewState.js`)**:
>   - Add session agent defaults (`DEFAULT_WORKFLOW_AGENT`, `DEFAULT_TOOL_USE_AGENT`) and helper `getSessionDefaultAgent`.
>   - Improve `getSelectDefaultValue` to prefer the first option with a non-empty `value`.
>   - On save, resolve agent via active select; if empty, set select to default/fallback and persist `state.agent`.
>   - In `applySessionType`, when activating an agent select with no value, set it to the computed default.
> - **Context collection (`src/webview/modules/state/currentContext.js`)**:
>   - Add same agent defaults and `getSessionDefaultAgent`.
>   - Update `getAgent` to return current select value, else first non-empty option, else session default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbae5eb07fb2b6faf60b9fb6d59e8b8156db5aa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->