### PR TITLE
refactor: dedupe progress view formatting paths

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,5 +1,4 @@
 // Local imports - progress view
-import { LogEntryFormatter } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { TaskGroupDomManager, LogEntryManager } from './taskManagers.js';
@@ -44,6 +43,3 @@ class ProgressViewDomHandler extends BaseDomHandler {
 }
 
 export const progressViewDomHandler = new ProgressViewDomHandler();
-
-// Export formatter classes for reuse
-export { LogEntryFormatter };

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -60,6 +60,55 @@ const TIME_FORMAT_OPTIONS = {
   hour12: false,
 };
 
+let cachedDateTimeFormatter = null;
+let cachedTimeFormatter = null;
+let dateTimeFormatterFailed = false;
+let timeFormatterFailed = false;
+
+function getSharedDateTimeFormatter() {
+  if (dateTimeFormatterFailed) {
+    return null;
+  }
+  if (!cachedDateTimeFormatter) {
+    try {
+      cachedDateTimeFormatter = new Intl.DateTimeFormat(
+        undefined,
+        DATETIME_FORMAT_OPTIONS,
+      );
+    } catch (error) {
+      dateTimeFormatterFailed = true;
+      cachedDateTimeFormatter = null;
+      return null;
+    }
+  }
+  return cachedDateTimeFormatter;
+}
+
+function getSharedTimeFormatter() {
+  if (timeFormatterFailed) {
+    return null;
+  }
+  if (!cachedTimeFormatter) {
+    try {
+      cachedTimeFormatter = new Intl.DateTimeFormat(
+        undefined,
+        TIME_FORMAT_OPTIONS,
+      );
+    } catch (error) {
+      timeFormatterFailed = true;
+      cachedTimeFormatter = null;
+      return null;
+    }
+  }
+  return cachedTimeFormatter;
+}
+
+function extractIsoParts(date) {
+  const isoTimestamp = date.toISOString();
+  const isoTimePart = isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
+  return { isoTimestamp, isoTimePart };
+}
+
 const toYamlString = (value) => {
   if (typeof value === 'string') {
     return value;
@@ -82,17 +131,12 @@ export const TaskGroupLevel = {
   ROOT: {
     name: 'root',
     formatTime: (date) => {
-      try {
-        return new Intl.DateTimeFormat(
-          undefined,
-          DATETIME_FORMAT_OPTIONS,
-        ).format(date);
-      } catch (error) {
-        const isoTimestamp = date.toISOString();
-        const timePart =
-          isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
-        return `${isoTimestamp.split('T')[0]} ${timePart}`;
+      const formatter = getSharedDateTimeFormatter();
+      if (formatter) {
+        return formatter.format(date);
       }
+      const { isoTimestamp, isoTimePart } = extractIsoParts(date);
+      return `${isoTimestamp.split('T')[0]} ${isoTimePart}`;
     },
     showTitle: false,
     headerOrder: 'time-first', // time → bullet → usage
@@ -101,15 +145,11 @@ export const TaskGroupLevel = {
   NESTED: {
     name: 'nested',
     formatTime: (date) => {
-      try {
-        return new Intl.DateTimeFormat(undefined, TIME_FORMAT_OPTIONS).format(
-          date,
-        );
-      } catch (error) {
-        return (
-          date.toISOString().split('T')[1]?.split('.')[0] ?? date.toISOString()
-        );
+      const formatter = getSharedTimeFormatter();
+      if (formatter) {
+        return formatter.format(date);
       }
+      return extractIsoParts(date).isoTimePart;
     },
     showTitle: true,
     headerOrder: 'usage-first', // usage → bullet → time
@@ -157,6 +197,7 @@ export class MessageTimestampExtractor {
 export class LogEntryFormatter {
   constructor() {
     this._initializeMarkdown();
+    this._formatters = this._createFormatterMap();
   }
 
   _initializeMarkdown() {
@@ -173,38 +214,91 @@ export class LogEntryFormatter {
       .use(highlight);
   }
 
+  _createFormatterMap() {
+    return Object.freeze({
+      thinking: (text, id, groupId, timestamp, options) =>
+        this._safeFormat(
+          () =>
+            this._formatBannerContent(
+              text,
+              'Thinking',
+              id,
+              groupId,
+              timestamp,
+              options,
+            ),
+          'thinking',
+        ),
+      scratchpad: (text, id, groupId, timestamp, options) =>
+        this._safeFormat(
+          () =>
+            this._formatBannerContent(
+              text,
+              'Scratchpad',
+              id,
+              groupId,
+              timestamp,
+              options,
+            ),
+          'scratchpad',
+        ),
+      toolUse: (text, data, id, groupId, timestamp) =>
+        this._safeFormat(
+          () => this._formatToolUse(text, data, id, groupId, timestamp),
+          'tool use',
+        ),
+      modelResponse: (params) =>
+        this._safeFormat(() => this._formatModelResponse(params), 'Assistant'),
+      fileList: (text, data, id) =>
+        this._safeFormat(
+          () => this._formatFileList(text, data, id),
+          'file list',
+        ),
+      missingOutputs: (text, data, id) =>
+        this._safeFormat(
+          () => this._formatMissingOutputs(text, data, id),
+          'missing outputs',
+        ),
+      latexdiff: (text, data, id) =>
+        this._safeFormat(
+          () => this._formatLatexdiff(text, data, id),
+          'latexdiff',
+        ),
+      statistics: (text, data, id) =>
+        this._safeFormat(
+          () => this._formatStatistics(text, data, id),
+          'statistics',
+        ),
+      userMessage: (text, id, timestamp) =>
+        this._safeFormat(
+          () => this._formatUserMessage(text, id, timestamp),
+          'user message',
+        ),
+      progressStatus: (text, id, timestamp) =>
+        this._safeFormat(
+          () => this._formatProgressStatus(text, id, timestamp),
+          'progress status',
+        ),
+    });
+  }
+
   /**
    * Format timestamp consistently across all methods
    * @param {Date} date - Date object to format
    * @returns {{fullTimestamp: string, timeDisplay: string}} Formatted timestamps
    */
   _formatTimestamp(date) {
-    const isoTimestamp = date.toISOString();
+    const { isoTimestamp, isoTimePart } = extractIsoParts(date);
+    const timeFormatter = getSharedTimeFormatter();
+    const dateTimeFormatter = getSharedDateTimeFormatter();
 
-    try {
-      const timeDisplay = new Intl.DateTimeFormat(
-        undefined,
-        TIME_FORMAT_OPTIONS,
-      ).format(date);
-      const tooltipTimestamp = new Intl.DateTimeFormat(
-        undefined,
-        DATETIME_FORMAT_OPTIONS,
-      ).format(date);
-
-      return {
-        fullTimestamp: isoTimestamp,
-        timeDisplay,
-        tooltipTimestamp,
-      };
-    } catch (error) {
-      const timeDisplay =
-        isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
-      return {
-        fullTimestamp: isoTimestamp,
-        timeDisplay,
-        tooltipTimestamp: isoTimestamp,
-      };
-    }
+    return {
+      fullTimestamp: isoTimestamp,
+      timeDisplay: timeFormatter ? timeFormatter.format(date) : isoTimePart,
+      tooltipTimestamp: dateTimeFormatter
+        ? dateTimeFormatter.format(date)
+        : isoTimestamp,
+    };
   }
 
   /**
@@ -262,71 +356,6 @@ export class LogEntryFormatter {
   }
 
   /**
-   * Get the formatter for a specific message type
-   * @private
-   * @returns {Object} Map of message types to their formatters with error handling
-   */
-  _getFormatters() {
-    return {
-      thinking: (text, id, groupId, timestamp) =>
-        this._safeFormat(
-          () =>
-            this._formatBannerContent(text, 'Thinking', id, groupId, timestamp),
-          'thinking',
-        ),
-      scratchpad: (text, id, groupId, timestamp) =>
-        this._safeFormat(
-          () =>
-            this._formatBannerContent(
-              text,
-              'Scratchpad',
-              id,
-              groupId,
-              timestamp,
-            ),
-          'scratchpad',
-        ),
-      toolUse: (text, data, id, groupId, timestamp) =>
-        this._safeFormat(
-          () => this._formatToolUse(text, data, id, groupId, timestamp),
-          'tool use',
-        ),
-      modelResponse: (params) =>
-        this._safeFormat(() => this._formatModelResponse(params), 'Assistant'),
-      fileList: (text, data, id) =>
-        this._safeFormat(
-          () => this._formatFileList(text, data, id),
-          'file list',
-        ),
-      missingOutputs: (text, data, id) =>
-        this._safeFormat(
-          () => this._formatMissingOutputs(text, data, id),
-          'missing outputs',
-        ),
-      latexdiff: (text, data, id) =>
-        this._safeFormat(
-          () => this._formatLatexdiff(text, data, id),
-          'latexdiff',
-        ),
-      statistics: (text, data, id) =>
-        this._safeFormat(
-          () => this._formatStatistics(text, data, id),
-          'statistics',
-        ),
-      userMessage: (text, id, timestamp) =>
-        this._safeFormat(
-          () => this._formatUserMessage(text, id, timestamp),
-          'user message',
-        ),
-      progressStatus: (text, id, timestamp) =>
-        this._safeFormat(
-          () => this._formatProgressStatus(text, id, timestamp),
-          'progress status',
-        ),
-    };
-  }
-
-  /**
    * Safely execute a formatting function with error handling
    * @private
    * @param {Function} formatter - The formatting function to execute
@@ -354,7 +383,7 @@ export class LogEntryFormatter {
    * DO NOT convert this to use templates unless you have a solution for the
    * whitespace formatting issue.
    */
-  format(logMessage) {
+  format(logMessage, options = {}) {
     const { id, text, level, timestamp, groupId, messageType, verbose, data } =
       logMessage;
 
@@ -364,8 +393,7 @@ export class LogEntryFormatter {
       this._formatTimestamp(date);
 
     // Check if we have a custom formatter for this message type
-    const formatters = this._getFormatters();
-    const formatter = formatters[messageType];
+    const formatter = this._formatters[messageType];
 
     if (formatter) {
       let result;
@@ -382,7 +410,7 @@ export class LogEntryFormatter {
       } else if (messageType === 'thinking' || messageType === 'scratchpad') {
         // Pass identifiers so the formatter can apply grouping metadata
         // Note: timestamp here is numeric (from Date.now())
-        result = formatter(text, id, groupId, timestamp);
+        result = formatter(text, id, groupId, timestamp, options);
       } else if (messageType === 'toolUse') {
         // Tool use needs both the rendered text and the structured payload
         result = formatter(text, data, id, groupId, timestamp);
@@ -431,7 +459,14 @@ export class LogEntryFormatter {
     return wrapper.firstElementChild;
   }
 
-  _formatBannerContent(content, contentType, logId, groupId, timestamp) {
+  _formatBannerContent(
+    content,
+    contentType,
+    logId,
+    groupId,
+    timestamp,
+    options = {},
+  ) {
     if (!content || !content.trim()) return null;
     const decodedContent = decodeHtml(content);
     if (!decodedContent.trim()) {
@@ -440,6 +475,7 @@ export class LogEntryFormatter {
 
     const parsedMarkdown = this._processMarkdownContent(decodedContent, false);
     const isThinking = contentType.includes('Thinking');
+    const shouldOpen = options?.defaultOpen === true;
     const bannerEntry = this._createBannerEntry({
       logId,
       groupId,
@@ -450,7 +486,7 @@ export class LogEntryFormatter {
       contentClass: isThinking
         ? 'banner-content--thinking'
         : 'banner-content--scratchpad',
-      open: false,
+      open: shouldOpen,
     });
 
     if (!bannerEntry || !bannerEntry.contentElem) {
@@ -1256,6 +1292,15 @@ export class LogEntryFormatter {
 
     return element;
   }
+}
+
+let sharedLogEntryFormatterInstance = null;
+
+export function getSharedLogEntryFormatter() {
+  if (!sharedLogEntryFormatterInstance) {
+    sharedLogEntryFormatterInstance = new LogEntryFormatter();
+  }
+  return sharedLogEntryFormatterInstance;
 }
 
 /**

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,6 +1,7 @@
 // Local imports - progress view
 import { COMMANDS, STATUS, ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
-import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
+import { progressViewDomHandler } from './domHandlers.js';
+import { getSharedLogEntryFormatter } from './formatters.js';
 import { createThemeHandlers } from './handlers/themeHandlers.js';
 import { appendFormatted } from './utils.js';
 // Local imports - log state
@@ -38,7 +39,7 @@ function scrollToBottom(element) {
 export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
     super();
-    this._entryFormatter = new LogEntryFormatter();
+    this._entryFormatter = getSharedLogEntryFormatter();
     this._handlers = {
       ...createThemeHandlers(),
       ...this._createHandlers(),
@@ -346,20 +347,21 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleAppendLog(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      const addedToGroup = dom.logEntries.append(message.logMessage);
+      const shouldAutoExpand =
+        message.logMessage.messageType === 'thinking' ||
+        message.logMessage.messageType === 'scratchpad';
+      const formatOptions = shouldAutoExpand
+        ? { defaultOpen: true }
+        : undefined;
+      const addedToGroup = dom.logEntries.append(
+        message.logMessage,
+        formatOptions,
+      );
       if (!addedToGroup) {
-        const formatted = this._entryFormatter.format(message.logMessage);
-        if (formatted instanceof HTMLElement) {
-          // For thinking and scratchpad, auto-expand when live streaming
-          const messageType = message.logMessage.messageType;
-          if (messageType === 'thinking' || messageType === 'scratchpad') {
-            formatted.setAttribute('open', '');
-            const toggleIcon = formatted.querySelector('.toggle-icon');
-            if (toggleIcon) {
-              toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
-            }
-          }
-        }
+        const formatted = this._entryFormatter.format(
+          message.logMessage,
+          formatOptions,
+        );
         appendFormatted(logContent, formatted);
       }
       scrollToBottom(logContent);
@@ -372,21 +374,21 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       const updated = dom.logEntries.update(message.logMessage);
       if (!updated) {
         // Fallback: append as new log with proper group placement
-        const addedToGroup = dom.logEntries.append(message.logMessage);
+        const shouldAutoExpand =
+          message.logMessage.messageType === 'thinking' ||
+          message.logMessage.messageType === 'scratchpad';
+        const formatOptions = shouldAutoExpand
+          ? { defaultOpen: true }
+          : undefined;
+        const addedToGroup = dom.logEntries.append(
+          message.logMessage,
+          formatOptions,
+        );
         if (!addedToGroup) {
-          const formatted = this._entryFormatter.format(message.logMessage);
-          if (formatted instanceof HTMLElement) {
-            // For thinking and scratchpad, auto-expand when live streaming
-            const messageType = message.logMessage.messageType;
-            if (messageType === 'thinking' || messageType === 'scratchpad') {
-              formatted.setAttribute('open', '');
-              const toggleIcon = formatted.querySelector('.toggle-icon');
-              if (toggleIcon) {
-                toggleIcon.className =
-                  'codicon codicon-chevron-down toggle-icon';
-              }
-            }
-          }
+          const formatted = this._entryFormatter.format(
+            message.logMessage,
+            formatOptions,
+          );
           appendFormatted(logContent, formatted);
         }
         scrollToBottom(logContent);

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -217,6 +217,84 @@ class StreamStatuses {
   }
 }
 
+class RunScopedStore {
+  constructor(resolveStreamId) {
+    this._resolveStreamId = resolveStreamId;
+    this._store = new Map();
+  }
+
+  _resolve(streamId) {
+    return this._resolveStreamId(streamId);
+  }
+
+  _getStreamMap(streamId, createIfMissing) {
+    const targetStream = this._resolve(streamId);
+    if (targetStream == null) {
+      return { targetStream: null, streamMap: null };
+    }
+
+    let streamMap = this._store.get(targetStream) || null;
+    if (!streamMap && createIfMissing) {
+      streamMap = new Map();
+      this._store.set(targetStream, streamMap);
+    }
+
+    return { targetStream, streamMap };
+  }
+
+  getStreamMap(streamId) {
+    return this._getStreamMap(streamId, false).streamMap;
+  }
+
+  set(streamId, runId, value) {
+    if (!runId) {
+      return;
+    }
+    const { streamMap } = this._getStreamMap(streamId, true);
+    if (streamMap) {
+      streamMap.set(runId, value);
+    }
+  }
+
+  get(streamId, runId) {
+    if (!runId) {
+      return null;
+    }
+    const { streamMap } = this._getStreamMap(streamId, false);
+    if (!streamMap) {
+      return null;
+    }
+    return streamMap.get(runId) ?? null;
+  }
+
+  delete(streamId, runId) {
+    if (!runId) {
+      return;
+    }
+    const { targetStream, streamMap } = this._getStreamMap(streamId, false);
+    if (!streamMap) {
+      return;
+    }
+    streamMap.delete(runId);
+    if (streamMap.size === 0 && targetStream != null) {
+      this._store.delete(targetStream);
+    }
+  }
+
+  clear(streamId) {
+    if (streamId !== undefined && streamId !== null) {
+      const targetStream = this._resolve(streamId);
+      if (targetStream == null) {
+        return;
+      }
+      this._store.delete(targetStream);
+      return;
+    }
+
+    this._store.clear();
+  }
+}
+
 /**
  * Tracks whether a stream has an execution directory available.
  */
@@ -260,10 +338,11 @@ export class ProgressViewState {
     this.pendingInstructions = new Map();
 
     this.activeRunIds = new Map();
-    this.runInstructions = new Map();
-    this.runFiles = new Map();
-    this.runMissingOutputs = new Map();
-    this.runUsage = new Map();
+    const streamResolver = (streamId) => this._resolveStreamId(streamId);
+    this.runInstructions = new RunScopedStore(streamResolver);
+    this.runFiles = new RunScopedStore(streamResolver);
+    this.runMissingOutputs = new RunScopedStore(streamResolver);
+    this.runUsage = new RunScopedStore(streamResolver);
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
@@ -282,20 +361,6 @@ export class ProgressViewState {
     }
 
     return null;
-  }
-
-  _getStreamMap(container, streamId, createIfMissing = false) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null) {
-      return null;
-    }
-
-    let streamMap = container.get(targetStream) || null;
-    if (!streamMap && createIfMissing) {
-      streamMap = new Map();
-      container.set(targetStream, streamMap);
-    }
-    return streamMap;
   }
 
   setExecutionIdAvailable(stream, hasExecutionId) {
@@ -398,7 +463,7 @@ export class ProgressViewState {
   _collectRunCandidates(streamId) {
     const candidates = new Set();
 
-    const instructionRuns = this.runInstructions.get(streamId);
+    const instructionRuns = this.runInstructions.getStreamMap(streamId);
     if (instructionRuns) {
       for (const runId of instructionRuns.keys()) {
         if (runId) {
@@ -407,7 +472,7 @@ export class ProgressViewState {
       }
     }
 
-    const fileRuns = this.runFiles.get(streamId);
+    const fileRuns = this.runFiles.getStreamMap(streamId);
     if (fileRuns) {
       for (const runId of fileRuns.keys()) {
         if (runId) {
@@ -416,7 +481,7 @@ export class ProgressViewState {
       }
     }
 
-    const missingRuns = this.runMissingOutputs.get(streamId);
+    const missingRuns = this.runMissingOutputs.getStreamMap(streamId);
     if (missingRuns) {
       for (const runId of missingRuns.keys()) {
         if (runId) {
@@ -425,7 +490,7 @@ export class ProgressViewState {
       }
     }
 
-    const usageRuns = this.runUsage.get(streamId);
+    const usageRuns = this.runUsage.getStreamMap(streamId);
     if (usageRuns) {
       for (const runId of usageRuns.keys()) {
         if (runId) {
@@ -454,7 +519,7 @@ export class ProgressViewState {
     }
 
     if (rootGroups.length === 0) {
-      const usageRuns = this.runUsage.get(streamId);
+      const usageRuns = this.runUsage.getStreamMap(streamId);
       if (usageRuns && usageRuns.size > 0) {
         return Array.from(usageRuns.keys())[usageRuns.size - 1] || null;
       }
@@ -527,12 +592,7 @@ export class ProgressViewState {
       return;
     }
 
-    const streamMap = this._getStreamMap(
-      this.runInstructions,
-      targetStream,
-      true,
-    );
-    streamMap.set(runId, {
+    this.runInstructions.set(targetStream, runId, {
       text: text.trim(),
       metadata: instruction?.metadata,
     });
@@ -543,14 +603,7 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const streamMap = this.runInstructions.get(targetStream);
-    if (!streamMap) {
-      return;
-    }
-    streamMap.delete(runId);
-    if (streamMap.size === 0) {
-      this.runInstructions.delete(targetStream);
-    }
+    this.runInstructions.delete(targetStream, runId);
   }
 
   getRunInstruction(streamId, runId) {
@@ -558,11 +611,7 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return null;
     }
-    const streamMap = this.runInstructions.get(targetStream);
-    if (!streamMap) {
-      return null;
-    }
-    return streamMap.get(runId) || null;
+    return this.runInstructions.get(targetStream, runId);
   }
 
   clearRunInstructions(streamId) {
@@ -571,7 +620,7 @@ export class ProgressViewState {
       if (targetStream == null) {
         return;
       }
-      this.runInstructions.delete(targetStream);
+      this.runInstructions.clear(targetStream);
       this.clearPendingInstruction(targetStream);
       return;
     }
@@ -585,8 +634,7 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const streamMap = this._getStreamMap(this.runFiles, targetStream, true);
-    streamMap.set(runId, filesByRound || {});
+    this.runFiles.set(targetStream, runId, filesByRound || {});
   }
 
   getRunFiles(streamId, runId) {
@@ -594,24 +642,11 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return null;
     }
-    const streamMap = this.runFiles.get(targetStream);
-    if (!streamMap) {
-      return null;
-    }
-    return streamMap.get(runId) || null;
+    return this.runFiles.get(targetStream, runId);
   }
 
   clearRunFiles(streamId) {
-    if (streamId !== undefined && streamId !== null) {
-      const targetStream = this._resolveStreamId(streamId);
-      if (targetStream == null) {
-        return;
-      }
-      this.runFiles.delete(targetStream);
-      return;
-    }
-
-    this.runFiles.clear();
+    this.runFiles.clear(streamId);
   }
 
   deleteRunFiles(streamId, runId) {
@@ -619,14 +654,7 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const streamMap = this.runFiles.get(targetStream);
-    if (!streamMap) {
-      return;
-    }
-    streamMap.delete(runId);
-    if (streamMap.size === 0) {
-      this.runFiles.delete(targetStream);
-    }
+    this.runFiles.delete(targetStream, runId);
   }
 
   setRunMissingOutputs(streamId, runId, filesByRound) {
@@ -634,12 +662,7 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const streamMap = this._getStreamMap(
-      this.runMissingOutputs,
-      targetStream,
-      true,
-    );
-    streamMap.set(runId, filesByRound || {});
+    this.runMissingOutputs.set(targetStream, runId, filesByRound || {});
   }
 
   getRunMissingOutputs(streamId, runId) {
@@ -647,24 +670,11 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return null;
     }
-    const streamMap = this.runMissingOutputs.get(targetStream);
-    if (!streamMap) {
-      return null;
-    }
-    return streamMap.get(runId) || null;
+    return this.runMissingOutputs.get(targetStream, runId);
   }
 
   clearRunMissingOutputs(streamId) {
-    if (streamId !== undefined && streamId !== null) {
-      const targetStream = this._resolveStreamId(streamId);
-      if (targetStream == null) {
-        return;
-      }
-      this.runMissingOutputs.delete(targetStream);
-      return;
-    }
-
-    this.runMissingOutputs.clear();
+    this.runMissingOutputs.clear(streamId);
   }
 
   setRunUsage(streamId, runId, usage) {
@@ -685,8 +695,7 @@ export class ProgressViewState {
       this.clearRunUsage(targetStream, runId);
       return;
     }
-    const streamMap = this._getStreamMap(this.runUsage, targetStream, true);
-    streamMap.set(runId, normalized);
+    this.runUsage.set(targetStream, runId, normalized);
   }
 
   getRunUsage(streamId, runId) {
@@ -694,11 +703,7 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return null;
     }
-    const streamMap = this.runUsage.get(targetStream);
-    if (!streamMap) {
-      return null;
-    }
-    return streamMap.get(runId) || null;
+    return this.runUsage.get(targetStream, runId);
   }
 
   clearRunUsage(streamId, runId) {
@@ -707,14 +712,7 @@ export class ProgressViewState {
       if (targetStream == null) {
         return;
       }
-      const streamMap = this.runUsage.get(targetStream);
-      if (!streamMap) {
-        return;
-      }
-      streamMap.delete(runId);
-      if (streamMap.size === 0) {
-        this.runUsage.delete(targetStream);
-      }
+      this.runUsage.delete(targetStream, runId);
       return;
     }
 
@@ -723,7 +721,7 @@ export class ProgressViewState {
       if (targetStream == null) {
         return;
       }
-      this.runUsage.delete(targetStream);
+      this.runUsage.clear(targetStream);
       return;
     }
 
@@ -735,14 +733,7 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const streamMap = this.runMissingOutputs.get(targetStream);
-    if (!streamMap) {
-      return;
-    }
-    streamMap.delete(runId);
-    if (streamMap.size === 0) {
-      this.runMissingOutputs.delete(targetStream);
-    }
+    this.runMissingOutputs.delete(targetStream, runId);
   }
 }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,6 +1,9 @@
 // Local imports - progress view
 import { ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
-import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
+import {
+  TaskGroupHeaderFormatter,
+  getSharedLogEntryFormatter,
+} from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { insertChronologically } from './utils.js';
@@ -469,8 +472,8 @@ export class TaskGroupDomManager {
  * Manages individual log entry DOM operations.
  */
 export class LogEntryManager {
-  constructor() {
-    this.entryFormatter = new LogEntryFormatter();
+  constructor(entryFormatter = getSharedLogEntryFormatter()) {
+    this.entryFormatter = entryFormatter;
   }
 
   /**
@@ -478,13 +481,16 @@ export class LogEntryManager {
    * @param {Object} logMessage - The log message to append
    * @returns {boolean} Whether the message was appended to a group
    */
-  append(logMessage) {
+  append(logMessage, formatOptions) {
     // If the message has a group ID, append it to the right group
     if (logMessage.groupId) {
       const groupContentId = `${GROUP_DOM_IDS.CONTENT_PREFIX}${logMessage.groupId}`;
       const groupContent = document.getElementById(groupContentId);
       if (groupContent) {
-        const logLineElement = this.entryFormatter.format(logMessage);
+        const logLineElement = this.entryFormatter.format(
+          logMessage,
+          formatOptions,
+        );
         if (!logLineElement) {
           console.debug(
             'LogEntryManager.append: formatter returned null for message',
@@ -519,23 +525,17 @@ export class LogEntryManager {
     if (existing) {
       // Preserve the expanded/collapsed state for thinking and scratchpad
       const wasOpen = existing.hasAttribute('open');
-      const newEl = this.entryFormatter.format(logMessage);
+      const shouldPreserveExpansion =
+        wasOpen &&
+        (logMessage.messageType === 'thinking' ||
+          logMessage.messageType === 'scratchpad');
+      const newEl = this.entryFormatter.format(
+        logMessage,
+        shouldPreserveExpansion ? { defaultOpen: true } : undefined,
+      );
       if (!newEl) {
         existing.remove();
         return true;
-      }
-
-      // Restore the expanded state if it was open
-      if (
-        wasOpen &&
-        (logMessage.messageType === 'thinking' ||
-          logMessage.messageType === 'scratchpad')
-      ) {
-        newEl.setAttribute('open', '');
-        const toggleIcon = newEl.querySelector('.toggle-icon');
-        if (toggleIcon) {
-          toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
-        }
       }
 
       existing.replaceWith(newEl);


### PR DESCRIPTION
## Summary
- share a memoized `LogEntryFormatter` across progress view components and centralize banner expansion
- cache expensive date/time formatter instances and remove per-call allocations
- replace ad-hoc run-scoped Maps with a reusable helper to reduce duplication in state management

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178f6ea5e083249f2befdf99e3bff9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Share a singleton LogEntryFormatter with centralized banner expansion, cache Intl.DateTimeFormat instances, and replace duplicated run-scoped Maps with a reusable store across progress view modules.
> 
> - **Progress View Formatting**:
>   - **Shared formatter**: Introduce `getSharedLogEntryFormatter()` and use it in `messageHandlers`, `taskManagers`, and `domHandlers` (removes direct `LogEntryFormatter` export/import).
>   - **Centralized banner expansion**: `LogEntryFormatter.format()` now accepts `options` (e.g., `{ defaultOpen: true }`) for `thinking`/`scratchpad`, removing ad-hoc DOM tweaks.
>   - **Formatter map**: Precompute `_formatters` mapping in `LogEntryFormatter`.
> - **Timestamp Optimization**:
>   - Cache `Intl.DateTimeFormat` instances with fallbacks via ISO parsing; unify time formatting in `TaskGroupLevel` and `_formatTimestamp()`.
> - **State Management**:
>   - Add `RunScopedStore` and refactor `ProgressViewState` run-scoped data (`runInstructions`, `runFiles`, `runMissingOutputs`, `runUsage`) to use it.
>   - Simplify helpers for resolving/clearing per-stream/run data and candidate run resolution.
> - **Task Group/Log Handling**:
>   - `LogEntryManager` accepts external formatter and passes `formatOptions`; preserves expansion on updates.
>   - `messageHandlers` passes expansion options on append/update and cleans up state interactions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f020ab3a5e065cf9d9041da519aeadf09cb3ab02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->